### PR TITLE
Remove redundant OnDeviceListUpdated() call

### DIFF
--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -150,7 +150,6 @@ void ConnectionHandlerImpl::OnDeviceAdded(
           device_info.device_handle(),
           Device(device_info.device_handle(), device_info.name(),
                  device_info.mac_address(), device_info.connection_type())));
-  sync_primitives::AutoLock lock(connection_handler_observer_lock_);
 }
 
 void ConnectionHandlerImpl::OnDeviceRemoved(

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -151,9 +151,6 @@ void ConnectionHandlerImpl::OnDeviceAdded(
           Device(device_info.device_handle(), device_info.name(),
                  device_info.mac_address(), device_info.connection_type())));
   sync_primitives::AutoLock lock(connection_handler_observer_lock_);
-  if (connection_handler_observer_) {
-    connection_handler_observer_->OnDeviceListUpdated(device_list_);
-  }
 }
 
 void ConnectionHandlerImpl::OnDeviceRemoved(
@@ -185,7 +182,6 @@ void ConnectionHandlerImpl::OnDeviceRemoved(
   sync_primitives::AutoLock lock(connection_handler_observer_lock_);
   if (connection_handler_observer_) {
     connection_handler_observer_->RemoveDevice(device_info.device_handle());
-    connection_handler_observer_->OnDeviceListUpdated(device_list_);
   }
 }
 


### PR DESCRIPTION
Remove redundant OnDeviceListUpdated() call from:
- ConnectionHandlerImpl::OnDeviceAdded()
- ConnectionHandlerImpl::OnDeviceRemoved()