### PR TITLE
Implement ability to send ttsName and vrSynonyms during QUERY_APP

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -970,7 +970,19 @@ class ApplicationManagerImpl : public ApplicationManager,
      */
     bool IsAppsQueriedFrom(const connection_handler::DeviceHandle handle) const;
 
-private:
+  private:
+    /**
+     * @brief PullLanguagesInfo allows to pull information about languages.
+     *
+     * @param app_data entry to parse
+     *
+     * @param ttsName tts name that should be filled.
+     * @param vrSynonym vr synonymus that should be filled.
+     */
+    void PullLanguagesInfo(const smart_objects::SmartObject& app_data,
+                           smart_objects::SmartObject& ttsName,
+                           smart_objects::SmartObject& vrSynonym);
+
     ApplicationManagerImpl();
 
     /**

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -287,6 +287,10 @@ const char urlScheme[] = "urlScheme";
 const char packageName[] = "packageName";
 const char response[] = "response";
 const char is_media_application[] = "isMediaApplication";
+const char default_[] = "default";
+const char languages[] = "languages";
+const char ttsName[] = "ttsName";
+const char vrSynonyms[] = "vrSynonyms";
 } // namespace json
 
 namespace http_request {

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -1205,14 +1205,18 @@ bool MessageHelper::CreateHMIApplicationStruct(ApplicationConstSharedPtr app,
 
   if (app->IsRegistered()) {
     output[strings::hmi_display_language_desired] = app->ui_language();
-  }
-
-  if (app->IsRegistered()) {
     output[strings::is_media_application] = app->is_media_application();
   }
 
   if (!app->IsRegistered()) {
     output[strings::greyOut] = app->is_greyed_out();
+    if (!app->tts_name()->empty()) {
+      output[json::ttsName][strings::text] = *(app->tts_name());
+      output[json::ttsName][strings::speech_capabilities] = hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+    }
+    if (!app->vr_synonyms()->empty()) {
+      output[json::vrSynonyms] = *(app->vr_synonyms());
+    }
   }
 
   if (ngn_media_screen_name) {

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1314,6 +1314,21 @@
     <param name="deviceName" type="String" mandatory="true">
       <description>The name of device which the provided application is running on.</description>
     </param>
+    <param name="ttsName" type="Common.TTSChunk" minsize="1" maxsize="100" array="true" mandatory="false" >
+      <description>
+        TTS string for VR recognition of the mobile application name, e.g. "Ford Drive Green".
+        Meant to overcome any failing on speech engine in properly pronouncing / understanding app name.
+        May not be empty.
+        May not start with a new line character.
+        Not unique value
+      </description>
+    </param>
+    <param name="vrSynonyms" type="String" maxlength="40" minsize="1" maxsize="100" array="true" mandatory="false">
+      <description>
+        Defines an additional voice recognition command.
+        Must not interfere with any name of previously registered applications(SDL makes check).
+      </description>
+    </param>
     <param name="appID" type="Integer" mandatory="true">
       <description>Unique (during ignition cycle) id of the application. To be used in all RPCs sent by both HU system and SDL</description>
     </param>

--- a/src/components/interfaces/QT_HMI_API.xml
+++ b/src/components/interfaces/QT_HMI_API.xml
@@ -1238,6 +1238,21 @@
       <param name="deviceName" type="String" mandatory="true">
         <description>The name of device which the provided application is running on.</description>
       </param>
+      <param name="ttsName" type="Common.TTSChunk" minsize="1" maxsize="100" array="true" mandatory="false" >
+        <description>
+          TTS string for VR recognition of the mobile application name, e.g. "Ford Drive Green".
+          Meant to overcome any failing on speech engine in properly pronouncing / understanding app name.
+          May not be empty.
+          May not start with a new line character.
+          Not unique value
+        </description>
+      </param>
+      <param name="vrSynonyms" type="String" maxlength="40" minsize="1" maxsize="100" array="true" mandatory="false">
+        <description>
+          Defines an additional voice recognition command.
+          Must not interfere with any name of previously registered applications(SDL makes check).
+        </description>
+      </param>
       <param name="appID" type="Integer" mandatory="true">
         <description>Unique (during ignition cycle) id of the application. To be used in all RPCs sent by both HU system and SDL</description>
       </param>


### PR DESCRIPTION
In case QUERY_APP system request executes that received JSON has to have
language entry where descibed proper values for ttsName and vrSynonyms fields.