### PR TITLE
Split logic that adds new application to the database and sends notifications to the device

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -325,6 +325,15 @@ class PolicyHandler :
    */
   virtual void OnAppsSearchCompleted();
 
+  /**
+   * @brief OnAppRegisteredOnMobile alows to handle event when application were
+   * succesfully registered on mobile device.
+   * It will send OnAppPermissionSend notification and will try to start PTU.
+   *
+   * @param application_id registered application.
+   */
+  void OnAppRegisteredOnMobile(const std::string& application_id);
+
 //TODO(AKutsan) REMOVE THIS UGLY HOTFIX
   virtual void Increment(usage_statistics::GlobalCounterId type);
   virtual void Increment(const std::string& app_id,

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -472,6 +472,8 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
 
   ApplicationListAccessor app_list_accesor;
   application->MarkRegistered();
+  policy::PolicyHandler::instance()->AddApplication(application->mobile_app_id());
+  application->set_hmi_level(GetDefaultHmiLevel(application));
   app_list_accesor.Insert(application);
 
   return application;

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
@@ -68,7 +68,7 @@ void RegisterAppInterfaceResponse::Run() {
   if (app.valid()) {
     policy::PolicyHandler *policy_handler = policy::PolicyHandler::instance();
     std::string mobile_app_id = app->mobile_app_id();
-    policy_handler->AddApplication(mobile_app_id);
+    policy_handler->OnAppRegisteredOnMobile(mobile_app_id);
     SetHeartBeatTimeout(connection_key, mobile_app_id);
   }
 }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1255,6 +1255,11 @@ void policy::PolicyHandler::OnAppsSearchCompleted() {
   policy_manager_->OnAppsSearchCompleted();
 }
 
+void PolicyHandler::OnAppRegisteredOnMobile(const std::string& application_id) {
+  POLICY_LIB_CHECK_VOID();
+  policy_manager_->OnAppRegisteredOnMobile(application_id);
+}
+
 void PolicyHandler::Increment(usage_statistics::GlobalCounterId type) {
   POLICY_LIB_CHECK();
   policy_manager_->Increment(type);

--- a/src/components/policy/src/policy/include/policy/policy_manager.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager.h
@@ -396,6 +396,15 @@ class PolicyManager : public usage_statistics::StatisticsManager {
      */
     virtual void OnAppsSearchCompleted() = 0;
 
+    /**
+     * @brief OnAppRegisteredOnMobile alows to handle event when application were
+     * succesfully registered on mobile device.
+     * It will send OnAppPermissionSend notification and will try to start PTU.
+     *
+     * @param application_id registered application.
+     */
+    virtual void OnAppRegisteredOnMobile(const std::string& application_id) = 0;
+
   protected:
     /**
      * Checks is PT exceeded IgnitionCycles

--- a/src/components/policy/src/policy/include/policy/policy_manager_impl.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager_impl.h
@@ -166,6 +166,7 @@ class PolicyManagerImpl : public PolicyManager {
 
     virtual void OnAppsSearchCompleted();
 
+    void OnAppRegisteredOnMobile(const std::string& application_id);
   protected:
     virtual utils::SharedPtr<policy_table::Table> Parse(
         const BinaryMessage& pt_content);

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -781,6 +781,12 @@ bool PolicyManagerImpl::CanAppStealFocus(const std::string& app_id) {
 void PolicyManagerImpl::MarkUnpairedDevice(const std::string& device_id) {
 }
 
+void PolicyManagerImpl::OnAppRegisteredOnMobile(
+    const std::string& application_id) {
+  StartPTExchange();
+  SendNotificationOnPermissionsUpdated(application_id);
+}
+
 void PolicyManagerImpl::AddApplication(const std::string& application_id) {
   LOG4CXX_INFO(logger_, "AddApplication");
   const std::string device_id = GetCurrentDeviceId(application_id);
@@ -793,8 +799,6 @@ void PolicyManagerImpl::AddApplication(const std::string& application_id) {
   } else {
     PromoteExistedApplication(application_id, device_consent);
   }
-  StartPTExchange();
-  SendNotificationOnPermissionsUpdated(application_id);
 }
 
 void PolicyManagerImpl::RemoveAppConsentForGroup(const std::string& app_id,


### PR DESCRIPTION
The application has to be added to the policy database during registration whereas `OnAppPermissionChange` notification and PTU should be performed after `RegisterAppInterfaceResponse`. SO the pull request contains changes that allows to split logic in `AddApplication` method on two parts: adding aplication and sending notification/starting PTU.