### PR TITLE
APPLINK-12321. Fixed nicknames comparing on PTU.

### DIFF
--- a/src/components/policy/src/policy/src/policy_helper.cc
+++ b/src/components/policy/src/policy/src/policy_helper.cc
@@ -297,7 +297,7 @@ bool CheckAppPolicy::NicknamesMatch(
          app_policy.second.nicknames->begin();
          app_policy.second.nicknames->end() != it; ++it) {
       std::string temp = *it;
-      if (temp.compare(app_name) == 0) {
+      if (!strcasecmp(temp.c_str(), app_name.c_str())) {
         return true;
       }
     }


### PR DESCRIPTION
Fixed app unauthorized issue during processing of policy update due to case-sensitive nicknames comparison.