### PR TITLE
Allow stresaming before hmi response

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -196,6 +196,11 @@ class DynamicApplicationData {
     virtual void set_audio_stream_retry_number(
         const uint32_t& audio_stream_retry_number) = 0;
 
+    virtual uint32_t video_stream_retry_number() const = 0;
+
+    virtual void set_video_stream_retry_number(
+        const uint32_t& video_stream_retry_number) = 0;
+
     /*
      * @brief Adds a command to the in application menu
      */

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -406,10 +406,10 @@ class Application : public virtual InitialApplicationData,
     virtual bool is_navi() const = 0;
     virtual void set_is_navi(bool allow) = 0;
 
-    virtual bool video_streaming_started() const = 0;
-    virtual void set_video_streaming_started(bool state) = 0;
-    virtual bool audio_streaming_started() const = 0;
-    virtual void set_audio_streaming_started(bool state) = 0;
+    virtual bool video_streaming_approved() const = 0;
+    virtual void set_video_streaming_approved(bool state) = 0;
+    virtual bool audio_streaming_approved() const = 0;
+    virtual void set_audio_streaming_approved(bool state) = 0;
 
     virtual bool video_streaming_allowed() const = 0;
     virtual void set_video_streaming_allowed(bool state) = 0;

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -190,6 +190,12 @@ class DynamicApplicationData {
         const smart_objects::SmartObject& menu_title) = 0;
     virtual void set_menu_icon(
         const smart_objects::SmartObject& menu_icon) = 0;
+
+    virtual uint32_t audio_stream_retry_number() const = 0;
+
+    virtual void set_audio_stream_retry_number(
+        const uint32_t& audio_stream_retry_number) = 0;
+
     /*
      * @brief Adds a command to the in application menu
      */

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -239,7 +239,11 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
    */
   virtual const HmiStatePtr RegularHmiState() const;
 
- protected:
+  uint32_t audio_stream_retry_number() const;
+
+  void set_audio_stream_retry_number(const uint32_t& audio_stream_retry_number);
+
+  protected:
 
   /**
    * @brief Clean up application folder. Persistent files will stay
@@ -259,12 +263,6 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
    * Sends start video stream request to HMI
    */
   void OnVideoStartStreamRetry();
-
-  /**
-   * @brief Callback for audio start stream retry timer.
-   * Sends start audio stream request to HMI
-   */
-  void OnAudioStartStreamRetry();
 
   /**
    * @brief Callback for video streaming suspend timer.
@@ -321,7 +319,6 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
   uint32_t                                 video_stream_suspend_timeout_;
   uint32_t                                 audio_stream_suspend_timeout_;
   ApplicationTimerPtr                      video_stream_retry_timer_;
-  ApplicationTimerPtr                      audio_stream_retry_timer_;
   ApplicationTimerPtr                      video_stream_suspend_timer_;
   ApplicationTimerPtr                      audio_stream_suspend_timer_;
 

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -87,10 +87,10 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
   inline bool is_navi() const { return is_navi_; }
   void set_is_navi(bool allow);
 
-  bool video_streaming_started() const;
-  void set_video_streaming_started(bool state);
-  bool audio_streaming_started() const;
-  void set_audio_streaming_started(bool state);
+  bool video_streaming_approved() const;
+  void set_video_streaming_approved(bool state);
+  bool audio_streaming_approved() const;
+  void set_audio_streaming_approved(bool state);
 
   bool video_streaming_allowed() const;
   void set_video_streaming_allowed(bool state);
@@ -289,8 +289,8 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
   bool                                     is_media_;
   bool                                     is_navi_;
 
-  bool                                     video_streaming_started_;
-  bool                                     audio_streaming_started_;
+  bool                                     video_streaming_approved_;
+  bool                                     audio_streaming_approved_;
   bool                                     video_streaming_allowed_;
   bool                                     audio_streaming_allowed_;
   bool                                     video_streaming_suspended_;

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -243,6 +243,10 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
 
   void set_audio_stream_retry_number(const uint32_t& audio_stream_retry_number);
 
+  uint32_t video_stream_retry_number() const;
+
+  void set_video_stream_retry_number(const uint32_t& video_stream_retry_number);
+
   protected:
 
   /**
@@ -257,12 +261,6 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
 
  private:
   typedef SharedPtr<TimerThread<ApplicationImpl>> ApplicationTimerPtr;
-
-  /**
-   * @brief Callback for video start stream retry timer.
-   * Sends start video stream request to HMI
-   */
-  void OnVideoStartStreamRetry();
 
   /**
    * @brief Callback for video streaming suspend timer.
@@ -318,7 +316,6 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
   uint32_t                                 audio_stream_retry_number_;
   uint32_t                                 video_stream_suspend_timeout_;
   uint32_t                                 audio_stream_suspend_timeout_;
-  ApplicationTimerPtr                      video_stream_retry_timer_;
   ApplicationTimerPtr                      video_stream_suspend_timer_;
   ApplicationTimerPtr                      audio_stream_suspend_timer_;
 

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -662,7 +662,7 @@ class ApplicationManagerImpl : public ApplicationManager,
      * @param service_type Service type to check
      * @return True if streaming is allowed, false in other case
      */
-    bool IsStreamingAllowed(
+    bool HMILevelAllowsStreaming(
         uint32_t app_id, protocol_handler::ServiceType service_type) const;
 
     /**

--- a/src/components/application_manager/include/application_manager/commands/hmi/navi_audio_start_stream_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/navi_audio_start_stream_request.h
@@ -57,9 +57,12 @@ class AudioStartStreamRequest : public RequestToHMI,
    **/
   virtual ~AudioStartStreamRequest();
 
-  virtual bool Init();
-
+    /**
+   * @brief onTimeOut from requrst Controller
+   */
   virtual void onTimeOut();
+
+
   /**
    * @brief Execute command
    **/
@@ -70,10 +73,15 @@ class AudioStartStreamRequest : public RequestToHMI,
    **/
   virtual void on_event(const event_engine::Event& event);
 
-    void RetryStartSession();
+    /**
+   * @brief RetryStartSession resend HMI startSession request if needed.
+   * If limit expired, set audio_stream_retry_number counter to 0
+   */
+  void RetryStartSession();
+
   private:
-  DISALLOW_COPY_AND_ASSIGN(AudioStartStreamRequest);
   uint32_t retry_number_;
+  DISALLOW_COPY_AND_ASSIGN(AudioStartStreamRequest);
 };
 
 }  // namespace commands

--- a/src/components/application_manager/include/application_manager/commands/hmi/navi_audio_start_stream_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/navi_audio_start_stream_request.h
@@ -57,6 +57,9 @@ class AudioStartStreamRequest : public RequestToHMI,
    **/
   virtual ~AudioStartStreamRequest();
 
+  virtual bool Init();
+
+  virtual void onTimeOut();
   /**
    * @brief Execute command
    **/
@@ -67,8 +70,10 @@ class AudioStartStreamRequest : public RequestToHMI,
    **/
   virtual void on_event(const event_engine::Event& event);
 
- private:
+    void RetryStartSession();
+  private:
   DISALLOW_COPY_AND_ASSIGN(AudioStartStreamRequest);
+  uint32_t retry_number_;
 };
 
 }  // namespace commands

--- a/src/components/application_manager/include/application_manager/commands/hmi/navi_start_stream_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/navi_start_stream_request.h
@@ -44,31 +44,44 @@ namespace commands {
  **/
 class NaviStartStreamRequest : public RequestToHMI,
                                public event_engine::EventObserver {
- public:
-  /**
+  public:
+    /**
    * @brief NaviStartStreamRequest class constructor
    *
    * @param message Incoming SmartObject message
    **/
-  explicit NaviStartStreamRequest(const MessageSharedPtr& message);
+    explicit NaviStartStreamRequest(const MessageSharedPtr& message);
 
-  /**
-   * @brief OnNaviStartStreamRequest class destructor
-   **/
-  virtual ~NaviStartStreamRequest();
+    /**
+     * @brief OnNaviStartStreamRequest class destructor
+     **/
+    virtual ~NaviStartStreamRequest();
 
-  /**
-   * @brief Execute command
-   **/
-  virtual void Run();
+    /**
+     * @brief Execute command
+     **/
+    virtual void Run();
 
-  /**
-   * @brief On event callback
-   **/
-  virtual void on_event(const event_engine::Event& event);
+    /**
+     * @brief On event callback
+     **/
+    virtual void on_event(const event_engine::Event& event);
 
- private:
-  DISALLOW_COPY_AND_ASSIGN(NaviStartStreamRequest);
+    /**
+     * @brief onTimeOut from requrst Controller
+     */
+    virtual void onTimeOut();
+
+
+    /**
+   * @brief RetryStartSession resend HMI startSession request if needed.
+   * If limit expired, set video_stream_retry_number counter to 0
+   */
+    void RetryStartSession();
+
+  private:
+    uint32_t retry_number_;
+    DISALLOW_COPY_AND_ASSIGN(NaviStartStreamRequest);
 };
 
 }  // namespace commands

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -394,11 +394,9 @@ void ApplicationImpl::set_video_streaming_started(bool state) {
     if (video_stream_retry_timer_->isRunning()) {
       video_stream_retry_timer_->stop();
       video_streaming_started_ = state;
-      set_video_streaming_allowed(state);
     }
   } else {
     video_streaming_started_ = state;
-    set_video_streaming_allowed(state);
   }
 }
 
@@ -411,11 +409,9 @@ void ApplicationImpl::set_audio_streaming_started(bool state) {
     if (audio_stream_retry_timer_->isRunning()) {
       audio_stream_retry_timer_->stop();
       audio_streaming_started_ = state;
-      set_audio_streaming_allowed(state);
     }
   } else {
     audio_streaming_started_ = state;
-    set_audio_streaming_allowed(state);
   }
 }
 

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -86,8 +86,8 @@ ApplicationImpl::ApplicationImpl(uint32_t application_id,
       active_message_(NULL),
       is_media_(false),
       is_navi_(false),
-      video_streaming_started_(false),
-      audio_streaming_started_(false),
+      video_streaming_approved_(false),
+      audio_streaming_approved_(false),
       video_streaming_allowed_(false),
       audio_streaming_allowed_(false),
       video_streaming_suspended_(true),
@@ -389,34 +389,34 @@ bool ApplicationImpl::tts_properties_in_full() {
   return tts_properties_in_full_;
 }
 
-void ApplicationImpl::set_video_streaming_started(bool state) {
+void ApplicationImpl::set_video_streaming_approved(bool state) {
   if (state) {
     if (video_stream_retry_timer_->isRunning()) {
       video_stream_retry_timer_->stop();
-      video_streaming_started_ = state;
+      video_streaming_approved_ = state;
     }
   } else {
-    video_streaming_started_ = state;
+    video_streaming_approved_ = state;
   }
 }
 
-bool ApplicationImpl::video_streaming_started() const {
-  return video_streaming_started_;
+bool ApplicationImpl::video_streaming_approved() const {
+  return video_streaming_approved_;
 }
 
-void ApplicationImpl::set_audio_streaming_started(bool state) {
+void ApplicationImpl::set_audio_streaming_approved(bool state) {
   if (state) {
     if (audio_stream_retry_timer_->isRunning()) {
       audio_stream_retry_timer_->stop();
-      audio_streaming_started_ = state;
+      audio_streaming_approved_ = state;
     }
   } else {
-    audio_streaming_started_ = state;
+    audio_streaming_approved_ = state;
   }
 }
 
-bool ApplicationImpl::audio_streaming_started() const {
-  return audio_streaming_started_;
+bool ApplicationImpl::audio_streaming_approved() const {
+  return audio_streaming_approved_;
 }
 
 void ApplicationImpl::set_video_streaming_allowed(bool state) {
@@ -444,13 +444,13 @@ void ApplicationImpl::StartStreaming(
       profile::Profile::instance()->start_stream_retry_amount();
 
   if (ServiceType::kMobileNav == service_type) {
-    if (!video_streaming_started()) {
+    if (!video_streaming_approved()) {
       MessageHelper::SendNaviStartStream(app_id());
       video_stream_retry_number_ = stream_retry.first;
       video_stream_retry_timer_->start(stream_retry.second);
     }
   } else if (ServiceType::kAudio == service_type) {
-    if (!audio_streaming_started()) {
+    if (!audio_streaming_approved()) {
       MessageHelper::SendAudioStartStream(app_id());
       audio_stream_retry_number_ = stream_retry.first;
       audio_stream_retry_timer_->start(stream_retry.second);
@@ -465,17 +465,17 @@ void ApplicationImpl::StopStreaming(
 
   if (ServiceType::kMobileNav == service_type) {
     video_stream_retry_timer_->stop();
-    if (video_streaming_started()) {
+    if (video_streaming_approved()) {
       video_stream_suspend_timer_->stop();
       MessageHelper::SendNaviStopStream(app_id());
-      set_video_streaming_started(false);
+      set_video_streaming_approved(false);
     }
   } else if (ServiceType::kAudio == service_type) {
     audio_stream_retry_timer_->stop();
-    if (audio_streaming_started()) {
+    if (audio_streaming_approved()) {
       audio_stream_suspend_timer_->stop();
       MessageHelper::SendAudioStopStream(app_id());
-      set_audio_streaming_started(false);
+      set_audio_streaming_approved(false);
     }
   }
 }

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -104,7 +104,7 @@ ApplicationImpl::ApplicationImpl(uint32_t application_id,
       protocol_version_(ProtocolVersion::kV3),
       is_voice_communication_application_(false),
       video_stream_retry_number_(0),
-      audio_stream_retry_number_(1) {
+      audio_stream_retry_number_(0) {
 
   cmd_number_to_time_limits_[mobile_apis::FunctionID::ReadDIDID] =
       {date_time::DateTime::getCurrentTime(), 0};
@@ -132,10 +132,6 @@ ApplicationImpl::ApplicationImpl(uint32_t application_id,
   audio_stream_suspend_timeout_ =
       profile::Profile::instance()->audio_data_stopped_timeout() / 1000;
 
-  video_stream_retry_timer_ = ApplicationTimerPtr(
-          new timer::TimerThread<ApplicationImpl>(
-              "VideoStartStreamRetry", this,
-              &ApplicationImpl::OnVideoStartStreamRetry, true));
   video_stream_suspend_timer_ = ApplicationTimerPtr(
           new timer::TimerThread<ApplicationImpl>(
               "VideoStreamSuspend", this,
@@ -385,14 +381,7 @@ bool ApplicationImpl::tts_properties_in_full() {
 }
 
 void ApplicationImpl::set_video_streaming_approved(bool state) {
-  if (state) {
-    if (video_stream_retry_timer_->isRunning()) {
-      video_stream_retry_timer_->stop();
-      video_streaming_approved_ = state;
-    }
-  } else {
-    video_streaming_approved_ = state;
-  }
+  video_streaming_approved_ = state;
 }
 
 bool ApplicationImpl::video_streaming_approved() const {
@@ -428,18 +417,15 @@ void ApplicationImpl::StartStreaming(
   using namespace protocol_handler;
   LOG4CXX_AUTO_TRACE(logger_);
 
-  std::pair<uint32_t, int32_t> stream_retry =
-      profile::Profile::instance()->start_stream_retry_amount();
-
   if (ServiceType::kMobileNav == service_type) {
     if (!video_streaming_approved()) {
       MessageHelper::SendNaviStartStream(app_id());
-      video_stream_retry_number_ = stream_retry.first;
-      video_stream_retry_timer_->start(stream_retry.second);
+      set_video_stream_retry_number(0);
     }
   } else if (ServiceType::kAudio == service_type) {
     if (!audio_streaming_approved()) {
       MessageHelper::SendAudioStartStream(app_id());
+      set_video_stream_retry_number(0);
     }
   }
 }
@@ -450,7 +436,6 @@ void ApplicationImpl::StopStreaming(
   LOG4CXX_AUTO_TRACE(logger_);
 
   if (ServiceType::kMobileNav == service_type) {
-    video_stream_retry_timer_->stop();
     if (video_streaming_approved()) {
       video_stream_suspend_timer_->stop();
       MessageHelper::SendNaviStopStream(app_id());
@@ -508,21 +493,6 @@ void ApplicationImpl::WakeUpStreaming(
   }
 }
 
-void ApplicationImpl::OnVideoStartStreamRetry() {
-  LOG4CXX_AUTO_TRACE(logger_);
-  if (video_stream_retry_number_) {
-    LOG4CXX_INFO(logger_, "Send video start stream retry "
-                 << video_stream_retry_number_);
-
-    MessageHelper::SendNaviStartStream(app_id());
-    --video_stream_retry_number_;
-  } else {
-    video_stream_retry_timer_->suspend();
-    ApplicationManagerImpl::instance()->EndNaviServices(app_id());
-    LOG4CXX_INFO(logger_, "Video start stream retry timer stopped");
-  }
-}
-
 void ApplicationImpl::OnVideoStreamSuspend() {
   using namespace protocol_handler;
   LOG4CXX_AUTO_TRACE(logger_);
@@ -536,8 +506,18 @@ void ApplicationImpl::OnAudioStreamSuspend() {
   LOG4CXX_INFO(logger_, "Suspend audio streaming by timer");
   SuspendStreaming(ServiceType::kAudio);
 }
+
 uint32_t ApplicationImpl::audio_stream_retry_number() const {
   return audio_stream_retry_number_;
+}
+
+uint32_t ApplicationImpl::video_stream_retry_number() const {
+  return video_stream_retry_number_;
+}
+
+void ApplicationImpl::set_video_stream_retry_number(
+    const uint32_t& video_stream_retry_number) {
+  video_stream_retry_number_ = video_stream_retry_number;
 }
 
 void ApplicationImpl::set_audio_stream_retry_number(

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -978,7 +978,7 @@ bool ApplicationManagerImpl::StartNaviService(
     return false;
   }
 
-  if (IsStreamingAllowed(app_id, service_type)) {
+  if (HMILevelAllowsStreaming(app_id, service_type)) {
     NaviServiceStatusMap::iterator it =
         navi_service_status_.find(app_id);
     if (navi_service_status_.end() == it) {
@@ -2480,7 +2480,7 @@ bool ApplicationManagerImpl::IsLowVoltage() {
   return is_low_voltage_;
 }
 
-bool ApplicationManagerImpl::IsStreamingAllowed(
+bool ApplicationManagerImpl::HMILevelAllowsStreaming(
     uint32_t app_id, protocol_handler::ServiceType service_type) const {
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace mobile_apis::HMILevel;
@@ -2514,7 +2514,7 @@ bool ApplicationManagerImpl::CanAppStream(
   } else {
     LOG4CXX_WARN(logger_, "Unsupported service_type " << service_type);
   }
-  return IsStreamingAllowed(app_id, service_type) && is_allowed;
+  return HMILevelAllowsStreaming(app_id, service_type) && is_allowed;
 }
 
 void ApplicationManagerImpl::ForbidStreaming(uint32_t app_id) {
@@ -2579,13 +2579,13 @@ void ApplicationManagerImpl::EndNaviServices(uint32_t app_id) {
     if (it->second.first) {
       LOG4CXX_DEBUG(logger_, "Going to end video service");
       connection_handler_->SendEndService(app_id, ServiceType::kMobileNav);
-      app->set_video_streaming_started(false);
+      app->set_video_streaming_approved(false);
       app->set_video_streaming_allowed(false);
     }
     if (it->second.second) {
       LOG4CXX_DEBUG(logger_, "Going to end audio service");
       connection_handler_->SendEndService(app_id, ServiceType::kAudio);
-      app->set_audio_streaming_started(false);
+      app->set_audio_streaming_approved(false);
       app->set_audio_streaming_allowed(false);
     }
     navi_app_to_stop_.push_back(app_id);

--- a/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
@@ -48,15 +48,13 @@ AudioStartStreamRequest::AudioStartStreamRequest(
       profile::Profile::instance()->start_stream_retry_amount();
   default_timeout_ = stream_retry.second * date_time::DateTime::MILLISECONDS_IN_SECOND;
   retry_number_ = stream_retry.first;
+  LOG4CXX_DEBUG(logger_, "default_timeout_ = " << default_timeout_
+                <<"; retry_number_ = " << retry_number_);
   //stream_retry.first times after stream_retry.second timeout
   //SDL should resend AudioStartStreamRequest
 }
 
 AudioStartStreamRequest::~AudioStartStreamRequest() {
-}
-
-bool AudioStartStreamRequest::Init() {
-   return true;
 }
 
 void AudioStartStreamRequest::RetryStartSession() {
@@ -66,7 +64,7 @@ void AudioStartStreamRequest::RetryStartSession() {
   ApplicationSharedPtr app = app_mgr->application_by_hmi_app(application_id());
   DCHECK_OR_RETURN_VOID(app);
   uint32_t curr_retry_number =  app->audio_stream_retry_number();
-  if (curr_retry_number < retry_number_) {
+  if (curr_retry_number < retry_number_ - 1) {
     LOG4CXX_INFO(logger_, "Send AudioStartStream retry. retry_number = "
                  << curr_retry_number);
     MessageHelper::SendAudioStartStream(app->app_id());

--- a/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
@@ -88,8 +88,8 @@ void AudioStartStreamRequest::on_event(const event_engine::Event& event) {
 
       if (hmi_apis::Common_Result::SUCCESS == code) {
         LOG4CXX_DEBUG(logger_, "StartAudioStreamResponse SUCCESS");
-        if (app_mgr->IsStreamingAllowed(app->app_id(), ServiceType::kAudio)) {
-          app->set_audio_streaming_started(true);
+        if (app_mgr->HMILevelAllowsStreaming(app->app_id(), ServiceType::kAudio)) {
+          app->set_audio_streaming_approved(true);
         } else {
           LOG4CXX_DEBUG(logger_,
                        "StartAudioStreamRequest aborted. Application can not stream");

--- a/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
@@ -94,7 +94,6 @@ void NaviStartStreamRequest::on_event(const event_engine::Event& event) {
         } else {
           LOG4CXX_DEBUG(logger_,
                        "NaviStartStreamRequest aborted. Application can not stream");
-          ApplicationManagerImpl::instance()->EndNaviServices(app->app_id());
         }
       }
       break;

--- a/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
@@ -89,8 +89,8 @@ void NaviStartStreamRequest::on_event(const event_engine::Event& event) {
 
       if (hmi_apis::Common_Result::SUCCESS == code) {
         LOG4CXX_DEBUG(logger_, "NaviStartStreamResponse SUCCESS");
-        if (app_mgr->IsStreamingAllowed(app->app_id(), ServiceType::kMobileNav)) {
-          app->set_video_streaming_started(true);
+        if (app_mgr->HMILevelAllowsStreaming(app->app_id(), ServiceType::kMobileNav)) {
+          app->set_video_streaming_approved(true);
         } else {
           LOG4CXX_DEBUG(logger_,
                        "NaviStartStreamRequest aborted. Application can not stream");

--- a/src/components/application_manager/test/mock/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/test/mock/include/application_manager/application_manager_impl.h
@@ -246,7 +246,7 @@ class ApplicationManagerImpl : public ApplicationManager,
   MOCK_METHOD0(resume_controller, ResumeCtrl&());
   MOCK_METHOD1(GetDefaultHmiLevel, mobile_api::HMILevel::eType (ApplicationSharedPtr));
 
-  MOCK_METHOD2(IsStreamingAllowed, bool(uint32_t, protocol_handler::ServiceType));
+  MOCK_METHOD2(HMILevelAllowsStreaming, bool(uint32_t, protocol_handler::ServiceType));
   MOCK_METHOD2(CanAppStream, bool(uint32_t, protocol_handler::ServiceType));
   MOCK_METHOD1(EndNaviServices, void(int32_t));
   MOCK_METHOD1(ForbidStreaming, void(int32_t));


### PR DESCRIPTION
Move video and audio stream timers to application_manager. Fix unregistering application ih HMI didn't response success on Startstream request. 