### PR TITLE
Alert maneuver app id and type addition

### DIFF
--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -103,6 +103,8 @@ void AlertManeuverRequest::Run() {
   smart_objects::SmartObject msg_params = smart_objects::SmartObject(
       smart_objects::SmartType_Map);
 
+  msg_params[strings::app_id] = app->app_id();
+
   if ((*message_)[strings::msg_params].keyExists(strings::soft_buttons)) {
     msg_params[hmi_request::soft_buttons] =
               (*message_)[strings::msg_params][strings::soft_buttons];
@@ -120,8 +122,9 @@ void AlertManeuverRequest::Run() {
 
     msg_params[hmi_request::tts_chunks] =
         (*message_)[strings::msg_params][strings::tts_chunks];
+    msg_params[hmi_request::speak_type] =
+        hmi_apis::Common_MethodName::ALERT_MANEUVER;
 
-    msg_params[strings::app_id] = app->app_id();
     SendHMIRequest(hmi_apis::FunctionID::TTS_Speak, &msg_params, true);
   }
 }

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1136,6 +1136,7 @@
   <element name="ALERT" />
   <element name="SPEAK" />
   <element name="AUDIO_PASS_THRU" />
+  <element name="ALERT_MANEUVER" />
 </enum>
 
 <enum name="AlertType">
@@ -3140,6 +3141,9 @@
     <description>Request from SmartDeviceLinkCore to HMI to announce navigation maneuver</description>
     <param name="softButtons" type="Common.SoftButton" minsize="0" maxsize="3" array="true" mandatory="false">
       <description>If omitted, only the system defined "Close" SoftButton should be displayed.</description>
+    </param>
+    <param name="appID" type="Integer" mandatory="true">
+      <description>ID of the application requested this RPC.</description>
     </param>
   </function>
   <function name="AlertManeuver" messagetype="response">

--- a/src/components/interfaces/QT_HMI_API.xml
+++ b/src/components/interfaces/QT_HMI_API.xml
@@ -1064,6 +1064,7 @@
   <element name="ALERT" />
   <element name="SPEAK" />
   <element name="AUDIO_PASS_THRU" />
+  <element name="ALERT_MANEUVER" />
 </enum>
 
 <enum name="AlertType">
@@ -3013,6 +3014,9 @@
       <description>Request from SmartDeviceLinkCore to HMI to announce navigation maneuver</description>
       <param name="softButtons" type="Common.SoftButton" minsize="0" maxsize="3" array="true" mandatory="false">
         <description>If omitted, only the system defined "Close" SoftButton should be displayed.</description>
+      </param>
+      <param name="appID" type="Integer" mandatory="true">
+        <description>ID of the application requested this RPC.</description>
       </param>
     </function>
     <function name="AlertManeuver" messagetype="response">


### PR DESCRIPTION
1. SDL must always include app's internal appID to Navigation.AlertManeuver request when transferring AlertManeuver from this app to HMI.

2. In case SDL receives AlertManeuver with TTS portion from the mobile app, SDL must include 'AlertManeuver' as speak type when transferring TTS.Speak to HMI.