### PR TITLE
Mb loose messages

### DIFF
--- a/src/3rd_party-static/MessageBroker/src/lib_messagebroker/CMessageBroker.cpp
+++ b/src/3rd_party-static/MessageBroker/src/lib_messagebroker/CMessageBroker.cpp
@@ -310,7 +310,7 @@ void CMessageBroker::onMessageReceived(int fd, std::string& aJSONData) {
       size_t offset = wmes.length();
       char msg_begin = '{';
       if (aJSONData.at(offset) != msg_begin) {
-        offset = aJSONData.find_last_of(msg_begin, offset);
+        offset -= 1; // wmes can contain redudant \n in the tail.
       }
       aJSONData.erase(aJSONData.begin(), aJSONData.begin() + offset);
       DBG_MSG(("Buffer after cut is:%s\n", aJSONData.c_str()));

--- a/src/3rd_party-static/MessageBroker/src/lib_messagebroker/CMessageBroker.cpp
+++ b/src/3rd_party-static/MessageBroker/src/lib_messagebroker/CMessageBroker.cpp
@@ -290,18 +290,16 @@ CMessageBroker* CMessageBroker::getInstance() {
 
 void CMessageBroker::onMessageReceived(int fd, std::string& aJSONData) {
   DBG_MSG(("CMessageBroker::onMessageReceived()\n"));
-  while (!aJSONData.empty())
-  {
+  while (!aJSONData.empty()) {
     Json::Value root;
     if (!p->m_reader.parse(aJSONData, root)) {
       DBG_MSG(("Received not JSON string! %s\n", aJSONData.c_str()));
       return;
     }
-    if(root["jsonrpc"]!="2.0")
-      {
-        DBG_MSG(("\t Json::Reader::parce didn't set up jsonrpc!  jsonrpc = '%s'\n", root["jsonrpc"].asString().c_str()));
-          return;
-      }
+    if(root["jsonrpc"]!="2.0") {
+      DBG_MSG(("\t Json::Reader::parce didn't set up jsonrpc!  jsonrpc = '%s'\n", root["jsonrpc"].asString().c_str()));
+      return;
+    }
     std::string wmes = p->m_recieverWriter.write(root);
     DBG_MSG(("Parsed JSON string:%s; length: %d\n", wmes.c_str(), wmes.length()));
     DBG_MSG(("Buffer is:%s\n", aJSONData.c_str()));

--- a/src/3rd_party-static/MessageBroker/src/lib_messagebroker/websocket_handler.cpp
+++ b/src/3rd_party-static/MessageBroker/src/lib_messagebroker/websocket_handler.cpp
@@ -80,7 +80,8 @@ namespace NsMessageBroker
      unsigned char position = 0; // current buffer position
      unsigned int size = b_size;
 
-     while (0 < size) {
+     static uint32_t minimum_heade_size = 4;
+     while (minimum_heade_size < size) {
 
        bool fin = ((recBuffer[0] & 0x80) | (recBuffer[0] & 0x01)) == 0x81;
        bool rsv1 = (recBuffer[0] & 0x40) == 0x40;
@@ -125,8 +126,8 @@ namespace NsMessageBroker
        position = 2;
 
        if (length > size) {
-          DBG_MSG_ERROR(("Incomplete message"));
-          return b_size;
+         DBG_MSG_ERROR(("Incomplete message"));
+         break;
        }
 
        switch(payload) {
@@ -164,16 +165,14 @@ namespace NsMessageBroker
        DBG_MSG(("CWebSocketHandler::parseWebSocketData()length:%d; size:%d;"
                 " position:%d\n", (int)length, size, position));
 
-       for (unsigned long i = position; (i < size && i < position+length); i++)
-       {
-          Buffer[parsedBufferPosition++] = recBuffer[i];
+       for (unsigned long i = 0; (i < size); i++) {
+         Buffer[parsedBufferPosition + i] = recBuffer[i+position];
        }
-
-       recBuffer += length+position;
+       b_size -= position;
+       parsedBufferPosition += length;
+       recBuffer += length;
        size -= length+position;
      }
-
-     b_size = parsedBufferPosition;
      return b_size;
    }
 

--- a/src/3rd_party-static/MessageBroker/src/lib_messagebroker/websocket_handler.cpp
+++ b/src/3rd_party-static/MessageBroker/src/lib_messagebroker/websocket_handler.cpp
@@ -69,8 +69,7 @@ namespace NsMessageBroker
       return length;
    }
 
-   int CWebSocketHandler::parseWebSocketData(char* Buffer, unsigned int& b_size)
-   {
+   int CWebSocketHandler::parseWebSocketData(char* Buffer, unsigned int& b_size) {
      // Please see RFC6455 standard protocol specification:
      //http://tools.ietf.org/html/rfc6455
      // Chapter 5.2
@@ -95,8 +94,8 @@ namespace NsMessageBroker
        DBG_MSG(("CWebSocketHandler::fin = %d recBuffer[0] = 0x%02X\n"
                 " parsedlength = %d b_size= %d parsedBufferPosition = %d\n"
                 "rsv1 = %d, rsv2 = %d, rsv3 = %d, opCode = %u\n",
-           fin, recBuffer[0], parsedBufferPosition + position,
-           size, parsedBufferPosition, rsv1, rsv2, rsv3, opCode));
+                fin, recBuffer[0], parsedBufferPosition + position,
+               size, parsedBufferPosition, rsv1, rsv2, rsv3, opCode));
 
        if ((rsv1)|(rsv2)|(rsv3)) {
          DBG_MSG(("rsv1 or rsv2 or rsv3 is 0 \n"));
@@ -114,13 +113,13 @@ namespace NsMessageBroker
        }
 
        if (false == fin) {
-          break;
+         break;
        }
 
        unsigned char payload = (unsigned char)
         ((recBuffer[1] & 0x40) | (recBuffer[1] & 0x20) | (recBuffer[1] & 0x10) |
-        (recBuffer[1] & 0x08) | (recBuffer[1] & 0x04) | (recBuffer[1] & 0x02) |
-        (recBuffer[1] & 0x01));
+         (recBuffer[1] & 0x08) | (recBuffer[1] & 0x04) | (recBuffer[1] & 0x02) |
+         (recBuffer[1] & 0x01));
 
        unsigned long length = parseWebSocketDataLength(recBuffer, size);
        position = 2;
@@ -131,36 +130,32 @@ namespace NsMessageBroker
        }
 
        switch(payload) {
-          case 126:
-             {
-                position +=2;
-                break;
-             }
-          case 127:
-             {
-                position +=8;
-                break;
-             }
-          default:
-             {
-                break;
-             }
+         case 126: {
+           position +=2;
+           break;
+         }
+         case 127: {
+           position +=8;
+           break;
+         }
+         default: {
+           break;
+         }
        }
 
-       if (mask)
-       {
-          unsigned char maskKeys[4];
-          maskKeys[0] = recBuffer[position++];
-          maskKeys[1] = recBuffer[position++];
-          maskKeys[2] = recBuffer[position++];
-          maskKeys[3] = recBuffer[position++];
-          DBG_MSG(("CWebSocketHandler::parseWebSocketData()maskKeys[0]:0x%02X;"
-                 " maskKeys[1]:0x%02X; maskKeys[2]:0x%02X; maskKeys[3]:0x%02X\n"
-                 , maskKeys[0], maskKeys[1], maskKeys[2], maskKeys[3]));
-          for (unsigned long i = position; i < position+length; i++)
-          {
-             recBuffer[i] = recBuffer[i] ^ maskKeys[(i-position)%4];
-          }
+       if (mask) {
+         unsigned char maskKeys[4];
+         maskKeys[0] = recBuffer[position++];
+         maskKeys[1] = recBuffer[position++];
+         maskKeys[2] = recBuffer[position++];
+         maskKeys[3] = recBuffer[position++];
+         DBG_MSG(("CWebSocketHandler::parseWebSocketData()maskKeys[0]:0x%02X;"
+                  "maskKeys[1]:0x%02X; maskKeys[2]:0x%02X; maskKeys[3]:0x%02X\n"
+                  , maskKeys[0], maskKeys[1], maskKeys[2], maskKeys[3]));
+         for (unsigned long i = position; i < position+length; i++)
+         {
+           recBuffer[i] = recBuffer[i] ^ maskKeys[(i-position)%4];
+         }
        }
        DBG_MSG(("CWebSocketHandler::parseWebSocketData()length:%d; size:%d;"
                 " position:%d\n", (int)length, size, position));

--- a/src/3rd_party-static/MessageBroker/src/server/mb_tcpserver.cpp
+++ b/src/3rd_party-static/MessageBroker/src/server/mb_tcpserver.cpp
@@ -74,7 +74,7 @@ bool TcpServer::Recv(int fd) {
     unsigned int recieved_data = nb;
     if (isWebSocket(fd)) {
       const unsigned int data_length =
-        mWebSocketHandler.parseWebSocketDataLength(&buf[0], recieved_data);
+          mWebSocketHandler.parseWebSocketDataLength(&buf[0], recieved_data);
 
       DBG_MSG(("Received %d actual data length %d\n",
                recieved_data, data_length));
@@ -104,7 +104,8 @@ bool TcpServer::Recv(int fd) {
       }
     } else { // client is a websocket
       std::string handshakeResponse =
-        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: WebSocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ";
+          "HTTP/1.1 101 Switching Protocols\r\nUpgrade: WebSocket\r\n"
+          "Connection: Upgrade\r\nSec-WebSocket-Accept: ";
       ssize_t webSocketKeyPos = pReceivingBuffer->find("Sec-WebSocket-Key: ");
       if (-1 != webSocketKeyPos) {
         std::string wsKey = pReceivingBuffer->substr(webSocketKeyPos + 19, 24);
@@ -112,7 +113,8 @@ bool TcpServer::Recv(int fd) {
         handshakeResponse += wsKey;
         handshakeResponse += "\r\n\r\n";
         pReceivingBuffer->clear();
-        std::list<int>::iterator acceptedClientIt = find(m_AcceptedClients.begin(), m_AcceptedClients.end(), fd);
+        std::list<int>::iterator acceptedClientIt =
+            find(m_AcceptedClients.begin(), m_AcceptedClients.end(), fd);
         if (m_AcceptedClients.end() != acceptedClientIt) {
           m_AcceptedClients.erase(acceptedClientIt);
         }


### PR DESCRIPTION
When HMI send more than 4096 bytes with multiple websocket messages , SDL incorrectly parse last message in this data 