### PR TITLE
Send hybrid service 0x0F if outgoing message has binary data

### DIFF
--- a/src/components/application_manager/src/mobile_message_handler.cc
+++ b/src/components/application_manager/src/mobile_message_handler.cc
@@ -231,8 +231,13 @@ MobileMessageHandler::HandleOutgoingMessageProtocolV2(
   dataForSending[offset++] = jsonSize;
 
   memcpy(dataForSending + offset, message->json_message().c_str(), jsonSize);
-
+  
+  // Default the service type to RPC Service
+  uint8_t type = 0x07;  
+    
   if (message->has_binary_data()) {
+    // Change the service type to Hybrid Service
+    type = 0x0F;
     const std::vector<uint8_t>& binaryData = *(message->binary_data());
     uint8_t* currentPointer = dataForSending + offset + jsonSize;
     for (uint32_t i = 0; i < binarySize; ++i) {
@@ -244,7 +249,8 @@ MobileMessageHandler::HandleOutgoingMessageProtocolV2(
     new protocol_handler::RawMessage(message->connection_key(),
                                      message->protocol_version(),
                                      dataForSending,
-                                     dataForSendingSize);
+                                     dataForSendingSize,
+                                     type);
 
   delete [] dataForSending;
 


### PR DESCRIPTION
[NOT READY TO MERGE]

This hotfix addresses an issue where a message being sent to mobile is not sent over the hybrid service if it contains binary data.

Fixes #110 

After this change is merged into the release, it should also be fixed in develop.