### PR TITLE
APPLINK-12828

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -159,6 +159,13 @@ class PolicyHandler :
   void PTExchangeAtUserRequest(uint32_t correlation_id);
 
   /**
+   * @brief Add's device to policy table
+   * @param device_id        Device mac address
+   * @param connection_type  Device connection type
+   */
+  void AddDevice(const std::string& device_id, const std::string& connection_type);
+
+  /**
    * @brief Save device info for specific device to policy table
    * @param device_id Device mac address
    * @param device_info Device params

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -840,6 +840,21 @@ void ApplicationManagerImpl::OnErrorSending(
 void ApplicationManagerImpl::OnDeviceListUpdated(
     const connection_handler::DeviceMap& device_list) {
   LOG4CXX_AUTO_TRACE(logger_);
+
+  // add device to policy DB
+  connection_handler::DeviceMap::const_iterator it = device_list.begin();
+  for (; device_list.end() != it; ++it) {
+    policy::DeviceParams dev_params;
+    MessageHelper::GetDeviceInfoForHandle(it->second.device_handle(),
+                                          &dev_params);
+
+    policy::DeviceInfo device_info;
+    device_info.AdoptDeviceType(dev_params.device_connection_type);
+
+    policy::PolicyHandler::instance()->AddDevice(dev_params.device_mac_address,
+        device_info.connection_type);
+  }
+
   smart_objects::SmartObjectSPtr msg_params = MessageHelper::CreateDeviceListSO(
         device_list);
   if (!msg_params) {

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -410,6 +410,13 @@ void PolicyHandler::AddApplication(const std::string& application_id) {
   policy_manager_->AddApplication(application_id);
 }
 
+void PolicyHandler::AddDevice(const std::string& device_id,
+                              const std::string& connection_type) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  POLICY_LIB_CHECK_VOID();
+  policy_manager_->AddDevice(device_id, connection_type);
+}
+
 void PolicyHandler::SetDeviceInfo(std::string& device_id,
                                   const DeviceInfo& device_info) {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/policy/src/policy/include/policy/cache_manager.h
+++ b/src/components/policy/src/policy/include/policy/cache_manager.h
@@ -345,6 +345,15 @@ class CacheManager : public CacheManagerInterface {
       rpc::policy_table_interface_base::Strings &preconsented_groups);
 
   /**
+   * @brief Add's information about mobile device in Policy Table.
+   * @param device_id Generated or obtained id of device
+   * @param connection_type device connection type
+   * @return bool Success of operation
+   */
+  bool AddDevice(const std::string& device_id,
+                 const std::string& connection_type);
+
+  /**
    * @brief Record information about mobile device in Policy Table.
    * @param device_id Generated or obtained id of device
    * @return bool Success of operation

--- a/src/components/policy/src/policy/include/policy/cache_manager_interface.h
+++ b/src/components/policy/src/policy/include/policy/cache_manager_interface.h
@@ -342,6 +342,15 @@ class CacheManagerInterface {
       rpc::policy_table_interface_base::Strings &preconsented_groups) = 0;
 
   /**
+   * @brief Add's information about mobile device in Policy Table.
+   * @param device_id Generated or obtained id of device
+   * @param connection_type device connection type
+   * @return bool Success of operation
+   */
+  virtual bool AddDevice(const std::string& device_id,
+                         const std::string& connection_type) = 0;
+
+  /**
    * @brief Record information about mobile device in Policy Table.
    * @param device_id Generated or obtained id of device
    * @return bool Success of operation

--- a/src/components/policy/src/policy/include/policy/policy_manager.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager.h
@@ -218,6 +218,15 @@ class PolicyManager : public usage_statistics::StatisticsManager {
     virtual bool GetInitialAppData(const std::string& application_id,
                                    StringArray* nicknames = NULL,
                                    StringArray* app_hmi_types = NULL) = 0;
+
+    /**
+     * @brief Add's device to policy table
+     * @param device_id        Device mac address
+     * @param connection_type  Device connection type
+     */
+    virtual void AddDevice(const std::string& device_id,
+                           const std::string& connection_type) = 0;
+
     /**
      * @brief Stores device parameters received during application registration
      * to policy table

--- a/src/components/policy/src/policy/include/policy/policy_manager_impl.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager_impl.h
@@ -98,6 +98,9 @@ class PolicyManagerImpl : public PolicyManager {
                                    StringArray* nicknames = NULL,
                                    StringArray* app_hmi_types = NULL);
 
+    virtual void AddDevice(const std::string& device_id,
+                           const std::string& connection_type);
+
     virtual void SetDeviceInfo(const std::string& device_id,
                                const DeviceInfo& device_info);
 

--- a/src/components/policy/src/policy/include/policy/policy_types.h
+++ b/src/components/policy/src/policy/include/policy/policy_types.h
@@ -38,6 +38,7 @@
 #include <map>
 #include <set>
 #include "utils/shared_ptr.h"
+#include "utils/helpers.h"
 
 namespace policy {
 
@@ -177,6 +178,16 @@ struct DeviceInfo {
     std::string carrier;
     uint32_t max_number_rfcom_ports;
     std::string connection_type;
+
+    void AdoptDeviceType(const std::string& deviceType) {
+      connection_type = "USB_serial_number";
+      using namespace helpers;
+      if (Compare<std::string, EQ, ONE> (deviceType,
+                                         "BLUETOOTH",
+                                         "WIFI")) {
+          connection_type.assign("BTMAC");
+      }
+    }
 };
 
 /**

--- a/src/components/policy/src/policy/src/cache_manager.cc
+++ b/src/components/policy/src/policy/src/cache_manager.cc
@@ -271,6 +271,16 @@ bool CacheManager::GetDeviceGroupsFromPolicies(
   return true;
 }
 
+bool CacheManager::AddDevice(const std::string& device_id,
+                             const std::string& connection_type) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  sync_primitives::AutoLock auto_lock(cache_lock_);
+  CACHE_MANAGER_CHECK(false);
+  Backup();
+  return true;
+}
+
 bool CacheManager::SetDeviceData(const std::string &device_id,
                                  const std::string &hardware,
                                  const std::string &firmware,

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -367,6 +367,12 @@ bool PolicyManagerImpl::GetInitialAppData(const std::string& application_id,
   return result;
 }
 
+void PolicyManagerImpl::AddDevice(const std::string& device_id,
+                                  const std::string& connection_type) {
+  LOG4CXX_INFO(logger_, "SetDeviceInfo");
+  LOG4CXX_DEBUG(logger_, "Device :" << device_id);
+}
+
 void PolicyManagerImpl::SetDeviceInfo(const std::string& device_id,
                                       const DeviceInfo& device_info) {
   LOG4CXX_INFO(logger_, "SetDeviceInfo");

--- a/src/components/policy/test/include/mock_cache_manager.h
+++ b/src/components/policy/test/include/mock_cache_manager.h
@@ -120,6 +120,8 @@ class MockCacheManagerInterface : public CacheManagerInterface {
       bool(const std::string& device_id, const std::string& app_id, FunctionalIdType &group_types));
   MOCK_METHOD2(GetDeviceGroupsFromPolicies,
       bool(rpc::policy_table_interface_base::Strings &groups, rpc::policy_table_interface_base::Strings &preconsented_groups));
+  MOCK_METHOD2(AddDevice,
+      bool(const std::string& device_id, const std::string& connection_type));
   MOCK_METHOD8(SetDeviceData,
       bool(const std::string& device_id, const std::string& hardware, const std::string& firmware, const std::string& os, const std::string& os_version, const std::string& carrier, const uint32_t number_of_ports, const std::string& connection_type));
   MOCK_METHOD3(SetUserPermissionsForDevice,


### PR DESCRIPTION
Requirements to SDL:
1) In case new device is connected over one of the available transports WITH SDL-enabled applications PoliciesManager must create device ID section in <device_data> table of Policy Table
2) In case new device is connected over one of the available transports WITHOUT SDL-enabled applications PoliciesManager must create device ID section in in <device_data> table of Policy Table
3) In case new device is connected over one of the available transports AND all applications from this device were successfully registered AND the User clears all these applications from the list of registered applications -> this device MUST be still visible by SDL and must NOT be removed from HMI`s list of connected devices