### PR TITLE
APPLINK-13018

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -373,10 +373,16 @@
   <element name="DYNAMIC" />
 </enum>
 
-<enum name="ApplicationToNONEReason">
-  <description>Describes the reasons of moving the app to NONE.</description>
-  <element name="DRIVER_DISTRACTION_VIOLATION" />
-  <element name="USER_EXIT" />
+<enum name="ApplicationExitReason">
+  <element name="DRIVER_DISTRACTION_VIOLATION" >
+    <description>By getting this value, SDL puts the named app to NONE HMILevel</description>
+  </element>
+  <element name="USER_EXIT" >
+    <description>By getting this value, SDL puts the named app to NONE HMILevel</description>
+  </element>
+  <element name="UNAUTHORIZED_TRANSPORT_REGISTRATION">
+    <description>By getting this value, SDL unregisters the named application</description>
+  </element>
 </enum>
 
 <enum name="TextFieldName">
@@ -2081,7 +2087,7 @@
     </function>
     <function name="OnExitApplication" messagetype="notification">
       <description>Must be sent by HMI when the User chooses to exit the application..</description>
-      <param name="reason" type="Common.ApplicationToNONEReason" mandatory="true">
+      <param name="reason" type="Common.ApplicationExitReason" mandatory="true">
         <description>Specifies reason of moving the app to NONE</description>
       </param>
       <param name="appID" type="Integer" mandatory="true">

--- a/src/components/interfaces/QT_HMI_API.xml
+++ b/src/components/interfaces/QT_HMI_API.xml
@@ -348,10 +348,16 @@
       <element name="STATIC"/>
       <element name="DYNAMIC"/>
     </enum>
-    <enum name="ApplicationToNONEReason">
-      <description>Describes the reasons of moving the app to NONE.</description>
-      <element name="DRIVER_DISTRACTION_VIOLATION" />
-      <element name="USER_EXIT" />
+    <enum name="ApplicationExitReason">
+      <element name="DRIVER_DISTRACTION_VIOLATION" >
+        <description>By getting this value, SDL puts the named app to NONE HMILevel</description>
+      </element>
+      <element name="USER_EXIT" >
+        <description>By getting this value, SDL puts the named app to NONE HMILevel</description>
+      </element>
+      <element name="UNAUTHORIZED_TRANSPORT_REGISTRATION">
+        <description>By getting this value, SDL unregisters the named application</description>
+      </element>
     </enum>
     <enum name="TextFieldName">
       <element name="mainField1">
@@ -1973,7 +1979,7 @@
     </function>
     <function name="OnExitApplication" messagetype="notification" provider="hmi">
       <description>Must be sent by HMI when the User chooses to exit the application..</description>
-      <param name="reason" type="Common.ApplicationToNONEReason" mandatory="true">
+      <param name="reason" type="Common.ApplicationExitReason" mandatory="true">
         <description>Specifies reason of moving the app to NONE</description>
       </param>
       <param name="appID" type="Integer" mandatory="true">


### PR DESCRIPTION
In case SDL receives OnExitApplication(UNAUTHORIZED_TRANSPORT_REGISTRATION, appID_1) notification from HMI SDL must:
1.1. - unregister application with appID_1 via OnAppInterfaceUnregistered(APP_UNATHORIZED) notification
1.2.- clear all temporary data for application with appID_1
1.3. - ignore all responses and notifications from HMI associated with appID_1