### PR TITLE
APPLINK-12868. Fixed wrong unexpectedDisconnect flag setting.

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -241,7 +241,7 @@ class ApplicationManagerImpl : public ApplicationManager,
     ApplicationSharedPtr get_limited_voice_application() const;
 
     /**
-     * @brief Checks if application with the same HMI type 
+     * @brief Checks if application with the same HMI type
      *        (media, voice communication or navi) exists
      *        in HMI_FULL or HMI_LIMITED level.
      *
@@ -595,8 +595,10 @@ class ApplicationManagerImpl : public ApplicationManager,
     bool OnServiceStartedCallback(
         const connection_handler::DeviceHandle& device_handle,
         const int32_t& session_key, const protocol_handler::ServiceType& type) OVERRIDE;
-    void OnServiceEndedCallback(const int32_t& session_key,
-                                const protocol_handler::ServiceType& type) OVERRIDE;
+    void OnServiceEndedCallback(
+        const int32_t& session_key,
+        const protocol_handler::ServiceType& type,
+        const connection_handler::CloseSessionReason& close_reason) OVERRIDE;
     void OnApplicationFloodCallBack(const uint32_t& connection_key) OVERRIDE;
     void OnMalformedMessageCallback(const uint32_t& connection_key) OVERRIDE;
     /**

--- a/src/components/connection_handler/include/connection_handler/connection_handler.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler.h
@@ -35,7 +35,6 @@
 
 #include "transport_manager/transport_manager_listener.h"
 #include "protocol_handler/session_observer.h"
-#include "connection_handler/connection_handler_observer.h"
 #include "connection_handler/device.h"
 #include "connection_handler/connection.h"
 #include "connection_handler/devices_discovery_starter.h"
@@ -48,8 +47,12 @@ namespace connection_handler {
 
   enum CloseSessionReason {
     kCommon = 0,
-    kFlood
+    kFlood,
+    kMalformed,
+    kUnauthorizedApp
   };
+
+  class ConnectionHandlerObserver;
 
 /**
  * \class ConnectionHandler

--- a/src/components/connection_handler/include/connection_handler/connection_handler_observer.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_observer.h
@@ -35,6 +35,7 @@
 
 #include "connection_handler/device.h"
 #include "connection_handler/connection.h"
+#include "connection_handler/connection_handler.h"
 #include "protocol/service_type.h"
 
 /**
@@ -90,11 +91,14 @@ class ConnectionHandlerObserver {
   /**
    * \brief Callback function used by connection_handler
    * when Mobile Application initiates service ending.
-   * \param sessionKey Key of session which should be ended
+   * \param session_key Key of session which should be ended
+   * \param type Type of service which should be ended
+   * \param close_reson Service close reason
    */
   virtual void OnServiceEndedCallback(
       const int32_t &session_key,
-      const protocol_handler::ServiceType &type) = 0;
+      const protocol_handler::ServiceType &type,
+      const connection_handler::CloseSessionReason& close_reason) = 0;
 
   /**
    * \brief Callback function used by ConnectionHandler

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -448,8 +448,8 @@ uint32_t ConnectionHandlerImpl::OnSessionEndedCallback(
 
   sync_primitives::AutoLock lock2(connection_handler_observer_lock_);
   if (connection_handler_observer_) {
-    connection_handler_observer_->OnServiceEndedCallback(session_key,
-                                                         service_type);
+    connection_handler_observer_->OnServiceEndedCallback(
+          session_key, service_type, CloseSessionReason::kCommon);
   }
   return session_key;
 }
@@ -805,8 +805,8 @@ void ConnectionHandlerImpl::CloseSession(ConnectionHandle connection_handle,
     for (;service_list_itr != service_list.end(); ++service_list_itr) {
       const protocol_handler::ServiceType service_type =
           service_list_itr->service_type;
-      connection_handler_observer_->OnServiceEndedCallback(session_key,
-                                                           service_type);
+      connection_handler_observer_->OnServiceEndedCallback(
+            session_key, service_type, close_reason);
     }
   } else {
     LOG4CXX_ERROR(logger_, "Session with id: " << session_id
@@ -939,7 +939,7 @@ void ConnectionHandlerImpl::OnConnectionEnded(
       for (ServiceList::const_iterator service_it = service_list.begin(), end =
            service_list.end(); service_it != end; ++service_it) {
         connection_handler_observer_->OnServiceEndedCallback(
-              session_key, service_it->service_type);
+              session_key, service_it->service_type, CloseSessionReason::kCommon);
       }
     }
   }
@@ -973,7 +973,7 @@ bool ConnectionHandlerImpl::IsHeartBeatSupported(
 }
 
 bool ConnectionHandlerImpl::ProtocolVersionUsed(uint32_t connection_id,
-		  uint8_t session_id, uint8_t& protocol_version) {
+          uint8_t session_id, uint8_t& protocol_version) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(connection_list_lock_);
   ConnectionList::iterator it = connection_list_.find(connection_id);


### PR DESCRIPTION
Fixed unexpectedDisconnect flag on application unauthorizing during PTU
processing.

Conflicts:
	src/components/application_manager/src/application_manager_impl.cc
	src/components/connection_handler/include/connection_handler/connection_handler.h