### PR TITLE
Feature/application storage folder naming change

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -424,6 +424,11 @@ class Application : public virtual InitialApplicationData,
     virtual uint32_t hmi_app_id() const = 0;
     virtual uint32_t app_id() const = 0;
     virtual const std::string& name() const = 0;
+    /**
+     * @brief Sets application folder name, which is used for storing of related
+     * files, e.g. icons
+     * @param folder_name Name of folder
+     */
     virtual void set_folder_name(const std::string& folder_name) = 0;
     virtual const std::string folder_name() const = 0;
     virtual bool is_media_application() const = 0;

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -424,6 +424,7 @@ class Application : public virtual InitialApplicationData,
     virtual uint32_t hmi_app_id() const = 0;
     virtual uint32_t app_id() const = 0;
     virtual const std::string& name() const = 0;
+    virtual void set_folder_name(const std::string& folder_name) = 0;
     virtual const std::string folder_name() const = 0;
     virtual bool is_media_application() const = 0;
     virtual const mobile_api::HMILevel::eType& hmi_level() const = 0;

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -621,6 +621,10 @@ class Application : public virtual InitialApplicationData,
      * otherwise - false
      */
     void set_greyed_out(bool is_greyed_out) {is_greyed_out_ = is_greyed_out;}
+    /**
+     * @brief Load persistent files from application folder.
+     */
+    virtual void LoadPersistentFiles() = 0;
 
   protected:
 

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -97,6 +97,7 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
   inline uint32_t hmi_app_id() const;
   inline uint32_t app_id() const;
   const std::string& name() const;
+  void set_folder_name(const std::string& folder_name);
   const std::string folder_name() const;
   bool is_media_application() const;
   const mobile_api::HMILevel::eType& hmi_level() const;
@@ -265,6 +266,7 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
   CommandSoftButtonID cmd_softbuttonid_;
   // Lock for command soft button id
   sync_primitives::Lock cmd_softbuttonid_lock_;
+  std::string folder_name_;
   DISALLOW_COPY_AND_ASSIGN(ApplicationImpl);
 };
 

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -180,17 +180,17 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
    */
   virtual bool IsAudioApplication() const;
 
- protected:
+  /**
+   * @brief Load persistent files from application folder.
+   */
+  virtual void LoadPersistentFiles();
 
+  protected:
   /**
    * @brief Clean up application folder. Persistent files will stay
    */
   void CleanupFiles();
 
-  /**
-   * @brief Load persistent files from application folder.
-   */
-  void LoadPersistentFiles();
 
  private:
 

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -97,7 +97,7 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
   inline uint32_t hmi_app_id() const;
   inline uint32_t app_id() const;
   const std::string& name() const;
-  void set_folder_name(const std::string& folder_name);
+  void set_folder_name(const std::string& folder_name) OVERRIDE;
   const std::string folder_name() const;
   bool is_media_application() const;
   const mobile_api::HMILevel::eType& hmi_level() const;

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -210,12 +210,13 @@ const std::string& ApplicationImpl::name() const {
   return app_name_;
 }
 
-const std::string ApplicationImpl::folder_name() const {
-  const std::string device_id =
-      MessageHelper::GetDeviceMacAddressForHandle(
-        static_cast<uint32_t>(device_));
+void application_manager::ApplicationImpl::set_folder_name(
+    const std::string& folder_name) {
+  folder_name_ = folder_name;
+}
 
-  return mobile_app_id()+"_"+device_id;
+const std::string ApplicationImpl::folder_name() const {
+  return folder_name_;
 }
 
 bool ApplicationImpl::is_media_application() const {

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -211,7 +211,11 @@ const std::string& ApplicationImpl::name() const {
 }
 
 const std::string ApplicationImpl::folder_name() const {
-  return name() + mobile_app_id();
+  const std::string device_id =
+      MessageHelper::GetDeviceMacAddressForHandle(
+        static_cast<uint32_t>(device_));
+
+  return mobile_app_id()+"_"+device_id;
 }
 
 bool ApplicationImpl::is_media_application() const {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -413,6 +413,10 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
   }
 
   application->set_device(device_id);
+  // To load persistent files, app folder name must be known first, which is now
+  // depends on device_id and mobile_app_id
+  application->LoadPersistentFiles();
+
   application->set_grammar_id(GenerateGrammarID());
   mobile_api::Language::eType launguage_desired =
     static_cast<mobile_api::Language::eType>(params[strings::language_desired]

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -412,10 +412,15 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
     return ApplicationSharedPtr();
   }
 
-  application->set_device(device_id);
+  const std::string device_mac =
+      MessageHelper::GetDeviceMacAddressForHandle(
+        static_cast<uint32_t>(device_id));
+
+  application->set_folder_name(mobile_app_id+"_"+device_mac);
   // To load persistent files, app folder name must be known first, which is now
   // depends on device_id and mobile_app_id
   application->LoadPersistentFiles();
+  application->set_device(device_id);
 
   application->set_grammar_id(GenerateGrammarID());
   mobile_api::Language::eType launguage_desired =


### PR DESCRIPTION
SDL will name folder for each app by the following template: <app_id>_<device_id> 

Note: the previous name of folder for each app was <appName><appID>