### PR TITLE
SDL bugfix

### DIFF
--- a/customer-specific/pasa/src/appMain/smartDeviceLink.ini
+++ b/customer-specific/pasa/src/appMain/smartDeviceLink.ini
@@ -62,6 +62,8 @@ LogFileMaxSize = 0K
 
 
 [MEDIA MANAGER]
+; where 3 is a number of retries and 1000 is a timeout in milliseconds for request frequency
+StartStreamRetry = 3, 1000
 EnableRedecoding = false
 ;VideoStreamConsumer = socket
 ;AudioStreamConsumer = socket

--- a/src/3rd_party-static/MessageBroker/include/CMessageBrokerRegistry.hpp
+++ b/src/3rd_party-static/MessageBroker/include/CMessageBrokerRegistry.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <iostream>
 #include <string>
+#include "utils/lock.h"
 
 /**
  * \namespace NsMessageBroker
@@ -91,12 +92,14 @@ namespace NsMessageBroker
       * For example PhoneController:1080
       */
       std::map <std::string, int> mControllersList;
+      sync_primitives::Lock mControllersListLock;
 
       /**
       * \brief Map to store subscribers information like ComponentName.PropertyName:socketFd:.
       * For example PhoneController.onPhoneBookChanged:1080
       */
       std::multimap <std::string, int> mSubscribersList;
+      sync_primitives::Lock mSubscribersListLock;
    };
 } /* namespace NsMessageBroker */
 

--- a/src/3rd_party-static/MessageBroker/include/CMessageBrokerRegistry.hpp
+++ b/src/3rd_party-static/MessageBroker/include/CMessageBrokerRegistry.hpp
@@ -53,6 +53,12 @@ namespace NsMessageBroker
       void removeControllersByDescriptor(const int fd);
 
       /**
+      * \brief Remove all subscribers by descriptor
+      * \param fd descriptor
+      */
+      void removeSubscribersByDescriptor(const int fd);
+
+      /**
       * \brief adds notification subscriber to the registry.
       * \param fd file descriptor of controller.
       * \param name name of property which should be observed.

--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -60,8 +60,8 @@ ReadDIDRequest = 5, 1
 GetVehicleDataRequest = 5, 1
 
 [MEDIA MANAGER]
-; where 3 is a number of retries and 1 is a timeout in seconds for request frequency
-StartStreamRetry = 3, 1
+; where 3 is a number of retries and 1000 is a timeout in milliseconds for request frequency
+StartStreamRetry = 3, 1000
 EnableRedecoding = false
 VideoStreamConsumer = socket
 AudioStreamConsumer = socket

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -703,9 +703,11 @@ class ApplicationManagerImpl : public ApplicationManager,
     /**
      * @brief Callback calls when application starts/stops data streaming
      * @param app_id Streaming application id
+     * @param service_type Streaming service type
      * @param state Shows if streaming started or stopped
      */
-    void OnAppStreaming(uint32_t app_id, bool state);
+    void OnAppStreaming(
+        uint32_t app_id, protocol_handler::ServiceType service_type, bool state);
 
     /**
      * @brief OnHMILevelChanged the callback that allows SDL to react when

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -611,7 +611,6 @@ class ApplicationManagerImpl : public ApplicationManager,
         const int32_t& session_key,
         const protocol_handler::ServiceType& type,
         const connection_handler::CloseSessionReason& close_reason) OVERRIDE;
-    void OnApplicationFloodCallBack(const uint32_t& connection_key) OVERRIDE;
 
     /**
      * @ Add notification to collection

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -55,6 +55,7 @@
 #include "hmi_message_handler/hmi_message_sender.h"
 #include "application_manager/policies/policy_handler_observer.h"
 #include "media_manager/media_manager_impl.h"
+#include "connection_handler/connection_handler.h"
 #include "connection_handler/connection_handler_observer.h"
 #include "connection_handler/device.h"
 #include "formatters/CSmartFactory.hpp"
@@ -611,7 +612,7 @@ class ApplicationManagerImpl : public ApplicationManager,
         const protocol_handler::ServiceType& type,
         const connection_handler::CloseSessionReason& close_reason) OVERRIDE;
     void OnApplicationFloodCallBack(const uint32_t& connection_key) OVERRIDE;
-    void OnMalformedMessageCallback(const uint32_t& connection_key) OVERRIDE;
+
     /**
      * @ Add notification to collection
      *

--- a/src/components/application_manager/include/application_manager/commands/mobile/create_interaction_choice_set_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/create_interaction_choice_set_request.h
@@ -91,9 +91,9 @@ class CreateInteractionChoiceSetRequest : public CommandRequestImpl {
     void DeleteChoices();
 
     /**
-     * @brief OnAllHMIResponsesReceived If HMI returnes some errors, delete
-     * choices.
-     * Delete self from request controller
+     * @brief Calls after all responses from HMI were received.
+     * Terminates request and sends successful response to mobile
+     * if all responses were SUCCESS or calls DeleteChoices in other case.
      */
     void OnAllHMIResponsesReceived();
 
@@ -116,14 +116,21 @@ class CreateInteractionChoiceSetRequest : public CommandRequestImpl {
 
     int32_t choice_set_id_;
     size_t expected_chs_count_;
-    size_t recived_chs_count_;
-
+    size_t received_chs_count_;
 
     /**
      * @brief Flag for stop sending VR commands to HMI, in case one of responses
      * failed
      */
     volatile bool error_from_hmi_;
+    sync_primitives::Lock error_from_hmi_lock_;
+
+    /**
+     * @brief Flag shows if request already was expired by timeout
+     */
+    volatile bool is_timed_out_;
+    sync_primitives::Lock is_timed_out_lock_;
+
     sync_primitives::Lock vr_commands_lock_;
     /*
      * @brief Sends VR AddCommand request to HMI

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -434,6 +434,8 @@ void ApplicationImpl::StopStreaming(
   using namespace protocol_handler;
   LOG4CXX_AUTO_TRACE(logger_);
 
+  SuspendStreaming(service_type);
+
   if (ServiceType::kMobileNav == service_type) {
     if (video_streaming_approved()) {
       video_stream_suspend_timer_->stop();
@@ -456,12 +458,14 @@ void ApplicationImpl::SuspendStreaming(
 
   if (ServiceType::kMobileNav == service_type) {
     video_stream_suspend_timer_->suspend();
-    ApplicationManagerImpl::instance()->OnAppStreaming(app_id(), false);
+    ApplicationManagerImpl::instance()->OnAppStreaming(
+        app_id(), service_type, false);
     sync_primitives::AutoLock lock(video_streaming_suspended_lock_);
     video_streaming_suspended_ = true;
   } else if (ServiceType::kAudio == service_type) {
     audio_stream_suspend_timer_->suspend();
-    ApplicationManagerImpl::instance()->OnAppStreaming(app_id(), false);
+    ApplicationManagerImpl::instance()->OnAppStreaming(
+        app_id(), service_type, false);
     sync_primitives::AutoLock lock(audio_streaming_suspended_lock_);
     audio_streaming_suspended_ = true;
   }
@@ -476,7 +480,8 @@ void ApplicationImpl::WakeUpStreaming(
   if (ServiceType::kMobileNav == service_type) {
     sync_primitives::AutoLock lock(video_streaming_suspended_lock_);
     if (video_streaming_suspended_) {
-      ApplicationManagerImpl::instance()->OnAppStreaming(app_id(), true);
+      ApplicationManagerImpl::instance()->OnAppStreaming(
+          app_id(), service_type, true);
       MessageHelper::SendOnDataStreaming(ServiceType::kMobileNav, true);
       video_streaming_suspended_ = false;
     }
@@ -484,7 +489,8 @@ void ApplicationImpl::WakeUpStreaming(
   } else if (ServiceType::kAudio == service_type) {
     sync_primitives::AutoLock lock(audio_streaming_suspended_lock_);
     if (audio_streaming_suspended_) {
-      ApplicationManagerImpl::instance()->OnAppStreaming(app_id(), true);
+      ApplicationManagerImpl::instance()->OnAppStreaming(
+          app_id(), service_type, true);
       MessageHelper::SendOnDataStreaming(ServiceType::kAudio, true);
       audio_streaming_suspended_ = false;
     }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -509,6 +509,7 @@ bool ApplicationManagerImpl::ActivateApplication(ApplicationSharedPtr app) {
   AudioStreamingState::eType audio_state;
   app->IsAudioApplication() ? audio_state = AudioStreamingState::AUDIBLE :
                               audio_state = AudioStreamingState::NOT_AUDIBLE;
+  state_ctrl_.ApplyStatesForApp(app);
   state_ctrl_.SetRegularState<false>(app, hmi_level, audio_state);
   return true;
 }

--- a/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
@@ -46,7 +46,7 @@ AudioStartStreamRequest::AudioStartStreamRequest(
   LOG4CXX_AUTO_TRACE(logger_);
   std::pair<uint32_t, int32_t> stream_retry =
       profile::Profile::instance()->start_stream_retry_amount();
-  default_timeout_ = stream_retry.second * date_time::DateTime::MILLISECONDS_IN_SECOND;
+  default_timeout_ = stream_retry.second;
   retry_number_ = stream_retry.first;
   LOG4CXX_DEBUG(logger_, "default_timeout_ = " << default_timeout_
                 <<"; retry_number_ = " << retry_number_);

--- a/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
@@ -58,6 +58,7 @@ NaviStartStreamRequest::~NaviStartStreamRequest() {
 void NaviStartStreamRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
+  SetAllowedToTerminate(false);
   subscribe_on_event(hmi_apis::FunctionID::Navigation_StartStream,
                      correlation_id());
   ApplicationManagerImpl* app_mgr = ApplicationManagerImpl::instance();
@@ -103,9 +104,6 @@ void NaviStartStreamRequest::on_event(const event_engine::Event& event) {
           LOG4CXX_DEBUG(logger_,
                        "NaviStartStreamRequest aborted. Application can not stream");
         }
-      } else {
-        LOG4CXX_DEBUG(logger_,"Error received from HMI : " << code);
-        RetryStartSession();
       }
       break;
     }
@@ -118,6 +116,10 @@ void NaviStartStreamRequest::on_event(const event_engine::Event& event) {
 
 void NaviStartStreamRequest::onTimeOut() {
   RetryStartSession();
+
+  ApplicationManagerImpl* app_mgr = ApplicationManagerImpl::instance();
+  DCHECK_OR_RETURN_VOID(app_mgr);
+  app_mgr->TerminateRequest(connection_key(), correlation_id());
 }
 
 void NaviStartStreamRequest::RetryStartSession() {
@@ -132,6 +134,12 @@ void NaviStartStreamRequest::RetryStartSession() {
         "NaviStartStreamRequest aborted. Application not found");
     return;
   }
+  if (app->video_streaming_approved()) {
+    LOG4CXX_INFO(logger_, "NaviStartStream retry sequence stopped. "
+                 << "SUCCESS received");
+    app->set_video_stream_retry_number(0);
+    return;
+  }
 
   uint32_t curr_retry_number = app->video_stream_retry_number();
   if (curr_retry_number < retry_number_ - 1) {
@@ -140,9 +148,10 @@ void NaviStartStreamRequest::RetryStartSession() {
     MessageHelper::SendNaviStartStream(app->app_id());
     app->set_video_stream_retry_number(++curr_retry_number);
   } else {
-    LOG4CXX_INFO(logger_, "NaviStartStream retry sequence stopped");
-    app_mgr->EndNaviServices(app->app_id());
+    LOG4CXX_INFO(logger_, "NaviStartStream retry sequence stopped. "
+                 << "Attempts expired");
     app->set_video_stream_retry_number(0);
+    app_mgr->EndNaviServices(app->app_id());
   }
 }
 

--- a/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
@@ -46,7 +46,7 @@ NaviStartStreamRequest::NaviStartStreamRequest(
   LOG4CXX_AUTO_TRACE(logger_);
   std::pair<uint32_t, int32_t> stream_retry =
       profile::Profile::instance()->start_stream_retry_amount();
-  default_timeout_ = stream_retry.second * date_time::DateTime::MILLISECONDS_IN_SECOND;
+  default_timeout_ = stream_retry.second;
   retry_number_ = stream_retry.first;
   LOG4CXX_DEBUG(logger_, "default_timeout_ = " << default_timeout_
                 <<"; retry_number_ = " << retry_number_);

--- a/src/components/application_manager/src/commands/hmi/on_tts_language_change_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_tts_language_change_notification.cc
@@ -73,8 +73,8 @@ void OnTTSLanguageChangeNotification::Run() {
   ApplicationManagerImpl::ApplicationListAccessor accessor;
 
   ApplicationManagerImpl::ApplictionSetIt it = accessor.begin();
-  for (;accessor.end() != it; ++it) {
-    ApplicationSharedPtr app = (*it);
+  for (; accessor.end() != it;) {
+    ApplicationSharedPtr app = *it++;
     (*message_)[strings::params][strings::connection_key] = app->app_id();
     SendNotificationToMobile(message_);
 

--- a/src/components/application_manager/src/commands/hmi/on_ui_language_change_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_ui_language_change_notification.cc
@@ -70,8 +70,8 @@ void OnUILanguageChangeNotification::Run() {
   ApplicationManagerImpl::ApplicationListAccessor accessor;
 
   ApplicationManagerImpl::ApplictionSetIt it = accessor.begin();
-  for (;accessor.end() != it; ++it) {
-    ApplicationSharedPtr app = *it;
+  for (; accessor.end() != it;) {
+    ApplicationSharedPtr app = *it++;
     (*message_)[strings::params][strings::connection_key] = app->app_id();
     SendNotificationToMobile(message_);
 

--- a/src/components/application_manager/src/commands/mobile/delete_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/delete_command_request.cc
@@ -170,6 +170,9 @@ void DeleteCommandRequest::on_event(const event_engine::Event& event) {
       }
 
       SendResponse(result, result_code, NULL, &(message[strings::msg_params]));
+      if (result) {
+        application->UpdateHash();
+      }
     }
   }
 }

--- a/src/components/application_manager/src/commands/mobile/unregister_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unregister_app_interface_request.cc
@@ -50,6 +50,9 @@ void UnregisterAppInterfaceRequest::Run() {
     return;
   }
 
+  MessageHelper::SendOnAppInterfaceUnregisteredNotificationToMobile(
+      connection_key(),
+      mobile_api::AppInterfaceUnregisteredReason::INVALID_ENUM);
   app_manager->UnregisterApplication(connection_key(),
                                      mobile_apis::Result::SUCCESS);
   SendResponse(true, mobile_apis::Result::SUCCESS);

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_button_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_button_request.cc
@@ -74,6 +74,7 @@ void UnsubscribeButtonRequest::Run() {
 
   SendUnsubscribeButtonNotification();
   SendResponse(true, mobile_apis::Result::SUCCESS);
+  app->UpdateHash();
 }
 
 void UnsubscribeButtonRequest::SendUnsubscribeButtonNotification() {

--- a/src/components/application_manager/src/hmi_state.cc
+++ b/src/components/application_manager/src/hmi_state.cc
@@ -67,8 +67,7 @@ NaviStreamingHmiState::audio_streaming_state() const {
   using namespace mobile_apis;
 
   AudioStreamingState::eType expected_state = parent()->audio_streaming_state();
-  if (Compare<HMILevel::eType, EQ, ONE> (hmi_level(), HMILevel::HMI_FULL) &&
-      !state_context_.is_navi_app(app_id_) &&
+  if (!state_context_.is_navi_app(app_id_) &&
       AudioStreamingState::AUDIBLE == expected_state) {
     if (state_context_.is_attenuated_supported()) {
       expected_state = AudioStreamingState::ATTENUATED;

--- a/src/components/application_manager/src/state_controller.cc
+++ b/src/components/application_manager/src/state_controller.cc
@@ -116,14 +116,14 @@ void StateController::SetupRegularHmiState(ApplicationSharedPtr app,
   if (state->hmi_level() == mobile_apis::HMILevel::HMI_NONE) {
     app->ResetDataInNone();
   }
-  if (!app->is_media_application()) {
+  if (!app->IsAudioApplication()) {
     if (state->hmi_level() == HMILevel::HMI_LIMITED) {
-      LOG4CXX_ERROR(logger_, "Trying to setup LIMITED to non media app");
+      LOG4CXX_ERROR(logger_, "Trying to setup LIMITED to non audio app");
       state->set_hmi_level(HMILevel::HMI_BACKGROUND);
     }
     if (state->audio_streaming_state() != AudioStreamingState::NOT_AUDIBLE) {
       LOG4CXX_ERROR(logger_, "Trying to setup audio state " <<
-                    state->audio_streaming_state() <<" to non media app");
+                    state->audio_streaming_state() <<" to non audio app");
       state->set_audio_streaming_state(AudioStreamingState::NOT_AUDIBLE);
     }
   }

--- a/src/components/application_manager/test/mock/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/test/mock/include/application_manager/application_manager_impl.h
@@ -174,7 +174,7 @@ class ApplicationManagerImpl : public ApplicationManager,
   MOCK_METHOD3(OnServiceStartedCallback, bool (const connection_handler::DeviceHandle&,
                                             const int32_t&,
                                             const protocol_handler::ServiceType&));
-  MOCK_METHOD2(OnServiceEndedCallback, void (const int32_t&,
+  MOCK_METHOD3(OnServiceEndedCallback, void (const int32_t&,
                                              const protocol_handler::ServiceType&,
                                              const connection_handler::CloseSessionReason&));
   MOCK_METHOD1(Handle, void (const impl::MessageFromMobile));

--- a/src/components/application_manager/test/mock/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/test/mock/include/application_manager/application_manager_impl.h
@@ -177,7 +177,6 @@ class ApplicationManagerImpl : public ApplicationManager,
   MOCK_METHOD2(OnServiceEndedCallback, void (const int32_t&,
                                              const protocol_handler::ServiceType&,
                                              const connection_handler::CloseSessionReason&));
-  MOCK_METHOD1(OnApplicationFloodCallBack, void(const uint32_t&));
   MOCK_METHOD1(Handle, void (const impl::MessageFromMobile));
   MOCK_METHOD1(Handle, void (const impl::MessageToMobile));
   MOCK_METHOD1(Handle, void (const impl::MessageFromHmi));

--- a/src/components/application_manager/test/mock/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/test/mock/include/application_manager/application_manager_impl.h
@@ -175,9 +175,9 @@ class ApplicationManagerImpl : public ApplicationManager,
                                             const int32_t&,
                                             const protocol_handler::ServiceType&));
   MOCK_METHOD2(OnServiceEndedCallback, void (const int32_t&,
-                                             const protocol_handler::ServiceType&));
+                                             const protocol_handler::ServiceType&,
+                                             const connection_handler::CloseSessionReason&));
   MOCK_METHOD1(OnApplicationFloodCallBack, void(const uint32_t&));
-  MOCK_METHOD1(OnMalformedMessageCallback, void(const uint32_t&));
   MOCK_METHOD1(Handle, void (const impl::MessageFromMobile));
   MOCK_METHOD1(Handle, void (const impl::MessageToMobile));
   MOCK_METHOD1(Handle, void (const impl::MessageFromHmi));

--- a/src/components/application_manager/test/mock/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/test/mock/include/application_manager/application_manager_impl.h
@@ -250,7 +250,7 @@ class ApplicationManagerImpl : public ApplicationManager,
   MOCK_METHOD2(CanAppStream, bool(uint32_t, protocol_handler::ServiceType));
   MOCK_METHOD1(EndNaviServices, void(int32_t));
   MOCK_METHOD1(ForbidStreaming, void(int32_t));
-  MOCK_METHOD2(OnAppStreaming, void(int32_t, bool));
+  MOCK_METHOD2(OnAppStreaming, void(int32_t, protocol_handler::ServiceType, bool));
 
   MOCK_METHOD1(Unmute, void(VRTTSSessionChanging));
   MOCK_METHOD1(Mute, void(VRTTSSessionChanging));

--- a/src/components/application_manager/test/mock/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/test/mock/include/application_manager/application_manager_impl.h
@@ -250,7 +250,7 @@ class ApplicationManagerImpl : public ApplicationManager,
   MOCK_METHOD2(CanAppStream, bool(uint32_t, protocol_handler::ServiceType));
   MOCK_METHOD1(EndNaviServices, void(int32_t));
   MOCK_METHOD1(ForbidStreaming, void(int32_t));
-  MOCK_METHOD2(OnAppStreaming, void(int32_t, protocol_handler::ServiceType, bool));
+  MOCK_METHOD3(OnAppStreaming, void(int32_t, protocol_handler::ServiceType, bool));
 
   MOCK_METHOD1(Unmute, void(VRTTSSessionChanging));
   MOCK_METHOD1(Mute, void(VRTTSSessionChanging));

--- a/src/components/connection_handler/include/connection_handler/connection_handler_observer.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_observer.h
@@ -100,13 +100,6 @@ class ConnectionHandlerObserver {
       const protocol_handler::ServiceType& type,
       const connection_handler::CloseSessionReason& close_reason) = 0;
 
-  /**
-   * \brief Callback function used by ConnectionHandler
-   * when Mobile Application start message flood
-   * \param connection_key used by other components as application identifier
-   */
-  virtual void OnApplicationFloodCallBack(const uint32_t &connection_key) = 0;
-
  protected:
   /**
    * \brief Destructor

--- a/src/components/connection_handler/include/connection_handler/connection_handler_observer.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_observer.h
@@ -96,8 +96,8 @@ class ConnectionHandlerObserver {
    * \param close_reson Service close reason
    */
   virtual void OnServiceEndedCallback(
-      const int32_t &session_key,
-      const protocol_handler::ServiceType &type,
+      const int32_t& session_key,
+      const protocol_handler::ServiceType& type,
       const connection_handler::CloseSessionReason& close_reason) = 0;
 
   /**
@@ -106,13 +106,6 @@ class ConnectionHandlerObserver {
    * \param connection_key used by other components as application identifier
    */
   virtual void OnApplicationFloodCallBack(const uint32_t &connection_key) = 0;
-
-  /**
-   * \brief Callback function used by ConnectionHandler
-   * when Mobile Application sends malformed message
-   * \param connection_key used by other components as application identifier
-   */
-  virtual void OnMalformedMessageCallback(const uint32_t &connection_key) = 0;
 
  protected:
   /**

--- a/src/components/connection_handler/src/connection.cc
+++ b/src/components/connection_handler/src/connection.cc
@@ -79,7 +79,8 @@ Connection::Connection(ConnectionHandle connection_handle,
                        int32_t heartbeat_timeout)
     : connection_handler_(connection_handler),
       connection_handle_(connection_handle),
-      connection_device_handle_(connection_device_handle) {
+      connection_device_handle_(connection_device_handle),
+      session_map_lock_(true) {
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK(connection_handler_);
 

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -384,14 +384,10 @@ void ConnectionHandlerImpl::OnApplicationFloodCallBack(const uint32_t &connectio
   }
 }
 
-void ConnectionHandlerImpl::OnMalformedMessageCallback(const uint32_t &connection_key) {
+void ConnectionHandlerImpl::OnMalformedMessageCallback(
+    const uint32_t &connection_key) {
   LOG4CXX_AUTO_TRACE(logger_);
-  {
-    sync_primitives::AutoLock lock(connection_handler_observer_lock_);
-    if(connection_handler_observer_) {
-      connection_handler_observer_->OnMalformedMessageCallback(connection_key);
-    }
-  }
+
   transport_manager::ConnectionUID connection_handle = 0;
   uint8_t session_id = 0;
   PairFromKey(connection_key, &connection_handle, &session_id);
@@ -449,7 +445,7 @@ uint32_t ConnectionHandlerImpl::OnSessionEndedCallback(
   sync_primitives::AutoLock lock2(connection_handler_observer_lock_);
   if (connection_handler_observer_) {
     connection_handler_observer_->OnServiceEndedCallback(
-          session_key, service_type, CloseSessionReason::kCommon);
+        session_key, service_type, CloseSessionReason::kCommon);
   }
   return session_key;
 }
@@ -810,8 +806,8 @@ void ConnectionHandlerImpl::CloseSession(ConnectionHandle connection_handle,
     for (;service_list_itr != service_list.end(); ++service_list_itr) {
       const protocol_handler::ServiceType service_type =
           service_list_itr->service_type;
-      connection_handler_observer_->OnServiceEndedCallback(session_key,
-                                                           service_type);
+      connection_handler_observer_->OnServiceEndedCallback(
+          session_key, service_type, close_reason);
     }
   } else {
     LOG4CXX_ERROR(logger_, "Session with id: "
@@ -942,7 +938,7 @@ void ConnectionHandlerImpl::OnConnectionEnded(
       for (ServiceList::const_iterator service_it = service_list.begin(), end =
            service_list.end(); service_it != end; ++service_it) {
         connection_handler_observer_->OnServiceEndedCallback(
-              session_key, service_it->service_type, CloseSessionReason::kCommon);
+            session_key, service_it->service_type, CloseSessionReason::kCommon);
       }
     }
   }

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -770,7 +770,9 @@ void ConnectionHandlerImpl::CloseSession(ConnectionHandle connection_handle,
   LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_DEBUG(logger_, "Closing session with id: " << session_id);
 
-  if (protocol_handler_) {
+  // In case of malformed message the connection should be broke up without
+  // any other notification to mobile.
+  if (close_reason != kMalformed && protocol_handler_) {
     protocol_handler_->SendEndSession(connection_handle, session_id);
   }
 
@@ -784,15 +786,18 @@ void ConnectionHandlerImpl::CloseSession(ConnectionHandle connection_handle,
     ConnectionList::iterator connection_list_itr =
         connection_list_.find(connection_id);
     if (connection_list_.end() != connection_list_itr) {
-      if (connection_handler_observer_ && kCommon == close_reason) {
-        session_map = connection_list_itr->second->session_map();
-      }
+      session_map = connection_list_itr->second->session_map();
       connection_list_itr->second->RemoveSession(session_id);
     } else {
       LOG4CXX_ERROR(logger_, "Connection with id: " << connection_id
                     << " not found");
       return;
     }
+  }
+
+  if (!connection_handler_observer_) {
+    LOG4CXX_ERROR(logger_, "Connection handler observer not found");
+    return;
   }
 
   SessionMap::const_iterator session_map_itr = session_map.find(session_id);
@@ -805,16 +810,14 @@ void ConnectionHandlerImpl::CloseSession(ConnectionHandle connection_handle,
     for (;service_list_itr != service_list.end(); ++service_list_itr) {
       const protocol_handler::ServiceType service_type =
           service_list_itr->service_type;
-      connection_handler_observer_->OnServiceEndedCallback(
-            session_key, service_type, close_reason);
+      connection_handler_observer_->OnServiceEndedCallback(session_key,
+                                                           service_type);
     }
   } else {
-    LOG4CXX_ERROR(logger_, "Session with id: " << session_id
-                  << " not found");
-    session_map.clear();
+    LOG4CXX_ERROR(logger_, "Session with id: "
+                  << session_id << " not found");
     return;
   }
-  session_map.clear();
   LOG4CXX_DEBUG(logger_, "Session with id: " << session_id
                 << " has been closed successfully");
 }

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -363,14 +363,10 @@ uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
   return new_session_id;
 }
 
-void ConnectionHandlerImpl::OnApplicationFloodCallBack(const uint32_t &connection_key) {
+void ConnectionHandlerImpl::OnApplicationFloodCallBack(
+    const uint32_t &connection_key) {
   LOG4CXX_AUTO_TRACE(logger_);
-  {
-    sync_primitives::AutoLock lock(connection_handler_observer_lock_);
-    if(connection_handler_observer_) {
-      connection_handler_observer_->OnApplicationFloodCallBack(connection_key);
-    }
-  }
+
   transport_manager::ConnectionUID connection_handle = 0;
   uint8_t session_id = 0;
   PairFromKey(connection_key, &connection_handle, &session_id);

--- a/src/components/media_manager/src/media_manager_impl.cc
+++ b/src/components/media_manager/src/media_manager_impl.cc
@@ -211,18 +211,12 @@ void MediaManagerImpl::StartStreaming(
   if (streamer_[service_type]) {
     streamer_[service_type]->StartActivity(application_key);
   }
-  if (streamer_listener_[service_type]) {
-    streamer_listener_[service_type]->OnActivityStarted(application_key);
-  }
 }
 
 void MediaManagerImpl::StopStreaming(
     int32_t application_key, protocol_handler::ServiceType service_type) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  if (streamer_listener_[service_type]) {
-    streamer_listener_[service_type]->OnActivityEnded(application_key);
-  }
   if (streamer_[service_type]) {
     streamer_[service_type]->StopActivity(application_key);
   }

--- a/src/components/policy/src/policy/sqlite_wrapper/src/sql_database.cc
+++ b/src/components/policy/src/policy/sqlite_wrapper/src/sql_database.cc
@@ -50,7 +50,9 @@ SQLDatabase::SQLDatabase(const std::string& db_name)
       error_(SQLITE_OK) {}
 
 SQLDatabase::~SQLDatabase() {
-  Close();
+  if (conn_) {
+    Close();
+  }
 }
 
 bool SQLDatabase::Open() {

--- a/src/components/policy/src/policy/sqlite_wrapper/src/sql_database.cc
+++ b/src/components/policy/src/policy/sqlite_wrapper/src/sql_database.cc
@@ -50,9 +50,7 @@ SQLDatabase::SQLDatabase(const std::string& db_name)
       error_(SQLITE_OK) {}
 
 SQLDatabase::~SQLDatabase() {
-  if (conn_) {
-    Close();
-  }
+  Close();
 }
 
 bool SQLDatabase::Open() {
@@ -68,6 +66,10 @@ bool SQLDatabase::IsReadWrite() {
 }
 
 void SQLDatabase::Close() {
+  if (!conn_) {
+    return;
+  }
+
   sync_primitives::AutoLock auto_lock(conn_lock_);
   error_ = sqlite3_close(conn_);
   if (error_ == SQLITE_OK) {

--- a/src/components/protocol_handler/test/include/protocol_observer_mock.h
+++ b/src/components/protocol_handler/test/include/protocol_observer_mock.h
@@ -46,10 +46,19 @@ namespace protocol_handler_test {
  */
 class ProtocolObserverMock : public ::protocol_handler::ProtocolObserver {
  public:
-  MOCK_METHOD1(OnMessageReceived,
-      void(const ::protocol_handler::RawMessagePtr));
-  MOCK_METHOD1(OnMobileMessageSent,
-      void(const ::protocol_handler::RawMessagePtr));
+  MOCK_METHOD1(OnDeviceListUpdated,
+      void(const connection_handler::DeviceMap &device_list));
+  MOCK_METHOD0(OnFindNewApplicationsRequest,void());
+  MOCK_METHOD1(RemoveDevice,
+      void(const connection_handler::DeviceHandle &device_handle));
+  MOCK_METHOD3(OnServiceStartedCallback,
+      bool(const connection_handler::DeviceHandle &device_handle,
+           const int32_t &session_key,
+           const protocol_handler::ServiceType &type));
+  MOCK_METHOD3(OnServiceEndedCallback,
+      void(const int32_t &session_key,
+           const protocol_handler::ServiceType &type,
+           const connection_handler::CloseSessionReason& close_reason));
 };
 } // namespace protocol_handler_test
 } // namespace components


### PR DESCRIPTION
Pull request contains fixes for following defects:
- Once core crashes after changing language with registered app
- SDL crashes when App starts streaming (audio or video)
- SDL does not remove app from HMI and ApplicationManager after disconnecting due to malformed message
- CreateInteractionChoiceSet: SDL returns GENERIC_ERROR when create InteractionChoiceSet with UpperBound
- SDL does not send FULL, ATTENUATED, MAIN state to app when another app streamin audio\video
- SDL doesn't send OnHashChanged notification to mobile app if DeleteCommand/DeleteSubMenu/DeleteInteractionChoiceSet/UnsubscribeButton/UnsubscribeVehicleData after successful
- Core crashes if unplug USB during audio/video streaming
- Core crashes by IGN_OFF if UseDBForResumption is set to "true"
- SDL assign HMI level 'BACKGROUND' to NAVI app when user switch to another page on HMI (media checkbox is unchecked)
- AudioStreaming: Audio is not played when Start File Streaming from the second time