### PR TITLE
Change DeviceInfo structure and extend TransportType

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -105,6 +105,7 @@ enum VRTTSSessionChanging {
 };
 
 struct CommandParametersPermissions;
+typedef std::map<std::string, hmi_apis::Common_TransportType::eType> DeviceTypes;
 
 namespace impl {
 using namespace threads;

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -64,9 +64,20 @@ namespace {
   int get_rand_from_range(uint32_t from = 0, int to = RAND_MAX) {
     return std::rand() % to + from;
   }
+
+
 }
 
 namespace application_manager {
+
+namespace {
+  DeviceTypes devicesType = {
+    std::make_pair(std::string("USB_AOA"), hmi_apis::Common_TransportType::USB_AOA),
+    std::make_pair(std::string("USB_IOS"), hmi_apis::Common_TransportType::USB_IOS),
+    std::make_pair(std::string("BLUETOOTH"), hmi_apis::Common_TransportType::BLUETOOTH),
+    std::make_pair(std::string("WIFI"), hmi_apis::Common_TransportType::WIFI)
+  };
+}
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "ApplicationManager")
 
@@ -709,17 +720,15 @@ std::string ApplicationManagerImpl::GetDeviceName(
   return device_name;
 }
 
-hmi_apis::Common_TransportType::eType ApplicationManagerImpl::GetDeviceTransportType(
+hmi_apis::Common_TransportType::eType
+ApplicationManagerImpl::GetDeviceTransportType(
     const std::string& transport_type) {
   hmi_apis::Common_TransportType::eType result =
       hmi_apis::Common_TransportType::INVALID_ENUM;
 
-  if ("BLUETOOTH" == transport_type) {
-    result = hmi_apis::Common_TransportType::BLUETOOTH;
-  } else if ("WIFI" == transport_type) {
-    result = hmi_apis::Common_TransportType::WIFI;
-  } else if ("USB" == transport_type) {
-    result = hmi_apis::Common_TransportType::USB;
+  DeviceTypes::const_iterator it = devicesType.find(transport_type);
+  if (it != devicesType.end()) {
+    return devicesType[transport_type];
   } else {
     LOG4CXX_ERROR(logger_, "Unknown transport type " << transport_type);
   }

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -388,7 +388,7 @@ void MessageHelper::SendOnAppRegisteredNotificationToHMI(
                   << application_impl.device());
   }
   device_info[strings::name] = device_name;
-  device_info[strings::id] = application_impl.device();
+  device_info[strings::id] = mac_address;
 
   const policy::DeviceConsent device_consent =
       policy::PolicyHandler::instance()->GetUserConsentForDevice(mac_address);

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -65,12 +65,11 @@
 </enum>
 
 <enum name="TransportType">
-    <description>
-      Lists of the transport types used for device connection to HU.
-    </description>
-    <element name="BLUETOOTH"/>
-    <element name="USB"/>
-    <element name="WIFI"/>
+  <description>Lists of the transport types used for device connection to HU.</description>
+  <element name="BLUETOOTH"/>
+  <element name="USB_IOS"/>
+  <element name="USB_AOA"/>
+  <element name="WIFI"/>
 </enum>
 
 <enum name="ButtonName">
@@ -1308,8 +1307,8 @@
   <param name="name" type="String" mandatory="true">
     <description>The name of the device connected.</description>
   </param>
-  <param name="id" type="Integer" mandatory="true">
-    <description>The ID of the device connected</description>
+  <param name="id" type="String" mandatory="true">
+    <description>The ID of the device connectedi: either hash of device's USB serial number(in case of USB connection) or has of device's MAC address(in case of BlueTooth or WIFI connection</description>
   </param>
   <param name="transportType" type="Common.TransportType" mandatory="false">
     <description>The transport type the named-app's-device is connected over HU(BlueTooth, USB or WiFi). It must be provided in OnAppRegistered and in UpdateDeviceList</description>

--- a/src/components/interfaces/QT_HMI_API.xml
+++ b/src/components/interfaces/QT_HMI_API.xml
@@ -63,7 +63,8 @@
         Lists of the transport types used for device connection to HU.
       </description>
       <element name="BLUETOOTH"/>
-      <element name="USB"/>
+      <element name="USB_IOS"/>
+      <element name="USB_AOA"/>
       <element name="WIFI"/>
     </enum>
     <enum name="ButtonName">
@@ -1180,6 +1181,20 @@
       </param>
       <param name="resultCode" type="Common.VehicleDataResultCode">
         <description>Published data result code.</description>
+      </param>
+    </struct>
+    <struct name="DeviceInfo">
+      <param name="name" type="String" mandatory="true">
+        <description>The name of the device connected.</description>
+      </param>
+      <param name="id" type="String" mandatory="true">
+        <description>The ID of the device connected: either hash of device's USB serial number(in case of USB connection) or hash of device's MAC address(in case of BlueTooth or WIFI connection).</description>
+      </param>
+      <param name="transportType" type="Common.TransportType" mandatory="false">
+        <description>The transport type the named-app's-device is connected over HU(BlueTooth, USB or  WiFi). It must be provided in OnAppRegistered and in UpdateDeviceList</description>
+      </param>
+      <param name="isSDLAllowed" type="Boolean" mandatory="false">
+        <description>Sent by SDL in UpdateDeviceList. ’true’ – if device is allowed for PolicyTable Exchange; ‘false’ – if device is NOT allowed for PolicyTable Exchange </description>
       </param>
     </struct>
     <struct name="TouchCoord">

--- a/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
+++ b/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
@@ -45,9 +45,9 @@ namespace transport_adapter {
 CREATE_LOGGERPTR_GLOBAL(logger_, "TransportManager")
 namespace {
 DeviceTypes devicesType = {
-  std::make_pair(AOA, std::string("USB")),
-  std::make_pair(PASA_AOA, std::string("USB")),
-  std::make_pair(MME, std::string("USB")),
+  std::make_pair(AOA, std::string("USB_AOA")),
+  std::make_pair(PASA_AOA, std::string("USB_AOA")),
+  std::make_pair(MME, std::string("USB_IOS")),
   std::make_pair(BLUETOOTH, std::string("BLUETOOTH")),
   std::make_pair(PASA_BLUETOOTH, std::string("BLUETOOTH")),
   std::make_pair(TCP, std::string("WIFI"))


### PR DESCRIPTION
Now `DeviceInfo` contains `String` value instead of Integer for id field
to be able to sent either USB serial number or MAC addres within this field.

Also `TransportType` structure has been extended and now it contains both
`USB_IOS` and `USB_AOA` to distinguish transport type during connection.
