### PR TITLE
Changes Un/SubscribeVehicleData requests behavior.

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -161,6 +161,16 @@ typedef std::map<uint32_t, PerformChoice> PerformChoiceSetMap;
  */
 typedef std::set<uint32_t> SoftButtonID;
 
+/**
+ * @brief Defines set of vehicle info types
+ */
+typedef std::set<uint32_t> VehicleInfoSubscriptions;
+
+/**
+ * @brief Defines set of buttons subscription
+ */
+typedef std::set<mobile_apis::ButtonName::eType> ButtonSubscriptions;
+
 class DynamicApplicationData {
   public:
     virtual ~DynamicApplicationData() {
@@ -172,8 +182,8 @@ class DynamicApplicationData {
     virtual const mobile_api::TBTState::eType& tbt_state() const = 0;
     virtual const smart_objects::SmartObject* show_command() const = 0;
     virtual const smart_objects::SmartObject* tbt_show_command() const = 0;
-    virtual const std::set<mobile_apis::ButtonName::eType>& SubscribedButtons() const = 0;
-    virtual const std::set<uint32_t>& SubscribesIVI() const = 0;
+    virtual DataAccessor<ButtonSubscriptions> SubscribedButtons() const = 0;
+    virtual DataAccessor<VehicleInfoSubscriptions> SubscribedIVI() const = 0;
     virtual const smart_objects::SmartObject* keyboard_props() const = 0;
     virtual const smart_objects::SmartObject* menu_title() const = 0;
     virtual const smart_objects::SmartObject* menu_icon() const = 0;
@@ -568,9 +578,9 @@ class Application : public virtual InitialApplicationData,
     virtual bool IsSubscribedToButton(mobile_apis::ButtonName::eType btn_name) = 0;
     virtual bool UnsubscribeFromButton(mobile_apis::ButtonName::eType btn_name) = 0;
 
-    virtual bool SubscribeToIVI(uint32_t vehicle_info_type_) = 0;
-    virtual bool IsSubscribedToIVI(uint32_t vehicle_info_type_) = 0;
-    virtual bool UnsubscribeFromIVI(uint32_t vehicle_info_type_) = 0;
+    virtual bool SubscribeToIVI(uint32_t vehicle_info_type) = 0;
+    virtual bool IsSubscribedToIVI(uint32_t vehicle_info_type) const = 0;
+    virtual bool UnsubscribeFromIVI(uint32_t vehicle_info_type) = 0;
 
     /**
      * @brief ResetDataInNone reset data counters in NONE

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -165,17 +165,17 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
   bool IsSubscribedToButton(mobile_apis::ButtonName::eType btn_name);
   bool UnsubscribeFromButton(mobile_apis::ButtonName::eType btn_name);
 
-  bool SubscribeToIVI(uint32_t vehicle_info_type_);
-  bool IsSubscribedToIVI(uint32_t vehicle_info_type_);
-  bool UnsubscribeFromIVI(uint32_t vehicle_info_type_);
+  bool SubscribeToIVI(uint32_t vehicle_info_type) OVERRIDE;
+  bool IsSubscribedToIVI(uint32_t vehicle_info_type) const OVERRIDE;
+  bool UnsubscribeFromIVI(uint32_t vehicle_info_type) OVERRIDE;
+  DataAccessor<VehicleInfoSubscriptions> SubscribedIVI() const OVERRIDE;
 
   /**
    * @brief ResetDataInNone reset data counters in NONE
    */
   virtual void ResetDataInNone();
 
-  virtual const std::set<mobile_apis::ButtonName::eType>& SubscribedButtons() const;
-  virtual const  std::set<uint32_t>& SubscribesIVI() const;
+  virtual DataAccessor<ButtonSubscriptions> SubscribedButtons() const OVERRIDE;
 
   virtual const std::string& curHash() const;
   /**
@@ -264,7 +264,6 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
    */
   void CleanupFiles();
 
-
  private:
   typedef SharedPtr<TimerThread<ApplicationImpl>> ApplicationTimerPtr;
 
@@ -314,7 +313,7 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
 
   AppFilesMap                              app_files_;
   std::set<mobile_apis::ButtonName::eType> subscribed_buttons_;
-  std::set<uint32_t>                       subscribed_vehicle_info_;
+  VehicleInfoSubscriptions                 subscribed_vehicle_info_;
   UsageStatistics                          usage_report_;
   ProtocolVersion                          protocol_version_;
   bool                                     is_voice_communication_application_;
@@ -346,6 +345,8 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
   CommandSoftButtonID cmd_softbuttonid_;
   // Lock for command soft button id
   sync_primitives::Lock cmd_softbuttonid_lock_;
+  mutable sync_primitives::Lock vi_lock_;
+  sync_primitives::Lock button_lock_;
   std::string folder_name_;
   DISALLOW_COPY_AND_ASSIGN(ApplicationImpl);
 };

--- a/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
@@ -35,6 +35,7 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_MOBILE_SUBSCRIBE_VEHICLE_DATA_REQUEST_H_
 
 #include "application_manager/commands/command_request_impl.h"
+#include "application_manager/application.h"
 #include "utils/macro.h"
 
 namespace application_manager {
@@ -85,8 +86,41 @@ class SubscribeVehicleDataRequest : public CommandRequestImpl {
 #endif // #ifdef HMI_DBUS_API
 
  private:
-  bool IsAnythingAlreadySubscribed(
+  /**
+   * @brief Checks, if any app is subscribed for particular VI parameter
+   * @param param_id VI parameter id
+   * @return true, if there are registered apps subscribed for VI parameter,
+   * otherwise - false
+   */
+  bool IsSomeoneSubscribedFor(const uint32_t param_id) const;
+
+  /**
+   * @brief Adds VI parameters being subscribed by another or the same app to
+   * response with appropriate results
+   * @param msg_params 'message_params' response section reference
+   */
+  void AddAlreadySubscribedVI(smart_objects::SmartObject& msg_params) const;
+
+  /**
+   * @brief Removes subscription for VI parameters which subsription attempt
+   * returned an error
+   * @param app Pointer to application sent subscribe request
+   * @param msg_params 'message_parameters' response section reference
+   */
+  void UnsubscribeFailedSubscriptions(
+      ApplicationSharedPtr app,
       const smart_objects::SmartObject& msg_params) const;
+
+  /**
+   * @brief VI parameters which had been already subscribed by another apps
+   * befor particular app subscribed for these parameters
+   */
+  VehicleInfoSubscriptions vi_already_subscribed_by_another_apps_;
+
+  /**
+   * @brief VI parameters which had been subscribed already by particular app
+   */
+  VehicleInfoSubscriptions vi_already_subscribed_by_this_app_;
 
   DISALLOW_COPY_AND_ASSIGN(SubscribeVehicleDataRequest);
 };

--- a/src/components/application_manager/include/application_manager/commands/mobile/unsubscribe_vehicle_data_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/unsubscribe_vehicle_data_request.h
@@ -35,6 +35,7 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_MOBILE_UNSUBSCRIBE_VEHICLE_DATA_REQUEST_H_
 
 #include "application_manager/commands/command_request_impl.h"
+#include "application_manager/application.h"
 #include "utils/macro.h"
 
 namespace application_manager {
@@ -85,12 +86,37 @@ class UnsubscribeVehicleDataRequest : public CommandRequestImpl {
 #endif // #ifdef HMI_DBUS_API
 
  private:
-  bool IsAnythingAlreadyUnsubscribed(
-      const smart_objects::SmartObject& msg_params) const;
+  /**
+   * @brief Checks, if any app is subscribed for particular VI parameter
+   * @param param_id VI parameter id
+   * @return true, if there are registered apps subscribed for VI parameter,
+   * otherwise - false
+   */
+  bool IsSomeoneSubscribedFor(const uint32_t param_id) const;
+
+  /**
+   * @brief Adds VI parameters being unsubscribed by another or the same app to
+   * response with appropriate results
+   * @param msg_params 'message_params' response section reference
+   */
+  void AddAlreadyUnsubscribedVI(smart_objects::SmartObject& response) const;
+
   /**
    * @brief Allows to update hash after sending response to mobile.
    */
   void UpdateHash() const;
+
+  /**
+   * @brief VI parameters which still being subscribed by another apps after
+   * particular app had been unsubscribed from these parameters
+   */
+  VehicleInfoSubscriptions vi_still_subscribed_by_another_apps_;
+
+  /**
+   * @brief VI parameters which had been unsubscribed already by particular app
+   */
+  VehicleInfoSubscriptions vi_already_unsubscribed_by_this_app_;
+
   DISALLOW_COPY_AND_ASSIGN(UnsubscribeVehicleDataRequest);
 };
 

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -731,11 +731,13 @@ smart_objects::SmartObjectList MessageHelper::GetIVISubscriptionRequests(
   msg_params[strings::app_id] = app->app_id();
   const VehicleData& vehicle_data = MessageHelper::vehicle_data_;
   VehicleData::const_iterator ivi_it = vehicle_data.begin();
-  const std::set<uint32_t>& subscribes = app->SubscribesIVI();
+  DataAccessor<VehicleInfoSubscriptions> vi_accessor =
+      app->SubscribedIVI();
+  const VehicleInfoSubscriptions& subscriptions = vi_accessor.GetData();
 
   for (; vehicle_data.end() != ivi_it; ++ivi_it) {
     uint32_t type_id = static_cast<int>(ivi_it->second);
-    if (subscribes.end() != subscribes.find(type_id)) {
+    if (subscriptions.end() != subscriptions.find(type_id)) {
       std::string key_name = ivi_it->first;
       msg_params[key_name] = true;
     }
@@ -808,8 +810,9 @@ void MessageHelper::SendAllOnButtonSubscriptionNotificationsForApp(
     return;
   }
 
-  std::set<ButtonName::eType> subscriptions = app->SubscribedButtons();
-  std::set<ButtonName::eType>::iterator it = subscriptions.begin();
+  DataAccessor<ButtonSubscriptions> button_accessor = app->SubscribedButtons();
+  ButtonSubscriptions subscriptions = button_accessor.GetData();
+  ButtonSubscriptions::iterator it = subscriptions.begin();
   for (; subscriptions.end() != it; ++it) {
     SendOnButtonSubscriptionNotification(
         app->hmi_app_id(), static_cast<Common_ButtonName::eType>(*it), true);

--- a/src/components/application_manager/src/resumption/resumption_data.cc
+++ b/src/components/application_manager/src/resumption/resumption_data.cc
@@ -112,7 +112,7 @@ smart_objects::SmartObject ResumptionData::GetApplicationInteractionChoiseSets(
 
 smart_objects::SmartObject ResumptionData::GetApplicationGlobalProperties(
       app_mngr::ApplicationConstSharedPtr application) const {
-  using namespace app_mngr; 
+  using namespace app_mngr;
   LOG4CXX_AUTO_TRACE(logger_);
 
   DCHECK(application.get());
@@ -144,7 +144,7 @@ smart_objects::SmartObject ResumptionData::GetApplicationGlobalProperties(
 
 smart_objects::SmartObject ResumptionData::GetApplicationSubscriptions(
         app_mngr::ApplicationConstSharedPtr application) const {
-  using namespace app_mngr; 
+  using namespace app_mngr;
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK(application.get());
   smart_objects::SmartObject subscriptions =
@@ -154,22 +154,30 @@ smart_objects::SmartObject ResumptionData::GetApplicationSubscriptions(
     return subscriptions;
   }
   LOG4CXX_DEBUG(logger_, "app_id:" << application->app_id());
-  LOG4CXX_DEBUG(logger_, "SubscribedButtons:"
-                << application->SubscribedButtons().size());
-  Append(application->SubscribedButtons().begin(),
-         application->SubscribedButtons().end(),
+
+  DataAccessor<ButtonSubscriptions> button_accessor =
+      application->SubscribedButtons();
+
+  const ButtonSubscriptions& button_subscriptions = button_accessor.GetData();
+
+  LOG4CXX_DEBUG(logger_, "SubscribedButtons:" << button_subscriptions.size());
+  Append(button_subscriptions.begin(), button_subscriptions.end(),
          strings::application_buttons, subscriptions);
-  LOG4CXX_DEBUG(logger_, "SubscribesIVI:"
-                << application->SubscribesIVI().size());
-  Append(application->SubscribesIVI().begin(),
-         application->SubscribesIVI().end(),
+
+  DataAccessor<VehicleInfoSubscriptions> vi_accessor =
+      application->SubscribedIVI();
+
+  const VehicleInfoSubscriptions& vi_subscription = vi_accessor.GetData();
+
+  LOG4CXX_DEBUG(logger_, "SubscribedIVI:" << vi_subscription.size());
+  Append(vi_subscription.begin(), vi_subscription.end(),
          strings::application_vehicle_info, subscriptions);
   return subscriptions;
 }
 
 smart_objects::SmartObject ResumptionData::GetApplicationFiles(
     app_mngr::ApplicationConstSharedPtr application) const {
-  using namespace app_mngr; 
+  using namespace app_mngr;
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK(application.get());
   LOG4CXX_TRACE(logger_, "ENTER app_id:"

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -3353,9 +3353,6 @@
         The application will be notified by the onVehicleData notification whenever new data is available.
         To unsubscribe the notifications, use unsubscribe with the same subscriptionType.
     </description>
-    <param name="appID" type="Integer" mandatory="true">
-      <description>ID of application that requested this RPC.</description>
-    </param>
     <param name="gps" type="Boolean" mandatory="false">
       <description>See GPSData</description>
     </param>
@@ -3741,9 +3738,6 @@
     </param>
     <param name="myKey" type="Boolean" mandatory="false">
       <description>Information related to the MyKey feature</description>
-    </param>
-    <param name="appID" type="Integer" mandatory="true">
-      <description>ID of application requested this RPC.</description>
     </param>
   </function>
   <function name="GetVehicleData" messagetype="response">

--- a/src/components/interfaces/QT_HMI_API.xml
+++ b/src/components/interfaces/QT_HMI_API.xml
@@ -1539,20 +1539,6 @@
         <description>e.g. SE</description>
       </param>
     </struct>
-    <struct name="DeviceInfo">
-      <param name="name" type="String" mandatory="true">
-        <description>The name of the device connected.</description>
-      </param>
-      <param name="id" type="Integer" mandatory="true">
-        <description>The ID of the device connected</description>
-      </param>
-      <param name="transportType" type="Common.TransportType" mandatory="false">
-        <description>The transport type the named-app's-device is connected over HU(BlueTooth, USB or  WiFi). It must be provided in OnAppRegistered and in UpdateDeviceList</description>
-      </param>
-      <param name="isSDLAllowed" type="Boolean" mandatory="false">
-        <description>Sent by SDL in UpdateDeviceList. ’true’ – if device is allowed for PolicyTable Exchange; ‘false’ – if device is NOT allowed for PolicyTable Exchange </description>
-      </param>
-    </struct>
     <!--IVI part-->
     <struct name="GPSData">
       <description>Struct with the GPS data.</description>
@@ -3629,9 +3615,6 @@
     <!--end Qt HMI version of OnVehicleData-->
     <!--Qt HMI version of SubscribeVehicleData/UnsubscribeVehicleData-->
     <function name="SubscribeGps" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeGps" messagetype="response">
       <param name="gps" type="Common.VehicleDataResult" mandatory="true">
@@ -3639,9 +3622,6 @@
       </param>
     </function>
     <function name="UnsubscribeGps" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeGps" messagetype="response">
       <param name="gps" type="Common.VehicleDataResult" mandatory="true">
@@ -3649,9 +3629,6 @@
       </param>
     </function>
     <function name="SubscribeSpeed" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeSpeed" messagetype="response">
       <param name="speed" type="Common.VehicleDataResult" mandatory="true">
@@ -3659,9 +3636,6 @@
       </param>
     </function>
     <function name="UnsubscribeSpeed" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeSpeed" messagetype="response">
       <param name="speed" type="Common.VehicleDataResult" mandatory="true">
@@ -3669,9 +3643,6 @@
       </param>
     </function>
     <function name="SubscribeRpm" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeRpm" messagetype="response">
       <param name="rpm" type="Common.VehicleDataResult" mandatory="true">
@@ -3679,9 +3650,6 @@
       </param>
     </function>
     <function name="UnsubscribeRpm" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeRpm" messagetype="response">
       <param name="rpm" type="Common.VehicleDataResult" mandatory="true">
@@ -3689,9 +3657,6 @@
       </param>
     </function>
     <function name="SubscribeFuelLevel" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeFuelLevel" messagetype="response">
       <param name="fuelLevel" type="Common.VehicleDataResult" mandatory="true">
@@ -3699,9 +3664,6 @@
       </param>
     </function>
     <function name="UnsubscribeFuelLevel" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeFuelLevel" messagetype="response">
       <param name="fuelLevel" type="Common.VehicleDataResult" mandatory="true">
@@ -3709,9 +3671,6 @@
       </param>
     </function>
     <function name="SubscribeFuelLevel_State" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeFuelLevel_State" messagetype="response">
       <param name="fuelLevel_State" type="Common.VehicleDataResult" mandatory="true">
@@ -3719,9 +3678,6 @@
       </param>
     </function>
     <function name="UnsubscribeFuelLevel_State" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeFuelLevel_State" messagetype="response">
       <param name="fuelLevel_State" type="Common.VehicleDataResult" mandatory="true">
@@ -3729,9 +3685,6 @@
       </param>
     </function>
     <function name="SubscribeInstantFuelConsumption" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeInstantFuelConsumption" messagetype="response">
       <param name="instantFuelConsumption" type="Common.VehicleDataResult" mandatory="true">
@@ -3739,9 +3692,6 @@
       </param>
     </function>
     <function name="UnsubscribeInstantFuelConsumption" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeInstantFuelConsumption" messagetype="response">
       <param name="instantFuelConsumption" type="Common.VehicleDataResult" mandatory="true">
@@ -3749,9 +3699,6 @@
       </param>
     </function>
     <function name="SubscribeExternalTemperature" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeExternalTemperature" messagetype="response">
       <param name="externalTemperature" type="Common.VehicleDataResult" mandatory="true">
@@ -3759,9 +3706,6 @@
       </param>
     </function>
     <function name="UnsubscribeExternalTemperature" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeExternalTemperature" messagetype="response">
       <param name="externalTemperature" type="Common.VehicleDataResult" mandatory="true">
@@ -3769,9 +3713,6 @@
       </param>
     </function>
     <function name="SubscribePrndl" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribePrndl" messagetype="response">
       <param name="prndl" type="Common.VehicleDataResult" mandatory="true">
@@ -3779,9 +3720,6 @@
       </param>
     </function>
     <function name="UnsubscribePrndl" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribePrndl" messagetype="response">
       <param name="prndl" type="Common.VehicleDataResult" mandatory="true">
@@ -3789,9 +3727,6 @@
       </param>
     </function>
     <function name="SubscribeVin" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeVin" messagetype="response">
       <param name="vin" type="String" maxlength="17" mandatory="true">
@@ -3799,9 +3734,6 @@
       </param>
     </function>
     <function name="UnsubscribeVin" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeVin" messagetype="response">
       <param name="vin" type="String" maxlength="17" mandatory="true">
@@ -3809,9 +3741,6 @@
       </param>
     </function>
     <function name="SubscribeTirePressure" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeTirePressure" messagetype="response">
       <param name="tirePressure" type="Common.VehicleDataResult" mandatory="true">
@@ -3819,9 +3748,6 @@
       </param>
     </function>
     <function name="UnsubscribeTirePressure" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeTirePressure" messagetype="response">
       <param name="tirePressure" type="Common.VehicleDataResult" mandatory="true">
@@ -3829,9 +3755,6 @@
       </param>
     </function>
     <function name="SubscribeOdometer" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeOdometer" messagetype="response">
       <param name="odometer" type="Common.VehicleDataResult" mandatory="true">
@@ -3839,9 +3762,6 @@
       </param>
     </function>
     <function name="UnsubscribeOdometer" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeOdometer" messagetype="response">
       <param name="odometer" type="Common.VehicleDataResult" mandatory="true">
@@ -3849,9 +3769,6 @@
       </param>
     </function>
     <function name="SubscribeBeltStatus" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeBeltStatus" messagetype="response">
       <param name="beltStatus" type="Common.VehicleDataResult" mandatory="true">
@@ -3859,9 +3776,6 @@
       </param>
     </function>
     <function name="UnsubscribeBeltStatus" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeBeltStatus" messagetype="response">
       <param name="beltStatus" type="Common.VehicleDataResult" mandatory="true">
@@ -3869,9 +3783,6 @@
       </param>
     </function>
     <function name="SubscribeBodyInformation" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeBodyInformation" messagetype="response">
       <param name="bodyInformation" type="Common.VehicleDataResult" mandatory="true">
@@ -3879,9 +3790,6 @@
       </param>
     </function>
     <function name="UnsubscribeBodyInformation" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeBodyInformation" messagetype="response">
       <param name="bodyInformation" type="Common.VehicleDataResult" mandatory="true">
@@ -3889,9 +3797,6 @@
       </param>
     </function>
     <function name="SubscribeDeviceStatus" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeDeviceStatus" messagetype="response">
       <param name="deviceStatus" type="Common.VehicleDataResult" mandatory="true">
@@ -3899,9 +3804,6 @@
       </param>
     </function>
     <function name="UnsubscribeDeviceStatus" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeDeviceStatus" messagetype="response">
       <param name="deviceStatus" type="Common.VehicleDataResult" mandatory="true">
@@ -3909,9 +3811,6 @@
       </param>
     </function>
     <function name="SubscribeDriverBraking" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeDriverBraking" messagetype="response">
       <param name="driverBraking" type="Common.VehicleDataResult" mandatory="true">
@@ -3919,9 +3818,6 @@
       </param>
     </function>
     <function name="UnsubscribeDriverBraking" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeDriverBraking" messagetype="response">
       <param name="driverBraking" type="Common.VehicleDataResult" mandatory="true">
@@ -3929,9 +3825,6 @@
       </param>
     </function>
     <function name="SubscribeWiperStatus" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeWiperStatus" messagetype="response">
       <param name="wiperStatus" type="Common.VehicleDataResult" mandatory="true">
@@ -3939,9 +3832,6 @@
       </param>
     </function>
     <function name="UnsubscribeWiperStatus" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeWiperStatus" messagetype="response">
       <param name="wiperStatus" type="Common.VehicleDataResult" mandatory="true">
@@ -3949,9 +3839,6 @@
       </param>
     </function>
     <function name="SubscribeHeadLampStatus" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeHeadLampStatus" messagetype="response">
       <param name="headLampStatus" type="Common.VehicleDataResult" mandatory="true">
@@ -3959,9 +3846,6 @@
       </param>
     </function>
     <function name="UnsubscribeHeadLampStatus" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeHeadLampStatus" messagetype="response">
       <param name="headLampStatus" type="Common.VehicleDataResult" mandatory="true">
@@ -3969,9 +3853,6 @@
       </param>
     </function>
     <function name="SubscribeEngineTorque" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeEngineTorque" messagetype="response">
       <param name="engineTorque" type="Common.VehicleDataResult" mandatory="true">
@@ -3979,9 +3860,6 @@
       </param>
     </function>
     <function name="UnsubscribeEngineTorque" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeEngineTorque" messagetype="response">
       <param name="engineTorque" type="Common.VehicleDataResult" mandatory="true">
@@ -3989,9 +3867,6 @@
       </param>
     </function>
     <function name="SubscribeAccPedalPosition" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeAccPedalPosition" messagetype="response">
       <param name="accPedalPosition" type="Common.VehicleDataResult" mandatory="true">
@@ -3999,9 +3874,6 @@
       </param>
     </function>
     <function name="UnsubscribeAccPedalPosition" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeAccPedalPosition" messagetype="response">
       <param name="accPedalPosition" type="Common.VehicleDataResult" mandatory="true">
@@ -4009,9 +3881,6 @@
       </param>
     </function>
     <function name="SubscribeSteeringWheelAngle" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeSteeringWheelAngle" messagetype="response">
       <param name="steeringWheelAngle" type="Common.VehicleDataResult" mandatory="true">
@@ -4019,9 +3888,6 @@
       </param>
     </function>
     <function name="UnsubscribeSteeringWheelAngle" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeSteeringWheelAngle" messagetype="response">
       <param name="steeringWheelAngle" type="Common.VehicleDataResult" mandatory="true">
@@ -4029,9 +3895,6 @@
       </param>
     </function>
     <function name="SubscribeECallInfo" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeECallInfo" messagetype="response">
       <param name="eCallInfo" type="Common.VehicleDataResult" mandatory="true">
@@ -4039,9 +3902,6 @@
       </param>
     </function>
     <function name="UnsubscribeECallInfo" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeECallInfo" messagetype="response">
       <param name="eCallInfo" type="Common.VehicleDataResult" mandatory="true">
@@ -4049,9 +3909,6 @@
       </param>
     </function>
     <function name="SubscribeAirbagStatus" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeAirbagStatus" messagetype="response">
       <param name="airbagStatus" type="Common.VehicleDataResult" mandatory="true">
@@ -4059,9 +3916,6 @@
       </param>
     </function>
     <function name="UnsubscribeAirbagStatus" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeAirbagStatus" messagetype="response">
       <param name="airbagStatus" type="Common.VehicleDataResult" mandatory="true">
@@ -4069,9 +3923,6 @@
       </param>
     </function>
     <function name="SubscribeEmergencyEvent" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeEmergencyEvent" messagetype="response">
       <param name="emergencyEvent" type="Common.VehicleDataResult" mandatory="true">
@@ -4079,9 +3930,6 @@
       </param>
     </function>
     <function name="UnsubscribeEmergencyEvent" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeEmergencyEvent" messagetype="response">
       <param name="emergencyEvent" type="Common.VehicleDataResult" mandatory="true">
@@ -4089,9 +3937,6 @@
       </param>
     </function>
     <function name="SubscribeClusterModeStatus" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeClusterModeStatus" messagetype="response">
       <param name="clusterModeStatus" type="Common.VehicleDataResult" mandatory="true">
@@ -4099,9 +3944,6 @@
       </param>
     </function>
     <function name="UnsubscribeClusterModeStatus" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeClusterModeStatus" messagetype="response">
       <param name="clusterModeStatus" type="Common.VehicleDataResult" mandatory="true">
@@ -4109,9 +3951,6 @@
       </param>
     </function>
     <function name="SubscribeMyKey" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="SubscribeMyKey" messagetype="response">
       <param name="myKey" type="Common.VehicleDataResult" mandatory="true">
@@ -4119,9 +3958,6 @@
       </param>
     </function>
     <function name="UnsubscribeMyKey" messagetype="request" provider="hmi">
-      <param name="appID" type="Integer" mandatory="true">
-        <description>ID of application requested this RPC.</description>
-      </param>
     </function>
     <function name="UnsubscribeMyKey" messagetype="response">
       <param name="myKey" type="Common.VehicleDataResult" mandatory="true">


### PR DESCRIPTION
'appID' parameter had been removed from Un/Subscribe requests for HMI API.
Logic of requests had been changed: un/subscribe request is sent only if
there are no apps subscribed for required parameters.

Implements: APPLINK-13345

Requirements to SDL:

1. In case app_2 sends SubscribeVehicleData (param_1, param_2) to SDL AND SDL has successfully already subscribed param_1 and param_2 via SubscribeVehicleData to app_1 SDL must:
1.1. must NOT send SubscribeVehicleData(param_1, param_2) to HMI.
1.2. respond via SubscribeVehicleData (SUCCESS) to app_2

2. In case app_1 sends SubscribeVehicleData (param_1) to SDL AND SDL does not have this param_1 in list of stored successfully subscribing params SDL must:
2.1. transfer SubscribeVehicleData(param_1) to HMI.
2.2. respond corresponding results received from HMI to app_2:
2.2.1. in case SDL receives SUCCESS for param_1 SDL must store this param in list AND respond SubscribeVehicleData (SUCCESS) to app_2
2.2.2. in case SDL receives erroneous result for param_1 SDL must NOT store this param in list AND respond SubscribeVehicleData (Result Code, success:false) to app_2

3. In case app_2 sends SubscribeVehicleData (param_1, param_3) to SDL AND SDL already subscribes param_1 via SubscribeVehicleData to app_1 SDL must send SubscribeVehicleData ONLY with param_3 to HMI.

4. In case SDL successfully subscribes param_1 for app_1 and app_2 via SubscribeVehicleData AND app_1 sends UnsubscribeVehicleData (param_1) SDL must:
4.1. respond via UnsubscribeVehicleData(SUCCESS) to app_1
4.2. stop sending OnVehicleData (param_1) ONLY to app_1
(meaning: does not send UnsubscribeVehicleData(param_1) to HMI while there are others app still subscribed on param_1)

HMI_API changes:
1. <appID> param must be removed from SubscribeVehicleData

    <function name="SubscribeVehicleData" messagetype="request">
    <description>
    Subscribes for specific published data items.
    The data will be only sent if it has changed.
    The application will be notified by the onVehicleData notification whenever new data is available.
    To unsubscribe the notifications, use unsubscribe with the same subscriptionType.
    </description>
    <param name="appID" type="Integer" mandatory="true">
    <description>ID of application that requested this RPC.</description>
    </param>
    <param name="gps" type="Boolean" mandatory="false">
    <description>See GPSData</description>
    </param>
    <param name="speed" type="Boolean" mandatory="false">
    <description>The vehicle speed in kilometers per hour</description>
    </param>

2. <appID> param must be removed from UnsubscribeVehicleData

    <function name="UnsubscribeVehicleData" messagetype="request">
    <description>
    This function is used to unsubscribe the notifications from the subscribeVehicleData function.
    </description>
    <param name="appID" type="Integer" mandatory="true">
    <description>ID of application that requested this RPC.</description>
    </param>
    <param name="gps" type="Boolean" mandatory="false">
    <description>See GPSData</description>
    </param>
    <param name="speed" type="Boolean" mandatory="false">
    <description>The vehicle speed in kilometers per hour</description>
    </param>