### PR TITLE
Removed explicit HMI level check within several commands.

### DIFF
--- a/src/components/application_manager/src/commands/hmi/on_driver_distraction_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_driver_distraction_notification.cc
@@ -81,11 +81,9 @@ void OnDriverDistractionNotification::Run() {
   for (; applications.end() != it; ++it) {
     const ApplicationSharedPtr app = *it;
     if (app) {
-      if (mobile_apis::HMILevel::eType::HMI_NONE != app->hmi_level()) {
-          (*on_driver_distraction)[strings::params]
-                                  [strings::connection_key] = app->app_id();
-          SendNotificationToMobile(on_driver_distraction);
-      }
+      (*on_driver_distraction)[strings::params]
+                              [strings::connection_key] = app->app_id();
+      SendNotificationToMobile(on_driver_distraction);
     }
   }
 }

--- a/src/components/application_manager/src/commands/mobile/get_dtcs_request.cc
+++ b/src/components/application_manager/src/commands/mobile/get_dtcs_request.cc
@@ -59,12 +59,6 @@ void GetDTCsRequest::Run() {
     return;
   }
 
-  if (mobile_api::HMILevel::HMI_NONE == app->hmi_level()) {
-    LOG4CXX_ERROR(logger_, "App has not been activated");
-    SendResponse(false, mobile_apis::Result::REJECTED);
-    return;
-  }
-
   smart_objects::SmartObject msg_params = smart_objects::SmartObject(
       smart_objects::SmartType_Map);
 

--- a/src/components/application_manager/src/commands/mobile/get_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/get_vehicle_data_request.cc
@@ -65,12 +65,6 @@ void GetVehicleDataRequest::Run() {
     return;
   }
 
-  if (mobile_api::HMILevel::HMI_NONE == app->hmi_level()) {
-    LOG4CXX_ERROR(logger_, "app in HMI level HMI_NONE");
-    SendResponse(false, mobile_apis::Result::REJECTED);
-    return;
-  }
-
   const VehicleData& vehicle_data = MessageHelper::vehicle_data();
   VehicleData::const_iterator it = vehicle_data.begin();
 
@@ -181,7 +175,7 @@ void GetVehicleDataRequest::on_event(const event_engine::Event& event) {
       }
       LOG4CXX_TRACE(logger_, "Status from HMI: " << it->status << ", so response status become " << status);
     } else {
-    	any_arg_success = true;
+        any_arg_success = true;
     }
   }
 
@@ -224,16 +218,11 @@ void GetVehicleDataRequest::Run() {
     return;
   }
 
-  if (mobile_api::HMILevel::HMI_NONE == app->hmi_level()) {
-    LOG4CXX_ERROR(logger_, "app in HMI level HMI_NONE.");
-    SendResponse(false, mobile_apis::Result::REJECTED);
-    return;
-  }
   if (app->IsCommandLimitsExceeded(
         static_cast<mobile_apis::FunctionID::eType>(function_id()),
         application_manager::TLimitSource::CONFIG_FILE)) {
     LOG4CXX_ERROR(logger_, "GetVehicleData frequency is too high.");
-    SendResponse(false, mobile_apis::Result::REJECTED);    
+    SendResponse(false, mobile_apis::Result::REJECTED);
     return;
   }
   const VehicleData& vehicle_data = MessageHelper::vehicle_data();

--- a/src/components/application_manager/src/commands/mobile/read_did_request.cc
+++ b/src/components/application_manager/src/commands/mobile/read_did_request.cc
@@ -64,12 +64,6 @@ void ReadDIDRequest::Run() {
     return;
   }
 
-  if (mobile_api::HMILevel::HMI_NONE == app->hmi_level()) {
-    SendResponse(false, mobile_apis::Result::REJECTED);
-    LOG4CXX_ERROR(logger_, "Rejected");
-    return;
-  }
-
   if (app->IsCommandLimitsExceeded(
         static_cast<mobile_apis::FunctionID::eType>(function_id()),
         application_manager::TLimitSource::CONFIG_FILE)) {


### PR DESCRIPTION
Affected commands: GetVehicleData, ReadDID, GetDTC, OnDriverDistraction

Policy table will regulate if request is allowed to run in certain HMI
level instead of explicit check.

Closes-bug: APPLINK-13894, APPLINK-14187