### PR TITLE
Avoid PROTOCOL_VIOLATION during streaming process

### DIFF
--- a/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
@@ -55,8 +55,10 @@ void RegisterAppInterfaceResponse::Run() {
       last_message = false;
     }
   }
-
+ 
   SendResponse(success, result_code, last_message);
+
+  if (mobile_apis::Result::SUCCESS != result_code) { return; }
 
   // Add registered application to the policy db right after response sent to
   // mobile to be able to check all other API according to app permissions


### PR DESCRIPTION
In case the application has been registered and
user tries to register the application with the same app id
SDL will respond with `APPLICATION_ALREADY_REGISTERED` to mobile.
In this case SDL should return immediately after response.
Currently SDL doesn't return and instead moves the application into
default HMI level which leads to switch application's level from `FULL`
to `BACKGROUND` one. Such behaviour causes `PROTOCOL_VIOLATION` and further
unregistration of the application since it tries to stream from
`BACKGROUND` which is forbidden by requirements.

Affects: `RegisterAppInterfaceResponse`
Closes-Bug: `APPLINK-14598`