### PR TITLE
Add Telnet logging

### DIFF
--- a/src/appMain/log4cxx.properties
+++ b/src/appMain/log4cxx.properties
@@ -3,6 +3,14 @@ log4j.appender.SmartDeviceLinkCoreSocketHub=org.apache.log4j.net.SocketHubAppend
 log4j.appender.SmartDeviceLinkCoreSocketHub.port=4555
 log4j.appender.SmartDeviceLinkCoreSocketHub.locationInfo=true
 
+# Logging via telnet
+log4j.appender.TelnetLogging=org.apache.log4j.TelnetAppender
+log4j.appender.TelnetLogging.port=6676
+log4j.appender.TelnetLogging.layout=org.apache.log4j.PatternLayout
+log4j.appender.TelnetLogging.layout.ConversionPattern=%-5p [%d{dd MMM yyyy HH:mm:ss,SSS}][%t][%c] %F:%L %M: %m%n
+
+
+
 # Only ERROR and FATAL messages are logged to console
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.ImmediateFlush=true
@@ -56,7 +64,7 @@ log4j.appender.ProtocolFordHandlingLogFile.layout=org.apache.log4j.PatternLayout
 log4j.appender.ProtocolFordHandlingLogFile.layout.ConversionPattern=%-5p [%d{dd MMM yyyy HH:mm:ss,SSS}][%c] %M: %m%n
 
 # All SmartDeviceLinkCore logs
-log4j.rootLogger=ALL, Console, SmartDeviceLinkCoreLogFile, SmartDeviceLinkCoreSocketHub
+log4j.rootLogger=ALL, Console, SmartDeviceLinkCoreLogFile, SmartDeviceLinkCoreSocketHub, TelnetLogging
 
 # TransportManager logs
 log4j.logger.TransportManager=ALL, TransportManagerLogFile


### PR DESCRIPTION
netcat can't collect logs via SocketHub or socket because of specific
log4cxx binary format of logs

Add to log4cxx.properties logging via telnet to collect
this logs with netcat or telnet in raw text format

Related Issues: APPLINK-14183