### PR TITLE
Adds API support of new languages

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -184,6 +184,21 @@
      <element name="NO-NO" internal_name="NO_NO">
       <description>Norwegian - Norway</description>
     </element>
+    <element name="NL-BE" internal_name="NL_BE">
+      <description>Dutch (Flemish) - Belgium</description>
+    </element>
+    <element name="EL-GR" internal_name="EL_GR">
+      <description>Greek - Greece</description>
+    </element>
+    <element name="HU-HU" internal_name="HU_HU">
+      <description>Hungarian - Hungary</description>
+    </element>
+    <element name="FI-FI" internal_name="FI_FI">
+      <description>Finnish - Finland</description>
+    </element>
+    <element name="SK-SK" internal_name="SK_SK">
+      <description>Slovak - Slovakia</description>
+    </element>
 </enum>
 
 <enum name="SoftButtonType">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -231,6 +231,21 @@
      <element name="NO-NO" internal_name="NO_NO">
       <description>Norwegian - Norway</description>
      </element>
+     <element name="NL-BE" internal_name="NL_BE">
+      <description>Dutch (Flemish) - Belgium</description>
+     </element>
+     <element name="EL-GR" internal_name="EL_GR">
+      <description>Greek - Greece</description>
+     </element>
+     <element name="HU-HU" internal_name="HU_HU">
+      <description>Hungarian - Hungary</description>
+     </element>
+     <element name="FI-FI" internal_name="FI_FI">
+      <description>Finnish - Finland</description>
+     </element>
+     <element name="SK-SK" internal_name="SK_SK">
+      <description>Slovak - Slovakia</description>
+     </element>
 </enum>
 
   <enum name="UpdateMode">

--- a/src/components/interfaces/QT_HMI_API.xml
+++ b/src/components/interfaces/QT_HMI_API.xml
@@ -176,6 +176,21 @@
       <element name="NO-NO" internal_name="NO_NO">
         <description>Norwegian - Norway</description>
       </element>
+      <element name="NL-BE" internal_name="NL_BE">
+        <description>Dutch (Flemish) - Belgium</description>
+      </element>
+      <element name="EL-GR" internal_name="EL_GR">
+        <description>Greek - Greece</description>
+      </element>
+      <element name="HU-HU" internal_name="HU_HU">
+        <description>Hungarian - Hungary</description>
+      </element>
+      <element name="FI-FI" internal_name="FI_FI">
+        <description>Finnish - Finland</description>
+      </element>
+      <element name="SK-SK" internal_name="SK_SK">
+        <description>Slovak - Slovakia</description>
+      </element>
     </enum>
     <enum name="SoftButtonType">
       <description>Contains information about the SoftButton capabilities.</description>


### PR DESCRIPTION
Five new languages had been added to MOBILE and HMI APIs

Implements: APPLINK-13745

Conflicts:
	src/components/interfaces/MOBILE_API.xml


Current Languges Supported By SDL:
Element Name 	Value 	Short Description
AR-SA 	0 	Arabic – Saudi Arabia
CS-CZ 	1 	Czech – Czech Republic
DA-DK 	2 	Danish – Denmark
DE-DE 	3 	German – Germany
EN-AU 	4 	English – Australia
EN-GB 	5 	English – GB
EN-US 	6 	English – US
ES-ES 	7 	Spanish – Spain
ES-MX 	8 	Spanish – Mexico
FR-CA 	9 	French – Canada
FR-FR 	10 	French – France
IT-IT 	11 	Italian – Italy
JA-JP 	12 	Japanese – Japan
KO-KR 	13 	Korean – South Korea
NL-NL 	14 	Dutch (Standard) – Netherlands
NO-NO 	15 	Norwegian - Norway
PL-PL 	16 	Polish – Poland
PT-PT 	17 	Portuguese – Portugal
PT-BR 	18 	Portuguese – Brazil
RU-RU 	19 	Russian - Russia
SV-SE 	20 	Swedish – Sweden
TR-TR 	21 	Turkish – Turkey
ZH-CN 	22 	Mandarin – China
ZH-TW 	23 	Mandarin – Taiwan

Apart from above mentioned languages, SYNC also supports additional languages listed below:
Flemish
Greek
Hungarian
Finnish
Slovak

This means the API needs to be expanded to include:
NL-BE 	24 	Dutch Belgium (Flemish)
EL-GR 	25 	Greek
HU-HU 	26 	Hungarian
FI-FI 	27 	Finnish
SK-SK 	28 	Slovak

The Language enumeration in the Mobile API needs to be expanded as follows:
Mobile API - Language enum

     <element name="NL-BE" internal_name="NL_BE">
      <description>Dutch (Flemish) - Belgium</description>
     </element>
     <element name="EL-GR" internal_name="EL_GR">
      <description>Greek - Greece</description>
     </element>
     <element name="HU-HU" internal_name="HU_HU">
      <description>Hungarian - Hungary</description>
     </element>
     <element name="FI-FI" internal_name="FI_FI">
      <description>Finnish - Finland</description>
     </element>
     <element name="SK-SK" internal_name="SK_SK">
      <description>Slovak - Slovakia</description>
     </element>

__________________________________________________________
Requirements to SDL:

Non-functional requirements: NL-BE, EL-GR, HU-HU, FI-FI, SK-SK languages codes must be added to HMI_API and Mobile_API
Functional requirements:: no changes (meaning: SDL must return these new languages codes in all responses which use "Language" enum)

HMI_API changes:
1. NL-BE, EL-GR, HU-HU, FI-FI, SK-SK must be added to "Language" enum

    <enum name="Language">
    <element name="EN-US" internal_name="EN_US">
    <description>English - US</description>
    </element>
    .................
    <element name="NO-NO" internal_name="NO_NO">
    <description>Norwegian - Norway</description>
    </element>
    <element name="NL-BE" internal_name="NL_BE">
    <description>Dutch (Flemish) - Belgium</description>
    </element>
    <element name="EL-GR" internal_name="EL_GR">
    <description>Greek - Greece</description>
    </element>
    <element name="HU-HU" internal_name="HU_HU">
    <description>Hungarian - Hungary</description>
    </element>
    <element name="FI-FI" internal_name="FI_FI">
    <description>Finnish - Finland</description>
    </element>
    <element name="SK-SK" internal_name="SK_SK">
    <description>Slovak - Slovakia</description>
    </element>
    </enum>

Mobile_API changes:
1. NL-BE, EL-GR, HU-HU, FI-FI, SK-SK must be added to "Language" enum

    <enum name="Language">
    <element name="EN-US" internal_name="EN_US">
    <description>English - US</description>
    </element>
    .................
    <element name="NO-NO" internal_name="NO_NO">
    <description>Norwegian - Norway</description>
    </element>
    <element name="NL-BE" internal_name="NL_BE">
    <description>Dutch (Flemish) - Belgium</description>
    </element>
    <element name="EL-GR" internal_name="EL_GR">
    <description>Greek - Greece</description>
    </element>
    <element name="HU-HU" internal_name="HU_HU">
    <description>Hungarian - Hungary</description>
    </element>
    <element name="FI-FI" internal_name="FI_FI">
    <description>Finnish - Finland</description>
    </element>
    <element name="SK-SK" internal_name="SK_SK">
    <description>Slovak - Slovakia</description>
    </element>
    </enum>