### PR TITLE
Add flags to enable/disable HMI policy table decryption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ option(ENABLE_LOG "Logging feature" ON)
 option(ENABLE_GCOV "gcov code coverage feature" OFF)
 option(ENABLE_SANITIZE "Sanitize tool" OFF)
 option(ENABLE_SECURITY "Security Ford protocol protection" ON)
-option(ENABLE_HMI_PTU_DECRYPTION "Policy table update parsed by hmi" OFF)
+option(ENABLE_HMI_PTU_DECRYPTION "Policy table update parsed by hmi" ON)
 
 set(OS_TYPE_OPTION 	"$ENV{OS_TYPE}")
 set(DEBUG_OPTION 	"$ENV{DEBUG}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(ENABLE_LOG "Logging feature" ON)
 option(ENABLE_GCOV "gcov code coverage feature" OFF)
 option(ENABLE_SANITIZE "Sanitize tool" OFF)
 option(ENABLE_SECURITY "Security Ford protocol protection" ON)
+option(ENABLE_HMI_PTU_DECRYPTION "Policy table update parsed by hmi" OFF)
 
 set(OS_TYPE_OPTION 	"$ENV{OS_TYPE}")
 set(DEBUG_OPTION 	"$ENV{DEBUG}")
@@ -237,6 +238,7 @@ find_package(PkgConfig)
 pkg_check_modules(GLIB2 REQUIRED glib-2.0)
 add_definitions(${GLIB2_CFLAGS})
 endif()
+
 
 # --- Interface generator
 
@@ -616,6 +618,11 @@ if(ENABLE_SECURITY)
   set(SecurityManagerLibrary SecurityManager)
   set(SecurityManagerIncludeDir ${COMPONENTS_DIR}/security_manager/include)
   #set(SecurityManagerTestIncludeDir ${CMAKE_SOURCE_DIR}/test/components/security_manager/include)
+endif()
+
+if(ENABLE_HMI_PTU_DECRYPTION)
+  MESSAGE("USE DHMI_PTU_PARSER")
+  add_definitions(-DUSE_HMI_PTU_DECRYPTION)
 endif()
 
 set(RTLIB rt)

--- a/src/components/policy/src/policy/include/policy/policy_manager_impl.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager_impl.h
@@ -172,8 +172,13 @@ class PolicyManagerImpl : public PolicyManager {
     virtual const std::vector<std::string> GetAppRequestTypes(
       const std::string policy_app_id) const;
   protected:
+    #ifdef USE_HMI_PTU_DECRYPTION
     virtual utils::SharedPtr<policy_table::Table> Parse(
         const BinaryMessage& pt_content);
+    #else
+    virtual utils::SharedPtr<policy_table::Table> ParseArray(
+        const BinaryMessage& pt_content);
+    #endif
 
   private:
     void CheckTriggers();

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -72,12 +72,12 @@ void PolicyManagerImpl::set_listener(PolicyListener* listener) {
 #ifdef USE_HMI_PTU_DECRYPTION
 
 utils::SharedPtr<policy_table::Table> PolicyManagerImpl::Parse(
-  const BinaryMessage& pt_content) {
+    const BinaryMessage& pt_content) {
   std::string json(pt_content.begin(), pt_content.end());
   Json::Value value;
   Json::Reader reader;
   if (reader.parse(json.c_str(), value)) {
-      return new policy_table::Table(&value);
+    return new policy_table::Table(&value);
   } else {
     return utils::SharedPtr<policy_table::Table>();
   } 
@@ -86,18 +86,17 @@ utils::SharedPtr<policy_table::Table> PolicyManagerImpl::Parse(
 #else
 
 utils::SharedPtr<policy_table::Table> PolicyManagerImpl::ParseArray(
-  const BinaryMessage& pt_content) {
+    const BinaryMessage& pt_content) {
   std::string json(pt_content.begin(), pt_content.end());
   Json::Value value;
   Json::Reader reader;
   if (reader.parse(json.c_str(), value)) {
     //For PT Update received from SDL Server.
-    if(value["data"].size()!=0){
-    Json::Value data = value["data"];
-    //First Element in 
-    return new policy_table::Table(&data[0]);
-    }
-    else {
+    if (value["data"].size()!=0) {
+      Json::Value data = value["data"];
+      //First Element in 
+      return new policy_table::Table(&data[0]);
+    } else {
       return new policy_table::Table(&value);
     }
   } else {

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -75,7 +75,15 @@ utils::SharedPtr<policy_table::Table> PolicyManagerImpl::Parse(
   Json::Value value;
   Json::Reader reader;
   if (reader.parse(json.c_str(), value)) {
-    return new policy_table::Table(&value);
+    //For PT Update received from SDL Server.
+    if(value["data"].size()!=0){
+    Json::Value data = value["data"];
+    //First Element in 
+    return new policy_table::Table(&data[0]);
+    }
+    else {
+      return new policy_table::Table(&value);
+    }
   } else {
     return utils::SharedPtr<policy_table::Table>();
   }


### PR DESCRIPTION
This pull request solves the policy table update issue addressed in issue #166 .

Added option for Policy Table to be parsed by SDL Core as an Array object form SDL Server, or the option for the HMI to do the "decryption" if an encrypted string is passed from SDL Server.

The #ifdef USE_HMI_PTU_DECRYPTION is set by the CMAKE option ENABLE_HMI_PTU_DECRYPTION in the top level cmakelists.txt file. When this option is set to "ON", the HMI will have to decode the policy table update (which is not implemented in the current web hmi). When this option is set to "OFF", Core will be expecting an array from sdl server with the policy table update located in the first element of the "data" array.