### PR TITLE
Proper handling of functional groups with same 'user_consent_prompt'

### DIFF
--- a/src/components/policy/src/policy/src/sql_pt_queries.cc
+++ b/src/components/policy/src/policy/src/sql_pt_queries.cc
@@ -78,7 +78,7 @@ const std::string kCreateSchema =
   "); "
   "CREATE TABLE IF NOT EXISTS `functional_group`( "
   "  `id` INTEGER PRIMARY KEY NOT NULL, "
-  "  `user_consent_prompt` TEXT UNIQUE ON CONFLICT REPLACE, "
+  "  `user_consent_prompt` TEXT, "
   "  `name` VARCHAR(100) NOT NULL "
   "); "
   "CREATE TABLE IF NOT EXISTS `priority`( "


### PR DESCRIPTION
In case preloaded/PTU will contain functional groups with same
'user_consent_prompt' policy will properly store this information in the
DB.

Implements: APPLINK-14654