### PR TITLE
Fixes setting device consent on data consent

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -260,10 +260,27 @@ class MessageHelper {
     static std::string GetDeviceMacAddressForHandle(
       const uint32_t device_handle);
 
+    /**
+     * @brief GetDeviceHandleForMac allows to obtain device handle by device mac
+     *
+     * @param device_mac devices mac address.
+     *
+     * @return device handle if appropriate devcice exists, 0 otherwise.
+     */
+    static uint32_t GetDeviceHandleForMac(const std::string& device_mac);
+
     static void GetDeviceInfoForHandle(const uint32_t device_handle,
                                        policy::DeviceParams* device_info);
     static void GetDeviceInfoForApp(uint32_t connection_key,
                                     policy::DeviceParams* device_info);
+
+    /**
+     * @brief GetConnectedDevicesMAC allows to obtain MAC adresses for all
+     * currently connected devices.
+     *
+     * @param device_macs collection of MAC adresses for connected devices.
+     */
+    static void GetConnectedDevicesMAC(std::vector<std::string>& device_macs);
 
     /**
     * @brief Send SDL_ActivateApp response to HMI

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -139,11 +139,11 @@ class PolicyHandler :
 
   /**
    * @brief Process user consent on mobile data connection access
-   * @param Device id or 0, if concern to all SDL functionality
+   * @param Device id or empty string, if concern to all SDL functionality
    * @param User consent from response
    */
   void OnAllowSDLFunctionalityNotification(bool is_allowed,
-                                           uint32_t device_id = 0);
+                                           const std::string& device_id);
 
   /**
    * @brief Increment counter for ignition cycles

--- a/src/components/application_manager/src/commands/hmi/on_allow_sdl_functionality_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_allow_sdl_functionality_notification.cc
@@ -47,9 +47,9 @@ OnAllowSDLFunctionalityNotification::~OnAllowSDLFunctionalityNotification() {
 
 void OnAllowSDLFunctionalityNotification::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
-  uint32_t device_id = 0;
+  std::string device_id;
   if ((*message_)[strings::msg_params].keyExists("device")) {
-    device_id = (*message_)[strings::msg_params]["device"]["id"].asUInt();
+    device_id = (*message_)[strings::msg_params]["device"]["id"].asString();
   }
   policy::PolicyHandler::instance()->OnAllowSDLFunctionalityNotification(
       (*message_)[strings::msg_params][hmi_response::allowed].asBool(),

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -1493,6 +1493,13 @@ std::string MessageHelper::GetDeviceMacAddressForHandle(
   return device_mac_address;
 }
 
+uint32_t MessageHelper::GetDeviceHandleForMac(const std::string& device_mac) {
+  uint32_t device_id(0);
+  connection_handler::ConnectionHandlerImpl::instance()->GetDeviceID(
+      device_mac, &device_id);
+  return device_id;
+}
+
 void MessageHelper::GetDeviceInfoForHandle(const uint32_t device_handle,
     policy::DeviceParams* device_info) {
   if (!device_info) {
@@ -1513,6 +1520,12 @@ void MessageHelper::GetDeviceInfoForApp(uint32_t connection_key,
                                  connection_key)->device();
 
   GetDeviceInfoForHandle(device_info->device_handle, device_info);
+}
+
+void MessageHelper::GetConnectedDevicesMAC(
+    std::vector<std::string>& device_macs) {
+  connection_handler::ConnectionHandlerImpl::instance()->GetConnectedDevicesMAC(
+      device_macs);
 }
 
 void MessageHelper::SendSDLActivateAppResponse(policy::AppPermissions& permissions,

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -677,7 +677,7 @@ void PolicyHandler::OnPendingPermissionChange(
       app_id, permissions);
     ApplicationManagerImpl::instance()->SetState<true>(app->app_id(),
                                                  mobile_apis::HMILevel::HMI_NONE,
-                                                 mobile_apis::AudioStreamingState::NOT_AUDIBLE);    
+                                                 mobile_apis::AudioStreamingState::NOT_AUDIBLE);
     policy_manager_->RemovePendingPermissionChanges(policy_app_id);
     return;
   }
@@ -817,55 +817,42 @@ bool PolicyHandler::UnloadPolicyLibrary() {
   return ret;
 }
 
-void PolicyHandler::OnAllowSDLFunctionalityNotification(bool is_allowed,
-    uint32_t device_id) {
+void PolicyHandler::OnAllowSDLFunctionalityNotification(
+    bool is_allowed,
+    const std::string& device_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK_VOID();
   // Device ids, need to be changed
-  std::set<uint32_t> device_ids;
-  bool device_specific = device_id != 0;
+  std::vector<std::string> device_macs;
+  const bool device_specific = !device_id.empty();
   // Common devices consents change
   if (!device_specific) {
-    ApplicationManagerImpl::ApplicationListAccessor accessor;
-    const ApplicationManagerImpl::ApplictionSet app_list = accessor.applications();
-
-    ApplicationManagerImpl::ApplictionSetConstIt it_app_list = app_list.begin();
-    ApplicationManagerImpl::ApplictionSetConstIt it_app_end = app_list.end();
-
-    for (;it_app_list != it_app_end; ++it_app_list) {
-      if (!(*it_app_list).valid()) {
-        continue;
-      }
-      device_ids.insert(it_app_list->get()->device());
-    }
+    MessageHelper::GetConnectedDevicesMAC(device_macs);
   } else {
-    device_ids.insert(device_id);
+    device_macs.push_back(device_id);
   }
 
-  std::set<uint32_t>::const_iterator it_ids = device_ids.begin();
-  std::set<uint32_t>::const_iterator it_ids_end = device_ids.end();
+  std::vector<std::string>::const_iterator it_ids = device_macs.begin();
+  std::vector<std::string>::const_iterator it_ids_end = device_macs.end();
   for (;it_ids != it_ids_end; ++it_ids) {
-    const uint32_t device_id = *it_ids;
+    const std::string device_id = *it_ids;
 
-    DeviceParams device_params;
-    MessageHelper::GetDeviceInfoForHandle(device_id,
-        &device_params);
-    device_params.device_handle = device_id;
-    if (kDefaultDeviceMacAddress == device_params.device_mac_address) {
-      LOG4CXX_WARN(logger_, "Device with handle " << device_id
+     if (kDefaultDeviceMacAddress == device_id) {
+      LOG4CXX_WARN(logger_, "Device with id " << device_id
                    << " wasn't found.");
       return;
     }
-    policy_manager_->SetUserConsentForDevice(device_params.device_mac_address,
-        is_allowed);
+    policy_manager_->SetUserConsentForDevice(device_id, is_allowed);
 
   }
 
   // Case, when specific device was changed
-  if (device_id) {
-    DeviceHandles::iterator it = std::find(pending_device_handles_.begin(),
-                                           pending_device_handles_.end(),
-                                           device_id);
+  if (device_specific) {
+    const uint32_t device_handle =
+        MessageHelper::GetDeviceHandleForMac(device_id);
+    DeviceHandles::iterator it =
+        std::find(pending_device_handles_.begin(),
+                  pending_device_handles_.end(), device_handle);
     // If consent done from HMI menu
     if (it == pending_device_handles_.end()) {
       return;

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -250,6 +250,15 @@ class ConnectionHandlerImpl : public ConnectionHandler,
                                     std::list<uint32_t> *applications_list = NULL,
                                     std::string *mac_address = NULL,
                                     std::string* connection_type = NULL);
+
+  /**
+   * @brief GetConnectedDevicesMAC allows to obtain MAC adresses for all
+   * currently connected devices.
+   *
+   * @param device_macs collection of MAC adresses for connected devices.
+   */
+  void GetConnectedDevicesMAC(std::vector<std::string> &device_macs) const;
+
 #ifdef ENABLE_SECURITY
   /**
    * \brief Sets crypto context of connection
@@ -402,7 +411,7 @@ class ConnectionHandlerImpl : public ConnectionHandler,
    * @return TRUE if session and connection exist otherwise returns FALSE
    */
   virtual bool ProtocolVersionUsed(uint32_t connection_id,
-  		  uint8_t session_id, uint8_t& protocol_version);
+                  uint8_t session_id, uint8_t& protocol_version);
   private:
   /**
    * \brief Default class constructor

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -591,6 +591,18 @@ int32_t ConnectionHandlerImpl::GetDataOnDeviceID(
 
   return result;
 }
+
+void ConnectionHandlerImpl::GetConnectedDevicesMAC(
+    std::vector<std::string> &device_macs) const {
+  DeviceMap::const_iterator first = device_list_.begin();
+  DeviceMap::const_iterator last = device_list_.end();
+
+  while(first != last) {
+    device_macs.push_back((*first).second.mac_address());
+    ++first;
+  }
+}
+
 #ifdef ENABLE_SECURITY
 int ConnectionHandlerImpl::SetSSLContext(
     const uint32_t &key, security_manager::SSLContext *context) {
@@ -801,7 +813,7 @@ void ConnectionHandlerImpl::CloseSession(ConnectionHandle connection_handle,
             service_list_itr->service_type;
         connection_handler_observer_->OnServiceEndedCallback(session_key,
                                                              service_type,
-							     close_reason);
+                                                             close_reason);
       }
     } else {
       LOG4CXX_ERROR(logger_, "Session with id: " << session_id << " not found");


### PR DESCRIPTION
In case data consent has been granted for particular device only this
device will get data consent and for other data consent should be asked
on app activation.

Fixes: APPLINK-15052

Conflicts:
	src/components/application_manager/src/policies/policy_handler.cc