### PR TITLE
Change DeviceInfo structure and extend TransportType

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -344,7 +344,7 @@ class ApplicationManagerImpl : public ApplicationManager,
      */
     mobile_api::HMILevel::eType IsHmiLevelFullAllowed(ApplicationSharedPtr app);
 
-    void ConnectToDevice(uint32_t id);
+    void ConnectToDevice(const std::string& device_mac);
     void OnHMIStartedCooperation();
 
     /*

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -563,14 +563,20 @@ mobile_api::HMILevel::eType ApplicationManagerImpl::IsHmiLevelFullAllowed(
   return result;
 }
 
-void ApplicationManagerImpl::ConnectToDevice(uint32_t id) {
+void ApplicationManagerImpl::ConnectToDevice(const std::string& device_mac) {
   // TODO(VS): Call function from ConnectionHandler
   if (!connection_handler_) {
     LOG4CXX_WARN(logger_, "Connection handler is not set.");
     return;
   }
 
-  connection_handler_->ConnectToDevice(id);
+  connection_handler::DeviceHandle handle;
+  if (!connection_handler_->GetDeviceID(device_mac, &handle) ) {
+    LOG4CXX_ERROR(logger_, "Attempt to connect to invalid device with mac:"
+                  << device_mac );
+    return;
+  }
+  connection_handler_->ConnectToDevice(handle);
 }
 
 void ApplicationManagerImpl::OnHMIStartedCooperation() {

--- a/src/components/application_manager/src/commands/hmi/on_device_chosen_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_device_chosen_notification.cc
@@ -50,7 +50,7 @@ void OnDeviceChosenNotification::Run() {
   if ((*message_)[strings::msg_params].keyExists(strings::device_info)) {
     ApplicationManagerImpl::instance()->ConnectToDevice(
         (*message_)[strings::msg_params][strings::device_info][strings::id]
-            .asInt());
+            .asString());
   }
 }
 

--- a/src/components/application_manager/src/commands/hmi/on_device_state_changed_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_device_state_changed_notification.cc
@@ -95,8 +95,7 @@ void OnDeviceStateChangedNotification::Run() {
                             .asString();
     if (device_id.empty()) {
       if ((*message_)[strings::msg_params].keyExists("deviceId")) {
-        device_id = MessageHelper::GetDeviceMacAddressForHandle(
-                      (*message_)[strings::msg_params]["deviceId"]["id"].asInt());
+        device_id = (*message_)[strings::msg_params]["deviceId"]["id"].asString();
       }
     } else {
      // Policy uses hashed MAC address as device_id

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -1334,7 +1334,7 @@ bool MessageHelper::CreateHMIApplicationStruct(ApplicationConstSharedPtr app,
 
   output[strings::device_info] = smart_objects::SmartObject(smart_objects::SmartType_Map);
   output[strings::device_info][strings::name] = device_name;
-  output[strings::device_info][strings::id] = app->device();
+  output[strings::device_info][strings::id] = mac_address;
   const policy::DeviceConsent device_consent =
       policy::PolicyHandler::instance()->GetUserConsentForDevice(mac_address);
   output[strings::device_info][strings::isSDLAllowed] =
@@ -1541,7 +1541,7 @@ void MessageHelper::SendSDLActivateAppResponse(policy::AppPermissions& permissio
     (*message)[strings::msg_params]["device"]["name"] = permissions.deviceInfo
         .device_name;
     (*message)[strings::msg_params]["device"]["id"] = permissions.deviceInfo
-        .device_handle;
+        .device_mac_address;
   }
 
   (*message)[strings::msg_params]["isAppRevoked"] = permissions.appRevoked;
@@ -1581,7 +1581,7 @@ void MessageHelper::SendOnSDLConsentNeeded(
   (*message)[strings::params][strings::message_type] =
     MessageType::kNotification;
 
-  (*message)[strings::msg_params]["device"]["id"] = device_info.device_handle;
+  (*message)[strings::msg_params]["device"]["id"] = device_info.device_mac_address;
   (*message)[strings::msg_params]["device"]["name"] = device_info.device_name;
 
   ApplicationManagerImpl::instance()->ManageHMICommand(message);


### PR DESCRIPTION
Now DeviceInfo contains String value instead of Integer for id field
to be able to sent either USB serial number or MAC addres within this field.

Also TransportType structure has been extended and now it contains both
USB_IOS and USB_AOA to distinguish transport type during connection.

Implements: APPLINK-14256, RTC 630168
Related-issues: APPLINK-14258