### PR TITLE
SDL does not apply heart beat timeout in ms

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -314,7 +314,7 @@ class PolicyHandler :
   /**
    * Returns heart beat timeout
    * @param app_id application id
-   * @return if timeout was set then value in seconds greater zero
+   * @return if timeout was set then value in milliseconds greater zero
    * otherwise heart beat for specific application isn't set
    */
   uint16_t HeartBeatTimeout(const std::string& app_id) const;

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -317,7 +317,7 @@ class PolicyHandler :
    * @return if timeout was set then value in milliseconds greater zero
    * otherwise heart beat for specific application isn't set
    */
-  uint16_t HeartBeatTimeout(const std::string& app_id) const;
+  uint32_t HeartBeatTimeout(const std::string& app_id) const;
 
   /**
    * @brief Returns URL for querying list of remote apps

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
@@ -80,7 +80,7 @@ void RegisterAppInterfaceResponse::SetHeartBeatTimeout(
   LOG4CXX_AUTO_TRACE(logger_);
   policy::PolicyHandler *policy_handler = policy::PolicyHandler::instance();
   if (policy_handler->PolicyEnabled()) {
-    const uint32_t timeout = policy_handler->HeartBeatTimeout(policy_app_id);
+    const uint32_t timeout = policy_handler->HeartBeatTimeout(mobile_app_id);
     if (timeout > 0) {
       application_manager::ApplicationManagerImpl::instance()->
           connection_handler()->SetHeartBeatTimeout(connection_key, timeout);

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
@@ -80,7 +80,7 @@ void RegisterAppInterfaceResponse::SetHeartBeatTimeout(
   LOG4CXX_AUTO_TRACE(logger_);
   policy::PolicyHandler *policy_handler = policy::PolicyHandler::instance();
   if (policy_handler->PolicyEnabled()) {
-    const int32_t timeout = policy_handler->HeartBeatTimeout(policy_app_id);
+    const uint32_t timeout = policy_handler->HeartBeatTimeout(policy_app_id);
     if (timeout > 0) {
       application_manager::ApplicationManagerImpl::instance()->
           connection_handler()->SetHeartBeatTimeout(connection_key, timeout);

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
@@ -80,8 +80,7 @@ void RegisterAppInterfaceResponse::SetHeartBeatTimeout(
   LOG4CXX_AUTO_TRACE(logger_);
   policy::PolicyHandler *policy_handler = policy::PolicyHandler::instance();
   if (policy_handler->PolicyEnabled()) {
-    const int32_t timeout = policy_handler->HeartBeatTimeout(mobile_app_id) /
-        date_time::DateTime::MILLISECONDS_IN_SECOND;
+    const int32_t timeout = policy_handler->HeartBeatTimeout(policy_app_id);
     if (timeout > 0) {
       application_manager::ApplicationManagerImpl::instance()->
           connection_handler()->SetHeartBeatTimeout(connection_key, timeout);

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1252,7 +1252,7 @@ bool PolicyHandler::CheckSystemAction(
   return false;
 }
 
-uint16_t PolicyHandler::HeartBeatTimeout(const std::string& app_id) const {
+uint32_t PolicyHandler::HeartBeatTimeout(const std::string& app_id) const {
   POLICY_LIB_CHECK(0);
   return policy_manager_->HeartBeatTimeout(app_id);
 }

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -308,7 +308,7 @@ class Profile : public utils::Singleton<Profile> {
     /*
      * @brief Heartbeat timeout before closing connection
      */
-    int32_t heart_beat_timeout() const;
+    uint32_t heart_beat_timeout() const;
 
     /*
      * @brief Path to preloaded policy file

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -521,7 +521,7 @@ const std::string& Profile::app_info_storage() const {
   return app_info_storage_;
 }
 
-int32_t Profile::heart_beat_timeout() const {
+uint32_t Profile::heart_beat_timeout() const {
   return heart_beat_timeout_;
 }
 

--- a/src/components/connection_handler/include/connection_handler/connection.h
+++ b/src/components/connection_handler/include/connection_handler/connection.h
@@ -242,7 +242,7 @@ class Connection {
 
   /**
    * @brief Sets heart beat timeout
-   * @param timeout in seconds
+   * @param timeout in milliseconds
    */
   void SetHeartBeatTimeout(int32_t timeout, uint8_t session_id);
 

--- a/src/components/connection_handler/include/connection_handler/connection.h
+++ b/src/components/connection_handler/include/connection_handler/connection.h
@@ -129,7 +129,7 @@ class Connection {
   Connection(ConnectionHandle connection_handle,
              DeviceHandle connection_device_handle,
              ConnectionHandler *connection_handler,
-             int32_t heartbeat_timeout);
+             uint32_t heartbeat_timeout);
 
   /**
    * @brief Destructor
@@ -244,7 +244,7 @@ class Connection {
    * @brief Sets heart beat timeout
    * @param timeout in milliseconds
    */
-  void SetHeartBeatTimeout(int32_t timeout, uint8_t session_id);
+  void SetHeartBeatTimeout(uint32_t timeout, uint8_t session_id);
 
   /**
    * @brief changes protocol version in session

--- a/src/components/connection_handler/include/connection_handler/connection_handler.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler.h
@@ -143,7 +143,7 @@ class ConnectionHandler {
   /**
    * Sets heart beat timeout for specified session
    * @param connection_key pair of connection and session id
-   * @param timeout in seconds
+   * @param timeout in milliseconds
    */
   virtual void SetHeartBeatTimeout(uint32_t connection_key,
                                    int32_t timeout) = 0;

--- a/src/components/connection_handler/include/connection_handler/connection_handler.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler.h
@@ -146,7 +146,7 @@ class ConnectionHandler {
    * @param timeout in milliseconds
    */
   virtual void SetHeartBeatTimeout(uint32_t connection_key,
-                                   int32_t timeout) = 0;
+                                   uint32_t timeout) = 0;
 
   /**
    * \brief binds protocol version with session

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -367,7 +367,7 @@ class ConnectionHandlerImpl : public ConnectionHandler,
    * @param connection_key pair of connection and session id
    * @param timeout in milliseconds
    */
-  virtual void SetHeartBeatTimeout(uint32_t connection_key, int32_t timeout);
+  virtual void SetHeartBeatTimeout(uint32_t connection_key, uint32_t timeout);
 
   /**
    * \brief Keep connection associated with the key from being closed by heartbeat monitor

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -365,7 +365,7 @@ class ConnectionHandlerImpl : public ConnectionHandler,
   /**
    * Sets heart beat timeout for specified session
    * @param connection_key pair of connection and session id
-   * @param timeout in seconds
+   * @param timeout in milliseconds
    */
   virtual void SetHeartBeatTimeout(uint32_t connection_key, int32_t timeout);
 

--- a/src/components/connection_handler/include/connection_handler/heartbeat_monitor.h
+++ b/src/components/connection_handler/include/connection_handler/heartbeat_monitor.h
@@ -50,7 +50,7 @@ class Connection;
  */
 class HeartBeatMonitor: public threads::ThreadDelegate {
  public:
-  HeartBeatMonitor(int32_t heartbeat_timeout_mseconds,
+  HeartBeatMonitor(uint32_t heartbeat_timeout_mseconds,
                    Connection *connection);
 
   /**
@@ -79,12 +79,12 @@ class HeartBeatMonitor: public threads::ThreadDelegate {
    * @param session_id contain id session for which update timeout
    * timeout
    **/
-  void set_heartbeat_timeout_milliseconds(int32_t timeout, uint8_t session_id);
+  void set_heartbeat_timeout_milliseconds(uint32_t timeout, uint8_t session_id);
 
  private:
 
   // \brief Heartbeat timeout, should be read from profile
-  int32_t default_heartbeat_timeout_;
+  uint32_t default_heartbeat_timeout_;
   // \brief Connection that must be closed when timeout elapsed
   Connection *connection_;
 
@@ -92,8 +92,8 @@ class HeartBeatMonitor: public threads::ThreadDelegate {
 
   class SessionState {
     public:
-      explicit SessionState(int32_t heartbeat_timeout_mseconds = 0);
-      void UpdateTimeout(int32_t heartbeat_timeout_mseconds);
+      explicit SessionState(uint32_t heartbeat_timeout_mseconds = 0);
+      void UpdateTimeout(uint32_t heartbeat_timeout_mseconds);
       void PrepareToClose();
       bool IsReadyToClose() const;
       void KeepAlive();
@@ -101,7 +101,7 @@ class HeartBeatMonitor: public threads::ThreadDelegate {
     private:
       void RefreshExpiration();
 
-      int32_t heartbeat_timeout_mseconds_;
+      uint32_t heartbeat_timeout_mseconds_;
       TimevalStruct heartbeat_expiration_;
       bool is_heartbeat_sent_;
 

--- a/src/components/connection_handler/include/connection_handler/heartbeat_monitor.h
+++ b/src/components/connection_handler/include/connection_handler/heartbeat_monitor.h
@@ -50,7 +50,7 @@ class Connection;
  */
 class HeartBeatMonitor: public threads::ThreadDelegate {
  public:
-  HeartBeatMonitor(int32_t heartbeat_timeout_seconds,
+  HeartBeatMonitor(int32_t heartbeat_timeout_mseconds,
                    Connection *connection);
 
   /**
@@ -73,8 +73,13 @@ class HeartBeatMonitor: public threads::ThreadDelegate {
    * \brief Thread exit procedure.
    */
   virtual void exitThreadMain();
-
-  void set_heartbeat_timeout_seconds(int32_t timeout, uint8_t session_id);
+  /**
+   * @brief Update heart beat timeout for session
+   * @param timeout contains timeout for updating
+   * @param session_id contain id session for which update timeout
+   * timeout
+   **/
+  void set_heartbeat_timeout_milliseconds(int32_t timeout, uint8_t session_id);
 
  private:
 
@@ -87,8 +92,8 @@ class HeartBeatMonitor: public threads::ThreadDelegate {
 
   class SessionState {
     public:
-      explicit SessionState(int32_t heartbeat_timeout_seconds = 0);
-      void UpdateTimeout(int32_t heartbeat_timeout_seconds);
+      explicit SessionState(int32_t heartbeat_timeout_mseconds = 0);
+      void UpdateTimeout(int32_t heartbeat_timeout_mseconds);
       void PrepareToClose();
       bool IsReadyToClose() const;
       void KeepAlive();
@@ -96,9 +101,9 @@ class HeartBeatMonitor: public threads::ThreadDelegate {
     private:
       void RefreshExpiration();
 
-      int32_t heartbeat_timeout_seconds_;
-      TimevalStruct heartbeat_expiration;
-      bool is_heartbeat_sent;
+      int32_t heartbeat_timeout_mseconds_;
+      TimevalStruct heartbeat_expiration_;
+      bool is_heartbeat_sent_;
 
   };
 

--- a/src/components/connection_handler/src/connection.cc
+++ b/src/components/connection_handler/src/connection.cc
@@ -375,7 +375,7 @@ void Connection::KeepAlive(uint8_t session_id) {
 }
 
 void Connection::SetHeartBeatTimeout(int32_t timeout, uint8_t session_id) {
-  heartbeat_monitor_->set_heartbeat_timeout_seconds(timeout, session_id);
+  heartbeat_monitor_->set_heartbeat_timeout_milliseconds(timeout, session_id);
 }
 
 }  // namespace connection_handler

--- a/src/components/connection_handler/src/connection.cc
+++ b/src/components/connection_handler/src/connection.cc
@@ -76,7 +76,7 @@ const Service *Session::FindService(const protocol_handler::ServiceType &service
 Connection::Connection(ConnectionHandle connection_handle,
                        DeviceHandle connection_device_handle,
                        ConnectionHandler *connection_handler,
-                       int32_t heartbeat_timeout)
+                       uint32_t heartbeat_timeout)
     : connection_handler_(connection_handler),
       connection_handle_(connection_handle),
       connection_device_handle_(connection_device_handle),
@@ -374,7 +374,7 @@ void Connection::KeepAlive(uint8_t session_id) {
   heartbeat_monitor_->KeepAlive(session_id);
 }
 
-void Connection::SetHeartBeatTimeout(int32_t timeout, uint8_t session_id) {
+void Connection::SetHeartBeatTimeout(uint32_t timeout, uint8_t session_id) {
   heartbeat_monitor_->set_heartbeat_timeout_milliseconds(timeout, session_id);
 }
 

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -45,7 +45,7 @@
 #endif  // ENABLE_SECURITY
 
 namespace {
-int32_t HeartBeatTimeout() {
+uint32_t HeartBeatTimeout() {
   return profile::Profile::instance()->heart_beat_timeout();
 }
 }  // namespace
@@ -875,7 +875,7 @@ void ConnectionHandlerImpl::StartSessionHeartBeat(uint32_t connection_key) {
 }
 
 void ConnectionHandlerImpl::SetHeartBeatTimeout(uint32_t connection_key,
-                                                int32_t timeout) {
+                                                uint32_t timeout) {
   uint32_t connection_handle = 0;
   uint8_t session_id = 0;
   PairFromKey(connection_key, &connection_handle, &session_id);

--- a/src/components/connection_handler/src/heartbeat_monitor.cc
+++ b/src/components/connection_handler/src/heartbeat_monitor.cc
@@ -43,9 +43,9 @@ using namespace sync_primitives;
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "HeartBeatMonitor")
 
-HeartBeatMonitor::HeartBeatMonitor(int32_t heartbeat_timeout_seconds,
+HeartBeatMonitor::HeartBeatMonitor(int32_t heartbeat_timeout_mseconds,
                                    Connection *connection)
-    : default_heartbeat_timeout_(heartbeat_timeout_seconds),
+    : default_heartbeat_timeout_(heartbeat_timeout_mseconds),
       connection_(connection),
       sessions_list_lock_(true),
       run_(true) {
@@ -95,8 +95,7 @@ void HeartBeatMonitor::AddSession(uint8_t session_id) {
         "Session with id " << static_cast<int32_t>(session_id) << " already exists");
     return;
   }
-  sessions_.insert(std::make_pair(session_id,
-                                  SessionState(default_heartbeat_timeout_)));
+  sessions_.insert(std::make_pair(session_id, SessionState(default_heartbeat_timeout_)));
   LOG4CXX_INFO(logger_, "Start heartbeat for session " << session_id);
 }
 
@@ -132,7 +131,7 @@ void HeartBeatMonitor::exitThreadMain() {
   AutoLock main_lock(main_thread_lock_);
 }
 
-void HeartBeatMonitor::set_heartbeat_timeout_seconds(int32_t timeout,
+void HeartBeatMonitor::set_heartbeat_timeout_milliseconds(int32_t timeout,
                                                      uint8_t session_id) {
   LOG4CXX_DEBUG(logger_, "Set new heart beat timeout " << timeout <<
                 "For session: " << session_id);
@@ -143,46 +142,51 @@ void HeartBeatMonitor::set_heartbeat_timeout_seconds(int32_t timeout,
   }
 }
 
-HeartBeatMonitor::SessionState::SessionState(int32_t heartbeat_timeout_seconds)
-  : heartbeat_timeout_seconds_(heartbeat_timeout_seconds),
-    is_heartbeat_sent(false) {
+HeartBeatMonitor::SessionState::SessionState(int32_t heartbeat_timeout_mseconds)
+  : heartbeat_timeout_mseconds_(heartbeat_timeout_mseconds),
+    is_heartbeat_sent_(false) {
   LOG4CXX_AUTO_TRACE(logger_);
   RefreshExpiration();
 }
 
-void HeartBeatMonitor::SessionState::RefreshExpiration () {
-  LOG4CXX_DEBUG(logger_, "Refresh expiration: " << heartbeat_timeout_seconds_);
-  heartbeat_expiration = date_time::DateTime::getCurrentTime();
-  heartbeat_expiration.tv_sec += heartbeat_timeout_seconds_;
+void HeartBeatMonitor::SessionState::RefreshExpiration() {
+  LOG4CXX_DEBUG(logger_, "Refresh expiration: " << heartbeat_timeout_mseconds_);
+  using namespace date_time;
+  heartbeat_expiration_ = DateTime::getCurrentTime();
+  uint32_t sec = heartbeat_timeout_mseconds_/DateTime::MILLISECONDS_IN_SECOND;
+  uint32_t usec = (heartbeat_timeout_mseconds_%DateTime::MILLISECONDS_IN_SECOND)*
+      DateTime::MICROSECONDS_IN_MILLISECONDS;
+  heartbeat_expiration_.tv_sec += sec;
+  heartbeat_expiration_.tv_usec += usec;
 }
 
 void HeartBeatMonitor::SessionState::UpdateTimeout(
-    int32_t heartbeat_timeout_seconds) {
+    int32_t heartbeat_timeout_mseconds) {
   LOG4CXX_DEBUG(logger_, "Update timout with value " <<
-                heartbeat_timeout_seconds_);
-  heartbeat_timeout_seconds_ = heartbeat_timeout_seconds;
+                heartbeat_timeout_mseconds_);
+  heartbeat_timeout_mseconds_ = heartbeat_timeout_mseconds;
   RefreshExpiration();
 }
 
 void HeartBeatMonitor::SessionState::PrepareToClose() {
-  is_heartbeat_sent = true;
+  is_heartbeat_sent_ = true;
   LOG4CXX_DEBUG(logger_, "Prepare to close");
   RefreshExpiration();
 }
 
 bool HeartBeatMonitor::SessionState::IsReadyToClose() const {
-  return is_heartbeat_sent;
+  return is_heartbeat_sent_;
 }
 
 void HeartBeatMonitor::SessionState::KeepAlive() {
-  is_heartbeat_sent = false;
+  is_heartbeat_sent_ = false;
   LOG4CXX_DEBUG(logger_, "keep alive");
   RefreshExpiration();
 }
 
 bool HeartBeatMonitor::SessionState::HasTimeoutElapsed() {
   TimevalStruct now = date_time::DateTime::getCurrentTime();
-  return date_time::DateTime::Greater(now, heartbeat_expiration);
+  return date_time::DateTime::Greater(now, heartbeat_expiration_);
 }
 
 }  // namespace connection_handler

--- a/src/components/include/utils/date_time.h
+++ b/src/components/include/utils/date_time.h
@@ -72,7 +72,7 @@ class DateTime {
   /**
    * @brief Adds milliseconds to time struct
    * @param time contains time struct
-   * @param milliseconds contains value wich need to
+   * @param milliseconds contains value which need to
    * add to time struct
    **/
   static void AddMilliseconds(TimevalStruct& time,

--- a/src/components/include/utils/date_time.h
+++ b/src/components/include/utils/date_time.h
@@ -69,6 +69,15 @@ class DateTime {
   static int64_t calculateTimeDiff(const TimevalStruct& time1,
                                    const TimevalStruct& time2);
 
+  /**
+   * @brief Adds milliseconds to time struct
+   * @param time contains time struct
+   * @param milliseconds contains value wich need to
+   * add to time struct
+   **/
+  static void AddMilliseconds(TimevalStruct& time,
+                             uint32_t milliseconds);
+
   static TimevalStruct Sub(const TimevalStruct& time1,
                            const TimevalStruct& time2);
 

--- a/src/components/policy/src/policy/include/policy/cache_manager.h
+++ b/src/components/policy/src/policy/include/policy/cache_manager.h
@@ -558,7 +558,7 @@ class CacheManager : public CacheManagerInterface {
    * @return if timeout was set then value in milliseconds greater zero
    * otherwise heart beat for specific application isn't set
    */
-  uint16_t HeartBeatTimeout(const std::string& app_id) const;
+  uint32_t HeartBeatTimeout(const std::string& app_id) const;
 
   /**
    * @brief Allows to generate hash from the specified string.

--- a/src/components/policy/src/policy/include/policy/cache_manager.h
+++ b/src/components/policy/src/policy/include/policy/cache_manager.h
@@ -555,7 +555,7 @@ class CacheManager : public CacheManagerInterface {
   /**
    * Returns heart beat timeout
    * @param app_id application id
-   * @return if timeout was set then value in seconds greater zero
+   * @return if timeout was set then value in milliseconds greater zero
    * otherwise heart beat for specific application isn't set
    */
   uint16_t HeartBeatTimeout(const std::string& app_id) const;

--- a/src/components/policy/src/policy/include/policy/cache_manager_interface.h
+++ b/src/components/policy/src/policy/include/policy/cache_manager_interface.h
@@ -548,7 +548,7 @@ class CacheManagerInterface {
   /**
    * Returns heart beat timeout
    * @param app_id application id
-   * @return if timeout was set then value in seconds greater zero
+   * @return if timeout was set then value in milliseconds greater zero
    * otherwise heart beat for specific application isn't set
    */
   virtual uint16_t HeartBeatTimeout(const std::string& app_id) const = 0;

--- a/src/components/policy/src/policy/include/policy/cache_manager_interface.h
+++ b/src/components/policy/src/policy/include/policy/cache_manager_interface.h
@@ -551,7 +551,7 @@ class CacheManagerInterface {
    * @return if timeout was set then value in milliseconds greater zero
    * otherwise heart beat for specific application isn't set
    */
-  virtual uint16_t HeartBeatTimeout(const std::string& app_id) const = 0;
+  virtual uint32_t HeartBeatTimeout(const std::string& app_id) const = 0;
 
   /**
    * @brief Resets all calculated permissions in cache

--- a/src/components/policy/src/policy/include/policy/policy_manager.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager.h
@@ -395,7 +395,7 @@ class PolicyManager : public usage_statistics::StatisticsManager {
      * @return if timeout was set then value in milliseconds greater zero
      * otherwise heart beat for specific application isn't set
      */
-    virtual uint16_t HeartBeatTimeout(const std::string& app_id) const = 0;
+    virtual uint32_t HeartBeatTimeout(const std::string& app_id) const = 0;
 
     /**
      * @brief SaveUpdateStatusRequired alows to save update status.

--- a/src/components/policy/src/policy/include/policy/policy_manager.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager.h
@@ -392,7 +392,7 @@ class PolicyManager : public usage_statistics::StatisticsManager {
     /**
      * Returns heart beat timeout
      * @param app_id application id
-     * @return if timeout was set then value in seconds greater zero
+     * @return if timeout was set then value in milliseconds greater zero
      * otherwise heart beat for specific application isn't set
      */
     virtual uint16_t HeartBeatTimeout(const std::string& app_id) const = 0;

--- a/src/components/policy/src/policy/include/policy/policy_manager_impl.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager_impl.h
@@ -161,7 +161,7 @@ class PolicyManagerImpl : public PolicyManager {
     virtual void RemoveAppConsentForGroup(const std::string& app_id,
                                           const std::string& group_name);
 
-    virtual uint16_t HeartBeatTimeout(const std::string& app_id) const;
+    virtual uint32_t HeartBeatTimeout(const std::string& app_id) const;
 
     virtual void SaveUpdateStatusRequired(bool is_update_needed);
 

--- a/src/components/policy/src/policy/policy_table/table_struct/types.h
+++ b/src/components/policy/src/policy/policy_table/table_struct/types.h
@@ -93,7 +93,7 @@ struct ApplicationParams : PolicyBase {
     Optional< AppHMITypes > AppHMIType;
     Optional< RequestTypes > RequestType;
     Optional< Integer<uint16_t, 0, 65225> > memory_kb;
-    Optional< Integer<uint16_t, 0, 65225> > heart_beat_timeout_ms;
+    Optional< Integer<uint32_t, 0, 65225> > heart_beat_timeout_ms;
     Optional< String<0, 255> > certificate;
   public:
     ApplicationParams();

--- a/src/components/policy/src/policy/policy_table/table_struct/types.h
+++ b/src/components/policy/src/policy/policy_table/table_struct/types.h
@@ -1,6 +1,8 @@
 // This file is generated, do not edit
 #ifndef POLICY_TABLE_INTERFACE_BASE_POLICY_TABLE_INTERFACE_BASE_TYPES_H_
 #define POLICY_TABLE_INTERFACE_BASE_POLICY_TABLE_INTERFACE_BASE_TYPES_H_
+#include <climits>
+
 #include "./enums.h"
 #include "rpc_base/rpc_message.h"
 namespace Json {
@@ -93,7 +95,7 @@ struct ApplicationParams : PolicyBase {
     Optional< AppHMITypes > AppHMIType;
     Optional< RequestTypes > RequestType;
     Optional< Integer<uint16_t, 0, 65225> > memory_kb;
-    Optional< Integer<uint32_t, 0, 65225> > heart_beat_timeout_ms;
+    Optional< Integer<uint32_t, 0, UINT_MAX> > heart_beat_timeout_ms;
     Optional< String<0, 255> > certificate;
   public:
     ApplicationParams();

--- a/src/components/policy/src/policy/src/cache_manager.cc
+++ b/src/components/policy/src/policy/src/cache_manager.cc
@@ -93,9 +93,9 @@ bool CacheManager::CanAppKeepContext(const std::string &app_id) {
   return result;
 }
 
-uint16_t CacheManager::HeartBeatTimeout(const std::string &app_id) const {
+uint32_t CacheManager::HeartBeatTimeout(const std::string& app_id) const {
   CACHE_MANAGER_CHECK(0);
-  uint16_t result = 0;
+  uint32_t result = 0;
   if (AppExists(app_id)) {
     if (pt_->policy_table.app_policies_section.apps[app_id].heart_beat_timeout_ms
         .is_initialized()) {

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -898,7 +898,7 @@ bool PolicyManagerImpl::InitPT(const std::string& file_name) {
   return ret;
 }
 
-uint16_t PolicyManagerImpl::HeartBeatTimeout(const std::string& app_id) const {
+uint32_t PolicyManagerImpl::HeartBeatTimeout(const std::string& app_id) const {
   return cache_->HeartBeatTimeout(app_id);
 }
 

--- a/src/components/policy/src/policy/src/sql_pt_ext_representation.cc
+++ b/src/components/policy/src/policy/src/sql_pt_ext_representation.cc
@@ -717,7 +717,7 @@ bool SQLPTExtRepresentation::SaveSpecificAppPolicy(
   app_query.Bind(
     5, app.second.is_null());
   app_query.Bind(6, *app.second.memory_kb);
-  app_query.Bind(7, *app.second.heart_beat_timeout_ms);
+  app_query.Bind(7, static_cast<int64_t>(*app.second.heart_beat_timeout_ms));
   app.second.certificate.is_initialized() ?
   app_query.Bind(8, *app.second.certificate) : app_query.Bind(8, std::string());
 
@@ -828,7 +828,7 @@ bool SQLPTExtRepresentation::GatherApplicationPoliciesSection(
     params.keep_context = query.GetBoolean(3);
     params.steal_focus = query.GetBoolean(4);
     *params.memory_kb = query.GetInteger(5);
-    *params.heart_beat_timeout_ms = query.GetInteger(6);
+    *params.heart_beat_timeout_ms = query.GetUInteger(6);
     if (!query.IsNull(7)) {
       *params.certificate = query.GetString(7);
     }

--- a/src/components/policy/src/policy/src/sql_pt_representation.cc
+++ b/src/components/policy/src/policy/src/sql_pt_representation.cc
@@ -657,7 +657,8 @@ bool SQLPTRepresentation::GatherApplicationPoliciesSection(
     params.priority = priority;
 
     *params.memory_kb = query.GetInteger(2);
-    *params.heart_beat_timeout_ms = query.GetInteger(3);
+
+    *params.heart_beat_timeout_ms = query.GetUInteger(3);
     if (!query.IsNull(3)) {
       *params.certificate = query.GetString(4);
     }
@@ -874,10 +875,9 @@ bool SQLPTRepresentation::SaveSpecificAppPolicy(
   app_query.Bind(1, std::string(policy_table::EnumToJsonString(app.second.priority)));
   app_query.Bind(2, app.second.is_null());
   app_query.Bind(3, *app.second.memory_kb);
-  app_query.Bind(4, *app.second.heart_beat_timeout_ms);
+  app_query.Bind(4, static_cast<int64_t>(*app.second.heart_beat_timeout_ms));
   app.second.certificate.is_initialized() ?
   app_query.Bind(5, *app.second.certificate) : app_query.Bind(5);
-
   if (!app_query.Exec() || !app_query.Reset()) {
     LOG4CXX_WARN(logger_, "Incorrect insert into application.");
     return false;

--- a/src/components/policy/test/include/mock_cache_manager.h
+++ b/src/components/policy/test/include/mock_cache_manager.h
@@ -177,7 +177,7 @@ class MockCacheManagerInterface : public CacheManagerInterface {
   MOCK_METHOD0(Backup,
       void());
   MOCK_CONST_METHOD1(HeartBeatTimeout,
-      uint16_t(const std::string& app_id));
+      uint32_t(const std::string& app_id));
   MOCK_CONST_METHOD2(GetAppRequestTypes,
       void(const std::string& policy_app_id,
            std::vector<std::string>& request_types));

--- a/src/components/policy/test/policy_manager_impl_test.cc
+++ b/src/components/policy/test/policy_manager_impl_test.cc
@@ -308,4 +308,4 @@ TEST_F(PolicyManagerImplTest, DISABLED_GetPolicyTableStatus) {
 }
 // namespace policy
 }// namespace components
-}  // namespace test
+}// namespace test

--- a/src/components/utils/src/date_time.cc
+++ b/src/components/utils/src/date_time.cc
@@ -80,6 +80,14 @@ int64_t DateTime::calculateTimeDiff(const TimevalStruct &time1,
   return getmSecs(ret);
 }
 
+void DateTime::AddMilliseconds(TimevalStruct& time,
+                             uint32_t milliseconds) {
+  uint32_t sec = milliseconds/MILLISECONDS_IN_SECOND;
+  uint32_t usec = (milliseconds%MILLISECONDS_IN_SECOND)*MICROSECONDS_IN_MILLISECONDS;
+  time.tv_sec += sec;
+  time.tv_usec += usec;
+}
+
 TimevalStruct DateTime::Sub(const TimevalStruct& time1,
                             const TimevalStruct& time2) {
   const TimevalStruct times1 = ConvertionUsecs(time1);

--- a/src/components/utils/src/date_time.cc
+++ b/src/components/utils/src/date_time.cc
@@ -82,8 +82,8 @@ int64_t DateTime::calculateTimeDiff(const TimevalStruct &time1,
 
 void DateTime::AddMilliseconds(TimevalStruct& time,
                              uint32_t milliseconds) {
-  uint32_t sec = milliseconds/MILLISECONDS_IN_SECOND;
-  uint32_t usec = (milliseconds%MILLISECONDS_IN_SECOND)*MICROSECONDS_IN_MILLISECONDS;
+  const uint32_t sec = milliseconds/MILLISECONDS_IN_SECOND;
+  const uint32_t usec = (milliseconds%MILLISECONDS_IN_SECOND)*MICROSECONDS_IN_MILLISECONDS;
   time.tv_sec += sec;
   time.tv_usec += usec;
   time = ConvertionUsecs(time);

--- a/src/components/utils/src/date_time.cc
+++ b/src/components/utils/src/date_time.cc
@@ -86,6 +86,7 @@ void DateTime::AddMilliseconds(TimevalStruct& time,
   uint32_t usec = (milliseconds%MILLISECONDS_IN_SECOND)*MICROSECONDS_IN_MILLISECONDS;
   time.tv_sec += sec;
   time.tv_usec += usec;
+  time = ConvertionUsecs(time);
 }
 
 TimevalStruct DateTime::Sub(const TimevalStruct& time1,

--- a/src/components/utils/test/date_time_test.cc
+++ b/src/components/utils/test/date_time_test.cc
@@ -322,7 +322,6 @@ TEST(DateTimeTest, DISABLED_CalculateEqualTimeSub_UsecConvertedInSec) {
   ASSERT_EQ(EQUAL, date_time::DateTime::compareTime(time_expected, time3));
   ASSERT_EQ(EQUAL, date_time::DateTime::compareTime(time_expected, time4));
 }
-
 }  // namespace utils
 }  // namespace components
 }  // namespace test


### PR DESCRIPTION
These changes allow to use heartbeat with milliseconds.