### PR TITLE
SDL does not save app into db after unexpected disconnect was done

### DIFF
--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
@@ -542,11 +542,23 @@ class ResumptionDataDB : public ResumptionData {
    * @return true if query was run successfully otherwise returns
    * false
    */
-  bool InsertApplicationData(app_mngr::ApplicationConstSharedPtr,
+  bool InsertApplicationData(app_mngr::ApplicationConstSharedPtr application,
                              const std::string& policy_app_id,
                              const std::string& device_id,
-                             int64_t* application_primary_key = NULL,
-                             int64_t global_properties_key = 0);
+                             int64_t* application_primary_key,
+                             int64_t global_properties_key);
+
+  /**
+   * @brief Calls InsertApplicationData method
+   * @param application contains data for saving to DB
+   * @param policy_app_id contains mobile application id of application
+   * @param device_id contains id of device on which is running application
+   * @return true if InsertApplicationData works successfully, otherwise
+   * returns false;
+   */
+  bool InsertApplicationData(app_mngr::ApplicationConstSharedPtr application,
+                             const std::string& policy_app_id,
+                             const std::string& device_id);
 
   /**
    * @brief Delete application data where ign_off_count >= application_lifes

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
@@ -545,8 +545,8 @@ class ResumptionDataDB : public ResumptionData {
   bool InsertApplicationData(app_mngr::ApplicationConstSharedPtr,
                              const std::string& policy_app_id,
                              const std::string& device_id,
-                             int64_t& application_primary_key,
-                             int64_t global_properties_key);
+                             int64_t* application_primary_key = NULL,
+                             int64_t global_properties_key = 0);
 
   /**
    * @brief Delete application data where ign_off_count >= application_lifes

--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -37,6 +37,7 @@
 #include "application_manager/smart_object_keys.h"
 #include "config_profile/profile.h"
 #include "application_manager/message_helper.h"
+#include "utils/helpers.h"
 
 namespace {
 const std::string kDatabaseName = "resumption";
@@ -129,6 +130,8 @@ bool ResumptionDataDB::Init() {
 void ResumptionDataDB::SaveApplication(
     app_mngr::ApplicationSharedPtr application) {
   using namespace app_mngr;
+  using namespace mobile_api;
+  using namespace helpers;
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK_OR_RETURN_VOID(application);
   bool application_exist = false;
@@ -166,8 +169,9 @@ void ResumptionDataDB::SaveApplication(
       }
       LOG4CXX_INFO(logger_, "Application data were updated successfully");
     } else {
-      if (mobile_api::HMILevel::HMI_FULL == application->hmi_level() ||
-          mobile_api::HMILevel::HMI_LIMITED == application->hmi_level()) {
+      if (Compare<HMILevel::eType, EQ, ONE>(application->hmi_level(),
+                                            HMILevel::HMI_FULL,
+                                            HMILevel::HMI_LIMITED)) {
         if (!InsertApplicationData(application, policy_app_id, device_id)) {
           LOG4CXX_ERROR(logger_, "Saving data of application is failed");
           return;
@@ -2240,6 +2244,13 @@ bool ResumptionDataDB::ExecInsertVRHelpItem(int64_t global_properties_key,
   }
   LOG4CXX_INFO(logger_, "Data were saved successfully to vrHelpItem array table");
   return true;
+}
+
+bool ResumptionDataDB::InsertApplicationData(app_mngr::ApplicationConstSharedPtr application,
+                                             const std::string& policy_app_id,
+                                             const std::string& device_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return InsertApplicationData(application, policy_app_id, device_id, NULL, 0);
 }
 
 bool ResumptionDataDB::InsertApplicationData(app_mngr::ApplicationConstSharedPtr application,


### PR DESCRIPTION
These changes allow to store application without data for saving (commands, submenu etc.), if this application has HMI leve FULL or LIMITED.