### PR TITLE
SDL moves navi app from full to limited by phone call

### DIFF
--- a/src/components/application_manager/src/hmi_state.cc
+++ b/src/components/application_manager/src/hmi_state.cc
@@ -85,9 +85,8 @@ PhoneCallHmiState::PhoneCallHmiState(uint32_t app_id, StateContext& state_contex
 mobile_apis::HMILevel::eType PhoneCallHmiState::hmi_level() const {
   using namespace mobile_apis;
    HMILevel::eType expected_level(HMILevel::HMI_BACKGROUND);
-   if (parent()->hmi_level() == HMILevel::HMI_FULL
-       && state_context_.is_navi_app(app_id_)) {
-     expected_level = HMILevel::HMI_LIMITED;
+   if (parent()->hmi_level() == HMILevel::HMI_NONE) {
+     expected_level = HMILevel::HMI_NONE;
    }
    return expected_level;
 }


### PR DESCRIPTION
Changed PhoneCallHmiState so that navi mobile application will be
moved to correct HMI level during PhoneCall.