### PR TITLE
128k MTU for v3 protocol

### DIFF
--- a/customer-specific/pasa/src/appMain/smartDeviceLink.ini
+++ b/customer-specific/pasa/src/appMain/smartDeviceLink.ini
@@ -145,7 +145,8 @@ ConnectionWaitTimeout = 10
 
 [ProtocolHandler]
 ; Packet with payload bigger than next value will be marked as a malformed
-; 1488 = 1500 - 12 = TCP MTU - header size
+; for protocol v3 or higher
+; For v2 protocol MaximumPayloadSize is 1488
 MaximumPayloadSize = 131072
 ; Application shall send less #FrequencyCount messages per #FrequencyTime mSecs
 ; Frequency check could be disabled by setting #FrequencyTime or

--- a/customer-specific/pasa/src/appMain/smartDeviceLink.ini
+++ b/customer-specific/pasa/src/appMain/smartDeviceLink.ini
@@ -146,7 +146,7 @@ ConnectionWaitTimeout = 10
 [ProtocolHandler]
 ; Packet with payload bigger than next value will be marked as a malformed
 ; 1488 = 1500 - 12 = TCP MTU - header size
-MaximumPayloadSize = 1488
+MaximumPayloadSize = 131072
 ; Application shall send less #FrequencyCount messages per #FrequencyTime mSecs
 ; Frequency check could be disabled by setting #FrequencyTime or
 ; #FrequencyCount to Zero

--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -164,7 +164,8 @@ IAP2HubConnectAttempts = 3
 
 [ProtocolHandler]
 ; Packet with payload bigger than next value will be marked as a malformed
-; 1488 = 1500 - 12 = TCP MTU - header size
+; for protocol v3 or higher
+; For v2 protocol MaximumPayloadSize is 1488
 MaximumPayloadSize = 131072
 ; Application shall send less #FrequencyCount messages per #FrequencyTime mSecs
 ; Frequency check could be disabled by setting #FrequencyTime or

--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -165,7 +165,7 @@ IAP2HubConnectAttempts = 3
 [ProtocolHandler]
 ; Packet with payload bigger than next value will be marked as a malformed
 ; 1488 = 1500 - 12 = TCP MTU - header size
-MaximumPayloadSize = 1488
+MaximumPayloadSize = 131072
 ; Application shall send less #FrequencyCount messages per #FrequencyTime mSecs
 ; Frequency check could be disabled by setting #FrequencyTime or
 ; #FrequencyCount to Zero

--- a/src/components/include/protocol/common.h
+++ b/src/components/include/protocol/common.h
@@ -196,9 +196,10 @@ enum {
 
 /**
  *\brief If FRAME_TYPE_CONTROL: Constant: Default maximum size of one frame
- *\brief excluding frame header (used Ethernet MTU as default target transport)
+ *\brief excluding frame header for protocol version 2
+ *\brief (used Ethernet MTU as default target transport)
  */
-const size_t DEFAULT_FRAME_DATA_SIZE = 1488;
+const size_t MAXIMUM_FRAME_DATA_V2_SIZE = 1488;
 
 /**
  *\brief If FRAME_TYPE_CONSECUTIVE: Constant: Size of first frame in

--- a/src/components/include/protocol/common.h
+++ b/src/components/include/protocol/common.h
@@ -195,10 +195,10 @@ enum {
 };
 
 /**
- *\brief If FRAME_TYPE_CONTROL: Constant: Maximum size of one frame excluding
- *\brief frame header (used Ethernet MTU as default target transport)
+ *\brief If FRAME_TYPE_CONTROL: Constant: Default maximum size of one frame
+ *\brief excluding frame header (used Ethernet MTU as default target transport)
  */
-const uint32_t MAXIMUM_FRAME_DATA_SIZE = 1500;
+const size_t DEFAULT_FRAME_DATA_SIZE = 1488;
 
 /**
  *\brief If FRAME_TYPE_CONSECUTIVE: Constant: Size of first frame in

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -341,7 +341,6 @@ void ProtocolHandlerImpl::SendMessageToMobileApp(const RawMessagePtr message,
     return;
   }
 
-
   if (!session_observer_) {
     LOG4CXX_ERROR(
         logger_,
@@ -361,15 +360,12 @@ void ProtocolHandlerImpl::SendMessageToMobileApp(const RawMessagePtr message,
 #endif  // TIME_TESTER
   const size_t max_frame_size =
       profile::Profile::instance()->maximum_payload_size();
-  size_t frame_size = DEFAULT_FRAME_DATA_SIZE;
+  size_t frame_size = MAXIMUM_FRAME_DATA_V2_SIZE;
   switch (message->protocol_version()) {
-    case PROTOCOL_VERSION_1:
-    case PROTOCOL_VERSION_2:
-      break;
     case PROTOCOL_VERSION_3:
     case PROTOCOL_VERSION_4:
-      frame_size = max_frame_size > DEFAULT_FRAME_DATA_SIZE ?
-                   max_frame_size : DEFAULT_FRAME_DATA_SIZE;
+      frame_size = max_frame_size > MAXIMUM_FRAME_DATA_V2_SIZE ?
+                   max_frame_size : MAXIMUM_FRAME_DATA_V2_SIZE;
       break;
     default:
       break;
@@ -389,7 +385,6 @@ void ProtocolHandlerImpl::SendMessageToMobileApp(const RawMessagePtr message,
   }
   LOG4CXX_DEBUG(logger_, "Optimal packet size is " << frame_size);
 #endif  // ENABLE_SECURITY
-  DCHECK(DEFAULT_FRAME_DATA_SIZE <= frame_size);
 
   if (message->data_size() <= frame_size) {
     RESULT_CODE result = SendSingleFrameMessage(connection_handle, sessionID,

--- a/src/components/protocol_handler/src/protocol_packet.cc
+++ b/src/components/protocol_handler/src/protocol_packet.cc
@@ -135,16 +135,16 @@ RESULT_CODE ProtocolPacket::ProtocolHeaderValidator::validate(
     const ProtocolHeader& header) const {
   // expected payload size will be calculated depending
   // on used protocol version
-  size_t payload_size = DEFAULT_FRAME_DATA_SIZE;
-  // Protocol version shall be from 1 to 3
+  size_t payload_size = MAXIMUM_FRAME_DATA_V2_SIZE;
+  // Protocol version shall be from 1 to 4
   switch (header.version) {
     case PROTOCOL_VERSION_1:
     case PROTOCOL_VERSION_2:
       break;
     case PROTOCOL_VERSION_3:
     case PROTOCOL_VERSION_4:
-      payload_size = max_payload_size_ > DEFAULT_FRAME_DATA_SIZE ?
-                     max_payload_size_ : DEFAULT_FRAME_DATA_SIZE;
+      payload_size = max_payload_size_ > MAXIMUM_FRAME_DATA_V2_SIZE ?
+                     max_payload_size_ : MAXIMUM_FRAME_DATA_V2_SIZE;
       break;
     default:
       return RESULT_FAIL;


### PR DESCRIPTION
1.	In case mobile app connects over protocol v3 or higher SDL must use the value of "MaximumPayloadSize" parameter defined in .ini file in bytes for validating MTU size	req_1_APPLINK-14636
 	 	 
2.	In case mobile app connects over protocol v2 SDL must use the default value of 1488 bytes for validating MTU size	req_2_APPLINK-14636
 	 	 
3.	In case mobile app connects over protocol v3 or higher AND the value of "MaximumPayloadSize" parameter is empty in .ini file SDL must use the default value of 1488 bytes for validating MTU size	req_3_APPLINK-14636
 	 	 
4.	In case mobile app connects over protocol v3 or higher AND the value of "MaximumPayloadSize" parameter in .ini file is less than default value SDL must use the default value of 1488 bytes for validating MTU size	req_4_APPLINK-14636
 	 	 
5.	SDL must use the value of "MaximumPayloadSize" defined in .ini file for applications of protocol v3 or higher AND the default value for applications of protocol v2 for each of the applications sessions correspondingly AND no matter how many sessions are currently established with SDL