### PR TITLE
Feature/warnings result handling

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/alert_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/alert_request.h
@@ -127,11 +127,11 @@ class AlertRequest : public CommandRequestImpl {
   bool                        awaiting_ui_alert_response_;
   bool                        awaiting_tts_speak_response_;
   bool                        awaiting_tts_stop_speaking_response_;
-  bool                        response_success_;
-  bool                        flag_other_component_sent_;
-  mobile_apis::Result::eType  response_result_;
-  smart_objects::SmartObject  response_params_;
-  mobile_apis::Result::eType  tts_speak_response_;
+  bool                        is_alert_succeeded_;
+  bool                        is_ui_alert_sent_;
+  mobile_apis::Result::eType  alert_result_;
+  smart_objects::SmartObject  alert_response_params_;
+  mobile_apis::Result::eType  tts_speak_result_;
 
   DISALLOW_COPY_AND_ASSIGN(AlertRequest);
 };

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_interaction_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_interaction_request.h
@@ -191,8 +191,6 @@ class PerformInteractionRequest : public CommandRequestImpl  {
    */
   bool CheckChoiceIDFromResponse(ApplicationSharedPtr app, int32_t choice_id);
 
-  // members
-  mobile_apis::Result::eType          vr_perform_interaction_code_;
   mobile_apis::InteractionMode::eType interaction_mode_;
   bool                                ui_response_recived_;
   bool                                vr_response_recived_;

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_interaction_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_interaction_request.h
@@ -132,12 +132,6 @@ class PerformInteractionRequest : public CommandRequestImpl  {
    */
   void SendUIShowVRHelpRequest(ApplicationSharedPtr const app);
 
-  /**
-   * @brief Creates and Sends Perform interaction to UI.
-   */
-  void CreateUIPerformInteraction(const smart_objects::SmartObject& msg_params,
-                                  application_manager::ApplicationSharedPtr const app);
-
   /*
    * @brief Checks if incoming choice set doesn't has similar menu names.
    *

--- a/src/components/application_manager/include/application_manager/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/register_app_interface_request.h
@@ -79,8 +79,7 @@ class RegisterAppInterfaceRequest : public CommandRequestImpl {
    *@param application_impl application
    *
    **/
-  void SendRegisterAppInterfaceResponseToMobile(
-      mobile_apis::Result::eType result = mobile_apis::Result::SUCCESS);
+  void SendRegisterAppInterfaceResponseToMobile();
 
  private:
   /*

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -133,6 +133,57 @@ class MessageHelper {
     static const VehicleData& vehicle_data();
 
     /**
+     * @brief Converts HMI Result enum value to string
+     * @param hmi_result HMI Result enum value
+     * @return stringified value for enum if succedeed, otherwise - empty string
+     */
+    static std::string StringifiedHMIResult(
+      hmi_apis::Common_Result::eType hmi_result);
+
+    /**
+     * @brief Converts string to HMI Result enum value
+     * @param hmi_result stringified value
+     * @return HMI Result enum value if succedeed, otherwise - INVALID_ENUM
+     * value
+     */
+    static hmi_apis::Common_Result::eType StringToHMIResult(
+      const std::string& hmi_result);
+
+    /**
+     * @brief Converts mobile Result enum value to string
+     * @param mobile_result mobile Result enum value
+     * @return stringified value for enum if succedeed, otherwise - empty string
+     */
+    static std::string StringifiedMobileResult(
+      mobile_apis::Result::eType mobile_result);
+
+    /**
+     * @brief Converts string to mobile Result enum value
+     * @param mobile_result stringified value
+     * @return mobile Result enum value if succedeed, otherwise - INVALID_ENUM
+     * value
+     */
+    static mobile_api::Result::eType StringToMobileResult(
+      const std::string& mobile_result);
+
+    /**
+     * @brief Converts HMI Result enum value to mobile Result enum value
+     * @param hmi_result HMI Result enum value
+     * @return mobile Result enum value if succedeed, otherwise - INVALID_ENUM
+     * value
+     */
+    static mobile_api::Result::eType HMIToMobileResult(
+            const hmi_apis::Common_Result::eType hmi_result);
+
+    /**
+     * @brief Converts mobile Result enum value to HMI Result enum value
+     * @param mobile_result mobile Result enum value
+     * @return HMI Result enum value
+     */
+    static hmi_apis::Common_Result::eType MobileToHMIResult(
+            const mobile_api::Result::eType mobile_result);
+
+    /**
      * @brief Convert string to HMI level, if possible
      * @param hmi_level Stringified HMI level
      * @return Appropriate enum from HMI level, or INVALID_ENUM, if conversiion

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -137,7 +137,7 @@ class MessageHelper {
      * @param hmi_result HMI Result enum value
      * @return stringified value for enum if succedeed, otherwise - empty string
      */
-    static std::string StringifiedHMIResult(
+    static std::string HMIResultToString(
       hmi_apis::Common_Result::eType hmi_result);
 
     /**
@@ -146,7 +146,7 @@ class MessageHelper {
      * @return HMI Result enum value if succedeed, otherwise - INVALID_ENUM
      * value
      */
-    static hmi_apis::Common_Result::eType StringToHMIResult(
+    static hmi_apis::Common_Result::eType HMIResultFromString(
       const std::string& hmi_result);
 
     /**
@@ -154,7 +154,7 @@ class MessageHelper {
      * @param mobile_result mobile Result enum value
      * @return stringified value for enum if succedeed, otherwise - empty string
      */
-    static std::string StringifiedMobileResult(
+    static std::string MobileResultToString(
       mobile_apis::Result::eType mobile_result);
 
     /**
@@ -163,7 +163,7 @@ class MessageHelper {
      * @return mobile Result enum value if succedeed, otherwise - INVALID_ENUM
      * value
      */
-    static mobile_api::Result::eType StringToMobileResult(
+    static mobile_api::Result::eType MobileResultFromString(
       const std::string& mobile_result);
 
     /**

--- a/src/components/application_manager/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_command_request.cc
@@ -373,10 +373,8 @@ void AddCommandRequest::on_event(const event_engine::Event& event) {
 
   bool result =
       (is_no_ui_error && is_no_vr_error) ||
-      (hmi_apis::Common_Result::SUCCESS == ui_result_ &&
-       is_vr_invalid_unsupported) ||
-      (hmi_apis::Common_Result::SUCCESS == vr_result_ &&
-       is_ui_ivalid_unsupported);
+      (is_no_ui_error && is_vr_invalid_unsupported) ||
+      (is_no_vr_error && is_ui_ivalid_unsupported);
 
   const bool is_vr_or_ui_warning =
       Compare<hmi_apis::Common_Result::eType, EQ, ONE>(

--- a/src/components/application_manager/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_command_request.cc
@@ -37,6 +37,7 @@
 #include "application_manager/application.h"
 #include "application_manager/message_helper.h"
 #include "utils/file_system.h"
+#include "utils/helpers.h"
 
 namespace application_manager {
 
@@ -287,6 +288,7 @@ bool AddCommandRequest::CheckCommandParentId(ApplicationConstSharedPtr app) {
 
 void AddCommandRequest::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
+  using namespace helpers;
 
   const smart_objects::SmartObject& message = event.smart_object();
 
@@ -331,74 +333,111 @@ void AddCommandRequest::on_event(const event_engine::Event& event) {
     }
   }
 
-  if (!IsPendingResponseExist()) {
+  if (IsPendingResponseExist()) {
+    return;
+  }
 
-    ApplicationSharedPtr application =
-        ApplicationManagerImpl::instance()->application(connection_key());
+  if (hmi_apis::Common_Result::REJECTED == ui_result_) {
+    RemoveCommand();
+  }
 
-    if (hmi_apis::Common_Result::REJECTED == ui_result_) {
-      RemoveCommand();
-    }
+  smart_objects::SmartObject msg_params(smart_objects::SmartType_Map);
+  msg_params[strings::cmd_id] = (*message_)[strings::msg_params][strings::cmd_id];
+  msg_params[strings::app_id] = application->app_id();
 
-    smart_objects::SmartObject msg_params(smart_objects::SmartType_Map);
-    msg_params[strings::cmd_id] = (*message_)[strings::msg_params][strings::cmd_id];
-    msg_params[strings::app_id] = application->app_id();
+  mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
 
-    mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
+  const bool is_vr_invalid_unsupported =
+      Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+        vr_result_,
+        hmi_apis::Common_Result::INVALID_ENUM,
+        hmi_apis::Common_Result::UNSUPPORTED_RESOURCE);
 
-    bool result = ((hmi_apis::Common_Result::SUCCESS == ui_result_) &&
-        (hmi_apis::Common_Result::SUCCESS == vr_result_)) ||
-        ((hmi_apis::Common_Result::SUCCESS == ui_result_) &&
-        (hmi_apis::Common_Result::INVALID_ENUM == vr_result_ ||
-         hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == vr_result_)) ||
-        ((hmi_apis::Common_Result::INVALID_ENUM == ui_result_ ||
-         hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == ui_result_ ) &&
-        (hmi_apis::Common_Result::SUCCESS == vr_result_));
+  const bool is_ui_ivalid_unsupported =
+      Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+        ui_result_,
+        hmi_apis::Common_Result::INVALID_ENUM,
+        hmi_apis::Common_Result::UNSUPPORTED_RESOURCE);
 
-    if (!result && (hmi_apis::Common_Result::REJECTED == ui_result_)) {
-      result_code = static_cast<mobile_apis::Result::eType>(ui_result_);
-    } else {
-      result_code = static_cast<mobile_apis::Result::eType>(
-          std::max(ui_result_, vr_result_));
-    }
+  const bool is_no_ui_error =
+      Compare<hmi_apis::Common_Result::eType, EQ, ALL>(
+        ui_result_,
+        hmi_apis::Common_Result::SUCCESS,
+        hmi_apis::Common_Result::WARNINGS);
 
-    if (BothSend() && hmi_apis::Common_Result::SUCCESS == vr_result_) {
-      if (hmi_apis::Common_Result::SUCCESS != ui_result_ &&
-          hmi_apis::Common_Result::WARNINGS != ui_result_ &&
-          hmi_apis::Common_Result::UNSUPPORTED_RESOURCE != ui_result_) {
+  const bool is_no_vr_error =
+      Compare<hmi_apis::Common_Result::eType, EQ, ALL>(
+        vr_result_,
+        hmi_apis::Common_Result::SUCCESS,
+        hmi_apis::Common_Result::WARNINGS);
 
-        result_code =
-            (ui_result_ == hmi_apis::Common_Result::REJECTED) ?
-              mobile_apis::Result::REJECTED : mobile_apis::Result::GENERIC_ERROR;
+  bool result =
+      (is_no_ui_error && is_no_vr_error) ||
+      (hmi_apis::Common_Result::SUCCESS == ui_result_ &&
+       is_vr_invalid_unsupported) ||
+      (hmi_apis::Common_Result::SUCCESS == vr_result_ &&
+       is_ui_ivalid_unsupported);
 
-        msg_params[strings::grammar_id] = application->get_grammar_id();
-        msg_params[strings::type] = hmi_apis::Common_VRCommandType::Command;
+  const bool is_vr_or_ui_warning =
+      Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+      hmi_apis::Common_Result::WARNINGS,
+      ui_result_,
+      vr_result_);
 
-        SendHMIRequest(hmi_apis::FunctionID::VR_DeleteCommand, &msg_params);
-        application->RemoveCommand((*message_)[strings::msg_params]
-                                       [strings::cmd_id].asUInt());
-        result = false;
-      }
-    }
+  if (!result &&
+      hmi_apis::Common_Result::REJECTED == ui_result_) {
+    result_code = MessageHelper::HMIToMobileResult(ui_result_);
+  } else if (is_vr_or_ui_warning) {
+    result_code = mobile_apis::Result::WARNINGS;
+  } else {
+    result_code = MessageHelper::HMIToMobileResult(
+        std::max(ui_result_, vr_result_));
+  }
 
-    if(BothSend() && hmi_apis::Common_Result::SUCCESS == ui_result_ &&
-       hmi_apis::Common_Result::SUCCESS != vr_result_) {
+  if (BothSend() && hmi_apis::Common_Result::SUCCESS == vr_result_) {
+    const bool is_ui_not_ok =
+        Compare<hmi_apis::Common_Result::eType, NEQ, ALL>(
+          ui_result_,
+          hmi_apis::Common_Result::SUCCESS,
+          hmi_apis::Common_Result::WARNINGS,
+          hmi_apis::Common_Result::UNSUPPORTED_RESOURCE);
 
+    if (is_ui_not_ok) {
       result_code =
-          (vr_result_ == hmi_apis::Common_Result::REJECTED) ?
-            mobile_apis::Result::REJECTED : mobile_apis::Result::GENERIC_ERROR;
+          ui_result_ == hmi_apis::Common_Result::REJECTED
+          ? mobile_apis::Result::REJECTED
+          : mobile_apis::Result::GENERIC_ERROR;
 
-      SendHMIRequest(hmi_apis::FunctionID::UI_DeleteCommand, &msg_params);
+      msg_params[strings::grammar_id] = application->get_grammar_id();
+      msg_params[strings::type] = hmi_apis::Common_VRCommandType::Command;
 
+      SendHMIRequest(hmi_apis::FunctionID::VR_DeleteCommand, &msg_params);
       application->RemoveCommand((*message_)[strings::msg_params]
                                      [strings::cmd_id].asUInt());
       result = false;
     }
+  }
 
-    SendResponse(result, result_code, NULL, &(message[strings::msg_params]));
-    if (true == result) {
-      application->UpdateHash();
-    }
+  if(BothSend() &&
+     hmi_apis::Common_Result::SUCCESS == ui_result_ &&
+     !is_no_vr_error) {
+
+    result_code =
+        vr_result_ == hmi_apis::Common_Result::REJECTED
+        ? mobile_apis::Result::REJECTED :
+          mobile_apis::Result::GENERIC_ERROR;
+
+    SendHMIRequest(hmi_apis::FunctionID::UI_DeleteCommand, &msg_params);
+
+    application->RemoveCommand((*message_)[strings::msg_params]
+                                   [strings::cmd_id].asUInt());
+    result = false;
+  }
+
+  SendResponse(result, result_code, NULL, &(message[strings::msg_params]));
+
+  if (result) {
+    application->UpdateHash();
   }
 }
 

--- a/src/components/application_manager/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_command_request.cc
@@ -360,13 +360,13 @@ void AddCommandRequest::on_event(const event_engine::Event& event) {
         hmi_apis::Common_Result::UNSUPPORTED_RESOURCE);
 
   const bool is_no_ui_error =
-      Compare<hmi_apis::Common_Result::eType, EQ, ALL>(
+      Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
         ui_result_,
         hmi_apis::Common_Result::SUCCESS,
         hmi_apis::Common_Result::WARNINGS);
 
   const bool is_no_vr_error =
-      Compare<hmi_apis::Common_Result::eType, EQ, ALL>(
+      Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
         vr_result_,
         hmi_apis::Common_Result::SUCCESS,
         hmi_apis::Common_Result::WARNINGS);

--- a/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
@@ -104,7 +104,9 @@ void AddSubMenuRequest::on_event(const event_engine::Event& event) {
           static_cast<mobile_apis::Result::eType>(
               message[strings::params][hmi_response::code].asInt());
 
-      bool result = mobile_apis::Result::SUCCESS == result_code;
+      bool result =
+          mobile_apis::Result::SUCCESS == result_code ||
+          mobile_apis::Result::WARNINGS == result_code;
 
       ApplicationSharedPtr application =
              ApplicationManagerImpl::instance()->application(connection_key());

--- a/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
@@ -34,6 +34,7 @@
 #include "application_manager/commands/mobile/add_sub_menu_request.h"
 #include "application_manager/application_manager_impl.h"
 #include "application_manager/application.h"
+#include "utils/helpers.h"
 
 namespace application_manager {
 
@@ -50,7 +51,7 @@ void AddSubMenuRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   ApplicationSharedPtr app = ApplicationManagerImpl::instance()->application(
-      (*message_)[strings::params][strings::connection_key].asUInt());
+      connection_key());
 
   if (!app) {
     LOG4CXX_ERROR(logger_, "NULL pointer");
@@ -58,22 +59,25 @@ void AddSubMenuRequest::Run() {
     return;
   }
 
-  if (app->FindSubMenu(
-      (*message_)[strings::msg_params][strings::menu_id].asInt())) {
-    LOG4CXX_ERROR(logger_, "INVALID_ID");
+  const int32_t menu_id =
+      (*message_)[strings::msg_params][strings::menu_id].asInt();
+  if (app->FindSubMenu(menu_id)) {
+    LOG4CXX_ERROR(logger_, "Menu with id " << menu_id << " is not found.");
     SendResponse(false, mobile_apis::Result::INVALID_ID);
     return;
   }
 
-  if (app->IsSubMenuNameAlreadyExist(
-      (*message_)[strings::msg_params][strings::menu_name].asString())) {
-    LOG4CXX_ERROR(logger_, "DUPLICATE_NAME");
+  const std::string menu_name =
+      (*message_)[strings::msg_params][strings::menu_name].asString();
+
+  if (app->IsSubMenuNameAlreadyExist(menu_name)) {
+    LOG4CXX_ERROR(logger_, "Menu name " << menu_name << " is duplicated.");
     SendResponse(false, mobile_apis::Result::DUPLICATE_NAME);
     return;
   }
 
   if (!CheckSubMenuName()) {
-    LOG4CXX_ERROR(logger_, "SubMenuName is not valid");
+    LOG4CXX_ERROR(logger_, "Sub-menu name is not valid.");
     SendResponse(false, mobile_apis::Result::INVALID_DATA);
     return;
   }
@@ -96,6 +100,7 @@ void AddSubMenuRequest::Run() {
 
 void AddSubMenuRequest::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
+  using namespace helpers;
   const smart_objects::SmartObject& message = event.smart_object();
 
   switch (event.id()) {
@@ -104,9 +109,11 @@ void AddSubMenuRequest::on_event(const event_engine::Event& event) {
           static_cast<mobile_apis::Result::eType>(
               message[strings::params][hmi_response::code].asInt());
 
-      bool result =
-          mobile_apis::Result::SUCCESS == result_code ||
-          mobile_apis::Result::WARNINGS == result_code;
+      const bool result =
+          Compare<mobile_api::Result::eType, EQ, ONE>(
+            result_code,
+            mobile_api::Result::SUCCESS,
+            mobile_api::Result::WARNINGS);
 
       ApplicationSharedPtr application =
              ApplicationManagerImpl::instance()->application(connection_key());
@@ -133,6 +140,7 @@ void AddSubMenuRequest::on_event(const event_engine::Event& event) {
 }
 
 bool AddSubMenuRequest::CheckSubMenuName() {
+  LOG4CXX_AUTO_TRACE(logger_);
   const char* str = NULL;
 
   str = (*message_)[strings::msg_params][strings::menu_name].asCharArray();

--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -175,9 +175,9 @@ void AlertManeuverRequest::on_event(const event_engine::Event& event) {
   }
 
   if (!pending_requests_.IsFinal(event_id)) {
-    LOG4CXX_INFO(logger_,
-                "There are some pending responses from HMI."
-                "AlertManeuverRequest still waiting.");
+    LOG4CXX_DEBUG(logger_,
+                  "There are some pending responses from HMI."
+                  "AlertManeuverRequest still waiting.");
     return;
   }
 

--- a/src/components/application_manager/src/commands/mobile/alert_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_request.cc
@@ -38,7 +38,7 @@
 #include "application_manager/message_helper.h"
 #include "application_manager/application_impl.h"
 #include "application_manager/application_manager_impl.h"
-
+#include "utils/helpers.h"
 
 namespace application_manager {
 
@@ -51,10 +51,10 @@ AlertRequest::AlertRequest(const MessageSharedPtr& message)
       awaiting_ui_alert_response_(false),
       awaiting_tts_speak_response_(false),
       awaiting_tts_stop_speaking_response_(false),
-      response_success_(false),
-      flag_other_component_sent_(false),
-      response_result_(mobile_apis::Result::INVALID_ENUM),
-      tts_speak_response_(mobile_apis::Result::INVALID_ENUM) {
+      is_alert_succeeded_(false),
+      is_ui_alert_sent_(false),
+      alert_result_(mobile_apis::Result::INVALID_ENUM),
+      tts_speak_result_(mobile_apis::Result::INVALID_ENUM) {
   subscribe_on_event(hmi_apis::FunctionID::UI_OnResetTimeout);
   subscribe_on_event(hmi_apis::FunctionID::TTS_OnResetTimeout);
 }
@@ -107,16 +107,19 @@ void AlertRequest::Run() {
 }
 
 void AlertRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
   if (false == (*message_)[strings::msg_params].keyExists(strings::soft_buttons)) {
     CommandRequestImpl::onTimeOut();
     return;
   }
-  LOG4CXX_INFO(logger_, "default timeout ignored. "
-                        "AlertRequest with soft buttons wait timeout on HMI side");
+  LOG4CXX_INFO(logger_, "Default timeout ignored. "
+               "AlertRequest with soft buttons wait timeout on HMI side");
 }
 
 void AlertRequest::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
+  using namespace helpers;
+
   const smart_objects::SmartObject& message = event.smart_object();
 
   switch (event.id()) {
@@ -146,12 +149,17 @@ void AlertRequest::on_event(const event_engine::Event& event) {
           static_cast<mobile_apis::Result::eType>(
               message[strings::params][hmi_response::code].asInt());
       // Mobile Alert request is successful when UI_Alert is successful
-      response_success_ =
-          mobile_apis::Result::SUCCESS == result_code ||
-          mobile_apis::Result::UNSUPPORTED_RESOURCE == result_code ||
-          mobile_apis::Result::WARNINGS == result_code;
-      response_result_ = result_code;
-      response_params_ = message[strings::msg_params];
+
+      const bool is_alert_ok =
+          Compare<mobile_api::Result::eType, EQ, ONE>(
+            result_code,
+            mobile_apis::Result::SUCCESS,
+            mobile_apis::Result::UNSUPPORTED_RESOURCE,
+            mobile_apis::Result::WARNINGS);
+
+      is_alert_succeeded_ = is_alert_ok;
+      alert_result_ = result_code;
+      alert_response_params_ = message[strings::msg_params];
       break;
     }
     case hmi_apis::FunctionID::TTS_Speak: {
@@ -159,7 +167,7 @@ void AlertRequest::on_event(const event_engine::Event& event) {
       // Unsubscribe from event to avoid unwanted messages
       unsubscribe_from_event(hmi_apis::FunctionID::TTS_Speak);
       awaiting_tts_speak_response_ = false;
-      tts_speak_response_ = static_cast<mobile_apis::Result::eType>(
+      tts_speak_result_ = static_cast<mobile_apis::Result::eType>(
           message[strings::params][hmi_response::code].asInt());
       break;
     }
@@ -175,48 +183,66 @@ void AlertRequest::on_event(const event_engine::Event& event) {
       return;
     }
   }
-  if (!HasHmiResponsesToWait()) {
-    std::string response_info("");
-    if ((mobile_apis::Result::UNSUPPORTED_RESOURCE == tts_speak_response_) &&
-        (!flag_other_component_sent_)) {
-      response_success_ = false;
-      response_result_ = mobile_apis::Result::WARNINGS;
-      response_info = "Unsupported phoneme type sent in a prompt";
-    } else if ((mobile_apis::Result::UNSUPPORTED_RESOURCE ==
-        tts_speak_response_) && (mobile_apis::Result::UNSUPPORTED_RESOURCE ==
-            response_result_)) {
-      response_result_ = mobile_apis::Result::WARNINGS;
-      response_info = "Unsupported phoneme type sent in a prompt and "
-          "unsupported image sent in soft buttons";
-    } else if ((mobile_apis::Result::UNSUPPORTED_RESOURCE ==
-        tts_speak_response_) && (mobile_apis::Result::SUCCESS ==
-            response_result_)) {
-      response_result_ = mobile_apis::Result::WARNINGS;
-      response_info = "Unsupported phoneme type sent in a prompt";
-    } else if ((mobile_apis::Result::SUCCESS == tts_speak_response_) &&
-              ((mobile_apis::Result::INVALID_ENUM == response_result_) &&
-              (!flag_other_component_sent_))) {
-      response_result_ = mobile_apis::Result::SUCCESS;
-      response_success_ = true;
-    }
 
-    if (((mobile_apis::Result::ABORTED == tts_speak_response_ )||
-        (mobile_apis::Result::REJECTED == tts_speak_response_)) &&
-        (!flag_other_component_sent_)) {
-      response_success_ = false;
-      response_result_ = tts_speak_response_;
-    }
-    SendResponse(response_success_, response_result_,
-                 response_info.empty() ? NULL : response_info.c_str(),
-                     &response_params_);
+  if (HasHmiResponsesToWait()) {
+    return;
   }
+
+  const bool is_tts_alert_unsupported =
+      Compare<mobile_api::Result::eType, EQ, ALL>(
+        mobile_api::Result::UNSUPPORTED_RESOURCE,
+        tts_speak_result_,
+        alert_result_);
+
+  const bool is_alert_ok =
+      Compare<mobile_api::Result::eType, EQ, ONE>(
+        alert_result_,
+        mobile_api::Result::SUCCESS,
+        mobile_api::Result::WARNINGS);
+
+  std::string response_info;
+  if (mobile_apis::Result::UNSUPPORTED_RESOURCE == tts_speak_result_ &&
+      !is_ui_alert_sent_) {
+    is_alert_succeeded_ = false;
+    alert_result_ = mobile_apis::Result::WARNINGS;
+    response_info = "Unsupported phoneme type sent in a prompt";
+  } else if (is_tts_alert_unsupported) {
+    alert_result_ = mobile_apis::Result::WARNINGS;
+    response_info = "Unsupported phoneme type sent in a prompt and "
+        "unsupported image sent in soft buttons";
+  } else if (mobile_apis::Result::UNSUPPORTED_RESOURCE == tts_speak_result_ &&
+             is_alert_ok) {
+    alert_result_ = mobile_apis::Result::WARNINGS;
+    response_info = "Unsupported phoneme type sent in a prompt";
+  } else if (mobile_apis::Result::SUCCESS == tts_speak_result_ &&
+            (mobile_apis::Result::INVALID_ENUM == alert_result_ &&
+            !is_ui_alert_sent_)) {
+    alert_result_ = mobile_apis::Result::SUCCESS;
+    is_alert_succeeded_ = true;
+  }
+
+  const bool is_tts_not_ok =
+      Compare<mobile_api::Result::eType, EQ, ONE>(
+        tts_speak_result_,
+        mobile_api::Result::ABORTED,
+        mobile_api::Result::REJECTED);
+
+  if (is_tts_not_ok && !is_ui_alert_sent_) {
+    is_alert_succeeded_ = false;
+    alert_result_ = tts_speak_result_;
+  }
+  SendResponse(is_alert_succeeded_, alert_result_,
+               response_info.empty() ? NULL : response_info.c_str(),
+               &alert_response_params_);
 }
 
 bool AlertRequest::Validate(uint32_t app_id) {
-  ApplicationSharedPtr app = ApplicationManagerImpl::instance()->application(app_id);
+  LOG4CXX_AUTO_TRACE(logger_);
+  ApplicationSharedPtr app =
+      ApplicationManagerImpl::instance()->application(app_id);
 
   if (!app) {
-    LOG4CXX_ERROR_EXT(logger_, "No application associated with session key");
+    LOG4CXX_ERROR(logger_, "No application associated with session key");
     SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
     return false;
   }
@@ -252,7 +278,7 @@ bool AlertRequest::Validate(uint32_t app_id) {
       && (!(*message_)[strings::msg_params].keyExists(strings::tts_chunks)
           && (1 > (*message_)[strings::msg_params]
                               [strings::tts_chunks].length()))) {
-    LOG4CXX_ERROR_EXT(logger_, "Mandatory parameters are missing");
+    LOG4CXX_ERROR(logger_, "Mandatory parameters are missing");
     SendResponse(false, mobile_apis::Result::INVALID_DATA,
                  "Mandatory parameters are missing");
     return false;
@@ -262,7 +288,9 @@ bool AlertRequest::Validate(uint32_t app_id) {
 }
 
 void AlertRequest::SendAlertRequest(int32_t app_id) {
-  ApplicationSharedPtr app = ApplicationManagerImpl::instance()->application(app_id);
+  LOG4CXX_AUTO_TRACE(logger_);
+  ApplicationSharedPtr app =
+      ApplicationManagerImpl::instance()->application(app_id);
 
   smart_objects::SmartObject msg_params = smart_objects::SmartObject(
       smart_objects::SmartType_Map);
@@ -320,18 +348,20 @@ void AlertRequest::SendAlertRequest(int32_t app_id) {
       msg_params.keyExists(hmi_request::soft_buttons)) {
 
     awaiting_ui_alert_response_ = true;
-    flag_other_component_sent_ = true;
+    is_ui_alert_sent_ = true;
     SendHMIRequest(hmi_apis::FunctionID::UI_Alert, &msg_params, true);
   }
 }
 
 void AlertRequest::SendSpeakRequest(int32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
   using namespace hmi_apis;
   using namespace smart_objects;
   // crate HMI speak request
   SmartObject msg_params = smart_objects::SmartObject(SmartType_Map);
 
-  msg_params[hmi_request::tts_chunks] = smart_objects::SmartObject(SmartType_Array);
+  msg_params[hmi_request::tts_chunks] =
+      smart_objects::SmartObject(SmartType_Array);
   msg_params[hmi_request::tts_chunks] =
     (*message_)[strings::msg_params][strings::tts_chunks];
   msg_params[strings::app_id] = app_id;
@@ -351,7 +381,8 @@ void AlertRequest::SendPlayToneNotification(int32_t app_id) {
       SmartObject msg_params = smart_objects::SmartObject(SmartType_Map);
       msg_params[strings::app_id] = app_id;
       msg_params[strings::method_name] = Common_MethodName::ALERT;
-      CreateHMINotification(FunctionID::BasicCommunication_PlayTone, msg_params);
+      CreateHMINotification(FunctionID::BasicCommunication_PlayTone,
+                            msg_params);
     }
   }
 }
@@ -399,6 +430,7 @@ bool AlertRequest::CheckStringsOfAlertRequest() {
 }
 
 bool AlertRequest::HasHmiResponsesToWait() {
+  LOG4CXX_AUTO_TRACE(logger_);
   return awaiting_ui_alert_response_ || awaiting_tts_speak_response_
       || awaiting_tts_stop_speaking_response_;
 }

--- a/src/components/application_manager/src/commands/mobile/alert_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_request.cc
@@ -146,8 +146,10 @@ void AlertRequest::on_event(const event_engine::Event& event) {
           static_cast<mobile_apis::Result::eType>(
               message[strings::params][hmi_response::code].asInt());
       // Mobile Alert request is successful when UI_Alert is successful
-      response_success_ = (mobile_apis::Result::SUCCESS == result_code ||
-          mobile_apis::Result::UNSUPPORTED_RESOURCE == result_code);
+      response_success_ =
+          mobile_apis::Result::SUCCESS == result_code ||
+          mobile_apis::Result::UNSUPPORTED_RESOURCE == result_code ||
+          mobile_apis::Result::WARNINGS == result_code;
       response_result_ = result_code;
       response_params_ = message[strings::msg_params];
       break;
@@ -224,7 +226,7 @@ bool AlertRequest::Validate(uint32_t app_id) {
         static_cast<mobile_apis::FunctionID::eType>(function_id()),
         application_manager::TLimitSource::POLICY_TABLE)) {
     LOG4CXX_ERROR(logger_, "Alert frequency is too high.");
-    SendResponse(false, mobile_apis::Result::REJECTED);    
+    SendResponse(false, mobile_apis::Result::REJECTED);
     return false;
   }
 

--- a/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -39,6 +39,8 @@
 #include "application_manager/application_manager_impl.h"
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
+#include "utils/gen_hash.h"
+#include "utils/helpers.h"
 
 namespace application_manager {
 
@@ -60,7 +62,7 @@ void CreateInteractionChoiceSetRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace mobile_apis;
   ApplicationSharedPtr app = ApplicationManagerImpl::instance()->application(
-                (*message_)[strings::params][strings::connection_key].asUInt());
+        connection_key());
 
   if (!app) {
     LOG4CXX_ERROR(logger_, "NULL pointer");
@@ -86,7 +88,7 @@ void CreateInteractionChoiceSetRequest::Run() {
     }
     if (verification_result_image == Result::INVALID_DATA ||
         verification_result_secondary_image == Result::INVALID_DATA) {
-      LOG4CXX_ERROR(logger_, "VerifyImage INVALID_DATA!");
+      LOG4CXX_ERROR(logger_, "Image verification failed.");
         SendResponse(false, Result::INVALID_DATA);
       return;
     }
@@ -96,7 +98,8 @@ void CreateInteractionChoiceSetRequest::Run() {
                    [strings::interaction_choice_set_id].asInt();
 
   if (app->FindChoiceSet(choice_set_id_)) {
-    LOG4CXX_ERROR(logger_, "Invalid ID");
+    LOG4CXX_ERROR(logger_, "Choice set with id " << choice_set_id_ <<
+                  " is not found.");
     SendResponse(false, Result::INVALID_ID);
     return;
   }
@@ -353,6 +356,7 @@ void CreateInteractionChoiceSetRequest::SendVRAddCommandRequests(
 void CreateInteractionChoiceSetRequest::on_event(
     const event_engine::Event& event) {
   using namespace hmi_apis;
+  using namespace helpers;
   LOG4CXX_AUTO_TRACE(logger_);
 
   const smart_objects::SmartObject& message = event.smart_object();
@@ -364,54 +368,44 @@ void CreateInteractionChoiceSetRequest::on_event(
 
     uint32_t corr_id = static_cast<uint32_t>(message[strings::params]
         [strings::correlation_id].asUInt());
-    SentCommandsMap::iterator it = sent_commands_map_.find(corr_id);
-    if (sent_commands_map_.end() == it) {
-      LOG4CXX_WARN(logger_, "HMI response for unknown VR command received");
+    {
+      sync_primitives::AutoLock commands_lock(vr_commands_lock_);
+      SentCommandsMap::iterator it = sent_commands_map_.find(corr_id);
+      if (sent_commands_map_.end() == it) {
+        LOG4CXX_WARN(logger_, "HMI response for unknown VR command received");
+        return;
+      }
+
+
+      Common_Result::eType  vr_result = static_cast<Common_Result::eType>(
+            message[strings::params][hmi_response::code].asInt());
+
+      const bool is_vr_no_error =
+          Compare<Common_Result::eType, EQ, ONE>(
+            vr_result,
+            Common_Result::SUCCESS,
+            Common_Result::WARNINGS);
+
+      if (is_vr_no_error) {
+        VRCommandInfo& vr_command = it->second;
+        vr_command.succesful_response_received_ = true;
+      } else {
+        LOG4CXX_DEBUG(logger_, "Hmi response is not Success: " << vr_result
+                      << ". Stop sending VRAddCommand requests");
+        if (!error_from_hmi_) {
+          error_from_hmi_ = true;
+          SendResponse(false, GetMobileResultCode(vr_result));
+        }
+      }
+    }
+
+    if (received_chs_count_ < expected_chs_count_) {
+      ApplicationManagerImpl::instance()->updateRequestTimeout(
+            connection_key(), correlation_id(), default_timeout());
+      LOG4CXX_DEBUG(logger_, "Timeout for request was updated");
       return;
     }
-
-    Common_Result::eType  vr_result_ = static_cast<Common_Result::eType>(
-          message[strings::params][hmi_response::code].asInt());
-    if (Common_Result::SUCCESS == vr_result_) {
-      VRCommandInfo& vr_command = it->second;
-      vr_command.succesful_response_received_ = true;
-    } else {
-      LOG4CXX_DEBUG(logger_, "Hmi response is not Success: " << vr_result_
-                    << ". Stop sending VRAddCommand requests");
-      sync_primitives::AutoLock error_lock(error_from_hmi_lock_);
-      if (!error_from_hmi_) {
-        error_from_hmi_ = true;
-        SendResponse(false, GetMobileResultCode(vr_result_));
-      }
-    }
-
-    // update request timeout for case we send many VR add command requests
-    // and HMI has no time to send responses for all of them
-    LOG4CXX_DEBUG(logger_, "expected_chs_count_ = " << expected_chs_count_
-                  << "received_chs_count_ = " << received_chs_count_);
-    if (received_chs_count_ < expected_chs_count_) {
-      sync_primitives::AutoLock timeout_lock_(is_timed_out_lock_);
-      if (!is_timed_out_) {
-        ApplicationManagerImpl::instance()->updateRequestTimeout(
-              connection_key(), correlation_id(), default_timeout());
-        Common_Result::eType  vr_result = static_cast<Common_Result::eType>(
-              message[strings::params][hmi_response::code].asInt());
-        if (Common_Result::SUCCESS == vr_result ||
-            Common_Result::WARNINGS == vr_result) {
-          VRCommandInfo& vr_command = it->second;
-          vr_command.succesful_response_received_ = true;
-        } else {
-          LOG4CXX_DEBUG(logger_, "Hmi response is not Success: " << vr_result
-                        << ". Stop sending VRAddCommand requests");
-          if (!error_from_hmi_) {
-            error_from_hmi_ = true;
-            SendResponse(false, GetMobileResultCode(vr_result));
-          }
-        }
-      } else {
-        OnAllHMIResponsesReceived();
-      }
-    }
+    OnAllHMIResponsesReceived();
   }
 }
 

--- a/src/components/application_manager/src/commands/mobile/delete_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/delete_command_request.cc
@@ -150,12 +150,10 @@ void DeleteCommandRequest::on_event(const event_engine::Event& event) {
     if (command) {
       mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
 
-      bool result = ((hmi_apis::Common_Result::SUCCESS == ui_result_) &&
-                     (hmi_apis::Common_Result::SUCCESS == vr_result_)) ||
-                     ((hmi_apis::Common_Result::SUCCESS == ui_result_) &&
-                     (hmi_apis::Common_Result::INVALID_ENUM == vr_result_)) ||
-                     ((hmi_apis::Common_Result::INVALID_ENUM == ui_result_) &&
-                     (hmi_apis::Common_Result::SUCCESS == vr_result_));
+      bool result =
+          ((hmi_apis::Common_Result::SUCCESS == ui_result_) && (hmi_apis::Common_Result::SUCCESS == vr_result_)) ||
+          ((hmi_apis::Common_Result::SUCCESS == ui_result_) && (hmi_apis::Common_Result::INVALID_ENUM == vr_result_)) ||
+          ((hmi_apis::Common_Result::INVALID_ENUM == ui_result_) && (hmi_apis::Common_Result::SUCCESS == vr_result_));
 
       if (result) {
         application->RemoveCommand(

--- a/src/components/application_manager/src/commands/mobile/delete_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/delete_command_request.cc
@@ -36,6 +36,7 @@
 #include "application_manager/application_impl.h"
 #include "interfaces/MOBILE_API.h"
 #include "interfaces/HMI_API.h"
+#include "utils/helpers.h"
 
 namespace application_manager {
 
@@ -57,8 +58,8 @@ DeleteCommandRequest::~DeleteCommandRequest() {
 void DeleteCommandRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  ApplicationSharedPtr application = ApplicationManagerImpl::instance()->application(
-      (*message_)[strings::params][strings::connection_key].asUInt());
+  ApplicationSharedPtr application = ApplicationManagerImpl::instance()->
+      application(connection_key());
 
   if (!application) {
     SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
@@ -66,12 +67,14 @@ void DeleteCommandRequest::Run() {
     return;
   }
 
-  smart_objects::SmartObject* command = application->FindCommand(
-      (*message_)[strings::msg_params][strings::cmd_id].asInt());
+  const int32_t cmd_id =
+      (*message_)[strings::msg_params][strings::cmd_id].asInt();
+
+  smart_objects::SmartObject* command = application->FindCommand(cmd_id);
 
   if (!command) {
     SendResponse(false, mobile_apis::Result::INVALID_ID);
-    LOG4CXX_ERROR(logger_, "Invalid ID");
+    LOG4CXX_ERROR(logger_, "Command with id " << cmd_id << " is not found.");
     return;
   }
 
@@ -110,6 +113,8 @@ void DeleteCommandRequest::Run() {
 
 void DeleteCommandRequest::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
+  using namespace helpers;
+
   const smart_objects::SmartObject& message = event.smart_object();
 
   switch (event.id()) {
@@ -135,47 +140,85 @@ void DeleteCommandRequest::on_event(const event_engine::Event& event) {
     }
   }
 
-  if (!IsPendingResponseExist()) {
-    ApplicationSharedPtr application =
-        ApplicationManagerImpl::instance()->application(connection_key());
+  if (IsPendingResponseExist()) {
+    LOG4CXX_DEBUG(logger_, "Still awaiting for other responses.");
+    return;
+  }
 
-    if (!application) {
-      LOG4CXX_ERROR(logger_, "NULL pointer");
-      return;
-    }
+  ApplicationSharedPtr application =
+      ApplicationManagerImpl::instance()->application(connection_key());
 
-    smart_objects::SmartObject* command = application->FindCommand(
-        (*message_)[strings::msg_params][strings::cmd_id].asInt());
+  if (!application) {
+    LOG4CXX_ERROR(logger_, "NULL pointer");
+    return;
+  }
 
-    if (command) {
-      mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
+  const int32_t cmd_id =
+      (*message_)[strings::msg_params][strings::cmd_id].asInt();
 
-      bool result =
-          ((hmi_apis::Common_Result::SUCCESS == ui_result_) && (hmi_apis::Common_Result::SUCCESS == vr_result_)) ||
-          ((hmi_apis::Common_Result::SUCCESS == ui_result_) && (hmi_apis::Common_Result::INVALID_ENUM == vr_result_)) ||
-          ((hmi_apis::Common_Result::INVALID_ENUM == ui_result_) && (hmi_apis::Common_Result::SUCCESS == vr_result_));
+  smart_objects::SmartObject* command = application->FindCommand(cmd_id);
 
-      if (result) {
-        application->RemoveCommand(
-          (*message_)[strings::msg_params][strings::cmd_id].asInt());
-      }
+  if (!command) {
+    LOG4CXX_ERROR(logger_, "Command id " << cmd_id << " not found for "
+                  "application with connection key " << connection_key());
+    return;
+  }
 
-      if (!result && (hmi_apis::Common_Result::REJECTED == ui_result_)) {
-        result_code = static_cast<mobile_apis::Result::eType>(vr_result_);
-      } else {
-        result_code = static_cast<mobile_apis::Result::eType>(
-            std::max(ui_result_, vr_result_));
-      }
+  mobile_apis::Result::eType result_code =
+      mobile_apis::Result::INVALID_ENUM;
 
-      SendResponse(result, result_code, NULL, &(message[strings::msg_params]));
-      if (result) {
-        application->UpdateHash();
-      }
-    }
+  const bool is_vr_success_invalid =
+      Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+        vr_result_,
+        hmi_apis::Common_Result::SUCCESS,
+        hmi_apis::Common_Result::INVALID_ENUM);
+
+  const bool is_ui_success_invalid =
+      Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+        ui_result_,
+        hmi_apis::Common_Result::SUCCESS,
+        hmi_apis::Common_Result::INVALID_ENUM);
+
+  const bool is_vr_ui_invalid =
+      Compare<hmi_apis::Common_Result::eType, EQ, ALL>(
+        hmi_apis::Common_Result::INVALID_ENUM,
+        vr_result_,
+        ui_result_);
+
+  bool result =
+      is_ui_success_invalid &&
+      is_vr_success_invalid &&
+      !is_vr_ui_invalid;
+
+  if (result) {
+    application->RemoveCommand(
+      (*message_)[strings::msg_params][strings::cmd_id].asInt());
+  }
+
+  const bool is_vr_or_ui_warning =
+      Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+        hmi_apis::Common_Result::WARNINGS,
+        ui_result_,
+        vr_result_);
+
+  if (!result &&
+      hmi_apis::Common_Result::REJECTED == ui_result_) {
+    result_code = MessageHelper::HMIToMobileResult(vr_result_);
+  } else if (is_vr_or_ui_warning) {
+    result_code = mobile_apis::Result::WARNINGS;
+  } else {
+    result_code = MessageHelper::HMIToMobileResult(
+          std::max(ui_result_, vr_result_));
+  }
+
+  SendResponse(result, result_code, NULL, &(message[strings::msg_params]));
+  if (result) {
+    application->UpdateHash();
   }
 }
 
 bool DeleteCommandRequest::IsPendingResponseExist() {
+  LOG4CXX_AUTO_TRACE(logger_);
   return is_ui_send_ != is_ui_received_ || is_vr_send_ != is_vr_received_;
 }
 

--- a/src/components/application_manager/src/commands/mobile/delete_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/delete_interaction_choice_set_request.cc
@@ -37,6 +37,7 @@
 #include "interfaces/MOBILE_API.h"
 #include "interfaces/HMI_API.h"
 #include "application_manager/message_helper.h"
+
 namespace application_manager {
 
 namespace commands {
@@ -52,27 +53,29 @@ DeleteInteractionChoiceSetRequest::~DeleteInteractionChoiceSetRequest() {
 void DeleteInteractionChoiceSetRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  ApplicationSharedPtr app = ApplicationManagerImpl::instance()->application(
-      (*message_)[strings::params][strings::connection_key].asUInt());
+  ApplicationSharedPtr app =
+      ApplicationManagerImpl::instance()->application(connection_key());
 
   if (!app) {
-    LOG4CXX_ERROR_EXT(logger_, "No application associated with session key");
+    LOG4CXX_ERROR(logger_, "No application associated with connection key "
+                  << connection_key());
     SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
     return;
   }
 
-  const int32_t choise_set_id =
+  const int32_t choice_set_id =
       (*message_)[strings::msg_params]
                   [strings::interaction_choice_set_id].asInt();
 
-  if (!app->FindChoiceSet(choise_set_id)) {
-    LOG4CXX_ERROR_EXT(logger_, "INVALID_ID");
+  if (!app->FindChoiceSet(choice_set_id)) {
+    LOG4CXX_ERROR(logger_, "Choice set with id " << choice_set_id
+                  << " is not found.");
     SendResponse(false, mobile_apis::Result::INVALID_ID);
     return;
   }
 
   if (ChoiceSetInUse(app)) {
-    LOG4CXX_ERROR_EXT(logger_, "Choice set currently in use");
+    LOG4CXX_ERROR(logger_, "Choice set currently in use.");
     SendResponse(false, mobile_apis::Result::IN_USE);
     return;
   }
@@ -81,61 +84,70 @@ void DeleteInteractionChoiceSetRequest::Run() {
   smart_objects::SmartObject msg_params = smart_objects::SmartObject(
       smart_objects::SmartType_Map);
 
-  msg_params[strings::interaction_choice_set_id] = choise_set_id;
+  msg_params[strings::interaction_choice_set_id] = choice_set_id;
   msg_params[strings::app_id] = app->app_id();
 
-  app->RemoveChoiceSet(choise_set_id);
+  app->RemoveChoiceSet(choice_set_id);
 
+  // Checking of HMI responses will be implemented with APPLINK-14600
   SendResponse(true, mobile_apis::Result::SUCCESS);
   app->UpdateHash();
-
-   /*CreateHMIRequest(hmi_apis::FunctionID::UI_DeleteInteractionChoiceSet,
-   msg_params, true);*/
 }
 
-bool DeleteInteractionChoiceSetRequest::ChoiceSetInUse(ApplicationConstSharedPtr app) {
-  if (app->is_perform_interaction_active()) {
-    // retrieve stored choice sets for perform interaction
+bool DeleteInteractionChoiceSetRequest::ChoiceSetInUse(
+    ApplicationConstSharedPtr app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!app->is_perform_interaction_active()) {
+    return false;
+  }
   const DataAccessor<PerformChoiceSetMap> accessor =
       app->performinteraction_choice_set_map();
   const PerformChoiceSetMap& choice_set_map = accessor.GetData();
 
-    PerformChoiceSetMap::const_iterator it = choice_set_map.begin();
-    for (; choice_set_map.end() != it; ++it) {
-      const PerformChoice& choice =  it->second;
-      PerformChoice::const_iterator choice_it = choice.begin();
-      for (; choice.end() != choice_it; ++choice_it) {
-        if (choice_it->first == (*message_)[strings::msg_params]
-                                [strings::interaction_choice_set_id].asUInt()) {
-          LOG4CXX_ERROR_EXT(logger_,
-                            "DeleteInteractionChoiceSetRequest::ChoiceSetInUse");
-          return true;
-        }
+  const uint32_t choice_set_id =
+      (*message_)[strings::msg_params][strings::interaction_choice_set_id].
+      asUInt();
+
+  PerformChoiceSetMap::const_iterator it = choice_set_map.begin();
+  for (; choice_set_map.end() != it; ++it) {
+    const PerformChoice& choice =  it->second;
+    PerformChoice::const_iterator choice_it = choice.begin();
+    for (; choice.end() != choice_it; ++choice_it) {
+      if (choice_it->first == choice_set_id) {
+        LOG4CXX_ERROR(logger_, "Choice set with id " << choice_set_id
+                      << " is in use.");
+        return true;
       }
     }
   }
-  return false;
+  return true;
 }
 
 void DeleteInteractionChoiceSetRequest::SendVrDeleteCommand(
     application_manager::ApplicationSharedPtr app) {
-  LOG4CXX_INFO(logger_, "PerformInteractionRequest::SendVrDeleteCommand");
+  LOG4CXX_AUTO_TRACE(logger_);
 
-  smart_objects::SmartObject* choice_set =
-                              app->FindChoiceSet((*message_)[strings::msg_params]
-                               [strings::interaction_choice_set_id].asInt());
+  const uint32_t choice_set_id =
+      (*message_)[strings::msg_params][strings::interaction_choice_set_id].
+      asUInt();
 
-  if (choice_set) {
-    smart_objects::SmartObject msg_params = smart_objects::SmartObject(
-        smart_objects::SmartType_Map);
-    msg_params[strings::app_id] = app->app_id();
-    msg_params[strings::type] = hmi_apis::Common_VRCommandType::Choice;
-    msg_params[strings::grammar_id] = (*choice_set)[strings::grammar_id];
-    choice_set = &((*choice_set)[strings::choice_set]);
-    for (uint32_t i = 0; i < (*choice_set).length() ; ++i) {
-      msg_params[strings::cmd_id] = (*choice_set)[i][strings::choice_id];
-      SendHMIRequest(hmi_apis::FunctionID::VR_DeleteCommand, &msg_params);
-    }
+  smart_objects::SmartObject* choice_set = app->FindChoiceSet(choice_set_id);
+
+  if (!choice_set) {
+    LOG4CXX_ERROR(logger_, "Choice set with id " << choice_set_id
+                  << " is not found.");
+    return;
+  }
+
+  smart_objects::SmartObject msg_params = smart_objects::SmartObject(
+      smart_objects::SmartType_Map);
+  msg_params[strings::app_id] = app->app_id();
+  msg_params[strings::type] = hmi_apis::Common_VRCommandType::Choice;
+  msg_params[strings::grammar_id] = (*choice_set)[strings::grammar_id];
+  choice_set = &((*choice_set)[strings::choice_set]);
+  for (uint32_t i = 0; i < (*choice_set).length() ; ++i) {
+    msg_params[strings::cmd_id] = (*choice_set)[i][strings::choice_id];
+    SendHMIRequest(hmi_apis::FunctionID::VR_DeleteCommand, &msg_params);
   }
 }
 

--- a/src/components/application_manager/src/commands/mobile/delete_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/delete_sub_menu_request.cc
@@ -146,7 +146,9 @@ void DeleteSubMenuRequest::on_event(const event_engine::Event& event) {
           static_cast<mobile_apis::Result::eType>(
               message[strings::params][hmi_response::code].asInt());
 
-      bool result = mobile_apis::Result::SUCCESS == result_code;
+      bool result =
+          mobile_apis::Result::SUCCESS == result_code ||
+          mobile_apis::Result::WARNINGS == result_code;
 
       ApplicationSharedPtr application =
              ApplicationManagerImpl::instance()->application(connection_key());

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -336,6 +336,7 @@ bool PerformAudioPassThruRequest::IsWhiteSpaceExist() {
 void PerformAudioPassThruRequest::FinishTTSSpeak(){
   LOG4CXX_AUTO_TRACE(logger_);
   if (!is_active_tts_speak_) {
+    LOG4CXX_DEBUG(logger_, "TTS Speak is inactive.");
     return;
   }
   is_active_tts_speak_ = false;

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -135,8 +135,10 @@ void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
       FinishTTSSpeak();
 
       std::string return_info;
-      bool result = mobile_apis::Result::SUCCESS == mobile_code ||
-                          mobile_apis::Result::RETRY == mobile_code;
+      bool result =
+          mobile_apis::Result::SUCCESS == mobile_code ||
+          mobile_apis::Result::RETRY == mobile_code ||
+          mobile_apis::Result::WARNINGS == mobile_code;
 
       if ((mobile_apis::Result::SUCCESS == mobile_code) &&
           (mobile_apis::Result::UNSUPPORTED_RESOURCE == result_tts_speak_)) {

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -36,6 +36,7 @@
 #include "application_manager/application_manager_impl.h"
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
+#include "utils/helpers.h"
 
 namespace application_manager {
 
@@ -92,7 +93,8 @@ void PerformAudioPassThruRequest::Run() {
 
   if (IsWhiteSpaceExist()) {
     LOG4CXX_ERROR(logger_,
-                  "Incoming perform audio pass thru has contains \\t\\n \\\\t \\\\n"
+                  "Incoming perform audio pass thru has contains "
+                  "\\t\\n \\\\t \\\\n"
                   " text contains only whitespace in initialPrompt");
     SendResponse(false, mobile_apis::Result::INVALID_DATA);
     return;
@@ -112,6 +114,8 @@ void PerformAudioPassThruRequest::Run() {
 
 void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
+  using namespace helpers;
+
   const smart_objects::SmartObject& message = event.smart_object();
 
   switch (event.id()) {
@@ -135,13 +139,21 @@ void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
       FinishTTSSpeak();
 
       std::string return_info;
-      bool result =
-          mobile_apis::Result::SUCCESS == mobile_code ||
-          mobile_apis::Result::RETRY == mobile_code ||
-          mobile_apis::Result::WARNINGS == mobile_code;
+      const bool result =
+          Compare<mobile_api::Result::eType, EQ, ONE>(
+            mobile_code,
+            mobile_apis::Result::SUCCESS,
+            mobile_apis::Result::RETRY,
+            mobile_apis::Result::WARNINGS);
 
-      if ((mobile_apis::Result::SUCCESS == mobile_code) &&
-          (mobile_apis::Result::UNSUPPORTED_RESOURCE == result_tts_speak_)) {
+      const bool is_result_ok =
+          Compare<mobile_api::Result::eType, EQ, ONE>(
+            mobile_code,
+            mobile_apis::Result::SUCCESS,
+            mobile_apis::Result::WARNINGS);
+
+      if (is_result_ok &&
+          mobile_apis::Result::UNSUPPORTED_RESOURCE == result_tts_speak_) {
         mobile_code = mobile_apis::Result::WARNINGS;
         return_info = "Unsupported phoneme type sent in a prompt";
       }
@@ -152,7 +164,8 @@ void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
     }
     case hmi_apis::FunctionID::TTS_Speak: {
       LOG4CXX_INFO(logger_, "Received TTS_Speak event");
-      result_tts_speak_ = GetMobileResultCode(static_cast<hmi_apis::Common_Result::eType>(
+      result_tts_speak_ = GetMobileResultCode(
+            static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asUInt()));
       is_active_tts_speak_ = false;
       if (mobile_apis::Result::SUCCESS == result_tts_speak_) {
@@ -182,7 +195,8 @@ void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
 }
 
 void PerformAudioPassThruRequest::SendSpeakRequest() {
-  // crate HMI TTS speak request
+  LOG4CXX_AUTO_TRACE(logger_);
+
   using namespace hmi_apis;
   using namespace smart_objects;
 
@@ -207,12 +221,13 @@ void PerformAudioPassThruRequest::SendSpeakRequest() {
 }
 
 void PerformAudioPassThruRequest::SendPerformAudioPassThruRequest() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
   smart_objects::SmartObject msg_params = smart_objects::SmartObject(
       smart_objects::SmartType_Map);
 
   msg_params[str::app_id] = connection_key();
 
-  // duration
   msg_params[hmi_request::max_duration] =
       (*message_)[str::msg_params][str::max_duration];
 
@@ -250,6 +265,8 @@ void PerformAudioPassThruRequest::SendPerformAudioPassThruRequest() {
 }
 
 void PerformAudioPassThruRequest::SendRecordStartNotification() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
   smart_objects::SmartObject msg_params = smart_objects::SmartObject(
       smart_objects::SmartType_Map);
   msg_params[strings::app_id] = connection_key();
@@ -258,6 +275,8 @@ void PerformAudioPassThruRequest::SendRecordStartNotification() {
 }
 
 void PerformAudioPassThruRequest::StartMicrophoneRecording() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
   ApplicationManagerImpl::instance()->begin_audio_pass_thru();
 
   ApplicationManagerImpl::instance()->StartAudioPassThruThread(
@@ -315,10 +334,12 @@ bool PerformAudioPassThruRequest::IsWhiteSpaceExist() {
 }
 
 void PerformAudioPassThruRequest::FinishTTSSpeak(){
-  if (is_active_tts_speak_) {
-    is_active_tts_speak_ = false;
-    SendHMIRequest(hmi_apis::FunctionID::TTS_StopSpeaking, NULL);
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!is_active_tts_speak_) {
+    return;
   }
+  is_active_tts_speak_ = false;
+  SendHMIRequest(hmi_apis::FunctionID::TTS_StopSpeaking, NULL);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
@@ -377,7 +377,8 @@ void PerformInteractionRequest::ProcessPerformInteractionResponse(
       GetMobileResultCode(static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asUInt()));
 
-  if (mobile_apis::Result::SUCCESS == result_code) {
+  if (mobile_apis::Result::SUCCESS == result_code ||
+      mobile_apis::Result::WARNINGS == result_code) {
     result = true;
   }
 

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -302,9 +302,10 @@ void RegisterAppInterfaceRequest::Run() {
   }
 }
 
-void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
-  mobile_apis::Result::eType result) {
+void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
   smart_objects::SmartObject response_params(smart_objects::SmartType_Map);
+
+  mobile_apis::Result::eType result_code = mobile_apis::Result::SUCCESS;
 
   ApplicationManagerImpl* app_manager = ApplicationManagerImpl::instance();
   const HMICapabilities& hmi_capabilities = app_manager->hmi_capabilities();
@@ -350,7 +351,7 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
       << " - "
       << hmi_capabilities.active_ui_language());
 
-    result = mobile_apis::Result::WRONG_LANGUAGE;
+    result_code = mobile_apis::Result::WRONG_LANGUAGE;
   }
 
   if (hmi_capabilities.display_capabilities()) {
@@ -487,22 +488,22 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
     hash_id = (*message_)[strings::msg_params][strings::hash_id].asString();
     if (!resumer.CheckApplicationHash(application, hash_id)) {
       LOG4CXX_WARN(logger_, "Hash does not match");
-      result = mobile_apis::Result::RESUME_FAILED;
+      result_code = mobile_apis::Result::RESUME_FAILED;
       add_info = "Hash does not match";
       need_restore_vr = false;
     } else if (!resumer.CheckPersistenceFilesForResumption(application)) {
       LOG4CXX_WARN(logger_, "Persistent data is missed");
-      result = mobile_apis::Result::RESUME_FAILED;
+      result_code = mobile_apis::Result::RESUME_FAILED;
       add_info = "Persistent data is missed";
       need_restore_vr = false;
     } else {
       add_info = " Resume Succeed";
     }
   }
-  if ((mobile_apis::Result::SUCCESS == result) &&
+  if ((mobile_apis::Result::SUCCESS == result_code) &&
       (mobile_apis::Result::INVALID_ENUM != result_checking_app_hmi_type_)) {
     add_info += response_info_;
-    result = result_checking_app_hmi_type_;
+    result_code = result_checking_app_hmi_type_;
   }
 
   // in case application exist in resumption we need to send resumeVrgrammars
@@ -519,11 +520,12 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
 
   MessageHelper::SendChangeRegistrationRequestToHMI(application);
 
-  SendResponse(true, result, add_info.c_str(), &response_params);
+  bool is_success = true;
+  SendResponse(is_success, result_code, add_info.c_str(), &response_params);
   MessageHelper::SendOnAppRegisteredNotificationToHMI(*(application.get()),
                                                       resumption,
                                                       need_restore_vr);
-  if (result != mobile_apis::Result::RESUME_FAILED) {
+  if (result_code != mobile_apis::Result::RESUME_FAILED) {
     resumer.StartResumption(application, hash_id);
   } else {
     resumer.StartResumptionOnlyHMILevel(application);

--- a/src/components/application_manager/src/commands/mobile/scrollable_message_request.cc
+++ b/src/components/application_manager/src/commands/mobile/scrollable_message_request.cc
@@ -133,7 +133,8 @@ void ScrollableMessageRequest::on_event(const event_engine::Event& event) {
       HMICapabilities& hmi_capabilities =
           ApplicationManagerImpl::instance()->hmi_capabilities();
       bool result = false;
-      if (mobile_apis::Result::SUCCESS == result_code) {
+      if (mobile_apis::Result::SUCCESS == result_code ||
+          mobile_apis::Result::WARNINGS == result_code) {
         result = true;
       } else if ((mobile_apis::Result::UNSUPPORTED_RESOURCE == result_code) &&
           hmi_capabilities.is_ui_cooperating()) {

--- a/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
@@ -38,6 +38,7 @@
 #include "interfaces/MOBILE_API.h"
 #include "interfaces/HMI_API.h"
 #include "utils/file_system.h"
+#include "utils/helpers.h"
 
 namespace application_manager {
 
@@ -230,17 +231,20 @@ bool SetAppIconRequest::IsEnoughSpaceForIcon(const uint64_t icon_size) const {
 
 void SetAppIconRequest::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
-  const smart_objects::SmartObject& event_message = event.smart_object();
+  using namespace helpers;
+  const smart_objects::SmartObject& message = event.smart_object();
 
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_SetAppIcon: {
       mobile_apis::Result::eType result_code =
           static_cast<mobile_apis::Result::eType>(
-              event_message[strings::params][hmi_response::code].asInt());
+              message[strings::params][hmi_response::code].asInt());
 
-      bool result =
-          mobile_apis::Result::SUCCESS == result_code ||
-          mobile_apis::Result::WARNINGS == result_code;
+     const bool result =
+         Compare<mobile_api::Result::eType, EQ, ONE>(
+           result_code,
+           mobile_api::Result::SUCCESS,
+           mobile_api::Result::WARNINGS);
 
       if (result) {
         ApplicationSharedPtr app =
@@ -260,7 +264,7 @@ void SetAppIconRequest::on_event(const event_engine::Event& event) {
                      "Icon path was set to '" << app->app_icon_path() << "'");
       }
 
-      SendResponse(result, result_code, NULL, &(event_message[strings::msg_params]));
+      SendResponse(result, result_code, NULL, &(message[strings::msg_params]));
       break;
     }
     default: {

--- a/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
@@ -238,7 +238,9 @@ void SetAppIconRequest::on_event(const event_engine::Event& event) {
           static_cast<mobile_apis::Result::eType>(
               event_message[strings::params][hmi_response::code].asInt());
 
-      bool result = mobile_apis::Result::SUCCESS == result_code;
+      bool result =
+          mobile_apis::Result::SUCCESS == result_code ||
+          mobile_apis::Result::WARNINGS == result_code;
 
       if (result) {
         ApplicationSharedPtr app =

--- a/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
@@ -331,17 +331,19 @@ void SetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
     return;
   }
 
-  const bool is_tts_success_unsupported =
+  const bool is_tts_succeeded =
       Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
         tts_result_,
         hmi_apis::Common_Result::SUCCESS,
-        hmi_apis::Common_Result::UNSUPPORTED_RESOURCE);
+        hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
+        hmi_apis::Common_Result::WARNINGS);
 
-  const bool is_ui_success_unsupported =
+  const bool is_ui_succeeded =
       Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
         ui_result_,
         hmi_apis::Common_Result::SUCCESS,
-        hmi_apis::Common_Result::UNSUPPORTED_RESOURCE);
+        hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
+        hmi_apis::Common_Result::WARNINGS);
 
   const bool is_ui_invalid_unsupported =
       Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
@@ -350,12 +352,10 @@ void SetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
         hmi_apis::Common_Result::UNSUPPORTED_RESOURCE);
 
   bool result =
-      (is_tts_success_unsupported &&
-       hmi_apis::Common_Result::SUCCESS == ui_result_) ||
-      (is_ui_success_unsupported &&
+      (is_tts_succeeded && is_ui_succeeded) ||
+      (is_ui_succeeded &&
        hmi_apis::Common_Result::INVALID_ENUM == tts_result_) ||
-      (is_ui_invalid_unsupported &&
-       hmi_apis::Common_Result::SUCCESS == tts_result_);
+      (is_ui_invalid_unsupported && is_tts_succeeded);
 
   mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
   const char* return_info = NULL;

--- a/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
@@ -308,8 +308,6 @@ void SetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
   const smart_objects::SmartObject& message = event.smart_object();
 
-  ApplicationSharedPtr app = ApplicationManagerImpl::instance()->application(CommandRequestImpl::connection_key());
-
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_SetGlobalProperties: {
       LOG4CXX_INFO(logger_, "Received UI_SetGlobalProperties event");

--- a/src/components/application_manager/src/commands/mobile/slider_request.cc
+++ b/src/components/application_manager/src/commands/mobile/slider_request.cc
@@ -126,7 +126,6 @@ void SliderRequest::on_event(const event_engine::Event& event) {
     return;
   }
 
-  //event_id == hmi_apis::FunctionID::UI_Slider:
   LOG4CXX_INFO(logger_, "Received UI_Slider event");
 
   const int response_code =
@@ -135,12 +134,13 @@ void SliderRequest::on_event(const event_engine::Event& event) {
   if (response_code == hmi_apis::Common_Result::ABORTED &&
       message[strings::params][strings::data].keyExists(strings::slider_position)) {
     //Copy slider_position info to msg_params section
-	response_msg_params[strings::slider_position] =
+        response_msg_params[strings::slider_position] =
         message[strings::params][strings::data][strings::slider_position];
   }
 
   const bool is_response_success =
-      (mobile_apis::Result::SUCCESS == response_code);
+      mobile_apis::Result::SUCCESS == response_code ||
+      mobile_apis::Result::WARNINGS == response_code;
 
   SendResponse(is_response_success,
                mobile_apis::Result::eType(response_code),

--- a/src/components/application_manager/src/commands/mobile/speak_request.cc
+++ b/src/components/application_manager/src/commands/mobile/speak_request.cc
@@ -35,6 +35,7 @@
 #include "application_manager/commands/mobile/speak_request.h"
 #include "application_manager/application_manager_impl.h"
 #include "application_manager/application_impl.h"
+#include "utils/helpers.h"
 
 namespace application_manager {
 
@@ -51,8 +52,9 @@ SpeakRequest::~SpeakRequest() {
 void SpeakRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  ApplicationSharedPtr app = application_manager::ApplicationManagerImpl::instance()
-                     ->application(connection_key());
+  ApplicationSharedPtr app =
+      application_manager::ApplicationManagerImpl::instance()->application(
+        connection_key());
 
   if (!app) {
     LOG4CXX_ERROR_EXT(logger_, "NULL pointer");
@@ -101,6 +103,8 @@ void SpeakRequest::on_event(const event_engine::Event& event) {
 void SpeakRequest::ProcessTTSSpeakResponse(
   const smart_objects::SmartObject& message) {
   LOG4CXX_AUTO_TRACE(logger_);
+  using namespace helpers;
+
   ApplicationSharedPtr application =
       ApplicationManagerImpl::instance()->application(connection_key());
 
@@ -109,24 +113,31 @@ void SpeakRequest::ProcessTTSSpeakResponse(
     return;
   }
 
-  bool result = false;
   hmi_apis::Common_Result::eType hmi_result_code =
       static_cast<hmi_apis::Common_Result::eType>(
       message[strings::params][hmi_response::code].asInt());
 
   mobile_apis::Result::eType result_code =
-    static_cast<mobile_apis::Result::eType>(hmi_result_code);
+    MessageHelper::HMIToMobileResult(hmi_result_code);
 
-  if (hmi_apis::Common_Result::SUCCESS == hmi_result_code ||
-      hmi_apis::Common_Result::WARNINGS == hmi_result_code) {
-    result = true;
-  }
+  const bool result =
+      Compare<mobile_api::Result::eType, EQ, ONE>(
+        result_code,
+        mobile_api::Result::SUCCESS,
+        mobile_api::Result::WARNINGS);
+
   (*message_)[strings::params][strings::function_id] =
-    mobile_apis::FunctionID::SpeakID;
+      mobile_apis::FunctionID::SpeakID;
 
   const char* return_info = NULL;
 
-  if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == hmi_result_code) {
+  const bool is_result_ok =
+      Compare<mobile_api::Result::eType, EQ, ONE>(
+        result_code,
+        mobile_api::Result::UNSUPPORTED_RESOURCE,
+        mobile_api::Result::WARNINGS);
+
+  if (is_result_ok) {
     result_code = mobile_apis::Result::WARNINGS;
     return_info = std::string(
         "Unsupported phoneme type sent in a prompt").c_str();

--- a/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -215,8 +215,8 @@ void SubscribeVehicleDataRequest::Run() {
       hmi_requests_.push_back(hmi_request);
     }
   }
-  LOG4CXX_INFO(logger_, hmi_requests_.size() <<
-               " requests are going to be sent to HMI");
+  LOG4CXX_DEBUG(logger_, hmi_requests_.size() <<
+                " requests are going to be sent to HMI");
 
   //Send subrequests
   for (HmiRequests::const_iterator it = hmi_requests_.begin();

--- a/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -230,6 +230,11 @@ void SubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
 
   const smart_objects::SmartObject& message = event.smart_object();
 
+  if (hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData != event.id()) {
+    LOG4CXX_ERROR(logger_, "Received unknown event.");
+    return;
+  }
+
   ApplicationSharedPtr app = ApplicationManagerImpl::instance()->application(
       CommandRequestImpl::connection_key());
 
@@ -288,14 +293,12 @@ void SubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
           message[strings::params][hmi_response::code].asInt());
 
   bool is_succeeded =
-      hmi_result == hmi_apis::Common_Result::SUCCESS ||
+      hmi_apis::Common_Result::SUCCESS == hmi_result||
+      hmi_apis::Common_Result::WARNINGS == hmi_result ||
       !vi_already_subscribed_by_another_apps_.empty();
 
   mobile_apis::Result::eType result_code =
-      hmi_result == hmi_apis::Common_Result::SUCCESS
-      ? mobile_apis::Result::SUCCESS
-      : static_cast<mobile_apis::Result::eType>(
-          message[strings::params][hmi_response::code].asInt());
+      static_cast<mobile_apis::Result::eType>(hmi_result);
 
   const char* return_info = NULL;
   if (is_succeeded) {

--- a/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -35,6 +35,7 @@
 #include "application_manager/application_manager_impl.h"
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
+#include "utils/helpers.h"
 
 namespace application_manager {
 namespace commands {
@@ -87,7 +88,7 @@ void SubscribeVehicleDataRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   ApplicationSharedPtr app = ApplicationManagerImpl::instance()->application(
-      CommandRequestImpl::connection_key());
+      connection_key());
 
   if (!app) {
     LOG4CXX_ERROR(logger_, "NULL pointer");
@@ -214,10 +215,12 @@ void SubscribeVehicleDataRequest::Run() {
       hmi_requests_.push_back(hmi_request);
     }
   }
-  LOG4CXX_INFO(logger_, hmi_requests_.size() << " requests are going to be sent to HMI");
+  LOG4CXX_INFO(logger_, hmi_requests_.size() <<
+               " requests are going to be sent to HMI");
 
   //Send subrequests
-  for (HmiRequests::const_iterator it = hmi_requests_.begin(); it != hmi_requests_.end(); ++it)
+  for (HmiRequests::const_iterator it = hmi_requests_.begin();
+       it != hmi_requests_.end(); ++it)
     SendHMIRequest(it->func_id, &msg_params, true);
 #else
   SendHMIRequest(hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData,
@@ -227,6 +230,7 @@ void SubscribeVehicleDataRequest::Run() {
 
 void SubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
+  using namespace helpers;
 
   const smart_objects::SmartObject& message = event.smart_object();
 
@@ -244,8 +248,8 @@ void SubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
     HmiRequest & hmi_request = *it;
     if (hmi_request.func_id == event.id()) {
       hmi_request.status =
-          static_cast<hmi_apis::Common_Result::eType>(message[strings::params][hmi_response::code]
-              .asInt());
+          static_cast<hmi_apis::Common_Result::eType>(
+            message[strings::params][hmi_response::code].asInt());
       if (hmi_apis::Common_Result::SUCCESS == hmi_request.status)
         hmi_request.value = message[strings::msg_params][hmi_request.str];
       hmi_request.complete = true;
@@ -292,13 +296,17 @@ void SubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
       static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
 
-  bool is_succeeded =
-      hmi_apis::Common_Result::SUCCESS == hmi_result||
-      hmi_apis::Common_Result::WARNINGS == hmi_result ||
+  const bool is_result_no_error =
+      Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+        hmi_result,
+        hmi_apis::Common_Result::SUCCESS,
+        hmi_apis::Common_Result::WARNINGS);
+
+  bool is_succeeded = is_result_no_error ||
       !vi_already_subscribed_by_another_apps_.empty();
 
   mobile_apis::Result::eType result_code =
-      static_cast<mobile_apis::Result::eType>(hmi_result);
+      MessageHelper::HMIToMobileResult(hmi_result);
 
   const char* return_info = NULL;
   if (is_succeeded) {

--- a/src/components/application_manager/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/src/commands/mobile/system_request.cc
@@ -199,7 +199,9 @@ void SystemRequest::on_event(const event_engine::Event& event) {
       mobile_apis::Result::eType result_code =
           GetMobileResultCode(static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asUInt()));
-      bool result = mobile_apis::Result::SUCCESS == result_code;
+      bool result =
+          mobile_apis::Result::SUCCESS == result_code ||
+          mobile_apis::Result::WARNINGS == result_code;
 
       ApplicationSharedPtr application =
              ApplicationManagerImpl::instance()->application(connection_key());

--- a/src/components/application_manager/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/src/commands/mobile/system_request.cc
@@ -43,6 +43,7 @@ Copyright (c) 2013, Ford Motor Company
 #include "utils/file_system.h"
 #include "formatters/CFormatterJsonBase.hpp"
 #include "json/json.h"
+#include "utils/helpers.h"
 
 namespace application_manager {
 
@@ -191,7 +192,9 @@ void SystemRequest::Run() {
 }
 
 void SystemRequest::on_event(const event_engine::Event& event) {
-  LOG4CXX_INFO(logger_, "AddSubMenuRequest::on_event");
+  LOG4CXX_AUTO_TRACE(logger_);
+  using namespace helpers;
+
   const smart_objects::SmartObject& message = event.smart_object();
 
   switch (event.id()) {
@@ -199,9 +202,12 @@ void SystemRequest::on_event(const event_engine::Event& event) {
       mobile_apis::Result::eType result_code =
           GetMobileResultCode(static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asUInt()));
-      bool result =
-          mobile_apis::Result::SUCCESS == result_code ||
-          mobile_apis::Result::WARNINGS == result_code;
+
+      const bool result =
+          Compare<mobile_api::Result::eType, EQ, ONE>(
+            result_code,
+            mobile_api::Result::SUCCESS,
+            mobile_api::Result::WARNINGS);
 
       ApplicationSharedPtr application =
              ApplicationManagerImpl::instance()->application(connection_key());

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -229,6 +229,11 @@ void UnsubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
 
   const smart_objects::SmartObject& message = event.smart_object();
 
+  if (hmi_apis::FunctionID::VehicleInfo_UnsubscribeVehicleData != event.id()) {
+    LOG4CXX_ERROR(logger_, "Received unknown event.");
+    return;
+  }
+
 #ifdef HMI_DBUS_API
   for (HmiRequests::iterator it = hmi_requests_.begin();
       it != hmi_requests_.end(); ++it) {
@@ -288,13 +293,11 @@ void UnsubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
           message[strings::params][hmi_response::code].asInt());
 
   bool is_succeeded =
-      hmi_result == hmi_apis::Common_Result::SUCCESS;
+      hmi_apis::Common_Result::SUCCESS == hmi_result ||
+      hmi_apis::Common_Result::WARNINGS == hmi_result;
 
   mobile_apis::Result::eType result_code =
-      hmi_result == hmi_apis::Common_Result::SUCCESS
-      ? mobile_apis::Result::SUCCESS
-      : static_cast<mobile_apis::Result::eType>(
-          message[strings::params][hmi_response::code].asInt());
+      static_cast<mobile_apis::Result::eType>(hmi_result);
 
   const char* return_info = NULL;
 

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -496,7 +496,7 @@ const VehicleData& MessageHelper::vehicle_data() {
   return vehicle_data_;
 }
 
-std::string MessageHelper::StringifiedHMIResult(
+std::string MessageHelper::HMIResultToString(
     hmi_apis::Common_Result::eType hmi_result) {
   using namespace NsSmartDeviceLink::NsSmartObjects;
   const char* str = 0;
@@ -507,7 +507,7 @@ std::string MessageHelper::StringifiedHMIResult(
   return std::string();
 }
 
-hmi_apis::Common_Result::eType MessageHelper::StringToHMIResult(
+hmi_apis::Common_Result::eType MessageHelper::HMIResultFromString(
     const std::string &hmi_result) {
   using namespace NsSmartDeviceLink::NsSmartObjects;
   hmi_apis::Common_Result::eType value;
@@ -518,7 +518,7 @@ hmi_apis::Common_Result::eType MessageHelper::StringToHMIResult(
   return hmi_apis::Common_Result::INVALID_ENUM;
 }
 
-std::string MessageHelper::StringifiedMobileResult(
+std::string MessageHelper::MobileResultToString(
     mobile_apis::Result::eType mobile_result) {
   using namespace NsSmartDeviceLink::NsSmartObjects;
   const char* str = 0;
@@ -529,7 +529,7 @@ std::string MessageHelper::StringifiedMobileResult(
   return std::string();
 }
 
-mobile_apis::Result::eType MessageHelper::StringToMobileResult(
+mobile_apis::Result::eType MessageHelper::MobileResultFromString(
     const std::string &mobile_result) {
   using namespace NsSmartDeviceLink::NsSmartObjects;
   mobile_apis::Result::eType value;
@@ -542,20 +542,20 @@ mobile_apis::Result::eType MessageHelper::StringToMobileResult(
 
 mobile_apis::Result::eType MessageHelper::HMIToMobileResult(
     const hmi_apis::Common_Result::eType hmi_result) {
-  const std::string result = StringifiedHMIResult(hmi_result);
+  const std::string result = HMIResultToString(hmi_result);
   if (result.empty()) {
     return mobile_api::Result::INVALID_ENUM;
   }
-  return StringToMobileResult(result);
+  return MobileResultFromString(result);
 }
 
 hmi_apis::Common_Result::eType MessageHelper::MobileToHMIResult(
     const mobile_apis::Result::eType mobile_result) {
-  const std::string result = StringifiedMobileResult(mobile_result);
+  const std::string result = MobileResultToString(mobile_result);
   if (result.empty()) {
     return hmi_apis::Common_Result::INVALID_ENUM;
   }
-  return StringToHMIResult(result);
+  return HMIResultFromString(result);
 }
 
 mobile_apis::HMILevel::eType MessageHelper::StringToHMILevel(

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -496,6 +496,68 @@ const VehicleData& MessageHelper::vehicle_data() {
   return vehicle_data_;
 }
 
+std::string MessageHelper::StringifiedHMIResult(
+    hmi_apis::Common_Result::eType hmi_result) {
+  using namespace NsSmartDeviceLink::NsSmartObjects;
+  const char* str = 0;
+  if (EnumConversionHelper<hmi_apis::Common_Result::eType>::EnumToCString(
+        hmi_result, &str)) {
+    return str;
+  }
+  return std::string();
+}
+
+hmi_apis::Common_Result::eType MessageHelper::StringToHMIResult(
+    const std::string &hmi_result) {
+  using namespace NsSmartDeviceLink::NsSmartObjects;
+  hmi_apis::Common_Result::eType value;
+  if (EnumConversionHelper<hmi_apis::Common_Result::eType>::StringToEnum(
+        hmi_result, &value)) {
+    return value;
+  }
+  return hmi_apis::Common_Result::INVALID_ENUM;
+}
+
+std::string MessageHelper::StringifiedMobileResult(
+    mobile_apis::Result::eType mobile_result) {
+  using namespace NsSmartDeviceLink::NsSmartObjects;
+  const char* str = 0;
+  if (EnumConversionHelper<mobile_apis::Result::eType>::EnumToCString(
+        mobile_result, &str)) {
+    return str;
+  }
+  return std::string();
+}
+
+mobile_apis::Result::eType MessageHelper::StringToMobileResult(
+    const std::string &mobile_result) {
+  using namespace NsSmartDeviceLink::NsSmartObjects;
+  mobile_apis::Result::eType value;
+  if (EnumConversionHelper<mobile_apis::Result::eType>::StringToEnum(
+        mobile_result, &value)) {
+    return value;
+  }
+  return mobile_apis::Result::INVALID_ENUM;
+}
+
+mobile_apis::Result::eType MessageHelper::HMIToMobileResult(
+    const hmi_apis::Common_Result::eType hmi_result) {
+  const std::string result = StringifiedHMIResult(hmi_result);
+  if (result.empty()) {
+    return mobile_api::Result::INVALID_ENUM;
+  }
+  return StringToMobileResult(result);
+}
+
+hmi_apis::Common_Result::eType MessageHelper::MobileToHMIResult(
+    const mobile_apis::Result::eType mobile_result) {
+  const std::string result = StringifiedMobileResult(mobile_result);
+  if (result.empty()) {
+    return hmi_apis::Common_Result::INVALID_ENUM;
+  }
+  return StringToHMIResult(result);
+}
+
 mobile_apis::HMILevel::eType MessageHelper::StringToHMILevel(
   const std::string& hmi_level) {
   using namespace NsSmartDeviceLink::NsSmartObjects;


### PR DESCRIPTION
1. 	In case SDL receives WARNINGS result code from HMI -> SDL must transfer WARNINGS (success:true) to mobile app

Information:
a. WARNINGS result code is applicable for the following RPCs:

    AlertManeuver
    SystemRequest
    RegisterAppInterface
    SetGlobalProperties
    AddCommand
    PerformInteraction
    Alert
    Show
    Speak
    PerformAudioPathThru
    SubscribeVehicleData
    UnsubscribeVehicleData
    DeleteCommand
    DeleteInteractionChoiceSet
    CreateInteractionChoiceSet
    AddSubMenu
    DeleteSubMenu
    SetAppIcon
    Slider
    ScrollableMessage
