### PR TITLE
Update INI files according to PASA and Genevi requirements

### DIFF
--- a/customer-specific/pasa/src/appMain/smartDeviceLink.ini
+++ b/customer-specific/pasa/src/appMain/smartDeviceLink.ini
@@ -3,55 +3,86 @@
 ; the name in square brackets. Syntax:
 ; [chapter]
 ; The chapters consists of a set of items with a
-; assinged value. The syntax is:
+; assigned value. The syntax is:
 ; item=value
 ; All white spaces an second encounters of chapters
 ; or items will be ignored.
 ; Remarks start with semicolon or star as first character.
-; It is alowed for names of chapters and items to
+; It is allowed for names of chapters and items to
 ; contain semicolon and star. Possible syntax is:
 ; [ chapter ]       ;Remark
 ;    item = value   ;Remark
 
 [HMI]
-LaunchHMI = true
+; WebSocket connection address and port
 ServerAddress = 127.0.0.1
 ServerPort = 8087
+; Socket ports for video and audio streaming
 VideoStreamingPort = 5050
 AudioStreamingPort = 5080
 
 [MAIN]
+; SDL source version 
+; represents as a git commit hash value
 SDLVersion = {GIT_COMMIT}
+; All logging event could be dropped by setting $LogsEnabled to false
+LogsEnabled = false
+; Contains SDL configuration files - .json/.ini
+; default value is current working directory
+AppConfigFolder = /fs/mp/etc/AppLink
+; Contains output files, e.g. .wav
+; default value is current working directory
+AppStorageFolder = /fs/rwdata/storage/sdl
 ; Standard min stack size
 ;     in Ubuntu : PTHREAD_STACK_MIN = 16384
 ;     in QNX : PTHREAD_STACK_MIN = 256
-;The value of a variable ThreadStackSize used only if its realy needed, other way stack size will be PTHREAD_STACK_MIN
-;
-LogsEnabled = false
-AppConfigFolder = /fs/mp/etc/AppLink
-AppStorageFolder = /fs/rwdata/storage/sdl
+; The value of a $ThreadStackSize used where its really needed,
+; other way stack size will be PTHREAD_STACK_MIN
 ThreadStackSize = 16384
+; Defines if HMI support attenuated mode (able to mix audio sources)
 MixingAudioSupported = true
+; In case HMI doesn’t send some capabilities to SDL, the values from the file are used by SDL
 HMICapabilities = hmi_capabilities.json
+; Maximum cmdId of VR command which may be registered on SDL 
+; Bigger value used for system VR commands processing by SDL
 MaxCmdID = 2000000000
+; SDL respond timeout (milliseconds) in case of HMI has not respond on a mobile request
 DefaultTimeout = 20000
-; HMI's heart beat timeout. The value specified in milliseconds.
-HMIHeartBeatTimeout = 3000;
+; The milliseconds to send heartbeat to HMI from SDL
+HMIHeartBeatTimeout = 3000
+; Available disk space in bytes for each application file handling
+; Default value is 100 MiB
 AppDirectoryQuota = 104857600
+; Allowed requests amount in HMI level NONE during time scale.
+; If value is 0 check will be skipped
 AppHMILevelNoneTimeScaleMaxRequests = 0
 AppHMILevelNoneRequestsTimeScale = 10
+; Allowed requests amount during time scale.
+; If value is 0 check will be skipped
 AppTimeScaleMaxRequests = 0
 AppRequestsTimeScale = 10
+; Allowed pending requests amount. If value is 0 check will be skipped
 PendingRequestsAmount = 0
-; Heart beat timeout used for protocol v3. Timeout must be specified in milliseconds. If timeout is 0 heart beat will be disabled.
+; Heart beat timeout used for protocol v3.
+; Timeout must be specified in milliseconds. If timeout is 0 heart beat will be disabled.
 HeartBeatTimeout = 0
+; The list of diagnostic modes supported on a vehicle.
+; Only the stated values are allowed by SDL in terms of DiagnosticMessage RPC, others are rejected
 SupportedDiagModes = 0x01, 0x02, 0x03, 0x05, 0x06, 0x07, 0x09, 0x0A, 0x18, 0x19, 0x22, 0x3E
+; The path to the system file directory for inter-operation between SDL and System (e.g. IVSU files and others).
+; If parameter is empty, SDL uses /tmp/fs/mp/images/ivsu_cache by default
 SystemFilesPath = /fs/images/ivsu_cache
+; To restore the last transport state (name, applications or channels) on SDL on a new device connection and on disconnect
 UseLastState = true
+; Port to obtain the performance information about messages processing
 TimeTestingPort = 8090
+; Limitation for a number of ReadDID requests (the 1st value) per (the 2nd value) seconds
 ReadDIDRequest = 5, 1
+; Limitation for a number of GetVehicleData requests (the 1st value) per (the 2nd value) seconds
 GetVehicleDataRequest = 5, 1
+; File with boot counter for creating appropriate log files
 TargetBootCountFile = /fs/rwdata/.flags/boot_count
+; Folder for log files saving
 TargetTmpDir = /fs/rwdata/logs
 
 [LOGGING]
@@ -73,18 +104,19 @@ EnableRedecoding = false
 ;AudioStreamConsumer = file
 VideoStreamConsumer = pipe
 AudioStreamConsumer = pipe
-;Temp solution: if you change NamedPipePath also change path to pipe in src/components/qt_hmi/qml_model_qtXX/views/SDLNavi.qml
-;Named pipe path will be constructed using AppStorageFolder + name
-NamedVideoPipePath = video_stream_pipe
-NamedAudioPipePath = audio_stream_pipe
+; Temp solution: if you change NamedPipePath also change path to pipe in src/components/qt_hmi/qml_model_qtXX/views/SDLNavi.qml
+; If no path is specified, named pipe path will be constructed using AppStorageFolder + name
+NamedVideoPipePath = /tmp/video_stream_pipe
+NamedAudioPipePath = /tmp/audio_stream_pipe
 ;File path will be constructed using AppStorageFolder + name
 VideoStreamFile = video_stream_file
 AudioStreamFile = audio_stream_file
-; Recording file source (used for audio pass thru emulation only)
-RecordingFileSource = audio.8bit.wav
 ; Recording file for audio pass thru
 RecordingFileName = audio.wav
+; The name of MQ which is used by system HMI to send AudioPassThru data
 MQAudioPath = /dev/mqueue/AppLinkAudioPass
+; The timeout in milliseconds for mobile to stop streaming or end up sessions.
+StopStreamingTimeout = 1000
 ; Defines time in milliseconds for SDL to wait for the next package of raw data over audio service
 AudioDataStoppedTimeout = 1000
 ; Defines time in milliseconds for SDL to wait for the next package of raw data over video service
@@ -93,7 +125,7 @@ VideoDataStoppedTimeout = 1000
 
 ; HelpPromt and TimeOutPrompt is a vector of strings separated by comma
 [GLOBAL PROPERTIES]
-; Delimiter, which will be appended to each TTS chunck, e.g. helpPrompt/timeoutPrompt
+; Delimiter, which will be appended to each TTS chunk, e.g. helpPrompt/timeoutPrompt
 TTSDelimiter = ,
 ; Default prompt items, separated by comma
 HelpPromt = Please speak one of the following commands,Please say a command
@@ -115,10 +147,30 @@ ListFilesRequest = 5
 [VR COMMANDS]
 HelpCommand = Help
 
-
 [AppInfo]
 ; The path for applications info storage.
 AppInfoStorage = app_info.dat
+
+[Security Manager]
+Protocol = TLSv1.2
+; Certificate and key path to pem file
+KeyPath         = /fs/mp/etc/AppLink/client.key
+CertificatePath = /fs/mp/etc/AppLink/client.crt
+; SSL mode could be SERVER or CLIENT
+SSLMode         = CLIENT
+; Could be ALL ciphers or list of chosen
+;CipherList      = AES256-GCM-SHA384
+CipherList      = ALL
+; Verify Mobile app certificate (could be used in both SSLMode Server and Client)
+VerifyPeer  = true
+; Preloaded CA certificates directory
+CACertificatePath = 
+; Services which can not be started unprotected (could be id's from 0x01 to 0xFF)
+;ForceProtectedService = 0x0A, 0x0B
+ForceProtectedService = Non
+; Services which can not be started protected or delayed protected 
+;ForceUnprotectedService = 0x07
+ForceUnprotectedService = Non
 
 [Policy]
 EnablePolicy = true
@@ -130,26 +182,42 @@ AttemptsToOpenPolicyDB = 5
 OpenAttemptTimeoutMs = 500
 
 [TransportManager]
+; Listening port for incoming TCP mobile connection
 TCPAdapterPort = 12345
-MMEDatabase = /dev/qdb/mediaservice_db
+; MQueue for IAP connection/disconnection events
 EventMQ = /dev/mqueue/ToSDLCoreUSBAdapter
+; MQueue for IAP connection/disconnection acknowledgment
 AckMQ = /dev/mqueue/FromSDLCoreUSBAdapter
 
 [IAP]
+; The default index being taken for the protocol to be used as hub
 DefaultHubProtocolIndex = 0
+; Mask for reading legacy protocols list from IAPSystemConfig/IAP2SystemConfig
 LegacyProtocol = com.ford.sync.prot
+; Sample string uses for testing purpose
+; Please change DedicatedProtocols with commented line below in order to test this functionaity
+; DedicatedProtocols = com.ford.sync.ownerapp,com.lincoln.sync.ownerapp
+DedicatedProtocols =
+; Mask for reading hub protocols from IAPSystemConfig/IAP2SystemConfig 
 HubProtocol = com.smartdevicelink.prot
+; Mask for reading poll protocols from IAPSystemConfig/IAP2SystemConfig 
 PoolProtocol = com.smartdevicelink.prot
-IAPSystemConfig = /fs/mp/etc/mm/ipod.cfg
+; Configuration file location for IAP/IAP2
+IAPSystemConfig = /fs/mp/etc/mm/iap1.cfg
 IAP2SystemConfig = /fs/mp/etc/mm/iap2.cfg
+; The number of connection attempts to hub protocol.
+; In case of overlimited, connection tries are being stopped
 IAP2HubConnectAttempts = 3
-; Connection timeout in milliseconds
+; The timeout for waiting of connection initiation for data transferring (IAP) in msecs
 ConnectionWaitTimeout = 10000
+; Timeout for waiting ARM events in msecs 
+ArmEventTimeout = 500
 
 [ProtocolHandler]
 ; Packet with payload bigger than next value will be marked as a malformed
-; 1488 = 1500 - 12 = TCP MTU - header size
-MaximumPayloadSize = 1488
+; for protocol v3 or higher
+; For v2 protocol MaximumPayloadSize is 1488
+MaximumPayloadSize = 131072
 ; Application shall send less #FrequencyCount messages per #FrequencyTime mSecs
 ; Frequency check could be disabled by setting #FrequencyTime or
 ; #FrequencyCount to Zero
@@ -168,29 +236,24 @@ MalformedFrequencyTime = 1000
 [ApplicationManager]
 ; Application list update timeout ms
 ApplicationListUpdateTimeout = 2000
-; Max allowed threads for handling mobile requests. Currently max allowed is 2
+; Threads count for handling mobile requests. Default value is 2
 ThreadPoolSize = 1
+; The max size of hash which is used by OnHashUpdated
+HashStringSize = 32
 
-# Timeout in milliseconds for resumption Application HMILevel
-# and resolving conflicts in case if multiple applications initiate resumption
-
+[Resumption]
+; Timeout in milliseconds for resumption Application HMILevel
+; and resolving conflicts in case if multiple applications initiate resumption
 ApplicationResumingTimeout = 3000
-
-# Timeout in seconds for pereodical saving resumption persisten data
-AppSavePersistentDataTimeout = 10 #seconds
-
-# Timeout in seconds to store hmi_level for media app before ign_off
+; Timeout in milliseconds for pereodical saving resumption persisten data
+AppSavePersistentDataTimeout = 10000
+; Timeout in seconds to store hmi_level for media app before ign_off
 ResumptionDelayBeforeIgn = 30;
-
-# Timeout in seconds to restore hmi_level for media app after sdl run
+; Timeout in seconds to restore hmi_level for media app after sdl run
 ResumptionDelayAfterIgn = 30;
-
-# Resumption ctrl uses JSON if UseDBForResumption=false for store data otherwise uses DB
+; Resumption ctrl uses JSON if UseDBForResumption=false for store data otherwise uses DB
 UseDBForResumption = false
-
-# Number of attempts to open resumption DB
-AttemptsToOpenResumptionDB = 10 
-
-# Timeout between attempts during opening DB in milliseconds
+; Number of attempts to open resumption DB
+AttemptsToOpenResumptionDB = 10
+; Timeout between attempts during opening DB in milliseconds
 OpenAttemptTimeoutMsResumptionDB = 1000
-

--- a/src/appMain/main.cc
+++ b/src/appMain/main.cc
@@ -83,7 +83,7 @@ bool InitHmi() {
   std::string hmi_link = profile::Profile::instance()->link_to_web_hmi();
   struct stat sb;
   if (stat(hmi_link.c_str(), &sb) == -1) {
-    LOG4CXX_FATAL(logger_, "HMI index.html doesn't exist!");
+    LOG4CXX_FATAL(logger_, "HMI index file " << hmi_link << " doesn't exist!");
     return false;
   }
   return utils::System(kBrowser, kBrowserName).Add(kBrowserParams).Add(hmi_link)

--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -1,47 +1,63 @@
-  ; The INI-file consists of different chapters.
+; The INI-file consists of different chapters.
 ; Each chapter begins with the line containing
 ; the name in square brackets. Syntax:
 ; [chapter]
 ; The chapters consists of a set of items with a
-; assinged value. The syntax is:
+; assigned value. The syntax is:
 ; item=value
 ; All white spaces an second encounters of chapters
 ; or items will be ignored.
 ; Remarks start with semicolon or star as first character.
-; It is alowed for names of chapters and items to
+; It is allowed for names of chapters and items to
 ; contain semicolon and star. Possible syntax is:
 ; [ chapter ]       ;Remark
 ;    item = value   ;Remark
 
 [HMI]
-LaunchHMI = true
-LinkToWebHMI = HMI/index.html
+; Open the $LinkToWebHMI in chromium browser
+LaunchHMI = false
+; Link to index HMTL page
+; correct format is without any quotes and with double forward slash (solidus) separator
+LinkToWebHMI = HMI//index.html
+; WebSocket connection address and port
 ServerAddress = 127.0.0.1
 ServerPort = 8087
+; Socket ports for video and audio streaming
 VideoStreamingPort = 5050
 AudioStreamingPort = 5080
 
 [MAIN]
-SDLVersion =
+; SDL source version 
+; represents as a git commit hash value
+SDLVersion = {GIT_COMMIT}
+; All logging event could be dropped by setting $LogsEnabled to false
 LogsEnabled = true
 ; Contains .json/.ini files
+; Default value is SDL working directory
 AppConfigFolder =
-; Contains output files, e.g. .wav
+; Contains SDL configuration files - .json/.ini
+; Default value is SDL working directory
 AppStorageFolder = storage
 ; Contains resourses, e.g. audio8bit.wav
+; Default value is SDL working directory
 AppResourceFolder =
 ; Standard min stack size
 ;     in Ubuntu : PTHREAD_STACK_MIN = 16384
 ;     in QNX : PTHREAD_STACK_MIN = 256
-;The value of a variable ThreadStackSize used only if its realy needed, other way stack size will be PTHREAD_STACK_MIN
-;
+; The value of a $ThreadStackSize used where its really needed,
+; other way stack size will be PTHREAD_STACK_MIN
 ThreadStackSize = 20480
+; Defines if HMI support attenuated mode (able to mix audio sources)
 MixingAudioSupported = true
+; In case HMI doesn’t send some capabilities to SDL, the values from the file are used by SDL
 HMICapabilities = hmi_capabilities.json
+; Maximum cmdId of VR command which may be registered on SDL
+; Bigger value used for system VR commands processing by SDL
 MaxCmdID = 2000000000
-; Default request timeout in milliseconds
+; SDL respond timeout (in milliseconds) in case of HMI has not respond on a mobile request
 DefaultTimeout = 10000
-
+; Available disk space in bytes for each application file handling
+; Default value is 100 MiB
 AppDirectoryQuota = 104857600
 ; Allowed requests amount in HMI level NONE during time scale.
 ; If value is 0 check will be skipped
@@ -53,13 +69,23 @@ AppTimeScaleMaxRequests = 1000
 AppRequestsTimeScale = 10
 ; Allowed pending requests amount. If value is 0 check will be skipped
 PendingRequestsAmount = 5000
-; HeartBeat timeout in ms
+PendingRequestsAmount = 0
+; Heart beat timeout used for protocol v3.
+; Timeout must be specified in milliseconds. If timeout is 0 heart beat will be disabled.
 HeartBeatTimeout = 7000
+; The list of diagnostic modes supported on a vehicle.
+; Only the stated values are allowed by SDL in terms of DiagnosticMessage RPC, others are rejected
 SupportedDiagModes = 0x01, 0x02, 0x03, 0x05, 0x06, 0x07, 0x09, 0x0A, 0x18, 0x19, 0x22, 0x3E
+; The path to the system file directory for inter-operation between SDL and System (e.g. IVSU files and others).
+; If parameter is empty, SDL uses /tmp/fs/mp/images/ivsu_cache by default
 SystemFilesPath = /tmp/fs/mp/images/ivsu_cache
+; To restore the last transport state (name, applications or channels) on SDL on a new device connection and on disconnect
 UseLastState = true
+; Port to obtain the performance information about messages processing
 TimeTestingPort = 8090
+; Limitation for a number of ReadDID requests (the 1st value) per (the 2nd value) seconds
 ReadDIDRequest = 5, 1
+; Limitation for a number of GetVehicleData requests (the 1st value) per (the 2nd value) seconds
 GetVehicleDataRequest = 5, 1
 
 [MEDIA MANAGER]
@@ -72,28 +98,27 @@ AudioStreamConsumer = socket
 ;AudioStreamConsumer = file
 ;VideoStreamConsumer = pipe
 ;AudioStreamConsumer = pipe
-;Temp solution: if you change NamedPipePath also change path to pipe in src/components/qt_hmi/qml_model_qtXX/views/SDLNavi.qml
-;Named pipe path will be constructed using AppStorageFolder + name
+; Temp solution: if you change NamedPipePath also change path to pipe in src/components/qt_hmi/qml_model_qtXX/views/SDLNavi.qml
+; Named pipe path will be constructed using AppStorageFolder + name
 NamedVideoPipePath = video_stream_pipe
 NamedAudioPipePath = audio_stream_pipe
-;File path will be constructed using AppStorageFolder + name
+; File path will be constructed using AppStorageFolder + name
 VideoStreamFile = video_stream_file
 AudioStreamFile = audio_stream_file
 ; Recording file source (used for audio pass thru emulation only)
 RecordingFileSource = audio.8bit.wav
 ; Recording file for audio pass thru
 RecordingFileName = audio.wav
-; The timeout in seconds for mobile to stop streaming or end up sessions.
-StopStreamingTimeout = 1
-; The timeout in miliseconds to suspend audio data streaming if no data received from mobile
+; The timeout in milliseconds for mobile to stop streaming or end up sessions.
+StopStreamingTimeout = 1000
+; The timeout in milliseconds to suspend audio data streaming if no data received from mobile
 AudioDataStoppedTimeout = 1000
-; The timeout in miliseconds to suspend video data streaming if no data received from mobile
+; The timeout in milliseconds to suspend video data streaming if no data received from mobile
 VideoDataStoppedTimeout = 1000
 
-; HelpPromt and TimeOutPrompt is a vector of strings separated by comma
 [GLOBAL PROPERTIES]
-
-; Delimiter, which will be appended to each TTS chunck, e.g. helpPrompt/timeoutPrompt
+; HelpPromt and TimeOutPrompt is a vector of strings separated by comma
+; Delimiter, which will be appended to each TTS chunk, e.g. helpPrompt/timeoutPrompt
 TTSDelimiter = ,
 ; Default prompt items, separated by comma
 HelpPromt = Please speak one of the following commands,Please say a command
@@ -113,6 +138,7 @@ DeleteFileRequest = 5
 ListFilesRequest = 5
 
 [VR COMMANDS]
+; TODO(EZamakhov): delete with APPLINK-15220 
 HelpCommand = Help
 
 [AppInfo]
@@ -131,14 +157,12 @@ SSLMode         = CLIENT
 CipherList      = ALL
 ; Verify Mobile app certificate (could be used in both SSLMode Server and Client)
 VerifyPeer  = false
-; If VerifyPeer is enable - terminate handshake if mobile app did not return a certificate
-FialOnNoCert = false
-; If VerifyPeer is enable - do not ask for a mobile app certificate again in case of a renegotiation
-VerifyClientOnce = false
-; Force protected services (could be id's from 0x01 to 0xFF)
+; Preloaded CA certificates directory
+CACertificatePath = .
+; Services which can not be started unprotected (could be id's from 0x01 to 0xFF)
 ;ForceProtectedService = 0x0A, 0x0B
 ForceProtectedService = Non
-; Force unprotected services
+; Services which can not be started protected or delayed protected 
 ;ForceUnprotectedService = 0x07
 ForceUnprotectedService = Non
 
@@ -152,23 +176,14 @@ AttemptsToOpenPolicyDB = 5
 OpenAttemptTimeoutMs = 500
 
 [TransportManager]
+; Listening port form incoming TCP mobile connection
 TCPAdapterPort = 12345
-MMEDatabase = /dev/qdb/mediaservice_db
-EventMQ = /dev/mqueue/ToSDLCoreUSBAdapter
-AckMQ = /dev/mqueue/FromSDLCoreUSBAdapter
-
-[IAP]
-LegacyProtocol = com.ford.sync.prot[0-29]
-HubProtocol = com.smartdevicelink.prot0
-PoolProtocol = com.smartdevicelink.prot[1-29]
-IAPSystemConfig = /fs/mp/etc/mm/ipod.cfg
-IAP2SystemConfig = /fs/mp/etc/mm/iap2.cfg
-IAP2HubConnectAttempts = 3
 
 [ProtocolHandler]
 ; Packet with payload bigger than next value will be marked as a malformed
-; 1488 = 1500 - 12 = TCP MTU - header size
-MaximumPayloadSize = 1488
+; for protocol v3 or higher
+; For v2 protocol MaximumPayloadSize is 1488
+MaximumPayloadSize = 131072
 ; Application shall send less #FrequencyCount messages per #FrequencyTime mSecs
 ; Frequency check could be disabled by setting #FrequencyTime or
 ; #FrequencyCount to Zero
@@ -187,8 +202,9 @@ MalformedFrequencyTime = 1000
 [ApplicationManager]
 ; Application list update timeout ms
 ApplicationListUpdateTimeout = 2000
-; Max allowed threads for handling mobile requests. Currently max allowed is 2
+; Max allowed threads for handling mobile requests. Default value is 2
 ThreadPoolSize = 1
+; The max size of hash which is used by OnHashUpdated
 HashStringSize = 32
 
 [SDL4]
@@ -202,26 +218,18 @@ AppIconsFolderMaxSize = 104857600
 AppIconsAmountToRemove = 1
 
 [Resumption]
-
-# Timeout in milliseconds for resumption Application HMILevel
-# and resolving conflicts in case if multiple applications initiate resumption
+; Timeout in milliseconds for resumption Application HMILevel
+; and resolving conflicts in case if multiple applications initiate resumption
 ApplicationResumingTimeout = 3000
-
-# Timeout in milliseconds for periodical saving resumption persistent data
+; Timeout in milliseconds for periodical saving resumption persistent data
 AppSavePersistentDataTimeout = 10000
-
-# Timeout in seconds to store hmi_level for media app before ign_off
+; Timeout in seconds to store hmi_level for media app before ign_off
 ResumptionDelayBeforeIgn = 30;
-
-# Timeout in seconds to restore hmi_level for media app after sdl run
+; Timeout in seconds to restore hmi_level for media app after sdl run
 ResumptionDelayAfterIgn = 30;
-
-# Resumption ctrl uses JSON if UseDBForResumption=false for store data otherwise uses DB
+; Resumption ctrl uses JSON if UseDBForResumption=false for store data otherwise uses DB
 UseDBForResumption = false
-
-# Number of attempts to open resumption DB
+; Number of attempts to open resumption DB
 AttemptsToOpenResumptionDB = 5
-
-# Timeout between attempts during opening DB in milliseconds
+; Timeout between attempts during opening DB in milliseconds
 OpenAttemptTimeoutMsResumptionDB = 500
-

--- a/src/components/application_manager/src/request_info.cc
+++ b/src/components/application_manager/src/request_info.cc
@@ -108,7 +108,7 @@ void RequestInfo::updateTimeOut(const uint64_t& timeout_sec)  {
 bool RequestInfo::isExpired() {
   TimevalStruct curr_time = date_time::DateTime::getCurrentTime();
   return end_time_.tv_sec <= curr_time.tv_sec;
-  // TODO(AKutsan) APPLINK-9711 Need to use compareTime method when timer will support millisecconds
+  // TODO(EZamakhov) APPLINK-15219 Need to use compareTime method when timer will support milliseconds
   // return date_time::GREATER == date_time::DateTime::compareTime(end_time_, curr_time);
 }
 

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -452,8 +452,6 @@ class Profile : public utils::Singleton<Profile> {
      */
     const std::string& recording_file_name() const;
 
-    const std::string& mme_db_name() const;
-
     const std::string& event_mq_name() const;
 
     const std::string& ack_mq_name() const;

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -143,7 +143,6 @@ const char* kTTSDelimiterKey = "TTSDelimiter";
 const char* kRecordingFileNameKey = "RecordingFileName";
 const char* kRecordingFileSourceKey = "RecordingFileSource";
 const char* kEnablePolicy = "EnablePolicy";
-const char* kMmeDatabaseNameKey = "MMEDatabase";
 const char* kEventMQKey = "EventMQ";
 const char* kAckMQKey = "AckMQ";
 const char* kApplicationListUpdateTimeoutKey = "ApplicationListUpdateTimeout";
@@ -181,7 +180,6 @@ const char* kDefaultSystemFilesPath = "/tmp/fs/mp/images/ivsu_cache";
 const char* kDefaultTtsDelimiter = ",";
 const uint32_t kDefaultAudioDataStoppedTimeout = 1000;
 const uint32_t kDefaultVideoDataStoppedTimeout = 1000;
-const char* kDefaultMmeDatabaseName = "/dev/qdb/mediaservice_db";
 const char* kDefaultEventMQ = "/dev/mqueue/ToSDLCoreUSBAdapter";
 const char* kDefaultAckMQ = "/dev/mqueue/FromSDLCoreUSBAdapter";
 const char* kDefaultRecordingFileSourceName = "audio.8bit.wav";
@@ -298,7 +296,6 @@ Profile::Profile()
       tts_delimiter_(kDefaultTtsDelimiter),
       audio_data_stopped_timeout_(kDefaultAudioDataStoppedTimeout),
       video_data_stopped_timeout_(kDefaultVideoDataStoppedTimeout),
-      mme_db_name_(kDefaultMmeDatabaseName),
       event_mq_name_(kDefaultEventMQ),
       ack_mq_name_(kDefaultAckMQ),
       recording_file_source_(kDefaultRecordingFileSourceName),
@@ -567,10 +564,6 @@ const std::string& Profile::recording_file_source() const {
 
 const std::string&Profile::recording_file_name() const {
   return recording_file_name_;
-}
-
-const std::string& Profile::mme_db_name() const {
-  return mme_db_name_;
 }
 
 const std::string& Profile::event_mq_name() const {
@@ -1253,13 +1246,6 @@ void Profile::UpdateValues() {
   LOG_UPDATED_VALUE(transport_manager_tcp_adapter_port_, kTCPAdapterPortKey,
                     kTransportManagerSection);
 
-  // MME database name
-  ReadStringValue(&mme_db_name_,
-                  kDefaultMmeDatabaseName,
-                  kTransportManagerSection,
-                  kMmeDatabaseNameKey);
-
-  LOG_UPDATED_VALUE(mme_db_name_, kMmeDatabaseNameKey, kTransportManagerSection);
   // Event MQ
   ReadStringValue(&event_mq_name_,
                   kDefaultEventMQ,


### PR DESCRIPTION
Removed PASA-specific parameters from customer-specific ini file.
Add comments for parameters of both ini files.
Update HMI start default values.
Removed MmeData value in ConfigProfile.
Fixed typo in ini file, initialize_git.sh.

Implements: [APPLINK-15096](https://adc.luxoft.com/jira/browse/APPLINK-15096)