### PR TITLE
Fixes conversion of language codes coming from HMI

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -514,6 +514,14 @@ class MessageHelper {
       hmi_apis::Common_Language::eType language);
 
     /**
+     * @brief Converts string to common language enum value
+     * @param language language as string
+     * @return Common language enum value
+     */
+    static hmi_apis::Common_Language::eType CommonLanguageFromString(
+       const std::string& language);
+
+    /**
      * @brief Gets command limit number per minute for specific application
      * @param policy_app_id Unique application id
      * @return Limit for number of command per minute

--- a/src/components/application_manager/src/hmi_capabilities.cc
+++ b/src/components/application_manager/src/hmi_capabilities.cc
@@ -49,34 +49,6 @@
 namespace application_manager {
 namespace Formatters = NsSmartDeviceLink::NsJSONHandler::Formatters;
 
-std::map<std::string, hmi_apis::Common_Language::eType> languages_enum_values =
-{
-    {"EN_US", hmi_apis::Common_Language::EN_US},
-    {"ES_MX", hmi_apis::Common_Language::ES_MX},
-    {"FR_CA", hmi_apis::Common_Language::FR_CA},
-    {"DE_DE", hmi_apis::Common_Language::DE_DE},
-    {"ES_ES", hmi_apis::Common_Language::ES_ES},
-    {"EN_GB", hmi_apis::Common_Language::EN_GB},
-    {"RU_RU", hmi_apis::Common_Language::RU_RU},
-    {"TR_TR", hmi_apis::Common_Language::TR_TR},
-    {"PL_PL", hmi_apis::Common_Language::PL_PL},
-    {"FR_FR", hmi_apis::Common_Language::FR_FR},
-    {"IT_IT", hmi_apis::Common_Language::IT_IT},
-    {"SV_SE", hmi_apis::Common_Language::SV_SE},
-    {"PT_PT", hmi_apis::Common_Language::PT_PT},
-    {"NL_NL", hmi_apis::Common_Language::NL_NL},
-    {"EN_AU", hmi_apis::Common_Language::EN_AU},
-    {"ZH_CN", hmi_apis::Common_Language::ZH_CN},
-    {"ZH_TW", hmi_apis::Common_Language::ZH_TW},
-    {"JA_JP", hmi_apis::Common_Language::JA_JP},
-    {"AR_SA", hmi_apis::Common_Language::AR_SA},
-    {"KO_KR", hmi_apis::Common_Language::KO_KR},
-    {"PT_BR", hmi_apis::Common_Language::PT_BR},
-    {"CS_CZ", hmi_apis::Common_Language::CS_CZ},
-    {"DA_DK", hmi_apis::Common_Language::DA_DK},
-    {"NO_NO", hmi_apis::Common_Language::NO_NO}
-};
-
 CREATE_LOGGERPTR_GLOBAL(logger_, "HMICapabilities")
 
 std::map<std::string, hmi_apis::Common_VrCapabilities::eType> vr_enum_capabilities =
@@ -594,12 +566,8 @@ bool HMICapabilities::load_capabilities_from_file() {
       Json::Value ui = root_json.get("UI", Json::Value::null);
 
       if (check_existing_json_member(ui, "language")) {
-        std::string lang = ui.get("language", "EN_US").asString();
-        std::map<std::string, hmi_apis::Common_Language::eType>::const_iterator
-          it = languages_enum_values.find(lang);
-        if (it != languages_enum_values.end()) {
-          set_active_ui_language(it->second);
-        }
+        const std::string lang = ui.get("language", "EN_US").asString();
+        set_active_ui_language(MessageHelper::CommonLanguageFromString(lang));
       }
 
       if (check_existing_json_member(ui, "languages")) {
@@ -779,8 +747,8 @@ bool HMICapabilities::load_capabilities_from_file() {
     if (check_existing_json_member(root_json, "VR")) {
       Json::Value vr = root_json.get("VR", "");
       if (check_existing_json_member(vr, "language")) {
-        set_active_vr_language(
-            languages_enum_values.find(vr.get("language", "").asString())->second);
+        const std::string lang = vr.get("language", "").asString();
+        set_active_vr_language(MessageHelper::CommonLanguageFromString(lang));
       }
 
       if (check_existing_json_member(vr, "languages")) {
@@ -808,8 +776,8 @@ bool HMICapabilities::load_capabilities_from_file() {
       Json::Value tts = root_json.get("TTS", "");
 
       if (check_existing_json_member(tts, "language")) {
-        set_active_tts_language(
-            languages_enum_values.find(tts.get("language", "").asString())->second);
+        const std::string lang = tts.get("language", "").asString();
+        set_active_tts_language(MessageHelper::CommonLanguageFromString(lang));
       }
 
       if (check_existing_json_member(tts, "languages")) {
@@ -881,11 +849,8 @@ bool HMICapabilities::check_existing_json_member(
 void HMICapabilities::convert_json_languages_to_obj(Json::Value& json_languages,
                                      smart_objects::SmartObject& languages) {
   for (uint32_t i = 0, j = 0; i < json_languages.size(); ++i) {
-    std::map<std::string, hmi_apis::Common_Language::eType>::const_iterator it =
-        languages_enum_values.find(json_languages[i].asString());
-    if (languages_enum_values.end() != it) {
-      languages[j++] =  it->second;
-    }
+    languages[j++] =  MessageHelper::CommonLanguageFromString(
+                        json_languages[i].asString());
   }
 }
 

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -185,58 +185,24 @@ static VehicleInfo_Requests ivi_subrequests[] = {
 
 std::string MessageHelper::CommonLanguageToString(
   hmi_apis::Common_Language::eType language) {
-  switch (language) {
-    case hmi_apis::Common_Language::EN_US:
-      return "en-us";
-    case hmi_apis::Common_Language::ES_MX:
-      return "es-mx";
-    case hmi_apis::Common_Language::FR_CA:
-      return "fr-ca";
-    case hmi_apis::Common_Language::DE_DE:
-      return "de-de";
-    case hmi_apis::Common_Language::ES_ES:
-      return "es-es";
-    case hmi_apis::Common_Language::EN_GB:
-      return "en-gb";
-    case hmi_apis::Common_Language::RU_RU:
-      return "ru-ru";
-    case hmi_apis::Common_Language::TR_TR:
-      return "tr-tr";
-    case hmi_apis::Common_Language::PL_PL:
-      return "pl-pl";
-    case hmi_apis::Common_Language::FR_FR:
-      return "fr-fr";
-    case hmi_apis::Common_Language::IT_IT:
-      return "it-it";
-    case hmi_apis::Common_Language::SV_SE:
-      return "sv-se";
-    case hmi_apis::Common_Language::PT_PT:
-      return "pt-pt";
-    case hmi_apis::Common_Language::NL_NL:
-      return "nl-nl";
-    case hmi_apis::Common_Language::EN_AU:
-      return "en-au";
-    case hmi_apis::Common_Language::ZH_CN:
-      return "zh-cn";
-    case hmi_apis::Common_Language::ZH_TW:
-      return "zh-tw";
-    case hmi_apis::Common_Language::JA_JP:
-      return "ja-jp";
-    case hmi_apis::Common_Language::AR_SA:
-      return "as-sa";
-    case hmi_apis::Common_Language::KO_KR:
-      return "ko-kr";
-    case hmi_apis::Common_Language::PT_BR:
-      return "pt-br";
-    case hmi_apis::Common_Language::CS_CZ:
-      return "cs-cz";
-    case hmi_apis::Common_Language::DA_DK:
-      return "da-dk";
-    case hmi_apis::Common_Language::NO_NO:
-      return "no-no";
-    default:
-      return "";
+  using namespace NsSmartDeviceLink::NsSmartObjects;
+  const char* str = 0;
+  if (EnumConversionHelper<hmi_apis::Common_Language::eType>::EnumToCString(
+        language, &str)) {
+    return str ? str : "";
   }
+  return std::string();
+}
+
+hmi_apis::Common_Language::eType MessageHelper::CommonLanguageFromString(
+    const std::string& language) {
+  using namespace NsSmartDeviceLink::NsSmartObjects;
+  hmi_apis::Common_Language::eType value;
+  if (EnumConversionHelper<hmi_apis::Common_Language::eType>::StringToEnum(
+        language, &value)) {
+    return value;
+  }
+  return hmi_apis::Common_Language::INVALID_ENUM;
 }
 
 uint32_t MessageHelper::GetAppCommandLimit(const std::string& policy_app_id) {
@@ -1672,12 +1638,6 @@ void MessageHelper::SendGetUserFriendlyMessageResponse(
   smart_objects::SmartObject& user_friendly_messages =
     (*message)[strings::msg_params][messages];
 
-
-  const std::string tts = "ttsString";
-  const std::string label = "label";
-  const std::string line1 = "line1";
-  const std::string line2 = "line2";
-  const std::string textBody = "textBody";
   const std::string message_code = "messageCode";
 
   std::vector<policy::UserFriendlyMessage>::const_iterator it = msg.begin();
@@ -1688,22 +1648,6 @@ void MessageHelper::SendGetUserFriendlyMessageResponse(
 
     smart_objects::SmartObject& obj = user_friendly_messages[index];
     obj[message_code] = it->message_code;
-
-    if (!it->tts.empty()) {
-      obj[tts] = it->tts;
-    }
-    if (!it->label.empty()) {
-      obj[label] = it->label;
-    }
-    if (!it->line1.empty()) {
-      obj[line1] = it->line1;
-    }
-    if (!it->line2.empty()) {
-      obj[line2] = it->line2;
-    }
-    if (!it->text_body.empty()) {
-      obj[textBody] = it->text_body;
-    }
   }
 
   ApplicationManagerImpl::instance()->ManageHMICommand(message);

--- a/src/components/policy/src/policy/include/policy/policy_types.h
+++ b/src/components/policy/src/policy/include/policy/policy_types.h
@@ -266,11 +266,6 @@ struct PermissionConsent {
  */
 struct UserFriendlyMessage {
     std::string message_code;
-    std::string tts;
-    std::string label;
-    std::string line1;
-    std::string line2;
-    std::string text_body;
 };
 
 /**

--- a/src/components/policy/src/policy/src/cache_manager.cc
+++ b/src/components/policy/src/policy/src/cache_manager.cc
@@ -65,6 +65,17 @@ CREATE_LOGGERPTR_GLOBAL(logger_, "CacheManager")
   }\
 }
 
+struct LanguageFinder {
+  LanguageFinder(const std::string& language):
+    language_(language) {
+  }
+  bool operator()(const policy_table::Languages::value_type& lang) const {
+    return !strcasecmp(language_.c_str(), lang.first.c_str());
+  }
+
+private:
+  const std::string& language_;
+};
 
 CacheManager::CacheManager()
   : CacheManagerInterface(),
@@ -525,10 +536,44 @@ std::vector<UserFriendlyMessage> CacheManager::GetUserFriendlyMsg(
   std::vector<UserFriendlyMessage> result;
   CACHE_MANAGER_CHECK(result);
 
-  const std::string fallback_language = "en-us";
   std::vector<std::string>::const_iterator it = msg_codes.begin();
   std::vector<std::string>::const_iterator it_end = msg_codes.end();
   for (; it != it_end; ++it) {
+
+    policy_table::MessageLanguages msg_languages =
+        (*pt_->policy_table.consumer_friendly_messages->messages)[*it];
+
+    policy_table::MessageString message_string;
+
+    // If message has no records with required language, fallback language
+    // should be used instead.
+    LanguageFinder finder(language);
+    policy_table::Languages::const_iterator it_language =
+        std::find_if(msg_languages.languages.begin(),
+                  msg_languages.languages.end(),
+                  finder);
+
+    if (msg_languages.languages.end() == it_language) {
+      LOG4CXX_WARN(logger_, "Language " << language <<
+                   " haven't been found for message code: " << *it);
+
+      LanguageFinder fallback_language_finder("en-us");
+
+      policy_table::Languages::const_iterator it_fallback_language =
+          std::find_if(msg_languages.languages.begin(),
+                       msg_languages.languages.end(),
+                       fallback_language_finder);
+
+      if (msg_languages.languages.end() == it_fallback_language) {
+        LOG4CXX_ERROR(logger_, "No fallback language found for message code: "
+                      << *it);
+        continue;
+      }
+
+      message_string = it_fallback_language->second;
+    } else {
+      message_string = it_language->second;
+    }
 
     UserFriendlyMessage msg;
     msg.message_code = *it;


### PR DESCRIPTION
Due to wrong conversion some languages couldn't be found in policy DB.
Also some recently added languages haven't been processed.

Fixes: APPLINK-15726

