### PR TITLE
Feature/sdl and sw version in rai

### DIFF
--- a/customer-specific/pasa/src/appMain/smartDeviceLink.ini
+++ b/customer-specific/pasa/src/appMain/smartDeviceLink.ini
@@ -21,6 +21,7 @@ VideoStreamingPort = 5050
 AudioStreamingPort = 5080
 
 [MAIN]
+SDLVersion = {GIT_COMMIT}
 ; Standard min stack size
 ;     in Ubuntu : PTHREAD_STACK_MIN = 16384
 ;     in QNX : PTHREAD_STACK_MIN = 256

--- a/src/appMain/CMakeLists.txt
+++ b/src/appMain/CMakeLists.txt
@@ -136,21 +136,10 @@ include_directories (
   ${CMAKE_SOURCE_DIR}/src/3rd_party/dbus-1.7.8/dbus/
 )
 
-add_custom_target(gitversion
-  COMMAND export GITVERSION=`git rev-parse HEAD` \;
-          if ! grep -s \"\$\${GITVERSION}\" ${CMAKE_CURRENT_BINARY_DIR}/gitversion.cc > /dev/null \;
-          then echo -n \"const char *gitVersion = \\\"Built against \$\${GITVERSION} revision\\\"\;\" > ${CMAKE_CURRENT_BINARY_DIR}/gitversion.cc\; fi
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-add_custom_command(
-  OUTPUT gitversion.cc
-  DEPENDS gitversion
-)
 set (SOURCES
   main.cc
   life_cycle.cc
   signal_handlers.cc
-  gitversion.cc
 )
 
 if( NOT CMAKE_BUILD_TYPE )
@@ -170,6 +159,28 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/sdl_preloaded_pt.json DESTINATION ${CMAKE_
 if (CMAKE_SYSTEM_NAME STREQUAL "QNX")
   file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/init_policy.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 endif ()
+
+# Replace commit in ini file
+set(GITCOMMIT "")
+if(EXISTS ${CMAKE_SOURCE_DIR}/.git)
+  find_package(Git)
+  if(GIT_FOUND)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+      OUTPUT_VARIABLE GITCOMMIT ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(INI_FILE ${CMAKE_CURRENT_BINARY_DIR}/smartDeviceLink.ini)
+    if(EXISTS ${INI_FILE})
+      file(READ ${INI_FILE} FILE_CONTENT)
+      set(LINE SDLVersion)
+      set(SEARCH_REGEX "${LINE}([^/\r/\n]+)")
+      string(REGEX REPLACE "${SEARCH_REGEX}" "${LINE} = ${GITCOMMIT}" 
+             MODIFIED_FILE_CONTENT "${FILE_CONTENT}")
+      file(WRITE "${INI_FILE}" "${MODIFIED_FILE_CONTENT}")
+    endif()
+  endif(GIT_FOUND)
+endif()
 
 if (${QT_HMI})
   set(main_qml "hmi/MainWindow.qml")

--- a/src/appMain/main.cc
+++ b/src/appMain/main.cc
@@ -67,14 +67,12 @@
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "appMain")
 
-extern const char* gitVersion;
 namespace {
 
 const std::string kBrowser = "/usr/bin/chromium-browser";
 const std::string kBrowserName = "chromium-browser";
 const std::string kBrowserParams = "--auth-schemes=basic,digest,ntlm";
 const std::string kLocalHostAddress = "127.0.0.1";
-const std::string kApplicationVersion = "Develop";
 
 #ifdef WEB_HMI
 /**
@@ -123,7 +121,6 @@ int32_t main(int32_t argc, char** argv) {
   // --------------------------------------------------------------------------
   // Logger initialization
   INIT_LOGGER("log4cxx.properties");
-  LOG4CXX_INFO(logger_, gitVersion);
 #if defined(__QNXNTO__) and defined(GCOV_ENABLED)
   LOG4CXX_WARN(logger_,
                 "Attention! This application was built with unsupported "
@@ -137,7 +134,8 @@ int32_t main(int32_t argc, char** argv) {
   }
 
   LOG4CXX_INFO(logger_, "Application started!");
-  LOG4CXX_INFO(logger_, "Application version " << kApplicationVersion);
+  LOG4CXX_INFO(logger_, "SDL version: "
+                         << profile::Profile::instance()->sdl_version());
 
   // Initialize gstreamer. Needed to activate debug from the command line.
 #if defined(EXTENDED_MEDIA_MODE)

--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -22,6 +22,8 @@ VideoStreamingPort = 5050
 AudioStreamingPort = 5080
 
 [MAIN]
+SDLVersion =
+LogsEnabled = true
 ; Contains .json/.ini files
 AppConfigFolder =
 ; Contains output files, e.g. .wav
@@ -190,7 +192,7 @@ HashStringSize = 32
 
 [SDL4]
 ; Enables SDL 4.0 support
-EnableProtocol4 = true 
+EnableProtocol4 = true
 ; Path where apps icons must be stored
 AppIconsFolder = storage
 ; Max size of the folder in bytes

--- a/src/components/application_manager/include/application_manager/hmi_capabilities.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities.h
@@ -392,6 +392,20 @@ class HMICapabilities {
    */
   inline bool phone_call_supported() const;
 
+  /*
+   * @brief Interface used to store information about software version of the target
+   *
+   * @param ccpu_version Received system/hmi software version
+   */
+  void set_ccpu_version(const std::string& ccpu_version);
+
+  /*
+   * @brief Returns software version of the target
+   *
+   * @return TRUE if it supported, otherwise FALSE
+   */
+  inline const std::string& ccpu_version() const;
+
  protected:
 
   /*
@@ -458,6 +472,7 @@ class HMICapabilities {
   smart_objects::SmartObject*      prerecorded_speech_;
   bool                             is_navigation_supported_;
   bool                             is_phone_call_supported_;
+  std::string                      ccpu_version_;
 
   ApplicationManagerImpl*          app_mngr_;
 
@@ -571,6 +586,10 @@ bool HMICapabilities::navigation_supported() const {
 
 bool HMICapabilities::phone_call_supported() const {
   return is_phone_call_supported_;
+}
+
+const std::string& HMICapabilities::ccpu_version() const {
+  return ccpu_version_;
 }
 
 }  //  namespace application_manager

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -245,6 +245,8 @@ const char supported_diag_modes[] = "supportedDiagModes";
 const char hmi_capabilities[] = "hmiCapabilities";
 const char navigation[] = "navigation";
 const char phone_call[] = "phoneCall";
+const char sdl_version[] = "sdlVersion";
+const char system_software_version[] = "systemSoftwareVersion";
 const char priority[] = "priority";
 
 //resuming

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -488,6 +488,9 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
   state_ctrl_.ApplyStatesForApp(application);
   app_list_accesor.Insert(application);
 
+  policy::PolicyHandler::instance()->AddApplication(
+        application->mobile_app_id());
+
   return application;
 }
 
@@ -555,6 +558,8 @@ void ApplicationManagerImpl::ConnectToDevice(uint32_t id) {
 void ApplicationManagerImpl::OnHMIStartedCooperation() {
   hmi_cooperating_ = true;
   LOG4CXX_INFO(logger_, "ApplicationManagerImpl::OnHMIStartedCooperation()");
+
+  MessageHelper::SendGetSystemInfoRequest();
 
   utils::SharedPtr<smart_objects::SmartObject> is_vr_ready(
       MessageHelper::CreateModuleInfoSO(

--- a/src/components/application_manager/src/commands/hmi/get_system_info_response.cc
+++ b/src/components/application_manager/src/commands/hmi/get_system_info_response.cc
@@ -30,6 +30,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include "application_manager/commands/hmi/get_system_info_response.h"
+#include "application_manager/application_manager_impl.h"
 #include "application_manager/policies/policy_handler.h"
 #include "application_manager/message_helper.h"
 
@@ -50,7 +51,23 @@ void GetSystemInfoResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
-  if (hmi_apis::Common_Result::SUCCESS != code) {
+  std::string ccpu_version;
+  std::string wers_country_code;
+  std::string language;
+
+  if (hmi_apis::Common_Result::SUCCESS == code) {
+    ccpu_version =
+        (*message_)[strings::msg_params]["ccpu_version"].asString();
+    wers_country_code =
+        (*message_)[strings::msg_params]["wersCountryCode"].asString();
+    uint32_t lang_code = (*message_)[strings::msg_params]["language"].asUInt();
+    language = application_manager::MessageHelper::CommonLanguageToString(
+        static_cast<hmi_apis::Common_Language::eType>(lang_code));
+
+    HMICapabilities& hmi_capabilities =
+      ApplicationManagerImpl::instance()->hmi_capabilities();
+    hmi_capabilities.set_ccpu_version(ccpu_version);
+  } else {
     LOG4CXX_WARN(logger_, "GetSystemError returns an error code " << code);
 
     // We have to set preloaded flag as false in policy table on any response
@@ -61,15 +78,9 @@ void GetSystemInfoResponse::Run() {
                                                        empty_value);
     return;
   }
-  const std::string ccpu_version =
-      (*message_)[strings::msg_params]["ccpu_version"].asString();
-  const std::string wers_country_code =
-      (*message_)[strings::msg_params]["wersCountryCode"].asString();
-  uint32_t lang_code = (*message_)[strings::msg_params]["language"].asUInt();
-  const std::string language =
-      application_manager::MessageHelper::CommonLanguageToString(
-        static_cast<hmi_apis::Common_Language::eType>(lang_code));
 
+  // We have to set preloaded flag as false in policy table on any response
+  // of GetSystemInfo (SDLAQ-CRS-2365)
   policy::PolicyHandler::instance()->OnGetSystemInfo(ccpu_version,
                                                      wers_country_code,
                                                      language);

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -454,6 +454,10 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
       hmi_capabilities.navigation_supported();
   response_params[strings::hmi_capabilities][strings::phone_call] =
       hmi_capabilities.phone_call_supported();
+  response_params[strings::sdl_version] =
+      profile::Profile::instance()->sdl_version();
+  response_params[strings::system_software_version] =
+      hmi_capabilities.ccpu_version();
 
   ResumeCtrl& resumer = ApplicationManagerImpl::instance()->resume_controller();
   std::string hash_id = "";

--- a/src/components/application_manager/src/hmi_capabilities.cc
+++ b/src/components/application_manager/src/hmi_capabilities.cc
@@ -535,8 +535,13 @@ void HMICapabilities::set_prerecorded_speech(
 void HMICapabilities::set_navigation_supported(bool supported) {
   is_navigation_supported_ = supported;
 }
+
 void HMICapabilities::set_phone_call_supported(bool supported) {
   is_phone_call_supported_ = supported;
+}
+
+void HMICapabilities::set_ccpu_version(const std::string& ccpu_version) {
+  ccpu_version_ = ccpu_version;
 }
 
 bool HMICapabilities::load_capabilities_from_file() {

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -58,6 +58,12 @@ class Profile : public utils::Singleton<Profile> {
     virtual ~Profile();
 
     /**
+     * @brief Returns sdl version represented
+     * by git commit or value specified by user
+     */
+    const std::string& sdl_version() const;
+
+    /**
       * @brief Returns true if HMI should be started, otherwise false
       */
     bool launch_hmi() const;
@@ -618,6 +624,7 @@ class Profile : public utils::Singleton<Profile> {
     bool StringToNumber(const std::string& input, uint64_t& output) const;
 
 private:
+    std::string                     sdl_version_;
     bool                            launch_hmi_;
 #ifdef WEB_HMI
     std::string                     link_to_web_hmi_;

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -73,6 +73,7 @@ const char* kProtocolHandlerSection = "ProtocolHandler";
 const char* kSDL4Section = "SDL4";
 const char* kResumptionSection = "Resumption";
 
+const char* kSDLVersionKey = "SDLVersion";
 const char* kHmiCapabilitiesKey = "HMICapabilities";
 const char* kPathToSnapshotKey = "PathToSnapshot";
 const char* kPreloadedPTKey = "PreloadedPT";
@@ -165,6 +166,7 @@ const char* kHashStringSizeKey = "HashStringSize";
 #ifdef WEB_HMI
 const char* kDefaultLinkToWebHMI = "HMI/index.html";
 #endif // WEB_HMI
+const char* kDefaultSDLVersion = "";
 const char* kDefaultPoliciesSnapshotFileName = "sdl_snapshot.json";
 const char* kDefaultHmiCapabilitiesFileName = "hmi_capabilities.json";
 const char* kDefaultPreloadedPTFileName = "sdl_preloaded_pt.json";
@@ -243,6 +245,7 @@ Profile::Profile()
 #ifdef WEB_HMI
       link_to_web_hmi_(kDefaultLinkToWebHMI),
 #endif // WEB_HMI
+      sdl_version_(kDefaultSDLVersion),
       app_config_folder_(),
       app_storage_folder_(),
       app_resourse_folder_(),
@@ -306,7 +309,11 @@ Profile::Profile()
       attempts_to_open_policy_db_(kDefaultAttemptsToOpenPolicyDB),
       open_attempt_timeout_ms_(kDefaultAttemptsToOpenPolicyDB),
       hash_string_size_(kDefaultHashStringSize) {
+  ReadStringValue(&sdl_version_, kDefaultSDLVersion,
+                  kMainSection, kSDLVersionKey);
 }
+
+
 
 Profile::~Profile() {
 }
@@ -320,6 +327,10 @@ void Profile::config_file_name(const std::string& fileName) {
 
 const std::string& Profile::config_file_name() const {
   return config_file_name_;
+}
+
+const std::string& Profile::sdl_version() const {
+  return sdl_version_;
 }
 
 bool Profile::launch_hmi() const {
@@ -684,6 +695,12 @@ uint16_t Profile::tts_global_properties_timeout() const {
 
 void Profile::UpdateValues() {
   LOG4CXX_AUTO_TRACE(logger_);
+
+  // SDL version
+  ReadStringValue(&sdl_version_, kDefaultSDLVersion,
+                  kMainSection, kSDLVersionKey);
+
+  LOG_UPDATED_VALUE(sdl_version_, kSDLVersionKey, kMainSection);
 
   // Launch HMI parameter
   std::string launch_value;
@@ -1374,7 +1391,7 @@ void Profile::UpdateValues() {
 
   LOG_UPDATED_VALUE(iap_hub_connection_wait_timeout_,
                     kIAPHubConnectionWaitTimeoutKey, kIAPSection);
- 
+
   ReadUIntValue(&default_hub_protocol_index_, kDefaultHubProtocolIndex, kIAPSection, kDefaultHubProtocolIndexKey);
 
   LOG_UPDATED_VALUE(default_hub_protocol_index_, kDefaultHubProtocolIndexKey, kIAPSection);

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -241,11 +241,11 @@ namespace profile {
 CREATE_LOGGERPTR_GLOBAL(logger_, "Profile")
 
 Profile::Profile()
-    : launch_hmi_(true),
+    : sdl_version_(kDefaultSDLVersion),
+      launch_hmi_(true),
 #ifdef WEB_HMI
       link_to_web_hmi_(kDefaultLinkToWebHMI),
 #endif // WEB_HMI
-      sdl_version_(kDefaultSDLVersion),
       app_config_folder_(),
       app_storage_folder_(),
       app_resourse_folder_(),


### PR DESCRIPTION
Both the SDL version as well as the current system software versions must be returned in the RAI response. This should be a plain-text string (for system sw, it must exactly match the version found in the system about screen).

<param name="sdlVersion" type="String" maxlength="100" mandatory="false" platform="documentation">
<description>The SmartDeviceLink version.</description>
</param>

<param name="systemSoftwareVersion" type="String" maxlength="100" mandatory="false" platform="documentation">
<description>The software version of the system that implements the SmartDeviceLink core.</description>
</param>
-------------------------------------------------------------------------------------------------------------------------------------------------------------------

Requirements to SDL:

1. SDL must send GetSystemInfo request to HMI to get information about "ccpu_version" parameter.

2. SDL must request the value of 'ccpu_version' parameter ONLY once after SDL having been started AND then use this value for each app registration during ignition cycle

Updated: 3. SDL must transfer the value of 'ccpu_version' param received in GetSystemInfo response from HMI to 'systemSoftwareVersion' param in RegisterAppInterface response to mobile app (according to confirmation from PASA per RE: Return SDL 7 System Software Version in RAI - question.msg attached)

4. SDL must set value of 'sdlVersion' parameter as commit hash automatically AND copy this value to corresponding parameter in .ini file in case SDL is in local git repository
5. In other cases SDL must extract the default value of 'sdlVersion' parameter from .ini file
6. Parameter 'sdlVersion' in .ini file must be configurable by User in any cases

7. In case SDL receives RegisterAppInterface request from app SDL must:
7.1. extract value of "sdlVersion" parameter from .ini file
7.2. transfer received value of "ccpu_version" from HMI to 'systemSoftwareVersion' param
7.3. provide values of "systemSoftwareVersion" and "sdlVersion" parameters via RegisterAppInterface response to app

8. In case 'sdlVersion' parameter is empty in .ini file (e.g. the value was deleted by User) SDL must report an empty string of 'sdlVersion' parameter via RegisterAppInterface response to mobile app.

9. In case the value of 'ccpu_version' param more than 100 symbols SDL must:
9.1. cut the number of symbols to 100 units
9.2. transfer received 100 symbols to 'systemSoftwareVersion' param in RegisterAppInterface response

INI file changes:
1. "sdlVersion" parameter (type=String) must be added to [MAIN] section