### PR TITLE
Changed device_info id to string and mac_address

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -343,7 +343,7 @@ class ApplicationManagerImpl : public ApplicationManager,
      */
     mobile_api::HMILevel::eType IsHmiLevelFullAllowed(ApplicationSharedPtr app);
 
-    void ConnectToDevice(uint32_t id);
+    void ConnectToDevice(const std::string& device_mac);
     void OnHMIStartedCooperation();
 
     /*

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -542,14 +542,20 @@ mobile_api::HMILevel::eType ApplicationManagerImpl::IsHmiLevelFullAllowed(
   return result;
 }
 
-void ApplicationManagerImpl::ConnectToDevice(uint32_t id) {
+void ApplicationManagerImpl::ConnectToDevice(const std::string& device_mac) {
   // TODO(VS): Call function from ConnectionHandler
   if (!connection_handler_) {
     LOG4CXX_WARN(logger_, "Connection handler is not set.");
     return;
   }
 
-  connection_handler_->ConnectToDevice(id);
+  connection_handler::DeviceHandle handle;
+  if (!connection_handler_->GetDeviceID(device_mac, &handle) ) {
+    LOG4CXX_ERROR(logger_, "Attempt to connect to invalid device with mac:"
+                  << device_mac );
+    return;
+  }
+  connection_handler_->ConnectToDevice(handle);
 }
 
 void ApplicationManagerImpl::OnHMIStartedCooperation() {

--- a/src/components/application_manager/src/commands/hmi/on_device_chosen_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_device_chosen_notification.cc
@@ -50,7 +50,7 @@ void OnDeviceChosenNotification::Run() {
   if ((*message_)[strings::msg_params].keyExists(strings::device_info)) {
     ApplicationManagerImpl::instance()->ConnectToDevice(
         (*message_)[strings::msg_params][strings::device_info][strings::id]
-            .asInt());
+            .asString());
   }
 }
 

--- a/src/components/application_manager/src/commands/hmi/on_device_state_changed_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_device_state_changed_notification.cc
@@ -95,8 +95,7 @@ void OnDeviceStateChangedNotification::Run() {
                             .asString();
     if (device_id.empty()) {
       if ((*message_)[strings::msg_params].keyExists("deviceId")) {
-        device_id = MessageHelper::GetDeviceMacAddressForHandle(
-                      (*message_)[strings::msg_params]["deviceId"]["id"].asInt());
+        device_id = (*message_)[strings::msg_params]["deviceId"]["id"].asString();
       }
     } else {
      // Policy uses hashed MAC address as device_id

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -335,7 +335,7 @@ void MessageHelper::SendOnAppRegisteredNotificationToHMI(
                   << application_impl.device());
   }
   device_info[strings::name] = device_name;
-  device_info[strings::id] = application_impl.device();
+  device_info[strings::id] = mac_address;
 
   const policy::DeviceConsent device_consent =
       policy::PolicyHandler::instance()->GetUserConsentForDevice(mac_address);
@@ -1320,7 +1320,7 @@ bool MessageHelper::CreateHMIApplicationStruct(ApplicationConstSharedPtr app,
 
   output[strings::device_info] = smart_objects::SmartObject(smart_objects::SmartType_Map);
   output[strings::device_info][strings::name] = device_name;
-  output[strings::device_info][strings::id] = app->device();
+  output[strings::device_info][strings::id] = mac_address;
   const policy::DeviceConsent device_consent =
       policy::PolicyHandler::instance()->GetUserConsentForDevice(mac_address);
   output[strings::device_info][strings::isSDLAllowed] =
@@ -1537,7 +1537,7 @@ void MessageHelper::SendSDLActivateAppResponse(policy::AppPermissions& permissio
     (*message)[strings::msg_params]["device"]["name"] = permissions.deviceInfo
         .device_name;
     (*message)[strings::msg_params]["device"]["id"] = permissions.deviceInfo
-        .device_handle;
+        .device_mac_address;
   }
 
   (*message)[strings::msg_params]["isAppRevoked"] = permissions.appRevoked;
@@ -1577,7 +1577,7 @@ void MessageHelper::SendOnSDLConsentNeeded(
   (*message)[strings::params][strings::message_type] =
     MessageType::kNotification;
 
-  (*message)[strings::msg_params]["device"]["id"] = device_info.device_handle;
+  (*message)[strings::msg_params]["device"]["id"] = device_info.device_mac_address;
   (*message)[strings::msg_params]["device"]["name"] = device_info.device_name;
 
   ApplicationManagerImpl::instance()->ManageHMICommand(message);

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1302,7 +1302,7 @@
   <param name="name" type="String" mandatory="true">
     <description>The name of the device connected.</description>
   </param>
-  <param name="id" type="Integer" mandatory="true">
+  <param name="id" type="String" mandatory="true">
     <description>The ID of the device connected</description>
   </param>
   <param name="transportType" type="Common.TransportType" mandatory="false">

--- a/src/components/interfaces/QT_HMI_API.xml
+++ b/src/components/interfaces/QT_HMI_API.xml
@@ -1114,7 +1114,7 @@
       <param name="name" type="String" mandatory="true">
         <description>The name of the device connected.</description>
       </param>
-      <param name="id" type="Integer" mandatory="true">
+      <param name="id" type="String" mandatory="true">
         <description>The ID of the device connected</description>
       </param>
       <param name="transportType" type="Common.TransportType" mandatory="false">


### PR DESCRIPTION
Pull request related to issue #199. Changed device info id field to type String and changed the field to use the mac address across sdl core uniformly, instead of the device handle in some places.

Code was forked from PR #179 and two lines from Pr #150 which were merged into develop. This code was needed as a hotfix into release to allow for OnDeviceChosen to not throw incorrect hmi parameter error, as well as creating uniform use of device_info id throughout core.