### PR TITLE
Fixes setting of HMI level for consequtive permissions validation.

### DIFF
--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -493,21 +493,26 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
   }
 
 
-  // By default app subscribed to CUSTOM_BUTTON
-  // Need to send notification to HMI
-  SendSubscribeCustomButtonNotification();
-
-  MessageHelper::SendChangeRegistrationRequestToHMI(application);
-
-  SendResponse(true, result, add_info.c_str(), &response_params);
   MessageHelper::SendOnAppRegisteredNotificationToHMI(*(application.get()),
                                                       resumption,
                                                       need_restore_vr);
+
+  SendResponse(true, result, add_info.c_str(), &response_params);
+
+  // Default HMI level should be set before any permissions validation, since it
+  // relies on HMI level.
+  resumer.SetupDefaultHMILevel(application);
+
   if (result != mobile_apis::Result::RESUME_FAILED) {
     resumer.StartResumption(application, hash_id);
   } else {
     resumer.StartResumptionOnlyHMILevel(application);
   }
+
+  // By default app subscribed to CUSTOM_BUTTON
+  // Need to send notification to HMI
+  SendSubscribeCustomButtonNotification();
+  MessageHelper::SendChangeRegistrationRequestToHMI(application);
 }
 
 mobile_apis::Result::eType

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
@@ -60,16 +60,14 @@ void RegisterAppInterfaceResponse::Run() {
 
   // Add registered application to the policy db right after response sent to
   // mobile to be able to check all other API according to app permissions
-  uint32_t connection_key =
-      (*message_)[strings::params][strings::connection_key].asUInt();
   application_manager::ApplicationConstSharedPtr app =
       application_manager::ApplicationManagerImpl::instance()->
-      application(connection_key);
+      application(connection_key());
   if (app.valid()) {
     policy::PolicyHandler *policy_handler = policy::PolicyHandler::instance();
     std::string mobile_app_id = app->mobile_app_id();
     policy_handler->AddApplication(mobile_app_id);
-    SetHeartBeatTimeout(connection_key, mobile_app_id);
+    SetHeartBeatTimeout(connection_key(), mobile_app_id);
   }
 }
 

--- a/src/components/application_manager/src/resume_ctrl.cpp
+++ b/src/components/application_manager/src/resume_ctrl.cpp
@@ -451,8 +451,6 @@ bool ResumeCtrl::StartResumption(ApplicationSharedPtr application,
     return false;
   }
 
-  SetupDefaultHMILevel(application);
-
   LOG4CXX_DEBUG(logger_, " Resume app_id = " << application->app_id()
                         << " hmi_app_id = " << application->hmi_app_id()
                         << " mobile_id = " << application->mobile_app_id()
@@ -543,8 +541,6 @@ bool ResumeCtrl::StartResumptionOnlyHMILevel(ApplicationSharedPtr application) {
     LOG4CXX_WARN(logger_, "Application do not exists");
     return false;
   }
-
-  SetupDefaultHMILevel(application);
 
   LOG4CXX_DEBUG(logger_, "ENTER app_id = " << application->app_id()
                         << "mobile_id = "


### PR DESCRIPTION
HMI level must be set for just registred application since permissions
validation rely on HMI level.

Fixes: APPLINK-15635

Conflicts:
	src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
	src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
	src/components/application_manager/src/resumption/resume_ctrl.cc