### PR TITLE
SDL will check application nicknames during ChangeRegistration

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/change_registration_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/change_registration_request.h
@@ -130,6 +130,13 @@ class ChangeRegistrationRequest : public CommandRequestImpl  {
    mobile_apis::Result::eType CheckCoincidence();
 
    /**
+    * @brief Checks if requested name is allowed by policy
+    * @param app_name Application name
+    * @return true, if allowed, otherwise - false
+    */
+   bool IsNicknameAllowed(const std::string& app_name) const;
+
+   /**
     * @brief Predicate for using with CheckCoincidence method to compare with VR synonym SO
     *
     * @return TRUE if there is coincidence of VR, otherwise FALSE


### PR DESCRIPTION
In case app sends ChangeRegistration SDL has to check app names towards
to its known nicknames.

Implements: APPLINK-14993

1. 	In case app_specific policies were assigned to app AND app sends ChangeRegistration request AND the value of "appName" does not presented in "nicknames" field in PolicyTable -> SDL must:
1.1. 	respond DISALLOWED to this app 
1.2. 	must NOT unregister this app 