### PR TITLE
Fix Logger's TelnetAppender socket reopen on fast restart

### DIFF
--- a/src/3rd_party/apache-log4cxx-0.10.0/src/main/cpp/serversocket.cpp
+++ b/src/3rd_party/apache-log4cxx-0.10.0/src/main/cpp/serversocket.cpp
@@ -39,6 +39,12 @@ ServerSocket::ServerSocket(int port) : pool(), mutex(pool), socket(0), timeout(0
     throw SocketException(status);
   }
   
+  // AKirov: Added SO_REUSEADDR option to fix APPLINK-15273
+  status = apr_socket_opt_set(socket, APR_SO_REUSEADDR, 1);
+  if (status != APR_SUCCESS) {
+    throw SocketException(status);
+  }
+
         // Create server socket address (including port number)
   apr_sockaddr_t *server_addr;
   status =


### PR DESCRIPTION
When SDL is stopped, TelnetAppender's server socket listening on port
6676 will remain in TIME_WAIT state (if there was a client connected
to it) fr some time, depending on the operating system settings.
With the old code, if we restart SDL soon after stopping it,
TelnetApplender will fail to bind to its port, because 'it is in use'.
The fix is to set SO_REUSEADDR option to server socket when opening
it - this will allow the port to be reused when it is in TIME_WAIT
state.