### PR TITLE
Fix crashes in the processing of SystemRequest(QUERY_APPS)

### DIFF
--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -1340,11 +1340,8 @@ bool MessageHelper::CreateHMIApplicationStruct(ApplicationConstSharedPtr app,
     const SmartObject* app_tts_name = app->tts_name();
     if (!app_tts_name->empty()) {
       SmartObject output_tts_name = SmartObject(SmartType_Array);
-
-      for (uint32_t i = 0; i < app_tts_name->length(); ++i) {
-        output_tts_name[i][strings::type] = hmi_apis::Common_SpeechCapabilities::SC_TEXT;
-        output_tts_name[i][strings::text] = (*app_tts_name)[i];
-      }
+      output_tts_name[0][strings::text] = *(app->tts_name());
+      output_tts_name[0][strings::type] = hmi_apis::Common_SpeechCapabilities::SC_TEXT;
       output[json::ttsName] = output_tts_name;
     }
     if (!app->vr_synonyms()->empty()) {

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -4975,7 +4975,7 @@
     <param name="url" type="String" maxlength="1000" minsize="1" maxsize="100" array="true" mandatory="false">
       <description>
         Optional URL for HTTP requests.
-	If blank, the binary data shall be forwarded to the app.
+        If blank, the binary data shall be forwarded to the app.
         If not blank, the binary data shall be forwarded to the url with a provided timeout in seconds.
       </description>
     </param>


### PR DESCRIPTION
1. Fix crash when processing SystemRequest with QUERY_APPS.
Process tts_name as string, not as array. tts_name in QueryApps json file is "string" according to APPLINK-11731, tts_name in QueryApps json file is "string" according to APPLINK-11731, tts_name in UpdateApplist is "array of strings" according to API.xml.
Fix: APPLINK-15783

2. Fix crash when accessing to non-existing object with Shared-pointer operator "->".
Use device_id from connection_handler.
Fix: APPLINK-15777, APPLINK-15778