### PR TITLE
Fix crash when processing SystemRequest with QUERY_APPS

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2005,28 +2005,28 @@ void ApplicationManagerImpl::CreateApplications(SmartArray& obj_array,
       continue;
     }
 
+    // AppId = 0 because this is query_app(provided by hmi for download, but not yet registered)
     ApplicationSharedPtr app(
           new ApplicationImpl(0,
                               mobile_app_id,
                               appName,
                               PolicyHandler::instance()->GetStatisticManager()));
-    if (app) {
-      app->SetShemaUrl(url_scheme);
-      app->SetPackageName(package_name);
-      app->set_app_icon_path(full_icon_path);
-      app->set_hmi_application_id(hmi_app_id);
-      app->set_device(device_id);
+    DCHECK_OR_RETURN_VOID(app);
+    app->SetShemaUrl(url_scheme);
+    app->SetPackageName(package_name);
+    app->set_app_icon_path(full_icon_path);
+    app->set_hmi_application_id(hmi_app_id);
+    app->set_device(device_id);
 
-      app->set_vr_synonyms(vrSynonym);
-      app->set_tts_name(ttsName);
+    app->set_vr_synonyms(vrSynonym);
+    app->set_tts_name(ttsName);
 
-      sync_primitives::AutoLock lock(apps_to_register_list_lock_);
-      LOG4CXX_DEBUG(logger_, "apps_to_register_ size before: "
-                    << apps_to_register_.size());
-      apps_to_register_.insert(app);
-      LOG4CXX_DEBUG(logger_, "apps_to_register_ size after: "
-                    << apps_to_register_.size());
-    }
+    sync_primitives::AutoLock lock(apps_to_register_list_lock_);
+    LOG4CXX_DEBUG(logger_, "apps_to_register_ size before: "
+                  << apps_to_register_.size());
+    apps_to_register_.insert(app);
+    LOG4CXX_DEBUG(logger_, "apps_to_register_ size after: "
+                  << apps_to_register_.size());
   }
 }
 

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -1299,11 +1299,8 @@ bool MessageHelper::CreateHMIApplicationStruct(ApplicationConstSharedPtr app,
     DCHECK_OR_RETURN(app_tts_name, false);
     if (!app_tts_name->empty()) {
       SmartObject output_tts_name = SmartObject(SmartType_Array);
-
-      for (uint32_t i = 0; i < app_tts_name->length(); ++i) {
-        output_tts_name[i][strings::type] = hmi_apis::Common_SpeechCapabilities::SC_TEXT;
-        output_tts_name[i][strings::text] = (*app_tts_name)[i];
-      }
+      output_tts_name[0][strings::text] = *(app->tts_name());
+      output_tts_name[0][strings::type] = hmi_apis::Common_SpeechCapabilities::SC_TEXT;
       output[json::ttsName] = output_tts_name;
     }
     if (!app->vr_synonyms()->empty()) {


### PR DESCRIPTION
Process tts_name as string, not as array. tts_name in QueryApps json file is "string" according to APPLINK-11731, tts_name in
UpdateApplist is "array of strings" according to API.xml
Fix: APPLINK-15783