### PR TITLE
Fixes core dump while sending ResetGlobalProperties

### DIFF
--- a/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
@@ -239,6 +239,9 @@ void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
   const smart_objects::SmartObject& message = event.smart_object();
 
+  ApplicationSharedPtr application =
+      ApplicationManagerImpl::instance()->application(connection_key());
+
   switch (event.id()) {
   case hmi_apis::FunctionID::UI_SetGlobalProperties: {
     LOG4CXX_INFO(logger_, "Received UI_SetGlobalProperties event");
@@ -287,9 +290,6 @@ void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
 
     SendResponse(result, static_cast<mobile_apis::Result::eType>(result_code),
                  return_info, &(message[strings::msg_params]));
-
-    ApplicationSharedPtr application =
-        ApplicationManagerImpl::instance()->application(connection_key());
 
     if (!application) {
       LOG4CXX_DEBUG(logger_, "NULL pointer");


### PR DESCRIPTION
Due to response deletion by request controller there is possibility of
using object members being destructed.

Closes-bug: APPLINK-16029