### PR TITLE
Mobile_API & HMI_API: SDL must treat integer value for params of float type as valid

### DIFF
--- a/src/components/smart_objects/include/smart_objects/number_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/number_schema_item.h
@@ -111,12 +111,13 @@ template<typename NumberType>
 bool TNumberSchemaItem<NumberType>::isValidNumberType(SmartType type) {
   NumberType value(0);
   if ((SmartType_Double == type) &&
-	  (typeid(double) == typeid(value))) {
+      (typeid(double) == typeid(value))) {
 	  return true;
   } else if ((SmartType_Integer == type) &&
 		     (typeid(int32_t) == typeid(value)  ||
 		      typeid(uint32_t) == typeid(value) ||
-		      typeid(int64_t) == typeid(value))) {
+              typeid(int64_t) == typeid(value)  ||
+              typeid(double) == typeid(value))) {
 	  return true;
   } else {
 	  return false;


### PR DESCRIPTION
Pull request contains changes to smart object validation rules:

- In case 
SDL gets RPC with integer value for a parameter stated as float in mobile_API, 
SDL must 
convert this integer value to float and process the RPC as assigned (meaning that "integer" value for "float" param should not be treated as an invalid_data by SDL)

- In case 
SDL gets RPC with integer value for a parameter stated as float in HMI_API, 
SDL must 
convert this integer value to float and process the RPC as assigned (meaning that "integer" value for "float" param should not be treated as an invalid_data by SDL)