### PR TITLE
Move check of expired certificate to start of hanshake

### DIFF
--- a/src/components/security_manager/src/security_manager_impl.cc
+++ b/src/components/security_manager/src/security_manager_impl.cc
@@ -187,6 +187,10 @@ void SecurityManagerImpl::StartHandshake(uint32_t connection_key) {
     return;
   }
 
+  if(crypto_manager_->IsCertificateUpdateRequired()) {
+    NotifyOnCertififcateUpdateRequired();
+  }
+
   if (ssl_context->IsInitCompleted()) {
     NotifyListenersOnHandshakeDone(connection_key,
                                    SSLContext::Handshake_Result_Success);


### PR DESCRIPTION
The SDL has checked module's certificate expiration only after
succed handshake. Now this logic has been changed and SDL checks
for module's certificate expiration each time during handshake starting

Close-Bug: APPLINK-16951