### PR TITLE
In case of empty vector SDL has been crashed

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1027,6 +1027,11 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string,
                                       int timeout_exchange) {
   EndpointUrls urls;
   policy_manager_->GetServiceUrls("0x07", urls);
+
+  if (urls.empty()) {
+    return;
+  }
+
   SendMessageToSDK(pt_string, urls.front().url.front());
 }
 


### PR DESCRIPTION
Add additional check for vector to avoid crash