### PR TITLE
Fix crash when second instance of SDL is started

### DIFF
--- a/src/appMain/main.cc
+++ b/src/appMain/main.cc
@@ -172,8 +172,9 @@ int32_t main(int32_t argc, char** argv) {
 
   if (!main_namespace::LifeCycle::instance()->InitMessageSystem()) {
     LOG4CXX_FATAL(logger_, "Failed to init message system");
+    main_namespace::LifeCycle::instance()->StopComponents();
     DEINIT_LOGGER();
-    exit(EXIT_FAILURE);
+    _exit(EXIT_FAILURE);
   }
   LOG4CXX_INFO(logger_, "InitMessageBroker successful");
 


### PR DESCRIPTION
When the app. is unabled to bind a socket return error, which caused
InitMessageSystem() to fail. The crash was occuring when exit is called.

Fixes: APPLINK-16303