### PR TITLE
Resumption for job 2

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -632,13 +632,13 @@ class Application : public virtual InitialApplicationData,
      * @brief HmiState of application within active events PhoneCall, TTS< etc ...
      * @return Active HmiState of application
      */
-    virtual const HmiStatePtr CurrentHmiState() const = 0;
+    virtual HmiStatePtr CurrentHmiState() const = 0;
 
     /**
      * @brief RegularHmiState of application without active events VR, TTS etc ...
      * @return HmiState of application
      */
-    virtual const HmiStatePtr RegularHmiState() const = 0;
+    virtual HmiStatePtr RegularHmiState() const = 0;
 
     /**
      * @brief PostponedHmiState returns postponed hmi state of application
@@ -646,7 +646,7 @@ class Application : public virtual InitialApplicationData,
      *
      * @return Postponed hmi state of application
      */
-    virtual const HmiStatePtr PostponedHmiState() const = 0;
+    virtual HmiStatePtr PostponedHmiState() const = 0;
 
     /**
      * @brief Keeps id of softbuttons which is created in commands:

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -506,18 +506,6 @@ class Application : public virtual InitialApplicationData,
     }
 
     /**
-     * @brief Current hmi state
-     */
-    virtual const HmiStatePtr CurrentHmiState() const = 0;
-
-
-    /**
-     * @brief RegularHmiState of application without active events VR, TTS etc ...
-     * @return HmiState of application
-     */
-    virtual const HmiStatePtr RegularHmiState() const = 0;
-
-    /**
      * @brief sets true if application has sent TTS GlobalProperties
      * request with empty array help_prompt to HMI with level
      * NONE BACKGROUND
@@ -559,6 +547,9 @@ class Application : public virtual InitialApplicationData,
     virtual void set_protocol_version(
         const ProtocolVersion& protocol_version) = 0;
     virtual ProtocolVersion protocol_version() const = 0;
+
+    virtual void set_is_resuming(bool is_resuming) = 0;
+    virtual bool is_resuming() const = 0;
 
     virtual bool AddFile(AppFile& file) = 0;
     virtual const AppFilesMap& getAppFiles() const = 0;
@@ -604,9 +595,18 @@ class Application : public virtual InitialApplicationData,
 
     /**
      * @brief SetRegularState set permanent state of application
+     *
      * @param state state to setup
      */
     virtual void SetRegularState(HmiStatePtr state)  = 0;
+
+    /**
+    * @brief SetPostponedState sets postponed state to application.
+    * This state could be set as regular later
+    *
+    * @param state state to setup
+    */
+    virtual void SetPostponedState(HmiStatePtr state) = 0;
 
     /**
      * @brief AddHMIState the function that will change application's
@@ -627,6 +627,26 @@ class Application : public virtual InitialApplicationData,
      * @param state_id that should be removed
      */
     virtual void RemoveHMIState(HmiState::StateID state_id) = 0;
+
+    /**
+     * @brief HmiState of application within active events PhoneCall, TTS< etc ...
+     * @return Active HmiState of application
+     */
+    virtual const HmiStatePtr CurrentHmiState() const = 0;
+
+    /**
+     * @brief RegularHmiState of application without active events VR, TTS etc ...
+     * @return HmiState of application
+     */
+    virtual const HmiStatePtr RegularHmiState() const = 0;
+
+    /**
+     * @brief PostponedHmiState returns postponed hmi state of application
+     * if it's present
+     *
+     * @return Postponed hmi state of application
+     */
+    virtual const HmiStatePtr PostponedHmiState() const = 0;
 
     /**
      * @brief Keeps id of softbuttons which is created in commands:

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -48,6 +48,7 @@
 #include "connection_handler/device.h"
 #include "utils/timer_thread.h"
 #include "utils/lock.h"
+#include "utils/atomic_object.h"
 
 namespace usage_statistics {
 
@@ -253,13 +254,13 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
    * @brief HmiState of application within active events PhoneCall, TTS< etc ...
    * @return Active HmiState of application
    */
-  virtual const HmiStatePtr CurrentHmiState() const;
+  virtual HmiStatePtr CurrentHmiState() const;
 
   /**
    * @brief RegularHmiState of application without active events VR, TTS etc ...
    * @return HmiState of application
    */
-  virtual const HmiStatePtr RegularHmiState() const;
+  virtual HmiStatePtr RegularHmiState() const;
 
   /**
    * @brief PostponedHmiState returns postponed hmi state of application
@@ -267,7 +268,7 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
    *
    * @return Postponed hmi state of application
    */
-  virtual const HmiStatePtr PostponedHmiState() const;
+  virtual HmiStatePtr PostponedHmiState() const;
 
   uint32_t audio_stream_retry_number() const;
 
@@ -336,9 +337,7 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
   UsageStatistics                          usage_report_;
   ProtocolVersion                          protocol_version_;
   bool                                     is_voice_communication_application_;
-
-  bool                                     is_resuming_;
-  mutable sync_primitives::Lock            is_resuming_lock;
+  sync_primitives::atomic_bool             is_resuming_;
 
   uint32_t                                 video_stream_retry_number_;
   uint32_t                                 audio_stream_retry_number_;

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -149,9 +149,11 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
   virtual uint32_t get_grammar_id() const;
   virtual void set_grammar_id(uint32_t value);
 
-
   virtual void set_protocol_version(const ProtocolVersion& protocol_version);
   virtual ProtocolVersion protocol_version() const;
+
+  virtual void set_is_resuming(bool is_resuming);
+  virtual bool is_resuming() const;
 
   bool AddFile(AppFile& file);
   bool UpdateFile(AppFile& file);
@@ -211,12 +213,21 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
    * @brief Load persistent files from application folder.
    */
   virtual void LoadPersistentFiles();
-  
-  /*
+
+  /**
   * @brief SetRegularState set permanent state of application
+  *
   * @param state state to setup
   */
   virtual void SetRegularState(HmiStatePtr state);
+
+  /**
+  * @brief SetPostponedState sets postponed state to application.
+  * This state could be set as regular later
+  *
+  * @param state state to setup
+  */
+  virtual void SetPostponedState(HmiStatePtr state);
 
   /**
    * @brief AddHMIState the function that will change application's
@@ -249,6 +260,14 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
    * @return HmiState of application
    */
   virtual const HmiStatePtr RegularHmiState() const;
+
+  /**
+   * @brief PostponedHmiState returns postponed hmi state of application
+   * if it's present
+   *
+   * @return Postponed hmi state of application
+   */
+  virtual const HmiStatePtr PostponedHmiState() const;
 
   uint32_t audio_stream_retry_number() const;
 
@@ -317,6 +336,9 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
   UsageStatistics                          usage_report_;
   ProtocolVersion                          protocol_version_;
   bool                                     is_voice_communication_application_;
+
+  bool                                     is_resuming_;
+  mutable sync_primitives::Lock            is_resuming_lock;
 
   uint32_t                                 video_stream_retry_number_;
   uint32_t                                 audio_stream_retry_number_;

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -537,6 +537,36 @@ class ApplicationManagerImpl : public ApplicationManager,
     }
 
     /**
+     * @brief SetState Change regular hmi level
+     * @param app appication to setup regular State
+     * @param hmi_level hmi level of new regular state
+     */
+    void SetState(uint32_t app_id,
+                  mobile_apis::HMILevel::eType hmi_level) {
+      ApplicationSharedPtr app  = application(app_id);
+      if (!app) {
+        LOG4CXX_ERROR(logger_, "Application with appID="<<app_id<<" does not exist");
+        return;
+      }
+      state_ctrl_.SetRegularState(app, hmi_level);
+    }
+
+    /**
+     * @brief SetState Change regular hmi state
+     * @param app appication to setup regular State
+     * @param state new regular hmi state
+     */
+    void SetState(uint32_t app_id,
+                  HmiStatePtr state) {
+      ApplicationSharedPtr app  = application(app_id);
+      if (!app) {
+        LOG4CXX_ERROR(logger_, "Application with appID="<<app_id<<" does not exist");
+        return;
+      }
+      state_ctrl_.SetRegularState(app, state);
+    }
+
+    /**
      * @brief Notification from PolicyHandler about PTU.
      * Compares AppHMIType between saved in app and received from PTU. If they are different method sends:
      * UI_ChangeRegistration with list new AppHMIType;

--- a/src/components/application_manager/include/application_manager/hmi_state.h
+++ b/src/components/application_manager/include/application_manager/hmi_state.h
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2015, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMISTATE_H
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMISTATE_H
 
@@ -12,21 +44,19 @@ class HmiState;
 typedef utils::SharedPtr<HmiState> HmiStatePtr;
 typedef std::list<HmiStatePtr> HmiStateList;
 
- /**
+/**
  * @brief The HmiState class
- *  Handle Hmi state of application (hmi level,
- *  audio streaming state, system context)
- *
+ * Handles Hmi state of application
+ * (hmi level, audio streaming state, system context)
  */
 class HmiState {
-
   public:
     /**
      * @brief The StateID enum describes state of application
-     * If no events occured STATE_ID_DEFAULT shuld be presented
      */
     enum StateID {
       STATE_ID_REGULAR,
+      STATE_ID_POSTPONED,
       STATE_ID_PHONE_CALL,
       STATE_ID_SAFETY_MODE,
       STATE_ID_VR_SESSION,
@@ -35,9 +65,8 @@ class HmiState {
     };
 
     HmiState(uint32_t app_id, const StateContext& state_context_);
-    HmiState(uint32_t app_id, const StateContext& state_context_,
-             StateID state_id);
-
+    HmiState(
+        uint32_t app_id, const StateContext& state_context_, StateID state_id);
 
     virtual ~HmiState() {}
 
@@ -120,6 +149,15 @@ class HmiState {
     StateID state_id() const {
       return state_id_;
     }
+
+    /**
+     * @brief set_state_id sets state id
+     * @param state_id state id to setup
+     */
+    virtual void set_state_id(StateID state_id) {
+      state_id_ = state_id;
+    }
+
   protected:
     uint32_t app_id_;
     StateID state_id_;
@@ -138,7 +176,7 @@ class HmiState {
 class VRHmiState : public HmiState {
   public:
     virtual mobile_apis::AudioStreamingState::eType audio_streaming_state() const;
-    VRHmiState(uint32_t app_id, StateContext& state_context);
+    VRHmiState(uint32_t app_id, const StateContext& state_context);
 };
 
 /**
@@ -146,7 +184,7 @@ class VRHmiState : public HmiState {
  */
 class TTSHmiState : public HmiState {
   public:
-    TTSHmiState(uint32_t app_id, StateContext& state_context);
+    TTSHmiState(uint32_t app_id, const StateContext& state_context);
     virtual  mobile_apis::AudioStreamingState::eType audio_streaming_state() const;
 };
 
@@ -155,7 +193,7 @@ class TTSHmiState : public HmiState {
  */
 class NaviStreamingHmiState : public HmiState {
   public:
-    NaviStreamingHmiState(uint32_t app_id, StateContext& state_context);
+    NaviStreamingHmiState(uint32_t app_id, const StateContext& state_context);
     virtual  mobile_apis::AudioStreamingState::eType audio_streaming_state() const;
 };
 
@@ -164,7 +202,7 @@ class NaviStreamingHmiState : public HmiState {
  */
 class PhoneCallHmiState : public HmiState {
   public:
-    PhoneCallHmiState(uint32_t app_id, StateContext& state_context);
+    PhoneCallHmiState(uint32_t app_id, const StateContext& state_context);
     virtual mobile_apis::HMILevel::eType hmi_level() const;
     virtual  mobile_apis::AudioStreamingState::eType audio_streaming_state() const {
       return mobile_apis::AudioStreamingState::NOT_AUDIBLE;
@@ -176,7 +214,7 @@ class PhoneCallHmiState : public HmiState {
  */
 class SafetyModeHmiState : public HmiState {
   public:
-    SafetyModeHmiState(uint32_t app_id, StateContext& state_context);
+    SafetyModeHmiState(uint32_t app_id, const StateContext& state_context);
     virtual  mobile_apis::AudioStreamingState::eType audio_streaming_state() const {
       return mobile_apis::AudioStreamingState::NOT_AUDIBLE;
     }

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -39,7 +39,6 @@
 #include <set>
 #include <list>
 
-
 #include "interfaces/HMI_API.h"
 #include "interfaces/HMI_API_schema.h"
 #include "interfaces/MOBILE_API_schema.h"
@@ -50,7 +49,6 @@
 #include "resumption_data.h"
 
 namespace application_manager {
-class ApplicationManagerImpl;
 class Application;
 }
 
@@ -245,24 +243,6 @@ class ResumeCtrl: public app_mngr::event_engine::EventObserver {
   void ResetLaunchTime();
 
   /**
-   * @brief IsLimitedAllowed return true if it is allowed to setup
-   * LIMITTED HmiLevel
-   * (if there are no app with the same type in FULL ot LIMITED))
-   * @return true if allowed otherwise false
-   */
-  bool IsLimitedAllowed();
-
-  /**
-   * @brief ResolveHMILevelConflicts found maximum allowed HMILevel
-   * @param application application to setup  hmi level
-   * @param hmi_level requested to setup
-   * @return maximum allowed HMILevel
-   */
-  mobile_apis::HMILevel::eType ResolveHMILevelConflicts(
-      app_mngr::ApplicationSharedPtr application,
-      const mobile_apis::HMILevel::eType hmi_level);
-
-  /**
    * @brief Timer callback for  restoring HMI Level
    *
    */
@@ -440,11 +420,7 @@ class ResumeCtrl: public app_mngr::event_engine::EventObserver {
 
   void AddToResumptionTimerQueue(uint32_t app_id);
 
-  mobile_apis::HMILevel::eType IsHmiLevelFullAllowed(
-      app_mngr::ApplicationConstSharedPtr app);
-
   void LoadResumeData();
-  app_mngr::ApplicationManagerImpl* appMngr();
 
   /**
    *@brief Mapping applications to time_stamps

--- a/src/components/application_manager/include/application_manager/state_controller.h
+++ b/src/components/application_manager/include/application_manager/state_controller.h
@@ -107,7 +107,6 @@ class StateController : public event_engine::EventObserver {
       SetRegularState<SendActivateApp>(app, hmi_state);
     }
 
-
     /**
      * @brief SetRegularState Change regular hmi level
      * @param app appication to setup regular State
@@ -123,8 +122,8 @@ class StateController : public event_engine::EventObserver {
           HmiState::StateID::STATE_ID_REGULAR);
       DCHECK_OR_RETURN_VOID(hmi_state);
       hmi_state->set_hmi_level(hmi_level);
-      hmi_state->set_audio_streaming_state(prev_regular->audio_streaming_state());
-      hmi_state->set_system_context(prev_regular->system_context());
+      hmi_state->set_audio_streaming_state(CalcAudioState(app, hmi_level));
+      hmi_state->set_system_context(mobile_apis::SystemContext::SYSCTXT_MAIN);
       SetRegularState<SendActivateApp>(app, hmi_state);
     }
 

--- a/src/components/application_manager/include/application_manager/state_controller.h
+++ b/src/components/application_manager/include/application_manager/state_controller.h
@@ -64,7 +64,8 @@ class StateController : public event_engine::EventObserver {
       DCHECK_OR_RETURN_VOID(state);
       DCHECK_OR_RETURN_VOID(state->state_id() == HmiState::STATE_ID_REGULAR);
 
-      if (!ResolveHmiState(app, state)) {
+      HmiStatePtr resolved_state = ResolveHmiState(app, state);
+      if (!resolved_state) {
         state->set_state_id(HmiState::STATE_ID_POSTPONED);
         app->SetPostponedState(state);
         return;
@@ -73,12 +74,12 @@ class StateController : public event_engine::EventObserver {
       if (SendActivateApp) {
         uint32_t corr_id = MessageHelper::SendActivateAppToHMI(app->app_id(),
             static_cast<hmi_apis::Common_HMILevel::eType>(
-                state->hmi_level()));
+                resolved_state->hmi_level()));
         subscribe_on_event(
             hmi_apis::FunctionID::BasicCommunication_ActivateApp, corr_id);
-        waiting_for_activate[app->app_id()] = state;
+        waiting_for_activate[app->app_id()] = resolved_state;
       } else {
-        ApplyRegularState(app, state);
+        ApplyRegularState(app, resolved_state);
       }
     }
 

--- a/src/components/application_manager/include/application_manager/state_controller.h
+++ b/src/components/application_manager/include/application_manager/state_controller.h
@@ -50,7 +50,7 @@ class StateController : public event_engine::EventObserver {
     StateController();
 
     /**
-     * @brief SetRegularState setup regular hmi state, tha will appear if no
+     * @brief SetRegularState setup regular hmi state, that will appear if no
      * specific events are active
      * @param app appication to setup regular State
      * @param state state of new regular state
@@ -64,23 +64,23 @@ class StateController : public event_engine::EventObserver {
       DCHECK_OR_RETURN_VOID(state);
       DCHECK_OR_RETURN_VOID(state->state_id() == HmiState::STATE_ID_REGULAR);
 
+      if (!ResolveHmiState(app, state)) {
+        state->set_state_id(HmiState::STATE_ID_POSTPONED);
+        app->SetPostponedState(state);
+        return;
+      }
+
       if (SendActivateApp) {
-        uint32_t corr_id = MessageHelper::SendActivateAppToHMI(app->app_id());
-        subscribe_on_event(hmi_apis::FunctionID::BasicCommunication_ActivateApp,
-                           corr_id);
+        uint32_t corr_id = MessageHelper::SendActivateAppToHMI(app->app_id(),
+            static_cast<hmi_apis::Common_HMILevel::eType>(
+                state->hmi_level()));
+        subscribe_on_event(
+            hmi_apis::FunctionID::BasicCommunication_ActivateApp, corr_id);
         waiting_for_activate[app->app_id()] = state;
       } else {
         ApplyRegularState(app, state);
       }
     }
-
-    /**
-     * @brief SetRegularState Change regular audio state
-     * @param app appication to setup regular State
-     * @param audio_state of new regular state
-     */
-    void SetRegularState(ApplicationSharedPtr app,
-                         const mobile_apis::AudioStreamingState::eType audio_state);
 
     /**
      * @brief SetRegularState Change regular hmi level and audio state
@@ -98,7 +98,7 @@ class StateController : public event_engine::EventObserver {
       HmiStatePtr prev_regular = app->RegularHmiState();
       DCHECK_OR_RETURN_VOID(prev_regular);
       HmiStatePtr hmi_state = CreateHmiState(app->app_id(),
-                                             HmiState::StateID::STATE_ID_REGULAR);
+          HmiState::StateID::STATE_ID_REGULAR);
       DCHECK_OR_RETURN_VOID(hmi_state);
       hmi_state->set_hmi_level(hmi_level);
       hmi_state->set_audio_streaming_state(audio_state);
@@ -118,10 +118,8 @@ class StateController : public event_engine::EventObserver {
       if (!app) {
         return;
       }
-      HmiStatePtr prev_regular = app->RegularHmiState();
-      DCHECK_OR_RETURN_VOID(prev_regular);
       HmiStatePtr hmi_state = CreateHmiState(app->app_id(),
-                                             HmiState::StateID::STATE_ID_REGULAR);
+          HmiState::StateID::STATE_ID_REGULAR);
       DCHECK_OR_RETURN_VOID(hmi_state);
       hmi_state->set_hmi_level(hmi_level);
       hmi_state->set_audio_streaming_state(prev_regular->audio_streaming_state());
@@ -144,9 +142,8 @@ class StateController : public event_engine::EventObserver {
       if (!app) {
         return;
       }
-
       HmiStatePtr hmi_state = CreateHmiState(app->app_id(),
-                                             HmiState::StateID::STATE_ID_REGULAR);
+          HmiState::StateID::STATE_ID_REGULAR);
       DCHECK_OR_RETURN_VOID(hmi_state);
       hmi_state->set_hmi_level(hmi_level);
       hmi_state->set_audio_streaming_state(audio_state);
@@ -155,7 +152,51 @@ class StateController : public event_engine::EventObserver {
     }
 
     /**
-     * @brief SetRegularState Change regular  system context
+     * @brief SetRegularState Sets regular state with new hmi level
+     * to application
+     * @param app appication to setup regular state
+     * @param hmi_level new hmi level for application
+     */
+    void SetRegularState(ApplicationSharedPtr app,
+                         const mobile_apis::HMILevel::eType hmi_level) {
+      if (!app) {
+        return;
+      }
+      HmiStatePtr prev_state = app->RegularHmiState();
+      HmiStatePtr hmi_state = CreateHmiState(app->app_id(),
+          HmiState::StateID::STATE_ID_REGULAR);
+      DCHECK_OR_RETURN_VOID(hmi_state);
+      hmi_state->set_hmi_level(hmi_level);
+      hmi_state->set_audio_streaming_state(CalcAudioState(app, hmi_level));
+      hmi_state->set_system_context(
+           prev_state ? prev_state->system_context()
+                      : mobile_apis::SystemContext::SYSCTXT_MAIN);
+      SetRegularState(app, hmi_state);
+    }
+
+    /**
+     * @brief SetRegularState Change regular audio state
+     * @param app appication to setup regular State
+     * @param audio_state of new regular state
+     */
+    void SetRegularState(ApplicationSharedPtr app,
+                         const mobile_apis::AudioStreamingState::eType audio_state) {
+      if (!app) {
+        return;
+      }
+      HmiStatePtr prev_state = app->RegularHmiState();
+      DCHECK_OR_RETURN_VOID(prev_state);
+      HmiStatePtr hmi_state = CreateHmiState(app->app_id(),
+          HmiState::StateID::STATE_ID_REGULAR);
+      DCHECK_OR_RETURN_VOID(hmi_state);
+      hmi_state->set_hmi_level(prev_state->hmi_level());
+      hmi_state->set_audio_streaming_state(audio_state);
+      hmi_state->set_system_context(prev_state->system_context());
+      SetRegularState<false>(app, hmi_state);
+    }
+
+    /**
+     * @brief SetRegularState Change regular system context
      * @param app appication to setup regular State
      * @param system_context of new regular state
      */
@@ -167,32 +208,35 @@ class StateController : public event_engine::EventObserver {
       HmiStatePtr prev_regular = app->RegularHmiState();
       DCHECK_OR_RETURN_VOID(prev_regular);
       HmiStatePtr hmi_state = CreateHmiState(app->app_id(),
-                                             HmiState::StateID::STATE_ID_REGULAR);
+          HmiState::StateID::STATE_ID_REGULAR);
       DCHECK_OR_RETURN_VOID(hmi_state);
       hmi_state->set_hmi_level(prev_regular->hmi_level());
-      hmi_state->set_audio_streaming_state(prev_regular->audio_streaming_state());
+      hmi_state->set_audio_streaming_state(
+           CalcAudioState(app, prev_regular->hmi_level()));
       hmi_state->set_system_context(system_context);
       SetRegularState<false>(app, hmi_state);
     }
 
+    /**
+     * @brief SetRegularState Sets new regular state to application
+     * @param app appication to setup regular state
+     * @param state new hmi state for application
+     */
+    void SetRegularState(ApplicationSharedPtr app,
+                         HmiStatePtr state) {
+      if (!app) {
+        return;
+      }
+      DCHECK_OR_RETURN_VOID(state);
+      if (mobile_apis::HMILevel::HMI_FULL == state->hmi_level()) {
+        SetRegularState<true>(app, state);
+      } else {
+        SetRegularState<false>(app, state);
+      }
+    }
+
     // EventObserver interface
     void on_event(const event_engine::Event& event);
-
-    /**
-     * @brief OnStateChanged send HMIStatusNotification if neded
-     * @param app application
-     * @param old_state state before change
-     * @param new_state state after change
-     */
-    void OnStateChanged(ApplicationSharedPtr app, HmiStatePtr old_state,
-                        HmiStatePtr new_state);
-    /**
-     * @brief state_context getter for state_context
-     * @return
-     */
-    const StateContext& state_context() const {
-      return state_context_;
-    }
 
     /**
      * @brief ApplyStatesForApp apply active HMI states for new App without s
@@ -210,6 +254,14 @@ class StateController : public event_engine::EventObserver {
      * @brief OnNaviStreamingStopped process Navi streaming stopped
      */
     void OnNaviStreamingStopped();
+
+    /**
+     * @brief state_context getter for state_context
+     * @return
+     */
+    const StateContext& state_context() const {
+      return state_context_;
+    }
 
   private:
     /**
@@ -231,7 +283,8 @@ class StateController : public event_engine::EventObserver {
 
     /**
      * @brief The HmiLevelConflictResolver struct
-     * Move other application to HmiStates if applied moved to FULL or LIMITED
+     * Resolves conflicts and moves OTHER applications to appropriate
+     * hmi states AFTER changing hmi state for some application
      */
     struct HmiLevelConflictResolver {
       ApplicationSharedPtr applied_;
@@ -243,6 +296,70 @@ class StateController : public event_engine::EventObserver {
         applied_(app), state_(state) {}
       void operator()(ApplicationSharedPtr to_resolve);
     };
+
+    /**
+     * @brief ResolveHmiState Checks if requested hmi state is
+     * allowed by current states context and correct it if it possible
+     *
+     * @param app application to apply state
+     *
+     * @param state state to be checked
+     *
+     * @return Resolved hmi state or empty pointer in case requested
+     * hmi state is not allowed
+     */
+    HmiStatePtr ResolveHmiState(
+        ApplicationSharedPtr app, HmiStatePtr state) const;
+
+    /**
+     * @brief GetAvailableHmiLevel Returns closest to requested
+     * available hmi level for application
+     *
+     * @param app application to apply state
+     *
+     * @param hmi_level requested hmi level
+     *
+     * @return Resolved hmi state or empty pointer in case requested
+     * hmi state is not allowed
+     */
+    mobile_apis::HMILevel::eType GetAvailableHmiLevel(
+        ApplicationSharedPtr app, mobile_apis::HMILevel::eType hmi_level) const;
+
+    /**
+     * @brief IsStateAvailable Checks if hmi state is available
+     * to apply for specified application
+     *
+     * @param app application to apply state
+     *
+     * @param state state to be checked
+     *
+     * @return true if state is available, false otherwise
+     */
+    bool IsStateAvailable(
+        ApplicationSharedPtr app, HmiStatePtr state) const;
+
+    /**
+     * @brief OnStateChanged send HMIStatusNotification if neded
+     * @param app application
+     * @param old_state state before change
+     * @param new_state state after change
+     */
+    void OnStateChanged(ApplicationSharedPtr app, HmiStatePtr old_state,
+                        HmiStatePtr new_state);
+
+    /**
+     * @brief ApplyPostponedStateForApp tries to apply postponed state
+     * to application if it's allowed by current active states
+     */
+    void ApplyPostponedStateForApp(ApplicationSharedPtr app);
+
+    /**
+     * @brief IsTempStateActive Checks if specified temp state
+     * is currently active
+     *
+     * @return true if state is active, false otherwise
+     */
+    bool IsTempStateActive(HmiState::StateID ID) const;
 
     /**
      *  Function to add new temporary HmiState for application
@@ -418,11 +535,16 @@ class StateController : public event_engine::EventObserver {
      * @param state_id state id
      * @return
      */
-    HmiStatePtr CreateHmiState(uint32_t app_id, HmiState::StateID state_id);
+    HmiStatePtr CreateHmiState(
+        uint32_t app_id, HmiState::StateID state_id) const;
+
+    mobile_apis::AudioStreamingState::eType
+    CalcAudioState(ApplicationSharedPtr app,
+        const mobile_apis::HMILevel::eType hmi_level) const;
 
     typedef std::list<HmiState::StateID> StateIDList;
     StateIDList active_states_;
-    sync_primitives::Lock active_states_lock_;
+    mutable sync_primitives::Lock active_states_lock_;
     std::map<uint32_t, HmiStatePtr> waiting_for_activate;
     StateContext state_context_;
 };

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -104,6 +104,7 @@ ApplicationImpl::ApplicationImpl(uint32_t application_id,
       usage_report_(mobile_app_id, statistics_manager),
       protocol_version_(ProtocolVersion::kV3),
       is_voice_communication_application_(false),
+      is_resuming_(false),
       video_stream_retry_number_(0),
       audio_stream_retry_number_(0) {
 
@@ -209,6 +210,7 @@ bool ApplicationImpl::IsAudioApplication() const {
 }
 
 void ApplicationImpl::SetRegularState(HmiStatePtr state) {
+  LOG4CXX_AUTO_TRACE(logger_);
   DCHECK_OR_RETURN_VOID(state);
   DCHECK_OR_RETURN_VOID(state->state_id() ==
       HmiState::StateID::STATE_ID_REGULAR);
@@ -229,6 +231,7 @@ void ApplicationImpl::SetRegularState(HmiStatePtr state) {
 }
 
 void ApplicationImpl::SetPostponedState(HmiStatePtr state) {
+  LOG4CXX_AUTO_TRACE(logger_);
   DCHECK_OR_RETURN_VOID(state);
   DCHECK_OR_RETURN_VOID(state->state_id() ==
       HmiState::StateID::STATE_ID_POSTPONED);
@@ -289,7 +292,7 @@ void ApplicationImpl::RemoveHMIState(HmiState::StateID state_id) {
   }
 }
 
-const HmiStatePtr ApplicationImpl::CurrentHmiState() const {
+HmiStatePtr ApplicationImpl::CurrentHmiState() const {
   sync_primitives::AutoLock auto_lock(hmi_states_lock_);
   DCHECK_OR_RETURN(!hmi_states_.empty(), HmiStatePtr());
   HmiStatePtr back_state = hmi_states_.back();
@@ -299,7 +302,7 @@ const HmiStatePtr ApplicationImpl::CurrentHmiState() const {
   return back_state;
 }
 
-const HmiStatePtr ApplicationImpl::RegularHmiState() const {
+HmiStatePtr ApplicationImpl::RegularHmiState() const {
   sync_primitives::AutoLock auto_lock(hmi_states_lock_);
   DCHECK_OR_RETURN(!hmi_states_.empty(), HmiStatePtr());
   HmiStateList::const_iterator front_itr = hmi_states_.begin();
@@ -309,7 +312,7 @@ const HmiStatePtr ApplicationImpl::RegularHmiState() const {
   return *front_itr;
 }
 
-const HmiStatePtr ApplicationImpl::PostponedHmiState() const {
+HmiStatePtr ApplicationImpl::PostponedHmiState() const {
   sync_primitives::AutoLock auto_lock(hmi_states_lock_);
   DCHECK_OR_RETURN(!hmi_states_.empty(), HmiStatePtr());
   HmiStatePtr front_state = hmi_states_.front();
@@ -641,12 +644,10 @@ ProtocolVersion ApplicationImpl::protocol_version() const {
 }
 
 void ApplicationImpl::set_is_resuming(bool is_resuming) {
-  sync_primitives::AutoLock lock(is_resuming_lock);
   is_resuming_ = is_resuming;
 }
 
 bool ApplicationImpl::is_resuming() const {
-  sync_primitives::AutoLock lock(is_resuming_lock);
   return is_resuming_;
 }
 

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -205,18 +205,38 @@ void ApplicationImpl::set_voice_communication_supported(
 bool ApplicationImpl::IsAudioApplication() const {
   return is_media_ ||
          is_voice_communication_application_ ||
-      is_navi_;
+         is_navi_;
 }
 
 void ApplicationImpl::SetRegularState(HmiStatePtr state) {
   DCHECK_OR_RETURN_VOID(state);
+  DCHECK_OR_RETURN_VOID(state->state_id() ==
+      HmiState::StateID::STATE_ID_REGULAR);
   sync_primitives::AutoLock auto_lock(hmi_states_lock_);
   DCHECK_OR_RETURN_VOID(!hmi_states_.empty());
-  hmi_states_.erase(hmi_states_.begin());
-  if (hmi_states_.begin() != hmi_states_.end()) {
-    HmiStatePtr first_temp = hmi_states_.front();
-    DCHECK_OR_RETURN_VOID(first_temp);
-    first_temp->set_parent(state);
+  hmi_states_.pop_front();
+  if (!hmi_states_.empty()) {
+    HmiStatePtr front_state = hmi_states_.front();
+    if (front_state->state_id() == HmiState::StateID::STATE_ID_REGULAR) {
+      hmi_states_.pop_front();
+    }
+  }
+  if (!hmi_states_.empty()) {
+    HmiStatePtr front_state = hmi_states_.front();
+    front_state->set_parent(state);
+  }
+  hmi_states_.push_front(state);
+}
+
+void ApplicationImpl::SetPostponedState(HmiStatePtr state) {
+  DCHECK_OR_RETURN_VOID(state);
+  DCHECK_OR_RETURN_VOID(state->state_id() ==
+      HmiState::StateID::STATE_ID_POSTPONED);
+  sync_primitives::AutoLock auto_lock(hmi_states_lock_);
+  DCHECK_OR_RETURN_VOID(!hmi_states_.empty());
+  HmiStatePtr front_state = hmi_states_.front();
+  if (front_state->state_id() == HmiState::StateID::STATE_ID_POSTPONED) {
+    hmi_states_.pop_front();
   }
   hmi_states_.push_front(state);
 }
@@ -272,14 +292,29 @@ void ApplicationImpl::RemoveHMIState(HmiState::StateID state_id) {
 const HmiStatePtr ApplicationImpl::CurrentHmiState() const {
   sync_primitives::AutoLock auto_lock(hmi_states_lock_);
   DCHECK_OR_RETURN(!hmi_states_.empty(), HmiStatePtr());
-  //TODO(APPLINK-11448) Need implement
-  return hmi_states_.back();
+  HmiStatePtr back_state = hmi_states_.back();
+  DCHECK_OR_RETURN(back_state->state_id() !=
+      HmiState::StateID::STATE_ID_POSTPONED,
+          HmiStatePtr());
+  return back_state;
 }
 
-const HmiStatePtr ApplicationImpl::RegularHmiState() const{
-  //sync_primitives::AutoLock auto_lock(hmi_states_lock_);
+const HmiStatePtr ApplicationImpl::RegularHmiState() const {
+  sync_primitives::AutoLock auto_lock(hmi_states_lock_);
   DCHECK_OR_RETURN(!hmi_states_.empty(), HmiStatePtr());
-  return hmi_states_.front();
+  HmiStateList::const_iterator front_itr = hmi_states_.begin();
+  if ((*front_itr)->state_id() == HmiState::StateID::STATE_ID_POSTPONED) {
+    ++front_itr;
+  }
+  return *front_itr;
+}
+
+const HmiStatePtr ApplicationImpl::PostponedHmiState() const {
+  sync_primitives::AutoLock auto_lock(hmi_states_lock_);
+  DCHECK_OR_RETURN(!hmi_states_.empty(), HmiStatePtr());
+  HmiStatePtr front_state = hmi_states_.front();
+  return front_state->state_id() == HmiState::StateID::STATE_ID_POSTPONED ?
+         front_state : HmiStatePtr();
 }
 
 const smart_objects::SmartObject* ApplicationImpl::active_message() const {
@@ -603,6 +638,16 @@ void ApplicationImpl::set_protocol_version(
 
 ProtocolVersion ApplicationImpl::protocol_version() const {
   return protocol_version_;
+}
+
+void ApplicationImpl::set_is_resuming(bool is_resuming) {
+  sync_primitives::AutoLock lock(is_resuming_lock);
+  is_resuming_ = is_resuming;
+}
+
+bool ApplicationImpl::is_resuming() const {
+  sync_primitives::AutoLock lock(is_resuming_lock);
+  return is_resuming_;
 }
 
 bool ApplicationImpl::AddFile(AppFile& file) {

--- a/src/components/application_manager/src/hmi_state.cc
+++ b/src/components/application_manager/src/hmi_state.cc
@@ -1,23 +1,54 @@
+/*
+ * Copyright (c) 2015, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include "application_manager/hmi_state.h"
 #include "utils/helpers.h"
 
 namespace application_manager {
 
-HmiState::HmiState(uint32_t app_id, const StateContext& state_context_,
-                   StateID state_id):
+HmiState::HmiState(uint32_t app_id, const StateContext& state_context):
   app_id_(app_id),
-  state_id_(state_id),
-  state_context_(state_context_),
+  state_id_(STATE_ID_REGULAR),
+  state_context_(state_context),
   hmi_level_(mobile_apis::HMILevel::INVALID_ENUM),
   audio_streaming_state_(mobile_apis::AudioStreamingState::INVALID_ENUM),
   system_context_(mobile_apis::SystemContext::INVALID_ENUM) {
 }
 
-
-HmiState::HmiState(uint32_t app_id, const StateContext& state_context):
+HmiState::HmiState(
+    uint32_t app_id, const StateContext& state_context_, StateID state_id):
   app_id_(app_id),
-  state_id_(STATE_ID_REGULAR),
-  state_context_(state_context),
+  state_id_(state_id),
+  state_context_(state_context_),
   hmi_level_(mobile_apis::HMILevel::INVALID_ENUM),
   audio_streaming_state_(mobile_apis::AudioStreamingState::INVALID_ENUM),
   system_context_(mobile_apis::SystemContext::INVALID_ENUM) {
@@ -34,11 +65,11 @@ VRHmiState::audio_streaming_state() const {
   return AudioStreamingState::NOT_AUDIBLE;
 }
 
-VRHmiState::VRHmiState(uint32_t app_id, StateContext& state_context):
+VRHmiState::VRHmiState(uint32_t app_id, const StateContext& state_context):
   HmiState(app_id, state_context, STATE_ID_VR_SESSION) {
 }
 
-TTSHmiState::TTSHmiState(uint32_t app_id, StateContext& state_context):
+TTSHmiState::TTSHmiState(uint32_t app_id, const StateContext& state_context):
   HmiState(app_id, state_context, STATE_ID_TTS_SESSION) {
 }
 
@@ -57,7 +88,8 @@ TTSHmiState::audio_streaming_state() const {
   return expected_state;
 }
 
-NaviStreamingHmiState::NaviStreamingHmiState(uint32_t app_id, StateContext& state_context):
+NaviStreamingHmiState::NaviStreamingHmiState(
+    uint32_t app_id, const StateContext& state_context):
   HmiState(app_id, state_context, STATE_ID_NAVI_STREAMING) {
 }
 
@@ -78,7 +110,8 @@ NaviStreamingHmiState::audio_streaming_state() const {
   return expected_state;
 }
 
-PhoneCallHmiState::PhoneCallHmiState(uint32_t app_id, StateContext& state_context):
+PhoneCallHmiState::PhoneCallHmiState(
+    uint32_t app_id, const StateContext& state_context):
   HmiState(app_id, state_context, STATE_ID_PHONE_CALL) {
 }
 
@@ -94,7 +127,8 @@ mobile_apis::HMILevel::eType PhoneCallHmiState::hmi_level() const {
    return expected_level;
 }
 
-SafetyModeHmiState::SafetyModeHmiState(uint32_t app_id, StateContext& state_context):
+SafetyModeHmiState::SafetyModeHmiState(
+    uint32_t app_id, const StateContext& state_context):
   HmiState(app_id, state_context, STATE_ID_SAFETY_MODE) {
 }
 

--- a/src/components/application_manager/src/resumption/resume_ctrl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl.cc
@@ -215,7 +215,7 @@ bool ResumeCtrl::SetAppHMIState(ApplicationSharedPtr application,
   ApplicationManagerImpl::instance()->SetState(
       application->app_id(), hmi_level);
   LOG4CXX_INFO(logger_, "Application with policy id "
-               << application->policy_app_id()
+               << application->mobile_app_id()
                << " got HMI level " << hmi_level);
   return true;
 }

--- a/src/components/application_manager/src/resumption/resume_ctrl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl.cc
@@ -162,42 +162,6 @@ bool ResumeCtrl::SetupDefaultHMILevel(ApplicationSharedPtr application) {
   return SetAppHMIState(application, default_hmi, false);
 }
 
-bool ResumeCtrl::IsLimitedAllowed() {
-  using namespace mobile_apis;
-  ApplicationManagerImpl::ApplicationListAccessor accessor;
-  ApplicationManagerImpl::ApplictionSetConstIt it = accessor.begin();
-  for (; accessor.end() != it ; ++it) {
-    const ApplicationSharedPtr curr_app = *it;
-    if (curr_app->is_media_application()) {
-      if (curr_app->hmi_level() == HMILevel::HMI_FULL ||
-          curr_app->hmi_level() == HMILevel::HMI_LIMITED) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
-mobile_apis::HMILevel::eType
-ResumeCtrl::ResolveHMILevelConflicts(ApplicationSharedPtr application,
-                                     const mobile_apis::HMILevel::eType hmi_level) {
-  using namespace mobile_apis;
-  LOG4CXX_AUTO_TRACE(logger_);
-  DCHECK_OR_RETURN(application, HMILevel::INVALID_ENUM);
-  HMILevel::eType restored_hmi_level = hmi_level;
-  if (HMILevel::HMI_FULL == hmi_level) {
-    restored_hmi_level = IsHmiLevelFullAllowed(application);
-  } else if (HMILevel::HMI_LIMITED == hmi_level) {
-    restored_hmi_level = IsLimitedAllowed() ?
-                           HMILevel::HMI_LIMITED:
-                           appMngr()->GetDefaultHmiLevel(application);
-  }
-  if (HMILevel::HMI_LIMITED == restored_hmi_level) {
-    MessageHelper::SendOnResumeAudioSourceToHMI(application->app_id());
-  }
-  return restored_hmi_level;
-}
-
 void ResumeCtrl::ApplicationResumptiOnTimer() {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock auto_lock(queue_lock_);
@@ -230,8 +194,8 @@ void ResumeCtrl::RemoveFromResumption(uint32_t app_id) {
 }
 
 bool ResumeCtrl::SetAppHMIState(ApplicationSharedPtr application,
-                               const mobile_apis::HMILevel::eType hmi_level,
-                               bool check_policy) {
+                                const mobile_apis::HMILevel::eType hmi_level,
+                                bool check_policy) {
   using namespace mobile_apis;
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK_OR_RETURN(application, false);
@@ -247,25 +211,12 @@ bool ResumeCtrl::SetAppHMIState(ApplicationSharedPtr application,
     SetupDefaultHMILevel(application);
     return false;
   }
-  const HMILevel::eType restored_hmi_level =
-      ResolveHMILevelConflicts(application, hmi_level);
-  const AudioStreamingState::eType restored_audio_state =
-      application->is_media_application() &&
-      (HMILevel::HMI_FULL == restored_hmi_level ||
-      HMILevel::HMI_LIMITED == restored_hmi_level) ? AudioStreamingState::AUDIBLE:
-                                                    AudioStreamingState::NOT_AUDIBLE;
-  if (restored_hmi_level == HMILevel::HMI_FULL) {
-    ApplicationManagerImpl::instance()->SetState<true>(application->app_id(),
-                                                       restored_hmi_level,
-                                                       restored_audio_state);
-  } else {
-    ApplicationManagerImpl::instance()->SetState<false>(application->app_id(),
-                                                        restored_hmi_level,
-                                                        restored_audio_state);
-  }
-  LOG4CXX_INFO(logger_, "Set up application "
-               << application->mobile_app_id()
-               << " to HMILevel " << restored_hmi_level);
+  application->set_is_resuming(true);
+  ApplicationManagerImpl::instance()->SetState(
+      application->app_id(), hmi_level);
+  LOG4CXX_INFO(logger_, "Application with policy id "
+               << application->policy_app_id()
+               << " got HMI level " << hmi_level);
   return true;
 }
 
@@ -739,35 +690,6 @@ void ResumeCtrl::AddToResumptionTimerQueue(uint32_t app_id) {
   }
 }
 
-mobile_apis::HMILevel::eType
-ResumeCtrl::IsHmiLevelFullAllowed(ApplicationConstSharedPtr app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  DCHECK_OR_RETURN(app, mobile_api::HMILevel::INVALID_ENUM);
-
-  bool is_audio_app = app->IsAudioApplication();
-  bool does_audio_app_with_same_type_exist =
-      appMngr()->IsAppTypeExistsInFullOrLimited(app);
-  bool is_active_app_exist = appMngr()->active_application().valid();
-
-  mobile_api::HMILevel::eType result = mobile_api::HMILevel::HMI_FULL;
-  if (is_audio_app) {
-    if (does_audio_app_with_same_type_exist) {
-      result = appMngr()->GetDefaultHmiLevel(app);
-    } else if (is_active_app_exist) {
-      result = mobile_apis::HMILevel::HMI_LIMITED;
-    }
-  } else if (is_active_app_exist) {
-    result = appMngr()->GetDefaultHmiLevel(app);
-  }
-
-  LOG4CXX_DEBUG(logger_, "is_audio_app : " << is_audio_app
-                << "; does_audio_app_with_same_type_exist : "
-                << does_audio_app_with_same_type_exist
-                << "; is_active_app_exist : " << is_active_app_exist
-                << "; result : " << result);
-  return result;
-}
-
 void ResumeCtrl::LoadResumeData() {
   LOG4CXX_AUTO_TRACE(logger_);
   smart_objects::SmartObject so_applications_data;
@@ -817,10 +739,6 @@ void ResumeCtrl::LoadResumeData() {
         (*limited_app)[strings::device_id].asString(),
         static_cast<int32_t>(mobile_apis::HMILevel::HMI_LIMITED));
   }
-}
-
-ApplicationManagerImpl* ResumeCtrl::appMngr() {
-  return ::application_manager::ApplicationManagerImpl::instance();
 }
 
 }  // namespce resumption

--- a/src/components/application_manager/src/state_controller.cc
+++ b/src/components/application_manager/src/state_controller.cc
@@ -166,16 +166,11 @@ bool StateController::IsStateAvailable(ApplicationSharedPtr app,
                 << ", audio_state " << state->audio_streaming_state()
                 << ", system_context " << state->system_context());
 
-  if (!app->is_resuming()) {
+  if (!app->is_resuming() ||
+      !Compare<HMILevel::eType, EQ, ONE>(state->hmi_level(),
+               HMILevel::HMI_FULL, HMILevel::HMI_LIMITED)) {
     LOG4CXX_DEBUG(logger_, "Application is not in resuming mode."
                   << " Requested state is available");
-    return true;
-  }
-
-  if (!Compare<HMILevel::eType, EQ, ONE>(state->hmi_level(),
-          HMILevel::HMI_FULL, HMILevel::HMI_LIMITED)) {
-    LOG4CXX_WARN(logger_, "Application is going to resume to background."
-                 << " Requested state is available");
     return true;
   }
 

--- a/src/components/application_manager/src/state_controller.cc
+++ b/src/components/application_manager/src/state_controller.cc
@@ -61,22 +61,6 @@ StateController::StateController():EventObserver() {
   subscribe_on_event(hmi_apis::FunctionID::VR_Stopped);
 }
 
-void StateController::SetRegularState(ApplicationSharedPtr app,
-                                      const mobile_apis::AudioStreamingState::eType audio_state) {
-  if (!app) {
-    return;
-  }
-  HmiStatePtr prev_state = app->RegularHmiState();
-  DCHECK_OR_RETURN_VOID(prev_state);
-  HmiStatePtr hmi_state = CreateHmiState(app->app_id(),
-                                         HmiState::StateID::STATE_ID_REGULAR);
-  DCHECK_OR_RETURN_VOID(hmi_state);
-  hmi_state->set_hmi_level(prev_state->hmi_level());
-  hmi_state->set_audio_streaming_state(audio_state);
-  hmi_state->set_system_context(prev_state->system_context());
-  SetRegularState<false>(app, hmi_state);
-}
-
 void StateController::HmiLevelConflictResolver::operator ()
     (ApplicationSharedPtr to_resolve) {
   using namespace mobile_apis;
@@ -108,6 +92,110 @@ void StateController::HmiLevelConflictResolver::operator ()
   }
 }
 
+HmiStatePtr StateController::ResolveHmiState(ApplicationSharedPtr app,
+                                             HmiStatePtr state) const {
+  using namespace mobile_apis;
+  using namespace helpers;
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(logger_, "State to resolve: hmi_level " << state->hmi_level()
+                << ", audio_state " << state->audio_streaming_state()
+                << ", system_context " << state->system_context());
+
+  HmiStatePtr available_state = CreateHmiState(app->app_id(),
+      HmiState::StateID::STATE_ID_REGULAR);
+  DCHECK_OR_RETURN(available_state, HmiStatePtr());
+  available_state->set_hmi_level(state->hmi_level());
+  available_state->set_audio_streaming_state(state->audio_streaming_state());
+  available_state->set_system_context(state->system_context());
+
+  if (app->is_resuming()) {
+    HMILevel::eType available_level = GetAvailableHmiLevel(
+        app, state->hmi_level());
+    available_state->set_hmi_level(available_level);
+    available_state->set_audio_streaming_state(
+        CalcAudioState(app, available_level));
+  }
+  return IsStateAvailable(app, available_state) ? available_state
+                                                : HmiStatePtr();
+}
+
+mobile_apis::HMILevel::eType
+StateController::GetAvailableHmiLevel(
+    ApplicationSharedPtr app, mobile_apis::HMILevel::eType hmi_level) const {
+  using namespace mobile_apis;
+  using namespace helpers;
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  mobile_apis::HMILevel::eType result = hmi_level;
+  if (!Compare<HMILevel::eType, EQ, ONE>(hmi_level,
+          HMILevel::HMI_FULL, HMILevel::HMI_LIMITED)) {
+    return result;
+  }
+
+  const bool is_audio_app = app->IsAudioApplication();
+  const bool does_audio_app_with_same_type_exist =
+      ApplicationManagerImpl::instance()->IsAppTypeExistsInFullOrLimited(app);
+  if (HMILevel::HMI_LIMITED == hmi_level) {
+    if (!is_audio_app || does_audio_app_with_same_type_exist) {
+      result = ApplicationManagerImpl::instance()->GetDefaultHmiLevel(app);
+    }
+    return result;
+  }
+
+  const bool is_active_app_exist =
+      ApplicationManagerImpl::instance()->active_application();
+  if (is_audio_app) {
+    if (does_audio_app_with_same_type_exist) {
+      result = ApplicationManagerImpl::instance()->GetDefaultHmiLevel(app);
+    } else if (is_active_app_exist) {
+      result = mobile_apis::HMILevel::HMI_LIMITED;
+    }
+  } else if (is_active_app_exist) {
+    result = ApplicationManagerImpl::instance()->GetDefaultHmiLevel(app);
+  }
+
+  return result;
+}
+
+bool StateController::IsStateAvailable(ApplicationSharedPtr app,
+                                       HmiStatePtr state) const {
+  using namespace mobile_apis;
+  using namespace helpers;
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(logger_, "Checking state: hmi_level " << state->hmi_level()
+                << ", audio_state " << state->audio_streaming_state()
+                << ", system_context " << state->system_context());
+
+  if (!app->is_resuming()) {
+    LOG4CXX_DEBUG(logger_, "Application is not in resuming mode."
+                  << " Requested state is available");
+    return true;
+  }
+
+  if (!Compare<HMILevel::eType, EQ, ONE>(state->hmi_level(),
+          HMILevel::HMI_FULL, HMILevel::HMI_LIMITED)) {
+    LOG4CXX_WARN(logger_, "Application is going to resume to background."
+                 << " Requested state is available");
+    return true;
+  }
+
+  if (IsTempStateActive(HmiState::StateID::STATE_ID_VR_SESSION) ||
+      IsTempStateActive(HmiState::StateID::STATE_ID_SAFETY_MODE)) {
+    LOG4CXX_DEBUG(logger_, "Requested state is not available. "
+                  << "VR session or emergency event is active");
+    return false;
+  }
+  if (IsTempStateActive(HmiState::StateID::STATE_ID_PHONE_CALL) &&
+      app->is_media_application()) {
+    LOG4CXX_DEBUG(logger_, "Requested state for media application "
+                  << "is not available. Phone call is active");
+    return false;
+  }
+
+  LOG4CXX_DEBUG(logger_, "Requested state is available");
+  return true;
+}
+
 void StateController::SetupRegularHmiState(ApplicationSharedPtr app,
                                            HmiStatePtr state) {
   using namespace mobile_apis;
@@ -118,26 +206,21 @@ void StateController::SetupRegularHmiState(ApplicationSharedPtr app,
                 ", system_context " << state->system_context());
   HmiStatePtr curr_state = app->CurrentHmiState();
   HmiStatePtr old_state = CreateHmiState(app->app_id(),
-                                         HmiState::StateID::STATE_ID_REGULAR);
+      HmiState::StateID::STATE_ID_REGULAR);
   DCHECK_OR_RETURN_VOID(old_state);
   old_state->set_hmi_level(curr_state->hmi_level());
   old_state->set_audio_streaming_state(curr_state->audio_streaming_state());
   old_state->set_system_context(curr_state->system_context());
   app->SetRegularState(state);
-  if (state->hmi_level() == mobile_apis::HMILevel::HMI_NONE) {
-    app->ResetDataInNone();
+
+  if (HMILevel::HMI_LIMITED == state->hmi_level() &&
+          app->is_resuming()) {
+    LOG4CXX_DEBUG(logger_, "Resuming to LIMITED level. "
+                  << "Send OnResumeAudioSource notification");
+    MessageHelper::SendOnResumeAudioSourceToHMI(app->app_id());
   }
-  if (!app->IsAudioApplication()) {
-    if (state->hmi_level() == HMILevel::HMI_LIMITED) {
-      LOG4CXX_ERROR(logger_, "Trying to setup LIMITED to non audio app");
-      state->set_hmi_level(HMILevel::HMI_BACKGROUND);
-    }
-    if (state->audio_streaming_state() != AudioStreamingState::NOT_AUDIBLE) {
-      LOG4CXX_ERROR(logger_, "Trying to setup audio state " <<
-                    state->audio_streaming_state() <<" to non audio app");
-      state->set_audio_streaming_state(AudioStreamingState::NOT_AUDIBLE);
-    }
-  }
+  app->set_is_resuming(false);
+
   HmiStatePtr new_state = app->CurrentHmiState();
   OnStateChanged(app, old_state, new_state);
 }
@@ -152,7 +235,7 @@ void StateController::SetupRegularHmiState(ApplicationSharedPtr app,
   HmiStatePtr prev_state = app->RegularHmiState();
   DCHECK_OR_RETURN_VOID(prev_state);
   HmiStatePtr new_state = CreateHmiState(app->app_id(),
-                                         HmiState::StateID::STATE_ID_REGULAR);
+      HmiState::StateID::STATE_ID_REGULAR);
   DCHECK_OR_RETURN_VOID(new_state);
   new_state->set_hmi_level(hmi_level);
   new_state->set_audio_streaming_state(audio_state);
@@ -161,7 +244,7 @@ void StateController::SetupRegularHmiState(ApplicationSharedPtr app,
 }
 
 void StateController::ApplyRegularState(ApplicationSharedPtr app,
-                                                  HmiStatePtr state) {
+                                        HmiStatePtr state) {
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK_OR_RETURN_VOID(app);
   DCHECK_OR_RETURN_VOID(state);
@@ -258,6 +341,13 @@ void StateController::OnStateChanged(ApplicationSharedPtr app,
   }
 }
 
+bool StateController::IsTempStateActive(HmiState::StateID ID) const {
+  sync_primitives::AutoLock autolock(active_states_lock_);
+  StateIDList::const_iterator itr =
+      std::find(active_states_.begin(), active_states_.end(), ID);
+  return active_states_.end() != itr;
+}
+
 void StateController::ApplyStatesForApp(ApplicationSharedPtr app) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock autolock(active_states_lock_);
@@ -271,7 +361,15 @@ void StateController::ApplyStatesForApp(ApplicationSharedPtr app) {
     new_state->set_parent(old_hmi_state);
     app->AddHMIState(new_state);
   }
+}
 
+void StateController::ApplyPostponedStateForApp(ApplicationSharedPtr app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  HmiStatePtr state = app->PostponedHmiState();
+  if (state) {
+    state->set_state_id(HmiState::STATE_ID_REGULAR);
+    SetRegularState(app, state);
+  }
 }
 
 void StateController::TempStateStarted(HmiState::StateID ID) {
@@ -288,8 +386,15 @@ void StateController::TempStateStarted(HmiState::StateID ID) {
 
 void StateController::TempStateStopped(HmiState::StateID ID) {
   LOG4CXX_AUTO_TRACE(logger_);
-  sync_primitives::AutoLock autolock(active_states_lock_);
-  active_states_.remove(ID);
+  {
+    sync_primitives::AutoLock autolock(active_states_lock_);
+    active_states_.remove(ID);
+  }
+  ForEachApplication(std::bind1st(
+                       std::mem_fun(
+                         &StateController::ApplyPostponedStateForApp),
+                       this)
+                     );
 }
 
 void StateController::DeactivateAppWithGeneralReason(ApplicationSharedPtr app) {
@@ -516,32 +621,38 @@ void StateController::OnNaviStreamingStopped() {
   TempStateStopped(HmiState::STATE_ID_NAVI_STREAMING);
 }
 
-HmiStatePtr StateController::CreateHmiState(uint32_t app_id, HmiState::StateID state_id) {
+HmiStatePtr StateController::CreateHmiState(
+    uint32_t app_id, HmiState::StateID state_id) const {
+  using namespace utils;
   LOG4CXX_AUTO_TRACE(logger_);
   HmiStatePtr new_state;
   switch (state_id) {
     case HmiState::STATE_ID_PHONE_CALL: {
-      new_state.reset(new PhoneCallHmiState(app_id, state_context_));
+      new_state = MakeShared<PhoneCallHmiState>(app_id, state_context_);
       break;
     }
     case HmiState::STATE_ID_SAFETY_MODE: {
-      new_state.reset(new SafetyModeHmiState(app_id, state_context_));
+      new_state = MakeShared<SafetyModeHmiState>(app_id, state_context_);
       break;
     }
     case HmiState::STATE_ID_VR_SESSION: {
-      new_state.reset(new VRHmiState(app_id, state_context_));
+      new_state = MakeShared<VRHmiState>(app_id, state_context_);
       break;
     }
     case HmiState::STATE_ID_TTS_SESSION: {
-      new_state.reset(new TTSHmiState(app_id, state_context_));
+      new_state = MakeShared<TTSHmiState>(app_id, state_context_);
       break;
     }
     case HmiState::STATE_ID_NAVI_STREAMING: {
-      new_state.reset(new NaviStreamingHmiState(app_id, state_context_));
+      new_state = MakeShared<NaviStreamingHmiState>(app_id, state_context_);
       break;
     }
     case HmiState::STATE_ID_REGULAR: {
-      new_state.reset(new HmiState(app_id, state_context_));
+      new_state = MakeShared<HmiState>(app_id, state_context_);
+      break;
+    }
+    case HmiState::STATE_ID_POSTPONED: {
+      new_state = MakeShared<HmiState>(app_id, state_context_, state_id);
       break;
     }
     default:
@@ -550,6 +661,22 @@ HmiStatePtr StateController::CreateHmiState(uint32_t app_id, HmiState::StateID s
       break;
   }
   return new_state;
+}
+
+mobile_apis::AudioStreamingState::eType
+StateController::CalcAudioState(ApplicationSharedPtr app,
+    const mobile_apis::HMILevel::eType hmi_level) const {
+  using namespace mobile_apis;
+  using namespace helpers;
+
+  AudioStreamingState::eType audio_state = AudioStreamingState::NOT_AUDIBLE;
+  if (Compare<HMILevel::eType, EQ, ONE>(hmi_level, HMILevel::HMI_FULL,
+                                        HMILevel::HMI_LIMITED)) {
+    if (app->IsAudioApplication()) {
+      audio_state = AudioStreamingState::AUDIBLE;
+    }
+  }
+  return audio_state;
 }
 
 }

--- a/src/components/application_manager/src/state_controller.cc
+++ b/src/components/application_manager/src/state_controller.cc
@@ -441,13 +441,9 @@ void StateController::OnActivateAppResponse(
                               application_id(correlation_id);
   ApplicationSharedPtr application = ApplicationManagerImpl::instance()->
                                      application_by_hmi_app(hmi_app_id);
-  if (application) {
+  if (application && hmi_apis::Common_Result::SUCCESS == code) {
     HmiStatePtr pending_state = waiting_for_activate[application->app_id()];
     DCHECK_OR_RETURN_VOID(pending_state);
-    if (code != hmi_apis::Common_Result::SUCCESS) {
-      const HmiStatePtr cur = application->RegularHmiState();
-      pending_state->set_hmi_level(cur->hmi_level());
-    }
     ApplyRegularState(application, pending_state);
   }
 }


### PR DESCRIPTION
New resumption functionality:

1)	HMILevel resumption of all non-media apps must be postponed under events of:
-	VR.Started notification
-	OnEmergencyEvent (enabled=true) -> including any kind of emergency event, park assist active, etc.
 
2)	HMILevel resumption of media apps must be postponed under events of:
- VR.Started notification
- OnEmergencyEvent (enabled=true) -> including any kind of emergency event, park assist active, etc.
-  OnPhoneCall (isActive=true) 