### PR TITLE
Fix OnVehidacleData sended to app with unsubscribed vehicleData

### DIFF
--- a/src/components/application_manager/src/commands/mobile/on_vehicle_data_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_vehicle_data_notification.cc
@@ -52,35 +52,52 @@ OnVehicleDataNotification::~OnVehicleDataNotification() {
 void OnVehicleDataNotification::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
+  std::vector<ApplicationSharedPtr> appNotification;
+  std::vector<ApplicationSharedPtr>::iterator appNotification_it =
+    appNotification.begin();
+  std::vector<smart_objects::SmartObject> appSO;
+
   const VehicleData& vehicle_data = MessageHelper::vehicle_data();
   VehicleData::const_iterator it = vehicle_data.begin();
 
   for (; vehicle_data.end() != it; ++it) {
     if (true == (*message_)[strings::msg_params].keyExists(it->first)) {
-      const std::vector<utils::SharedPtr<Application>>& applications =
-            ApplicationManagerImpl::instance()->IviInfoUpdated(it->second,
-                (*message_)[strings::msg_params][it->first].asInt());
+      const std::vector<ApplicationSharedPtr>& applications =
+        ApplicationManagerImpl::instance()->IviInfoUpdated(it->second,
+                                                           (*message_)[strings::msg_params][it->first].asInt());
 
-      std::vector<utils::SharedPtr<Application>>::const_iterator it = applications.begin();
-      for (; applications.end() != it; ++it) {
-        utils::SharedPtr<Application> app = *it;
-        if (!app) {
-          LOG4CXX_ERROR_EXT(logger_, "NULL pointer");
-          continue;
+      std::vector<ApplicationSharedPtr>::const_iterator app_it = applications.begin();
+      for (; applications.end() != app_it; ++app_it) {
+        const ApplicationSharedPtr app = *app_it;
+        DCHECK(app);
+
+        appNotification_it = find(appNotification.begin(), appNotification.end(), app);
+        if (appNotification_it == appNotification.end()) {
+          appNotification.push_back(app);
+          smart_objects::SmartObject msg_param = smart_objects::SmartObject(
+                                                   smart_objects::SmartType_Map);
+          msg_param[it->first] = (*message_)[strings::msg_params][it->first];
+          appSO.push_back(msg_param);
+        } else {
+          size_t idx = std::distance(appNotification.begin(), appNotification_it);
+          appSO[idx][it->first] = (*message_)[strings::msg_params][it->first];
         }
-
-        LOG4CXX_INFO(
-          logger_,
-          "Send OnVehicleData PRNDL notification to " << app->name()
-          << " application id " << app->app_id());
-
-        (*message_)[strings::params][strings::connection_key] = app->app_id();
-
-        SendNotification();
       }
-
-      return;
     }
+  }
+
+  LOG4CXX_DEBUG(logger_, "Number of Notifications to be send: " <<
+                appNotification.size());
+
+  for (size_t idx = 0; idx < appNotification.size(); idx++) {
+    LOG4CXX_INFO(
+      logger_,
+      "Send OnVehicleData PRNDL notification to " << appNotification[idx]->name()
+      << " application id " << appNotification[idx]->app_id());
+    (*message_)[strings::params][strings::connection_key] =
+      appNotification[idx]->app_id();
+    (*message_)[strings::msg_params] = appSO[idx];
+    SendNotification();
   }
 }
 


### PR DESCRIPTION
The vehicleData parameters in the notification massage (received
from hmi) are used for finding the subscribed applications i.e all
app. id`s are saved as well as every subscribed parameter. Then for
every app. specific notification is sent.