### PR TITLE
Fix_Genivi_branch_compilation_without_Unit-tests

### DIFF
--- a/src/components/time_tester/include/time_tester/time_manager.h
+++ b/src/components/time_tester/include/time_tester/time_manager.h
@@ -85,17 +85,14 @@ class TimeManager {
   virtual void SendMetric(utils::SharedPtr<MetricWrapper> metric);
   void set_streamer(Streamer* streamer);
 
-#ifdef BUILD_TESTS
   const std::string ip() const{
     return ip_;
   }
   const int16_t port() const {
     return port_;
   }
-#endif  // BUILD_TESTS
 
  private:
-
   int16_t port_;
   std::string ip_;
   bool is_ready_;


### PR DESCRIPTION
Deleted redundant wrapper #ifdef BUILD_TESTS around 2 getter methods
as used not only by unit-tests