### PR TITLE
hotfix/UnitTests_Fix_in_transportManager

### DIFF
--- a/src/components/transport_manager/include/transport_manager/tcp/tcp_device.h
+++ b/src/components/transport_manager/include/transport_manager/tcp/tcp_device.h
@@ -121,7 +121,7 @@ class TcpDevice : public Device {
    *
    * @return Application's port No.
    */
-  int GetApplicationPort(const ApplicationHandle app_handle) const;
+  virtual int GetApplicationPort(const ApplicationHandle app_handle) const;
 
   /**
    * @brief Return address.

--- a/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
+++ b/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
@@ -446,7 +446,7 @@ class TransportAdapterImpl : public TransportAdapter,
    *
    * @return pointer to the connection.
    */
-  ConnectionSPtr FindEstablishedConnection(const DeviceUID& device_handle,
+  virtual ConnectionSPtr FindEstablishedConnection(const DeviceUID& device_handle,
                                            const ApplicationHandle& app_handle) const;
 
  private:

--- a/src/components/transport_manager/test/tcp_transport_adapter_test.cc
+++ b/src/components/transport_manager/test/tcp_transport_adapter_test.cc
@@ -85,8 +85,7 @@ class TcpAdapterTest : public ::testing::Test {
   const std::string string_port = "12345";
 };
 
-// TODO(AByzhynar) : Fix and enable all DISABLED tests
-TEST_F(TcpAdapterTest, DISABLED_StoreDataWithOneDeviceAndOneApplication) {
+TEST_F(TcpAdapterTest, StoreDataWithOneDeviceAndOneApplication) {
   // Prepare
   TestTCPTransportAdapter transport_adapter(port);
   std::string uniq_id = "unique_device_name";
@@ -124,7 +123,7 @@ TEST_F(TcpAdapterTest, DISABLED_StoreDataWithOneDeviceAndOneApplication) {
   EXPECT_EQ(uniq_id, tcp_dict["devices"][0]["name"].asString());
 }
 
-TEST_F(TcpAdapterTest, DISABLED_StoreDataWithSeveralDevicesAndOneApplication) {
+TEST_F(TcpAdapterTest, StoreDataWithSeveralDevicesAndOneApplication) {
   // Prepare
   TestTCPTransportAdapter transport_adapter(port);
   const uint32_t count_dev = 10;
@@ -176,7 +175,7 @@ TEST_F(TcpAdapterTest, DISABLED_StoreDataWithSeveralDevicesAndOneApplication) {
   }
 }
 
-TEST_F(TcpAdapterTest, DISABLED_StoreDataWithSeveralDevicesAndSeveralApplications) {
+TEST_F(TcpAdapterTest, StoreDataWithSeveralDevicesAndSeveralApplications) {
   // Prepare
   TestTCPTransportAdapter transport_adapter(port);
   const uint32_t count_dev = 10;
@@ -270,7 +269,7 @@ TEST_F(TcpAdapterTest, RestoreData_DataNotStored) {
   EXPECT_TRUE(transport_adapter.CallRestore());
 }
 
-TEST_F(TcpAdapterTest, DISABLED_StoreDataWithOneDevice_RestoreData) {
+TEST_F(TcpAdapterTest, StoreDataWithOneDevice_RestoreData) {
   TestTCPTransportAdapter transport_adapter(port);
   std::string uniq_id = "unique_device_name";
   utils::SharedPtr<TCPDeviceMock> mockdev = new TCPDeviceMock(port, uniq_id);
@@ -303,7 +302,7 @@ TEST_F(TcpAdapterTest, DISABLED_StoreDataWithOneDevice_RestoreData) {
   EXPECT_EQ(uniq_id, devList[0]);
 }
 
-TEST_F(TcpAdapterTest, DISABLED_StoreDataWithSeveralDevices_RestoreData) {
+TEST_F(TcpAdapterTest, StoreDataWithSeveralDevices_RestoreData) {
   TestTCPTransportAdapter transport_adapter(port);
   const uint32_t count_dev = 10;
 

--- a/src/components/transport_manager/test/transport_manager_impl_test.cc
+++ b/src/components/transport_manager/test/transport_manager_impl_test.cc
@@ -337,18 +337,6 @@ TEST_F(TransportManagerImplTest, DisconnectDevice) {
   EXPECT_EQ(E_SUCCESS, tm.DisconnectDevice(device_handle_));
 }
 
-TEST_F(TransportManagerImplTest, DISABLED_DisconnectDevice_ConnectionFailed) {
-  HandleDeviceListUpdated();
-  EXPECT_CALL(*mock_adapter, ConnectDevice(mac_address_))
-      .WillOnce(Return(TransportAdapter::FAIL));
-  EXPECT_EQ(E_INTERNAL_ERROR, tm.ConnectDevice(device_handle_));
-
-  EXPECT_CALL(*mock_adapter, DisconnectDevice(mac_address_))
-      .WillOnce(Return(TransportAdapter::FAIL));
-
-  EXPECT_EQ(E_INTERNAL_ERROR, tm.DisconnectDevice(device_handle_));
-}
-
 TEST_F(TransportManagerImplTest, DisconnectDevice_DeviceNotConnected) {
   EXPECT_CALL(*mock_adapter, DisconnectDevice(mac_address_)).Times(0);
   EXPECT_EQ(E_INVALID_HANDLE, tm.DisconnectDevice(device_handle_));
@@ -362,16 +350,6 @@ TEST_F(TransportManagerImplTest, Disconnect) {
       .WillOnce(Return(TransportAdapter::OK));
   // Assert
   EXPECT_EQ(E_SUCCESS, tm.Disconnect(connection_key_));
-}
-
-TEST_F(TransportManagerImplTest, DISABLED_Disconnect_DisconnectionFailed) {
-  // Arrange
-  HandleConnection();
-
-  EXPECT_CALL(*mock_adapter, Disconnect(mac_address_, application_id))
-      .WillOnce(Return(TransportAdapter::FAIL));
-  // Assert
-  EXPECT_EQ(E_INTERNAL_ERROR, tm.Disconnect(connection_key_));
 }
 
 TEST_F(TransportManagerImplTest, Disconnect_ConnectionNotExist) {


### PR DESCRIPTION
	1. Changed virtuality of 2 methods =>
		Fixed 4 unit tests in tcp_transport_adapter_test
	2. Removed 2 unit tests in transport_manager_impl_test
		(functionality is absent)

	Related : APPLINK-17584