### PR TITLE
Send policy app id during application registration

### DIFF
--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -398,7 +398,7 @@ const char templates_available[] = "templatesAvailable";
 const char screen_params[] = "screenParams";
 const char num_custom_presets_available[] = "numCustomPresetsAvailable";
 const char urls[] = "urls";
-const char policy_app_id[] = "policyAppId";
+const char policy_app_id[] = "policyAppID";
 const char enabled[] = "enabled";
 
 }  // namespace hmi_response

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -303,7 +303,6 @@ void MessageHelper::SendOnAppRegisteredNotificationToHMI(
     msg_params[strings::priority] = GetPriorityCode(priority);
   }
 
-  msg_params[strings::msg_params] = SmartObject(SmartType_Map);
   smart_objects::SmartObject& application = msg_params[strings::application];
   application[strings::app_name] = application_impl.name();
   application[strings::app_id] = application_impl.app_id();


### PR DESCRIPTION
There was the bug in notification parameter naming
the SmartObject has removed invalid parameter `policyAppId`
the proper name for the parameter is `policyAppID`.

Closes-Bug: [APPLINK-18660](https://adc.luxoft.com/jira/browse/APPLINK-18660)