### PR TITLE
Update UI.SetGlobalProperties sending on mobile SetGlobalProperties

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/set_global_properties_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/set_global_properties_request.h
@@ -1,6 +1,5 @@
 /*
-
- Copyright (c) 2013, Ford Motor Company
+ Copyright (c) 2015, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -36,6 +35,7 @@
 
 #include "application_manager/commands/command_request_impl.h"
 #include "utils/macro.h"
+#include "application_manager/application.h"
 
 namespace application_manager {
 
@@ -71,21 +71,38 @@ class SetGlobalPropertiesRequest : public CommandRequestImpl {
   void on_event(const event_engine::Event& event);
 
  private:
-  /*
-   * @brief Chec if HelpItems order is correct
-   *
-   * @return TRUE on success, otherwise FALSE
-   */
-  bool CheckVrHelpItemsOrder();
+  // Verify correctness VrHelptitle value
+  static bool ValidateVRHelpTitle(const smart_objects::SmartObject* const vr_help_so_ptr);
 
-  /*
+  // prepare UI sending data (VrHelps, Menus, Keyboard) to SmartObject
+  static void PrepareUIRequestVRHelpData(const ApplicationSharedPtr app,
+                                         const smart_objects::SmartObject& msg_params,
+                                         smart_objects::SmartObject& out_params);
+
+  static bool PrepareUIRequestDefaultVRHelpData(const ApplicationSharedPtr app,
+                                                smart_objects::SmartObject& out_params);
+
+  static void PrepareUIRequestMenuAndKeyboardData(const ApplicationSharedPtr app,
+                                        const smart_objects::SmartObject& msg_params,
+                                        smart_objects::SmartObject& out_params);
+
+  // Send TTS request to HMI
+  void SendTTSRequest(const smart_objects::SmartObject& params, bool use_events);
+
+  // Send UI request to HMI
+  void SendUIRequest(const smart_objects::SmartObject& params, bool use_events);
+
+  // VRHelp shall contain sequential positions and start from 1
+  static bool CheckVrHelpItemsOrder(const smart_objects::SmartObject& vr_help);
+
+  /**
    * @brief Check if there some not delivered hmi responses exist
    *
    * @return true if all responses received
    */
   bool IsPendingResponseExist();
 
-  /*
+  /**
    * @brief Checks if request has at least one parameter
    *
    * @param params request parameters
@@ -103,8 +120,6 @@ class SetGlobalPropertiesRequest : public CommandRequestImpl {
    */
   bool IsWhiteSpaceExist();
 
-  DISALLOW_COPY_AND_ASSIGN(SetGlobalPropertiesRequest);
-
   bool is_ui_send_;
   bool is_tts_send_;
 
@@ -113,6 +128,8 @@ class SetGlobalPropertiesRequest : public CommandRequestImpl {
 
   hmi_apis::Common_Result::eType ui_result_;
   hmi_apis::Common_Result::eType tts_result_;
+
+  DISALLOW_COPY_AND_ASSIGN(SetGlobalPropertiesRequest);
 };
 
 }  // namespace commands

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3045,7 +3045,7 @@ void ApplicationManagerImpl::RemoveAppFromTTSGlobalPropertiesList(
   if (tts_global_properties_app_list_.end() != it) {
     tts_global_properties_app_list_.erase(it);
     if (tts_global_properties_app_list_.empty()) {
-      LOG4CXX_INFO(logger_, "Stop tts_global_properties_timer_");
+      LOG4CXX_DEBUG(logger_, "Stop tts_global_properties_timer_");
       // if container is empty need to stop timer
       tts_global_properties_app_list_lock_.Release();
       tts_global_properties_timer_.suspend();


### PR DESCRIPTION
In case of Empty vr_help_title of application update - vr_help_title and
vr_help are updated by default values and provided to HMI.

In case of re-registering UI.SetGlobalProperties will be send indirectly
on resumption

Extracted few private methods of SetGlobalPropertiesRequest with
duplicated logics.
Simplified SetGlobalProperties::CheckVrHelpItemsOrder
Fixed cpplint warnings

Issues:APPLINK-19025, APPLINK-19027