### PR TITLE
Fix deadlocks in AM when stopping SDL and log socket endless blocking

### DIFF
--- a/src/3rd_party/apache-log4cxx-0.10.0/src/main/cpp/serversocket.cpp
+++ b/src/3rd_party/apache-log4cxx-0.10.0/src/main/cpp/serversocket.cpp
@@ -128,6 +128,13 @@ SocketPtr ServerSocket::accept() {
         throw SocketException(status);
     }
     
+    // Added 5 seconds timeout to fix endless blocking on write() when the client is not reading
+    status = apr_socket_timeout_set(newSocket, 5000000);
+    if (status != APR_SUCCESS) {
+        apr_pool_destroy(newPool);
+        throw SocketException(status);
+    }
+
     return new Socket(newSocket, newPool);
 }
 

--- a/src/components/application_manager/include/application_manager/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resume_ctrl.h
@@ -154,6 +154,11 @@ class ResumeCtrl: public event_engine::EventObserver {
      */
     void StopSavePersistentDataTimer();
 
+  /**
+   * @brief Method stops restore_hmi_level_timer_ "RsmCtrlRstore" in Suspend()
+   */
+  void StopRestoreHmiLevelTimer();
+
     /**
      * @brief Start timer for resumption applications
      *        Restore D1-D5 data

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2213,6 +2213,8 @@ void ApplicationManagerImpl::UnregisterAllApplications() {
   bool is_unexpected_disconnect =
       Compare<eType, NEQ, ALL>(unregister_reason_,
                                IGNITION_OFF, MASTER_RESET, FACTORY_DEFAULTS);
+
+  {  // A local scope to limit accessor's lifetime and release app list lock.
   ApplicationListAccessor accessor;
   ApplictionSetConstIt it = accessor.begin();
   while (it != accessor.end()) {
@@ -2234,7 +2236,9 @@ void ApplicationManagerImpl::UnregisterAllApplications() {
                                       connection_handler::kCommon);
     it = accessor.begin();
   }
-  if (is_ignition_off) {
+  }
+
+  if (is_ignition_off) {  // Move this block before unregistering apps?
     resume_controller().Suspend();
   }
   request_ctrl_.terminateAllHMIRequests();

--- a/src/components/application_manager/src/resume_ctrl.cpp
+++ b/src/components/application_manager/src/resume_ctrl.cpp
@@ -376,6 +376,7 @@ bool ResumeCtrl::RemoveApplicationFromSaved(const std::string& mobile_app_id) {
 
 void ResumeCtrl::Suspend() {
   LOG4CXX_AUTO_TRACE(logger_);
+  StopRestoreHmiLevelTimer();
   StopSavePersistentDataTimer();
   SaveAllApplications();
   Json::Value to_save;
@@ -439,6 +440,14 @@ void ResumeCtrl::StopSavePersistentDataTimer() {
   LOG4CXX_AUTO_TRACE(logger_);
   if (save_persistent_data_timer_.isRunning()) {
     save_persistent_data_timer_.stop();
+  }
+}
+
+
+void ResumeCtrl::StopRestoreHmiLevelTimer() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (restore_hmi_level_timer_.isRunning()) {
+    restore_hmi_level_timer_.stop();
   }
 }
 


### PR DESCRIPTION
When we stop AM we unregister apps and call StopSavePersistentDataTimer().
If the timer callback by chance is active at this moment we can have a
deadlock between AM and ResumeController. To prevent it limit the lifetime
of ApplicationListAccessor and allow ResumeController to finish his job.
Another option is to move resume_controller().OnSuspend() call before
unregitering apps.
Another deadlock problem arises when while destroying AM an app tries to
register (3 seconds before that actually). Then AM tries to destroy
ResumeController, but RC is in ApplicationResumptiOnTimer() callback
and tries to get AM instance, and blocks on AM singleton's lock. The
fix is to StopRestoreHmiLevelTimer() before destroyng AM.
A third reason for SDL not stopping normally is when a logger is writing
on a socket, but the client on the other side is not reading (and is not
closing the socket neither). Then write() blocks and logger, and therefore
SDL, cannot be stopped. The fix is to put timeout option to the socket.