### PR TITLE
Fix AutoTrace usage with LogsEnabled=false

### DIFF
--- a/src/components/utils/src/auto_trace.cc
+++ b/src/components/utils/src/auto_trace.cc
@@ -42,7 +42,8 @@ AutoTrace::AutoTrace(
   log4cxx::LoggerPtr logger,
   const log4cxx::spi::LocationInfo& location) :
   logger_(logger), location_(location) {
-  if (logger_->isTraceEnabled()) {
+  if (logger::logs_enabled() &&
+      logger_->isTraceEnabled()) {
     push_log(logger_,
              ::log4cxx::Level::getTrace(),
              "Enter",
@@ -54,7 +55,8 @@ AutoTrace::AutoTrace(
 }
 
 AutoTrace::~AutoTrace() {
-  if (logger_->isTraceEnabled()) {
+  if (logger::logs_enabled() &&
+      logger_->isTraceEnabled()) {
     push_log(logger_,
              ::log4cxx::Level::getTrace(),
              "Exit",


### PR DESCRIPTION
Added usage of logger::logs_enabled (config parameter LogsEnabled) in
AutoTrace class