### PR TITLE
Add checking of SO field.

### DIFF
--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -1102,11 +1102,11 @@ smart_objects::SmartObjectList MessageHelper::CreateAddCommandRequestToHMI(
       msg_params[strings::menu_params] = (*i->second)[strings::menu_params];
       msg_params[strings::app_id] = app->app_id();
 
-      if (((*i->second)[strings::cmd_icon].keyExists(strings::value))
+      if (((*i->second).keyExists(strings::cmd_icon))
           && (0 < (*i->second)[strings::cmd_icon][strings::value].length())) {
         msg_params[strings::cmd_icon] = (*i->second)[strings::cmd_icon];
         msg_params[strings::cmd_icon][strings::value] =
-          (*i->second)[strings::cmd_icon][strings::value].asString();
+            (*i->second)[strings::cmd_icon][strings::value].asString();
       }
       (*ui_command)[strings::msg_params] = msg_params;
       requests.push_back(ui_command);


### PR DESCRIPTION
Add checking of SO field during creation of request to HMI.
If user calls to nonexistent field from SO, SO creates this field with default value.

Closes-bug: APPLINK-13006