### PR TITLE
Hotfix/core dump if make master reset

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1381,6 +1381,7 @@ class ApplicationManagerImpl : public ApplicationManager,
 
     std::vector<ApplicationManagerTimerPtr> timer_pool_;
     sync_primitives::Lock                   timer_pool_lock_;
+    sync_primitives::Lock stopping_flag_lock_;
 
     StateController state_ctrl_;
 
@@ -1401,8 +1402,7 @@ class ApplicationManagerImpl : public ApplicationManager,
     timer::TimerThread<ApplicationManagerImpl>  tts_global_properties_timer_;
 
     bool is_low_voltage_;
-
-    bool is_stopping_;
+    volatile bool is_stopping_;
 
     DISALLOW_COPY_AND_ASSIGN(ApplicationManagerImpl);
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2361,12 +2361,11 @@ void ApplicationManagerImpl::Handle(const impl::MessageFromMobile message) {
     LOG4CXX_ERROR(logger_, "Null-pointer message received.");
     return;
   }
-  {
-    sync_primitives::AutoLock lock(stopping_flag_lock_);
-    if (is_stopping_) {
-      LOG4CXX_INFO(logger_, "Application manager is stopping");
-      return;
-    }
+
+  sync_primitives::AutoLock lock(stopping_flag_lock_);
+  if (is_stopping_) {
+    LOG4CXX_INFO(logger_, "Application manager is stopping");
+    return;
   }
   ProcessMessageFromMobile(message);
 }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -102,6 +102,7 @@ ApplicationManagerImpl::ApplicationManagerImpl()
     resume_ctrl_(this),
     navi_close_app_timeout_(profile::Profile::instance()->stop_streaming_timeout()),
     navi_end_stream_timeout_(profile::Profile::instance()->stop_streaming_timeout()),
+    stopping_flag_lock_(true),
 #ifdef TIME_TESTER
     metric_observer_(NULL),
 #endif  // TIME_TESTER
@@ -160,7 +161,9 @@ ApplicationManagerImpl::~ApplicationManagerImpl() {
 
 bool ApplicationManagerImpl::Stop() {
   LOG4CXX_INFO(logger_, "Stop ApplicationManager.");
+  stopping_flag_lock_.Acquire();
   is_stopping_ = true;
+  stopping_flag_lock_.Release();
   application_list_update_timer_->stop();
   try {
     UnregisterAllApplications();
@@ -2126,6 +2129,9 @@ void ApplicationManagerImpl::SetUnregisterAllApplicationsReason(
 
 void ApplicationManagerImpl::HeadUnitReset(
     mobile_api::AppInterfaceUnregisteredReason::eType reason) {
+  stopping_flag_lock_.Acquire();
+  is_stopping_ = true;
+  stopping_flag_lock_.Release();
   switch (reason) {
     case mobile_api::AppInterfaceUnregisteredReason::MASTER_RESET: {
       UnregisterAllApplications();
@@ -2354,6 +2360,13 @@ void ApplicationManagerImpl::Handle(const impl::MessageFromMobile message) {
   if (!message) {
     LOG4CXX_ERROR(logger_, "Null-pointer message received.");
     return;
+  }
+  {
+    sync_primitives::AutoLock lock(stopping_flag_lock_);
+    if (is_stopping_) {
+      LOG4CXX_INFO(logger_, "Application manager is stopping");
+      return;
+    }
   }
   ProcessMessageFromMobile(message);
 }


### PR DESCRIPTION
Fix core crash during MASTER_RESET
    
Forbid processing message from mobile if Core begins stopping of work.
    
Closes-bug: APPLINK-17367