### PR TITLE
Fix core crash: assert to double taking mutex

### DIFF
--- a/src/components/security_manager/src/ssl_context_impl.cc
+++ b/src/components/security_manager/src/ssl_context_impl.cc
@@ -50,6 +50,8 @@ CryptoManagerImpl::SSLContextImpl::SSLContextImpl(SSL *conn, Mode mode)
     bioIn_(BIO_new(BIO_s_mem())),
     bioOut_(BIO_new(BIO_s_mem())),
     bioFilter_(NULL),
+    //recursive mutex
+    bio_locker(true),
     // TODO(EZamakhov): get MTU by parameter (from transport)
     // default buffer size is TCP MTU
     buffer_size_(1500),
@@ -299,11 +301,13 @@ DoHandshakeStep(const uint8_t*  const in_data,  size_t in_data_size,
 
   // TODO(Ezamakhov): add test - hanshake fail -> restart StartHandshake
   sync_primitives::AutoLock locker(bio_locker);
+
   if (SSL_is_init_finished(connection_)) {
     LOG4CXX_DEBUG(logger_, "SSL initilization is finished");
     is_handshake_pending_ = false;
     return Handshake_Result_Success;
   }
+
 
   if (!WriteHandshakeData(in_data, in_data_size)) {
     return Handshake_Result_AbnormalFail;


### PR DESCRIPTION
SDL crashed when trying got mutex in sub method. Change normal mutex to recursive to fix this problem.
Fixes: [APPLINK-19317](https://adc.luxoft.com/jira/browse/APPLINK-19317)