### PR TITLE
hotfix/Data_race_in_ThreadedSocketConnection

### DIFF
--- a/src/components/transport_manager/include/transport_manager/transport_adapter/threaded_socket_connection.h
+++ b/src/components/transport_manager/include/transport_manager/transport_adapter/threaded_socket_connection.h
@@ -81,6 +81,13 @@ class ThreadedSocketConnection : public Connection {
   TransportAdapter::Error Start();
 
   /**
+   * @brief Checks is queue with frames to send empty or not.
+   *
+   * @return Information about queue is empty or not.
+   */
+  bool IsFramesToSendQueueEmpty() const;
+
+  /**
    * @brief Set variable that hold socket No.
    */
   void set_socket(int socket) {

--- a/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
+++ b/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
@@ -232,7 +232,7 @@ void ThreadedSocketConnection::Transmit() {
     return;
   }
 
-    bool is_queue_empty = true;
+  bool is_queue_empty = true;
   {
     // Check Frames queue is empty or not
     sync_primitives::AutoLock auto_lock(frames_to_send_mutex_);
@@ -298,10 +298,10 @@ bool ThreadedSocketConnection::Send() {
   LOG4CXX_AUTO_TRACE(logger_);
   FrameQueue frames_to_send;
 
-{
-  sync_primitives::AutoLock auto_lock(frames_to_send_mutex_);
-  std::swap(frames_to_send, frames_to_send_);
-}
+  {
+    sync_primitives::AutoLock auto_lock(frames_to_send_mutex_);
+    std::swap(frames_to_send, frames_to_send_);
+  }
 
   size_t offset = 0;
   while (!frames_to_send.empty()) {


### PR DESCRIPTION
Added protection for usage of the frames_to_send_ with the mutex as it's done in the other places

Relates:APPLINK-19408