### PR TITLE
hotfix/Fix_Genivi_develop_branch_compilation_without_Unit-tests

### DIFF
--- a/src/components/time_tester/include/time_tester/time_manager.h
+++ b/src/components/time_tester/include/time_tester/time_manager.h
@@ -84,8 +84,8 @@ class TimeManager {
   virtual void Start();
   virtual void SendMetric(utils::SharedPtr<MetricWrapper> metric);
   void set_streamer(Streamer* streamer);
-  const std::string ip() const;
-  const int16_t port() const;
+  const std::string& ip() const;
+  int16_t port() const;
 
  private:
   int16_t port_;

--- a/src/components/time_tester/include/time_tester/time_manager.h
+++ b/src/components/time_tester/include/time_tester/time_manager.h
@@ -85,14 +85,12 @@ class TimeManager {
   virtual void SendMetric(utils::SharedPtr<MetricWrapper> metric);
   void set_streamer(Streamer* streamer);
 
-#ifdef BUILD_TESTS
   const std::string ip() const{
     return ip_;
   }
   const int16_t port() const {
     return port_;
   }
-#endif  // BUILD_TESTS
 
  private:
   int16_t port_;

--- a/src/components/time_tester/include/time_tester/time_manager.h
+++ b/src/components/time_tester/include/time_tester/time_manager.h
@@ -84,13 +84,8 @@ class TimeManager {
   virtual void Start();
   virtual void SendMetric(utils::SharedPtr<MetricWrapper> metric);
   void set_streamer(Streamer* streamer);
-
-  const std::string ip() const{
-    return ip_;
-  }
-  const int16_t port() const {
-    return port_;
-  }
+  const std::string ip() const;
+  const int16_t port() const;
 
  private:
   int16_t port_;

--- a/src/components/time_tester/src/time_manager.cc
+++ b/src/components/time_tester/src/time_manager.cc
@@ -79,6 +79,14 @@ void TimeManager::set_streamer(Streamer* streamer) {
   }
 }
 
+const std::string TimeManager::ip() const  {
+  return ip_;
+}
+
+const int16_t TimeManager::port() const {
+  return port_;
+}
+
 TimeManager::~TimeManager() {
   Stop();
 }

--- a/src/components/time_tester/src/time_manager.cc
+++ b/src/components/time_tester/src/time_manager.cc
@@ -39,8 +39,6 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>
-#include <string.h>
-
 
 #include "transport_manager/transport_manager_default.h"
 #include "config_profile/profile.h"
@@ -79,11 +77,11 @@ void TimeManager::set_streamer(Streamer* streamer) {
   }
 }
 
-const std::string TimeManager::ip() const  {
+const std::string& TimeManager::ip() const  {
   return ip_;
 }
 
-const int16_t TimeManager::port() const {
+int16_t TimeManager::port() const {
   return port_;
 }
 


### PR DESCRIPTION
Deleted redundant #ifdef BUILD_TESTS wrapper for getter methods in time_manager
as they are used not only in tests

Relates: APPLINK-20030