### PR TITLE
EndServiceAck processing

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2854,9 +2854,10 @@ void ApplicationManagerImpl::EndNaviServices(uint32_t app_id) {
 
     navi_app_to_stop_.push_back(app_id);
 
-    ApplicationManagerTimerPtr closeTimer(
-        new TimerThread<ApplicationManagerImpl>(
-            "CloseNaviAppTimer", this, &ApplicationManagerImpl::CloseNaviApp));
+    ApplicationManagerTimerPtr closeTimer;
+    closeTimer = utils::MakeShared< TimerThread<ApplicationManagerImpl> >(
+        "CloseNaviAppTimer", this, &ApplicationManagerImpl::CloseNaviApp);
+
     closeTimer->start(navi_close_app_timeout_);
 
     sync_primitives::AutoLock lock(timer_pool_lock_);
@@ -2894,10 +2895,10 @@ void ApplicationManagerImpl::OnHMILevelChanged(uint32_t app_id,
       LOG4CXX_TRACE(logger_, "HMILevel from FULL or LIMITED");
       navi_app_to_end_stream_.push_back(app_id);
 
-      ApplicationManagerTimerPtr endStreamTimer(
-          new TimerThread<ApplicationManagerImpl>(
-              "AppShouldFinishStreaming", this,
-              &ApplicationManagerImpl::EndNaviStreaming));
+      ApplicationManagerTimerPtr endStreamTimer;
+      endStreamTimer = utils::MakeShared< TimerThread<ApplicationManagerImpl> >(
+        "AppShouldFinishStreaming", this, &ApplicationManagerImpl::EndNaviStreaming);
+
       endStreamTimer->start(navi_end_stream_timeout_);
 
       sync_primitives::AutoLock lock(timer_pool_lock_);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2767,7 +2767,8 @@ bool ApplicationManagerImpl::CanAppStream(
   } else {
     LOG4CXX_WARN(logger_, "Unsupported service_type " << service_type);
   }
-  return HMILevelAllowsStreaming(app_id, service_type) && is_allowed;
+
+  return HMILevelAllowsStreaming(app_id, service_type) && is_allowed; 
 }
 
 void ApplicationManagerImpl::ForbidStreaming(uint32_t app_id) {
@@ -2840,17 +2841,18 @@ void ApplicationManagerImpl::EndNaviServices(uint32_t app_id) {
     return;
   }
 
+
   if (connection_handler_) {
     if (it->second.first) {
       LOG4CXX_DEBUG(logger_, "Going to end video service");
       connection_handler_->SendEndService(app_id, ServiceType::kMobileNav);
-      StopNaviService(app_id, ServiceType::kMobileNav);
     }
     if (it->second.second) {
       LOG4CXX_DEBUG(logger_, "Going to end audio service");
       connection_handler_->SendEndService(app_id, ServiceType::kAudio);
-      StopNaviService(app_id, ServiceType::kAudio);
     }
+    DisallowStreaming(app_id);
+
     navi_app_to_stop_.push_back(app_id);
 
     ApplicationManagerTimerPtr closeTimer(
@@ -2968,6 +2970,7 @@ void ApplicationManagerImpl::CloseNaviApp() {
   NaviServiceStatusMap::iterator it = navi_service_status_.find(app_id);
   if (navi_service_status_.end() != it) {
     if (it->second.first || it->second.second) {
+      LOG4CXX_INFO(logger_, "App haven't answered for EndService. Unregister it.");
       MessageHelper::SendOnAppInterfaceUnregisteredNotificationToMobile(
           app_id, PROTOCOL_VIOLATION);
       UnregisterApplication(app_id, ABORTED);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2841,7 +2841,6 @@ void ApplicationManagerImpl::EndNaviServices(uint32_t app_id) {
     return;
   }
 
-
   if (connection_handler_) {
     if (it->second.first) {
       LOG4CXX_DEBUG(logger_, "Going to end video service");

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -53,6 +53,7 @@ enum {
   HASH_ID_NOT_SUPPORTED = 0,
   HASH_ID_WRONG = 0xFFFF0000
 };
+
 /**
  * \class SessionObserver
  * \brief Interface for making a bridge between ProtocolHandler and
@@ -79,6 +80,7 @@ class SessionObserver {
     const uint8_t sessionId,
     const protocol_handler::ServiceType &service_type,
     const bool is_protected, uint32_t* hash_id) = 0;
+
   /**
    * \brief Callback function used by ProtocolHandler
    * when Mobile Application initiates session ending.

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -432,13 +432,13 @@ class ProtocolHandlerImpl
    */
   RESULT_CODE HandleControlMessage(const ProtocolFramePtr packet);
 
-  RESULT_CODE HandleControlMessageEndSession(const ProtocolPacket &packet);
+  RESULT_CODE HandleControlMessageEndSession(const ProtocolPacket& packet);
 
-  RESULT_CODE HandleControlMessageEndServiceACK(const ProtocolPacket &packet);
+  RESULT_CODE HandleControlMessageEndServiceACK(const ProtocolPacket& packet);
 
-  RESULT_CODE HandleControlMessageStartSession(const ProtocolPacket &packet);
+  RESULT_CODE HandleControlMessageStartSession(const ProtocolPacket& packet);
 
-  RESULT_CODE HandleControlMessageHeartBeat(const ProtocolPacket &packet);
+  RESULT_CODE HandleControlMessageHeartBeat(const ProtocolPacket& packet);
 
   void PopValideAndExpirateMultiframes();
 

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -430,10 +430,11 @@ class ProtocolHandlerImpl
    * \param packet Received message with protocol header.
    * \return \saRESULT_CODE Status of operation
    */
-  RESULT_CODE HandleControlMessage(
-    const ProtocolFramePtr packet);
+  RESULT_CODE HandleControlMessage(const ProtocolFramePtr packet);
 
   RESULT_CODE HandleControlMessageEndSession(const ProtocolPacket &packet);
+
+  RESULT_CODE HandleControlMessageEndServiceACK(const ProtocolPacket &packet);
 
   RESULT_CODE HandleControlMessageStartSession(const ProtocolPacket &packet);
 

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -852,7 +852,7 @@ uint32_t get_hash_id(const ProtocolPacket &packet) {
   return hash_le == HASH_ID_NOT_SUPPORTED ? HASH_ID_WRONG : hash_le;
 }
 
-RESULT_CODE ProtocolHandlerImpl::HandleControlMessageEndSession(const ProtocolPacket &packet) {
+RESULT_CODE ProtocolHandlerImpl::HandleControlMessageEndSession(const ProtocolPacket& packet) {
   LOG4CXX_AUTO_TRACE(logger_);
 
   const uint8_t current_session_id = packet.session_id();
@@ -878,7 +878,7 @@ RESULT_CODE ProtocolHandlerImpl::HandleControlMessageEndSession(const ProtocolPa
   return RESULT_OK;
 }
 
-RESULT_CODE ProtocolHandlerImpl::HandleControlMessageEndServiceACK(const ProtocolPacket &packet) {
+RESULT_CODE ProtocolHandlerImpl::HandleControlMessageEndServiceACK(const ProtocolPacket& packet) {
   LOG4CXX_AUTO_TRACE(logger_);
 
   if (!session_observer_) {
@@ -894,7 +894,7 @@ RESULT_CODE ProtocolHandlerImpl::HandleControlMessageEndServiceACK(const Protoco
   const uint32_t session_key = session_observer_->OnSessionEndedCallback(
       connection_id, current_session_id, hash_id, service_type);
 
-  if (session_key == 0) {
+  if (0 == session_key) {
     LOG4CXX_WARN(logger_, "Refused to end service");
     return RESULT_FAIL;
   }
@@ -980,7 +980,7 @@ class StartSessionHandler : public security_manager::SecurityManagerListener {
 }  // namespace
 #endif  // ENABLE_SECURITY
 
-RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(const ProtocolPacket &packet) {
+RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(const ProtocolPacket& packet) {
   LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_DEBUG(logger_,
                 "Protocol version:" <<
@@ -1056,7 +1056,7 @@ RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(const Protocol
   return RESULT_OK;
 }
 
-RESULT_CODE ProtocolHandlerImpl::HandleControlMessageHeartBeat(const ProtocolPacket &packet) {
+RESULT_CODE ProtocolHandlerImpl::HandleControlMessageHeartBeat(const ProtocolPacket& packet) {
   const ConnectionID connection_id = packet.connection_id();
   LOG4CXX_DEBUG(
       logger_,


### PR DESCRIPTION
Process EndServiceAck from mobile;
    
Add EndServiceAck message processing on protocol_handler level.
PH notify connection_handler, CH notify application_manager.
On AM level SDL turns off video/audio service for application.