### PR TITLE
Make function handler checking to prevent main thread crash

### DIFF
--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -797,7 +797,7 @@ void ConnectionHandlerImpl::CloseSession(ConnectionHandle connection_handle,
     }
 
     SessionMap::const_iterator session_map_itr = session_map.find(session_id);
-    if (session_map_itr != session_map.end()) {
+    if (session_map_itr != session_map.end() && connection_handler_observer_) {
       const uint32_t session_key = KeyFromPair(connection_id, session_id);
       const Session &session = session_map_itr->second;
       const ServiceList &service_list = session.service_list;

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -812,8 +812,8 @@ void ConnectionHandlerImpl::CloseSession(ConnectionHandle connection_handle,
                                                                close_reason);
         }
       } else {
-          LOG4CXX_ERROR(logger_, "Session with id: " << session_id << " not found");
-          return;
+        LOG4CXX_ERROR(logger_, "Session with id: " << session_id << " not found");
+        return;
       }
     }
     LOG4CXX_DEBUG(logger_, "Session with id: " << session_id << " has been closed successfully");

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -767,7 +767,7 @@ void ConnectionHandlerImpl::CloseSession(ConnectionHandle connection_handle,
   // In case of malformed message the connection should be broke up without
   // any other notification to mobile.
   if (close_reason != kMalformed && protocol_handler_) {
-      protocol_handler_->SendEndSession(connection_handle, session_id);
+    protocol_handler_->SendEndSession(connection_handle, session_id);
   }
 
   transport_manager::ConnectionUID connection_id =

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -764,12 +764,6 @@ void ConnectionHandlerImpl::CloseSession(ConnectionHandle connection_handle,
   LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_DEBUG(logger_, "Closing session with id: " << session_id);
 
-  // In case of malformed message the connection should be broke up without
-  // any other notification to mobile.
-  if (close_reason != kMalformed && protocol_handler_) {
-    protocol_handler_->SendEndSession(connection_handle, session_id);
-  }
-
   transport_manager::ConnectionUID connection_id =
         ConnectionUIDFromHandle(connection_handle);
 

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -796,23 +796,25 @@ void ConnectionHandlerImpl::CloseSession(ConnectionHandle connection_handle,
       protocol_handler_->SendEndSession(connection_handle, session_id);
     }
 
-    SessionMap::const_iterator session_map_itr = session_map.find(session_id);
-    if (session_map_itr != session_map.end() && connection_handler_observer_) {
-      const uint32_t session_key = KeyFromPair(connection_id, session_id);
-      const Session &session = session_map_itr->second;
-      const ServiceList &service_list = session.service_list;
+    if ( connection_handler_observer_ ) {
+      SessionMap::const_iterator session_map_itr = session_map.find(session_id);
+      if (session_map_itr != session_map.end()) {
+        const uint32_t session_key = KeyFromPair(connection_id, session_id);
+        const Session &session = session_map_itr->second;
+        const ServiceList &service_list = session.service_list;
 
-      ServiceList::const_iterator service_list_itr = service_list.begin();
-      for (;service_list_itr != service_list.end(); ++service_list_itr) {
-        const protocol_handler::ServiceType service_type =
-            service_list_itr->service_type;
-        connection_handler_observer_->OnServiceEndedCallback(session_key,
-                                                             service_type,
-                                                             close_reason);
+        ServiceList::const_iterator service_list_itr = service_list.begin();
+        for (;service_list_itr != service_list.end(); ++service_list_itr) {
+          const protocol_handler::ServiceType service_type =
+              service_list_itr->service_type;
+          connection_handler_observer_->OnServiceEndedCallback(session_key,
+                                                               service_type,
+                                                               close_reason);
+        }
+      } else {
+          LOG4CXX_ERROR(logger_, "Session with id: " << session_id << " not found");
+          return;
       }
-    } else {
-      LOG4CXX_ERROR(logger_, "Session with id: " << session_id << " not found");
-      return;
     }
     LOG4CXX_DEBUG(logger_, "Session with id: " << session_id << " has been closed successfully");
   }


### PR DESCRIPTION
Handler to observer can be set to null in any moment. Make check
before call handler.
Bug-fixes: [APPLINK-20011](https://adc.luxoft.com/jira/browse/APPLINK-20011)

Please review @anosach-luxoft, @malirod, @pestOO .