### PR TITLE
Fix defect SDL responds with SUCCESS resultCode in case of TTS Speak …

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -114,6 +114,13 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
   bool IsWhiteSpaceExist();
 
   /**
+   * @brief Waiting for TTS.Speak response, after default timeout send
+   * GENERIC_ERROR response
+   * @return if receive TTS.Speak return TRUE, FALSE otherwise
+   */
+  bool WaitTTSSpeak();
+
+  /**
    * @brief If is_active_tts_speak_ TRUE - set up to FALSE and send request
    * TTS_StopSpeaking to HMI
    */

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -31,6 +31,7 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <string>
 #include "application_manager/commands/mobile/perform_audio_pass_thru_request.h"
 #include "application_manager/application_manager_impl.h"
 #include "application_manager/application_impl.h"
@@ -115,10 +116,10 @@ void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
 
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_PerformAudioPassThru: {
-      LOG4CXX_INFO(logger_, "Received UI_PerformAudioPassThru");
+      LOG4CXX_TRACE(logger_, "Received UI_PerformAudioPassThru");
 
       if (!WaitTTSSpeak()) {
-        LOG4CXX_AUTO_TRACE(logger_);
+        LOG4CXX_DEBUG(logger_, "TTS.Speak is absent");
         return;
       }
 
@@ -358,7 +359,7 @@ bool PerformAudioPassThruRequest::WaitTTSSpeak() {
     // Send GENERIC_ERROR after default timeout
     if (difference_between_start_current_time > default_timeout_msec) {
       LOG4CXX_WARN(logger_, "Expired timeout for TTS.Speak response");
-      // Don't use onTimeOut(), becouse default_timeout_ is bigger than
+      // Don't use onTimeOut(), because default_timeout_ is bigger than
       // Default time in *.ini file
       FinishTTSSpeak();
       SendResponse(false, mobile_apis::Result::eType::GENERIC_ERROR,

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -36,6 +36,7 @@
 #include "application_manager/application_manager_impl.h"
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
+#include "config_profile/profile.h"
 #include "utils/helpers.h"
 
 namespace application_manager {
@@ -58,12 +59,7 @@ PerformAudioPassThruRequest::~PerformAudioPassThruRequest() {
 void PerformAudioPassThruRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  if (ApplicationManagerImpl::instance()->end_audio_pass_thru()) {
-    ApplicationManagerImpl::instance()->StopAudioPassThru(connection_key());
-  }
-
   FinishTTSSpeak();
-
   CommandRequestImpl::onTimeOut();
 }
 
@@ -120,6 +116,10 @@ void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
 
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_PerformAudioPassThru: {
+      LOG4CXX_INFO(logger_, "Received UI_PerformAudioPassThru");
+
+      if (!WaitTTSSpeak())
+        return;
 
       mobile_apis::Result::eType mobile_code =
           GetMobileResultCode(static_cast<hmi_apis::Common_Result::eType>(
@@ -130,10 +130,6 @@ void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
         LOG4CXX_ERROR(logger_, "Request was rejected");
         SendResponse(false, mobile_code, NULL, &(message[strings::msg_params]));
         return;
-      }
-
-      if (ApplicationManagerImpl::instance()->end_audio_pass_thru()) {
-        ApplicationManagerImpl::instance()->StopAudioPassThru(connection_key());
       }
 
       FinishTTSSpeak();
@@ -335,12 +331,40 @@ bool PerformAudioPassThruRequest::IsWhiteSpaceExist() {
 
 void PerformAudioPassThruRequest::FinishTTSSpeak(){
   LOG4CXX_AUTO_TRACE(logger_);
+  if (ApplicationManagerImpl::instance()->end_audio_pass_thru()) {
+    ApplicationManagerImpl::instance()->
+        StopAudioPassThru(connection_key());
+  }
   if (!is_active_tts_speak_) {
     LOG4CXX_DEBUG(logger_, "TTS Speak is inactive.");
     return;
   }
   is_active_tts_speak_ = false;
   SendHMIRequest(hmi_apis::FunctionID::TTS_StopSpeaking, NULL);
+}
+
+bool PerformAudioPassThruRequest::WaitTTSSpeak() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  uint32_t default_timeout_msec =
+      profile::Profile::instance()->default_timeout();
+  TimevalStruct start_time = date_time::DateTime::getCurrentTime();
+
+  // Waiting for TTS_Speak
+  while (is_active_tts_speak_) {
+    int64_t difference_between_start_current_time
+        = date_time::DateTime::calculateTimeSpan(start_time);
+    // Send GENERIC_ERROR after default timeout
+    if (difference_between_start_current_time > default_timeout_msec) {
+      LOG4CXX_ERROR(logger_, "Expired timeout for TTS.Speak response");
+      // Don't using onTimeOut(), becouse there default time is bigger than
+      // Default time in *.ini file
+      FinishTTSSpeak();
+      SendResponse(false, mobile_apis::Result::eType::GENERIC_ERROR,
+        "Expired timeout for TTS.Speak response");
+      return false;
+    }
+  }
+  return true;
 }
 
 }  // namespace commands


### PR DESCRIPTION
Fix defect SDL responds with SUCCESS resultCode in case of TTS Speak absent.

Add WaitTTSSpeak method.
Add TTS Check in case PerformAudioPassThru.

Related:
       APPLINK-17728