### PR TITLE
Fix endpoints data copying during Policy Table Update

### DIFF
--- a/src/components/policy/src/policy/policy_table/table_struct/types.cc
+++ b/src/components/policy/src/policy/policy_table/table_struct/types.cc
@@ -489,6 +489,24 @@ ModuleConfig::ModuleConfig(const Json::Value* value__)
     vehicle_model(impl::ValueMember(value__, "vehicle_model")),
     vehicle_year(impl::ValueMember(value__, "vehicle_year")) {
 }
+
+void ModuleConfig::SafeCopyFrom(const ModuleConfig& from) {
+//  device_certificates = from.device_certificates;  // According to the requirements this is optional.
+  exchange_after_x_ignition_cycles = from.exchange_after_x_ignition_cycles;
+  exchange_after_x_kilometers = from.exchange_after_x_kilometers;
+  exchange_after_x_days = from.exchange_after_x_days;
+  timeout_after_x_seconds = from.timeout_after_x_seconds;
+  seconds_between_retries = from.seconds_between_retries;
+  endpoints = from.endpoints;
+  notifications_per_minute_by_priority = from.notifications_per_minute_by_priority;
+
+  vehicle_make.assign_if_valid(from.vehicle_make);
+  vehicle_model.assign_if_valid(from.vehicle_model);
+  vehicle_year.assign_if_valid(from.vehicle_year);
+  certificate .assign_if_valid(from.certificate);
+
+}
+
 Json::Value ModuleConfig::ToJsonValue() const {
   Json::Value result__(Json::objectValue);
   impl::WriteJsonField("device_certificates", device_certificates, &result__);

--- a/src/components/policy/src/policy/policy_table/table_struct/types.h
+++ b/src/components/policy/src/policy/policy_table/table_struct/types.h
@@ -187,6 +187,7 @@ struct ModuleConfig : CompositeType {
     ModuleConfig(uint8_t exchange_after_x_ignition_cycles, int64_t exchange_after_x_kilometers, uint8_t exchange_after_x_days, uint16_t timeout_after_x_seconds, const SecondsBetweenRetries& seconds_between_retries, const ServiceEndpoints& endpoints, const NumberOfNotificationsPerMinute& notifications_per_minute_by_priority);
     ~ModuleConfig();
     explicit ModuleConfig(const Json::Value* value__);
+    void SafeCopyFrom(const ModuleConfig& from);
     Json::Value ToJsonValue() const;
     bool is_valid() const;
     bool is_initialized() const;

--- a/src/components/policy/src/policy/src/cache_manager.cc
+++ b/src/components/policy/src/policy/src/cache_manager.cc
@@ -228,8 +228,13 @@ bool CacheManager::ApplyUpdate(const policy_table::Table& update_pt) {
       pt_->policy_table.app_policies_section.apps[iter->first].set_to_null();
       pt_->policy_table.app_policies_section.apps[iter->first].set_to_string("");
     } else if (policy::kDefaultId == (iter->second).get_string()) {
-      pt_->policy_table.app_policies_section.apps[iter->first] =
-          pt_->policy_table.app_policies_section.apps[kDefaultId];
+        policy_table::ApplicationPolicies::const_iterator iter_default =
+            update_pt.policy_table.app_policies_section.apps.find(kDefaultId);
+        if (update_pt.policy_table.app_policies_section.apps.end() == iter_default) {
+            LOG4CXX_ERROR(logger_, "The default section was not found in PTU");
+            continue;
+        }
+      pt_->policy_table.app_policies_section.apps[iter->first] = iter_default->second;
     } else {
       pt_->policy_table.app_policies_section.apps[iter->first] = iter->second;
     }
@@ -238,10 +243,11 @@ bool CacheManager::ApplyUpdate(const policy_table::Table& update_pt) {
   pt_->policy_table.app_policies_section.device =
       update_pt.policy_table.app_policies_section.device;
 
-  if (update_pt.policy_table.consumer_friendly_messages.is_initialized()) {
-    pt_->policy_table.consumer_friendly_messages =
-        update_pt.policy_table.consumer_friendly_messages;
-  }
+  pt_->policy_table.module_config.SafeCopyFrom(update_pt.policy_table.module_config);
+
+  pt_->policy_table.consumer_friendly_messages.assign_if_valid(
+        update_pt.policy_table.consumer_friendly_messages);
+
   ResetCalculatedPermissions();
   Backup();
   return true;

--- a/src/components/rpc_base/include/rpc_base/rpc_base.h
+++ b/src/components/rpc_base/include/rpc_base/rpc_base.h
@@ -393,6 +393,8 @@ class Optional {
     const T& operator*() const;
     T* operator->();
     const T* operator->() const;
+
+    void assign_if_valid(const Optional<T>& value);
     // For pointer-like 'if (optional_value)' tests
     // Better than operator bool because bool can be implicitly
     // casted to integral types

--- a/src/components/rpc_base/include/rpc_base/rpc_base_inl.h
+++ b/src/components/rpc_base/include/rpc_base/rpc_base_inl.h
@@ -604,6 +604,13 @@ const T* Optional<T>::operator->() const {
 }
 
 template<typename T>
+void Optional<T>::assign_if_valid(const Optional<T>& value) {
+  if (value.is_initialized()) {
+    value_ = value.value_;
+  }
+}
+
+template<typename T>
 Optional<T>::operator const void*() const {
   return is_initialized() ? &value_ : NULL;
 }


### PR DESCRIPTION
Up to now, when performing Policy Table Update, the module_config part
of the policy table was not copied. The change adds copying of this
part. The code is taken from CustomSDL/sdl_panasonic/develop (dd8ade70),
with just a small fix about copying exchange_after_x_ignition_cycles.

Fixes: APPLINK-20261