### PR TITLE
Add Mock::AsyncVerifyAndClearExpectations in failed tests.

### DIFF
--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -798,8 +798,8 @@ void ConnectionHandlerImpl::CloseSession(ConnectionHandle connection_handle,
       const Session &session = session_map_itr->second;
       const ServiceList &service_list = session.service_list;
 
-      ServiceList::const_iterator service_list_itr = service_list.begin();
-      for (;service_list_itr != service_list.end(); ++service_list_itr) {
+      ServiceList::const_reverse_iterator service_list_itr = service_list.rbegin();
+      for (;service_list_itr != service_list.rend(); ++service_list_itr) {
         const protocol_handler::ServiceType service_type =
             service_list_itr->service_type;
         connection_handler_observer_->OnServiceEndedCallback(session_key,

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -52,6 +52,7 @@ using ::protocol_handler::ServiceType;
 using namespace ::protocol_handler;
 using ::testing::_;
 using ::testing::InSequence;
+using ::testing::Mock;
 // For service types and PROTECTION_ON/OFF
 
 class ConnectionHandlerTest : public ::testing::Test {
@@ -412,13 +413,13 @@ TEST_F(ConnectionHandlerTest, OnMalformedMessageCallback) {
 
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kMobileNav, kMalformed)).Times(0);
+              OnServiceEndedCallback(connection_key_,kMobileNav, kMalformed)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kAudio, kMalformed)).Times(0);
+              OnServiceEndedCallback(connection_key_,kAudio, kMalformed)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kMalformed)).Times(0);
+              OnServiceEndedCallback(connection_key_,kBulk, kMalformed)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kMalformed)).Times(0);
+              OnServiceEndedCallback(connection_key_,kRpc, kMalformed)).Times(1);
   connection_handler_->OnMalformedMessageCallback(uid_);
 }
 
@@ -433,17 +434,17 @@ TEST_F(ConnectionHandlerTest, OnApplicationFloodCallBack) {
   protocol_handler_test::ProtocolHandlerMock mock_protocol_handler;
   connection_handler_->set_protocol_handler(&mock_protocol_handler);
 
-  EXPECT_CALL(mock_protocol_handler, SendEndSession(uid_,start_session_id_)).Times(2);
+  EXPECT_CALL(mock_protocol_handler, SendEndSession(uid_,start_session_id_)).Times(1);
 
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kCommon)).Times(1);
-  EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kCommon)).Times(1);
+              OnServiceEndedCallback(connection_key_,kMobileNav, kCommon)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_,kAudio, kCommon)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kMobileNav, kCommon)).Times(1);
+              OnServiceEndedCallback(connection_key_,kBulk, kCommon)).Times(1);
+  EXPECT_CALL(mock_connection_handler_observer,
+              OnServiceEndedCallback(connection_key_,kRpc, kCommon)).Times(1);
   connection_handler_->OnApplicationFloodCallBack(uid_);
 }
 
@@ -498,18 +499,19 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithCommonReason) {
   protocol_handler_test::ProtocolHandlerMock mock_protocol_handler;
   connection_handler_->set_protocol_handler(&mock_protocol_handler);
 
-  EXPECT_CALL(mock_protocol_handler, SendEndSession(uid_,start_session_id_)).Times(2);
+  EXPECT_CALL(mock_protocol_handler, SendEndSession(uid_,start_session_id_)).Times(1);
 
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kCommon)).Times(1);
-  EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kCommon)).Times(1);
+              OnServiceEndedCallback(connection_key_,kMobileNav, kCommon)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_,kAudio, kCommon)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kMobileNav, kCommon)).Times(1);
+              OnServiceEndedCallback(connection_key_,kBulk, kCommon)).Times(1);
+  EXPECT_CALL(mock_connection_handler_observer,
+              OnServiceEndedCallback(connection_key_,kRpc, kCommon)).Times(1);
   connection_handler_->CloseSession(connection_key_, kCommon);
+  Mock::AsyncVerifyAndClearExpectations(10000);
 }
 
 TEST_F(ConnectionHandlerTest, CloseSessionWithFloodReason) {
@@ -523,18 +525,19 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithFloodReason) {
   protocol_handler_test::ProtocolHandlerMock mock_protocol_handler;
   connection_handler_->set_protocol_handler(&mock_protocol_handler);
 
-  EXPECT_CALL(mock_protocol_handler, SendEndSession(uid_,start_session_id_)).Times(2);
+  EXPECT_CALL(mock_protocol_handler, SendEndSession(uid_,start_session_id_)).Times(1);
 
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kFlood)).Times(1);
-  EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kFlood)).Times(1);
+              OnServiceEndedCallback(connection_key_,kMobileNav, kFlood)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_,kAudio, kFlood)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kMobileNav, kFlood)).Times(1);
+              OnServiceEndedCallback(connection_key_,kBulk, kFlood)).Times(1);
+  EXPECT_CALL(mock_connection_handler_observer,
+              OnServiceEndedCallback(connection_key_,kRpc, kFlood)).Times(1);
   connection_handler_->CloseSession(connection_key_, kFlood);
+  Mock::AsyncVerifyAndClearExpectations(10000);
 }
 
 TEST_F(ConnectionHandlerTest, CloseSessionWithMalformedMessage) {
@@ -552,14 +555,15 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithMalformedMessage) {
 
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kMobileNav, kMalformed)).Times(0);
+              OnServiceEndedCallback(connection_key_,kMobileNav, kMalformed)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kAudio, kMalformed)).Times(0);
+              OnServiceEndedCallback(connection_key_,kAudio, kMalformed)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kMalformed)).Times(0);
+              OnServiceEndedCallback(connection_key_,kBulk, kMalformed)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kMalformed)).Times(0);
+              OnServiceEndedCallback(connection_key_,kRpc, kMalformed)).Times(1);
   connection_handler_->CloseSession(connection_key_, kMalformed);
+  Mock::AsyncVerifyAndClearExpectations(10000);
 }
 
 TEST_F(ConnectionHandlerTest, CloseConnectionSessionsWithMalformedMessage) {
@@ -577,14 +581,15 @@ TEST_F(ConnectionHandlerTest, CloseConnectionSessionsWithMalformedMessage) {
 
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kMobileNav, kMalformed)).Times(0);
+              OnServiceEndedCallback(connection_key_,kMobileNav, kMalformed)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kAudio, kMalformed)).Times(0);
+              OnServiceEndedCallback(connection_key_,kAudio, kMalformed)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kMalformed)).Times(0);
+              OnServiceEndedCallback(connection_key_,kBulk, kMalformed)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kMalformed)).Times(0);
+              OnServiceEndedCallback(connection_key_,kRpc, kMalformed)).Times(1);
   connection_handler_->CloseConnectionSessions(uid_, kMalformed);
+  Mock::AsyncVerifyAndClearExpectations(10000);
 }
 
 TEST_F(ConnectionHandlerTest, CloseConnectionSessionsWithCommonReason) {
@@ -598,18 +603,19 @@ TEST_F(ConnectionHandlerTest, CloseConnectionSessionsWithCommonReason) {
   protocol_handler_test::ProtocolHandlerMock mock_protocol_handler;
   connection_handler_->set_protocol_handler(&mock_protocol_handler);
 
-  EXPECT_CALL(mock_protocol_handler, SendEndSession(uid_,start_session_id_)).Times(2);
+  EXPECT_CALL(mock_protocol_handler, SendEndSession(uid_,start_session_id_)).Times(1);
 
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_, kRpc, kCommon)).Times(1);
-  EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kCommon)).Times(1);
+              OnServiceEndedCallback(connection_key_, kMobileNav, kCommon)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_,kAudio, kCommon)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kMobileNav, kCommon)).Times(1);
+              OnServiceEndedCallback(connection_key_,kBulk, kCommon)).Times(1);
+  EXPECT_CALL(mock_connection_handler_observer,
+              OnServiceEndedCallback(connection_key_,kRpc, kCommon)).Times(1);
   connection_handler_->CloseConnectionSessions(uid_, kCommon);
+  Mock::AsyncVerifyAndClearExpectations(10000);
 }
 
 TEST_F(ConnectionHandlerTest, StartService_withServices) {


### PR DESCRIPTION
Change in CloseSession const iterator to const reverse iterator.

Related:
       [APPLINK-20523](https://adc.luxoft.com/jira/browse/APPLINK-20523)