### PR TITLE
Converting upper bound values

### DIFF
--- a/src/components/application_manager/src/commands/mobile/put_file_request.cc
+++ b/src/components/application_manager/src/commands/mobile/put_file_request.cc
@@ -127,7 +127,7 @@ void PutFileRequest::Run() {
       (*message_)[strings::msg_params].keyExists(strings::offset);
 
   if (offset_exist) {
-    offset_ = (*message_)[strings::msg_params][strings::offset].asInt64();
+    offset_ = (*message_)[strings::msg_params][strings::offset].asInt();
   }
 
   if ((*message_)[strings::msg_params].

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -2555,7 +2555,7 @@ bool MessageHelper::PrintSmartObject(const smart_objects::SmartObject& object) {
       break;
     }
     case NsSmartDeviceLink::NsSmartObjects::SmartType_Integer:
-      printf("%" PRId64 "\n", object.asInt64());
+      printf("%" PRId64 "\n", object.asInt());
       break;
     case NsSmartDeviceLink::NsSmartObjects::SmartType_String:
       printf("%s", object.asString().c_str());

--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -2615,11 +2615,11 @@ ApplicationParams::ApplicationParams(
   }
   m_is_valid = true;
   m_hash = application[hash_id].asString();
-  m_grammar_id = application[grammar_id].asInt64();
-  m_connection_key = application[connection_key].asInt64();
-  m_hmi_app_id = application[hmi_app_id].asInt64();
-  m_hmi_level = static_cast<mobile_apis::HMILevel::eType>(
-                  application[hmi_level].asInt());
+  m_grammar_id = application[grammar_id].asInt();
+  m_connection_key = application[connection_key].asInt();
+  m_hmi_app_id = application[hmi_app_id].asInt();
+  m_hmi_level =
+      static_cast<mobile_apis::HMILevel::eType>(application[hmi_level].asInt());
   m_is_media_application = application[is_media_application].asBool();
 }
 

--- a/src/components/formatters/CMakeLists.txt
+++ b/src/components/formatters/CMakeLists.txt
@@ -38,6 +38,7 @@ include_directories (
   ${JSONCPP_INCLUDE_DIRECTORY}
   ${MESSAGE_BROKER_INCLUDE_DIRECTORY}
   ${COMPONENTS_DIR}/smart_objects/include
+  ${COMPONENTS_DIR}/utils/include
 )
 
 set (SOURCES

--- a/src/components/formatters/src/CFormatterJsonBase.cc
+++ b/src/components/formatters/src/CFormatterJsonBase.cc
@@ -32,8 +32,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #include "json/json.h"
-
 #include "formatters/CFormatterJsonBase.h"
+#include "utils/convert_utils.h"
 
 void NsSmartDeviceLink::NsJSONHandler::Formatters::CFormatterJsonBase::jsonValueToObj(
     const Json::Value& value,
@@ -56,9 +56,9 @@ void NsSmartDeviceLink::NsJSONHandler::Formatters::CFormatterJsonBase::jsonValue
         jsonValueToObj(value[i], obj[i]);
       }
     } else if (value.type() == Json::intValue) {
-      obj = value.asInt();
+      obj = utils::ConvertLongLongIntToInt64(value.asInt64());
     } else if (value.type() == Json::uintValue) {
-      obj = value.asUInt();
+      obj = utils::ConvertLongLongUIntToUInt64(value.asUInt64());
     } else if (value.type() == Json::realValue) {
       obj = value.asDouble();
     } else if (value.type() == Json::booleanValue) {
@@ -104,10 +104,10 @@ void NsSmartDeviceLink::NsJSONHandler::Formatters::CFormatterJsonBase::objToJson
       item = obj.asBool();
     } else if (NsSmartDeviceLink::NsSmartObjects::SmartType_Integer
         == obj.getType()) {
-      item = obj.asInt();
+      item = utils::ConvertInt64ToLongLongInt(obj.asInt());
     } else if (NsSmartDeviceLink::NsSmartObjects::SmartType_UInteger
         == obj.getType()) {
-      item = obj.asUInt();
+      item = utils::ConvertUInt64ToLongLongUInt(obj.asUInt());
     } else if (NsSmartDeviceLink::NsSmartObjects::SmartType_Double
         == obj.getType()) {
       item = obj.asDouble();

--- a/src/components/formatters/src/CFormatterJsonSDLRPCv1.cc
+++ b/src/components/formatters/src/CFormatterJsonSDLRPCv1.cc
@@ -1,34 +1,38 @@
-// Copyright (c) 2013, Ford Motor Company
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// Redistributions of source code must retain the above copyright notice, this
-// list of conditions and the following disclaimer.
-//
-// Redistributions in binary form must reproduce the above copyright notice,
-// this list of conditions and the following
-// disclaimer in the documentation and/or other materials provided with the
-// distribution.
-//
-// Neither the name of the Ford Motor Company nor the names of its contributors
-// may be used to endorse or promote products derived from this software
-// without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 'A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+/*
+ * Copyright (c) 2015, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include "formatters/CFormatterJsonSDLRPCv1.h"
 #include "formatters/meta_formatter.h"
+#include "utils/convert_utils.h"
 
 namespace strings = NsSmartDeviceLink::NsJSONHandler::strings;
 namespace smart_objects_ns = NsSmartDeviceLink::NsSmartObjects;
@@ -96,8 +100,8 @@ bool CFormatterJsonSDLRPCv1::toString(const smart_objects_ns::SmartObject& obj,
     root[type][S_PARAMETERS] = params;
 
     if (formattedObj[strings::S_PARAMS].keyExists(strings::S_CORRELATION_ID)) {
-      root[type][S_CORRELATION_ID] =
-          formattedObj[strings::S_PARAMS][strings::S_CORRELATION_ID].asInt();
+      root[type][S_CORRELATION_ID] = utils::ConvertInt64ToLongLongInt(
+          formattedObj[strings::S_PARAMS][strings::S_CORRELATION_ID].asInt());
     }
 
     root[type][S_NAME] = formattedObj[strings::S_PARAMS][strings::S_FUNCTION_ID]

--- a/src/components/formatters/src/formatter_json_rpc.cc
+++ b/src/components/formatters/src/formatter_json_rpc.cc
@@ -33,6 +33,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "formatters/formatter_json_rpc.h"
+#include "utils/convert_utils.h"
 
 namespace NsSmartDeviceLink {
 namespace NsJSONHandler {
@@ -118,7 +119,7 @@ bool FormatterJsonRpc::ToString(const NsSmartObjects::SmartObject &obj,
               if (NsSmartObjects::SmartType_Integer != code.getType()) {
                 result = false;
               } else {
-                root[kResult][kCode] = code.asInt();
+                root[kResult][kCode] = utils::ConvertInt64ToLongLongInt(code.asInt());
               }
             }
           } else if (kNotification == message_type) {
@@ -134,7 +135,7 @@ bool FormatterJsonRpc::ToString(const NsSmartObjects::SmartObject &obj,
             if (NsSmartObjects::SmartType_Integer != code.getType()) {
               result = false;
             } else {
-              root[kError][kCode] = code.asInt();
+              root[kError][kCode] = utils::ConvertInt64ToLongLongInt(code.asInt());
             }
           }
         }
@@ -174,7 +175,7 @@ bool FormatterJsonRpc::SetId(const NsSmartObjects::SmartObject &params,
         strings::S_CORRELATION_ID);
 
     if (NsSmartObjects::SmartType_Integer == id.getType()) {
-      id_container[kId] = id.asUInt();
+      id_container[kId] = utils::ConvertUInt64ToLongLongUInt(id.asUInt());
       result = true;
     }
   }

--- a/src/components/formatters/test/CFormatterJsonBase_test.cc
+++ b/src/components/formatters/test/CFormatterJsonBase_test.cc
@@ -111,15 +111,26 @@ TEST(CFormatterJsonBaseTest, JSonUnsignedMaxIntValueToSmartObj_ExpectSuccessful)
   EXPECT_EQ(ui_val, object.asUInt());
 }
 
-TEST(CFormatterJsonBaseTest, JSonSignedMaxInt64ValueToSmartObj_ExpectFailed) {
+TEST(CFormatterJsonBaseTest, JSonSignedMaxInt64ValueToSmartObj_ExpectSuccess) {
   // Arrange value
   Json::Int64 ival = Json::Value::maxInt64;
   Json::Value json_value(ival);  // Json value from maximum possible signed int
   SmartObject object;
   // Convert json to smart object
   CFormatterJsonBase::jsonValueToObj(json_value, object);
+  // Check conversion was successful
+  EXPECT_EQ(ival, object.asInt());
+}
+
+TEST(CFormatterJsonBaseTest, JSonUnsignedMaxInt64ValueToSmartObj_ExpectFailed) {
+  // Arrange value
+  Json::UInt64 ival = Json::Value::maxUInt64;
+  Json::Value json_value(ival);  // Json value from max possible unsigned int
+  SmartObject object;
+  // Convert json to smart object
+  CFormatterJsonBase::jsonValueToObj(json_value, object);
   // Check conversion was not successful as there is no such conversion
-  EXPECT_EQ(invalid_int64_value, object.asInt64());
+  EXPECT_EQ(invalid_int64_value, object.asInt());
 }
 
 TEST(CFormatterJsonBaseTest, JSonBoolValueToSmartObj_ExpectSuccessful) {
@@ -169,11 +180,14 @@ TEST(CFormatterJsonBaseTest, JSonArrayValueToSmartObj_ExpectSuccessful) {
 TEST(CFormatterJsonBaseTest, JSonObjectValueToSmartObj_ExpectSuccessful) {
   // Arrange value
   const char* json_object =
-      "{ \"json_test_object\": [\"test1\", \"test2\", \"test3\"], \"json_test_object2\": [\"test11\", \"test12\", \"test13\" ]}";  // Json object
+      "{ \"json_test_object\": [\"test1\", \"test2\", \"test3\"], "
+      "\"json_test_object2\": [\"test11\", \"test12\", \"test13\" ]}";
   Json::Value json_value;  // Json value from object. Will be initialized later
   SmartObject object;
   Json::Reader reader;  // Json reader - Needed for correct parsing
-  ASSERT_TRUE(reader.parse(json_object, json_value));  // If parsing not successful - no sense to continue
+  ASSERT_TRUE(reader.parse(
+      json_object,
+      json_value));  // If parsing not successful - no sense to continue
   CFormatterJsonBase::jsonValueToObj(json_value, object);
   // Check conversion was successful
   EXPECT_TRUE(json_value.isObject());
@@ -299,8 +313,10 @@ TEST(CFormatterJsonBaseTest, ArraySmartObjectToJSon_ExpectSuccessful) {
 TEST(CFormatterJsonBaseTest, JSonObjectValueToObj_ExpectSuccessful) {
   // Arrange value
   const char* json_object =
-      "{ \"json_test_object\": [\"test1\", \"test2\", \"test3\"], \"json_test_object2\": [\"test11\", \"test12\", \"test13\" ]}";  // Json object
-  Json::Value json_value;  // Json value from json object. Will be initialized later
+      "{ \"json_test_object\": [\"test1\", \"test2\", \"test3\"], "
+      "\"json_test_object2\": [\"test11\", \"test12\", \"test13\" ]}";
+  Json::Value
+      json_value;      // Json value from json object. Will be initialized later
   Json::Value result;  // Json value from Smart object. Will keep conversion result
   SmartObject object;
   Json::Reader reader;  // Json reader - Needed for correct parsing

--- a/src/components/formatters/test/formatter_json_rpc_test.cc
+++ b/src/components/formatters/test/formatter_json_rpc_test.cc
@@ -59,14 +59,32 @@ void CompactJson(std::string& str) {
   reader.parse(str, root);
   Json::FastWriter writer;
   str = writer.write(root);
-  std::string::iterator end_pos = std::remove(str.begin(), str.end(), '\n');
-  str.erase(end_pos, str.end());
+  if (str[str.size() - 1] == '\n') {
+      str.erase(str.size()-1,1);
+  }
 }
 
 namespace {
 const int64_t big_64int = 100000000000;
 const std::string str_with_big_int64 = "100000000000";
 }  // namespace
+
+TEST(FormatterJsonRPCTest, CheckCompactJson){
+  std::string before_compact(
+     "{\n   \"jsonrpc\" : \"2.0\",\n   \"method\" : \"BasicCommunication.OnSystemRequest\","
+     "\n   \"params\" : {\n      \"fileName\" : \"file \n Name\",\n      \"length\" : 100000000000,\n"
+     "\"offset\" : 100000000000,\n      \"requestType\" : \"PROPRIETARY\"\n   }\n}\n");
+  std::string after_compact = before_compact;
+  CompactJson(after_compact);
+
+  EXPECT_NE(before_compact, after_compact);
+
+  std::string expected(
+      "{\"jsonrpc\":\"2.0\",\"method\":\"BasicCommunication.OnSystemRequest\","
+      "\"params\":{\"fileName\":\"file \\n Name\",\"length\":100000000000,"
+      "\"offset\":100000000000,\"requestType\":\"PROPRIETARY\"}}");
+  EXPECT_EQ(expected, after_compact);
+}
 
 TEST(FormatterJsonRPCTest, CorrectRPCv1Request_ToString_Success) {
   // Create SmartObject

--- a/src/components/formatters/test/formatter_json_rpc_test.cc
+++ b/src/components/formatters/test/formatter_json_rpc_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -348,13 +348,18 @@ TEST(FormatterJsonRPCTest, RequestToSmartObject_Success) {
   // Get keys collection from Smart Object
   std::set<std::string> keys = obj["params"].enumerate();
   EXPECT_EQ(5u, keys.size());
+  EXPECT_EQ(4444, obj["params"]["correlation_id"].asInt());
+  EXPECT_EQ(35, obj["params"]["function_id"].asInt());
+  EXPECT_EQ(0, obj["params"]["message_type"].asInt());
+  EXPECT_EQ(1, obj["params"]["protocol_type"].asInt());
+  EXPECT_EQ(2, obj["params"]["protocol_version"].asInt());
 }
 
 TEST(FormatterJsonRPCTest, ResponseToSmartObject_Success) {
   // Source Json string
   const std::string json_string(
-      "{\n   \"id\" : 4444,\n   \"jsonrpc\" : \"2.0\",\n   \"method\" : "
-      "\"VR.IsReady\"\n}\n");
+      "{\"id\":4440,\"jsonrpc\":\"2.0\",\"result\":{\"code\":0,\"method\":\"VR."
+      "AddCommand\"}}");
   // Smart Object to keep result
   SmartObject obj;
   // Convert json string to smart object
@@ -364,7 +369,13 @@ TEST(FormatterJsonRPCTest, ResponseToSmartObject_Success) {
   EXPECT_EQ(0, result);
   // Get keys collection from Smart Object
   std::set<std::string> keys = obj["params"].enumerate();
-  EXPECT_EQ(5u, keys.size());
+  EXPECT_EQ(6u, keys.size());
+  EXPECT_EQ(0, obj["params"]["code"].asInt());
+  EXPECT_EQ(4440, obj["params"]["correlation_id"].asInt());
+  EXPECT_EQ(38, obj["params"]["function_id"].asInt());
+  EXPECT_EQ(1, obj["params"]["message_type"].asInt());
+  EXPECT_EQ(1, obj["params"]["protocol_type"].asInt());
+  EXPECT_EQ(2, obj["params"]["protocol_version"].asInt());
 }
 
 TEST(FormatterJsonRPCTest, StringWithUpperBoundValueToSmartObject_Success) {

--- a/src/components/smart_objects/include/smart_objects/number_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/number_schema_item.h
@@ -137,7 +137,7 @@ Errors::eType TNumberSchemaItem<NumberType>::validate(const SmartObject& Object)
   } else if (typeid(double) == typeid(value)) {
     value = Object.asDouble();
   } else if (typeid(int64_t) == typeid(value)) {
-    value = Object.asInt64();
+    value = Object.asInt();
   } else {
     NOTREACHED();
   }

--- a/src/components/smart_objects/include/smart_objects/number_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/number_schema_item.h
@@ -34,7 +34,7 @@
 #define SRC_COMPONENTS_SMART_OBJECTS_INCLUDE_SMART_OBJECTS_NUMBER_SCHEMA_ITEM_H_
 
 #include <typeinfo>
-
+#include <limits>
 #include "utils/shared_ptr.h"
 #include "smart_objects/default_shema_item.h"
 #include "smart_objects/schema_item_parameter.h"
@@ -124,20 +124,35 @@ bool TNumberSchemaItem<NumberType>::isValidNumberType(SmartType type) {
   }
 }
 
-template<typename NumberType>
-Errors::eType TNumberSchemaItem<NumberType>::validate(const SmartObject& Object) {
+template <typename NumberType>
+Errors::eType TNumberSchemaItem<NumberType>::validate(
+    const SmartObject& Object) {
   if (!isValidNumberType(Object.getType())) {
     return Errors::INVALID_VALUE;
   }
   NumberType value(0);
   if (typeid(int32_t) == typeid(value)) {
-    value = Object.asInt();
+    DCHECK_OR_RETURN(
+        Object.asInt() >= std::numeric_limits<int32_t>::min(),
+        Errors::OUT_OF_RANGE);
+    DCHECK_OR_RETURN(
+        Object.asInt() <= std::numeric_limits<int32_t>::max(),
+        Errors::OUT_OF_RANGE);
+    value = static_cast<int32_t>(Object.asInt());
   } else if (typeid(uint32_t) == typeid(value)) {
-    value = Object.asUInt();
+    DCHECK_OR_RETURN(
+        Object.asUInt() >= std::numeric_limits<uint32_t>::min(),
+        Errors::OUT_OF_RANGE);
+    DCHECK_OR_RETURN(
+        Object.asUInt() <= std::numeric_limits<uint32_t>::max(),
+        Errors::OUT_OF_RANGE);
+    value = static_cast<uint32_t>(Object.asUInt());
   } else if (typeid(double) == typeid(value)) {
     value = Object.asDouble();
   } else if (typeid(int64_t) == typeid(value)) {
     value = Object.asInt();
+  } else if (typeid(uint64_t) == typeid(value)) {
+    value = Object.asUInt();
   } else {
     NOTREACHED();
   }
@@ -184,7 +199,7 @@ template<>
 SmartType TNumberSchemaItem<uint32_t>::getSmartType() const;
 
 template<>
-SmartType TNumberSchemaItem<uint32_t>::getSmartType() const;
+SmartType TNumberSchemaItem<int64_t>::getSmartType() const;
 
 template<>
 SmartType TNumberSchemaItem<double>::getSmartType() const;

--- a/src/components/smart_objects/include/smart_objects/number_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/number_schema_item.h
@@ -124,6 +124,15 @@ bool TNumberSchemaItem<NumberType>::isValidNumberType(SmartType type) {
   }
 }
 
+template <typename InputType, typename OutputType>
+OutputType IntStaticCast(const InputType& value) {
+  DCHECK_OR_RETURN(value >= std::numeric_limits<OutputType>::min(),
+                   std::numeric_limits<OutputType>::min());
+  DCHECK_OR_RETURN(value <= std::numeric_limits<OutputType>::max(),
+                   std::numeric_limits<OutputType>::max());
+  return static_cast<OutputType>(value);
+}
+
 template <typename NumberType>
 Errors::eType TNumberSchemaItem<NumberType>::validate(
     const SmartObject& Object) {
@@ -132,21 +141,9 @@ Errors::eType TNumberSchemaItem<NumberType>::validate(
   }
   NumberType value(0);
   if (typeid(int32_t) == typeid(value)) {
-    DCHECK_OR_RETURN(
-        Object.asInt() >= std::numeric_limits<int32_t>::min(),
-        Errors::OUT_OF_RANGE);
-    DCHECK_OR_RETURN(
-        Object.asInt() <= std::numeric_limits<int32_t>::max(),
-        Errors::OUT_OF_RANGE);
-    value = static_cast<int32_t>(Object.asInt());
+    value = IntStaticCast<int64_t,int32_t>(Object.asInt());
   } else if (typeid(uint32_t) == typeid(value)) {
-    DCHECK_OR_RETURN(
-        Object.asUInt() >= std::numeric_limits<uint32_t>::min(),
-        Errors::OUT_OF_RANGE);
-    DCHECK_OR_RETURN(
-        Object.asUInt() <= std::numeric_limits<uint32_t>::max(),
-        Errors::OUT_OF_RANGE);
-    value = static_cast<uint32_t>(Object.asUInt());
+    value = IntStaticCast<uint64_t,uint32_t>(Object.asUInt());
   } else if (typeid(double) == typeid(value)) {
     value = Object.asDouble();
   } else if (typeid(int64_t) == typeid(value)) {

--- a/src/components/smart_objects/include/smart_objects/number_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/number_schema_item.h
@@ -38,6 +38,7 @@
 #include "utils/shared_ptr.h"
 #include "smart_objects/default_shema_item.h"
 #include "smart_objects/schema_item_parameter.h"
+#include "utils/convert_utils.h"
 
 namespace NsSmartDeviceLink {
 namespace NsSmartObjects {
@@ -124,15 +125,6 @@ bool TNumberSchemaItem<NumberType>::isValidNumberType(SmartType type) {
   }
 }
 
-template <typename InputType, typename OutputType>
-OutputType IntStaticCast(const InputType& value) {
-  DCHECK_OR_RETURN(value >= std::numeric_limits<OutputType>::min(),
-                   std::numeric_limits<OutputType>::min());
-  DCHECK_OR_RETURN(value <= std::numeric_limits<OutputType>::max(),
-                   std::numeric_limits<OutputType>::max());
-  return static_cast<OutputType>(value);
-}
-
 template <typename NumberType>
 Errors::eType TNumberSchemaItem<NumberType>::validate(
     const SmartObject& Object) {
@@ -141,9 +133,9 @@ Errors::eType TNumberSchemaItem<NumberType>::validate(
   }
   NumberType value(0);
   if (typeid(int32_t) == typeid(value)) {
-    value = IntStaticCast<int64_t,int32_t>(Object.asInt());
+    value = utils::SafeStaticCast<int64_t,int32_t>(Object.asInt());
   } else if (typeid(uint32_t) == typeid(value)) {
-    value = IntStaticCast<uint64_t,uint32_t>(Object.asUInt());
+    value = utils::SafeStaticCast<uint64_t,uint32_t>(Object.asUInt());
   } else if (typeid(double) == typeid(value)) {
     value = Object.asDouble();
   } else if (typeid(int64_t) == typeid(value)) {

--- a/src/components/smart_objects/include/smart_objects/smart_object.h
+++ b/src/components/smart_objects/include/smart_objects/smart_object.h
@@ -132,6 +132,7 @@ typedef std::vector<SmartObjectSPtr> SmartObjectList;
  * This class act as Variant type from other languages and can be used as primitive type
  * like bool, int32_t, char, double, string and as complex type like array and map.
  **/
+
 class SmartObject FINAL {
  public:
   /**
@@ -200,11 +201,11 @@ class SmartObject FINAL {
   explicit SmartObject(int32_t InitialValue);
 
   /**
-   * @brief Returns current object converted to int32_t
+   * @brief Returns current object converted to int64_t
    *
-   * @return int32_t
+   * @return int64_t
    **/
-  int32_t asInt() const;
+  int64_t asInt() const;
 
   /**
    * @brief Assignment operator for type: int32_t
@@ -231,11 +232,11 @@ class SmartObject FINAL {
   explicit SmartObject(uint32_t InitialValue);
 
   /**
-   * @brief Returns current object converted to uint32_t int32_t
+   * @brief Returns current object converted to uint64_t
    *
-   * @return double
+   * @return uint64_t
    **/
-  uint32_t asUInt() const;
+  uint64_t asUInt() const;
 
   /**
    * @brief Assignment operator for type: int32_t
@@ -286,6 +287,19 @@ class SmartObject FINAL {
    * @return bool
    **/
   bool operator==(int64_t Value) const;
+
+  /**
+    * @name Support of type: uint64_t
+    * @{
+   **/
+
+   /**
+    * @brief Assignment operator for type: uint64_t
+    *
+    * @param  NewValue New object value
+    * @return SmartObject&
+    **/
+   SmartObject& operator=(const uint64_t NewValue);
 
   /** @} */
 

--- a/src/components/smart_objects/include/smart_objects/smart_object.h
+++ b/src/components/smart_objects/include/smart_objects/smart_object.h
@@ -198,7 +198,7 @@ class SmartObject FINAL {
    *
    * @param InitialValue Initial object value
    **/
-  explicit SmartObject(int32_t InitialValue);
+  explicit SmartObject(const int32_t InitialValue);
 
   /**
    * @brief Returns current object converted to int64_t
@@ -213,7 +213,7 @@ class SmartObject FINAL {
    * @param  NewValue New object value
    * @return SmartObject&
    **/
-  SmartObject& operator=(int32_t NewValue);
+  SmartObject& operator=(const int32_t NewValue);
 
   /**
    * @brief Comparison operator for comparing object with integer value
@@ -221,7 +221,7 @@ class SmartObject FINAL {
    * @param  Value Value to compare object with
    * @return bool
    **/
-  bool operator==(int32_t Value) const;
+  bool operator==(const int32_t Value) const;
 
   // Support of type: uint32_t
   /**
@@ -229,7 +229,7 @@ class SmartObject FINAL {
    *
    * @param InitialValue Initial object value
    **/
-  explicit SmartObject(uint32_t InitialValue);
+  explicit SmartObject(const uint32_t InitialValue);
 
   /**
    * @brief Returns current object converted to uint64_t
@@ -244,7 +244,7 @@ class SmartObject FINAL {
    * @param  NewValue New object value
    * @return SmartObject&
    **/
-  SmartObject& operator=(uint32_t NewValue);
+  SmartObject& operator=(const uint32_t NewValue);
 
   /**
    * @brief Comparison operator for comparing object with uint32_t value
@@ -252,7 +252,7 @@ class SmartObject FINAL {
    * @param  Value Value to compare object with
    * @return bool
    **/
-  bool operator==(uint32_t Value) const;
+  bool operator==(const uint32_t Value) const;
 
   /**
    * @name Support of type: int64_t
@@ -263,7 +263,7 @@ class SmartObject FINAL {
    *
    * @param InitialValue Initial object value
    **/
-  explicit SmartObject(int64_t InitialValue);
+  explicit SmartObject(const int64_t InitialValue);
 
   /**
    * @brief Returns current object converted to int64_t
@@ -278,7 +278,7 @@ class SmartObject FINAL {
    * @param  NewValue New object value
    * @return SmartObject&
    **/
-  SmartObject& operator=(int64_t NewValue);
+  SmartObject& operator=(const int64_t NewValue);
 
   /**
    * @brief Comparison operator for comparing object with integer value
@@ -286,7 +286,7 @@ class SmartObject FINAL {
    * @param  Value Value to compare object with
    * @return bool
    **/
-  bool operator==(int64_t Value) const;
+  bool operator==(const int64_t Value) const;
 
   /**
     * @name Support of type: uint64_t

--- a/src/components/smart_objects/src/smart_object.cc
+++ b/src/components/smart_objects/src/smart_object.cc
@@ -180,14 +180,12 @@ SmartObject::SmartObject(int32_t InitialValue)
   set_value_integer(InitialValue);
 }
 
-int32_t SmartObject::asInt() const {
+int64_t SmartObject::asInt() const {
   const int64_t convert = convert_int();
   if (invalid_int64_value == convert) {
     return invalid_int_value;
   }
-  DCHECK(convert >= std::numeric_limits<int32_t>::min());
-  DCHECK(convert <= std::numeric_limits<int32_t>::max());
-  return static_cast<int32_t>(convert);
+  return convert;
 }
 
 SmartObject& SmartObject::operator=(const int32_t NewValue) {
@@ -243,14 +241,12 @@ SmartObject::SmartObject(uint32_t InitialValue)
   set_value_integer(InitialValue);
 }
 
-uint32_t SmartObject::asUInt() const {
+uint64_t SmartObject::asUInt() const {
   const int64_t convert = convert_int();
-  if (invalid_int64_value == convert) {
-    return invalid_unsigned_int_value;
+  if (convert <= invalid_int_value) {
+      return invalid_unsigned_int_value;
   }
-  DCHECK(convert >= std::numeric_limits<uint32_t>::min());
-  DCHECK(convert <= std::numeric_limits<uint32_t>::max());
-  return static_cast<uint32_t>(convert);
+  return static_cast<uint64_t>(convert);
 }
 
 SmartObject& SmartObject::operator=(const uint32_t NewValue) {
@@ -278,10 +274,6 @@ SmartObject::SmartObject(int64_t InitialValue)
   set_value_integer(InitialValue);
 }
 
-int64_t SmartObject::asInt64() const {
-  return convert_int();
-}
-
 SmartObject& SmartObject::operator=(const int64_t NewValue) {
   if (m_type != SmartType_Invalid) {
     set_value_integer(NewValue);
@@ -296,6 +288,17 @@ bool SmartObject::operator==(const int64_t Value) const {
   }
   return comp == Value;
 }
+
+// =============================================================
+// uint64_t TYPE SUPPORT
+// =============================================================
+SmartObject& SmartObject::operator=(const uint64_t NewValue) {
+  if (m_type != SmartType_Invalid) {
+    set_value_integer(NewValue);
+  }
+  return *this;
+}
+
 
 // =============================================================
 // DOUBLE TYPE SUPPORT

--- a/src/components/smart_objects/src/smart_object.cc
+++ b/src/components/smart_objects/src/smart_object.cc
@@ -170,9 +170,6 @@ bool SmartObject::operator==(const SmartObject& Other) const {
   return false;
 }
 
-// =============================================================
-// INTEGER TYPE SUPPORT
-// =============================================================
 SmartObject::SmartObject(int32_t InitialValue)
     : m_type(SmartType_Null),
       m_schema() {
@@ -231,9 +228,6 @@ int64_t SmartObject::convert_int() const {
   return invalid_int64_value;
 }
 
-// =============================================================
-// uint32_t TYPE SUPPORT
-// =============================================================
 SmartObject::SmartObject(uint32_t InitialValue)
     : m_type(SmartType_Null),
       m_schema() {
@@ -264,9 +258,6 @@ bool SmartObject::operator==(const uint32_t Value) const {
   return comp == static_cast<int64_t>(Value);
 }
 
-// =============================================================
-// int64_t TYPE SUPPORT
-// =============================================================
 SmartObject::SmartObject(int64_t InitialValue)
     : m_type(SmartType_Null),
       m_schema() {
@@ -289,9 +280,6 @@ bool SmartObject::operator==(const int64_t Value) const {
   return comp == Value;
 }
 
-// =============================================================
-// uint64_t TYPE SUPPORT
-// =============================================================
 SmartObject& SmartObject::operator=(const uint64_t NewValue) {
   if (m_type != SmartType_Invalid) {
     set_value_integer(NewValue);
@@ -299,9 +287,6 @@ SmartObject& SmartObject::operator=(const uint64_t NewValue) {
   return *this;
 }
 
-// =============================================================
-// DOUBLE TYPE SUPPORT
-// =============================================================
 SmartObject::SmartObject(double InitialValue)
     : m_type(SmartType_Null),
       m_schema() {
@@ -349,10 +334,6 @@ double SmartObject::convert_double() const {
   return invalid_double_value;
 }
 
-// =============================================================
-// BOOL TYPE SUPPORT
-// =============================================================
-
 SmartObject::SmartObject(bool InitialValue)
     : m_type(SmartType_Null),
       m_schema() {
@@ -399,10 +380,6 @@ bool SmartObject::convert_bool() const {
   return invalid_bool_value;
 }
 
-// =============================================================
-// CHAR TYPE SUPPORT
-// =============================================================
-
 SmartObject::SmartObject(char InitialValue)
     : m_type(SmartType_Null),
       m_schema() {
@@ -447,10 +424,6 @@ char SmartObject::convert_char() const {
   }
   return invalid_char_value;
 }
-
-// =============================================================
-// STD::STRING TYPE SUPPORT
-// =============================================================
 
 SmartObject::SmartObject(const std::string& InitialValue)
     : m_type(SmartType_Null),
@@ -509,10 +482,6 @@ std::string SmartObject::convert_string() const {
   return NsSmartDeviceLink::NsSmartObjects::invalid_cstr_value;
 }
 
-// =============================================================
-// CHAR* TYPE SUPPORT
-// =============================================================
-
 SmartObject::SmartObject(const char* const InitialValue)
     : m_type(SmartType_Null),
       m_schema() {
@@ -540,9 +509,6 @@ void SmartObject::set_value_cstr(const char* NewValue) {
   set_value_string(NewValue ? std::string(NewValue) : std::string());
 }
 
-// =============================================================
-// BINARY TYPE SUPPORT
-// =============================================================
 SmartObject::SmartObject(const SmartBinary& InitialValue)
     : m_type(SmartType_Null),
       m_schema() {
@@ -593,10 +559,6 @@ SmartBinary SmartObject::convert_binary() const {
   return invalid_binary_value;
 }
 
-// =============================================================
-// ARRAY INTERFACE SUPPORT
-// =============================================================
-
 SmartObject& SmartObject::operator[](const int32_t Index) {
   return handle_array_access(Index);
 }
@@ -627,10 +589,6 @@ inline SmartObject& SmartObject::handle_array_access(const int32_t Index) {
   // FIXME(EZamakhov): return always the same reference - multi-thread problem?
   return invalid_object_value;
 }
-
-// =============================================================
-// MAP INTERFACE SUPPORT
-// =============================================================
 
 SmartObject& SmartObject::operator[](const std::string& Key) {
   return handle_map_access(Key);
@@ -690,9 +648,6 @@ SmartObject& SmartObject::handle_map_access(const std::string& Key) {
   return map[Key];
 }
 
-// =============================================================
-// OTHER METHODS
-// =============================================================
 void SmartObject::duplicate(const SmartObject& OtherObject) {
   SmartData newData;
   const SmartType newType = OtherObject.m_type;

--- a/src/components/smart_objects/src/smart_object.cc
+++ b/src/components/smart_objects/src/smart_object.cc
@@ -244,7 +244,7 @@ SmartObject::SmartObject(uint32_t InitialValue)
 uint64_t SmartObject::asUInt() const {
   const int64_t convert = convert_int();
   if (convert <= invalid_int_value) {
-      return invalid_unsigned_int_value;
+    return invalid_unsigned_int_value;
   }
   return static_cast<uint64_t>(convert);
 }
@@ -298,7 +298,6 @@ SmartObject& SmartObject::operator=(const uint64_t NewValue) {
   }
   return *this;
 }
-
 
 // =============================================================
 // DOUBLE TYPE SUPPORT

--- a/src/components/utils/CMakeLists.txt
+++ b/src/components/utils/CMakeLists.txt
@@ -56,6 +56,7 @@ set (SOURCES
     ${UTILS_SRC_DIR}/resource_usage.cc
     ${UTILS_SRC_DIR}/appenders_loader.cc
     ${UTILS_SRC_DIR}/gen_hash.cc
+    ${UTILS_SRC_DIR}/convert_utils.cc
 )
 
 if(ENABLE_LOG)

--- a/src/components/utils/include/utils/convert_utils.h
+++ b/src/components/utils/include/utils/convert_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,14 +37,28 @@
 
 namespace utils {
 
+/**
+ * Convert int64 value to long long int value
+ * Using when int64 value should be assign to JSON value
+ */
 long long int ConvertInt64ToLongLongInt(const int64_t value);
 
-int64_t ConvertLongLongIntToInt64(long long int value);
+/**
+ * Convert long long int value to int64 value
+ */
+int64_t ConvertLongLongIntToInt64(const long long int value);
 
-unsigned long long int ConvertUInt64ToLongLongUInt(uint64_t value);
+/**
+ * Convert uint64 value to unsigned long long int value
+ * Using when uint64 value should be assign to JSON value
+ */
+unsigned long long int ConvertUInt64ToLongLongUInt(const uint64_t value);
 
-uint64_t ConvertLongLongUIntToUInt64(unsigned long long int value);
+/**
+ * Convert unsigned long long int value to uint64 value
+ */
+uint64_t ConvertLongLongUIntToUInt64(const unsigned long long int value);
 
 }  // namespace utils
 
-#endif // SRC_COMPONENTS_UTILS_INCLUDE_UTILS_CONVERT_UTILS_H_
+#endif  // SRC_COMPONENTS_UTILS_INCLUDE_UTILS_CONVERT_UTILS_H_

--- a/src/components/utils/include/utils/convert_utils.h
+++ b/src/components/utils/include/utils/convert_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Ford Motor Company
+ * Copyright (c) 2015, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,26 +30,21 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "time_tester/application_manager_metric.h"
-#include "time_tester/json_keys.h"
-#include "application_manager/smart_object_keys.h"
-#include "utils/convert_utils.h"
+#ifndef SRC_COMPONENTS_UTILS_INCLUDE_UTILS_CONVERT_UTILS_H_
+#define SRC_COMPONENTS_UTILS_INCLUDE_UTILS_CONVERT_UTILS_H_
 
-namespace time_tester {
+#include <stdint.h>
 
-Json::Value ApplicationManagerMetricWrapper::GetJsonMetric() {
-  Json::Value result = MetricWrapper::GetJsonMetric();
-  result[strings::logger] = "ApplicationManager";
-  result[strings::begin] =
-      Json::Int64(date_time::DateTime::getuSecs(message_metric->begin));
-  result[strings::end] =
-      Json::Int64(date_time::DateTime::getuSecs(message_metric->end));
-  const NsSmartDeviceLink::NsSmartObjects::SmartObject& params =
-      message_metric->message->getElement(application_manager::strings::params);
-  result[strings::correlation_id] = utils::ConvertInt64ToLongLongInt(
-      params[application_manager::strings::correlation_id].asInt());
-  result[strings::connection_key] = utils::ConvertInt64ToLongLongInt(
-      params[application_manager::strings::connection_key].asInt());
-  return result;
-}
-}  // namespace time_tester
+namespace utils {
+
+long long int ConvertInt64ToLongLongInt(const int64_t value);
+
+int64_t ConvertLongLongIntToInt64(long long int value);
+
+unsigned long long int ConvertUInt64ToLongLongUInt(uint64_t value);
+
+uint64_t ConvertLongLongUIntToUInt64(unsigned long long int value);
+
+}  // namespace utils
+
+#endif // SRC_COMPONENTS_UTILS_INCLUDE_UTILS_CONVERT_UTILS_H_

--- a/src/components/utils/include/utils/convert_utils.h
+++ b/src/components/utils/include/utils/convert_utils.h
@@ -34,6 +34,7 @@
 #define SRC_COMPONENTS_UTILS_INCLUDE_UTILS_CONVERT_UTILS_H_
 
 #include <stdint.h>
+#include <limits>
 
 namespace utils {
 
@@ -58,6 +59,19 @@ unsigned long long int ConvertUInt64ToLongLongUInt(const uint64_t value);
  * Convert unsigned long long int value to uint64 value
  */
 uint64_t ConvertLongLongUIntToUInt64(const unsigned long long int value);
+
+
+/**
+ * Convert one number value to another type value
+ */
+template <typename InputType, typename OutputType>
+OutputType SafeStaticCast(const InputType value) {
+  DCHECK_OR_RETURN(value >= std::numeric_limits<OutputType>::min(),
+                   std::numeric_limits<OutputType>::min());
+  DCHECK_OR_RETURN(value <= std::numeric_limits<OutputType>::max(),
+                   std::numeric_limits<OutputType>::max());
+  return static_cast<OutputType>(value);
+}
 
 }  // namespace utils
 

--- a/src/components/utils/src/convert_utils.cc
+++ b/src/components/utils/src/convert_utils.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,7 +40,7 @@ long long int utils::ConvertInt64ToLongLongInt(const int64_t value) {
   return static_cast<long long int>(value);
 }
 
-int64_t utils::ConvertLongLongIntToInt64(long long int value) {
+int64_t utils::ConvertLongLongIntToInt64(const long long int value) {
   DCHECK_OR_RETURN(
       value >= std::numeric_limits<int64_t>::min(),
       std::min<int64_t>(value, std::numeric_limits<int64_t>::min()));
@@ -50,11 +50,11 @@ int64_t utils::ConvertLongLongIntToInt64(long long int value) {
   return static_cast<int64_t>(value);
 }
 
-unsigned long long int utils::ConvertUInt64ToLongLongUInt(uint64_t value) {
+unsigned long long int utils::ConvertUInt64ToLongLongUInt(const uint64_t value) {
   return static_cast<unsigned long long int>(value);
 }
 
-uint64_t utils::ConvertLongLongUIntToUInt64(unsigned long long int value) {
+uint64_t utils::ConvertLongLongUIntToUInt64(const unsigned long long int value) {
   DCHECK_OR_RETURN(
       value >= std::numeric_limits<uint64_t>::min(),
       std::min<uint64_t>(value, std::numeric_limits<uint64_t>::min()));

--- a/src/components/utils/src/convert_utils.cc
+++ b/src/components/utils/src/convert_utils.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Ford Motor Company
+ * Copyright (c) 2015, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,26 +30,36 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "time_tester/application_manager_metric.h"
-#include "time_tester/json_keys.h"
-#include "application_manager/smart_object_keys.h"
 #include "utils/convert_utils.h"
+#include <stdint.h>
+#include <limits>
+#include <algorithm>
+#include "utils/macro.h"
 
-namespace time_tester {
-
-Json::Value ApplicationManagerMetricWrapper::GetJsonMetric() {
-  Json::Value result = MetricWrapper::GetJsonMetric();
-  result[strings::logger] = "ApplicationManager";
-  result[strings::begin] =
-      Json::Int64(date_time::DateTime::getuSecs(message_metric->begin));
-  result[strings::end] =
-      Json::Int64(date_time::DateTime::getuSecs(message_metric->end));
-  const NsSmartDeviceLink::NsSmartObjects::SmartObject& params =
-      message_metric->message->getElement(application_manager::strings::params);
-  result[strings::correlation_id] = utils::ConvertInt64ToLongLongInt(
-      params[application_manager::strings::correlation_id].asInt());
-  result[strings::connection_key] = utils::ConvertInt64ToLongLongInt(
-      params[application_manager::strings::connection_key].asInt());
-  return result;
+long long int utils::ConvertInt64ToLongLongInt(const int64_t value) {
+  return static_cast<long long int>(value);
 }
-}  // namespace time_tester
+
+int64_t utils::ConvertLongLongIntToInt64(long long int value) {
+  if (value <= std::numeric_limits<int64_t>::min()) {
+    return std::min<int64_t>(value, std::numeric_limits<int64_t>::min());
+  }
+  if (value >= std::numeric_limits<int64_t>::max()) {
+    return std::max<int64_t>(value, std::numeric_limits<int64_t>::max());
+  }
+  return static_cast<int64_t>(value);
+}
+
+unsigned long long int utils::ConvertUInt64ToLongLongUInt(uint64_t value) {
+  return static_cast<unsigned long long int>(value);
+}
+
+uint64_t utils::ConvertLongLongUIntToUInt64(unsigned long long int value) {
+  if (value <= std::numeric_limits<uint64_t>::min()) {
+    return std::min<uint64_t>(value, std::numeric_limits<uint64_t>::min());
+  }
+  if (value >= std::numeric_limits<uint64_t>::max()) {
+    return std::max<uint64_t>(value, std::numeric_limits<uint64_t>::max());
+  }
+  return static_cast<uint64_t>(value);
+}

--- a/src/components/utils/src/convert_utils.cc
+++ b/src/components/utils/src/convert_utils.cc
@@ -37,6 +37,8 @@
 #include "utils/macro.h"
 
 long long int utils::ConvertInt64ToLongLongInt(const int64_t value) {
+  DCHECK(value >= std::numeric_limits<long long int>::min());
+  DCHECK(value <= std::numeric_limits<long long int>::max());
   return static_cast<long long int>(value);
 }
 
@@ -51,6 +53,8 @@ int64_t utils::ConvertLongLongIntToInt64(const long long int value) {
 }
 
 unsigned long long int utils::ConvertUInt64ToLongLongUInt(const uint64_t value) {
+  DCHECK(value >= std::numeric_limits<unsigned long long int>::min());
+  DCHECK(value <= std::numeric_limits<unsigned long long int>::max());
   return static_cast<unsigned long long int>(value);
 }
 

--- a/src/components/utils/src/convert_utils.cc
+++ b/src/components/utils/src/convert_utils.cc
@@ -41,12 +41,12 @@ long long int utils::ConvertInt64ToLongLongInt(const int64_t value) {
 }
 
 int64_t utils::ConvertLongLongIntToInt64(long long int value) {
-  if (value <= std::numeric_limits<int64_t>::min()) {
-    return std::min<int64_t>(value, std::numeric_limits<int64_t>::min());
-  }
-  if (value >= std::numeric_limits<int64_t>::max()) {
-    return std::max<int64_t>(value, std::numeric_limits<int64_t>::max());
-  }
+  DCHECK_OR_RETURN(
+      value >= std::numeric_limits<int64_t>::min(),
+      std::min<int64_t>(value, std::numeric_limits<int64_t>::min()));
+  DCHECK_OR_RETURN(
+      value <= std::numeric_limits<int64_t>::max(),
+      std::max<int64_t>(value, std::numeric_limits<int64_t>::max()));
   return static_cast<int64_t>(value);
 }
 
@@ -55,11 +55,12 @@ unsigned long long int utils::ConvertUInt64ToLongLongUInt(uint64_t value) {
 }
 
 uint64_t utils::ConvertLongLongUIntToUInt64(unsigned long long int value) {
-  if (value <= std::numeric_limits<uint64_t>::min()) {
-    return std::min<uint64_t>(value, std::numeric_limits<uint64_t>::min());
-  }
-  if (value >= std::numeric_limits<uint64_t>::max()) {
-    return std::max<uint64_t>(value, std::numeric_limits<uint64_t>::max());
-  }
+  DCHECK_OR_RETURN(
+      value >= std::numeric_limits<uint64_t>::min(),
+      std::min<uint64_t>(value, std::numeric_limits<uint64_t>::min()));
+  DCHECK_OR_RETURN(
+      value <= std::numeric_limits<uint64_t>::max(),
+      std::max<uint64_t>(value, std::numeric_limits<uint64_t>::max()));
+
   return static_cast<uint64_t>(value);
 }


### PR DESCRIPTION
Smart Object now returns 64bit integer instead of 32bit.
Added assignment operator for Json value with 64bit (long long int) numbers.
Added getter for Json value.
Added functions for converting int64 to long long int and back
Removed calls asInt64() as duplicate of getter asInt().