### PR TITLE
Hotfix/fix of ignition counter handling

### DIFF
--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -423,6 +423,14 @@ class ResumeCtrl: public app_mngr::event_engine::EventObserver {
   void LoadResumeData();
 
   /**
+   * @brief Checks, if application data needs to be resumed
+   * @param application Application data from storage
+   * @return true, if data resumption must be skipped, otherwise - false
+   */
+  bool IsAppDataResumptionExpired(
+          const smart_objects::SmartObject& application) const;
+
+  /**
    *@brief Mapping applications to time_stamps
    *       wait for timer to resume HMI Level
    *

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data.h
@@ -183,9 +183,18 @@ class ResumptionData {
                               mobile_apis::HMILevel::eType hmi_level) = 0;
 
   /**
-   * @brief Uses for overload on heir classes
+   * @brief Init storage
    */
   virtual bool Init();
+
+  /**
+   * @brief Drops data related to applicaton data resumption
+   * @param device_id Device ID
+   * @param app_id Application ID
+   * @return true, if dropped successfully, otherwise - false
+   */
+  virtual bool DropAppDataResumption(const std::string& device_id,
+                                     const std::string& app_id) = 0;
 
  protected:
   /**

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
@@ -824,6 +824,17 @@ class ResumptionDataDB : public ResumptionData {
    */
   utils::dbms::SQLDatabase* db() const;
 
+  /**
+   * @brief Updates grammarID for application
+   * @param policy_app_id Application ID
+   * @param device_id Device ID
+   * @param grammar_id GrammarID
+   * @return true if succedeed, otherwise - false
+   */
+  bool UpdateGrammarID(const std::string& policy_app_id,
+                       const std::string& device_id,
+                       const uint32_t grammar_id);
+
   DISALLOW_COPY_AND_ASSIGN(ResumptionDataDB);
 
   utils::dbms::SQLDatabase* db_;

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
@@ -232,6 +232,9 @@ class ResumptionDataDB : public ResumptionData {
    */
   bool UpdateDBVersion() const;
 
+  bool DropAppDataResumption(const std::string& device_id,
+                             const std::string& app_id) OVERRIDE;
+
  private:
   /**
    * @brief Calculates DB version from current schema

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_json.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_json.h
@@ -179,6 +179,9 @@ class ResumptionDataJson : public ResumptionData {
 
   virtual bool Init();
 
+  bool DropAppDataResumption(const std::string& device_id,
+                             const std::string& app_id) OVERRIDE;
+
  private:
   /**
    * @brief GetFromSavedOrAppend allows to get existed record about application

--- a/src/components/application_manager/include/application_manager/resumption/resumption_sql_queries.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_sql_queries.h
@@ -129,6 +129,7 @@ extern const std::string kSelectAllApps;
 extern const std::string kUpdateApplicationData;
 extern const std::string kSelectDBVersion;
 extern const std::string kUpdateDBVersion;
+extern const std::string kUpdateGrammarID;
 }  // namespace resumption
 
 #endif  //  SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_RESUMPTION_SQL_QUERY_H_

--- a/src/components/application_manager/src/resumption/resume_ctrl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl.cc
@@ -731,7 +731,7 @@ void ResumeCtrl::LoadResumeData() {
     if (IsAppDataResumptionExpired(application)) {
       const std::string device_id = application[strings::device_id].asString();
       const std::string app_id = application[strings::app_id].asString();
-      LOG4CXX_DEBUG(logger_, "Data resumption is expired.");
+      LOG4CXX_INFO(logger_, "Data resumption is expired.");
       LOG4CXX_DEBUG(logger_, "Resumption data for application " << app_id
                     << " and device id " << device_id
                     << " will be dropped.");

--- a/src/components/application_manager/src/resumption/resume_ctrl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl.cc
@@ -726,50 +726,25 @@ void ResumeCtrl::LoadResumeData() {
   smart_objects::SmartObject so_applications_data;
   resumption_storage_->GetDataForLoadResumeData(so_applications_data);
   size_t length = so_applications_data.length();
-  smart_objects::SmartObject* full_app = NULL;
-  smart_objects::SmartObject* limited_app = NULL;
-  time_t time_stamp_full = 0;
-  time_t time_stamp_limited = 0;
-  // only apps with first IGN should be resumed
-  const int32_t first_ign = 1;
   for (size_t i = 0; i < length; ++i) {
-    if (first_ign == so_applications_data[i][strings::ign_off_count].asInt()) {
-      const mobile_apis::HMILevel::eType saved_hmi_level =
-          static_cast<mobile_apis::HMILevel::eType>(
-              so_applications_data[i][strings::hmi_level].asInt());
-      const time_t saved_time_stamp = static_cast<time_t>(
-          so_applications_data[i][strings::time_stamp].asUInt());
-      if (mobile_apis::HMILevel::HMI_FULL == saved_hmi_level) {
-        if (time_stamp_full < saved_time_stamp) {
-          time_stamp_full = saved_time_stamp;
-          full_app = &(so_applications_data[i]);
-        }
-      }
-      if (mobile_apis::HMILevel::HMI_LIMITED == saved_hmi_level) {
-        if (time_stamp_limited < saved_time_stamp) {
-          time_stamp_limited = saved_time_stamp;
-          limited_app = &(so_applications_data[i]);
-        }
-      }
+    smart_objects::SmartObject& application = so_applications_data[i];
+    if (IsAppDataResumptionExpired(application)) {
+      const std::string device_id = application[strings::device_id].asString();
+      const std::string app_id = application[strings::app_id].asString();
+      LOG4CXX_DEBUG(logger_, "Data resumption is expired.");
+      LOG4CXX_DEBUG(logger_, "Resumption data for application " << app_id
+                    << " and device id " << device_id
+                    << " will be dropped.");
+      resumption_storage_->DropAppDataResumption(device_id, app_id);
+      continue;
     }
-    // set invalid HMI level for all
-    resumption_storage_->UpdateHmiLevel(
-        so_applications_data[i][strings::app_id].asString(),
-        so_applications_data[i][strings::device_id].asString(),
-        mobile_apis::HMILevel::INVALID_ENUM);
   }
-  if (full_app != NULL) {
-    resumption_storage_->UpdateHmiLevel(
-        (*full_app)[strings::app_id].asString(),
-        (*full_app)[strings::device_id].asString(),
-        mobile_apis::HMILevel::HMI_FULL);
-  }
-  if (limited_app != NULL) {
-    resumption_storage_->UpdateHmiLevel(
-        (*limited_app)[strings::app_id].asString(),
-        (*limited_app)[strings::device_id].asString(),
-        mobile_apis::HMILevel::HMI_LIMITED);
-  }
+}
+
+bool ResumeCtrl::IsAppDataResumptionExpired(
+    const smart_objects::SmartObject& application) const {
+  const int32_t max_ign_off_count = 3;
+  return max_ign_off_count <= application[strings::ign_off_count].asInt();
 }
 
 }  // namespce resumption

--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -39,6 +39,7 @@
 #include "application_manager/message_helper.h"
 #include "utils/helpers.h"
 #include "utils/gen_hash.h"
+#include "utils/scope_guard.h"
 
 namespace {
 const std::string kDatabaseName = "resumption";
@@ -754,36 +755,36 @@ bool ResumptionDataDB::UpdateDBVersion() const {
 bool ResumptionDataDB::DropAppDataResumption(const std::string& device_id,
                                              const std::string& app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
+
+  utils::ScopeGuard guard = utils::MakeObjGuard(
+                              *db_,
+                              &utils::dbms::SQLDatabase::RollbackTransaction);
+
   db_->BeginTransaction();
   if (!DeleteSavedFiles(app_id, device_id)) {
-    db_->RollbackTransaction();
     return false;
   }
   if (!DeleteSavedSubMenu(app_id, device_id)) {
-    db_->RollbackTransaction();
     return false;
   }
   if (!DeleteSavedSubscriptions(app_id, device_id)) {
-    db_->RollbackTransaction();
     return false;
   }
   if (!DeleteSavedCommands(app_id, device_id)) {
-    db_->RollbackTransaction();
     return false;
   }
   if (!DeleteSavedChoiceSet(app_id, device_id)) {
-    db_->RollbackTransaction();
     return false;
   }
   if (!DeleteSavedGlobalProperties(app_id, device_id)) {
-    db_->RollbackTransaction();
     return false;
   }
   if(!UpdateGrammarID(app_id, device_id, 0)) {
-    db_->RollbackTransaction();
     return false;
   }
   db_->CommitTransaction();
+
+  guard.Dismiss();
   return true;
 }
 
@@ -1459,36 +1460,36 @@ bool ResumptionDataDB::SelectCountFromArray(
 bool ResumptionDataDB::DeleteSavedApplication(const std::string& policy_app_id,
                                               const std::string& device_id) {
   LOG4CXX_AUTO_TRACE(logger_);
+
+  utils::ScopeGuard guard = utils::MakeObjGuard(
+                              *db_,
+                              &utils::dbms::SQLDatabase::RollbackTransaction);
+
   db_->BeginTransaction();
   if (!DeleteSavedFiles(policy_app_id, device_id)) {
-    db_->RollbackTransaction();
     return false;
   }
   if (!DeleteSavedSubMenu(policy_app_id, device_id)) {
-    db_->RollbackTransaction();
     return false;
   }
   if (!DeleteSavedSubscriptions(policy_app_id, device_id)) {
-    db_->RollbackTransaction();
     return false;
   }
   if (!DeleteSavedCommands(policy_app_id, device_id)) {
-    db_->RollbackTransaction();
     return false;
   }
   if (!DeleteSavedChoiceSet(policy_app_id, device_id)) {
-    db_->RollbackTransaction();
     return false;
   }
   if (!DeleteSavedGlobalProperties(policy_app_id, device_id)) {
-    db_->RollbackTransaction();
     return false;
   }
   if (!DeleteDataFromApplicationTable(policy_app_id, device_id)) {
-    db_->RollbackTransaction();
     return false;
   }
   db_->CommitTransaction();
+
+  guard.Dismiss();
   return true;
 }
 

--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -751,6 +751,39 @@ bool ResumptionDataDB::UpdateDBVersion() const {
   return true;
 }
 
+bool ResumptionDataDB::DropAppDataResumption(const std::string& device_id,
+                                             const std::string& app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  db_->BeginTransaction();
+  if (!DeleteSavedFiles(app_id, device_id)) {
+    db_->RollbackTransaction();
+    return false;
+  }
+  if (!DeleteSavedSubMenu(app_id, device_id)) {
+    db_->RollbackTransaction();
+    return false;
+  }
+  if (!DeleteSavedSubscriptions(app_id, device_id)) {
+    db_->RollbackTransaction();
+    return false;
+  }
+  if (!DeleteSavedCommands(app_id, device_id)) {
+    db_->RollbackTransaction();
+    return false;
+  }
+  if (!DeleteSavedChoiceSet(app_id, device_id)) {
+    db_->RollbackTransaction();
+    return false;
+  }
+  if (!DeleteSavedGlobalProperties(app_id, device_id)) {
+    db_->RollbackTransaction();
+    return false;
+  }
+  //TODO(AOleynik): add removal of grammar id
+  db_->CommitTransaction();
+  return true;
+}
+
 const int32_t ResumptionDataDB::GetDBVersion() const {
   return utils::Djb2HashFromString(resumption::kCreateSchema);
 }

--- a/src/components/application_manager/src/resumption/resumption_data_json.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_json.cc
@@ -195,11 +195,13 @@ void ResumptionDataJson::OnSuspend() {
       (*it)[strings::suspend_count] = 1;
     }
     if ((*it).isMember(strings::ign_off_count)) {
-      const uint32_t ign_off_count = (*it)[strings::ign_off_count].asUInt();
-      (*it)[strings::ign_off_count] = ign_off_count + 1;
+      Json::Value& ign_off_count = (*it)[strings::ign_off_count];
+      const uint32_t counter_value = ign_off_count.asUInt();
+      ign_off_count = counter_value + 1;
     } else {
       LOG4CXX_WARN(logger_, "Unknown key among saved applications");
-      (*it)[strings::ign_off_count] = 1;
+      Json::Value& ign_off_count = (*it)[strings::ign_off_count];
+      ign_off_count = 1;
     }
     to_save.append(*it);
   }
@@ -495,8 +497,9 @@ bool ResumptionDataJson::DropAppDataResumption(const std::string& device_id,
                                                const std::string& app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace app_mngr;
+  sync_primitives::AutoLock autolock(resumption_lock_);
   Json::Value& application = GetFromSavedOrAppend(app_id, device_id);
-  if (Json::Value() == application) {
+  if (application.isNull()) {
     LOG4CXX_DEBUG(logger_, "Application " << app_id << " with device_id "
                   << device_id << " hasn't been found in resumption data.");
     return false;

--- a/src/components/application_manager/src/resumption/resumption_sql_queries.cc
+++ b/src/components/application_manager/src/resumption/resumption_sql_queries.cc
@@ -959,4 +959,9 @@ const std::string kSelectDBVersion =
 const std::string kUpdateDBVersion =
     "UPDATE `_internal_data` SET `db_version_hash` = ? ; ";
 
+const std::string kUpdateGrammarID =
+    "UPDATE `application` "
+    "SET `grammarID` = ? "
+    "WHERE `appID` = ? AND `deviceID` = ?;";
+
 }  // namespace resumption

--- a/src/components/application_manager/test/resumption/include/resumption_data_mock.h
+++ b/src/components/application_manager/test/resumption/include/resumption_data_mock.h
@@ -77,6 +77,8 @@ class ResumptionDataMock : public ::resumption::ResumptionData {
                                     const std::string& device_id,
                                     mobile_apis::HMILevel::eType hmi_level));
   MOCK_METHOD0(Init, bool());
+  MOCK_METHOD2(DropAppDataResumption, bool(const std::string& device_id,
+                                           const std::string& app_id));
 };
 
 }  // namespace resumption_test


### PR DESCRIPTION
Ignition off counter in resumption data should specify number of ignition cycles passed. According to its value data resumption should happen (if less than 3), otherwise data resumption must be skipped and related data should be dropped.