### PR TITLE
Fixes issue with RAI execution after connection is dropped

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2397,6 +2397,12 @@ void ApplicationManagerImpl::UnregisterApplication(
     }
     if (!app_to_remove) {
       LOG4CXX_ERROR(logger_, "Cant find application with app_id = " << app_id);
+
+      // Just to terminate RAI in case of connection is dropped (rare case)
+      // App won't be unregistered since RAI has not been started yet
+      LOG4CXX_DEBUG(logger_, "Trying to terminate possible RAI request.");
+      request_ctrl_.terminateAppRequests(app_id);
+
       return;
     }
     accessor.Erase(app_to_remove);


### PR DESCRIPTION
There is possible rare case, when connection is dropped right after RAI
is received by SDL, but not started yet. SDL has to drop that request,
otherwise app will register, but won't have any valid connection and
will prevent same app re-registration from valid connections.

Fixes: APPLINK-20521