### PR TITLE
DialNubmerRequest send "info" fix

### DIFF
--- a/src/components/application_manager/src/commands/mobile/dial_number_request.cc
+++ b/src/components/application_manager/src/commands/mobile/dial_number_request.cc
@@ -115,7 +115,18 @@ void DialNumberRequest::on_event(const event_engine::Event& event) {
     }
   }
 
-  SendResponse((mobile_apis::Result::SUCCESS == result_code), result_code);
+  const bool is_success = mobile_apis::Result::SUCCESS == result_code;
+  const bool is_info_valid =
+      message[strings::msg_params].keyExists(strings::info);
+
+  if (is_info_valid) {
+    const char* info_char_array =
+        message[strings::msg_params][strings::info].asCharArray();
+    SendResponse(is_success, result_code, info_char_array);
+    return;
+  }
+
+  SendResponse(is_success, result_code);
 }
 
 void DialNumberRequest::StripNumberParam(std::string &number) {


### PR DESCRIPTION
SDL mush send response with info field which was gotten from HMI.
Fix add this sending. 

Reviewed in : https://github.com/CustomSDL/sdl_panasonic/pull/160