### PR TITLE
Implementing refactoring of EventDispatcher

### DIFF
--- a/src/components/application_manager/include/application_manager/event_engine/event.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event.h
@@ -141,7 +141,7 @@ int32_t Event::smart_object_type() const {
         strings::params).getElement(strings::message_type).asInt();
 }
 
-} // namespace event_engine
-} // namespace application_manager
+}  // namespace event_engine
+}  // namespace application_manager
 
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_H_

--- a/src/components/application_manager/include/application_manager/event_engine/event.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event.h
@@ -141,7 +141,7 @@ int32_t Event::smart_object_type() const {
         strings::params).getElement(strings::message_type).asInt();
 }
 
-}
-}
+} // namespace event_engine
+} // namespace application_manager
 
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_H_

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher.h
@@ -85,7 +85,7 @@ class EventDispatcher {
   };
 };
 
-}
-}
+} // namespace event_engine
+} // namespace application_manager
 
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_DISPATCHER_H_

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher.h
@@ -88,11 +88,6 @@ class EventDispatcher {
    */
   virtual ~EventDispatcher() {
   };
-
- protected:
-
- private:
-
 };
 
 }

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher.h
@@ -85,7 +85,7 @@ class EventDispatcher {
   };
 };
 
-} // namespace event_engine
-} // namespace application_manager
+}  // namespace event_engine
+}  // namespace application_manager
 
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_DISPATCHER_H_

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher.h
@@ -34,11 +34,6 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_DISPATCHER_H_
 
 #include <list>
-#include <map>
-
-#include "utils/lock.h"
-#include "utils/singleton.h"
-
 #include "application_manager/event_engine/event.h"
 
 namespace application_manager {

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
@@ -30,8 +30,8 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_DISPATCHER_H_
-#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_DISPATCHER_H_
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_DISPATCHER_IMPL_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_DISPATCHER_IMPL_H_
 
 #include <list>
 #include <map>
@@ -40,13 +40,15 @@
 #include "utils/singleton.h"
 
 #include "application_manager/event_engine/event.h"
+#include "application_manager/event_engine/event_dispatcher.h"
 
 namespace application_manager {
 namespace event_engine {
 
 class EventObserver;
 
-class EventDispatcher {
+class EventDispatcherImpl : public EventDispatcher,
+  public utils::Singleton<EventDispatcherImpl> {
  public:
 
   /*
@@ -54,7 +56,7 @@ class EventDispatcher {
    *
    * @param event Received event
    */
-  virtual void raise_event(const Event& event) = 0;
+  virtual void raise_event(const Event& event);
 
   /*
    * @brief Subscribe the observer to event
@@ -65,7 +67,7 @@ class EventDispatcher {
    */
   virtual void add_observer(const Event::EventID& event_id,
                     int32_t hmi_correlation_id,
-                    EventObserver* const observer) = 0;
+                    EventObserver* const observer);
 
   /*
    * @brief Unsubscribes the observer from specific event
@@ -74,28 +76,54 @@ class EventDispatcher {
    * @param observer    The observer to be unsubscribed
    */
   virtual void remove_observer(const Event::EventID& event_id,
-                       EventObserver* const observer) = 0;
+                       EventObserver* const observer);
 
   /*
    * @brief Unsubscribes the observer from all events
    *
    * @param observer  The observer to be unsubscribed
    */
-  virtual void remove_observer(EventObserver* const observer) = 0;
+  virtual void remove_observer(EventObserver* const observer);
 
   /*
    * @brief Destructor
    */
-  virtual ~EventDispatcher() {
-  };
+ virtual ~EventDispatcherImpl();
 
  protected:
 
  private:
+
+  /*
+   * @brief Default constructor
+   */
+  EventDispatcherImpl();
+
+  /*
+   * @brief removes observer
+   * when occurs unsubscribe from event
+   * @param observer to be removed
+   */
+  void remove_observer_from_list(EventObserver* const observer);
+
+  DISALLOW_COPY_AND_ASSIGN(EventDispatcherImpl);
+
+  FRIEND_BASE_SINGLETON_CLASS(EventDispatcherImpl);
+
+  // Data types section
+  typedef std::list<EventObserver*>                   ObserverList;
+  typedef std::map<int32_t, ObserverList>             ObserversMap;
+  typedef std::map<Event::EventID, ObserversMap>      EventObserverMap;
+
+  // Members section
+  sync_primitives::Lock                               state_lock_;
+  sync_primitives::Lock                               observer_list_lock_;
+  EventObserverMap                                    observers_;
+  ObserverList                                        observers_list_;
 
 };
 
 }
 }
 
-#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_DISPATCHER_H_
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_DISPATCHER_IMPL_H_

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
@@ -90,8 +90,6 @@ class EventDispatcherImpl : public EventDispatcher,
    */
  virtual ~EventDispatcherImpl();
 
- protected:
-
  private:
 
   /*
@@ -122,6 +120,7 @@ class EventDispatcherImpl : public EventDispatcher,
   ObserverVector                                      observers_vector_;
 
 };
+
 
 }
 }

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
@@ -122,7 +122,7 @@ class EventDispatcherImpl : public EventDispatcher,
 };
 
 
-}
-}
+} // namespace event_engine
+} // namespace application_manager
 
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_DISPATCHER_IMPL_H_

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
@@ -121,8 +121,7 @@ class EventDispatcherImpl : public EventDispatcher,
 
 };
 
-
-} // namespace event_engine
-} // namespace application_manager
+}  // namespace event_engine
+}  // namespace application_manager
 
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_DISPATCHER_IMPL_H_

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_DISPATCHER_IMPL_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_DISPATCHER_IMPL_H_
 
-#include <list>
+#include <vector>
 #include <map>
 
 #include "utils/lock.h"
@@ -104,22 +104,22 @@ class EventDispatcherImpl : public EventDispatcher,
    * when occurs unsubscribe from event
    * @param observer to be removed
    */
-  void remove_observer_from_list(EventObserver* const observer);
+  void remove_observer_from_vector(EventObserver* const observer);
 
   DISALLOW_COPY_AND_ASSIGN(EventDispatcherImpl);
 
   FRIEND_BASE_SINGLETON_CLASS(EventDispatcherImpl);
 
   // Data types section
-  typedef std::list<EventObserver*>                   ObserverList;
-  typedef std::map<int32_t, ObserverList>             ObserversMap;
+  typedef std::vector<EventObserver*>                 ObserverVector;
+  typedef std::map<int32_t, ObserverVector>           ObserversMap;
   typedef std::map<Event::EventID, ObserversMap>      EventObserverMap;
 
   // Members section
   sync_primitives::Lock                               state_lock_;
-  sync_primitives::Lock                               observer_list_lock_;
+  sync_primitives::Lock                               observer_vec_lock_;
   EventObserverMap                                    observers_;
-  ObserverList                                        observers_list_;
+  ObserverVector                                      observers_vector_;
 
 };
 

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
@@ -116,8 +116,8 @@ class EventDispatcherImpl : public EventDispatcher,
   // Members section
   sync_primitives::Lock                               state_lock_;
   sync_primitives::Lock                               observer_lock_;
-  EventObserverMap                                    observers_event;
-  ObserverVector                                      observers;
+  EventObserverMap                                    observers_event_;
+  ObserverVector                                      observers_;
 
 };
 

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
@@ -115,9 +115,9 @@ class EventDispatcherImpl : public EventDispatcher,
 
   // Members section
   sync_primitives::Lock                               state_lock_;
-  sync_primitives::Lock                               observer_vec_lock_;
-  EventObserverMap                                    observers_;
-  ObserverVector                                      observers_vector_;
+  sync_primitives::Lock                               observer_lock_;
+  EventObserverMap                                    observers_event;
+  ObserverVector                                      observers;
 
 };
 

--- a/src/components/application_manager/include/application_manager/event_engine/event_observer.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_observer.h
@@ -108,7 +108,7 @@ const EventObserver::ObserverID& EventObserver::id() const {
   return id_;
 }
 
-} // namespace event_engine
-} // namespace application_manager
+}  // namespace event_engine
+}  // namespace application_manager
 
 #endif // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_OBSERVER_H_

--- a/src/components/application_manager/include/application_manager/event_engine/event_observer.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_observer.h
@@ -108,7 +108,7 @@ const EventObserver::ObserverID& EventObserver::id() const {
   return id_;
 }
 
-}
-}
+} // namespace event_engine
+} // namespace application_manager
 
 #endif // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_EVENT_OBSERVER_H_

--- a/src/components/application_manager/include/application_manager/event_engine/event_observer.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_observer.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2013, Ford Motor Company
+ Copyright (c) 2016, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,7 @@
 
 #include <string>
 #include "application_manager/event_engine/event.h"
-#include "application_manager/event_engine/event_dispatcher.h"
+#include "application_manager/event_engine/event_dispatcher_impl.h"
 
 namespace application_manager {
 namespace event_engine {
@@ -44,7 +44,7 @@ class EventObserver
 {
  public:
 
-  friend class EventDispatcher;
+  friend class EventDispatcherImpl;
 
   // Typedef for possible Observer ID's from mobile_apis functionID enum
   typedef unsigned long ObserverID;

--- a/src/components/application_manager/include/application_manager/event_engine/event_observer.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_observer.h
@@ -44,8 +44,6 @@ class EventObserver
 {
  public:
 
-  friend class EventDispatcherImpl;
-
   // Typedef for possible Observer ID's from mobile_apis functionID enum
   typedef unsigned long ObserverID;
 
@@ -102,6 +100,8 @@ class EventObserver
  private:
 
   ObserverID id_;
+
+  EventDispatcher*  pEventDispatcher;
 
   DISALLOW_COPY_AND_ASSIGN(EventObserver);
 };

--- a/src/components/application_manager/include/application_manager/event_engine/event_observer.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_observer.h
@@ -72,6 +72,15 @@ class EventObserver
    */
   virtual void on_event(const Event& event) = 0;
 
+  /*
+   * @brief Change the default EventDispatcher
+   *
+   * @param Pointer to different EventDispatcher
+   */
+  inline void  set_event_dispatcher(EventDispatcher* event_dispatcher)
+  {
+    pEventDispatcher = event_dispatcher;
+  }
  protected:
 
   /*

--- a/src/components/application_manager/include/application_manager/event_engine/event_observer.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_observer.h
@@ -72,15 +72,6 @@ class EventObserver
    */
   virtual void on_event(const Event& event) = 0;
 
-  /*
-   * @brief Change the default EventDispatcher
-   *
-   * @param Pointer to different EventDispatcher
-   */
-  inline void  set_event_dispatcher(EventDispatcher* event_dispatcher)
-  {
-    pEventDispatcher = event_dispatcher;
-  }
  protected:
 
   /*
@@ -109,8 +100,6 @@ class EventObserver
  private:
 
   ObserverID id_;
-
-  EventDispatcher*  pEventDispatcher;
 
   DISALLOW_COPY_AND_ASSIGN(EventObserver);
 };

--- a/src/components/application_manager/src/event_engine/event.cc
+++ b/src/components/application_manager/src/event_engine/event.cc
@@ -31,7 +31,7 @@
  */
 
 #include "application_manager/event_engine/event.h"
-#include "application_manager/event_engine/event_dispatcher.h"
+#include "application_manager/event_engine/event_dispatcher_impl.h"
 
 namespace application_manager {
 namespace event_engine {
@@ -45,7 +45,7 @@ Event::~Event() {
 }
 
 void Event::raise() {
-  EventDispatcher::instance()->raise_event(*this);
+  EventDispatcherImpl::instance()->raise_event(*this);
 }
 
 void Event::set_smart_object(const smart_objects::SmartObject& so) {

--- a/src/components/application_manager/src/event_engine/event.cc
+++ b/src/components/application_manager/src/event_engine/event.cc
@@ -52,5 +52,5 @@ void Event::set_smart_object(const smart_objects::SmartObject& so) {
   response_so_ = so;
 }
 
-} // namespace event_engine
-} // namespace application_manager
+}  // namespace event_engine
+}  // namespace application_manager

--- a/src/components/application_manager/src/event_engine/event.cc
+++ b/src/components/application_manager/src/event_engine/event.cc
@@ -52,5 +52,5 @@ void Event::set_smart_object(const smart_objects::SmartObject& so) {
   response_so_ = so;
 }
 
-}
-}
+} // namespace event_engine
+} // namespace application_manager

--- a/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
+++ b/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
@@ -33,31 +33,30 @@
 #include "interfaces/HMI_API.h"
 #include "application_manager/event_engine/event_observer.h"
 #include "application_manager/event_engine/event_dispatcher_impl.h"
+#include <algorithm>
 
 namespace application_manager {
 namespace event_engine {
 using namespace sync_primitives;
 
 EventDispatcherImpl::EventDispatcherImpl()
-    : observer_vec_lock_(true),
-      observers_() {
-}
+    : observer_vec_lock_(true), observers_() {}
 
-EventDispatcherImpl::~EventDispatcherImpl() {
-}
+EventDispatcherImpl::~EventDispatcherImpl() {}
 
 void EventDispatcherImpl::raise_event(const Event& event) {
   {
     AutoLock auto_lock(state_lock_);
     // check if event is notification
     if (hmi_apis::messageType::notification == event.smart_object_type()) {
-    	const uint32_t notification_correlation_id = 0;
-    	observers_vector_ = observers_[event.id()][notification_correlation_id];
+      const uint32_t notification_correlation_id = 0;
+      observers_vector_ = observers_[event.id()][notification_correlation_id];
     }
 
-    if (hmi_apis::messageType::response == event.smart_object_type()
-        || hmi_apis::messageType::error_response == event.smart_object_type()) {
-    	observers_vector_ = observers_[event.id()][event.smart_object_correlation_id()];
+    if (hmi_apis::messageType::response == event.smart_object_type() ||
+        hmi_apis::messageType::error_response == event.smart_object_type()) {
+      observers_vector_ =
+          observers_[event.id()][event.smart_object_correlation_id()];
     }
   }
 
@@ -75,66 +74,70 @@ void EventDispatcherImpl::raise_event(const Event& event) {
 }
 
 void EventDispatcherImpl::add_observer(const Event::EventID& event_id,
-                                   int32_t hmi_correlation_id,
-                                   EventObserver* const observer) {
+                                       int32_t hmi_correlation_id,
+                                       EventObserver* const observer) {
   AutoLock auto_lock(state_lock_);
   observers_[event_id][hmi_correlation_id].push_back(observer);
 }
 
-void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
-		                              EventObserver* const observer) {
-  remove_observer_from_vector(observer);
-  AutoLock auto_lock(state_lock_);
-  ObserversMap::iterator it =  observers_[event_id].begin();
-  for (; observers_[event_id].end() != it; ++it) {
+struct check_id {
+  check_id(unsigned long id) : target_id(id) {}
 
-    //ObserverList iterator
-	ObserverVector::iterator observer_it =  it->second.begin();
-	while (it->second.end() != observer_it) {
-	  if (observer->id() == (*observer_it)->id()) {
-	    observer_it = it->second.erase(observer_it);
-	  } else {
-	    ++observer_it;
-	  }
-	}
+  bool operator()(EventObserver* ov) {
+    return (ov->id() == target_id);
+  }
+
+ private:
+  unsigned long target_id;
+};
+
+void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
+                                          EventObserver* const observer) {
+  remove_observer_from_vector(observer);
+
+  struct check_id check_id_func(observer->id());
+
+  AutoLock auto_lock(state_lock_);
+  ObserversMap::iterator it = observers_[event_id].begin();
+
+  for (; observers_[event_id].end() != it; ++it) {
+    it->second.erase(
+        std::remove_if(it->second.begin(), it->second.end(), check_id_func),
+        it->second.end());
   }
 }
 
 void EventDispatcherImpl::remove_observer(EventObserver* const observer) {
   remove_observer_from_vector(observer);
+
+  struct check_id check_id_func(observer->id());
   AutoLock auto_lock(state_lock_);
   EventObserverMap::iterator event_map = observers_.begin();
+
   for (; observers_.end() != event_map; ++event_map) {
-    ObserversMap::iterator it =  event_map->second.begin();
-	for (; event_map->second.end() != it; ++it) {
+    ObserversMap::iterator it = event_map->second.begin();
 
-	  //ObserverList iterator
-	  ObserverVector::iterator observer_it =  it->second.begin();
-	  while (it->second.end() != observer_it) {
-	    if (observer->id() == (*observer_it)->id()) {
-	      observer_it = it->second.erase(observer_it);
-		} else {
-		  ++observer_it;
-		}
-	  }
-	}
-  }
-}
-
-void EventDispatcherImpl::remove_observer_from_vector(EventObserver* const observer) {
-  AutoLock auto_lock(observer_vec_lock_);
-  if (!observers_vector_.empty()) {
-    ObserverVector::iterator it_begin = observers_vector_.begin();
-    while (it_begin != observers_vector_.end()) {
-      if ((*it_begin)->id() == observer->id()) {
-        it_begin = observers_vector_.erase(it_begin);
-      }else{
-        ++it_begin;
-      }
+    for (; event_map->second.end() != it; ++it) {
+      it->second.erase(
+          std::remove_if(it->second.begin(), it->second.end(), check_id_func),
+          it->second.end());
     }
   }
 }
 
-} // namespace event_engine
+void EventDispatcherImpl::remove_observer_from_vector(
+    EventObserver* const observer) {
+  struct check_id check_id_func(observer->id());
 
-}// namespace application_manager
+  AutoLock auto_lock(observer_vec_lock_);
+  if (!observers_vector_.empty()) {
+    observers_vector_.erase(
+        std::remove_if(observers_vector_.begin(), observers_vector_.end(),
+                       check_id_func),
+        observers_vector_.end());
+  }
+}
+
+}  // namespace event_engine
+
+}  // namespace application_manager

--- a/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
+++ b/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2013, Ford Motor Company
+ Copyright (c) 2016, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -32,21 +32,21 @@
 
 #include "interfaces/HMI_API.h"
 #include "application_manager/event_engine/event_observer.h"
-#include "application_manager/event_engine/event_dispatcher.h"
+#include "application_manager/event_engine/event_dispatcher_impl.h"
 
 namespace application_manager {
 namespace event_engine {
 using namespace sync_primitives;
 
-EventDispatcher::EventDispatcher()
+EventDispatcherImpl::EventDispatcherImpl()
     : observer_list_lock_(true),
       observers_() {
 }
 
-EventDispatcher::~EventDispatcher() {
+EventDispatcherImpl::~EventDispatcherImpl() {
 }
 
-void EventDispatcher::raise_event(const Event& event) {
+void EventDispatcherImpl::raise_event(const Event& event) {
   {
     AutoLock auto_lock(state_lock_);
     // check if event is notification
@@ -74,14 +74,14 @@ void EventDispatcher::raise_event(const Event& event) {
   }
 }
 
-void EventDispatcher::add_observer(const Event::EventID& event_id,
+void EventDispatcherImpl::add_observer(const Event::EventID& event_id,
                                    int32_t hmi_correlation_id,
                                    EventObserver* const observer) {
   AutoLock auto_lock(state_lock_);
   observers_[event_id][hmi_correlation_id].push_back(observer);
 }
 
-void EventDispatcher::remove_observer(const Event::EventID& event_id,
+void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
 		                              EventObserver* const observer) {
   remove_observer_from_list(observer);
   AutoLock auto_lock(state_lock_);
@@ -100,7 +100,7 @@ void EventDispatcher::remove_observer(const Event::EventID& event_id,
   }
 }
 
-void EventDispatcher::remove_observer(EventObserver* const observer) {
+void EventDispatcherImpl::remove_observer(EventObserver* const observer) {
   remove_observer_from_list(observer);
   AutoLock auto_lock(state_lock_);
   EventObserverMap::iterator event_map = observers_.begin();
@@ -121,7 +121,7 @@ void EventDispatcher::remove_observer(EventObserver* const observer) {
   }
 }
 
-void EventDispatcher::remove_observer_from_list(EventObserver* const observer) {
+void EventDispatcherImpl::remove_observer_from_list(EventObserver* const observer) {
   AutoLock auto_lock(observer_list_lock_);
   if (!observers_list_.empty()) {
     ObserverList::iterator it_begin = observers_list_.begin();

--- a/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
+++ b/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
@@ -40,7 +40,7 @@ namespace event_engine {
 using namespace sync_primitives;
 
 EventDispatcherImpl::EventDispatcherImpl()
-    : observer_vec_lock_(true), observers_() {}
+    : state_lock_(false), observer_lock_(true), observers_event() {}
 
 EventDispatcherImpl::~EventDispatcherImpl() {}
 
@@ -50,26 +50,25 @@ void EventDispatcherImpl::raise_event(const Event& event) {
     // check if event is notification
     if (hmi_apis::messageType::notification == event.smart_object_type()) {
       const uint32_t notification_correlation_id = 0;
-      observers_vector_ = observers_[event.id()][notification_correlation_id];
+      observers = observers_event[event.id()][notification_correlation_id];
     }
 
     if (hmi_apis::messageType::response == event.smart_object_type() ||
         hmi_apis::messageType::error_response == event.smart_object_type()) {
-      observers_vector_ =
-          observers_[event.id()][event.smart_object_correlation_id()];
+      observers =
+          observers_event[event.id()][event.smart_object_correlation_id()];
     }
   }
 
   // Call observers
   EventObserver* temp;
-  while (observers_vector_.size() > 0) {
-    observer_vec_lock_.Acquire();
-    if (!observers_vector_.empty()) {
-      temp = *observers_vector_.begin();
-      observers_vector_.erase(observers_vector_.begin());
+  while (observers.size() > 0) {
+    AutoLock auto_lock(observer_lock_);
+    if (!observers.empty()) {
+      temp = *observers.begin();
+      observers.erase(observers.begin());
       temp->on_event(event);
     }
-    observer_vec_lock_.Release();
   }
 }
 
@@ -77,65 +76,51 @@ void EventDispatcherImpl::add_observer(const Event::EventID& event_id,
                                        int32_t hmi_correlation_id,
                                        EventObserver* const observer) {
   AutoLock auto_lock(state_lock_);
-  observers_[event_id][hmi_correlation_id].push_back(observer);
+  observers_event[event_id][hmi_correlation_id].push_back(observer);
 }
 
-struct check_id {
-  check_id(unsigned long id) : target_id(id) {}
+struct IdCheckFunctor {
+  IdCheckFunctor(const unsigned long id) : target_id(id) {}
 
-  bool operator()(EventObserver* ov) {
-    return (ov->id() == target_id);
+  bool operator()(const EventObserver* obs) const {
+    return (obs->id() == target_id);
   }
 
  private:
-  unsigned long target_id;
+  const unsigned long target_id;
 };
 
 void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
                                           EventObserver* const observer) {
   remove_observer_from_vector(observer);
-
-  struct check_id check_id_func(observer->id());
-
   AutoLock auto_lock(state_lock_);
-  ObserversMap::iterator it = observers_[event_id].begin();
+  ObserversMap::iterator it = observers_event[event_id].begin();
 
-  for (; observers_[event_id].end() != it; ++it) {
-    it->second.erase(
-        std::remove_if(it->second.begin(), it->second.end(), check_id_func),
-        it->second.end());
+  for (; observers_event[event_id].end() != it; ++it) {
+    ObserverVector obs_vec = it->second;
+    obs_vec.erase(
+        std::remove_if(obs_vec.begin(), obs_vec.end(), IdCheckFunctor(observer->id())),
+        obs_vec.end());
   }
 }
 
 void EventDispatcherImpl::remove_observer(EventObserver* const observer) {
   remove_observer_from_vector(observer);
+  EventObserverMap::iterator event_map = observers_event.begin();
 
-  struct check_id check_id_func(observer->id());
-  AutoLock auto_lock(state_lock_);
-  EventObserverMap::iterator event_map = observers_.begin();
-
-  for (; observers_.end() != event_map; ++event_map) {
-    ObserversMap::iterator it = event_map->second.begin();
-
-    for (; event_map->second.end() != it; ++it) {
-      it->second.erase(
-          std::remove_if(it->second.begin(), it->second.end(), check_id_func),
-          it->second.end());
-    }
+  for (; observers_event.end() != event_map; ++event_map) {
+    remove_observer(event_map->first, observer);
   }
 }
 
 void EventDispatcherImpl::remove_observer_from_vector(
     EventObserver* const observer) {
-  struct check_id check_id_func(observer->id());
+  AutoLock auto_lock(observer_lock_);
 
-  AutoLock auto_lock(observer_vec_lock_);
-  if (!observers_vector_.empty()) {
-    observers_vector_.erase(
-        std::remove_if(observers_vector_.begin(), observers_vector_.end(),
-                       check_id_func),
-        observers_vector_.end());
-  }
+  observers.erase(
+      std::remove_if(observers.begin(), observers.end(),
+                     IdCheckFunctor(observer->id())),
+      observers.end());
 }
 
 }  // namespace event_engine

--- a/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
+++ b/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
@@ -40,7 +40,7 @@ namespace event_engine {
 using namespace sync_primitives;
 
 EventDispatcherImpl::EventDispatcherImpl()
-    : state_lock_(false), observer_lock_(true), observers_event() {}
+    : state_lock_(false), observer_lock_(true), observers_event_() {}
 
 EventDispatcherImpl::~EventDispatcherImpl() {}
 
@@ -50,24 +50,26 @@ void EventDispatcherImpl::raise_event(const Event& event) {
     // check if event is notification
     if (hmi_apis::messageType::notification == event.smart_object_type()) {
       const uint32_t notification_correlation_id = 0;
-      observers = observers_event[event.id()][notification_correlation_id];
+      observers_ = observers_event_[event.id()][notification_correlation_id];
     }
 
     if (hmi_apis::messageType::response == event.smart_object_type() ||
         hmi_apis::messageType::error_response == event.smart_object_type()) {
-      observers =
-          observers_event[event.id()][event.smart_object_correlation_id()];
+      observers_ =
+          observers_event_[event.id()][event.smart_object_correlation_id()];
     }
   }
 
   // Call observers
   EventObserver* temp;
-  while (observers.size() > 0) {
-    AutoLock auto_lock(observer_lock_);
-    if (!observers.empty()) {
-      temp = *observers.begin();
-      observers.erase(observers.begin());
-      temp->on_event(event);
+  while (observers_.size() > 0) {
+    {
+      AutoLock auto_lock(observer_lock_);
+      if (!observers_.empty()) {
+        temp = *observers_.begin();
+        observers_.erase(observers_.begin());
+        temp->on_event(event);
+      }
     }
   }
 }
@@ -76,7 +78,7 @@ void EventDispatcherImpl::add_observer(const Event::EventID& event_id,
                                        int32_t hmi_correlation_id,
                                        EventObserver* const observer) {
   AutoLock auto_lock(state_lock_);
-  observers_event[event_id][hmi_correlation_id].push_back(observer);
+  observers_event_[event_id][hmi_correlation_id].push_back(observer);
 }
 
 struct IdCheckFunctor {
@@ -94,10 +96,10 @@ void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
                                           EventObserver* const observer) {
   remove_observer_from_vector(observer);
   AutoLock auto_lock(state_lock_);
-  ObserversMap::iterator it = observers_event[event_id].begin();
+  ObserversMap::iterator it = observers_event_[event_id].begin();
 
-  for (; observers_event[event_id].end() != it; ++it) {
-    ObserverVector obs_vec = it->second;
+  for (; observers_event_[event_id].end() != it; ++it) {
+    ObserverVector& obs_vec = it->second;
     obs_vec.erase(
         std::remove_if(obs_vec.begin(), obs_vec.end(), IdCheckFunctor(observer->id())),
         obs_vec.end());
@@ -106,9 +108,9 @@ void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
 
 void EventDispatcherImpl::remove_observer(EventObserver* const observer) {
   remove_observer_from_vector(observer);
-  EventObserverMap::iterator event_map = observers_event.begin();
+  EventObserverMap::iterator event_map = observers_event_.begin();
 
-  for (; observers_event.end() != event_map; ++event_map) {
+  for (; observers_event_.end() != event_map; ++event_map) {
     remove_observer(event_map->first, observer);
   }
 }
@@ -117,10 +119,10 @@ void EventDispatcherImpl::remove_observer_from_vector(
     EventObserver* const observer) {
   AutoLock auto_lock(observer_lock_);
 
-  observers.erase(
-      std::remove_if(observers.begin(), observers.end(),
+  observers_.erase(
+      std::remove_if(observers_.begin(), observers_.end(),
                      IdCheckFunctor(observer->id())),
-      observers.end());
+      observers_.end());
 }
 
 }  // namespace event_engine

--- a/src/components/application_manager/src/event_engine/event_observer.cc
+++ b/src/components/application_manager/src/event_engine/event_observer.cc
@@ -40,6 +40,7 @@ EventObserver::EventObserver()
  : id_(0) {
   //Get unique id based on this
   id_ = reinterpret_cast<unsigned long>(this);
+  pEventDispatcher = EventDispatcherImpl::instance();
 }
 
 EventObserver::~EventObserver() {

--- a/src/components/application_manager/src/event_engine/event_observer.cc
+++ b/src/components/application_manager/src/event_engine/event_observer.cc
@@ -49,15 +49,15 @@ EventObserver::~EventObserver() {
 
 void EventObserver::subscribe_on_event(const Event::EventID& event_id,
                                        int32_t hmi_correlation_id) {
-  EventDispatcherImpl::instance()->add_observer(event_id, hmi_correlation_id, this);
+  pEventDispatcher->add_observer(event_id, hmi_correlation_id, this);
 }
 
 void EventObserver::unsubscribe_from_event(const Event::EventID& event_id) {
-  EventDispatcherImpl::instance()->remove_observer(event_id, this);
+  pEventDispatcher->remove_observer(event_id, this);
 }
 
 void EventObserver::unsubscribe_from_all_events() {
-  EventDispatcherImpl::instance()->remove_observer(this);
+  pEventDispatcher->remove_observer(this);
 }
 
 }

--- a/src/components/application_manager/src/event_engine/event_observer.cc
+++ b/src/components/application_manager/src/event_engine/event_observer.cc
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2013, Ford Motor Company
+ Copyright (c) 2016, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -48,15 +48,15 @@ EventObserver::~EventObserver() {
 
 void EventObserver::subscribe_on_event(const Event::EventID& event_id,
                                        int32_t hmi_correlation_id) {
-  EventDispatcher::instance()->add_observer(event_id, hmi_correlation_id, this);
+  EventDispatcherImpl::instance()->add_observer(event_id, hmi_correlation_id, this);
 }
 
 void EventObserver::unsubscribe_from_event(const Event::EventID& event_id) {
-  EventDispatcher::instance()->remove_observer(event_id, this);
+  EventDispatcherImpl::instance()->remove_observer(event_id, this);
 }
 
 void EventObserver::unsubscribe_from_all_events() {
-  EventDispatcher::instance()->remove_observer(this);
+  EventDispatcherImpl::instance()->remove_observer(this);
 }
 
 }

--- a/src/components/application_manager/src/event_engine/event_observer.cc
+++ b/src/components/application_manager/src/event_engine/event_observer.cc
@@ -30,8 +30,8 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "application_manager/event_engine/event.h"
 #include "application_manager/event_engine/event_observer.h"
+#include "application_manager/event_engine/event.h"
 
 namespace application_manager {
 namespace event_engine {
@@ -59,5 +59,5 @@ void EventObserver::unsubscribe_from_all_events() {
   EventDispatcherImpl::instance()->remove_observer(this);
 }
 
-}
-}
+} // namespace event_engine
+} // namespace aplication_manager

--- a/src/components/application_manager/src/event_engine/event_observer.cc
+++ b/src/components/application_manager/src/event_engine/event_observer.cc
@@ -40,7 +40,6 @@ EventObserver::EventObserver()
  : id_(0) {
   //Get unique id based on this
   id_ = reinterpret_cast<unsigned long>(this);
-  pEventDispatcher = EventDispatcherImpl::instance();
 }
 
 EventObserver::~EventObserver() {
@@ -49,15 +48,15 @@ EventObserver::~EventObserver() {
 
 void EventObserver::subscribe_on_event(const Event::EventID& event_id,
                                        int32_t hmi_correlation_id) {
-  pEventDispatcher->add_observer(event_id, hmi_correlation_id, this);
+  EventDispatcherImpl::instance()->add_observer(event_id, hmi_correlation_id, this);
 }
 
 void EventObserver::unsubscribe_from_event(const Event::EventID& event_id) {
-  pEventDispatcher->remove_observer(event_id, this);
+  EventDispatcherImpl::instance()->remove_observer(event_id, this);
 }
 
 void EventObserver::unsubscribe_from_all_events() {
-  pEventDispatcher->remove_observer(this);
+  EventDispatcherImpl::instance()->remove_observer(this);
 }
 
 }

--- a/src/components/application_manager/src/event_engine/event_observer.cc
+++ b/src/components/application_manager/src/event_engine/event_observer.cc
@@ -59,5 +59,5 @@ void EventObserver::unsubscribe_from_all_events() {
   EventDispatcherImpl::instance()->remove_observer(this);
 }
 
-} // namespace event_engine
-} // namespace aplication_manager
+}  // namespace event_engine
+}  // namespace application_manager

--- a/src/components/application_manager/test/mock/include/application_manager/event_engine/event_dispatcher_impl.h
+++ b/src/components/application_manager/test/mock/include/application_manager/event_engine/event_dispatcher_impl.h
@@ -1,0 +1,1 @@
+../../../../../include/application_manager/event_engine/event_dispatcher_impl.h


### PR DESCRIPTION
In this pull request we separate the EventDispatcher from the EventObserver by creating interface class and appropriate implementation. Its added possibility to add default EventDispatcher for the EventObserver, as well as the possibility to set a EventDispatcher for testing purposes.

