### PR TITLE
Fix sending Policy Table snapshot in OnSystemRequest

### DIFF
--- a/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
@@ -76,12 +76,10 @@ void OnSystemRequestNotification::Run() {
   }
 
   if (RequestType::PROPRIETARY == request_type) {
-  std::string filename =
-      (*message_)[strings::msg_params][strings::file_name].asString();
-
-  std::vector<uint8_t> binary_data;
-  file_system::ReadBinaryFile(filename, binary_data);
-    (*message_)[strings::params][strings::binary_data] = binary_data;
+    /* According to requirements:
+       "If the requestType = PROPRIETARY, add to mobile API fileType = JSON
+        If the requestType = HTTP, add to mobile API fileType = BINARY"
+       Also in Genivi SDL we don't save the PT to file - we put it directly in binary_data */
     (*message_)[strings::msg_params][strings::file_type] = FileType::JSON;
   } else if (RequestType::HTTP == request_type) {
     (*message_)[strings::msg_params][strings::file_type] = FileType::BINARY;

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2016,9 +2016,12 @@ void MessageHelper::SendPolicySnapshotNotification(
   DCHECK(app.get());
 
   smart_objects::SmartObject* content =
-      new smart_objects::SmartObject(smart_objects::SmartType_Map);
+      new smart_objects::SmartObject(smart_objects::SmartType_Map);  // AKirov: possible memory leak here
+
   if (!url.empty()) {
-    (*content)[strings::msg_params][mobile_notification::syncp_url] = url;
+    (*content)[strings::msg_params][strings::url] = url;  // Doesn't work with mobile_notification::syncp_url ("URL")
+  } else {
+    LOG4CXX_WARN(logger_, "No service URLs");
   }
 
   (*content)[strings::msg_params][strings::request_type] =

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1044,6 +1044,7 @@ void PolicyHandler::OnSnapshotCreated(
   policy_manager_->GetServiceUrls("0x07", urls);
 
   if (urls.empty()) {
+    LOG4CXX_ERROR(logger_, "Service URLs are empty! NOT sending PT to mobile!");
     return;
   }
   SendMessageToSDK(pt_string, urls.front().url.front());


### PR DESCRIPTION
Before this change OnSystemRequest notification with PT snapshot and an
update URL, sent by SDL to mobile when the mobile app registers, was
actually empty. The reason was that when sending the notification we
were trying to read PT data from a non existing file, while the actual
data was discarded.
This change fixes the problem by removing reading from file and using
the already built PT data in memory.
It also fixes sending the PTU url in the message (it was also missing).

Fixes: APPLINK-17788