### PR TITLE
Add DeleteChoices to ontimeOut

### DIFF
--- a/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -422,8 +422,8 @@ void CreateInteractionChoiceSetRequest::onTimeOut() {
   // according to SDLAQ-CRS-2976
   sync_primitives::AutoLock timeout_lock_(is_timed_out_lock_);
   is_timed_out_ = true;
-  ApplicationManagerImpl::instance()->updateRequestTimeout(
-      connection_key(), correlation_id(), 0);
+  ApplicationManagerImpl::instance()->TerminateRequest(
+      connection_key(), correlation_id());
 }
 
 void CreateInteractionChoiceSetRequest::DeleteChoices() {

--- a/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -416,6 +416,7 @@ void CreateInteractionChoiceSetRequest::onTimeOut() {
   if (!error_from_hmi_) {
     SendResponse(false, mobile_apis::Result::GENERIC_ERROR);
   }
+  DeleteChoices();
 
   // We have to keep request alive until receive all responses from HMI
   // according to SDLAQ-CRS-2976


### PR DESCRIPTION
Fix defect: SDL doesn't send VR.DeleteCommand to HMI in case
ChoiceSet commands and HMI sends a VR.AddCommand
responses with error

Related:
        [APPLINK-17652](https://adc.luxoft.com/jira/browse/APPLINK-17652)