### PR TITLE
Genivi build fail with turned off logging

### DIFF
--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -31,7 +31,7 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <string.h>
+#include <cstring>
 #include <string>
 #include "application_manager/commands/mobile/perform_audio_pass_thru_request.h"
 #include "application_manager/application_manager_impl.h"
@@ -299,7 +299,7 @@ bool PerformAudioPassThruRequest::IsWhiteSpaceExist() {
 
     for (; it_ip != it_ip_end; ++it_ip) {
       str = (*it_ip)[strings::text].asCharArray();
-      if (strlen(str) && !CheckSyntax(str)) {
+      if (std::strlen(str) && !CheckSyntax(str)) {
         LOG4CXX_ERROR(logger_, "Invalid initial_prompt syntax check failed");
         return true;
       }

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -31,6 +31,7 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <string.h>
 #include <string>
 #include "application_manager/commands/mobile/perform_audio_pass_thru_request.h"
 #include "application_manager/application_manager_impl.h"

--- a/src/components/application_manager/src/resumption/resume_ctrl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl.cc
@@ -631,7 +631,6 @@ bool ResumeCtrl::CheckAppRestrictions(
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK_OR_RETURN(saved_app.keyExists(strings::hmi_level), false);
 
-  const bool is_media_app = application->is_media_application();
   const HMILevel::eType hmi_level =
       static_cast<HMILevel::eType>(saved_app[strings::hmi_level].asInt());
   const bool result = Compare<HMILevel::eType, EQ, ONE>(
@@ -639,7 +638,8 @@ bool ResumeCtrl::CheckAppRestrictions(
                           ? true
                           : false;
   LOG4CXX_DEBUG(logger_,
-                "is_media_app " << is_media_app << "; hmi_level " << hmi_level
+                "is_media_app " << application->is_media_application()
+                                << "; hmi_level " << hmi_level
                                 << " result "
                                 << result);
   return result;

--- a/src/components/media_manager/include/media_manager/media_manager_impl.h
+++ b/src/components/media_manager/include/media_manager/media_manager_impl.h
@@ -34,6 +34,7 @@
 #define SRC_COMPONENTS_MEDIA_MANAGER_INCLUDE_MEDIA_MANAGER_MEDIA_MANAGER_IMPL_H_
 
 #include <string>
+#include <map>
 #include "utils/singleton.h"
 #include "protocol_handler/protocol_observer.h"
 #include "protocol_handler/protocol_handler.h"


### PR DESCRIPTION
Added missed links to header files which added automatically when
logging turned on. Removed const bool is_media_app because it become
unused with log turned off.
Related to: [APPLINK-20489](https://adc.luxoft.com/jira/browse/APPLINK-20489)