### PR TITLE
Stash connection_key before calling SendResponse()

### DIFF
--- a/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
@@ -289,11 +289,15 @@ void SetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
           std::max(ui_result_, tts_result_));
   }
 
+  //TODO{ALeshin} APPLINK-15858. connection_key removed during SendResponse
+  const uint32_t stashedConnectionKey = connection_key();
+
   SendResponse(result, result_code, return_info,
                &(message[strings::msg_params]));
 
   ApplicationSharedPtr application =
-      ApplicationManagerImpl::instance()->application(connection_key());
+      ApplicationManagerImpl::instance()->application(stashedConnectionKey);
+
   if (!application) {
     LOG4CXX_DEBUG(logger_, "NULL pointer.");
     return;


### PR DESCRIPTION
Stash connection_key before calling SendResponse(),
because command is deleted during SendResponse

Fix: APPLINK-17064