### PR TITLE
Fix OnHMIStatusNotificationFromMobile command creation

### DIFF
--- a/src/components/application_manager/src/mobile_command_factory.cc
+++ b/src/components/application_manager/src/mobile_command_factory.cc
@@ -532,8 +532,9 @@ CommandSharedPtr MobileCommandFactory::CreateCommand(
     case mobile_apis::FunctionID::OnHMIStatusID: {
       if (origin == commands::Command::ORIGIN_MOBILE) {
         command = utils::MakeShared<commands::OnHMIStatusNotificationFromMobile>(message);
+      } else {
+        command = utils::MakeShared<commands::OnHMIStatusNotification>(message);
       }
-      command = utils::MakeShared<commands::OnHMIStatusNotification>(message);
       break;
     }
     case mobile_apis::FunctionID::OnKeyboardInputID: {


### PR DESCRIPTION
There was s bug in MobileCommandFactory::CreateCommand(), which was
causing always to create OnHMIStatusNotification command, not
OnHMIStatusNotificationFromMobile, even when the origin of the command
is Command::ORIGIN_MOBILE. Fixing this allows SDLv4 QUERY_APPS to
be handled correctly, in particilar to gray them out when the launcher
app goes in BACKGROUND by sending UpdateAppList with greyOut parameter.

Fixes: APPLINK-17866