### PR TITLE
After ignition cycle SDL app_info.dat is 0 size

### DIFF
--- a/src/components/resumption/src/last_state.cc
+++ b/src/components/resumption/src/last_state.cc
@@ -76,7 +76,7 @@ LastState::LastState() {
 }
 
 LastState::~LastState() {
-  SaveToFileSystem();
+
 }
 
 }


### PR DESCRIPTION
Excepted posibility to save data on HU during Ignition OFF.

Fix bug [APPLINK-19589](https://adc.luxoft.com/jira/browse/APPLINK-19589)