### PR TITLE
SDL sends OnHMIStatus(FULL) to non-media app only after end Phone Call if app resumes during active phone call 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+*.user

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -532,9 +532,13 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
                  : GenerateNewHMIAppID());
   }
 
-  ApplicationListAccessor app_list_accesor;
+  // Add application to registered app list and set appropriate mark.
+  // Lock has to be released before adding app to policy DB to avoid possible
+  // deadlock with simultaneous PTU processing
+  applications_list_lock_.Acquire();
   application->MarkRegistered();
-  app_list_accesor.Insert(application);
+  applications_.insert(application);
+  applications_list_lock_.Release();
 
   policy::PolicyHandler::instance()->AddApplication(
       application->mobile_app_id());

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -540,15 +540,6 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
       *(application.get()), resumption, need_restore_vr);
   SendResponse(true, result_code, add_info.c_str(), &response_params);
 
-  // Default HMI level should be set before any permissions validation, since it
-  // relies on HMI level.
-  ApplicationManagerImpl::instance()->OnApplicationRegistered(application);
-
-  // Sends OnPermissionChange notification to mobile right after RAI response
-  // and HMI level set-up
-  policy::PolicyHandler::instance()->OnAppRegisteredOnMobile(
-      application->mobile_app_id());
-
   if (result_code != mobile_apis::Result::RESUME_FAILED) {
     resumer.StartResumption(application, hash_id);
   } else {

--- a/src/components/application_manager/test/mock/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/test/mock/include/application_manager/application_manager_impl.h
@@ -369,6 +369,7 @@ class ApplicationManagerImpl
   MOCK_CONST_METHOD0(get_limited_voice_application, ApplicationSharedPtr());
   MOCK_CONST_METHOD1(IsAppTypeExistsInFullOrLimited,
                      bool(ApplicationConstSharedPtr));
+  MOCK_METHOD1(OnApplicationRegistered, void(ApplicationSharedPtr));
   MOCK_CONST_METHOD0(active_application, ApplicationSharedPtr());
   MOCK_METHOD0(OnApplicationListUpdateTimer, void());
   MOCK_METHOD0(OnLowVoltage, void());


### PR DESCRIPTION
In case default HMI level of app is the same as level assigned during phone call, than no notification is sent to mobile, which is wrong.
With this fix changes sequence of assigning of active states in state controller during application registration, which allow to send notification to mobile side anyway.