### PR TITLE
Hotfix/create interaction choice set doesnt send vr delete command

### DIFF
--- a/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -408,6 +408,7 @@ void CreateInteractionChoiceSetRequest::onTimeOut() {
   if (!error_from_hmi_) {
     SendResponse(false, mobile_apis::Result::GENERIC_ERROR);
   }
+  DeleteChoices();
 
   // We have to keep request alive until receive all responses from HMI
   // according to SDLAQ-CRS-2976

--- a/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -414,8 +414,8 @@ void CreateInteractionChoiceSetRequest::onTimeOut() {
   // according to SDLAQ-CRS-2976
   sync_primitives::AutoLock timeout_lock_(is_timed_out_lock_);
   is_timed_out_ = true;
-  ApplicationManagerImpl::instance()->updateRequestTimeout(
-      connection_key(), correlation_id(), 0);
+  ApplicationManagerImpl::instance()->TerminateRequest(
+      connection_key(), correlation_id());
 }
 
 void CreateInteractionChoiceSetRequest::DeleteChoices() {


### PR DESCRIPTION
Add DeleteChoices to ontimeOut
Related:
            [APPLINK-17652](https://adc.luxoft.com/jira/browse/APPLINK-17652)