### PR TITLE
Fixes double sending of GetUserFriendlyMessage in case of absent message

### DIFF
--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1733,6 +1733,7 @@ void MessageHelper::SendGetUserFriendlyMessageResponse(
   // If no any messages found - skip sending of "messages" param
   if (msg.empty()) {
     ApplicationManagerImpl::instance()->ManageHMICommand(message);
+    return;
   }
 
   const std::string messages = "messages";


### PR DESCRIPTION
In case of absent message in policy DB SDL was returning response twice
- one time without 'messages' and another time with empty 'messages'.

Closes-bug: APPLINK-20985