### PR TITLE
Fixes resume flow for non-media application during phone call and tests.

### DIFF
--- a/src/components/application_manager/src/hmi_state.cc
+++ b/src/components/application_manager/src/hmi_state.cc
@@ -142,6 +142,9 @@ mobile_apis::HMILevel::eType PhoneCallHmiState::hmi_level() const {
   if (is_navi_app(app_id_)) {
     return HMILevel::HMI_LIMITED;
   }
+  if (!is_media_app(app_id_)) {
+    return parent()->hmi_level();
+  }
   return HMILevel::HMI_BACKGROUND;
 }
 


### PR DESCRIPTION
Non-media applicaton is allowed to be resumed to FULL during phone call

Closes-bug: APPLINK-16662

Conflicts:
	src/components/application_manager/test/state_controller/state_controller_test.cc