### PR TITLE
Fix dead locks if user register 30 and more applications

### DIFF
--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -452,7 +452,7 @@ class ConnectionHandlerImpl : public ConnectionHandler,
   /**
    *  \brief Lock for applications list
    */
-  mutable sync_primitives::Lock connection_list_lock_;
+  mutable sync_primitives::RWLock connection_list_lock_;
   mutable sync_primitives::Lock connection_handler_observer_lock_;
 
   /**

--- a/src/components/connection_handler/src/heartbeat_monitor.cc
+++ b/src/components/connection_handler/src/heartbeat_monitor.cc
@@ -52,8 +52,7 @@ HeartBeatMonitor::HeartBeatMonitor(uint32_t heartbeat_timeout_mseconds,
 }
 
 void HeartBeatMonitor::Process() {
-  AutoLock auto_lock(sessions_list_lock_);
-
+  sessions_list_lock_.Acquire();
   SessionMap::iterator it = sessions_.begin();
   while (it != sessions_.end()) {
     SessionState &state = it->second;
@@ -61,7 +60,10 @@ void HeartBeatMonitor::Process() {
       const uint8_t session_id = it->first;
       if (state.IsReadyToClose()) {
         LOG4CXX_WARN(logger_, "Will close session");
+        sessions_list_lock_.Release();
+        RemoveSession(session_id);
         connection_->CloseSession(session_id);
+        sessions_list_lock_.Acquire();
         it = sessions_.begin();
         continue;
       } else {
@@ -73,6 +75,7 @@ void HeartBeatMonitor::Process() {
     }
     ++it;
   }
+  sessions_list_lock_.Release();
 }
 
 void HeartBeatMonitor::threadMain() {
@@ -100,6 +103,7 @@ void HeartBeatMonitor::AddSession(uint8_t session_id) {
 }
 
 void HeartBeatMonitor::RemoveSession(uint8_t session_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
   AutoLock auto_lock(sessions_list_lock_);
 
   LOG4CXX_DEBUG(logger_,
@@ -113,6 +117,7 @@ void HeartBeatMonitor::RemoveSession(uint8_t session_id) {
 }
 
 void HeartBeatMonitor::KeepAlive(uint8_t session_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
   AutoLock auto_lock(sessions_list_lock_);
 
   if (sessions_.end() != sessions_.find(session_id)) {

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -319,15 +319,13 @@ void ProtocolHandlerImpl::SendHeartBeat(int32_t connection_id,
   LOG4CXX_AUTO_TRACE(logger_);
   uint8_t protocol_version;
   if (session_observer_->ProtocolVersionUsed(connection_id,
-      session_id, protocol_version)) {
+        session_id, protocol_version)) {
     ProtocolFramePtr ptr(new protocol_handler::ProtocolPacket(connection_id,
-      protocol_version, PROTECTION_OFF, FRAME_TYPE_CONTROL,
+        protocol_version, PROTECTION_OFF, FRAME_TYPE_CONTROL,
         SERVICE_TYPE_CONTROL, FRAME_DATA_HEART_BEAT, session_id,
         0u, message_counters_[session_id]++));
-
-    raw_ford_messages_to_mobile_.PostMessage(
-        impl::RawFordMessageToMobile(ptr, false));
-    LOG4CXX_DEBUG(logger_, "SendHeartBeat finished successfully");
+    raw_ford_messages_to_mobile_.PostMessage(impl::RawFordMessageToMobile(ptr, false));
+  LOG4CXX_DEBUG(logger_, "SendHeartBeat finished successfully");
   } else {
     LOG4CXX_WARN(logger_, "SendHeartBeat is failed connection or session does not exist");
   }


### PR DESCRIPTION
During processing this defect I found 3 dead locks in
components: conection_handler, hearbeat_monitor.
First deadlock:
First thread:
Calls KeepConnectionAlive() from connection_handler
in this method thread locked connection_list_lock_,
after that calls method KeepAlive() from heartbeat_monitor
and thread tries to lock sessions_list_lock_ wich was locked by
second thread
Second thread:
Blocks sessions_list_lock_ in method Process() from heartbeat_monitor
after that sends hearbeat to mobile
and calls method SendHeartBeat() from protocol_handler.
In this method calls ProtocolVersionUsed() where thread
tries to lock connection_list_lock_ wich was locked by
first thread -> DEAD LOCK
I fixed this problem using RWLock().

Second and third dead locks were associated with
time of action of sessions_list_lock in method Process()
from heartbeat_monitor

I decreased time of action this lock in order to
fix this problem.

Closes-bug:[APPLINK-19632](https://adc.luxoft.com/jira/browse/APPLINK-19632)