### PR TITLE
Fixed IviInfoUpdated App Query

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -296,7 +296,7 @@ std::vector<ApplicationSharedPtr> ApplicationManagerImpl::IviInfoUpdated(
   SubscribedToIVIPredicate finder(
         static_cast<int32_t>(vehicle_info));
   ApplicationListAccessor accessor;
-  std::vector<ApplicationSharedPtr> apps = accessor.FindAll(NaviAppPredicate);
+  std::vector<ApplicationSharedPtr> apps = accessor.FindAll(finder);
   LOG4CXX_DEBUG(logger_, " vehicle_info << " << vehicle_info << "Found count: " << apps.size());
   return apps;
 }


### PR DESCRIPTION
The query in IviInfoUpdated was only returing connected navigation apps. It now returns apps that are subscribed to vehicle info.