### PR TITLE
Increase Slider mobile request timeout to receive HMI response

### DIFF
--- a/src/components/application_manager/src/commands/mobile/slider_request.cc
+++ b/src/components/application_manager/src/commands/mobile/slider_request.cc
@@ -54,8 +54,12 @@ bool SliderRequest::Init() {
   /* Timeout in milliseconds.
      If omitted a standard value of 10000 milliseconds is used.*/
   if ((*message_)[strings::msg_params].keyExists(strings::timeout)) {
-    default_timeout_ =
-        (*message_)[strings::msg_params][strings::timeout].asUInt();
+    // Add 2 seconds reserve to compensate HMI communication and processing.
+    uint32_t request_timeout_plus_reserve =
+        (*message_)[strings::msg_params][strings::timeout].asUInt() + 2000;
+    if (request_timeout_plus_reserve > default_timeout_) {
+      default_timeout_ = request_timeout_plus_reserve;
+    }
   }
 
   return true;

--- a/src/components/application_manager/src/commands/mobile/slider_request.cc
+++ b/src/components/application_manager/src/commands/mobile/slider_request.cc
@@ -36,6 +36,7 @@
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
 #include "utils/helpers.h"
+#include "config_profile/profile.h"
 
 namespace application_manager {
 
@@ -54,12 +55,10 @@ bool SliderRequest::Init() {
   /* Timeout in milliseconds.
      If omitted a standard value of 10000 milliseconds is used.*/
   if ((*message_)[strings::msg_params].keyExists(strings::timeout)) {
-    // Add 2 seconds reserve to compensate HMI communication and processing.
-    uint32_t request_timeout_plus_reserve =
-        (*message_)[strings::msg_params][strings::timeout].asUInt() + 2000;
-    if (request_timeout_plus_reserve > default_timeout_) {
-      default_timeout_ = request_timeout_plus_reserve;
-    }
+    /* According to APPLINK-21499 set mobile command timeout (default_timeout_)
+       to slider RPC timeout plus default command timeout */
+    default_timeout_ = profile::Profile::instance()->default_timeout() +
+        (*message_)[strings::msg_params][strings::timeout].asUInt();
   }
 
   return true;


### PR DESCRIPTION
Until now we were setting generic command timeout for Slider request
equal to Slider's own timeout immediatelly after receiving the command.
Then we send the command to HMI and wait for HMI response. If we don't
do anything in HMI it sends TIMED_OUT response to SDL, but this response
comes AFTER the generic command timeout has expired (because it was
started a litle bit earlier). The generic timeout triggers GENERIC_ERROR
response and HMI's TIMED_OUT response is ignored.
The fix is to set generic command timeout bigger that slider timeout.

Fixes: APPLINK-20738