### PR TITLE
Resumption failed : not getting Activate App (for Media App - Full)

### DIFF
--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -268,6 +268,20 @@ class ResumeCtrl: public app_mngr::event_engine::EventObserver {
    * returns false
    */
   bool Init();
+
+  /**
+   * @brief Notify resume controller about new application
+   * @param policy_app_id - mobile application id
+   * @param device_id - id of device where application is run
+   */
+  void OnAppRegistrationStart(const std::string& policy_app_id,
+                                const std::string& device_id);
+
+  /**
+   * @brief Notify resume controller about delete new application
+   */
+  void OnAppRegistrationEnd();
+
  private:
 
   /**

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -545,6 +545,11 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
                  : GenerateNewHMIAppID());
   }
 
+  // Stops timer of saving data to resumption in order to
+  // doesn't erase data from resumption storage.
+  // Timer will be started after hmi level resumption.
+  resume_ctrl_.OnAppRegistrationStart(policy_app_id, device_mac);
+
   // Add application to registered app list and set appropriate mark.
   // Lock has to be released before adding app to policy DB to avoid possible
   // deadlock with simultaneous PTU processing

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -327,9 +327,11 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
   ApplicationSharedPtr application =
       ApplicationManagerImpl::instance()->application(key);
 
+  resumption::ResumeCtrl& resumer = ApplicationManagerImpl::instance()->resume_controller();
   if (!application) {
-    LOG4CXX_ERROR(logger_,
-                  "There is no application for such connection key" << key);
+    LOG4CXX_ERROR(logger_, "There is no application for such connection key" << key);
+    LOG4CXX_DEBUG(logger_, "Need to start resume data persistent timer");
+    resumer.OnAppRegistrationEnd();
     return;
   }
 
@@ -502,9 +504,6 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
 
   std::string hash_id;
   std::string add_info;
-
-  resumption::ResumeCtrl& resumer =
-      ApplicationManagerImpl::instance()->resume_controller();
 
   if (resumption) {
     hash_id = (*message_)[strings::msg_params][strings::hash_id].asString();

--- a/src/components/application_manager/src/resumption/resume_ctrl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl.cc
@@ -177,6 +177,7 @@ void ResumeCtrl::ApplicationResumptiOnTimer() {
   }
   is_resumption_active_ = false;
   waiting_for_timer_.clear();
+  StartSavePersistentDataTimer();
 }
 
 void ResumeCtrl::OnAppActivated(ApplicationSharedPtr application) {
@@ -741,10 +742,27 @@ void ResumeCtrl::LoadResumeData() {
   }
 }
 
+void ResumeCtrl::OnAppRegistrationStart(const std::string& policy_app_id,
+                                          const std::string& device_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (IsApplicationSaved(policy_app_id, device_id)) {
+    LOG4CXX_INFO(logger_, "Application is found in resumption "
+        "data and will try to resume. Stopping resume data persistent timer");
+    StopSavePersistentDataTimer();
+  }
+}
+
+void ResumeCtrl::OnAppRegistrationEnd() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  StartSavePersistentDataTimer();
+}
+
 bool ResumeCtrl::IsAppDataResumptionExpired(
     const smart_objects::SmartObject& application) const {
   const int32_t max_ign_off_count = 3;
   return max_ign_off_count <= application[strings::ign_off_count].asInt();
 }
+
+
 
 }  // namespce resumption


### PR DESCRIPTION
Forbidden ability to store data during from registration new
application till restoring HMI level from resumption data.
Resolved problem: timer for restore data erases resumption data
by data from new application.

Closes-bug [APPLINK-19641](https://adc.luxoft.com/jira/browse/APPLINK-19641)