### PR TITLE
Fix wrong language codes in hmi_capabilities.json

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -1,10 +1,10 @@
 {
 	"UI":
 	{
-		"language":"EN_US",
+		"language":"EN-US",
 	    "languages":[ 
-          "EN_US","ES_MX","FR_CA","DE_DE","ES_ES","EN_GB","RU_RU","TR_TR","PL_PL","FR_FR","IT_IT","SV_SE","PT_PT","NL_NL","ZH_TW",
-"JA_JP","AR_SA","KO_KR","PT_BR","CS_CZ","DA_DK","NO_NO"
+          "EN-US","ES-MX","FR-CA","DE-DE","ES-ES","EN-GB","RU-RU","TR-TR","PL-PL","FR-FR","IT-IT","SV-SE","PT-PT","NL-NL","ZH-TW",
+"JA-JP","AR-SA","KO-KR","PT-BR","CS-CZ","DA-DK","NO-NO"
 	    ],
 	    "displayCapabilities":
 		{
@@ -328,21 +328,21 @@
     "VR":
 	{
 		"capabilities":["TEXT"],
-		"language":"EN_US",
+		"language":"EN-US",
 	    "languages":    
             [ 
-         "EN_US","ES_MX","FR_CA","DE_DE","ES_ES","EN_GB","RU_RU","TR_TR","PL_PL","FR_FR","IT_IT","SV_SE","PT_PT","NL_NL","ZH_TW",
-"JA_JP","AR_SA","KO_KR","PT_BR","CS_CZ","DA_DK","NO_NO"
+         "EN-US","ES-MX","FR-CA","DE-DE","ES-ES","EN-GB","RU-RU","TR-TR","PL-PL","FR-FR","IT-IT","SV-SE","PT-PT","NL-NL","ZH-TW",
+"JA-JP","AR-SA","KO-KR","PT-BR","CS-CZ","DA-DK","NO-NO"
             ]	    
 },
     "TTS":
 	{
 		"capabilities":"TEXT",
-		"language":"EN_US",
+		"language":"EN-US",
 	    "languages":
 	    [
-	  "EN_US","ES_MX","FR_CA","DE_DE","ES_ES","EN_GB","RU_RU","TR_TR","PL_PL","FR_FR","IT_IT","SV_SE","PT_PT","NL_NL","ZH_TW",
-"JA_JP","AR_SA","KO_KR","PT_BR","CS_CZ","DA_DK","NO_NO"
+	  "EN-US","ES-MX","FR-CA","DE-DE","ES-ES","EN-GB","RU-RU","TR-TR","PL-PL","FR-FR","IT-IT","SV-SE","PT-PT","NL-NL","ZH-TW",
+"JA-JP","AR-SA","KO-KR","PT-BR","CS-CZ","DA-DK","NO-NO"
 	    ]
     },
     "Buttons":

--- a/src/components/application_manager/src/hmi_capabilities.cc
+++ b/src/components/application_manager/src/hmi_capabilities.cc
@@ -599,7 +599,7 @@ bool HMICapabilities::load_capabilities_from_file() {
 
       if (check_existing_json_member(ui, "language")) {
         const std::string lang = ui.get("language", "EN-US").asString();
-        ui_language_ = (MessageHelper::CommonLanguageFromString(lang));
+        set_active_ui_language(MessageHelper::CommonLanguageFromString(lang));
       }
 
       if (check_existing_json_member(ui, "languages")) {
@@ -801,7 +801,7 @@ bool HMICapabilities::load_capabilities_from_file() {
       Json::Value vr = root_json.get("VR", "");
       if (check_existing_json_member(vr, "language")) {
         const std::string lang = vr.get("language", "EN-US").asString();
-        vr_language_ = MessageHelper::CommonLanguageFromString(lang);
+        set_active_vr_language(MessageHelper::CommonLanguageFromString(lang));
       }
 
       if (check_existing_json_member(vr, "languages")) {
@@ -830,7 +830,7 @@ bool HMICapabilities::load_capabilities_from_file() {
 
       if (check_existing_json_member(tts, "language")) {
         const std::string lang = tts.get("language", "EN-US").asString();
-        tts_language_ = MessageHelper::CommonLanguageFromString(lang);
+        set_active_tts_language(MessageHelper::CommonLanguageFromString(lang));
       }
 
       if (check_existing_json_member(tts, "languages")) {


### PR DESCRIPTION
Change strings with language (in hmi_capabilities.json), in order to fix
problem with conversion string to enum.

Closes-bug [APPLINK-20442](https://adc.luxoft.com/jira/browse/APPLINK-20442)