### PR TITLE
Fix SDL behavior in case mobile try to start audio and video services

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -430,7 +430,15 @@ class Application : public virtual InitialApplicationData,
    * @brief Stops streaming service for application
    * @param service_type Type of streaming service
    */
-  virtual void StopStreaming(protocol_handler::ServiceType service_type) = 0;
+  virtual void StopStreaming(
+      protocol_handler::ServiceType service_type) = 0;
+
+  /**
+   * @brief Stops streaming for application whether it is allowed or not HMI
+   * @param service_type video or audio
+   */
+  virtual void StopStreamingForce(
+      protocol_handler::ServiceType service_type) = 0;
 
   /**
    * @brief Suspends streaming process for application

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -103,11 +103,16 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
   bool audio_streaming_allowed() const;
   void set_audio_streaming_allowed(bool state);
 
-  void StartStreaming(protocol_handler::ServiceType service_type);
-  void StopStreaming(protocol_handler::ServiceType service_type);
-
-  void SuspendStreaming(protocol_handler::ServiceType service_type);
-  void WakeUpStreaming(protocol_handler::ServiceType service_type);
+  void StartStreaming(
+      protocol_handler::ServiceType service_type);
+  void StopStreamingForce(
+      protocol_handler::ServiceType service_type);
+  void StopStreaming(
+      protocol_handler::ServiceType service_type);
+  void SuspendStreaming(
+      protocol_handler::ServiceType service_type);
+  void WakeUpStreaming(
+      protocol_handler::ServiceType service_type);
 
   virtual bool is_voice_communication_supported() const;
   virtual void set_voice_communication_supported(
@@ -293,6 +298,16 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
    * Suspends video streaming process for application
    */
   void OnVideoStreamSuspend();
+
+  /**
+   * @brief Stops video streaming for application
+   */
+  inline void StopNaviStreaming();
+
+  /**
+   * @brief Stops audio streaming for application
+   */
+  inline void StopAudioStreaming();
 
   /**
    * @brief Callback for audio streaming suspend timer.

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -405,6 +405,20 @@ void ApplicationImpl::StartStreaming(
   }
 }
 
+void ApplicationImpl::StopStreamingForce(
+    protocol_handler::ServiceType service_type) {
+  using namespace protocol_handler;
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  SuspendStreaming(service_type);
+
+  if (service_type == ServiceType::kMobileNav) {
+    StopNaviStreaming();
+  } else if (service_type == ServiceType::kAudio) {
+    StopAudioStreaming();
+  }
+}
+
 void ApplicationImpl::StopStreaming(
     protocol_handler::ServiceType service_type) {
   using namespace protocol_handler;
@@ -412,19 +426,29 @@ void ApplicationImpl::StopStreaming(
 
   SuspendStreaming(service_type);
 
-  if (ServiceType::kMobileNav == service_type) {
-    if (video_streaming_approved()) {
-      video_stream_suspend_timer_.Stop();
-      MessageHelper::SendNaviStopStream(app_id());
-      set_video_streaming_approved(false);
-    }
-  } else if (ServiceType::kAudio == service_type) {
-    if (audio_streaming_approved()) {
-      audio_stream_suspend_timer_.Stop();
-      MessageHelper::SendAudioStopStream(app_id());
-      set_audio_streaming_approved(false);
-    }
+  if (service_type == ServiceType::kMobileNav &&
+      video_streaming_approved()) {
+    StopNaviStreaming();
+  } else if (service_type == ServiceType::kAudio &&
+             audio_streaming_approved()) {
+    StopAudioStreaming();
   }
+}
+
+void ApplicationImpl::StopNaviStreaming() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  video_stream_suspend_timer_->stop();
+  MessageHelper::SendNaviStopStream(app_id());
+  set_video_streaming_approved(false);
+  set_video_stream_retry_number(0);
+}
+
+void ApplicationImpl::StopAudioStreaming() {
+  LOG4CXX_AUTO_TRACE(logger_);    
+  audio_stream_suspend_timer_->stop();
+  MessageHelper::SendAudioStopStream(app_id());
+  set_audio_streaming_approved(false);
+  set_audio_stream_retry_number(0);
 }
 
 void ApplicationImpl::SuspendStreaming(

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -389,14 +389,14 @@ void ApplicationImpl::StartStreaming(
   LOG4CXX_AUTO_TRACE(logger_);
 
   if (ServiceType::kMobileNav == service_type) {
-    LOG4CXX_TRACE(logger_, "Service type = Video");
+    LOG4CXX_TRACE(logger_, "ServiceType = Video");
     if (!video_streaming_approved()) {
       LOG4CXX_TRACE(logger_, "Video streaming not approved");
       MessageHelper::SendNaviStartStream(app_id());
       set_video_stream_retry_number(0);
     }
   } else if (ServiceType::kAudio == service_type) {
-    LOG4CXX_TRACE(logger_, "Service type = Audio");
+    LOG4CXX_TRACE(logger_, "ServiceType = Audio");
     if (!audio_streaming_approved()) {
       LOG4CXX_TRACE(logger_, "Audio streaming not approved");
       MessageHelper::SendAudioStartStream(app_id());
@@ -437,7 +437,7 @@ void ApplicationImpl::StopStreaming(
 
 void ApplicationImpl::StopNaviStreaming() {
   LOG4CXX_AUTO_TRACE(logger_);
-  video_stream_suspend_timer_->stop();
+  video_stream_suspend_timer_.Stop();
   MessageHelper::SendNaviStopStream(app_id());
   set_video_streaming_approved(false);
   set_video_stream_retry_number(0);
@@ -445,7 +445,7 @@ void ApplicationImpl::StopNaviStreaming() {
 
 void ApplicationImpl::StopAudioStreaming() {
   LOG4CXX_AUTO_TRACE(logger_);    
-  audio_stream_suspend_timer_->stop();
+  audio_stream_suspend_timer_.Stop();
   MessageHelper::SendAudioStopStream(app_id());
   set_audio_streaming_approved(false);
   set_audio_stream_retry_number(0);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2881,10 +2881,12 @@ void ApplicationManagerImpl::EndNaviServices(uint32_t app_id) {
     if (it->second.first) {
       LOG4CXX_DEBUG(logger_, "Going to end video service");
       connection_handler_->SendEndService(app_id, ServiceType::kMobileNav);
+      app->StopStreamingForce(ServiceType::kMobileNav);
     }
     if (it->second.second) {
       LOG4CXX_DEBUG(logger_, "Going to end audio service");
       connection_handler_->SendEndService(app_id, ServiceType::kAudio);
+      app->StopStreamingForce(ServiceType::kAudio);
     }
     DisallowStreaming(app_id);
 

--- a/src/components/application_manager/test/state_controller/include/application_mock.h
+++ b/src/components/application_manager/test/state_controller/include/application_mock.h
@@ -67,6 +67,8 @@ class ApplicationMock : public am::Application {
   MOCK_METHOD1(set_audio_streaming_allowed, void(bool state));
   MOCK_METHOD1(StartStreaming,
                void(protocol_handler::ServiceType service_type));
+  MOCK_METHOD1(StopStreamingForce,
+               void(protocol_handler::ServiceType service_type));
   MOCK_METHOD1(StopStreaming, void(protocol_handler::ServiceType service_type));
   MOCK_METHOD1(SuspendStreaming,
                void(protocol_handler::ServiceType service_type));


### PR DESCRIPTION
Fix SDL behavior in case mobile try to start audio and video services, but
HMI doesn't answer success for any reason.
    
Add StopStreamForce() method to have possibility to send StopStream to HMI
in case streaming wasn't approved by HMI.
    
Fix: APPLINK-17270
