### PR TITLE
Fixes resumption sequence for media/navi app during active EMBEDDED_N…

### DIFF
--- a/src/components/application_manager/include/application_manager/state_controller.h
+++ b/src/components/application_manager/include/application_manager/state_controller.h
@@ -84,11 +84,16 @@ class StateController : public event_engine::EventObserver {
       return;
     }
 
-    if (SendActivateApp) {
-      uint32_t corr_id = MessageHelper::SendActivateAppToHMI(
-          app->app_id(),
-          static_cast<hmi_apis::Common_HMILevel::eType>(
-              resolved_state->hmi_level()));
+    const bool is_full_allowed =
+            mobile_apis::HMILevel::HMI_FULL == resolved_state->hmi_level()
+            ? true
+            : false;
+
+    if (SendActivateApp && is_full_allowed) {
+        uint32_t corr_id = MessageHelper::SendActivateAppToHMI(
+            app->app_id(), static_cast<hmi_apis::Common_HMILevel::eType>(
+                                   resolved_state->hmi_level()));
+
       subscribe_on_event(hmi_apis::FunctionID::BasicCommunication_ActivateApp,
                          corr_id);
       waiting_for_activate[app->app_id()] = resolved_state;


### PR DESCRIPTION
…AVI/AUDIO_SOURCE

Per current requirements media/navi apps should resume to
LIMITED/NON_AUDIBLE during EMBEDDED_NAVI/AUDIO_SOURCE accordingly
without sending BC.ActivateApp request to HMI. SDL has to send only
OnResumeAudioSource in that case. Before that fix both BC.ActivateApp
and OnResumeAudioSource have been sent, which is wrong.

Closes-bug: APPLINK-19952

Conflicts:
	src/components/application_manager/include/application_manager/state_controller.h