### PR TITLE
Fix for sending policy table snapshot (Genivi implementation)

### DIFF
--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -1934,7 +1934,7 @@ void MessageHelper::SendPolicySnapshotNotification(
 
   SmartObject content (SmartType_Map);
   if (!url.empty()) {
-    content[strings::msg_params][mobile_notification::syncp_url] = url;
+    content[strings::msg_params][strings::url] = url;
   }
 
   content[strings::msg_params][strings::request_type] = RequestType::HTTP;

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -730,11 +730,8 @@ bool PolicyHandler::SendMessageToSDK(const BinaryMessage& pt_string,
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK(false);
 
-  if (last_used_app_ids_.empty()) {
-    LOG4CXX_WARN(logger_, "last_used_app_ids_ is empty");
-    return false;
-  }
-  uint32_t app_id = last_used_app_ids_.back();
+
+  uint32_t app_id = GetAppIdForSending();
 
   ApplicationSharedPtr app =
     ApplicationManagerImpl::instance()->application(app_id);


### PR DESCRIPTION
Policy handler was checking an unimplemented contained last_used_app_ids_. Replaced with 'GetAppIdForSending() to properly find app id to send policy snapshot to.

Also in message_helper.cc, I fixed the url paremeter to what actually corresponds to onSystemRequests in the mobile_api.xml