### PR TITLE
Use Aplication name in UpdateAppList request

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2123,21 +2123,15 @@ void ApplicationManagerImpl::PullLanguagesInfo(const SmartObject& app_data,
   if (app_data[json::languages][specific_idx][cur_vr_lang].keyExists(json::ttsName)) {
     LOG4CXX_DEBUG(logger_, "Get ttsName from " << cur_vr_lang << " language");
     ttsName = app_data[json::languages][specific_idx][cur_vr_lang][json::ttsName];
-  } else if (app_data[json::languages][default_idx][json::default_].keyExists(json::ttsName)) {
-      LOG4CXX_DEBUG(logger_, "Get ttsName from " << json::default_ << " language");
-      ttsName = app_data[json::languages][default_idx][json::default_][json::ttsName];
-    } else {
-      LOG4CXX_DEBUG(logger_, "No data for ttsName");
+  }  else {
+      LOG4CXX_DEBUG(logger_, "No data for ttsName for" << cur_vr_lang << " language");
     }
 
   if (app_data[json::languages][specific_idx][cur_vr_lang].keyExists(json::vrSynonyms)) {
     LOG4CXX_DEBUG(logger_, "Get vrSynonyms from " << cur_vr_lang << " language");
     vrSynonym = app_data[json::languages][specific_idx][cur_vr_lang][json::vrSynonyms];
-  } else if (app_data[json::languages][default_idx][json::default_].keyExists(json::vrSynonyms)) {
-      LOG4CXX_DEBUG(logger_, "Get vrSynonyms from " << json::default_ << " language");
-      vrSynonym = app_data[json::languages][default_idx][json::default_][json::vrSynonyms];
-    } else {
-      LOG4CXX_DEBUG(logger_, "No data for vrSynonyms");
+  }  else {
+      LOG4CXX_DEBUG(logger_, "No data for vrSynonyms for " << cur_vr_lang << " language");
     }
 }
 


### PR DESCRIPTION
Use application name in UpdateAppList
requests when QUERY_APPS settings have empty TTS_NAME or VRSynonyms for current HMI language.