### PR TITLE
Fixes issue with SDL data resetting during MASTER_RESET

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1305,6 +1305,11 @@ class ApplicationManagerImpl : public ApplicationManager,
     void RemoveAppsWaitingForRegistration(
         const connection_handler::DeviceHandle handle);
 
+    /**
+     * @brief Clears TTS global properties list of apps
+     */
+    void ClearTTSGlobalPropertiesList();
+
   private:
     /**
      * @brief List of applications

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1219,7 +1219,7 @@ void ApplicationManagerImpl::SendMessageToMobile(
   mobile_so_factory().attachSchema(*message, false);
   LOG4CXX_INFO(logger_, "Attached schema to message, result if valid: "
                             << message->isValid());
-  
+
   // Messages to mobile are not yet prioritized so use default priority value
   utils::SharedPtr<Message> message_to_send(new Message(
         protocol_handler::MessagePriority::kDefault));
@@ -2218,6 +2218,8 @@ void ApplicationManagerImpl::UnregisterAllApplications() {
       Compare<eType, NEQ, ALL>(unregister_reason_,
                                IGNITION_OFF, MASTER_RESET, FACTORY_DEFAULTS);
 
+  ClearTTSGlobalPropertiesList();
+
   {  // A local scope to limit accessor's lifetime and release app list lock.
   ApplicationListAccessor accessor;
   ApplictionSetConstIt it = accessor.begin();
@@ -3137,6 +3139,12 @@ bool ApplicationManagerImpl::IsReadWriteAllowed(
                 << " directory has read/write permissions.");
 
   return true;
+}
+
+void ApplicationManagerImpl::ClearTTSGlobalPropertiesList() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock lock(tts_global_properties_app_list_lock_);
+  tts_global_properties_app_list_.clear();
 }
 
 ApplicationManagerImpl::ApplicationListAccessor::~ApplicationListAccessor() {

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -51,6 +51,7 @@
 #include "utils/lock.h"
 #include "utils/stl_utils.h"
 #include "utils/singleton.h"
+#include "utils/rwlock.h"
 
 /**
  * \namespace connection_handler
@@ -402,7 +403,7 @@ class ConnectionHandlerImpl : public ConnectionHandler,
    * @return TRUE if session and connection exist otherwise returns FALSE
    */
   virtual bool ProtocolVersionUsed(uint32_t connection_id,
-  		  uint8_t session_id, uint8_t& protocol_version);
+                  uint8_t session_id, uint8_t& protocol_version);
   private:
   /**
    * \brief Default class constructor
@@ -446,7 +447,7 @@ class ConnectionHandlerImpl : public ConnectionHandler,
    *  \brief Lock for applications list
    */
   mutable sync_primitives::Lock connection_list_lock_;
-  mutable sync_primitives::Lock connection_handler_observer_lock_;
+  mutable sync_primitives::RWLock connection_handler_observer_lock_;
 
   /**
    * \brief Cleans connection list on destruction


### PR DESCRIPTION
There were two deadlocks during unregistering of all apps because of
MASTER_RESET:
- ApplicationManagerImpl::UnregisterAllApplications vs
ConnectionHandler::CloseSessionServices
- ApplicationManagerImpl::UnregisterApplication vs
ApplicationManagerImpl::RemoveAppFromTTSGlobalPropertiesList

That was causing reset flow blocking and data had not been cleaned up
completely.

Closes-bug: APPLINK-22117

Conflicts:
	src/components/application_manager/include/application_manager/application_manager_impl.h
	src/components/application_manager/src/application_manager_impl.cc
	src/components/connection_handler/include/connection_handler/connection_handler_impl.h
	src/components/connection_handler/src/connection_handler_impl.cc