### PR TITLE
Implement address and DateTime fields in SendLocation RPC

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/send_location_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/send_location_request.h
@@ -34,6 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_MOBILE_SEND_LOCATION_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_MOBILE_SEND_LOCATION_REQUEST_H_
 
+#include <list>
 #include "application_manager/commands/command_request_impl.h"
 
 namespace application_manager {
@@ -69,6 +70,12 @@ class SendLocationRequest : public CommandRequestImpl {
 
 
  private:
+
+    /**
+   * @brief CheckFieldsCompatibility checks if fields are compatible with each other.
+   * @return true if compatible, otherwise return false
+   */
+  bool CheckFieldsCompatibility();
 
   /**
    * @brief Checks sendlocation params(locationName, locationDescription, ...).

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -277,12 +277,17 @@ const char time_stamp[] = "timeStamp";
 const char manual_text_entry[] = "manualTextEntry";
 const char image_type_supported[] = "imageTypeSupported";
 const char unexpected_disconnect[] = "unexpectedDisconnect";
+
+const char longitude_degrees[] = "longitudeDegrees";
+const char latitude_degrees[] = "latitudeDegrees";
 const char location_name[] = "locationName";
 const char location_description[] = "locationDescription";
 const char address_lines[] = "addressLines";
 const char phone_number[] = "phoneNumber";
 const char number[] = "number";
 const char location_image[] = "locationImage";
+const char address[] = "address";
+
 const char is_suscribed[] = "isSubscribed";
 const char message_data[] = "messageData";
 }  // namespace strings

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -350,6 +350,10 @@ mobile_apis::Result::eType CommandRequestImpl::GetMobileResultCode(
       mobile_result = mobile_apis::Result::USER_DISALLOWED;
       break;
     }
+    case hmi_apis::Common_Result::SAVED: {
+      mobile_result = mobile_apis::Result::SAVED;
+      break;
+    }
     default: {
       LOG4CXX_ERROR(logger_, "Unknown HMI result code " << hmi_code);
       break;

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -34,7 +34,7 @@
 
 <interfaces name="SmartDeviceLink HMI API">
 
-<interface name="Common" version="1.1" date="2013-10-02">
+<interface name="Common" version="1.3" date="2016-03-20">
 
 <enum name="Result">
     <element name="SUCCESS" value="0"/>
@@ -62,6 +62,7 @@
     <element name="GENERIC_ERROR" value="22"/>
     <element name="USER_DISALLOWED" value="23"/>
     <element name="TRUNCATED_DATA" value="24"/>
+    <element name="SAVED" value="25"/>
 </enum>
 
 <enum name="TransportType">
@@ -1956,6 +1957,63 @@
 </struct>
 <!--end of IVI part-->
 
+<struct name="DateTime">
+       <param name="second" type="Integer" minvalue="0" maxvalue="60" mandatory="true">
+          <description>Seconds part of time</description>
+       </param>
+       <param name="minute" type="Integer" minvalue="0" maxvalue="59" mandatory="true">
+          <description>Minutes part of time</description>
+       </param>
+       <param name="hour" type="Integer" minvalue="0" maxvalue="23" mandatory="true">
+          <description>Hours part of time. Note that this structure accepts time only in 24 Hr format</description>
+       </param>
+       <param name="day" type="Integer" minvalue="1" maxvalue="31" mandatory="true">
+          <description>Day of the month</description>
+       </param>
+       <param name="month" type="Integer" minvalue="1" maxvalue="12" mandatory="true">
+          <description>Month of the year</description>
+       </param>
+       <param name="year" type="Integer" maxvalue="4095" mandatory="true">
+          <description>The year in YYYY format</description>
+       </param>
+       <param name="tz_hour" type="Integer" minvalue="-12" maxvalue="14" defvalue="0" mandatory="true">
+          <description>Time zone offset in Hours wrt UTC.</description>
+       </param>
+       <param name="tz_minute" type="Integer" minvalue="0" maxvalue="59" defvalue="0" mandatory="true">
+          <description>Time zone offset in Min wrt UTC.</description>
+       </param>
+    </struct>
+
+<struct name="OASISAddress">
+  <param name="countryName" minlength="0" maxlength="200" type="String" mandatory="false">
+    <description>Name of the country (localized)</description>
+  </param>
+  <param name="countryCode" minlength="0" maxlength="50" type="String" mandatory="false">
+    <description>Name of country (ISO 3166-2)</description>
+  </param>
+  <param name="postalCode" minlength="0" maxlength="16" type="String" mandatory="false">
+    <description>(PLZ, ZIP, PIN, CAP etc.)</description>
+  </param>
+  <param name="administrativeArea" minlength="0" maxlength="200" type="String" mandatory="false">
+    <description>Portion of country (e.g. state)</description>
+  </param>
+  <param name="subAdministrativeArea" minlength="0" maxlength="200" type="String" mandatory="false">
+    <description>Portion of e.g. state (e.g. county)</description>
+  </param>
+  <param name="locality" minlength="0" maxlength="200" type="String" mandatory="false">
+    <description>Hypernym for e.g. city/village</description>
+  </param>
+  <param name="subLocality" minlength="0" maxlength="200" type="String" mandatory="false">
+    <description>Hypernym for e.g. district</description>
+  </param>
+  <param name="thoroughfare" minlength="0" maxlength="200" type="String" mandatory="false">
+    <description>Hypernym for street, road etc.</description>
+  </param>
+  <param name="subThoroughfare" minlength="0" maxlength="200" type="String" mandatory="false">
+    <description>Portion of thoroughfare e.g. house number</description>
+  </param>
+</struct>
+
 </interface>
 
 <interface name="Buttons" version="1.0" date="2013-04-12">
@@ -3152,9 +3210,9 @@
     <param name="appID" type="Integer" mandatory="true">
       <description>ID of application related to this RPC.</description>
     </param>
-    <param name="longitudeDegrees" type="Float" minvalue="-180" maxvalue="180" mandatory="true">
+    <param name="longitudeDegrees" type="Float" minvalue="-180" maxvalue="180" mandatory="false">
     </param>
-    <param name="latitudeDegrees" type="Float" minvalue="-90" maxvalue="90" mandatory="true">
+    <param name="latitudeDegrees" type="Float" minvalue="-90" maxvalue="90" mandatory="false">
     </param>
     <param name="locationName" type="String" maxlength="500" mandatory="false">
       <description>     Name / title of intended location   </description>
@@ -3171,6 +3229,16 @@
     <param name="locationImage" type="Common.Image" mandatory="false">
       <description>     Image / icon of intended location (if applicable and supported)   </description>
     </param>
+    <param name="timeStamp" type="Common.DateTime" mandatory="false">
+        <description>
+            timestamp in ISO 8601 format
+        </description>
+    </param>
+
+    <param name="address" type="Common.OASISAddress" mandatory="false">
+        <description>Address to be used for setting destination</description>
+    </param>
+
   </function>
   <function name="SendLocation" messagetype="response" >
   </function>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -2245,6 +2245,62 @@
     <element name="notification" value="2" />
   </enum>
 
+    <struct name="DateTime">
+       <param name="second" type="Integer" minvalue="0" maxvalue="60" mandatory="true">
+          <description>Seconds part of time</description>
+       </param>
+       <param name="minute" type="Integer" minvalue="0" maxvalue="59" mandatory="true">
+          <description>Minutes part of time</description>
+       </param>
+       <param name="hour" type="Integer" minvalue="0" maxvalue="23" mandatory="true">
+          <description>Hours part of time. Note that this structure accepts time only in 24 Hr format</description>
+       </param>
+       <param name="day" type="Integer" minvalue="1" maxvalue="31" mandatory="true">
+          <description>Day of the month</description>
+       </param>
+       <param name="month" type="Integer" minvalue="1" maxvalue="12" mandatory="true">
+          <description>Month of the year</description>
+       </param>
+       <param name="year" type="Integer" maxvalue="4095" mandatory="true">
+          <description>The year in YYYY format</description>
+       </param>
+       <param name="tz_hour" type="Integer" minvalue="-12" maxvalue="14" defvalue="0" mandatory="true">
+          <description>Time zone offset in Hours wrt UTC.</description>
+       </param>
+       <param name="tz_minute" type="Integer" minvalue="0" maxvalue="59" defvalue="0" mandatory="true">
+          <description>Time zone offset in Min wrt UTC.</description>
+       </param>
+    </struct>
+
+<struct name="OASISAddress">
+  <param name="countryName" minlength="0" maxlength="200" type="String" mandatory="false">
+    <description>Name of the country (localized)</description>
+  </param>
+  <param name="countryCode" minlength="0" maxlength="50" type="String" mandatory="false">
+    <description>Name of country (ISO 3166-2)</description>
+  </param>
+  <param name="postalCode" minlength="0" maxlength="16" type="String" mandatory="false">
+    <description>(PLZ, ZIP, PIN, CAP etc.)</description>
+  </param>
+  <param name="administrativeArea" minlength="0" maxlength="200" type="String" mandatory="false">
+    <description>Portion of country (e.g. state)</description>
+  </param>
+  <param name="subAdministrativeArea" minlength="0" maxlength="200" type="String" mandatory="false">
+    <description>Portion of e.g. state (e.g. county)</description>
+  </param>
+  <param name="locality" minlength="0" maxlength="200" type="String" mandatory="false">
+    <description>Hypernym for e.g. city/village</description>
+  </param>
+  <param name="subLocality" minlength="0" maxlength="200" type="String" mandatory="false">
+    <description>Hypernym for e.g. district</description>
+  </param>
+  <param name="thoroughfare" minlength="0" maxlength="200" type="String" mandatory="false">
+    <description>Hypernym for street, road etc.</description>
+  </param>
+  <param name="subThoroughfare" minlength="0" maxlength="200" type="String" mandatory="false">
+    <description>Portion of thoroughfare e.g. house number</description>
+  </param>
+</struct>
   <!-- Requests/Responses -->
 
   <function name="RegisterAppInterface" functionID="RegisterAppInterfaceID" messagetype="request">
@@ -4679,9 +4735,9 @@
   </function>
 
   <function name="SendLocation" functionID="SendLocationID" messagetype="request">
-    <param name="longitudeDegrees" type="Float" minvalue="-180" maxvalue="180" mandatory="true">
+     <param name="longitudeDegrees" type="Float" minvalue="-180" maxvalue="180" mandatory="false">
     </param>
-    <param name="latitudeDegrees" type="Float" minvalue="-90" maxvalue="90" mandatory="true">
+     <param name="latitudeDegrees" type="Float" minvalue="-90" maxvalue="90" mandatory="false">
     </param>
     <param name="locationName" type="String" maxlength="500" mandatory="false">
       <description>
@@ -4707,6 +4763,16 @@
       <description>
         Image / icon of intended location (if applicable and supported)
       </description>
+     </param>
+
+     <param name="timeStamp" type="DateTime" mandatory="false">
+        <description>
+            timestamp in ISO 8601 format
+        </description>
+    </param>
+
+    <param name="address" type="OASISAddress" mandatory="false">
+        <description>Address to be used for setting destination</description>
     </param>
   </function>
 


### PR DESCRIPTION
Send location now support new fields.

CRQ delails: [SendLocation: SDL must support new "address" and "timeStamp" parameters](https://adc.luxoft.com/jira/browse/APPLINK-21336)