### PR TITLE
 Move UT for Usage Statistics class from PASA to Genivi

### DIFF
--- a/src/components/application_manager/include/application_manager/usage_statistics.h
+++ b/src/components/application_manager/include/application_manager/usage_statistics.h
@@ -34,16 +34,24 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_USAGE_STATISTICS_H_
 
 #include <string>
+#include <memory>
 #include "usage_statistics/counter.h"
+#include "usage_statistics/app_stopwatch.h"
+#include "utils/macro.h"
+#include "utils/shared_ptr.h"
 #include "interfaces/MOBILE_API.h"
 
 namespace application_manager {
 
 class UsageStatistics {
  public:
-  UsageStatistics(const std::string& app_id,
-                  utils::SharedPtr<usage_statistics::StatisticsManager>
-                  statistics_manager);
+  UsageStatistics(
+      const std::string& app_id,
+      utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager);
+  UsageStatistics(
+      const std::string& app_id,
+      utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager,
+      usage_statistics::AppStopwatch* time_in_hmi_state_ptr);
   void RecordHmiStateChanged(mobile_apis::HMILevel::eType new_hmi_level);
   void RecordAppRegistrationGuiLanguage(
       mobile_apis::Language::eType gui_language);
@@ -57,7 +65,7 @@ class UsageStatistics {
   void RecordTLSError();
 
  private:
-  usage_statistics::AppStopwatch time_in_hmi_state_;
+  std::auto_ptr<usage_statistics::AppStopwatch> time_in_hmi_state_sptr_;
   usage_statistics::AppInfo app_registration_language_gui_;
   usage_statistics::AppInfo app_registration_language_vui_;
   usage_statistics::AppCounter count_of_rejected_rpc_calls_;
@@ -66,6 +74,7 @@ class UsageStatistics {
   usage_statistics::AppCounter count_of_run_attempts_while_revoked_;
   usage_statistics::AppCounter count_of_removals_for_bad_behavior_;
   usage_statistics::AppCounter count_of_tls_error_;
+  DISALLOW_COPY_AND_ASSIGN(UsageStatistics);
 };
 
 }  // namespace application_manager

--- a/src/components/application_manager/src/usage_statistics.cc
+++ b/src/components/application_manager/src/usage_statistics.cc
@@ -31,11 +31,11 @@
  */
 
 #include "application_manager/usage_statistics.h"
-
 #include "smart_objects/smart_object.h"
 #include "smart_objects/enum_schema_item.h"
 #include "usage_statistics/statistics_manager.h"
 #include "utils/macro.h"
+#include "utils/make_shared.h"
 
 using namespace mobile_apis;
 using namespace NsSmartDeviceLink::NsSmartObjects;
@@ -53,22 +53,44 @@ std::string LanguageIdToString(Language::eType lang_id) {
 
 }  // namespace
 
+UsageStatistics::UsageStatistics(
+    const std::string& app_id,
+    utils::SharedPtr<StatisticsManager> statistics_manager)
+    : time_in_hmi_state_sptr_(
+          new usage_statistics::AppStopwatchImpl(statistics_manager, app_id))
+    , app_registration_language_gui_(statistics_manager, app_id, LANGUAGE_GUI)
+    , app_registration_language_vui_(statistics_manager, app_id, LANGUAGE_VUI)
+    , count_of_rejected_rpc_calls_(
+          statistics_manager, app_id, REJECTED_RPC_CALLS)
+    , count_of_rpcs_sent_in_hmi_none_(
+          statistics_manager, app_id, RPCS_IN_HMI_NONE)
+    , count_of_user_selections_(statistics_manager, app_id, USER_SELECTIONS)
+    , count_of_run_attempts_while_revoked_(
+          statistics_manager, app_id, RUN_ATTEMPTS_WHILE_REVOKED)
+    , count_of_removals_for_bad_behavior_(
+          statistics_manager, app_id, REMOVALS_MISBEHAVED)
+    , count_of_tls_error_(statistics_manager, app_id, COUNT_OF_TLS_ERRORS) {
+  time_in_hmi_state_sptr_->Start(SECONDS_HMI_NONE);
+}
+
 UsageStatistics::UsageStatistics(const std::string& app_id,
-    utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager)
-    : time_in_hmi_state_(statistics_manager, app_id),
-      app_registration_language_gui_(statistics_manager, app_id, LANGUAGE_GUI),
-      app_registration_language_vui_(statistics_manager, app_id, LANGUAGE_VUI),
-      count_of_rejected_rpc_calls_(statistics_manager, app_id,
-                                   REJECTED_RPC_CALLS),
-      count_of_rpcs_sent_in_hmi_none_(statistics_manager, app_id,
-                                      RPCS_IN_HMI_NONE),
-      count_of_user_selections_(statistics_manager, app_id, USER_SELECTIONS),
-      count_of_run_attempts_while_revoked_(statistics_manager, app_id,
-                                           RUN_ATTEMPTS_WHILE_REVOKED),
-      count_of_removals_for_bad_behavior_(statistics_manager, app_id,
-                                          REMOVALS_MISBEHAVED),
-      count_of_tls_error_(statistics_manager, app_id, COUNT_OF_TLS_ERRORS) {
-  time_in_hmi_state_.Start(SECONDS_HMI_NONE);
+    utils::SharedPtr<StatisticsManager> statistics_manager,
+      AppStopwatch* time_in_hmi_state_ptr)
+    : time_in_hmi_state_sptr_(time_in_hmi_state_ptr)
+    , app_registration_language_gui_(statistics_manager, app_id, LANGUAGE_GUI)
+    , app_registration_language_vui_(statistics_manager, app_id, LANGUAGE_VUI)
+    , count_of_rejected_rpc_calls_(
+          statistics_manager, app_id, REJECTED_RPC_CALLS)
+    , count_of_rpcs_sent_in_hmi_none_(
+          statistics_manager, app_id, RPCS_IN_HMI_NONE)
+    , count_of_user_selections_(statistics_manager, app_id, USER_SELECTIONS)
+    , count_of_run_attempts_while_revoked_(
+          statistics_manager, app_id, RUN_ATTEMPTS_WHILE_REVOKED)
+    , count_of_removals_for_bad_behavior_(
+          statistics_manager, app_id, REMOVALS_MISBEHAVED)
+    , count_of_tls_error_(statistics_manager, app_id, COUNT_OF_TLS_ERRORS) {
+  DCHECK(time_in_hmi_state_sptr_.get());
+  time_in_hmi_state_sptr_->Start(SECONDS_HMI_NONE);
 }
 
 void UsageStatistics::RecordHmiStateChanged(HMILevel::eType new_hmi_level) {
@@ -90,7 +112,7 @@ void UsageStatistics::RecordHmiStateChanged(HMILevel::eType new_hmi_level) {
     default:
       NOTREACHED();
   }
-  time_in_hmi_state_.Switch(next_stopwatch);
+  time_in_hmi_state_sptr_->Switch(next_stopwatch);
 }
 
 void UsageStatistics::RecordAppRegistrationGuiLanguage(

--- a/src/components/application_manager/test/CMakeLists.txt
+++ b/src/components/application_manager/test/CMakeLists.txt
@@ -89,6 +89,7 @@ set(testSources
     ${AM_TEST_DIR}/request_info_test.cc
     ${AM_TEST_DIR}/resumption_sql_queries_test.cc
     ${AM_TEST_DIR}/event_engine_test.cc
+    ${AM_TEST_DIR}/usage_statistics_test.cc
     # TODO(VVeremjova) APPLINK-12835
     #${AM_TEST_DIR}/zero_request_amount_test.cc
   )

--- a/src/components/application_manager/test/usage_statistics_test.cc
+++ b/src/components/application_manager/test/usage_statistics_test.cc
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/usage_statistics.h"
+#include <memory>
+#include "gmock/gmock.h"
+#include "smart_objects/enum_schema_item.h"
+#include "mock_statistics_manager.h"
+#include "mock_app_stopwatch.h"
+#include "utils/make_shared.h"
+#include "utils/shared_ptr.h"
+
+namespace test {
+namespace components {
+namespace usage_statistics_test {
+
+using namespace mobile_apis;                        // For Language enums
+using namespace NsSmartDeviceLink::NsSmartObjects;  // For EnumToCString &
+                                                    // EnumConversionHelper
+using namespace usage_statistics;
+using testing::_;
+
+namespace {
+
+std::string LanguageIdToString(Language::eType lang_id) {
+  const char* str;
+  const bool ok =
+      EnumConversionHelper<Language::eType>::EnumToCString(lang_id, &str);
+  return ok ? str : "unknown";
+}
+
+// Constant values used in tests
+const Language::eType kTestLanguageId = Language::eType::DE_DE;
+const usage_statistics::AppStopwatchId kTestAppStopwatchId =
+    usage_statistics::AppStopwatchId::SECONDS_HMI_NONE;
+const std::string kAppId = "SPT";
+
+}  // namespace
+
+class UsageStatisticsTest : public testing::Test {
+ public:
+  UsageStatisticsTest()
+      : mock_statistics_manager_sptr_(
+            utils::MakeShared<MockStatisticsManager>())
+      , usage_statistics_test_object1_sptr_(
+            new application_manager::UsageStatistics(
+                kAppId, mock_statistics_manager_sptr_))
+      , language_(LanguageIdToString(kTestLanguageId)) {}
+
+ protected:
+  utils::SharedPtr<MockStatisticsManager>
+      mock_statistics_manager_sptr_;
+  std::auto_ptr<application_manager::UsageStatistics>
+      usage_statistics_test_object1_sptr_;
+  const std::string language_;
+};
+
+TEST_F(UsageStatisticsTest, RecordHmiStateChanged_CallMethod_ExpectMethodCall) {
+  // Arrange
+  std::auto_ptr<MockAppStopwatch> mock_app_stopwatch_object(new MockAppStopwatch);
+
+  // Checks
+  EXPECT_CALL(*mock_app_stopwatch_object, Start(kTestAppStopwatchId));
+  EXPECT_CALL(*mock_app_stopwatch_object, Switch(kTestAppStopwatchId));
+
+  // Act
+  std::auto_ptr<application_manager::UsageStatistics>
+      usage_statistics_test_object2_sptr_(
+          new application_manager::UsageStatistics(
+              kAppId,
+              mock_statistics_manager_sptr_,
+              mock_app_stopwatch_object.release()));
+  usage_statistics_test_object2_sptr_->RecordHmiStateChanged(
+      HMILevel::eType::HMI_NONE);
+}
+
+TEST_F(UsageStatisticsTest,
+       RecordAppRegistrationGuiLanguage_CallMethod_ExpectSetMethodCall) {
+  // Expectation
+  EXPECT_CALL(*mock_statistics_manager_sptr_, Set(kAppId, _, language_));
+  // Act
+  usage_statistics_test_object1_sptr_->RecordAppRegistrationGuiLanguage(
+      kTestLanguageId);
+}
+
+TEST_F(UsageStatisticsTest,
+       RecordAppRegistrationVuiLanguage_CallMethod_ExpectSetMethodCall) {
+  // Expectation
+  EXPECT_CALL(*mock_statistics_manager_sptr_, Set(kAppId, _, language_));
+  // Act
+  usage_statistics_test_object1_sptr_->RecordAppRegistrationVuiLanguage(
+      kTestLanguageId);
+}
+
+TEST_F(UsageStatisticsTest,
+       RecordRpcSentInHMINone_CallMethod_ExpectIncrementMethodCall) {
+  // Expectation
+  EXPECT_CALL(*mock_statistics_manager_sptr_, Increment(kAppId, _));
+  // Act
+  usage_statistics_test_object1_sptr_->RecordRpcSentInHMINone();
+}
+
+TEST_F(UsageStatisticsTest,
+       RecordPolicyRejectedRpcCall_CallMethod_ExpectIncrementMethodCall) {
+  // Expectation
+  EXPECT_CALL(*mock_statistics_manager_sptr_, Increment(kAppId, _));
+  // Act
+  usage_statistics_test_object1_sptr_->RecordPolicyRejectedRpcCall();
+}
+
+TEST_F(UsageStatisticsTest,
+       RecordAppUserSelection_CallMethod_ExpectIncrementMethodCall) {
+  // Expectation
+  EXPECT_CALL(*mock_statistics_manager_sptr_, Increment(kAppId, _));
+  // Act
+  usage_statistics_test_object1_sptr_->RecordAppUserSelection();
+}
+
+TEST_F(UsageStatisticsTest,
+       RecordRunAttemptsWhileRevoked_CallMethod_ExpectIncrementMethodCall) {
+  // Expectation
+  EXPECT_CALL(*mock_statistics_manager_sptr_, Increment(kAppId, _));
+  // Act
+  usage_statistics_test_object1_sptr_->RecordRunAttemptsWhileRevoked();
+}
+
+TEST_F(UsageStatisticsTest,
+       RecordRemovalsForBadBehavior_CallMethod_ExpectIncrementMethodCall) {
+  // Expectation
+  EXPECT_CALL(*mock_statistics_manager_sptr_, Increment(kAppId, _));
+  // Act
+  usage_statistics_test_object1_sptr_->RecordRemovalsForBadBehavior();
+}
+
+TEST_F(UsageStatisticsTest,
+       RecordTLSError_CallMethod_ExpectIncrementMethodCall) {
+  // Expectation
+  EXPECT_CALL(*mock_statistics_manager_sptr_, Increment(kAppId, _));
+  // Act
+  usage_statistics_test_object1_sptr_->RecordTLSError();
+}
+
+}  // namespace usage_statistics_test
+}  // namespace components
+}  // namespace test

--- a/src/components/policy/src/policy/usage_statistics/include/usage_statistics/app_stopwatch.h
+++ b/src/components/policy/src/policy/usage_statistics/include/usage_statistics/app_stopwatch.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
@@ -30,50 +30,21 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SRC_COMPONENTS_POLICY_INCLUDE_POLICY_USAGE_STATISTICS_STATISTICS_MANAGER_H_
-#define SRC_COMPONENTS_POLICY_INCLUDE_POLICY_USAGE_STATISTICS_STATISTICS_MANAGER_H_
+#ifndef SRC_COMPONENTS_INCLUDE_POLICY_USAGE_STATISTICS_APP_STOPWATCH_H_
+#define SRC_COMPONENTS_INCLUDE_POLICY_USAGE_STATISTICS_APP_STOPWATCH_H_
 
-#include <stdint.h>
-#include <string>
+#include "statistics_manager.h"
 
 namespace usage_statistics {
 
-enum GlobalCounterId { IAP_BUFFER_FULL, SYNC_OUT_OF_MEMORY, SYNC_REBOOTS };
-
-enum AppInfoId { LANGUAGE_GUI, LANGUAGE_VUI };
-
-enum AppStopwatchId {
-  SECONDS_HMI_FULL,
-  SECONDS_HMI_LIMITED,
-  SECONDS_HMI_BACKGROUND,
-  SECONDS_HMI_NONE
-};
-
-enum AppCounterId {
-  USER_SELECTIONS,
-  REJECTIONS_SYNC_OUT_OF_MEMORY,
-  REJECTIONS_NICKNAME_MISMATCH,
-  REJECTIONS_DUPLICATE_NAME,
-  REJECTED_RPC_CALLS,
-  RPCS_IN_HMI_NONE,
-  REMOVALS_MISBEHAVED,
-  RUN_ATTEMPTS_WHILE_REVOKED,
-  COUNT_OF_TLS_ERRORS,
-};
-
-class StatisticsManager {
+class AppStopwatch {
  public:
-  virtual ~StatisticsManager() {}
-  virtual void Increment(GlobalCounterId type) = 0;
-  virtual void Increment(const std::string& app_id, AppCounterId type) = 0;
-  virtual void Set(const std::string& app_id,
-                   AppInfoId type,
-                   const std::string& value) = 0;
-  virtual void Add(const std::string& app_id,
-                   AppStopwatchId type,
-                   int32_t timespan_seconds) = 0;
+  virtual ~AppStopwatch() {}
+  virtual void Start(AppStopwatchId stopwatch_type) = 0;
+  virtual void Switch(AppStopwatchId stopwatch_type) = 0;
+  virtual void WriteTime() = 0;
 };
 
 }  //  namespace usage_statistics
 
-#endif  // SRC_COMPONENTS_INCLUDE_POLICY_USAGE_STATISTICS_STATISTICS_MANAGER_H_
+#endif  // SRC_COMPONENTS_INCLUDE_POLICY_USAGE_STATISTICS_APP_STOPWATCH_H_

--- a/src/components/policy/src/policy/usage_statistics/include/usage_statistics/counter.h
+++ b/src/components/policy/src/policy/usage_statistics/include/usage_statistics/counter.h
@@ -35,8 +35,10 @@
 
 #include <ctime>
 #include "usage_statistics/statistics_manager.h"
+#include "usage_statistics/app_stopwatch.h"
 #include "utils/shared_ptr.h"
 #include "utils/timer.h"
+#include "utils/macro.h"
 
 namespace usage_statistics {
 
@@ -44,56 +46,60 @@ using timer::Timer;
 
 class GlobalCounter {
  public:
-  GlobalCounter(utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager,
+  GlobalCounter(utils::SharedPtr<StatisticsManager> statistics_manager,
                 GlobalCounterId counter_type);
   void operator++() const;
+
  private:
   GlobalCounterId counter_type_;
-  utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager_;
+  utils::SharedPtr<StatisticsManager> statistics_manager_;
 };
 
 class AppCounter {
  public:
-  AppCounter(utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager,
+  AppCounter(utils::SharedPtr<StatisticsManager> statistics_manager,
              const std::string& app_id,
              AppCounterId counter_type);
   void operator++() const;
+
  private:
   std::string app_id_;
   AppCounterId counter_type_;
-  utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager_;
+  utils::SharedPtr<StatisticsManager> statistics_manager_;
 };
 
 class AppInfo {
  public:
-  AppInfo(utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager,
+  AppInfo(utils::SharedPtr<StatisticsManager> statistics_manager,
           const std::string& app_id,
           AppInfoId info_type);
   void Update(const std::string& new_info) const;
+
  private:
   std::string app_id_;
   AppInfoId info_type_;
-  utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager_;
+  utils::SharedPtr<StatisticsManager> statistics_manager_;
 };
 
-class AppStopwatch {
+class AppStopwatchImpl : public AppStopwatch {
  public:
-  AppStopwatch(utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager,
-               const std::string& app_id);
-  AppStopwatch(utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager,
-               const std::string& app_id,
-               uint32_t timeout);
-  ~AppStopwatch();
-  void Start(AppStopwatchId stopwatch_type);
-  void Switch(AppStopwatchId stopwatch_type);
-  void WriteTime();
+  AppStopwatchImpl(utils::SharedPtr<StatisticsManager> statistics_manager,
+                   const std::string& app_id);
+  AppStopwatchImpl(utils::SharedPtr<StatisticsManager> statistics_manager,
+                   const std::string& app_id,
+                   std::uint32_t timeout);
+  void Start(AppStopwatchId stopwatch_type) OVERRIDE;
+  void Switch(AppStopwatchId stopwatch_type) OVERRIDE;
+  void WriteTime() OVERRIDE;
+
  private:
   // Fields
   std::string app_id_;
   AppStopwatchId stopwatch_type_;
-  utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager_;
+  utils::SharedPtr<StatisticsManager> statistics_manager_;
   timer::Timer timer_;
-  const uint32_t time_out_;
+  const std::uint32_t time_out_;
+  DISALLOW_COPY_AND_ASSIGN(AppStopwatchImpl);
 };
 
 }  // namespace usage_statistics

--- a/src/components/policy/src/policy/usage_statistics/src/counter.cc
+++ b/src/components/policy/src/policy/usage_statistics/src/counter.cc
@@ -41,11 +41,10 @@
 
 namespace usage_statistics {
 
-GlobalCounter::GlobalCounter(utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager,
-                             GlobalCounterId counter_type)
-    : counter_type_(counter_type),
-      statistics_manager_(statistics_manager) {
-}
+GlobalCounter::GlobalCounter(
+    utils::SharedPtr<StatisticsManager> statistics_manager,
+    GlobalCounterId counter_type)
+    : counter_type_(counter_type), statistics_manager_(statistics_manager) {}
 
 void GlobalCounter::operator++() const {
   if (statistics_manager_) {
@@ -53,13 +52,12 @@ void GlobalCounter::operator++() const {
   }
 }
 
-AppCounter::AppCounter(utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager,
+AppCounter::AppCounter(utils::SharedPtr<StatisticsManager> statistics_manager,
                        const std::string& app_id,
                        AppCounterId counter_type)
-    : app_id_(app_id),
-      counter_type_(counter_type),
-      statistics_manager_(statistics_manager) {
-}
+    : app_id_(app_id)
+    , counter_type_(counter_type)
+    , statistics_manager_(statistics_manager) {}
 
 void AppCounter::operator++() const {
   if (statistics_manager_) {
@@ -67,13 +65,12 @@ void AppCounter::operator++() const {
   }
 }
 
-AppInfo::AppInfo(utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager,
+AppInfo::AppInfo(utils::SharedPtr<StatisticsManager> statistics_manager,
                  const std::string& app_id,
                  AppInfoId info_type)
-    : app_id_(app_id),
-      info_type_(info_type),
-      statistics_manager_(statistics_manager) {
-}
+    : app_id_(app_id)
+    , info_type_(info_type)
+    , statistics_manager_(statistics_manager) {}
 
 void AppInfo::Update(const std::string& new_info) const {
   if (statistics_manager_) {
@@ -81,39 +78,39 @@ void AppInfo::Update(const std::string& new_info) const {
   }
 }
 
-AppStopwatch::AppStopwatch(
-    utils::SharedPtr<usage_statistics::StatisticsManager> statistics_manager,
-    const std::string& app_id)
-    : app_id_(app_id),
-      stopwatch_type_(SECONDS_HMI_NONE),
-      statistics_manager_(statistics_manager),
-      timer_("HMI levels timer",
-             new timer::TimerTaskImpl<AppStopwatch>(this, &AppStopwatch::WriteTime)),
-      time_out_(60) {}
-
-AppStopwatch::AppStopwatch(
+AppStopwatchImpl::AppStopwatchImpl(
     utils::SharedPtr<StatisticsManager> statistics_manager,
-    const std::string& app_id, uint32_t timeout)
-    : app_id_(app_id),
-      stopwatch_type_(SECONDS_HMI_NONE),
-      statistics_manager_(statistics_manager),
-      timer_("HMI levels timer",
-             new timer::TimerTaskImpl<AppStopwatch>(this, &AppStopwatch::WriteTime)),
-      time_out_(timeout) {}
+    const std::string& app_id)
+    : app_id_(app_id)
+    , stopwatch_type_(SECONDS_HMI_NONE)
+    , statistics_manager_(statistics_manager)
+    , timer_("HMI levels timer",
+             new timer::TimerTaskImpl<AppStopwatchImpl>(
+                 this, &AppStopwatchImpl::WriteTime))
+    , time_out_(60) {}
 
-AppStopwatch::~AppStopwatch() {
-}
+AppStopwatchImpl::AppStopwatchImpl(
+    utils::SharedPtr<StatisticsManager> statistics_manager,
+    const std::string& app_id,
+    uint32_t timeout)
+    : app_id_(app_id)
+    , stopwatch_type_(SECONDS_HMI_NONE)
+    , statistics_manager_(statistics_manager)
+    , timer_("HMI levels timer",
+             new timer::TimerTaskImpl<AppStopwatchImpl>(
+                 this, &AppStopwatchImpl::WriteTime))
+    , time_out_(timeout) {}
 
-void AppStopwatch::Start(AppStopwatchId stopwatch_type) {
+void AppStopwatchImpl::Start(AppStopwatchId stopwatch_type) {
   stopwatch_type_ = stopwatch_type;
   timer_.Start(time_out_ * date_time::DateTime::MILLISECONDS_IN_SECOND, true);
 }
 
-void AppStopwatch::Switch(AppStopwatchId stopwatch_type) {
+void AppStopwatchImpl::Switch(AppStopwatchId stopwatch_type) {
   Start(stopwatch_type);
 }
 
-void AppStopwatch::WriteTime() {
+void AppStopwatchImpl::WriteTime() {
   if (statistics_manager_) {
     statistics_manager_->Add(app_id_, stopwatch_type_, time_out_);
   }

--- a/src/components/policy/test/CMakeLists.txt
+++ b/src/components/policy/test/CMakeLists.txt
@@ -51,7 +51,7 @@ set(testLibraries
 )
 
 set(testSources
-  usage_statistics_test.cc
+  counter_test.cc
   shared_library_test.cc
   generated_code_test.cc
   policy_manager_impl_test.cc

--- a/src/components/policy/test/counter_test.cc
+++ b/src/components/policy/test/counter_test.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015, Ford Motor Company
+/* Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include "gtest/gtest.h"
+
+#include "gmock/gmock.h"
 
 #include "mock_statistics_manager.h"
 #include "usage_statistics/counter.h"
@@ -36,8 +37,11 @@
 using ::testing::StrictMock;
 using ::testing::InSequence;
 
-namespace usage_statistics {
 namespace test {
+namespace components {
+namespace usage_statistics_test {
+
+using namespace usage_statistics;
 
 // TEST(A, B_C_D) { ... }
 // A - What you test
@@ -126,7 +130,7 @@ TEST(StatisticsManagerAddMethod, AppStopwatchStartMethod_CallONCE_StatisticsMana
   // Arrange
   MockStatisticsManager* msm = new StrictMock<MockStatisticsManager>();
   const std::uint32_t time_out = 1;
-  AppStopwatch hmi_full_stopwatch(msm, "HelloApp", time_out);
+  AppStopwatchImpl hmi_full_stopwatch(msm, "HelloApp", time_out);
 
   hmi_full_stopwatch.Start(SECONDS_HMI_FULL);
   // Assert
@@ -139,7 +143,7 @@ TEST(StatisticsManagerAddMethod, AppStopwatchStartMethod_CallONCE_StatisticsMana
 TEST(StatisticsManagerAddMethod, AppStopwatchSwitchMethod_Call_StatisticsManagerAddMethodCalled) {
   // Arrange
   MockStatisticsManager* msm = new StrictMock<MockStatisticsManager>();
-  AppStopwatch hmi_full_stopwatch(msm, "HelloApp");
+  AppStopwatchImpl hmi_full_stopwatch(msm, "HelloApp");
   hmi_full_stopwatch.Start(SECONDS_HMI_FULL);
 
   hmi_full_stopwatch.Switch(SECONDS_HMI_FULL);
@@ -155,7 +159,7 @@ TEST(StatisticsManagerAddMethod, AppStopwatchSwitchMethod_CallAnd1SecSleepAfter_
   // Arrange
   MockStatisticsManager* msm = new StrictMock<MockStatisticsManager>();
   const std::uint32_t time_out = 1;
-  AppStopwatch hmi_full_stopwatch(msm, "HelloApp", time_out);
+  AppStopwatchImpl hmi_full_stopwatch(msm, "HelloApp", time_out);
 
   // Act
   hmi_full_stopwatch.Start(SECONDS_HMI_NONE);
@@ -170,5 +174,7 @@ TEST(StatisticsManagerAddMethod, AppStopwatchSwitchMethod_CallAnd1SecSleepAfter_
   // Act
   hmi_full_stopwatch.WriteTime();
 }
+
+}  // namespace usage_statistics_test
+}  // namespace components
 }  // namespace test
-}  // namespace usage_statistics

--- a/src/components/policy/test/include/mock_app_stopwatch.h
+++ b/src/components/policy/test/include/mock_app_stopwatch.h
@@ -1,5 +1,4 @@
-﻿/*
- * Copyright (c) 2016, Ford Motor Company
+/* Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,50 +29,26 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SRC_COMPONENTS_POLICY_INCLUDE_POLICY_USAGE_STATISTICS_STATISTICS_MANAGER_H_
-#define SRC_COMPONENTS_POLICY_INCLUDE_POLICY_USAGE_STATISTICS_STATISTICS_MANAGER_H_
+#ifndef SRC_COMPONENTS_INCLUDE_TEST_POLICY_USAGE_STATISTICS_MOCK_APP_STOPWATCH_H_
+#define SRC_COMPONENTS_INCLUDE_TEST_POLICY_USAGE_STATISTICS_MOCK_APP_STOPWATCH_H_
 
-#include <stdint.h>
-#include <string>
+#include "gmock/gmock.h"
+#include "usage_statistics/app_stopwatch.h"
+#include "usage_statistics/statistics_manager.h"
 
-namespace usage_statistics {
+namespace test {
+namespace components {
+namespace usage_statistics_test {
 
-enum GlobalCounterId { IAP_BUFFER_FULL, SYNC_OUT_OF_MEMORY, SYNC_REBOOTS };
-
-enum AppInfoId { LANGUAGE_GUI, LANGUAGE_VUI };
-
-enum AppStopwatchId {
-  SECONDS_HMI_FULL,
-  SECONDS_HMI_LIMITED,
-  SECONDS_HMI_BACKGROUND,
-  SECONDS_HMI_NONE
-};
-
-enum AppCounterId {
-  USER_SELECTIONS,
-  REJECTIONS_SYNC_OUT_OF_MEMORY,
-  REJECTIONS_NICKNAME_MISMATCH,
-  REJECTIONS_DUPLICATE_NAME,
-  REJECTED_RPC_CALLS,
-  RPCS_IN_HMI_NONE,
-  REMOVALS_MISBEHAVED,
-  RUN_ATTEMPTS_WHILE_REVOKED,
-  COUNT_OF_TLS_ERRORS,
-};
-
-class StatisticsManager {
+class MockAppStopwatch : public usage_statistics::AppStopwatch {
  public:
-  virtual ~StatisticsManager() {}
-  virtual void Increment(GlobalCounterId type) = 0;
-  virtual void Increment(const std::string& app_id, AppCounterId type) = 0;
-  virtual void Set(const std::string& app_id,
-                   AppInfoId type,
-                   const std::string& value) = 0;
-  virtual void Add(const std::string& app_id,
-                   AppStopwatchId type,
-                   int32_t timespan_seconds) = 0;
+  MOCK_METHOD1(Start, void(usage_statistics::AppStopwatchId stopwatch_type));
+  MOCK_METHOD1(Switch, void(usage_statistics::AppStopwatchId stopwatch_type));
+  MOCK_METHOD0(WriteTime, void());
 };
 
-}  //  namespace usage_statistics
+}  // namespace usage_statistics_test
+}  // namespace components
+}  // namespace test
 
-#endif  // SRC_COMPONENTS_INCLUDE_POLICY_USAGE_STATISTICS_STATISTICS_MANAGER_H_
+#endif  // SRC_COMPONENTS_INCLUDE_TEST_POLICY_USAGE_STATISTICS_MOCK_APP_STOPWATCH_H_

--- a/src/components/policy/test/include/mock_statistics_manager.h
+++ b/src/components/policy/test/include/mock_statistics_manager.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013, Ford Motor Company
+/* Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,31 +28,36 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef SRC_COMPONENTS_POLICY_TEST_POLICY_INCLUDE_MOCK_STATISTICS_MANAGER_H_
-#define SRC_COMPONENTS_POLICY_TEST_POLICY_INCLUDE_MOCK_STATISTICS_MANAGER_H_
+#ifndef SRC_COMPONENTS_INCLUDE_TEST_POLICY_USAGE_STATISTICS_MOCK_STATISTICS_MANAGER_H_
+#define SRC_COMPONENTS_INCLUDE_TEST_POLICY_USAGE_STATISTICS_MOCK_STATISTICS_MANAGER_H_
 
 #include <string>
 
 #include "gmock/gmock.h"
-
 #include "usage_statistics/statistics_manager.h"
 
-namespace usage_statistics {
 namespace test {
+namespace components {
+namespace usage_statistics_test {
 
-class MockStatisticsManager: public StatisticsManager {
+class MockStatisticsManager : public usage_statistics::StatisticsManager {
  public:
-  MOCK_METHOD1(Increment, void(GlobalCounterId type));
-  MOCK_METHOD2(Increment, void(const std::string& app_id, AppCounterId type));
-  MOCK_METHOD3(Set, void(const std::string& app_id,
-                         AppInfoId type,
-                         const std::string& value));
-  MOCK_METHOD3(Add, void(const std::string& app_id,
-                         AppStopwatchId type,
-                         int32_t timespan_seconds));
+  MOCK_METHOD1(Increment, void(usage_statistics::GlobalCounterId type));
+  MOCK_METHOD2(Increment,
+               void(const std::string& app_id,
+                    usage_statistics::AppCounterId type));
+  MOCK_METHOD3(Set,
+               void(const std::string& app_id,
+                    usage_statistics::AppInfoId type,
+                    const std::string& value));
+  MOCK_METHOD3(Add,
+               void(const std::string& app_id,
+                    usage_statistics::AppStopwatchId type,
+                    int32_t timespan_seconds));
 };
 
+}  // namespace usage_statistics_test
+}  // namespace components
 }  // namespace test
-}  // namespace usage_statistics
 
-#endif  // SRC_COMPONENTS_POLICY_TEST_POLICY_INCLUDE_MOCK_STATISTICS_MANAGER_H_
+#endif  // SRC_COMPONENTS_INCLUDE_TEST_POLICY_USAGE_STATISTICS_MOCK_STATISTICS_MANAGER_H_


### PR DESCRIPTION
 1) Created unit tests for Usage Statistics class
 2) Added one more ctor to Usage Statistics class to make it testable
 3) Changed variable type from object to auto_ptr to object in Usage Statistics class
 4) Made small refactoring. Deleted redundant namespaces using
 5) AppStopWatch class renamed to AppStopWatchImpl. Added interface for this class.
 6) Added Mock class for interface AppStopWatch
 7) Changed counter.h & counter.cc to use new AppStopWatchImpl class.
 8) Fixed merge conflicts

 Relates: APPLINK-20087

[PR from PASA](https://github.com/CustomSDL/sdl_panasonic/pull/270) 