### PR TITLE
Check allowance of SendLocation by "deliveryMode" value

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -136,10 +136,8 @@ class CommandRequestImpl : public CommandImpl,
 
   /**
    * @brief Remove from current message parameters disallowed by policy table
-   * @param params_permissions Parameters permissions from policy table
    */
-  void RemoveDisallowedParameters(
-      const CommandParametersPermissions& params_permissions);
+  void RemoveDisallowedParameters();
 
   /**
    * @brief Adds disallowed parameters back to response with appropriate
@@ -156,9 +154,16 @@ class CommandRequestImpl : public CommandImpl,
   bool HasDisallowedParams() const;
 
  protected:
+  /**
+   * @brief Returns policy parameters permissions
+   * @return Parameters permissions struct reference
+   */
+  const CommandParametersPermissions& parameters_permissions() const;
+
   RequestState current_state_;
   sync_primitives::Lock state_lock_;
   CommandParametersPermissions parameters_permissions_;
+  CommandParametersPermissions removed_parameters_permissions_;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(CommandRequestImpl);

--- a/src/components/application_manager/include/application_manager/commands/mobile/send_location_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/send_location_request.h
@@ -85,7 +85,7 @@ class SendLocationRequest : public CommandRequestImpl {
   bool IsWhiteSpaceExist();
 
   bool CheckHMICapabilities(
-      std::list<hmi_apis::Common_TextFieldName::eType>& fields_names);
+      std::vector<hmi_apis::Common_TextFieldName::eType>& fields_names);
   DISALLOW_COPY_AND_ASSIGN(SendLocationRequest);
 };
 

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -300,6 +300,8 @@ extern const char* number;
 extern const char* location_image;
 extern const char* is_suscribed;
 extern const char* message_data;
+
+extern const char* delivery_mode;
 }  // namespace strings
 
 namespace json {

--- a/src/components/application_manager/src/commands/mobile/send_location_request.cc
+++ b/src/components/application_manager/src/commands/mobile/send_location_request.cc
@@ -30,6 +30,8 @@
  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  POSSIBILITY OF SUCH DAMAGE.
  */
+#include <algorithm>
+
 #include "application_manager/commands/mobile/send_location_request.h"
 
 #include "application_manager/message_helper.h"
@@ -61,9 +63,18 @@ void SendLocationRequest::Run() {
     return;
   }
 
-  SmartObject& msg_params = (*message_)[strings::msg_params];
-  std::list<Common_TextFieldName::eType> fields_to_check;
+  smart_objects::SmartObject& msg_params = (*message_)[strings::msg_params];
+  if (msg_params.keyExists(strings::delivery_mode)) {
+    const std::vector<std::string>& allowed_params =
+        parameters_permissions().allowed_params;
+    if (allowed_params.end() == std::find(allowed_params.begin(),
+                                          allowed_params.end(),
+                                          strings::delivery_mode)) {
+      msg_params.erase(strings::delivery_mode);
+    }
+  }
 
+  std::list<Common_TextFieldName::eType> fields_to_check;
   if (msg_params.keyExists(strings::location_name)) {
     fields_to_check.push_back(Common_TextFieldName::locationName);
   }

--- a/src/components/application_manager/src/commands/mobile/send_location_request.cc
+++ b/src/components/application_manager/src/commands/mobile/send_location_request.cc
@@ -74,7 +74,7 @@ void SendLocationRequest::Run() {
     }
   }
 
-  std::list<Common_TextFieldName::eType> fields_to_check;
+  std::vector<Common_TextFieldName::eType> fields_to_check;
   if (msg_params.keyExists(strings::location_name)) {
     fields_to_check.push_back(Common_TextFieldName::locationName);
   }
@@ -236,8 +236,7 @@ bool SendLocationRequest::IsWhiteSpaceExist() {
 }
 
 bool SendLocationRequest::CheckHMICapabilities(
-    std::list<hmi_apis::Common_TextFieldName::eType>& fields_names) {
-  LOG4CXX_AUTO_TRACE(logger_);
+    std::vector<hmi_apis::Common_TextFieldName::eType>& fields_names) {
   using namespace smart_objects;
   using namespace hmi_apis;
   if (fields_names.empty()) {
@@ -261,7 +260,7 @@ bool SendLocationRequest::CheckHMICapabilities(
       const Common_TextFieldName::eType filed_name =
           static_cast<Common_TextFieldName::eType>(
               text_field.getElement(strings::name).asInt());
-      const std::list<Common_TextFieldName::eType>::iterator it =
+      const std::vector<Common_TextFieldName::eType>::iterator it =
           std::find(fields_names.begin(), fields_names.end(), filed_name);
       if (it != fields_names.end()) {
         fields_names.erase(it);

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -265,6 +265,8 @@ const char* number = "number";
 const char* location_image = "locationImage";
 const char* is_suscribed = "isSubscribed";
 const char* message_data = "messageData";
+
+const char* delivery_mode = "deliveryMode";
 }  // namespace strings
 
 namespace json {

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="yes"?>
 
 <!--
-* Copyright (c) 2013, Ford Motor Company
+* Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,7 +34,7 @@
 
 <interfaces name="SmartDeviceLink HMI API">
 
-<interface name="Common" version="1.3" date="2016-03-20">
+<interface name="Common" version="1.4" date="2016-05-11">
 
 <enum name="Result">
     <element name="SUCCESS" value="0"/>
@@ -1196,6 +1196,13 @@
   <element name="DEACTIVATE_HMI">
     <description> GAL/DIO is active </description>
   </element>
+</enum>
+
+<enum name="DeliveryMode">
+  <description>The mode in which the SendLocation request is sent</description>
+  <element name="PROMPT" />
+  <element name="DESTINATION" />
+  <element name="QUEUE" />
 </enum>
 
 <!-- Policies -->
@@ -3233,7 +3240,7 @@
   </function>
 </interface>
 
-<interface name="Navigation" version="1.0" date="2013-05-22">
+<interface name="Navigation" version="1.1" date="2016-05-11">
 
   <function name="IsReady" messagetype="request">
     <description>Method is invoked at system startup. Response must provide the information about presence of UI Navigation module and its readiness to cooperate with SDL.</description>
@@ -3272,11 +3279,12 @@
             timestamp in ISO 8601 format
         </description>
     </param>
-
     <param name="address" type="Common.OASISAddress" mandatory="false">
         <description>Address to be used for setting destination</description>
     </param>
-
+    <param name="deliveryMode" type="Common.DeliveryMode" mandatory="false">
+      <description>Defines the mode of prompt for user</description>
+    </param>
   </function>
   <function name="SendLocation" messagetype="response" >
   </function>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -797,6 +797,13 @@
     <element name="DYNAMIC" />
   </enum>
 
+  <enum name="DeliveryMode">
+    <description>The mode in which the SendLocation request is sent</description>
+    <element name="PROMPT" />
+    <element name="DESTINATION" />
+    <element name="QUEUE" />
+  </enum>
+
   <struct name="Image">
     <param name="value" minlength="0" maxlength="65535" type="String"> 
       <description>Either the static hex icon value or the binary image file name identifier (sent by PutFile).</description>
@@ -4820,6 +4827,9 @@
 
     <param name="address" type="OASISAddress" mandatory="false">
         <description>Address to be used for setting destination</description>
+    </param>
+    <param name="deliveryMode" type="DeliveryMode" mandatory="false">
+      <description>Defines the mode of prompt for user</description>
     </param>
   </function>
 


### PR DESCRIPTION
1. In case
mobile app sends the SendLocation_request with “deliveryMode” parameter and other params 
and “deliveryMode” parameter is allowed by Policies 
SDL must: 
transfer _SendLocation_request to HMI
respond with <resultCode_received_from_HMI> to mobile app
 	 	 
2. In case
mobile app sends the SendLocation_request with “deliveryMode” parameter and other params 
and “deliveryMode” parameter is NOT allowed by Policies 
SDL must: 
cut off the "deliveryMode" parameter from SendLocation request
transfer SendLocation without "deliveryMode" parameter to HMI
respond with <resultCode_received_from_HMI> to mobile app

See [full](https://adc.luxoft.com/jira/browse/APPLINK-21103) CRQ description.
[JIRA](https://adc.luxoft.com/jira/browse/APPLINK-23313) ticket.

@dev-gh @AGaliuzov please review