### PR TITLE
Remove POSIX timer usage

### DIFF
--- a/src/components/application_manager/include/application_manager/request_controller.h
+++ b/src/components/application_manager/include/application_manager/request_controller.h
@@ -282,7 +282,6 @@ class RequestController {
      * timer for checking requests timeout
      */
     timer::Timer timer_;
-    static const uint32_t default_sleep_time_ = UINT_MAX;
 
     bool is_low_voltage_;
     DISALLOW_COPY_AND_ASSIGN(RequestController);

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -492,7 +492,7 @@ void ApplicationImpl::WakeUpStreaming(
       MessageHelper::SendOnDataStreaming(ServiceType::kMobileNav, true);
       video_streaming_suspended_ = false;
     }
-    video_stream_suspend_timer_.Start(video_stream_suspend_timeout_, true);
+    video_stream_suspend_timer_.Start(video_stream_suspend_timeout_, false);
   } else if (ServiceType::kAudio == service_type) {
     sync_primitives::AutoLock lock(audio_streaming_suspended_lock_);
     if (audio_streaming_suspended_) {
@@ -501,7 +501,7 @@ void ApplicationImpl::WakeUpStreaming(
       MessageHelper::SendOnDataStreaming(ServiceType::kAudio, true);
       audio_streaming_suspended_ = false;
     }
-    audio_stream_suspend_timer_.Start(audio_stream_suspend_timeout_, true);
+    audio_stream_suspend_timer_.Start(audio_stream_suspend_timeout_, false);
   }
 }
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -153,7 +153,7 @@ ApplicationManagerImpl::ApplicationManagerImpl()
                                   this,
                                   &ApplicationManagerImpl::ClearTimerPool)));
   const uint32_t timeout_ms = 10000u;
-  clearing_timer->Start(timeout_ms, true);
+  clearing_timer->Start(timeout_ms, false);
   timer_pool_.push_back(clearing_timer);
 }
 
@@ -442,7 +442,7 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
   GetPolicyHandler().OnAppsSearchStarted();
   uint32_t timeout =
       profile::Profile::instance()->application_list_update_timeout();
-  application_list_update_timer_.Start(timeout, false);
+  application_list_update_timer_.Start(timeout, true);
 
   if (!is_all_apps_allowed_) {
     LOG4CXX_WARN(logger_,
@@ -954,7 +954,7 @@ void ApplicationManagerImpl::OnFindNewApplicationsRequest() {
   LOG4CXX_DEBUG(logger_, "Starting application list update timer");
   uint32_t timeout =
       profile::Profile::instance()->application_list_update_timeout();
-  application_list_update_timer_.Start(timeout, false);
+  application_list_update_timer_.Start(timeout, true);
   GetPolicyHandler().OnAppsSearchStarted();
 }
 
@@ -2929,7 +2929,7 @@ void ApplicationManagerImpl::EndNaviServices(uint32_t app_id) {
                              new TimerTaskImpl<ApplicationManagerImpl>(
                                  this,
                                  &ApplicationManagerImpl::CloseNaviApp)));
-    close_timer->Start(navi_close_app_timeout_, false);
+    close_timer->Start(navi_close_app_timeout_, true);
 
     sync_primitives::AutoLock lock(timer_pool_lock_);
     timer_pool_.push_back(close_timer);
@@ -2972,7 +2972,7 @@ void ApplicationManagerImpl::OnHMILevelChanged(uint32_t app_id,
                                      this,
                                      &ApplicationManagerImpl::EndNaviStreaming)
                                  ));
-      end_stream_timer->Start(navi_end_stream_timeout_, false);
+      end_stream_timer->Start(navi_end_stream_timeout_, true);
 
       sync_primitives::AutoLock lock(timer_pool_lock_);
       timer_pool_.push_back(end_stream_timer);
@@ -3023,7 +3023,7 @@ void ApplicationManagerImpl::ClearTimerPool() {
   new_timer_pool.push_back(timer_pool_[0]);
 
   for (size_t i = 1; i < timer_pool_.size(); ++i) {
-    if (timer_pool_[i]->IsRunning()) {
+    if (timer_pool_[i]->is_running()) {
       new_timer_pool.push_back(timer_pool_[i]);
     }
   }
@@ -3251,7 +3251,7 @@ void ApplicationManagerImpl::AddAppToTTSGlobalPropertiesList(
     LOG4CXX_INFO(logger_, "Start tts_global_properties_timer_");
     tts_global_properties_app_list_lock_.Release();
     const uint32_t timeout_ms = 1000;
-    tts_global_properties_timer_.Start(timeout_ms, true);
+    tts_global_properties_timer_.Start(timeout_ms, false);
     return;
   }
   tts_global_properties_app_list_lock_.Release();

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -56,7 +56,6 @@ RequestController::RequestController()
       is_low_voltage_(false) {
   LOG4CXX_AUTO_TRACE(logger_);
   InitializeThreadpool();
-  timer_.Start(default_sleep_time_, true);
 }
 
 RequestController::~RequestController() {
@@ -498,10 +497,6 @@ void RequestController::UpdateTimer() {
                    << front->timeout_msec()/date_time::DateTime::MILLISECONDS_IN_SECOND);
       timer_.Start(0u, true);
     }
-  } else {
-    LOG4CXX_DEBUG(logger_, "Sleep for default sleep time "
-                  << default_sleep_time_ << " milliseconds.");
-    timer_.Start(default_sleep_time_, true);
   }
 }
 

--- a/src/components/application_manager/src/resumption/resume_ctrl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl.cc
@@ -105,7 +105,7 @@ bool ResumeCtrl::Init(resumption::LastState& last_state) {
   save_persistent_data_timer_.Start(
       profile::Profile::instance()
           ->app_resumption_save_persistent_data_timeout(),
-      true);
+      false);
   return true;
 }
 
@@ -269,17 +269,17 @@ void ResumeCtrl::OnAwake() {
 
 void ResumeCtrl::StartSavePersistentDataTimer() {
   LOG4CXX_AUTO_TRACE(logger_);
-  if (!save_persistent_data_timer_.IsRunning()) {
+  if (!save_persistent_data_timer_.is_running()) {
     save_persistent_data_timer_.Start(
         profile::Profile::instance()
             ->app_resumption_save_persistent_data_timeout(),
-        true);
+        false);
   }
 }
 
 void ResumeCtrl::StopSavePersistentDataTimer() {
   LOG4CXX_AUTO_TRACE(logger_);
-  if (save_persistent_data_timer_.IsRunning()) {
+  if (save_persistent_data_timer_.is_running()) {
     save_persistent_data_timer_.Stop();
   }
 }
@@ -731,7 +731,7 @@ void ResumeCtrl::AddToResumptionTimerQueue(uint32_t app_id) {
   if (!is_resumption_active_) {
     is_resumption_active_ = true;
     restore_hmi_level_timer_.Start(
-        profile::Profile::instance()->app_resuming_timeout(), false);
+        profile::Profile::instance()->app_resuming_timeout(), true);
   }
 }
 

--- a/src/components/include/utils/conditional_variable.h
+++ b/src/components/include/utils/conditional_variable.h
@@ -83,7 +83,7 @@ class ConditionalVariable {
   // Wait forever or up to milliseconds time limit
   bool Wait(AutoLock& auto_lock);
   bool Wait(Lock& lock);
-  WaitStatus WaitFor(AutoLock& auto_lock, int32_t milliseconds);
+  WaitStatus WaitFor(AutoLock& auto_lock, uint32_t milliseconds);
  private:
   impl::PlatformConditionalVariable cond_var_;
 

--- a/src/components/include/utils/threads/thread.h
+++ b/src/components/include/utils/threads/thread.h
@@ -198,6 +198,12 @@ class Thread {
   }
 
   /**
+   * @brief Checks if invoked in this Thread context
+   * @return True if called from this Thread class, false otherwise
+   */
+  bool IsCurrentThread() const;
+
+  /**
    * @brief Thread options.
    * @return thread options.
    */

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -161,7 +161,7 @@ bool PolicyManagerImpl::LoadPT(const std::string& file,
   cache_->SaveUpdateRequired(false);
 
   // Update finished, no need retry
-  if (timer_retry_sequence_.IsRunning()) {
+  if (timer_retry_sequence_.is_running()) {
     LOG4CXX_INFO(logger_, "Stop retry sequence");
     timer_retry_sequence_.Stop();
   }
@@ -302,9 +302,9 @@ void PolicyManagerImpl::StartPTExchange() {
     }
 
     if (update_status_manager_.IsUpdateRequired()) {
-      if (RequestPTUpdate() && !timer_retry_sequence_.IsRunning()) {
+      if (RequestPTUpdate() && !timer_retry_sequence_.is_running()) {
         // Start retry sequency
-        timer_retry_sequence_.Start(NextRetryTimeout(), true);
+        timer_retry_sequence_.Start(NextRetryTimeout(), false);
       }
     }
   }
@@ -999,12 +999,12 @@ void PolicyManagerImpl::RetrySequence() {
 
   uint32_t timeout = NextRetryTimeout();
 
-  if (!timeout && timer_retry_sequence_.IsRunning()) {
+  if (!timeout && timer_retry_sequence_.is_running()) {
     timer_retry_sequence_.Stop();
     return;
   }
 
-  timer_retry_sequence_.Start(timeout, true);
+  timer_retry_sequence_.Start(timeout, false);
 }
 
 }  //  namespace policy

--- a/src/components/policy/src/policy/usage_statistics/src/counter.cc
+++ b/src/components/policy/src/policy/usage_statistics/src/counter.cc
@@ -103,7 +103,7 @@ AppStopwatchImpl::AppStopwatchImpl(
 
 void AppStopwatchImpl::Start(AppStopwatchId stopwatch_type) {
   stopwatch_type_ = stopwatch_type;
-  timer_.Start(time_out_ * date_time::DateTime::MILLISECONDS_IN_SECOND, true);
+  timer_.Start(time_out_ * date_time::DateTime::MILLISECONDS_IN_SECOND, false);
 }
 
 void AppStopwatchImpl::Switch(AppStopwatchId stopwatch_type) {

--- a/src/components/utils/src/conditional_variable_posix.cc
+++ b/src/components/utils/src/conditional_variable_posix.cc
@@ -49,7 +49,7 @@ CREATE_LOGGERPTR_GLOBAL(logger_, "Utils")
 
 ConditionalVariable::ConditionalVariable() {
   pthread_condattr_t attrs;
-  int32_t initialized  = pthread_condattr_init(&attrs);
+  int initialized  = pthread_condattr_init(&attrs);
   if (initialized != 0)
     LOG4CXX_ERROR(logger_, "Failed to initialize "
                             "conditional variable attributes");
@@ -58,7 +58,7 @@ ConditionalVariable::ConditionalVariable() {
   if (initialized != 0)
     LOG4CXX_ERROR(logger_, "Failed to initialize "
                             "conditional variable");
-  int32_t rv = pthread_condattr_destroy(&attrs);
+  int rv = pthread_condattr_destroy(&attrs);
   if (rv != 0)
     LOG4CXX_ERROR(logger_, "Failed to destroy "
                             "conditional variable attributes");
@@ -70,14 +70,14 @@ ConditionalVariable::~ConditionalVariable() {
 }
 
 void ConditionalVariable::NotifyOne() {
-  int32_t signaled = pthread_cond_signal(&cond_var_);
+  int signaled = pthread_cond_signal(&cond_var_);
   if (signaled != 0)
     LOG4CXX_ERROR(logger_, "Failed to signal conditional variable");
 
 }
 
 void ConditionalVariable::Broadcast() {
-  int32_t signaled = pthread_cond_broadcast(&cond_var_);
+  int signaled = pthread_cond_broadcast(&cond_var_);
   if (signaled != 0)
     LOG4CXX_ERROR(logger_, "Failed to broadcast conditional variable");
 
@@ -85,7 +85,7 @@ void ConditionalVariable::Broadcast() {
 
 bool ConditionalVariable::Wait(Lock& lock) {
   lock.AssertTakenAndMarkFree();
-  int32_t wait_status = pthread_cond_wait(&cond_var_,
+  int wait_status = pthread_cond_wait(&cond_var_,
                                       &lock.mutex_);
   lock.AssertFreeAndMarkTaken();
   if (wait_status != 0) {
@@ -98,7 +98,7 @@ bool ConditionalVariable::Wait(Lock& lock) {
 bool ConditionalVariable::Wait(AutoLock& auto_lock) {
   Lock& lock = auto_lock.GetLock();
   lock.AssertTakenAndMarkFree();
-  int32_t wait_status = pthread_cond_wait(&cond_var_,
+  int wait_status = pthread_cond_wait(&cond_var_,
                                       &lock.mutex_);
   lock.AssertFreeAndMarkTaken();
   if (wait_status != 0) {
@@ -109,7 +109,7 @@ bool ConditionalVariable::Wait(AutoLock& auto_lock) {
 }
 
 ConditionalVariable::WaitStatus ConditionalVariable::WaitFor(
-    AutoLock& auto_lock, int32_t milliseconds){
+    AutoLock& auto_lock, uint32_t milliseconds){
   struct timespec now;
   clock_gettime(CLOCK_MONOTONIC, &now);
   timespec wait_interval;
@@ -121,7 +121,7 @@ ConditionalVariable::WaitStatus ConditionalVariable::WaitFor(
   wait_interval.tv_nsec %= kNanosecondsPerSecond;
   Lock& lock = auto_lock.GetLock();
   lock.AssertTakenAndMarkFree();
-  int32_t timedwait_status = pthread_cond_timedwait(&cond_var_,
+  int timedwait_status = pthread_cond_timedwait(&cond_var_,
                                                 &lock.mutex_,
                                                 &wait_interval);
   lock.AssertFreeAndMarkTaken();

--- a/src/components/utils/src/threads/posix_thread.cc
+++ b/src/components/utils/src/threads/posix_thread.cc
@@ -151,6 +151,10 @@ PlatformThreadHandle Thread::CurrentId() {
   return pthread_self();
 }
 
+bool Thread::IsCurrentThread() const {
+  return pthread_equal(CurrentId(), thread_handle());
+}
+
 bool Thread::start(const ThreadOptions& options) {
   LOG4CXX_AUTO_TRACE(logger_);
 
@@ -258,7 +262,7 @@ void Thread::stop() {
 
 void Thread::join() {
   LOG4CXX_AUTO_TRACE(logger_);
-  DCHECK(!pthread_equal(pthread_self(), handle_));
+  DCHECK_OR_RETURN_VOID(!IsCurrentThread());
 
   stop();
 

--- a/src/components/utils/src/threads/thread_delegate.cc
+++ b/src/components/utils/src/threads/thread_delegate.cc
@@ -47,7 +47,7 @@ ThreadDelegate::~ThreadDelegate() {
 
 void ThreadDelegate::exitThreadMain() {
   if (thread_) {
-    if (thread_->thread_handle() == pthread_self()) {
+    if (thread_->IsCurrentThread()) {
       pthread_exit(NULL);
     } else {
       pthread_cancel(thread_->thread_handle());


### PR DESCRIPTION
Roll back previous timer implementation based on `pthread`s because of issues with native POSIX timer. Also, restored implementation had been refactored and simplified.

@AGritsevich, @AGaliuzov, @Kozoriz @Kozoriz, @OHerasym, @pestOO, @malirod, @LuxoftAKutsan, @AByzhynar please review