### PR TITLE
Adds implementation of DialNumber RPC

### DIFF
--- a/src/components/application_manager/CMakeLists.txt
+++ b/src/components/application_manager/CMakeLists.txt
@@ -279,6 +279,8 @@ file (GLOB MOBILE_COMMANDS_SOURCES
   ${AM_SOURCE_DIR}/src/commands/hmi/on_device_state_changed_notification.cc
   ${AM_SOURCE_DIR}/src/commands/hmi/on_tts_reset_timeout_notification.cc
   ${AM_SOURCE_DIR}/src/commands/hmi/on_phone_call_notification.cc
+  ${AM_SOURCE_DIR}/src/commands/hmi/dial_number_request.cc
+  ${AM_SOURCE_DIR}/src/commands/hmi/dial_number_response.cc
 )
 
 set (HMI_COMMANDS_SOURCES_JSON

--- a/src/components/application_manager/include/application_manager/commands/hmi/dial_number_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/dial_number_request.h
@@ -60,7 +60,7 @@ class DialNumberRequest : public RequestToHMI {
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(DialNumberRequest);

--- a/src/components/application_manager/include/application_manager/commands/hmi/dial_number_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/dial_number_request.h
@@ -55,7 +55,7 @@ class DialNumberRequest : public RequestToHMI {
   /**
    * @brief DialNumberRequest class destructor
    **/
-  virtual ~DialNumberRequest();
+  ~DialNumberRequest() OVERRIDE;
 
   /**
    * @brief Execute command

--- a/src/components/application_manager/include/application_manager/commands/hmi/dial_number_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/dial_number_request.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_DIAL_NUMBER_REQUEST_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_DIAL_NUMBER_REQUEST_H_
+
+#include "application_manager/commands/hmi/request_to_hmi.h"
+
+namespace application_manager {
+
+namespace commands {
+
+namespace hmi {
+/**
+ * @brief DialNumberRequest command class
+ **/
+class DialNumberRequest : public RequestToHMI {
+ public:
+  /**
+   * @brief DialNumberRequest class constructor
+   *
+   * @param message Incoming SmartObject message
+   **/
+  explicit DialNumberRequest(const MessageSharedPtr& message);
+
+  /**
+   * @brief DialNumberRequest class destructor
+   **/
+  virtual ~DialNumberRequest();
+
+  /**
+   * @brief Execute command
+   **/
+  virtual void Run();
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(DialNumberRequest);
+};
+
+} // namespace hmi
+
+}  // namespace commands
+
+}  // namespace application_manager
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_DIAL_NUMBER_REQUEST_H_

--- a/src/components/application_manager/include/application_manager/commands/hmi/dial_number_response.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/dial_number_response.h
@@ -56,7 +56,7 @@ class DialNumberResponse : public ResponseFromHMI {
   /**
    * @brief DialNumberResponse class destructor
    **/
-  virtual ~DialNumberResponse();
+  ~DialNumberResponse() OVERRIDE;
 
   /**
    * @brief Execute command

--- a/src/components/application_manager/include/application_manager/commands/hmi/dial_number_response.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/dial_number_response.h
@@ -61,7 +61,7 @@ class DialNumberResponse : public ResponseFromHMI {
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(DialNumberResponse);

--- a/src/components/application_manager/include/application_manager/commands/hmi/dial_number_response.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/dial_number_response.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_DIAL_NUMBER_RESPONSE_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_DIAL_NUMBER_RESPONSE_H_
+
+#include "application_manager/commands/hmi/response_from_hmi.h"
+
+namespace application_manager {
+
+namespace commands {
+
+namespace hmi {
+
+/**
+ * @brief DialNumberResponse command class
+ **/
+class DialNumberResponse : public ResponseFromHMI {
+ public:
+  /**
+   * @brief DialNumberResponse class constructor
+   *
+   * @param message Incoming SmartObject message
+   **/
+  explicit DialNumberResponse(const MessageSharedPtr& message);
+
+  /**
+   * @brief DialNumberResponse class destructor
+   **/
+  virtual ~DialNumberResponse();
+
+  /**
+   * @brief Execute command
+   **/
+  virtual void Run();
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(DialNumberResponse);
+};
+
+} // namespace hmi
+
+}  // namespace commands
+
+}  // namespace application_manager
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_DIAL_NUMBER_RESPONSE_H_

--- a/src/components/application_manager/include/application_manager/commands/mobile/dial_number_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/dial_number_request.h
@@ -53,17 +53,17 @@ class DialNumberRequest : public CommandRequestImpl {
   /**
    * \brief DialNumberRequest class destructor
    **/
-  virtual ~DialNumberRequest();
+  ~DialNumberRequest() OVERRIDE;
 
   /**
     * @brief Initialize request params
    **/
-   virtual bool Init();
+   bool Init() OVERRIDE;
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() OVERRIDE;
 
   /**
    * @brief Interface method that is called whenever new event received

--- a/src/components/application_manager/include/application_manager/commands/mobile/dial_number_response.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/dial_number_response.h
@@ -30,10 +30,10 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_DIAL_NUMBER_REQUEST_H_
-#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_DIAL_NUMBER_REQUEST_H_
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_DIAL_NUMBER_RESPONSE_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_DIAL_NUMBER_RESPONSE_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/command_response_impl.h"
 #include "utils/macro.h"
 
 namespace application_manager {
@@ -41,51 +41,32 @@ namespace application_manager {
 namespace commands {
 
 /**
- * @brief DialNumber request command class
+ * @brief DialNumberResponse command class
  **/
-class DialNumberRequest : public CommandRequestImpl {
+class DialNumberResponse : public CommandResponseImpl {
  public:
   /**
-   * \brief DialNumberRequest class constructor
+   * @brief DialNumberResponse class constructor
+   *
+   * @param message Incoming SmartObject message
    **/
-  explicit DialNumberRequest(const MessageSharedPtr& message);
+  explicit DialNumberResponse(const MessageSharedPtr& message);
 
   /**
-   * \brief DialNumberRequest class destructor
+   * @brief DialNumberResponse class destructor
    **/
-  virtual ~DialNumberRequest();
-
-  /**
-    * @brief Initialize request params
-   **/
-   virtual bool Init();
+  virtual ~DialNumberResponse();
 
   /**
    * @brief Execute command
    **/
   virtual void Run();
 
-  /**
-   * @brief Interface method that is called whenever new event received
-   *
-   * @param event The received event
-   */
-  void on_event(const event_engine::Event& event);
-
  private:
-
-  /**
-   * @brief Removes from number param all characters
-   * except the + character and digits.
-   *
-   */
-  void StripNumberParam(std::string &number);
-
-  DISALLOW_COPY_AND_ASSIGN(DialNumberRequest);
+  DISALLOW_COPY_AND_ASSIGN(DialNumberResponse);
 };
 
 }  // namespace commands
-
 }  // namespace application_manager
 
-#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_DIAL_NUMBER_REQUEST_H_
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_DIAL_NUMBER_RESPONSE_H_

--- a/src/components/application_manager/include/application_manager/commands/mobile/dial_number_response.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/dial_number_response.h
@@ -55,12 +55,12 @@ class DialNumberResponse : public CommandResponseImpl {
   /**
    * @brief DialNumberResponse class destructor
    **/
-  virtual ~DialNumberResponse();
+  ~DialNumberResponse() OVERRIDE;
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(DialNumberResponse);

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -280,6 +280,7 @@ const char location_name[] = "locationName";
 const char location_description[] = "locationDescription";
 const char address_lines[] = "addressLines";
 const char phone_number[] = "phoneNumber";
+const char number[] = "number";
 const char location_image[] = "locationImage";
 const char is_suscribed[] = "isSubscribed";
 const char message_data[] = "messageData";

--- a/src/components/application_manager/src/commands/hmi/dial_number_request.cc
+++ b/src/components/application_manager/src/commands/hmi/dial_number_request.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/commands/hmi/dial_number_request.h"
+
+namespace application_manager {
+
+namespace commands {
+
+namespace hmi {
+
+DialNumberRequest::DialNumberRequest(const MessageSharedPtr& message)
+    : RequestToHMI(message) {
+}
+
+DialNumberRequest::~DialNumberRequest() {
+}
+
+void DialNumberRequest::Run() {
+  SendRequest();
+}
+
+} // namespace hmi
+
+}  // namespace commands
+
+}  // namespace application_manager
+

--- a/src/components/application_manager/src/commands/hmi/dial_number_response.cc
+++ b/src/components/application_manager/src/commands/hmi/dial_number_response.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "application_manager/commands/hmi/dial_number_response.h"
+
+namespace application_manager {
+
+namespace commands {
+
+namespace hmi {
+
+DialNumberResponse::DialNumberResponse(const MessageSharedPtr& message)
+    : ResponseFromHMI(message) {
+}
+
+DialNumberResponse::~DialNumberResponse() {
+}
+
+void DialNumberResponse::Run() {
+  event_engine::Event event(hmi_apis::FunctionID::BasicCommunication_DialNumber);
+  event.set_smart_object(*message_);
+  event.raise();
+}
+
+} // namespace hmi
+
+}  // namespace commands
+
+}  // namespace application_manager

--- a/src/components/application_manager/src/commands/mobile/dial_number_request.cc
+++ b/src/components/application_manager/src/commands/mobile/dial_number_request.cc
@@ -1,6 +1,5 @@
 /*
-
- Copyright (c) 2013, Ford Motor Company
+ Copyright (c) 2016, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -31,6 +30,8 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <algorithm>
+#include <string>
 #include "application_manager/commands/mobile/dial_number_request.h"
 #include "application_manager/application_manager_impl.h"
 #include "application_manager/application_impl.h"
@@ -40,16 +41,99 @@ namespace application_manager {
 namespace commands {
 
 DialNumberRequest::DialNumberRequest(const MessageSharedPtr& message)
-    : CommandRequestImpl(message) {
-}
+    : CommandRequestImpl(message) {}
 
-DialNumberRequest::~DialNumberRequest() {
+DialNumberRequest::~DialNumberRequest() {}
+
+bool DialNumberRequest::Init() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  default_timeout_ = 0;
+
+  return true;
 }
 
 void DialNumberRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  SendResponse(false, mobile_apis::Result::UNSUPPORTED_REQUEST);
+  ApplicationSharedPtr application =
+      ApplicationManagerImpl::instance()->application(connection_key());
+
+  if (!application) {
+    LOG4CXX_ERROR(logger_, "NULL pointer");
+    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
+    return;
+  }
+  std::string number =
+      (*message_)[strings::msg_params][strings::number].asString();
+  if (!CheckSyntax(number)) {
+    LOG4CXX_ERROR(logger_, "Invalid incoming data");
+    SendResponse(false, mobile_apis::Result::INVALID_DATA);
+    return;
+  }
+  StripNumberParam(number);
+  if (number.empty()) {
+    LOG4CXX_WARN(logger_,
+                 "After strip number param is empty. Invalid incoming data");
+    SendResponse(false, mobile_apis::Result::INVALID_DATA);
+    return;
+  }
+  smart_objects::SmartObject msg_params =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  msg_params[strings::number] =
+      (*message_)[strings::msg_params][strings::number].asString();
+  msg_params[strings::app_id] = application->hmi_app_id();
+
+  SendHMIRequest(
+      hmi_apis::FunctionID::BasicCommunication_DialNumber, &msg_params, true);
+}
+
+void DialNumberRequest::on_event(const event_engine::Event& event) {
+  ApplicationSharedPtr application =
+      ApplicationManagerImpl::instance()->application(connection_key());
+
+  if (!application) {
+    LOG4CXX_ERROR(logger_, "NULL pointer");
+    return;
+  }
+
+  const smart_objects::SmartObject& message = event.smart_object();
+  mobile_apis::Result::eType result_code = mobile_apis::Result::SUCCESS;
+  switch (event.id()) {
+    case hmi_apis::FunctionID::BasicCommunication_DialNumber: {
+      LOG4CXX_INFO(logger_, "Received DialNumber event");
+      result_code = CommandRequestImpl::GetMobileResultCode(
+          static_cast<hmi_apis::Common_Result::eType>(
+              message[strings::params][hmi_response::code].asInt()));
+      break;
+    }
+    default: {
+      LOG4CXX_ERROR(logger_, "Received unknown event" << event.id());
+      return;
+    }
+  }
+
+  const bool is_success = mobile_apis::Result::SUCCESS == result_code;
+  const bool is_info_valid =
+      message[strings::msg_params].keyExists(strings::info);
+
+  if (is_info_valid) {
+    const char* info_char_array =
+        message[strings::msg_params][strings::info].asCharArray();
+    SendResponse(is_success, result_code, info_char_array);
+    return;
+  }
+
+  SendResponse(is_success, result_code);
+}
+
+void DialNumberRequest::StripNumberParam(std::string& number) {
+  std::size_t found = 0;
+  while (std::string::npos !=
+         (found = number.find_first_not_of("+0123456789"))) {
+    number.erase(number.begin() + found);
+  }
+  (*message_)[strings::msg_params][strings::number] = number;
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/dial_number_request.cc
+++ b/src/components/application_manager/src/commands/mobile/dial_number_request.cc
@@ -130,7 +130,7 @@ void DialNumberRequest::on_event(const event_engine::Event& event) {
 void DialNumberRequest::StripNumberParam(std::string& number) {
   std::size_t found = 0;
   while (std::string::npos !=
-         (found = number.find_first_not_of("+0123456789"))) {
+         (found = number.find_first_not_of("+*#,;0123456789"))) {
     number.erase(number.begin() + found);
   }
   (*message_)[strings::msg_params][strings::number] = number;

--- a/src/components/application_manager/src/commands/mobile/dial_number_response.cc
+++ b/src/components/application_manager/src/commands/mobile/dial_number_response.cc
@@ -30,62 +30,24 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_DIAL_NUMBER_REQUEST_H_
-#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_DIAL_NUMBER_REQUEST_H_
-
-#include "application_manager/commands/command_request_impl.h"
-#include "utils/macro.h"
+#include "application_manager/commands/mobile/dial_number_response.h"
+#include "application_manager/application_manager_impl.h"
 
 namespace application_manager {
 
 namespace commands {
 
-/**
- * @brief DialNumber request command class
- **/
-class DialNumberRequest : public CommandRequestImpl {
- public:
-  /**
-   * \brief DialNumberRequest class constructor
-   **/
-  explicit DialNumberRequest(const MessageSharedPtr& message);
+DialNumberResponse::DialNumberResponse(const MessageSharedPtr& message)
+    : CommandResponseImpl(message) {
+}
 
-  /**
-   * \brief DialNumberRequest class destructor
-   **/
-  virtual ~DialNumberRequest();
+DialNumberResponse::~DialNumberResponse() {
+}
 
-  /**
-    * @brief Initialize request params
-   **/
-   virtual bool Init();
-
-  /**
-   * @brief Execute command
-   **/
-  virtual void Run();
-
-  /**
-   * @brief Interface method that is called whenever new event received
-   *
-   * @param event The received event
-   */
-  void on_event(const event_engine::Event& event);
-
- private:
-
-  /**
-   * @brief Removes from number param all characters
-   * except the + character and digits.
-   *
-   */
-  void StripNumberParam(std::string &number);
-
-  DISALLOW_COPY_AND_ASSIGN(DialNumberRequest);
-};
+void DialNumberResponse::Run() {
+  ApplicationManagerImpl::instance()->SendMessageToMobile(message_);
+}
 
 }  // namespace commands
 
 }  // namespace application_manager
-
-#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_DIAL_NUMBER_REQUEST_H_

--- a/src/components/application_manager/src/hmi_command_factory.cc
+++ b/src/components/application_manager/src/hmi_command_factory.cc
@@ -264,6 +264,8 @@
 #include "application_manager/commands/hmi/navi_send_location_response.h"
 #include "application_manager/commands/hmi/on_tts_reset_timeout_notification.h"
 #include "application_manager/commands/hmi/on_phone_call_notification.h"
+#include "application_manager/commands/hmi/dial_number_request.h"
+#include "application_manager/commands/hmi/dial_number_response.h"
 
 namespace application_manager {
 
@@ -2058,6 +2060,14 @@ CommandSharedPtr HMICommandFactory::CreateCommand(
     }
     case hmi_apis::FunctionID::BasicCommunication_OnPhoneCall: {
       command.reset(new commands::hmi::OnPhoneCallNotification(message));
+      break;
+    }
+    case hmi_apis::FunctionID::BasicCommunication_DialNumber: {
+      if (is_response) {
+        command.reset(new commands::hmi::DialNumberResponse(message));
+      } else {
+        command.reset(new commands::hmi::DialNumberRequest(message));
+      }
       break;
     }
   }

--- a/src/components/application_manager/src/mobile_command_factory.cc
+++ b/src/components/application_manager/src/mobile_command_factory.cc
@@ -125,6 +125,8 @@
 #include "application_manager/commands/mobile/diagnostic_message_response.h"
 #include "application_manager/commands/mobile/send_location_request.h"
 #include "application_manager/commands/mobile/send_location_response.h"
+#include "application_manager/commands/mobile/dial_number_request.h"
+#include "application_manager/commands/mobile/dial_number_response.h"
 #include "interfaces/MOBILE_API.h"
 
 namespace application_manager {
@@ -475,6 +477,15 @@ commands::Command *MobileCommandFactory::CreateCommand(
         return new commands::SendLocationResponse(message);
       } else {
         return new commands::SendLocationRequest(message);
+      }
+      break;
+    }
+    case mobile_apis::FunctionID::DialNumberID: {
+      if ((*message)[strings::params][strings::message_type]
+          == static_cast<int>(application_manager::MessageType::kResponse)) {
+        return  new commands::DialNumberResponse(message);
+      } else {
+        return new commands::DialNumberRequest(message);
       }
       break;
     }

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -2188,6 +2188,18 @@
          <description>Defines the name of app's request that initiates playing a tone</description>
       </param>
     </function>
+    <function name="DialNumber" messagetype="request">
+      <description>Request from SDL to call a specific number.</description>
+      <param name="number" type="String" maxlength="40">
+        <description>The number to dial. Only the character + and numbers are allowed.</description>
+      </param>
+      <param name="appID" type="Integer" mandatory="true">
+        <description>ID of application that concerns this RPC.</description>
+      </param>
+    </function>
+
+    <function name="DialNumber" messagetype="response">
+    </function>
     <!-- Policies -->
 
     <!-- SyncP RPC-->

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -2191,7 +2191,9 @@
     <function name="DialNumber" messagetype="request">
       <description>Request from SDL to call a specific number.</description>
       <param name="number" type="String" maxlength="40">
-        <description>The number to dial. Only the character + and numbers are allowed.</description>
+        <description>Phone number is a string, which can be up to 40 chars.
+        All characters shall be stripped from string except digits 0-9 and * # , ; +
+        </description>
       </param>
       <param name="appID" type="Integer" mandatory="true">
         <description>ID of application that concerns this RPC.</description>


### PR DESCRIPTION
DialNumber allows to initiate call from user's device trough device attached to the system.

All characters shall be stripped from string except digits 0-9 and * # , ; (SDL must validate the "number" param of DialNumber RPC received from mobile app and strip all characters from string except digits 0-9 and * # , ; when transferring this DialNumber RPC to HMI).

Implements: APPLINK-11266