### PR TITLE
Complete covering of protocol handler with UT

### DIFF
--- a/src/components/application_manager/test/state_controller/state_controller_test.cc
+++ b/src/components/application_manager/test/state_controller/state_controller_test.cc
@@ -38,7 +38,7 @@
 #include "application_mock.h"
 #include "connection_handler/mock_connection_handler_settings.h"
 #include "connection_handler/connection_handler_impl.h"
-#include "transport_manager/transport_manager_mock.h"
+#include "transport_manager/mock_transport_manager.h"
 #include "statistics_manager_mock.h"
 #include "utils/lock.h"
 #include "utils/data_accessor.h"

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -42,7 +42,7 @@
 #include "protocol_handler/mock_protocol_handler.h"
 #include "connection_handler_observer_mock.h"
 #include "connection_handler/mock_connection_handler_settings.h"
-#include "transport_manager/transport_manager_mock.h"
+#include "transport_manager/mock_transport_manager.h"
 #include "encryption/hashing.h"
 
 namespace test {
@@ -60,17 +60,13 @@ using ::testing::ReturnRefOfCopy;
 
 // For service types and PROTECTION_ON/OFF
 
-enum UnnamedService {
-    served_service1 = 0x06,
-   served_service2 = 0x08
-};
+enum UnnamedService { served_service1 = 0x06, served_service2 = 0x08 };
 
 class ConnectionHandlerTest : public ::testing::Test {
  protected:
   void SetUp() OVERRIDE {
-    connection_handler_ =  new ConnectionHandlerImpl(
-          mock_connection_handler_settings,
-          mock_transport_manager);
+    connection_handler_ = new ConnectionHandlerImpl(
+        mock_connection_handler_settings, mock_transport_manager);
     uid_ = 1u;
     connection_key_ = connection_handler_->KeyFromPair(0, 0u);
     protected_services_.clear();
@@ -97,10 +93,8 @@ class ConnectionHandlerTest : public ::testing::Test {
     device_name_ = "test_name";
     mac_address_ = "test_address";
 
-    const transport_manager::DeviceInfo device_info(device_handle_,
-                                                    mac_address_,
-                                                    device_name_,
-                                                    connection_type_);
+    const transport_manager::DeviceInfo device_info(
+        device_handle_, mac_address_, device_name_, connection_type_);
     // Add Device and connection
     ON_CALL(mock_connection_handler_settings, heart_beat_timeout())
         .WillByDefault(Return(1000u));
@@ -110,7 +104,7 @@ class ConnectionHandlerTest : public ::testing::Test {
   }
   void AddTestSession() {
     start_session_id_ = connection_handler_->OnSessionStartedCallback(
-                       uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_);
+        uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_);
     EXPECT_NE(0u, start_session_id_);
     EXPECT_EQ(SessionHash(uid_, start_session_id_), out_hash_id_);
     connection_key_ = connection_handler_->KeyFromPair(uid_, start_session_id_);
@@ -133,7 +127,8 @@ class ConnectionHandlerTest : public ::testing::Test {
   // If session_id is NULL - check that there is no sessions in connection
   void CheckSessionExists(const int connectionId, const int session_id) {
     // Check all tree to find Session and check own protected value
-    const ConnectionList& connection_list = connection_handler_->getConnectionList();
+    const ConnectionList& connection_list =
+        connection_handler_->getConnectionList();
     ASSERT_FALSE(connection_list.empty());
     ConnectionList::const_iterator conn_it = connection_list.find(connectionId);
     ASSERT_NE(conn_it, connection_list.end());
@@ -150,17 +145,21 @@ class ConnectionHandlerTest : public ::testing::Test {
       const ServiceList& service_list = session.service_list;
       ASSERT_FALSE(service_list.empty());
       // Check RPC and bulk services in session
-      ASSERT_NE(service_list.end(), std::find(service_list.begin(), service_list.end(), kRpc));
-      ASSERT_NE(service_list.end(), std::find(service_list.begin(), service_list.end(), kBulk));
+      ASSERT_NE(service_list.end(),
+                std::find(service_list.begin(), service_list.end(), kRpc));
+      ASSERT_NE(service_list.end(),
+                std::find(service_list.begin(), service_list.end(), kBulk));
     }
   }
 
   // Check Service Wrapper
-  void CheckServiceExists(const int connectionId, const int session_id,
+  void CheckServiceExists(const int connectionId,
+                          const int session_id,
                           const ::protocol_handler::ServiceType serviceId,
                           const bool exists) {
     // Check all trees to find Service and check own protected value
-    const ConnectionList& connection_list = connection_handler_->getConnectionList();
+    const ConnectionList& connection_list =
+        connection_handler_->getConnectionList();
     ASSERT_FALSE(connection_list.empty());
     ConnectionList::const_iterator conn_it = connection_list.find(connectionId);
     ASSERT_NE(conn_it, connection_list.end());
@@ -173,7 +172,8 @@ class ConnectionHandlerTest : public ::testing::Test {
     const Session& session = sess_it->second;
     const ServiceList& service_list = session.service_list;
     ASSERT_FALSE(service_list.empty());
-    ServiceList::const_iterator serv_it = std::find(service_list.begin(), service_list.end(), serviceId);
+    ServiceList::const_iterator serv_it =
+        std::find(service_list.begin(), service_list.end(), serviceId);
     if (exists) {
       ASSERT_NE(serv_it, service_list.end());
     } else {
@@ -181,12 +181,14 @@ class ConnectionHandlerTest : public ::testing::Test {
     }
   }
   // Check Service Wrapper
-  void CheckService(const int connectionId, const int session_id,
+  void CheckService(const int connectionId,
+                    const int session_id,
                     const ::protocol_handler::ServiceType serviceId,
                     const ::security_manager::SSLContext* ssl_context,
                     const bool is_protected) {
     // Check all tree to find Service and check own protected value
-    const ConnectionList& connection_list = connection_handler_->getConnectionList();
+    const ConnectionList& connection_list =
+        connection_handler_->getConnectionList();
     ASSERT_FALSE(connection_list.empty());
     ConnectionList::const_iterator conn_it = connection_list.find(connectionId);
     ASSERT_NE(conn_it, connection_list.end());
@@ -202,7 +204,8 @@ class ConnectionHandlerTest : public ::testing::Test {
 #endif  // ENABLE_SECURITY
     const ServiceList& service_list = session.service_list;
     ASSERT_FALSE(service_list.empty());
-    ServiceList::const_iterator serv_it = std::find(service_list.begin(), service_list.end(), serviceId);
+    ServiceList::const_iterator serv_it =
+        std::find(service_list.begin(), service_list.end(), serviceId);
     ASSERT_NE(serv_it, service_list.end());
 
     const Service& service = *serv_it;
@@ -210,25 +213,28 @@ class ConnectionHandlerTest : public ::testing::Test {
 #ifdef ENABLE_SECURITY
     if (is_protected) {
       // Emulate success protection - check enable service flag
-      const uint32_t connection_key_ = connection_handler_->KeyFromPair(
-          connectionId, session_id);
+      const uint32_t connection_key_ =
+          connection_handler_->KeyFromPair(connectionId, session_id);
       connection_handler_->SetProtectionFlag(connection_key_, serviceId);
     }
 #endif  // ENABLE_SECURITY
   }
 
-  void ChangeProtocol(const int connectionId, const int session_id, const uint8_t protocol_version) {
+  void ChangeProtocol(const int connectionId,
+                      const int session_id,
+                      const uint8_t protocol_version) {
     ConnectionList connection_list = connection_handler_->getConnectionList();
 
-    ConnectionList::const_iterator conn_it = (connection_handler_->getConnectionList()).find(connectionId);
+    ConnectionList::const_iterator conn_it =
+        (connection_handler_->getConnectionList()).find(connectionId);
     ASSERT_NE(conn_it, connection_list.end());
-    Connection * connection = conn_it->second;
+    Connection* connection = conn_it->second;
     ASSERT_TRUE(connection != NULL);
     connection->UpdateProtocolVersionSession(session_id, protocol_version);
     uint8_t check_protocol_version;
-    EXPECT_TRUE(connection->ProtocolVersion(session_id, check_protocol_version));
-    EXPECT_EQ(check_protocol_version,protocol_version);
-
+    EXPECT_TRUE(
+        connection->ProtocolVersion(session_id, check_protocol_version));
+    EXPECT_EQ(check_protocol_version, protocol_version);
   }
 
   ConnectionHandlerImpl* connection_handler_;
@@ -256,7 +262,8 @@ TEST_F(ConnectionHandlerTest, StartSession_NoConnection) {
   // Null sessionId for start new session
   const uint8_t sessionID = 0;
   // Start new session with RPC service
-  const uint32_t result_fail = connection_handler_->OnSessionStartedCallback(uid_, sessionID, kRpc, PROTECTION_ON, &out_hash_id_);
+  const uint32_t result_fail = connection_handler_->OnSessionStartedCallback(
+      uid_, sessionID, kRpc, PROTECTION_ON, &out_hash_id_);
   // Unknown connection error is '0'
   EXPECT_EQ(0u, result_fail);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
@@ -281,10 +288,12 @@ TEST_F(ConnectionHandlerTest, AddConnection_StopConnection) {
 
 TEST_F(ConnectionHandlerTest, GetConnectionSessionsCount) {
   AddTestDeviceConnection();
-  EXPECT_EQ(0u, connection_handler_->GetConnectionSessionsCount(connection_key_));
+  EXPECT_EQ(0u,
+            connection_handler_->GetConnectionSessionsCount(connection_key_));
 
   AddTestSession();
-  EXPECT_EQ(1u, connection_handler_->GetConnectionSessionsCount(connection_key_));
+  EXPECT_EQ(1u,
+            connection_handler_->GetConnectionSessionsCount(connection_key_));
 }
 
 TEST_F(ConnectionHandlerTest, GetAppIdOnSessionKey) {
@@ -294,7 +303,9 @@ TEST_F(ConnectionHandlerTest, GetAppIdOnSessionKey) {
   uint32_t app_id = 0;
   const uint32_t testid = SessionHash(uid_, start_session_id_);
 
-  EXPECT_EQ(0, connection_handler_->GetDataOnSessionKey(connection_key_, &app_id, NULL, NULL));
+  EXPECT_EQ(0,
+            connection_handler_->GetDataOnSessionKey(
+                connection_key_, &app_id, NULL, NULL));
   EXPECT_EQ(testid, app_id);
 }
 
@@ -302,41 +313,46 @@ TEST_F(ConnectionHandlerTest, GetAppIdOnSessionKey_SessionNotStarted) {
   AddTestDeviceConnection();
 
   uint32_t app_id = 0;
-  EXPECT_EQ(-1, connection_handler_->GetDataOnSessionKey(connection_key_, &app_id, NULL, NULL));
+  EXPECT_EQ(-1,
+            connection_handler_->GetDataOnSessionKey(
+                connection_key_, &app_id, NULL, NULL));
 }
 
-TEST_F(ConnectionHandlerTest,GetDeviceID) {
+TEST_F(ConnectionHandlerTest, GetDeviceID) {
   AddTestDeviceConnection();
   AddTestSession();
 
   DeviceHandle test_handle;
-  const DeviceMap & devmap = connection_handler_->getDeviceList();
+  const DeviceMap& devmap = connection_handler_->getDeviceList();
   DeviceMap::const_iterator pos = devmap.find(device_handle_);
   ASSERT_NE(pos, devmap.end());
-  const Device & devres = pos->second;
+  const Device& devres = pos->second;
   std::string test_mac_address = devres.mac_address();
 
   EXPECT_TRUE(connection_handler_->GetDeviceID(test_mac_address, &test_handle));
   EXPECT_EQ(device_handle_, test_handle);
 }
 
-TEST_F(ConnectionHandlerTest,GetDeviceName) {
+TEST_F(ConnectionHandlerTest, GetDeviceName) {
   AddTestDeviceConnection();
   AddTestSession();
 
   std::string test_device_name;
   DeviceHandle handle = 0;
-  EXPECT_EQ(0, connection_handler_->GetDataOnDeviceID(handle, &test_device_name));
+  EXPECT_EQ(0,
+            connection_handler_->GetDataOnDeviceID(handle, &test_device_name));
   EXPECT_EQ(device_name_, test_device_name);
 }
 
-TEST_F(ConnectionHandlerTest,GetConnectionType) {
+TEST_F(ConnectionHandlerTest, GetConnectionType) {
   AddTestDeviceConnection();
   AddTestSession();
 
   const DeviceHandle handle = 0;
   std::string test_connection_type;
-  EXPECT_EQ(0, connection_handler_->GetDataOnDeviceID(handle, NULL, NULL, NULL, &test_connection_type));
+  EXPECT_EQ(0,
+            connection_handler_->GetDataOnDeviceID(
+                handle, NULL, NULL, NULL, &test_connection_type));
   EXPECT_EQ(connection_type_, test_connection_type);
 }
 
@@ -346,8 +362,9 @@ TEST_F(ConnectionHandlerTest, GetApplicationsOnDevice) {
 
   const DeviceHandle handle = 0;
   std::list<uint32_t> applications_list;
-  EXPECT_EQ(0, connection_handler_->GetDataOnDeviceID(handle, NULL,
-                                                      &applications_list));
+  EXPECT_EQ(
+      0,
+      connection_handler_->GetDataOnDeviceID(handle, NULL, &applications_list));
 
   uint32_t test_id = connection_handler_->KeyFromPair(uid_, start_session_id_);
   EXPECT_EQ(1u, applications_list.size());
@@ -360,7 +377,8 @@ TEST_F(ConnectionHandlerTest, GetDefaultProtocolVersion) {
   AddTestSession();
 
   uint8_t protocol_version = 0;
-  EXPECT_TRUE(connection_handler_->ProtocolVersionUsed(uid_, start_session_id_, protocol_version));
+  EXPECT_TRUE(connection_handler_->ProtocolVersionUsed(
+      uid_, start_session_id_, protocol_version));
 
   EXPECT_EQ(PROTOCOL_VERSION_2, protocol_version);
 }
@@ -371,7 +389,8 @@ TEST_F(ConnectionHandlerTest, GetProtocolVersion) {
   ChangeProtocol(uid_, start_session_id_, PROTOCOL_VERSION_3);
 
   uint8_t protocol_version = 0;
-  EXPECT_TRUE(connection_handler_->ProtocolVersionUsed(uid_, start_session_id_, protocol_version));
+  EXPECT_TRUE(connection_handler_->ProtocolVersionUsed(
+      uid_, start_session_id_, protocol_version));
 
   EXPECT_EQ(PROTOCOL_VERSION_3, protocol_version);
 }
@@ -380,12 +399,15 @@ TEST_F(ConnectionHandlerTest, GetProtocolVersionAfterBinding) {
   AddTestDeviceConnection();
   AddTestSession();
   uint8_t protocol_version = 0;
-  EXPECT_TRUE(connection_handler_->ProtocolVersionUsed(uid_, start_session_id_, protocol_version));
+  EXPECT_TRUE(connection_handler_->ProtocolVersionUsed(
+      uid_, start_session_id_, protocol_version));
   EXPECT_EQ(PROTOCOL_VERSION_2, protocol_version);
 
-  connection_handler_->BindProtocolVersionWithSession(connection_key_, PROTOCOL_VERSION_3);
+  connection_handler_->BindProtocolVersionWithSession(connection_key_,
+                                                      PROTOCOL_VERSION_3);
 
-  EXPECT_TRUE(connection_handler_->ProtocolVersionUsed(uid_, start_session_id_, protocol_version));
+  EXPECT_TRUE(connection_handler_->ProtocolVersionUsed(
+      uid_, start_session_id_, protocol_version));
   EXPECT_EQ(PROTOCOL_VERSION_3, protocol_version);
 }
 
@@ -404,47 +426,50 @@ TEST_F(ConnectionHandlerTest, IsHeartBeatSupported) {
   AddTestDeviceConnection();
   AddTestSession();
   ChangeProtocol(uid_, start_session_id_, PROTOCOL_VERSION_3);
-  EXPECT_TRUE(connection_handler_->IsHeartBeatSupported(uid_, start_session_id_));
+  EXPECT_TRUE(
+      connection_handler_->IsHeartBeatSupported(uid_, start_session_id_));
 }
 
-TEST_F(ConnectionHandlerTest,SendEndServiceWithoutSetProtocolHandler) {
+TEST_F(ConnectionHandlerTest, SendEndServiceWithoutSetProtocolHandler) {
   AddTestDeviceConnection();
   AddTestSession();
-
-
   EXPECT_CALL(mock_protocol_handler_, SendEndService(_,_,kRpc)).Times(0);
   connection_handler_->SendEndService(connection_key_, kRpc);
 }
 
-TEST_F(ConnectionHandlerTest,SendEndService) {
+TEST_F(ConnectionHandlerTest, SendEndService) {
   AddTestDeviceConnection();
   AddTestSession();
-
-
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
   EXPECT_CALL(mock_protocol_handler_, SendEndService(_,_,kRpc));
   connection_handler_->SendEndService(connection_key_, kRpc);
 }
 
-TEST_F(ConnectionHandlerTest,OnFindNewApplicationsRequest) {
+TEST_F(ConnectionHandlerTest, OnFindNewApplicationsRequest) {
   AddTestDeviceConnection();
   AddTestSession();
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
 
   EXPECT_CALL(mock_connection_handler_observer, OnFindNewApplicationsRequest());
   connection_handler_->OnFindNewApplicationsRequest();
 }
 
-TEST_F(ConnectionHandlerTest,OnFindNewApplicationsRequestWithoutObserver) {
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  EXPECT_CALL(mock_connection_handler_observer, OnFindNewApplicationsRequest()).Times(0);
+TEST_F(ConnectionHandlerTest, OnFindNewApplicationsRequestWithoutObserver) {
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  EXPECT_CALL(mock_connection_handler_observer, OnFindNewApplicationsRequest())
+      .Times(0);
   connection_handler_->OnFindNewApplicationsRequest();
 }
 
-TEST_F(ConnectionHandlerTest,OnFindNewApplicationsRequestWithoutSession) {
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
+TEST_F(ConnectionHandlerTest, OnFindNewApplicationsRequestWithoutSession) {
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
 
   EXPECT_CALL(mock_connection_handler_observer, OnFindNewApplicationsRequest());
   connection_handler_->OnFindNewApplicationsRequest();
@@ -455,18 +480,24 @@ TEST_F(ConnectionHandlerTest, OnMalformedMessageCallback) {
   AddTestSession();
   AddTestService(kAudio);
   AddTestService(kMobileNav);
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
 
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kMobileNav, kMalformed)).Times(1);
+              OnServiceEndedCallback(connection_key_, kMobileNav, kMalformed))
+      .Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kAudio, kMalformed)).Times(1);
+              OnServiceEndedCallback(connection_key_, kAudio, kMalformed))
+      .Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kMalformed)).Times(1);
+              OnServiceEndedCallback(connection_key_, kBulk, kMalformed))
+      .Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kMalformed)).Times(1);
+              OnServiceEndedCallback(connection_key_, kRpc, kMalformed))
+      .Times(1);
   connection_handler_->OnMalformedMessageCallback(uid_);
 }
 
@@ -475,23 +506,23 @@ TEST_F(ConnectionHandlerTest, OnApplicationFloodCallBack) {
   AddTestSession();
   AddTestService(kAudio);
   AddTestService(kMobileNav);
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
-
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
   EXPECT_CALL(mock_protocol_handler_, SendEndSession(uid_,start_session_id_)).Times(1);
-
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kMobileNav, kCommon));
+              OnServiceEndedCallback(connection_key_, kMobileNav, kCommon));
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kAudio, kCommon));
+              OnServiceEndedCallback(connection_key_, kAudio, kCommon));
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kCommon));
+              OnServiceEndedCallback(connection_key_, kBulk, kCommon));
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kCommon));
+              OnServiceEndedCallback(connection_key_, kRpc, kCommon));
   connection_handler_->OnApplicationFloodCallBack(uid_);
 }
 
@@ -502,23 +533,22 @@ TEST_F(ConnectionHandlerTest, OnApplicationFloodCallBack_SessionFound) {
   AddTestService(kAudio);
   AddTestService(kMobileNav);
 
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
-
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-
   EXPECT_CALL(mock_protocol_handler_, SendEndSession(uid_,start_session_id_));
-
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kMobileNav, kFlood));
+              OnServiceEndedCallback(connection_key_, kMobileNav, kFlood));
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kAudio, kFlood));
+              OnServiceEndedCallback(connection_key_, kAudio, kFlood));
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kFlood));
+              OnServiceEndedCallback(connection_key_, kBulk, kFlood));
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kFlood));
+              OnServiceEndedCallback(connection_key_, kRpc, kFlood));
 
   connection_handler_->OnApplicationFloodCallBack(connection_key_);
 }
@@ -527,8 +557,10 @@ TEST_F(ConnectionHandlerTest, StartDevicesDiscovery) {
   AddTestDeviceConnection();
   AddTestSession();
 
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
 
   EXPECT_CALL(mock_transport_manager, SearchDevices());
   EXPECT_CALL(mock_connection_handler_observer, OnDeviceListUpdated(_));
@@ -549,13 +581,14 @@ MATCHER_P(CheckDevList, check_device_map, "") {
       return false;
     }
     if ((*it).second.device_handle() != (*check_it).second.device_handle()) {
-       return false;
+      return false;
     }
     if ((*it).second.mac_address() != (*check_it).second.mac_address()) {
-       return false;
+      return false;
     }
-    if ((*it).second.connection_type() != (*check_it).second.connection_type()) {
-       return false;
+    if ((*it).second.connection_type() !=
+        (*check_it).second.connection_type()) {
+      return false;
     }
   }
   return true;
@@ -573,8 +606,8 @@ TEST_F(ConnectionHandlerTest, UpdateDeviceList) {
   connection_type_ = "BTMAC";
   device_name_ = "test_name";
   mac_address_ = "test_address";
-  const transport_manager::DeviceInfo added_info(0, "test_address", "test_name",
-                                                 "BTMAC");
+  const transport_manager::DeviceInfo added_info(
+      0, "test_address", "test_name", "BTMAC");
   connection_handler_->OnDeviceAdded(added_info);
 
   // Prepare map with DeviceInfo that sets in OnDeviceListUpdated
@@ -583,11 +616,12 @@ TEST_F(ConnectionHandlerTest, UpdateDeviceList) {
   std::vector<transport_manager::DeviceInfo> unused_info;
   unused_info.push_back(unused_parameter);
   DeviceMap map_with_unused_var;
-  map_with_unused_var.insert(DeviceMap::value_type(
-      unused_parameter.device_handle(),
-      Device(unused_parameter.device_handle(), unused_parameter.name(),
-             unused_parameter.mac_address(),
-             unused_parameter.connection_type())));
+  map_with_unused_var.insert(
+      DeviceMap::value_type(unused_parameter.device_handle(),
+                            Device(unused_parameter.device_handle(),
+                                   unused_parameter.name(),
+                                   unused_parameter.mac_address(),
+                                   unused_parameter.connection_type())));
 
   // Only previously added devices is updated
   EXPECT_CALL(
@@ -606,10 +640,10 @@ TEST_F(ConnectionHandlerTest, GetConnectedDevicesMAC) {
   const std::string mac_address1 = "test_address1";
   const std::string mac_address2 = "test_address2";
 
-  const transport_manager::DeviceInfo device1(0, mac_address1, device_name_,
-                                                 connection_type_);
-  const transport_manager::DeviceInfo device2(1, mac_address2, device_name_,
-                                                 connection_type_);
+  const transport_manager::DeviceInfo device1(
+      0, mac_address1, device_name_, connection_type_);
+  const transport_manager::DeviceInfo device2(
+      1, mac_address2, device_name_, connection_type_);
   connection_handler_->OnDeviceAdded(device1);
   connection_handler_->OnDeviceAdded(device2);
 
@@ -618,7 +652,7 @@ TEST_F(ConnectionHandlerTest, GetConnectedDevicesMAC) {
   const std::string check_mac2 = encryption::MakeHash(mac_address2);
   std::vector<std::string> device_macs;
   connection_handler_->GetConnectedDevicesMAC(device_macs);
-  ASSERT_EQ(2u,device_macs.size());
+  ASSERT_EQ(2u, device_macs.size());
   EXPECT_EQ(check_mac1, device_macs.at(0));
   EXPECT_EQ(check_mac2, device_macs.at(1));
 }
@@ -636,19 +670,21 @@ TEST_F(ConnectionHandlerTest, OnDeviceRemoved_ServiceNotStarted) {
   const uint32_t dev_handle1 = 1;
   const uint32_t dev_handle2 = 2;
 
-  const transport_manager::DeviceInfo device1(dev_handle1, mac_address_,
-                                              device_name_, connection_type_);
-  const transport_manager::DeviceInfo device2(dev_handle2, mac_address_,
-                                              device_name_, connection_type_);
+  const transport_manager::DeviceInfo device1(
+      dev_handle1, mac_address_, device_name_, connection_type_);
+  const transport_manager::DeviceInfo device2(
+      dev_handle2, mac_address_, device_name_, connection_type_);
   connection_handler_->OnDeviceAdded(device1);
   connection_handler_->OnDeviceAdded(device2);
 
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
 
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
-
-  EXPECT_CALL(mock_connection_handler_observer, RemoveDevice(dev_handle1) );
-  EXPECT_CALL(mock_connection_handler_observer, OnServiceEndedCallback(_,_,_)).Times(0);
+  EXPECT_CALL(mock_connection_handler_observer, RemoveDevice(dev_handle1));
+  EXPECT_CALL(mock_connection_handler_observer, OnServiceEndedCallback(_, _, _))
+      .Times(0);
   connection_handler_->OnDeviceRemoved(device1);
 }
 
@@ -657,20 +693,20 @@ TEST_F(ConnectionHandlerTest, OnDeviceRemoved_ServiceStarted) {
   AddTestDeviceConnection();
   AddTestSession();
 
-  const transport_manager::DeviceInfo device1(device_handle_,
-                                                  mac_address_,
-                                                  device_name_,
-                                                  connection_type_);
+  const transport_manager::DeviceInfo device1(
+      device_handle_, mac_address_, device_name_, connection_type_);
 
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
 
   EXPECT_CALL(mock_connection_handler_observer, RemoveDevice(device_handle_));
 
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kCommon));
+              OnServiceEndedCallback(connection_key_, kBulk, kCommon));
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kCommon));
+              OnServiceEndedCallback(connection_key_, kRpc, kCommon));
   connection_handler_->OnDeviceRemoved(device1);
 }
 
@@ -678,13 +714,15 @@ TEST_F(ConnectionHandlerTest, OnConnectionClosed) {
   AddTestDeviceConnection();
   AddTestSession();
 
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
 
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kCommon));
+              OnServiceEndedCallback(connection_key_, kBulk, kCommon));
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kCommon));
+              OnServiceEndedCallback(connection_key_, kRpc, kCommon));
 
   connection_handler_->OnConnectionClosed(uid_);
 }
@@ -693,27 +731,30 @@ TEST_F(ConnectionHandlerTest, OnUnexpectedDisconnect) {
   AddTestDeviceConnection();
   AddTestSession();
 
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
   transport_manager::CommunicationError err;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, CloseSessionReason::kCommon));
+              OnServiceEndedCallback(
+                  connection_key_, kBulk, CloseSessionReason::kCommon));
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, CloseSessionReason::kCommon));
+              OnServiceEndedCallback(
+                  connection_key_, kRpc, CloseSessionReason::kCommon));
 
-  connection_handler_->OnUnexpectedDisconnect(uid_,err);
+  connection_handler_->OnUnexpectedDisconnect(uid_, err);
 }
-
 
 TEST_F(ConnectionHandlerTest, ConnectToDevice) {
   // Precondition
   const uint32_t dev_handle1 = 1;
   const uint32_t dev_handle2 = 2;
 
-  const transport_manager::DeviceInfo device1(dev_handle1, mac_address_,
-                                              device_name_, connection_type_);
-  const transport_manager::DeviceInfo device2(dev_handle2, mac_address_,
-                                              device_name_, connection_type_);
+  const transport_manager::DeviceInfo device1(
+      dev_handle1, mac_address_, device_name_, connection_type_);
+  const transport_manager::DeviceInfo device2(
+      dev_handle2, mac_address_, device_name_, connection_type_);
   connection_handler_->OnDeviceAdded(device1);
   connection_handler_->OnDeviceAdded(device2);
 
@@ -728,10 +769,10 @@ TEST_F(ConnectionHandlerTest, ConnectToAllDevices) {
   const uint32_t dev_handle1 = 1;
   const uint32_t dev_handle2 = 2;
 
-  const transport_manager::DeviceInfo device1(dev_handle1, mac_address_,
-                                              device_name_, connection_type_);
-  const transport_manager::DeviceInfo device2(dev_handle2, mac_address_,
-                                              device_name_, connection_type_);
+  const transport_manager::DeviceInfo device1(
+      dev_handle1, mac_address_, device_name_, connection_type_);
+  const transport_manager::DeviceInfo device2(
+      dev_handle2, mac_address_, device_name_, connection_type_);
   connection_handler_->OnDeviceAdded(device1);
   connection_handler_->OnDeviceAdded(device2);
 
@@ -763,23 +804,24 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithCommonReason) {
   AddTestSession();
   AddTestService(kAudio);
   AddTestService(kMobileNav);
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
-
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-
   EXPECT_CALL(mock_protocol_handler_, SendEndSession(uid_,start_session_id_)).Times(1);
-
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kMobileNav, kCommon)).Times(1);
+              OnServiceEndedCallback(connection_key_, kMobileNav, kCommon))
+      .Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kAudio, kCommon)).Times(1);
+              OnServiceEndedCallback(connection_key_, kAudio, kCommon))
+      .Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kCommon)).Times(1);
+              OnServiceEndedCallback(connection_key_, kBulk, kCommon)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kCommon)).Times(1);
+              OnServiceEndedCallback(connection_key_, kRpc, kCommon)).Times(1);
   connection_handler_->CloseSession(connection_key_, kCommon);
   Mock::AsyncVerifyAndClearExpectations(10000);
 }
@@ -789,23 +831,24 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithFloodReason) {
   AddTestSession();
   AddTestService(kAudio);
   AddTestService(kMobileNav);
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
-
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-
   EXPECT_CALL(mock_protocol_handler_, SendEndSession(uid_,start_session_id_)).Times(1);
 
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kMobileNav, kFlood)).Times(1);
+              OnServiceEndedCallback(connection_key_, kMobileNav, kFlood))
+      .Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kAudio, kFlood)).Times(1);
+              OnServiceEndedCallback(connection_key_, kAudio, kFlood)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kFlood)).Times(1);
+              OnServiceEndedCallback(connection_key_, kBulk, kFlood)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kFlood)).Times(1);
+              OnServiceEndedCallback(connection_key_, kRpc, kFlood)).Times(1);
   connection_handler_->CloseSession(connection_key_, kFlood);
   Mock::AsyncVerifyAndClearExpectations(10000);
 }
@@ -815,23 +858,27 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithMalformedMessage) {
   AddTestSession();
   AddTestService(kAudio);
   AddTestService(kMobileNav);
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
-
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
   EXPECT_CALL(mock_protocol_handler_, SendEndSession(uid_,start_session_id_)).Times(0);
-
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kMobileNav, kMalformed)).Times(1);
+              OnServiceEndedCallback(connection_key_, kMobileNav, kMalformed))
+      .Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kAudio, kMalformed)).Times(1);
+              OnServiceEndedCallback(connection_key_, kAudio, kMalformed))
+      .Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kMalformed)).Times(1);
+              OnServiceEndedCallback(connection_key_, kBulk, kMalformed))
+      .Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kMalformed)).Times(1);
+              OnServiceEndedCallback(connection_key_, kRpc, kMalformed))
+      .Times(1);
   connection_handler_->CloseSession(connection_key_, kMalformed);
   Mock::AsyncVerifyAndClearExpectations(10000);
 }
@@ -841,23 +888,27 @@ TEST_F(ConnectionHandlerTest, CloseConnectionSessionsWithMalformedMessage) {
   AddTestSession();
   AddTestService(kAudio);
   AddTestService(kMobileNav);
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
-
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
   EXPECT_CALL(mock_protocol_handler_, SendEndSession(uid_,start_session_id_)).Times(0);
-
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kMobileNav, kMalformed)).Times(1);
+              OnServiceEndedCallback(connection_key_, kMobileNav, kMalformed))
+      .Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kAudio, kMalformed)).Times(1);
+              OnServiceEndedCallback(connection_key_, kAudio, kMalformed))
+      .Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kMalformed)).Times(1);
+              OnServiceEndedCallback(connection_key_, kBulk, kMalformed))
+      .Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kMalformed)).Times(1);
+              OnServiceEndedCallback(connection_key_, kRpc, kMalformed))
+      .Times(1);
   connection_handler_->CloseConnectionSessions(uid_, kMalformed);
   Mock::AsyncVerifyAndClearExpectations(10000);
 }
@@ -867,23 +918,25 @@ TEST_F(ConnectionHandlerTest, CloseConnectionSessionsWithCommonReason) {
   AddTestSession();
   AddTestService(kAudio);
   AddTestService(kMobileNav);
-  connection_handler_test::ConnectionHandlerObserverMock mock_connection_handler_observer;
-  connection_handler_->set_connection_handler_observer(&mock_connection_handler_observer);
-
+  connection_handler_test::ConnectionHandlerObserverMock
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
   EXPECT_CALL(mock_protocol_handler_, SendEndSession(uid_,start_session_id_)).Times(1);
-
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_, kMobileNav, kCommon)).Times(1);
+              OnServiceEndedCallback(connection_key_, kMobileNav, kCommon))
+      .Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kAudio, kCommon)).Times(1);
+              OnServiceEndedCallback(connection_key_, kAudio, kCommon))
+      .Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kBulk, kCommon)).Times(1);
+              OnServiceEndedCallback(connection_key_, kBulk, kCommon)).Times(1);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceEndedCallback(connection_key_,kRpc, kCommon)).Times(1);
+              OnServiceEndedCallback(connection_key_, kRpc, kCommon)).Times(1);
   connection_handler_->CloseConnectionSessions(uid_, kCommon);
   Mock::AsyncVerifyAndClearExpectations(10000);
 }
@@ -895,7 +948,7 @@ TEST_F(ConnectionHandlerTest, StartService_withServices) {
 
   // Start Audio service
   const uint32_t start_audio = connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
   EXPECT_EQ(start_session_id_, start_audio);
   CheckServiceExists(uid_, start_session_id_, kAudio, true);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
@@ -911,8 +964,8 @@ TEST_F(ConnectionHandlerTest, StartService_withServices) {
 TEST_F(ConnectionHandlerTest, ServiceStop_UnExistSession) {
   AddTestDeviceConnection();
 
-  const uint32_t end_session_result = connection_handler_->OnSessionEndedCallback(
-        uid_, 0u, 0u, kAudio);
+  const uint32_t end_session_result =
+      connection_handler_->OnSessionEndedCallback(uid_, 0u, 0u, kAudio);
   EXPECT_EQ(0u, end_session_result);
   CheckSessionExists(uid_, 0);
 }
@@ -920,8 +973,9 @@ TEST_F(ConnectionHandlerTest, ServiceStop_UnExistSession) {
 TEST_F(ConnectionHandlerTest, ServiceStop_UnExistService) {
   AddTestDeviceConnection();
   AddTestSession();
-  const uint32_t end_session_result = connection_handler_->OnSessionEndedCallback(
-        uid_, start_session_id_, 0u, kAudio);
+  const uint32_t end_session_result =
+      connection_handler_->OnSessionEndedCallback(
+          uid_, start_session_id_, 0u, kAudio);
   EXPECT_EQ(0u, end_session_result);
   CheckServiceExists(uid_, start_session_id_, kAudio, false);
 }
@@ -933,12 +987,13 @@ TEST_F(ConnectionHandlerTest, ServiceStop) {
   for (uint32_t some_hash_id = 0; some_hash_id < 0xFF; ++some_hash_id) {
     // Start audio service
     const uint32_t start_audio = connection_handler_->OnSessionStartedCallback(
-          uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
+        uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
     EXPECT_EQ(start_session_id_, start_audio);
     EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
 
-    const uint32_t end_session_result = connection_handler_->OnSessionEndedCallback(
-          uid_, start_session_id_, some_hash_id, kAudio);
+    const uint32_t end_session_result =
+        connection_handler_->OnSessionEndedCallback(
+            uid_, start_session_id_, some_hash_id, kAudio);
     EXPECT_EQ(connection_key_, end_session_result);
     CheckServiceExists(uid_, start_session_id_, kAudio, false);
   }
@@ -952,13 +1007,14 @@ TEST_F(ConnectionHandlerTest, SessionStop_CheckHash) {
     const uint32_t hash = connection_key_;
     const uint32_t wrong_hash = hash + 1;
 
-    const uint32_t end_audio_wrong_hash = connection_handler_->OnSessionEndedCallback(
-          uid_, start_session_id_, wrong_hash, kRpc);
+    const uint32_t end_audio_wrong_hash =
+        connection_handler_->OnSessionEndedCallback(
+            uid_, start_session_id_, wrong_hash, kRpc);
     EXPECT_EQ(0u, end_audio_wrong_hash);
     CheckSessionExists(uid_, start_session_id_);
 
     const uint32_t end_audio = connection_handler_->OnSessionEndedCallback(
-          uid_, start_session_id_, hash, kRpc);
+        uid_, start_session_id_, hash, kRpc);
     EXPECT_EQ(connection_key_, end_audio);
     CheckSessionExists(uid_, 0);
   }
@@ -972,13 +1028,14 @@ TEST_F(ConnectionHandlerTest, SessionStop_CheckSpecificHash) {
     const uint32_t wrong_hash = protocol_handler::HASH_ID_WRONG;
     const uint32_t hash = protocol_handler::HASH_ID_NOT_SUPPORTED;
 
-    const uint32_t end_audio_wrong_hash = connection_handler_->OnSessionEndedCallback(
-          uid_, start_session_id_, wrong_hash, kRpc);
+    const uint32_t end_audio_wrong_hash =
+        connection_handler_->OnSessionEndedCallback(
+            uid_, start_session_id_, wrong_hash, kRpc);
     EXPECT_EQ(0u, end_audio_wrong_hash);
     CheckSessionExists(uid_, start_session_id_);
 
     const uint32_t end_audio = connection_handler_->OnSessionEndedCallback(
-          uid_, start_session_id_, hash, kRpc);
+        uid_, start_session_id_, hash, kRpc);
     EXPECT_EQ(connection_key_, end_audio);
     CheckSessionExists(uid_, 0);
   }
@@ -1005,7 +1062,8 @@ TEST_F(ConnectionHandlerTest, SessionStarted_WithRpc) {
   EXPECT_NE(0u, new_session_id);
 }
 
-TEST_F(ConnectionHandlerTest, SessionStarted_StartSession_SecureSpecific_Unprotect) {
+TEST_F(ConnectionHandlerTest,
+       SessionStarted_StartSession_SecureSpecific_Unprotect) {
   EXPECT_CALL(mock_connection_handler_settings, heart_beat_timeout())
       .WillOnce(Return(heartbeat_timeout));
   // Add virtual device and connection
@@ -1014,8 +1072,9 @@ TEST_F(ConnectionHandlerTest, SessionStarted_StartSession_SecureSpecific_Unprote
   protected_services_.push_back(kRpc);
   SetSpecificServices();
   // Start new session with RPC service
-  const uint32_t session_id_fail = connection_handler_->OnSessionStartedCallback(
-        uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_);
+  const uint32_t session_id_fail =
+      connection_handler_->OnSessionStartedCallback(
+          uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_fail);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
@@ -1030,13 +1089,14 @@ TEST_F(ConnectionHandlerTest, SessionStarted_StartSession_SecureSpecific_Unprote
   SetSpecificServices();
   // Start new session with RPC service
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-        uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_);
+      uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_);
   EXPECT_NE(0u, session_id);
   CheckService(uid_, session_id, kRpc, NULL, PROTECTION_OFF);
   EXPECT_EQ(SessionHash(uid_, session_id), out_hash_id_);
 }
 
-TEST_F(ConnectionHandlerTest, SessionStarted_StartSession_SecureSpecific_Protect) {
+TEST_F(ConnectionHandlerTest,
+       SessionStarted_StartSession_SecureSpecific_Protect) {
   // Add virtual device and connection
   AddTestDeviceConnection();
   // Forbid start kRPC with encryption
@@ -1046,8 +1106,9 @@ TEST_F(ConnectionHandlerTest, SessionStarted_StartSession_SecureSpecific_Protect
   unprotected_services_.push_back(kControl);
   SetSpecificServices();
   // Start new session with RPC service
-  const uint32_t session_id_fail = connection_handler_->OnSessionStartedCallback(
-        uid_, 0, kRpc, PROTECTION_ON, NULL);
+  const uint32_t session_id_fail =
+      connection_handler_->OnSessionStartedCallback(
+          uid_, 0, kRpc, PROTECTION_ON, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_fail);
 #else
@@ -1060,7 +1121,7 @@ TEST_F(ConnectionHandlerTest, SessionStarted_StartSession_SecureSpecific_Protect
   SetSpecificServices();
   // Start new session with RPC service
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-        uid_, 0, kRpc, PROTECTION_ON, &out_hash_id_);
+      uid_, 0, kRpc, PROTECTION_ON, &out_hash_id_);
   EXPECT_NE(0u, session_id);
   EXPECT_EQ(SessionHash(uid_, session_id), out_hash_id_);
 
@@ -1068,7 +1129,8 @@ TEST_F(ConnectionHandlerTest, SessionStarted_StartSession_SecureSpecific_Protect
   CheckService(uid_, session_id, kRpc, NULL, PROTECTION_OFF);
 }
 
-TEST_F(ConnectionHandlerTest, SessionStarted_StartService_SecureSpecific_Unprotect) {
+TEST_F(ConnectionHandlerTest,
+       SessionStarted_StartService_SecureSpecific_Unprotect) {
   AddTestDeviceConnection();
   AddTestSession();
 
@@ -1080,7 +1142,7 @@ TEST_F(ConnectionHandlerTest, SessionStarted_StartService_SecureSpecific_Unprote
   SetSpecificServices();
   // Start new session with Audio service
   const uint32_t session_id2 = connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL);
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id2);
 #else
@@ -1094,21 +1156,20 @@ TEST_F(ConnectionHandlerTest, SessionStarted_StartService_SecureSpecific_Unprote
   protected_services_.push_back(kControl);
   SetSpecificServices();
   const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
-  // Returned original session id
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
+// Returned original session id
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
-  CheckService(uid_, session_id3, kRpc,
-      NULL,
-      PROTECTION_OFF);
+  CheckService(uid_, session_id3, kRpc, NULL, PROTECTION_OFF);
 #else
   EXPECT_EQ(0u, session_id3);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
 #endif  // ENABLE_SECURITY
 }
 
-TEST_F(ConnectionHandlerTest, SessionStarted_StartService_SecureSpecific_Protect) {
+TEST_F(ConnectionHandlerTest,
+       SessionStarted_StartService_SecureSpecific_Protect) {
   AddTestDeviceConnection();
   AddTestSession();
 
@@ -1119,8 +1180,9 @@ TEST_F(ConnectionHandlerTest, SessionStarted_StartService_SecureSpecific_Protect
   unprotected_services_.push_back(kControl);
   SetSpecificServices();
   // Start new session with Audio service
-  const uint32_t session_id_reject = connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
+  const uint32_t session_id_reject =
+      connection_handler_->OnSessionStartedCallback(
+          uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_reject);
 #else
@@ -1130,14 +1192,12 @@ TEST_F(ConnectionHandlerTest, SessionStarted_StartService_SecureSpecific_Protect
   unprotected_services_.clear();
   SetSpecificServices();
   const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, kAudio, PROTECTION_ON, &out_hash_id_);
-  // Returned original session id
+      uid_, start_session_id_, kAudio, PROTECTION_ON, &out_hash_id_);
+// Returned original session id
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
-  CheckService(uid_, session_id3, kAudio,
-      NULL,
-      PROTECTION_ON);
+  CheckService(uid_, session_id3, kAudio, NULL, PROTECTION_ON);
 #else
   EXPECT_EQ(0u, session_id3);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
@@ -1151,14 +1211,12 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtect) {
 
   // Start RPC protection
   const uint32_t session_id_new = connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, kRpc, PROTECTION_ON, &out_hash_id_);
+      uid_, start_session_id_, kRpc, PROTECTION_ON, &out_hash_id_);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id_new);
   // Post protection nedd no hash
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
-  CheckService(uid_, start_session_id_, kRpc,
-      NULL,
-      PROTECTION_ON);
+  CheckService(uid_, start_session_id_, kRpc, NULL, PROTECTION_ON);
 #else
   EXPECT_EQ(0u, session_id_new);
   // Post protection nedd no hash
@@ -1168,20 +1226,18 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtect) {
 
   // Start Audio session without protection
   const uint32_t session_id2 = connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
   EXPECT_EQ(start_session_id_, session_id2);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
   CheckService(uid_, start_session_id_, kAudio, NULL, PROTECTION_OFF);
 
   // Start Audio protection
   const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, kAudio, PROTECTION_ON, &out_hash_id_);
+      uid_, start_session_id_, kAudio, PROTECTION_ON, &out_hash_id_);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
-  CheckService(uid_, start_session_id_, kAudio,
-      NULL,
-      PROTECTION_ON);
+  CheckService(uid_, start_session_id_, kAudio, NULL, PROTECTION_ON);
 #else
   EXPECT_EQ(0u, session_id3);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
@@ -1194,12 +1250,10 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtectBulk) {
   AddTestSession();
 
   const uint32_t session_id_new = connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, kBulk, PROTECTION_ON, NULL);
+      uid_, start_session_id_, kBulk, PROTECTION_ON, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id_new);
-  CheckService(uid_, start_session_id_, kRpc,
-      NULL,
-      PROTECTION_ON);
+  CheckService(uid_, start_session_id_, kRpc, NULL, PROTECTION_ON);
 #else
   EXPECT_EQ(0u, session_id_new);
   CheckService(uid_, start_session_id_, kRpc, NULL, PROTECTION_OFF);
@@ -1210,31 +1264,31 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtectBulk) {
 TEST_F(ConnectionHandlerTest, SetSSLContext_Null) {
   // No SSLContext on start up
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kControl),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
   EXPECT_EQ(::security_manager::SecurityManager::ERROR_INTERNAL,
-      connection_handler_->SetSSLContext(connection_key_, NULL));
+            connection_handler_->SetSSLContext(connection_key_, NULL));
   // No SSLContext after error
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kControl),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
 
   AddTestDeviceConnection();
   EXPECT_EQ(::security_manager::SecurityManager::ERROR_INTERNAL,
-      connection_handler_->SetSSLContext(connection_key_, NULL));
+            connection_handler_->SetSSLContext(connection_key_, NULL));
   // No SSLContext after error
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kControl),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
 
   AddTestSession();
   EXPECT_EQ(::security_manager::SecurityManager::ERROR_SUCCESS,
-      connection_handler_->SetSSLContext(connection_key_, NULL));
+            connection_handler_->SetSSLContext(connection_key_, NULL));
   // NULL SSLContext after success
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kControl),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
 }
 TEST_F(ConnectionHandlerTest, SetSSLContext) {
   // No SSLContext on start up
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kControl),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
 
   testing::StrictMock<security_manager_test::MockSSLContext> mock_ssl_context;
   // Error on no connection
@@ -1243,7 +1297,7 @@ TEST_F(ConnectionHandlerTest, SetSSLContext) {
       ::security_manager::SecurityManager::ERROR_INTERNAL);
   // No SSLContext after error
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kControl),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
 
   AddTestDeviceConnection();
   // Error on no session
@@ -1252,7 +1306,7 @@ TEST_F(ConnectionHandlerTest, SetSSLContext) {
       ::security_manager::SecurityManager::ERROR_INTERNAL);
   // No SSLContext after error
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kControl),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
   AddTestSession();
   // Success
   EXPECT_EQ(
@@ -1260,22 +1314,22 @@ TEST_F(ConnectionHandlerTest, SetSSLContext) {
       ::security_manager::SecurityManager::ERROR_SUCCESS);
   // SSLContext set on Success
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kControl),
-      &mock_ssl_context);
+            &mock_ssl_context);
   // Null SSLContext for unprotected services
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kRpc),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kBulk),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kAudio),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kMobileNav),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
 }
 
 TEST_F(ConnectionHandlerTest, GetSSLContext_ByProtectedService) {
   // No SSLContext on start up
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kControl),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
 
   testing::StrictMock<security_manager_test::MockSSLContext> mock_ssl_context;
   AddTestDeviceConnection();
@@ -1285,11 +1339,11 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByProtectedService) {
       ::security_manager::SecurityManager::ERROR_SUCCESS);
   // kControl service mean - return for all connection
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kControl),
-      &mock_ssl_context);
+            &mock_ssl_context);
 
   // kAudio is not exists yet
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kAudio),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
   // Open kAudio service
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
       uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
@@ -1298,7 +1352,7 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByProtectedService) {
 
   // kAudio is not exists yet
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kAudio),
-      &mock_ssl_context);
+            &mock_ssl_context);
 }
 TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedRPC) {
   testing::StrictMock<security_manager_test::MockSSLContext> mock_ssl_context;
@@ -1308,11 +1362,11 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedRPC) {
       connection_handler_->SetSSLContext(connection_key_, &mock_ssl_context),
       ::security_manager::SecurityManager::ERROR_SUCCESS);
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kControl),
-      &mock_ssl_context);
+            &mock_ssl_context);
 
   // kRpc is not protected
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kRpc),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
 
   // Protect kRpc (Bulk will be protect also)
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
@@ -1322,10 +1376,10 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedRPC) {
 
   // kRpc is protected
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kRpc),
-      &mock_ssl_context);
+            &mock_ssl_context);
   // kBulk is protected
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kBulk),
-      &mock_ssl_context);
+            &mock_ssl_context);
 }
 TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedBulk) {
   testing::StrictMock<security_manager_test::MockSSLContext> mock_ssl_context;
@@ -1335,11 +1389,11 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedBulk) {
       connection_handler_->SetSSLContext(connection_key_, &mock_ssl_context),
       ::security_manager::SecurityManager::ERROR_SUCCESS);
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kControl),
-      &mock_ssl_context);
+            &mock_ssl_context);
 
   // kRpc is not protected
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kRpc),
-      reinterpret_cast<security_manager::SSLContext *>(NULL));
+            reinterpret_cast<security_manager::SSLContext*>(NULL));
 
   // Protect Bulk (kRpc will be protected also)
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
@@ -1349,10 +1403,10 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedBulk) {
 
   // kRpc is protected
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kRpc),
-      &mock_ssl_context);
+            &mock_ssl_context);
   // kBulk is protected
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kBulk),
-      &mock_ssl_context);
+            &mock_ssl_context);
 }
 #endif  // ENABLE_SECURITY
 
@@ -1360,9 +1414,7 @@ TEST_F(ConnectionHandlerTest, SendHeartBeat) {
   // Add virtual device and connection
   AddTestDeviceConnection();
   AddTestSession();
-
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-
   EXPECT_CALL(mock_protocol_handler_,SendHeartBeat(uid_,start_session_id_) );
   connection_handler_->SendHeartBeat(uid_, start_session_id_);
 }

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -60,7 +60,7 @@ using ::testing::ReturnRefOfCopy;
 
 // For service types and PROTECTION_ON/OFF
 
-enum UnnamedService { served_service1 = 0x06, served_service2 = 0x08 };
+enum UnnamedService { kServedService1 = 0x06, kServedService2 = 0x08 };
 
 class ConnectionHandlerTest : public ::testing::Test {
  protected:
@@ -1100,9 +1100,9 @@ TEST_F(ConnectionHandlerTest,
   // Add virtual device and connection
   AddTestDeviceConnection();
   // Forbid start kRPC with encryption
-  unprotected_services_.push_back(UnnamedService::served_service1);
+  unprotected_services_.push_back(UnnamedService::kServedService1);
   unprotected_services_.push_back(kRpc);
-  unprotected_services_.push_back(UnnamedService::served_service2);
+  unprotected_services_.push_back(UnnamedService::kServedService2);
   unprotected_services_.push_back(kControl);
   SetSpecificServices();
   // Start new session with RPC service
@@ -1135,9 +1135,9 @@ TEST_F(ConnectionHandlerTest,
   AddTestSession();
 
   // Forbid start kAudio without encryption
-  protected_services_.push_back(UnnamedService::served_service1);
+  protected_services_.push_back(UnnamedService::kServedService1);
   protected_services_.push_back(kAudio);
-  protected_services_.push_back(UnnamedService::served_service2);
+  protected_services_.push_back(UnnamedService::kServedService2);
   protected_services_.push_back(kControl);
   SetSpecificServices();
   // Start new session with Audio service
@@ -1150,9 +1150,9 @@ TEST_F(ConnectionHandlerTest,
 #endif  // ENABLE_SECURITY
   // Allow start kAudio without encryption
   protected_services_.clear();
-  protected_services_.push_back(UnnamedService::served_service1);
+  protected_services_.push_back(UnnamedService::kServedService1);
   protected_services_.push_back(kMobileNav);
-  protected_services_.push_back(UnnamedService::served_service2);
+  protected_services_.push_back(UnnamedService::kServedService2);
   protected_services_.push_back(kControl);
   SetSpecificServices();
   const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
@@ -1174,9 +1174,9 @@ TEST_F(ConnectionHandlerTest,
   AddTestSession();
 
   // Forbid start kAudio with encryption
-  unprotected_services_.push_back(UnnamedService::served_service1);
+  unprotected_services_.push_back(UnnamedService::kServedService1);
   unprotected_services_.push_back(kAudio);
-  unprotected_services_.push_back(UnnamedService::served_service2);
+  unprotected_services_.push_back(UnnamedService::kServedService2);
   unprotected_services_.push_back(kControl);
   SetSpecificServices();
   // Start new session with Audio service
@@ -1285,6 +1285,7 @@ TEST_F(ConnectionHandlerTest, SetSSLContext_Null) {
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kControl),
             reinterpret_cast<security_manager::SSLContext*>(NULL));
 }
+
 TEST_F(ConnectionHandlerTest, SetSSLContext) {
   // No SSLContext on start up
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kControl),
@@ -1354,6 +1355,7 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByProtectedService) {
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kAudio),
             &mock_ssl_context);
 }
+
 TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedRPC) {
   testing::StrictMock<security_manager_test::MockSSLContext> mock_ssl_context;
   AddTestDeviceConnection();
@@ -1381,6 +1383,7 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedRPC) {
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kBulk),
             &mock_ssl_context);
 }
+
 TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedBulk) {
   testing::StrictMock<security_manager_test::MockSSLContext> mock_ssl_context;
   AddTestDeviceConnection();

--- a/src/components/connection_handler/test/connection_test.cc
+++ b/src/components/connection_handler/test/connection_test.cc
@@ -39,7 +39,7 @@
 #include "connection_handler/connection_handler_impl.h"
 #include "protocol/service_type.h"
 #include "connection_handler/mock_connection_handler_settings.h"
-#include "transport_manager/transport_manager_mock.h"
+#include "transport_manager/mock_transport_manager.h"
 #include "security_manager/mock_security_manager.h"
 #include "security_manager/mock_ssl_context.h"
 

--- a/src/components/connection_handler/test/include/connection_handler_observer_mock.h
+++ b/src/components/connection_handler/test/include/connection_handler_observer_mock.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_CONNECTION_HANDLER_TEST_INCLUDE_CONNECTION_HANDLER_OBSERVER_MOCK_H_
 #define SRC_COMPONENTS_CONNECTION_HANDLER_TEST_INCLUDE_CONNECTION_HANDLER_OBSERVER_MOCK_H_
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <string>
 #include "connection_handler/connection_handler_observer.h"
 

--- a/src/components/include/test/transport_manager/mock_transport_manager.h
+++ b/src/components/include/test/transport_manager/mock_transport_manager.h
@@ -30,10 +30,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef TEST_COMPONENTS_INCLUDE_TRANSPORT_MANAGER_TRANSPORT_MANAGER_MOCK_H_
-#define TEST_COMPONENTS_INCLUDE_TRANSPORT_MANAGER_TRANSPORT_MANAGER_MOCK_H_
+#ifndef SRC_COMPONENTS_INCLUDE_TEST_TRANSPORT_MANAGER_MOCK_TRANSPORT_MANAGER_H_
+#define SRC_COMPONENTS_INCLUDE_TEST_TRANSPORT_MANAGER_MOCK_TRANSPORT_MANAGER_H_
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <string>
 #include "transport_manager/transport_manager.h"
 #include "transport_manager/transport_adapter/transport_adapter_event.h"
@@ -81,4 +81,4 @@ class MockTransportManager
 }  // namespace transport_manager_test
 }  // namespace components
 }  // namespace test
-#endif  // TEST_COMPONENTS_INCLUDE_TRANSPORT_MANAGER_TRANSPORT_MANAGER_MOCK_H_
+#endif  // SRC_COMPONENTS_INCLUDE_TEST_TRANSPORT_MANAGER_MOCK_TRANSPORT_MANAGER_H_

--- a/src/components/protocol_handler/test/CMakeLists.txt
+++ b/src/components/protocol_handler/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2015, Ford Motor Company
+# Copyright (c) 2016, Ford Motor Company
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,9 +28,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-if(BUILD_TESTS)
+if (BUILD_TESTS)
 
-include_directories(
+include_directories (
   include
   ${COMPONENTS_DIR}/resumption/include
   ${GMOCK_INCLUDE_DIRECTORY}
@@ -40,7 +40,7 @@ include_directories(
   ${JSONCPP_INCLUDE_DIRECTORY}
 )
 
-set(LIBRARIES
+set (LIBRARIES
   gmock
   ProtocolHandler
   connectionHandler
@@ -49,7 +49,7 @@ set(LIBRARIES
   ProtocolLibrary
 )
 
-set(SOURCES
+set (SOURCES
   incoming_data_handler_test.cc
   protocol_header_validator_test.cc
   protocol_handler_tm_test.cc
@@ -58,6 +58,6 @@ set(SOURCES
   multiframe_builder_test.cc
 )
 
-create_test("protocol_handler_test" "${SOURCES}" "${LIBRARIES}")
+create_test ("protocol_handler_test" "${SOURCES}" "${LIBRARIES}")
 
-endif()
+endif ()

--- a/src/components/protocol_handler/test/include/protocol_handler/control_message_matcher.h
+++ b/src/components/protocol_handler/test/include/protocol_handler/control_message_matcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,10 +29,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef TEST_COMPONENTS_INCLUDE_PROTOCOL_HANDLER_CONTROL_MESSAGE_MATCHER_H_
-#define TEST_COMPONENTS_INCLUDE_PROTOCOL_HANDLER_CONTROL_MESSAGE_MATCHER_H_
+#ifndef SRC_COMPONENTS_PROTOCOL_HANDLER_TEST_INCLUDE_PROTOCOL_HANDLER_CONTROL_MESSAGE_MATCHER_H_
+#define SRC_COMPONENTS_PROTOCOL_HANDLER_TEST_INCLUDE_PROTOCOL_HANDLER_CONTROL_MESSAGE_MATCHER_H_
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
+#include <ios>
 #include <string>
 #include <vector>
 #include "protocol/raw_message.h"
@@ -41,82 +42,106 @@
 namespace test {
 namespace components {
 namespace protocol_handler_test {
-/*
- * Matcher for checking RawMessage with ControlMessage
- * Check error id
- */
 
-MATCHER_P2(ControlMessage, ExpectedFrameData, ExpectedEncryption,
-           (std::string(ExpectedEncryption ? "Protected" : "Unprotected")
-           + " control message ")) {
-  // Nack shall be always with flag protected off
-  DCHECK(ExpectedFrameData  != 0x03 /*FRAME_DATA_START_SERVICE_NACK*/ ||
-         !ExpectedEncryption);
-  const ::protocol_handler::RawMessagePtr message = arg;
-  ::protocol_handler::ProtocolPacket packet(message->connection_key());
-  const protocol_handler::RESULT_CODE result =
-      packet.deserializePacket(message->data(), message->data_size());
+using protocol_handler::ProtocolPacket;
+using protocol_handler::RawMessagePtr;
+using protocol_handler::RESULT_CODE;
+using protocol_handler::FRAME_TYPE_CONTROL;
+using protocol_handler::FRAME_DATA_START_SERVICE_NACK;
+
+bool CheckRegularMatches(const ProtocolPacket& packet,
+                         RESULT_CODE result,
+                         testing::MatchResultListener& result_listener,
+                         uint8_t ExpectedFrameType,
+                         uint8_t ExpectedFrameData,
+                         uint8_t ExpectedEncryption) {
   if (result != protocol_handler::RESULT_OK) {
-    *result_listener <<  "Error while message deserialization.";
+    result_listener << "Error while message deserialization.";
     return false;
   }
-  if (::protocol_handler::FRAME_TYPE_CONTROL != packet.frame_type()) {
-    *result_listener << "Is not control message";
+  if (ExpectedFrameType != packet.frame_type()) {
+    result_listener << "Message with frame type 0x" << std::hex
+                    << static_cast<int>(packet.frame_type()) << ", not 0x"
+                    << std::hex << static_cast<int>(ExpectedFrameType);
     return false;
   }
   if (ExpectedFrameData != packet.frame_data()) {
-    *result_listener << "Control message with data 0x"
-                     << std::hex << static_cast<int>(packet.frame_data())
-                     << ", not 0x"
-                     << std::hex << static_cast<int>(ExpectedFrameData);
+    result_listener << "Message with data 0x" << std::hex
+                    << static_cast<int>(packet.frame_data()) << ", not 0x"
+                    << std::hex << static_cast<int>(ExpectedFrameData);
     return false;
   }
   if (ExpectedEncryption != packet.protection_flag()) {
-    *result_listener << "Control message is " <<
-                     (ExpectedEncryption ? "" : "not ") << "protected";
+    result_listener << "Message is " << (ExpectedEncryption ? "" : "not ")
+                    << "protected";
     return false;
   }
   return true;
 }
 
+/*
+ * Matcher for checking RawMessage with ControlMessage
+ * Check error id
+ */
 
-
-MATCHER_P4(ControlMessage, ExpectedFrameData, ExpectedEncryption,
-           ConnectionKey, VectorMatcher,
-           (std::string(ExpectedEncryption ? "Protected" : "Unprotected")
-           + " control message ")) {
+MATCHER_P2(ControlMessage,
+           ExpectedFrameData,
+           ExpectedEncryption,
+           (std::string(ExpectedEncryption ? "Protected" : "Unprotected") +
+            " control message ")) {
   // Nack shall be always with flag protected off
-  DCHECK(ExpectedFrameData  != 0x03 /*FRAME_DATA_START_SERVICE_NACK*/ ||
-         !ExpectedEncryption);
-
-  const ::protocol_handler::RawMessagePtr message = arg;
-  ::protocol_handler::ProtocolPacket packet(message->connection_key());
-  const protocol_handler::RESULT_CODE result =
+  if (ExpectedFrameData == FRAME_DATA_START_SERVICE_NACK &&
+      ExpectedEncryption) {
+    *result_listener << "NACK message with PROTECYION_ON flag";
+    return false;
+  }
+  const RawMessagePtr message = arg;
+  ProtocolPacket packet(message->connection_key());
+  const RESULT_CODE result =
       packet.deserializePacket(message->data(), message->data_size());
-  if (result != protocol_handler::RESULT_OK) {
-    *result_listener <<  "Error while message deserialization.";
+
+  if (!CheckRegularMatches(packet,
+                           result,
+                           *result_listener,
+                           FRAME_TYPE_CONTROL,
+                           ExpectedFrameData,
+                           ExpectedEncryption)) {
+    return false;
+  }
+  return true;
+}
+
+MATCHER_P4(ControlMessage,
+           ExpectedFrameData,
+           ExpectedEncryption,
+           ConnectionKey,
+           VectorMatcher,
+           (std::string(ExpectedEncryption ? "Protected" : "Unprotected") +
+            " control message ")) {
+  // Nack shall be always with flag protected off
+  if (ExpectedFrameData == FRAME_DATA_START_SERVICE_NACK &&
+      ExpectedEncryption) {
+    *result_listener << "NACK message with PROTECYION_ON flag";
+    return false;
+  }
+  const RawMessagePtr message = arg;
+  ProtocolPacket packet(message->connection_key());
+  const RESULT_CODE result =
+      packet.deserializePacket(message->data(), message->data_size());
+
+  if (!CheckRegularMatches(packet,
+                           result,
+                           *result_listener,
+                           FRAME_TYPE_CONTROL,
+                           ExpectedFrameData,
+                           ExpectedEncryption)) {
     return false;
   }
 
-  if (::protocol_handler::FRAME_TYPE_CONTROL != packet.frame_type()) {
-    *result_listener << "Is not control message";
-    return false;
-  }
-  if (ExpectedFrameData != packet.frame_data()) {
-    *result_listener << "Control message with data 0x"
-                     << std::hex << static_cast<int>(packet.frame_data())
-                     << ", not 0x"
-                     << std::hex << static_cast<int>(ExpectedFrameData);
-    return false;
-  }
-  if (ExpectedEncryption != packet.protection_flag()) {
-    *result_listener << "Control message is " <<
-                     (ExpectedEncryption ? "" : "not ") << "protected";
-    return false;
-  }
   if (ConnectionKey != message->connection_key()) {
-    *result_listener << "Message for connection_id " << message->connection_key() <<
-                        ", expected for connection_id " << ConnectionKey;
+    *result_listener << "Message for connection_id "
+                     << message->connection_key()
+                     << ", expected for connection_id " << ConnectionKey;
     return false;
   }
   std::vector<uint8_t> data_vector;
@@ -128,17 +153,55 @@ MATCHER_P4(ControlMessage, ExpectedFrameData, ExpectedEncryption,
     *result_listener << "Message with " << data_vector.size()
                      << " byte data : 0x";
     for (size_t i = 0u; i < data_vector.size(); ++i) {
-      *result_listener  << std::hex << static_cast<int>(data_vector[i]);
+      *result_listener << std::hex << static_cast<int>(data_vector[i]);
     }
     return false;
   }
   return true;
 }
 
+/*
+ * Matcher for checking RawMessage with any ExpectedMessage
+ */
 
+MATCHER_P4(ExpectedMessage,
+           ExpectedFrameType,
+           ExpectedFrameData,
+           ExpectedEncryption,
+           ExpectedServiceType,
+           (std::string(ExpectedEncryption ? "Protected" : "Unprotected") +
+            " message ")) {
+  // Nack shall be always with flag protected off
+  if (ExpectedFrameType == FRAME_TYPE_CONTROL &&
+      ExpectedFrameData == FRAME_DATA_START_SERVICE_NACK &&
+      ExpectedEncryption) {
+    *result_listener << "NACK message with PROTECYION_ON flag";
+    return false;
+  }
+  const RawMessagePtr message = arg;
+  ProtocolPacket packet(message->connection_key());
+  const RESULT_CODE result =
+      packet.deserializePacket(message->data(), message->data_size());
 
+  if (!CheckRegularMatches(packet,
+                           result,
+                           *result_listener,
+                           ExpectedFrameType,
+                           ExpectedFrameData,
+                           ExpectedEncryption)) {
+    return false;
+  }
+  if (ExpectedServiceType != packet.service_type()) {
+    *result_listener << "Service type is 0x" << std::hex
+                     << static_cast<int>(packet.service_type()) << ", not 0x"
+                     << std::hex << static_cast<int>(ExpectedServiceType);
+    return false;
+  }
+  return true;
+}
 
 }  // namespace protocol_handler_test
 }  // namespace components
 }  // namespace test
-#endif  // TEST_COMPONENTS_INCLUDE_PROTOCOL_HANDLER_CONTROL_MESSAGE_MATCHER_H_
+
+#endif  // SRC_COMPONENTS_PROTOCOL_HANDLER_TEST_INCLUDE_PROTOCOL_HANDLER_CONTROL_MESSAGE_MATCHER_H_

--- a/src/components/protocol_handler/test/include/protocol_handler/control_message_matcher.h
+++ b/src/components/protocol_handler/test/include/protocol_handler/control_message_matcher.h
@@ -92,7 +92,7 @@ MATCHER_P2(ControlMessage,
   // Nack shall be always with flag protected off
   if (ExpectedFrameData == FRAME_DATA_START_SERVICE_NACK &&
       ExpectedEncryption) {
-    *result_listener << "NACK message with PROTECYION_ON flag";
+    *result_listener << "NACK message with PROTECTION_ON flag";
     return false;
   }
   const RawMessagePtr message = arg;
@@ -121,7 +121,7 @@ MATCHER_P4(ControlMessage,
   // Nack shall be always with flag protected off
   if (ExpectedFrameData == FRAME_DATA_START_SERVICE_NACK &&
       ExpectedEncryption) {
-    *result_listener << "NACK message with PROTECYION_ON flag";
+    *result_listener << "NACK message with PROTECTION_ON flag";
     return false;
   }
   const RawMessagePtr message = arg;
@@ -175,7 +175,7 @@ MATCHER_P4(ExpectedMessage,
   if (ExpectedFrameType == FRAME_TYPE_CONTROL &&
       ExpectedFrameData == FRAME_DATA_START_SERVICE_NACK &&
       ExpectedEncryption) {
-    *result_listener << "NACK message with PROTECYION_ON flag";
+    *result_listener << "NACK message with PROTECTION_ON flag";
     return false;
   }
   const RawMessagePtr message = arg;

--- a/src/components/protocol_handler/test/multiframe_builder_test.cc
+++ b/src/components/protocol_handler/test/multiframe_builder_test.cc
@@ -184,9 +184,6 @@ class MultiFrameBuilderTest : public ::testing::Test {
                           const UCharDataVector& data,
                           ProtocolFramePtrList& out_frames) {
     ASSERT_LT(FIRST_FRAME_DATA_SIZE, max_payload_size);
-    ASSERT_EQ(0x08, FIRST_FRAME_DATA_SIZE)
-        << "Size of FIRST_FRAME_DATA: " << FIRST_FRAME_DATA_SIZE
-        << ", it must be only 0x08";
 
     // TODO(EZamakhov): move to the separate class
     const size_t data_size = data.size();
@@ -336,7 +333,7 @@ TEST_F(MultiFrameBuilderTest, Add_FirstFrames_NoConnections) {
         const ProtocolFramePtr first_frame = multiframes.front();
         ASSERT_TRUE(first_frame);
         EXPECT_EQ(RESULT_FAIL, multiframe_builder_.AddFrame(first_frame))
-            << "Unexisting connection " << connection_id
+            << "Non-existed connection " << connection_id
             << "- to be skipped first frame: " << first_frame;
 
         EXPECT_EQ(ProtocolFramePtrList(), multiframe_builder_.PopMultiframes())

--- a/src/components/protocol_handler/test/multiframe_builder_test.cc
+++ b/src/components/protocol_handler/test/multiframe_builder_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,8 +29,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 #include <vector>
+#include <map>
+#include <algorithm>
 #include <utility>
 #include <limits>
 #include "utils/make_shared.h"
@@ -42,8 +44,8 @@ namespace protocol_handler_test {
 
 using namespace protocol_handler;
 
-typedef std::vector<ConnectionID>     ConnectionList;
-typedef std::vector<uint8_t>          UCharDataVector;
+typedef std::vector<ConnectionID> ConnectionList;
+typedef std::vector<uint8_t> UCharDataVector;
 
 struct MutiframeData {
   UCharDataVector binary_data;
@@ -57,44 +59,40 @@ typedef std::map<MessageID, MutiframeData> MessageIDToMutiframeDataTestMap;
 /**
  *\brief Map of MessageIDToMutiframeDataMap by SessionID key
  */
-typedef std::map<SessionID, MessageIDToMutiframeDataTestMap> SessionToMutiframeDataTestMap;
+typedef std::map<SessionID, MessageIDToMutiframeDataTestMap>
+    SessionToMutiframeDataTestMap;
 /**
  *\brief Map of SessionToMutiframeDataMap by ConnectionID key
  */
 typedef std::map<ConnectionID, SessionToMutiframeDataTestMap> MultiFrameTestMap;
 
-template<typename IntegerType>
-std::vector<IntegerType> getTestVector() {
+template <typename IntegerType>
+std::vector<IntegerType> GetTestVector() {
   // Prepare array with a few minimals, middle and a few maximum values
-  const IntegerType array[] = {
-    std::numeric_limits<IntegerType>::min(),
-    std::numeric_limits<IntegerType>::min() + 1,
-    std::numeric_limits<IntegerType>::max() / 2,
-    std::numeric_limits<IntegerType>::max() - 1 ,
-    std::numeric_limits<IntegerType>::max()
-  };
+  const IntegerType array[] = {std::numeric_limits<IntegerType>::min(),
+                               std::numeric_limits<IntegerType>::min() + 1,
+                               std::numeric_limits<IntegerType>::max() / 2,
+                               std::numeric_limits<IntegerType>::max() - 1,
+                               std::numeric_limits<IntegerType>::max()};
   return std::vector<IntegerType>(array,
-                                  array + sizeof(array) / sizeof(array[0]) );
+                                  array + sizeof(array) / sizeof(array[0]));
 }
-template<typename IntegerType>
+
+template <typename IntegerType>
 struct Incrementor {
   IntegerType value;
-  Incrementor(const IntegerType value = 0u)
-    : value(value) {
-  }
-  IntegerType operator() () {
+  explicit Incrementor(const IntegerType value = 0u) : value(value) {}
+  IntegerType operator()() {
     return ++value;
   }
 };
 
-
 class MultiFrameBuilderTest : public ::testing::Test {
  protected:
   void SetUp() OVERRIDE {
-
-    const std::vector<ConnectionID> connections = getTestVector<ConnectionID>();
-    const std::vector<SessionID>    sessions    = getTestVector<SessionID>();
-    const std::vector<MessageID>    messages    = getTestVector<MessageID>();
+    const std::vector<ConnectionID> connections = GetTestVector<ConnectionID>();
+    const std::vector<SessionID> sessions = GetTestVector<SessionID>();
+    const std::vector<MessageID> messages = GetTestVector<MessageID>();
 
     MutiframeData some_data;
 
@@ -121,16 +119,17 @@ class MultiFrameBuilderTest : public ::testing::Test {
           ASSERT_GT(multi_frames_count, 1);
           data_vector.resize(++multi_frames_count * mtu_);
 
-          std::generate(data_vector.begin(), data_vector.end(), Incrementor<uint8_t>(0u));
+          std::generate(
+              data_vector.begin(), data_vector.end(), Incrementor<uint8_t>(0u));
 
           PrepareMultiFrames(connection_id,
-          protocol_version,
-          service_type,
-          session_id,
-          message_id,
-          mtu_,
-          data_vector,
-          some_data.multiframes);
+                             protocol_version,
+                             service_type,
+                             session_id,
+                             message_id,
+                             mtu_,
+                             data_vector,
+                             some_data.multiframes);
           messages_map.insert(std::make_pair(message_id, some_data));
         }
         sessions_map.insert(std::make_pair(session_id, messages_map));
@@ -139,22 +138,127 @@ class MultiFrameBuilderTest : public ::testing::Test {
     }
   }
 
+  void VerifyConsecutiveAdd(const MutiframeData& multiframe_data) {
+    const ProtocolFramePtrList& multiframes = multiframe_data.multiframes;
+    const UCharDataVector& binary_data = multiframe_data.binary_data;
+    ASSERT_FALSE(multiframes.empty());
+
+    // Frame of multiframe loop
+    ProtocolFramePtrList::const_iterator it = multiframes.begin();
+    // Skip last final frame
+    const ProtocolFramePtrList::const_iterator it_last = --(multiframes.end());
+    while (it != it_last) {
+      const ProtocolFramePtr frame = *it;
+      ASSERT_TRUE(frame);
+      EXPECT_EQ(RESULT_OK, multiframe_builder_.AddFrame(frame))
+          << "Non final CONSECUTIVE frame: " << frame;
+      EXPECT_EQ(ProtocolFramePtrList(), multiframe_builder_.PopMultiframes())
+          << "Non final CONSECUTIVE frame: " << frame;
+      ++it;
+      // Skip last final frame
+    }
+
+    const ProtocolFramePtr final_frame = multiframes.back();
+
+    EXPECT_EQ(RESULT_OK, multiframe_builder_.AddFrame(final_frame))
+        << "Final CONSECUTIVE frame: " << final_frame;
+
+    const ProtocolFramePtrList& multiframe_list =
+        multiframe_builder_.PopMultiframes();
+    ASSERT_EQ(1u, multiframe_list.size());
+
+    const ProtocolFramePtr result_multiframe = multiframe_list.front();
+    EXPECT_EQ(binary_data,
+              UCharDataVector(result_multiframe->data(),
+                              result_multiframe->data() +
+                                  result_multiframe->payload_size()));
+  }
+
   // Support method for first and consecutive frame disassembling
-  static void PrepareMultiFrames(
-    const ConnectionID connection_id,
-    const uint8_t protocol_version,
-    const uint8_t service_type,
-    const uint8_t session_id,
-    const uint32_t message_id,
-    const size_t max_frame_size,
-    const UCharDataVector& data,
-    ProtocolFramePtrList& out_frames);
+  void PrepareMultiFrames(const ConnectionID connection_id,
+                          const uint8_t protocol_version,
+                          const uint8_t service_type,
+                          const uint8_t session_id,
+                          const uint32_t message_id,
+                          const size_t max_payload_size,
+                          const UCharDataVector& data,
+                          ProtocolFramePtrList& out_frames) {
+    ASSERT_LT(FIRST_FRAME_DATA_SIZE, max_payload_size);
+    ASSERT_EQ(0x08, FIRST_FRAME_DATA_SIZE)
+        << "Size of FIRST_FRAME_DATA: " << FIRST_FRAME_DATA_SIZE
+        << ", it must be only 0x08";
 
-  void AddConnection(const ConnectionID connection_id);
+    // TODO(EZamakhov): move to the separate class
+    const size_t data_size = data.size();
+    // remainder of last frame
+    const size_t lastframe_remainder = data_size % max_payload_size;
+    // size of last frame (full fill or not)
+    const size_t lastframe_size =
+        lastframe_remainder > 0 ? lastframe_remainder : max_payload_size;
 
-  void AddConnections();
+    const size_t frames_count = data_size / max_payload_size +
+                                // add last frame if not empty
+                                (lastframe_remainder > 0 ? 1 : 0);
 
-  void VerifyConsecutiveAdd(const MutiframeData& multiframe_data);
+    uint8_t out_data[FIRST_FRAME_DATA_SIZE];
+    out_data[0] = data_size >> 24;
+    out_data[1] = data_size >> 16;
+    out_data[2] = data_size >> 8;
+    out_data[3] = data_size;
+
+    out_data[4] = frames_count >> 24;
+    out_data[5] = frames_count >> 16;
+    out_data[6] = frames_count >> 8;
+    out_data[7] = frames_count;
+
+    ProtocolFramePtr first_frame(new ProtocolPacket(connection_id,
+                                                    protocol_version,
+                                                    PROTECTION_OFF,
+                                                    FRAME_TYPE_FIRST,
+                                                    service_type,
+                                                    FRAME_DATA_FIRST,
+                                                    session_id,
+                                                    FIRST_FRAME_DATA_SIZE,
+                                                    message_id,
+                                                    out_data));
+    // Note: PHIMpl already prepare First frames the total_data_bytes on
+    // desirialization
+    first_frame->set_total_data_bytes(data_size);
+
+    out_frames.clear();
+    out_frames.push_back(first_frame);
+
+    for (size_t i = 0; i < frames_count; ++i) {
+      const bool is_last_frame = ((frames_count - 1) == i);
+      const size_t frame_size =
+          is_last_frame ? lastframe_size : max_payload_size;
+      const uint8_t data_type = is_last_frame
+                                    ? FRAME_DATA_LAST_CONSECUTIVE
+                                    : (i % FRAME_DATA_MAX_CONSECUTIVE + 1);
+
+      const ProtocolFramePtr consecutive_frame(
+          new ProtocolPacket(connection_id,
+                             protocol_version,
+                             PROTECTION_OFF,
+                             FRAME_TYPE_CONSECUTIVE,
+                             service_type,
+                             data_type,
+                             session_id,
+                             frame_size,
+                             message_id,
+                             &data[max_payload_size * i]));
+      out_frames.push_back(consecutive_frame);
+    }
+  }
+
+  void AddConnections() {
+    for (MultiFrameTestMap::iterator connection_it = test_data_map_.begin();
+         connection_it != test_data_map_.end();
+         ++connection_it) {
+      const ConnectionID connection_id = connection_it->first;
+      ASSERT_TRUE(multiframe_builder_.AddConnection(connection_id));
+    }
+  }
 
   MultiFrameBuilder multiframe_builder_;
   MultiFrameTestMap test_data_map_;
@@ -164,30 +268,26 @@ class MultiFrameBuilderTest : public ::testing::Test {
 size_t MultiFrameBuilderTest::mtu_ = 10;
 
 TEST_F(MultiFrameBuilderTest, Pop_Frames_From_Empty_builder) {
-  EXPECT_EQ(ProtocolFramePtrList(),
-            multiframe_builder_.PopMultiframes());
+  EXPECT_EQ(ProtocolFramePtrList(), multiframe_builder_.PopMultiframes());
 }
 
 TEST_F(MultiFrameBuilderTest, Pop_Frames_with_existing_connections) {
   AddConnections();
-  EXPECT_EQ(ProtocolFramePtrList(),
-            multiframe_builder_.PopMultiframes());
+  EXPECT_EQ(ProtocolFramePtrList(), multiframe_builder_.PopMultiframes());
 }
 
 TEST_F(MultiFrameBuilderTest, Add_EmptyFrame) {
-  EXPECT_EQ(RESULT_FAIL,
-            multiframe_builder_.AddFrame(ProtocolFramePtr()));
-  EXPECT_EQ(ProtocolFramePtrList(),
-            multiframe_builder_.PopMultiframes());
+  EXPECT_EQ(RESULT_FAIL, multiframe_builder_.AddFrame(ProtocolFramePtr()));
+  EXPECT_EQ(ProtocolFramePtrList(), multiframe_builder_.PopMultiframes());
 }
 
 TEST_F(MultiFrameBuilderTest, Add_NonSingleOrConsecutive_Frames) {
   UCharDataVector types;
   types.reserve(std::numeric_limits<uint8_t>::max());
   for (uint8_t type = std::numeric_limits<uint8_t>::min();
-       type < std::numeric_limits<uint8_t>::max(); ++type) {
-    if (type != FRAME_TYPE_FIRST &&
-        type != FRAME_TYPE_CONSECUTIVE) {
+       type < std::numeric_limits<uint8_t>::max();
+       ++type) {
+    if (type != FRAME_TYPE_FIRST && type != FRAME_TYPE_CONSECUTIVE) {
       types.push_back(type);
     }
   }
@@ -195,43 +295,51 @@ TEST_F(MultiFrameBuilderTest, Add_NonSingleOrConsecutive_Frames) {
   for (UCharDataVector::iterator it = types.begin(); it != types.end(); ++it) {
     const uint8_t frame_type = *it;
     const ProtocolFramePtr unexpected_frame(
-      new ProtocolPacket( 0u, PROTOCOL_VERSION_3, PROTECTION_OFF, frame_type,
-                          SERVICE_TYPE_RPC, FRAME_DATA_FIRST, 0u, 0u, 0u));
-    EXPECT_EQ(RESULT_FAIL,
-              multiframe_builder_.AddFrame(unexpected_frame))
+        new ProtocolPacket(0u,
+                           PROTOCOL_VERSION_3,
+                           PROTECTION_OFF,
+                           frame_type,
+                           SERVICE_TYPE_RPC,
+                           FRAME_DATA_FIRST,
+                           0u,
+                           0u,
+                           0u));
+    EXPECT_EQ(RESULT_FAIL, multiframe_builder_.AddFrame(unexpected_frame))
         << "Unexpected frame: " << unexpected_frame;
 
-    EXPECT_EQ(ProtocolFramePtrList(),
-              multiframe_builder_.PopMultiframes())
+    EXPECT_EQ(ProtocolFramePtrList(), multiframe_builder_.PopMultiframes())
         << "Unexpected frame: " << unexpected_frame;
   }
 }
 
 TEST_F(MultiFrameBuilderTest, Add_FirstFrames_NoConnections) {
   for (MultiFrameTestMap::iterator connection_it = test_data_map_.begin();
-       connection_it != test_data_map_.end(); ++connection_it) {
+       connection_it != test_data_map_.end();
+       ++connection_it) {
     SessionToMutiframeDataTestMap& session_map = connection_it->second;
-    const ConnectionID           connection_id = connection_it->first;
+    const ConnectionID connection_id = connection_it->first;
 
-    for (SessionToMutiframeDataTestMap::iterator session_it = session_map.begin();
-         session_it != session_map.end(); ++session_it) {
+    for (SessionToMutiframeDataTestMap::iterator session_it =
+             session_map.begin();
+         session_it != session_map.end();
+         ++session_it) {
       MessageIDToMutiframeDataTestMap& messageId_map = session_it->second;
 
-      for (MessageIDToMutiframeDataTestMap::iterator messageId_it = messageId_map.begin();
-           messageId_it != messageId_map.end(); ++messageId_it) {
+      for (MessageIDToMutiframeDataTestMap::iterator messageId_it =
+               messageId_map.begin();
+           messageId_it != messageId_map.end();
+           ++messageId_it) {
         const MutiframeData& multiframe_data = messageId_it->second;
 
         const ProtocolFramePtrList& multiframes = multiframe_data.multiframes;
         ASSERT_FALSE(multiframes.empty());
         const ProtocolFramePtr first_frame = multiframes.front();
         ASSERT_TRUE(first_frame);
-        EXPECT_EQ(RESULT_FAIL,
-                  multiframe_builder_.AddFrame(first_frame))
+        EXPECT_EQ(RESULT_FAIL, multiframe_builder_.AddFrame(first_frame))
             << "Unexisting connection " << connection_id
             << "- to be skipped first frame: " << first_frame;
 
-        EXPECT_EQ(ProtocolFramePtrList(),
-                  multiframe_builder_.PopMultiframes())
+        EXPECT_EQ(ProtocolFramePtrList(), multiframe_builder_.PopMultiframes())
             << "First frame: " << first_frame;
       }
     }
@@ -241,27 +349,30 @@ TEST_F(MultiFrameBuilderTest, Add_FirstFrames_NoConnections) {
 TEST_F(MultiFrameBuilderTest, Add_FirstFrames_only) {
   AddConnections();
   for (MultiFrameTestMap::iterator connection_it = test_data_map_.begin();
-       connection_it != test_data_map_.end(); ++connection_it) {
+       connection_it != test_data_map_.end();
+       ++connection_it) {
     SessionToMutiframeDataTestMap& session_map = connection_it->second;
 
-    for (SessionToMutiframeDataTestMap::iterator session_it = session_map.begin();
-         session_it != session_map.end(); ++session_it) {
+    for (SessionToMutiframeDataTestMap::iterator session_it =
+             session_map.begin();
+         session_it != session_map.end();
+         ++session_it) {
       MessageIDToMutiframeDataTestMap& messageId_map = session_it->second;
 
-      for (MessageIDToMutiframeDataTestMap::iterator messageId_it = messageId_map.begin();
-           messageId_it != messageId_map.end(); ++messageId_it) {
+      for (MessageIDToMutiframeDataTestMap::iterator messageId_it =
+               messageId_map.begin();
+           messageId_it != messageId_map.end();
+           ++messageId_it) {
         const MutiframeData& multiframe_data = messageId_it->second;
 
         const ProtocolFramePtrList& multiframes = multiframe_data.multiframes;
         ASSERT_FALSE(multiframes.empty());
         const ProtocolFramePtr first_frame = multiframes.front();
         ASSERT_TRUE(first_frame);
-        EXPECT_EQ(RESULT_OK,
-                  multiframe_builder_.AddFrame(first_frame))
+        EXPECT_EQ(RESULT_OK, multiframe_builder_.AddFrame(first_frame))
             << "First frame: " << first_frame;
 
-        EXPECT_EQ(ProtocolFramePtrList(),
-                  multiframe_builder_.PopMultiframes())
+        EXPECT_EQ(ProtocolFramePtrList(), multiframe_builder_.PopMultiframes())
             << "First frame: " << first_frame;
       }
     }
@@ -270,11 +381,10 @@ TEST_F(MultiFrameBuilderTest, Add_FirstFrames_only) {
 
 TEST_F(MultiFrameBuilderTest, Add_ConsecutiveFrame) {
   ASSERT_FALSE(test_data_map_.empty());
-  const ConnectionID& connection_id          = test_data_map_.begin()->first;
+  const ConnectionID& connection_id = test_data_map_.begin()->first;
   SessionToMutiframeDataTestMap& session_map = test_data_map_.begin()->second;
 
-  AddConnection(connection_id);
-
+  ASSERT_TRUE(multiframe_builder_.AddConnection(connection_id));
   ASSERT_FALSE(session_map.empty());
   MessageIDToMutiframeDataTestMap& messageId_map = session_map.begin()->second;
 
@@ -287,15 +397,20 @@ TEST_F(MultiFrameBuilderTest, Add_ConsecutiveFrame) {
 TEST_F(MultiFrameBuilderTest, Add_ConsecutiveFrames_OneByOne) {
   AddConnections();
   for (MultiFrameTestMap::iterator connection_it = test_data_map_.begin();
-       connection_it != test_data_map_.end(); ++connection_it) {
+       connection_it != test_data_map_.end();
+       ++connection_it) {
     SessionToMutiframeDataTestMap& session_map = connection_it->second;
 
-    for (SessionToMutiframeDataTestMap::iterator session_it = session_map.begin();
-         session_it != session_map.end(); ++session_it) {
+    for (SessionToMutiframeDataTestMap::iterator session_it =
+             session_map.begin();
+         session_it != session_map.end();
+         ++session_it) {
       MessageIDToMutiframeDataTestMap& messageId_map = session_it->second;
 
-      for (MessageIDToMutiframeDataTestMap::iterator messageId_it = messageId_map.begin();
-           messageId_it != messageId_map.end(); ++messageId_it) {
+      for (MessageIDToMutiframeDataTestMap::iterator messageId_it =
+               messageId_map.begin();
+           messageId_it != messageId_map.end();
+           ++messageId_it) {
         const MutiframeData& multiframe_data = messageId_it->second;
 
         VerifyConsecutiveAdd(multiframe_data);
@@ -320,38 +435,39 @@ TEST_F(MultiFrameBuilderTest, Add_ConsecutiveFrames_per1) {
       while (session_it != session_map.end()) {
         MessageIDToMutiframeDataTestMap& messageId_map = session_it->second;
 
-        MessageIDToMutiframeDataTestMap::iterator messageId_it = messageId_map.begin();
+        MessageIDToMutiframeDataTestMap::iterator messageId_it =
+            messageId_map.begin();
         while (messageId_it != messageId_map.end()) {
-
-          MutiframeData& multiframe_data    = messageId_it->second;
+          MutiframeData& multiframe_data = messageId_it->second;
           ProtocolFramePtrList& multiframes = multiframe_data.multiframes;
           ASSERT_FALSE(multiframes.empty());
 
           const ProtocolFramePtr frame = multiframes.front();
           ASSERT_TRUE(frame);
 
-          EXPECT_EQ(RESULT_OK,
-                    multiframe_builder_.AddFrame(frame)) << "Frame: " << frame;
+          EXPECT_EQ(RESULT_OK, multiframe_builder_.AddFrame(frame))
+              << "Frame: " << frame;
 
           multiframes.pop_front();
 
           // If all frames are assembled
           if (multiframes.empty()) {
-            const ProtocolFramePtrList& multiframe_list
-              = multiframe_builder_.PopMultiframes();
-            ASSERT_EQ(multiframe_list.size(), 1u);
+            const ProtocolFramePtrList& multiframe_list =
+                multiframe_builder_.PopMultiframes();
+            ASSERT_EQ(1u, multiframe_list.size());
 
             const ProtocolFramePtr result_multiframe = multiframe_list.front();
-            const UCharDataVector&      binary_data  = multiframe_data.binary_data;
+            const UCharDataVector& binary_data = multiframe_data.binary_data;
             EXPECT_EQ(binary_data,
                       UCharDataVector(result_multiframe->data(),
                                       result_multiframe->data() +
-                                      result_multiframe->payload_size()));
+                                          result_multiframe->payload_size()));
             messageId_map.erase(messageId_it++);
           } else {
             // Multiframe is not completed
             EXPECT_EQ(ProtocolFramePtrList(),
-                      multiframe_builder_.PopMultiframes()) << "Frame: " << frame;
+                      multiframe_builder_.PopMultiframes())
+                << "Frame: " << frame;
             ++messageId_it;
           }
         }
@@ -374,10 +490,10 @@ TEST_F(MultiFrameBuilderTest, FrameExpired_OneMSec) {
   multiframe_builder_.set_waiting_timeout(1);
 
   ASSERT_FALSE(test_data_map_.empty());
-  const ConnectionID& connection_id          = test_data_map_.begin()->first;
+  const ConnectionID& connection_id = test_data_map_.begin()->first;
   SessionToMutiframeDataTestMap& session_map = test_data_map_.begin()->second;
 
-  AddConnection(connection_id);
+  ASSERT_TRUE(multiframe_builder_.AddConnection(connection_id));
 
   ASSERT_FALSE(session_map.empty());
   MessageIDToMutiframeDataTestMap& messageId_map = session_map.begin()->second;
@@ -389,132 +505,37 @@ TEST_F(MultiFrameBuilderTest, FrameExpired_OneMSec) {
   ASSERT_FALSE(multiframes.empty());
   const ProtocolFramePtr first_frame = multiframes.front();
   ASSERT_TRUE(first_frame);
-  EXPECT_EQ(RESULT_OK,
-            multiframe_builder_.AddFrame(first_frame))
+  EXPECT_EQ(RESULT_OK, multiframe_builder_.AddFrame(first_frame))
       << "First frame: " << first_frame;
 
   // Wait frame expire
   usleep(1000);
   const ProtocolFramePtrList& list = multiframe_builder_.PopMultiframes();
   ASSERT_FALSE(list.empty());
-  EXPECT_EQ(first_frame,
-            list.front());
+  EXPECT_EQ(first_frame, list.front());
 }
 
-/*
- * Testing support methods
- */
-
-void MultiFrameBuilderTest::VerifyConsecutiveAdd(const MutiframeData& multiframe_data) {
-  const ProtocolFramePtrList& multiframes = multiframe_data.multiframes;
-  const UCharDataVector&      binary_data = multiframe_data.binary_data;
-  ASSERT_FALSE(multiframes.empty());
-
-  // Frame of multiframe loop
-  ProtocolFramePtrList::const_iterator it = multiframes.begin();
-  // Skip last final frame
-  const ProtocolFramePtrList::const_iterator it_last = --(multiframes.end());
-  while (it != it_last) {
-    const ProtocolFramePtr frame = *it;
-    ASSERT_TRUE(frame);
-    EXPECT_EQ(RESULT_OK,
-              multiframe_builder_.AddFrame(frame))
-        << "Non final CONSECUTIVE frame: " << frame;
-    EXPECT_EQ(ProtocolFramePtrList(),
-              multiframe_builder_.PopMultiframes())
-        << "Non final CONSECUTIVE frame: " << frame;
-    ++it;
-    // Skip last final frame
-  }
-
-  const ProtocolFramePtr final_frame = multiframes.back();
-
-  EXPECT_EQ(RESULT_OK,
-            multiframe_builder_.AddFrame(final_frame))
-      << "Final CONSECUTIVE frame: " << final_frame;
-
-  const ProtocolFramePtrList& multiframe_list
-    = multiframe_builder_.PopMultiframes();
-  ASSERT_EQ(multiframe_list.size(), 1u);
-
-  const ProtocolFramePtr result_multiframe = multiframe_list.front();
-  EXPECT_EQ(binary_data,
-            UCharDataVector(result_multiframe->data(),
-                            result_multiframe->data() + result_multiframe->payload_size()));
+TEST_F(MultiFrameBuilderTest, RemoveConnection_NoConnection_ResultFail) {
+  // Arrange
+  const ConnectionID& connection_id = test_data_map_.begin()->first;
+  // Act
+  const bool connection_result =
+      multiframe_builder_.RemoveConnection(connection_id);
+  // Assert
+  ASSERT_FALSE(connection_result);
 }
 
-void MultiFrameBuilderTest::PrepareMultiFrames(const ConnectionID connection_id,
-                                               const uint8_t protocol_version,
-                                               const uint8_t service_type,
-                                               const uint8_t session_id,
-                                               const uint32_t message_id,
-                                               const size_t max_payload_size,
-                                               const UCharDataVector& data,
-                                               ProtocolFramePtrList& out_frames) {
-  ASSERT_GT(max_payload_size, FIRST_FRAME_DATA_SIZE);
-  ASSERT_EQ(FIRST_FRAME_DATA_SIZE, 0x08);
-
-  // TODO(EZamakhov): move to the separate class
-  const size_t data_size =  data.size();
-  // remainder of last frame
-  const size_t lastframe_remainder = data_size % max_payload_size;
-  // size of last frame (full fill or not)
-  const size_t lastframe_size =
-    lastframe_remainder > 0 ? lastframe_remainder : max_payload_size;
-
-  const size_t frames_count = data_size / max_payload_size +
-                              // add last frame if not empty
-                              (lastframe_remainder > 0 ? 1 : 0);
-
-  uint8_t out_data[FIRST_FRAME_DATA_SIZE];
-  out_data[0] = data_size >> 24;
-  out_data[1] = data_size >> 16;
-  out_data[2] = data_size >> 8;
-  out_data[3] = data_size;
-
-  out_data[4] = frames_count >> 24;
-  out_data[5] = frames_count >> 16;
-  out_data[6] = frames_count >> 8;
-  out_data[7] = frames_count;
-
-  ProtocolFramePtr first_frame(
-    new ProtocolPacket(
-      connection_id, protocol_version, PROTECTION_OFF, FRAME_TYPE_FIRST,
-      service_type, FRAME_DATA_FIRST, session_id, FIRST_FRAME_DATA_SIZE,
-      message_id, out_data));
-  // Note: PHIMpl already prepare First frames the total_data_bytes on desirialization
-  first_frame->set_total_data_bytes(data_size);
-
-  out_frames.clear();
-  out_frames.push_back(first_frame);
-
-  for (size_t i = 0; i < frames_count; ++i) {
-    const bool is_last_frame = (i == (frames_count - 1));
-    const size_t frame_size = is_last_frame ? lastframe_size : max_payload_size;
-    const uint8_t data_type =
-      is_last_frame
-      ? FRAME_DATA_LAST_CONSECUTIVE
-      : (i % FRAME_DATA_MAX_CONSECUTIVE + 1);
-
-    const ProtocolFramePtr consecutive_frame(
-      new ProtocolPacket(
-        connection_id, protocol_version, PROTECTION_OFF, FRAME_TYPE_CONSECUTIVE,
-        service_type, data_type, session_id, frame_size, message_id,
-        &data[max_payload_size * i]));
-    out_frames.push_back(consecutive_frame);
-  }
-}
-
-void MultiFrameBuilderTest::AddConnection(const ConnectionID connection_id) {
+TEST_F(MultiFrameBuilderTest, RemoveConnection_Successful) {
+  // Arrange
+  const ConnectionID& connection_id = test_data_map_.begin()->first;
+  // Variable test_data_map initially contains IDs of not existed in
+  // MultiframeBuilder connections
   ASSERT_TRUE(multiframe_builder_.AddConnection(connection_id));
-}
-
-void MultiFrameBuilderTest::AddConnections() {
-  for (MultiFrameTestMap::iterator connection_it = test_data_map_.begin();
-       connection_it != test_data_map_.end(); ++connection_it) {
-    const ConnectionID connection_id = connection_it->first;
-    ASSERT_TRUE(multiframe_builder_.AddConnection(connection_id));
-  }
+  // Act
+  const bool connection_result =
+      multiframe_builder_.RemoveConnection(connection_id);
+  // Assert
+  ASSERT_TRUE(connection_result);
 }
 
 }  // namespace protocol_handler_test

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,9 +40,9 @@
 #include "protocol_handler/mock_protocol_handler_settings.h"
 #include "protocol_handler/mock_session_observer.h"
 #include "connection_handler/mock_connection_handler.h"
-#include "transport_manager/transport_manager_mock.h"
 #include "security_manager/mock_security_manager.h"
 #include "security_manager/mock_ssl_context.h"
+#include "transport_manager/mock_transport_manager.h"
 
 #include "utils/make_shared.h"
 
@@ -51,48 +51,79 @@ namespace components {
 namespace protocol_handler_test {
 
 // Id passed as NULL for new session establishing
-#define NEW_SESSION_ID        0u
-#define SESSION_START_REJECT  0u
+#define NEW_SESSION_ID 0u
+#define SESSION_START_REJECT 0u
 
-using namespace ::protocol_handler;
-using namespace ::transport_manager;
-using ::transport_manager::TransportManagerListener;
+using protocol_handler::ServiceType;
+using protocol_handler::RawMessage;
+using protocol_handler::RawMessagePtr;
+using protocol_handler::PROTECTION_ON;
+using protocol_handler::PROTECTION_OFF;
+using protocol_handler::PROTOCOL_VERSION_1;
+using protocol_handler::PROTOCOL_VERSION_3;
+using protocol_handler::PROTOCOL_VERSION_MAX;
+using protocol_handler::FRAME_TYPE_CONTROL;
+using protocol_handler::FRAME_TYPE_SINGLE;
+using protocol_handler::FRAME_TYPE_MAX_VALUE;
+using protocol_handler::FRAME_DATA_START_SERVICE;
+using protocol_handler::FRAME_DATA_START_SERVICE_ACK;
+using protocol_handler::FRAME_DATA_END_SERVICE;
+using protocol_handler::FRAME_DATA_HEART_BEAT;
+using protocol_handler::FRAME_DATA_HEART_BEAT_ACK;
+using protocol_handler::FRAME_DATA_SINGLE;
+using protocol_handler::kRpc;
+using protocol_handler::kControl;
+using protocol_handler::kAudio;
+using protocol_handler::kMobileNav;
+using protocol_handler::kBulk;
+using protocol_handler::kInvalidServiceType;
+// For TM states
+using transport_manager::TransportManagerListener;
+using transport_manager::E_SUCCESS;
+
 using ::testing::Return;
 using ::testing::ReturnRefOfCopy;
 using ::testing::ReturnNull;
 using ::testing::AnyOf;
+using ::testing::DoAll;
 using ::testing::_;
 using ::testing::Invoke;
+using ::testing::SetArgReferee;
+using ::testing::SetArgPointee;
+
+typedef std::vector<uint8_t> UCharDataVector;
 
 class ProtocolHandlerImplTest : public ::testing::Test {
  protected:
-  void InitProtocolHandlerImpl(
-      const size_t period_msec, const size_t max_messages,
-      bool malformed_message_filtering = false,
-      const size_t malformd_period_msec = 0u,
-      const size_t malformd_max_messages = 0u,
-                                     const int32_t multiframe_waiting_timeout = 0,
-                                     const size_t maximum_payload_size = 0u) {
-          ON_CALL(protocol_handler_settings_mock, maximum_payload_size())
-              .WillByDefault(Return(maximum_payload_size));
-          ON_CALL(protocol_handler_settings_mock, message_frequency_time())
-              .WillByDefault(Return(period_msec));
-          ON_CALL(protocol_handler_settings_mock, message_frequency_count())
-              .WillByDefault(Return(max_messages));
-          ON_CALL(protocol_handler_settings_mock, malformed_message_filtering())
-              .WillByDefault(Return(malformed_message_filtering));
-          ON_CALL(protocol_handler_settings_mock, malformed_frequency_time())
-              .WillByDefault(Return(malformd_period_msec));
-          ON_CALL(protocol_handler_settings_mock, malformed_frequency_count())
-              .WillByDefault(Return(malformd_max_messages));
-          ON_CALL(protocol_handler_settings_mock, multiframe_waiting_timeout())
-              .WillByDefault(Return(multiframe_waiting_timeout));
-          protocol_handler_impl.reset(new ProtocolHandlerImpl(protocol_handler_settings_mock,
-                                      session_observer_mock,
-                                      connection_handler_mock,
-                                      transport_manager_mock));
+  void InitProtocolHandlerImpl(const size_t period_msec,
+                               const size_t max_messages,
+                               bool malformed_message_filtering = false,
+                               const size_t malformd_period_msec = 0u,
+                               const size_t malformd_max_messages = 0u,
+                               const int32_t multiframe_waiting_timeout = 0,
+                               const size_t maximum_payload_size = 0u) {
+    ON_CALL(protocol_handler_settings_mock, maximum_payload_size())
+        .WillByDefault(Return(maximum_payload_size));
+    ON_CALL(protocol_handler_settings_mock, message_frequency_time())
+        .WillByDefault(Return(period_msec));
+    ON_CALL(protocol_handler_settings_mock, message_frequency_count())
+        .WillByDefault(Return(max_messages));
+    ON_CALL(protocol_handler_settings_mock, malformed_message_filtering())
+        .WillByDefault(Return(malformed_message_filtering));
+    ON_CALL(protocol_handler_settings_mock, malformed_frequency_time())
+        .WillByDefault(Return(malformd_period_msec));
+    ON_CALL(protocol_handler_settings_mock, malformed_frequency_count())
+        .WillByDefault(Return(malformd_max_messages));
+    ON_CALL(protocol_handler_settings_mock, multiframe_waiting_timeout())
+        .WillByDefault(Return(multiframe_waiting_timeout));
+    protocol_handler_impl.reset(
+        new ProtocolHandlerImpl(protocol_handler_settings_mock,
+                                session_observer_mock,
+                                connection_handler_mock,
+                                transport_manager_mock));
     tm_listener = protocol_handler_impl.get();
   }
+
   void SetUp() OVERRIDE {
     InitProtocolHandlerImpl(0u, 0u);
     connection_id = 0xAu;
@@ -101,15 +132,16 @@ class ProtocolHandlerImplTest : public ::testing::Test {
     message_id = 0xABCDEFu;
     some_data.resize(256, 0xAB);
 
-    // Expect ConnectionHandler support methods call (conversion, check heartbeat)
-    EXPECT_CALL(session_observer_mock,
-        KeyFromPair(connection_id, _)).
-    // Return some connection_key
-    WillRepeatedly(Return(connection_key));
-    EXPECT_CALL(session_observer_mock,
-        IsHeartBeatSupported(connection_id, _)).
-    // Return false to avoid call KeepConnectionAlive
-    WillRepeatedly(Return(false));
+    // Expect ConnectionHandler support methods call (conversion, check
+    // heartbeat)
+    EXPECT_CALL(session_observer_mock, KeyFromPair(connection_id, _))
+        .
+        // Return some connection_key
+        WillRepeatedly(Return(connection_key));
+    EXPECT_CALL(session_observer_mock, IsHeartBeatSupported(connection_id, _))
+        .
+        // Return false to avoid call KeepConnectionAlive
+        WillRepeatedly(Return(false));
   }
 
   void TearDown() OVERRIDE {
@@ -119,10 +151,11 @@ class ProtocolHandlerImplTest : public ::testing::Test {
 
   // Emulate connection establish
   void AddConnection() {
-    tm_listener->OnConnectionEstablished(
-        DeviceInfo(DeviceHandle(1u), std::string("mac"), std::string("name"),
-                   std::string("BTMAC")),
-        connection_id);
+    tm_listener->OnConnectionEstablished(DeviceInfo(DeviceHandle(1u),
+                                                    std::string("mac"),
+                                                    std::string("name"),
+                                                    std::string("BTMAC")),
+                                         connection_id);
   }
   void AddSession() {
     AddConnection();
@@ -131,23 +164,29 @@ class ProtocolHandlerImplTest : public ::testing::Test {
     // For enabled protection callback shall use protection ON
     const bool callback_protection_flag = PROTECTION_ON;
 #else
-    // For disabled protection callback shall ignore protection income flad and use protection OFF
+    // For disabled protection callback shall ignore protection income flad and
+    // use protection OFF
     const bool callback_protection_flag = PROTECTION_OFF;
 #endif  // ENABLE_SECURITY
     // Expect ConnectionHandler check
     EXPECT_CALL(session_observer_mock,
-        OnSessionStartedCallback(connection_id, NEW_SESSION_ID, start_service,
-            callback_protection_flag, _)).
-    // Return sessions start success
-    WillOnce(Return(session_id));
+                OnSessionStartedCallback(connection_id,
+                                         NEW_SESSION_ID,
+                                         start_service,
+                                         callback_protection_flag,
+                                         _))
+        .
+        // Return sessions start success
+        WillOnce(Return(session_id));
 
     // Expect send Ack with PROTECTION_OFF (on no Security Manager)
     EXPECT_CALL(transport_manager_mock,
-        SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_OFF)))
+                SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_ACK,
+                                                   PROTECTION_OFF)))
         .WillOnce(Return(E_SUCCESS));
 
-    SendControlMessage(PROTECTION_ON, start_service, NEW_SESSION_ID,
-                       FRAME_DATA_START_SERVICE);
+    SendControlMessage(
+        PROTECTION_ON, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
   }
 
 #ifdef ENABLE_SECURITY
@@ -156,14 +195,27 @@ class ProtocolHandlerImplTest : public ::testing::Test {
     protocol_handler_impl->set_security_manager(&security_manager_mock);
   }
 #endif  // ENABLE_SECURITY
-  void SendTMMessage(uint8_t connection_id, uint8_t version, bool protection,
-                     uint8_t frameType, uint8_t serviceType, uint8_t frameData,
-                     uint8_t sessionId, uint32_t dataSize, uint32_t messageID,
-                     const uint8_t *data = 0) {
+  void SendTMMessage(uint8_t connection_id,
+                     uint8_t version,
+                     bool protection,
+                     uint8_t frameType,
+                     uint8_t serviceType,
+                     uint8_t frameData,
+                     uint8_t sessionId,
+                     uint32_t dataSize,
+                     uint32_t messageID,
+                     const uint8_t* data = 0) {
     // Create packet
-    const ProtocolPacket packet(connection_id, version, protection, frameType,
-                                serviceType, frameData, sessionId, dataSize,
-                                messageID, data);
+    const ProtocolPacket packet(connection_id,
+                                version,
+                                protection,
+                                frameType,
+                                serviceType,
+                                frameData,
+                                sessionId,
+                                dataSize,
+                                messageID,
+                                data);
     // Emulate receive packet from transoprt manager
     tm_listener->OnTMMessageReceived(packet.serializePacket());
   }
@@ -174,12 +226,22 @@ class ProtocolHandlerImplTest : public ::testing::Test {
         .WillByDefault(Return(PROTOCOL_VERSION_2));
   }
 
-  void SendControlMessage(bool protection, uint8_t service_type,
-                          uint8_t sessionId, uint32_t frame_data,
-                          uint32_t dataSize = 0u, const uint8_t *data = NULL) {
-    SendTMMessage(connection_id, PROTOCOL_VERSION_3, protection,
-                  FRAME_TYPE_CONTROL, service_type, frame_data, sessionId,
-                  dataSize, message_id, data);
+  void SendControlMessage(bool protection,
+                          uint8_t service_type,
+                          uint8_t sessionId,
+                          uint32_t frame_data,
+                          uint32_t dataSize = 0u,
+                          const uint8_t* data = NULL) {
+    SendTMMessage(connection_id,
+                  PROTOCOL_VERSION_3,
+                  protection,
+                  FRAME_TYPE_CONTROL,
+                  service_type,
+                  frame_data,
+                  sessionId,
+                  dataSize,
+                  message_id,
+                  data);
   }
 
   testing::NiceMock<MockProtocolHandlerSettings> protocol_handler_settings_mock;
@@ -192,11 +254,14 @@ class ProtocolHandlerImplTest : public ::testing::Test {
   // Uniq id as connection_id and session_id in one
   uint32_t connection_key;
   uint32_t message_id;
-  std::vector<uint8_t> some_data;
+  UCharDataVector some_data;
   // Strict mocks (same as all methods EXPECT_CALL().Times(0))
-  testing::NiceMock<connection_handler_test::MockConnectionHandler> connection_handler_mock;
-  testing::StrictMock<transport_manager_test::MockTransportManager> transport_manager_mock;
-  testing::StrictMock<protocol_handler_test::MockSessionObserver> session_observer_mock;
+  testing::NiceMock<connection_handler_test::MockConnectionHandler>
+      connection_handler_mock;
+  testing::StrictMock<transport_manager_test::MockTransportManager>
+      transport_manager_mock;
+  testing::StrictMock<protocol_handler_test::MockSessionObserver>
+      session_observer_mock;
 #ifdef ENABLE_SECURITY
   testing::NiceMock<security_manager_test::MockSecurityManager> security_manager_mock;
   testing::NiceMock<security_manager_test::MockSSLContext> ssl_context_mock;
@@ -205,14 +270,15 @@ class ProtocolHandlerImplTest : public ::testing::Test {
 
 #ifdef ENABLE_SECURITY
 class OnHandshakeDoneFunctor {
-public:
+ public:
   OnHandshakeDoneFunctor(const uint32_t connection_key,
                          security_manager::SSLContext::HandshakeResult error)
-  : connection_key(connection_key), result(error) {}
-  void operator()(security_manager::SecurityManagerListener * listener) const {
+      : connection_key(connection_key), result(error) {}
+  void operator()(security_manager::SecurityManagerListener* listener) const {
     listener->OnHandshakeDone(connection_key, result);
   }
-private:
+
+ private:
   const uint32_t connection_key;
   const security_manager::SSLContext::HandshakeResult result;
 };
@@ -228,48 +294,63 @@ TEST_F(ProtocolHandlerImplTest, RecieveEmptyRawMessage) {
  * ProtocolHandler shall disconnect on no connection
  */
 TEST_F(ProtocolHandlerImplTest, RecieveOnUnknownConnection) {
-  EXPECT_CALL(transport_manager_mock, DisconnectForce(connection_id)).
-      WillOnce(Return(E_SUCCESS));
+  EXPECT_CALL(transport_manager_mock, DisconnectForce(connection_id))
+      .WillOnce(Return(E_SUCCESS));
 
-  SendTMMessage(connection_id, PROTOCOL_VERSION_3, PROTECTION_OFF,
-                FRAME_TYPE_CONTROL, kRpc, FRAME_DATA_START_SERVICE,
-                NEW_SESSION_ID, 0, message_id);
+  SendTMMessage(connection_id,
+                PROTOCOL_VERSION_3,
+                PROTECTION_OFF,
+                FRAME_TYPE_CONTROL,
+                kRpc,
+                FRAME_DATA_START_SERVICE,
+                NEW_SESSION_ID,
+                0,
+                message_id);
 }
 /*
  * ProtocolHandler shall send NAck on session_observer rejection
  * Check protection flag OFF for all services from kControl to kBulk
  */
-TEST_F(ProtocolHandlerImplTest, StartSession_Unprotected_SessionObserverReject) {
+TEST_F(ProtocolHandlerImplTest,
+       StartSession_Unprotected_SessionObserverReject) {
   const int call_times = 5;
   AddConnection();
   // Expect ConnectionHandler check
-  EXPECT_CALL(session_observer_mock,
-      OnSessionStartedCallback(
-          connection_id, NEW_SESSION_ID, AnyOf(kControl, kRpc, kAudio,
-              kMobileNav, kBulk), PROTECTION_OFF, _)).Times(call_times).
-  // Return sessions start rejection
+  EXPECT_CALL(
+      session_observer_mock,
+      OnSessionStartedCallback(connection_id,
+                               NEW_SESSION_ID,
+                               AnyOf(kControl, kRpc, kAudio, kMobileNav, kBulk),
+                               PROTECTION_OFF,
+                               _))
+      .Times(call_times)
+      .
+      // Return sessions start rejection
       WillRepeatedly(Return(SESSION_START_REJECT));
 
   // Expect send NAck
   EXPECT_CALL(transport_manager_mock,
-      SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_NACK, PROTECTION_OFF)))
-      .Times(call_times).WillRepeatedly(Return(E_SUCCESS));
+              SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_NACK,
+                                                 PROTECTION_OFF)))
+      .Times(call_times)
+      .WillRepeatedly(Return(E_SUCCESS));
 
-  SendControlMessage(PROTECTION_OFF, kControl, NEW_SESSION_ID,
-                     FRAME_DATA_START_SERVICE);
-  SendControlMessage(PROTECTION_OFF, kRpc, NEW_SESSION_ID,
-                     FRAME_DATA_START_SERVICE);
-  SendControlMessage(PROTECTION_OFF, kAudio, NEW_SESSION_ID,
-                     FRAME_DATA_START_SERVICE);
-  SendControlMessage(PROTECTION_OFF, kMobileNav, NEW_SESSION_ID,
-                     FRAME_DATA_START_SERVICE);
-  SendControlMessage(PROTECTION_OFF, kBulk, NEW_SESSION_ID,
-                     FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_OFF, kControl, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_OFF, kRpc, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_OFF, kAudio, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_OFF, kMobileNav, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_OFF, kBulk, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
 }
 /*
  * ProtocolHandler shall send NAck on session_observer rejection
  * Emulate getting PROTECTION_ON and check protection flag OFF in NAck
- * For ENABLE_SECURITY=OFF session_observer shall be called with protection flag OFF
+ * For ENABLE_SECURITY=OFF session_observer shall be called with protection flag
+ * OFF
  */
 TEST_F(ProtocolHandlerImplTest, StartSession_Protected_SessionObserverReject) {
   const int call_times = 5;
@@ -278,67 +359,80 @@ TEST_F(ProtocolHandlerImplTest, StartSession_Protected_SessionObserverReject) {
   // For enabled protection callback shall use protection ON
   const bool callback_protection_flag = PROTECTION_ON;
 #else
-  // For disabled protection callback shall ignore protection income flag and use protection OFF
+  // For disabled protection callback shall ignore protection income flag and
+  // use protection OFF
   const bool callback_protection_flag = PROTECTION_OFF;
 #endif  // ENABLE_SECURITY
   // Expect ConnectionHandler check
-  EXPECT_CALL(session_observer_mock,
-      OnSessionStartedCallback(
-          connection_id, NEW_SESSION_ID, AnyOf(kControl, kRpc, kAudio,
-              kMobileNav, kBulk), callback_protection_flag, _)).Times(
-      call_times).
-  // Return sessions start rejection
+  EXPECT_CALL(
+      session_observer_mock,
+      OnSessionStartedCallback(connection_id,
+                               NEW_SESSION_ID,
+                               AnyOf(kControl, kRpc, kAudio, kMobileNav, kBulk),
+                               callback_protection_flag,
+                               _))
+      .Times(call_times)
+      .
+      // Return sessions start rejection
       WillRepeatedly(Return(SESSION_START_REJECT));
 
   // Expect send NAck with encryption OFF
   EXPECT_CALL(transport_manager_mock,
-      SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_NACK, PROTECTION_OFF)))
-      .Times(call_times).WillRepeatedly(Return(E_SUCCESS));
+              SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_NACK,
+                                                 PROTECTION_OFF)))
+      .Times(call_times)
+      .WillRepeatedly(Return(E_SUCCESS));
 
-  SendControlMessage(PROTECTION_ON, kControl, NEW_SESSION_ID,
-                     FRAME_DATA_START_SERVICE);
-  SendControlMessage(PROTECTION_ON, kRpc, NEW_SESSION_ID,
-                     FRAME_DATA_START_SERVICE);
-  SendControlMessage(PROTECTION_ON, kAudio, NEW_SESSION_ID,
-                     FRAME_DATA_START_SERVICE);
-  SendControlMessage(PROTECTION_ON, kMobileNav, NEW_SESSION_ID,
-                     FRAME_DATA_START_SERVICE);
-  SendControlMessage(PROTECTION_ON, kBulk, NEW_SESSION_ID,
-                     FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_ON, kControl, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_ON, kRpc, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_ON, kAudio, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_ON, kMobileNav, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_ON, kBulk, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
 }
 /*
  * ProtocolHandler shall send Ack on session_observer accept
  * Check protection flag OFF
  */
-TEST_F(ProtocolHandlerImplTest, StartSession_Unprotected_SessionObserverAccept) {
+TEST_F(ProtocolHandlerImplTest,
+       StartSession_Unprotected_SessionObserverAccept) {
   AddConnection();
   const ServiceType start_service = kRpc;
   // Expect ConnectionHandler check
-  EXPECT_CALL(session_observer_mock,
-      OnSessionStartedCallback(connection_id, NEW_SESSION_ID, start_service, PROTECTION_OFF, _))
+  EXPECT_CALL(
+      session_observer_mock,
+      OnSessionStartedCallback(
+          connection_id, NEW_SESSION_ID, start_service, PROTECTION_OFF, _))
       .
       // Return sessions start success
-  WillOnce(Return(session_id));
+      WillOnce(Return(session_id));
 
   SetProtocolVersion2();
   // Expect send Ack
   EXPECT_CALL(transport_manager_mock,
-      SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_OFF)))
+              SendMessageToDevice(
+                  ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_OFF)))
       .WillOnce(Return(E_SUCCESS));
 
-  SendControlMessage(PROTECTION_OFF, start_service, NEW_SESSION_ID,
-                     FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_OFF, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
 }
 /*
  * ProtocolHandler shall send Ack on session_observer accept
  * Emulate getting PROTECTION_ON and check protection flag OFF in Ack
- * For ENABLE_SECURITY=OFF session_observer shall be called with protection flag OFF
+ * For ENABLE_SECURITY=OFF session_observer shall be called with protection flag
+ * OFF
  */
 TEST_F(ProtocolHandlerImplTest, StartSession_Protected_SessionObserverAccept) {
   SetProtocolVersion2();
   AddSession();
 }
-// TODO(EZamakhov): add test for get_hash_id/set_hash_id from protocol_handler_impl.cc
+// TODO(EZamakhov): add test for get_hash_id/set_hash_id from
+// protocol_handler_impl.cc
 /*
  * ProtocolHandler shall send NAck on session_observer rejection
  */
@@ -348,18 +442,20 @@ TEST_F(ProtocolHandlerImplTest, EndSession_SessionObserverReject) {
 
   // Expect ConnectionHandler check
   EXPECT_CALL(session_observer_mock,
-      OnSessionEndedCallback(connection_id, session_id, _, service)).
-  // reject session start
-  WillOnce(Return(SESSION_START_REJECT));
+              OnSessionEndedCallback(connection_id, session_id, _, service))
+      .
+      // reject session start
+      WillOnce(Return(SESSION_START_REJECT));
 
   SetProtocolVersion2();
   // Expect send NAck
   EXPECT_CALL(transport_manager_mock,
-      SendMessageToDevice(ControlMessage(FRAME_DATA_END_SERVICE_NACK, PROTECTION_OFF)))
+              SendMessageToDevice(
+                  ControlMessage(FRAME_DATA_END_SERVICE_NACK, PROTECTION_OFF)))
       .WillOnce(Return(E_SUCCESS));
 
-  SendControlMessage(PROTECTION_OFF, service, session_id,
-                     FRAME_DATA_END_SERVICE);
+  SendControlMessage(
+      PROTECTION_OFF, service, session_id, FRAME_DATA_END_SERVICE);
 }
 /*
  * ProtocolHandler shall send NAck on wrong hash code
@@ -370,18 +466,20 @@ TEST_F(ProtocolHandlerImplTest, EndSession_Success) {
 
   // Expect ConnectionHandler check
   EXPECT_CALL(session_observer_mock,
-      OnSessionEndedCallback(connection_id, session_id, _, service)).
-  // return sessions start success
-  WillOnce(Return(connection_key));
+              OnSessionEndedCallback(connection_id, session_id, _, service))
+      .
+      // return sessions start success
+      WillOnce(Return(connection_key));
 
   SetProtocolVersion2();
   // Expect send Ack
   EXPECT_CALL(transport_manager_mock,
-      SendMessageToDevice(ControlMessage(FRAME_DATA_END_SERVICE_ACK, PROTECTION_OFF)))
+              SendMessageToDevice(
+                  ControlMessage(FRAME_DATA_END_SERVICE_ACK, PROTECTION_OFF)))
       .WillOnce(Return(E_SUCCESS));
 
-  SendControlMessage(PROTECTION_OFF, service, session_id,
-                     FRAME_DATA_END_SERVICE);
+  SendControlMessage(
+      PROTECTION_OFF, service, session_id, FRAME_DATA_END_SERVICE);
 }
 
 #ifdef ENABLE_SECURITY
@@ -395,22 +493,34 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtocoloV1) {
   AddSecurityManager();
   const ServiceType start_service = kRpc;
   // Expect ConnectionHandler check
-  EXPECT_CALL(session_observer_mock,
-      OnSessionStartedCallback(connection_id, NEW_SESSION_ID, start_service, PROTECTION_OFF, _)).
-  // Return sessions start success
-  WillOnce(Return(session_id));
+  EXPECT_CALL(
+      session_observer_mock,
+      OnSessionStartedCallback(
+          connection_id, NEW_SESSION_ID, start_service, PROTECTION_OFF, _))
+      .
+      // Return sessions start success
+      WillOnce(Return(session_id));
 
   SetProtocolVersion2();
   // Expect send Ack with PROTECTION_OFF (on no Security Manager)
   EXPECT_CALL(transport_manager_mock,
-      SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_OFF))).
-  WillOnce(Return(E_SUCCESS));
+              SendMessageToDevice(
+                  ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_OFF)))
+      .WillOnce(Return(E_SUCCESS));
 
-  SendTMMessage(connection_id, PROTOCOL_VERSION_1, PROTECTION_ON, FRAME_TYPE_CONTROL,
-      start_service, FRAME_DATA_START_SERVICE, NEW_SESSION_ID, 0, message_id);
+  SendTMMessage(connection_id,
+                PROTOCOL_VERSION_1,
+                PROTECTION_ON,
+                FRAME_TYPE_CONTROL,
+                start_service,
+                FRAME_DATA_START_SERVICE,
+                NEW_SESSION_ID,
+                0,
+                message_id);
 }
 /*
- * ProtocolHandler shall not call Security logics on start session with PROTECTION_OFF
+ * ProtocolHandler shall not call Security logics on start session with
+ * PROTECTION_OFF
  */
 TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionUnprotected) {
   AddConnection();
@@ -418,18 +528,23 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionUnprotected) {
   AddSecurityManager();
   const ServiceType start_service = kRpc;
   // Expect ConnectionHandler check
-  EXPECT_CALL(session_observer_mock,
-      OnSessionStartedCallback(connection_id, NEW_SESSION_ID, start_service, PROTECTION_OFF, _)).
-  // Return sessions start success
-  WillOnce(Return(session_id));
+  EXPECT_CALL(
+      session_observer_mock,
+      OnSessionStartedCallback(
+          connection_id, NEW_SESSION_ID, start_service, PROTECTION_OFF, _))
+      .
+      // Return sessions start success
+      WillOnce(Return(session_id));
 
   SetProtocolVersion2();
   // Expect send Ack with PROTECTION_OFF (on no Security Manager)
   EXPECT_CALL(transport_manager_mock,
-      SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_OFF))).
-  WillOnce(Return(E_SUCCESS));
+              SendMessageToDevice(
+                  ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_OFF)))
+      .WillOnce(Return(E_SUCCESS));
 
-  SendControlMessage(PROTECTION_OFF, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_OFF, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
 }
 /*
  * ProtocolHandler shall send Ack with PROTECTION_OFF on fail SLL creation
@@ -439,74 +554,90 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtected_Fail) {
   AddSecurityManager();
   const ServiceType start_service = kRpc;
   // Expect ConnectionHandler check
-  EXPECT_CALL(session_observer_mock,
-      OnSessionStartedCallback(connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _)).
-  // Return sessions start success
-  WillOnce(Return(session_id));
+  EXPECT_CALL(
+      session_observer_mock,
+      OnSessionStartedCallback(
+          connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _))
+      .
+      // Return sessions start success
+      WillOnce(Return(session_id));
 
   SetProtocolVersion2();
   // Expect start protection for unprotected session
-  EXPECT_CALL(security_manager_mock,
-      CreateSSLContext(connection_key)).
-  // Return fail protection
-  WillOnce(ReturnNull());
+  EXPECT_CALL(security_manager_mock, CreateSSLContext(connection_key))
+      .
+      // Return fail protection
+      WillOnce(ReturnNull());
 
   // Expect send Ack with PROTECTION_OFF (on fail SLL creation)
   EXPECT_CALL(transport_manager_mock,
-      SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_OFF))).
-  WillOnce(Return(E_SUCCESS));
+              SendMessageToDevice(
+                  ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_OFF)))
+      .WillOnce(Return(E_SUCCESS));
 
-  SendControlMessage(PROTECTION_ON, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_ON, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
 }
 /*
- * ProtocolHandler shall send Ack with PROTECTION_ON on already established and initialized SLLContext
+ * ProtocolHandler shall send Ack with PROTECTION_ON on already established and
+ * initialized SLLContext
  */
-TEST_F(ProtocolHandlerImplTest,SecurityEnable_StartSessionProtected_SSLInitialized) {
+TEST_F(ProtocolHandlerImplTest,
+       SecurityEnable_StartSessionProtected_SSLInitialized) {
   AddConnection();
   AddSecurityManager();
   const ServiceType start_service = kRpc;
   // Expect ConnectionHandler check
-  EXPECT_CALL(session_observer_mock,
-      OnSessionStartedCallback(connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _)).
-  // Return sessions start success
-  WillOnce(Return(session_id));
+  EXPECT_CALL(
+      session_observer_mock,
+      OnSessionStartedCallback(
+          connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _))
+      .
+      // Return sessions start success
+      WillOnce(Return(session_id));
 
   SetProtocolVersion2();
   // call new SSLContext creation
-  EXPECT_CALL(security_manager_mock,
-      CreateSSLContext(connection_key)).
-  // Return new SSLContext
-  WillOnce(Return(&ssl_context_mock));
+  EXPECT_CALL(security_manager_mock, CreateSSLContext(connection_key))
+      .
+      // Return new SSLContext
+      WillOnce(Return(&ssl_context_mock));
 
   // Initilization check
-  EXPECT_CALL(ssl_context_mock,
-      IsInitCompleted()).
-  //emulate SSL is initilized
-  WillOnce(Return(true));
+  EXPECT_CALL(ssl_context_mock, IsInitCompleted())
+      .
+      // emulate SSL is initilized
+      WillOnce(Return(true));
 
   // Expect service protection enable
   EXPECT_CALL(session_observer_mock,
-      SetProtectionFlag(connection_key, start_service));
+              SetProtectionFlag(connection_key, start_service));
 
   // Expect send Ack with PROTECTION_ON (on SSL is initilized)
   EXPECT_CALL(transport_manager_mock,
-      SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_ON))).
-  WillOnce(Return(E_SUCCESS));
+              SendMessageToDevice(
+                  ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_ON)))
+      .WillOnce(Return(E_SUCCESS));
 
-  SendControlMessage(PROTECTION_ON, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_ON, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
 }
 /*
  * ProtocolHandler shall send Ack with PROTECTION_OFF on session handshhake fail
  */
-TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtected_HandshakeFail) {
+TEST_F(ProtocolHandlerImplTest,
+       SecurityEnable_StartSessionProtected_HandshakeFail) {
   AddConnection();
   AddSecurityManager();
   const ServiceType start_service = kRpc;
   // Expect ConnectionHandler check
-  EXPECT_CALL(session_observer_mock,
-      OnSessionStartedCallback(connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _)).
-  // Return sessions start success
-  WillOnce(Return(session_id));
+  EXPECT_CALL(
+      session_observer_mock,
+      OnSessionStartedCallback(
+          connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _))
+      .
+      // Return sessions start success
+      WillOnce(Return(session_id));
 
   std::vector<int> services;
   // TODO(AKutsan) : APPLINK-21398 use named constants instead of magic numbers
@@ -516,48 +647,52 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtected_HandshakeFa
       .WillByDefault(ReturnRefOfCopy(services));
 
   // call new SSLContext creation
-  EXPECT_CALL(security_manager_mock,
-      CreateSSLContext(connection_key)).
-  // Return new SSLContext
-  WillOnce(Return(&ssl_context_mock));
+  EXPECT_CALL(security_manager_mock, CreateSSLContext(connection_key))
+      .
+      // Return new SSLContext
+      WillOnce(Return(&ssl_context_mock));
 
   // Initilization check
-  EXPECT_CALL(ssl_context_mock,
-      IsInitCompleted()).
-  //emulate SSL is not initilized
-  WillOnce(Return(false));
+  EXPECT_CALL(ssl_context_mock, IsInitCompleted())
+      .
+      // emulate SSL is not initilized
+      WillOnce(Return(false));
 
   // Pending handshake check
-  EXPECT_CALL(ssl_context_mock,
-      IsHandshakePending()).
-  //emulate is pending
-  WillOnce(Return(true));
+  EXPECT_CALL(ssl_context_mock, IsHandshakePending())
+      .
+      // emulate is pending
+      WillOnce(Return(true));
 
   // Expect add listener for handshake result
-  EXPECT_CALL(security_manager_mock,
-      AddListener(_))
-  // Emulate handshake fail
-  .WillOnce(Invoke(OnHandshakeDoneFunctor(
-                     connection_key,
-                     security_manager::SSLContext::Handshake_Result_Fail)));
+  EXPECT_CALL(security_manager_mock, AddListener(_))
+      // Emulate handshake fail
+      .WillOnce(Invoke(OnHandshakeDoneFunctor(
+          connection_key,
+          security_manager::SSLContext::Handshake_Result_Fail)));
 
   // Listener check SSLContext
   EXPECT_CALL(session_observer_mock,
-      GetSSLContext(connection_key, start_service)).
-  // Emulate protection for service is not enabled
-  WillOnce(ReturnNull());
+              GetSSLContext(connection_key, start_service))
+      .
+      // Emulate protection for service is not enabled
+      WillOnce(ReturnNull());
 
   // Expect send Ack with PROTECTION_OFF (on fail handshake)
   EXPECT_CALL(transport_manager_mock,
-      SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_OFF))).
-  WillOnce(Return(E_SUCCESS));
+              SendMessageToDevice(
+                  ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_OFF)))
+      .WillOnce(Return(E_SUCCESS));
 
-  SendControlMessage(PROTECTION_ON, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_ON, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
 }
 /*
- * ProtocolHandler shall send Ack with PROTECTION_ON on session handshhake success
+ * ProtocolHandler shall send Ack with PROTECTION_ON on session handshhake
+ * success
  */
-TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtected_HandshakeSuccess) {
+TEST_F(ProtocolHandlerImplTest,
+       SecurityEnable_StartSessionProtected_HandshakeSuccess) {
   AddConnection();
   AddSecurityManager();
   const ServiceType start_service = kRpc;
@@ -568,58 +703,65 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtected_HandshakeSu
       .WillByDefault(ReturnRefOfCopy(services));
 
   // Expect ConnectionHandler check
-  EXPECT_CALL(session_observer_mock,
-      OnSessionStartedCallback(connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _)).
-  // Return sessions start success
-  WillOnce(Return(session_id));
+  EXPECT_CALL(
+      session_observer_mock,
+      OnSessionStartedCallback(
+          connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _))
+      .
+      // Return sessions start success
+      WillOnce(Return(session_id));
 
   // call new SSLContext creation
-  EXPECT_CALL(security_manager_mock,
-      CreateSSLContext(connection_key)).
-  // Return new SSLContext
-  WillOnce(Return(&ssl_context_mock));
+  EXPECT_CALL(security_manager_mock, CreateSSLContext(connection_key))
+      .
+      // Return new SSLContext
+      WillOnce(Return(&ssl_context_mock));
 
   // Initilization check
-  EXPECT_CALL(ssl_context_mock,
-      IsInitCompleted()).
-  //emulate SSL is not initilized
-  WillOnce(Return(false));
+  EXPECT_CALL(ssl_context_mock, IsInitCompleted())
+      .
+      // emulate SSL is not initilized
+      WillOnce(Return(false));
 
   // Pending handshake check
-  EXPECT_CALL(ssl_context_mock,
-      IsHandshakePending()).
-  //emulate is pending
-  WillOnce(Return(true));
+  EXPECT_CALL(ssl_context_mock, IsHandshakePending())
+      .
+      // emulate is pending
+      WillOnce(Return(true));
 
   // Expect add listener for handshake result
-  EXPECT_CALL(security_manager_mock,
-      AddListener(_))
-  // Emulate handshake fail
-  .WillOnce(Invoke(OnHandshakeDoneFunctor(
-                     connection_key,
-                     security_manager::SSLContext::Handshake_Result_Success)));
+  EXPECT_CALL(security_manager_mock, AddListener(_))
+      // Emulate handshake fail
+      .WillOnce(Invoke(OnHandshakeDoneFunctor(
+          connection_key,
+          security_manager::SSLContext::Handshake_Result_Success)));
 
   // Listener check SSLContext
   EXPECT_CALL(session_observer_mock,
-      GetSSLContext(connection_key, start_service)).
-  // Emulate protection for service is not enabled
-  WillOnce(ReturnNull());
+              GetSSLContext(connection_key, start_service))
+      .
+      // Emulate protection for service is not enabled
+      WillOnce(ReturnNull());
 
   // Expect service protection enable
   EXPECT_CALL(session_observer_mock,
-      SetProtectionFlag(connection_key, start_service));
+              SetProtectionFlag(connection_key, start_service));
 
   // Expect send Ack with PROTECTION_OFF (on fail handshake)
   EXPECT_CALL(transport_manager_mock,
-      SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_ON))).
-  WillOnce(Return(E_SUCCESS));
+              SendMessageToDevice(
+                  ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_ON)))
+      .WillOnce(Return(E_SUCCESS));
 
-  SendControlMessage(PROTECTION_ON, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_ON, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
 }
 /*
- * ProtocolHandler shall send Ack with PROTECTION_ON on session handshhake success
+ * ProtocolHandler shall send Ack with PROTECTION_ON on session handshhake
+ * success
  */
-TEST_F(ProtocolHandlerImplTest,
+TEST_F(
+    ProtocolHandlerImplTest,
     SecurityEnable_StartSessionProtected_HandshakeSuccess_ServiceProtectedBefore) {
   AddConnection();
   AddSecurityManager();
@@ -630,59 +772,65 @@ TEST_F(ProtocolHandlerImplTest,
       .WillByDefault(ReturnRefOfCopy(services));
 
   // Expect ConnectionHandler check
-  EXPECT_CALL(session_observer_mock,
-      OnSessionStartedCallback(connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _)).
-  // Return sessions start success
-  WillOnce(Return(session_id));
+  EXPECT_CALL(
+      session_observer_mock,
+      OnSessionStartedCallback(
+          connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _))
+      .
+      // Return sessions start success
+      WillOnce(Return(session_id));
 
   // call new SSLContext creation
-  EXPECT_CALL(security_manager_mock,
-      CreateSSLContext(connection_key)).
-  // Return new SSLContext
-  WillOnce(Return(&ssl_context_mock));
+  EXPECT_CALL(security_manager_mock, CreateSSLContext(connection_key))
+      .
+      // Return new SSLContext
+      WillOnce(Return(&ssl_context_mock));
 
   // Initilization check
-  EXPECT_CALL(ssl_context_mock,
-      IsInitCompleted()).
-  //emulate SSL is not initilized
-  WillOnce(Return(false));
+  EXPECT_CALL(ssl_context_mock, IsInitCompleted())
+      .
+      // emulate SSL is not initilized
+      WillOnce(Return(false));
 
   // Pending handshake check
-  EXPECT_CALL(ssl_context_mock,
-      IsHandshakePending()).
-  //emulate is pending
-  WillOnce(Return(true));
+  EXPECT_CALL(ssl_context_mock, IsHandshakePending())
+      .
+      // emulate is pending
+      WillOnce(Return(true));
 
   // Expect add listener for handshake result
-  EXPECT_CALL(security_manager_mock,
-      AddListener(_))
-  // Emulate handshake fail
-  .WillOnce(Invoke(OnHandshakeDoneFunctor(
-                     connection_key,
-                     security_manager::SSLContext::Handshake_Result_Success)));
+  EXPECT_CALL(security_manager_mock, AddListener(_))
+      // Emulate handshake fail
+      .WillOnce(Invoke(OnHandshakeDoneFunctor(
+          connection_key,
+          security_manager::SSLContext::Handshake_Result_Success)));
 
   // Listener check SSLContext
   EXPECT_CALL(session_observer_mock,
-      GetSSLContext(connection_key, start_service)).
-  // Emulate protection for service is not enabled
-  WillOnce(ReturnNull());
+              GetSSLContext(connection_key, start_service))
+      .
+      // Emulate protection for service is not enabled
+      WillOnce(ReturnNull());
 
   // Expect service protection enable
   EXPECT_CALL(session_observer_mock,
-      SetProtectionFlag(connection_key, start_service));
+              SetProtectionFlag(connection_key, start_service));
 
   // Expect send Ack with PROTECTION_OFF (on fail handshake)
   EXPECT_CALL(transport_manager_mock,
-      SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_ON))).
-  WillOnce(Return(E_SUCCESS));
+              SendMessageToDevice(
+                  ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_ON)))
+      .WillOnce(Return(E_SUCCESS));
 
-  SendControlMessage(PROTECTION_ON, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_ON, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
 }
 /*
- * ProtocolHandler shall send Ack with PROTECTION_ON on session handshhake success
+ * ProtocolHandler shall send Ack with PROTECTION_ON on session handshhake
+ * success
  */
 TEST_F(ProtocolHandlerImplTest,
-    SecurityEnable_StartSessionProtected_HandshakeSuccess_SSLIsNotPending) {
+       SecurityEnable_StartSessionProtected_HandshakeSuccess_SSLIsNotPending) {
   AddConnection();
   AddSecurityManager();
   const ServiceType start_service = kRpc;
@@ -692,62 +840,65 @@ TEST_F(ProtocolHandlerImplTest,
       .WillByDefault(ReturnRefOfCopy(services));
 
   // Expect ConnectionHandler check
-  EXPECT_CALL(session_observer_mock,
-      OnSessionStartedCallback(connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _)).
-  // Return sessions start success
-  WillOnce(Return(session_id));
+  EXPECT_CALL(
+      session_observer_mock,
+      OnSessionStartedCallback(
+          connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _))
+      .
+      // Return sessions start success
+      WillOnce(Return(session_id));
 
   // call new SSLContext creation
-  EXPECT_CALL(security_manager_mock,
-      CreateSSLContext(connection_key)).
-  // Return new SSLContext
-  WillOnce(Return(&ssl_context_mock));
+  EXPECT_CALL(security_manager_mock, CreateSSLContext(connection_key))
+      .
+      // Return new SSLContext
+      WillOnce(Return(&ssl_context_mock));
 
   // Initilization check
-  EXPECT_CALL(ssl_context_mock,
-      IsInitCompleted()).
-  //emulate SSL is not initilized
-  WillOnce(Return(false));
+  EXPECT_CALL(ssl_context_mock, IsInitCompleted())
+      .
+      // emulate SSL is not initilized
+      WillOnce(Return(false));
 
   // Pending handshake check
-  EXPECT_CALL(ssl_context_mock,
-      IsHandshakePending()).
-  //emulate is pending
-  WillOnce(Return(false));
+  EXPECT_CALL(ssl_context_mock, IsHandshakePending())
+      .
+      // emulate is pending
+      WillOnce(Return(false));
 
   // Wait restart handshake operation
-  EXPECT_CALL(security_manager_mock,
-      StartHandshake(connection_key));
+  EXPECT_CALL(security_manager_mock, StartHandshake(connection_key));
 
   // Expect add listener for handshake result
-  EXPECT_CALL(security_manager_mock,
-      AddListener(_))
-  // Emulate handshake fail
-  .WillOnce(Invoke(OnHandshakeDoneFunctor(
-                     connection_key,
-                     security_manager::SSLContext::Handshake_Result_Success)));
+  EXPECT_CALL(security_manager_mock, AddListener(_))
+      // Emulate handshake fail
+      .WillOnce(Invoke(OnHandshakeDoneFunctor(
+          connection_key,
+          security_manager::SSLContext::Handshake_Result_Success)));
 
   // Listener check SSLContext
   EXPECT_CALL(session_observer_mock,
-      GetSSLContext(connection_key, start_service)).
-  // Emulate protection for service is not enabled
-  WillOnce(ReturnNull());
+              GetSSLContext(connection_key, start_service))
+      .
+      // Emulate protection for service is not enabled
+      WillOnce(ReturnNull());
 
   // Expect service protection enable
   EXPECT_CALL(session_observer_mock,
-      SetProtectionFlag(connection_key, start_service));
+              SetProtectionFlag(connection_key, start_service));
 
   // Expect send Ack with PROTECTION_OFF (on fail handshake)
   EXPECT_CALL(transport_manager_mock,
-      SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_ON))).
-  WillOnce(Return(E_SUCCESS));
+              SendMessageToDevice(
+                  ControlMessage(FRAME_DATA_START_SERVICE_ACK, PROTECTION_ON)))
+      .WillOnce(Return(E_SUCCESS));
 
-  SendControlMessage(PROTECTION_ON, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+  SendControlMessage(
+      PROTECTION_ON, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
 }
 #endif  // ENABLE_SECURITY
 
-TEST_F(ProtocolHandlerImplTest,
-    FloodVerification) {
+TEST_F(ProtocolHandlerImplTest, FloodVerification) {
   const size_t period_msec = 10000;
   const size_t max_messages = 1000;
   InitProtocolHandlerImpl(period_msec, max_messages);
@@ -755,9 +906,8 @@ TEST_F(ProtocolHandlerImplTest,
   AddSession();
 
   // Expect flood notification to CH
-  EXPECT_CALL(session_observer_mock,
-      OnApplicationFloodCallBack(connection_key)).
-  Times(1);
+  EXPECT_CALL(session_observer_mock, OnApplicationFloodCallBack(connection_key))
+      .Times(1);
 
   ON_CALL(protocol_handler_settings_mock, message_frequency_time())
       .WillByDefault(Return(period_msec));
@@ -765,13 +915,19 @@ TEST_F(ProtocolHandlerImplTest,
       .WillByDefault(Return(max_messages));
 
   for (size_t i = 0; i < max_messages + 1; ++i) {
-    SendTMMessage(connection_id, PROTOCOL_VERSION_3, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-        kControl, FRAME_DATA_SINGLE, session_id,
-        some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  PROTOCOL_VERSION_3,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  kControl,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
   }
 }
-TEST_F(ProtocolHandlerImplTest,
-    FloodVerification_ThresholdValue) {
+TEST_F(ProtocolHandlerImplTest, FloodVerification_ThresholdValue) {
   const size_t period_msec = 10000;
   const size_t max_messages = 1000;
   InitProtocolHandlerImpl(period_msec, max_messages);
@@ -787,13 +943,19 @@ TEST_F(ProtocolHandlerImplTest,
   EXPECT_CALL(session_observer_mock, OnApplicationFloodCallBack(connection_key))
       .Times(0);
   for (size_t i = 0; i < max_messages - 1; ++i) {
-    SendTMMessage(connection_id, PROTOCOL_VERSION_3, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-        kControl, FRAME_DATA_SINGLE, session_id,
-        some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  PROTOCOL_VERSION_3,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  kControl,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
   }
 }
-TEST_F(ProtocolHandlerImplTest,
-    FloodVerification_VideoFrameSkip) {
+TEST_F(ProtocolHandlerImplTest, FloodVerification_VideoFrameSkip) {
   const size_t period_msec = 10000;
   const size_t max_messages = 1000;
   InitProtocolHandlerImpl(period_msec, max_messages);
@@ -802,13 +964,19 @@ TEST_F(ProtocolHandlerImplTest,
 
   // Expect NO flood notification to CH on video data streaming
   for (size_t i = 0; i < max_messages + 1; ++i) {
-    SendTMMessage(connection_id, PROTOCOL_VERSION_3, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-        kMobileNav, FRAME_DATA_SINGLE, session_id,
-        some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  PROTOCOL_VERSION_3,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  kMobileNav,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
   }
 }
-TEST_F(ProtocolHandlerImplTest,
-    FloodVerification_AudioFrameSkip) {
+TEST_F(ProtocolHandlerImplTest, FloodVerification_AudioFrameSkip) {
   const size_t period_msec = 10000;
   const size_t max_messages = 1000;
   InitProtocolHandlerImpl(period_msec, max_messages);
@@ -817,13 +985,19 @@ TEST_F(ProtocolHandlerImplTest,
 
   // Expect NO flood notification to CH on video data streaming
   for (size_t i = 0; i < max_messages + 1; ++i) {
-    SendTMMessage(connection_id, PROTOCOL_VERSION_3, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-        kAudio, FRAME_DATA_SINGLE, session_id,
-        some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  PROTOCOL_VERSION_3,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  kAudio,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
   }
 }
-TEST_F(ProtocolHandlerImplTest,
-    FloodVerificationDisable) {
+TEST_F(ProtocolHandlerImplTest, FloodVerificationDisable) {
   const size_t period_msec = 0;
   const size_t max_messages = 0;
   InitProtocolHandlerImpl(period_msec, max_messages);
@@ -832,15 +1006,20 @@ TEST_F(ProtocolHandlerImplTest,
 
   // Expect NO flood notification to session observer
   for (size_t i = 0; i < max_messages + 1; ++i) {
-    SendTMMessage(connection_id, PROTOCOL_VERSION_3, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-        kControl, FRAME_DATA_SINGLE, session_id,
-        some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  PROTOCOL_VERSION_3,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  kControl,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
   }
 }
 
-
-TEST_F(ProtocolHandlerImplTest,
-       MalformedVerificationDisable) {
+TEST_F(ProtocolHandlerImplTest, MalformedVerificationDisable) {
   const size_t period_msec = 10000;
   const size_t max_messages = 100;
   InitProtocolHandlerImpl(0u, 0u, false, period_msec, max_messages);
@@ -848,20 +1027,25 @@ TEST_F(ProtocolHandlerImplTest,
   AddSession();
 
   // Expect malformed notification to CH
-  EXPECT_CALL(session_observer_mock,
-              OnMalformedMessageCallback(connection_id)).
-      Times(max_messages);
+  EXPECT_CALL(session_observer_mock, OnMalformedMessageCallback(connection_id))
+      .Times(max_messages);
 
   const uint8_t malformed_version = PROTOCOL_VERSION_MAX;
   for (size_t i = 0; i < max_messages; ++i) {
-    SendTMMessage(connection_id, malformed_version, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-                  kControl, FRAME_DATA_SINGLE, session_id,
-                  some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  malformed_version,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  kControl,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
   }
 }
 
-TEST_F(ProtocolHandlerImplTest,
-       MalformedLimitVerification) {
+TEST_F(ProtocolHandlerImplTest, MalformedLimitVerification) {
   const size_t period_msec = 10000;
   const size_t max_messages = 100;
   InitProtocolHandlerImpl(0u, 0u, true, period_msec, max_messages);
@@ -869,26 +1053,38 @@ TEST_F(ProtocolHandlerImplTest,
   AddSession();
 
   // Expect malformed notification to CH
-  EXPECT_CALL(session_observer_mock,
-              OnMalformedMessageCallback(connection_id)).
-      Times(1);
+  EXPECT_CALL(session_observer_mock, OnMalformedMessageCallback(connection_id))
+      .Times(1);
 
   // Sending malformed packets
   const uint8_t malformed_version = PROTOCOL_VERSION_MAX;
   for (size_t i = 0; i < max_messages * 2; ++i) {
     // Malformed message
-    SendTMMessage(connection_id, malformed_version, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-                  kControl, FRAME_DATA_SINGLE, session_id,
-                  some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  malformed_version,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  kControl,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
     // Common message
-    SendTMMessage(connection_id, PROTOCOL_VERSION_1, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-                  kControl, FRAME_DATA_SINGLE, session_id,
-                  some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  PROTOCOL_VERSION_1,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  kControl,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
   }
 }
 
-TEST_F(ProtocolHandlerImplTest,
-    MalformedLimitVerification_MalformedStock) {
+TEST_F(ProtocolHandlerImplTest, MalformedLimitVerification_MalformedStock) {
   const size_t period_msec = 10000;
   const size_t max_messages = 100;
   InitProtocolHandlerImpl(0u, 0u, true, period_msec, max_messages);
@@ -896,9 +1092,8 @@ TEST_F(ProtocolHandlerImplTest,
   AddSession();
 
   // Expect malformed notification to CH
-  EXPECT_CALL(session_observer_mock,
-      OnMalformedMessageCallback(connection_id)).
-  Times(1);
+  EXPECT_CALL(session_observer_mock, OnMalformedMessageCallback(connection_id))
+      .Times(1);
 
   // Sending malformed packets
   const uint8_t malformed_version = PROTOCOL_VERSION_MAX;
@@ -906,27 +1101,54 @@ TEST_F(ProtocolHandlerImplTest,
   const uint8_t malformed_service_type = kInvalidServiceType;
   for (size_t i = 0; i < max_messages * 2; ++i) {
     // Malformed message 1
-    SendTMMessage(connection_id, malformed_version, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-        kControl, FRAME_DATA_SINGLE, session_id,
-        some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  malformed_version,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  kControl,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
     // Malformed message 2
-    SendTMMessage(connection_id, PROTOCOL_VERSION_1, PROTECTION_OFF, malformed_frame_type,
-        kControl, FRAME_DATA_SINGLE, session_id,
-        some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  PROTOCOL_VERSION_1,
+                  PROTECTION_OFF,
+                  malformed_frame_type,
+                  kControl,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
     // Malformed message 3
-    SendTMMessage(connection_id, PROTOCOL_VERSION_1, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-        malformed_service_type, FRAME_DATA_SINGLE, session_id,
-        some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  PROTOCOL_VERSION_1,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  malformed_service_type,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
 
     // Common message
-    SendTMMessage(connection_id, PROTOCOL_VERSION_1, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-                  kControl, FRAME_DATA_SINGLE, session_id,
-                  some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  PROTOCOL_VERSION_1,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  kControl,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
   }
 }
 
-TEST_F(ProtocolHandlerImplTest,
-       MalformedLimitVerification_MalformedOnly) {
+TEST_F(ProtocolHandlerImplTest, MalformedLimitVerification_MalformedOnly) {
   const size_t period_msec = 10000;
   const size_t max_messages = 100;
   InitProtocolHandlerImpl(0u, 0u, true, period_msec, max_messages);
@@ -934,9 +1156,8 @@ TEST_F(ProtocolHandlerImplTest,
   AddSession();
 
   // Expect NO malformed notification to CH
-  EXPECT_CALL(session_observer_mock,
-              OnMalformedMessageCallback(connection_id)).
-      Times(0);
+  EXPECT_CALL(session_observer_mock, OnMalformedMessageCallback(connection_id))
+      .Times(0);
 
   // Sending malformed packets
   const uint8_t malformed_version = PROTOCOL_VERSION_MAX;
@@ -944,24 +1165,44 @@ TEST_F(ProtocolHandlerImplTest,
   const uint8_t malformed_service_type = kInvalidServiceType;
   for (size_t i = 0; i < max_messages * 2; ++i) {
     // Malformed message 1
-    SendTMMessage(connection_id, malformed_version, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-                  kControl, FRAME_DATA_SINGLE, session_id,
-                  some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  malformed_version,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  kControl,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
     // Malformed message 2
-    SendTMMessage(connection_id, PROTOCOL_VERSION_1, PROTECTION_OFF, malformed_frame_type,
-                  kControl, FRAME_DATA_SINGLE, session_id,
-                  some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  PROTOCOL_VERSION_1,
+                  PROTECTION_OFF,
+                  malformed_frame_type,
+                  kControl,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
     // Malformed message 3
-    SendTMMessage(connection_id, PROTOCOL_VERSION_1, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-                  malformed_service_type, FRAME_DATA_SINGLE, session_id,
-                  some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  PROTOCOL_VERSION_1,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  malformed_service_type,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
 
     // No common message
   }
 }
 
-TEST_F(ProtocolHandlerImplTest,
-       MalformedLimitVerification_NullTimePeriod) {
+TEST_F(ProtocolHandlerImplTest, MalformedLimitVerification_NullTimePeriod) {
   const size_t period_msec = 0;
   const size_t max_messages = 1000;
   InitProtocolHandlerImpl(0u, 0u, true, period_msec, max_messages);
@@ -969,20 +1210,25 @@ TEST_F(ProtocolHandlerImplTest,
   AddSession();
 
   // Expect no malformed notification to CH
-  EXPECT_CALL(session_observer_mock,
-              OnMalformedMessageCallback(connection_id)).
-      Times(0);
+  EXPECT_CALL(session_observer_mock, OnMalformedMessageCallback(connection_id))
+      .Times(0);
 
   // Sending malformed packets
   const uint8_t malformed_version = PROTOCOL_VERSION_MAX;
   for (size_t i = 0; i < max_messages + 1; ++i) {
-    SendTMMessage(connection_id, malformed_version, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-                  kControl, FRAME_DATA_SINGLE, session_id,
-                  some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  malformed_version,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  kControl,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
   }
 }
-TEST_F(ProtocolHandlerImplTest,
-       MalformedLimitVerification_NullCount) {
+TEST_F(ProtocolHandlerImplTest, MalformedLimitVerification_NullCount) {
   const size_t period_msec = 10000;
   const size_t max_messages = 0;
   InitProtocolHandlerImpl(0u, 0u, true, period_msec, max_messages);
@@ -990,19 +1236,247 @@ TEST_F(ProtocolHandlerImplTest,
   AddSession();
 
   // Expect no malformed notification to CH
-  EXPECT_CALL(session_observer_mock,
-              OnMalformedMessageCallback(connection_id)).
-      Times(0);
+  EXPECT_CALL(session_observer_mock, OnMalformedMessageCallback(connection_id))
+      .Times(0);
 
   // Sending malformed packets
   const uint8_t malformed_version = PROTOCOL_VERSION_MAX;
   for (size_t i = 0; i < max_messages + 1; ++i) {
-    SendTMMessage(connection_id, malformed_version, PROTECTION_OFF, FRAME_TYPE_SINGLE,
-                  kControl, FRAME_DATA_SINGLE, session_id,
-                  some_data.size(), message_id, &some_data[0]);
+    SendTMMessage(connection_id,
+                  malformed_version,
+                  PROTECTION_OFF,
+                  FRAME_TYPE_SINGLE,
+                  kControl,
+                  FRAME_DATA_SINGLE,
+                  session_id,
+                  some_data.size(),
+                  message_id,
+                  &some_data[0]);
   }
 }
 
-}  // namespace test
-}  // namespace components
+TEST_F(ProtocolHandlerImplTest,
+       SendEndServicePrivate_NoConnection_MessageNotSent) {
+  // Expect check connection with ProtocolVersionUsed
+  EXPECT_CALL(session_observer_mock,
+              ProtocolVersionUsed(connection_id, session_id, _))
+      .WillOnce(Return(false));
+  // Expect not send End Service
+  EXPECT_CALL(transport_manager_mock, SendMessageToDevice(_)).Times(0);
+  // Act
+  protocol_handler_impl->SendEndSession(connection_id, session_id);
+}
+
+TEST_F(ProtocolHandlerImplTest, SendEndServicePrivate_EndSession_MessageSent) {
+  // Arrange
+  AddSession();
+  // Expect check connection with ProtocolVersionUsed
+  EXPECT_CALL(session_observer_mock,
+              ProtocolVersionUsed(connection_id, session_id, _))
+      .WillOnce(Return(true));
+  // Expect send End Service
+  EXPECT_CALL(
+      transport_manager_mock,
+      SendMessageToDevice(ExpectedMessage(
+          FRAME_TYPE_CONTROL, FRAME_DATA_END_SERVICE, PROTECTION_OFF, kRpc)))
+      .WillOnce(Return(E_SUCCESS));
+  // Act
+  protocol_handler_impl->SendEndSession(connection_id, session_id);
+}
+
+TEST_F(ProtocolHandlerImplTest,
+       SendEndServicePrivate_ServiceTypeControl_MessageSent) {
+  // Arrange
+  AddSession();
+  // Expect check connection with ProtocolVersionUsed
+  EXPECT_CALL(session_observer_mock,
+              ProtocolVersionUsed(connection_id, session_id, _))
+      .WillOnce(Return(true));
+  // Expect send End Service
+  EXPECT_CALL(transport_manager_mock,
+              SendMessageToDevice(ExpectedMessage(FRAME_TYPE_CONTROL,
+                                                  FRAME_DATA_END_SERVICE,
+                                                  PROTECTION_OFF,
+                                                  kControl)))
+      .WillOnce(Return(E_SUCCESS));
+  // Act
+  protocol_handler_impl->SendEndService(connection_id, session_id, kControl);
+}
+
+TEST_F(ProtocolHandlerImplTest, SendHeartBeat_NoConnection_NotSent) {
+  // Expect check connection with ProtocolVersionUsed
+  EXPECT_CALL(session_observer_mock,
+              ProtocolVersionUsed(connection_id, session_id, _))
+      .WillOnce(Return(false));
+  // Expect not send HeartBeat
+  EXPECT_CALL(transport_manager_mock, SendMessageToDevice(_)).Times(0);
+  // Act
+  protocol_handler_impl->SendHeartBeat(connection_id, session_id);
+}
+
+TEST_F(ProtocolHandlerImplTest, SendHeartBeat_Successful) {
+  // Arrange
+  AddSession();
+  // Expect check connection with ProtocolVersionUsed
+  EXPECT_CALL(session_observer_mock,
+              ProtocolVersionUsed(connection_id, session_id, _))
+      .WillOnce(Return(true));
+  // Expect send HeartBeat
+  EXPECT_CALL(
+      transport_manager_mock,
+      SendMessageToDevice(ExpectedMessage(
+          FRAME_TYPE_CONTROL, FRAME_DATA_HEART_BEAT, PROTECTION_OFF, kControl)))
+      .WillOnce(Return(E_SUCCESS));
+  // Act
+  protocol_handler_impl->SendHeartBeat(connection_id, session_id);
+}
+
+TEST_F(ProtocolHandlerImplTest, SendHeartBeatAck_Successful) {
+  // Arrange
+  AddSession();
+  // Expect double check connection and protocol version with
+  // ProtocolVersionUsed
+  EXPECT_CALL(session_observer_mock, ProtocolVersionUsed(connection_id, _, _))
+      .WillRepeatedly(
+          DoAll(SetArgReferee<2>(PROTOCOL_VERSION_3), Return(true)));
+  // Expect send HeartBeatAck
+  EXPECT_CALL(transport_manager_mock,
+              SendMessageToDevice(ExpectedMessage(FRAME_TYPE_CONTROL,
+                                                  FRAME_DATA_HEART_BEAT_ACK,
+                                                  PROTECTION_OFF,
+                                                  kControl)))
+      .WillOnce(Return(E_SUCCESS));
+  // Act
+  SendControlMessage(
+      PROTECTION_OFF, kControl, session_id, FRAME_DATA_HEART_BEAT);
+}
+
+TEST_F(ProtocolHandlerImplTest, SendHeartBeatAck_WrongProtocolVersion_NotSent) {
+  // Arrange
+  AddSession();
+  // Expect two checks of connection and protocol version with
+  // ProtocolVersionUsed
+  EXPECT_CALL(session_observer_mock, ProtocolVersionUsed(connection_id, _, _))
+      .Times(2)
+      .WillRepeatedly(
+          DoAll(SetArgReferee<2>(PROTOCOL_VERSION_1), Return(true)));
+  // Expect not send HeartBeatAck
+  EXPECT_CALL(transport_manager_mock,
+              SendMessageToDevice(ExpectedMessage(FRAME_TYPE_CONTROL,
+                                                  FRAME_DATA_HEART_BEAT_ACK,
+                                                  PROTECTION_OFF,
+                                                  kControl))).Times(0);
+  // Act
+  SendControlMessage(
+      PROTECTION_OFF, kControl, session_id, FRAME_DATA_HEART_BEAT);
+  SendControlMessage(
+      PROTECTION_OFF, kControl, session_id, FRAME_DATA_HEART_BEAT);
+}
+
+TEST_F(ProtocolHandlerImplTest,
+       SendMessageToMobileApp_SendSingleControlMessage) {
+  // Arrange
+  AddSession();
+  const bool is_final = true;
+  const uint32_t total_data_size = 1;
+  UCharDataVector data(total_data_size);
+  RawMessagePtr message = utils::MakeShared<RawMessage>(
+      connection_key, PROTOCOL_VERSION_3, &data[0], total_data_size, kControl);
+  // Expect getting pair from key from session observer
+  EXPECT_CALL(session_observer_mock,
+              PairFromKey(message->connection_key(), _, _))
+      .WillOnce(
+          DoAll(SetArgPointee<1>(connection_id), SetArgPointee<2>(session_id)));
+// Expect getting ssl context
+#ifdef ENABLE_SECURITY
+  EXPECT_CALL(session_observer_mock,
+              GetSSLContext(message->connection_key(), message->service_type()))
+      .WillOnce(Return(&ssl_context_mock));
+#endif  // ENABLE_SECURITY
+  // Expect send message to mobile
+  EXPECT_CALL(
+      transport_manager_mock,
+      SendMessageToDevice(ExpectedMessage(
+          FRAME_TYPE_SINGLE, FRAME_DATA_SINGLE, PROTECTION_OFF, kControl)))
+      .WillOnce(Return(E_SUCCESS));
+  // Act
+  protocol_handler_impl->SendMessageToMobileApp(message, is_final);
+}
+
+TEST_F(ProtocolHandlerImplTest,
+       SendMessageToMobileApp_SendSingleNonControlMessage) {
+  // Arrange
+  AddSession();
+  const bool is_final = true;
+  const uint32_t total_data_size = 1;
+  UCharDataVector data(total_data_size);
+  RawMessagePtr message = utils::MakeShared<RawMessage>(
+      connection_key, PROTOCOL_VERSION_3, &data[0], total_data_size, kRpc);
+  // Expect getting pair from key from session observer
+  EXPECT_CALL(session_observer_mock,
+              PairFromKey(message->connection_key(), _, _))
+      .WillOnce(
+          DoAll(SetArgPointee<1>(connection_id), SetArgPointee<2>(session_id)));
+// Expect getting ssl context
+#ifdef ENABLE_SECURITY
+  EXPECT_CALL(session_observer_mock,
+              GetSSLContext(message->connection_key(), message->service_type()))
+      .Times(2)
+      .WillRepeatedly(Return(&ssl_context_mock));
+  AddSecurityManager();
+#endif  // ENABLE_SECURITY
+  // Expect send message to mobile
+  EXPECT_CALL(transport_manager_mock,
+              SendMessageToDevice(ExpectedMessage(
+                  FRAME_TYPE_SINGLE, FRAME_DATA_SINGLE, PROTECTION_OFF, kRpc)))
+      .WillOnce(Return(E_SUCCESS));
+  // Act
+  protocol_handler_impl->SendMessageToMobileApp(message, is_final);
+}
+
+TEST_F(ProtocolHandlerImplTest, SendMessageToMobileApp_SendMultiframeMessage) {
+  // Arrange
+  AddSession();
+  const bool is_final = true;
+  const uint32_t total_data_size = MAXIMUM_FRAME_DATA_V2_SIZE * 2;
+  UCharDataVector data(total_data_size);
+  const uint8_t first_consecutive_frame = 0x01;
+  RawMessagePtr message = utils::MakeShared<RawMessage>(
+      connection_key, PROTOCOL_VERSION_3, &data[0], total_data_size, kBulk);
+  // Expect getting pair from key from session observer
+  EXPECT_CALL(session_observer_mock,
+              PairFromKey(message->connection_key(), _, _))
+      .WillOnce(
+          DoAll(SetArgPointee<1>(connection_id), SetArgPointee<2>(session_id)));
+// Expect getting ssl context
+#ifdef ENABLE_SECURITY
+  EXPECT_CALL(session_observer_mock,
+              GetSSLContext(message->connection_key(), message->service_type()))
+      .Times(4)
+      .WillRepeatedly(Return(&ssl_context_mock));
+  AddSecurityManager();
+#endif  // ENABLE_SECURITY
+  // Expect sending message frame by frame to mobile
+  EXPECT_CALL(transport_manager_mock,
+              SendMessageToDevice(ExpectedMessage(
+                  FRAME_TYPE_FIRST, FRAME_DATA_FIRST, PROTECTION_OFF, kBulk)))
+      .WillOnce(Return(E_SUCCESS));
+  EXPECT_CALL(transport_manager_mock,
+              SendMessageToDevice(ExpectedMessage(FRAME_TYPE_CONSECUTIVE,
+                                                  first_consecutive_frame,
+                                                  PROTECTION_OFF,
+                                                  kBulk)))
+      .WillOnce(Return(E_SUCCESS));
+  EXPECT_CALL(transport_manager_mock,
+              SendMessageToDevice(ExpectedMessage(FRAME_TYPE_CONSECUTIVE,
+                                                  FRAME_DATA_LAST_CONSECUTIVE,
+                                                  PROTECTION_OFF,
+                                                  kBulk)))
+      .WillOnce(Return(E_SUCCESS));
+  // Act
+  protocol_handler_impl->SendMessageToMobileApp(message, is_final);
+}
+
 }  // namespace protocol_handler_test
+}  // namespace components
+}  // namespace test

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -43,7 +43,6 @@
 #include "security_manager/mock_security_manager.h"
 #include "security_manager/mock_ssl_context.h"
 #include "transport_manager/mock_transport_manager.h"
-
 #include "utils/make_shared.h"
 
 namespace test {
@@ -53,24 +52,33 @@ namespace protocol_handler_test {
 // Id passed as NULL for new session establishing
 #define NEW_SESSION_ID 0u
 #define SESSION_START_REJECT 0u
-
+// Protocol Handler Entities
+using protocol_handler::ProtocolHandlerImpl;
 using protocol_handler::ServiceType;
 using protocol_handler::RawMessage;
 using protocol_handler::RawMessagePtr;
 using protocol_handler::PROTECTION_ON;
 using protocol_handler::PROTECTION_OFF;
 using protocol_handler::PROTOCOL_VERSION_1;
+using protocol_handler::PROTOCOL_VERSION_2;
 using protocol_handler::PROTOCOL_VERSION_3;
 using protocol_handler::PROTOCOL_VERSION_MAX;
 using protocol_handler::FRAME_TYPE_CONTROL;
 using protocol_handler::FRAME_TYPE_SINGLE;
+using protocol_handler::FRAME_TYPE_FIRST;
+using protocol_handler::FRAME_TYPE_CONSECUTIVE;
 using protocol_handler::FRAME_TYPE_MAX_VALUE;
+using protocol_handler::MAXIMUM_FRAME_DATA_V2_SIZE;
 using protocol_handler::FRAME_DATA_START_SERVICE;
 using protocol_handler::FRAME_DATA_START_SERVICE_ACK;
+using protocol_handler::FRAME_DATA_END_SERVICE_NACK;
+using protocol_handler::FRAME_DATA_END_SERVICE_ACK;
 using protocol_handler::FRAME_DATA_END_SERVICE;
 using protocol_handler::FRAME_DATA_HEART_BEAT;
 using protocol_handler::FRAME_DATA_HEART_BEAT_ACK;
 using protocol_handler::FRAME_DATA_SINGLE;
+using protocol_handler::FRAME_DATA_FIRST;
+using protocol_handler::FRAME_DATA_LAST_CONSECUTIVE;
 using protocol_handler::kRpc;
 using protocol_handler::kControl;
 using protocol_handler::kAudio;
@@ -80,7 +88,10 @@ using protocol_handler::kInvalidServiceType;
 // For TM states
 using transport_manager::TransportManagerListener;
 using transport_manager::E_SUCCESS;
-
+using transport_manager::DeviceInfo;
+// For CH entities
+using connection_handler::DeviceHandle;
+// Google Testing Framework Entities
 using ::testing::Return;
 using ::testing::ReturnRefOfCopy;
 using ::testing::ReturnNull;

--- a/src/components/protocol_handler/test/protocol_packet_test.cc
+++ b/src/components/protocol_handler/test/protocol_packet_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,17 +30,41 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 #include <vector>
-#include <list>
 
 #include "utils/macro.h"
 #include "protocol_handler/protocol_packet.h"
+#include "protocol/common.h"
 
 namespace test {
 namespace components {
 namespace protocol_handler_test {
-using namespace ::protocol_handler;
+
+using protocol_handler::RawMessagePtr;
+using protocol_handler::ProtocolPacket;
+using protocol_handler::ConnectionID;
+using protocol_handler::FRAME_TYPE_MAX_VALUE;
+using protocol_handler::FRAME_DATA_FIRST;
+using protocol_handler::FRAME_TYPE_FIRST;
+using protocol_handler::PROTOCOL_VERSION_1;
+using protocol_handler::PROTOCOL_VERSION_3;
+using protocol_handler::PROTECTION_OFF;
+using protocol_handler::RESULT_CODE;
+using protocol_handler::RESULT_OK;
+using protocol_handler::RESULT_FAIL;
+using protocol_handler::FRAME_TYPE_CONTROL;
+using protocol_handler::kControl;
+using protocol_handler::kRpc;
+using protocol_handler::kAudio;
+using protocol_handler::kMobileNav;
+using protocol_handler::kBulk;
+using protocol_handler::kInvalidServiceType;
+using protocol_handler::FRAME_DATA_HEART_BEAT;
+using protocol_handler::FRAME_DATA_START_SERVICE_ACK;
+using protocol_handler::PROTOCOL_HEADER_V1_SIZE;
+using protocol_handler::PROTOCOL_HEADER_V2_SIZE;
+using protocol_handler::PROTOCOL_VERSION_MAX;
 
 class ProtocolPacketTest : public ::testing::Test {
  protected:
@@ -49,26 +73,39 @@ class ProtocolPacketTest : public ::testing::Test {
     some_session_id = 0xFEDCBA0;
     some_connection_id = 10;
   }
+
+  RawMessagePtr GetRawMessage(uint8_t version,
+                              uint8_t frame_type,
+                              uint8_t service_type) {
+    ProtocolPacket prot_packet(some_connection_id,
+                               version,
+                               PROTECTION_OFF,
+                               frame_type,
+                               service_type,
+                               FRAME_DATA_HEART_BEAT,
+                               some_session_id,
+                               0u,
+                               some_message_id);
+    EXPECT_EQ(frame_type, prot_packet.frame_type());
+    return prot_packet.serializePacket();
+  }
+
   uint32_t some_message_id;
   uint32_t some_session_id;
   ConnectionID some_connection_id;
 };
 
 TEST_F(ProtocolPacketTest, SerializePacketWithDiffVersions) {
-  RawMessagePtr res;
   uint8_t version = PROTOCOL_VERSION_1;
   for (; version <= PROTOCOL_VERSION_MAX; ++version) {
-    ProtocolPacket prot_packet(
-        some_connection_id, version, PROTECTION_OFF, FRAME_TYPE_CONTROL,
-        kControl, FRAME_DATA_HEART_BEAT, some_session_id, 0u, some_message_id);
-    res = prot_packet.serializePacket();
-    EXPECT_EQ(res->protocol_version(), version);
-    EXPECT_EQ(res->service_type(), kControl);
-    EXPECT_EQ(res->connection_key(), some_connection_id);
+    RawMessagePtr res = GetRawMessage(version, FRAME_TYPE_CONTROL, kControl);
+    EXPECT_EQ(version, res->protocol_version());
+    EXPECT_EQ(kControl, res->service_type());
+    EXPECT_EQ(some_connection_id, res->connection_key());
     if (res->protocol_version() == PROTOCOL_VERSION_1) {
-      EXPECT_EQ(res->data_size(), 8u);
+      EXPECT_EQ(PROTOCOL_HEADER_V1_SIZE, res->data_size());
     } else {
-      EXPECT_EQ(res->data_size(), 12u);
+      EXPECT_EQ(PROTOCOL_HEADER_V2_SIZE, res->data_size());
     }
   }
 }
@@ -77,22 +114,18 @@ TEST_F(ProtocolPacketTest, SerializePacketWithDiffVersions) {
 // (Video), 0x0F (Bulk)
 TEST_F(ProtocolPacketTest, SerializePacketWithDiffServiceType) {
   std::vector<uint8_t> serv_types;
-  serv_types.push_back(0x0);
-  serv_types.push_back(0x07);
-  serv_types.push_back(0x0A);
-  serv_types.push_back(0x0B);
-  serv_types.push_back(0x0F);
+  serv_types.push_back(kControl);
+  serv_types.push_back(kRpc);
+  serv_types.push_back(kAudio);
+  serv_types.push_back(kMobileNav);
+  serv_types.push_back(kBulk);
 
-  RawMessagePtr res;
   for (size_t i = 0; i < serv_types.size(); ++i) {
-    ProtocolPacket prot_packet(some_connection_id, PROTOCOL_VERSION_3,
-                               PROTECTION_OFF, FRAME_TYPE_CONTROL,
-                               serv_types[i], FRAME_DATA_HEART_BEAT,
-                               some_session_id, 0u, some_message_id);
-    res = prot_packet.serializePacket();
+    RawMessagePtr res =
+        GetRawMessage(PROTOCOL_VERSION_3, FRAME_TYPE_CONTROL, serv_types[i]);
     EXPECT_EQ(PROTOCOL_VERSION_3, res->protocol_version());
     EXPECT_EQ(serv_types[i], res->service_type());
-    EXPECT_EQ(12u, res->data_size());
+    EXPECT_EQ(PROTOCOL_HEADER_V2_SIZE, res->data_size());
   }
 }
 
@@ -108,74 +141,63 @@ TEST_F(ProtocolPacketTest, SerializePacketWithWrongServiceType) {
   serv_types.push_back(0x0D);
   serv_types.push_back(0x0E);
 
-  RawMessagePtr res;
   for (size_t i = 0; i < serv_types.size(); ++i) {
-    ProtocolPacket prot_packet(some_connection_id, PROTOCOL_VERSION_3,
-                               PROTECTION_OFF, FRAME_TYPE_CONTROL,
-                               serv_types[i], FRAME_DATA_HEART_BEAT,
-                               some_session_id, 0u, some_message_id);
-    res = prot_packet.serializePacket();
+    RawMessagePtr res =
+        GetRawMessage(PROTOCOL_VERSION_3, FRAME_TYPE_CONTROL, serv_types[i]);
     EXPECT_EQ(PROTOCOL_VERSION_3, res->protocol_version());
     EXPECT_EQ(kInvalidServiceType, res->service_type());
   }
 }
 
 TEST_F(ProtocolPacketTest, SetPacketWithDiffFrameType) {
-  RawMessagePtr res;
   uint8_t frame_type;
-  for (frame_type = FRAME_TYPE_CONTROL + 1; frame_type <= FRAME_TYPE_MAX_VALUE;
+  for (frame_type = FRAME_TYPE_CONTROL + 1;
+       frame_type <= FRAME_TYPE_MAX_VALUE;
        ++frame_type) {
-    ProtocolPacket prot_packet(
-        some_connection_id, PROTOCOL_VERSION_3, PROTECTION_OFF, frame_type,
-        kControl, FRAME_DATA_HEART_BEAT, some_session_id, 0u, some_message_id);
-    res = prot_packet.serializePacket();
+    RawMessagePtr res = GetRawMessage(PROTOCOL_VERSION_3, frame_type, kControl);
     EXPECT_EQ(PROTOCOL_VERSION_3, res->protocol_version());
     EXPECT_EQ(kControl, res->service_type());
-    EXPECT_EQ(frame_type, prot_packet.frame_type());
   }
 }
 
 TEST_F(ProtocolPacketTest, AppendDataToEmptyPacket) {
   // Set version, serviceType, frameData, sessionId
-  uint8_t session_id = 1u;
-  uint8_t some_data[] = {0x0, 0x07, 0x02, session_id};
+  const uint8_t session_id = 1u;
+  uint8_t some_data[] = {0x0, kRpc, FRAME_DATA_START_SERVICE_ACK, session_id};
   ProtocolPacket protocol_packet;
   RESULT_CODE res = protocol_packet.appendData(some_data, sizeof(some_data));
   EXPECT_EQ(RESULT_FAIL, res);
 }
 
 TEST_F(ProtocolPacketTest, SetTotalDataBytes) {
-  uint8_t new_data_size = 10u;
+  const uint8_t new_data_size = 10u;
   ProtocolPacket protocol_packet;
   protocol_packet.set_total_data_bytes(new_data_size);
-
   EXPECT_EQ(new_data_size, protocol_packet.total_data_bytes());
 }
 
 TEST_F(ProtocolPacketTest, AppendDataToPacketWithNonZeroSize) {
   // Set version, serviceType, frameData, sessionId
-  uint8_t session_id = 1u;
-  uint8_t some_data[] = {0x0, 0x07, FRAME_TYPE_CONTROL, session_id};
+  const uint8_t session_id = 1u;
+  uint8_t some_data[] = {0x0, kRpc, FRAME_DATA_HEART_BEAT, session_id};
   ProtocolPacket protocol_packet;
   protocol_packet.set_total_data_bytes(sizeof(some_data) + 1);
   RESULT_CODE res = protocol_packet.appendData(some_data, sizeof(some_data));
   EXPECT_EQ(RESULT_OK, res);
-
   EXPECT_EQ(0x0, protocol_packet.data()[0]);
-  EXPECT_EQ(0x07, protocol_packet.data()[1]);
-  EXPECT_EQ(FRAME_TYPE_CONTROL, protocol_packet.data()[2]);
+  EXPECT_EQ(kRpc, protocol_packet.data()[1]);
+  EXPECT_EQ(FRAME_DATA_HEART_BEAT, protocol_packet.data()[2]);
   EXPECT_EQ(session_id, protocol_packet.data()[3]);
 }
 
 TEST_F(ProtocolPacketTest, SetData) {
-  uint8_t session_id = 1u;
-  uint8_t some_data[] = {0x0, 0x07, FRAME_TYPE_CONTROL, session_id};
+  const uint8_t session_id = 1u;
+  uint8_t some_data[] = {0x0, kRpc, FRAME_DATA_HEART_BEAT, session_id};
   ProtocolPacket protocol_packet;
   protocol_packet.set_data(some_data, sizeof(some_data));
-
   EXPECT_EQ(0x0, protocol_packet.data()[0]);
-  EXPECT_EQ(0x07, protocol_packet.data()[1]);
-  EXPECT_EQ(FRAME_TYPE_CONTROL, protocol_packet.data()[2]);
+  EXPECT_EQ(kRpc, protocol_packet.data()[1]);
+  EXPECT_EQ(FRAME_DATA_HEART_BEAT, protocol_packet.data()[2]);
   EXPECT_EQ(session_id, protocol_packet.data()[3]);
 }
 
@@ -188,11 +210,42 @@ TEST_F(ProtocolPacketTest, DeserializeZeroPacket) {
 
 TEST_F(ProtocolPacketTest, DeserializeNonZeroPacket) {
   // Set header, serviceType, frameData, sessionId
-  uint8_t session_id = 1u;
-  uint8_t some_message[] = {0x21, 0x07, 0x02, session_id};
+  const uint8_t session_id = 1u;
+  const uint8_t version_frame_type = 0x21;
+  uint8_t some_message[] = {
+      version_frame_type, kRpc, FRAME_DATA_START_SERVICE_ACK, session_id};
   ProtocolPacket protocol_packet;
   RESULT_CODE res =
       protocol_packet.deserializePacket(some_message, PROTOCOL_HEADER_V2_SIZE);
+  EXPECT_EQ(RESULT_OK, res);
+}
+
+TEST_F(ProtocolPacketTest, DeserializePacket_FrameTypeFirst_ResultOK) {
+  // Arrange
+  const uint8_t session_id = 1u;
+  const uint8_t data_size = 1u;
+  const uint8_t version_frame_type = 0x22;
+  // Set protol version - 2 and frame type - first
+  uint8_t message[] = {version_frame_type,
+                       kRpc,
+                       FRAME_DATA_FIRST,
+                       session_id,
+                       0x00,
+                       0x00,
+                       0x00,
+                       data_size,
+                       0x00,
+                       0x00,
+                       0x00,
+                       0x00,
+                       0x00};
+  ProtocolPacket protocol_packet;
+  // Act
+  RESULT_CODE res =
+      protocol_packet.deserializePacket(message, PROTOCOL_HEADER_V2_SIZE);
+  uint8_t frame_type = protocol_packet.frame_type();
+  // Assert
+  EXPECT_EQ(FRAME_TYPE_FIRST, frame_type);
   EXPECT_EQ(RESULT_OK, res);
 }
 

--- a/src/components/protocol_handler/test/protocol_packet_test.cc
+++ b/src/components/protocol_handler/test/protocol_packet_test.cc
@@ -62,6 +62,7 @@ using protocol_handler::kBulk;
 using protocol_handler::kInvalidServiceType;
 using protocol_handler::FRAME_DATA_HEART_BEAT;
 using protocol_handler::FRAME_DATA_START_SERVICE_ACK;
+using protocol_handler::FRAME_DATA_LAST_CONSECUTIVE;
 using protocol_handler::PROTOCOL_HEADER_V1_SIZE;
 using protocol_handler::PROTOCOL_HEADER_V2_SIZE;
 using protocol_handler::PROTOCOL_VERSION_MAX;
@@ -69,30 +70,31 @@ using protocol_handler::PROTOCOL_VERSION_MAX;
 class ProtocolPacketTest : public ::testing::Test {
  protected:
   void SetUp() OVERRIDE {
-    some_message_id = 0xABCDEF0;
-    some_session_id = 0xFEDCBA0;
-    some_connection_id = 10;
+    some_message_id_ = 0xABCDEF0;
+    some_session_id_ = 0xFEDCBA0;
+    some_connection_id_ = 10;
   }
 
   RawMessagePtr GetRawMessage(uint8_t version,
                               uint8_t frame_type,
                               uint8_t service_type) {
-    ProtocolPacket prot_packet(some_connection_id,
+    ProtocolPacket prot_packet(some_connection_id_,
                                version,
                                PROTECTION_OFF,
                                frame_type,
                                service_type,
                                FRAME_DATA_HEART_BEAT,
-                               some_session_id,
+                               some_session_id_,
                                0u,
-                               some_message_id);
+                               some_message_id_);
     EXPECT_EQ(frame_type, prot_packet.frame_type());
     return prot_packet.serializePacket();
   }
 
-  uint32_t some_message_id;
-  uint32_t some_session_id;
-  ConnectionID some_connection_id;
+  const uint8_t zero_test_data_element_ = 0x0u;
+  uint32_t some_message_id_;
+  uint32_t some_session_id_;
+  ConnectionID some_connection_id_;
 };
 
 TEST_F(ProtocolPacketTest, SerializePacketWithDiffVersions) {
@@ -101,7 +103,7 @@ TEST_F(ProtocolPacketTest, SerializePacketWithDiffVersions) {
     RawMessagePtr res = GetRawMessage(version, FRAME_TYPE_CONTROL, kControl);
     EXPECT_EQ(version, res->protocol_version());
     EXPECT_EQ(kControl, res->service_type());
-    EXPECT_EQ(some_connection_id, res->connection_key());
+    EXPECT_EQ(some_connection_id_, res->connection_key());
     if (res->protocol_version() == PROTOCOL_VERSION_1) {
       EXPECT_EQ(PROTOCOL_HEADER_V1_SIZE, res->data_size());
     } else {
@@ -163,7 +165,8 @@ TEST_F(ProtocolPacketTest, SetPacketWithDiffFrameType) {
 TEST_F(ProtocolPacketTest, AppendDataToEmptyPacket) {
   // Set version, serviceType, frameData, sessionId
   const uint8_t session_id = 1u;
-  uint8_t some_data[] = {0x0, kRpc, FRAME_DATA_START_SERVICE_ACK, session_id};
+  uint8_t some_data[] = {
+      zero_test_data_element_, kRpc, FRAME_DATA_START_SERVICE_ACK, session_id};
   ProtocolPacket protocol_packet;
   RESULT_CODE res = protocol_packet.appendData(some_data, sizeof(some_data));
   EXPECT_EQ(RESULT_FAIL, res);
@@ -179,23 +182,25 @@ TEST_F(ProtocolPacketTest, SetTotalDataBytes) {
 TEST_F(ProtocolPacketTest, AppendDataToPacketWithNonZeroSize) {
   // Set version, serviceType, frameData, sessionId
   const uint8_t session_id = 1u;
-  uint8_t some_data[] = {0x0, kRpc, FRAME_DATA_HEART_BEAT, session_id};
+  uint8_t some_data[] = {
+      zero_test_data_element_, kRpc, FRAME_DATA_LAST_CONSECUTIVE, session_id};
   ProtocolPacket protocol_packet;
   protocol_packet.set_total_data_bytes(sizeof(some_data) + 1);
   RESULT_CODE res = protocol_packet.appendData(some_data, sizeof(some_data));
   EXPECT_EQ(RESULT_OK, res);
-  EXPECT_EQ(0x0, protocol_packet.data()[0]);
+  EXPECT_EQ(zero_test_data_element_, protocol_packet.data()[0]);
   EXPECT_EQ(kRpc, protocol_packet.data()[1]);
-  EXPECT_EQ(FRAME_DATA_HEART_BEAT, protocol_packet.data()[2]);
+  EXPECT_EQ(FRAME_DATA_LAST_CONSECUTIVE, protocol_packet.data()[2]);
   EXPECT_EQ(session_id, protocol_packet.data()[3]);
 }
 
 TEST_F(ProtocolPacketTest, SetData) {
   const uint8_t session_id = 1u;
-  uint8_t some_data[] = {0x0, kRpc, FRAME_DATA_HEART_BEAT, session_id};
+  uint8_t some_data[] = {
+      zero_test_data_element_, kRpc, FRAME_DATA_HEART_BEAT, session_id};
   ProtocolPacket protocol_packet;
   protocol_packet.set_data(some_data, sizeof(some_data));
-  EXPECT_EQ(0x0, protocol_packet.data()[0]);
+  EXPECT_EQ(zero_test_data_element_, protocol_packet.data()[0]);
   EXPECT_EQ(kRpc, protocol_packet.data()[1]);
   EXPECT_EQ(FRAME_DATA_HEART_BEAT, protocol_packet.data()[2]);
   EXPECT_EQ(session_id, protocol_packet.data()[3]);
@@ -230,15 +235,15 @@ TEST_F(ProtocolPacketTest, DeserializePacket_FrameTypeFirst_ResultOK) {
                        kRpc,
                        FRAME_DATA_FIRST,
                        session_id,
-                       0x00,
-                       0x00,
-                       0x00,
+                       zero_test_data_element_,
+                       zero_test_data_element_,
+                       zero_test_data_element_,
                        data_size,
-                       0x00,
-                       0x00,
-                       0x00,
-                       0x00,
-                       0x00};
+                       zero_test_data_element_,
+                       zero_test_data_element_,
+                       zero_test_data_element_,
+                       zero_test_data_element_,
+                       zero_test_data_element_};
   ProtocolPacket protocol_packet;
   // Act
   RESULT_CODE res =

--- a/src/components/telemetry_monitor/test/telemetry_monitor_test.cc
+++ b/src/components/telemetry_monitor/test/telemetry_monitor_test.cc
@@ -38,7 +38,7 @@
 #include "protocol_handler/mock_session_observer.h"
 #include "protocol_handler/mock_protocol_handler_settings.h"
 #include "connection_handler/mock_connection_handler.h"
-#include "transport_manager/transport_manager_mock.h"
+#include "transport_manager/mock_transport_manager.h"
 #include "telemetry_monitor/mock_telemetry_observable.h"
 
 

--- a/src/components/transport_manager/test/tcp_client_listener_test.cc
+++ b/src/components/transport_manager/test/tcp_client_listener_test.cc
@@ -33,7 +33,7 @@
 #include "gtest/gtest.h"
 #include "include/transport_adapter_mock.h"
 #include "transport_manager/tcp/tcp_client_listener.h"
-#include "transport_manager/transport_manager_mock.h"
+#include "transport_manager/mock_transport_manager.h"
 #include "transport_manager/transport_adapter/transport_adapter_controller.h"
 #include "transport_manager/transport_adapter/device.h"
 

--- a/src/components/transport_manager/test/transport_adapter_listener_test.cc
+++ b/src/components/transport_manager/test/transport_adapter_listener_test.cc
@@ -33,7 +33,7 @@
 #include "gtest/gtest.h"
 #include "include/transport_adapter_mock.h"
 #include "transport_manager/transport_adapter/transport_adapter_listener_impl.h"
-#include "transport_manager/transport_manager_mock.h"
+#include "transport_manager/mock_transport_manager.h"
 
 namespace test {
 namespace components {


### PR DESCRIPTION
Complete covering of Protocol handler
    
    1) Modified existing tests cases
    2) Added new tests
    3) Changed using entire namespaces to using particular entities from those namespaves
    4) Changed header files according new code changes.
    5) Changed header files in tests
    6) Renamed transport_manager_mock to mok=ck)transport_manager
    7) Renamed other mock classes to match naming rules
    8) Deleted redundant headers and namespaces.
    9) Changed year in Ford headers
    10) Changed raw "new" operator using to MakeShared for creating shared_ptr
    11) Corrected header guards
    12) Added new method CheckRegularMatches to control_message_matcher

Relates: APPLINK-22767