### PR TITLE
Fix send info in AlertManever

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/alert_maneuver_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/alert_maneuver_request.h
@@ -84,6 +84,8 @@ class AlertManeuverRequest : public CommandRequestImpl {
 
   mobile_apis::Result::eType tts_speak_result_code_;
   mobile_apis::Result::eType navi_alert_maneuver_result_code_;
+  std::string info_navi_;
+  std::string info_tts_;
   Pending pending_requests_;
 
   DISALLOW_COPY_AND_ASSIGN(AlertManeuverRequest);


### PR DESCRIPTION
Fix for AlertManever response to mobile. AlertManaver sends wrong "info" parameter to mobile.
Related:
        [APPLINK-23121](https://adc.luxoft.com/jira/browse/APPLINK-23121)