### PR TITLE
Adds partial support of proprietary policy flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ option(ENABLE_GCOV "gcov code coverage feature" OFF)
 option(ENABLE_SANITIZE "Sanitize tool" OFF)
 option(ENABLE_SECURITY "Security Ford protocol protection" ON)
 option(ENABLE_HMI_PTU_DECRYPTION "Policy table update parsed by hmi" ON)
+option(ENABLE_EXTENDED_POLICY "Turns extended flow which requires embedded system interaction" OFF)
 
 set(OS_TYPE_OPTION 	"$ENV{OS_TYPE}")
 set(DEBUG_OPTION 	"$ENV{DEBUG}")
@@ -226,6 +227,10 @@ endif()
 
 if (TIME_TESTER)
     add_definitions(-DTIME_TESTER)
+endif()
+
+if (ENABLE_EXTENDED_POLICY)
+    add_definitions(-DEXTENDED_POLICY)
 endif()
 
 # TODO(AK): check current OS here

--- a/src/components/application_manager/include/application_manager/commands/hmi/get_urls.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/get_urls.h
@@ -34,6 +34,7 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_GET_URLS_H_
 
 #include "application_manager/commands/hmi/request_from_hmi.h"
+#include "policy/policy_types.h"
 
 namespace application_manager {
 namespace commands {
@@ -58,9 +59,29 @@ class GetUrls : public RequestFromHMI {
     /**
      * @brief Execute command
      **/
-    virtual void Run();
+    void Run() OVERRIDE;
 
   private:
+#ifdef EXTENDED_POLICY
+    /**
+     * @brief Processes URLs collecting for policy service
+     * @param endpoints Endpoints section of policy table
+     */
+    void ProcessPolicyServiceURLs(const policy::EndpointUrls& endpoints);
+#endif
+
+    /**
+     * @brief Process URLs collecting for service
+     * @param endpoints Endpoints section of policy table
+     */
+    void ProcessServiceURLs(const policy::EndpointUrls& endpoints);
+
+    /**
+     * @brief Sends response to HMI
+     * @param result Result code
+     */
+    void SendResponseToHMI(hmi_apis::Common_Result::eType result);
+
     DISALLOW_COPY_AND_ASSIGN(GetUrls);
 };
 

--- a/src/components/application_manager/include/application_manager/commands/hmi/on_received_policy_update.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/on_received_policy_update.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,26 +40,26 @@ namespace application_manager {
 namespace commands {
 
 class OnReceivedPolicyUpdate : public NotificationFromHMI {
-  public:
-    /**
-       * @brief OnReceivedPolicyUpdate class constructor
-       *
-       * @param message Incoming SmartObject message
-       **/
-    explicit OnReceivedPolicyUpdate(const MessageSharedPtr& message);
-
-    /**
-     * @brief OnReceivedPolicyUpdate class destructor
+ public:
+  /**
+     * @brief OnReceivedPolicyUpdate class constructor
+     *
+     * @param message Incoming SmartObject message
      **/
-    virtual ~OnReceivedPolicyUpdate();
+  explicit OnReceivedPolicyUpdate(const MessageSharedPtr& message);
 
-    /**
-     * @brief Execute command
-     **/
-    virtual void Run();
+  /**
+   * @brief OnReceivedPolicyUpdate class destructor
+   **/
+  ~OnReceivedPolicyUpdate() OVERRIDE;
 
-  private:
-    DISALLOW_COPY_AND_ASSIGN(OnReceivedPolicyUpdate);
+  /**
+   * @brief Execute command
+   **/
+  void Run() OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(OnReceivedPolicyUpdate);
 };
 
 }  // namespace commands

--- a/src/components/application_manager/include/application_manager/commands/hmi/sdl_policy_update.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/sdl_policy_update.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,20 +40,23 @@ namespace application_manager {
 namespace commands {
 
 class SDLPolicyUpdate : public RequestToHMI {
-  public:
-    /**
-       * @brief SDLPolicyUpdate class constructor
-       *
-       * @param message Incoming SmartObject message
-       **/
-    explicit SDLPolicyUpdate(const MessageSharedPtr& message);
-    virtual ~SDLPolicyUpdate();
-    /**
-     * @brief Execute command
+ public:
+  /**
+     * @brief SDLPolicyUpdate class constructor
+     *
+     * @param message Incoming SmartObject message
      **/
-    virtual void Run();
-  private:
-    DISALLOW_COPY_AND_ASSIGN(SDLPolicyUpdate);
+  explicit SDLPolicyUpdate(const MessageSharedPtr& message);
+
+  ~SDLPolicyUpdate() OVERRIDE;
+
+  /**
+   * @brief Execute command
+   **/
+  void Run() OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(SDLPolicyUpdate);
 };
 
 }  // namespace commands

--- a/src/components/application_manager/include/application_manager/commands/mobile/on_system_request_notification.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/on_system_request_notification.h
@@ -1,6 +1,5 @@
 /*
-
- Copyright (c) 2013, Ford Motor Company
+ Copyright (c) 2016, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -34,8 +33,8 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_ON_SYSTEM_REQUEST_NOTIFICATION_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_ON_SYSTEM_REQUEST_NOTIFICATION_H_
 
-
 #include "application_manager/commands/command_notification_impl.h"
+#include <vector>
 
 namespace application_manager {
 
@@ -48,6 +47,7 @@ namespace mobile {
  **/
 class OnSystemRequestNotification : public CommandNotificationImpl {
  public:
+  typedef std::vector<uint8_t> BinaryMessage;
   /**
    * @brief OnSystemRequestNotification class constructor
    *
@@ -58,13 +58,22 @@ class OnSystemRequestNotification : public CommandNotificationImpl {
   /**
    * @brief OnSystemRequestNotification class destructor
    **/
-  virtual ~OnSystemRequestNotification();
+  ~OnSystemRequestNotification() OVERRIDE;
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
-  private:
+  void Run() OVERRIDE;
+
+ private:
+#ifdef EXTENDED_POLICY
+  /**
+   * @brief Adds HTTP header to message
+   * @param message Message
+   */
+  void AddHeader(BinaryMessage& message) const;
+#endif
+
   DISALLOW_COPY_AND_ASSIGN(OnSystemRequestNotification);
 };
 

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -81,9 +81,7 @@ class PolicyHandler :
   virtual void OnPermissionsUpdated(const std::string& policy_app_id,
                                     const Permissions& permissions);
 
-  virtual void OnSnapshotCreated(const BinaryMessage& pt_string,
-                                 const std::vector<int>& retry_delay_seconds,
-                                 int timeout_exchange);
+  virtual void OnSnapshotCreated(const BinaryMessage& pt_string);
 
   bool GetPriority(const std::string& policy_app_id, std::string* priority);
   void CheckPermissions(const PTString& app_id,

--- a/src/components/application_manager/src/commands/hmi/get_urls.cc
+++ b/src/components/application_manager/src/commands/hmi/get_urls.cc
@@ -49,49 +49,135 @@ void GetUrls::Run() {
   using namespace strings;
   using namespace hmi_apis;
 
-  SmartObject& object = *message_;
-  object[params][message_type] = MessageType::kResponse;
   if (!policy::PolicyHandler::instance()->PolicyEnabled()) {
-    object[params][hmi_response::code] = Common_Result::DATA_NOT_AVAILABLE;
-    ApplicationManagerImpl::instance()->ManageHMICommand(message_);
+    SendResponseToHMI(Common_Result::DATA_NOT_AVAILABLE);
     return;
   }
+
+  SmartObject& object = *message_;
+  const std::string service_to_check =
+      object[msg_params][hmi_request::service].asString();
 
   policy::EndpointUrls endpoints;
   policy::PolicyHandler::instance()->GetServiceUrls(
       object[strings::msg_params][hmi_request::service].asString(),
       endpoints);
   if (endpoints.empty()) {
-    object[params][hmi_response::code] = Common_Result::DATA_NOT_AVAILABLE;
+    LOG4CXX_ERROR(logger_, "No URLs for service " << service_to_check);
+    SendResponseToHMI(Common_Result::DATA_NOT_AVAILABLE);
+    return;
+  }
+
+#ifdef EXTENDED_POLICY
+  const std::string policy_service = "7";
+
+  if (policy_service == service_to_check) {
+    ProcessPolicyServiceURLs(endpoints);
+    return;
+  }
+#endif
+  ProcessServiceURLs(endpoints);
+}
+
+#ifdef EXTENDED_POLICY
+void GetUrls::ProcessPolicyServiceURLs(const policy::EndpointUrls& endpoints) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  using namespace smart_objects;
+  using namespace application_manager;
+  using namespace strings;
+  using namespace hmi_apis;
+
+  const uint32_t app_id_to_send_to =
+      policy::PolicyHandler::instance()->GetAppIdForSending();
+
+  if (!app_id_to_send_to) {
+    LOG4CXX_ERROR(logger_,
+                  "There are no available applications for processing.");
     ApplicationManagerImpl::instance()->ManageHMICommand(message_);
     return;
   }
 
+  ApplicationSharedPtr app =
+      ApplicationManagerImpl::instance()->application(app_id_to_send_to);
+
+  if (!app.valid()) {
+    LOG4CXX_WARN(logger_,
+                 "There is no registered application with "
+                 "connection key '" << app_id_to_send_to << "'");
+    SendResponseToHMI(Common_Result::DATA_NOT_AVAILABLE);
+    return;
+  }
+
+  SmartObject& object = *message_;
+  object[msg_params].erase(hmi_request::service);
+  object[msg_params][hmi_response::urls] = SmartObject(SmartType_Array);
+
+  SmartObject& urls = object[msg_params][hmi_response::urls];
+
+  const std::string mobile_app_id = app->mobile_app_id();
+  std::string default_url = "URL is not found";
+
+  // Will use only one URL for particular application if it will be found
+  // Otherwise URL from default section will used
+  SmartObject service_info = SmartObject(SmartType_Map);
+
+  for (size_t e = 0; e < endpoints.size(); ++e) {
+
+    if (mobile_app_id == endpoints[e].app_id) {
+      if (endpoints[e].url.size()) {
+        service_info[url] = endpoints[e].url[0];
+        SendResponseToHMI(Common_Result::SUCCESS);
+        return;
+      }
+    }
+    if (policy::kDefaultId == endpoints[e].app_id) {
+      if (endpoints[e].url.size()) {
+        default_url = endpoints[e].url[0];
+      }
+    }
+  }
+
+  service_info[hmi_response::policy_app_id] = mobile_app_id;
+  service_info[strings::url] = default_url;
+  urls[0] = service_info;
+  // TODO(AOleynik): Issue with absent policy_app_id. Need to fix later on.
+  // Possibly related to smart schema
+  SendResponseToHMI(Common_Result::SUCCESS);
+  return;
+}
+#endif
+
+void GetUrls::ProcessServiceURLs(const policy::EndpointUrls& endpoints) {
+  using namespace smart_objects;
+  using namespace strings;
+  using namespace hmi_apis;
+
+  SmartObject& object = *message_;
   object[msg_params].erase(hmi_request::service);
   object[msg_params][hmi_response::urls] = SmartObject(SmartType_Array);
 
   SmartObject& urls = object[msg_params][hmi_response::urls];
 
   size_t index = 0;
-
-  for (size_t service = 0; service < endpoints.size(); ++service) {
-    for (size_t app = 0; app < endpoints[service].url.size(); ++app, ++index) {
-      const std::string app_url = endpoints[service].url[app];
+  for (size_t e = 0; e < endpoints.size(); ++e) {
+    for (size_t u = 0; u < endpoints[e].url.size(); ++u, ++index) {
+      const std::string app_url = endpoints[e].url[u];
 
       urls[index] = SmartObject(SmartType_Map);
       SmartObject& service_info = urls[index];
 
-      // TODO(AOleynik): Currently sends default for service 7
-      // Must be changed to send choosen app_id, but logic should be clarified
-      // first
       service_info[url] = app_url;
-      if (policy::kDefaultId != endpoints[service].app_id) {
-        service_info[hmi_response::policy_app_id] = endpoints[service].app_id;
+      if (policy::kDefaultId != endpoints[e].app_id) {
+        service_info[hmi_response::policy_app_id] = endpoints[e].app_id;
       }
     }
   }
+  SendResponseToHMI(Common_Result::SUCCESS);
+}
 
-  object[params][hmi_response::code] = Common_Result::SUCCESS;
+void GetUrls::SendResponseToHMI(hmi_apis::Common_Result::eType result) {
+  (*message_)[strings::params][strings::message_type] = MessageType::kResponse;
+  (*message_)[strings::params][hmi_response::code] = result;
   ApplicationManagerImpl::instance()->ManageHMICommand(message_);
 }
 

--- a/src/components/application_manager/src/commands/hmi/get_urls.cc
+++ b/src/components/application_manager/src/commands/hmi/get_urls.cc
@@ -137,7 +137,7 @@ void GetUrls::ProcessPolicyServiceURLs(const policy::EndpointUrls& endpoints) {
     }
   }
 
-  service_info[hmi_response::policy_app_id] = mobile_app_id;
+  service_info[strings::app_id] = app->app_id();
   service_info[strings::url] = default_url;
   urls[0] = service_info;
   // TODO(AOleynik): Issue with absent policy_app_id. Need to fix later on.

--- a/src/components/application_manager/src/commands/hmi/on_received_policy_update.cc
+++ b/src/components/application_manager/src/commands/hmi/on_received_policy_update.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,6 +48,7 @@ OnReceivedPolicyUpdate::~OnReceivedPolicyUpdate() {
 
 void OnReceivedPolicyUpdate::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
+#ifdef EXTENDED_POLICY
   const std::string& file_path =
     (*message_)[strings::msg_params][hmi_notification::policyfile].asString();
   policy::BinaryMessage file_content;
@@ -55,7 +56,13 @@ void OnReceivedPolicyUpdate::Run() {
     LOG4CXX_ERROR(logger_, "Failed to read Update file.");
     return;
   }
-  policy::PolicyHandler::instance()->ReceiveMessageFromSDK(file_path, file_content);
+  policy::PolicyHandler::instance()->ReceiveMessageFromSDK(file_path,
+                                                           file_content);
+#else
+  LOG4CXX_WARN(logger_,
+               "This RPC is part of extended policy flow."
+               "Please re-build with extended policy mode enabled.");
+#endif
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/hmi/sdl_policy_update.cc
+++ b/src/components/application_manager/src/commands/hmi/sdl_policy_update.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,16 +36,20 @@ namespace application_manager {
 
 namespace commands {
 
-SDLPolicyUpdate::SDLPolicyUpdate(
-  const MessageSharedPtr& message): RequestToHMI(message) {
-}
+SDLPolicyUpdate::SDLPolicyUpdate(const MessageSharedPtr& message)
+    : RequestToHMI(message) {}
 
-SDLPolicyUpdate::~SDLPolicyUpdate() {
-}
+SDLPolicyUpdate::~SDLPolicyUpdate() {}
 
 void SDLPolicyUpdate::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
+#ifdef EXTENDED_POLICY
   SendRequest();
+#else
+  LOG4CXX_WARN(logger_,
+               "This RPC is part of extended policy flow."
+               "Please re-build with extended policy mode enabled.");
+#endif
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
@@ -108,7 +108,7 @@ void OnSystemRequestNotification::AddHeader(BinaryMessage& message) const {
 
   char size_str[24];
 
-  if (0 > sprintf(size_str, "%lu", message.size())) {
+  if (0 > sprintf(size_str, "%zu", static_cast<size_t>(message.size()))) {
     memset(size_str, 0, sizeof(size_str));
   }
 

--- a/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
@@ -1,6 +1,5 @@
 /*
-
- Copyright (c) 2013, Ford Motor Company
+ Copyright (c) 2016, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -31,6 +30,9 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <cstring>
+#include <cstdio>
+#include <string>
 #include "application_manager/commands/mobile/on_system_request_notification.h"
 #include "interfaces/MOBILE_API.h"
 #include "utils/file_system.h"
@@ -45,43 +47,52 @@ namespace mobile {
 
 OnSystemRequestNotification::OnSystemRequestNotification(
     const MessageSharedPtr& message)
-    : CommandNotificationImpl(message) {
-}
+    : CommandNotificationImpl(message) {}
 
-OnSystemRequestNotification::~OnSystemRequestNotification() {
-}
+OnSystemRequestNotification::~OnSystemRequestNotification() {}
 
 void OnSystemRequestNotification::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace application_manager;
   using namespace mobile_apis;
 
-  ApplicationSharedPtr app = ApplicationManagerImpl::instance()->
-                             application(connection_key());
+  ApplicationSharedPtr app =
+      ApplicationManagerImpl::instance()->application(connection_key());
 
   if (!app.valid()) {
-    LOG4CXX_ERROR(logger_, "Application with connection key "
-                  << connection_key() << " is not registered.");
+    LOG4CXX_ERROR(logger_,
+                  "Application with connection key " << connection_key()
+                                                     << " is not registered.");
     return;
   }
 
-  RequestType::eType request_type = static_cast<RequestType::eType>
-      ((*message_)[strings::msg_params][strings::request_type].asInt());
+  RequestType::eType request_type = static_cast<RequestType::eType>(
+      (*message_)[strings::msg_params][strings::request_type].asInt());
 
   if (!policy::PolicyHandler::instance()->IsRequestTypeAllowed(
-           app->mobile_app_id(), request_type)) {
-    LOG4CXX_WARN(logger_, "Request type "  << request_type
-                 <<" is not allowed by policies");
+        app->mobile_app_id(), request_type)) {
+    LOG4CXX_WARN(logger_,
+                 "Request type " << request_type
+                                 << " is not allowed by policies");
     return;
   }
 
   if (RequestType::PROPRIETARY == request_type) {
-  std::string filename =
-      (*message_)[strings::msg_params][strings::file_name].asString();
+/* According to requirements:
+   "If the requestType = PROPRIETARY, add to mobile API fileType = JSON
+    If the requestType = HTTP, add to mobile API fileType = BINARY"
+   Also in Genivi SDL we don't save the PT to file - we put it directly in
+   binary_data */
 
-  std::vector<uint8_t> binary_data;
-  file_system::ReadBinaryFile(filename, binary_data);
+#ifdef EXTENDED_POLICY
+    const std::string filename =
+        (*message_)[strings::msg_params][strings::file_name].asString();
+
+    BinaryMessage binary_data;
+    file_system::ReadBinaryFile(filename, binary_data);
+    AddHeader(binary_data);
     (*message_)[strings::params][strings::binary_data] = binary_data;
+#endif
     (*message_)[strings::msg_params][strings::file_type] = FileType::JSON;
   } else if (RequestType::HTTP == request_type) {
     (*message_)[strings::msg_params][strings::file_type] = FileType::BINARY;
@@ -89,6 +100,50 @@ void OnSystemRequestNotification::Run() {
 
   SendNotification();
 }
+
+#ifdef EXTENDED_POLICY
+void OnSystemRequestNotification::AddHeader(BinaryMessage& message) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const int timeout = policy::PolicyHandler::instance()->TimeoutExchange();
+
+  char size_str[24];
+
+  if (0 > sprintf(size_str, "%lu", message.size())) {
+    memset(size_str, 0, sizeof(size_str));
+  }
+
+  char timeout_str[24];
+  if (0 > sprintf(timeout_str, "%d", timeout)) {
+    memset(timeout_str, 0, sizeof(timeout_str));
+  }
+
+  const std::string header =
+
+  "{"
+     " \"HTTPRequest\": {"
+          "\"headers\": {"
+              "\"ContentType\": \"application/json\","
+              "\"ConnectTimeout\": " + std::string(timeout_str) + ","
+              "\"DoOutput\": true,"
+              "\"DoInput\": true,"
+              "\"UseCaches\": false,"
+              "\"RequestMethod\": \"POST\","
+              "\"ReadTimeout\":" + std::string(timeout_str) + ","
+              "\"InstanceFollowRedirects\": false,"
+              "\"charset\": \"utf-8\","
+              "\"Content_Length\": " + std::string(size_str) +
+          "},"
+          "\"body\": \"" + std::string(message.begin(), message.end()) + "\""
+      "}"
+  "}";
+
+  message.clear();
+  message.assign(header.begin(), header.end());
+
+  LOG4CXX_DEBUG(
+      logger_, "Header added: " << std::string(message.begin(), message.end()));
+}
+#endif
 
 }  //namespace mobile
 

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1206,8 +1206,8 @@
     <param name="url" type="String" mandatory="true">
       <description>Get URL based on service type.</description>
     </param>
-    <param name="policyAppId" type="String" mandatory="false">
-      <description>Used if URL needed are specific for application.</description>
+    <param name="appID" type="Integer" mandatory="false">
+      <description>ID of application that requested this RPC.</description>
     </param>
   </struct>
 <!-- End of Policies -->
@@ -2230,7 +2230,7 @@
       <param name="fileName" type="String" maxlength="255" minlength="1" mandatory="true">
         <description>File reference name.</description>
       </param>
-      <param name="appID" type="String" maxlength="50" minlength="1" mandatory="false">
+      <param name="appID" type="Integer" mandatory="false">
         <description>ID of application that requested this RPC.</description>
       </param>
     </function>
@@ -2242,7 +2242,7 @@
       <param name="fileName" type="String" maxlength="255" minlength="1" mandatory="true">
           <description>The path to file.</description>
       </param>
-      <param name="appID" type="String" maxlength="50" minlength="1" mandatory="false">
+      <param name="appID" type="Integer" mandatory="false">
         <description>ID of application that requested this RPC.</description>
       </param>
     </function>

--- a/src/components/policy/src/policy/include/policy/policy_listener.h
+++ b/src/components/policy/src/policy/include/policy/policy_listener.h
@@ -69,14 +69,8 @@ class PolicyListener {
    * when snapshot for PTU has been created.
    *
    * @param pt_string the snapshot
-   *
-   * @param retry_seconds retry sequence timeouts.
-   *
-   * @param timeout_exceed timeout.
    */
-  virtual void OnSnapshotCreated(const BinaryMessage& pt_string,
-                                 const std::vector<int>& retry_seconds,
-                                 int timeout_exceed) = 0;
+  virtual void OnSnapshotCreated(const BinaryMessage& pt_string) = 0;
 
   /**
    * @brief Make appropriate changes for related applications permissions and

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -80,7 +80,7 @@ utils::SharedPtr<policy_table::Table> PolicyManagerImpl::Parse(
     return new policy_table::Table(&value);
   } else {
     return utils::SharedPtr<policy_table::Table>();
-  } 
+  }
 }
 
 #else
@@ -94,7 +94,7 @@ utils::SharedPtr<policy_table::Table> PolicyManagerImpl::ParseArray(
     //For PT Update received from SDL Server.
     if (value["data"].size()!=0) {
       Json::Value data = value["data"];
-      //First Element in 
+      //First Element in
       return new policy_table::Table(&data[0]);
     } else {
       return new policy_table::Table(&value);
@@ -131,9 +131,9 @@ bool PolicyManagerImpl::LoadPT(const std::string& file,
   // Parse message into table struct
   utils::SharedPtr<policy_table::Table> pt_update = Parse(pt_content);
   #else
-  //Message Received from server unecnrypted with PTU in first element 
+  //Message Received from server unecnrypted with PTU in first element
   //of 'data' array. No Parsing was done by HMI.
-  utils::SharedPtr<policy_table::Table> pt_update = ParseArray(pt_content); 
+  utils::SharedPtr<policy_table::Table> pt_update = ParseArray(pt_content);
   #endif
   if (!pt_update) {
     LOG4CXX_WARN(logger_, "Parsed table pointer is 0.");
@@ -250,9 +250,7 @@ void PolicyManagerImpl::RequestPTUpdate() {
   BinaryMessage update(message_string.begin(), message_string.end());
 
 
-  listener_->OnSnapshotCreated(update,
-                               RetrySequenceDelaysSeconds(),
-                               TimeoutExchange());
+  listener_->OnSnapshotCreated(update);
 
   // Need to reset update schedule since all currenly registered applications
   // were already added to the snapshot so no update for them required.


### PR DESCRIPTION
1. In case
SDL is built with "-DEXTENDED_POLICY: ON" flag,
and PolicyTableUpdate is triggered 
SDL must
send BasicCommunication.PolicyUpdate ( <path to SnapshotPolicyTable>, <timeout from policies>, <set of retry timeouts>) to HMI.

2.In case
SDL is built with "-DEXTENDED_POLICY: ON" flag,
and SDL gets SDL.GetURLs (service: 7) from HMI
SDL must
respond SDL.GetURLs_response (SUCCESS, urls: array(<SDL-chosen appID> + <url from policy database for service 7>)) to HMI.

3. In case
SDL is built with "-DEXTENDED_POLICY: ON" flag,
and SDL gets BC.OnSystemRequest (PROPRIETARY, fileName: <path to Snapshot>, url, appID) from HMI
SDL must
send OnSystemRequest to the specified appID app with Snapshot and Binary Header (below) in payload:

 {
	"HTTPRequest": {
		"headers": {
			"ContentType": "application/json",
			"ConnectTimeout": <int value from policy table:timeout_after_x_seconds>,
			"DoOutput": true,
			"DoInput": true,
			"UseCaches": false,
			"RequestMethod": "POST",
			"ReadTimeout": <int value from policy table:timeout_after_x_seconds>,
			"InstanceFollowRedirects": false,
			"charset": "utf-8",
			"Content_Length": <value of the length of the "body" string>
		},
		"body": "{"data":["this is either the syncp packet or raw policy table BgcYTArvdz62FO7yHgOTXtE3EP0E0WsbFeDqzYY="]}"
	}
}

4. In case
SDL is built with "-DEXTENDED_POLICY: ON" flag,
and SDL has sent OnSystemRequest with SnapshotPT to mobile app
and SDL gets SystemRequest with UpdatedPT in payload during "timeout_after_x_seconds" value taken from Policy Database and started after OnSystemRequest sending out to mobile app
SDL must
send BasicCommunication.SystemRequest (<path to UpdatedPT>, PROPRIETARY, params) to HMI.

5. In case
SDL is built with "-DEXTENDED_POLICY: ON" flag,
and SDL has sent BasicCommunication.SystemRequest to HMI
and SDL gets BasicCommunication.SystemRequest_response (<resultCode>) during "SDL timeout for HMI requests" (= 10 sec by default) from HMI
SDL must
send SystemRequest_response (<resultCode from HMI response>) to mobile app.

6. In case
SDL is built with "-DEXTENDED_POLICY: ON" flag,
and SDL gets SDL.OnReceivedPolicyUpdate (<path to UpdatedPT>) from HMI
SDL must
apply the valid UpdatedPT to Policy Database 

7. In case
SDL is built with "-DEXTENDED_POLICY: OFF" flag or without this flag at all,
SDL must support original open-source flow.