### PR TITLE
Remove mark_initialization() on SaveUsageAndErrorCounts()

### DIFF
--- a/src/components/policy/src/policy/src/sql_pt_representation.cc
+++ b/src/components/policy/src/policy/src/sql_pt_representation.cc
@@ -1267,7 +1267,6 @@ bool SQLPTRepresentation::SaveDeviceData(
 
 bool SQLPTRepresentation::SaveUsageAndErrorCounts(
   const policy_table::UsageAndErrorCounts& counts) {
-  const_cast<policy_table::UsageAndErrorCounts&>(counts).mark_initialized();
   dbms::SQLQuery query(db());
   if (!query.Exec(sql_pt::kDeleteAppLevel)) {
     LOG4CXX_WARN(logger_, "Incorrect delete from app level.");
@@ -1280,7 +1279,6 @@ bool SQLPTRepresentation::SaveUsageAndErrorCounts(
 
   policy_table::AppLevels::const_iterator it;
   const policy_table::AppLevels& app_levels = *counts.app_level;
-  const_cast<policy_table::AppLevels&>(*counts.app_level).mark_initialized();
   for (it = app_levels.begin(); it != app_levels.end(); ++it) {
     query.Bind(0, it->first);
     if (!query.Exec()) {


### PR DESCRIPTION
Original Problem #461 
In cache_manager.cc, the recent addition of [generate snapshot](https://github.com/smartdevicelink/sdl_core/blob/master/src/components/policy/src/policy/src/cache_manager.cc#L1050) post loading the policy table from file would cause Core to crash on its first startup. 

The crash would happen due to the snapshot returning false on [a call to see if the snapshot is valid](https://github.com/smartdevicelink/sdl_core/blob/master/src/components/policy/src/policy/src/cache_manager.cc#L1051).

That call to is_valid() was returning false ultimately due to the two lines which I removed in my pull request.

I couldn't find anywhere in the code where marking count and app_levels as initialized made a difference other than this initial snapshot generation. There is also an inconsistency in what parts of the policy table are actually marked as initialized so that drives me to further believe that "mark_initialized()" serves no functional purpose. 

Needs Review