### PR TITLE
SDL doesn't crash with Core dump caused by double free on app exit

### DIFF
--- a/src/3rd_party-static/MessageBroker/src/lib_messagebroker/CMessageBrokerRegistry.cpp
+++ b/src/3rd_party-static/MessageBroker/src/lib_messagebroker/CMessageBrokerRegistry.cpp
@@ -77,7 +77,7 @@ namespace NsMessageBroker
         std::map <std::string, int>::iterator it = mControllersList.begin();
         for (; it != mControllersList.end();) {
           if (it->second == fd) {
-            mControllersList.erase(it);
+            mControllersList.erase(it++);
           } else {
             ++it;
           }

--- a/src/components/utils/CMakeLists.txt
+++ b/src/components/utils/CMakeLists.txt
@@ -80,7 +80,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "QNX")
     )
 endif()
 
-add_library("Utils" SHARED ${SOURCES})
+add_library("Utils" ${SOURCES})
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
  list(APPEND LIBRARIES dl) 


### PR DESCRIPTION
Iterator increment operator was missed in map erase operation.
Related to: APPLINK-18922

@AGritsevich @Anatoliy-Leshin @anosach-luxoft @VProdanov  @VVeremjova : please review.
