### PR TITLE
Remove TIMED_OUT&IN_USE from SubscribeWayPoints

### DIFF
--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -5233,12 +5233,10 @@
         <description>See Result</description>
         <element name="SUCCESS"/>
         <element name="INVALID_DATA"/>
-        <element name="TIMED_OUT"/>
         <element name="GENERIC_ERROR"/>
         <element name="REJECTED"/>
         <element name="UNSUPPORTED_RESOURCE"/>
         <element name="IGNORED"/>
-        <element name="IN_USE"/>
         <element name="DISALLOWED"/>
       </param>
       <param name="info" type="String" maxlength="1000" mandatory="false" platform="documentation">


### PR DESCRIPTION
Remove deprecated `TIMED_OUT` and `IN_USE` result codes from `SubscribeWayPoints` response.

Implements:
[APPLINK-23724](https://adc.luxoft.com/jira/browse/APPLINK-23724)