### PR TITLE
Improve Atomic by changing mutex with SpinLock

### DIFF
--- a/src/components/include/utils/atomic_object.h
+++ b/src/components/include/utils/atomic_object.h
@@ -33,8 +33,7 @@
 #ifndef SRC_COMPONENTS_INCLUDE_UTILS_ATOMIC_OBJECT_H_
 #define SRC_COMPONENTS_INCLUDE_UTILS_ATOMIC_OBJECT_H_
 
-#include "utils/rwlock.h"
-#include "utils/conditional_variable.h"
+#include "utils/lock.h"
 #include "utils/macro.h"
 
 namespace sync_primitives {
@@ -68,7 +67,7 @@ class Atomic {
    * @return mofified value.
    */
   T& operator=(const T& val) {
-    sync_primitives::AutoWriteLock lock(rw_lock_);
+    sync_primitives::AutoSpin lock(spin_lock_);
     value_ = val;
     return value_;
   }
@@ -79,7 +78,7 @@ class Atomic {
    * return stored value.
    */
   operator T() const {
-    sync_primitives::AutoReadLock lock(rw_lock_);
+    sync_primitives::AutoSpin lock(spin_lock_);
     return value_;
   }
 
@@ -90,13 +89,13 @@ class Atomic {
    */
   template <typename U>
   operator U() const {
-    sync_primitives::AutoReadLock lock(rw_lock_);
+    sync_primitives::AutoSpin lock(spin_lock_);
     return static_cast<U>(value_);
   }
 
  private:
   T value_;
-  mutable sync_primitives::RWLock rw_lock_;
+  mutable sync_primitives::SpinMutex spin_lock_;
 };
 
 typedef Atomic<int> atomic_int;

--- a/src/components/include/utils/lock.h
+++ b/src/components/include/utils/lock.h
@@ -80,6 +80,23 @@ class SpinMutex {
   volatile unsigned int state_;
 };
 
+/**
+ * @brief The AutoSpin class used to automatically lock and unlock certain SpinMutex
+ */
+class AutoSpin {
+ public:
+   AutoSpin(SpinMutex& spin)
+       : spin_(spin) {
+       spin_.Lock();
+   }
+   ~AutoSpin() {
+       spin_.Unlock();
+   }
+ private:
+  SpinMutex& spin_;
+  DISALLOW_COPY_AND_ASSIGN(SpinMutex);
+};
+
 /* Platform-indepenednt NON-RECURSIVE lock (mutex) wrapper
    Please use AutoLock to ackquire and (automatically) release it
    It eases balancing of multple lock taking/releasing and makes it


### PR DESCRIPTION
Since we use `Atomic` class with primitive types
it makes sense to use spinlock insted of mutex for better
performance