### PR TITLE
hotfix/SDL does not release memory after app unregistering

### DIFF
--- a/src/components/include/transport_manager/transport_adapter/transport_adapter.h
+++ b/src/components/include/transport_manager/transport_adapter/transport_adapter.h
@@ -196,6 +196,15 @@ class TransportAdapter {
   virtual Error StopClientListening() = 0;
 
   /**
+   * @brief Remove marked as FINALISING connection from accounting.
+   *
+   * @param device_handle Device unique identifier.
+   * @param app_handle Handle of application.
+   */
+  virtual void RemoveFinalizedConnection(const DeviceUID& device_handle,
+                                         const ApplicationHandle& app_handle) = 0;
+
+  /**
    * @brief Disconnect from specified session.
    *
    * @param device_handle Handle of device to Disconnect from.

--- a/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_controller.h
+++ b/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_controller.h
@@ -121,7 +121,7 @@ class TransportAdapterController {
                              const ConnectError& error) = 0;
 
   /**
-   * @brief Make state of specified connection - FINILIZING.
+   * @brief Make state of specified connection - FINALISING.
    *
    * @param device_handle Device unique identifier.
    * @param app_handle Handle of application.

--- a/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
+++ b/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
@@ -93,7 +93,7 @@ class TransportAdapterImpl : public TransportAdapter,
    * @return true if initialized.
    * @return false if not initialized.
    */
-  virtual bool IsInitialised() const;
+  bool IsInitialised() const OVERRIDE;
 
  public:
   /**
@@ -103,20 +103,20 @@ class TransportAdapterImpl : public TransportAdapter,
    *
    * @return Error information about possible reason of failure.
    **/
-  virtual TransportAdapter::Error Init();
+  TransportAdapter::Error Init() OVERRIDE;
 
   /**
    * @brief Stops device adapter
    * Called from transport manager to stop device adapter
    */
-  virtual void Terminate();
+  void Terminate() OVERRIDE;
 
   /**
    * @brief Add listener to the container(list) of device adapter listeners.
    *
    * @param listener Pointer to the device adapter listener.
    */
-  virtual void AddListener(TransportAdapterListener* listener);
+  void AddListener(TransportAdapterListener* listener) OVERRIDE;
 
   /**
    * @brief Start scanning for new devices.
@@ -125,7 +125,7 @@ class TransportAdapterImpl : public TransportAdapter,
    *
    * @return Error information about possible reason of search devices failure.
    **/
-  virtual TransportAdapter::Error SearchDevices();
+  TransportAdapter::Error SearchDevices() OVERRIDE;
 
   /**
    * @brief Connect to the specified application discovered on device.
@@ -135,15 +135,16 @@ class TransportAdapterImpl : public TransportAdapter,
    *
    * @return Error information about possible reason of failure.
    **/
-  virtual TransportAdapter::Error Connect(const DeviceUID& device_handle,
-                                          const ApplicationHandle& app_handle);
+  TransportAdapter::Error Connect(const DeviceUID& device_handle,
+                                  const ApplicationHandle& app_handle) OVERRIDE;
 
   /**
    * @brief Connect to all applications discovered on device
    * @param device_handle Handle of device
    * @return Error information about connecting applications on device
    */
-  virtual TransportAdapter::Error ConnectDevice(const DeviceUID& device_handle);
+  TransportAdapter::Error ConnectDevice(const DeviceUID& device_handle)
+      OVERRIDE;
 
   /**
    * @brief Disconnect from specified session.
@@ -153,8 +154,9 @@ class TransportAdapterImpl : public TransportAdapter,
    *
    * @return Error information about possible reason of disconnecting failure.
    **/
-  virtual TransportAdapter::Error Disconnect(
-      const DeviceUID& device_handle, const ApplicationHandle& app_handle);
+  TransportAdapter::Error Disconnect(const DeviceUID& device_handle,
+                                     const ApplicationHandle& app_handle)
+                                         OVERRIDE;
 
   /**
    * @brief Disconnect from all sessions on specified device.
@@ -164,8 +166,8 @@ class TransportAdapterImpl : public TransportAdapter,
    * @return Error information about possible reason of disconnecting from
    *specified device failure.
    **/
-  virtual TransportAdapter::Error DisconnectDevice(
-      const DeviceUID& device_handle);
+  TransportAdapter::Error DisconnectDevice(const DeviceUID& device_handle)
+      OVERRIDE;
 
   /**
    * @brief Send frame of data.
@@ -176,52 +178,52 @@ class TransportAdapterImpl : public TransportAdapter,
    *
    * @return Error information about possible reason of sending data failure
    **/
-  virtual TransportAdapter::Error SendData(
-      const DeviceUID& device_handle,
-      const ApplicationHandle& app_handle,
-      const ::protocol_handler::RawMessagePtr data);
+  TransportAdapter::Error SendData(const DeviceUID& device_handle,
+                                   const ApplicationHandle& app_handle,
+                                   const ::protocol_handler::RawMessagePtr data)
+                                       OVERRIDE;
 
   /**
    * @brief Start client listener.
    *
    * @return Error information about possible reason of failure.
    */
-  virtual TransportAdapter::Error StartClientListening();
+  TransportAdapter::Error StartClientListening() OVERRIDE;
 
   /**
    * @brief Stop client listener.
    *
    * @return Error information about possible reason of failure.
    */
-  virtual TransportAdapter::Error StopClientListening();
+  TransportAdapter::Error StopClientListening() OVERRIDE;
 
   /**
    * @brief Notify that device scanner is available.
    *
    * @return True - available, false - not available.
    */
-  virtual bool IsSearchDevicesSupported() const;
+  bool IsSearchDevicesSupported() const OVERRIDE;
 
   /**
    * @brief Notify that server connection factory is available.
    *
    * @return True - available, false - not available.
    */
-  virtual bool IsServerOriginatedConnectSupported() const;
+  bool IsServerOriginatedConnectSupported() const OVERRIDE;
 
   /**
    * @brief Notify that listener of client connection is available.
    *
    * @return True - available, false - not available.
    */
-  virtual bool IsClientOriginatedConnectSupported() const;
+  bool IsClientOriginatedConnectSupported() const OVERRIDE;
 
   /**
    * @brief Create container(vector) of device unique identifiers.
    *
    * @return Container(vector) of device unique identifiers.
    */
-  virtual DeviceList GetDeviceList() const;
+  DeviceList GetDeviceList() const OVERRIDE;
 
   /**
    * @brief Get container(vector) of application unique identifiers that
@@ -231,8 +233,8 @@ class TransportAdapterImpl : public TransportAdapter,
    *
    * @return Container(vector) that holds application unique identifiers.
    */
-  virtual ApplicationList GetApplicationList(
-      const DeviceUID& device_handle) const;
+  ApplicationList GetApplicationList(const DeviceUID& device_handle) const
+      OVERRIDE;
 
   /**
    * @brief Find device in the internal container(map).
@@ -241,7 +243,7 @@ class TransportAdapterImpl : public TransportAdapter,
    *
    * @return Smart pointer to device.
    */
-  virtual DeviceSptr FindDevice(const DeviceUID& device_handle) const;
+  DeviceSptr FindDevice(const DeviceUID& device_handle) const OVERRIDE;
 
   /**
    * @brief Search for device in container of devices, if it is not there - adds
@@ -249,18 +251,18 @@ class TransportAdapterImpl : public TransportAdapter,
    *
    * @param devices Container(vector) of smart pointers to devices.
    */
-  virtual void SearchDeviceDone(const DeviceVector& devices);
+  void SearchDeviceDone(const DeviceVector& devices) OVERRIDE;
 
-  virtual void ApplicationListUpdated(const DeviceUID& device_handle);
+  void ApplicationListUpdated(const DeviceUID& device_handle) OVERRIDE;
 
-  virtual void FindNewApplicationsRequest();
+  void FindNewApplicationsRequest() OVERRIDE;
 
   /**
    * @brief Launch OnSearchDeviceFailed event in device adapter listener.
    *
    * @param error Error class that contains details of this error situation.
    */
-  virtual void SearchDeviceFailed(const SearchDeviceError& error);
+  void SearchDeviceFailed(const SearchDeviceError& error) OVERRIDE;
 
   /**
    * @brief Add device to the container(map), if container doesn't hold it yet.
@@ -269,7 +271,7 @@ class TransportAdapterImpl : public TransportAdapter,
    *
    * @return Smart pointer to the device.
    */
-  virtual DeviceSptr AddDevice(DeviceSptr device);
+  DeviceSptr AddDevice(DeviceSptr device) OVERRIDE;
 
   /**
    * @brief Create connection and fill its parameters.
@@ -278,30 +280,30 @@ class TransportAdapterImpl : public TransportAdapter,
    * @param device_handle Device unique identifier.
    * @param app_handle Handle of application.
    */
-  virtual void ConnectionCreated(ConnectionSPtr connection,
-                                 const DeviceUID& device_handle,
-                                 const ApplicationHandle& app_handle);
+  void ConnectionCreated(ConnectionSPtr connection,
+                         const DeviceUID& device_handle,
+                         const ApplicationHandle& app_handle) OVERRIDE;
 
   /**
-   * @brief Set state of specified connection - FINILIZING.
+   * @brief Set state of specified connection - FINALISING.
    *
    * @param device_handle Device unique identifier.
    * @param app_handle Handle of application.
    */
-  virtual void ConnectionFinished(const DeviceUID& device_handle,
-                                  const ApplicationHandle& app_handle);
+  void ConnectionFinished(const DeviceUID& device_handle,
+                          const ApplicationHandle& app_handle) OVERRIDE;
 
   /**
-   * @brief Set specified connection state to FINILIZING and launch
+   * @brief Set specified connection state to FINALISING and launch
    *OnUnexpectedDisconnect event in the device adapter listener.
    *
    * @param device_handle Device unique identifier.
    * @param app_handle Handle of application.
    * @param error Error class that contains details of this error situation.
    */
-  virtual void ConnectionAborted(const DeviceUID& device_handle,
-                                 const ApplicationHandle& app_handle,
-                                 const CommunicationError& error);
+  void ConnectionAborted(const DeviceUID& device_handle,
+                         const ApplicationHandle& app_handle,
+                         const CommunicationError& error) OVERRIDE;
 
   /**
    * @brief Set state of specified connection - ESTABLISHED and launch
@@ -310,8 +312,8 @@ class TransportAdapterImpl : public TransportAdapter,
    * @param devcie_handle Device unique identifier.
    * @param app_handle Handle of application.
    */
-  virtual void ConnectDone(const DeviceUID& device_handle,
-                           const ApplicationHandle& app_handle);
+  void ConnectDone(const DeviceUID& device_handle,
+                   const ApplicationHandle& app_handle) OVERRIDE;
 
   /**
    * @brief Delete connection from the container of connections and launch
@@ -320,17 +322,26 @@ class TransportAdapterImpl : public TransportAdapter,
    * @param device_handle Device unique identifier.
    * @param app_handle Handle of application.
    */
-  virtual void ConnectFailed(const DeviceUID& device_handle,
-                             const ApplicationHandle& app_handle,
-                             const ConnectError& error);
+  void ConnectFailed(const DeviceUID& device_handle,
+                     const ApplicationHandle& app_handle,
+                     const ConnectError& error) OVERRIDE;
+
+  /**
+   * @brief Remove marked as FINALISING connection from accounting.
+   *
+   * @param device_handle Device unique identifier.
+   * @param app_handle Handle of application.
+   */
+  void RemoveFinalizedConnection(const DeviceUID& device_handle,
+                                 const ApplicationHandle& app_handle) OVERRIDE;
 
   /**
    * @brief Remove specified device and all its connections
    * @param device_handle Device unique identifier.
    * @param error Error class that contains details of this error situation.
    */
-  virtual void DeviceDisconnected(const DeviceUID& device_handle,
-                                  const DisconnectDeviceError& error);
+  void DeviceDisconnected(const DeviceUID& device_handle,
+                          const DisconnectDeviceError& error) OVERRIDE;
 
   /**
    * @brief Delete specified connection from the container(map) of connections
@@ -339,8 +350,8 @@ class TransportAdapterImpl : public TransportAdapter,
    * @param device_handle Device unique identifier.
    * @param app_handle Handle of application.
    */
-  virtual void DisconnectDone(const DeviceUID& device_handle,
-                              const ApplicationHandle& app_handle);
+  void DisconnectDone(const DeviceUID& device_handle,
+                      const ApplicationHandle& app_handle) OVERRIDE;
 
   /**
    * @brief Launch OnDataReceiveDone event in the device adapter listener.
@@ -349,9 +360,9 @@ class TransportAdapterImpl : public TransportAdapter,
    * @param app_handle Handle of application.
    * @param message Smart pointer to the raw message.
    */
-  virtual void DataReceiveDone(const DeviceUID& device_handle,
-                               const ApplicationHandle& app_handle,
-                               ::protocol_handler::RawMessagePtr message);
+  void DataReceiveDone(const DeviceUID& device_handle,
+                       const ApplicationHandle& app_handle,
+                       ::protocol_handler::RawMessagePtr message) OVERRIDE;
 
   /**
    * @brief Launch OnDataReceiveFailed event in the device adapter listener.
@@ -360,9 +371,9 @@ class TransportAdapterImpl : public TransportAdapter,
    * @param app_handle Handle of application.
    * @param error Class that contains details of this error situation.
    */
-  virtual void DataReceiveFailed(const DeviceUID& device_handle,
-                                 const ApplicationHandle& app_handle,
-                                 const DataReceiveError& error);
+  void DataReceiveFailed(const DeviceUID& device_handle,
+                         const ApplicationHandle& app_handle,
+                         const DataReceiveError& error) OVERRIDE;
 
   /**
    * @brief Launch OnDataSendDone event in the device adapter listener.
@@ -371,9 +382,9 @@ class TransportAdapterImpl : public TransportAdapter,
    * @param app_handle Handle of application.
    * @param message Smart pointer to raw message.
    */
-  virtual void DataSendDone(const DeviceUID& device_handle,
-                            const ApplicationHandle& app_handle,
-                            ::protocol_handler::RawMessagePtr message);
+  void DataSendDone(const DeviceUID& device_handle,
+                    const ApplicationHandle& app_handle,
+                    ::protocol_handler::RawMessagePtr message) OVERRIDE;
 
   /**
    * @brief Launch OnDataSendFailed event in the device adapter listener.
@@ -383,10 +394,10 @@ class TransportAdapterImpl : public TransportAdapter,
    * @param message Smart pointer to raw message.
    * @param error Class that contains details of this error situation.
    */
-  virtual void DataSendFailed(const DeviceUID& device_handle,
-                              const ApplicationHandle& app_handle,
-                              ::protocol_handler::RawMessagePtr message,
-                              const DataSendError& error);
+  void DataSendFailed(const DeviceUID& device_handle,
+                      const ApplicationHandle& app_handle,
+                      ::protocol_handler::RawMessagePtr message,
+                      const DataSendError& error) OVERRIDE;
 
   /**
    * @brief Return name of device.
@@ -395,13 +406,13 @@ class TransportAdapterImpl : public TransportAdapter,
    *
    * @return String with name.
    */
-  virtual std::string DeviceName(const DeviceUID& device_id) const;
+  std::string DeviceName(const DeviceUID& device_id) const OVERRIDE;
 
   /**
    * @brief Allows to obtain connection type used by device.
    * @return connection type.
    */
-  virtual std::string GetConnectionType() const;
+  std::string GetConnectionType() const OVERRIDE;
 
 #ifdef TELEMETRY_MONITOR
   /**
@@ -416,7 +427,7 @@ class TransportAdapterImpl : public TransportAdapter,
    *
    * @param return pointer to Time metric observer
    */
-  virtual TMTelemetryObserver* GetTelemetryObserver();
+  TMTelemetryObserver* GetTelemetryObserver() OVERRIDE;
 #endif  // TELEMETRY_MONITOR
 
  protected:

--- a/src/components/transport_manager/include/transport_manager/transport_manager_impl.h
+++ b/src/components/transport_manager/include/transport_manager/transport_manager_impl.h
@@ -323,7 +323,7 @@ class TransportManagerImpl
       return conversion_table_.size();  // handle begin since 1 (one)
     }
 
-    DeviceUID HandleToUid(DeviceHandle handle) {
+    DeviceUID HandleToUid(const DeviceHandle handle) {
       sync_primitives::AutoReadLock lock(conversion_table_lock);
       if (handle == 0 || handle > conversion_table_.size()) {
         return DeviceUID();
@@ -361,7 +361,8 @@ class TransportManagerImpl
   DeviceInfoList device_list_;
 
   void AddConnection(const ConnectionInternal& c);
-  void RemoveConnection(uint32_t id);
+  void RemoveConnection(const uint32_t id,
+                        transport_adapter::TransportAdapter* transport_adapter);
   ConnectionInternal* GetConnection(const ConnectionUID id);
   ConnectionInternal* GetConnection(const DeviceUID& device,
                                     const ApplicationHandle& application);

--- a/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
+++ b/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
@@ -748,6 +748,30 @@ void TransportAdapterImpl::ConnectFailed(const DeviceUID& device_handle,
   LOG4CXX_TRACE(logger_, "exit");
 }
 
+void TransportAdapterImpl::RemoveFinalizedConnection(
+    const DeviceUID& device_handle, const ApplicationHandle& app_handle) {
+  const DeviceUID device_uid = device_handle;
+  const ApplicationHandle app_uid = app_handle;
+  LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoWriteLock lock(connections_lock_);
+  ConnectionMap::iterator it_conn = connections_.find(
+      std::make_pair(device_uid, app_handle));
+  if (it_conn == connections_.end()) {
+    LOG4CXX_WARN(
+        logger_,
+        "Device_id: " << &device_uid << ", app_handle: " << &app_uid << " connection not found");
+    return;
+  }
+  const ConnectionInfo& info = it_conn->second;
+  if (info.state != ConnectionInfo::FINALISING) {
+    LOG4CXX_WARN(
+        logger_,
+        "Device_id: " << &device_uid << ", app_handle: " << &app_uid << " connection not finalized");
+    return;
+  }
+  connections_.erase(it_conn);
+}
+
 void TransportAdapterImpl::AddListener(TransportAdapterListener* listener) {
   LOG4CXX_TRACE(logger_, "enter");
   listeners_.push_back(listener);

--- a/src/components/transport_manager/test/include/transport_manager/transport_adapter_mock.h
+++ b/src/components/transport_manager/test/include/transport_manager/transport_adapter_mock.h
@@ -73,6 +73,9 @@ class MockTransportAdapter
   MOCK_METHOD0(
       StopClientListening,
       ::transport_manager::transport_adapter::TransportAdapter::Error());
+  MOCK_METHOD2(RemoveFinalizedConnection, void(
+                  const ::transport_manager::DeviceUID& device_handle,
+                  const ::transport_manager::ApplicationHandle& app_handle));
   MOCK_METHOD2(Disconnect,
                ::transport_manager::transport_adapter::TransportAdapter::Error(
                    const ::transport_manager::DeviceUID& device_handle,

--- a/src/components/transport_manager/test/transport_manager_impl_test.cc
+++ b/src/components/transport_manager/test/transport_manager_impl_test.cc
@@ -285,6 +285,7 @@ class TransportManagerImplTest : public ::testing::Test {
                                      error_);
 
     EXPECT_CALL(*tm_listener_, OnConnectionClosed(application_id_));
+    EXPECT_CALL(*mock_adapter_, RemoveFinalizedConnection(mac_address_, application_id_));
 
     tm_.TestHandle(test_event);
   }
@@ -772,6 +773,7 @@ TEST_F(TransportManagerImplTest, CheckUnexpectedDisconnect) {
   HandleConnection();
   // Act and Assert
   EXPECT_CALL(*tm_listener_, OnUnexpectedDisconnect(connection_key_, _));
+  EXPECT_CALL(*mock_adapter_, RemoveFinalizedConnection(mac_address_, application_id_));  
   tm_.TestHandle(test_event);
 }
 


### PR DESCRIPTION
SDL does not release memory after app unregistering under 
WiFi and BlueTooth connection.

TcpSocketConnection and BluetoothSocketConnection objects 
allocation wrap in shared pointer to ensure resource release 
after program termination.

TcpSocketConnections and BluetoothSocketConnections store in 
associative container to check multiple creation of same connections.

TransportAdapterController interface includes a method
IsConnectionFinished called by the listener loop to release
the unused connections from the container. Test was modified accordingly.

Methods add to TcpClientListener and BluetoothConnectionFactory 
to create new Tcp and BlueTooth connections and to release 
the unused connections from the container.

Issues: APPLINK-22910, APPLINK-23563