### PR TITLE
Add isSDLAllowed to AppPermissions initializer list

### DIFF
--- a/src/components/policy/src/policy/include/policy/policy_types.h
+++ b/src/components/policy/src/policy/include/policy/policy_types.h
@@ -234,7 +234,8 @@ struct AppPermissions {
           appRevoked(false),
           appPermissionsConsentNeeded(false),
           appUnauthorized(false),
-          requestTypeChanged(false) {
+          requestTypeChanged(false),
+          isSDLAllowed(false) {
     }
 
     std::string application_id;


### PR DESCRIPTION
Fix "Using uninitialized value permissions.isSDLAllowed when calling AppPermissions"