### PR TITLE
Rewrite GenerateSnapshot()

### DIFF
--- a/src/components/policy/src/policy/policy_table/table_struct/validation.cc
+++ b/src/components/policy/src/policy/policy_table/table_struct/validation.cc
@@ -153,7 +153,8 @@ bool MessageLanguages::Validate() const {
 }
 
 bool ConsumerFriendlyMessages::Validate() const {
-  if (PT_SNAPSHOT == GetPolicyTableType()) {
+  if (PT_SNAPSHOT == GetPolicyTableType() && 
+    messages.is_initialized()) {
     return false;
   }
   return true;

--- a/src/components/policy/src/policy/src/cache_manager.cc
+++ b/src/components/policy/src/policy/src/cache_manager.cc
@@ -790,8 +790,22 @@ utils::SharedPtr<policy_table::Table>
 CacheManager::GenerateSnapshot() {
   CACHE_MANAGER_CHECK(snapshot_);
   sync_primitives::AutoLock lock(cache_lock_);
+
   snapshot_ = new policy_table::Table();
-  snapshot_->policy_table = pt_->policy_table;
+
+  //Copy all members of policy table except messages in consumer friendly messages
+  snapshot_->policy_table.app_policies_section = pt_->policy_table.app_policies_section;
+  snapshot_->policy_table.functional_groupings = pt_->policy_table.functional_groupings;
+  snapshot_->policy_table.consumer_friendly_messages->version = pt_->policy_table.consumer_friendly_messages->version;
+  snapshot_->policy_table.consumer_friendly_messages->mark_initialized();
+  snapshot_->policy_table.module_config = pt_->policy_table.module_config;
+  snapshot_->policy_table.module_meta = pt_->policy_table.module_meta;
+  snapshot_->policy_table.usage_and_error_counts = pt_->policy_table.usage_and_error_counts;
+  snapshot_->policy_table.device_data = pt_->policy_table.device_data;
+
+  //Set policy table type to Snapshot
+  snapshot_->SetPolicyTableType(rpc::policy_table_interface_base::PolicyTableType::PT_SNAPSHOT);
+  
   CheckSnapshotInitialization();
   return snapshot_;
 }


### PR DESCRIPTION
This pr is to fix issue #461. SDL core was crashing due to the snapshot returned from CacheManager::GenerateSnapshot() was being ruled as invalid.

When generating a snapshot, instead of copying the entire contents of the policy table, I copy all contents except for the messages in consumer friendly messages. Policy table snapshot are not supposed to include the actual messages in consumer friendly messages, just the version number of the messages.

I also added an extra condition in ConsumerFriendlyMessages::Validate() that looks to see if messages is initialized. A pt snapshot can have a consumer friendly messages portion, just not the messages included in consumer fiendly messages.