### PR TITLE
Remove MongoDB reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Below are instructions for testing app launching and query with a full system se
 ### SDL Server
 The app querying specification defines an endpoint within Policies where sdl_core will reach out to receive a list of applications that can be launched. The SDL Server provides the back end functionality for app launching and querying.
 
-You can find the SDL Server on [GitHub](https://github.com/smartdevicelink/sdl_server). The README contains detailed instructions for installing and launching the server. Launch the server on your local machine, and direct your browser to http://localhost:3000. Note that you need `mongod` running on your machine before launching the server.
+You can find the SDL Server on [GitHub](https://github.com/smartdevicelink/sdl_server). The README contains detailed instructions for installing and launching the server. Launch the server on your local machine, and direct your browser to http://localhost:3000.
 
 The [App Launching Server Specification](https://github.com/smartdevicelink/sdl_server/blob/master/docs/application_launching_v1.0.md) defines an endpoint `/applications/available/:moduleId.json` which return a list of applications available for launching to the handset for filtering.
 


### PR DESCRIPTION
Correct me if I'm wrong, but the [`sdl_server`](https://github.com/smartdevicelink/sdl_server) has recently been updated and simplified to not use Mongo anymore.