### PR TITLE
Policy Manager Impl Tests Fix

### DIFF
--- a/src/components/policy/test/CMakeLists.txt
+++ b/src/components/policy/test/CMakeLists.txt
@@ -53,7 +53,7 @@ set(testSources
   usage_statistics_test.cc    
   shared_library_test.cc    
   generated_code_test.cc 
-  #policy_manager_impl_test.cc
+  policy_manager_impl_test.cc
 )
 
   include_directories(${COMPONENTS_DIR}/policy/src/policy/policy_table/table_struct)

--- a/src/components/policy/test/policy_manager_impl_test.cc
+++ b/src/components/policy/test/policy_manager_impl_test.cc
@@ -242,6 +242,7 @@ TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
   app_policies["default"]["keep_context"] = Json::Value(true);
   app_policies["default"]["steal_focus"] = Json::Value(true);
   app_policies["default"]["certificate"] = Json::Value("sign");
+
   app_policies["1234"] = Json::Value(Json::objectValue);
   app_policies["1234"]["memory_kb"] = Json::Value(50);
   app_policies["1234"]["heart_beat_timeout_ms"] = Json::Value(100);
@@ -252,6 +253,22 @@ TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
   app_policies["1234"]["keep_context"] = Json::Value(true);
   app_policies["1234"]["steal_focus"] = Json::Value(true);
   app_policies["1234"]["certificate"] = Json::Value("sign");
+
+  app_policies["device"] = Json::Value(Json::objectValue);
+  app_policies["device"]["keep_context"] = Json::Value(false);
+  app_policies["device"]["steal_focus"] = Json::Value(false);
+  app_policies["device"]["priority"] = Json::Value("NONE");
+  app_policies["device"]["default_hmi"] = Json::Value("NONE");
+  app_policies["device"]["groups"] = Json::Value(Json::arrayValue);
+  app_policies["device"]["groups"][0] = Json::Value("DataConsent-2");  
+
+  app_policies["pre_DataConsent"] = Json::Value(Json::objectValue);
+  app_policies["pre_DataConsent"]["keep_context"] = Json::Value(false);
+  app_policies["pre_DataConsent"]["steal_focus"] = Json::Value(false);
+  app_policies["pre_DataConsent"]["priority"] = Json::Value("NONE");
+  app_policies["pre_DataConsent"]["default_hmi"] = Json::Value("NONE");
+  app_policies["pre_DataConsent"]["groups"] = Json::Value(Json::arrayValue);
+  app_policies["pre_DataConsent"]["groups"][0] = Json::Value("BaseBeforeDataConsent");
 
   policy_table::Table update(&table);
   update.SetPolicyTableType(rpc::policy_table_interface_base::PT_UPDATE);


### PR DESCRIPTION
Uncommented out policy tests so policy unit tests are included in the build. Also fixed one of the test cases to include the necessary parts for app_policies in the 'LoadPT_SetPT_PTIsLoaded' test. "make test" now passes.

Fixes #517 