### PR TITLE
Revert to right state condition some timers

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -426,7 +426,7 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
   LOG4CXX_DEBUG(logger_, "Restarting application list update timer");
   GetPolicyHandler().OnAppsSearchStarted();
   uint32_t timeout = get_settings().application_list_update_timeout();
-  application_list_update_timer_.Start(timeout, false);
+  application_list_update_timer_.Start(timeout, true);
 
   if (!is_all_apps_allowed_) {
     LOG4CXX_WARN(logger_,
@@ -917,7 +917,7 @@ void ApplicationManagerImpl::OnFindNewApplicationsRequest() {
   connection_handler().ConnectToAllDevices();
   LOG4CXX_DEBUG(logger_, "Starting application list update timer");
   uint32_t timeout = get_settings().application_list_update_timeout();
-  application_list_update_timer_.Start(timeout, false);
+  application_list_update_timer_.Start(timeout, true);
   GetPolicyHandler().OnAppsSearchStarted();
 }
 

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -510,7 +510,6 @@ void RequestController::UpdateTimer() {
               << " Request timeout (sec): "
               << front->timeout_msec() /
                      date_time::DateTime::MILLISECONDS_IN_SECOND);
-      timer_.Start(0u, true);
     }
   }
 }

--- a/src/components/application_manager/src/resumption/resume_ctrl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl.cc
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015, Ford Motor Company
+ Copyright (c) 2016, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -114,7 +114,7 @@ bool ResumeCtrl::Init(resumption::LastState& last_state) {
   save_persistent_data_timer_.Start(
       application_manager_.get_settings()
           .app_resumption_save_persistent_data_timeout(),
-      true);
+      false);
   return true;
 }
 
@@ -278,7 +278,7 @@ void ResumeCtrl::StartSavePersistentDataTimer() {
     save_persistent_data_timer_.Start(
         application_manager_.get_settings()
             .app_resumption_save_persistent_data_timeout(),
-        true);
+        false);
   }
 }
 
@@ -738,7 +738,7 @@ void ResumeCtrl::AddToResumptionTimerQueue(const uint32_t app_id) {
   if (!is_resumption_active_) {
     is_resumption_active_ = true;
     restore_hmi_level_timer_.Start(
-        application_manager_.get_settings().app_resuming_timeout(), false);
+        application_manager_.get_settings().app_resuming_timeout(), true);
   }
 }
 


### PR DESCRIPTION
After re-implement thread-timer to Genivi,
has been inverted timer condition flag.
Earlier was 'true' is loop timer, 'false' one shot timer.
After re-implement 'false' is loop timer, 'true' one shot timer.
Now in code repository exist mixing both variants. Need check
all timers with some commit that happen before re-factoring timer,
and after it change timer flag where it need.

Related-issues: [APPLINK-24255](https://adc.luxoft.com/jira/browse/APPLINK-24255)

Please review @anosach-luxoft, @AByzhynar , @OHerasym, @LuxoftAKutsan .