### PR TITLE
Re-adds policy_manager_impl_stress_test.cc with fix

### DIFF
--- a/src/components/policy/test/CMakeLists.txt
+++ b/src/components/policy/test/CMakeLists.txt
@@ -81,8 +81,7 @@ else ()
     sqlite_wrapper/sql_query_test.cc   
     generated_code_with_sqlite_test.cc   
 
-    # TODO{ALeshin} AssertTrue in SetUpTestCase() return false
-    #policy_manager_impl_stress_test.cc
+    policy_manager_impl_stress_test.cc
   )
   list (APPEND testLibraries sqlite3)
 endif()

--- a/src/components/policy/test/include/mock_policy_listener.h
+++ b/src/components/policy/test/include/mock_policy_listener.h
@@ -73,10 +73,8 @@ class MockPolicyListener : public PolicyListener {
                void(std::map<std::string, StringArray>));
   MOCK_METHOD1(GetAvailableApps,
                void(std::queue<std::string>&));
-  MOCK_METHOD3(OnSnapshotCreated,
-               void(const BinaryMessage& pt_string,
-                    const std::vector<int>& retry_seconds,
-                    int timeout_exceed));
+  MOCK_METHOD1(OnSnapshotCreated,
+               void(const BinaryMessage& pt_string));
   MOCK_METHOD0(CanUpdate,
                bool());
   MOCK_METHOD1(OnCertificateUpdated, void (const std::string&));

--- a/src/components/policy/test/policy_manager_impl_stress_test.cc
+++ b/src/components/policy/test/policy_manager_impl_stress_test.cc
@@ -47,8 +47,8 @@ namespace policy {
 class PolicyManagerImplStressTest : public ::testing::Test {
  protected:
   static const std::string kNameFile;
-  static const int kNumberGroups = 3;  //10;
-  static const int kNumberFuncs = 4;  //100;
+  static const int kNumberGroups = 3;
+  static const int kNumberFuncs = 4;  
   static const int kNumberApps = 5;
   static const int kNumberAppGroups = 5;
   static PolicyManagerImpl* manager;
@@ -138,6 +138,28 @@ void PolicyManagerImplStressTest::CreateApps(std::ofstream& ofs) {
       "\"steal_focus\": true,\n"
       "\"priority\": \"NORMAL\",\n"
       "\"default_hmi\": \"FULL\",\n";
+  ofs << "\"groups\":["
+      "\"Group-1\""
+      "]"
+      "},\n";
+
+  //Device app_policies object must be present and initialized for PT to be valid.    
+  ofs << "\"device\":{\n";
+  ofs << "\"keep_context\": false,\n"
+      "\"steal_focus\": false,\n"
+      "\"priority\": \"NONE\",\n"
+      "\"default_hmi\": \"NONE\",\n";
+  ofs << "\"groups\":["
+      "\"Group-1\""
+      "]"
+      "},\n";
+
+  //preData app_policies must be present and initialized for PT to be valid.
+  ofs << "\"pre_DataConsent\":{\n";
+  ofs << "\"keep_context\": false,\n"
+      "\"steal_focus\": false,\n"
+      "\"priority\": \"NONE\",\n"
+      "\"default_hmi\": \"NONE\",\n";
   ofs << "\"groups\":["
       "\"Group-1\""
       "]"


### PR DESCRIPTION
Adds "device" and "pre_DataConsent" to the app_policies section when the test case is building a sample policy table.