### PR TITLE
Fix crash on DCHECK in process SDLActivateApp()

### DIFF
--- a/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
@@ -55,9 +55,12 @@ void SDLActivateAppRequest::Run() {
       application_manager_.application(application_id);
 
   if (!app) {
-    LOG4CXX_WARN(
+    LOG4CXX_ERROR(
         logger_,
         "Can't find application within regular apps: " << application_id);
+    //APPLINK-16115
+    SendResponse(false, correlation_id(), SDL_ActivateApp, INVALID_DATA);
+    return;
   }
 
   DevicesApps devices_apps = FindAllAppOnParticularDevice(app->device());


### PR DESCRIPTION
After unsuccessful search application, SDL used to do
nothing. That's why on next code line in DCHECK by pointer to app
crash SDL. Now, after unsuccesessful search app, SDL sent to HMI
INVALID_DATA (according to req-t APPLINK-16115) and finish request.

Closes-bug: [APPLINK-24365](https://adc.luxoft.com/jira/browse/APPLINK-24365)