### PR TITLE
Fix sdl crash on dcheck via sdl active app

### DIFF
--- a/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
@@ -55,9 +55,10 @@ void SDLActivateAppRequest::Run() {
       application_manager_.application(application_id);
 
   if (!app) {
-    LOG4CXX_WARN(
+    LOG4CXX_ERROR(
         logger_,
         "Can't find application within regular apps: " << application_id);
+    return;
   }
 
   DevicesApps devices_apps = FindAllAppOnParticularDevice(app->device());


### PR DESCRIPTION
After unsuccessful search application, sdl used to do
nothing. Thats why on next code line in DCHECK by pointer to app
crash SDL. Now, after unsuccessful search app, sdl sent hmi
error code and finish request.

Closes-bug: [APPLINK-24414](https://adc.luxoft.com/jira/browse/APPLINK-24414)