### PR TITLE
Fix_OnSystemRequestNotification_not_sent_to_Mobile

### DIFF
--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -5112,13 +5112,13 @@
     <param name="fileType" type="FileType" mandatory="false">
        <description>Optional file type (meant for HTTP file requests).</description>
     </param>
-    <param name="offset" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="false">
+    <param name="offset" type="Integer" minvalue="0" maxvalue="100000000000" mandatory="false">
       <description>Optional offset in bytes for resuming partial data chunks</description>
     </param>
-    <param name="length" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="false">
+    <param name="length" type="Integer" minvalue="0" maxvalue="100000000000" mandatory="false">
       <description>Optional length in bytes for resuming partial data chunks</description>
-    </param>    
-  </function>	
+    </param>
+  </function>
 
   <function name="OnHashChange" functionID="OnHashChangeID" messagetype="notification">
 	<description>


### PR DESCRIPTION
    The main reason for the HMI notification to not be sent to Mobile side
was the missing appID which was causing fail check in app.valid(). The appID
was missing, because it was not sent from HMI. In this case we loop over
the registered applications and take the first which device is allowed
by policy.[see APPLINK-12696].

- Add app_id handling in on_system_request_notification.cc
- Modify MOBILE_API.xml with the correct maxvalues for OnSystemRequest`s
offset and lenght parameters. Also remove whitespace at the end of line.

Related: APPLINK-12369
	[https://adc.luxoft.com/jira/browse/APPLINK-12369]