### PR TITLE
Fix StartStream retry sequence

### DIFF
--- a/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
@@ -110,7 +110,7 @@ void NaviStartStreamRequest::on_event(const event_engine::Event& event) {
       }
       if (hmi_apis::Common_Result::REJECTED == code) {
         LOG4CXX_INFO(logger_, "StartStream response REJECTED ");
-        SendRequest();
+        RetryStartSession();
         break;
       }
     }


### PR DESCRIPTION
    Fix StartStream retry sequence
    
    Start retry sequence in case user press "Cancel" in pop-up which appears when application
    try to start video service
    
    Issue: APPLINK-21628
