### PR TITLE
Replace bool with enum TimerType value in timer start

### DIFF
--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -489,7 +489,8 @@ void ApplicationImpl::WakeUpStreaming(
           ServiceType::kMobileNav, true, application_manager_);
       video_streaming_suspended_ = false;
     }
-    video_stream_suspend_timer_.Start(video_stream_suspend_timeout_, false);
+    video_stream_suspend_timer_.Start(video_stream_suspend_timeout_,
+                                      timer::kPeriodic);
   } else if (ServiceType::kAudio == service_type) {
     sync_primitives::AutoLock lock(audio_streaming_suspended_lock_);
     if (audio_streaming_suspended_) {
@@ -498,7 +499,8 @@ void ApplicationImpl::WakeUpStreaming(
           ServiceType::kAudio, true, application_manager_);
       audio_streaming_suspended_ = false;
     }
-    audio_stream_suspend_timer_.Start(audio_stream_suspend_timeout_, false);
+    audio_stream_suspend_timer_.Start(audio_stream_suspend_timeout_,
+                                      timer::kPeriodic);
   }
 }
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -148,7 +148,7 @@ ApplicationManagerImpl::ApplicationManagerImpl(
       new TimerTaskImpl<ApplicationManagerImpl>(
           this, &ApplicationManagerImpl::ClearTimerPool)));
   const uint32_t timeout_ms = 10000u;
-  clearing_timer->Start(timeout_ms, false);
+  clearing_timer->Start(timeout_ms, timer::kPeriodic);
   timer_pool_.push_back(clearing_timer);
 }
 
@@ -426,7 +426,7 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
   LOG4CXX_DEBUG(logger_, "Restarting application list update timer");
   GetPolicyHandler().OnAppsSearchStarted();
   uint32_t timeout = get_settings().application_list_update_timeout();
-  application_list_update_timer_.Start(timeout, true);
+  application_list_update_timer_.Start(timeout, timer::kSingleShot);
 
   if (!is_all_apps_allowed_) {
     LOG4CXX_WARN(logger_,
@@ -917,7 +917,7 @@ void ApplicationManagerImpl::OnFindNewApplicationsRequest() {
   connection_handler().ConnectToAllDevices();
   LOG4CXX_DEBUG(logger_, "Starting application list update timer");
   uint32_t timeout = get_settings().application_list_update_timeout();
-  application_list_update_timer_.Start(timeout, true);
+  application_list_update_timer_.Start(timeout, timer::kSingleShot);
   GetPolicyHandler().OnAppsSearchStarted();
 }
 
@@ -2945,7 +2945,7 @@ void ApplicationManagerImpl::EndNaviServices(uint32_t app_id) {
         "CloseNaviAppTimer",
         new TimerTaskImpl<ApplicationManagerImpl>(
             this, &ApplicationManagerImpl::CloseNaviApp)));
-    close_timer->Start(navi_close_app_timeout_, true);
+    close_timer->Start(navi_close_app_timeout_, timer::kSingleShot);
 
     sync_primitives::AutoLock lock(timer_pool_lock_);
     timer_pool_.push_back(close_timer);
@@ -2986,7 +2986,7 @@ void ApplicationManagerImpl::OnHMILevelChanged(
           "AppShouldFinishStreaming",
           new TimerTaskImpl<ApplicationManagerImpl>(
               this, &ApplicationManagerImpl::EndNaviStreaming)));
-      end_stream_timer->Start(navi_end_stream_timeout_, true);
+      end_stream_timer->Start(navi_end_stream_timeout_, timer::kSingleShot);
 
       sync_primitives::AutoLock lock(timer_pool_lock_);
       timer_pool_.push_back(end_stream_timer);
@@ -3272,7 +3272,7 @@ void ApplicationManagerImpl::AddAppToTTSGlobalPropertiesList(
     LOG4CXX_INFO(logger_, "Start tts_global_properties_timer_");
     tts_global_properties_app_list_lock_.Release();
     const uint32_t timeout_ms = 1000;
-    tts_global_properties_timer_.Start(timeout_ms, false);
+    tts_global_properties_timer_.Start(timeout_ms, timer::kPeriodic);
     return;
   }
   tts_global_properties_app_list_lock_.Release();

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -495,7 +495,7 @@ void RequestController::UpdateTimer() {
           date_time::DateTime::getmSecs(end_time - current_time));
       LOG4CXX_DEBUG(logger_, "Sleep for " << msecs << " millisecs");
       // Timeout for bigger than 5 minutes is a mistake
-      timer_.Start(msecs, true);
+      timer_.Start(msecs, timer::kSingleShot);
     } else {
       LOG4CXX_WARN(
           logger_,

--- a/src/components/application_manager/src/resumption/resume_ctrl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl.cc
@@ -115,7 +115,7 @@ bool ResumeCtrl::Init(resumption::LastState& last_state) {
   save_persistent_data_timer_.Start(
       application_manager_.get_settings()
           .app_resumption_save_persistent_data_timeout(),
-      false);
+      timer::kPeriodic);
   return true;
 }
 
@@ -279,7 +279,7 @@ void ResumeCtrl::StartSavePersistentDataTimer() {
     save_persistent_data_timer_.Start(
         application_manager_.get_settings()
             .app_resumption_save_persistent_data_timeout(),
-        false);
+        timer::kPeriodic);
   }
 }
 
@@ -744,7 +744,8 @@ void ResumeCtrl::AddToResumptionTimerQueue(const uint32_t app_id) {
   if (!is_resumption_active_) {
     is_resumption_active_ = true;
     restore_hmi_level_timer_.Start(
-        application_manager_.get_settings().app_resuming_timeout(), true);
+        application_manager_.get_settings().app_resuming_timeout(),
+        timer::kSingleShot);
   }
 }
 

--- a/src/components/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy_manager_impl.cc
@@ -308,7 +308,7 @@ void PolicyManagerImpl::StartPTExchange() {
     if (update_status_manager_.IsUpdateRequired()) {
       if (RequestPTUpdate() && !timer_retry_sequence_.is_running()) {
         // Start retry sequency
-        timer_retry_sequence_.Start(NextRetryTimeout(), false);
+        timer_retry_sequence_.Start(NextRetryTimeout(), timer::kPeriodic);
       }
     }
   }
@@ -1002,7 +1002,7 @@ void PolicyManagerImpl::RetrySequence() {
     return;
   }
 
-  timer_retry_sequence_.Start(timeout, false);
+  timer_retry_sequence_.Start(timeout, timer::kPeriodic);
 }
 
 }  //  namespace policy

--- a/src/components/policy/src/usage_statistics/counter.cc
+++ b/src/components/policy/src/usage_statistics/counter.cc
@@ -103,7 +103,8 @@ AppStopwatchImpl::AppStopwatchImpl(
 
 void AppStopwatchImpl::Start(AppStopwatchId stopwatch_type) {
   stopwatch_type_ = stopwatch_type;
-  timer_.Start(time_out_ * date_time::DateTime::MILLISECONDS_IN_SECOND, false);
+  timer_.Start(time_out_ * date_time::DateTime::MILLISECONDS_IN_SECOND,
+               timer::kPeriodic);
 }
 
 void AppStopwatchImpl::Switch(AppStopwatchId stopwatch_type) {

--- a/src/components/utils/include/utils/timer.h
+++ b/src/components/utils/include/utils/timer.h
@@ -46,6 +46,23 @@ namespace timer {
 typedef uint32_t Milliseconds;
 
 /**
+ * @brief Enumeration listing of possible timer types.
+ * Single shot timer signals only once and then stops counting.
+ * Periodic timer signals every time specific value is reached
+ * and then restarts.
+ */
+enum TimerType {
+  /**
+   * @brief Periodic calls to task
+   */
+  kPeriodic = 0,
+  /**
+   * @brief Single call to task
+   */
+  kSingleShot = 1
+};
+
+/**
  * @brief Timer calls custom callback function after
  * specified timeout has been elapsed.
  * Thread-safe class
@@ -69,9 +86,9 @@ class Timer {
   /**
    * @brief Starts timer with specified timeout
    * @param timeout Timer timeout
-   * @param single_shot Single shot flag for timer
+   * @param enum timer_type Timer type enum value.
    */
-  void Start(const Milliseconds timeout, const bool single_shot);
+  void Start(const Milliseconds timeout, const TimerType timer_type);
 
   /**
    * @brief Stops timer if it's running

--- a/src/components/utils/src/timer.cc
+++ b/src/components/utils/src/timer.cc
@@ -70,11 +70,22 @@ timer::Timer::~Timer() {
   LOG4CXX_DEBUG(logger_, "Timer " << name_ << " has been destroyed");
 }
 
-void timer::Timer::Start(const Milliseconds timeout, const bool single_shot) {
+void timer::Timer::Start(const Milliseconds timeout,
+                         const TimerType timer_type) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock auto_lock(state_lock_);
   StopThread();
-  single_shot_ = single_shot;
+  switch (timer_type) {
+    case kSingleShot: {
+      single_shot_ = true;
+      break;
+    }
+    case kPeriodic: {
+      single_shot_ = false;
+      break;
+    }
+    default: { ASSERT("timer_type should be kSingleShot or kPeriodic"); }
+  };
   StartDelegate(timeout);
   StartThread();
   LOG4CXX_DEBUG(logger_, "Timer " << name_ << " has been started");

--- a/src/components/utils/test/timer_test.cc
+++ b/src/components/utils/test/timer_test.cc
@@ -47,12 +47,11 @@ sync_primitives::Lock shot_lock;
 sync_primitives::ConditionalVariable shot_condition;
 
 const std::string kTimerName = "TestTimer";
-const bool kSingleShot = true;
 
 /*
  * Default timeout used during timer testing.
  * Value should be greater than at least 30 ms
- * to avoid timer firing beetwen two sequental Start/Stop calls
+ * to avoid timer firing between two sequental Start/Stop calls
  */
 const uint32_t kDefaultTimeoutMs = 30u;
 const uint32_t kDefaultTimeoutRestartMs = 45u;
@@ -87,7 +86,7 @@ class TestTaskWithStart : public TestTask {
  public:
   void PerformTimer() const OVERRIDE {
     if (timer_) {
-      timer_->Start(kDefaultTimeoutRestartMs, !kSingleShot);
+      timer_->Start(kDefaultTimeoutRestartMs, timer::kPeriodic);
     }
   }
 };
@@ -113,7 +112,7 @@ TEST(TimerTest, Start_Stop_NoLoop_NoCall) {
   EXPECT_FALSE(timer.is_running());
   EXPECT_EQ(0u, timer.timeout());
 
-  timer.Start(kDefaultTimeoutMs, kSingleShot);
+  timer.Start(kDefaultTimeoutMs, timer::kSingleShot);
   EXPECT_TRUE(timer.is_running());
   EXPECT_EQ(kDefaultTimeoutMs, timer.timeout());
 
@@ -130,7 +129,7 @@ TEST(TimerTest, Start_Stop_Loop_NoCall) {
   EXPECT_FALSE(timer.is_running());
   EXPECT_EQ(0u, timer.timeout());
 
-  timer.Start(kDefaultTimeoutMs, !kSingleShot);
+  timer.Start(kDefaultTimeoutMs, timer::kPeriodic);
   EXPECT_TRUE(timer.is_running());
   EXPECT_EQ(kDefaultTimeoutMs, timer.timeout());
 
@@ -147,7 +146,7 @@ TEST(TimerTest, Start_Stop_NoLoop_OneCall) {
   EXPECT_FALSE(timer.is_running());
   EXPECT_EQ(0u, timer.timeout());
 
-  timer.Start(kDefaultTimeoutMs, kSingleShot);
+  timer.Start(kDefaultTimeoutMs, timer::kSingleShot);
   EXPECT_TRUE(timer.is_running());
   EXPECT_EQ(kDefaultTimeoutMs, timer.timeout());
 
@@ -172,7 +171,7 @@ TEST(TimerTest, Start_Stop_Loop_3Calls) {
   EXPECT_FALSE(timer.is_running());
   EXPECT_EQ(0u, timer.timeout());
 
-  timer.Start(kDefaultTimeoutMs, !kSingleShot);
+  timer.Start(kDefaultTimeoutMs, timer::kPeriodic);
   EXPECT_TRUE(timer.is_running());
   EXPECT_EQ(kDefaultTimeoutMs, timer.timeout());
 
@@ -197,11 +196,11 @@ TEST(TimerTest, Restart_NoLoop_NoCall) {
 
   timer::Timer timer(kTimerName, mock_task);
 
-  timer.Start(kDefaultTimeoutMs, kSingleShot);
+  timer.Start(kDefaultTimeoutMs, timer::kSingleShot);
   EXPECT_TRUE(timer.is_running());
   EXPECT_EQ(kDefaultTimeoutMs, timer.timeout());
 
-  timer.Start(kDefaultTimeoutRestartMs, kSingleShot);
+  timer.Start(kDefaultTimeoutRestartMs, timer::kSingleShot);
   EXPECT_TRUE(timer.is_running());
   EXPECT_EQ(kDefaultTimeoutRestartMs, timer.timeout());
 }
@@ -212,11 +211,11 @@ TEST(TimerTest, Restart_Loop_NoCall) {
 
   timer::Timer timer(kTimerName, mock_task);
 
-  timer.Start(kDefaultTimeoutMs, !kSingleShot);
+  timer.Start(kDefaultTimeoutMs, timer::kPeriodic);
   EXPECT_TRUE(timer.is_running());
   EXPECT_EQ(kDefaultTimeoutMs, timer.timeout());
 
-  timer.Start(kDefaultTimeoutRestartMs, !kSingleShot);
+  timer.Start(kDefaultTimeoutRestartMs, timer::kPeriodic);
   EXPECT_TRUE(timer.is_running());
   EXPECT_EQ(kDefaultTimeoutRestartMs, timer.timeout());
 }
@@ -228,7 +227,7 @@ TEST(TimerTest, Restart_Loop_3Calls) {
   TestTask* task = new TestTask();
   timer::Timer timer(kTimerName, task);
 
-  timer.Start(kDefaultTimeoutMs, !kSingleShot);
+  timer.Start(kDefaultTimeoutMs, timer::kPeriodic);
   EXPECT_TRUE(timer.is_running());
   EXPECT_EQ(kDefaultTimeoutMs, timer.timeout());
 
@@ -236,7 +235,7 @@ TEST(TimerTest, Restart_Loop_3Calls) {
   for (size_t i = 0; i < loops_count; ++i) {
     shot_condition.Wait(shot_lock);
   }
-  timer.Start(kDefaultTimeoutRestartMs, !kSingleShot);
+  timer.Start(kDefaultTimeoutRestartMs, timer::kPeriodic);
   EXPECT_TRUE(timer.is_running());
   EXPECT_EQ(kDefaultTimeoutRestartMs, timer.timeout());
 
@@ -251,7 +250,7 @@ TEST(TimerTest, Restart_NoLoop_FromCall) {
   timer::Timer timer(kTimerName, task);
   task->set_timer(&timer);
 
-  timer.Start(kDefaultTimeoutMs, kSingleShot);
+  timer.Start(kDefaultTimeoutMs, timer::kSingleShot);
   EXPECT_TRUE(timer.is_running());
   EXPECT_EQ(kDefaultTimeoutMs, timer.timeout());
 
@@ -270,7 +269,7 @@ TEST(TimerTest, Restart_Loop_FromCall) {
   timer::Timer timer(kTimerName, task);
   task->set_timer(&timer);
 
-  timer.Start(kDefaultTimeoutMs, !kSingleShot);
+  timer.Start(kDefaultTimeoutMs, timer::kPeriodic);
   EXPECT_TRUE(timer.is_running());
   EXPECT_EQ(kDefaultTimeoutMs, timer.timeout());
 
@@ -291,7 +290,7 @@ TEST(TimerTest, Stop_Loop_FromCall) {
   timer::Timer timer(kTimerName, task);
   task->set_timer(&timer);
 
-  timer.Start(kDefaultTimeoutMs, !kSingleShot);
+  timer.Start(kDefaultTimeoutMs, timer::kPeriodic);
   EXPECT_TRUE(timer.is_running());
   EXPECT_EQ(kDefaultTimeoutMs, timer.timeout());
 
@@ -314,7 +313,7 @@ TEST(TimerTest, Delete_Running_NoLoop) {
   EXPECT_FALSE(timer->is_running());
   EXPECT_EQ(0u, timer->timeout());
 
-  timer->Start(kDefaultTimeoutMs, kSingleShot);
+  timer->Start(kDefaultTimeoutMs, timer::kSingleShot);
   EXPECT_TRUE(timer->is_running());
   EXPECT_EQ(kDefaultTimeoutMs, timer->timeout());
 


### PR DESCRIPTION
Enum type created in the Timer header.
Timer types defined: Single Shot and Periodic
Corresponding boolean values are replaced with enum type values.