### PR TITLE
Fix tests after ptu impl moving

### DIFF
--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -64,12 +64,16 @@ class HMICapabilitiesTest : public ::testing::Test {
  protected:
   HMICapabilitiesTest() : last_state_("app_storage_folder", "app_info_data") {}
   virtual void SetUp() OVERRIDE {
-    ON_CALL(app_mngr_, event_dispatcher())
-        .WillByDefault(ReturnRef(mock_event_dispatcher));
-    ON_CALL(app_mngr_, get_settings())
-        .WillByDefault(ReturnRef(mock_application_manager_settings_));
-    ON_CALL(mock_application_manager_settings_, hmi_capabilities_file_name())
-        .WillByDefault(ReturnRef(kFileName));
+    EXPECT_CALL(app_mngr_, event_dispatcher())
+        .WillOnce(ReturnRef(mock_event_dispatcher));
+    EXPECT_CALL(app_mngr_, get_settings())
+        .WillRepeatedly(ReturnRef(mock_application_manager_settings_));
+    EXPECT_CALL(mock_application_manager_settings_,
+                hmi_capabilities_file_name()).WillOnce(ReturnRef(kFileName));
+    EXPECT_CALL(mock_event_dispatcher, add_observer(_, _, _)).Times(1);
+    EXPECT_CALL(mock_event_dispatcher, remove_observer(_)).Times(1);
+    EXPECT_CALL(mock_application_manager_settings_, launch_hmi())
+        .WillOnce(Return(false));
     hmi_capabilities_test =
         utils::MakeShared<HMICapabilitiesForTesting>(app_mngr_);
     hmi_capabilities_test->Init(&last_state_);

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -163,7 +163,10 @@ hmi_apis::Common_Language::eType TestCommonLanguageFromString(
   return hmi_apis::Common_Language::INVALID_ENUM;
 }
 
-TEST_F(HMICapabilitiesTest, DISABLED_LoadCapabilitiesFromFile) {
+TEST_F(HMICapabilitiesTest, LoadCapabilitiesFromFile) {
+  const std::string hmi_capabilities_file = "hmi_capabilities.json";
+  EXPECT_CALL(mock_application_manager_settings_, hmi_capabilities_file_name())
+      .WillOnce(ReturnRef(hmi_capabilities_file));
   EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
               CommonLanguageFromString(_))
       .WillRepeatedly(Invoke(TestCommonLanguageFromString));

--- a/src/components/policy/test/policy_manager_impl_test.cc
+++ b/src/components/policy/test/policy_manager_impl_test.cc
@@ -565,7 +565,7 @@ TEST_F(PolicyManagerImplTest, LoadPT_SetInvalidUpdatePT_PTIsNotLoaded) {
 }
 
 TEST_F(PolicyManagerImplTest2,
-       DISABLED_KmsChanged_SetExceededKms_ExpectCorrectSchedule) {
+       KmsChanged_SetExceededKms_ExpectCorrectSchedule) {
   // Arrange
   CreateLocalPT("sdl_preloaded_pt.json");
   ::policy::Counters counter = ::policy::Counters::KILOMETERS;
@@ -573,7 +573,7 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ("UP_TO_DATE", manager->GetPolicyTableStatus());
   // Set kms changed but not exceed limit
   manager->KmsChanged(51500);
-  EXPECT_EQ("UPDATE_NEEDED", manager->GetPolicyTableStatus());
+  EXPECT_EQ("UP_TO_DATE", manager->GetPolicyTableStatus());
   // Set kms changed and exceed limit
   manager->KmsChanged(52500);
   EXPECT_EQ("UPDATE_NEEDED", manager->GetPolicyTableStatus());

--- a/src/components/policy/test/sql_pt_representation_test.cc
+++ b/src/components/policy/test/sql_pt_representation_test.cc
@@ -1436,6 +1436,8 @@ TEST(SQLPTRepresentationTest3, RemoveDB_RemoveDB_ExpectFileDeleted) {
   delete reps;
 }
 
+// TODO {AKozoriz} : Snapshot must have module meta section, but test
+// generates snapshot without it.
 TEST_F(SQLPTRepresentationTest,
        DISABLED_GenerateSnapshot_SetPolicyTable_SnapshotIsPresent) {
   // Arrange


### PR DESCRIPTION
- Removed warnings in some tests.
- Fixed and enabled tests which had disabled.
- One of tests wasn`t enabled(GenerateSnapshot_SetPolicyTable_SnapshotIsPresent), will be repaired in another task.

This pull was reviewed  in : https://github.com/smartdevicelink/sdl_core/pull/556