### PR TITLE
Fix long waiting in Async Gmock

### DIFF
--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -549,12 +549,11 @@ class ProtocolHandlerImpl
   security_manager::SecurityManager* security_manager_;
 #endif  // ENABLE_SECURITY
 
+  sync_primitives::Lock protocol_observers_lock_;
   // Thread that pumps non-parsed messages coming from mobile side.
   impl::FromMobileQueue raw_ford_messages_from_mobile_;
   // Thread that pumps messages prepared to being sent to mobile side.
   impl::ToMobileQueue raw_ford_messages_to_mobile_;
-
-  sync_primitives::Lock protocol_observers_lock_;
 
 #ifdef TELEMETRY_MONITOR
   PHTelemetryObserver* metric_observer_;

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -145,14 +145,12 @@ class ProtocolHandlerImplTest : public ::testing::Test {
 
     // Expect ConnectionHandler support methods call (conversion, check
     // heartbeat)
-    EXPECT_CALL(session_observer_mock, KeyFromPair(connection_id, _))
-        .
-        // Return some connection_key
-        WillRepeatedly(Return(connection_key));
-    EXPECT_CALL(session_observer_mock, IsHeartBeatSupported(connection_id, _))
-        .
-        // Return false to avoid call KeepConnectionAlive
-        WillRepeatedly(Return(false));
+    ON_CALL(session_observer_mock, KeyFromPair(connection_id, _))
+        // return some connection_key
+        .WillByDefault(Return(connection_key));
+    ON_CALL(session_observer_mock, IsHeartBeatSupported(connection_id, _))
+        // return false to avoid call KeepConnectionAlive
+        .WillByDefault(Return(false));
   }
 
   void TearDown() OVERRIDE {
@@ -256,7 +254,6 @@ class ProtocolHandlerImplTest : public ::testing::Test {
   }
 
   testing::NiceMock<MockProtocolHandlerSettings> protocol_handler_settings_mock;
-  ::utils::SharedPtr<ProtocolHandlerImpl> protocol_handler_impl;
   TransportManagerListener* tm_listener;
   // Uniq connection
   ::transport_manager::ConnectionUID connection_id;
@@ -269,15 +266,16 @@ class ProtocolHandlerImplTest : public ::testing::Test {
   // Strict mocks (same as all methods EXPECT_CALL().Times(0))
   testing::NiceMock<connection_handler_test::MockConnectionHandler>
       connection_handler_mock;
-  testing::StrictMock<transport_manager_test::MockTransportManager>
+  testing::NiceMock<transport_manager_test::MockTransportManager>
       transport_manager_mock;
-  testing::StrictMock<protocol_handler_test::MockSessionObserver>
+  testing::NiceMock<protocol_handler_test::MockSessionObserver>
       session_observer_mock;
 #ifdef ENABLE_SECURITY
   testing::NiceMock<security_manager_test::MockSecurityManager>
       security_manager_mock;
   testing::NiceMock<security_manager_test::MockSSLContext> ssl_context_mock;
 #endif  // ENABLE_SECURITY
+  ::utils::SharedPtr<ProtocolHandlerImpl> protocol_handler_impl;
 };
 
 #ifdef ENABLE_SECURITY


### PR DESCRIPTION
   Remove dependency of wait time from count of mocked objects
    In old realisation wait time depends from count of mocked objects
    because waiting in cycle. In new realisation Async Wait will wait
    exactly so much time that was passed within parameter

