### PR TITLE
Fix of SDL4.1.0. SDL doesn't send OnSystemRequest(QUERY_APPS) to the App

### DIFF
--- a/src/components/application_manager/src/mobile_command_factory.cc
+++ b/src/components/application_manager/src/mobile_command_factory.cc
@@ -658,6 +658,9 @@ CommandSharedPtr MobileCommandFactory::CreateCommand(
       if (commands::Command::ORIGIN_SDL == origin) {
         command.reset(new commands::OnHMIStatusNotification(
             message, application_manager));
+      } else {
+        command.reset(new commands::OnHMIStatusNotificationFromMobile(
+            message, application_manager));
       }
       break;
     }


### PR DESCRIPTION
SDL 4.1.0 bug: SDL doesn't send OnSystemRequest(QUERY_APPS) to the App after receive OnHMIStatus(FULL).
See details on [SDLAQ-CRS-3018](https://adc.luxoft.com/contour/perspective.req?projectId=65&docId=776078)

Related Issue: [APPLINK-24782](https://adc.luxoft.com/jira/browse/APPLINK-24782)