### PR TITLE
Fix application manager test crash on policy lib load failure

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -304,11 +304,11 @@ bool PolicyHandler::LoadPolicyLibrary() {
                  "System is configured to work without policy "
                  "functionality.");
     policy_manager_.reset();
-    return NULL;
+    return false;
   }
   dl_handle_ = dlopen(kLibrary.c_str(), RTLD_LAZY);
 
-  char* error = dlerror();
+  const char* error = dlerror();
   if (!error) {
     if (CreateManager()) {
       policy_manager_->set_listener(this);

--- a/src/components/utils/src/push_log.cc
+++ b/src/components/utils/src/push_log.cc
@@ -95,7 +95,9 @@ void flush_logger() {
   logger::LoggerStatus old_status = logger::logger_status;
   // Stop pushing new messages to the log queue
   logger::logger_status = logger::DeletingLoggerThread;
-  log_message_loop_thread->WaitDumpQueue();
+  if (log_message_loop_thread) {
+    log_message_loop_thread->WaitDumpQueue();
+  }
   logger::logger_status = old_status;
 }
 


### PR DESCRIPTION
    The log_message_loop_thread pointer was dereferenced and
    flush_logger method is called without checking the validity
    of the pointer. This check was added.