### PR TITLE
Add QT5 build support for Travis CI and verify with DBUS support as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+
 addons:
   apt:
     sources:
@@ -11,5 +12,12 @@ before_install:
   - sudo add-apt-repository ppa:kalakris/cmake -y
   - sudo apt-get update -q
   - sudo apt-get install -y cmake
+  - sudo add-apt-repository ppa:beineri/opt-qt521 -y
+  - sudo apt-get update -q
+  - sudo apt-get install -y qt52base qt52declarative qt52graphicaleffects qt52quick1 qt52quickcontrols qt52script
+  - sudo apt-get install mlocate
+  - sudo updatedb
 script:
+  - source /opt/qt52/bin/qt52-env.sh && mkdir build_dbus && cd build_dbus && cmake ../ -DHMI2=ON -DHMI=qt && make && make install
+  - mkdir build_dbus && cd build_dbus && cmake ../ -DHMI2=ON -DHMI=qt && make && make install
   - mkdir build && cd build && cmake ../ && make && make install

--- a/src/components/interfaces/QT_HMI_API.xml
+++ b/src/components/interfaces/QT_HMI_API.xml
@@ -2072,6 +2072,20 @@
         <description>Defines the name of app's request that initiates playing a tone</description>
       </param>
     </function>
+    <function name="DialNumber" messagetype="request">
+      <description>Request from SDL to call a specific number.</description>
+      <param name="number" type="String" maxlength="40">
+        <description>Phone number is a string, which can be up to 40 chars.
+        All characters shall be stripped from string except digits 0-9 and * # , ; +
+        </description>
+      </param>
+      <param name="appID" type="Integer" mandatory="true">
+        <description>ID of application that concerns this RPC.</description>
+      </param>
+    </function>
+
+    <function name="DialNumber" messagetype="response">
+    </function>
     <!-- Policies -->
     <!-- SyncP RPC-->
     <function name="OnSystemRequest" messagetype="notification" provider="hmi">


### PR DESCRIPTION
1. Qt 5.1 support for Travis CI build
2. Build with dbus & json to ensure latest code is not broken for both version
Note: https://github.com/smartdevicelink/sdl_core/pull/565 requires merged first
           or it will have compiler error for the dbus version (HMI2=ON)