### PR TITLE
Applink-24911 Transfer required changes from [PASA] to [GENIVI]

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -39,6 +39,7 @@
 #include <set>
 #include <deque>
 #include <algorithm>
+#include <memory>
 
 #include "application_manager/hmi_command_factory.h"
 #include "application_manager/application_manager.h"
@@ -1416,7 +1417,7 @@ class ApplicationManagerImpl
   // Thread that pumps messages audio pass thru to mobile.
   impl::AudioPassThruQueue audio_pass_thru_messages_;
 
-  HMICapabilities hmi_capabilities_;
+  std::auto_ptr<HMICapabilities> hmi_capabilities_;
   // The reason of HU shutdown
   mobile_api::AppInterfaceUnregisteredReason::eType unregister_reason_;
 

--- a/src/components/application_manager/include/application_manager/hmi_capabilities.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities.h
@@ -97,7 +97,8 @@ class HMICapabilities {
   virtual void set_is_ivi_cooperating(const bool value) = 0;
 
   /*
-   * @brief Interface used to store information about software version of the target
+   * @brief Interface used to store information about software version of the
+   *target
    *
    * @param ccpu_version Received system/hmi software version
    */
@@ -108,7 +109,7 @@ class HMICapabilities {
    *
    * @return TRUE if it supported, otherwise FALSE
    */
-  virtual  const std::string& ccpu_version() const = 0;
+  virtual const std::string& ccpu_version() const = 0;
 
   /*
    * @brief Retrieves if mixing audio is supported by HMI

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -30,9 +30,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_H_
-#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_H_
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_IMPL_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_IMPL_H_
 
+#include "hmi_capabilities.h"
 #include "interfaces/HMI_API.h"
 #include "interfaces/MOBILE_API.h"
 #include "json/json.h"
@@ -42,31 +43,39 @@
 namespace NsSmartDeviceLink {
 namespace NsSmartObjects {
 class SmartObject;
-}
-}
+}  // namespace NsSmartObjects
+}  // namespace NsSmartDeviceLink
+
 namespace resumption {
 class LastState;
-}
+}  // namespace resumption
 
 namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 namespace application_manager {
 class ApplicationManager;
 
-class HMICapabilities {
+class HMICapabilitiesImpl : public HMICapabilities {
  public:
+  /*
+   * @ Class constructor
+   *
+   * @param app_mngr Application manager pointer
+   */
+  explicit HMICapabilitiesImpl(ApplicationManager& app_mngr);
+
   /*
    * @brief Class destructor
    *
    */
-  virtual ~HMICapabilities() {}
+  ~HMICapabilitiesImpl();
 
   /**
    * @brief Checks if all HMI capabilities received
    *
    * @return TRUE if all information received, otherwise FALSE
    */
-  virtual bool is_hmi_capabilities_initialized() const = 0;
+  bool is_hmi_capabilities_initialized() const OVERRIDE;
 
   /*
    * @brief Checks is image type(Static/Dynamic) requested by
@@ -74,41 +83,41 @@ class HMICapabilities {
    * @param image_type recieved type of image from Enum.
    * @return Bool true if supported
    */
-  virtual bool VerifyImageType(const int32_t image_type) const = 0;
+  bool VerifyImageType(int32_t image_type) const OVERRIDE;
 
   /**
    * @brief Checks if all HMI capabilities received
    *
    * @return TRUE if all information received, otherwise FALSE
    */
-  virtual bool is_vr_cooperating() const = 0;
-  virtual void set_is_vr_cooperating(const bool value) = 0;
+  bool is_vr_cooperating() const OVERRIDE;
+  void set_is_vr_cooperating(const bool value) OVERRIDE;
 
-  virtual bool is_tts_cooperating() const = 0;
-  virtual void set_is_tts_cooperating(const bool value) = 0;
+  bool is_tts_cooperating() const OVERRIDE;
+  void set_is_tts_cooperating(const bool value) OVERRIDE;
 
-  virtual bool is_ui_cooperating() const = 0;
-  virtual void set_is_ui_cooperating(const bool value) = 0;
+  bool is_ui_cooperating() const OVERRIDE;
+  void set_is_ui_cooperating(const bool value) OVERRIDE;
 
-  virtual bool is_navi_cooperating() const = 0;
-  virtual void set_is_navi_cooperating(const bool value) = 0;
+  bool is_navi_cooperating() const OVERRIDE;
+  void set_is_navi_cooperating(const bool value) OVERRIDE;
 
-  virtual bool is_ivi_cooperating() const = 0;
-  virtual void set_is_ivi_cooperating(const bool value) = 0;
+  bool is_ivi_cooperating() const OVERRIDE;
+  void set_is_ivi_cooperating(const bool value) OVERRIDE;
 
   /*
    * @brief Interface used to store information about software version of the target
    *
    * @param ccpu_version Received system/hmi software version
    */
-  virtual void set_ccpu_version(const std::string& ccpu_version) = 0;
+  void set_ccpu_version(const std::string& ccpu_version) OVERRIDE;
 
   /*
    * @brief Returns software version of the target
    *
    * @return TRUE if it supported, otherwise FALSE
    */
-  virtual  const std::string& ccpu_version() const = 0;
+  const std::string& ccpu_version() const OVERRIDE;
 
   /*
    * @brief Retrieves if mixing audio is supported by HMI
@@ -116,273 +125,270 @@ class HMICapabilities {
    *
    * @return Current state of the mixing audio flag
    */
-  virtual bool attenuated_supported() const = 0;
+  bool attenuated_supported() const OVERRIDE;
 
   /*
    * @brief Sets state for mixing audio
    *
    * @param state New state to be set
    */
-  virtual void set_attenuated_supported(const bool state) = 0;
+  void set_attenuated_supported(const bool state) OVERRIDE;
 
   /*
    * @brief Retrieves currently active UI language
    *
    * @return Currently active UI language
    */
-  virtual const hmi_apis::Common_Language::eType active_ui_language() const = 0;
+  const hmi_apis::Common_Language::eType active_ui_language() const OVERRIDE;
 
   /*
    * @brief Sets currently active UI language
    *
    * @param language Currently active UI language
    */
-  virtual void set_active_ui_language(
-      const hmi_apis::Common_Language::eType language) = 0;
+  void set_active_ui_language(
+      const hmi_apis::Common_Language::eType language) OVERRIDE;
 
   /*
    * @brief Retrieves UI supported languages
    *
    * @return Currently supported UI languages
    */
-  virtual const smart_objects::SmartObject* ui_supported_languages() const = 0;
+  const smart_objects::SmartObject* ui_supported_languages() const OVERRIDE;
 
   /*
    * @brief Sets supported UI languages
    *
    * @param supported_languages Supported UI languages
    */
-  virtual void set_ui_supported_languages(
-      const smart_objects::SmartObject& supported_languages) = 0;
+  void set_ui_supported_languages(
+      const smart_objects::SmartObject& supported_languages) OVERRIDE;
 
   /*
    * @brief Retrieves currently active VR language
    *
    * @return Currently active VR language
    */
-  virtual const hmi_apis::Common_Language::eType active_vr_language() const = 0;
+  const hmi_apis::Common_Language::eType active_vr_language() const OVERRIDE;
 
   /*
    * @brief Sets currently active VR language
    *
    * @param language Currently active VR language
    */
-  virtual void set_active_vr_language(
-      const hmi_apis::Common_Language::eType language) = 0;
+  void set_active_vr_language(
+      const hmi_apis::Common_Language::eType language) OVERRIDE;
 
   /*
    * @brief Retrieves VR supported languages
    *
    * @return Currently supported VR languages
    */
-  virtual const smart_objects::SmartObject* vr_supported_languages() const = 0;
+  const smart_objects::SmartObject* vr_supported_languages() const OVERRIDE;
 
   /*
    * @brief Sets supported VR languages
    *
    * @param supported_languages Supported VR languages
    */
-  virtual void set_vr_supported_languages(
-      const smart_objects::SmartObject& supported_languages) = 0;
+  void set_vr_supported_languages(
+      const smart_objects::SmartObject& supported_languages) OVERRIDE;
 
   /*
    * @brief Retrieves currently active TTS language
    *
    * @return Currently active TTS language
    */
-  virtual const hmi_apis::Common_Language::eType active_tts_language()
-      const = 0;
+  const hmi_apis::Common_Language::eType active_tts_language() const OVERRIDE;
 
   /*
    * @brief Sets currently active TTS language
    *
    * @param language Currently active TTS language
    */
-  virtual void set_active_tts_language(
-      const hmi_apis::Common_Language::eType language) = 0;
+  void set_active_tts_language(
+      const hmi_apis::Common_Language::eType language) OVERRIDE;
 
   /*
    * @brief Retrieves TTS  supported languages
    *
    * @return Currently supported TTS languages
    */
-  virtual const smart_objects::SmartObject* tts_supported_languages() const = 0;
+  const smart_objects::SmartObject* tts_supported_languages() const OVERRIDE;
 
   /*
    * @brief Sets supported TTS languages
    *
    * @param supported_languages Supported TTS languages
    */
-  virtual void set_tts_supported_languages(
-      const smart_objects::SmartObject& supported_languages) = 0;
+  void set_tts_supported_languages(
+      const smart_objects::SmartObject& supported_languages) OVERRIDE;
 
   /*
    * @brief Retrieves information about the display capabilities
    *
    * @return Currently supported display capabilities
    */
-  virtual const smart_objects::SmartObject* display_capabilities() const = 0;
+  const smart_objects::SmartObject* display_capabilities() const OVERRIDE;
 
   /*
    * @brief Sets supported display capabilities
    *
    * @param display_capabilities supported display capabilities
    */
-  virtual void set_display_capabilities(
-      const smart_objects::SmartObject& display_capabilities) = 0;
+  void set_display_capabilities(
+      const smart_objects::SmartObject& display_capabilities) OVERRIDE;
 
   /*
    * @brief Retrieves information about the HMI zone capabilities
    *
    * @return Currently supported HMI zone capabilities
    */
-  virtual const smart_objects::SmartObject* hmi_zone_capabilities() const = 0;
+  const smart_objects::SmartObject* hmi_zone_capabilities() const OVERRIDE;
 
   /*
    * @brief Sets supported HMI zone capabilities
    *
    * @param hmi_zone_capabilities supported HMI zone capabilities
    */
-  virtual void set_hmi_zone_capabilities(
-      const smart_objects::SmartObject& hmi_zone_capabilities) = 0;
+  void set_hmi_zone_capabilities(
+      const smart_objects::SmartObject& hmi_zone_capabilities) OVERRIDE;
 
   /*
    * @brief Retrieves information about the SoftButton's capabilities
    *
    * @return Currently supported SoftButton's capabilities
    */
-  virtual const smart_objects::SmartObject* soft_button_capabilities()
-      const = 0;
+  const smart_objects::SmartObject* soft_button_capabilities() const OVERRIDE;
 
   /*
    * @brief Sets supported SoftButton's capabilities
    *
    * @param soft_button_capabilities supported SoftButton's capabilities
    */
-  virtual void set_soft_button_capabilities(
-      const smart_objects::SmartObject& soft_button_capabilities) = 0;
+  void set_soft_button_capabilities(
+      const smart_objects::SmartObject& soft_button_capabilities) OVERRIDE;
 
   /*
    * @brief Retrieves information about the Button's capabilities
    *
    * @return Currently supported Button's capabilities
    */
-  virtual const smart_objects::SmartObject* button_capabilities() const = 0;
+  const smart_objects::SmartObject* button_capabilities() const OVERRIDE;
 
   /*
    * @brief Sets supported Button's capabilities
    *
    * @param soft_button_capabilities supported Button's capabilities
    */
-  virtual void set_button_capabilities(
-      const smart_objects::SmartObject& button_capabilities) = 0;
+  void set_button_capabilities(
+      const smart_objects::SmartObject& button_capabilities) OVERRIDE;
 
   /*
    * @brief Sets supported speech capabilities
    *
    * @param speech_capabilities supported speech capabilities
    */
-  virtual void set_speech_capabilities(
-      const smart_objects::SmartObject& speech_capabilities) = 0;
+  void set_speech_capabilities(
+      const smart_objects::SmartObject& speech_capabilities) OVERRIDE;
 
   /*
    * @brief Retrieves information about the speech capabilities
    *
    * @return Currently supported speech capabilities
    */
-  virtual const smart_objects::SmartObject* speech_capabilities() const = 0;
+  const smart_objects::SmartObject* speech_capabilities() const OVERRIDE;
 
   /*
    * @brief Sets supported VR capabilities
    *
    * @param vr_capabilities supported VR capabilities
    */
-  virtual void set_vr_capabilities(
-      const smart_objects::SmartObject& vr_capabilities) = 0;
+  void set_vr_capabilities(
+      const smart_objects::SmartObject& vr_capabilities) OVERRIDE;
 
   /*
    * @brief Retrieves information about the VR capabilities
    *
    * @return Currently supported VR capabilities
    */
-  virtual const smart_objects::SmartObject* vr_capabilities() const = 0;
+  const smart_objects::SmartObject* vr_capabilities() const OVERRIDE;
 
   /*
    * @brief Sets supported audio_pass_thru capabilities
    *
    * @param vr_capabilities supported audio_pass_thru capabilities
    */
-  virtual void set_audio_pass_thru_capabilities(
-      const smart_objects::SmartObject& audio_pass_thru_capabilities) = 0;
+  void set_audio_pass_thru_capabilities(
+      const smart_objects::SmartObject& audio_pass_thru_capabilities) OVERRIDE;
 
   /*
    * @brief Retrieves information about the audio_pass_thru capabilities
    *
    * @return Currently supported audio_pass_thru capabilities
    */
-  virtual const smart_objects::SmartObject* audio_pass_thru_capabilities()
-      const = 0;
+  const smart_objects::SmartObject* audio_pass_thru_capabilities()
+      const OVERRIDE;
 
   /*
    * @brief Sets supported pcm_stream capabilities
    *
    * @param supported pcm_stream capabilities
    */
-  virtual void set_pcm_stream_capabilities(
-      const smart_objects::SmartObject& pcm_stream_capabilities) = 0;
+  void set_pcm_stream_capabilities(
+      const smart_objects::SmartObject& pcm_stream_capabilities) OVERRIDE;
 
   /*
    * @brief Retrieves information about the pcm_stream capabilities
    *
    * @return Currently supported pcm_streaming capabilities
    */
-  virtual const smart_objects::SmartObject* pcm_stream_capabilities() const = 0;
+  const smart_objects::SmartObject* pcm_stream_capabilities() const OVERRIDE;
 
   /*
    * @brief Retrieves information about the preset bank capabilities
    *
    * @return Currently supported preset bank capabilities
    */
-  virtual const smart_objects::SmartObject* preset_bank_capabilities()
-      const = 0;
+  const smart_objects::SmartObject* preset_bank_capabilities() const OVERRIDE;
 
   /*
    * @brief Sets supported preset bank capabilities
    *
    * @param soft_button_capabilities supported preset bank capabilities
    */
-  virtual void set_preset_bank_capabilities(
-      const smart_objects::SmartObject& preset_bank_capabilities) = 0;
+  void set_preset_bank_capabilities(
+      const smart_objects::SmartObject& preset_bank_capabilities) OVERRIDE;
 
   /*
    * @brief Sets vehicle information(make, model, modelYear)
    *
    * @param vehicle_type Cuurent vehicle information
    */
-  virtual void set_vehicle_type(
-      const smart_objects::SmartObject& vehicle_type) = 0;
+  void set_vehicle_type(
+      const smart_objects::SmartObject& vehicle_type) OVERRIDE;
 
   /*
    * @brief Retrieves vehicle information(make, model, modelYear)
    *
    * @param vehicle_type Cuurent vehicle information
    */
-  virtual const smart_objects::SmartObject* vehicle_type() const = 0;
+  const smart_objects::SmartObject* vehicle_type() const OVERRIDE;
 
   /*
    * @brief Retrieves information about the prerecorded speech
    *
    * @return Currently supported prerecorded speech
    */
-  virtual const smart_objects::SmartObject* prerecorded_speech() const = 0;
+  const smart_objects::SmartObject* prerecorded_speech() const OVERRIDE;
 
   /*
    * @brief Sets supported prerecorded speech
    *
    * @param prerecorded_speech supported prerecorded speech
    */
-  virtual void set_prerecorded_speech(
-      const smart_objects::SmartObject& prerecorded_speech) = 0;
+  void set_prerecorded_speech(
+      const smart_objects::SmartObject& prerecorded_speech) OVERRIDE;
 
   /*
    * @brief Interface used to store information if navigation
@@ -390,14 +396,14 @@ class HMICapabilities {
    *
    * @param supported Indicates if navigation supported by the system
    */
-  virtual void set_navigation_supported(const bool supported) = 0;
+  void set_navigation_supported(const bool supported) OVERRIDE;
 
   /*
    * @brief Retrieves information if navi supported by the system
    *
    * @return TRUE if it supported, otherwise FALSE
    */
-  virtual bool navigation_supported() const = 0;
+  bool navigation_supported() const OVERRIDE;
 
   /*
    * @brief Interface used to store information if phone call
@@ -405,18 +411,26 @@ class HMICapabilities {
    *
    * @param supported Indicates if navigation supported by the sustem
    */
-  virtual void set_phone_call_supported(const bool supported) = 0;
+  void set_phone_call_supported(const bool supported) OVERRIDE;
 
   /*
    * @brief Retrieves information if phone call supported by the system
    *
    * @return TRUE if it supported, otherwise FALSE
    */
-  virtual bool phone_call_supported() const = 0;
+  bool phone_call_supported() const OVERRIDE;
 
-  virtual void Init(resumption::LastState* last_state) = 0;
+  void Init(resumption::LastState* last_state) OVERRIDE;
 
  protected:
+  /*
+   * @brief Loads capabilities from local file in case SDL was launched
+   * without HMI
+   *
+   * @return TRUE if capabilities loaded successfully, otherwise FALSE.
+   */
+  bool load_capabilities_from_file();
+
   /*
    * @brief function checks if json member exists
    *
@@ -427,8 +441,8 @@ class HMICapabilities {
    * @returns TRUE if member exists and returns FALSE if
    * member does not exist.
    */
-  virtual bool check_existing_json_member(const Json::Value& json_member,
-                                          const char* name_of_member) = 0;
+  bool check_existing_json_member(const Json::Value& json_member,
+                                  const char* name_of_member) OVERRIDE;
 
   /*
    * @brief function converts json object "languages" to smart object
@@ -437,10 +451,52 @@ class HMICapabilities {
    * @param languages - the converted object
    *
    */
-  virtual void convert_json_languages_to_obj(
-      Json::Value& json_languages, smart_objects::SmartObject& languages) = 0;
+  void convert_json_languages_to_obj(
+      Json::Value& json_languages,
+      smart_objects::SmartObject& languages) OVERRIDE;
+
+ private:
+  bool is_vr_cooperating_;
+  bool is_tts_cooperating_;
+  bool is_ui_cooperating_;
+  bool is_navi_cooperating_;
+  bool is_ivi_cooperating_;
+
+  // to check if IsReady response for corresponding interface received
+  bool is_vr_ready_response_recieved_;
+  bool is_tts_ready_response_recieved_;
+  bool is_ui_ready_response_recieved_;
+  bool is_navi_ready_response_recieved_;
+  bool is_ivi_ready_response_recieved_;
+
+  bool attenuated_supported_;
+  hmi_apis::Common_Language::eType ui_language_;
+  hmi_apis::Common_Language::eType vr_language_;
+  hmi_apis::Common_Language::eType tts_language_;
+  smart_objects::SmartObject* vehicle_type_;
+  smart_objects::SmartObject* ui_supported_languages_;
+  smart_objects::SmartObject* tts_supported_languages_;
+  smart_objects::SmartObject* vr_supported_languages_;
+  smart_objects::SmartObject* display_capabilities_;
+  smart_objects::SmartObject* hmi_zone_capabilities_;
+  smart_objects::SmartObject* soft_buttons_capabilities_;
+  smart_objects::SmartObject* button_capabilities_;
+  smart_objects::SmartObject* preset_bank_capabilities_;
+  smart_objects::SmartObject* vr_capabilities_;
+  smart_objects::SmartObject* speech_capabilities_;
+  smart_objects::SmartObject* audio_pass_thru_capabilities_;
+  smart_objects::SmartObject* pcm_stream_capabilities_;
+  smart_objects::SmartObject* prerecorded_speech_;
+  bool is_navigation_supported_;
+  bool is_phone_call_supported_;
+  std::string ccpu_version_;
+
+  ApplicationManager& app_mngr_;
+  HMILanguageHandler hmi_language_handler_;
+
+  DISALLOW_COPY_AND_ASSIGN(HMICapabilitiesImpl);
 };
 
 }  //  namespace application_manager
 
-#endif  //  SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_H_
+#endif  //  SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_IMPL_H_

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -106,7 +106,8 @@ class HMICapabilitiesImpl : public HMICapabilities {
   void set_is_ivi_cooperating(const bool value) OVERRIDE;
 
   /*
-   * @brief Interface used to store information about software version of the target
+   * @brief Interface used to store information about software version of the
+   *target
    *
    * @param ccpu_version Received system/hmi software version
    */

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -42,6 +42,7 @@
 #include "application_manager/commands/command_impl.h"
 #include "application_manager/commands/command_notification_impl.h"
 #include "application_manager/message_helper.h"
+#include "application_manager/hmi_capabilities_impl.h"
 #include "application_manager/mobile_message_handler.h"
 #include "application_manager/policies/policy_handler.h"
 #include "protocol_handler/protocol_handler.h"
@@ -114,7 +115,7 @@ ApplicationManagerImpl::ApplicationManagerImpl(
     , messages_from_hmi_("AM FromHMI", this)
     , messages_to_hmi_("AM ToHMI", this)
     , audio_pass_thru_messages_("AudioPassThru", this)
-    , hmi_capabilities_(*this)
+    , hmi_capabilities_(new HMICapabilitiesImpl(*this))
     , unregister_reason_(
           mobile_api::AppInterfaceUnregisteredReason::INVALID_ENUM)
     , resume_ctrl_(*this)
@@ -1676,7 +1677,7 @@ bool ApplicationManagerImpl::Init(resumption::LastState& last_state,
     LOG4CXX_ERROR(logger_, "Problem with initialization of resume controller");
     return false;
   }
-  hmi_capabilities_.Init(&last_state);
+  hmi_capabilities_->Init(&last_state);
 
   if (!(file_system::IsWritingAllowed(app_storage_folder) &&
         file_system::IsReadingAllowed(app_storage_folder))) {
@@ -2098,11 +2099,11 @@ mobile_apis::MOBILE_API& ApplicationManagerImpl::mobile_so_factory() {
 }
 
 HMICapabilities& ApplicationManagerImpl::hmi_capabilities() {
-  return hmi_capabilities_;
+  return *hmi_capabilities_;
 }
 
 const HMICapabilities& ApplicationManagerImpl::hmi_capabilities() const {
-  return hmi_capabilities_;
+  return *hmi_capabilities_;
 }
 
 void ApplicationManagerImpl::PullLanguagesInfo(const SmartObject& app_data,

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -238,7 +238,6 @@ HMICapabilitiesImpl::HMICapabilitiesImpl(ApplicationManager& app_mngr)
     , is_phone_call_supported_(false)
     , app_mngr_(app_mngr)
     , hmi_language_handler_(app_mngr) {
-
   if (false == load_capabilities_from_file()) {
     LOG4CXX_ERROR(logger_, "file hmi_capabilities.json was not loaded");
   } else {
@@ -716,7 +715,7 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
 
       if (check_existing_json_member(ui, "language")) {
         const std::string lang = ui.get("language", "EN-US").asString();
-        ui_language_ = (MessageHelper::CommonLanguageFromString(lang));
+        ui_language_ = MessageHelper::CommonLanguageFromString(lang);
       }
 
       if (check_existing_json_member(ui, "languages")) {

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -30,13 +30,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "application_manager/hmi_capabilities.h"
+#include "application_manager/hmi_capabilities_impl.h"
 
 #include <map>
 
 #include "json/json.h"
 #include "utils/file_system.h"
 #include "interfaces/HMI_API.h"
+
 #include "smart_objects/smart_object.h"
 #include "application_manager/smart_object_keys.h"
 #include "application_manager/message_helper.h"
@@ -204,7 +205,7 @@ const std::map<std::string, hmi_apis::Common_CharacterSet::eType>
                           {"CID1SET", hmi_apis::Common_CharacterSet::CID1SET},
                           {"CID2SET", hmi_apis::Common_CharacterSet::CID2SET}};
 
-HMICapabilities::HMICapabilities(ApplicationManager& app_mngr)
+HMICapabilitiesImpl::HMICapabilitiesImpl(ApplicationManager& app_mngr)
     : is_vr_cooperating_(false)
     , is_tts_cooperating_(false)
     , is_ui_cooperating_(false)
@@ -236,7 +237,13 @@ HMICapabilities::HMICapabilities(ApplicationManager& app_mngr)
     , is_navigation_supported_(false)
     , is_phone_call_supported_(false)
     , app_mngr_(app_mngr)
-    , hmi_language_handler_(app_mngr_) {
+    , hmi_language_handler_(app_mngr) {
+
+  if (false == load_capabilities_from_file()) {
+    LOG4CXX_ERROR(logger_, "file hmi_capabilities.json was not loaded");
+  } else {
+    LOG4CXX_INFO(logger_, "file hmi_capabilities.json was loaded");
+  }
   if (false == app_mngr_.get_settings().launch_hmi()) {
     is_vr_ready_response_recieved_ = true;
     is_tts_ready_response_recieved_ = true;
@@ -252,7 +259,7 @@ HMICapabilities::HMICapabilities(ApplicationManager& app_mngr)
   }
 }
 
-HMICapabilities::~HMICapabilities() {
+HMICapabilitiesImpl::~HMICapabilitiesImpl() {
   delete vehicle_type_;
   delete ui_supported_languages_;
   delete tts_supported_languages_;
@@ -269,7 +276,7 @@ HMICapabilities::~HMICapabilities() {
   delete prerecorded_speech_;
 }
 
-bool HMICapabilities::is_hmi_capabilities_initialized() const {
+bool HMICapabilitiesImpl::is_hmi_capabilities_initialized() const {
   bool result = true;
 
   if (is_vr_ready_response_recieved_ && is_tts_ready_response_recieved_ &&
@@ -308,7 +315,7 @@ bool HMICapabilities::is_hmi_capabilities_initialized() const {
   return result;
 }
 
-bool HMICapabilities::VerifyImageType(int32_t image_type) const {
+bool HMICapabilitiesImpl::VerifyImageType(int32_t image_type) const {
   if (!display_capabilities_) {
     return false;
   }
@@ -326,7 +333,7 @@ bool HMICapabilities::VerifyImageType(int32_t image_type) const {
   return false;
 }
 
-void HMICapabilities::set_is_vr_cooperating(bool value) {
+void HMICapabilitiesImpl::set_is_vr_cooperating(bool value) {
   is_vr_ready_response_recieved_ = true;
   is_vr_cooperating_ = value;
   if (is_vr_cooperating_) {
@@ -346,7 +353,7 @@ void HMICapabilities::set_is_vr_cooperating(bool value) {
   }
 }
 
-void HMICapabilities::set_is_tts_cooperating(bool value) {
+void HMICapabilitiesImpl::set_is_tts_cooperating(bool value) {
   is_tts_ready_response_recieved_ = true;
   is_tts_cooperating_ = value;
   if (is_tts_cooperating_) {
@@ -366,7 +373,7 @@ void HMICapabilities::set_is_tts_cooperating(bool value) {
   }
 }
 
-void HMICapabilities::set_is_ui_cooperating(bool value) {
+void HMICapabilitiesImpl::set_is_ui_cooperating(bool value) {
   is_ui_ready_response_recieved_ = true;
   is_ui_cooperating_ = value;
   if (is_ui_cooperating_) {
@@ -386,12 +393,12 @@ void HMICapabilities::set_is_ui_cooperating(bool value) {
   }
 }
 
-void HMICapabilities::set_is_navi_cooperating(bool value) {
+void HMICapabilitiesImpl::set_is_navi_cooperating(bool value) {
   is_navi_ready_response_recieved_ = true;
   is_navi_cooperating_ = value;
 }
 
-void HMICapabilities::set_is_ivi_cooperating(bool value) {
+void HMICapabilitiesImpl::set_is_ivi_cooperating(bool value) {
   is_ivi_ready_response_recieved_ = true;
   is_ivi_cooperating_ = value;
   if (is_ivi_cooperating_) {
@@ -402,32 +409,32 @@ void HMICapabilities::set_is_ivi_cooperating(bool value) {
   }
 }
 
-void HMICapabilities::set_attenuated_supported(bool state) {
+void HMICapabilitiesImpl::set_attenuated_supported(bool state) {
   attenuated_supported_ = state;
 }
 
-void HMICapabilities::set_active_ui_language(
-    const hmi_apis::Common_Language::eType& language) {
+void HMICapabilitiesImpl::set_active_ui_language(
+    const hmi_apis::Common_Language::eType language) {
   ui_language_ = language;
   hmi_language_handler_.set_language_for(HMILanguageHandler::INTERFACE_UI,
                                          language);
 }
 
-void HMICapabilities::set_active_vr_language(
-    const hmi_apis::Common_Language::eType& language) {
+void HMICapabilitiesImpl::set_active_vr_language(
+    const hmi_apis::Common_Language::eType language) {
   vr_language_ = language;
   hmi_language_handler_.set_language_for(HMILanguageHandler::INTERFACE_VR,
                                          language);
 }
 
-void HMICapabilities::set_active_tts_language(
-    const hmi_apis::Common_Language::eType& language) {
+void HMICapabilitiesImpl::set_active_tts_language(
+    const hmi_apis::Common_Language::eType language) {
   tts_language_ = language;
   hmi_language_handler_.set_language_for(HMILanguageHandler::INTERFACE_TTS,
                                          language);
 }
 
-const hmi_apis::Common_Language::eType HMICapabilities::active_ui_language()
+const hmi_apis::Common_Language::eType HMICapabilitiesImpl::active_ui_language()
     const {
   using namespace hmi_apis;
   const Common_Language::eType language =
@@ -435,7 +442,7 @@ const hmi_apis::Common_Language::eType HMICapabilities::active_ui_language()
   return Common_Language::INVALID_ENUM != language ? language : ui_language_;
 }
 
-const hmi_apis::Common_Language::eType HMICapabilities::active_vr_language()
+const hmi_apis::Common_Language::eType HMICapabilitiesImpl::active_vr_language()
     const {
   using namespace hmi_apis;
   const Common_Language::eType language =
@@ -443,15 +450,15 @@ const hmi_apis::Common_Language::eType HMICapabilities::active_vr_language()
   return Common_Language::INVALID_ENUM != language ? language : vr_language_;
 }
 
-const hmi_apis::Common_Language::eType HMICapabilities::active_tts_language()
-    const {
+const hmi_apis::Common_Language::eType
+HMICapabilitiesImpl::active_tts_language() const {
   using namespace hmi_apis;
   const Common_Language::eType language =
       hmi_language_handler_.get_language_for(HMILanguageHandler::INTERFACE_TTS);
   return Common_Language::INVALID_ENUM != language ? language : tts_language_;
 }
 
-void HMICapabilities::set_ui_supported_languages(
+void HMICapabilitiesImpl::set_ui_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
   if (ui_supported_languages_) {
     delete ui_supported_languages_;
@@ -459,7 +466,7 @@ void HMICapabilities::set_ui_supported_languages(
   ui_supported_languages_ = new smart_objects::SmartObject(supported_languages);
 }
 
-void HMICapabilities::set_tts_supported_languages(
+void HMICapabilitiesImpl::set_tts_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
   if (tts_supported_languages_) {
     delete tts_supported_languages_;
@@ -468,7 +475,7 @@ void HMICapabilities::set_tts_supported_languages(
       new smart_objects::SmartObject(supported_languages);
 }
 
-void HMICapabilities::set_vr_supported_languages(
+void HMICapabilitiesImpl::set_vr_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
   if (vr_supported_languages_) {
     delete vr_supported_languages_;
@@ -476,7 +483,7 @@ void HMICapabilities::set_vr_supported_languages(
   vr_supported_languages_ = new smart_objects::SmartObject(supported_languages);
 }
 
-void HMICapabilities::set_display_capabilities(
+void HMICapabilitiesImpl::set_display_capabilities(
     const smart_objects::SmartObject& display_capabilities) {
   if (display_capabilities_) {
     delete display_capabilities_;
@@ -484,7 +491,7 @@ void HMICapabilities::set_display_capabilities(
   display_capabilities_ = new smart_objects::SmartObject(display_capabilities);
 }
 
-void HMICapabilities::set_hmi_zone_capabilities(
+void HMICapabilitiesImpl::set_hmi_zone_capabilities(
     const smart_objects::SmartObject& hmi_zone_capabilities) {
   if (hmi_zone_capabilities_) {
     delete hmi_zone_capabilities_;
@@ -493,7 +500,7 @@ void HMICapabilities::set_hmi_zone_capabilities(
       new smart_objects::SmartObject(hmi_zone_capabilities);
 }
 
-void HMICapabilities::set_soft_button_capabilities(
+void HMICapabilitiesImpl::set_soft_button_capabilities(
     const smart_objects::SmartObject& soft_button_capabilities) {
   if (soft_buttons_capabilities_) {
     delete soft_buttons_capabilities_;
@@ -502,7 +509,7 @@ void HMICapabilities::set_soft_button_capabilities(
       new smart_objects::SmartObject(soft_button_capabilities);
 }
 
-void HMICapabilities::set_button_capabilities(
+void HMICapabilitiesImpl::set_button_capabilities(
     const smart_objects::SmartObject& button_capabilities) {
   if (button_capabilities_) {
     delete button_capabilities_;
@@ -510,7 +517,7 @@ void HMICapabilities::set_button_capabilities(
   button_capabilities_ = new smart_objects::SmartObject(button_capabilities);
 }
 
-void HMICapabilities::set_vr_capabilities(
+void HMICapabilitiesImpl::set_vr_capabilities(
     const smart_objects::SmartObject& vr_capabilities) {
   if (vr_capabilities_) {
     delete vr_capabilities_;
@@ -518,7 +525,7 @@ void HMICapabilities::set_vr_capabilities(
   vr_capabilities_ = new smart_objects::SmartObject(vr_capabilities);
 }
 
-void HMICapabilities::set_speech_capabilities(
+void HMICapabilitiesImpl::set_speech_capabilities(
     const smart_objects::SmartObject& speech_capabilities) {
   if (speech_capabilities_) {
     delete speech_capabilities_;
@@ -526,7 +533,7 @@ void HMICapabilities::set_speech_capabilities(
   speech_capabilities_ = new smart_objects::SmartObject(speech_capabilities);
 }
 
-void HMICapabilities::set_audio_pass_thru_capabilities(
+void HMICapabilitiesImpl::set_audio_pass_thru_capabilities(
     const smart_objects::SmartObject& audio_pass_thru_capabilities) {
   if (audio_pass_thru_capabilities_) {
     delete audio_pass_thru_capabilities_;
@@ -535,7 +542,7 @@ void HMICapabilities::set_audio_pass_thru_capabilities(
       new smart_objects::SmartObject(audio_pass_thru_capabilities);
 }
 
-void HMICapabilities::set_pcm_stream_capabilities(
+void HMICapabilitiesImpl::set_pcm_stream_capabilities(
     const smart_objects::SmartObject& pcm_stream_capabilities) {
   if (pcm_stream_capabilities_) {
     delete pcm_stream_capabilities_;
@@ -544,7 +551,7 @@ void HMICapabilities::set_pcm_stream_capabilities(
       new smart_objects::SmartObject(pcm_stream_capabilities);
 }
 
-void HMICapabilities::set_preset_bank_capabilities(
+void HMICapabilitiesImpl::set_preset_bank_capabilities(
     const smart_objects::SmartObject& preset_bank_capabilities) {
   if (preset_bank_capabilities_) {
     delete preset_bank_capabilities_;
@@ -553,7 +560,7 @@ void HMICapabilities::set_preset_bank_capabilities(
       new smart_objects::SmartObject(preset_bank_capabilities);
 }
 
-void HMICapabilities::set_vehicle_type(
+void HMICapabilitiesImpl::set_vehicle_type(
     const smart_objects::SmartObject& vehicle_type) {
   if (vehicle_type_) {
     delete vehicle_type_;
@@ -561,7 +568,7 @@ void HMICapabilities::set_vehicle_type(
   vehicle_type_ = new smart_objects::SmartObject(vehicle_type);
 }
 
-void HMICapabilities::set_prerecorded_speech(
+void HMICapabilitiesImpl::set_prerecorded_speech(
     const smart_objects::SmartObject& prerecorded_speech) {
   if (prerecorded_speech_) {
     delete prerecorded_speech_;
@@ -570,30 +577,120 @@ void HMICapabilities::set_prerecorded_speech(
   prerecorded_speech_ = new smart_objects::SmartObject(prerecorded_speech);
 }
 
-void HMICapabilities::set_ccpu_version(const std::string& ccpu_version) {
-  ccpu_version_ = ccpu_version;
-}
-
-void HMICapabilities::set_navigation_supported(const bool supported) {
+void HMICapabilitiesImpl::set_navigation_supported(bool supported) {
   is_navigation_supported_ = supported;
 }
-
-void HMICapabilities::set_phone_call_supported(const bool supported) {
+void HMICapabilitiesImpl::set_phone_call_supported(bool supported) {
   is_phone_call_supported_ = supported;
 }
 
-void HMICapabilities::Init(resumption::LastState* last_state) {
+void HMICapabilitiesImpl::Init(resumption::LastState* last_state) {
   hmi_language_handler_.Init(last_state);
-  if (false == load_capabilities_from_file()) {
-    LOG4CXX_ERROR(logger_, "file hmi_capabilities.json was not loaded");
-  } else {
-    LOG4CXX_INFO(logger_, "file hmi_capabilities.json was loaded");
-  }
   hmi_language_handler_.set_default_capabilities_languages(
       ui_language_, vr_language_, tts_language_);
 }
 
-bool HMICapabilities::load_capabilities_from_file() {
+bool HMICapabilitiesImpl::is_ui_cooperating() const {
+  return is_ui_cooperating_;
+}
+
+bool HMICapabilitiesImpl::is_vr_cooperating() const {
+  return is_vr_cooperating_;
+}
+
+bool HMICapabilitiesImpl::is_tts_cooperating() const {
+  return is_tts_cooperating_;
+}
+
+bool HMICapabilitiesImpl::is_navi_cooperating() const {
+  return is_navi_cooperating_;
+}
+
+bool HMICapabilitiesImpl::is_ivi_cooperating() const {
+  return is_ivi_cooperating_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::ui_supported_languages()
+    const {
+  return ui_supported_languages_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::vr_supported_languages()
+    const {
+  return vr_supported_languages_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::tts_supported_languages()
+    const {
+  return tts_supported_languages_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::display_capabilities()
+    const {
+  return display_capabilities_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::hmi_zone_capabilities()
+    const {
+  return hmi_zone_capabilities_;
+}
+
+const smart_objects::SmartObject*
+HMICapabilitiesImpl::soft_button_capabilities() const {
+  return soft_buttons_capabilities_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::button_capabilities()
+    const {
+  return button_capabilities_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::speech_capabilities()
+    const {
+  return speech_capabilities_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::vr_capabilities() const {
+  return vr_capabilities_;
+}
+
+const smart_objects::SmartObject*
+HMICapabilitiesImpl::audio_pass_thru_capabilities() const {
+  return audio_pass_thru_capabilities_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::pcm_stream_capabilities()
+    const {
+  return pcm_stream_capabilities_;
+}
+
+const smart_objects::SmartObject*
+HMICapabilitiesImpl::preset_bank_capabilities() const {
+  return preset_bank_capabilities_;
+}
+
+bool HMICapabilitiesImpl::attenuated_supported() const {
+  return attenuated_supported_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::vehicle_type() const {
+  return vehicle_type_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::prerecorded_speech()
+    const {
+  return prerecorded_speech_;
+}
+
+bool HMICapabilitiesImpl::navigation_supported() const {
+  return is_navigation_supported_;
+}
+
+bool HMICapabilitiesImpl::phone_call_supported() const {
+  return is_phone_call_supported_;
+}
+
+bool HMICapabilitiesImpl::load_capabilities_from_file() {
   std::string json_string;
   std::string file_name = app_mngr_.get_settings().hmi_capabilities_file_name();
 
@@ -619,7 +716,7 @@ bool HMICapabilities::load_capabilities_from_file() {
 
       if (check_existing_json_member(ui, "language")) {
         const std::string lang = ui.get("language", "EN-US").asString();
-        set_active_ui_language(MessageHelper::CommonLanguageFromString(lang));
+        ui_language_ = (MessageHelper::CommonLanguageFromString(lang));
       }
 
       if (check_existing_json_member(ui, "languages")) {
@@ -651,7 +748,6 @@ bool HMICapabilities::load_capabilities_from_file() {
         if (display_capabilities_so.keyExists(hmi_response::text_fields)) {
           uint32_t len =
               display_capabilities_so[hmi_response::text_fields].length();
-
           for (uint32_t i = 0; i < len; ++i) {
             if ((display_capabilities_so[hmi_response::text_fields][i])
                     .keyExists(strings::name)) {
@@ -745,6 +841,32 @@ bool HMICapabilities::load_capabilities_from_file() {
               media_clock_formats_enum;
         }
 
+        if (check_existing_json_member(ui, "pcmStreamCapabilities")) {
+          Json::Value pcm_capabilities = ui.get("pcmStreamCapabilities", "");
+          smart_objects::SmartObject pcm_capabilities_so;
+
+          pcm_capabilities_so =
+              smart_objects::SmartObject(smart_objects::SmartType_Map);
+          if (check_existing_json_member(pcm_capabilities, "samplingRate")) {
+            pcm_capabilities_so["samplingRate"] =
+                sampling_rate_enum.find(pcm_capabilities.get("samplingRate", "")
+                                            .asString())->second;
+          }
+          if (check_existing_json_member(pcm_capabilities, "bitsPerSample")) {
+            pcm_capabilities_so["bitsPerSample"] =
+                bit_per_sample_enum.find(pcm_capabilities.get("bitsPerSample",
+                                                              "").asString())
+                    ->second;
+          }
+          if (check_existing_json_member(pcm_capabilities, "audioType")) {
+            pcm_capabilities_so["audioType"] =
+                audio_type_enum.find(pcm_capabilities.get("audioType", "")
+                                         .asString())->second;
+          }
+
+          set_pcm_stream_capabilities(pcm_capabilities_so);
+        }
+
         if (display_capabilities_so.keyExists(
                 hmi_response::image_capabilities)) {
           smart_objects::SmartObject& image_capabilities_array =
@@ -793,35 +915,11 @@ bool HMICapabilities::load_capabilities_from_file() {
         set_audio_pass_thru_capabilities(audio_capabilities_so);
       }
 
-      if (check_existing_json_member(ui, "pcmStreamCapabilities")) {
-        Json::Value pcm_capabilities = ui.get("pcmStreamCapabilities", "");
-        smart_objects::SmartObject pcm_capabilities_so =
-            smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-        if (check_existing_json_member(pcm_capabilities, "samplingRate")) {
-          pcm_capabilities_so["samplingRate"] =
-              sampling_rate_enum.find(pcm_capabilities.get("samplingRate", "")
-                                          .asString())->second;
-        }
-        if (check_existing_json_member(pcm_capabilities, "bitsPerSample")) {
-          pcm_capabilities_so["bitsPerSample"] =
-              bit_per_sample_enum.find(pcm_capabilities.get("bitsPerSample", "")
-                                           .asString())->second;
-        }
-        if (check_existing_json_member(pcm_capabilities, "audioType")) {
-          pcm_capabilities_so["audioType"] =
-              audio_type_enum.find(pcm_capabilities.get("audioType", "")
-                                       .asString())->second;
-        }
-
-        set_pcm_stream_capabilities(pcm_capabilities_so);
-      }
-
       if (check_existing_json_member(ui, "hmiZoneCapabilities")) {
         smart_objects::SmartObject hmi_zone_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
         hmi_zone_capabilities_so =
-            hmi_zone_enum.find(ui.get("hmiZoneCapabilities", "").asString())
+            (hmi_zone_enum.find(ui.get("hmiZoneCapabilities", "").asString()))
                 ->second;
         set_hmi_zone_capabilities(hmi_zone_capabilities_so);
       }
@@ -841,7 +939,7 @@ bool HMICapabilities::load_capabilities_from_file() {
       Json::Value vr = root_json.get("VR", "");
       if (check_existing_json_member(vr, "language")) {
         const std::string lang = vr.get("language", "EN-US").asString();
-        set_active_vr_language(MessageHelper::CommonLanguageFromString(lang));
+        vr_language_ = MessageHelper::CommonLanguageFromString(lang);
       }
 
       if (check_existing_json_member(vr, "languages")) {
@@ -870,7 +968,7 @@ bool HMICapabilities::load_capabilities_from_file() {
 
       if (check_existing_json_member(tts, "language")) {
         const std::string lang = tts.get("language", "EN-US").asString();
-        set_active_tts_language(MessageHelper::CommonLanguageFromString(lang));
+        tts_language_ = MessageHelper::CommonLanguageFromString(lang);
       }
 
       if (check_existing_json_member(tts, "languages")) {
@@ -934,12 +1032,20 @@ bool HMICapabilities::load_capabilities_from_file() {
   return true;
 }
 
-bool HMICapabilities::check_existing_json_member(const Json::Value& json_member,
-                                                 const char* name_of_member) {
+void HMICapabilitiesImpl::set_ccpu_version(const std::string& ccpu_version) {
+  ccpu_version_ = ccpu_version;
+}
+
+const std::string& HMICapabilitiesImpl::ccpu_version() const {
+  return ccpu_version_;
+}
+
+bool HMICapabilitiesImpl::check_existing_json_member(
+    const Json::Value& json_member, const char* name_of_member) {
   return json_member.isMember(name_of_member);
 }
 
-void HMICapabilities::convert_json_languages_to_obj(
+void HMICapabilitiesImpl::convert_json_languages_to_obj(
     Json::Value& json_languages, smart_objects::SmartObject& languages) {
   for (uint32_t i = 0, j = 0; i < json_languages.size(); ++i) {
     languages[j++] =

--- a/src/components/application_manager/test/CMakeLists.txt
+++ b/src/components/application_manager/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2015, Ford Motor Company
+# Copyright (c) 2016, Ford Motor Company
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -169,4 +169,5 @@ OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libPolicy.so
   create_test("resumption/data_resumption_test" "${ResumptionData_SOURCES}" "${testLibraries}")
 
   add_subdirectory(state_controller)
+  add_subdirectory(commands)
 endif()

--- a/src/components/application_manager/test/commands/CMakeLists.txt
+++ b/src/components/application_manager/test/commands/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Copyright (c) 2016, Ford Motor Company
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the
+# distribution.
+#
+# Neither the name of the Ford Motor Company nor the names of its contributors
+# may be used to endorse or promote products derived from this software
+# without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+include_directories(
+  ${GMOCK_INCLUDE_DIRECTORY}
+  ${COMPONENTS_DIR}/application_manager/include/
+  ${COMPONENTS_DIR}/application_manager/test/include/
+)
+
+set (SOURCES
+  ${COMPONENTS_DIR}/application_manager/src/message_helper/message_helper.cc
+  ${AM_TEST_DIR}/commands/command_impl_test.cc
+  ${AM_TEST_DIR}/commands/command_response_impl_test.cc
+  ${AM_TEST_DIR}/commands/command_request_impl_test.cc
+)
+
+set(LIBRARIES
+  gmock
+  Utils
+  ApplicationManager
+  connectionHandler
+  HMI_API
+  MOBILE_API
+  SmartObjects
+  jsoncpp
+  MessageHelper
+)
+
+create_test("commands_test" "${SOURCES}" "${LIBRARIES}" )
+
+add_subdirectory(mobile)

--- a/src/components/application_manager/test/commands/command_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_impl_test.cc
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+#include <set>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command.h"
+#include "application_manager/commands/command_impl.h"
+#include "application_manager/application_manager.h"
+#include "application_manager/mock_application.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+
+using ::testing::Return;
+using ::testing::AtLeast;
+using ::testing::_;
+
+using ::utils::SharedPtr;
+namespace strings = ::application_manager::strings;
+using ::application_manager::commands::CommandImpl;
+using ::application_manager::ApplicationManager;
+using ::application_manager::commands::MessageSharedPtr;
+using ::application_manager::ApplicationSharedPtr;
+using ::test::components::application_manager_test::MockApplication;
+
+typedef SharedPtr<MockApplication> MockAppPtr;
+
+class CommandImplTest : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  class UnwrappedCommandImpl : CommandImpl {
+   public:
+    using CommandImpl::ReplaceMobileByHMIAppId;
+    using CommandImpl::ReplaceHMIByMobileAppId;
+
+    UnwrappedCommandImpl(const MessageSharedPtr& message,
+                         ApplicationManager& application_manager)
+        : CommandImpl(message, application_manager) {}
+
+   private:
+    DISALLOW_COPY_AND_ASSIGN(UnwrappedCommandImpl);
+  };
+
+  // Create `SmartObject` which handle array of `SmartObjects`
+  static void CreateArray(MessageSharedPtr& msg,
+                          const size_t msg_count = kDefaultMsgCount_) {
+    if (!msg) {
+      msg = CreateMessage(smart_objects::SmartType_Array);
+    }
+    ::smart_objects::SmartArray* array = msg->asArray();
+    SmartObject obj;
+    for (size_t i = 0u; i < msg_count; ++i) {
+      obj[strings::app_id] = i;
+      array->push_back(obj);
+    }
+  }
+  // Create `SmartObject` which handle map of `SmartObjects`
+  static void CreateMap(MessageSharedPtr& msg,
+                        const size_t msg_count = kDefaultMsgCount_) {
+    if (!msg) {
+      msg = CreateMessage(smart_objects::SmartType_Map);
+    }
+    char key[] = {'A', '\0'};
+    SmartObject obj;
+    for (size_t i = 0u; i < msg_count; ++i, ++key[0]) {
+      obj[strings::app_id] = i;
+      (*msg)[key] = obj;
+    }
+  }
+
+  static const uint32_t kDefaultMsgCount_ = 5u;
+  const uint32_t kAppId1_ = 5u;
+  const uint32_t kAppId2_ = 10u;
+};
+
+typedef CommandImplTest::UnwrappedCommandImpl UCommandImpl;
+typedef SharedPtr<UCommandImpl> UCommandImplPtr;
+
+TEST_F(CommandImplTest, GetMethods_SUCCESS) {
+  MessageSharedPtr msg;
+  SharedPtr<CommandImpl> command =
+      CreateCommand<CommandImpl>(kDefaultTimeout_, msg);
+
+  // Current implementation always return `true`
+  EXPECT_TRUE(command->Init());
+  EXPECT_TRUE(command->CheckPermissions());
+  EXPECT_TRUE(command->CleanUp());
+
+  // Default value of `allowed_to_terminate_` is true
+  EXPECT_TRUE(command->AllowedToTerminate());
+  command->SetAllowedToTerminate(false);
+  EXPECT_FALSE(command->AllowedToTerminate());
+
+  const uint32_t kCorrelationId = 3u;
+  const int32_t kFunctionId = 4u;
+  const uint32_t kConnectionKey = 5u;
+
+  (*msg)[strings::params][strings::correlation_id] = kCorrelationId;
+  (*msg)[strings::params][strings::function_id] = kFunctionId;
+  (*msg)[strings::params][strings::connection_key] = kConnectionKey;
+
+  EXPECT_EQ(kDefaultTimeout_, command->default_timeout());
+  EXPECT_EQ(kCorrelationId, command->correlation_id());
+  EXPECT_EQ(kConnectionKey, command->connection_key());
+  EXPECT_EQ(kFunctionId, command->function_id());
+  EXPECT_NO_THROW(command->Run());
+  EXPECT_NO_THROW(command->onTimeOut());
+}
+
+TEST_F(CommandImplTest, ReplaceMobileByHMIAppId_NoAppIdInMessage_UNSUCCESS) {
+  MessageSharedPtr msg;
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+
+  EXPECT_CALL(app_mngr_, application(_)).Times(0);
+
+  command->ReplaceMobileByHMIAppId(*msg);
+}
+
+TEST_F(CommandImplTest, ReplaceMobileByHMIAppId_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::app_id] = kAppId1_;
+
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+
+  MockAppPtr app = CreateMockApp();
+
+  EXPECT_CALL(app_mngr_, application(kAppId1_)).WillOnce(Return(app));
+  ON_CALL(*app, hmi_app_id()).WillByDefault(Return(kAppId2_));
+
+  command->ReplaceMobileByHMIAppId(*msg);
+
+  EXPECT_EQ(kAppId2_, (*msg)[strings::app_id].asUInt());
+}
+
+TEST_F(CommandImplTest, ReplaceMobileByHMIAppId_Array_SUCCESS) {
+  MessageSharedPtr msg;
+  CreateArray(msg, kDefaultMsgCount_);
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+
+  MockAppPtr app = CreateMockApp();
+
+  EXPECT_CALL(app_mngr_, application(_))
+      .Times(kDefaultMsgCount_)
+      .WillRepeatedly(Return(app));
+  ON_CALL(*app, hmi_app_id()).WillByDefault(Return(kAppId2_));
+
+  command->ReplaceMobileByHMIAppId(*msg);
+
+  EXPECT_TRUE(msg->asArray());
+  smart_objects::SmartArray::const_iterator it(msg->asArray()->begin());
+  const smart_objects::SmartArray::const_iterator it_end(msg->asArray()->end());
+  for (; it != it_end; ++it) {
+    EXPECT_EQ(kAppId2_, (*it)[strings::app_id].asUInt());
+  }
+}
+
+TEST_F(CommandImplTest, ReplaceMobileByHMIAppId_Map_SUCCESS) {
+  MessageSharedPtr msg;
+  CreateMap(msg, kDefaultMsgCount_);
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+
+  MockAppPtr app = CreateMockApp();
+
+  EXPECT_CALL(app_mngr_, application(_))
+      .Times(kDefaultMsgCount_)
+      .WillRepeatedly(Return(app));
+  ON_CALL(*app, hmi_app_id()).WillByDefault(Return(kAppId2_));
+
+  command->ReplaceMobileByHMIAppId(*msg);
+
+  std::set<std::string> keys(msg->enumerate());
+  std::set<std::string>::const_iterator key(keys.begin());
+  for (; key != keys.end(); ++key) {
+    EXPECT_EQ(kAppId2_, (*msg)[*key][strings::app_id].asUInt());
+  }
+}
+
+TEST_F(CommandImplTest, ReplaceHMIByMobileAppId_NoHMIAppIdInMessage_UNSUCCESS) {
+  MessageSharedPtr msg;
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+
+  EXPECT_CALL(app_mngr_, application_by_hmi_app(_)).Times(0);
+
+  command->ReplaceHMIByMobileAppId(*msg);
+}
+
+TEST_F(CommandImplTest, ReplaceHMIByMobileAppId_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::app_id] = kAppId1_;
+
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+
+  MockAppPtr app = CreateMockApp();
+
+  EXPECT_CALL(app_mngr_, application_by_hmi_app(kAppId1_))
+      .WillOnce(Return(app));
+  ON_CALL(*app, app_id()).WillByDefault(Return(kAppId2_));
+
+  command->ReplaceHMIByMobileAppId(*msg);
+
+  EXPECT_EQ(kAppId2_, (*msg)[strings::app_id].asUInt());
+}
+
+TEST_F(CommandImplTest, ReplaceHMIByMobileAppId_Array_SUCCESS) {
+  MessageSharedPtr msg;
+  CreateArray(msg, kDefaultMsgCount_);
+
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+  MockAppPtr app = CreateMockApp();
+
+  EXPECT_CALL(app_mngr_, application_by_hmi_app(_))
+      .Times(kDefaultMsgCount_)
+      .WillRepeatedly(Return(app));
+  ON_CALL(*app, app_id()).WillByDefault(Return(kAppId2_));
+
+  command->ReplaceHMIByMobileAppId(*msg);
+
+  EXPECT_TRUE(msg->asArray());
+  smart_objects::SmartArray::const_iterator it(msg->asArray()->begin());
+  const smart_objects::SmartArray::const_iterator it_end(msg->asArray()->end());
+  for (; it != it_end; ++it) {
+    EXPECT_EQ(kAppId2_, (*it)[strings::app_id].asUInt());
+  }
+}
+
+TEST_F(CommandImplTest, ReplaceHMIByMobileAppId_Map_SUCCESS) {
+  MessageSharedPtr msg;
+  CreateMap(msg, kDefaultMsgCount_);
+
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+  MockAppPtr app = CreateMockApp();
+
+  EXPECT_CALL(app_mngr_, application_by_hmi_app(_))
+      .Times(kDefaultMsgCount_)
+      .WillRepeatedly(Return(app));
+  ON_CALL(*app, app_id()).WillByDefault(Return(kAppId2_));
+
+  command->ReplaceHMIByMobileAppId(*msg);
+
+  std::set<std::string> keys = msg->enumerate();
+  std::set<std::string>::const_iterator key = keys.begin();
+  for (; key != keys.end(); ++key) {
+    EXPECT_EQ(kAppId2_, (*msg)[*key][strings::app_id].asUInt());
+  }
+}
+
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -1,0 +1,483 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+#include <algorithm>
+
+#include "gtest/gtest.h"
+#include "application_manager/commands/command_impl.h"
+#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_request_test.h"
+#include "utils/lock.h"
+#include "utils/shared_ptr.h"
+#include "utils/data_accessor.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/application_manager.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/event_engine/event.h"
+#include "application_manager/message_helper.h"
+#include "interfaces/MOBILE_API.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+
+namespace strings = ::application_manager::strings;
+namespace hmi_response = ::application_manager::hmi_response;
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::SaveArg;
+using ::testing::DoAll;
+
+using ::utils::SharedPtr;
+using ::application_manager::commands::MessageSharedPtr;
+using ::application_manager::CommandParametersPermissions;
+using ::application_manager::event_engine::EventObserver;
+using ::application_manager::commands::CommandImpl;
+using ::application_manager::commands::CommandRequestImpl;
+using ::application_manager::ApplicationManager;
+using ::application_manager::ApplicationSet;
+using ::application_manager::RPCParams;
+
+typedef ::application_manager::commands::CommandRequestImpl::RequestState
+    RequestState;
+
+class CommandRequestImplTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  class UnwrappedCommandRequestImpl : public CommandRequestImpl {
+   public:
+    using CommandRequestImpl::CheckAllowedParameters;
+    using CommandRequestImpl::RemoveDisallowedParameters;
+    using CommandRequestImpl::AddDisallowedParameters;
+    using CommandRequestImpl::HasDisallowedParams;
+
+    UnwrappedCommandRequestImpl(const MessageSharedPtr& message,
+                                ApplicationManager& application_manager)
+        : CommandRequestImpl(message, application_manager) {}
+
+    const RequestState current_state() const {
+      return current_state_;
+    }
+    void set_current_state(const RequestState state) {
+      current_state_ = state;
+    }
+
+    CommandParametersPermissions& parameters_permissions() {
+      return parameters_permissions_;
+    }
+
+    CommandParametersPermissions& removed_parameters_permissions() {
+      return removed_parameters_permissions_;
+    }
+  };
+
+  const uint32_t kConnectionKey_ = 5u;
+  const uint32_t kCorrelationId_ = 3u;
+  const hmi_apis::FunctionID::eType kInvalidFunctionId_ =
+      hmi_apis::FunctionID::INVALID_ENUM;
+  const std::string kPolicyAppId_ = "Test";
+  const mobile_apis::Result::eType kMobResultSuccess_ =
+      mobile_apis::Result::SUCCESS;
+
+  sync_primitives::Lock app_set_lock_;
+};
+
+typedef CommandRequestImplTest::UnwrappedCommandRequestImpl UCommandRequestImpl;
+typedef SharedPtr<UCommandRequestImpl> CommandPtr;
+
+TEST_F(CommandRequestImplTest, OnTimeOut_StateCompleted_UNSUCCESS) {
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  // Should be called twice:
+  // First -- on `onTimeOut` method call
+  // Second -- on destruction;
+  EXPECT_CALL(ev_disp_, remove_observer(_)).Times(2);
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+
+  // If `command` already done, then state should change to `kCompleted`.
+  command->set_current_state(RequestState::kCompleted);
+
+  command->onTimeOut();
+
+  EXPECT_EQ(RequestState::kCompleted, command->current_state());
+}
+
+TEST_F(CommandRequestImplTest, OnTimeOut_StateAwaitingHMIResponse_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::correlation_id] = kCorrelationId_;
+  (*msg)[strings::params][strings::function_id] = kInvalidFunctionId_;
+  (*msg)[strings::params][strings::connection_key] = kConnectionKey_;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  // Should be called twice:
+  // First -- on `onTimeOut` method call
+  // Second -- on destruction;
+  EXPECT_CALL(ev_disp_, remove_observer(_)).Times(2);
+  EXPECT_CALL(app_mngr_,
+              ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
+
+  command->onTimeOut();
+
+  // If `command` not done till now, then state should change to `kTimedOut`
+  // and sent it to application manager to deal with it.
+  EXPECT_EQ(RequestState::kTimedOut, command->current_state());
+}
+
+TEST_F(CommandRequestImplTest, CheckSyntax_SUCCESS) {
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  // Checking message syntax.
+  const std::string str1("\t\n");
+  EXPECT_FALSE(command->CheckSyntax(str1, false));
+  const std::string str2("\\n");
+  EXPECT_FALSE(command->CheckSyntax(str2, false));
+  const std::string str3("\\t");
+  EXPECT_FALSE(command->CheckSyntax(str3, false));
+  const std::string str4(" ");
+  EXPECT_FALSE(command->CheckSyntax(str4, false));
+  EXPECT_TRUE(command->CheckSyntax(str4, true));
+}
+
+TEST_F(CommandRequestImplTest, GetMobileResultCode_SUCCESS) {
+  union ResultU {
+    int32_t value_;
+    hmi_apis::Common_Result::eType hmi_;
+    mobile_apis::Result::eType mobile_;
+  };
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  // Run thru all possible accordance
+  // of HMI and Mobile result codes.
+  ResultU result_it;
+  for (result_it.hmi_ = hmi_apis::Common_Result::SUCCESS;
+       result_it.value_ < hmi_apis::Common_Result::TRUNCATED_DATA;
+       ++result_it.value_) {
+    if (result_it.hmi_ != hmi_apis::Common_Result::NO_DEVICES_CONNECTED &&
+        result_it.hmi_ != hmi_apis::Common_Result::NO_APPS_REGISTERED) {
+      EXPECT_EQ(result_it.mobile_,
+                command->GetMobileResultCode(result_it.hmi_));
+    }
+  }
+  EXPECT_EQ(mobile_apis::Result::APPLICATION_NOT_REGISTERED,
+            command->GetMobileResultCode(
+                hmi_apis::Common_Result::NO_DEVICES_CONNECTED));
+  EXPECT_EQ(mobile_apis::Result::APPLICATION_NOT_REGISTERED,
+            command->GetMobileResultCode(
+                hmi_apis::Common_Result::NO_APPS_REGISTERED));
+  EXPECT_EQ(
+      mobile_apis::Result::GENERIC_ERROR,
+      command->GetMobileResultCode(hmi_apis::Common_Result::TRUNCATED_DATA));
+}
+
+TEST_F(CommandRequestImplTest, BasicMethodsOverloads_SUCCESS) {
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  // Current implementation always return `true`
+  EXPECT_TRUE(command->Init());
+  EXPECT_TRUE(command->CleanUp());
+  EXPECT_NO_THROW(command->Run());
+  application_manager::event_engine::Event ev(kInvalidFunctionId_);
+  EXPECT_NO_THROW(command->on_event(ev));
+}
+
+TEST_F(CommandRequestImplTest, CreateHMINotification_SUCCESS) {
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  const std::string kTestParamsKey = "test_msg_params";
+
+  MessageSharedPtr msg_params = CreateMessage();
+  (*msg_params)[kTestParamsKey] = 0;
+
+  MessageSharedPtr result;
+
+  EXPECT_CALL(app_mngr_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+
+  command->CreateHMINotification(kInvalidFunctionId_, *msg_params);
+
+  // Check if message been formed and sent to application manager.
+  EXPECT_TRUE((*result).keyExists(strings::msg_params));
+  EXPECT_TRUE((*result)[strings::msg_params].keyExists(kTestParamsKey));
+}
+
+TEST_F(CommandRequestImplTest, SendHMIRequest_NoUseEvent_SUCCESS) {
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())
+      .WillOnce(Return(kCorrelationId_));
+  // Return `true` prevents call of `SendResponse` method;
+  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
+
+  EXPECT_EQ(kCorrelationId_,
+            command->SendHMIRequest(kInvalidFunctionId_, NULL, false));
+}
+
+TEST_F(CommandRequestImplTest, SendHMIRequest_UseEvent_SUCCESS) {
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())
+      .WillOnce(Return(kCorrelationId_));
+  // Return `true` prevents call of `SendResponse` method;
+  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
+
+  EXPECT_CALL(ev_disp_, add_observer(_, _, _));
+
+  EXPECT_EQ(kCorrelationId_,
+            command->SendHMIRequest(kInvalidFunctionId_, NULL, true));
+}
+
+TEST_F(CommandRequestImplTest, RemoveDisallowedParameters_SUCCESS) {
+  const std::string kDisParam1 = "disallowed_param1";
+  const std::string kDisParam2 = "disallowed_param2";
+  const std::string kAlParam = "allowed_param";
+  const std::string kUnParam = "undefined_params";
+  const std::string kMisParam =
+      ::application_manager::MessageHelper::vehicle_data().begin()->first;
+
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::msg_params][kDisParam1] = 0u;
+  (*msg)[strings::msg_params][kDisParam2] = 0u;
+  (*msg)[strings::msg_params][kAlParam] = 0u;
+  (*msg)[strings::msg_params][kUnParam] = 0u;
+  (*msg)[strings::msg_params][kMisParam] = 0u;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  CommandParametersPermissions& permission = command->parameters_permissions();
+  permission.disallowed_params.push_back(kDisParam1);
+  permission.disallowed_params.push_back(kDisParam2);
+  permission.allowed_params.push_back(kAlParam);
+  permission.undefined_params.push_back(kUnParam);
+
+  command->RemoveDisallowedParameters();
+
+  EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kDisParam1));
+  EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kDisParam2));
+  EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kUnParam));
+  EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kMisParam));
+  EXPECT_TRUE((*msg)[strings::msg_params].keyExists(kAlParam));
+  EXPECT_TRUE(command->HasDisallowedParams());
+}
+
+TEST_F(CommandRequestImplTest,
+       CheckAllowedParameters_RegisterAppInterface_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::function_id] =
+      mobile_apis::FunctionID::RegisterAppInterfaceID;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  EXPECT_CALL(app_mngr_, applications()).Times(0);
+  EXPECT_TRUE(command->CheckPermissions());
+}
+
+TEST_F(CommandRequestImplTest,
+       CheckAllowedParameters_NoAppWithSameConnectionKey_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::connection_key] = kConnectionKey_;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  MockAppPtr app = CreateMockApp();
+  ApplicationSet app_set;
+  app_set.insert(app);
+
+  DataAccessor<ApplicationSet> accessor(app_set, app_set_lock_);
+
+  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  EXPECT_CALL(*app, app_id()).WillOnce(Return(6u));
+  EXPECT_TRUE(command->CheckPermissions());
+}
+
+TEST_F(CommandRequestImplTest, CheckAllowedParameters_NoMsgParamsMap_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::connection_key] = kConnectionKey_;
+  (*msg)[strings::msg_params] = 0u;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  MockAppPtr app = CreateMockApp();
+  ApplicationSet app_set;
+  app_set.insert(app);
+
+  DataAccessor<ApplicationSet> accessor(app_set, app_set_lock_);
+
+  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  EXPECT_CALL(*app, app_id()).WillOnce(Return(kConnectionKey_));
+  EXPECT_CALL(*app, policy_app_id()).WillOnce(Return(kPolicyAppId_));
+  EXPECT_CALL(*app, hmi_level())
+      .WillOnce(Return(mobile_apis::HMILevel::HMI_NONE));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _, _))
+      .WillOnce(Return(kMobResultSuccess_));
+
+  EXPECT_TRUE(command->CheckPermissions());
+}
+
+TEST_F(CommandRequestImplTest,
+       CheckAllowedParameters_WrongPolicyPermissions_UNSUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::connection_key] = kConnectionKey_;
+  (*msg)[strings::msg_params] = 0u;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  MockAppPtr app = CreateMockApp();
+  ApplicationSet app_set;
+  app_set.insert(app);
+
+  DataAccessor<ApplicationSet> accessor(app_set, app_set_lock_);
+
+  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  EXPECT_CALL(*app, app_id()).Times(2).WillRepeatedly(Return(kConnectionKey_));
+  EXPECT_CALL(*app, policy_app_id()).WillOnce(Return(kPolicyAppId_));
+  EXPECT_CALL(*app, hmi_level())
+      .WillOnce(Return(mobile_apis::HMILevel::HMI_NONE));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::INVALID_ENUM));
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _));
+  EXPECT_FALSE(command->CheckPermissions());
+}
+
+ACTION_P(GetArg3, output) {
+  *output = arg3;
+}
+
+TEST_F(CommandRequestImplTest, CheckAllowedParameters_MsgParamsMap_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::connection_key] = kConnectionKey_;
+  (*msg)[strings::msg_params][kPolicyAppId_] = true;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  MockAppPtr app = CreateMockApp();
+  ApplicationSet app_set;
+  app_set.insert(app);
+
+  DataAccessor<ApplicationSet> accessor(app_set, app_set_lock_);
+
+  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  EXPECT_CALL(*app, app_id()).WillOnce(Return(kConnectionKey_));
+  EXPECT_CALL(*app, policy_app_id()).WillOnce(Return(kPolicyAppId_));
+  EXPECT_CALL(*app, hmi_level())
+      .WillOnce(Return(mobile_apis::HMILevel::HMI_NONE));
+
+  RPCParams params;
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _, _))
+      .WillOnce(DoAll(GetArg3(&params), Return(kMobResultSuccess_)));
+
+  EXPECT_TRUE(command->CheckPermissions());
+  EXPECT_TRUE(params.end() !=
+              std::find(params.begin(), params.end(), kPolicyAppId_));
+}
+
+TEST_F(CommandRequestImplTest, AddDisallowedParameters_SUCCESS) {
+  const std::string kDisParam =
+      ::application_manager::MessageHelper::vehicle_data().begin()->first;
+
+  MessageSharedPtr msg;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  command->removed_parameters_permissions().disallowed_params.push_back(kDisParam);
+
+  command->AddDisallowedParameters(*msg);
+
+  EXPECT_TRUE((*msg)[strings::msg_params].keyExists(kDisParam));
+}
+
+TEST_F(CommandRequestImplTest, SendResponse_TimedOut_UNSUCCESS) {
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  command->set_current_state(RequestState::kTimedOut);
+
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+
+  // Args do not affect on anything in this case;
+  command->SendResponse(true, kMobResultSuccess_, NULL, NULL);
+
+  EXPECT_EQ(RequestState::kTimedOut, command->current_state());
+}
+
+TEST_F(CommandRequestImplTest, SendResponse_SUCCESS) {
+  MessageSharedPtr msg;
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  EXPECT_TRUE(smart_objects::SmartType_Null == (*msg).getType());
+
+  MessageSharedPtr result;
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+
+  // Args do not affect on anything in this case;
+  command->SendResponse(true, kMobResultSuccess_, NULL, NULL);
+
+  EXPECT_EQ(RequestState::kCompleted, command->current_state());
+
+  EXPECT_TRUE(smart_objects::SmartType_Map == (*msg).getType());
+}
+
+TEST_F(CommandRequestImplTest,
+       SendResponse_AddDisallowedParametersToInfo_SUCCESS) {
+  const std::string kDisParam = "disallowed_param";
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::function_id] =
+      mobile_apis::FunctionID::SubscribeVehicleDataID;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  command->removed_parameters_permissions().disallowed_params.push_back(kDisParam);
+
+  MessageSharedPtr result;
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+
+  command->SendResponse(true, kMobResultSuccess_, NULL, NULL);
+
+  EXPECT_EQ(RequestState::kCompleted, command->current_state());
+
+  EXPECT_TRUE((*result)[strings::msg_params].keyExists(strings::info));
+  EXPECT_NE("", (*result)[strings::msg_params][strings::info].asString());
+}
+
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -212,8 +212,8 @@ TEST_F(CommandRequestImplTest, BasicMethodsOverloads_SUCCESS) {
   EXPECT_TRUE(command->Init());
   EXPECT_TRUE(command->CleanUp());
   EXPECT_NO_THROW(command->Run());
-  application_manager::event_engine::Event ev(kInvalidFunctionId_);
-  EXPECT_NO_THROW(command->on_event(ev));
+  application_manager::event_engine::Event event(kInvalidFunctionId_);
+  EXPECT_NO_THROW(command->on_event(event));
 }
 
 TEST_F(CommandRequestImplTest, CreateHMINotification_SUCCESS) {
@@ -417,7 +417,8 @@ TEST_F(CommandRequestImplTest, AddDisallowedParameters_SUCCESS) {
 
   CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
 
-  command->removed_parameters_permissions().disallowed_params.push_back(kDisParam);
+  command->removed_parameters_permissions().disallowed_params.push_back(
+      kDisParam);
 
   command->AddDisallowedParameters(*msg);
 
@@ -464,7 +465,8 @@ TEST_F(CommandRequestImplTest,
 
   CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
 
-  command->removed_parameters_permissions().disallowed_params.push_back(kDisParam);
+  command->removed_parameters_permissions().disallowed_params.push_back(
+      kDisParam);
 
   MessageSharedPtr result;
   EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _))

--- a/src/components/application_manager/test/commands/command_response_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_response_impl_test.cc
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command.h"
+#include "application_manager/commands/command_response_impl.h"
+#include "application_manager/mock_application.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+
+namespace strings = ::application_manager::strings;
+namespace hmi_response = ::application_manager::hmi_response;
+using ::utils::SharedPtr;
+using ::application_manager::commands::MessageSharedPtr;
+using ::application_manager::commands::CommandResponseImpl;
+
+class CommandResponseImplTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(CommandResponseImplTest, BasicMethodsOverloads_SUCCESS) {
+  SharedPtr<CommandResponseImpl> command = CreateCommand<CommandResponseImpl>();
+  // Current implementation always return `true`
+  EXPECT_TRUE(command->Init());
+  EXPECT_TRUE(command->CleanUp());
+  EXPECT_NO_THROW(command->Run());
+}
+
+TEST_F(CommandResponseImplTest, SendResponse_MessageWithResultCode_SUCCESS) {
+  MessageSharedPtr msg;
+  SharedPtr<CommandResponseImpl> command =
+      CreateCommand<CommandResponseImpl>(msg);
+  // Do not have a weight in this case
+  const bool kSuccess = true;
+  const mobile_apis::Result::eType kResultCode =
+      mobile_apis::Result::eType::INVALID_ENUM;
+  const bool kFinalResponse = true;
+
+  // If `msg_params->result_code` exist in message,
+  // then send message to mobile.
+  (*msg)[strings::msg_params][strings::result_code] = kResultCode;
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+
+  command->SendResponse(kSuccess, kResultCode, kFinalResponse);
+}
+
+TEST_F(CommandResponseImplTest,
+       SendResponse_EmptyMessageValidResultCode_SUCCESS) {
+  MessageSharedPtr msg;
+  SharedPtr<CommandResponseImpl> command =
+      CreateCommand<CommandResponseImpl>(msg);
+
+  const bool kSuccess = true;
+  const mobile_apis::Result::eType kResultCode =
+      mobile_apis::Result::eType::SUCCESS;
+  const bool kFinalResponse = true;
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+
+  // If `msg_params->result_code` does not exist in message
+  // and arg `result_code` not equals `INVALID_ENUM`,
+  // then set it to `msg_params->result_code` and send message to mobile.
+  command->SendResponse(kSuccess, kResultCode, kFinalResponse);
+
+  EXPECT_EQ(kResultCode,
+            (*msg)[strings::msg_params][strings::result_code].asInt());
+}
+
+TEST_F(CommandResponseImplTest,
+       SendResponse_EmptyMessageInvalidResultCode_SUCCESS) {
+  MessageSharedPtr msg;
+  SharedPtr<CommandResponseImpl> command =
+      CreateCommand<CommandResponseImpl>(msg);
+
+  const bool kSuccess = true;
+  const mobile_apis::Result::eType kResultCode =
+      mobile_apis::Result::eType::INVALID_ENUM;
+  const bool kFinalResponse = true;
+
+  // If `msg_params->result_code` does not exist in message
+  // and arg `result_code` equals `INVALID_ENUM`,
+  // then if `params->hmi_response::code` exist in message,
+  // then set it to `msg_params->result_code` and send message to mobile.
+  (*msg)[strings::params][hmi_response::code] = mobile_apis::Result::SUCCESS;
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+
+  command->SendResponse(kSuccess, kResultCode, kFinalResponse);
+
+  EXPECT_EQ((*msg)[strings::params][hmi_response::code].asInt(),
+            (*msg)[strings::msg_params][strings::result_code].asInt());
+}
+
+TEST_F(CommandResponseImplTest,
+       SendResponse_EmptyMessageInvalidResultCodeNoHmiResponse_SUCCESS) {
+  MessageSharedPtr msg;
+  SharedPtr<CommandResponseImpl> command =
+      CreateCommand<CommandResponseImpl>(msg);
+
+  const mobile_apis::Result::eType kResultCode =
+      mobile_apis::Result::eType::INVALID_ENUM;
+  const bool kFinalResponse = true;
+
+  // If `msg_params->result_code` does not exist in message
+  // and arg `result_code` equals `INVALID_ENUM`,
+  // then if `params->hmi_response::code` does not exist in message,
+  // then if `kSuccess` equals `true`,
+  // then `msg_params->result_code` will be `SUCCESS`
+  const bool kSuccess = true;
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+
+  command->SendResponse(kSuccess, kResultCode, kFinalResponse);
+
+  EXPECT_EQ(mobile_apis::Result::SUCCESS,
+            (*msg)[strings::msg_params][strings::result_code].asInt());
+}
+
+TEST_F(CommandResponseImplTest,
+       SendResponse_EmptyMessageInvalidResultCodeNoHmiResponse_INVALID_ENUM) {
+  MessageSharedPtr msg;
+  SharedPtr<CommandResponseImpl> command =
+      CreateCommand<CommandResponseImpl>(msg);
+
+  const mobile_apis::Result::eType kResultCode =
+      mobile_apis::Result::eType::INVALID_ENUM;
+  const bool kFinalResponse = true;
+
+  // If `msg_params->result_code` does not exist in message
+  // and arg `result_code` equals `INVALID_ENUM`,
+  // then if `params->hmi_response::code` does not exist in message,
+  // then if `kSuccess` equals `false`,
+  // then `msg_params->result_code` will be `INVALID_ENUM`
+  const bool kSuccess = false;
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+
+  command->SendResponse(kSuccess, kResultCode, kFinalResponse);
+
+  EXPECT_EQ(mobile_apis::Result::INVALID_ENUM,
+            (*msg)[strings::msg_params][strings::result_code].asInt());
+}
+
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/CMakeLists.txt
+++ b/src/components/application_manager/test/commands/mobile/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Copyright (c) 2016, Ford Motor Company
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the
+# distribution.
+#
+# Neither the name of the Ford Motor Company nor the names of its contributors
+# may be used to endorse or promote products derived from this software
+# without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+include_directories(
+  ${GMOCK_INCLUDE_DIRECTORY}
+  ${COMPONENTS_DIR}/application_manager/include/application_manager/commands/
+  ${COMPONENTS_DIR}/application_manager/test/include/
+  ${COMPONENTS_DIR}/application_manager/test/include/application_manager/
+)
+
+set (SOURCES
+  ${COMPONENTS_DIR}/application_manager/src/smart_object_keys.cc
+  ${AM_TEST_DIR}/commands/mobile/simple_response_commands.cc
+)
+
+set(LIBRARIES
+  gmock
+  Utils
+  ApplicationManager
+  connectionHandler
+  HMI_API
+  MOBILE_API
+  SmartObjects
+  MessageHelper
+)
+
+create_test("mobile_commands_test" "${SOURCES}" "${LIBRARIES}" )

--- a/src/components/application_manager/test/include/application_manager/commands/command_request_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/command_request_test.h
@@ -30,33 +30,45 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_FOR_TESTING_H_
-#define SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_FOR_TESTING_H_
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_COMMAND_RESPONSES_TEST_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_COMMAND_RESPONSES_TEST_H_
 
-#include "application_manager/hmi_capabilities_impl.h"
+#include <stdint.h>
+
+#include "gtest/gtest.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/mock_event_dispatcher.h"
 
 namespace test {
 namespace components {
-namespace application_manager_test {
+namespace commands_test {
 
-class HMICapabilitiesForTesting
-    : public ::application_manager::HMICapabilitiesImpl {
+using ::testing::ReturnRef;
+using ::testing::NiceMock;
+using ::test::components::event_engine_test::MockEventDispatcher;
+using ::application_manager::commands::Command;
+
+template <const CommandsTestMocks kIsNice = CommandsTestMocks::kNotNice>
+class CommandRequestTest : public CommandsTest<kIsNice> {
  public:
-  HMICapabilitiesForTesting(::application_manager::ApplicationManager& app_mngr)
-      : HMICapabilitiesImpl(app_mngr) {}
-  bool LoadCapabilitiesFromFile() {
-    return load_capabilities_from_file();
-  }
+  typedef typename TypeIf<kIsNice,
+                          NiceMock<MockEventDispatcher>,
+                          MockEventDispatcher>::Result MockEventDisp;
 
-  void ConvertJsonLanguagesToObj(
-      Json::Value& json_languages,
-      ::NsSmartDeviceLink::NsSmartObjects::SmartObject& languages) {
-    convert_json_languages_to_obj(json_languages, languages);
+  MockEventDisp ev_disp_;
+
+ protected:
+  CommandRequestTest() : CommandsTest<kIsNice>() {}
+
+  virtual void InitCommand(const uint32_t& default_timeout) OVERRIDE {
+    CommandsTest<kIsNice>::InitCommand(default_timeout);
+    EXPECT_CALL(CommandsTest<kIsNice>::app_mngr_, event_dispatcher())
+        .WillOnce(ReturnRef(ev_disp_));
   }
 };
 
-}  // namespace application_manager_test
+}  // namespace commands_test
 }  // namespace components
 }  // namespace test
 
-#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_FOR_TESTING_H_
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_COMMAND_RESPONSES_TEST_H_

--- a/src/components/application_manager/test/include/application_manager/commands/commands_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/commands_test.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_COMMANDS_TEST_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_COMMANDS_TEST_H_
+
+#include <stdint.h>
+#include "gtest/gtest.h"
+
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/commands/command.h"
+#include "utils/make_shared.h"
+#include "application_manager/mock_application_manager.h"
+#include "test/application_manager/mock_application_manager_settings.h"
+#include "application_manager/mock_application.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+
+using ::testing::ReturnRef;
+using ::testing::NiceMock;
+
+using ::utils::SharedPtr;
+using ::smart_objects::SmartObject;
+using ::application_manager::commands::MessageSharedPtr;
+using ::test::components::application_manager_test::MockApplicationManager;
+using ::test::components::application_manager_test::
+    MockApplicationManagerSettings;
+using ::application_manager::ApplicationSharedPtr;
+using ::test::components::application_manager_test::MockApplication;
+
+// Depending on the value type will be selected
+template <const bool kIf, class ThenT, class ElseT>
+struct TypeIf {
+  typedef ThenT Result;
+};
+template <class ThenT, class ElseT>
+struct TypeIf<false, ThenT, ElseT> {
+  typedef ElseT Result;
+};
+
+// If `kIsNice` is `true` then all used mock types
+// will be wrapped by a `NiceMock`
+
+enum CommandsTestMocks { kNotNice = 0, kIsNice };
+
+template <const CommandsTestMocks kIsNice = CommandsTestMocks::kNotNice>
+class CommandsTest : public ::testing::Test {
+ public:
+  typedef typename TypeIf<kIsNice,
+                          NiceMock<MockApplicationManager>,
+                          MockApplicationManager>::Result MockAppManager;
+  typedef typename TypeIf<kIsNice,
+                          NiceMock<MockApplicationManagerSettings>,
+                          MockApplicationManagerSettings>::Result
+      MockAppManagerSettings;
+
+  typedef typename TypeIf<kIsNice,
+                          NiceMock<MockApplication>,
+                          MockApplication>::Result MockApp;
+
+  typedef SharedPtr<MockApp> MockAppPtr;
+
+  virtual ~CommandsTest() {}
+
+  static MessageSharedPtr CreateMessage(
+      const smart_objects::SmartType type = smart_objects::SmartType_Null) {
+    return ::utils::MakeShared<SmartObject>(type);
+  }
+
+  static MockAppPtr CreateMockApp() {
+    return ::utils::MakeShared<MockApp>();
+  }
+
+  template <class Command>
+  SharedPtr<Command> CreateCommand(const uint32_t timeout,
+                                   MessageSharedPtr& msg) {
+    InitCommand(timeout);
+    return ::utils::MakeShared<Command>((msg ? msg : msg = CreateMessage()),
+                                        app_mngr_);
+  }
+  template <class Command>
+  SharedPtr<Command> CreateCommand(MessageSharedPtr& msg) {
+    return CreateCommand<Command>(kDefaultTimeout_, msg);
+  }
+  template <class Command>
+  SharedPtr<Command> CreateCommand(const uint32_t timeout = kDefaultTimeout_) {
+    InitCommand(timeout);
+    MessageSharedPtr msg = CreateMessage();
+    return ::utils::MakeShared<Command>(msg, app_mngr_);
+  }
+
+  enum { kDefaultTimeout_ = 100u };
+
+  MockAppManager app_mngr_;
+  MockAppManagerSettings app_mngr_set_;
+
+ protected:
+  virtual void InitCommand(const uint32_t& timeout) {
+    EXPECT_CALL(app_mngr_, get_settings()).WillOnce(ReturnRef(app_mngr_set_));
+    EXPECT_CALL(app_mngr_set_, default_timeout()).WillOnce(ReturnRef(timeout));
+  }
+
+  CommandsTest() {}
+};
+
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_COMMANDS_TEST_H_


### PR DESCRIPTION
Been done:
- `HMICapabilities` class been
  divided on interface and realization;
- Added specific abstract classes
  for commands testing(`CommandsTest`
  and `CommandRequestTest`);
- Been added unit tests for
  base command classes(`CommandImpl`,
  `CommandRequestImpl`,
  `CommandResponseImpl`);
- Been added unit tests for
  next mobile response commands:
  - `ListFilesResponse`
  - `ReadDIDResponse`
  - `AlertManeuverResponse`
  - `AlertResponse`
  - `SubscribeButtonResponse`

Resolves: [APPLINK-24911](https://adc.luxoft.com/jira/browse/APPLINK-24911)