### PR TITLE
Create script counting DISABLED tests amount

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ script:
   - mkdir build && cd build && cmake ../ -DBUILD_TESTS=ON -DENABLE_GCOV=ON && make install
   - sudo ldconfig
   - make test
+  - bash ../tools/infrastructure/show_disabled.sh 
   - bash -ex ../tools/infrastructure/collect_coverage.sh ./
 env:
   global:

--- a/tools/infrastructure/show_disabled.sh
+++ b/tools/infrastructure/show_disabled.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Variable to store total amount of disabled unit tests
+total_disabled=0
+
+echo ""
+echo "===== DISABLED Unit-tests amount ===== "
+echo ""
+
+# Getting the list of all UT executables
+for test_file in $(ctest -N | awk '{print $3}'); do
+        full_path=`find . -name $test_file -type f 2>/dev/null`
+	if [ $full_path ] ; then
+        # Count amount of disabled tests cases
+		count_of_disabled=$(${full_path} --gtest_list_tests | grep DISABLED | wc -l)
+		if [ 0 != $count_of_disabled ] ; then
+		let "total_disabled = $total_disabled + $count_of_disabled"
+			echo $count_of_disabled " : " $test_file;
+		fi
+	fi
+done
+echo ""
+echo "TOTAL AMOUNT OF DISABLED TESTS : " $total_disabled;
+
+exit 0
+
+


### PR DESCRIPTION
Created bash script which counts all DISABLED unit tests amount and shows it

Related issue: APPLINK-24966