### PR TITLE
Response with error if HMI send SDL.ActivateApp request to not registered applicaiton

### DIFF
--- a/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
@@ -58,6 +58,7 @@ void SDLActivateAppRequest::Run() {
     LOG4CXX_ERROR(
         logger_,
         "Can't find application within regular apps: " << application_id);
+    SendResponse(false, correlation_id(), SDL_ActivateApp, APPLICATION_NOT_REGISTERED);
     return;
   }
 


### PR DESCRIPTION
If during resumption application was unregistered HMI still can send SDL.ActivateAppRequest to SDL.
SDL should not fail in this condition, but just report about it in log file and send response with error to HMI.  