### PR TITLE
Create tools to test commands

### DIFF
--- a/src/components/application_manager/test/CMakeLists.txt
+++ b/src/components/application_manager/test/CMakeLists.txt
@@ -199,3 +199,4 @@
     create_test("data_resumption_test" "${ResumptionData_SOURCES}" "${testLibraries}")
 
     add_subdirectory(state_controller)
+    add_subdirectory(commands)

--- a/src/components/application_manager/test/commands/CMakeLists.txt
+++ b/src/components/application_manager/test/commands/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Copyright (c) 2016, Ford Motor Company
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the
+# distribution.
+#
+# Neither the name of the Ford Motor Company nor the names of its contributors
+# may be used to endorse or promote products derived from this software
+# without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+include_directories(
+  ${GMOCK_INCLUDE_DIRECTORY}
+  ${COMPONENTS_DIR}/application_manager/include/
+  ${COMPONENTS_DIR}/application_manager/test/include/
+)
+
+set (SOURCES
+  ${COMPONENTS_DIR}/application_manager/src/message_helper.cc
+  ${AM_TEST_DIR}/commands/command_impl_test.cc
+  ${AM_TEST_DIR}/commands/command_response_impl_test.cc
+  ${AM_TEST_DIR}/commands/command_request_impl_test.cc
+)
+
+set(LIBRARIES
+  gmock
+  Utils
+  ApplicationManager
+  connectionHandler
+  HMI_API
+  MOBILE_API
+  SmartObjects
+  jsoncpp
+  MessageHelper
+)
+
+create_test("commands_test" "${SOURCES}" "${LIBRARIES}" )
+
+add_subdirectory(mobile)

--- a/src/components/application_manager/test/commands/command_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_impl_test.cc
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+#include <set>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command.h"
+#include "application_manager/commands/command_impl.h"
+#include "application_manager/application_manager.h"
+#include "application_manager/mock_application.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+
+using ::testing::Return;
+using ::testing::AtLeast;
+using ::testing::_;
+
+using ::utils::SharedPtr;
+namespace strings = ::application_manager::strings;
+using ::application_manager::commands::CommandImpl;
+using ::application_manager::ApplicationManager;
+using ::application_manager::commands::MessageSharedPtr;
+using ::application_manager::ApplicationSharedPtr;
+using ::test::components::application_manager_test::MockApplication;
+
+typedef SharedPtr<MockApplication> MockAppPtr;
+
+class CommandImplTest : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  class UnwrappedCommandImpl : CommandImpl {
+   public:
+    using CommandImpl::ReplaceMobileByHMIAppId;
+    using CommandImpl::ReplaceHMIByMobileAppId;
+
+    UnwrappedCommandImpl(const MessageSharedPtr& message,
+                         ApplicationManager& application_manager)
+        : CommandImpl(message, application_manager) {}
+
+   private:
+    DISALLOW_COPY_AND_ASSIGN(UnwrappedCommandImpl);
+  };
+
+  // Create `SmartObject` which handle array of `SmartObjects`
+  static MessageSharedPtr CreateArrayMessage(
+      const size_t msg_count = kDefaultMsgCount_) {
+    MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Array);
+    smart_objects::SmartArray* array = msg->asArray();
+    for (size_t i = 0u; i < msg_count; ++i) {
+      SmartObject obj;
+      obj[strings::app_id] = i;
+      array->push_back(obj);
+    }
+    return msg;
+  }
+  // Create `SmartObject` which handle map of `SmartObjects`
+  static MessageSharedPtr CreateMapMessage(
+      const size_t msg_count = kDefaultMsgCount_) {
+    MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
+    char key[] = {'A', '\0'};
+    for (size_t i = 0u; i < msg_count; ++i, ++key[0]) {
+      SmartObject obj;
+      obj[strings::app_id] = i;
+      (*msg)[key] = obj;
+    }
+    return msg;
+  }
+
+  static const uint32_t kDefaultMsgCount_ = 5u;
+  const uint32_t kAppId1_ = 5u;
+  const uint32_t kAppId2_ = 10u;
+};
+
+typedef CommandImplTest::UnwrappedCommandImpl UCommandImpl;
+typedef SharedPtr<UCommandImpl> UCommandImplPtr;
+
+TEST_F(CommandImplTest, GetMethods_SUCCESS) {
+  MessageSharedPtr msg;
+  SharedPtr<CommandImpl> command =
+      CreateCommand<CommandImpl>(kDefaultTimeout_, msg);
+
+  // Current implementation always return `true`
+  EXPECT_TRUE(command->Init());
+  EXPECT_TRUE(command->CheckPermissions());
+  EXPECT_TRUE(command->CleanUp());
+
+  // Default value of `allowed_to_terminate_` is true
+  EXPECT_TRUE(command->AllowedToTerminate());
+  command->SetAllowedToTerminate(false);
+  EXPECT_FALSE(command->AllowedToTerminate());
+
+  const uint32_t kCorrelationId = 3u;
+  const int32_t kFunctionId = 4u;
+  const uint32_t kConnectionKey = 5u;
+
+  (*msg)[strings::params][strings::correlation_id] = kCorrelationId;
+  (*msg)[strings::params][strings::function_id] = kFunctionId;
+  (*msg)[strings::params][strings::connection_key] = kConnectionKey;
+
+  EXPECT_EQ(kDefaultTimeout_, command->default_timeout());
+  EXPECT_EQ(kCorrelationId, command->correlation_id());
+  EXPECT_EQ(kConnectionKey, command->connection_key());
+  EXPECT_EQ(kFunctionId, command->function_id());
+  EXPECT_NO_THROW(command->Run());
+  EXPECT_NO_THROW(command->onTimeOut());
+}
+
+TEST_F(CommandImplTest, ReplaceMobileByHMIAppId_NoAppIdInMessage_UNSUCCESS) {
+  MessageSharedPtr msg;
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+
+  EXPECT_CALL(app_mngr_, application(_)).Times(0);
+
+  command->ReplaceMobileByHMIAppId(*msg);
+}
+
+TEST_F(CommandImplTest, ReplaceMobileByHMIAppId_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::app_id] = kAppId1_;
+
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+
+  MockAppPtr app = CreateMockApp();
+
+  EXPECT_CALL(app_mngr_, application(kAppId1_)).WillOnce(Return(app));
+  ON_CALL(*app, hmi_app_id()).WillByDefault(Return(kAppId2_));
+
+  command->ReplaceMobileByHMIAppId(*msg);
+
+  EXPECT_EQ(kAppId2_, (*msg)[strings::app_id].asUInt());
+}
+
+TEST_F(CommandImplTest, ReplaceMobileByHMIAppId_Array_SUCCESS) {
+  MessageSharedPtr msg = CreateArrayMessage(kDefaultMsgCount_);
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+
+  MockAppPtr app = CreateMockApp();
+
+  EXPECT_CALL(app_mngr_, application(_))
+      .Times(kDefaultMsgCount_)
+      .WillRepeatedly(Return(app));
+  ON_CALL(*app, hmi_app_id()).WillByDefault(Return(kAppId2_));
+
+  command->ReplaceMobileByHMIAppId(*msg);
+
+  EXPECT_TRUE(msg->asArray());
+  smart_objects::SmartArray::const_iterator it(msg->asArray()->begin());
+  const smart_objects::SmartArray::const_iterator it_end(msg->asArray()->end());
+  for (; it != it_end; ++it) {
+    EXPECT_EQ(kAppId2_, (*it)[strings::app_id].asUInt());
+  }
+}
+
+TEST_F(CommandImplTest, ReplaceMobileByHMIAppId_Map_SUCCESS) {
+  MessageSharedPtr msg = CreateMapMessage(kDefaultMsgCount_);
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+
+  MockAppPtr app = CreateMockApp();
+
+  EXPECT_CALL(app_mngr_, application(_))
+      .Times(kDefaultMsgCount_)
+      .WillRepeatedly(Return(app));
+  ON_CALL(*app, hmi_app_id()).WillByDefault(Return(kAppId2_));
+
+  command->ReplaceMobileByHMIAppId(*msg);
+
+  std::set<std::string> keys(msg->enumerate());
+  std::set<std::string>::const_iterator key(keys.begin());
+  for (; key != keys.end(); ++key) {
+    EXPECT_EQ(kAppId2_, (*msg)[*key][strings::app_id].asUInt());
+  }
+}
+
+TEST_F(CommandImplTest, ReplaceHMIByMobileAppId_NoHMIAppIdInMessage_UNSUCCESS) {
+  MessageSharedPtr msg;
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+
+  EXPECT_CALL(app_mngr_, application_by_hmi_app(_)).Times(0);
+
+  command->ReplaceHMIByMobileAppId(*msg);
+}
+
+TEST_F(CommandImplTest, ReplaceHMIByMobileAppId_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::app_id] = kAppId1_;
+
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+
+  MockAppPtr app = CreateMockApp();
+
+  EXPECT_CALL(app_mngr_, application_by_hmi_app(kAppId1_))
+      .WillOnce(Return(app));
+  ON_CALL(*app, app_id()).WillByDefault(Return(kAppId2_));
+
+  command->ReplaceHMIByMobileAppId(*msg);
+
+  EXPECT_EQ(kAppId2_, (*msg)[strings::app_id].asUInt());
+}
+
+TEST_F(CommandImplTest, ReplaceHMIByMobileAppId_Array_SUCCESS) {
+  MessageSharedPtr msg = CreateArrayMessage(kDefaultMsgCount_);
+
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+  MockAppPtr app = CreateMockApp();
+
+  EXPECT_CALL(app_mngr_, application_by_hmi_app(_))
+      .Times(kDefaultMsgCount_)
+      .WillRepeatedly(Return(app));
+  ON_CALL(*app, app_id()).WillByDefault(Return(kAppId2_));
+
+  command->ReplaceHMIByMobileAppId(*msg);
+
+  EXPECT_TRUE(msg->asArray());
+  smart_objects::SmartArray::const_iterator it(msg->asArray()->begin());
+  const smart_objects::SmartArray::const_iterator it_end(msg->asArray()->end());
+  for (; it != it_end; ++it) {
+    EXPECT_EQ(kAppId2_, (*it)[strings::app_id].asUInt());
+  }
+}
+
+TEST_F(CommandImplTest, ReplaceHMIByMobileAppId_Map_SUCCESS) {
+  MessageSharedPtr msg = CreateMapMessage(kDefaultMsgCount_);
+
+  UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
+  MockAppPtr app = CreateMockApp();
+
+  EXPECT_CALL(app_mngr_, application_by_hmi_app(_))
+      .Times(kDefaultMsgCount_)
+      .WillRepeatedly(Return(app));
+  ON_CALL(*app, app_id()).WillByDefault(Return(kAppId2_));
+
+  command->ReplaceHMIByMobileAppId(*msg);
+
+  std::set<std::string> keys = msg->enumerate();
+  std::set<std::string>::const_iterator key = keys.begin();
+  for (; key != keys.end(); ++key) {
+    EXPECT_EQ(kAppId2_, (*msg)[*key][strings::app_id].asUInt());
+  }
+}
+
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -1,0 +1,474 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+#include <algorithm>
+
+#include "gtest/gtest.h"
+#include "application_manager/commands/command_impl.h"
+#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_request_test.h"
+#include "utils/lock.h"
+#include "utils/shared_ptr.h"
+#include "utils/data_accessor.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/application_manager.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/event_engine/event.h"
+#include "application_manager/message_helper.h"
+#include "interfaces/MOBILE_API.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+
+namespace strings = ::application_manager::strings;
+namespace hmi_response = ::application_manager::hmi_response;
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::SaveArg;
+using ::testing::DoAll;
+
+using ::utils::SharedPtr;
+using ::application_manager::commands::MessageSharedPtr;
+using ::application_manager::CommandParametersPermissions;
+using ::application_manager::event_engine::EventObserver;
+using ::application_manager::commands::CommandImpl;
+using ::application_manager::commands::CommandRequestImpl;
+using ::application_manager::ApplicationManager;
+using ::application_manager::ApplicationSet;
+using ::application_manager::RPCParams;
+
+typedef ::application_manager::commands::CommandRequestImpl::RequestState
+    RequestState;
+
+class CommandRequestImplTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  class UnwrappedCommandRequestImpl : public CommandRequestImpl {
+   public:
+    using CommandRequestImpl::CheckAllowedParameters;
+    using CommandRequestImpl::RemoveDisallowedParameters;
+    using CommandRequestImpl::AddDisallowedParameters;
+    using CommandRequestImpl::HasDisallowedParams;
+
+    UnwrappedCommandRequestImpl(const MessageSharedPtr& message,
+                                ApplicationManager& application_manager)
+        : CommandRequestImpl(message, application_manager) {}
+
+    const RequestState current_state() const {
+      return current_state_;
+    }
+    void set_current_state(const RequestState state) {
+      current_state_ = state;
+    }
+
+    CommandParametersPermissions& parameters_permissions() {
+      return parameters_permissions_;
+    }
+
+    CommandParametersPermissions& removed_parameters_permissions() {
+      return removed_parameters_permissions_;
+    }
+  };
+
+  MockAppPtr InitAppSetDataAccessor(SharedPtr<ApplicationSet>& app_set) {
+    app_set = (!app_set ? ::utils::MakeShared<ApplicationSet>() : app_set);
+    MockAppPtr app(CreateMockApp());
+    app_set->insert(app);
+    EXPECT_CALL(app_mngr_, applications())
+        .WillOnce(
+            Return(DataAccessor<ApplicationSet>(*app_set, app_set_lock_)));
+    return app;
+  }
+
+  const uint32_t kConnectionKey_ = 5u;
+  const uint32_t kCorrelationId_ = 3u;
+  const hmi_apis::FunctionID::eType kInvalidFunctionId_ =
+      hmi_apis::FunctionID::INVALID_ENUM;
+  const std::string kPolicyAppId_ = "Test";
+  const mobile_apis::Result::eType kMobResultSuccess_ =
+      mobile_apis::Result::SUCCESS;
+  sync_primitives::Lock app_set_lock_;
+};
+
+typedef CommandRequestImplTest::UnwrappedCommandRequestImpl UCommandRequestImpl;
+typedef SharedPtr<UCommandRequestImpl> CommandPtr;
+
+TEST_F(CommandRequestImplTest, OnTimeOut_StateCompleted_UNSUCCESS) {
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  // Should be called twice:
+  // First -- on `onTimeOut` method call
+  // Second -- on destruction;
+  EXPECT_CALL(event_dispatcher_, remove_observer(_)).Times(2);
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+
+  // If `command` already done, then state should change to `kCompleted`.
+  command->set_current_state(RequestState::kCompleted);
+
+  command->onTimeOut();
+
+  EXPECT_EQ(RequestState::kCompleted, command->current_state());
+}
+
+TEST_F(CommandRequestImplTest, OnTimeOut_StateAwaitingHMIResponse_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::correlation_id] = kCorrelationId_;
+  (*msg)[strings::params][strings::function_id] = kInvalidFunctionId_;
+  (*msg)[strings::params][strings::connection_key] = kConnectionKey_;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  // Should be called twice:
+  // First -- on `onTimeOut` method call
+  // Second -- on destruction;
+  EXPECT_CALL(event_dispatcher_, remove_observer(_)).Times(2);
+  EXPECT_CALL(app_mngr_,
+              ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
+
+  command->onTimeOut();
+
+  // If `command` not done till now, then state should change to `kTimedOut`
+  // and sent it to application manager to deal with it.
+  EXPECT_EQ(RequestState::kTimedOut, command->current_state());
+}
+
+TEST_F(CommandRequestImplTest, CheckSyntax_SUCCESS) {
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  // Checking message syntax.
+  const std::string str1("\t\n");
+  EXPECT_FALSE(command->CheckSyntax(str1, false));
+  const std::string str2("\\n");
+  EXPECT_FALSE(command->CheckSyntax(str2, false));
+  const std::string str3("\\t");
+  EXPECT_FALSE(command->CheckSyntax(str3, false));
+  const std::string str4(" ");
+  EXPECT_FALSE(command->CheckSyntax(str4, false));
+  EXPECT_TRUE(command->CheckSyntax(str4, true));
+}
+
+TEST_F(CommandRequestImplTest, GetMobileResultCode_SUCCESS) {
+  union ResultU {
+    int32_t value_;
+    hmi_apis::Common_Result::eType hmi_;
+    mobile_apis::Result::eType mobile_;
+  };
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  // Run thru all possible accordance
+  // of HMI and Mobile result codes.
+  ResultU result_it;
+  for (result_it.hmi_ = hmi_apis::Common_Result::SUCCESS;
+       result_it.value_ < hmi_apis::Common_Result::TRUNCATED_DATA;
+       ++result_it.value_) {
+    if (result_it.hmi_ != hmi_apis::Common_Result::NO_DEVICES_CONNECTED &&
+        result_it.hmi_ != hmi_apis::Common_Result::NO_APPS_REGISTERED) {
+      EXPECT_EQ(result_it.mobile_,
+                command->GetMobileResultCode(result_it.hmi_));
+    }
+  }
+  EXPECT_EQ(mobile_apis::Result::APPLICATION_NOT_REGISTERED,
+            command->GetMobileResultCode(
+                hmi_apis::Common_Result::NO_DEVICES_CONNECTED));
+  EXPECT_EQ(mobile_apis::Result::APPLICATION_NOT_REGISTERED,
+            command->GetMobileResultCode(
+                hmi_apis::Common_Result::NO_APPS_REGISTERED));
+  EXPECT_EQ(
+      mobile_apis::Result::GENERIC_ERROR,
+      command->GetMobileResultCode(hmi_apis::Common_Result::TRUNCATED_DATA));
+}
+
+TEST_F(CommandRequestImplTest, BasicMethodsOverloads_SUCCESS) {
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  // Current implementation always return `true`
+  EXPECT_TRUE(command->Init());
+  EXPECT_TRUE(command->CleanUp());
+  EXPECT_NO_THROW(command->Run());
+  application_manager::event_engine::Event event(kInvalidFunctionId_);
+  EXPECT_NO_THROW(command->on_event(event));
+}
+
+TEST_F(CommandRequestImplTest, CreateHMINotification_SUCCESS) {
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  const std::string kTestParamsKey = "test_msg_params";
+
+  MessageSharedPtr msg_params = CreateMessage();
+  (*msg_params)[kTestParamsKey] = 0;
+
+  MessageSharedPtr result;
+
+  EXPECT_CALL(app_mngr_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+
+  command->CreateHMINotification(kInvalidFunctionId_, *msg_params);
+
+  // Check if message been formed and sent to application manager.
+  EXPECT_TRUE((*result).keyExists(strings::msg_params));
+  EXPECT_TRUE((*result)[strings::msg_params].keyExists(kTestParamsKey));
+}
+
+TEST_F(CommandRequestImplTest, SendHMIRequest_NoUseEvent_SUCCESS) {
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())
+      .WillOnce(Return(kCorrelationId_));
+  // Return `true` prevents call of `SendResponse` method;
+  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
+
+  EXPECT_EQ(kCorrelationId_,
+            command->SendHMIRequest(kInvalidFunctionId_, NULL, false));
+}
+
+TEST_F(CommandRequestImplTest, SendHMIRequest_UseEvent_SUCCESS) {
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())
+      .WillOnce(Return(kCorrelationId_));
+  // Return `true` prevents call of `SendResponse` method;
+  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
+
+  EXPECT_CALL(event_dispatcher_, add_observer(_, _, _));
+
+  EXPECT_EQ(kCorrelationId_,
+            command->SendHMIRequest(kInvalidFunctionId_, NULL, true));
+}
+
+TEST_F(CommandRequestImplTest, RemoveDisallowedParameters_SUCCESS) {
+  const std::string kDisallowedParam1 = "disallowed_param1";
+  const std::string kDisallowedParam2 = "disallowed_param2";
+  const std::string kAllowedParam = "allowed_param";
+  const std::string kUndefinedParam = "undefined_params";
+  const std::string kMissedParam =
+      ::application_manager::MessageHelper::vehicle_data().begin()->first;
+
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::msg_params][kDisallowedParam1] = 0u;
+  (*msg)[strings::msg_params][kDisallowedParam2] = 0u;
+  (*msg)[strings::msg_params][kAllowedParam] = 0u;
+  (*msg)[strings::msg_params][kUndefinedParam] = 0u;
+  (*msg)[strings::msg_params][kMissedParam] = 0u;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  CommandParametersPermissions& permission = command->parameters_permissions();
+  permission.disallowed_params.push_back(kDisallowedParam1);
+  permission.disallowed_params.push_back(kDisallowedParam2);
+  permission.allowed_params.push_back(kAllowedParam);
+  permission.undefined_params.push_back(kUndefinedParam);
+
+  command->RemoveDisallowedParameters();
+
+  EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kDisallowedParam1));
+  EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kDisallowedParam2));
+  EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kUndefinedParam));
+  EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kMissedParam));
+  EXPECT_TRUE((*msg)[strings::msg_params].keyExists(kAllowedParam));
+  EXPECT_TRUE(command->HasDisallowedParams());
+}
+
+TEST_F(CommandRequestImplTest,
+       CheckAllowedParameters_RegisterAppInterface_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::function_id] =
+      mobile_apis::FunctionID::RegisterAppInterfaceID;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  EXPECT_CALL(app_mngr_, applications()).Times(0);
+  EXPECT_TRUE(command->CheckPermissions());
+}
+
+TEST_F(CommandRequestImplTest,
+       CheckAllowedParameters_NoAppWithSameConnectionKey_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::connection_key] = kConnectionKey_;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  SharedPtr<ApplicationSet> app_set;
+  MockAppPtr app(InitAppSetDataAccessor(app_set));
+  EXPECT_CALL(*app, app_id()).WillOnce(Return(6u));
+  EXPECT_TRUE(command->CheckPermissions());
+}
+
+TEST_F(CommandRequestImplTest, CheckAllowedParameters_NoMsgParamsMap_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::connection_key] = kConnectionKey_;
+  (*msg)[strings::msg_params] = 0u;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  SharedPtr<ApplicationSet> app_set;
+  MockAppPtr app(InitAppSetDataAccessor(app_set));
+  EXPECT_CALL(*app, app_id()).WillOnce(Return(kConnectionKey_));
+  EXPECT_CALL(*app, policy_app_id()).WillOnce(Return(kPolicyAppId_));
+  EXPECT_CALL(*app, hmi_level())
+      .WillOnce(Return(mobile_apis::HMILevel::HMI_NONE));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _, _))
+      .WillOnce(Return(kMobResultSuccess_));
+
+  EXPECT_TRUE(command->CheckPermissions());
+}
+
+TEST_F(CommandRequestImplTest,
+       CheckAllowedParameters_WrongPolicyPermissions_UNSUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::connection_key] = kConnectionKey_;
+  (*msg)[strings::msg_params] = 0u;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  SharedPtr<ApplicationSet> app_set;
+  MockAppPtr app(InitAppSetDataAccessor(app_set));
+  EXPECT_CALL(*app, app_id()).Times(2).WillRepeatedly(Return(kConnectionKey_));
+  EXPECT_CALL(*app, policy_app_id()).WillOnce(Return(kPolicyAppId_));
+  EXPECT_CALL(*app, hmi_level())
+      .WillOnce(Return(mobile_apis::HMILevel::HMI_NONE));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::INVALID_ENUM));
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _));
+  EXPECT_FALSE(command->CheckPermissions());
+}
+
+ACTION_P(GetArg3, output) {
+  *output = arg3;
+}
+
+TEST_F(CommandRequestImplTest, CheckAllowedParameters_MsgParamsMap_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::connection_key] = kConnectionKey_;
+  (*msg)[strings::msg_params][kPolicyAppId_] = true;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  SharedPtr<ApplicationSet> app_set;
+  MockAppPtr app(InitAppSetDataAccessor(app_set));
+  EXPECT_CALL(*app, app_id()).WillOnce(Return(kConnectionKey_));
+  EXPECT_CALL(*app, policy_app_id()).WillOnce(Return(kPolicyAppId_));
+  EXPECT_CALL(*app, hmi_level())
+      .WillOnce(Return(mobile_apis::HMILevel::HMI_NONE));
+
+  RPCParams params;
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _, _))
+      .WillOnce(DoAll(GetArg3(&params), Return(kMobResultSuccess_)));
+
+  EXPECT_TRUE(command->CheckPermissions());
+  EXPECT_TRUE(params.end() !=
+              std::find(params.begin(), params.end(), kPolicyAppId_));
+}
+
+TEST_F(CommandRequestImplTest, AddDisallowedParameters_SUCCESS) {
+  const std::string kDisallowedParam =
+      ::application_manager::MessageHelper::vehicle_data().begin()->first;
+
+  MessageSharedPtr msg;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  command->removed_parameters_permissions().disallowed_params.push_back(
+      kDisallowedParam);
+
+  command->AddDisallowedParameters(*msg);
+
+  EXPECT_TRUE((*msg)[strings::msg_params].keyExists(kDisallowedParam));
+}
+
+TEST_F(CommandRequestImplTest, SendResponse_TimedOut_UNSUCCESS) {
+  CommandPtr command = CreateCommand<UCommandRequestImpl>();
+
+  command->set_current_state(RequestState::kTimedOut);
+
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+
+  // Args do not affect on anything in this case;
+  command->SendResponse(true, kMobResultSuccess_, NULL, NULL);
+
+  EXPECT_EQ(RequestState::kTimedOut, command->current_state());
+}
+
+TEST_F(CommandRequestImplTest, SendResponse_SUCCESS) {
+  MessageSharedPtr msg;
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  EXPECT_TRUE(smart_objects::SmartType_Null == (*msg).getType());
+
+  MessageSharedPtr result;
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+
+  // Args do not affect on anything in this case;
+  command->SendResponse(true, kMobResultSuccess_, NULL, NULL);
+
+  EXPECT_EQ(RequestState::kCompleted, command->current_state());
+
+  EXPECT_TRUE(smart_objects::SmartType_Map == (*msg).getType());
+}
+
+TEST_F(CommandRequestImplTest,
+       SendResponse_AddDisallowedParametersToInfo_SUCCESS) {
+  const std::string kDisallowedParam = "disallowed_param";
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::function_id] =
+      mobile_apis::FunctionID::SubscribeVehicleDataID;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+
+  command->removed_parameters_permissions().disallowed_params.push_back(
+      kDisallowedParam);
+
+  MessageSharedPtr result;
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+
+  command->SendResponse(true, kMobResultSuccess_, NULL, NULL);
+
+  EXPECT_EQ(RequestState::kCompleted, command->current_state());
+
+  EXPECT_TRUE((*result)[strings::msg_params].keyExists(strings::info));
+  EXPECT_NE("", (*result)[strings::msg_params][strings::info].asString());
+}
+
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/command_response_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_response_impl_test.cc
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command.h"
+#include "application_manager/commands/command_response_impl.h"
+#include "application_manager/mock_application.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+
+namespace strings = ::application_manager::strings;
+namespace hmi_response = ::application_manager::hmi_response;
+using ::utils::SharedPtr;
+using ::application_manager::commands::MessageSharedPtr;
+using ::application_manager::commands::CommandResponseImpl;
+
+class CommandResponseImplTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(CommandResponseImplTest, BasicMethodsOverloads_SUCCESS) {
+  SharedPtr<CommandResponseImpl> command = CreateCommand<CommandResponseImpl>();
+  // Current implementation always return `true`
+  EXPECT_TRUE(command->Init());
+  EXPECT_TRUE(command->CleanUp());
+  EXPECT_NO_THROW(command->Run());
+}
+
+TEST_F(CommandResponseImplTest, SendResponse_MessageWithResultCode_SUCCESS) {
+  MessageSharedPtr msg;
+  SharedPtr<CommandResponseImpl> command =
+      CreateCommand<CommandResponseImpl>(msg);
+  // Do not have a weight in this case
+  const bool kSuccess = true;
+  const mobile_apis::Result::eType kResultCode =
+      mobile_apis::Result::eType::INVALID_ENUM;
+  const bool kFinalResponse = true;
+
+  // If `msg_params->result_code` exist in message,
+  // then send message to mobile.
+  (*msg)[strings::msg_params][strings::result_code] = kResultCode;
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+
+  command->SendResponse(kSuccess, kResultCode, kFinalResponse);
+}
+
+TEST_F(CommandResponseImplTest,
+       SendResponse_EmptyMessageValidResultCode_SUCCESS) {
+  MessageSharedPtr msg;
+  SharedPtr<CommandResponseImpl> command =
+      CreateCommand<CommandResponseImpl>(msg);
+
+  const bool kSuccess = true;
+  const mobile_apis::Result::eType kResultCode =
+      mobile_apis::Result::eType::SUCCESS;
+  const bool kFinalResponse = true;
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+
+  // If `msg_params->result_code` does not exist in message
+  // and arg `result_code` not equals `INVALID_ENUM`,
+  // then set it to `msg_params->result_code` and send message to mobile.
+  command->SendResponse(kSuccess, kResultCode, kFinalResponse);
+
+  EXPECT_EQ(kResultCode,
+            (*msg)[strings::msg_params][strings::result_code].asInt());
+}
+
+TEST_F(CommandResponseImplTest,
+       SendResponse_EmptyMessageInvalidResultCode_SUCCESS) {
+  MessageSharedPtr msg;
+  SharedPtr<CommandResponseImpl> command =
+      CreateCommand<CommandResponseImpl>(msg);
+
+  const bool kSuccess = true;
+  const mobile_apis::Result::eType kResultCode =
+      mobile_apis::Result::eType::INVALID_ENUM;
+  const bool kFinalResponse = true;
+
+  // If `msg_params->result_code` does not exist in message
+  // and arg `result_code` equals `INVALID_ENUM`,
+  // then if `params->hmi_response::code` exist in message,
+  // then set it to `msg_params->result_code` and send message to mobile.
+  (*msg)[strings::params][hmi_response::code] = mobile_apis::Result::SUCCESS;
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+
+  command->SendResponse(kSuccess, kResultCode, kFinalResponse);
+
+  EXPECT_EQ((*msg)[strings::params][hmi_response::code].asInt(),
+            (*msg)[strings::msg_params][strings::result_code].asInt());
+}
+
+TEST_F(CommandResponseImplTest,
+       SendResponse_EmptyMessageInvalidResultCodeNoHmiResponse_SUCCESS) {
+  MessageSharedPtr msg;
+  SharedPtr<CommandResponseImpl> command =
+      CreateCommand<CommandResponseImpl>(msg);
+
+  const mobile_apis::Result::eType kResultCode =
+      mobile_apis::Result::eType::INVALID_ENUM;
+  const bool kFinalResponse = true;
+
+  // If `msg_params->result_code` does not exist in message
+  // and arg `result_code` equals `INVALID_ENUM`,
+  // then if `params->hmi_response::code` does not exist in message,
+  // then if `kSuccess` equals `true`,
+  // then `msg_params->result_code` will be `SUCCESS`
+  const bool kSuccess = true;
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+
+  command->SendResponse(kSuccess, kResultCode, kFinalResponse);
+
+  EXPECT_EQ(mobile_apis::Result::SUCCESS,
+            (*msg)[strings::msg_params][strings::result_code].asInt());
+}
+
+TEST_F(CommandResponseImplTest,
+       SendResponse_EmptyMessageInvalidResultCodeNoHmiResponse_INVALID_ENUM) {
+  MessageSharedPtr msg;
+  SharedPtr<CommandResponseImpl> command =
+      CreateCommand<CommandResponseImpl>(msg);
+
+  const mobile_apis::Result::eType kResultCode =
+      mobile_apis::Result::eType::INVALID_ENUM;
+  const bool kFinalResponse = true;
+
+  // If `msg_params->result_code` does not exist in message
+  // and arg `result_code` equals `INVALID_ENUM`,
+  // then if `params->hmi_response::code` does not exist in message,
+  // then if `kSuccess` equals `false`,
+  // then `msg_params->result_code` will be `INVALID_ENUM`
+  const bool kSuccess = false;
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+
+  command->SendResponse(kSuccess, kResultCode, kFinalResponse);
+
+  EXPECT_EQ(mobile_apis::Result::INVALID_ENUM,
+            (*msg)[strings::msg_params][strings::result_code].asInt());
+}
+
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/CMakeLists.txt
+++ b/src/components/application_manager/test/commands/mobile/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Copyright (c) 2016, Ford Motor Company
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the
+# distribution.
+#
+# Neither the name of the Ford Motor Company nor the names of its contributors
+# may be used to endorse or promote products derived from this software
+# without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+include_directories(
+  ${GMOCK_INCLUDE_DIRECTORY}
+  ${COMPONENTS_DIR}/application_manager/include/application_manager/commands/
+  ${COMPONENTS_DIR}/application_manager/test/include/
+  ${COMPONENTS_DIR}/application_manager/test/include/application_manager/
+)
+
+set (SOURCES
+  ${COMPONENTS_DIR}/application_manager/src/smart_object_keys.cc
+  ${AM_TEST_DIR}/commands/mobile/simple_response_commands.cc
+)
+
+set(LIBRARIES
+  gmock
+  Utils
+  ApplicationManager
+  connectionHandler
+  HMI_API
+  MOBILE_API
+  SmartObjects
+  MessageHelper
+)
+
+create_test("mobile_commands_test" "${SOURCES}" "${LIBRARIES}" )

--- a/src/components/application_manager/test/commands/mobile/simple_response_commands.cc
+++ b/src/components/application_manager/test/commands/mobile/simple_response_commands.cc
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "commands/commands_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "mobile/read_did_response.h"
+#include "mobile/alert_maneuver_response.h"
+#include "mobile/alert_response.h"
+#include "mobile/list_files_response.h"
+#include "mobile/subscribe_button_response.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using ::testing::_;
+using ::testing::NotNull;
+using ::testing::Types;
+namespace commands = ::application_manager::commands;
+using commands::MessageSharedPtr;
+
+template <class Command>
+class MobileResponseCommandsTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  typedef Command CommandType;
+};
+
+typedef Types<commands::ListFilesResponse,
+              commands::ReadDIDResponse,
+              commands::AlertManeuverResponse,
+              commands::AlertResponse,
+              commands::SubscribeButtonResponse> ResponseCommandsList;
+TYPED_TEST_CASE(MobileResponseCommandsTest, ResponseCommandsList);
+
+TYPED_TEST(MobileResponseCommandsTest, Run_SendResponseToMobile_SUCCESS) {
+  ::utils::SharedPtr<typename TestFixture::CommandType> command =
+      this->template CreateCommand<typename TestFixture::CommandType>();
+  EXPECT_CALL(this->app_mngr_, SendMessageToMobile(NotNull(), _));
+  command->Run();
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/include/application_manager/commands/command_request_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/command_request_test.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_COMMAND_RESPONSES_TEST_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_COMMAND_RESPONSES_TEST_H_
+
+#include <stdint.h>
+
+#include "gtest/gtest.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/mock_event_dispatcher.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+
+using ::testing::ReturnRef;
+using ::testing::NiceMock;
+using ::test::components::event_engine_test::MockEventDispatcher;
+using ::application_manager::commands::Command;
+
+template <const CommandsTestMocks kIsNice = CommandsTestMocks::kNotNice>
+class CommandRequestTest : public CommandsTest<kIsNice> {
+ public:
+  typedef typename TypeIf<kIsNice,
+                          NiceMock<MockEventDispatcher>,
+                          MockEventDispatcher>::Result MockEventDisp;
+
+  MockEventDisp event_dispatcher_;
+
+ protected:
+  CommandRequestTest() : CommandsTest<kIsNice>() {}
+
+  virtual void InitCommand(const uint32_t& default_timeout) OVERRIDE {
+    CommandsTest<kIsNice>::InitCommand(default_timeout);
+    EXPECT_CALL(CommandsTest<kIsNice>::app_mngr_, event_dispatcher())
+        .WillOnce(ReturnRef(event_dispatcher_));
+  }
+};
+
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_COMMAND_RESPONSES_TEST_H_

--- a/src/components/application_manager/test/include/application_manager/commands/commands_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/commands_test.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_COMMANDS_TEST_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_COMMANDS_TEST_H_
+
+#include <stdint.h>
+#include "gtest/gtest.h"
+
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/commands/command.h"
+#include "utils/make_shared.h"
+#include "application_manager/mock_application_manager.h"
+#include "test/application_manager/mock_application_manager_settings.h"
+#include "application_manager/mock_application.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+
+using ::testing::ReturnRef;
+using ::testing::NiceMock;
+
+using ::utils::SharedPtr;
+using ::smart_objects::SmartObject;
+using ::application_manager::commands::MessageSharedPtr;
+using ::test::components::application_manager_test::MockApplicationManager;
+using ::test::components::application_manager_test::
+    MockApplicationManagerSettings;
+using ::application_manager::ApplicationSharedPtr;
+using ::test::components::application_manager_test::MockApplication;
+
+// Depending on the value type will be selected
+template <const bool kIf, class ThenT, class ElseT>
+struct TypeIf {
+  typedef ThenT Result;
+};
+template <class ThenT, class ElseT>
+struct TypeIf<false, ThenT, ElseT> {
+  typedef ElseT Result;
+};
+
+// If `kIsNice` is `true` then all used mock types
+// will be wrapped by a `NiceMock`
+
+enum CommandsTestMocks { kNotNice = 0, kIsNice };
+
+template <const CommandsTestMocks kIsNice = CommandsTestMocks::kNotNice>
+class CommandsTest : public ::testing::Test {
+ public:
+  typedef NiceMock<MockApplicationManagerSettings> MockAppManagerSettings;
+  typedef typename TypeIf<kIsNice,
+                          NiceMock<MockApplicationManager>,
+                          MockApplicationManager>::Result MockAppManager;
+  typedef typename TypeIf<kIsNice,
+                          NiceMock<MockApplication>,
+                          MockApplication>::Result MockApp;
+
+  typedef SharedPtr<MockApp> MockAppPtr;
+
+  virtual ~CommandsTest() {}
+
+  static MessageSharedPtr CreateMessage(
+      const smart_objects::SmartType type = smart_objects::SmartType_Null) {
+    return ::utils::MakeShared<SmartObject>(type);
+  }
+
+  static MockAppPtr CreateMockApp() {
+    return ::utils::MakeShared<MockApp>();
+  }
+
+  template <class Command>
+  SharedPtr<Command> CreateCommand(const uint32_t timeout,
+                                   MessageSharedPtr& msg) {
+    InitCommand(timeout);
+    return ::utils::MakeShared<Command>((msg ? msg : msg = CreateMessage()),
+                                        app_mngr_);
+  }
+
+  template <class Command>
+  SharedPtr<Command> CreateCommand(MessageSharedPtr& msg) {
+    return CreateCommand<Command>(kDefaultTimeout_, msg);
+  }
+
+  template <class Command>
+  SharedPtr<Command> CreateCommand(const uint32_t timeout = kDefaultTimeout_) {
+    InitCommand(timeout);
+    MessageSharedPtr msg = CreateMessage();
+    return ::utils::MakeShared<Command>(msg, app_mngr_);
+  }
+
+  enum { kDefaultTimeout_ = 100u };
+
+  MockAppManager app_mngr_;
+  MockAppManagerSettings app_mngr_settings_;
+
+ protected:
+  virtual void InitCommand(const uint32_t& timeout) {
+    EXPECT_CALL(app_mngr_, get_settings())
+        .WillOnce(ReturnRef(app_mngr_settings_));
+    ON_CALL(app_mngr_settings_, default_timeout())
+        .WillByDefault(ReturnRef(timeout));
+  }
+
+  CommandsTest() {}
+};
+
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_COMMANDS_TEST_H_


### PR DESCRIPTION
Been done:
- Added specific abstract classes for
  commands testing (CommandsTest
  and CommandRequestTest);
- Been added unit tests for base
  command classes (CommandImpl,
  CommandRequestImpl, CommandResponseImpl);
- Been added unit tests for next
  mobile response commands:
  - ListFilesResponse
  - ReadDIDResponse
  - AlertManeuverResponse
  - AlertResponse
  - SubscribeButtonResponse

Recreated pull request [#578](https://github.com/smartdevicelink/sdl_core/pull/578)

Related to: APPLINK-24911