### PR TITLE
Parse PT String for HTTP Request Body

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/on_system_request_notification.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/on_system_request_notification.h
@@ -72,7 +72,7 @@ class OnSystemRequestNotification : public CommandNotificationImpl {
    * @param message Message
    */
   void AddHeader(BinaryMessage& message) const;
-  std::string ParsePTString(std::string& pt_string) const;
+  void ParsePTString(std::string& pt_string) const;
 #endif
 
   DISALLOW_COPY_AND_ASSIGN(OnSystemRequestNotification);

--- a/src/components/application_manager/include/application_manager/commands/mobile/on_system_request_notification.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/on_system_request_notification.h
@@ -72,6 +72,7 @@ class OnSystemRequestNotification : public CommandNotificationImpl {
    * @param message Message
    */
   void AddHeader(BinaryMessage& message) const;
+  std::string ParsePTString(std::string& pt_string) const;
 #endif
 
   DISALLOW_COPY_AND_ASSIGN(OnSystemRequestNotification);

--- a/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
@@ -116,8 +116,8 @@ void OnSystemRequestNotification::AddHeader(BinaryMessage& message) const {
   if (0 > sprintf(timeout_str, "%d", timeout)) {
     memset(timeout_str, 0, sizeof(timeout_str));
   }
-  std::string temp_string = std::string(message.begin(), message.end());
-  std::string policy_table_string = ParsePTString(temp_string);
+  std::string policy_table_string = std::string(message.begin(), message.end());
+  ParsePTString(policy_table_string);
   const std::string header =
 
   "{"
@@ -145,11 +145,11 @@ void OnSystemRequestNotification::AddHeader(BinaryMessage& message) const {
       logger_, "Header added: " << std::string(message.begin(), message.end()));
 }
 
-std::string OnSystemRequestNotification::ParsePTString(std::string& pt_string) const{
+void OnSystemRequestNotification::ParsePTString(std::string& pt_string) const{
   std::string result;
-  int length = pt_string.length();  
+  size_t length = pt_string.length();  
   result.reserve(length*2);
-  for(int i=0;i<length;++i){
+  for(size_t i=0;i<length;++i){
     if(pt_string[i]=='\"' || pt_string[i]=='\\'){
       result += '\\';
     } else if(pt_string[i] == '\n') {
@@ -157,7 +157,7 @@ std::string OnSystemRequestNotification::ParsePTString(std::string& pt_string) c
     }
     result += pt_string[i];
   }
-  return result;
+  pt_string = result;
 }
 #endif
 

--- a/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
@@ -116,7 +116,8 @@ void OnSystemRequestNotification::AddHeader(BinaryMessage& message) const {
   if (0 > sprintf(timeout_str, "%d", timeout)) {
     memset(timeout_str, 0, sizeof(timeout_str));
   }
-
+  std::string temp_string = std::string(message.begin(), message.end());
+  std::string policy_table_string = ParsePTString(temp_string);
   const std::string header =
 
   "{"
@@ -133,7 +134,7 @@ void OnSystemRequestNotification::AddHeader(BinaryMessage& message) const {
               "\"charset\": \"utf-8\","
               "\"Content_Length\": " + std::string(size_str) +
           "},"
-          "\"body\": \"" + std::string(message.begin(), message.end()) + "\""
+          "\"body\": \"" + policy_table_string + "\""
       "}"
   "}";
 
@@ -142,6 +143,21 @@ void OnSystemRequestNotification::AddHeader(BinaryMessage& message) const {
 
   LOG4CXX_DEBUG(
       logger_, "Header added: " << std::string(message.begin(), message.end()));
+}
+
+std::string OnSystemRequestNotification::ParsePTString(std::string& pt_string) const{
+  std::string result;
+  int length = pt_string.length();  
+  result.reserve(length*2);
+  for(int i=0;i<length;++i){
+    if(pt_string[i]=='\"' || pt_string[i]=='\\'){
+      result += '\\';
+    } else if(pt_string[i] == '\n') {
+      continue;
+    }
+    result += pt_string[i];
+  }
+  return result;
 }
 #endif
 


### PR DESCRIPTION
The "body" portion of the httprequest needs to be a valid string. Before this fix, the policy table content of the request did not have properly escaped double quotes and was causing the JSON received by the mobile side to be considered invalid.

The new method "ParsePtString()" adds an escaped backslash for every occurance of a double quote or other escaped backslash. This method also removes any newlines located in the policy table string.