### PR TITLE
Minor fix for MSVC build

### DIFF
--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -417,7 +417,7 @@ TEST_F(PolicyHandlerTest, CheckPermissions) {
   // Arrange
   EnablePolicyAndPolicyManagerMock();
   CheckPermissionResult result;
-  RPCParams kRpc_params;
+  policy::RPCParams kRpc_params;
   // Check expectations
   EXPECT_CALL(
       *mock_policy_manager_,


### PR DESCRIPTION
Add explicit namespace specifying to avoid MSVC compiler `ambiguous symbol` error

Related-issues: APPLINK-22713, APPLINK-22716

@nk0leg, @LuxoftAKutsan, @dev-gh, @LevchenkoS, @Kozoriz please review