### PR TITLE
SDL does not resend appID and wayPointType in GetWayPoints rps to HMI

### DIFF
--- a/src/components/application_manager/src/commands/mobile/get_way_points_request.cc
+++ b/src/components/application_manager/src/commands/mobile/get_way_points_request.cc
@@ -23,8 +23,14 @@ void GetWayPointsRequest::Run() {
     SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
     return;
   }
+  smart_objects::SmartObject msg_params =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
 
-  SendHMIRequest(hmi_apis::FunctionID::Navigation_GetWayPoints, NULL, true);
+  msg_params = (*message_)[strings::msg_params];
+  msg_params[strings::app_id] = app->app_id();
+  SendHMIRequest(hmi_apis::FunctionID::Navigation_GetWayPoints,
+                 msg_params.empty() ? NULL : &msg_params,
+                 true);
 }
 
 void GetWayPointsRequest::on_event(const event_engine::Event& event) {

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -3240,7 +3240,7 @@
   </function>
 </interface>
 
-<interface name="Navigation" version="1.1" date="2016-05-11">
+<interface name="Navigation" version="1.2" date="2016-06-09">
 
   <function name="IsReady" messagetype="request">
     <description>Method is invoked at system startup. Response must provide the information about presence of UI Navigation module and its readiness to cooperate with SDL.</description>
@@ -3410,6 +3410,9 @@
     <param name="wayPointType" type="Common.WayPointType" defvalue="ALL" mandatory="false">
       <description>To request for either the destination only or for all waypoints including destination</description>
     </param>
+    <param name="appID" type="Integer" mandatory="true"> 
+      <description>ID of the application.</description> 
+    </param> 
   </function>
   <function name="GetWayPoints" functionID="GetWayPointsID" messagetype="response">
     <param name="appID" type="Integer" mandatory="true">


### PR DESCRIPTION
Add parameters in mobile command

Closes bug [APPLINK-23766](https://adc.luxoft.com/jira/browse/APPLINK-23766)