### PR TITLE
Divide `HMICapabilities` into interface and implementation

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -39,6 +39,7 @@
 #include <set>
 #include <deque>
 #include <algorithm>
+#include <memory>
 
 #include "application_manager/hmi_command_factory.h"
 #include "application_manager/application_manager.h"
@@ -1418,7 +1419,7 @@ class ApplicationManagerImpl
   // Thread that pumps messages audio pass thru to mobile.
   impl::AudioPassThruQueue audio_pass_thru_messages_;
 
-  HMICapabilities hmi_capabilities_;
+  std::auto_ptr<HMICapabilities> hmi_capabilities_;
   // The reason of HU shutdown
   mobile_api::AppInterfaceUnregisteredReason::eType unregister_reason_;
 

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -30,9 +30,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_H_
-#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_H_
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_IMPL_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_IMPL_H_
 
+#include "application_manager/hmi_capabilities.h"
 #include "interfaces/HMI_API.h"
 #include "interfaces/MOBILE_API.h"
 #include "json/json.h"
@@ -43,38 +44,39 @@
 namespace NsSmartDeviceLink {
 namespace NsSmartObjects {
 class SmartObject;
-}
-}
+}  // namespace NsSmartObjects
+}  // namespace NsSmartDeviceLink
+
 namespace resumption {
 class LastState;
-}
+}  // namespace resumption
 
 namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 namespace application_manager {
 class ApplicationManager;
 
-class HMICapabilities {
+class HMICapabilitiesImpl : public HMICapabilities {
  public:
   /*
    * @ Class constructor
    *
    * @param app_mngr Application manager pointer
    */
-  explicit HMICapabilities(ApplicationManager& app_mngr);
+  explicit HMICapabilitiesImpl(ApplicationManager& app_mngr);
 
   /*
    * @brief Class destructor
    *
    */
-  virtual ~HMICapabilities();
+  virtual ~HMICapabilitiesImpl();
 
   /**
    * @brief Checks if all HMI capabilities received
    *
    * @return TRUE if all information received, otherwise FALSE
    */
-  bool is_hmi_capabilities_initialized() const;
+  bool is_hmi_capabilities_initialized() const OVERRIDE;
 
   /*
    * @brief Checks is image type(Static/Dynamic) requested by
@@ -82,323 +84,27 @@ class HMICapabilities {
    * @param image_type recieved type of image from Enum.
    * @return Bool true if supported
    */
-  bool VerifyImageType(int32_t image_type) const;
+  bool VerifyImageType(const int32_t image_type) const OVERRIDE;
 
   /**
    * @brief Checks if all HMI capabilities received
    *
    * @return TRUE if all information received, otherwise FALSE
    */
-  inline bool is_vr_cooperating() const;
-  void set_is_vr_cooperating(bool value);
+  bool is_vr_cooperating() const OVERRIDE;
+  void set_is_vr_cooperating(const bool value) OVERRIDE;
 
-  inline bool is_tts_cooperating() const;
-  void set_is_tts_cooperating(bool value);
+  bool is_tts_cooperating() const OVERRIDE;
+  void set_is_tts_cooperating(const bool value) OVERRIDE;
 
-  inline bool is_ui_cooperating() const;
-  void set_is_ui_cooperating(bool value);
+  bool is_ui_cooperating() const OVERRIDE;
+  void set_is_ui_cooperating(const bool value) OVERRIDE;
 
-  inline bool is_navi_cooperating() const;
-  void set_is_navi_cooperating(bool value);
+  bool is_navi_cooperating() const OVERRIDE;
+  void set_is_navi_cooperating(const bool value) OVERRIDE;
 
-  inline bool is_ivi_cooperating() const;
-  void set_is_ivi_cooperating(bool value);
-
-  /*
-   * @brief Retrieves if mixing audio is supported by HMI
-   * (ie recording TTS command and playing audio)
-   *
-   * @return Current state of the mixing audio flag
-   */
-  inline bool attenuated_supported() const;
-
-  /*
-   * @brief Sets state for mixing audio
-   *
-   * @param state New state to be set
-   */
-  void set_attenuated_supported(bool state);
-
-  /*
-   * @brief Retrieves currently active UI language
-   *
-   * @return Currently active UI language
-   */
-  const hmi_apis::Common_Language::eType active_ui_language() const;
-
-  /*
-   * @brief Sets currently active UI language
-   *
-   * @param language Currently active UI language
-   */
-  void set_active_ui_language(const hmi_apis::Common_Language::eType& language);
-
-  /*
-   * @brief Retrieves UI supported languages
-   *
-   * @return Currently supported UI languages
-   */
-  inline const smart_objects::SmartObject* ui_supported_languages() const;
-
-  /*
-   * @brief Sets supported UI languages
-   *
-   * @param supported_languages Supported UI languages
-   */
-  void set_ui_supported_languages(
-      const smart_objects::SmartObject& supported_languages);
-
-  /*
-   * @brief Retrieves currently active VR language
-   *
-   * @return Currently active VR language
-   */
-  const hmi_apis::Common_Language::eType active_vr_language() const;
-
-  /*
-   * @brief Sets currently active VR language
-   *
-   * @param language Currently active VR language
-   */
-  void set_active_vr_language(const hmi_apis::Common_Language::eType& language);
-
-  /*
-   * @brief Retrieves VR supported languages
-   *
-   * @return Currently supported VR languages
-   */
-  inline const smart_objects::SmartObject* vr_supported_languages() const;
-
-  /*
-   * @brief Sets supported VR languages
-   *
-   * @param supported_languages Supported VR languages
-   */
-  void set_vr_supported_languages(
-      const smart_objects::SmartObject& supported_languages);
-
-  /*
-   * @brief Retrieves currently active TTS language
-   *
-   * @return Currently active TTS language
-   */
-  const hmi_apis::Common_Language::eType active_tts_language() const;
-
-  /*
-   * @brief Sets currently active TTS language
-   *
-   * @param language Currently active TTS language
-   */
-  void set_active_tts_language(
-      const hmi_apis::Common_Language::eType& language);
-
-  /*
-   * @brief Retrieves TTS  supported languages
-   *
-   * @return Currently supported TTS languages
-   */
-  inline const smart_objects::SmartObject* tts_supported_languages() const;
-
-  /*
-   * @brief Sets supported TTS languages
-   *
-   * @param supported_languages Supported TTS languages
-   */
-  void set_tts_supported_languages(
-      const smart_objects::SmartObject& supported_languages);
-
-  /*
-   * @brief Retrieves information about the display capabilities
-   *
-   * @return Currently supported display capabilities
-   */
-  inline const smart_objects::SmartObject* display_capabilities() const;
-
-  /*
-   * @brief Sets supported display capabilities
-   *
-   * @param display_capabilities supported display capabilities
-   */
-  void set_display_capabilities(
-      const smart_objects::SmartObject& display_capabilities);
-
-  /*
-   * @brief Retrieves information about the HMI zone capabilities
-   *
-   * @return Currently supported HMI zone capabilities
-   */
-  inline const smart_objects::SmartObject* hmi_zone_capabilities() const;
-
-  /*
-   * @brief Sets supported HMI zone capabilities
-   *
-   * @param hmi_zone_capabilities supported HMI zone capabilities
-   */
-  void set_hmi_zone_capabilities(
-      const smart_objects::SmartObject& hmi_zone_capabilities);
-
-  /*
-   * @brief Retrieves information about the SoftButton's capabilities
-   *
-   * @return Currently supported SoftButton's capabilities
-   */
-  inline const smart_objects::SmartObject* soft_button_capabilities() const;
-
-  /*
-   * @brief Sets supported SoftButton's capabilities
-   *
-   * @param soft_button_capabilities supported SoftButton's capabilities
-   */
-  void set_soft_button_capabilities(
-      const smart_objects::SmartObject& soft_button_capabilities);
-
-  /*
-   * @brief Retrieves information about the Button's capabilities
-   *
-   * @return Currently supported Button's capabilities
-   */
-  inline const smart_objects::SmartObject* button_capabilities() const;
-
-  /*
-   * @brief Sets supported Button's capabilities
-   *
-   * @param soft_button_capabilities supported Button's capabilities
-   */
-  void set_button_capabilities(
-      const smart_objects::SmartObject& button_capabilities);
-
-  /*
-   * @brief Sets supported speech capabilities
-   *
-   * @param speech_capabilities supported speech capabilities
-   */
-  void set_speech_capabilities(
-      const smart_objects::SmartObject& speech_capabilities);
-
-  /*
-   * @brief Retrieves information about the speech capabilities
-   *
-   * @return Currently supported speech capabilities
-   */
-  inline const smart_objects::SmartObject* speech_capabilities() const;
-
-  /*
-   * @brief Sets supported VR capabilities
-   *
-   * @param vr_capabilities supported VR capabilities
-   */
-  void set_vr_capabilities(const smart_objects::SmartObject& vr_capabilities);
-
-  /*
-   * @brief Retrieves information about the VR capabilities
-   *
-   * @return Currently supported VR capabilities
-   */
-  inline const smart_objects::SmartObject* vr_capabilities() const;
-
-  /*
-   * @brief Sets supported audio_pass_thru capabilities
-   *
-   * @param vr_capabilities supported audio_pass_thru capabilities
-   */
-  void set_audio_pass_thru_capabilities(
-      const smart_objects::SmartObject& audio_pass_thru_capabilities);
-
-  /*
-   * @brief Sets supported pcm_stream capabilities
-   *
-   * @param supported pcm stream capabilities
-   */
-  void set_pcm_stream_capabilities(
-      const smart_objects::SmartObject& pcm_stream_capabilities);
-
-  /*
-   * @brief Retrieves information about the audio_pass_thru capabilities
-   *
-   * @return Currently supported audio_pass_thru capabilities
-   */
-  inline const smart_objects::SmartObject* audio_pass_thru_capabilities() const;
-
-  /*
-   * @brief Retrieves information about the pcm_stream capabilities
-   *
-   * @return Currently supported pcm_streaming capabilities
-   */
-  inline const smart_objects::SmartObject* pcm_stream_capabilities() const;
-
-  /*
-   * @brief Retrieves information about the preset bank capabilities
-   *
-   * @return Currently supported preset bank capabilities
-   */
-  inline const smart_objects::SmartObject* preset_bank_capabilities() const;
-
-  /*
-   * @brief Sets supported preset bank capabilities
-   *
-   * @param soft_button_capabilities supported preset bank capabilities
-   */
-  void set_preset_bank_capabilities(
-      const smart_objects::SmartObject& preset_bank_capabilities);
-
-  /*
-   * @brief Sets vehicle information(make, model, modelYear)
-   *
-   * @param vehicle_type Cuurent vehicle information
-   */
-  void set_vehicle_type(const smart_objects::SmartObject& vehicle_type);
-
-  /*
-   * @brief Retrieves vehicle information(make, model, modelYear)
-   *
-   * @param vehicle_type Cuurent vehicle information
-   */
-  inline const smart_objects::SmartObject* vehicle_type() const;
-
-  /*
-   * @brief Retrieves information about the prerecorded speech
-   *
-   * @return Currently supported prerecorded speech
-   */
-  inline const smart_objects::SmartObject* prerecorded_speech() const;
-
-  /*
-   * @brief Sets supported prerecorded speech
-   *
-   * @param prerecorded_speech supported prerecorded speech
-   */
-  void set_prerecorded_speech(
-      const smart_objects::SmartObject& prerecorded_speech);
-
-  /*
-   * @brief Interface used to store information if navigation
-   * supported by the system
-   *
-   * @param supported Indicates if navigation supported by the system
-   */
-  void set_navigation_supported(bool supported);
-
-  /*
-   * @brief Retrieves information if navi supported by the system
-   *
-   * @return TRUE if it supported, otherwise FALSE
-   */
-  inline bool navigation_supported() const;
-
-  /*
-   * @brief Interface used to store information if phone call
-   * supported by the system
-   *
-   * @param supported Indicates if navigation supported by the sustem
-   */
-  void set_phone_call_supported(bool supported);
-
-  /*
-   * @brief Retrieves information if phone call supported by the system
-   *
-   * @return TRUE if it supported, otherwise FALSE
-   */
-  inline bool phone_call_supported() const;
+  bool is_ivi_cooperating() const OVERRIDE;
+  void set_is_ivi_cooperating(const bool value) OVERRIDE;
 
   /*
    * @brief Interface used to store information about software version of the
@@ -406,14 +112,315 @@ class HMICapabilities {
    *
    * @param ccpu_version Received system/hmi software version
    */
-  void set_ccpu_version(const std::string& ccpu_version);
+  void set_ccpu_version(const std::string& ccpu_version) OVERRIDE;
 
   /*
    * @brief Returns software version of the target
    *
    * @return TRUE if it supported, otherwise FALSE
    */
-  inline const std::string& ccpu_version() const;
+  const std::string& ccpu_version() const OVERRIDE;
+
+  /*
+   * @brief Retrieves if mixing audio is supported by HMI
+   * (ie recording TTS command and playing audio)
+   *
+   * @return Current state of the mixing audio flag
+   */
+  bool attenuated_supported() const OVERRIDE;
+
+  /*
+   * @brief Sets state for mixing audio
+   *
+   * @param state New state to be set
+   */
+  void set_attenuated_supported(const bool state) OVERRIDE;
+
+  /*
+   * @brief Retrieves currently active UI language
+   *
+   * @return Currently active UI language
+   */
+  const hmi_apis::Common_Language::eType active_ui_language() const OVERRIDE;
+
+  /*
+   * @brief Sets currently active UI language
+   *
+   * @param language Currently active UI language
+   */
+  void set_active_ui_language(
+      const hmi_apis::Common_Language::eType language) OVERRIDE;
+
+  /*
+   * @brief Retrieves UI supported languages
+   *
+   * @return Currently supported UI languages
+   */
+  const smart_objects::SmartObject* ui_supported_languages() const OVERRIDE;
+
+  /*
+   * @brief Sets supported UI languages
+   *
+   * @param supported_languages Supported UI languages
+   */
+  void set_ui_supported_languages(
+      const smart_objects::SmartObject& supported_languages) OVERRIDE;
+
+  /*
+   * @brief Retrieves currently active VR language
+   *
+   * @return Currently active VR language
+   */
+  const hmi_apis::Common_Language::eType active_vr_language() const OVERRIDE;
+
+  /*
+   * @brief Sets currently active VR language
+   *
+   * @param language Currently active VR language
+   */
+  void set_active_vr_language(
+      const hmi_apis::Common_Language::eType language) OVERRIDE;
+
+  /*
+   * @brief Retrieves VR supported languages
+   *
+   * @return Currently supported VR languages
+   */
+  const smart_objects::SmartObject* vr_supported_languages() const OVERRIDE;
+
+  /*
+   * @brief Sets supported VR languages
+   *
+   * @param supported_languages Supported VR languages
+   */
+  void set_vr_supported_languages(
+      const smart_objects::SmartObject& supported_languages) OVERRIDE;
+
+  /*
+   * @brief Retrieves currently active TTS language
+   *
+   * @return Currently active TTS language
+   */
+  const hmi_apis::Common_Language::eType active_tts_language() const OVERRIDE;
+
+  /*
+   * @brief Sets currently active TTS language
+   *
+   * @param language Currently active TTS language
+   */
+  void set_active_tts_language(
+      const hmi_apis::Common_Language::eType language) OVERRIDE;
+
+  /*
+   * @brief Retrieves TTS  supported languages
+   *
+   * @return Currently supported TTS languages
+   */
+  const smart_objects::SmartObject* tts_supported_languages() const OVERRIDE;
+
+  /*
+   * @brief Sets supported TTS languages
+   *
+   * @param supported_languages Supported TTS languages
+   */
+  void set_tts_supported_languages(
+      const smart_objects::SmartObject& supported_languages) OVERRIDE;
+
+  /*
+   * @brief Retrieves information about the display capabilities
+   *
+   * @return Currently supported display capabilities
+   */
+  const smart_objects::SmartObject* display_capabilities() const OVERRIDE;
+
+  /*
+   * @brief Sets supported display capabilities
+   *
+   * @param display_capabilities supported display capabilities
+   */
+  void set_display_capabilities(
+      const smart_objects::SmartObject& display_capabilities) OVERRIDE;
+
+  /*
+   * @brief Retrieves information about the HMI zone capabilities
+   *
+   * @return Currently supported HMI zone capabilities
+   */
+  const smart_objects::SmartObject* hmi_zone_capabilities() const OVERRIDE;
+
+  /*
+   * @brief Sets supported HMI zone capabilities
+   *
+   * @param hmi_zone_capabilities supported HMI zone capabilities
+   */
+  void set_hmi_zone_capabilities(
+      const smart_objects::SmartObject& hmi_zone_capabilities) OVERRIDE;
+
+  /*
+   * @brief Retrieves information about the SoftButton's capabilities
+   *
+   * @return Currently supported SoftButton's capabilities
+   */
+  const smart_objects::SmartObject* soft_button_capabilities() const OVERRIDE;
+
+  /*
+   * @brief Sets supported SoftButton's capabilities
+   *
+   * @param soft_button_capabilities supported SoftButton's capabilities
+   */
+  void set_soft_button_capabilities(
+      const smart_objects::SmartObject& soft_button_capabilities) OVERRIDE;
+
+  /*
+   * @brief Retrieves information about the Button's capabilities
+   *
+   * @return Currently supported Button's capabilities
+   */
+  const smart_objects::SmartObject* button_capabilities() const OVERRIDE;
+
+  /*
+   * @brief Sets supported Button's capabilities
+   *
+   * @param soft_button_capabilities supported Button's capabilities
+   */
+  void set_button_capabilities(
+      const smart_objects::SmartObject& button_capabilities) OVERRIDE;
+
+  /*
+   * @brief Sets supported speech capabilities
+   *
+   * @param speech_capabilities supported speech capabilities
+   */
+  void set_speech_capabilities(
+      const smart_objects::SmartObject& speech_capabilities) OVERRIDE;
+
+  /*
+   * @brief Retrieves information about the speech capabilities
+   *
+   * @return Currently supported speech capabilities
+   */
+  const smart_objects::SmartObject* speech_capabilities() const OVERRIDE;
+
+  /*
+   * @brief Sets supported VR capabilities
+   *
+   * @param vr_capabilities supported VR capabilities
+   */
+  void set_vr_capabilities(
+      const smart_objects::SmartObject& vr_capabilities) OVERRIDE;
+
+  /*
+   * @brief Retrieves information about the VR capabilities
+   *
+   * @return Currently supported VR capabilities
+   */
+  const smart_objects::SmartObject* vr_capabilities() const OVERRIDE;
+
+  /*
+   * @brief Sets supported audio_pass_thru capabilities
+   *
+   * @param vr_capabilities supported audio_pass_thru capabilities
+   */
+  void set_audio_pass_thru_capabilities(
+      const smart_objects::SmartObject& audio_pass_thru_capabilities) OVERRIDE;
+
+  /*
+   * @brief Retrieves information about the audio_pass_thru capabilities
+   *
+   * @return Currently supported audio_pass_thru capabilities
+   */
+  const smart_objects::SmartObject* audio_pass_thru_capabilities()
+      const OVERRIDE;
+
+  /*
+   * @brief Sets supported pcm_stream capabilities
+   *
+   * @param supported pcm_stream capabilities
+   */
+  void set_pcm_stream_capabilities(
+      const smart_objects::SmartObject& pcm_stream_capabilities) OVERRIDE;
+
+  /*
+   * @brief Retrieves information about the pcm_stream capabilities
+   *
+   * @return Currently supported pcm_streaming capabilities
+   */
+  const smart_objects::SmartObject* pcm_stream_capabilities() const OVERRIDE;
+
+  /*
+   * @brief Retrieves information about the preset bank capabilities
+   *
+   * @return Currently supported preset bank capabilities
+   */
+  const smart_objects::SmartObject* preset_bank_capabilities() const OVERRIDE;
+
+  /*
+   * @brief Sets supported preset bank capabilities
+   *
+   * @param soft_button_capabilities supported preset bank capabilities
+   */
+  void set_preset_bank_capabilities(
+      const smart_objects::SmartObject& preset_bank_capabilities) OVERRIDE;
+
+  /*
+   * @brief Sets vehicle information(make, model, modelYear)
+   *
+   * @param vehicle_type Cuurent vehicle information
+   */
+  void set_vehicle_type(
+      const smart_objects::SmartObject& vehicle_type) OVERRIDE;
+
+  /*
+   * @brief Retrieves vehicle information(make, model, modelYear)
+   *
+   * @param vehicle_type Cuurent vehicle information
+   */
+  const smart_objects::SmartObject* vehicle_type() const OVERRIDE;
+
+  /*
+   * @brief Retrieves information about the prerecorded speech
+   *
+   * @return Currently supported prerecorded speech
+   */
+  const smart_objects::SmartObject* prerecorded_speech() const OVERRIDE;
+
+  /*
+   * @brief Sets supported prerecorded speech
+   *
+   * @param prerecorded_speech supported prerecorded speech
+   */
+  void set_prerecorded_speech(
+      const smart_objects::SmartObject& prerecorded_speech) OVERRIDE;
+
+  /*
+   * @brief Interface used to store information if navigation
+   * supported by the system
+   *
+   * @param supported Indicates if navigation supported by the system
+   */
+  void set_navigation_supported(const bool supported) OVERRIDE;
+
+  /*
+   * @brief Retrieves information if navi supported by the system
+   *
+   * @return TRUE if it supported, otherwise FALSE
+   */
+  bool navigation_supported() const OVERRIDE;
+
+  /*
+   * @brief Interface used to store information if phone call
+   * supported by the system
+   *
+   * @param supported Indicates if navigation supported by the sustem
+   */
+  void set_phone_call_supported(const bool supported) OVERRIDE;
+
+  /*
+   * @brief Retrieves information if phone call supported by the system
+   *
+   * @return TRUE if it supported, otherwise FALSE
+   */
+  bool phone_call_supported() const OVERRIDE;
 
   void Init(resumption::LastState* last_state);
 
@@ -437,7 +444,18 @@ class HMICapabilities {
    * member does not exist.
    */
   bool check_existing_json_member(const Json::Value& json_member,
-                                  const char* name_of_member);
+                                  const char* name_of_member) const OVERRIDE;
+
+  /*
+   * @brief function converts json object "languages" to smart object
+   *
+   * @param json_languages from file hmi_capabilities.json
+   * @param languages - the converted object
+   *
+   */
+  void convert_json_languages_to_obj(
+      const Json::Value& json_languages,
+      smart_objects::SmartObject& languages) const OVERRIDE;
 
  private:
   bool is_vr_cooperating_;
@@ -471,117 +489,16 @@ class HMICapabilities {
   smart_objects::SmartObject* audio_pass_thru_capabilities_;
   smart_objects::SmartObject* pcm_stream_capabilities_;
   smart_objects::SmartObject* prerecorded_speech_;
-  std::string ccpu_version_;
   bool is_navigation_supported_;
   bool is_phone_call_supported_;
+  std::string ccpu_version_;
 
   ApplicationManager& app_mngr_;
   HMILanguageHandler hmi_language_handler_;
 
-  DISALLOW_COPY_AND_ASSIGN(HMICapabilities);
+  DISALLOW_COPY_AND_ASSIGN(HMICapabilitiesImpl);
 };
-
-bool HMICapabilities::is_ui_cooperating() const {
-  return is_ui_cooperating_;
-}
-
-bool HMICapabilities::is_vr_cooperating() const {
-  return is_vr_cooperating_;
-}
-
-bool HMICapabilities::is_tts_cooperating() const {
-  return is_tts_cooperating_;
-}
-
-bool HMICapabilities::is_navi_cooperating() const {
-  return is_navi_cooperating_;
-}
-
-bool HMICapabilities::is_ivi_cooperating() const {
-  return is_ivi_cooperating_;
-}
-
-const smart_objects::SmartObject* HMICapabilities::ui_supported_languages()
-    const {
-  return ui_supported_languages_;
-}
-
-const smart_objects::SmartObject* HMICapabilities::vr_supported_languages()
-    const {
-  return vr_supported_languages_;
-}
-
-const smart_objects::SmartObject* HMICapabilities::tts_supported_languages()
-    const {
-  return tts_supported_languages_;
-}
-
-const smart_objects::SmartObject* HMICapabilities::display_capabilities()
-    const {
-  return display_capabilities_;
-}
-
-const smart_objects::SmartObject* HMICapabilities::hmi_zone_capabilities()
-    const {
-  return hmi_zone_capabilities_;
-}
-
-const smart_objects::SmartObject* HMICapabilities::soft_button_capabilities()
-    const {
-  return soft_buttons_capabilities_;
-}
-
-const smart_objects::SmartObject* HMICapabilities::button_capabilities() const {
-  return button_capabilities_;
-}
-
-const smart_objects::SmartObject* HMICapabilities::speech_capabilities() const {
-  return speech_capabilities_;
-}
-
-const smart_objects::SmartObject* HMICapabilities::vr_capabilities() const {
-  return vr_capabilities_;
-}
-
-const smart_objects::SmartObject*
-HMICapabilities::audio_pass_thru_capabilities() const {
-  return audio_pass_thru_capabilities_;
-}
-
-const smart_objects::SmartObject* HMICapabilities::pcm_stream_capabilities()
-    const {
-  return pcm_stream_capabilities_;
-}
-
-const smart_objects::SmartObject* HMICapabilities::preset_bank_capabilities()
-    const {
-  return preset_bank_capabilities_;
-}
-
-bool HMICapabilities::attenuated_supported() const {
-  return attenuated_supported_;
-}
-
-const smart_objects::SmartObject* HMICapabilities::vehicle_type() const {
-  return vehicle_type_;
-}
-
-const smart_objects::SmartObject* HMICapabilities::prerecorded_speech() const {
-  return prerecorded_speech_;
-}
-
-const std::string& HMICapabilities::ccpu_version() const {
-  return ccpu_version_;
-}
-
-bool HMICapabilities::navigation_supported() const {
-  return is_navigation_supported_;
-}
-
-bool HMICapabilities::phone_call_supported() const {
-  return is_phone_call_supported_;
-}
 
 }  //  namespace application_manager
 
-#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_H_
+#endif  //  SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_IMPL_H_

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -42,6 +42,7 @@
 #include "application_manager/commands/command_impl.h"
 #include "application_manager/commands/command_notification_impl.h"
 #include "application_manager/message_helper.h"
+#include "application_manager/hmi_capabilities_impl.h"
 #include "application_manager/mobile_message_handler.h"
 #include "application_manager/policies/policy_handler.h"
 #include "protocol_handler/protocol_handler.h"
@@ -135,7 +136,7 @@ ApplicationManagerImpl::ApplicationManagerImpl(
     , messages_from_hmi_("AM FromHMI", this)
     , messages_to_hmi_("AM ToHMI", this)
     , audio_pass_thru_messages_("AudioPassThru", this)
-    , hmi_capabilities_(*this)
+    , hmi_capabilities_(new HMICapabilitiesImpl(*this))
     , unregister_reason_(
           mobile_api::AppInterfaceUnregisteredReason::INVALID_ENUM)
     , resume_ctrl_(*this)
@@ -1699,7 +1700,7 @@ bool ApplicationManagerImpl::Init(resumption::LastState& last_state,
     LOGGER_ERROR(logger_, "Problem with initialization of resume controller");
     return false;
   }
-  hmi_capabilities_.Init(&last_state);
+  hmi_capabilities_->Init(&last_state);
 
   if (!(file_system::IsWritingAllowed(app_storage_folder) &&
         file_system::IsReadingAllowed(app_storage_folder))) {
@@ -2121,11 +2122,11 @@ mobile_apis::MOBILE_API& ApplicationManagerImpl::mobile_so_factory() {
 }
 
 HMICapabilities& ApplicationManagerImpl::hmi_capabilities() {
-  return hmi_capabilities_;
+  return *hmi_capabilities_;
 }
 
 const HMICapabilities& ApplicationManagerImpl::hmi_capabilities() const {
-  return hmi_capabilities_;
+  return *hmi_capabilities_;
 }
 
 void ApplicationManagerImpl::PullLanguagesInfo(const SmartObject& app_data,

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -30,19 +30,16 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "application_manager/hmi_capabilities.h"
-
 #include <map>
 
+#include "application_manager/hmi_capabilities_impl.h"
 #include "application_manager/application_manager_impl.h"
+#include "smart_objects/smart_object.h"
 #include "application_manager/message_helper.h"
-#include "application_manager/message_helper.h"
-#include "application_manager/smart_object_keys.h"
 #include "application_manager/smart_object_keys.h"
 #include "config_profile/profile.h"
 #include "formatters/CFormatterJsonBase.h"
 #include "interfaces/HMI_API.h"
-#include "smart_objects/smart_object.h"
 #include "utils/file_system.h"
 #include "utils/json_utils.h"
 
@@ -324,7 +321,7 @@ void InitCapabilities() {
 
 }  // namespace
 
-HMICapabilities::HMICapabilities(ApplicationManager& app_mngr)
+HMICapabilitiesImpl::HMICapabilitiesImpl(ApplicationManager& app_mngr)
     : is_vr_cooperating_(false)
     , is_tts_cooperating_(false)
     , is_ui_cooperating_(false)
@@ -373,7 +370,7 @@ HMICapabilities::HMICapabilities(ApplicationManager& app_mngr)
   }
 }
 
-HMICapabilities::~HMICapabilities() {
+HMICapabilitiesImpl::~HMICapabilitiesImpl() {
   delete vehicle_type_;
   delete ui_supported_languages_;
   delete tts_supported_languages_;
@@ -390,7 +387,7 @@ HMICapabilities::~HMICapabilities() {
   delete prerecorded_speech_;
 }
 
-bool HMICapabilities::is_hmi_capabilities_initialized() const {
+bool HMICapabilitiesImpl::is_hmi_capabilities_initialized() const {
   bool result = true;
 
   if (is_vr_ready_response_recieved_ && is_tts_ready_response_recieved_ &&
@@ -429,7 +426,7 @@ bool HMICapabilities::is_hmi_capabilities_initialized() const {
   return result;
 }
 
-bool HMICapabilities::VerifyImageType(int32_t image_type) const {
+bool HMICapabilitiesImpl::VerifyImageType(const int32_t image_type) const {
   if (!display_capabilities_) {
     return false;
   }
@@ -447,7 +444,7 @@ bool HMICapabilities::VerifyImageType(int32_t image_type) const {
   return false;
 }
 
-void HMICapabilities::set_is_vr_cooperating(bool value) {
+void HMICapabilitiesImpl::set_is_vr_cooperating(const bool value) {
   is_vr_ready_response_recieved_ = true;
   is_vr_cooperating_ = value;
   if (is_vr_cooperating_) {
@@ -467,7 +464,7 @@ void HMICapabilities::set_is_vr_cooperating(bool value) {
   }
 }
 
-void HMICapabilities::set_is_tts_cooperating(bool value) {
+void HMICapabilitiesImpl::set_is_tts_cooperating(const bool value) {
   is_tts_ready_response_recieved_ = true;
   is_tts_cooperating_ = value;
   if (is_tts_cooperating_) {
@@ -487,7 +484,7 @@ void HMICapabilities::set_is_tts_cooperating(bool value) {
   }
 }
 
-void HMICapabilities::set_is_ui_cooperating(bool value) {
+void HMICapabilitiesImpl::set_is_ui_cooperating(const bool value) {
   is_ui_ready_response_recieved_ = true;
   is_ui_cooperating_ = value;
   if (is_ui_cooperating_) {
@@ -507,12 +504,12 @@ void HMICapabilities::set_is_ui_cooperating(bool value) {
   }
 }
 
-void HMICapabilities::set_is_navi_cooperating(bool value) {
+void HMICapabilitiesImpl::set_is_navi_cooperating(const bool value) {
   is_navi_ready_response_recieved_ = true;
   is_navi_cooperating_ = value;
 }
 
-void HMICapabilities::set_is_ivi_cooperating(bool value) {
+void HMICapabilitiesImpl::set_is_ivi_cooperating(const bool value) {
   is_ivi_ready_response_recieved_ = true;
   is_ivi_cooperating_ = value;
   if (is_ivi_cooperating_) {
@@ -523,32 +520,32 @@ void HMICapabilities::set_is_ivi_cooperating(bool value) {
   }
 }
 
-void HMICapabilities::set_attenuated_supported(bool state) {
+void HMICapabilitiesImpl::set_attenuated_supported(const bool state) {
   attenuated_supported_ = state;
 }
 
-void HMICapabilities::set_active_ui_language(
-    const hmi_apis::Common_Language::eType& language) {
+void HMICapabilitiesImpl::set_active_ui_language(
+    const hmi_apis::Common_Language::eType language) {
   ui_language_ = language;
   hmi_language_handler_.set_language_for(HMILanguageHandler::INTERFACE_UI,
                                          language);
 }
 
-void HMICapabilities::set_active_vr_language(
-    const hmi_apis::Common_Language::eType& language) {
+void HMICapabilitiesImpl::set_active_vr_language(
+    const hmi_apis::Common_Language::eType language) {
   vr_language_ = language;
   hmi_language_handler_.set_language_for(HMILanguageHandler::INTERFACE_VR,
                                          language);
 }
 
-void HMICapabilities::set_active_tts_language(
-    const hmi_apis::Common_Language::eType& language) {
+void HMICapabilitiesImpl::set_active_tts_language(
+    const hmi_apis::Common_Language::eType language) {
   tts_language_ = language;
   hmi_language_handler_.set_language_for(HMILanguageHandler::INTERFACE_TTS,
                                          language);
 }
 
-const hmi_apis::Common_Language::eType HMICapabilities::active_ui_language()
+const hmi_apis::Common_Language::eType HMICapabilitiesImpl::active_ui_language()
     const {
   using namespace hmi_apis;
   const Common_Language::eType language =
@@ -556,7 +553,7 @@ const hmi_apis::Common_Language::eType HMICapabilities::active_ui_language()
   return Common_Language::INVALID_ENUM != language ? language : ui_language_;
 }
 
-const hmi_apis::Common_Language::eType HMICapabilities::active_vr_language()
+const hmi_apis::Common_Language::eType HMICapabilitiesImpl::active_vr_language()
     const {
   using namespace hmi_apis;
   const Common_Language::eType language =
@@ -564,15 +561,15 @@ const hmi_apis::Common_Language::eType HMICapabilities::active_vr_language()
   return Common_Language::INVALID_ENUM != language ? language : vr_language_;
 }
 
-const hmi_apis::Common_Language::eType HMICapabilities::active_tts_language()
-    const {
+const hmi_apis::Common_Language::eType
+HMICapabilitiesImpl::active_tts_language() const {
   using namespace hmi_apis;
   const Common_Language::eType language =
       hmi_language_handler_.get_language_for(HMILanguageHandler::INTERFACE_TTS);
   return Common_Language::INVALID_ENUM != language ? language : tts_language_;
 }
 
-void HMICapabilities::set_ui_supported_languages(
+void HMICapabilitiesImpl::set_ui_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
   if (ui_supported_languages_) {
     delete ui_supported_languages_;
@@ -580,7 +577,7 @@ void HMICapabilities::set_ui_supported_languages(
   ui_supported_languages_ = new smart_objects::SmartObject(supported_languages);
 }
 
-void HMICapabilities::set_tts_supported_languages(
+void HMICapabilitiesImpl::set_tts_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
   if (tts_supported_languages_) {
     delete tts_supported_languages_;
@@ -589,7 +586,7 @@ void HMICapabilities::set_tts_supported_languages(
       new smart_objects::SmartObject(supported_languages);
 }
 
-void HMICapabilities::set_vr_supported_languages(
+void HMICapabilitiesImpl::set_vr_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
   if (vr_supported_languages_) {
     delete vr_supported_languages_;
@@ -597,7 +594,7 @@ void HMICapabilities::set_vr_supported_languages(
   vr_supported_languages_ = new smart_objects::SmartObject(supported_languages);
 }
 
-void HMICapabilities::set_display_capabilities(
+void HMICapabilitiesImpl::set_display_capabilities(
     const smart_objects::SmartObject& display_capabilities) {
   if (display_capabilities_) {
     delete display_capabilities_;
@@ -605,7 +602,7 @@ void HMICapabilities::set_display_capabilities(
   display_capabilities_ = new smart_objects::SmartObject(display_capabilities);
 }
 
-void HMICapabilities::set_hmi_zone_capabilities(
+void HMICapabilitiesImpl::set_hmi_zone_capabilities(
     const smart_objects::SmartObject& hmi_zone_capabilities) {
   if (hmi_zone_capabilities_) {
     delete hmi_zone_capabilities_;
@@ -614,7 +611,7 @@ void HMICapabilities::set_hmi_zone_capabilities(
       new smart_objects::SmartObject(hmi_zone_capabilities);
 }
 
-void HMICapabilities::set_soft_button_capabilities(
+void HMICapabilitiesImpl::set_soft_button_capabilities(
     const smart_objects::SmartObject& soft_button_capabilities) {
   if (soft_buttons_capabilities_) {
     delete soft_buttons_capabilities_;
@@ -623,7 +620,7 @@ void HMICapabilities::set_soft_button_capabilities(
       new smart_objects::SmartObject(soft_button_capabilities);
 }
 
-void HMICapabilities::set_button_capabilities(
+void HMICapabilitiesImpl::set_button_capabilities(
     const smart_objects::SmartObject& button_capabilities) {
   if (button_capabilities_) {
     delete button_capabilities_;
@@ -631,7 +628,7 @@ void HMICapabilities::set_button_capabilities(
   button_capabilities_ = new smart_objects::SmartObject(button_capabilities);
 }
 
-void HMICapabilities::set_vr_capabilities(
+void HMICapabilitiesImpl::set_vr_capabilities(
     const smart_objects::SmartObject& vr_capabilities) {
   if (vr_capabilities_) {
     delete vr_capabilities_;
@@ -639,7 +636,7 @@ void HMICapabilities::set_vr_capabilities(
   vr_capabilities_ = new smart_objects::SmartObject(vr_capabilities);
 }
 
-void HMICapabilities::set_speech_capabilities(
+void HMICapabilitiesImpl::set_speech_capabilities(
     const smart_objects::SmartObject& speech_capabilities) {
   if (speech_capabilities_) {
     delete speech_capabilities_;
@@ -647,7 +644,7 @@ void HMICapabilities::set_speech_capabilities(
   speech_capabilities_ = new smart_objects::SmartObject(speech_capabilities);
 }
 
-void HMICapabilities::set_audio_pass_thru_capabilities(
+void HMICapabilitiesImpl::set_audio_pass_thru_capabilities(
     const smart_objects::SmartObject& audio_pass_thru_capabilities) {
   if (audio_pass_thru_capabilities_) {
     delete audio_pass_thru_capabilities_;
@@ -656,7 +653,7 @@ void HMICapabilities::set_audio_pass_thru_capabilities(
       new smart_objects::SmartObject(audio_pass_thru_capabilities);
 }
 
-void HMICapabilities::set_pcm_stream_capabilities(
+void HMICapabilitiesImpl::set_pcm_stream_capabilities(
     const smart_objects::SmartObject& pcm_stream_capabilities) {
   if (pcm_stream_capabilities_) {
     delete pcm_stream_capabilities_;
@@ -665,7 +662,7 @@ void HMICapabilities::set_pcm_stream_capabilities(
       new smart_objects::SmartObject(pcm_stream_capabilities);
 }
 
-void HMICapabilities::set_preset_bank_capabilities(
+void HMICapabilitiesImpl::set_preset_bank_capabilities(
     const smart_objects::SmartObject& preset_bank_capabilities) {
   if (preset_bank_capabilities_) {
     delete preset_bank_capabilities_;
@@ -674,7 +671,7 @@ void HMICapabilities::set_preset_bank_capabilities(
       new smart_objects::SmartObject(preset_bank_capabilities);
 }
 
-void HMICapabilities::set_vehicle_type(
+void HMICapabilitiesImpl::set_vehicle_type(
     const smart_objects::SmartObject& vehicle_type) {
   if (vehicle_type_) {
     delete vehicle_type_;
@@ -682,7 +679,7 @@ void HMICapabilities::set_vehicle_type(
   vehicle_type_ = new smart_objects::SmartObject(vehicle_type);
 }
 
-void HMICapabilities::set_prerecorded_speech(
+void HMICapabilitiesImpl::set_prerecorded_speech(
     const smart_objects::SmartObject& prerecorded_speech) {
   if (prerecorded_speech_) {
     delete prerecorded_speech_;
@@ -691,15 +688,10 @@ void HMICapabilities::set_prerecorded_speech(
   prerecorded_speech_ = new smart_objects::SmartObject(prerecorded_speech);
 }
 
-void HMICapabilities::set_ccpu_version(const std::string& ccpu_version) {
-  ccpu_version_ = ccpu_version;
-}
-
-void HMICapabilities::set_navigation_supported(const bool supported) {
+void HMICapabilitiesImpl::set_navigation_supported(const bool supported) {
   is_navigation_supported_ = supported;
 }
-
-void HMICapabilities::set_phone_call_supported(const bool supported) {
+void HMICapabilitiesImpl::set_phone_call_supported(const bool supported) {
   is_phone_call_supported_ = supported;
 }
 namespace {
@@ -710,8 +702,8 @@ namespace {
 * @param json_languages from file hmi_capabilities.json
 * @param languages - the converted object
 */
-void convert_json_languages_to_obj(
-    const utils::json::JsonValueRef json_languages,
+void convert_json_languages_to_sm_obj(
+    const utils::json::JsonValueRef& json_languages,
     smart_objects::SmartObject& languages) {
   using namespace utils::json;
   uint32_t j = 0;
@@ -725,7 +717,7 @@ void convert_json_languages_to_obj(
 
 }  // namespace
 
-void HMICapabilities::Init(resumption::LastState* last_state) {
+void HMICapabilitiesImpl::Init(resumption::LastState* last_state) {
   hmi_language_handler_.Init(last_state);
   if (false == load_capabilities_from_file()) {
     LOGGER_ERROR(logger_, "file hmi_capabilities.json was not loaded");
@@ -736,8 +728,107 @@ void HMICapabilities::Init(resumption::LastState* last_state) {
       ui_language_, vr_language_, tts_language_);
 }
 
-bool HMICapabilities::load_capabilities_from_file() {
-  using namespace utils::json;
+bool HMICapabilitiesImpl::is_ui_cooperating() const {
+  return is_ui_cooperating_;
+}
+
+bool HMICapabilitiesImpl::is_vr_cooperating() const {
+  return is_vr_cooperating_;
+}
+
+bool HMICapabilitiesImpl::is_tts_cooperating() const {
+  return is_tts_cooperating_;
+}
+
+bool HMICapabilitiesImpl::is_navi_cooperating() const {
+  return is_navi_cooperating_;
+}
+
+bool HMICapabilitiesImpl::is_ivi_cooperating() const {
+  return is_ivi_cooperating_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::ui_supported_languages()
+    const {
+  return ui_supported_languages_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::vr_supported_languages()
+    const {
+  return vr_supported_languages_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::tts_supported_languages()
+    const {
+  return tts_supported_languages_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::display_capabilities()
+    const {
+  return display_capabilities_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::hmi_zone_capabilities()
+    const {
+  return hmi_zone_capabilities_;
+}
+
+const smart_objects::SmartObject*
+HMICapabilitiesImpl::soft_button_capabilities() const {
+  return soft_buttons_capabilities_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::button_capabilities()
+    const {
+  return button_capabilities_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::speech_capabilities()
+    const {
+  return speech_capabilities_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::vr_capabilities() const {
+  return vr_capabilities_;
+}
+
+const smart_objects::SmartObject*
+HMICapabilitiesImpl::audio_pass_thru_capabilities() const {
+  return audio_pass_thru_capabilities_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::pcm_stream_capabilities()
+    const {
+  return pcm_stream_capabilities_;
+}
+
+const smart_objects::SmartObject*
+HMICapabilitiesImpl::preset_bank_capabilities() const {
+  return preset_bank_capabilities_;
+}
+
+bool HMICapabilitiesImpl::attenuated_supported() const {
+  return attenuated_supported_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::vehicle_type() const {
+  return vehicle_type_;
+}
+
+const smart_objects::SmartObject* HMICapabilitiesImpl::prerecorded_speech()
+    const {
+  return prerecorded_speech_;
+}
+
+bool HMICapabilitiesImpl::navigation_supported() const {
+  return is_navigation_supported_;
+}
+
+bool HMICapabilitiesImpl::phone_call_supported() const {
+  return is_phone_call_supported_;
+}
+
+bool HMICapabilitiesImpl::load_capabilities_from_file() {
   std::string json_string;
   std::string file_name = app_mngr_.get_settings().hmi_capabilities_file_name();
 
@@ -750,14 +841,15 @@ bool HMICapabilities::load_capabilities_from_file() {
   }
 
   try {
-    JsonValue::ParseResult parse_result = JsonValue::Parse(json_string);
+    utils::json::JsonValue::ParseResult parse_result =
+        utils::json::JsonValue::Parse(json_string);
     if (!parse_result.second) {
       return false;
     }
-    const JsonValue& root_json = parse_result.first;
+    const utils::json::JsonValue& root_json = parse_result.first;
     // UI
     if (root_json.HasMember("UI")) {
-      const JsonValueRef ui = root_json["UI"];
+      const utils::json::JsonValueRef ui = root_json["UI"];
 
       if (ui.HasMember("language")) {
         const std::string lang = ui["language"].AsString();
@@ -770,14 +862,15 @@ bool HMICapabilities::load_capabilities_from_file() {
       if (ui.HasMember("languages")) {
         smart_objects::SmartObject ui_languages_so(
             smart_objects::SmartType_Array);
-        const JsonValueRef languages_ui = ui["languages"];
-        convert_json_languages_to_obj(languages_ui, ui_languages_so);
+        const utils::json::JsonValueRef languages_ui = ui["languages"];
+        convert_json_languages_to_sm_obj(languages_ui, ui_languages_so);
         set_ui_supported_languages(ui_languages_so);
       }
 
       if (ui.HasMember("displayCapabilities")) {
         smart_objects::SmartObject display_capabilities_so;
-        const JsonValueRef display_capabilities = ui["displayCapabilities"];
+        const utils::json::JsonValueRef display_capabilities =
+            ui["displayCapabilities"];
         Formatters::CFormatterJsonBase::jsonValueToObj(display_capabilities,
                                                        display_capabilities_so);
 
@@ -794,10 +887,10 @@ bool HMICapabilities::load_capabilities_from_file() {
         }
 
         if (display_capabilities_so.keyExists(hmi_response::text_fields)) {
-          uint32_t len =
+          const uint32_t kLen =
               display_capabilities_so[hmi_response::text_fields].length();
 
-          for (uint32_t i = 0; i < len; ++i) {
+          for (uint32_t i = 0; i < kLen; ++i) {
             if ((display_capabilities_so[hmi_response::text_fields][i])
                     .keyExists(strings::name)) {
               std::map<std::string,
@@ -913,7 +1006,8 @@ bool HMICapabilities::load_capabilities_from_file() {
       }
 
       if (ui.HasMember("audioPassThruCapabilities")) {
-        const JsonValueRef audio_capabilities = ui["audioPassThruCapabilities"];
+        const utils::json::JsonValueRef audio_capabilities =
+            ui["audioPassThruCapabilities"];
         smart_objects::SmartObject audio_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
         audio_capabilities_so =
@@ -937,7 +1031,8 @@ bool HMICapabilities::load_capabilities_from_file() {
       }
 
       if (ui.HasMember("pcmStreamCapabilities")) {
-        const JsonValueRef pcm_capabilities = ui["pcmStreamCapabilities"];
+        const utils::json::JsonValueRef pcm_capabilities =
+            ui["pcmStreamCapabilities"];
         smart_objects::SmartObject pcm_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Map);
 
@@ -969,7 +1064,7 @@ bool HMICapabilities::load_capabilities_from_file() {
       }
 
       if (ui.HasMember("softButtonCapabilities")) {
-        const JsonValueRef soft_button_capabilities =
+        const utils::json::JsonValueRef soft_button_capabilities =
             ui["softButtonCapabilities"];
         smart_objects::SmartObject soft_button_capabilities_so;
         Formatters::CFormatterJsonBase::jsonValueToObj(
@@ -980,7 +1075,7 @@ bool HMICapabilities::load_capabilities_from_file() {
 
     // VR
     if (root_json.HasMember("VR")) {
-      const JsonValueRef vr = root_json["VR"];
+      const utils::json::JsonValueRef vr = root_json["VR"];
       if (vr.HasMember("language")) {
         const std::string lang = vr["language"].AsString();
         set_active_vr_language(MessageHelper::CommonLanguageFromString(lang));
@@ -990,18 +1085,20 @@ bool HMICapabilities::load_capabilities_from_file() {
       }
 
       if (vr.HasMember("languages")) {
-        const JsonValueRef languages_vr = vr["languages"];
+        const utils::json::JsonValueRef languages_vr = vr["languages"];
         smart_objects::SmartObject vr_languages_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
-        convert_json_languages_to_obj(languages_vr, vr_languages_so);
+        convert_json_languages_to_sm_obj(languages_vr, vr_languages_so);
         set_vr_supported_languages(vr_languages_so);
       }
 
       if (vr.HasMember("capabilities")) {
-        const JsonValueRef capabilities = vr["capabilities"];
+        const utils::json::JsonValueRef capabilities = vr["capabilities"];
         smart_objects::SmartObject vr_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
-        for (JsonValue::ArrayIndex i = 0, size = capabilities.Size(); i < size;
+        for (utils::json::JsonValue::ArrayIndex i = 0,
+                                                size = capabilities.Size();
+             i < size;
              ++i) {
           vr_capabilities_so[i] =
               vr_enum_capabilities.find(capabilities[i].AsString())->second;
@@ -1012,7 +1109,7 @@ bool HMICapabilities::load_capabilities_from_file() {
 
     // TTS
     if (root_json.HasMember("TTS")) {
-      const JsonValueRef tts = root_json["TTS"];
+      const utils::json::JsonValueRef tts = root_json["TTS"];
 
       if (tts.HasMember("language")) {
         const std::string lang = tts["language"].AsString();
@@ -1023,10 +1120,10 @@ bool HMICapabilities::load_capabilities_from_file() {
       }
 
       if (tts.HasMember("languages")) {
-        const JsonValueRef languages_tts = tts["languages"];
+        const utils::json::JsonValueRef languages_tts = tts["languages"];
         smart_objects::SmartObject tts_languages_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
-        convert_json_languages_to_obj(languages_tts, tts_languages_so);
+        convert_json_languages_to_sm_obj(languages_tts, tts_languages_so);
         set_tts_supported_languages(tts_languages_so);
       }
 
@@ -1038,9 +1135,10 @@ bool HMICapabilities::load_capabilities_from_file() {
 
     // Buttons
     if (root_json.HasMember("Buttons")) {
-      const JsonValueRef buttons = root_json["Buttons"];
+      const utils::json::JsonValueRef buttons = root_json["Buttons"];
       if (buttons.HasMember("capabilities")) {
-        const JsonValueRef bt_capabilities = buttons["capabilities"];
+        const utils::json::JsonValueRef bt_capabilities =
+            buttons["capabilities"];
         smart_objects::SmartObject buttons_capabilities_so;
         Formatters::CFormatterJsonBase::jsonValueToObj(bt_capabilities,
                                                        buttons_capabilities_so);
@@ -1060,7 +1158,8 @@ bool HMICapabilities::load_capabilities_from_file() {
         set_button_capabilities(buttons_capabilities_so);
       }
       if (buttons.HasMember("presetBankCapabilities")) {
-        const JsonValueRef presetBank = buttons["presetBankCapabilities"];
+        const utils::json::JsonValueRef presetBank =
+            buttons["presetBankCapabilities"];
         smart_objects::SmartObject preset_bank_so;
         Formatters::CFormatterJsonBase::jsonValueToObj(presetBank,
                                                        preset_bank_so);
@@ -1070,7 +1169,7 @@ bool HMICapabilities::load_capabilities_from_file() {
 
     // VehicleType
     if (root_json.HasMember("VehicleInfo")) {
-      const JsonValueRef vehicle_info = root_json["VehicleInfo"];
+      const utils::json::JsonValueRef vehicle_info = root_json["VehicleInfo"];
       smart_objects::SmartObject vehicle_type_so;
       Formatters::CFormatterJsonBase::jsonValueToObj(vehicle_info,
                                                      vehicle_type_so);
@@ -1081,6 +1180,28 @@ bool HMICapabilities::load_capabilities_from_file() {
     return false;
   }
   return true;
+}
+
+void HMICapabilitiesImpl::set_ccpu_version(const std::string& ccpu_version) {
+  ccpu_version_ = ccpu_version;
+}
+
+const std::string& HMICapabilitiesImpl::ccpu_version() const {
+  return ccpu_version_;
+}
+
+bool HMICapabilitiesImpl::check_existing_json_member(
+    const Json::Value& json_member, const char* name_of_member) const {
+  return json_member.isMember(name_of_member);
+}
+
+void HMICapabilitiesImpl::convert_json_languages_to_obj(
+    const Json::Value& json_languages,
+    smart_objects::SmartObject& languages) const {
+  for (uint32_t i = 0, j = 0; i < json_languages.size(); ++i) {
+    languages[j++] =
+        MessageHelper::CommonLanguageFromString(json_languages[i].asString());
+  }
 }
 
 }  //  namespace application_manager

--- a/src/components/application_manager/test/include/application_manager/hmi_capabilities_for_testing.h
+++ b/src/components/application_manager/test/include/application_manager/hmi_capabilities_for_testing.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,17 +33,17 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_FOR_TESTING_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_FOR_TESTING_H_
 
-#include "application_manager/hmi_capabilities.h"
+#include "application_manager/hmi_capabilities_impl.h"
 
 namespace test {
 namespace components {
 namespace application_manager_test {
 
 class HMICapabilitiesForTesting
-    : public ::application_manager::HMICapabilities {
+    : public ::application_manager::HMICapabilitiesImpl {
  public:
   HMICapabilitiesForTesting(::application_manager::ApplicationManager& app_mngr)
-      : HMICapabilities(app_mngr) {}
+      : HMICapabilitiesImpl(app_mngr) {}
   bool LoadCapabilitiesFromFile() {
     return load_capabilities_from_file();
   }

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_HMI_CAPABILITIES_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_HMI_CAPABILITIES_H_
+
+#include <stdint.h>
+
+#include "application_manager/hmi_capabilities.h"
+#include "gmock/gmock.h"
+
+namespace test {
+namespace components {
+namespace application_manager_test {
+
+class MockHMICapabilities : public ::application_manager::HMICapabilities {
+ public:
+  MOCK_CONST_METHOD0(is_hmi_capabilities_initialized, bool());
+  MOCK_CONST_METHOD1(VerifyImageType, bool(const int32_t image_type));
+
+  MOCK_CONST_METHOD0(is_vr_cooperating, bool());
+  MOCK_METHOD1(set_is_vr_cooperating, void(const bool value));
+
+  MOCK_CONST_METHOD0(is_tts_cooperating, bool());
+  MOCK_METHOD1(set_is_tts_cooperating, void(const bool value));
+
+  MOCK_CONST_METHOD0(is_ui_cooperating, bool());
+  MOCK_METHOD1(set_is_ui_cooperating, void(const bool value));
+
+  MOCK_CONST_METHOD0(is_navi_cooperating, bool());
+  MOCK_METHOD1(set_is_navi_cooperating, void(const bool value));
+
+  MOCK_CONST_METHOD0(is_ivi_cooperating, bool());
+  MOCK_METHOD1(set_is_ivi_cooperating, void(const bool value));
+
+  MOCK_CONST_METHOD0(attenuated_supported, bool());
+
+  MOCK_METHOD1(set_attenuated_supported, void(const bool state));
+
+  MOCK_CONST_METHOD0(active_ui_language,
+                     const hmi_apis::Common_Language::eType());
+
+  MOCK_METHOD1(set_active_ui_language,
+               void(const hmi_apis::Common_Language::eType language));
+
+  MOCK_CONST_METHOD0(ui_supported_languages,
+                     const smart_objects::SmartObject*());
+  MOCK_METHOD1(set_ui_supported_languages,
+               void(const smart_objects::SmartObject& supported_languages));
+
+  MOCK_CONST_METHOD0(active_vr_language,
+                     const hmi_apis::Common_Language::eType());
+  MOCK_METHOD1(set_active_vr_language,
+               void(const hmi_apis::Common_Language::eType language));
+
+  MOCK_CONST_METHOD0(vr_supported_languages,
+                     const smart_objects::SmartObject*());
+  MOCK_METHOD1(set_vr_supported_languages,
+               void(const smart_objects::SmartObject& supported_languages));
+
+  MOCK_CONST_METHOD0(active_tts_language,
+                     const hmi_apis::Common_Language::eType());
+  MOCK_METHOD1(set_active_tts_language,
+               void(const hmi_apis::Common_Language::eType language));
+
+  MOCK_CONST_METHOD0(tts_supported_languages,
+                     const smart_objects::SmartObject*());
+  MOCK_METHOD1(set_tts_supported_languages,
+               void(const smart_objects::SmartObject& supported_languages));
+
+  MOCK_CONST_METHOD0(display_capabilities, const smart_objects::SmartObject*());
+  MOCK_METHOD1(set_display_capabilities,
+               void(const smart_objects::SmartObject& display_capabilities));
+
+  MOCK_CONST_METHOD0(hmi_zone_capabilities,
+                     const smart_objects::SmartObject*());
+  MOCK_METHOD1(set_hmi_zone_capabilities,
+               void(const smart_objects::SmartObject& hmi_zone_capabilities));
+
+  MOCK_CONST_METHOD0(soft_button_capabilities,
+                     const smart_objects::SmartObject*());
+  MOCK_METHOD1(
+      set_soft_button_capabilities,
+      void(const smart_objects::SmartObject& soft_button_capabilities));
+
+  MOCK_CONST_METHOD0(button_capabilities, const smart_objects::SmartObject*());
+  MOCK_METHOD1(set_button_capabilities,
+               void(const smart_objects::SmartObject& button_capabilities));
+
+  MOCK_CONST_METHOD0(speech_capabilities, const smart_objects::SmartObject*());
+  MOCK_METHOD1(set_speech_capabilities,
+               void(const smart_objects::SmartObject& speech_capabilities));
+
+  MOCK_CONST_METHOD0(vr_capabilities, const smart_objects::SmartObject*());
+  MOCK_METHOD1(set_vr_capabilities,
+               void(const smart_objects::SmartObject& vr_capabilities));
+
+  MOCK_CONST_METHOD0(audio_pass_thru_capabilities,
+                     const smart_objects::SmartObject*());
+  MOCK_METHOD1(
+      set_audio_pass_thru_capabilities,
+      void(const smart_objects::SmartObject& audio_pass_thru_capabilities));
+
+  MOCK_CONST_METHOD0(pcm_stream_capabilities,
+                     const smart_objects::SmartObject*());
+  MOCK_METHOD1(set_pcm_stream_capabilities,
+               void(const smart_objects::SmartObject& pcm_stream_capabilities));
+
+  MOCK_CONST_METHOD0(preset_bank_capabilities,
+                     const smart_objects::SmartObject*());
+  MOCK_METHOD1(
+      set_preset_bank_capabilities,
+      void(const smart_objects::SmartObject& preset_bank_capabilities));
+
+  MOCK_CONST_METHOD0(vehicle_type, const smart_objects::SmartObject*());
+  MOCK_METHOD1(set_vehicle_type,
+               void(const smart_objects::SmartObject& vehicle_type));
+
+  MOCK_CONST_METHOD0(prerecorded_speech, const smart_objects::SmartObject*());
+  MOCK_METHOD1(set_prerecorded_speech,
+               void(const smart_objects::SmartObject& prerecorded_speech));
+
+  MOCK_CONST_METHOD0(navigation_supported, bool());
+  MOCK_METHOD1(set_navigation_supported, void(const bool supported));
+
+  MOCK_CONST_METHOD0(phone_call_supported, bool());
+  MOCK_METHOD1(set_phone_call_supported, void(const bool supported));
+
+  MOCK_METHOD1(Init, void(resumption::LastState* last_state));
+
+ protected:
+  MOCK_CONST_METHOD2(check_existing_json_member,
+                     bool(const Json::Value& json_member,
+                          const char* name_of_member));
+
+  MOCK_CONST_METHOD2(convert_json_languages_to_obj,
+                     void(const Json::Value& json_languages,
+                          smart_objects::SmartObject& languages));
+};
+
+}  // namespace application_manager_test
+}  // namespace components
+}  // namespace test
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_HMI_CAPABILITIES_H_

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -1,0 +1,442 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef SRC_COMPONENTS_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_H_
+#define SRC_COMPONENTS_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_H_
+
+#include "interfaces/HMI_API.h"
+#include "interfaces/MOBILE_API.h"
+#include "json/json.h"
+#include "utils/macro.h"
+#include "utils/json_utils.h"
+#include "application_manager/hmi_language_handler.h"
+
+namespace NsSmartDeviceLink {
+namespace NsSmartObjects {
+class SmartObject;
+}
+}
+namespace resumption {
+class LastState;
+}
+
+namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
+
+namespace application_manager {
+class ApplicationManager;
+
+class HMICapabilities {
+ public:
+  /*
+   * @brief Class destructor
+   *
+   */
+  virtual ~HMICapabilities() {}
+
+  /**
+   * @brief Checks if all HMI capabilities received
+   *
+   * @return TRUE if all information received, otherwise FALSE
+   */
+  virtual bool is_hmi_capabilities_initialized() const = 0;
+
+  /*
+   * @brief Checks is image type(Static/Dynamic) requested by
+   * Mobile Device is supported on current HMI.
+   * @param image_type recieved type of image from Enum.
+   * @return Bool true if supported
+   */
+  virtual bool VerifyImageType(const int32_t image_type) const = 0;
+
+  /**
+   * @brief Checks if all HMI capabilities received
+   *
+   * @return TRUE if all information received, otherwise FALSE
+   */
+  virtual bool is_vr_cooperating() const = 0;
+  virtual void set_is_vr_cooperating(const bool value) = 0;
+
+  virtual bool is_tts_cooperating() const = 0;
+  virtual void set_is_tts_cooperating(const bool value) = 0;
+
+  virtual bool is_ui_cooperating() const = 0;
+  virtual void set_is_ui_cooperating(const bool value) = 0;
+
+  virtual bool is_navi_cooperating() const = 0;
+  virtual void set_is_navi_cooperating(const bool value) = 0;
+
+  virtual bool is_ivi_cooperating() const = 0;
+  virtual void set_is_ivi_cooperating(const bool value) = 0;
+
+  /*
+   * @brief Interface used to store information about software version of the
+   *target
+   *
+   * @param ccpu_version Received system/hmi software version
+   */
+  virtual void set_ccpu_version(const std::string& ccpu_version) = 0;
+
+  /*
+   * @brief Returns software version of the target
+   *
+   * @return TRUE if it supported, otherwise FALSE
+   */
+  virtual const std::string& ccpu_version() const = 0;
+
+  /*
+   * @brief Retrieves if mixing audio is supported by HMI
+   * (ie recording TTS command and playing audio)
+   *
+   * @return Current state of the mixing audio flag
+   */
+  virtual bool attenuated_supported() const = 0;
+
+  /*
+   * @brief Sets state for mixing audio
+   *
+   * @param state New state to be set
+   */
+  virtual void set_attenuated_supported(const bool state) = 0;
+
+  /*
+   * @brief Retrieves currently active UI language
+   *
+   * @return Currently active UI language
+   */
+  virtual const hmi_apis::Common_Language::eType active_ui_language() const = 0;
+
+  /*
+   * @brief Sets currently active UI language
+   *
+   * @param language Currently active UI language
+   */
+  virtual void set_active_ui_language(
+      const hmi_apis::Common_Language::eType language) = 0;
+
+  /*
+   * @brief Retrieves UI supported languages
+   *
+   * @return Currently supported UI languages
+   */
+  virtual const smart_objects::SmartObject* ui_supported_languages() const = 0;
+
+  /*
+   * @brief Sets supported UI languages
+   *
+   * @param supported_languages Supported UI languages
+   */
+  virtual void set_ui_supported_languages(
+      const smart_objects::SmartObject& supported_languages) = 0;
+
+  /*
+   * @brief Retrieves currently active VR language
+   *
+   * @return Currently active VR language
+   */
+  virtual const hmi_apis::Common_Language::eType active_vr_language() const = 0;
+
+  /*
+   * @brief Sets currently active VR language
+   *
+   * @param language Currently active VR language
+   */
+  virtual void set_active_vr_language(
+      const hmi_apis::Common_Language::eType language) = 0;
+
+  /*
+   * @brief Retrieves VR supported languages
+   *
+   * @return Currently supported VR languages
+   */
+  virtual const smart_objects::SmartObject* vr_supported_languages() const = 0;
+
+  /*
+   * @brief Sets supported VR languages
+   *
+   * @param supported_languages Supported VR languages
+   */
+  virtual void set_vr_supported_languages(
+      const smart_objects::SmartObject& supported_languages) = 0;
+
+  /*
+   * @brief Retrieves currently active TTS language
+   *
+   * @return Currently active TTS language
+   */
+  virtual const hmi_apis::Common_Language::eType active_tts_language()
+      const = 0;
+
+  /*
+   * @brief Sets currently active TTS language
+   *
+   * @param language Currently active TTS language
+   */
+  virtual void set_active_tts_language(
+      const hmi_apis::Common_Language::eType language) = 0;
+
+  /*
+   * @brief Retrieves TTS  supported languages
+   *
+   * @return Currently supported TTS languages
+   */
+  virtual const smart_objects::SmartObject* tts_supported_languages() const = 0;
+
+  /*
+   * @brief Sets supported TTS languages
+   *
+   * @param supported_languages Supported TTS languages
+   */
+  virtual void set_tts_supported_languages(
+      const smart_objects::SmartObject& supported_languages) = 0;
+
+  /*
+   * @brief Retrieves information about the display capabilities
+   *
+   * @return Currently supported display capabilities
+   */
+  virtual const smart_objects::SmartObject* display_capabilities() const = 0;
+
+  /*
+   * @brief Sets supported display capabilities
+   *
+   * @param display_capabilities supported display capabilities
+   */
+  virtual void set_display_capabilities(
+      const smart_objects::SmartObject& display_capabilities) = 0;
+
+  /*
+   * @brief Retrieves information about the HMI zone capabilities
+   *
+   * @return Currently supported HMI zone capabilities
+   */
+  virtual const smart_objects::SmartObject* hmi_zone_capabilities() const = 0;
+
+  /*
+   * @brief Sets supported HMI zone capabilities
+   *
+   * @param hmi_zone_capabilities supported HMI zone capabilities
+   */
+  virtual void set_hmi_zone_capabilities(
+      const smart_objects::SmartObject& hmi_zone_capabilities) = 0;
+
+  /*
+   * @brief Retrieves information about the SoftButton's capabilities
+   *
+   * @return Currently supported SoftButton's capabilities
+   */
+  virtual const smart_objects::SmartObject* soft_button_capabilities()
+      const = 0;
+
+  /*
+   * @brief Sets supported SoftButton's capabilities
+   *
+   * @param soft_button_capabilities supported SoftButton's capabilities
+   */
+  virtual void set_soft_button_capabilities(
+      const smart_objects::SmartObject& soft_button_capabilities) = 0;
+
+  /*
+   * @brief Retrieves information about the Button's capabilities
+   *
+   * @return Currently supported Button's capabilities
+   */
+  virtual const smart_objects::SmartObject* button_capabilities() const = 0;
+
+  /*
+   * @brief Sets supported Button's capabilities
+   *
+   * @param soft_button_capabilities supported Button's capabilities
+   */
+  virtual void set_button_capabilities(
+      const smart_objects::SmartObject& button_capabilities) = 0;
+
+  /*
+   * @brief Sets supported speech capabilities
+   *
+   * @param speech_capabilities supported speech capabilities
+   */
+  virtual void set_speech_capabilities(
+      const smart_objects::SmartObject& speech_capabilities) = 0;
+
+  /*
+   * @brief Retrieves information about the speech capabilities
+   *
+   * @return Currently supported speech capabilities
+   */
+  virtual const smart_objects::SmartObject* speech_capabilities() const = 0;
+
+  /*
+   * @brief Sets supported VR capabilities
+   *
+   * @param vr_capabilities supported VR capabilities
+   */
+  virtual void set_vr_capabilities(
+      const smart_objects::SmartObject& vr_capabilities) = 0;
+
+  /*
+   * @brief Retrieves information about the VR capabilities
+   *
+   * @return Currently supported VR capabilities
+   */
+  virtual const smart_objects::SmartObject* vr_capabilities() const = 0;
+
+  /*
+   * @brief Sets supported audio_pass_thru capabilities
+   *
+   * @param vr_capabilities supported audio_pass_thru capabilities
+   */
+  virtual void set_audio_pass_thru_capabilities(
+      const smart_objects::SmartObject& audio_pass_thru_capabilities) = 0;
+
+  /*
+   * @brief Retrieves information about the audio_pass_thru capabilities
+   *
+   * @return Currently supported audio_pass_thru capabilities
+   */
+  virtual const smart_objects::SmartObject* audio_pass_thru_capabilities()
+      const = 0;
+
+  /*
+   * @brief Sets supported pcm_stream capabilities
+   *
+   * @param supported pcm_stream capabilities
+   */
+  virtual void set_pcm_stream_capabilities(
+      const smart_objects::SmartObject& pcm_stream_capabilities) = 0;
+
+  /*
+   * @brief Retrieves information about the pcm_stream capabilities
+   *
+   * @return Currently supported pcm_streaming capabilities
+   */
+  virtual const smart_objects::SmartObject* pcm_stream_capabilities() const = 0;
+
+  /*
+   * @brief Retrieves information about the preset bank capabilities
+   *
+   * @return Currently supported preset bank capabilities
+   */
+  virtual const smart_objects::SmartObject* preset_bank_capabilities()
+      const = 0;
+
+  /*
+   * @brief Sets supported preset bank capabilities
+   *
+   * @param soft_button_capabilities supported preset bank capabilities
+   */
+  virtual void set_preset_bank_capabilities(
+      const smart_objects::SmartObject& preset_bank_capabilities) = 0;
+
+  /*
+   * @brief Sets vehicle information(make, model, modelYear)
+   *
+   * @param vehicle_type Cuurent vehicle information
+   */
+  virtual void set_vehicle_type(
+      const smart_objects::SmartObject& vehicle_type) = 0;
+
+  /*
+   * @brief Retrieves vehicle information(make, model, modelYear)
+   *
+   * @param vehicle_type Cuurent vehicle information
+   */
+  virtual const smart_objects::SmartObject* vehicle_type() const = 0;
+
+  /*
+   * @brief Retrieves information about the prerecorded speech
+   *
+   * @return Currently supported prerecorded speech
+   */
+  virtual const smart_objects::SmartObject* prerecorded_speech() const = 0;
+
+  /*
+   * @brief Sets supported prerecorded speech
+   *
+   * @param prerecorded_speech supported prerecorded speech
+   */
+  virtual void set_prerecorded_speech(
+      const smart_objects::SmartObject& prerecorded_speech) = 0;
+
+  /*
+   * @brief Interface used to store information if navigation
+   * supported by the system
+   *
+   * @param supported Indicates if navigation supported by the system
+   */
+  virtual void set_navigation_supported(const bool supported) = 0;
+
+  /*
+   * @brief Retrieves information if navi supported by the system
+   *
+   * @return TRUE if it supported, otherwise FALSE
+   */
+  virtual bool navigation_supported() const = 0;
+
+  /*
+   * @brief Interface used to store information if phone call
+   * supported by the system
+   *
+   * @param supported Indicates if navigation supported by the sustem
+   */
+  virtual void set_phone_call_supported(const bool supported) = 0;
+
+  /*
+   * @brief Retrieves information if phone call supported by the system
+   *
+   * @return TRUE if it supported, otherwise FALSE
+   */
+  virtual bool phone_call_supported() const = 0;
+
+  virtual void Init(resumption::LastState* last_state) = 0;
+
+ protected:
+  /*
+   * @brief function checks if json member exists
+   *
+   * @param json_member from file hmi_capabilities.json
+   * @param name_of_member name which we should check
+   *     hmi_capabilities.json
+   *
+   * @returns TRUE if member exists and returns FALSE if
+   * member does not exist.
+   */
+  virtual bool check_existing_json_member(const Json::Value& json_member,
+                                          const char* name_of_member) const = 0;
+
+  virtual void convert_json_languages_to_obj(
+      const Json::Value& json_languages,
+      smart_objects::SmartObject& languages) const = 0;
+};
+
+}  //  namespace application_manager
+
+#endif  //  SRC_COMPONENTS_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_H_


### PR DESCRIPTION
Been done:
- `HMICapabilities` class divided into interface and implementation;
- New amendments to the dependent files, in accordance with the change of
  `HMICapabilities` class;
- Created `MockHMICapabilities` class;
- Changed `HMICapabilities` class to `HMICapabilities`
  interface in `ApplicationManagerImpl` class;
- Removed unnecessary `virtual inline` modifiers from `HMICapabilitiesImpl` class;
- Corrected coding style to all changed files;

Recreated pull request [#577](https://github.com/smartdevicelink/sdl_core/pull/577)

Resolves: [APPLINK-24911](https://adc.luxoft.com/jira/browse/APPLINK-24911)