### PR TITLE
Move is app subscribed for way points

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -767,6 +767,7 @@ class Application : public virtual InitialApplicationData,
    * @brief Load persistent files from application folder.
    */
   virtual void LoadPersistentFiles() = 0;
+  virtual bool IsAppSubscribedForWayPoints(const uint32_t app_id) const = 0;
   /**
    * @brief Get available app space
    * @param name of the app folder(make + mobile app id)

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -296,6 +296,9 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
    */
   uint32_t GetAvailableDiskSpace() OVERRIDE;
 
+  virtual bool IsAppSubscribedForWayPoints(
+      const uint32_t app_id) const OVERRIDE;
+
  protected:
   /**
    * @brief Clean up application folder. Persistent files will stay

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data.h
@@ -60,8 +60,8 @@ class ResumptionData {
   /**
    * @brief Constructor of ResumptionData
    */
-  ResumptionData(
-      const application_manager::ApplicationManager& application_manager);
+  ResumptionData(const application_manager::ApplicationManagerSettings&
+                     application_manager_settings);
 
   /**
    * @brief Destructor of ResumptionData
@@ -270,7 +270,8 @@ class ResumptionData {
     }
   }
   mutable sync_primitives::Lock resumption_lock_;
-  const application_manager::ApplicationManager& application_manager_;
+  const application_manager::ApplicationManagerSettings&
+      application_manager_settings_;
 };
 }  // namespace resumption
 

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
@@ -54,6 +54,7 @@ struct ApplicationParams {
   mobile_apis::HMILevel::eType m_hmi_level;
   bool m_is_media_application;
   bool m_is_valid;
+  bool m_is_subscribed_for_way_points;
 };
 
 /**

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
@@ -72,9 +72,9 @@ class ResumptionDataDB : public ResumptionData {
    * @brief Constructor of ResumptionDataDB
    * @param db_storage show database should be saved in a disk file or in memory
    */
-  ResumptionDataDB(
-      DbStorage db_storage,
-      const application_manager::ApplicationManager& application_manager);
+  ResumptionDataDB(DbStorage db_storage,
+                   const application_manager::ApplicationManagerSettings&
+                       application_manager_settings);
 
   /**
    * @brief allows to destroy ResumptionDataDB object

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_json.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_json.h
@@ -48,9 +48,9 @@ class ResumptionDataJson : public ResumptionData {
   /**
    * @brief Constructor of ResumptionDataJson
    */
-  ResumptionDataJson(
-      LastState& last_state,
-      const application_manager::ApplicationManager& application_manager);
+  ResumptionDataJson(LastState& last_state,
+                     const application_manager::ApplicationManagerSettings&
+                         application_manager_settings);
 
   /**
    * @brief allows to destroy ResumptionDataJson object

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -950,4 +950,8 @@ void ApplicationImpl::UnsubscribeFromSoftButtons(int32_t cmd_id) {
   }
 }
 
+bool ApplicationImpl::IsAppSubscribedForWayPoints(const uint32_t app_id) const {
+  return application_manager_.IsAppSubscribedForWayPoints(app_id);
+}
+
 }  // namespace application_manager

--- a/src/components/application_manager/src/resumption/resume_ctrl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl.cc
@@ -80,8 +80,8 @@ void ResumeCtrl::set_resumption_storage(
 bool ResumeCtrl::Init(resumption::LastState& last_state) {
   bool use_db = application_manager_.get_settings().use_db_for_resumption();
   if (use_db) {
-    resumption_storage_.reset(
-        new ResumptionDataDB(In_File_Storage, application_manager_));
+    resumption_storage_.reset(new ResumptionDataDB(
+        In_File_Storage, application_manager_.get_settings()));
     if (!resumption_storage_->Init()) {
       return false;
     }
@@ -105,8 +105,8 @@ bool ResumeCtrl::Init(resumption::LastState& last_state) {
       db->UpdateDBVersion();
     }
   } else {
-    resumption_storage_.reset(
-        new ResumptionDataJson(last_state, application_manager_));
+    resumption_storage_.reset(new ResumptionDataJson(
+        last_state, application_manager_.get_settings()));
     if (!resumption_storage_->Init()) {
       LOGGER_DEBUG(logger_, "Resumption storage initialisation failed");
       return false;

--- a/src/components/application_manager/src/resumption/resumption_data.cc
+++ b/src/components/application_manager/src/resumption/resumption_data.cc
@@ -41,8 +41,10 @@ namespace resumption {
 CREATE_LOGGERPTR_GLOBAL(logger_, "Resumption")
 
 ResumptionData::ResumptionData(
-    const application_manager::ApplicationManager& application_manager)
-    : resumption_lock_(true), application_manager_(application_manager) {}
+    const application_manager::ApplicationManagerSettings&
+        application_manager_settings)
+    : resumption_lock_(true)
+    , application_manager_settings_(application_manager_settings) {}
 
 smart_objects::SmartObject ResumptionData::GetApplicationCommands(
     app_mngr::ApplicationConstSharedPtr application) const {

--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -57,13 +57,14 @@ CREATE_LOGGERPTR_GLOBAL(logger_, "Resumption")
 
 ResumptionDataDB::ResumptionDataDB(
     DbStorage db_storage,
-    const application_manager::ApplicationManager& application_manager)
-    : ResumptionData(application_manager) {
+    const application_manager::ApplicationManagerSettings&
+        application_manager_settings)
+    : ResumptionData(application_manager_settings) {
   if (db_storage == In_File_Storage) {
 #ifndef __QNX__
     db_ = new utils::dbms::SQLDatabase(
         file_system::ConcatPath(
-            application_manager_.get_settings().app_storage_folder(),
+            application_manager_settings.app_storage_folder(),
             kDatabaseName),
         "ResumptionDatabase");
 #else
@@ -88,11 +89,11 @@ bool ResumptionDataDB::Init() {
     LOGGER_ERROR(logger_, "Failed opening database.");
     LOGGER_INFO(logger_, "Starting opening retries.");
     const uint16_t attempts =
-        application_manager_.get_settings().attempts_to_open_resumption_db();
+        application_manager_settings_.attempts_to_open_resumption_db();
     LOGGER_DEBUG(logger_, "Total attempts number is: " << attempts);
     bool is_opened = false;
     const uint16_t open_attempt_timeout_ms =
-        application_manager_.get_settings()
+        application_manager_settings_
             .open_attempt_timeout_ms_resumption_db();
 #if defined(OS_POSIX)
     const useconds_t sleep_interval_mcsec = open_attempt_timeout_ms * 1000;

--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -2589,7 +2589,7 @@ bool ResumptionDataDB::InsertApplicationData(
   const mobile_apis::HMILevel::eType hmi_level = application.m_hmi_level;
   bool is_media_application = application.m_is_media_application;
   bool is_subscribed_for_way_points =
-      application_manager_.IsAppSubscribedForWayPoints(connection_key);
+      application.m_is_subscribed_for_way_points;
 
   if (!query.Prepare(kInsertApplication)) {
     LOGGER_WARN(logger_,
@@ -2780,7 +2780,8 @@ ApplicationParams::ApplicationParams(
     , m_hmi_app_id(0)
     , m_hmi_level(mobile_apis::HMILevel::INVALID_ENUM)
     , m_is_media_application(false)
-    , m_is_valid(false) {
+    , m_is_valid(false)
+    , m_is_subscribed_for_way_points(false) {
   using namespace app_mngr::strings;
   if (!application.keyExists(app_id) || !application.keyExists(hash_id) ||
       !application.keyExists(grammar_id) ||
@@ -2797,6 +2798,8 @@ ApplicationParams::ApplicationParams(
   m_hmi_level =
       static_cast<mobile_apis::HMILevel::eType>(application[hmi_level].asInt());
   m_is_media_application = application[is_media_application].asBool();
+  m_is_subscribed_for_way_points =
+      application[subscribed_for_way_points].asBool();
 }
 
 ApplicationParams::ApplicationParams(app_mngr::ApplicationSharedPtr application)
@@ -2806,7 +2809,8 @@ ApplicationParams::ApplicationParams(app_mngr::ApplicationSharedPtr application)
     , m_hmi_app_id(0)
     , m_hmi_level(mobile_apis::HMILevel::INVALID_ENUM)
     , m_is_media_application(false)
-    , m_is_valid(false) {
+    , m_is_valid(false)
+    , m_is_subscribed_for_way_points(false) {
   if (application) {
     m_is_valid = true;
     m_hash = application->curHash();
@@ -2815,6 +2819,8 @@ ApplicationParams::ApplicationParams(app_mngr::ApplicationSharedPtr application)
     m_hmi_app_id = application->hmi_app_id();
     m_hmi_level = application->hmi_level();
     m_is_media_application = application->IsAudioApplication();
+    m_is_subscribed_for_way_points =
+        application->IsAppSubscribedForWayPoints(m_connection_key);
   }
 }
 

--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -2788,7 +2788,8 @@ ApplicationParams::ApplicationParams(
       !application.keyExists(grammar_id) ||
       !application.keyExists(connection_key) ||
       !application.keyExists(hmi_app_id) || !application.keyExists(hmi_level) ||
-      !application.keyExists(is_media_application)) {
+      !application.keyExists(is_media_application) ||
+      !application.keyExists(subscribed_for_way_points)) {
     return;
   }
   m_is_valid = true;

--- a/src/components/application_manager/src/resumption/resumption_data_json.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_json.cc
@@ -50,8 +50,9 @@ CREATE_LOGGERPTR_GLOBAL(logger_, "Resumption")
 
 ResumptionDataJson::ResumptionDataJson(
     LastState& last_state,
-    const application_manager::ApplicationManager& application_manager)
-    : ResumptionData(application_manager), last_state_(last_state) {}
+    const application_manager::ApplicationManagerSettings&
+        application_manager_settings)
+    : ResumptionData(application_manager_settings), last_state_(last_state) {}
 
 void ResumptionDataJson::SaveApplication(
     app_mngr::ApplicationSharedPtr application) {
@@ -71,7 +72,7 @@ void ResumptionDataJson::SaveApplication(
   const std::string device_mac = application->mac_address();
   const mobile_apis::HMILevel::eType hmi_level = application->hmi_level();
   const bool is_subscribed_for_way_points =
-      application_manager_.IsAppSubscribedForWayPoints(application->app_id());
+      application->IsAppSubscribedForWayPoints(application->app_id());
 
   sync_primitives::AutoLock autolock(resumption_lock_);
   JsonValue tmp;

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -276,6 +276,7 @@ class MockApplication : public ::application_manager::Application {
   MOCK_CONST_METHOD0(is_foreground, bool());
   MOCK_METHOD1(set_foreground, void(bool is_foreground));
   MOCK_CONST_METHOD0(IsRegistered, bool());
+  MOCK_CONST_METHOD1(IsAppSubscribedForWayPoints, bool(const uint32_t app_id));
 };
 
 }  // namespace application_manager_test

--- a/src/components/application_manager/test/include/application_manager/mock_resumption_data.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resumption_data.h
@@ -37,6 +37,7 @@
 #include "application_manager/application.h"
 #include "application_manager/mock_application_manager_settings.h"
 #include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_application_manager_settings.h"
 
 namespace test {
 namespace components {
@@ -48,8 +49,9 @@ namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 class MockResumptionData : public ::resumption::ResumptionData {
  public:
   MockResumptionData(
-      const application_manager_test::MockApplicationManager& settings)
-      : ResumptionData(settings) {}
+      const application_manager_test::MockApplicationManagerSettings&
+          application_manager_settings)
+      : ResumptionData(application_manager_settings) {}
   MOCK_METHOD1(SaveApplication,
                void(app_mngr::ApplicationSharedPtr application));
   MOCK_CONST_METHOD2(GetStoredHMILevel,

--- a/src/components/application_manager/test/include/application_manager/test_resumption_data_db.h
+++ b/src/components/application_manager/test/include/application_manager/test_resumption_data_db.h
@@ -37,6 +37,7 @@
 #include "application_manager/resumption/resumption_data_db.h"
 #include "application_manager/mock_application_manager_settings.h"
 #include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_application_manager_settings.h"
 
 using ::resumption::ResumptionDataDB;
 
@@ -50,9 +51,10 @@ class TestResumptionDataDB : public ResumptionDataDB {
     return db();
   }
 
-  application_manager_test::MockApplicationManager mock_application_manager_;
+  application_manager_test::MockApplicationManagerSettings
+      mock_application_manager_settings_;
   TestResumptionDataDB(DbStorage db_storage)
-      : ResumptionDataDB(db_storage, mock_application_manager_) {}
+      : ResumptionDataDB(db_storage, mock_application_manager_settings_) {}
 };
 
 }  // namespace resumption_test

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -83,7 +83,7 @@ class ResumeCtrlTest : public ::testing::Test {
         .WillByDefault(ReturnRef(mock_event_dispatcher_));
     mock_storage =
         ::utils::MakeShared<NiceMock<resumption_test::MockResumptionData>>(
-            app_mngr_);
+            mock_application_manager_settings_);
     app_mock = utils::MakeShared<NiceMock<MockApplication>>();
     res_ctrl = utils::MakeShared<ResumeCtrl>(app_mngr_);
     res_ctrl->set_resumption_storage(mock_storage);

--- a/src/components/application_manager/test/resumption/resumption_data_json_test.cc
+++ b/src/components/application_manager/test/resumption/resumption_data_json_test.cc
@@ -66,7 +66,7 @@ class ResumptionDataJsonTest : public ResumptionDataTest {
  protected:
   ResumptionDataJsonTest()
       : last_state_("app_storage_folder", "app_info_storage")
-      , res_json(last_state_, mock_application_manager_) {}
+      , res_json(last_state_, mock_application_manager_settings_) {}
   virtual void SetUp() {
     app_mock = new NiceMock<application_manager_test::MockApplication>();
 


### PR DESCRIPTION
IsAppSubscribedForWayPoints was moved from AM to application impl to use AM Settings instead of AM in Resumption Data.

This pull request was moved from PASA to GENIVI repo. PR on PASA - [#344](https://github.com/CustomSDL/sdl_panasonic/pull/344)

Related to [APPLINK-24305](https://adc.luxoft.com/jira/browse/APPLINK-24305)
