### PR TITLE
Fix_core_dump_when_app_is_in_LIMITED_and_ignition_off_is_sent

### DIFF
--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -48,12 +48,12 @@
 #include "utils/file_system.h"
 #include "application_manager/application_manager_settings.h"
 
-namespace {
-const std::string kDatabaseName = "resumption";
-}
-
 namespace resumption {
 CREATE_LOGGERPTR_GLOBAL(logger_, "Resumption")
+
+namespace {
+const char* kDatabaseName = "resumption";
+}  // namespace
 
 ResumptionDataDB::ResumptionDataDB(
     DbStorage db_storage,

--- a/src/components/policy/include/policy/sql_pt_representation.h
+++ b/src/components/policy/include/policy/sql_pt_representation.h
@@ -193,7 +193,6 @@ class SQLPTRepresentation : public virtual PTRepresentation {
   virtual bool UpdateDBVersion() const OVERRIDE;
 
  private:
-  static const std::string kDatabaseName;
   utils::dbms::SQLDatabase* db_;
 
 #ifdef BUILD_TESTS

--- a/src/components/policy/src/sql_pt_representation.cc
+++ b/src/components/policy/src/sql_pt_representation.cc
@@ -66,9 +66,8 @@ void InsertUnique(K value, T* array) {
     array->push_back(value);
   }
 }
+const char* kDatabaseName = "policy";
 }  //  namespace
-
-const std::string SQLPTRepresentation::kDatabaseName = "policy";
 
 SQLPTRepresentation::SQLPTRepresentation(const std::string& app_storage_folder,
                                          uint16_t attempts_to_open_policy_db,

--- a/src/components/utils/include/utils/sqlite_wrapper/sql_database.h
+++ b/src/components/utils/include/utils/sqlite_wrapper/sql_database.h
@@ -149,17 +149,6 @@ class SQLDatabase {
   int error_;
 
   /**
-   *  The temporary in-memory database
-   *  @see SQLite manual
-   */
-  static const std::string kInMemory;
-
-  /**
-   * The extension of filename of database
-   */
-  static const std::string kExtension;
-
-  /**
    * Execs query for internal using in this class
    * @param query sql query without return results
    * @return true if query was executed successfully

--- a/src/components/utils/src/sqlite_wrapper/sql_database.cc
+++ b/src/components/utils/src/sqlite_wrapper/sql_database.cc
@@ -36,8 +36,10 @@
 namespace utils {
 namespace dbms {
 
-const std::string SQLDatabase::kInMemory = ":memory:";
-const std::string SQLDatabase::kExtension = ".sqlite";
+namespace {
+const char* kInMemory = ":memory:";
+const char* kExtension = ".sqlite";
+}  // namespace
 
 SQLDatabase::SQLDatabase()
     : conn_(NULL), database_path_(kInMemory), error_(SQLITE_OK) {}


### PR DESCRIPTION
The reason for the coredump was a string destructor call after the
string was already destructed. After checking the address in memory
where we were dummped the involved strings were discovered.

Related-Issue: APPLINK-22355