### PR TITLE
Cover with unit tests some `MessageHelper` methods

### DIFF
--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -798,16 +798,6 @@ void MessageHelper::SendSetAppIcon(
   }
 }
 
-void MessageHelper::SendAppDataToHMI(ApplicationConstSharedPtr app,
-                                     ApplicationManager& app_man) {
-  SDL_AUTO_TRACE();
-  if (app) {
-    SendSetAppIcon(app, app->app_icon_path(), app_man);
-    SendGlobalPropertiesToHMI(app, app_man);
-    SendShowRequestToHMI(app, app_man);
-  }
-}
-
 void MessageHelper::SendGlobalPropertiesToHMI(ApplicationConstSharedPtr app,
                                               ApplicationManager& app_mngr) {
   if (!app.valid()) {

--- a/src/components/application_manager/test/message_helper/CMakeLists.txt
+++ b/src/components/application_manager/test/message_helper/CMakeLists.txt
@@ -28,38 +28,38 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-    include_directories(
-        ${GMOCK_INCLUDE_DIRECTORY}
-        ${COMPONENTS_DIR}/include/test
-        ${COMPONENTS_DIR}/application_manager/test/include
-    )
+include_directories(
+    ${GMOCK_INCLUDE_DIRECTORY}
+    ${COMPONENTS_DIR}/include/test
+    ${COMPONENTS_DIR}/application_manager/test/include
+)
 
-    set(LIBRARIES
-        gmock
-        ApplicationManager
-        jsoncpp
-        connectionHandler
-        Utils
-    )
+set(LIBRARIES
+    gmock
+    ApplicationManager
+    jsoncpp
+    connectionHandler
+    Utils
+)
 
-    if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-      list(APPEND LIBRARIES MessageHelper)
-    endif()
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  list(APPEND LIBRARIES MessageHelper)
+endif()
 
-    set(SOURCES
-        message_helper_test.cc
-    )
+set(SOURCES
+    message_helper_test.cc
+)
 
-    if(QT_PORT)
-      link_directories (${CMAKE_SOURCE_DIR}/build/openssl_win_x86/lib)
-    endif()
+if(QT_PORT)
+  link_directories (${CMAKE_SOURCE_DIR}/build/openssl_win_x86/lib)
+endif()
 
-    if(NOT QT_PORT AND ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-      link_directories(${CMAKE_SOURCE_DIR}/build/openssl_win_x64/lib/)
-    endif()
+if(NOT QT_PORT AND ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  link_directories(${CMAKE_SOURCE_DIR}/build/openssl_win_x64/lib/)
+endif()
 
-    if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
-    endif()
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+endif()
 
-    create_test("message_helper_test" "${SOURCES}" "${LIBRARIES}")
+create_test("message_helper_test" "${SOURCES}" "${LIBRARIES}")


### PR DESCRIPTION
Removed unused method `SendAppDataToHMI`;
Covered next `MessageHelper` methods:
- `CreateChangeRegistration`;
- `CreateDeviceListSO`;
- `CreateGetVehicleDataRequest`;
- `CreateHMIApplicationStruct`;
- `SendPolicyUpdate`;
- `SendQueryApps`;
- `SendSDLActivateAppResponse`;
- `SendSetAppIcon`;
- `SendShowRequestToHMI`;
- `SendStopAudioPathThru`;
- `SendSystemRequestNotification`;
- `SendTTSGlobalProperties`;
- `SendUIChangeRegistrationRequestToHMI`;
- `SendAddCommandRequestToHMI`;
- `SendAddSubMenuRequestToHMI`;
- `SendAddVRCommandToHMI`;
- `SendAllOnButtonSubscriptionNotificationsForApp`;
- `SendAudioStartStream`;
- `SendAudioStopStream`;
- `SendChangeRegistrationRequestToHMI`;
- `SendGetListOfPermissionsResponse`;
- `SendGetStatusUpdateResponse`.

Related to: [APPLINK-25335](https://adc.luxoft.com/jira/browse/APPLINK-25335), [APPLINK-25336](https://adc.luxoft.com/jira/browse/APPLINK-25336), [APPLINK-25340](https://adc.luxoft.com/jira/browse/APPLINK-25340)