### PR TITLE
Resolve Qt build issues

### DIFF
--- a/src/components/application_manager/test/commands/CMakeLists.txt
+++ b/src/components/application_manager/test/commands/CMakeLists.txt
@@ -35,7 +35,6 @@ include_directories(
 )
 
 set (SOURCES
-  ${COMPONENTS_DIR}/application_manager/src/message_helper.cc
   ${AM_TEST_DIR}/commands/command_impl_test.cc
   ${AM_TEST_DIR}/commands/command_response_impl_test.cc
   ${AM_TEST_DIR}/commands/command_request_impl_test.cc
@@ -50,7 +49,6 @@ set(LIBRARIES
   MOBILE_API
   SmartObjects
   jsoncpp
-  MessageHelper
 )
 
 create_test("commands_test" "${SOURCES}" "${LIBRARIES}" )

--- a/src/components/application_manager/test/commands/command_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_impl_test.cc
@@ -62,6 +62,12 @@ using ::test::components::application_manager_test::MockApplication;
 
 typedef SharedPtr<MockApplication> MockAppPtr;
 
+namespace {
+static const uint32_t kDefaultMsgCount_ = 5u;
+static const uint32_t kAppId1_ = 5u;
+static const uint32_t kAppId2_ = 10u;
+}  // namespace
+
 class CommandImplTest : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
   class UnwrappedCommandImpl : CommandImpl {
@@ -101,10 +107,6 @@ class CommandImplTest : public CommandsTest<CommandsTestMocks::kIsNice> {
     }
     return msg;
   }
-
-  static const uint32_t kDefaultMsgCount_ = 5u;
-  const uint32_t kAppId1_ = 5u;
-  const uint32_t kAppId2_ = 10u;
 };
 
 typedef CommandImplTest::UnwrappedCommandImpl UCommandImpl;

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -75,6 +75,16 @@ using ::application_manager::RPCParams;
 typedef ::application_manager::commands::CommandRequestImpl::RequestState
     RequestState;
 
+namespace {
+const uint32_t kConnectionKey_ = 5u;
+const uint32_t kCorrelationId_ = 3u;
+const hmi_apis::FunctionID::eType kInvalidFunctionId_ =
+    hmi_apis::FunctionID::INVALID_ENUM;
+const std::string kPolicyAppId_ = "Test";
+const mobile_apis::Result::eType kMobResultSuccess_ =
+    mobile_apis::Result::SUCCESS;
+}  // namespace
+
 class CommandRequestImplTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
@@ -115,13 +125,6 @@ class CommandRequestImplTest
     return app;
   }
 
-  const uint32_t kConnectionKey_ = 5u;
-  const uint32_t kCorrelationId_ = 3u;
-  const hmi_apis::FunctionID::eType kInvalidFunctionId_ =
-      hmi_apis::FunctionID::INVALID_ENUM;
-  const std::string kPolicyAppId_ = "Test";
-  const mobile_apis::Result::eType kMobResultSuccess_ =
-      mobile_apis::Result::SUCCESS;
   sync_primitives::Lock app_set_lock_;
 };
 

--- a/src/components/application_manager/test/commands/mobile/CMakeLists.txt
+++ b/src/components/application_manager/test/commands/mobile/CMakeLists.txt
@@ -48,7 +48,6 @@ set(LIBRARIES
   HMI_API
   MOBILE_API
   SmartObjects
-  MessageHelper
 )
 
 create_test("mobile_commands_test" "${SOURCES}" "${LIBRARIES}" )


### PR DESCRIPTION
- `const` variables are moved to
  anonymous namespace from next classes:
  - `CommandImplTest`;
  - `CommandRequestImplTest`;
- Removed unnecessary library includes
  from `CMakeLists.txt` files related to
  commands unit tests.

Resolves: [APPLINK-25431](https://adc.luxoft.com/jira/browse/APPLINK-25431)

Recreated pull request #603
Reason: wrong branch name.