### PR TITLE
Feature/cover message helper send methods with ut p1

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -101,7 +101,7 @@ class MessageHelper {
    * @brief Sends OnLanguageChange notification to application
    * @param connection_key Connection key of application
    */
-  static void SendOnLanguageChangeToMobile(uint32_t connection_key);
+  static void SendOnLanguageChangeToMobile(const uint32_t connection_key);
 
   /*
    * @brief Retrieve vehicle data map for param name in mobile request
@@ -117,7 +117,7 @@ class MessageHelper {
    * @return stringified value for enum if succedeed, otherwise - empty string
    */
   static std::string HMIResultToString(
-      hmi_apis::Common_Result::eType hmi_result);
+      const hmi_apis::Common_Result::eType hmi_result);
 
   /**
    * @brief Converts string to HMI Result enum value
@@ -134,7 +134,7 @@ class MessageHelper {
    * @return stringified value for enum if succedeed, otherwise - empty string
    */
   static std::string MobileResultToString(
-      mobile_apis::Result::eType mobile_result);
+      const mobile_apis::Result::eType mobile_result);
 
   /**
    * @brief Converts string to mobile Result enum value
@@ -177,20 +177,20 @@ class MessageHelper {
   * @param hmi_level Desired HMI Level
   */
   static std::string StringifiedHMILevel(
-      mobile_apis::HMILevel::eType hmi_level);
+      const mobile_apis::HMILevel::eType hmi_level);
 
   /*
   * @brief Used to obtain function name by its id
   * @param function_id Function ID
   */
   static std::string StringifiedFunctionID(
-      mobile_apis::FunctionID::eType function_id);
+      const mobile_apis::FunctionID::eType function_id);
 
   static smart_objects::SmartObjectSPtr CreateBlockedByPoliciesResponse(
-      mobile_apis::FunctionID::eType function_id,
-      mobile_apis::Result::eType result,
+      const mobile_apis::FunctionID::eType function_id,
+      const mobile_apis::Result::eType result,
       const uint32_t correlation_id,
-      uint32_t connection_key);
+      const uint32_t connection_key);
 
   /*
    * @brief Prepare GetDeviceListResponse
@@ -205,10 +205,10 @@ class MessageHelper {
       ApplicationManager& app_mngr);
 
   static smart_objects::SmartObjectSPtr CreateModuleInfoSO(
-      uint32_t function_id, ApplicationManager& app_mngr);
+      const uint32_t function_id, ApplicationManager& app_mngr);
 
   static smart_objects::SmartObjectSPtr CreateSetAppIcon(
-      const std::string& path_to_icon, uint32_t app_id);
+      const std::string& path_to_icon, const uint32_t app_id);
 
   /**
    * @brief Sends IVI subscription requests
@@ -272,13 +272,13 @@ class MessageHelper {
   static void SendChangeRegistrationRequestToHMI(ApplicationConstSharedPtr app,
                                                  ApplicationManager& app_mngr);
   static void SendAddVRCommandToHMI(
-      uint32_t cmd_id,
+      const uint32_t cmd_id,
       const smart_objects::SmartObject& vr_commands,
       const uint32_t app_id,
       ApplicationManager& app_mngr);
 
   static smart_objects::SmartObjectSPtr CreateAddVRCommandToHMI(
-      uint32_t cmd_id,
+      const uint32_t cmd_id,
       const smart_objects::SmartObject& vr_commands,
       const uint32_t app_id,
       ApplicationManager& app_mngr);
@@ -307,16 +307,17 @@ class MessageHelper {
    * @param is_unexpected_disconnect
    * Indicates if connection was unexpectedly lost by TM or HB
    */
-  static void SendOnAppUnregNotificationToHMI(ApplicationConstSharedPtr app,
-                                              bool is_unexpected_disconnect,
-                                              ApplicationManager& app_mngr);
+  static void SendOnAppUnregNotificationToHMI(
+      ApplicationConstSharedPtr app,
+      const bool is_unexpected_disconnect,
+      ApplicationManager& app_mngr);
 
   static NsSmartDeviceLink::NsSmartObjects::SmartObjectSPtr
   GetBCActivateAppRequestToHMI(
       ApplicationConstSharedPtr app,
       const protocol_handler::SessionObserver& session_observer,
       const policy::PolicyHandlerInterface& policy_handler,
-      hmi_apis::Common_HMILevel::eType level,
+      const hmi_apis::Common_HMILevel::eType level,
       bool send_policy_priority,
       ApplicationManager& app_mngr);
 
@@ -328,7 +329,7 @@ class MessageHelper {
   * @param permissions response parameters
   */
   static void SendSDLActivateAppResponse(policy::AppPermissions& permissions,
-                                         uint32_t correlation_id,
+                                         const uint32_t correlation_id,
                                          ApplicationManager& app_mngr);
 
   /**
@@ -346,7 +347,7 @@ class MessageHelper {
     * @param retries Seconds between retries
     */
   static void SendPolicyUpdate(const std::string& file_path,
-                               int timeout,
+                               const int timeout,
                                const std::vector<int>& retries,
                                ApplicationManager& app_mngr);
 
@@ -357,7 +358,7 @@ class MessageHelper {
    */
   static void SendGetUserFriendlyMessageResponse(
       const std::vector<policy::UserFriendlyMessage>& msg,
-      uint32_t correlation_id,
+      const uint32_t correlation_id,
       ApplicationManager& app_mngr);
 
   /**
@@ -367,7 +368,7 @@ class MessageHelper {
    */
   static void SendGetListOfPermissionsResponse(
       const std::vector<policy::FunctionalGroupPermission>& permissions,
-      uint32_t correlation_id,
+      const uint32_t correlation_id,
       ApplicationManager& app_mngr);
 
   /*
@@ -376,7 +377,8 @@ class MessageHelper {
    * @param connection_key  Application connection key
    *
    */
-  static void SendNaviStartStream(int32_t app_id, ApplicationManager& app_mngr);
+  static void SendNaviStartStream(const int32_t app_id,
+                                  ApplicationManager& app_mngr);
 
   /*
    * @brief Sends notification to HMI to stop video streaming
@@ -384,7 +386,8 @@ class MessageHelper {
    * @param connection_key  Application connection key
    *
    */
-  static void SendNaviStopStream(int32_t app_id, ApplicationManager& app_mngr);
+  static void SendNaviStopStream(const int32_t app_id,
+                                 ApplicationManager& app_mngr);
 
   /*
   * @brief Send notification for Update of Policy Table
@@ -395,13 +398,13 @@ class MessageHelper {
   * @param timeout If -1 no timeout is provdied
   */
   static void SendPolicySnapshotNotification(
-      uint32_t connection_key,
+      const uint32_t connection_key,
       const std::vector<uint8_t>& policy_data,
       const std::string& url,
       ApplicationManager& app_mngr);
 
   static void SendSystemRequestNotification(
-      uint32_t connection_key,
+      const uint32_t connection_key,
       NsSmartDeviceLink::NsSmartObjects::SmartObject& content,
       ApplicationManager& app_mngr);
 
@@ -432,7 +435,7 @@ class MessageHelper {
   * @param permissions updated permissions for application
   */
   static void SendOnPermissionsChangeNotification(
-      uint32_t connection_key,
+      const uint32_t connection_key,
       const policy::Permissions& permissions,
       ApplicationManager& app_mngr);
 
@@ -483,7 +486,7 @@ class MessageHelper {
    * @param connection_key  Application connection key
    *
    */
-  static void SendAudioStartStream(int32_t app_id,
+  static void SendAudioStartStream(const int32_t app_id,
                                    ApplicationManager& app_mngr);
 
   /*
@@ -492,11 +495,11 @@ class MessageHelper {
    * @param connection_key  Application connection key
    *
    */
-  static void SendAudioStopStream(int32_t connection_key,
+  static void SendAudioStopStream(const int32_t connection_key,
                                   ApplicationManager& app_mngr);
 
-  static void SendOnDataStreaming(protocol_handler::ServiceType service,
-                                  bool available,
+  static void SendOnDataStreaming(const protocol_handler::ServiceType service,
+                                  const bool available,
                                   ApplicationManager& app_mngr);
 
   /*
@@ -515,10 +518,10 @@ class MessageHelper {
   static bool SendUnsubscribedWayPoints(ApplicationManager& app_mngr);
 
   static smart_objects::SmartObjectSPtr CreateNegativeResponse(
-      uint32_t connection_key,
-      int32_t function_id,
+      const uint32_t connection_key,
+      const int32_t function_id,
       const uint32_t correlation_id,
-      int32_t result_code);
+      const int32_t result_code);
 
   /*
    * @brief Verify image and add image file full path
@@ -583,7 +586,7 @@ class MessageHelper {
   static void SubscribeApplicationToSoftButton(
       smart_objects::SmartObject& message_params,
       ApplicationSharedPtr app,
-      int32_t function_id);
+      const int32_t function_id);
 
   static bool PrintSmartObject(const smart_objects::SmartObject& object);
 
@@ -600,7 +603,7 @@ class MessageHelper {
    * @return Common language string representation
    */
   static std::string CommonLanguageToString(
-      hmi_apis::Common_Language::eType language);
+      const hmi_apis::Common_Language::eType language);
 
   /**
    * @brief Converts string to mobile language enum value
@@ -665,7 +668,7 @@ class MessageHelper {
       const std::string& language);
   static smart_objects::SmartObjectSPtr
   GetOnAppInterfaceUnregisteredNotificationToMobile(
-      int32_t connection_key,
+      const int32_t connection_key,
       mobile_api::AppInterfaceUnregisteredReason::eType reason);
 
  private:

--- a/src/components/application_manager/test/message_helper/CMakeLists.txt
+++ b/src/components/application_manager/test/message_helper/CMakeLists.txt
@@ -58,4 +58,8 @@
       link_directories(${CMAKE_SOURCE_DIR}/build/openssl_win_x64/lib/)
     endif()
 
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+    endif()
+
     create_test("message_helper_test" "${SOURCES}" "${LIBRARIES}")

--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -61,9 +61,12 @@ typedef utils::SharedPtr<AppMock> MockApplicationSharedPtr;
 typedef std::vector<std::string> StringArray;
 typedef utils::SharedPtr<application_manager::Application> ApplicationSharedPtr;
 
-using testing::AtLeast;
-using testing::Return;
-using testing::ReturnRef;
+using ::testing::AtLeast;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::SaveArg;
 
 TEST(MessageHelperTestCreate,
      CreateBlockedByPoliciesResponse_SmartObject_Equal) {
@@ -258,12 +261,14 @@ TEST(MessageHelperTestCreate,
   object[strings::cmd_icon] = 1;
   object[strings::cmd_icon][strings::value] = "10";
 
-  vis.insert(std::pair<uint32_t, smart_objects::SmartObject*>(5, &object));
+  vis.insert(CommandsMap::value_type(5, &object));
 
   MockApplicationSharedPtr appSharedMock = utils::MakeShared<AppMock>();
   EXPECT_CALL(*appSharedMock, commands_map()).WillOnce(Return(data_accessor));
   EXPECT_CALL(*appSharedMock, app_id()).WillOnce(Return(1u));
   application_manager_test::MockApplicationManager mock_application_manager;
+  EXPECT_CALL(mock_application_manager, GetNextHMICorrelationID())
+      .WillOnce(Return(0u));
 
   smart_objects::SmartObjectList ptr =
       MessageHelper::CreateAddCommandRequestToHMI(appSharedMock,
@@ -334,6 +339,9 @@ TEST(MessageHelperTestCreate,
       .Times(AtLeast(5))
       .WillRepeatedly(Return(1u));
   application_manager_test::MockApplicationManager mock_application_manager;
+  EXPECT_CALL(mock_application_manager, GetNextHMICorrelationID())
+      .Times(AtLeast(5))
+      .WillRepeatedly(Return(0u));
 
   smart_objects::SmartObjectList ptr =
       MessageHelper::CreateAddVRCommandRequestFromChoiceToHMI(
@@ -455,171 +463,178 @@ TEST(MessageHelperTestCreate, CreateNegativeResponse_SendSmartObject_Equal) {
 
 class MessageHelperTest : public ::testing::Test {
  public:
-  MessageHelperTest() : delta_from_functions_id(32768) {
-    language_strings.push_back("EN-US");
-    language_strings.push_back("ES-MX");
-    language_strings.push_back("FR-CA");
-    language_strings.push_back("DE-DE");
-    language_strings.push_back("ES-ES");
-    language_strings.push_back("EN-GB");
-    language_strings.push_back("RU-RU");
-    language_strings.push_back("TR-TR");
-    language_strings.push_back("PL-PL");
-    language_strings.push_back("FR-FR");
-    language_strings.push_back("IT-IT");
-    language_strings.push_back("SV-SE");
-    language_strings.push_back("PT-PT");
-    language_strings.push_back("NL-NL");
-    language_strings.push_back("EN-AU");
-    language_strings.push_back("ZH-CN");
-    language_strings.push_back("ZH-TW");
-    language_strings.push_back("JA-JP");
-    language_strings.push_back("AR-SA");
-    language_strings.push_back("KO-KR");
-    language_strings.push_back("PT-BR");
-    language_strings.push_back("CS-CZ");
-    language_strings.push_back("DA-DK");
-    language_strings.push_back("NO-NO");
-    language_strings.push_back("NL-BE");
-    language_strings.push_back("EL-GR");
-    language_strings.push_back("HU-HU");
-    language_strings.push_back("FI-FI");
-    language_strings.push_back("SK-SK");
+  MessageHelperTest()
+      : kDeltaFromFunctionsId(32768)
+      , kAppId(1u)
+      , kAvailable(true)
+      , kConnectionKey(1u) {
+    language_strings_.push_back("EN-US");
+    language_strings_.push_back("ES-MX");
+    language_strings_.push_back("FR-CA");
+    language_strings_.push_back("DE-DE");
+    language_strings_.push_back("ES-ES");
+    language_strings_.push_back("EN-GB");
+    language_strings_.push_back("RU-RU");
+    language_strings_.push_back("TR-TR");
+    language_strings_.push_back("PL-PL");
+    language_strings_.push_back("FR-FR");
+    language_strings_.push_back("IT-IT");
+    language_strings_.push_back("SV-SE");
+    language_strings_.push_back("PT-PT");
+    language_strings_.push_back("NL-NL");
+    language_strings_.push_back("EN-AU");
+    language_strings_.push_back("ZH-CN");
+    language_strings_.push_back("ZH-TW");
+    language_strings_.push_back("JA-JP");
+    language_strings_.push_back("AR-SA");
+    language_strings_.push_back("KO-KR");
+    language_strings_.push_back("PT-BR");
+    language_strings_.push_back("CS-CZ");
+    language_strings_.push_back("DA-DK");
+    language_strings_.push_back("NO-NO");
+    language_strings_.push_back("NL-BE");
+    language_strings_.push_back("EL-GR");
+    language_strings_.push_back("HU-HU");
+    language_strings_.push_back("FI-FI");
+    language_strings_.push_back("SK-SK");
 
-    hmi_result_strings.push_back("SUCCESS");
-    hmi_result_strings.push_back("UNSUPPORTED_REQUEST");
-    hmi_result_strings.push_back("UNSUPPORTED_RESOURCE");
-    hmi_result_strings.push_back("DISALLOWED");
-    hmi_result_strings.push_back("REJECTED");
-    hmi_result_strings.push_back("ABORTED");
-    hmi_result_strings.push_back("IGNORED");
-    hmi_result_strings.push_back("RETRY");
-    hmi_result_strings.push_back("IN_USE");
-    hmi_result_strings.push_back("DATA_NOT_AVAILABLE");
-    hmi_result_strings.push_back("TIMED_OUT");
-    hmi_result_strings.push_back("INVALID_DATA");
-    hmi_result_strings.push_back("CHAR_LIMIT_EXCEEDED");
-    hmi_result_strings.push_back("INVALID_ID");
-    hmi_result_strings.push_back("DUPLICATE_NAME");
-    hmi_result_strings.push_back("APPLICATION_NOT_REGISTERED");
-    hmi_result_strings.push_back("WRONG_LANGUAGE");
-    hmi_result_strings.push_back("OUT_OF_MEMORY");
-    hmi_result_strings.push_back("TOO_MANY_PENDING_REQUESTS");
-    hmi_result_strings.push_back("NO_APPS_REGISTERED");
-    hmi_result_strings.push_back("NO_DEVICES_CONNECTED");
-    hmi_result_strings.push_back("WARNINGS");
-    hmi_result_strings.push_back("GENERIC_ERROR");
-    hmi_result_strings.push_back("USER_DISALLOWED");
-    hmi_result_strings.push_back("TRUNCATED_DATA");
+    hmi_result_strings_.push_back("SUCCESS");
+    hmi_result_strings_.push_back("UNSUPPORTED_REQUEST");
+    hmi_result_strings_.push_back("UNSUPPORTED_RESOURCE");
+    hmi_result_strings_.push_back("DISALLOWED");
+    hmi_result_strings_.push_back("REJECTED");
+    hmi_result_strings_.push_back("ABORTED");
+    hmi_result_strings_.push_back("IGNORED");
+    hmi_result_strings_.push_back("RETRY");
+    hmi_result_strings_.push_back("IN_USE");
+    hmi_result_strings_.push_back("DATA_NOT_AVAILABLE");
+    hmi_result_strings_.push_back("TIMED_OUT");
+    hmi_result_strings_.push_back("INVALID_DATA");
+    hmi_result_strings_.push_back("CHAR_LIMIT_EXCEEDED");
+    hmi_result_strings_.push_back("INVALID_ID");
+    hmi_result_strings_.push_back("DUPLICATE_NAME");
+    hmi_result_strings_.push_back("APPLICATION_NOT_REGISTERED");
+    hmi_result_strings_.push_back("WRONG_LANGUAGE");
+    hmi_result_strings_.push_back("OUT_OF_MEMORY");
+    hmi_result_strings_.push_back("TOO_MANY_PENDING_REQUESTS");
+    hmi_result_strings_.push_back("NO_APPS_REGISTERED");
+    hmi_result_strings_.push_back("NO_DEVICES_CONNECTED");
+    hmi_result_strings_.push_back("WARNINGS");
+    hmi_result_strings_.push_back("GENERIC_ERROR");
+    hmi_result_strings_.push_back("USER_DISALLOWED");
+    hmi_result_strings_.push_back("TRUNCATED_DATA");
 
-    mobile_result_strings.push_back("SUCCESS");
-    mobile_result_strings.push_back("UNSUPPORTED_REQUEST");
-    mobile_result_strings.push_back("UNSUPPORTED_RESOURCE");
-    mobile_result_strings.push_back("DISALLOWED");
-    mobile_result_strings.push_back("REJECTED");
-    mobile_result_strings.push_back("ABORTED");
-    mobile_result_strings.push_back("IGNORED");
-    mobile_result_strings.push_back("RETRY");
-    mobile_result_strings.push_back("IN_USE");
-    mobile_result_strings.push_back("VEHICLE_DATA_NOT_AVAILABLE");
-    mobile_result_strings.push_back("TIMED_OUT");
-    mobile_result_strings.push_back("INVALID_DATA");
-    mobile_result_strings.push_back("CHAR_LIMIT_EXCEEDED");
-    mobile_result_strings.push_back("INVALID_ID");
-    mobile_result_strings.push_back("DUPLICATE_NAME");
-    mobile_result_strings.push_back("APPLICATION_NOT_REGISTERED");
-    mobile_result_strings.push_back("WRONG_LANGUAGE");
-    mobile_result_strings.push_back("OUT_OF_MEMORY");
-    mobile_result_strings.push_back("TOO_MANY_PENDING_REQUESTS");
-    mobile_result_strings.push_back("TOO_MANY_APPLICATIONS");
-    mobile_result_strings.push_back("APPLICATION_REGISTERED_ALREADY");
-    mobile_result_strings.push_back("WARNINGS");
-    mobile_result_strings.push_back("GENERIC_ERROR");
-    mobile_result_strings.push_back("USER_DISALLOWED");
-    mobile_result_strings.push_back("TRUNCATED_DATA");
-    mobile_result_strings.push_back("UNSUPPORTED_VERSION");
-    mobile_result_strings.push_back("VEHICLE_DATA_NOT_ALLOWED");
-    mobile_result_strings.push_back("FILE_NOT_FOUND");
-    mobile_result_strings.push_back("CANCEL_ROUTE");
-    mobile_result_strings.push_back("SAVED");
-    mobile_result_strings.push_back("INVALID_CERT");
-    mobile_result_strings.push_back("EXPIRED_CERT");
-    mobile_result_strings.push_back("RESUME_FAILED");
+    mobile_result_strings_.push_back("SUCCESS");
+    mobile_result_strings_.push_back("UNSUPPORTED_REQUEST");
+    mobile_result_strings_.push_back("UNSUPPORTED_RESOURCE");
+    mobile_result_strings_.push_back("DISALLOWED");
+    mobile_result_strings_.push_back("REJECTED");
+    mobile_result_strings_.push_back("ABORTED");
+    mobile_result_strings_.push_back("IGNORED");
+    mobile_result_strings_.push_back("RETRY");
+    mobile_result_strings_.push_back("IN_USE");
+    mobile_result_strings_.push_back("VEHICLE_DATA_NOT_AVAILABLE");
+    mobile_result_strings_.push_back("TIMED_OUT");
+    mobile_result_strings_.push_back("INVALID_DATA");
+    mobile_result_strings_.push_back("CHAR_LIMIT_EXCEEDED");
+    mobile_result_strings_.push_back("INVALID_ID");
+    mobile_result_strings_.push_back("DUPLICATE_NAME");
+    mobile_result_strings_.push_back("APPLICATION_NOT_REGISTERED");
+    mobile_result_strings_.push_back("WRONG_LANGUAGE");
+    mobile_result_strings_.push_back("OUT_OF_MEMORY");
+    mobile_result_strings_.push_back("TOO_MANY_PENDING_REQUESTS");
+    mobile_result_strings_.push_back("TOO_MANY_APPLICATIONS");
+    mobile_result_strings_.push_back("APPLICATION_REGISTERED_ALREADY");
+    mobile_result_strings_.push_back("WARNINGS");
+    mobile_result_strings_.push_back("GENERIC_ERROR");
+    mobile_result_strings_.push_back("USER_DISALLOWED");
+    mobile_result_strings_.push_back("TRUNCATED_DATA");
+    mobile_result_strings_.push_back("UNSUPPORTED_VERSION");
+    mobile_result_strings_.push_back("VEHICLE_DATA_NOT_ALLOWED");
+    mobile_result_strings_.push_back("FILE_NOT_FOUND");
+    mobile_result_strings_.push_back("CANCEL_ROUTE");
+    mobile_result_strings_.push_back("SAVED");
+    mobile_result_strings_.push_back("INVALID_CERT");
+    mobile_result_strings_.push_back("EXPIRED_CERT");
+    mobile_result_strings_.push_back("RESUME_FAILED");
 
-    function_id_strings.push_back("RESERVED");
-    function_id_strings.push_back("RegisterAppInterface");
-    function_id_strings.push_back("UnregisterAppInterface");
-    function_id_strings.push_back("SetGlobalProperties");
-    function_id_strings.push_back("ResetGlobalProperties");
-    function_id_strings.push_back("AddCommand");
-    function_id_strings.push_back("DeleteCommand");
-    function_id_strings.push_back("AddSubMenu");
-    function_id_strings.push_back("DeleteSubMenu");
-    function_id_strings.push_back("CreateInteractionChoiceSet");
-    function_id_strings.push_back("PerformInteraction");
-    function_id_strings.push_back("DeleteInteractionChoiceSet");
-    function_id_strings.push_back("Alert");
-    function_id_strings.push_back("Show");
-    function_id_strings.push_back("Speak");
-    function_id_strings.push_back("SetMediaClockTimer");
-    function_id_strings.push_back("PerformAudioPassThru");
-    function_id_strings.push_back("EndAudioPassThru");
-    function_id_strings.push_back("SubscribeButton");
-    function_id_strings.push_back("UnsubscribeButton");
-    function_id_strings.push_back("SubscribeVehicleData");
-    function_id_strings.push_back("UnsubscribeVehicleData");
-    function_id_strings.push_back("GetVehicleData");
-    function_id_strings.push_back("ReadDID");
-    function_id_strings.push_back("GetDTCs");
-    function_id_strings.push_back("ScrollableMessage");
-    function_id_strings.push_back("Slider");
-    function_id_strings.push_back("ShowConstantTBT");
-    function_id_strings.push_back("AlertManeuver");
-    function_id_strings.push_back("UpdateTurnList");
-    function_id_strings.push_back("ChangeRegistration");
-    function_id_strings.push_back("GenericResponse");
-    function_id_strings.push_back("PutFile");
-    function_id_strings.push_back("DeleteFile");
-    function_id_strings.push_back("ListFiles");
-    function_id_strings.push_back("SetAppIcon");
-    function_id_strings.push_back("SetDisplayLayout");
-    function_id_strings.push_back("DiagnosticMessage");
-    function_id_strings.push_back("SystemRequest");
-    function_id_strings.push_back("SendLocation");
-    function_id_strings.push_back("DialNumber");
+    function_id_strings_.push_back("RESERVED");
+    function_id_strings_.push_back("RegisterAppInterface");
+    function_id_strings_.push_back("UnregisterAppInterface");
+    function_id_strings_.push_back("SetGlobalProperties");
+    function_id_strings_.push_back("ResetGlobalProperties");
+    function_id_strings_.push_back("AddCommand");
+    function_id_strings_.push_back("DeleteCommand");
+    function_id_strings_.push_back("AddSubMenu");
+    function_id_strings_.push_back("DeleteSubMenu");
+    function_id_strings_.push_back("CreateInteractionChoiceSet");
+    function_id_strings_.push_back("PerformInteraction");
+    function_id_strings_.push_back("DeleteInteractionChoiceSet");
+    function_id_strings_.push_back("Alert");
+    function_id_strings_.push_back("Show");
+    function_id_strings_.push_back("Speak");
+    function_id_strings_.push_back("SetMediaClockTimer");
+    function_id_strings_.push_back("PerformAudioPassThru");
+    function_id_strings_.push_back("EndAudioPassThru");
+    function_id_strings_.push_back("SubscribeButton");
+    function_id_strings_.push_back("UnsubscribeButton");
+    function_id_strings_.push_back("SubscribeVehicleData");
+    function_id_strings_.push_back("UnsubscribeVehicleData");
+    function_id_strings_.push_back("GetVehicleData");
+    function_id_strings_.push_back("ReadDID");
+    function_id_strings_.push_back("GetDTCs");
+    function_id_strings_.push_back("ScrollableMessage");
+    function_id_strings_.push_back("Slider");
+    function_id_strings_.push_back("ShowConstantTBT");
+    function_id_strings_.push_back("AlertManeuver");
+    function_id_strings_.push_back("UpdateTurnList");
+    function_id_strings_.push_back("ChangeRegistration");
+    function_id_strings_.push_back("GenericResponse");
+    function_id_strings_.push_back("PutFile");
+    function_id_strings_.push_back("DeleteFile");
+    function_id_strings_.push_back("ListFiles");
+    function_id_strings_.push_back("SetAppIcon");
+    function_id_strings_.push_back("SetDisplayLayout");
+    function_id_strings_.push_back("DiagnosticMessage");
+    function_id_strings_.push_back("SystemRequest");
+    function_id_strings_.push_back("SendLocation");
+    function_id_strings_.push_back("DialNumber");
 
-    events_id_strings.push_back("OnHMIStatus");
-    events_id_strings.push_back("OnAppInterfaceUnregistered");
-    events_id_strings.push_back("OnButtonEvent");
-    events_id_strings.push_back("OnButtonPress");
-    events_id_strings.push_back("OnVehicleData");
-    events_id_strings.push_back("OnCommand");
-    events_id_strings.push_back("OnTBTClientState");
-    events_id_strings.push_back("OnDriverDistraction");
-    events_id_strings.push_back("OnPermissionsChange");
-    events_id_strings.push_back("OnAudioPassThru");
-    events_id_strings.push_back("OnLanguageChange");
-    events_id_strings.push_back("OnKeyboardInput");
-    events_id_strings.push_back("OnTouchEvent");
-    events_id_strings.push_back("OnSystemRequest");
-    events_id_strings.push_back("OnHashChange");
+    events_id_strings_.push_back("OnHMIStatus");
+    events_id_strings_.push_back("OnAppInterfaceUnregistered");
+    events_id_strings_.push_back("OnButtonEvent");
+    events_id_strings_.push_back("OnButtonPress");
+    events_id_strings_.push_back("OnVehicleData");
+    events_id_strings_.push_back("OnCommand");
+    events_id_strings_.push_back("OnTBTClientState");
+    events_id_strings_.push_back("OnDriverDistraction");
+    events_id_strings_.push_back("OnPermissionsChange");
+    events_id_strings_.push_back("OnAudioPassThru");
+    events_id_strings_.push_back("OnLanguageChange");
+    events_id_strings_.push_back("OnKeyboardInput");
+    events_id_strings_.push_back("OnTouchEvent");
+    events_id_strings_.push_back("OnSystemRequest");
+    events_id_strings_.push_back("OnHashChange");
 
-    hmi_level_strings.push_back("FULL");
-    hmi_level_strings.push_back("LIMITED");
-    hmi_level_strings.push_back("BACKGROUND");
-    hmi_level_strings.push_back("NONE");
+    hmi_level_strings_.push_back("FULL");
+    hmi_level_strings_.push_back("LIMITED");
+    hmi_level_strings_.push_back("BACKGROUND");
+    hmi_level_strings_.push_back("NONE");
   }
 
  protected:
-  application_manager_test::MockApplicationManager mock_application_manager;
-  StringArray language_strings;
-  StringArray hmi_result_strings;
-  StringArray mobile_result_strings;
-  StringArray function_id_strings;
-  StringArray events_id_strings;
-  StringArray hmi_level_strings;
+  application_manager_test::MockApplicationManager mock_application_manager_;
+  StringArray language_strings_;
+  StringArray hmi_result_strings_;
+  StringArray mobile_result_strings_;
+  StringArray function_id_strings_;
+  StringArray events_id_strings_;
+  StringArray hmi_level_strings_;
 
-  const size_t delta_from_functions_id;
+  const size_t kDeltaFromFunctionsId;
+  const uint32_t kAppId;
+  const bool kAvailable;
+  const uint32_t kConnectionKey;
 };
 
 TEST_F(MessageHelperTest,
@@ -627,11 +642,11 @@ TEST_F(MessageHelperTest,
   HmiLanguage::eType enum_value;
   HmiLanguage::eType enum_from_string_value;
   // Check all languages >= 0
-  for (size_t array_index = 0; array_index < language_strings.size();
+  for (size_t array_index = 0; array_index < language_strings_.size();
        ++array_index) {
     enum_value = static_cast<HmiLanguage::eType>(array_index);
     enum_from_string_value =
-        MessageHelper::CommonLanguageFromString(language_strings[array_index]);
+        MessageHelper::CommonLanguageFromString(language_strings_[array_index]);
     EXPECT_EQ(enum_value, enum_from_string_value);
   }
   // Check InvalidEnum == -1
@@ -645,11 +660,11 @@ TEST_F(MessageHelperTest,
   std::string string_from_enum;
   HmiLanguage::eType casted_enum;
   // Check all languages >=0
-  for (size_t array_index = 0; array_index < language_strings.size();
+  for (size_t array_index = 0; array_index < language_strings_.size();
        ++array_index) {
     casted_enum = static_cast<HmiLanguage::eType>(array_index);
     string_from_enum = MessageHelper::CommonLanguageToString(casted_enum);
-    EXPECT_EQ(language_strings[array_index], string_from_enum);
+    EXPECT_EQ(language_strings_[array_index], string_from_enum);
   }
   // Check InvalidEnum == -1
   string_from_enum =
@@ -671,11 +686,11 @@ TEST_F(MessageHelperTest, HMIResultFromString_StringValueOfEnum_CorrectEType) {
   HmiResults::eType enum_value;
   HmiResults::eType enum_from_string_value;
   // Check all results >= 0
-  for (size_t array_index = 0; array_index < hmi_result_strings.size();
+  for (size_t array_index = 0; array_index < hmi_result_strings_.size();
        ++array_index) {
     enum_value = static_cast<HmiResults::eType>(array_index);
     enum_from_string_value =
-        MessageHelper::HMIResultFromString(hmi_result_strings[array_index]);
+        MessageHelper::HMIResultFromString(hmi_result_strings_[array_index]);
     EXPECT_EQ(enum_value, enum_from_string_value);
   }
   // Check InvalidEnum == -1
@@ -688,11 +703,11 @@ TEST_F(MessageHelperTest, HMIResultToString_ETypeValueOfEnum_CorrectString) {
   std::string string_from_enum;
   HmiResults::eType casted_enum;
   // Check all results >=0
-  for (size_t array_index = 0; array_index < hmi_result_strings.size();
+  for (size_t array_index = 0; array_index < hmi_result_strings_.size();
        ++array_index) {
     casted_enum = static_cast<HmiResults::eType>(array_index);
     string_from_enum = MessageHelper::HMIResultToString(casted_enum);
-    EXPECT_EQ(hmi_result_strings[array_index], string_from_enum);
+    EXPECT_EQ(hmi_result_strings_[array_index], string_from_enum);
   }
   // Check InvalidEnum == -1
   string_from_enum = MessageHelper::HMIResultToString(HmiResults::INVALID_ENUM);
@@ -705,10 +720,10 @@ TEST_F(MessageHelperTest,
   HmiResults::eType casted_hmi_enum;
   MobileResults::eType converted_enum;
   // Check enums >=0
-  for (size_t enum_index = 0; enum_index < hmi_result_strings.size();
+  for (size_t enum_index = 0; enum_index < hmi_result_strings_.size();
        ++enum_index) {
     tested_enum =
-        MessageHelper::MobileResultFromString(hmi_result_strings[enum_index]);
+        MessageHelper::MobileResultFromString(hmi_result_strings_[enum_index]);
     casted_hmi_enum = static_cast<HmiResults::eType>(enum_index);
     converted_enum = MessageHelper::HMIToMobileResult(casted_hmi_enum);
     EXPECT_EQ(tested_enum, converted_enum);
@@ -758,14 +773,18 @@ TEST_F(MessageHelperTest,
   DataAccessor<application_manager::VehicleInfoSubscriptions> data_accessor(
       vis, lock);
 
-  // Calls for ApplicationManager
+// Calls for ApplicationManager
+#ifdef HMI_JSON_API
+  EXPECT_CALL(mock_application_manager_, GetNextHMICorrelationID())
+      .WillOnce(Return(0u));
+#endif
   // Creating sharedPtr to MockApplication
   MockApplicationSharedPtr appSharedMock = utils::MakeShared<AppMock>();
   EXPECT_CALL(*appSharedMock, app_id()).WillOnce(Return(1u));
   EXPECT_CALL(*appSharedMock, SubscribedIVI()).WillOnce(Return(data_accessor));
   smart_objects::SmartObjectList outList =
       MessageHelper::GetIVISubscriptionRequests(appSharedMock,
-                                                mock_application_manager);
+                                                mock_application_manager_);
   // Expect not empty request
   EXPECT_FALSE(outList.empty());
 }
@@ -776,12 +795,12 @@ TEST_F(MessageHelperTest,
   smart_objects::SmartObject object;
   policy_handler_test::MockPolicySettings policy_settings_;
   policy::PolicyHandler policy_handler(policy_settings_,
-                                       mock_application_manager);
+                                       mock_application_manager_);
   // Method call
   // Creating sharedPtr to MockApplication
   MockApplicationSharedPtr appSharedMock = utils::MakeShared<AppMock>();
   mobile_apis::Result::eType result = MessageHelper::ProcessSoftButtons(
-      object, appSharedMock, policy_handler, mock_application_manager);
+      object, appSharedMock, policy_handler, mock_application_manager_);
   // Expect
   EXPECT_EQ(mobile_apis::Result::SUCCESS, result);
 }
@@ -795,12 +814,12 @@ TEST_F(MessageHelperTest,
   buttons[0][strings::image][strings::value] = "invalid\\nvalue";
   policy_handler_test::MockPolicySettings policy_settings_;
   const policy::PolicyHandler policy_handler(policy_settings_,
-                                             mock_application_manager);
+                                             mock_application_manager_);
   // Creating sharedPtr to MockApplication
   MockApplicationSharedPtr appSharedMock = utils::MakeShared<AppMock>();
   // Method call
   mobile_apis::Result::eType result = MessageHelper::ProcessSoftButtons(
-      object, appSharedMock, policy_handler, mock_application_manager);
+      object, appSharedMock, policy_handler, mock_application_manager_);
   // Expect
   EXPECT_EQ(mobile_apis::Result::INVALID_DATA, result);
 }
@@ -813,7 +832,7 @@ TEST_F(MessageHelperTest, VerifyImage_ImageTypeIsStatic_Success) {
   image[strings::image_type] = mobile_apis::ImageType::STATIC;
   // Method call
   mobile_apis::Result::eType result = MessageHelper::VerifyImage(
-      image, appSharedMock, mock_application_manager);
+      image, appSharedMock, mock_application_manager_);
   // EXPECT
   EXPECT_EQ(mobile_apis::Result::SUCCESS, result);
 }
@@ -828,7 +847,7 @@ TEST_F(MessageHelperTest, VerifyImage_ImageValueNotValid_InvalidData) {
   image[strings::value] = "   ";
   // Method call
   mobile_apis::Result::eType result = MessageHelper::VerifyImage(
-      image, appSharedMock, mock_application_manager);
+      image, appSharedMock, mock_application_manager_);
   // EXPECT
   EXPECT_EQ(mobile_apis::Result::INVALID_DATA, result);
 }
@@ -842,7 +861,7 @@ TEST_F(MessageHelperTest, VerifyImageFiles_SmartObjectWithValidData_Success) {
   images[1][strings::image_type] = mobile_apis::ImageType::STATIC;
   // Method call
   mobile_apis::Result::eType result = MessageHelper::VerifyImageFiles(
-      images, appSharedMock, mock_application_manager);
+      images, appSharedMock, mock_application_manager_);
   // EXPECT
   EXPECT_EQ(mobile_apis::Result::SUCCESS, result);
 }
@@ -860,7 +879,7 @@ TEST_F(MessageHelperTest,
   images[1][strings::value] = "image\\n";
   // Method call
   mobile_apis::Result::eType result = MessageHelper::VerifyImageFiles(
-      images, appSharedMock, mock_application_manager);
+      images, appSharedMock, mock_application_manager_);
   // EXPECT
   EXPECT_EQ(mobile_apis::Result::INVALID_DATA, result);
 }
@@ -877,7 +896,7 @@ TEST_F(MessageHelperTest,
       mobile_apis::ImageType::STATIC;
   // Method call
   mobile_apis::Result::eType result = MessageHelper::VerifyImageVrHelpItems(
-      message, appSharedMock, mock_application_manager);
+      message, appSharedMock, mock_application_manager_);
   // EXPECT
   EXPECT_EQ(mobile_apis::Result::SUCCESS, result);
 }
@@ -897,7 +916,7 @@ TEST_F(MessageHelperTest,
   message[1][strings::image][strings::value] = "image\\n";
   // Method call
   mobile_apis::Result::eType result = MessageHelper::VerifyImageVrHelpItems(
-      message, appSharedMock, mock_application_manager);
+      message, appSharedMock, mock_application_manager_);
   // EXPECT
   EXPECT_EQ(mobile_apis::Result::INVALID_DATA, result);
 }
@@ -908,18 +927,18 @@ TEST_F(MessageHelperTest,
   // if FUNCTION ID == 1 inner DCHECK is false
   mobile_apis::FunctionID::eType casted_enum;
   std::string converted;
-  for (size_t i = 1; i < function_id_strings.size(); ++i) {
+  for (size_t i = 1; i < function_id_strings_.size(); ++i) {
     casted_enum = static_cast<mobile_apis::FunctionID::eType>(i);
     converted = MessageHelper::StringifiedFunctionID(casted_enum);
-    EXPECT_EQ(function_id_strings[i], converted);
+    EXPECT_EQ(function_id_strings_[i], converted);
   }
   // EventIDs emum strarts from delta_from_functions_id = 32768
-  for (size_t i = delta_from_functions_id;
-       i < events_id_strings.size() + delta_from_functions_id;
+  for (size_t i = kDeltaFromFunctionsId;
+       i < events_id_strings_.size() + kDeltaFromFunctionsId;
        ++i) {
     casted_enum = static_cast<mobile_apis::FunctionID::eType>(i);
     converted = MessageHelper::StringifiedFunctionID(casted_enum);
-    EXPECT_EQ(events_id_strings[i - delta_from_functions_id], converted);
+    EXPECT_EQ(events_id_strings_[i - kDeltaFromFunctionsId], converted);
   }
 }
 
@@ -927,19 +946,19 @@ TEST_F(MessageHelperTest,
        StringifiedHmiLevel_LevelEnum_EqualsWithStringsInArray) {
   mobile_apis::HMILevel::eType casted_enum;
   std::string converted_value;
-  for (size_t i = 0; i < hmi_level_strings.size(); ++i) {
+  for (size_t i = 0; i < hmi_level_strings_.size(); ++i) {
     casted_enum = static_cast<mobile_apis::HMILevel::eType>(i);
     converted_value = MessageHelper::StringifiedHMILevel(casted_enum);
-    EXPECT_EQ(hmi_level_strings[i], converted_value);
+    EXPECT_EQ(hmi_level_strings_[i], converted_value);
   }
 }
 
 TEST_F(MessageHelperTest, StringToHmiLevel_LevelString_EqEType) {
   mobile_apis::HMILevel::eType tested_enum;
   mobile_apis::HMILevel::eType converted_enum;
-  for (size_t i = 0; i < hmi_level_strings.size(); ++i) {
+  for (size_t i = 0; i < hmi_level_strings_.size(); ++i) {
     tested_enum = static_cast<mobile_apis::HMILevel::eType>(i);
-    converted_enum = MessageHelper::StringToHMILevel(hmi_level_strings[i]);
+    converted_enum = MessageHelper::StringToHMILevel(hmi_level_strings_[i]);
     EXPECT_EQ(tested_enum, converted_enum);
   }
 }
@@ -955,6 +974,422 @@ TEST_F(MessageHelperTest, SubscribeApplicationToSoftButton_CallFromApp) {
               SubscribeToSoftButtons(function_id, SoftButtonID())).Times(1);
   MessageHelper::SubscribeApplicationToSoftButton(
       message_params, appSharedPtr, function_id);
+}
+
+TEST_F(MessageHelperTest, SendOnAppUnregNotificationToHMI) {
+  const bool kIsUnexpectedDisconnect = false;
+
+  MockApplicationSharedPtr mock_app = ::utils::MakeShared<AppMock>();
+
+  const uint32_t kMockHmiAppId = 1u;
+  EXPECT_CALL(*mock_app, hmi_app_id()).WillOnce(Return(kMockHmiAppId));
+
+  smart_objects::SmartObjectSPtr test_notification;
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&test_notification), Return(true)));
+
+  MessageHelper::SendOnAppUnregNotificationToHMI(
+      mock_app, kIsUnexpectedDisconnect, mock_application_manager_);
+
+  EXPECT_EQ(
+      hmi_apis::FunctionID::BasicCommunication_OnAppUnregistered,
+      (*test_notification)[strings::params][strings::function_id].asInt());
+  EXPECT_EQ(
+      MessageType::kNotification,
+      (*test_notification)[strings::params][strings::message_type].asInt());
+  EXPECT_EQ(kMockHmiAppId,
+            (*test_notification)[strings::msg_params][strings::app_id].asInt());
+  EXPECT_EQ(
+      kIsUnexpectedDisconnect,
+      (*test_notification)[strings::msg_params][strings::unexpected_disconnect]
+          .asInt());
+}
+
+TEST_F(MessageHelperTest, SendOnAppUnregNotificationToHMI_InvalidApp) {
+  const bool kIsUnexpectedDisconnect = false;
+
+  MockApplicationSharedPtr mock_app;
+
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_)).Times(0);
+
+  MessageHelper::SendOnAppUnregNotificationToHMI(
+      mock_app, kIsUnexpectedDisconnect, mock_application_manager_);
+}
+
+TEST_F(MessageHelperTest, SendOnButtonSubscriptionNotification) {
+  const hmi_apis::Common_ButtonName::eType kButton =
+      hmi_apis::Common_ButtonName::OK;
+  const bool kIsSubscribed = true;
+
+  smart_objects::SmartObject msg_params(smart_objects::SmartType_Map);
+  msg_params[strings::app_id] = kAppId;
+  msg_params[strings::name] = kButton;
+  msg_params[strings::is_suscribed] = kIsSubscribed;
+
+  smart_objects::SmartObjectSPtr test_notification;
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&test_notification), Return(true)));
+
+  MessageHelper::SendOnButtonSubscriptionNotification(
+      kAppId, kButton, kIsSubscribed, mock_application_manager_);
+
+  EXPECT_EQ(
+      application_manager::MessageType::kNotification,
+      (*test_notification)[strings::params][strings::message_type].asInt());
+  EXPECT_EQ(
+      commands::CommandImpl::protocol_version_,
+      (*test_notification)[strings::params][strings::protocol_version].asInt());
+  EXPECT_EQ(
+      commands::CommandImpl::hmi_protocol_type_,
+      (*test_notification)[strings::params][strings::protocol_type].asInt());
+  EXPECT_EQ(
+      hmi_apis::FunctionID::Buttons_OnButtonSubscription,
+      (*test_notification)[strings::params][strings::function_id].asInt());
+  EXPECT_EQ(
+      hmi_apis::FunctionID::Buttons_OnButtonSubscription,
+      (*test_notification)[strings::params][strings::function_id].asInt());
+  EXPECT_EQ(msg_params, (*test_notification)[strings::msg_params]);
+}
+
+TEST_F(MessageHelperTest, SendOnDataStreaming_Audio) {
+  const protocol_handler::ServiceType kService =
+      protocol_handler::ServiceType::kAudio;
+
+  smart_objects::SmartObjectSPtr test_notification;
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&test_notification), Return(true)));
+
+  MessageHelper::SendOnDataStreaming(
+      kService, kAvailable, mock_application_manager_);
+
+  EXPECT_EQ(
+      hmi_apis::FunctionID::Navigation_OnAudioDataStreaming,
+      (*test_notification)[strings::params][strings::function_id].asInt());
+  EXPECT_EQ(
+      hmi_apis::messageType::notification,
+      (*test_notification)[strings::params][strings::message_type].asInt());
+  EXPECT_EQ(
+      commands::CommandImpl::protocol_version_,
+      (*test_notification)[strings::params][strings::protocol_version].asInt());
+  EXPECT_EQ(
+      commands::CommandImpl::hmi_protocol_type_,
+      (*test_notification)[strings::params][strings::protocol_type].asInt());
+  EXPECT_EQ(kAvailable,
+            (*test_notification)[strings::msg_params]["available"].asInt());
+}
+
+TEST_F(MessageHelperTest, SendOnDataStreaming_MobileNav) {
+  const protocol_handler::ServiceType kService =
+      protocol_handler::ServiceType::kMobileNav;
+
+  smart_objects::SmartObjectSPtr test_notification;
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&test_notification), Return(true)));
+
+  MessageHelper::SendOnDataStreaming(
+      kService, kAvailable, mock_application_manager_);
+
+  EXPECT_EQ(
+      hmi_apis::FunctionID::Navigation_OnVideoDataStreaming,
+      (*test_notification)[strings::params][strings::function_id].asInt());
+  EXPECT_EQ(
+      hmi_apis::messageType::notification,
+      (*test_notification)[strings::params][strings::message_type].asInt());
+  EXPECT_EQ(
+      commands::CommandImpl::protocol_version_,
+      (*test_notification)[strings::params][strings::protocol_version].asInt());
+  EXPECT_EQ(
+      commands::CommandImpl::hmi_protocol_type_,
+      (*test_notification)[strings::params][strings::protocol_type].asInt());
+  EXPECT_EQ(kAvailable,
+            (*test_notification)[strings::msg_params]["available"].asInt());
+}
+
+TEST_F(MessageHelperTest, SendOnDataStreaming_Fail) {
+  const protocol_handler::ServiceType kService =
+      protocol_handler::ServiceType::kInvalidServiceType;
+
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_)).Times(0);
+
+  MessageHelper::SendOnDataStreaming(
+      kService, kAvailable, mock_application_manager_);
+}
+
+TEST_F(MessageHelperTest, SendOnPermissionsChangeNotification) {
+  const policy::RpcName kRpcName1 = "rpc_name_1";
+  const std::string kHMIPermissionLabel1 = "level_1";
+  const std::string kHMIPermissionValue1 = "hmi_level_1";
+
+  std::set<policy::HMILevel> hmi_levels_1;
+  hmi_levels_1.insert(kHMIPermissionValue1);
+
+  policy::HMIPermissions hmi_permissions_1;
+  hmi_permissions_1[kHMIPermissionLabel1] = hmi_levels_1;
+
+  std::set<policy::Parameter> parameters_1;
+  parameters_1.insert("parameter_1");
+
+  policy::ParameterPermissions parameter_permissions_1;
+  parameter_permissions_1["1"] = parameters_1;
+
+  const policy::RpcPermissions kRpcPermissions1 = {hmi_permissions_1,
+                                                   parameter_permissions_1};
+
+  policy::Permissions permissions;
+  permissions[kRpcName1] = kRpcPermissions1;
+
+  smart_objects::SmartObjectSPtr test_notification;
+  EXPECT_CALL(mock_application_manager_,
+              ManageMobileCommand(_, commands::Command::ORIGIN_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&test_notification), Return(true)));
+
+  MessageHelper::SendOnPermissionsChangeNotification(
+      kConnectionKey, permissions, mock_application_manager_);
+
+  EXPECT_EQ(
+      mobile_apis::FunctionID::OnPermissionsChangeID,
+      (*test_notification)[strings::params][strings::function_id].asInt());
+  EXPECT_EQ(
+      mobile_apis::messageType::notification,
+      (*test_notification)[strings::params][strings::message_type].asInt());
+  EXPECT_EQ(
+      commands::CommandImpl::mobile_protocol_type_,
+      (*test_notification)[strings::params][strings::protocol_type].asInt());
+  EXPECT_EQ(
+      kConnectionKey,
+      (*test_notification)[strings::params][strings::connection_key].asUInt());
+
+  // Permissions Data check
+  policy::Permissions::const_iterator it_permissions = permissions.begin();
+  policy::Permissions::const_iterator it_permissions_end = permissions.end();
+  const smart_objects::SmartObject& kPermissionsItemArray =
+      (*test_notification)[strings::msg_params]["permissionItem"];
+
+  for (size_t index_pi = 0; it_permissions != it_permissions_end;
+       ++it_permissions, ++index_pi) {
+    const smart_objects::SmartObject& kPermissionItem =
+        kPermissionsItemArray[index_pi];
+
+    EXPECT_EQ((*it_permissions).first, kPermissionItem["rpcName"].asString());
+
+    // Checking the hmiPermissions
+    const smart_objects::SmartObject& kHmiPermissions =
+        kPermissionItem["hmiPermissions"];
+    const policy::RpcPermissions& rpc_permissions = (*it_permissions).second;
+    policy::HMIPermissions::const_iterator it_hmi_permissions =
+        rpc_permissions.hmi_permissions.begin();
+    policy::HMIPermissions::const_iterator it_hmi_permissions_end =
+        rpc_permissions.hmi_permissions.end();
+
+    for (; it_hmi_permissions != it_hmi_permissions_end; ++it_hmi_permissions) {
+      std::set<policy::HMILevel>::const_iterator it_hmi_levels =
+          (*it_hmi_permissions).second.begin();
+      std::set<policy::HMILevel>::const_iterator it_hmi_levels_end =
+          (*it_hmi_permissions).second.end();
+      const smart_objects::SmartObject& kHmiLevels =
+          kHmiPermissions[(*it_hmi_permissions).first];
+
+      for (size_t index_hmi_levels = 0; it_hmi_levels != it_hmi_levels_end;
+           ++it_hmi_levels, ++index_hmi_levels) {
+        EXPECT_EQ(kHMIPermissionValue1,
+                  kHmiLevels[index_hmi_levels].asString());
+      }
+    }
+
+    // Checking the parameterPermissions
+    const smart_objects::SmartObject& kParameterPermissions =
+        kPermissionItem["parameterPermissions"];
+    policy::ParameterPermissions::const_iterator it_parameter_permissions =
+        rpc_permissions.parameter_permissions.begin();
+    policy::ParameterPermissions::const_iterator it_parameter_permissions_end =
+        rpc_permissions.parameter_permissions.end();
+
+    for (; it_parameter_permissions != it_parameter_permissions_end;
+         ++it_parameter_permissions) {
+      const smart_objects::SmartObject& kParameters =
+          kParameterPermissions[(*it_parameter_permissions).first];
+
+      std::set<policy::Parameter>::const_iterator it_parameters =
+          (*it_parameter_permissions).second.begin();
+      std::set<policy::Parameter>::const_iterator it_parameters_end =
+          (*it_parameter_permissions).second.end();
+
+      for (size_t index_parameters = 0; it_parameters != it_parameters_end;
+           ++it_parameters, ++index_parameters) {
+        EXPECT_EQ(*it_parameters, kParameters[index_parameters].asString());
+      }
+    }
+  }
+}
+
+TEST_F(MessageHelperTest, SendOnResumeAudioSourceToHMI) {
+  MockApplicationSharedPtr mock_app = utils::MakeShared<AppMock>();
+  EXPECT_CALL(mock_application_manager_, application(kAppId))
+      .WillOnce(Return(mock_app));
+  EXPECT_EQ(mock_app, true);
+
+  const uint32_t kCorrelationId = 0;
+  EXPECT_CALL(mock_application_manager_, GetNextHMICorrelationID())
+      .WillOnce(Return(kCorrelationId));
+  smart_objects::SmartObjectSPtr test_notification;
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&test_notification), Return(true)));
+
+  MessageHelper::SendOnResumeAudioSourceToHMI(kAppId,
+                                              mock_application_manager_);
+
+  EXPECT_EQ(
+      hmi_apis::FunctionID::BasicCommunication_OnResumeAudioSource,
+      (*test_notification)[strings::params][strings::function_id].asInt());
+  EXPECT_EQ(
+      MessageType::kNotification,
+      (*test_notification)[strings::params][strings::message_type].asInt());
+  EXPECT_EQ(
+      kCorrelationId,
+      (*test_notification)[strings::params][strings::correlation_id].asUInt());
+  EXPECT_EQ(kAppId,
+            (*test_notification)[strings::msg_params][strings::app_id].asInt());
+}
+
+TEST_F(MessageHelperTest, SendOnResumeAudioSourceToHMI_InvalidAppId) {
+  MockApplicationSharedPtr mock_app;
+  EXPECT_CALL(mock_application_manager_, application(kAppId))
+      .WillOnce(Return(MockApplicationSharedPtr()));
+  EXPECT_EQ(mock_app, false);
+  EXPECT_CALL(mock_application_manager_, GetNextHMICorrelationID()).Times(0);
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_)).Times(0);
+
+  MessageHelper::SendOnResumeAudioSourceToHMI(kAppId,
+                                              mock_application_manager_);
+}
+
+TEST_F(MessageHelperTest, SendOnSDLConsentNeeded) {
+  const policy::DeviceParams kDeviceInfo;
+
+  smart_objects::SmartObjectSPtr test_notification;
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&test_notification), Return(true)));
+
+  MessageHelper::SendOnSDLConsentNeeded(kDeviceInfo, mock_application_manager_);
+
+  EXPECT_EQ(
+      hmi_apis::FunctionID::SDL_OnSDLConsentNeeded,
+      (*test_notification)[strings::params][strings::function_id].asInt());
+  EXPECT_EQ(
+      MessageType::kNotification,
+      (*test_notification)[strings::params][strings::message_type].asInt());
+  EXPECT_EQ(
+      kDeviceInfo.device_mac_address,
+      (*test_notification)[strings::msg_params]["device"]["id"].asString());
+  EXPECT_EQ(
+      kDeviceInfo.device_name,
+      (*test_notification)[strings::msg_params]["device"]["name"].asString());
+}
+
+TEST_F(MessageHelperTest, SendOnStatusUpdate) {
+  const std::string& kStatus = "test_status";
+
+  smart_objects::SmartObjectSPtr test_notification;
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&test_notification), Return(true)));
+
+  MessageHelper::SendOnStatusUpdate(kStatus, mock_application_manager_);
+
+  EXPECT_EQ(
+      hmi_apis::FunctionID::SDL_OnStatusUpdate,
+      (*test_notification)[strings::params][strings::function_id].asInt());
+  EXPECT_EQ(
+      MessageType::kNotification,
+      (*test_notification)[strings::params][strings::message_type].asInt());
+  EXPECT_EQ(kStatus,
+            (*test_notification)[strings::msg_params]["status"].asString());
+}
+
+TEST_F(MessageHelperTest, SendPolicySnapshotNotification) {
+  const std::vector<uint8_t> kPolicyData;
+  const std::string& kUrl = "test_url";
+
+  smart_objects::SmartObjectSPtr test_notification;
+  EXPECT_CALL(mock_application_manager_,
+              ManageMobileCommand(_, commands::Command::ORIGIN_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&test_notification), Return(true)));
+
+  MessageHelper::SendPolicySnapshotNotification(
+      kConnectionKey, kPolicyData, kUrl, mock_application_manager_);
+
+  EXPECT_EQ(
+      mobile_apis::FunctionID::OnSystemRequestID,
+      (*test_notification)[strings::params][strings::function_id].asInt());
+  EXPECT_EQ(
+      mobile_apis::messageType::notification,
+      (*test_notification)[strings::params][strings::message_type].asInt());
+  EXPECT_EQ(
+      commands::CommandImpl::mobile_protocol_type_,
+      (*test_notification)[strings::params][strings::protocol_type].asInt());
+  EXPECT_EQ(
+      commands::CommandImpl::protocol_version_,
+      (*test_notification)[strings::params][strings::protocol_version].asInt());
+  EXPECT_EQ(
+      kConnectionKey,
+      (*test_notification)[strings::params][strings::connection_key].asInt());
+  EXPECT_EQ(kUrl,
+            (*test_notification)[strings::msg_params][strings::url].asString());
+}
+
+TEST_F(MessageHelperTest, SendUnsubscribedWayPoints) {
+  const uint32_t kCorrelationId = 0;
+  EXPECT_CALL(mock_application_manager_, GetNextHMICorrelationID())
+      .WillOnce(Return(kCorrelationId));
+
+  smart_objects::SmartObjectSPtr test_notification;
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&test_notification), Return(true)));
+
+  const bool kRes =
+      MessageHelper::SendUnsubscribedWayPoints(mock_application_manager_);
+  EXPECT_TRUE(kRes);
+
+  EXPECT_EQ(
+      hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints,
+      (*test_notification)[strings::params][strings::function_id].asInt());
+  EXPECT_EQ(
+      hmi_apis::messageType::request,
+      (*test_notification)[strings::params][strings::message_type].asInt());
+  EXPECT_EQ(
+      commands::CommandImpl::protocol_version_,
+      (*test_notification)[strings::params][strings::protocol_version].asInt());
+  EXPECT_EQ(
+      commands::CommandImpl::hmi_protocol_type_,
+      (*test_notification)[strings::params][strings::protocol_type].asInt());
+  EXPECT_EQ(
+      kCorrelationId,
+      (*test_notification)[strings::params][strings::correlation_id].asInt());
+}
+
+TEST_F(MessageHelperTest, SendUpdateSDLResponse) {
+  const std::string& kResult = "test_result";
+  const uint32_t kCorrelationId = 1u;
+
+  smart_objects::SmartObjectSPtr test_notification;
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&test_notification), Return(true)));
+
+  MessageHelper::SendUpdateSDLResponse(
+      kResult, kCorrelationId, mock_application_manager_);
+
+  EXPECT_EQ(
+      hmi_apis::FunctionID::SDL_UpdateSDL,
+      (*test_notification)[strings::params][strings::function_id].asInt());
+  EXPECT_EQ(
+      MessageType::kResponse,
+      (*test_notification)[strings::params][strings::message_type].asInt());
+  EXPECT_EQ(
+      kCorrelationId,
+      (*test_notification)[strings::params][strings::correlation_id].asInt());
+  EXPECT_EQ(0,
+            (*test_notification)[strings::params][hmi_response::code].asInt());
+  EXPECT_EQ(kResult,
+            (*test_notification)[strings::msg_params]["result"].asString());
 }
 
 TEST(MessageHelperTestCreate, CreateHashUpdateNotification_FunctionId_Equal) {
@@ -1013,11 +1448,11 @@ TEST_F(MessageHelperTest,
   MobileResults::eType tested_enum;
   MobileResults::eType converted_enum;
   // Check enums >=0
-  for (size_t array_index = 0; array_index < mobile_result_strings.size();
+  for (size_t array_index = 0; array_index < mobile_result_strings_.size();
        ++array_index) {
     tested_enum = static_cast<MobileResults::eType>(array_index);
     converted_enum = MessageHelper::MobileResultFromString(
-        mobile_result_strings[array_index]);
+        mobile_result_strings_[array_index]);
     EXPECT_EQ(tested_enum, converted_enum);
   }
   // Check invalid enums == -1
@@ -1030,11 +1465,11 @@ TEST_F(MessageHelperTest, MobileResultToString_ETypeValueOfEnum_CorrectString) {
   std::string string_from_enum;
   MobileResults::eType casted_enum;
   // Check all results >=0
-  for (size_t array_index = 0; array_index < mobile_result_strings.size();
+  for (size_t array_index = 0; array_index < mobile_result_strings_.size();
        ++array_index) {
     casted_enum = static_cast<MobileResults::eType>(array_index);
     string_from_enum = MessageHelper::MobileResultToString(casted_enum);
-    EXPECT_EQ(mobile_result_strings[array_index], string_from_enum);
+    EXPECT_EQ(mobile_result_strings_[array_index], string_from_enum);
   }
   // Check InvalidEnum == -1
   string_from_enum =
@@ -1048,10 +1483,10 @@ TEST_F(MessageHelperTest,
   MobileResults::eType casted_mobile_enum;
   HmiResults::eType converted_enum;
   // Check enums >=0
-  for (size_t enum_index = 0; enum_index < mobile_result_strings.size();
+  for (size_t enum_index = 0; enum_index < mobile_result_strings_.size();
        ++enum_index) {
     tested_enum =
-        MessageHelper::HMIResultFromString(mobile_result_strings[enum_index]);
+        MessageHelper::HMIResultFromString(mobile_result_strings_[enum_index]);
     casted_mobile_enum = static_cast<MobileResults::eType>(enum_index);
     converted_enum = MessageHelper::MobileToHMIResult(casted_mobile_enum);
     EXPECT_EQ(tested_enum, converted_enum);


### PR DESCRIPTION
Added Unit tests for the following `MessageHelper` methods:

- SendOnAppUnregNotificationToHMI
- SendOnButtonSubscriptionNotification
- SendOnDataStreaming
- SendOnPermissionsChangeNotification
- SendOnResumeAudioSourceToHMI
- SendOnSDLConsentNeeded
- SendOnStatusUpdate
- SendPolicySnapshotNotification
- SendUnsubscribedWayPoints
- SendUpdateSDLResponse

Methods were refactored to log the command management failures and to avoid the use of the empty smart objects.