### PR TITLE
Exclude commands from coverage

### DIFF
--- a/tools/infrastructure/collect_coverage.sh
+++ b/tools/infrastructure/collect_coverage.sh
@@ -18,7 +18,7 @@ rm -rf $REPORTS_DIR -
 
 mkdir $COVERAGE_DIR
 lcov --quiet --capture --directory . --output-file $COVERAGE_DIR/full_report.info
-lcov --quiet --remove $COVERAGE_DIR/full_report.info '/usr/*' '*/test/*' '*/src/3rd*' '*/build/src/*'  --output-file $COVERAGE_DIR/coverage.info
+lcov --quiet --remove $COVERAGE_DIR/full_report.info '/usr/*' '*/test/*' '*/commands/*' '*/src/3rd*' '*/build/src/*'  --output-file $COVERAGE_DIR/coverage.info
 
 mkdir $REPORTS_DIR
 genhtml --quiet $COVERAGE_DIR/coverage.info --output-directory $REPORTS_DIR


### PR DESCRIPTION
 Currently commands are not covered and even do not included in coverage
 report.
 In case if any unit tests will include commands object files, coverage
 will fail to 40 - 50%
 Commit  will shadow this failing until most of commands won't be
 covered with UT

 Related issue: APPLINK-25332