### PR TITLE
Replace `MessageHelper` by `MockMessageHelper` in `commands_test`

### DIFF
--- a/src/components/application_manager/test/commands/CMakeLists.txt
+++ b/src/components/application_manager/test/commands/CMakeLists.txt
@@ -39,6 +39,7 @@ set(COMMANDS_TEST_SOURCE_DIR
 )
 
 set (SOURCES
+  ${COMPONENTS_DIR}/application_manager/test/mock_message_helper.cc
   ${COMMANDS_TEST_SOURCE_DIR}/command_impl_test.cc
   ${COMMANDS_TEST_SOURCE_DIR}/command_response_impl_test.cc
   ${COMMANDS_TEST_SOURCE_DIR}/command_request_impl_test.cc


### PR DESCRIPTION
Been done:
- `MessageHelper` been replaced by
  `MockMessageHelper` in `commands_test`;
- Fixed variable naming;
- Parameters moved to nameless namespace.

Related to: [APPLINK-25670](https://adc.luxoft.com/jira/browse/APPLINK-25670)