### PR TITLE
Fix transport manager protocol connection handlers ut

### DIFF
--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1037,7 +1037,7 @@ RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(
   const bool protection = false;
 #endif  // ENABLE_SECURITY
 
-  uint32_t hash_id;
+  uint32_t hash_id = protocol_handler::HASH_ID_WRONG;
   const ConnectionID connection_id = packet.connection_id();
   const uint32_t session_id = session_observer_.OnSessionStartedCallback(
       connection_id, packet.session_id(), service_type, protection, &hash_id);

--- a/src/components/protocol_handler/src/protocol_packet.cc
+++ b/src/components/protocol_handler/src/protocol_packet.cc
@@ -371,6 +371,7 @@ bool ProtocolPacket::operator==(const ProtocolPacket& other) const {
     }
     // Compare payload data
     if (packet_data_.data && other.packet_data_.data &&
+        packet_data_.totalDataBytes == other.packet_data_.totalDataBytes &&
         0 == memcmp(packet_data_.data,
                     other.packet_data_.data,
                     packet_data_.totalDataBytes)) {

--- a/src/components/protocol_handler/test/protocol_payload_test.cc
+++ b/src/components/protocol_handler/test/protocol_payload_test.cc
@@ -229,7 +229,6 @@ TEST(ProtocolPayloadTest, ExtractCorrectProtocolWithDataWithJSON) {
   delete[] data_for_sending;
 }
 
-// TODO(OHerasym) : heap corruption on Windows platform
 TEST(ProtocolPayloadTest, ExtractProtocolWithJSONWithDataWithWrongPayloadSize) {
   ProtocolPayloadV2 prot_payload_test;
 
@@ -247,9 +246,11 @@ TEST(ProtocolPayloadTest, ExtractProtocolWithJSONWithDataWithWrongPayloadSize) {
   prot_payload_test.json = expect_output_json_string;
   prot_payload_test.header.json_size = prot_payload_test.json.length();
 
-  const size_t data_for_sending_size =
-      PROTOCOL_HEADER_V2_SIZE + prot_payload_test.json.length();
-  uint8_t* data_for_sending = new uint8_t[data_for_sending_size];
+  const size_t data_for_sending_size = PROTOCOL_HEADER_V2_SIZE +
+                                       prot_payload_test.json.length() +
+                                       prot_payload_test.data.size();
+  std::vector<uint8_t> data_for_sending_container(data_for_sending_size);
+  uint8_t* data_for_sending = &data_for_sending_container[0];
   prepare_data(data_for_sending, prot_payload_test);
 
   BitStream bs(data_for_sending, data_for_sending_size);
@@ -269,7 +270,6 @@ TEST(ProtocolPayloadTest, ExtractProtocolWithJSONWithDataWithWrongPayloadSize) {
   EXPECT_EQ(prot_payload_test.json.length(), prot_payload.json.length());
   EXPECT_EQ(prot_payload_test.json, prot_payload.json);
   EXPECT_EQ(0u, prot_payload.data.size());
-  delete[] data_for_sending;
 }
 
 }  // namespace protocol_handler_test

--- a/src/components/transport_manager/src/tcp/tcp_device.cc.orig
+++ b/src/components/transport_manager/src/tcp/tcp_device.cc.orig
@@ -1,0 +1,129 @@
+/*
+ *
+ * Copyright (c) 2013, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "transport_manager/tcp/tcp_device.h"
+#include "utils/logger.h"
+
+namespace transport_manager {
+namespace transport_adapter {
+
+SDL_CREATE_LOGGER("TransportManager")
+
+TcpDevice::TcpDevice(const utils::HostAddress& address, const std::string& name)
+    : Device(name, name)
+    , applications_mutex_()
+    , address_(address)
+    , last_handle_(0) {
+  SDL_AUTO_TRACE();
+  SDL_DEBUG("Created TCPDevice with name " << name);
+}
+
+bool TcpDevice::IsSameAs(const Device* other) const {
+  SDL_TRACE("enter. Device: " << other->unique_device_id());
+
+  // TODO(AKutsan): remove dynamic cast after APPLINK-25700
+  const TcpDevice* other_tcp_device = dynamic_cast<const TcpDevice*>(other);
+  if (NULL == other_tcp_device) {
+<<<<<<< HEAD
+    SDL_TRACE("Exit with FALSE. Comparison with non TCP device");
+=======
+    SDL_TRACE("exit with FALSE. comapre with not TCP device");
+>>>>>>> Fix style
+    return false;
+  }
+
+  if (other_tcp_device->address_ == address_) {
+    SDL_TRACE(
+        "exit with TRUE. Condition: other_tcp_device->address_ == address_");
+    return true;
+  } else {
+    SDL_TRACE("exit with FALSE");
+    return false;
+  }
+}
+
+ApplicationList TcpDevice::GetApplicationList() const {
+  SDL_AUTO_TRACE();
+  ApplicationList app_list;
+  app_list.reserve(applications_.size());
+  sync_primitives::AutoLock locker(applications_mutex_);
+  for (std::map<ApplicationHandle, Application>::const_iterator it =
+           applications_.begin();
+       it != applications_.end();
+       ++it) {
+    app_list.push_back(it->first);
+  }
+  return app_list;
+}
+
+ApplicationHandle TcpDevice::AddApplication(const uint16_t port,
+                                            const bool is_incomming) {
+  SDL_AUTO_TRACE();
+  SDL_DEBUG("Port " << port);
+  Application appplication(is_incomming, port);
+  sync_primitives::AutoLock locker(applications_mutex_);
+  const ApplicationHandle app_handle = ++last_handle_;
+  applications_[app_handle] = appplication;
+  SDL_DEBUG("App_handle " << app_handle);
+  return app_handle;
+}
+
+void TcpDevice::RemoveApplication(const ApplicationHandle app_handle) {
+  SDL_AUTO_TRACE();
+  SDL_DEBUG("ApplicationHandle: " << app_handle);
+  sync_primitives::AutoLock locker(applications_mutex_);
+  applications_.erase(app_handle);
+}
+
+TcpDevice::~TcpDevice() {
+  SDL_AUTO_TRACE();
+}
+
+int TcpDevice::GetApplicationPort(const ApplicationHandle app_handle) const {
+  SDL_AUTO_TRACE();
+  SDL_DEBUG("ApplicationHandle: " << app_handle);
+  std::map<ApplicationHandle, Application>::const_iterator it =
+      applications_.find(app_handle);
+  if (applications_.end() == it) {
+    SDL_WARN("Application was not found");
+    return -1;
+  }
+  if (it->second.incoming) {
+    SDL_DEBUG("Application is incoming");
+    return -1;
+  }
+  SDL_DEBUG("port " << it->second.port);
+  return it->second.port;
+}
+
+}  // namespace transport_adapter
+}  // namespace transport_manager

--- a/src/components/utils/include/utils/timer.h
+++ b/src/components/utils/include/utils/timer.h
@@ -34,6 +34,7 @@
 
 #include <string>
 #include <stdint.h>
+#include <memory>
 
 #include "utils/macro.h"
 #include "utils/lock.h"
@@ -217,7 +218,7 @@ class Timer {
 
   mutable sync_primitives::Lock state_lock_;
 
-  mutable TimerDelegate delegate_;
+  mutable std::auto_ptr<TimerDelegate> delegate_;
   threads::Thread* thread_;
 
   /**

--- a/src/components/utils/src/lock_win.cc
+++ b/src/components/utils/src/lock_win.cc
@@ -76,9 +76,11 @@ void Lock::Release() {
 }
 
 bool Lock::Try() {
+#ifndef NDEBUG
   if ((lock_taken_ > 0) && !is_mutex_recursive_) {
     return false;
   }
+#endif
   if (!TryEnterCriticalSection(&mutex_)) {
     return false;
   }


### PR DESCRIPTION
Fixed following Unit Tests for Windows:

Transport manager:
-  TransportManagerImplTest Disconnect

Protocol handler (tests passing take too much time)

- ProtocolHandlerImplTest MalformedLimitVerification
- ProtocolHandlerImplTest MalformedLimitVerification_MalformedStock
- ProtocolPayloadTest ExtractProtocolWithJSONWithDataWithWrongPayloadSize

Connection handler
- ConnectionHandlerTest GetProtocolVersion
- ConnectionHandlerTest SessionStarted_WithRpc