### PR TITLE
Fix "Content-Length" Spelling and Calculation

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/on_system_request_notification.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/on_system_request_notification.h
@@ -72,7 +72,7 @@ class OnSystemRequestNotification : public CommandNotificationImpl {
    * @param message Message
    */
   void AddHeader(BinaryMessage& message) const;
-  void ParsePTString(std::string& pt_string, size_t& contentLength) const;
+  size_t ParsePTString(std::string& pt_string) const;
 #endif
 
   DISALLOW_COPY_AND_ASSIGN(OnSystemRequestNotification);

--- a/src/components/application_manager/include/application_manager/commands/mobile/on_system_request_notification.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/on_system_request_notification.h
@@ -72,7 +72,7 @@ class OnSystemRequestNotification : public CommandNotificationImpl {
    * @param message Message
    */
   void AddHeader(BinaryMessage& message) const;
-  void ParsePTString(std::string& pt_string) const;
+  void ParsePTString(std::string& pt_string, size_t& contentLength) const;
 #endif
 
   DISALLOW_COPY_AND_ASSIGN(OnSystemRequestNotification);

--- a/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
@@ -106,18 +106,28 @@ void OnSystemRequestNotification::AddHeader(BinaryMessage& message) const {
   LOG4CXX_AUTO_TRACE(logger_);
   const int timeout = policy::PolicyHandler::instance()->TimeoutExchange();
 
-  char size_str[24];
-
-  if (0 > sprintf(size_str, "%zu", static_cast<size_t>(message.size()))) {
-    memset(size_str, 0, sizeof(size_str));
-  }
-
+  size_t contentLength;
+  char size_str[24];  
   char timeout_str[24];
+
   if (0 > sprintf(timeout_str, "%d", timeout)) {
     memset(timeout_str, 0, sizeof(timeout_str));
   }
+
   std::string policy_table_string = std::string(message.begin(), message.end());
-  ParsePTString(policy_table_string);
+  
+  /* The Content-Length to be sent in the HTTP Request header should be 
+  calculated before additional escape characters are added to the 
+  policy table string. The mobile proxy will remove the escape 
+  characters after receiving this request. */
+  contentLength = policy_table_string.length();
+
+  ParsePTString(policy_table_string, contentLength);
+  
+  if (0 > sprintf(size_str, "%zu", contentLength)) {
+    memset(size_str, 0, sizeof(size_str));
+  }
+
   const std::string header =
 
   "{"
@@ -132,7 +142,7 @@ void OnSystemRequestNotification::AddHeader(BinaryMessage& message) const {
               "\"ReadTimeout\":" + std::string(timeout_str) + ","
               "\"InstanceFollowRedirects\": false,"
               "\"charset\": \"utf-8\","
-              "\"Content_Length\": " + std::string(size_str) +
+              "\"Content-Length\": " + std::string(size_str) +
           "},"
           "\"body\": \"" + policy_table_string + "\""
       "}"
@@ -145,7 +155,7 @@ void OnSystemRequestNotification::AddHeader(BinaryMessage& message) const {
       logger_, "Header added: " << std::string(message.begin(), message.end()));
 }
 
-void OnSystemRequestNotification::ParsePTString(std::string& pt_string) const{
+void OnSystemRequestNotification::ParsePTString(std::string& pt_string, size_t& contentLength) const{
   std::string result;
   size_t length = pt_string.length();  
   result.reserve(length*2);
@@ -153,6 +163,7 @@ void OnSystemRequestNotification::ParsePTString(std::string& pt_string) const{
     if(pt_string[i]=='\"' || pt_string[i]=='\\'){
       result += '\\';
     } else if(pt_string[i] == '\n') {
+      contentLength--;  // contentLength is adjusted when this character is not copied to result.
       continue;
     }
     result += pt_string[i];

--- a/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
@@ -106,7 +106,7 @@ void OnSystemRequestNotification::AddHeader(BinaryMessage& message) const {
   LOG4CXX_AUTO_TRACE(logger_);
   const int timeout = policy::PolicyHandler::instance()->TimeoutExchange();
 
-  size_t contentLength;
+  size_t content_length;
   char size_str[24];  
   char timeout_str[24];
 
@@ -120,11 +120,10 @@ void OnSystemRequestNotification::AddHeader(BinaryMessage& message) const {
   calculated before additional escape characters are added to the 
   policy table string. The mobile proxy will remove the escape 
   characters after receiving this request. */
-  contentLength = policy_table_string.length();
 
-  ParsePTString(policy_table_string, contentLength);
+  content_length = ParsePTString(policy_table_string);
   
-  if (0 > sprintf(size_str, "%zu", contentLength)) {
+  if (0 > sprintf(size_str, "%zu", content_length)) {
     memset(size_str, 0, sizeof(size_str));
   }
 
@@ -155,20 +154,22 @@ void OnSystemRequestNotification::AddHeader(BinaryMessage& message) const {
       logger_, "Header added: " << std::string(message.begin(), message.end()));
 }
 
-void OnSystemRequestNotification::ParsePTString(std::string& pt_string, size_t& contentLength) const{
+size_t OnSystemRequestNotification::ParsePTString(std::string& pt_string) const{
   std::string result;
   size_t length = pt_string.length();  
+  size_t result_length = length;
   result.reserve(length*2);
   for(size_t i=0;i<length;++i){
     if(pt_string[i]=='\"' || pt_string[i]=='\\'){
       result += '\\';
     } else if(pt_string[i] == '\n') {
-      contentLength--;  // contentLength is adjusted when this character is not copied to result.
+      result_length--;  // contentLength is adjusted when this character is not copied to result.
       continue;
     }
     result += pt_string[i];
   }
   pt_string = result;
+  return result_length;
 }
 #endif
 


### PR DESCRIPTION
Content-Length was using an underscore instead of a Hyphen. Android was throwing an exception because there was no "Content-Length" key supplied in the request header.

Also fixed the way the Content-Length is calculated. Android removes the extra backslashes before sending the request to sdl server so I have Content-Length calculated first before "ParsePTString()" is called and the escaping backslashes are added. Then contentLength is sent to ParsePtString to be adjusted if characters are removed from the parsed policy table string (ie '\n' the newline character).

Tested on android and ios.