### PR TITLE
Create unit tests for message helper

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -838,7 +838,7 @@ class ApplicationManagerImpl
     * @return Resume Controller
     */
   resumption::ResumeCtrl& resume_controller() OVERRIDE {
-    return resume_ctrl_;
+    return *resume_ctrl_.get();
   }
 
   /**
@@ -1422,7 +1422,7 @@ class ApplicationManagerImpl
    * about persistent application data on disk, and save session ID for resuming
    * application in case INGITION_OFF or MASTER_RESSET
    */
-  resumption::ResumeCtrl resume_ctrl_;
+  std::auto_ptr<resumption::ResumeCtrl> resume_ctrl_;
 
   NaviServiceStatusMap navi_service_status_;
   std::deque<uint32_t> navi_app_to_stop_;

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -211,12 +211,6 @@ class MessageHelper {
       const std::string& path_to_icon, const uint32_t app_id);
 
   /**
-   * @brief Sends IVI subscription requests
-   */
-  static bool SendIVISubscribtions(const uint32_t app_id,
-                                   ApplicationManager& app_mngr);
-
-  /**
    * @brief Returns IVI subscription requests
    */
   static smart_objects::SmartObjectList GetIVISubscriptionRequests(

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015, Ford Motor Company
+ Copyright (c) 2016, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,24 +34,15 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_RESUME_CTRL_H_
 
 #include <stdint.h>
-#include <vector>
-#include <map>
-#include <set>
-#include <list>
-
-#include "interfaces/HMI_API.h"
-#include "interfaces/HMI_API_schema.h"
-#include "interfaces/MOBILE_API_schema.h"
-#include "application_manager/event_engine/event_observer.h"
-#include "smart_objects/smart_object.h"
-#include "application_manager/application.h"
-#include "application_manager/resumption/resumption_data.h"
-#include "utils/timer.h"
+#include "utils/shared_ptr.h"
 
 namespace application_manager {
 class ApplicationManager;
 class Application;
+typedef utils::SharedPtr<Application> ApplicationSharedPtr;
+typedef utils::SharedPtr<const Application> ApplicationConstSharedPtr;
 }
+namespace app_mngr = application_manager;
 
 namespace resumption {
 
@@ -60,109 +51,40 @@ class LastState;
 /**
  * @brief Contains logic for storage/restore data of applications.
  */
-
-class ResumeCtrl : public application_manager::event_engine::EventObserver {
+class ResumeCtrl {
  public:
-  /**
-   * @brief allows to create ResumeCtrl object
-   */
-  ResumeCtrl(application_manager::ApplicationManager& application_manager);
-
-  /**
-   * @brief allows to destroy ResumeCtrl object
-   */
-  ~ResumeCtrl();
-
-  /**
-   * @brief Event, that raised if application get resumption response from HMI
-   * @param event : event object, that contains smart_object with HMI message
-   */
-  virtual void on_event(const application_manager::event_engine::Event& event);
-
-  /**
-   * @brief Save all applications info to the file system
-   */
-  void SaveAllApplications();
-
   /**
    * @brief Save application persistent info for future resuming
    * @param application is application witch need to be saved
    */
-  void SaveApplication(application_manager::ApplicationSharedPtr application);
-
-  /**
-   * @brief Set application HMI Level and ausio_state as saved
-   * @param application is application witch HMI Level is need to restore
-   * @return true if success, otherwise return false
-   */
-  bool RestoreAppHMIState(
-      application_manager::ApplicationSharedPtr application);
-
-  /**
-   * @brief Set application HMI Level as stored in policy
-   * @param application is application witch HMI Level is need to setup
-   * @return true if success, otherwise return false
-   */
-  bool SetupDefaultHMILevel(
-      application_manager::ApplicationSharedPtr application);
-
-  /**
-   * @brief Setup HmiLevel for application
-   * Do routine of setting up hmi_level
-   * @param application is application witch HMI Level is need to setup
-   * @param hmi_level HMI Level is needed to setup
-   * @param hmi_level AudioStreamingState is needed to setup
-   * @param check_policy indicate if policy data consent must be verified
-   * @return true if success, otherwise return false
-   */
-  bool SetAppHMIState(application_manager::ApplicationSharedPtr application,
-                      const mobile_apis::HMILevel::eType hmi_level,
-                      bool check_policy = true);
-
-  /**
-   * @brief Check if Resume controller have saved instance of application
-   * @param application is application witch need to be checked
-   * @return true if exist, false otherwise
-   */
-  bool ApplicationIsSaved(
-      application_manager::ApplicationConstSharedPtr application);
+  virtual void SaveApplication(
+      application_manager::ApplicationSharedPtr application) = 0;
 
   /**
    * @brief Remove application from list of saved applications
    * @param application is application which need to be removed
    * @return return true, if success, otherwise return false
    */
-  bool RemoveApplicationFromSaved(
-      application_manager::ApplicationConstSharedPtr application);
+  virtual bool RemoveApplicationFromSaved(
+      app_mngr::ApplicationConstSharedPtr application) = 0;
+  /**
+   * @brief Increments ignition counter for all registered applications
+   * and remember ign_off time stamp
+   */
+  virtual void OnSuspend() = 0;
 
   /**
    * @brief Increments ignition counter for all registered applications
    * and remember ign_off time stamp
    */
-  void OnSuspend();
-
-  /**
-   * @brief Increments ignition counter for all registered applications
-   * and remember ign_off time stamp
-   */
-  void OnAwake();
-
-  /**
-   * @brief Method starts timer "RsmCtrlPercist" when
-   * SDL receives onAwakeSDL notification
-   */
-  void StartSavePersistentDataTimer();
+  virtual void OnAwake() = 0;
 
   /**
    * @brief Method stops timer "RsmCtrlPercist" when SDL
    * receives OnExitAllApplication notification
    * with reason "SUSPEND"
    */
-  void StopSavePersistentDataTimer();
-  /**
-   * @brief Method stops restore_hmi_level_timer_ "RsmCtrlRstore" in OnSuspend()
-   */
-  void StopRestoreHmiLevelTimer();
+  virtual void StopSavePersistentDataTimer() = 0;
 
   /**
    * @brief Start timer for resumption applications
@@ -170,41 +92,39 @@ class ResumeCtrl : public application_manager::event_engine::EventObserver {
    * @param application that is need to be restored
    * @return true if it was saved, otherwise return false
    */
-  bool StartResumption(application_manager::ApplicationSharedPtr application,
-                       const std::string& hash);
-
+  virtual bool StartResumption(app_mngr::ApplicationSharedPtr application,
+                               const std::string& hash) = 0;
   /**
    * @brief Start timer for resumption applications
    *        Does not restore D1-D5 data
    * @param application that is need to be restored
    * @return true if it was saved, otherwise return false
    */
-  bool StartResumptionOnlyHMILevel(
-      application_manager::ApplicationSharedPtr application);
+  virtual bool StartResumptionOnlyHMILevel(
+      app_mngr::ApplicationSharedPtr application) = 0;
 
   /**
    * @brief Check if there are all files need for resumption
    * @param application that is need to be restored
    * @return true if it all files exist, otherwise return false
    */
-  bool CheckPersistenceFilesForResumption(
-      application_manager::ApplicationSharedPtr application);
+  virtual bool CheckPersistenceFilesForResumption(
+      app_mngr::ApplicationSharedPtr application) = 0;
 
   /**
    * @brief Check application hash
    * @param application that is need to be restored
    * @return true if it was saved, otherwise return false
    */
-  bool CheckApplicationHash(
-      application_manager::ApplicationSharedPtr application,
-      const std::string& hash);
+  virtual bool CheckApplicationHash(app_mngr::ApplicationSharedPtr application,
+                                    const std::string& hash) = 0;
 
   /**
    * @brief Checks if Resume controller have saved application with hmi app id
    * @param hmi_app_id - hmi application id
    * @return true if exist, false otherwise
    */
-  bool IsHMIApplicationIdExist(uint32_t hmi_app_id);
+  virtual bool IsHMIApplicationIdExist(uint32_t hmi_app_id) = 0;
 
   /**
    * @brief Check if Resume controller have saved instance of application
@@ -212,8 +132,8 @@ class ResumeCtrl : public application_manager::event_engine::EventObserver {
    * @param device_id - id of device where application is run
    * @return true if exist, false otherwise
    */
-  bool IsApplicationSaved(const std::string& policy_app_id,
-                          const std::string& device_id);
+  virtual bool IsApplicationSaved(const std::string& policy_app_id,
+                                  const std::string& device_id) = 0;
 
   /**
    * @brief Function is used for application resume. HMI app ID must be
@@ -223,282 +143,52 @@ class ResumeCtrl : public application_manager::event_engine::EventObserver {
    * @param device_id - id of device where application is run
    * @return HMI app ID
    */
-  uint32_t GetHMIApplicationID(const std::string& policy_app_id,
-                               const std::string& device_id) const;
-  /**
-   * @brief SaveDataOnTimer :
-   *  Timer callback for persisting ResumptionData each N seconds
-   *  N gets from property
-   */
-  void SaveDataOnTimer();
+  virtual uint32_t GetHMIApplicationID(const std::string& policy_app_id,
+                                       const std::string& device_id) const = 0;
 
   /**
    * @brief Updates flag for saving application data
    */
-  void ApplicationsDataUpdated() {
-    is_data_saved_ = false;
-  }
-
-  /**
-   * @brief Resume HMI Level and audio streaming state if needed
-   * @param application - application to restore hmi level
-   * and audio streaming state
-   */
-  void StartAppHmiStateResumption(
-      application_manager::ApplicationSharedPtr application);
+  virtual void ApplicationsDataUpdated() = 0;
 
   /**
    * @brief Update launch_time_ to current
    */
-  void ResetLaunchTime();
-
-  /**
-   * @brief Timer callback for  restoring HMI Level
-   *
-   */
-  void ApplicationResumptiOnTimer();
+  virtual void ResetLaunchTime() = 0;
 
   /**
    * @brief Removes activated application from resumption list
    *
    * @param application application witch need to be removed from resumption
    */
-  void OnAppActivated(application_manager::ApplicationSharedPtr application);
+  virtual void OnAppActivated(app_mngr::ApplicationSharedPtr application) = 0;
 
   /**
    * @brief Removes app from resumption list
    *
    * app_id Application to remove
    */
-  void RemoveFromResumption(uint32_t app_id);
+  virtual void RemoveFromResumption(uint32_t app_id) = 0;
 
   /**
    * @brief Initialization data for Resume controller
    * @return true if initialization is success otherwise
    * returns false
    */
-  bool Init(LastState& last_state);
+  virtual bool Init(LastState& last_state) = 0;
 
   /**
    * @brief Notify resume controller about new application
    * @param policy_app_id - mobile application id
    * @param device_id - id of device where application is run
    */
-  void OnAppRegistrationStart(const std::string& policy_app_id,
-                              const std::string& device_id);
+  virtual void OnAppRegistrationStart(const std::string& policy_app_id,
+                                      const std::string& device_id) = 0;
 
   /**
    * @brief Notify resume controller about delete new application
    */
-  void OnAppRegistrationEnd();
-
-#ifdef BUILD_TESTS
-  void set_resumption_storage(utils::SharedPtr<ResumptionData> mock_storage);
-#endif  // BUILD_TESTS
- private:
-  /**
-   * @brief restores saved data of application
-   * @param application contains application for which restores data
-   * @return true if success, otherwise return false
-   */
-  bool RestoreApplicationData(
-      application_manager::ApplicationSharedPtr application);
-
-  /**
-   * @brief AddFiles allows to add files for the application
-   * which should be resumed
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  void AddFiles(application_manager::ApplicationSharedPtr application,
-                const smart_objects::SmartObject& saved_app);
-
-  /**
-   * @brief AddSubmenues allows to add sub menues for the application
-   * which should be resumed
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  void AddSubmenues(application_manager::ApplicationSharedPtr application,
-                    const smart_objects::SmartObject& saved_app);
-
-  /**
-   * @brief AddCommands allows to add commands for the application
-   * which should be resumed
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  void AddCommands(application_manager::ApplicationSharedPtr application,
-                   const smart_objects::SmartObject& saved_app);
-
-  /**
-   * @brief AddChoicesets allows to add choice sets for the application
-   * which should be resumed
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  void AddChoicesets(application_manager::ApplicationSharedPtr application,
-                     const smart_objects::SmartObject& saved_app);
-
-  /**
-   * @brief SetGlobalProperties allows to restore global properties.
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  void SetGlobalProperties(
-      application_manager::ApplicationSharedPtr application,
-      const smart_objects::SmartObject& saved_app);
-
-  /**
-   * @brief AddSubscriptions allows to restore subscriptions
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  void AddSubscriptions(application_manager::ApplicationSharedPtr application,
-                        const smart_objects::SmartObject& saved_app);
-
-  /**
-   * @brief AddWayPointsSubscription allows to restore subscription
-   * for WayPoints
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  void AddWayPointsSubscription(
-      application_manager::ApplicationSharedPtr application,
-      const smart_objects::SmartObject& saved_app);
-
-  bool CheckIgnCycleRestrictions(const smart_objects::SmartObject& saved_app);
-
-  bool DisconnectedJustBeforeIgnOff(
-      const smart_objects::SmartObject& saved_app);
-
-  bool CheckAppRestrictions(
-      application_manager::ApplicationConstSharedPtr application,
-      const smart_objects::SmartObject& saved_app);
-
-  /**
-   * @brief CheckIcons allows to check application icons
-   * @param application application under resumtion  application
-   * @param json_object
-   * @return true in case icons exists, false otherwise
-   */
-  bool CheckIcons(application_manager::ApplicationSharedPtr application,
-                  smart_objects::SmartObject& obj);
-
-  /**
-   * @brief CheckDelayAfterIgnOn should check if SDL was started less
-   * then N secconds ago. N will be readed from profile.
-   * @return true if SDL started N secconds ago, otherwise return false
-   */
-  bool CheckDelayAfterIgnOn();
-
-  typedef std::pair<uint32_t, uint32_t> ApplicationTimestamp;
-
-  std::set<application_manager::ApplicationSharedPtr> retrieve_application();
-
-  /**
-   * @brief This struct need to map
-   * timestamp and application from correlationID
-   */
-  struct ResumingApp {
-    uint32_t old_session_key;  // session key is the same as app_id
-    application_manager::ApplicationSharedPtr app;
-  };
-
-  struct TimeStampComparator {
-    bool operator()(const ApplicationTimestamp& lhs,
-                    const ApplicationTimestamp& rhs) const {
-      return lhs.second < rhs.second;
-    }
-  };
-
-  /**
-   * @brief geter for launch_time_
-   * @return value of launch_time_
-   */
-  time_t launch_time() const;
-
-  /**
-   * @brief Check device MAC address
-   * @param application that is need to be restored
-   * @param saved_device_mac Saved device MAC address
-   * @return TRUE on success, otherwise FALSE
-   */
-  bool IsDeviceMacAddressEqual(
-      application_manager::ApplicationSharedPtr application,
-      const std::string& saved_device_mac);
-
-  /**
-   * @brief Get the last ignition off time from LastState
-   * @return the last ignition off time from LastState
-   */
-  time_t GetIgnOffTime();
-
-  /**
-   * @brief Setup IgnOff time to LastState
-   * @param ign_off_time - igition off time
-   */
-  void SetLastIgnOffTime(time_t ign_off_time);
-
-  /**
-   * @brief Process specified HMI request
-   * @param request Request to process
-   * @param use_events Process request events or not flag
-   * @return TRUE on success, otherwise FALSE
-   */
-  bool ProcessHMIRequest(smart_objects::SmartObjectSPtr request = NULL,
-                         bool use_events = false);
-
-  /**
-   * @brief Process list of HMI requests using ProcessHMIRequest method
-   * @param requests List of requests to process
-   */
-  void ProcessHMIRequests(const smart_objects::SmartObjectList& requests);
-
-  void InsertToTimerQueue(uint32_t app_id, uint32_t time_stamp);
-
-  void AddToResumptionTimerQueue(const uint32_t app_id);
-
-  void LoadResumeData();
-
-  /**
-   * @brief Checks, if application data needs to be resumed
-   * @param application Application data from storage
-   * @return true, if data resumption must be skipped, otherwise - false
-   */
-  bool IsAppDataResumptionExpired(
-      const smart_objects::SmartObject& application) const;
-  /**
-   * @brief Checks from resume data, if application has been disconnected
-   * unexpectedly
-   * @param app Application section from resume data
-   * @return true, if it has been unexpectedly disconnected, otherwise - false
-   */
-  bool IsUnexpectedlyDisconnected(const smart_objects::SmartObject& app) const;
-
-  /**
-   * @brief Checks, if application can be resumed
-   * @param application Application
-   * @return true, if no restrictions currently, otherwise - false
-   */
-  bool IsResumeAllowed(
-      const application_manager::ApplicationSharedPtr application) const;
-
-  /**
-   *@brief Mapping applications to time_stamps
-   *       wait for timer to resume HMI Level
-   *
-   */
-  mutable sync_primitives::Lock queue_lock_;
-  timer::Timer restore_hmi_level_timer_;
-  timer::Timer save_persistent_data_timer_;
-  typedef std::list<uint32_t> WaitingForTimerList;
-  WaitingForTimerList waiting_for_timer_;
-  bool is_resumption_active_;
-  bool is_data_saved_;
-  time_t launch_time_;
-  utils::SharedPtr<ResumptionData> resumption_storage_;
-  application_manager::ApplicationManager& application_manager_;
+  virtual void OnAppRegistrationEnd() = 0;
 };
 
 }  // namespace resumption

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -68,14 +68,12 @@ class ResumeCtrl {
   virtual bool RemoveApplicationFromSaved(
       app_mngr::ApplicationConstSharedPtr application) = 0;
   /**
-   * @brief Increments ignition counter for all registered applications
-   * and remember ign_off time stamp
+   * @brief Processes resumption data after receiving signal "Suspend"
    */
   virtual void OnSuspend() = 0;
 
   /**
-   * @brief Increments ignition counter for all registered applications
-   * and remember ign_off time stamp
+   * @brief Processes resumption data after receiving signal "Awake"
    */
   virtual void OnAwake() = 0;
 

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,8 +30,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_RESUME_CTRL_H
-#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_RESUME_CTRL_H
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_RESUME_CTRL_IMPL_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_RESUME_CTRL_IMPL_H_
 
 #include <stdint.h>
 #include <vector>
@@ -74,7 +74,7 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @brief Event, that raised if application get resumption response from HMI
    * @param event : event object, that contains smart_object with HMI message
    */
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
   /**
    * @brief Save all applications info to the file system
@@ -85,7 +85,7 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @brief Save application persistent info for future resuming
    * @param application is application witch need to be saved
    */
-  void SaveApplication(app_mngr::ApplicationSharedPtr application);
+  void SaveApplication(app_mngr::ApplicationSharedPtr application) OVERRIDE;
 
   /**
    * @brief Set application HMI Level and ausio_state as saved
@@ -120,19 +120,17 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @return return true, if success, otherwise return false
    */
   bool RemoveApplicationFromSaved(
-      app_mngr::ApplicationConstSharedPtr application);
+      app_mngr::ApplicationConstSharedPtr application) OVERRIDE;
 
   /**
-   * @brief Increments ignition counter for all registered applications
-   * and remember ign_off time stamp
+   * @brief Processes resumption data after receiving signal "Suspend"
    */
-  void OnSuspend();
+  void OnSuspend() OVERRIDE;
 
   /**
-   * @brief Increments ignition counter for all registered applications
-   * and remember ign_off time stamp
+   * @brief Processes resumption data after receiving signal "Awake"
    */
-  void OnAwake();
+  void OnAwake() OVERRIDE;
 
   /**
    * @brief Method starts timer "RsmCtrlPercist" when
@@ -145,7 +143,7 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * receives OnExitAllApplication notification
    * with reason "SUSPEND"
    */
-  void StopSavePersistentDataTimer();
+  void StopSavePersistentDataTimer() OVERRIDE;
 
   /**
    * @brief Start timer for resumption applications
@@ -154,7 +152,7 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @return true if it was saved, otherwise return false
    */
   bool StartResumption(app_mngr::ApplicationSharedPtr application,
-                       const std::string& hash);
+                       const std::string& hash) OVERRIDE;
 
   /**
    * @brief Start timer for resumption applications
@@ -162,7 +160,8 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @param application that is need to be restored
    * @return true if it was saved, otherwise return false
    */
-  bool StartResumptionOnlyHMILevel(app_mngr::ApplicationSharedPtr application);
+  bool StartResumptionOnlyHMILevel(
+      app_mngr::ApplicationSharedPtr application) OVERRIDE;
 
   /**
    * @brief Check if there are all files need for resumption
@@ -170,7 +169,7 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @return true if it all files exist, otherwise return false
    */
   bool CheckPersistenceFilesForResumption(
-      app_mngr::ApplicationSharedPtr application);
+      app_mngr::ApplicationSharedPtr application) OVERRIDE;
 
   /**
    * @brief Check application hash
@@ -178,14 +177,14 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @return true if it was saved, otherwise return false
    */
   bool CheckApplicationHash(app_mngr::ApplicationSharedPtr application,
-                            const std::string& hash);
+                            const std::string& hash) OVERRIDE;
 
   /**
    * @brief Checks if Resume controller have saved application with hmi app id
    * @param hmi_app_id - hmi application id
    * @return true if exist, false otherwise
    */
-  bool IsHMIApplicationIdExist(uint32_t hmi_app_id);
+  bool IsHMIApplicationIdExist(uint32_t hmi_app_id) OVERRIDE;
 
   /**
    * @brief Check if Resume controller have saved instance of application
@@ -194,7 +193,7 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @return true if exist, false otherwise
    */
   bool IsApplicationSaved(const std::string& policy_app_id,
-                          const std::string& device_id);
+                          const std::string& device_id) OVERRIDE;
 
   /**
    * @brief Function is used for application resume. HMI app ID must be
@@ -205,12 +204,12 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @return HMI app ID
    */
   uint32_t GetHMIApplicationID(const std::string& policy_app_id,
-                               const std::string& device_id) const;
+                               const std::string& device_id) const OVERRIDE;
 
   /**
    * @brief Updates flag for saving application data
    */
-  void ApplicationsDataUpdated() {
+  void ApplicationsDataUpdated() OVERRIDE {
     is_data_saved_ = false;
   }
 
@@ -224,7 +223,7 @@ class ResumeCtrlImpl : public ResumeCtrl,
   /**
    * @brief Update launch_time_ to current
    */
-  void ResetLaunchTime();
+  void ResetLaunchTime() OVERRIDE;
 
   /**
    * @brief Timer callback for  restoring HMI Level
@@ -237,21 +236,21 @@ class ResumeCtrlImpl : public ResumeCtrl,
    *
    * @param application application witch need to be removed from resumption
    */
-  void OnAppActivated(app_mngr::ApplicationSharedPtr application);
+  void OnAppActivated(app_mngr::ApplicationSharedPtr application) OVERRIDE;
 
   /**
    * @brief Removes app from resumption list
    *
    * app_id Application to remove
    */
-  void RemoveFromResumption(uint32_t app_id);
+  void RemoveFromResumption(uint32_t app_id) OVERRIDE;
 
   /**
    * @brief Initialization data for Resume controller
    * @return true if initialization is success otherwise
    * returns false
    */
-  bool Init(LastState& last_state);
+  bool Init(LastState& last_state) OVERRIDE;
 
   /**
    * @brief Notify resume controller about new application
@@ -259,12 +258,12 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @param device_id - id of device where application is run
    */
   void OnAppRegistrationStart(const std::string& policy_app_id,
-                              const std::string& device_id);
+                              const std::string& device_id) OVERRIDE;
 
   /**
    * @brief Notify resume controller about delete new application
    */
-  void OnAppRegistrationEnd();
+  void OnAppRegistrationEnd() OVERRIDE;
 
 #ifdef BUILD_TESTS
   void set_resumption_storage(utils::SharedPtr<ResumptionData> mock_storage);
@@ -461,4 +460,4 @@ class ResumeCtrlImpl : public ResumeCtrl,
 };
 
 }  // namespace resumption
-#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_RESUME_CTRL_H
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_RESUME_CTRL_IMPL_H_

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -1,0 +1,464 @@
+/*
+ * Copyright (c) 2015, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_RESUME_CTRL_H
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_RESUME_CTRL_H
+
+#include <stdint.h>
+#include <vector>
+#include <map>
+#include <set>
+#include <list>
+
+#include "interfaces/HMI_API.h"
+#include "interfaces/HMI_API_schema.h"
+#include "interfaces/MOBILE_API_schema.h"
+#include "application_manager/event_engine/event_observer.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/application.h"
+#include "application_manager/resumption/resumption_data.h"
+#include "application_manager/resumption/resume_ctrl.h"
+#include "utils/timer.h"
+
+namespace resumption {
+
+class LastState;
+
+/**
+ * @brief Contains logic for storage/restore data of applications.
+ */
+
+class ResumeCtrlImpl : public ResumeCtrl,
+                       public app_mngr::event_engine::EventObserver {
+ public:
+  /**
+   * @brief allows to create ResumeCtrlImpl object
+   */
+  ResumeCtrlImpl(application_manager::ApplicationManager& application_manager);
+
+  /**
+   * @brief allows to destroy ResumeCtrlImpl object
+   */
+  ~ResumeCtrlImpl();
+
+  /**
+   * @brief Event, that raised if application get resumption response from HMI
+   * @param event : event object, that contains smart_object with HMI message
+   */
+  virtual void on_event(const app_mngr::event_engine::Event& event);
+
+  /**
+   * @brief Save all applications info to the file system
+   */
+  void SaveAllApplications();
+
+  /**
+   * @brief Save application persistent info for future resuming
+   * @param application is application witch need to be saved
+   */
+  void SaveApplication(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief Set application HMI Level and ausio_state as saved
+   * @param application is application witch HMI Level is need to restore
+   * @return true if success, otherwise return false
+   */
+  bool RestoreAppHMIState(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief Set application HMI Level as stored in policy
+   * @param application is application witch HMI Level is need to setup
+   * @return true if success, otherwise return false
+   */
+  bool SetupDefaultHMILevel(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief Setup HmiLevel for application
+   * Do routine of setting up hmi_level
+   * @param application is application witch HMI Level is need to setup
+   * @param hmi_level HMI Level is needed to setup
+   * @param hmi_level AudioStreamingState is needed to setup
+   * @param check_policy indicate if policy data consent must be verified
+   * @return true if success, otherwise return false
+   */
+  bool SetAppHMIState(app_mngr::ApplicationSharedPtr application,
+                      const mobile_apis::HMILevel::eType hmi_level,
+                      bool check_policy = true);
+
+  /**
+   * @brief Remove application from list of saved applications
+   * @param application is application which need to be removed
+   * @return return true, if success, otherwise return false
+   */
+  bool RemoveApplicationFromSaved(
+      app_mngr::ApplicationConstSharedPtr application);
+
+  /**
+   * @brief Increments ignition counter for all registered applications
+   * and remember ign_off time stamp
+   */
+  void OnSuspend();
+
+  /**
+   * @brief Increments ignition counter for all registered applications
+   * and remember ign_off time stamp
+   */
+  void OnAwake();
+
+  /**
+   * @brief Method starts timer "RsmCtrlPercist" when
+   * SDL receives onAwakeSDL notification
+   */
+  void StartSavePersistentDataTimer();
+
+  /**
+   * @brief Method stops timer "RsmCtrlPercist" when SDL
+   * receives OnExitAllApplication notification
+   * with reason "SUSPEND"
+   */
+  void StopSavePersistentDataTimer();
+
+  /**
+   * @brief Start timer for resumption applications
+   *        Restore D1-D5 data
+   * @param application that is need to be restored
+   * @return true if it was saved, otherwise return false
+   */
+  bool StartResumption(app_mngr::ApplicationSharedPtr application,
+                       const std::string& hash);
+
+  /**
+   * @brief Start timer for resumption applications
+   *        Does not restore D1-D5 data
+   * @param application that is need to be restored
+   * @return true if it was saved, otherwise return false
+   */
+  bool StartResumptionOnlyHMILevel(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief Check if there are all files need for resumption
+   * @param application that is need to be restored
+   * @return true if it all files exist, otherwise return false
+   */
+  bool CheckPersistenceFilesForResumption(
+      app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief Check application hash
+   * @param application that is need to be restored
+   * @return true if it was saved, otherwise return false
+   */
+  bool CheckApplicationHash(app_mngr::ApplicationSharedPtr application,
+                            const std::string& hash);
+
+  /**
+   * @brief Checks if Resume controller have saved application with hmi app id
+   * @param hmi_app_id - hmi application id
+   * @return true if exist, false otherwise
+   */
+  bool IsHMIApplicationIdExist(uint32_t hmi_app_id);
+
+  /**
+   * @brief Check if Resume controller have saved instance of application
+   * @param policy_app_id - mobile application id
+   * @param device_id - id of device where application is run
+   * @return true if exist, false otherwise
+   */
+  bool IsApplicationSaved(const std::string& policy_app_id,
+                          const std::string& device_id);
+
+  /**
+   * @brief Function is used for application resume. HMI app ID must be
+   * the same(PASA VCA module use it for stored app info).
+   * Retrieves HMI app ID for the given policy app ID from stored information.
+   * @param policy_app_id - mobile application id
+   * @param device_id - id of device where application is run
+   * @return HMI app ID
+   */
+  uint32_t GetHMIApplicationID(const std::string& policy_app_id,
+                               const std::string& device_id) const;
+
+  /**
+   * @brief Updates flag for saving application data
+   */
+  void ApplicationsDataUpdated() {
+    is_data_saved_ = false;
+  }
+
+  /**
+   * @brief Resume HMI Level and audio streaming state if needed
+   * @param application - application to restore hmi level
+   * and audio streaming state
+   */
+  void StartAppHmiStateResumption(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief Update launch_time_ to current
+   */
+  void ResetLaunchTime();
+
+  /**
+   * @brief Timer callback for  restoring HMI Level
+   *
+   */
+  void ApplicationResumptiOnTimer();
+
+  /**
+   * @brief Removes activated application from resumption list
+   *
+   * @param application application witch need to be removed from resumption
+   */
+  void OnAppActivated(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief Removes app from resumption list
+   *
+   * app_id Application to remove
+   */
+  void RemoveFromResumption(uint32_t app_id);
+
+  /**
+   * @brief Initialization data for Resume controller
+   * @return true if initialization is success otherwise
+   * returns false
+   */
+  bool Init(LastState& last_state);
+
+  /**
+   * @brief Notify resume controller about new application
+   * @param policy_app_id - mobile application id
+   * @param device_id - id of device where application is run
+   */
+  void OnAppRegistrationStart(const std::string& policy_app_id,
+                              const std::string& device_id);
+
+  /**
+   * @brief Notify resume controller about delete new application
+   */
+  void OnAppRegistrationEnd();
+
+#ifdef BUILD_TESTS
+  void set_resumption_storage(utils::SharedPtr<ResumptionData> mock_storage);
+#endif  // BUILD_TESTS
+ private:
+  /**
+   * @brief restores saved data of application
+   * @param application contains application for which restores data
+   * @return true if success, otherwise return false
+   */
+  bool RestoreApplicationData(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief SaveDataOnTimer :
+   *  Timer callback for persisting ResumptionData each N seconds
+   *  N gets from property
+   */
+  void SaveDataOnTimer();
+
+  /**
+   * @brief AddFiles allows to add files for the application
+   * which should be resumed
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddFiles(app_mngr::ApplicationSharedPtr application,
+                const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief AddSubmenues allows to add sub menues for the application
+   * which should be resumed
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddSubmenues(app_mngr::ApplicationSharedPtr application,
+                    const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief AddCommands allows to add commands for the application
+   * which should be resumed
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddCommands(app_mngr::ApplicationSharedPtr application,
+                   const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief AddChoicesets allows to add choice sets for the application
+   * which should be resumed
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddChoicesets(app_mngr::ApplicationSharedPtr application,
+                     const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief SetGlobalProperties allows to restore global properties.
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void SetGlobalProperties(app_mngr::ApplicationSharedPtr application,
+                           const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief AddSubscriptions allows to restore subscriptions
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddSubscriptions(app_mngr::ApplicationSharedPtr application,
+                        const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief AddWayPointsSubscription allows to restore subscription
+   * for WayPoints
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddWayPointsSubscription(app_mngr::ApplicationSharedPtr application,
+                                const smart_objects::SmartObject& saved_app);
+
+  bool CheckIgnCycleRestrictions(const smart_objects::SmartObject& saved_app);
+
+  bool DisconnectedJustBeforeIgnOff(
+      const smart_objects::SmartObject& saved_app);
+
+  bool CheckAppRestrictions(app_mngr::ApplicationConstSharedPtr application,
+                            const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief CheckIcons allows to check application icons
+   * @param application application under resumtion  application
+   * @param json_object
+   * @return true in case icons exists, false otherwise
+   */
+  bool CheckIcons(app_mngr::ApplicationSharedPtr application,
+                  smart_objects::SmartObject& obj);
+
+  /**
+   * @brief CheckDelayAfterIgnOn should check if SDL was started less
+   * then N secconds ago. N will be readed from profile.
+   * @return true if SDL started N secconds ago, otherwise return false
+   */
+  bool CheckDelayAfterIgnOn();
+
+  typedef std::pair<uint32_t, uint32_t> application_timestamp;
+
+  /**
+   * @brief This struct need to map
+   * timestamp and application from correlationID
+   */
+  struct ResumingApp {
+    uint32_t old_session_key;  // session key is the same as app_id
+    app_mngr::ApplicationSharedPtr app;
+  };
+
+  struct TimeStampComparator {
+    bool operator()(const application_timestamp& lhs,
+                    const application_timestamp& rhs) const {
+      return lhs.second < rhs.second;
+    }
+  };
+
+  /**
+   * @brief geter for launch_time_
+   * @return value of launch_time_
+   */
+  time_t launch_time() const;
+
+  /**
+   * @brief Check device MAC address
+   * @param application that is need to be restored
+   * @param saved_device_mac Saved device MAC address
+   * @return TRUE on success, otherwise FALSE
+   */
+  bool IsDeviceMacAddressEqual(app_mngr::ApplicationSharedPtr application,
+                               const std::string& saved_device_mac);
+
+  /**
+   * @brief Get the last ignition off time from LastState
+   * @return the last ignition off time from LastState
+   */
+  time_t GetIgnOffTime();
+
+  /**
+   * @brief Setup IgnOff time to LastState
+   * @param ign_off_time - igition off time
+   */
+  void SetLastIgnOffTime(time_t ign_off_time);
+
+  /**
+   * @brief Process specified HMI request
+   * @param request Request to process
+   * @param use_events Process request events or not flag
+   * @return TRUE on success, otherwise FALSE
+   */
+  bool ProcessHMIRequest(smart_objects::SmartObjectSPtr request = NULL,
+                         bool use_events = false);
+
+  /**
+   * @brief Process list of HMI requests using ProcessHMIRequest method
+   * @param requests List of requests to process
+   */
+  void ProcessHMIRequests(const smart_objects::SmartObjectList& requests);
+
+  void InsertToTimerQueue(uint32_t app_id, uint32_t time_stamp);
+
+  void AddToResumptionTimerQueue(const uint32_t app_id);
+
+  void LoadResumeData();
+
+  /**
+   * @brief Checks, if application data needs to be resumed
+   * @param application Application data from storage
+   * @return true, if data resumption must be skipped, otherwise - false
+   */
+  bool IsAppDataResumptionExpired(
+      const smart_objects::SmartObject& application) const;
+
+  /**
+   *@brief Mapping applications to time_stamps
+   *       wait for timer to resume HMI Level
+   *
+   */
+  mutable sync_primitives::Lock queue_lock_;
+  timer::Timer restore_hmi_level_timer_;
+  timer::Timer save_persistent_data_timer_;
+  typedef std::list<uint32_t> WaitingForTimerList;
+  WaitingForTimerList waiting_for_timer_;
+  bool is_resumption_active_;
+  bool is_data_saved_;
+  time_t launch_time_;
+  utils::SharedPtr<ResumptionData> resumption_storage_;
+  application_manager::ApplicationManager& application_manager_;
+};
+
+}  // namespace resumption
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_RESUME_CTRL_H

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2013, Ford Motor Company
+ Copyright (c) 2016, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -640,30 +640,6 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateSetAppIcon(
   return set_icon;
 }
 
-bool MessageHelper::SendIVISubscribtions(const uint32_t app_id,
-                                         ApplicationManager& app_mngr) {
-  SDL_AUTO_TRACE();
-
-  bool result = true;
-  ApplicationSharedPtr app = app_mngr.application(app_id);
-
-  if (!app.valid()) {
-    SDL_ERROR("Invalid application " << app_id);
-    return result;
-  }
-
-  smart_objects::SmartObjectList requests =
-      GetIVISubscriptionRequests(app, app_mngr);
-  for (smart_objects::SmartObjectList::const_iterator it = requests.begin();
-       it != requests.end();
-       ++it) {
-    if (!app_mngr.ManageHMICommand(*it)) {
-      result = false;
-    }
-  }
-  return result;
-}
-
 smart_objects::SmartObjectList MessageHelper::GetIVISubscriptionRequests(
     ApplicationSharedPtr app, ApplicationManager& app_mngr) {
   SDL_AUTO_TRACE();
@@ -1593,7 +1569,10 @@ void MessageHelper::SendGetUserFriendlyMessageResponse(
   smart_objects::SmartObjectSPtr message =
       utils::MakeShared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-
+  if (!message) {
+    SDL_ERROR("Memory allocation for message failed.");
+    return;
+  }
   (*message)[strings::params][strings::function_id] =
       hmi_apis::FunctionID::SDL_GetUserFriendlyMessage;
   (*message)[strings::params][strings::message_type] = MessageType::kResponse;

--- a/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_RESUME_CTRL_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_RESUME_CTRL_H_
+#include "gmock/gmock.h"
+#include "application_manager/resumption/resume_ctrl.h"
+#include "application_manager/application.h"
+#include "resumption/last_state.h"
+
+namespace resumption {
+
+class MockResumeCtrl : public ResumeCtrl {
+ public:
+  MOCK_METHOD1(SaveApplication,
+               void(app_mngr::ApplicationSharedPtr application));
+  MOCK_METHOD1(RemoveApplicationFromSaved,
+               bool(app_mngr::ApplicationConstSharedPtr application));
+  MOCK_METHOD0(OnSuspend, void());
+  MOCK_METHOD0(OnAwake, void());
+  MOCK_METHOD0(StopSavePersistentDataTimer, void());
+  MOCK_METHOD2(StartResumption,
+               bool(app_mngr::ApplicationSharedPtr application,
+                    const std::string& hash));
+  MOCK_METHOD1(StartResumptionOnlyHMILevel,
+               bool(app_mngr::ApplicationSharedPtr application));
+  MOCK_METHOD1(CheckPersistenceFilesForResumption,
+               bool(app_mngr::ApplicationSharedPtr application));
+  MOCK_METHOD2(CheckApplicationHash,
+               bool(app_mngr::ApplicationSharedPtr application,
+                    const std::string& hash));
+  MOCK_METHOD1(IsHMIApplicationIdExist, bool(uint32_t hmi_app_id));
+  MOCK_METHOD2(IsApplicationSaved,
+               bool(const std::string& policy_app_id,
+                    const std::string& device_id));
+  MOCK_CONST_METHOD2(GetHMIApplicationID,
+                     uint32_t(const std::string& policy_app_id,
+                              const std::string& device_id));
+  MOCK_METHOD0(ApplicationsDataUpdated, void());
+  MOCK_METHOD0(ResetLaunchTime, void());
+  MOCK_METHOD1(OnAppActivated,
+               void(app_mngr::ApplicationSharedPtr application));
+  MOCK_METHOD1(RemoveFromResumption, void(uint32_t app_id));
+  MOCK_METHOD1(Init, bool(LastState& last_state));
+  MOCK_METHOD2(OnAppRegistrationStart,
+               void(const std::string& policy_app_id,
+                    const std::string& device_id));
+  MOCK_METHOD0(OnAppRegistrationEnd, void());
+};
+
+}  // namespace resumption
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_RESUME_CTRL_H_

--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -32,6 +32,9 @@
 
 #include <string>
 #include <vector>
+#include <set>
+#include <algorithm>
+#include <iostream>
 
 #include "gmock/gmock.h"
 #include "application_manager/message_helper.h"
@@ -49,10 +52,16 @@
 #include "application_manager/policies/mock_policy_handler_interface.h"
 #include "connection_handler/device.h"
 #include "protocol_handler/mock_session_observer.h"
+#include "application_manager/mock_resume_ctrl.h"
 
 namespace test {
 namespace components {
 namespace application_manager_test {
+
+namespace {
+const uint32_t kCorrelationId = 1;
+const uint32_t kAppId = 123;
+}  // namespace
 
 namespace HmiLanguage = hmi_apis::Common_Language;
 namespace HmiResults = hmi_apis::Common_Result;
@@ -71,6 +80,7 @@ typedef utils::SharedPtr<application_manager::Application> ApplicationSharedPtr;
 using ::testing::AtLeast;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::ReturnPointee;
 using ::testing::_;
 using ::testing::DoAll;
 using ::testing::SaveArg;
@@ -627,6 +637,161 @@ class MessageHelperTest : public ::testing::Test {
     hmi_level_strings_.push_back("LIMITED");
     hmi_level_strings_.push_back("BACKGROUND");
     hmi_level_strings_.push_back("NONE");
+  }
+
+  /**
+   * @brief Check GetUserFriendly message which is sent to HMI
+   * @param msg contain message for sending to HMI.
+   */
+  void CheckSendingGetUserFriendlyMessage(
+      const std::vector<policy::UserFriendlyMessage>& msg) {
+    smart_objects::SmartObjectSPtr result;
+    EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+        .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+
+    MessageHelper::SendGetUserFriendlyMessageResponse(
+        msg, kCorrelationId, mock_application_manager_);
+    ASSERT_TRUE(result.valid());
+    EXPECT_EQ(hmi_apis::FunctionID::SDL_GetUserFriendlyMessage,
+              (*result)[strings::params][strings::function_id].asInt());
+    EXPECT_EQ(kCorrelationId,
+              (*result)[strings::params][strings::correlation_id].asInt());
+    if (msg.empty()) {
+      EXPECT_FALSE((*result)[strings::msg_params].keyExists("messages"));
+    } else {
+      smart_objects::SmartObject& user_friendly_messages =
+          (*result)[strings::msg_params]["messages"];
+      EXPECT_TRUE(user_friendly_messages.length() == msg.size());
+      std::vector<policy::UserFriendlyMessage>::const_iterator it = msg.begin();
+      for (int i = 0; it != msg.end(); ++i, ++it) {
+        EXPECT_TRUE(it->message_code ==
+                    user_friendly_messages[i]["messageCode"].asString());
+      }
+    }
+  }
+
+  /**
+   * @brief Check LaunchApp message which is sent to HMI
+   * @param urlSchema parameter for filling of message structure .
+   * @param packageName parameter for filling of message structure .
+   */
+  void CheckParametersLaunchAppMessage(const std::string& urlSchema,
+                                       const std::string& packageName) {
+    smart_objects::SmartObjectSPtr result;
+    EXPECT_CALL(mock_application_manager_, ManageMobileCommand(_, _))
+        .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+    MessageHelper::SendLaunchApp(
+        kAppId, urlSchema, packageName, mock_application_manager_);
+
+    ASSERT_TRUE(result.valid());
+    if (!urlSchema.empty() || !packageName.empty()) {
+      EXPECT_TRUE((*result)[strings::msg_params].keyExists(strings::url));
+    } else {
+      EXPECT_FALSE((*result)[strings::msg_params].keyExists(strings::url));
+    }
+
+    if (!urlSchema.empty()) {
+      EXPECT_EQ((*result)[strings::msg_params][strings::url].asString(),
+                urlSchema);
+    } else if (!packageName.empty()) {
+      EXPECT_EQ((*result)[strings::msg_params][strings::url].asString(),
+                packageName);
+    }
+    EXPECT_TRUE(
+        (*result)[strings::msg_params].keyExists(strings::request_type));
+    EXPECT_EQ((*result)[strings::msg_params][strings::request_type].asInt(),
+              mobile_apis::RequestType::LAUNCH_APP);
+    CheckParamsOfMessage(result, true, false);
+    EXPECT_TRUE((*result)[strings::params].keyExists(strings::function_id));
+    EXPECT_EQ((*result)[strings::params][strings::function_id].asInt(),
+              mobile_apis::FunctionID::OnSystemRequestID);
+  }
+
+  /**
+   * @brief Check NaviStartStream message which is sent to HMI
+   * @param url parameter for filling of message structure.
+   * @param video_server_type type of servise that is used for streaming.
+   * @param server_path contains name of pipe, file or adres of socket
+   * @param port contains port for socket.
+   */
+  void CheckParametersNaviStartStreamMessage(
+      const std::string url,
+      const std::string video_server_type,
+      const std::string server_path,
+      const uint16_t port = 0) {
+    MockApplicationManagerSettings mock_app_mngr_settings;
+    EXPECT_CALL(mock_application_manager_, GetNextHMICorrelationID())
+        .WillOnce(Return(kCorrelationId));
+    EXPECT_CALL(mock_application_manager_, get_settings())
+        .WillRepeatedly(ReturnRef(mock_app_mngr_settings));
+    EXPECT_CALL(mock_app_mngr_settings, video_server_type())
+        .WillRepeatedly(ReturnRef(video_server_type));
+    if (video_server_type == "socket") {
+      EXPECT_CALL(mock_app_mngr_settings, server_address())
+          .WillOnce(ReturnRef(server_path));
+      EXPECT_CALL(mock_app_mngr_settings, video_streaming_port())
+          .WillOnce(Return(port));
+    } else if (video_server_type == "pipe") {
+      EXPECT_CALL(mock_app_mngr_settings, named_video_pipe_path())
+          .WillOnce(ReturnRef(server_path));
+    } else {
+      EXPECT_CALL(mock_app_mngr_settings, video_stream_file())
+          .WillOnce(ReturnRef(server_path));
+    }
+    smart_objects::SmartObjectSPtr result;
+    EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+        .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+    MessageHelper::SendNaviStartStream(kAppId, mock_application_manager_);
+
+    ASSERT_TRUE(result.valid());
+    EXPECT_TRUE((*result)[strings::params].keyExists(strings::function_id));
+    EXPECT_EQ((*result)[strings::params][strings::function_id].asInt(),
+              hmi_apis::FunctionID::Navigation_StartStream);
+    CheckParamsOfMessage(result, true, true);
+    EXPECT_TRUE((*result)[strings::msg_params].keyExists(strings::url));
+    EXPECT_TRUE((*result)[strings::msg_params][strings::url].asString() == url);
+  }
+
+  /**
+   * @brief Check common parameters from messag
+   * @param result contains message which need to check
+   * @param is_app_id flag for checking application id parameter
+   * @param is_corr_id flag for checking correlation id parameter
+   */
+  void CheckParamsOfMessage(smart_objects::SmartObjectSPtr result,
+                            bool is_app_id,
+                            bool is_corr_id) {
+    if (is_app_id) {
+      EXPECT_TRUE((*result)[strings::msg_params].keyExists(strings::app_id));
+      EXPECT_EQ((*result)[strings::msg_params][strings::app_id].asInt(),
+                kAppId);
+    }
+
+    if (is_corr_id) {
+      EXPECT_TRUE(
+          (*result)[strings::params].keyExists(strings::correlation_id));
+      EXPECT_EQ(kCorrelationId,
+                (*result)[strings::params][strings::correlation_id].asInt());
+    }
+  }
+
+  /**
+   * @brief Fill structure for testing
+   * @param obj structure wich need to fill
+   * @param group_alias parameter from structure
+   * @param group_name parameter from structure
+   * @param group_id parameter from structure
+   * @param state parameter from structure
+   */
+  void FillFunctionalGroupPermissionObj(policy::FunctionalGroupPermission& obj,
+                                        const std::string group_alias,
+                                        const std::string group_name,
+                                        const int32_t group_id,
+                                        const policy::GroupConsent state) {
+    obj.group_alias = group_alias;
+    obj.group_name = group_name;
+    obj.group_id = group_id;
+    obj.state = state;
   }
 
  protected:
@@ -2489,6 +2654,298 @@ TEST_F(MessageHelperTest, SendGetListOfPermissionsResponse_SUCCESS) {
 
   EXPECT_EQ(hmi_apis::FunctionID::SDL_GetListOfPermissions,
             (*result)[strings::params][strings::function_id].asInt());
+}
+TEST_F(MessageHelperTest,
+       SendGetSystemInfoRequest_ExpectSendCorrectMessageToHMI) {
+  EXPECT_CALL(mock_application_manager_, GetNextHMICorrelationID())
+      .WillOnce(Return(kCorrelationId));
+  smart_objects::SmartObjectSPtr result;
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+
+  MessageHelper::SendGetSystemInfoRequest(mock_application_manager_);
+
+  ASSERT_TRUE(result.valid());
+  EXPECT_EQ(hmi_apis::FunctionID::BasicCommunication_GetSystemInfo,
+            (*result)[strings::params][strings::function_id].asInt());
+  CheckParamsOfMessage(result, false, true);
+}
+
+TEST_F(
+    MessageHelperTest,
+    SendGetUserFriendlyMessageResponseWithEmptyMessages_ExpectSendCorrectMessageToHMI) {
+  std::vector<policy::UserFriendlyMessage> msg;
+  CheckSendingGetUserFriendlyMessage(msg);
+}
+
+TEST_F(
+    MessageHelperTest,
+    SendGetUserFriendlyMessageResponseWithMessages_ExpectSendCorrectMessageToHMI) {
+  policy::UserFriendlyMessage arr[] = {
+      {"first_code"}, {"second_code"}, {"third_code"}};
+  std::vector<policy::UserFriendlyMessage> msg(arr, arr + 3);
+  CheckSendingGetUserFriendlyMessage(msg);
+}
+
+TEST_F(MessageHelperTest,
+       SendGlobalPropertiesToHMIApplicationIsNotValid_ExpectReturnFromMethod) {
+  MockApplicationSharedPtr app;
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_)).Times(0);
+  MessageHelper::SendGlobalPropertiesToHMI(app, mock_application_manager_);
+}
+
+TEST_F(
+    MessageHelperTest,
+    SendGlobalPropertiesToHMIWithUIGlobalProperties_ExpectSendCorrectMessageToHMI) {
+  MockApplicationSharedPtr app = ::utils::MakeShared<AppMock>();
+  const uint8_t number_msg_params = 6;
+  EXPECT_CALL(mock_application_manager_, GetNextHMICorrelationID())
+      .WillOnce(Return(kCorrelationId));
+  smart_objects::SmartObject dummy_so(smart_objects::SmartType_Map);
+  dummy_so["dummy_param"] = "dummy_param";
+  EXPECT_CALL(*app, vr_help_title()).Times(3).WillRepeatedly(Return(&dummy_so));
+  EXPECT_CALL(*app, vr_help()).Times(2).WillRepeatedly(Return(&dummy_so));
+  EXPECT_CALL(*app, keyboard_props())
+      .Times(2)
+      .WillRepeatedly(Return(&dummy_so));
+  EXPECT_CALL(*app, menu_title()).Times(2).WillRepeatedly(Return(&dummy_so));
+  EXPECT_CALL(*app, menu_icon()).Times(2).WillRepeatedly(Return(&dummy_so));
+  EXPECT_CALL(*app, app_id()).WillOnce(Return(kAppId));
+  EXPECT_CALL(*app, help_prompt())
+      .WillOnce(Return(static_cast<smart_objects::SmartObject*>(NULL)));
+  EXPECT_CALL(*app, timeout_prompt())
+      .WillOnce(Return(static_cast<smart_objects::SmartObject*>(NULL)));
+
+  smart_objects::SmartObjectSPtr result;
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+  MessageHelper::SendGlobalPropertiesToHMI(app, mock_application_manager_);
+
+  ASSERT_TRUE(result.valid());
+  smart_objects::SmartObject& global_properties_msg_params =
+      (*result)[strings::msg_params];
+
+  EXPECT_EQ((*result)[strings::params][strings::function_id].asInt(),
+            hmi_apis::FunctionID::UI_SetGlobalProperties);
+  CheckParamsOfMessage(result, true, true);
+
+  EXPECT_EQ(global_properties_msg_params.length(), number_msg_params);
+  EXPECT_TRUE(global_properties_msg_params.keyExists(strings::vr_help_title));
+  EXPECT_TRUE(global_properties_msg_params.keyExists(strings::vr_help));
+  EXPECT_TRUE(
+      global_properties_msg_params.keyExists(strings::keyboard_properties));
+  EXPECT_TRUE(global_properties_msg_params.keyExists(strings::menu_title));
+  EXPECT_TRUE(global_properties_msg_params.keyExists(strings::menu_icon));
+  std::set<std::string> keys = global_properties_msg_params.enumerate();
+  keys.erase(strings::app_id);
+  for (std::set<std::string>::iterator it = keys.begin(); it != keys.end();
+       ++it) {
+    EXPECT_TRUE(global_properties_msg_params[(*it)] == dummy_so);
+  }
+}
+
+TEST_F(
+    MessageHelperTest,
+    SendGlobalPropertiesToHMIWithTTSGlobalProperties_ExpectSendCorrectMessageToHMI) {
+  MockApplicationSharedPtr app = ::utils::MakeShared<AppMock>();
+  const uint8_t number_msg_params = 3;
+  EXPECT_CALL(mock_application_manager_, GetNextHMICorrelationID())
+      .WillOnce(Return(kCorrelationId));
+  smart_objects::SmartObject dummy_so(smart_objects::SmartType_Map);
+  dummy_so["dummy_param"] = "dummy_param";
+  EXPECT_CALL(*app, vr_help_title())
+      .WillOnce(Return(static_cast<smart_objects::SmartObject*>(NULL)));
+  EXPECT_CALL(*app, vr_help())
+      .WillOnce(Return(static_cast<smart_objects::SmartObject*>(NULL)));
+  EXPECT_CALL(*app, help_prompt()).Times(3).WillRepeatedly(Return(&dummy_so));
+  EXPECT_CALL(*app, timeout_prompt())
+      .Times(2)
+      .WillRepeatedly(Return(&dummy_so));
+  EXPECT_CALL(*app, app_id()).WillOnce(Return(kAppId));
+
+  smart_objects::SmartObjectSPtr result;
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+  MessageHelper::SendGlobalPropertiesToHMI(app, mock_application_manager_);
+
+  ASSERT_TRUE(result.valid());
+  smart_objects::SmartObject& global_properties_msg_params =
+      (*result)[strings::msg_params];
+
+  EXPECT_EQ((*result)[strings::params][strings::function_id].asInt(),
+            hmi_apis::FunctionID::TTS_SetGlobalProperties);
+  CheckParamsOfMessage(result, true, true);
+  EXPECT_EQ(global_properties_msg_params.length(), number_msg_params);
+  EXPECT_TRUE(global_properties_msg_params.keyExists(strings::help_prompt));
+  EXPECT_TRUE(global_properties_msg_params.keyExists(strings::timeout_prompt));
+  std::set<std::string> keys = global_properties_msg_params.enumerate();
+  keys.erase(strings::app_id);
+  for (std::set<std::string>::iterator it = keys.begin(); it != keys.end();
+       ++it) {
+    EXPECT_TRUE(global_properties_msg_params[(*it)] == dummy_so);
+  }
+}
+
+TEST_F(MessageHelperTest,
+       SendHashUpdateNotificationApplicationIsNotValid_ExpectReturnFromMethod) {
+  MockApplicationSharedPtr app;
+  EXPECT_CALL(mock_application_manager_, application(_)).WillOnce(Return(app));
+  EXPECT_CALL(mock_application_manager_, ManageMobileCommand(_, _)).Times(0);
+  MessageHelper::SendHashUpdateNotification(kAppId, mock_application_manager_);
+}
+
+TEST_F(MessageHelperTest,
+       SendHashUpdateNotification_ExpectSendCorrectMessageToMobile) {
+  MockApplicationSharedPtr app = ::utils::MakeShared<AppMock>();
+  resumption::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(mock_application_manager_, application(_)).WillOnce(Return(app));
+  smart_objects::SmartObjectSPtr result;
+  EXPECT_CALL(mock_application_manager_, ManageMobileCommand(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+  EXPECT_CALL(mock_application_manager_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, ApplicationsDataUpdated()).Times(1);
+  MessageHelper::SendHashUpdateNotification(kAppId, mock_application_manager_);
+  ASSERT_TRUE(result.valid());
+  EXPECT_EQ((*result)[strings::params][strings::function_id].asInt(),
+            mobile_apis::FunctionID::OnHashChangeID);
+  EXPECT_EQ((*result)[strings::params][strings::connection_key].asInt(),
+            kAppId);
+}
+
+TEST_F(MessageHelperTest, SendLaunchApp_ExpectSendCorrectMessageToMobile) {
+  std::string urlSchema;
+  std::string packageName;
+  CheckParametersLaunchAppMessage(urlSchema, packageName);
+  urlSchema = "url_shema";
+  CheckParametersLaunchAppMessage(urlSchema, packageName);
+  urlSchema = "";
+  packageName = "package_name";
+  CheckParametersLaunchAppMessage(urlSchema, packageName);
+}
+
+TEST_F(MessageHelperTest, SendNaviStartStream_ExpectSendCorrectMessageToHMI) {
+  uint16_t video_streaming_port = 8080;
+  CheckParametersNaviStartStreamMessage(
+      "http://127.0.0.1:8080", "socket", "127.0.0.1", video_streaming_port);
+  CheckParametersNaviStartStreamMessage("pipe_name", "pipe", "pipe_name");
+  CheckParametersNaviStartStreamMessage("file_name", "file", "file_name");
+}
+
+TEST_F(MessageHelperTest, SendNaviStopStream_ExpectSendCorrectMessageToHMI) {
+  smart_objects::SmartObjectSPtr result;
+  EXPECT_CALL(mock_application_manager_, GetNextHMICorrelationID())
+      .WillOnce(Return(kCorrelationId));
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+  MessageHelper::SendNaviStopStream(kAppId, mock_application_manager_);
+
+  ASSERT_TRUE(result.valid());
+  EXPECT_TRUE((*result)[strings::params].keyExists(strings::function_id));
+  EXPECT_EQ((*result)[strings::params][strings::function_id].asInt(),
+            hmi_apis::FunctionID::Navigation_StopStream);
+  CheckParamsOfMessage(result, true, true);
+}
+
+TEST_F(MessageHelperTest,
+       SendOnAppPermissionsChangedNotification_ExpectSendCorrectMessageToHMI) {
+  std::string policy_app_id("policyappid");
+  policy::AppPermissions dummy_permissions(policy_app_id);
+  dummy_permissions.appRevoked = true;
+  dummy_permissions.isAppPermissionsRevoked = true;
+  std::vector<policy::FunctionalGroupPermission> functional_group_permissions;
+  policy::FunctionalGroupPermission obj;
+  FillFunctionalGroupPermissionObj(obj,
+                                   "group_alias1",
+                                   "group_name1",
+                                   1,
+                                   policy::GroupConsent::kGroupAllowed);
+  functional_group_permissions.push_back(obj);
+  FillFunctionalGroupPermissionObj(obj,
+                                   "group_alias2",
+                                   "group_name2",
+                                   2,
+                                   policy::GroupConsent::kGroupDisallowed);
+  functional_group_permissions.push_back(obj);
+  FillFunctionalGroupPermissionObj(obj,
+                                   "group_alias3",
+                                   "group_name3",
+                                   3,
+                                   policy::GroupConsent::kGroupUndefined);
+  dummy_permissions.appRevokedPermissions = functional_group_permissions;
+  dummy_permissions.appPermissionsConsentNeeded = true;
+  dummy_permissions.appUnauthorized = true;
+  dummy_permissions.priority = "NORMAL";
+  dummy_permissions.requestTypeChanged = true;
+  std::vector<std::string> request_type(3, "dummy");
+  dummy_permissions.requestType = request_type;
+  smart_objects::SmartObjectSPtr result;
+  EXPECT_CALL(mock_application_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+  MessageHelper::SendOnAppPermissionsChangedNotification(
+      kAppId, dummy_permissions, mock_application_manager_);
+  ASSERT_TRUE(result.valid());
+  EXPECT_TRUE((*result)[strings::params].keyExists(strings::function_id));
+  EXPECT_EQ((*result)[strings::params][strings::function_id].asInt(),
+            hmi_apis::FunctionID::SDL_OnAppPermissionChanged);
+  CheckParamsOfMessage(result, true, false);
+  uint16_t number_msg_params = 8;
+  EXPECT_EQ((*result)[strings::msg_params].length(), number_msg_params);
+  EXPECT_TRUE((*result)[strings::msg_params].keyExists("appRevoked"));
+  EXPECT_TRUE((*result)[strings::msg_params]["appRevoked"].asBool());
+  EXPECT_TRUE(
+      (*result)[strings::msg_params].keyExists("isAppPermissionsRevoked"));
+  EXPECT_TRUE(
+      (*result)[strings::msg_params]["isAppPermissionsRevoked"].asBool());
+  EXPECT_TRUE(
+      (*result)[strings::msg_params].keyExists("appRevokedPermissions"));
+  EXPECT_TRUE(
+      ((*result)[strings::msg_params]["appRevokedPermissions"].length() ==
+       functional_group_permissions.size()));
+  uint16_t number_revoked_params = 3;
+  uint16_t number_revoked_params_without_allowed = 2;
+  smart_objects::SmartObject& revoked_items =
+      (*result)[strings::msg_params]["appRevokedPermissions"];
+  for (uint16_t i = 0; i < revoked_items.length(); ++i) {
+    if (policy::GroupConsent::kGroupUndefined ==
+        functional_group_permissions[i].state) {
+      EXPECT_TRUE(revoked_items[i].length() ==
+                  number_revoked_params_without_allowed);
+      EXPECT_FALSE(revoked_items[i].keyExists("allowed"));
+    } else {
+      EXPECT_TRUE(revoked_items[i].length() == number_revoked_params);
+      EXPECT_TRUE(revoked_items[i].keyExists("allowed"));
+      if (policy::kGroupAllowed == functional_group_permissions[i].state) {
+        EXPECT_TRUE(revoked_items[i]["allowed"].asBool());
+      } else {
+        EXPECT_FALSE(revoked_items[i]["allowed"].asBool());
+      }
+    }
+    EXPECT_TRUE(revoked_items[i].keyExists("name"));
+    EXPECT_TRUE(revoked_items[i]["name"].asString() ==
+                functional_group_permissions[i].group_alias);
+    EXPECT_TRUE(revoked_items[i].keyExists("id"));
+    EXPECT_TRUE(revoked_items[i]["id"].asInt() ==
+                functional_group_permissions[i].group_id);
+  }
+  EXPECT_TRUE(
+      (*result)[strings::msg_params].keyExists("appPermissionsConsentNeeded"));
+  EXPECT_TRUE(
+      (*result)[strings::msg_params]["appPermissionsConsentNeeded"].asBool());
+  EXPECT_TRUE((*result)[strings::msg_params].keyExists("appUnauthorized"));
+  EXPECT_TRUE((*result)[strings::msg_params]["appUnauthorized"].asBool());
+  EXPECT_TRUE((*result)[strings::msg_params].keyExists("priority"));
+  EXPECT_EQ((*result)[strings::msg_params]["priority"].asInt(),
+            hmi_apis::Common_AppPriority::NORMAL);
+  EXPECT_TRUE((*result)[strings::msg_params].keyExists(strings::request_type));
+  smart_objects::SmartObject& request_types_array =
+      (*result)[strings::msg_params][strings::request_type];
+  EXPECT_TRUE(request_types_array.length() ==
+              dummy_permissions.requestType.size());
+  for (uint16_t i = 0; i < request_types_array.length(); ++i) {
+    EXPECT_TRUE(request_types_array[i].asString() ==
+                dummy_permissions.requestType[i]);
+  }
 }
 
 }  // namespace application_manager_test

--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -715,9 +715,9 @@ class MessageHelperTest : public ::testing::Test {
    * @param port contains port for socket.
    */
   void CheckParametersNaviStartStreamMessage(
-      const std::string url,
-      const std::string video_server_type,
-      const std::string server_path,
+      const std::string& url,
+      const std::string& video_server_type,
+      const std::string& server_path,
       const uint16_t port = 0) {
     MockApplicationManagerSettings mock_app_mngr_settings;
     EXPECT_CALL(mock_application_manager_, GetNextHMICorrelationID())
@@ -753,7 +753,7 @@ class MessageHelperTest : public ::testing::Test {
   }
 
   /**
-   * @brief Check common parameters from messag
+   * @brief Check common parameters from message
    * @param result contains message which need to check
    * @param is_app_id flag for checking application id parameter
    * @param is_corr_id flag for checking correlation id parameter
@@ -784,8 +784,8 @@ class MessageHelperTest : public ::testing::Test {
    * @param state parameter from structure
    */
   void FillFunctionalGroupPermissionObj(policy::FunctionalGroupPermission& obj,
-                                        const std::string group_alias,
-                                        const std::string group_name,
+                                        const std::string& group_alias,
+                                        const std::string& group_name,
                                         const int32_t group_id,
                                         const policy::GroupConsent state) {
     obj.group_alias = group_alias;
@@ -2890,52 +2890,63 @@ TEST_F(MessageHelperTest,
             hmi_apis::FunctionID::SDL_OnAppPermissionChanged);
   CheckParamsOfMessage(result, true, false);
   uint16_t number_msg_params = 8;
+  std::string app_revoked("appRevoked");
+  std::string is_app_permissions_revoked("isAppPermissionsRevoked");
+  std::string app_revoked_permissions("appRevokedPermissions");
+  std::string allowed("allowed");
+  std::string name("name");
+  std::string id("id");
+
   EXPECT_EQ((*result)[strings::msg_params].length(), number_msg_params);
-  EXPECT_TRUE((*result)[strings::msg_params].keyExists("appRevoked"));
-  EXPECT_TRUE((*result)[strings::msg_params]["appRevoked"].asBool());
+  EXPECT_TRUE((*result)[strings::msg_params].keyExists(app_revoked));
+  EXPECT_TRUE((*result)[strings::msg_params][app_revoked].asBool());
   EXPECT_TRUE(
-      (*result)[strings::msg_params].keyExists("isAppPermissionsRevoked"));
+      (*result)[strings::msg_params].keyExists(is_app_permissions_revoked));
   EXPECT_TRUE(
-      (*result)[strings::msg_params]["isAppPermissionsRevoked"].asBool());
+      (*result)[strings::msg_params][is_app_permissions_revoked].asBool());
   EXPECT_TRUE(
-      (*result)[strings::msg_params].keyExists("appRevokedPermissions"));
+      (*result)[strings::msg_params].keyExists(app_revoked_permissions));
   EXPECT_TRUE(
-      ((*result)[strings::msg_params]["appRevokedPermissions"].length() ==
+      ((*result)[strings::msg_params][app_revoked_permissions].length() ==
        functional_group_permissions.size()));
   uint16_t number_revoked_params = 3;
   uint16_t number_revoked_params_without_allowed = 2;
   smart_objects::SmartObject& revoked_items =
-      (*result)[strings::msg_params]["appRevokedPermissions"];
+      (*result)[strings::msg_params][app_revoked_permissions];
   for (uint16_t i = 0; i < revoked_items.length(); ++i) {
     if (policy::GroupConsent::kGroupUndefined ==
         functional_group_permissions[i].state) {
       EXPECT_TRUE(revoked_items[i].length() ==
                   number_revoked_params_without_allowed);
-      EXPECT_FALSE(revoked_items[i].keyExists("allowed"));
+      EXPECT_FALSE(revoked_items[i].keyExists(allowed));
     } else {
       EXPECT_TRUE(revoked_items[i].length() == number_revoked_params);
-      EXPECT_TRUE(revoked_items[i].keyExists("allowed"));
+      EXPECT_TRUE(revoked_items[i].keyExists(allowed));
       if (policy::kGroupAllowed == functional_group_permissions[i].state) {
-        EXPECT_TRUE(revoked_items[i]["allowed"].asBool());
+        EXPECT_TRUE(revoked_items[i][allowed].asBool());
       } else {
-        EXPECT_FALSE(revoked_items[i]["allowed"].asBool());
+        EXPECT_FALSE(revoked_items[i][allowed].asBool());
       }
     }
-    EXPECT_TRUE(revoked_items[i].keyExists("name"));
-    EXPECT_TRUE(revoked_items[i]["name"].asString() ==
+    EXPECT_TRUE(revoked_items[i].keyExists(name));
+    EXPECT_TRUE(revoked_items[i][name].asString() ==
                 functional_group_permissions[i].group_alias);
-    EXPECT_TRUE(revoked_items[i].keyExists("id"));
-    EXPECT_TRUE(revoked_items[i]["id"].asInt() ==
+    EXPECT_TRUE(revoked_items[i].keyExists(id));
+    EXPECT_TRUE(revoked_items[i][id].asInt() ==
                 functional_group_permissions[i].group_id);
   }
+
+  std::string app_permissions_consent_needed("appPermissionsConsentNeeded");
+  std::string app_unauthorized("appUnauthorized");
+  std::string priority("priority");
   EXPECT_TRUE(
-      (*result)[strings::msg_params].keyExists("appPermissionsConsentNeeded"));
+      (*result)[strings::msg_params].keyExists(app_permissions_consent_needed));
   EXPECT_TRUE(
-      (*result)[strings::msg_params]["appPermissionsConsentNeeded"].asBool());
-  EXPECT_TRUE((*result)[strings::msg_params].keyExists("appUnauthorized"));
-  EXPECT_TRUE((*result)[strings::msg_params]["appUnauthorized"].asBool());
-  EXPECT_TRUE((*result)[strings::msg_params].keyExists("priority"));
-  EXPECT_EQ((*result)[strings::msg_params]["priority"].asInt(),
+      (*result)[strings::msg_params][app_permissions_consent_needed].asBool());
+  EXPECT_TRUE((*result)[strings::msg_params].keyExists(app_unauthorized));
+  EXPECT_TRUE((*result)[strings::msg_params][app_unauthorized].asBool());
+  EXPECT_TRUE((*result)[strings::msg_params].keyExists(priority));
+  EXPECT_EQ((*result)[strings::msg_params][priority].asInt(),
             hmi_apis::Common_AppPriority::NORMAL);
   EXPECT_TRUE((*result)[strings::msg_params].keyExists(strings::request_type));
   smart_objects::SmartObject& request_types_array =

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -30,7 +30,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "application_manager/resumption/resume_ctrl.h"
+#include "application_manager/resumption/resume_ctrl_impl.h"
 #include <string>
 #include <algorithm>
 #include "gtest/gtest.h"
@@ -90,7 +90,7 @@ class ResumeCtrlTest : public ::testing::Test {
         ::utils::MakeShared<NiceMock<resumption_test::MockResumptionData>>(
             mock_app_mngr_);
     app_mock = utils::MakeShared<NiceMock<MockApplication>>();
-    res_ctrl = utils::MakeShared<ResumeCtrl>(mock_app_mngr_);
+    res_ctrl = utils::MakeShared<ResumeCtrlImpl>(mock_app_mngr_);
     res_ctrl->set_resumption_storage(mock_storage);
 
     ON_CALL(mock_app_mngr_, state_controller())
@@ -116,7 +116,7 @@ class ResumeCtrlTest : public ::testing::Test {
       mock_application_manager_settings_;
   application_manager_test::MockApplicationManager mock_app_mngr_;
   MockStateController state_controller_;
-  utils::SharedPtr<ResumeCtrl> res_ctrl;
+  utils::SharedPtr<ResumeCtrlImpl> res_ctrl;
   utils::SharedPtr<NiceMock<resumption_test::MockResumptionData>> mock_storage;
   utils::SharedPtr<NiceMock<MockApplication>> app_mock;
   // app_mock.app_id() will return this value


### PR DESCRIPTION
Create tests for methods:
SendGetSystemInfoRequest
SendGetUserFriendlyMessageResponse
SendGlobalPropertiesToHMI
SendHashUpdateNotification
SendLaunchApp
SendNaviStartStream
SendNaviStopStream
SendOnAppPermissionsChangedNotification
Remove method SendIVISubscribtions because it is unused
Refactor resume_ctrl in order to create mock object.

Related issue [APPLINK-25339](https://adc.luxoft.com/jira/browse/APPLINK-25339)