### PR TITLE
Change policy url to public smartdevicelink policy url

### DIFF
--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -15,7 +15,7 @@
       ],
       "endpoints": {
         "0x07": {
-          "default": ["http://policies.telematics.ford.com/api/policies"]
+          "default": ["https://policies.smartdevicelink.com/api/1/policies"]
          },
          "0x04": {
            "default": ["http://ivsu.software.ford.com/api/getsoftwareupdates"]


### PR DESCRIPTION
Right now the policy update link is to a ford proprietary server. I have updated it to a live implementation of the [sdl server](https://github.com/smartdevicelink/sdl_server)

@AGaliuzov 