### PR TITLE
Hotfix/ATF_AddSubMenu known issues resolve

### DIFF
--- a/src/components/application_manager/include/application_manager/request_controller.h
+++ b/src/components/application_manager/include/application_manager/request_controller.h
@@ -285,7 +285,7 @@ class RequestController {
   /*
    * Timer for lock
    */
-  bool stop_flag_;
+  volatile bool timer_stop_flag_;
   sync_primitives::Lock timer_lock;
   sync_primitives::ConditionalVariable timer_condition_;
 

--- a/src/components/application_manager/include/application_manager/request_controller.h
+++ b/src/components/application_manager/include/application_manager/request_controller.h
@@ -282,6 +282,13 @@ class RequestController {
    */
   timer::Timer timer_;
 
+  /*
+   * Timer for lock
+   */
+  bool stop_flag_;
+  sync_primitives::Lock timer_lock;
+  sync_primitives::ConditionalVariable timer_condition_;
+
   bool is_low_voltage_;
   const RequestControlerSettings& settings_;
   DISALLOW_COPY_AND_ASSIGN(RequestController);

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -59,7 +59,7 @@ RequestController::RequestController(const RequestControlerSettings& settings)
     , timer_("AM RequestCtrlTimer",
              new timer::TimerTaskImpl<RequestController>(
                  this, &RequestController::onTimer))
-	, stop_flag_(false)
+	  , stop_flag_(false)
     , is_low_voltage_(false)
     , settings_(settings) {
   SDL_AUTO_TRACE();
@@ -376,20 +376,20 @@ void RequestController::onTimer() {
 	  sync_primitives::AutoLock auto_lock(timer_lock);
 	  timer_condition_.Wait(auto_lock);
 	  continue;
-	}
-	if (!probably_expired->isExpired()) {
-	  SDL_INFO("onTimer:isExpired");
-	  sync_primitives::AutoLock auto_lock(timer_lock);
-	  const TimevalStruct current_time = date_time::DateTime::getCurrentTime();
-	  const TimevalStruct end_time = probably_expired->end_time();
-	  if (current_time < end_time) {
-	    const uint32_t msecs = 
-			static_cast<uint32_t>(date_time::DateTime::getmSecs(end_time - current_time));
-		SDL_DEBUG("Sleep for" << msecs << " millisecs");
-		timer_condition_.WaitFor(auto_lock, msecs);
+	  }
+	  if (!probably_expired->isExpired()) {
+	    SDL_INFO("onTimer:isExpired");
+	    sync_primitives::AutoLock auto_lock(timer_lock);
+	    const TimevalStruct current_time = date_time::DateTime::getCurrentTime();
+	    const TimevalStruct end_time = probably_expired->end_time();
+	    if (current_time < end_time) {
+	      const uint32_t msecs = 
+			  static_cast<uint32_t>(date_time::DateTime::getmSecs(end_time - current_time));
+		    SDL_DEBUG("Sleep for" << msecs << " millisecs");
+		    timer_condition_.WaitFor(auto_lock, msecs);
 	  }
 	  continue;
-	}
+	  }
     SDL_INFO("Timeout for "
              << (RequestInfo::HMIRequest == probably_expired->requst_type()
                      ? "HMI"

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -59,14 +59,19 @@ RequestController::RequestController(const RequestControlerSettings& settings)
     , timer_("AM RequestCtrlTimer",
              new timer::TimerTaskImpl<RequestController>(
                  this, &RequestController::onTimer))
+	, stop_flag_(false)
     , is_low_voltage_(false)
     , settings_(settings) {
   SDL_AUTO_TRACE();
   InitializeThreadpool();
+  timer_.Start(0, timer::kSingleShot);
 }
 
 RequestController::~RequestController() {
   SDL_AUTO_TRACE();
+  stop_flag_ = true;
+  timer_condition_.Broadcast();
+  timer_.Stop();
   if (pool_state_ != TPoolState::STOPPED) {
     DestroyThreadpool();
   }
@@ -364,9 +369,27 @@ void RequestController::onTimer() {
   SDL_AUTO_TRACE();
   SDL_DEBUG(
       "ENTER Waiting fore response count: " << waiting_for_response_.Size());
-  RequestInfoPtr probably_expired =
-      waiting_for_response_.FrontWithNotNullTimeout();
-  while (probably_expired && probably_expired->isExpired()) {
+  while(!stop_flag_) {
+    RequestInfoPtr probably_expired =
+        waiting_for_response_.FrontWithNotNullTimeout();
+    if (!probably_expired) {
+	  sync_primitives::AutoLock auto_lock(timer_lock);
+	  timer_condition_.Wait(auto_lock);
+	  continue;
+	}
+	if (!probably_expired->isExpired()) {
+	  SDL_INFO("onTimer:isExpired");
+	  sync_primitives::AutoLock auto_lock(timer_lock);
+	  const TimevalStruct current_time = date_time::DateTime::getCurrentTime();
+	  const TimevalStruct end_time = probably_expired->end_time();
+	  if (current_time < end_time) {
+	    const uint32_t msecs = 
+			static_cast<uint32_t>(date_time::DateTime::getmSecs(end_time - current_time));
+		SDL_DEBUG("Sleep for" << msecs << " millisecs");
+		timer_condition_.WaitFor(auto_lock, msecs);
+	  }
+	  continue;
+	}
     SDL_INFO("Timeout for "
              << (RequestInfo::HMIRequest == probably_expired->requst_type()
                      ? "HMI"
@@ -470,32 +493,7 @@ void RequestController::Worker::exitThreadMain() {
 
 void RequestController::UpdateTimer() {
   SDL_AUTO_TRACE();
-  RequestInfoPtr front = waiting_for_response_.FrontWithNotNullTimeout();
-  // Buffer for sending request
-  const uint32_t delay_time = 100u;
-  if (front) {
-    const TimevalStruct current_time = date_time::DateTime::getCurrentTime();
-    TimevalStruct end_time = front->end_time();
-    date_time::DateTime::AddMilliseconds(end_time, delay_time);
-    if (current_time < end_time) {
-      const uint32_t msecs = static_cast<uint32_t>(
-          date_time::DateTime::getmSecs(end_time - current_time));
-      SDL_DEBUG("Sleep for " << msecs << " millisecs");
-      // Timeout for bigger than 5 minutes is a mistake
-      timer_.Start(msecs, timer::kSingleShot);
-    } else {
-      SDL_WARN("Request app_id: "
-               << front->app_id() << " correlation_id: " << front->requestId()
-               << " is expired. "
-               << "End time (ms): " << date_time::DateTime::getmSecs(end_time)
-               << " Current time (ms): "
-               << date_time::DateTime::getmSecs(current_time)
-               << " Diff (current - end) (ms): "
-               << date_time::DateTime::getmSecs(current_time - end_time)
-               << " Request timeout (sec): "
-               << front->timeout_msec() / date_time::kMillisecondsInSecond);
-    }
-  }
+  timer_condition_.NotifyOne();
 }
 
 }  //  namespace request_controller

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -59,7 +59,7 @@ RequestController::RequestController(const RequestControlerSettings& settings)
     , timer_("AM RequestCtrlTimer",
              new timer::TimerTaskImpl<RequestController>(
                  this, &RequestController::onTimer))
-    , stop_flag_(false)
+    , timer_stop_flag_(false)
     , is_low_voltage_(false)
     , settings_(settings) {
   SDL_AUTO_TRACE();
@@ -69,7 +69,7 @@ RequestController::RequestController(const RequestControlerSettings& settings)
 
 RequestController::~RequestController() {
   SDL_AUTO_TRACE();
-  stop_flag_ = true;
+  timer_stop_flag_ = true;
   timer_condition_.Broadcast();
   timer_.Stop();
   if (pool_state_ != TPoolState::STOPPED) {
@@ -369,7 +369,7 @@ void RequestController::onTimer() {
   SDL_AUTO_TRACE();
   SDL_DEBUG(
       "ENTER Waiting fore response count: " << waiting_for_response_.Size());
-  while(!stop_flag_) {
+  while(!timer_stop_flag_) {
     RequestInfoPtr probably_expired =
         waiting_for_response_.FrontWithNotNullTimeout();
     if (!probably_expired) {

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -59,7 +59,7 @@ RequestController::RequestController(const RequestControlerSettings& settings)
     , timer_("AM RequestCtrlTimer",
              new timer::TimerTaskImpl<RequestController>(
                  this, &RequestController::onTimer))
-	  , stop_flag_(false)
+    , stop_flag_(false)
     , is_low_voltage_(false)
     , settings_(settings) {
   SDL_AUTO_TRACE();
@@ -373,23 +373,23 @@ void RequestController::onTimer() {
     RequestInfoPtr probably_expired =
         waiting_for_response_.FrontWithNotNullTimeout();
     if (!probably_expired) {
-	  sync_primitives::AutoLock auto_lock(timer_lock);
-	  timer_condition_.Wait(auto_lock);
-	  continue;
-	  }
-	  if (!probably_expired->isExpired()) {
-	    SDL_INFO("onTimer:isExpired");
-	    sync_primitives::AutoLock auto_lock(timer_lock);
-	    const TimevalStruct current_time = date_time::DateTime::getCurrentTime();
-	    const TimevalStruct end_time = probably_expired->end_time();
-	    if (current_time < end_time) {
-	      const uint32_t msecs = 
-			  static_cast<uint32_t>(date_time::DateTime::getmSecs(end_time - current_time));
-		    SDL_DEBUG("Sleep for" << msecs << " millisecs");
-		    timer_condition_.WaitFor(auto_lock, msecs);
-	  }
-	  continue;
-	  }
+      sync_primitives::AutoLock auto_lock(timer_lock);
+      timer_condition_.Wait(auto_lock);
+      continue;
+    }
+    if (!probably_expired->isExpired()) {
+      SDL_INFO("onTimer:isExpired");
+      sync_primitives::AutoLock auto_lock(timer_lock);
+      const TimevalStruct current_time = date_time::DateTime::getCurrentTime();
+      const TimevalStruct end_time = probably_expired->end_time();
+      if (current_time < end_time) {
+        const uint32_t msecs = static_cast<uint32_t>(
+            date_time::DateTime::getmSecs(end_time - current_time));
+        SDL_DEBUG("Sleep for" << msecs << " millisecs");
+        timer_condition_.WaitFor(auto_lock, msecs);
+      }
+      continue;
+    }
     SDL_INFO("Timeout for "
              << (RequestInfo::HMIRequest == probably_expired->requst_type()
                      ? "HMI"

--- a/src/components/smart_objects/src/smart_object.cc
+++ b/src/components/smart_objects/src/smart_object.cc
@@ -723,16 +723,28 @@ void SmartObject::duplicate(const SmartObject& OtherObject) {
 void SmartObject::cleanup_data() {
   switch (m_type) {
     case SmartType_String:
-      delete m_data.str_value;
+	  if (m_data.str_value) {
+        delete m_data.str_value;
+	    m_data.str_value = NULL;
+	  }
       break;
     case SmartType_Map:
-      delete m_data.map_value;
+	  if (m_data.map_value) {
+	    delete m_data.map_value;
+		m_data.map_value = NULL;
+	  }
       break;
     case SmartType_Array:
-      delete m_data.array_value;
+	  if (m_data.array_value) {
+	    delete m_data.array_value;
+		m_data.array_value = NULL;
+	  }
       break;
     case SmartType_Binary:
-      delete m_data.binary_value;
+	  if (m_data.binary_value) {
+	    delete m_data.binary_value;
+		m_data.array_value = NULL;
+	  }
       break;
     default:
       break;

--- a/src/components/smart_objects/src/smart_object.cc
+++ b/src/components/smart_objects/src/smart_object.cc
@@ -723,28 +723,28 @@ void SmartObject::duplicate(const SmartObject& OtherObject) {
 void SmartObject::cleanup_data() {
   switch (m_type) {
     case SmartType_String:
-	  if (m_data.str_value) {
+	    if (m_data.str_value) {
         delete m_data.str_value;
-	    m_data.str_value = NULL;
-	  }
+	      m_data.str_value = NULL;
+	    }
       break;
     case SmartType_Map:
-	  if (m_data.map_value) {
-	    delete m_data.map_value;
-		m_data.map_value = NULL;
-	  }
+	    if (m_data.map_value) {
+	      delete m_data.map_value;
+		    m_data.map_value = NULL;
+	    }
       break;
     case SmartType_Array:
-	  if (m_data.array_value) {
-	    delete m_data.array_value;
-		m_data.array_value = NULL;
-	  }
+	    if (m_data.array_value) {
+	      delete m_data.array_value;
+		    m_data.array_value = NULL;
+	    }
       break;
     case SmartType_Binary:
-	  if (m_data.binary_value) {
-	    delete m_data.binary_value;
-		m_data.array_value = NULL;
-	  }
+	    if (m_data.binary_value) {
+	      delete m_data.binary_value;
+		    m_data.array_value = NULL;
+	    }
       break;
     default:
       break;

--- a/src/components/smart_objects/src/smart_object.cc
+++ b/src/components/smart_objects/src/smart_object.cc
@@ -723,28 +723,28 @@ void SmartObject::duplicate(const SmartObject& OtherObject) {
 void SmartObject::cleanup_data() {
   switch (m_type) {
     case SmartType_String:
-	    if (m_data.str_value) {
+      if (m_data.str_value) {
         delete m_data.str_value;
-	      m_data.str_value = NULL;
-	    }
+        m_data.str_value = NULL;
+      }
       break;
     case SmartType_Map:
-	    if (m_data.map_value) {
-	      delete m_data.map_value;
-		    m_data.map_value = NULL;
-	    }
+      if (m_data.map_value) {
+        delete m_data.map_value;
+        m_data.map_value = NULL;
+      }
       break;
     case SmartType_Array:
-	    if (m_data.array_value) {
-	      delete m_data.array_value;
-		    m_data.array_value = NULL;
-	    }
+      if (m_data.array_value) {
+        delete m_data.array_value;
+        m_data.array_value = NULL;
+      }
       break;
     case SmartType_Binary:
-	    if (m_data.binary_value) {
-	      delete m_data.binary_value;
-		    m_data.array_value = NULL;
-	    }
+      if (m_data.binary_value) {
+        delete m_data.binary_value;
+        m_data.array_value = NULL;
+      }
       break;
     default:
       break;


### PR DESCRIPTION
Please review @pestOO @AGaliuzov @anosach-luxoft 
### Update:
- RequestController::UpdateTimer():<br>
  Change the timer update logic from waiting until close and restart to unblock the waiting threads, avoid timeout issue
- RequestController::OnTimer():<br>
  Add Autolock and wait to process the condition of NOT probably_expired
- Set clean up data to NULL after it's deleted

### Test:
- Both ATF_AddSubMenu and ATF_SetMediaClockTimer ATF tests are passed, do the test several times
- SPT AddSubMenu test passed(successfully add ten submenu)
- make test passed result:

      Start  1: test_JSONCPP
 1/21 Test  #1: test_JSONCPP .....................   Passed    0.04 sec
      Start  2: transport_manager_test
 2/21 Test  #2: transport_manager_test ...........   Passed    0.32 sec
      Start  3: resumption_test
 3/21 Test  #3: resumption_test ..................   Passed    0.02 sec
      Start  4: formatters_test
 4/21 Test  #4: formatters_test ..................   Passed    0.22 sec
      Start  5: protocol_handler_test
 5/21 Test  #5: protocol_handler_test ............   Passed   42.93 sec
      Start  6: connection_handler_test
 6/21 Test  #6: connection_handler_test ..........   Passed   83.30 sec
      Start  7: utils_test
 7/21 Test  #7: utils_test .......................   Passed   20.61 sec
      Start  8: generator_test
 8/21 Test  #8: generator_test ...................   Passed    0.02 sec
      Start  9: security_manager_test
 9/21 Test  #9: security_manager_test ............   Passed    1.00 sec
      Start 10: policy_test
10/21 Test #10: policy_test ......................   Passed    7.29 sec
      Start 11: rpc_base_test
11/21 Test #11: rpc_base_test ....................   Passed    0.03 sec
      Start 12: smart_object_test
12/21 Test #12: smart_object_test ................   Passed    0.73 sec
      Start 13: application_manager_test
13/21 Test #13: application_manager_test .........   Passed    1.89 sec
      Start 14: data_resumption_test
14/21 Test #14: data_resumption_test .............   Passed    0.03 sec
      Start 15: state_controller_test
15/21 Test #15: state_controller_test ............   Passed    0.39 sec
      Start 16: commands_test
16/21 Test #16: commands_test ....................   Passed    0.11 sec
      Start 17: mobile_commands_test
17/21 Test #17: mobile_commands_test .............   Passed    0.08 sec
      Start 18: message_helper_test
18/21 Test #18: message_helper_test ..............   Passed    0.10 sec
      Start 19: hmi_message_handler_test
19/21 Test #19: hmi_message_handler_test .........   Passed    0.02 sec
      Start 20: config_profile_test
20/21 Test #20: config_profile_test ..............   Passed    0.41 sec
      Start 21: media_manager_test
21/21 Test #21: media_manager_test ...............   Passed    0.04 sec

100% tests passed, 0 tests failed out of 21

Total Test time (real) = 159.64 sec
