### PR TITLE
Reset logger default path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
   - bash -e tools/infrastructure/check_style.sh
   - mkdir build && cd build && cmake ../ -DBUILD_TESTS=ON -DENABLE_GCOV=ON && make install
   - sudo ldconfig
-  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bin/lib ; make test
+  - make test
   - bash ../tools/infrastructure/show_disabled.sh 
   - bash -ex ../tools/infrastructure/collect_coverage.sh ./
 env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@
 
 cmake_minimum_required(VERSION 2.8.11)
 
+set(PROJECT smartDeviceLinkCore)
+project(${PROJECT})
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/tools/cmake/modules/")
 
 include(${CMAKE_SOURCE_DIR}/tools/cmake/helpers/platform.cmake)
@@ -45,8 +48,6 @@ get_sdk(SDK)
 if(SDK)
   message(STATUS "SDK: " ${SDK})
 endif()
-
-set(PROJECT smartDeviceLinkCore)
 
 # Build options
 option(QT_HMI "Use Qt HMI" OFF)
@@ -188,7 +189,6 @@ endif()
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/components/include
-  ${CMAKE_BINARY_DIR}/bin/include
 )
 
 if(BUILD_TESTS)
@@ -201,7 +201,7 @@ if(BUILD_TESTS)
 endif()
 
 # --- 3rd party libs
-add_subdirectory(./src/3rd_party)
+add_subdirectory(./src/3rd_party EXCLUDE_FROM_ALL)
 
 # --- 3rd party libs (static)
 add_subdirectory(./src/3rd_party-static)

--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -30,7 +30,12 @@
 
 set(3RD_PARTY_INSTALL_PREFIX $ENV{THIRD_PARTY_INSTALL_PREFIX})
 if(NOT 3RD_PARTY_INSTALL_PREFIX)
-  set(3RD_PARTY_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/bin)
+  # set default 3rd party install path
+  # TODO ANosach: change default 3rd party install path (APPLINK-25980)
+  set(3RD_PARTY_INSTALL_PREFIX /usr/local)
+  set(USE_DEFAULT_3RD_PARTY_PATH "true")
+else()
+  set(USE_DEFAULT_3RD_PARTY_PATH "false")
 endif()
 
 set(3RD_PARTY_INSTALL_PREFIX_ARCH $ENV{THIRD_PARTY_INSTALL_PREFIX_ARCH})

--- a/src/components/utils/CMakeLists.txt
+++ b/src/components/utils/CMakeLists.txt
@@ -163,7 +163,7 @@ collect_sources(SOURCES "${PATHS}" "${EXCLUDE_PATHS}")
 add_library(utils ${SOURCES})
 target_link_libraries(utils ${LIBRARIES})
 
-if(ENABLE_LOG AND LOG4CXX_LOGGER)
+if(LOG4CXX_LOGGER)
   add_dependencies(utils install-3rd_party_logger)
 endif()
 

--- a/src/plugins/appenders/CMakeLists.txt
+++ b/src/plugins/appenders/CMakeLists.txt
@@ -40,7 +40,7 @@ set(LIBRARIES
   log4cxx -L${LOG4CXX_LIBS_DIRECTORY}
 )
 
-add_library(appenders ${SOURCES})
+add_library(appenders SHARED ${SOURCES})
 target_link_libraries(appenders ${LIBRARIES})
 
 install(TARGETS appenders


### PR DESCRIPTION
3rd party install directory has been changed to */build/bin* during cmake files refactoring and this PR reverts it to default */usr/local* value

Related-issue: [APPLINK-25969](https://adc.luxoft.com/jira/browse/APPLINK-25969)

@LuxoftAKutsan, @dev-gh, @LevchenkoS, @Kozoriz, @nk0leg please review