### PR TITLE
Fix problem with incorrect removing data from resumption data

### DIFF
--- a/src/components/application_manager/src/resumption/resumption_data_json.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_json.cc
@@ -244,11 +244,11 @@ bool ResumptionDataJson::RemoveApplicationFromSaved(
       const std::string& saved_policy_app_id =
           (*it)[strings::app_id].asString();
       const std::string& saved_device_id = (*it)[strings::device_id].asString();
-      if (saved_policy_app_id != policy_app_id &&
-          saved_device_id != device_id) {
-        temp.push_back((*it));
-      } else {
+      if (saved_policy_app_id == policy_app_id &&
+          saved_device_id == device_id) {
         result = true;
+      } else {
+        temp.push_back((*it));
       }
     }
   }


### PR DESCRIPTION
SDL was crashed by DCHECK because of incorect removing data after resumption
first application.

Closes bug [APPLINK-24803](https://adc.luxoft.com/jira/browse/APPLINK-24803c)