### PR TITLE
Fix DCHECK on secure rpc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ only:
   - \/feature\/.+
   - \/fix\/.+
   - \/hotfix\/.+
+  - \/release\/.+
 
 addons:
   apt:

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1261,11 +1261,13 @@ void ApplicationManagerImpl::OnCertificateUpdateRequired() {
 security_manager::SSLContext::HandshakeContext
 ApplicationManagerImpl::GetHandshakeContext(uint32_t key) const {
   LOG4CXX_AUTO_TRACE(logger_);
+  using security_manager::SSLContext;
   ApplicationConstSharedPtr app = application(key);
-  security_manager::SSLContext::HandshakeContext res;
-  DCHECK_OR_RETURN(app.valid(), res);
-  return res.make_context(custom_str::CustomString(app->policy_app_id()),
-                          app->name());
+  if (app) {
+    SSLContext::HandshakeContext(custom_str::CustomString(app->policy_app_id()),
+                                 app->name());
+  }
+  return SSLContext::HandshakeContext();
 }
 #endif  // ENABLE_SECURITY
 

--- a/src/components/include/security_manager/ssl_context.h
+++ b/src/components/include/security_manager/ssl_context.h
@@ -77,15 +77,14 @@ class SSLContext {
   };
 
   struct HandshakeContext {
+    HandshakeContext() : expected_sn(""), expected_cn("") {}
+
+    HandshakeContext(const custom_str::CustomString& exp_sn,
+                     const custom_str::CustomString& exp_cn)
+        : expected_sn(exp_sn), expected_cn(exp_cn) {}
+
     custom_str::CustomString expected_sn;
     custom_str::CustomString expected_cn;
-
-    HandshakeContext& make_context(const custom_str::CustomString& sn,
-                                   const custom_str::CustomString& cn) {
-      expected_sn = sn;
-      expected_cn = cn;
-      return *this;
-    }
   };
 
   virtual HandshakeResult StartHandshake(const uint8_t** const out_data,

--- a/src/components/security_manager/test/ssl_certificate_handshake_test.cc
+++ b/src/components/security_manager/test/ssl_certificate_handshake_test.cc
@@ -168,9 +168,10 @@ class SSLHandshakeTest : public testing::Test {
       return false;
     }
 
-    security_manager::SSLContext::HandshakeContext ctx;
-    server_ctx->SetHandshakeContext(ctx.make_context(
-        custom_str::CustomString("SPT"), custom_str::CustomString("client")));
+    server_ctx->SetHandshakeContext(
+        security_manager::SSLContext::HandshakeContext(
+            custom_str::CustomString("SPT"),
+            custom_str::CustomString("client")));
 
     return true;
   }
@@ -201,9 +202,10 @@ class SSLHandshakeTest : public testing::Test {
       return false;
     }
 
-    security_manager::SSLContext::HandshakeContext ctx;
-    client_ctx->SetHandshakeContext(ctx.make_context(
-        custom_str::CustomString("SPT"), custom_str::CustomString("server")));
+    client_ctx->SetHandshakeContext(
+        security_manager::SSLContext::HandshakeContext(
+            custom_str::CustomString("SPT"),
+            custom_str::CustomString("server")));
 
     return true;
   }
@@ -508,16 +510,19 @@ TEST_F(SSLHandshakeTest, AppNameAndAppIDInvalid) {
                                  server_ca_cert_filename))
       << client_manager->LastError();
 
-  security_manager::SSLContext::HandshakeContext ctx;
-  client_ctx->SetHandshakeContext(ctx.make_context(
-      custom_str::CustomString("server"), custom_str::CustomString("Wrong")));
+  client_ctx->SetHandshakeContext(
+      security_manager::SSLContext::HandshakeContext(
+          custom_str::CustomString("server"),
+          custom_str::CustomString("Wrong")));
 
   GTEST_TRACE(HandshakeProcedure_ClientSideFail(
       security_manager::SSLContext::Handshake_Result_AppNameMismatch));
 
   ResetConnections();
-  client_ctx->SetHandshakeContext(ctx.make_context(
-      custom_str::CustomString("Wrong"), custom_str::CustomString("server")));
+  client_ctx->SetHandshakeContext(
+      security_manager::SSLContext::HandshakeContext(
+          custom_str::CustomString("Wrong"),
+          custom_str::CustomString("server")));
 
   GTEST_TRACE(HandshakeProcedure_ClientSideFail(
       security_manager::SSLContext::Handshake_Result_AppIDMismatch));

--- a/src/components/security_manager/test/ssl_context_test.cc
+++ b/src/components/security_manager/test/ssl_context_test.cc
@@ -157,9 +157,9 @@ class SSLTest : public testing::Test {
         .WillRepeatedly(Return(security_manager::CLIENT));
     client_ctx = client_manager_->CreateSSLContext();
 
-    security_manager::SSLContext::HandshakeContext ctx;
-    ctx.make_context(custom_str::CustomString("SPT"),
-                     custom_str::CustomString("client"));
+    using custom_str::CustomString;
+    security_manager::SSLContext::HandshakeContext ctx(CustomString("SPT"),
+                                                       CustomString("client"));
     server_ctx->SetHandshakeContext(ctx);
 
     ctx.expected_cn = "server";
@@ -236,9 +236,9 @@ class SSLTestParam : public testing::TestWithParam<ProtocolAndCipher> {
     server_ctx = crypto_manager->CreateSSLContext();
     client_ctx = client_manager->CreateSSLContext();
 
-    security_manager::SSLContext::HandshakeContext ctx;
-    ctx.make_context(custom_str::CustomString("SPT"),
-                     custom_str::CustomString("client"));
+    using custom_str::CustomString;
+    security_manager::SSLContext::HandshakeContext ctx(CustomString("SPT"),
+                                                       CustomString("client"));
     server_ctx->SetHandshakeContext(ctx);
 
     ctx.expected_cn = "server";

--- a/tools/infrastructure/check_style.sh
+++ b/tools/infrastructure/check_style.sh
@@ -28,7 +28,20 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 FILE_NAMES=$(find src -name \*.h -print -o -name \*.cpp -print  -o -name \*.cc -print | grep -v 3rd_party)
-for FILE_NAME in $FILE_NAMES
-do
-	clang-format-3.6 -style=file $FILE_NAME | diff $FILE_NAME -
-done
+
+
+check_style() {
+	clang-format-3.6 -style=file $1 | diff $1 -
+}
+
+fix_style() {
+	clang-format-3.6 -style=file -i $1
+}
+
+if [ "$1" = "--fix" ]
+then
+  for FILE_NAME in $FILE_NAMES; do fix_style $FILE_NAME; done
+else
+  for FILE_NAME in $FILE_NAMES; do check_style $FILE_NAME; done
+fi
+


### PR DESCRIPTION
If anyone call GetHandshakeContext with invalid application id
application manager should not assert this case, just return empty SSLContext

Related Issue : APPLINK-24766

