### PR TITLE
Cover Mobile commands with Unit Tests

### DIFF
--- a/src/components/application_manager/test/commands/mobile/diagnostic_message_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/diagnostic_message_request_test.cc
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "commands/commands_test.h"
+#include "commands/command_request_test.h"
+#include "application_manager/application.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/event_engine/event.h"
+#include "mobile/diagnostic_message_request.h"
+#include "interfaces/MOBILE_API.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::ReturnRef;
+namespace am = ::application_manager;
+using am::commands::MessageSharedPtr;
+using am::commands::DiagnosticMessageRequest;
+using am::event_engine::Event;
+namespace mobile_result = mobile_apis::Result;
+
+typedef SharedPtr<DiagnosticMessageRequest> DiagnosticMessageRequestPtr;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const uint32_t kDiagnosticMode = 5u;
+}  // namespace
+
+class DiagnosticMessageRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(DiagnosticMessageRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  DiagnosticMessageRequestPtr command(
+      CreateCommand<DiagnosticMessageRequest>(command_msg));
+
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(ApplicationSharedPtr()));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(
+          MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
+
+  command->Run();
+}
+
+TEST_F(DiagnosticMessageRequestTest, Run_NotSupportedDiagnosticMode_UNSUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::message_data][0] =
+      kDiagnosticMode;
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  DiagnosticMessageRequestPtr command(
+      CreateCommand<DiagnosticMessageRequest>(command_msg));
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+
+  EXPECT_CALL(app_mngr_, get_settings())
+      .WillOnce(ReturnRef(app_mngr_settings_));
+
+  const std::vector<uint32_t> empty_supported_diag_modes;
+  EXPECT_CALL(app_mngr_settings_, supported_diag_modes())
+      .WillOnce(ReturnRef(empty_supported_diag_modes));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::REJECTED), _));
+
+  command->Run();
+}
+
+TEST_F(DiagnosticMessageRequestTest, Run_SUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::message_data][0] =
+      kDiagnosticMode;
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  DiagnosticMessageRequestPtr command(
+      CreateCommand<DiagnosticMessageRequest>(command_msg));
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+
+  EXPECT_CALL(app_mngr_, get_settings())
+      .WillOnce(ReturnRef(app_mngr_settings_));
+
+  std::vector<uint32_t> supported_diag_modes;
+  supported_diag_modes.push_back(kDiagnosticMode);
+
+  EXPECT_CALL(app_mngr_settings_, supported_diag_modes())
+      .WillOnce(ReturnRef(supported_diag_modes));
+
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::VehicleInfo_DiagnosticMessage)));
+
+  command->Run();
+}
+
+TEST_F(DiagnosticMessageRequestTest, OnEvent_UNSUCCESS) {
+  Event event(hmi_apis::FunctionID::INVALID_ENUM);
+
+  DiagnosticMessageRequestPtr command(
+      CreateCommand<DiagnosticMessageRequest>());
+
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+
+  command->on_event(event);
+}
+
+TEST_F(DiagnosticMessageRequestTest, OnEvent_SUCCESS) {
+  Event event(hmi_apis::FunctionID::VehicleInfo_DiagnosticMessage);
+
+  MessageSharedPtr event_message(CreateMessage(smart_objects::SmartType_Map));
+  (*event_message)[am::strings::msg_params] = 0;
+  (*event_message)[am::strings::params][am::hmi_response::code] =
+      mobile_result::SUCCESS;
+  event.set_smart_object(*event_message);
+
+  DiagnosticMessageRequestPtr command(
+      CreateCommand<DiagnosticMessageRequest>());
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
+
+  command->on_event(event);
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/dial_number_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/dial_number_request_test.cc
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "commands/commands_test.h"
+#include "commands/command_request_test.h"
+#include "application_manager/application.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/event_engine/event.h"
+#include "mobile/dial_number_request.h"
+#include "interfaces/MOBILE_API.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using ::testing::_;
+using ::testing::Return;
+namespace am = ::application_manager;
+using am::commands::MessageSharedPtr;
+using am::commands::DialNumberRequest;
+using am::event_engine::Event;
+namespace mobile_result = mobile_apis::Result;
+
+typedef SharedPtr<DialNumberRequest> DialNumberRequestPtr;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+}  // namespace
+
+class DialNumberRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(DialNumberRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
+  DialNumberRequestPtr command(CreateCommand<DialNumberRequest>());
+
+  EXPECT_CALL(app_mngr_, application(_))
+      .WillOnce(Return(ApplicationSharedPtr()));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(
+          MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
+
+  command->Run();
+}
+
+TEST_F(DialNumberRequestTest, Run_InvalidNumber_UNSUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = "\t\n";
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  DialNumberRequestPtr command(CreateCommand<DialNumberRequest>(command_msg));
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
+
+  command->Run();
+}
+
+TEST_F(DialNumberRequestTest, Run_EmptyNumber_UNSUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = "NotANumber";
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  DialNumberRequestPtr command(CreateCommand<DialNumberRequest>(command_msg));
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
+
+  command->Run();
+}
+
+TEST_F(DialNumberRequestTest, Run_SUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  DialNumberRequestPtr command(CreateCommand<DialNumberRequest>(command_msg));
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::BasicCommunication_DialNumber)));
+
+  command->Run();
+}
+
+TEST_F(DialNumberRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  DialNumberRequestPtr command(CreateCommand<DialNumberRequest>(command_msg));
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+
+  Event event(hmi_apis::FunctionID::INVALID_ENUM);
+
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+
+  command->on_event(event);
+}
+
+TEST_F(DialNumberRequestTest, OnEvent_SUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  DialNumberRequestPtr command(CreateCommand<DialNumberRequest>(command_msg));
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+
+  MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*event_msg)[am::strings::params][am::hmi_response::code] =
+      mobile_apis::Result::SUCCESS;
+  (*event_msg)[am::strings::params][am::strings::info] = "test_info";
+
+  Event event(hmi_apis::FunctionID::BasicCommunication_DialNumber);
+  event.set_smart_object(*event_msg);
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
+
+  command->on_event(event);
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/end_audio_pass_thru_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/end_audio_pass_thru_request_test.cc
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "commands/commands_test.h"
+#include "commands/command_request_test.h"
+#include "application_manager/application.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/event_engine/event.h"
+#include "mobile/end_audio_pass_thru_request.h"
+#include "interfaces/MOBILE_API.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using ::testing::_;
+using ::testing::Return;
+namespace am = ::application_manager;
+using am::commands::MessageSharedPtr;
+using am::commands::EndAudioPassThruRequest;
+using am::event_engine::Event;
+namespace mobile_result = mobile_apis::Result;
+
+typedef SharedPtr<EndAudioPassThruRequest> EndAudioPassThruRequestPtr;
+
+class EndAudioPassThruRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(EndAudioPassThruRequestTest, Run_SUCCESS) {
+  EndAudioPassThruRequestPtr command(CreateCommand<EndAudioPassThruRequest>());
+
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(
+                  HMIResultCodeIs(hmi_apis::FunctionID::UI_EndAudioPassThru)));
+
+  command->Run();
+}
+
+TEST_F(EndAudioPassThruRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
+  EndAudioPassThruRequestPtr command(CreateCommand<EndAudioPassThruRequest>());
+
+  Event event(hmi_apis::FunctionID::INVALID_ENUM);
+
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+
+  command->on_event(event);
+}
+
+TEST_F(EndAudioPassThruRequestTest, OnEvent_SUCCESS) {
+  const uint32_t kConnectionKey = 2u;
+
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  EndAudioPassThruRequestPtr command(
+      CreateCommand<EndAudioPassThruRequest>(command_msg));
+
+  MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*event_msg)[am::strings::msg_params] = 0;
+  (*event_msg)[am::strings::params][am::hmi_response::code] =
+      mobile_apis::Result::SUCCESS;
+
+  Event event(hmi_apis::FunctionID::UI_EndAudioPassThru);
+  event.set_smart_object(*event_msg);
+
+  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_, StopAudioPassThru(kConnectionKey));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
+
+  command->on_event(event);
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/get_dtcs_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/get_dtcs_request_test.cc
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "commands/commands_test.h"
+#include "commands/command_request_test.h"
+#include "application_manager/application.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/event_engine/event.h"
+#include "mobile/get_dtcs_request.h"
+#include "interfaces/MOBILE_API.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using ::testing::_;
+using ::testing::Return;
+namespace am = ::application_manager;
+using am::commands::MessageSharedPtr;
+using am::commands::GetDTCsRequest;
+using am::event_engine::Event;
+namespace mobile_result = mobile_apis::Result;
+
+typedef SharedPtr<GetDTCsRequest> GetDTCsRequestPtr;
+
+class GetDTCsRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(GetDTCsRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
+  GetDTCsRequestPtr command(CreateCommand<GetDTCsRequest>());
+
+  EXPECT_CALL(app_mngr_, application(_))
+      .WillOnce(Return(ApplicationSharedPtr()));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(
+          MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
+
+  command->Run();
+}
+
+TEST_F(GetDTCsRequestTest, Run_SUCCESS) {
+  const uint32_t kConnectionKey = 2u;
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::dtc_mask] = 0;
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  GetDTCsRequestPtr command(CreateCommand<GetDTCsRequest>(command_msg));
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(
+                  HMIResultCodeIs(hmi_apis::FunctionID::VehicleInfo_GetDTCs)));
+
+  command->Run();
+}
+
+TEST_F(GetDTCsRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
+  GetDTCsRequestPtr command(CreateCommand<GetDTCsRequest>());
+
+  Event event(hmi_apis::FunctionID::INVALID_ENUM);
+
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+
+  command->on_event(event);
+}
+
+TEST_F(GetDTCsRequestTest, OnEvent_SUCCESS) {
+  GetDTCsRequestPtr command(CreateCommand<GetDTCsRequest>());
+
+  MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*event_msg)[am::strings::msg_params] = 0;
+  (*event_msg)[am::strings::params][am::hmi_response::code] =
+      mobile_apis::Result::SUCCESS;
+
+  Event event(hmi_apis::FunctionID::VehicleInfo_GetDTCs);
+  event.set_smart_object(*event_msg);
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
+
+  command->on_event(event);
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/get_vehicle_data_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/get_vehicle_data_request_test.cc
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "commands/commands_test.h"
+#include "commands/command_request_test.h"
+#include "application_manager/application.h"
+#include "application_manager/message_helper.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/event_engine/event.h"
+#include "mobile/get_vehicle_data_request.h"
+#include "interfaces/MOBILE_API.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::ReturnRef;
+namespace am = ::application_manager;
+using am::commands::MessageSharedPtr;
+using am::commands::GetVehicleDataRequest;
+using am::event_engine::Event;
+namespace mobile_result = mobile_apis::Result;
+
+typedef SharedPtr<GetVehicleDataRequest> GetVehicleDataRequestPtr;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+}  // namespace
+
+class GetVehicleDataRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
+
+class UnwrappedGetVehicleDataRequest : public GetVehicleDataRequest {
+ public:
+  UnwrappedGetVehicleDataRequest(const MessageSharedPtr& message,
+                                 am::ApplicationManager& application_manager)
+      : GetVehicleDataRequest(message, application_manager) {}
+
+  std::vector<std::string>& get_disallowed_params() {
+    return removed_parameters_permissions_.disallowed_params;
+  }
+
+  using GetVehicleDataRequest::on_event;
+};
+
+#ifdef HMI_DBUS_API
+// HMI_DBUS_API currently not supported
+#else
+
+TEST_F(GetVehicleDataRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
+  GetVehicleDataRequestPtr command(CreateCommand<GetVehicleDataRequest>());
+
+  EXPECT_CALL(app_mngr_, application(_))
+      .WillOnce(Return(ApplicationSharedPtr()));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(
+          MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
+
+  command->Run();
+}
+
+TEST_F(GetVehicleDataRequestTest, Run_TooHighFrequency_UNSUCCESS) {
+  const mobile_apis::FunctionID::eType kFunctionId =
+      mobile_apis::FunctionID::GetVehicleDataID;
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::function_id] = kFunctionId;
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  GetVehicleDataRequestPtr command(
+      CreateCommand<GetVehicleDataRequest>(command_msg));
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+
+  EXPECT_CALL(
+      *app,
+      AreCommandLimitsExceeded(kFunctionId, am::TLimitSource::CONFIG_FILE))
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::REJECTED), _));
+
+  command->Run();
+}
+
+TEST_F(GetVehicleDataRequestTest, Run_EmptyMsgParams_UNSUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  GetVehicleDataRequestPtr command(
+      CreateCommand<GetVehicleDataRequest>(command_msg));
+
+  const am::VehicleData kEmptyVehicleData;
+  EXPECT_CALL(*am::MockMessageHelper::message_helper_mock(), vehicle_data())
+      .WillOnce(ReturnRef(kEmptyVehicleData));
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
+
+  command->Run();
+}
+
+TEST_F(GetVehicleDataRequestTest,
+       Run_EmptyMsgParamsAndHasDisallowedParams_UNSUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  SharedPtr<UnwrappedGetVehicleDataRequest> command(
+      CreateCommand<UnwrappedGetVehicleDataRequest>(command_msg));
+
+  const am::VehicleData kEmptyVehicleData;
+  EXPECT_CALL(*am::MockMessageHelper::message_helper_mock(), vehicle_data())
+      .WillRepeatedly(ReturnRef(kEmptyVehicleData));
+
+  std::vector<std::string>& disallowed_params =
+      command->get_disallowed_params();
+  disallowed_params.push_back("test_param");
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::DISALLOWED), _));
+
+  command->Run();
+}
+
+TEST_F(GetVehicleDataRequestTest, Run_SUCCESS) {
+  const std::string kMsgParamKey("test_key");
+
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*command_msg)[am::strings::msg_params][kMsgParamKey] = true;
+
+  GetVehicleDataRequestPtr command(
+      CreateCommand<GetVehicleDataRequest>(command_msg));
+
+  am::VehicleData vehicle_data;
+  vehicle_data.insert(
+      am::VehicleData::value_type(kMsgParamKey, am::VehicleDataType::SPEED));
+  EXPECT_CALL(*am::MockMessageHelper::message_helper_mock(), vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data));
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::VehicleInfo_GetVehicleData)));
+
+  command->Run();
+}
+
+TEST_F(GetVehicleDataRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  SharedPtr<UnwrappedGetVehicleDataRequest> command(
+      CreateCommand<UnwrappedGetVehicleDataRequest>(command_msg));
+
+  Event event(hmi_apis::FunctionID::INVALID_ENUM);
+
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+
+  command->on_event(event);
+}
+
+TEST_F(GetVehicleDataRequestTest, OnEvent_DataNotAvailable_SUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  SharedPtr<UnwrappedGetVehicleDataRequest> command(
+      CreateCommand<UnwrappedGetVehicleDataRequest>(command_msg));
+
+  MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*event_msg)[am::strings::params][am::hmi_response::code] =
+      mobile_result::VEHICLE_DATA_NOT_AVAILABLE;
+  (*event_msg)[am::strings::params][am::strings::error_msg] = "test_error";
+  (*event_msg)[am::strings::msg_params][am::hmi_response::method] = 0;
+
+  Event event(hmi_apis::FunctionID::VehicleInfo_GetVehicleData);
+  event.set_smart_object(*event_msg);
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(
+          MobileResultCodeIs(mobile_result::VEHICLE_DATA_NOT_AVAILABLE), _));
+
+  command->on_event(event);
+}
+
+#endif  // HMI_DBUS_API
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/simple_response_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/simple_response_commands_test.cc
@@ -44,6 +44,11 @@
 #include "mobile/list_files_response.h"
 #include "mobile/subscribe_button_response.h"
 #include "mobile/add_sub_menu_response.h"
+#include "mobile/diagnostic_message_response.h"
+#include "mobile/dial_number_response.h"
+#include "mobile/end_audio_pass_thru_response.h"
+#include "mobile/get_dtcs_response.h"
+#include "mobile/get_vehicle_data_response.h"
 
 namespace test {
 namespace components {
@@ -69,7 +74,12 @@ typedef Types<commands::ListFilesResponse,
               commands::AlertManeuverResponse,
               commands::AlertResponse,
               commands::SubscribeButtonResponse,
-              commands::AddSubMenuResponse> ResponseCommandsList;
+              commands::AddSubMenuResponse,
+              commands::DiagnosticMessageResponse,
+              commands::DialNumberResponse,
+              commands::EndAudioPassThruResponse,
+              commands::GetDTCsResponse,
+              commands::GetVehicleDataResponse> ResponseCommandsList;
 TYPED_TEST_CASE(MobileResponseCommandsTest, ResponseCommandsList);
 
 TYPED_TEST(MobileResponseCommandsTest, Run_SendResponseToMobile_SUCCESS) {

--- a/src/components/application_manager/test/include/application_manager/commands/command_request_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/command_request_test.h
@@ -36,6 +36,9 @@
 #include <stdint.h>
 
 #include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
 #include "application_manager/commands/commands_test.h"
 #include "application_manager/commands/command_request_impl.h"
 #include "application_manager/mock_event_dispatcher.h"
@@ -51,9 +54,10 @@ using ::testing::SaveArg;
 using ::testing::DoAll;
 using ::testing::NiceMock;
 using ::test::components::event_engine_test::MockEventDispatcher;
-using ::application_manager::commands::Command;
-using ::application_manager::commands::CommandRequestImpl;
-using ::application_manager::event_engine::Event;
+namespace am = ::application_manager;
+using am::commands::Command;
+using am::commands::CommandRequestImpl;
+using am::event_engine::Event;
 
 class CallRun {
  public:
@@ -117,6 +121,18 @@ class CommandRequestTest : public CommandsTest<kIsNice> {
         .WillByDefault(ReturnRef(event_dispatcher_));
   }
 };
+
+MATCHER_P(MobileResultCodeIs, result_code, "") {
+  return result_code ==
+         static_cast<mobile_apis::Result::eType>(
+             (*arg)[am::strings::msg_params][am::strings::result_code].asInt());
+}
+
+MATCHER_P(HMIResultCodeIs, result_code, "") {
+  return result_code ==
+         static_cast<hmi_apis::FunctionID::eType>(
+             (*arg)[am::strings::params][am::strings::function_id].asInt());
+}
 
 }  // namespace commands_test
 }  // namespace components


### PR DESCRIPTION
Has been covered next commands:
- `DiagnosticMessageRequest`;
- `DiagnosticMessageResponse`;
- `DialNumberRequest`;
- `DialNumberResponse`;
- `EndAudioPassThruRequest`;
- `EndAudioPassThruResponse`;
- `GetDTCsRequest`;
- `GetDTCsResponse`;
- `GetVehicleDataRequest`;
- `GetVehicleDataResponse`.

Related to: [APPLINK-25905](https://adc.luxoft.com/jira/browse/APPLINK-25905)

@AByzhynar, @okozlovlux, @Kozoriz, @LuxoftAKutsan, @vlantonov, @wolfylambova22, please review.