### PR TITLE
Read endpoints services from database correctly

### DIFF
--- a/src/components/policy/src/sql_pt_representation.cc
+++ b/src/components/policy/src/sql_pt_representation.cc
@@ -528,10 +528,10 @@ void SQLPTRepresentation::GatherModuleConfig(
     LOG4CXX_WARN(logger_, "Incorrect select statement for endpoints");
   } else {
     while (endpoints.Next()) {
-      std::stringstream stream;
-      stream << "0x0" << endpoints.GetInteger(1);
-      config->endpoints[stream.str()][endpoints.GetString(2)].push_back(
-          endpoints.GetString(0));
+      const std::string& url = endpoints.GetString(0);
+      const std::string& service = endpoints.GetString(1);
+      const std::string& app_id = endpoints.GetString(2);
+      config->endpoints[service][app_id].push_back(url);
     }
   }
 
@@ -644,7 +644,6 @@ bool SQLPTRepresentation::GatherConsumerFriendlyMessages(
 
   if (query.Prepare(sql_pt::kCollectFriendlyMsg)) {
     while (query.Next()) {
-
       UserFriendlyMessage msg;
       msg.message_code = query.GetString(7);
       std::string language = query.GetString(6);


### PR DESCRIPTION
Read service field from endpoint table as string instead of integer because it stored as string `VARCHAR(100)` See [declaration](https://github.com/smartdevicelink/sdl_core/blob/master/src/components/policy/src/policy/src/sql_pt_queries.cc#L296).

Fixes: [APPLINK-25363](https://adc.luxoft.com/jira/browse/APPLINK-25363)

@LuxoftAKutsan, @dev-gh, @LevchenkoS, @Kozoriz, @nk0leg please review