### PR TITLE
Fix crash on DCHECK in process SystemRequest(LAUNCH_APP)

### DIFF
--- a/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
@@ -55,9 +55,10 @@ void SDLActivateAppRequest::Run() {
       application_manager_.application(application_id);
 
   if (!app) {
-    LOG4CXX_WARN(
+    LOG4CXX_ERROR(
         logger_,
         "Can't find application within regular apps: " << application_id);
+    return;
   }
 
   DevicesApps devices_apps = FindAllAppOnParticularDevice(app->device());

--- a/src/components/policy/src/sql_pt_representation.cc
+++ b/src/components/policy/src/sql_pt_representation.cc
@@ -644,7 +644,6 @@ bool SQLPTRepresentation::GatherConsumerFriendlyMessages(
 
   if (query.Prepare(sql_pt::kCollectFriendlyMsg)) {
     while (query.Next()) {
-
       UserFriendlyMessage msg;
       msg.message_code = query.GetString(7);
       std::string language = query.GetString(6);


### PR DESCRIPTION
After unsuccessful search application, sdl used to do
nothing. Thats why on next code line in DCHECK by pointer to app
crash SDL. Now, after unsuccessful search app, sdl sent hmi
error code by timer and finish request.
Related issue : APPLINK-24905 