### PR TITLE
Fixes SDL4.0 LAUNCH_APP flow

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager.h
+++ b/src/components/application_manager/include/application_manager/application_manager.h
@@ -347,14 +347,14 @@ class ApplicationManager {
    * @param hmi_id HMI application id
    * @return Pointer to application or uninitialized shared pointer
    */
-  virtual ApplicationConstSharedPtr app_to_be_registered(
+  virtual ApplicationConstSharedPtr WaitingApplicationByID(
       const uint32_t hmi_id) const = 0;
 
   /**
    * @brief Returns list of applications-to-be-registered (QUERY_APP list)
    * @return Locked list of applications
    */
-  virtual DataAccessor<AppsWaitRegistrationSet> apps_waiting_for_registration()
+  virtual DataAccessor<AppsWaitRegistrationSet> AppsWaitingForRegistration()
       const = 0;
 
   virtual bool IsAppsQueriedFrom(

--- a/src/components/application_manager/include/application_manager/application_manager.h
+++ b/src/components/application_manager/include/application_manager/application_manager.h
@@ -83,26 +83,25 @@ typedef std::vector<std::string> RPCParams;
 
 struct ApplicationsAppIdSorter {
   bool operator()(const ApplicationSharedPtr lhs,
-				  const ApplicationSharedPtr rhs) const {
-	return lhs->app_id() < rhs->app_id();
+                  const ApplicationSharedPtr rhs) const {
+    return lhs->app_id() < rhs->app_id();
   }
 };
 
 struct ApplicationsPolicyAppIdSorter {
   bool operator()(const ApplicationSharedPtr lhs,
-				  const ApplicationSharedPtr rhs) {
-	if (lhs->policy_app_id() == rhs->policy_app_id()) {
-	  return lhs->device() < rhs->device();
-	}
-	return lhs->policy_app_id() < rhs->policy_app_id();
+                  const ApplicationSharedPtr rhs) {
+    if (lhs->policy_app_id() == rhs->policy_app_id()) {
+      return lhs->device() < rhs->device();
+    }
+    return lhs->policy_app_id() < rhs->policy_app_id();
   }
 };
 
 typedef std::set<ApplicationSharedPtr, ApplicationsAppIdSorter> ApplicationSet;
 
 typedef std::set<ApplicationSharedPtr, ApplicationsPolicyAppIdSorter>
-	AppsWaitRegistrationSet;
-
+    AppsWaitRegistrationSet;
 
 // typedef for Applications list iterator
 typedef ApplicationSet::iterator ApplicationSetIt;
@@ -118,7 +117,7 @@ class ApplicationManager {
    * Inits application manager
    */
   virtual bool Init(resumption::LastState& last_state,
-					media_manager::MediaManager* media_manager) = 0;
+                    media_manager::MediaManager* media_manager) = 0;
 
   /**
    * @brief Stop work.
@@ -128,11 +127,11 @@ class ApplicationManager {
   virtual bool Stop() = 0;
 
   virtual void set_hmi_message_handler(
-	  hmi_message_handler::HMIMessageHandler* handler) = 0;
+      hmi_message_handler::HMIMessageHandler* handler) = 0;
   virtual void set_protocol_handler(
-	  protocol_handler::ProtocolHandler* handler) = 0;
+      protocol_handler::ProtocolHandler* handler) = 0;
   virtual void set_connection_handler(
-	  connection_handler::ConnectionHandler* handler) = 0;
+      connection_handler::ConnectionHandler* handler) = 0;
 
   virtual DataAccessor<ApplicationSet> applications() const = 0;
 
@@ -145,13 +144,13 @@ class ApplicationManager {
    * Don't use it inside Core
    */
   virtual ApplicationSharedPtr application_by_hmi_app(
-	  uint32_t hmi_app_id) const = 0;
+      uint32_t hmi_app_id) const = 0;
 
   virtual ApplicationSharedPtr application_by_policy_id(
-	  const std::string& policy_app_id) const = 0;
+      const std::string& policy_app_id) const = 0;
 
   virtual std::vector<ApplicationSharedPtr> applications_by_button(
-	  uint32_t button) = 0;
+      uint32_t button) = 0;
   virtual std::vector<ApplicationSharedPtr> applications_with_navi() = 0;
 
   /**
@@ -195,7 +194,7 @@ class ApplicationManager {
    * @param app_id Application ID
    */
   virtual void set_application_id(const int32_t correlation_id,
-								  const uint32_t app_id) = 0;
+                                  const uint32_t app_id) = 0;
 
   /**
    * @brief OnHMILevelChanged the callback that allows SDL to react when
@@ -207,8 +206,8 @@ class ApplicationManager {
    * @param to current HMILevel.
    */
   virtual void OnHMILevelChanged(uint32_t app_id,
-								 mobile_apis::HMILevel::eType from,
-								 mobile_apis::HMILevel::eType to) = 0;
+                                 mobile_apis::HMILevel::eType from,
+                                 mobile_apis::HMILevel::eType to) = 0;
 
   /**
    * @brief Sends HMI status notification to mobile
@@ -217,7 +216,7 @@ class ApplicationManager {
    *
    **/
   virtual void SendHMIStatusNotification(
-	  const utils::SharedPtr<Application> app) = 0;
+      const utils::SharedPtr<Application> app) = 0;
 
   /**
    * @brief Checks if Application is subscribed for way points
@@ -252,15 +251,15 @@ class ApplicationManager {
   virtual const std::set<int32_t> GetAppsSubscribedForWayPoints() const = 0;
 
   virtual void SendMessageToMobile(const commands::MessageSharedPtr message,
-								   bool final_message = false) = 0;
+                                   bool final_message = false) = 0;
 
   virtual void SendMessageToHMI(const commands::MessageSharedPtr message) = 0;
 
   virtual bool ManageHMICommand(const commands::MessageSharedPtr message) = 0;
   virtual bool ManageMobileCommand(const commands::MessageSharedPtr message,
-								   commands::Command::CommandOrigin origin) = 0;
+                                   commands::Command::CommandOrigin origin) = 0;
   virtual mobile_api::HMILevel::eType GetDefaultHmiLevel(
-	  ApplicationConstSharedPtr application) const = 0;
+      ApplicationConstSharedPtr application) const = 0;
   /**
    * @brief hmi_capabilities return capabilities of hmi
    * @return capabilities of hmi
@@ -270,7 +269,7 @@ class ApplicationManager {
   virtual const HMICapabilities& hmi_capabilities() const = 0;
 
   virtual void ProcessQueryApp(const smart_objects::SmartObject& sm_object,
-							   const uint32_t connection_key) = 0;
+                               const uint32_t connection_key) = 0;
 
   virtual bool is_attenuated_supported() const = 0;
 
@@ -284,7 +283,7 @@ class ApplicationManager {
    * @return true if exist otherwise false
    */
   virtual bool IsAppTypeExistsInFullOrLimited(
-	  ApplicationConstSharedPtr app) const = 0;
+      ApplicationConstSharedPtr app) const = 0;
 
   /**
    * @brief Sets default HMI level and configure application after its
@@ -332,15 +331,15 @@ class ApplicationManager {
    * @param new value (for integer values currently) of vehicle data
    */
   virtual std::vector<ApplicationSharedPtr> IviInfoUpdated(
-	  VehicleDataType vehicle_info, int value) = 0;
+      VehicleDataType vehicle_info, int value) = 0;
 
   virtual ApplicationSharedPtr RegisterApplication(const utils::SharedPtr<
-	  smart_objects::SmartObject>& request_for_registration) = 0;
+      smart_objects::SmartObject>& request_for_registration) = 0;
 
   virtual void SendUpdateAppList() = 0;
 
   virtual void MarkAppsGreyOut(const connection_handler::DeviceHandle handle,
-							   bool is_greyed_out) = 0;
+                               bool is_greyed_out) = 0;
 
   /**
    * @brief Returns pointer to application-to-be-registered (from QUERY_APP
@@ -348,29 +347,28 @@ class ApplicationManager {
    * @param hmi_id HMI application id
    * @return Pointer to application or uninitialized shared pointer
    */
-  virtual ApplicationConstSharedPtr
-  app_to_be_registered(const uint32_t hmi_id) const = 0;
+  virtual ApplicationConstSharedPtr app_to_be_registered(
+      const uint32_t hmi_id) const = 0;
 
   /**
    * @brief Returns list of applications-to-be-registered (QUERY_APP list)
    * @return Locked list of applications
    */
-  virtual DataAccessor<AppsWaitRegistrationSet>
-  apps_waiting_for_registration() const = 0;
-
+  virtual DataAccessor<AppsWaitRegistrationSet> apps_waiting_for_registration()
+      const = 0;
 
   virtual bool IsAppsQueriedFrom(
-	  const connection_handler::DeviceHandle handle) const = 0;
+      const connection_handler::DeviceHandle handle) const = 0;
 
   virtual bool IsStopping() const = 0;
 
   virtual void RemoveAppFromTTSGlobalPropertiesList(const uint32_t app_id) = 0;
 
   virtual mobile_apis::Result::eType SaveBinary(
-	  const std::vector<uint8_t>& binary_data,
-	  const std::string& file_path,
-	  const std::string& file_name,
-	  const int64_t offset) = 0;
+      const std::vector<uint8_t>& binary_data,
+      const std::string& file_path,
+      const std::string& file_name,
+      const int64_t offset) = 0;
   /*
    * @brief Sets SDL access to all mobile apps
    *
@@ -396,11 +394,11 @@ class ApplicationManager {
    * @param audio_type      Type of audio data
    */
   virtual void StartAudioPassThruThread(int32_t session_key,
-										int32_t correlation_id,
-										int32_t max_duration,
-										int32_t sampling_rate,
-										int32_t bits_per_sample,
-										int32_t audio_type) = 0;
+                                        int32_t correlation_id,
+                                        int32_t max_duration,
+                                        int32_t sampling_rate,
+                                        int32_t bits_per_sample,
+                                        int32_t audio_type) = 0;
 
   virtual void StartDevicesDiscovery() = 0;
 
@@ -424,9 +422,9 @@ class ApplicationManager {
    * Indicates if connection was unexpectedly lost(TM layer, HB)
    */
   virtual void UnregisterApplication(const uint32_t& app_id,
-									 mobile_apis::Result::eType reason,
-									 bool is_resuming = false,
-									 bool is_unexpected_disconnect = false) = 0;
+                                     mobile_apis::Result::eType reason,
+                                     bool is_resuming = false,
+                                     bool is_unexpected_disconnect = false) = 0;
 
   /**
    * @ Updates request timeout
@@ -436,13 +434,13 @@ class ApplicationManager {
    * @param new_timeout_value New timeout in milliseconds to be set
    */
   virtual void updateRequestTimeout(uint32_t connection_key,
-									uint32_t mobile_correlation_id,
-									uint32_t new_timeout_value) = 0;
+                                    uint32_t mobile_correlation_id,
+                                    uint32_t new_timeout_value) = 0;
 
   virtual StateController& state_controller() = 0;
 
   virtual void SetUnregisterAllApplicationsReason(
-	  mobile_api::AppInterfaceUnregisteredReason::eType reason) = 0;
+      mobile_api::AppInterfaceUnregisteredReason::eType reason) = 0;
 
   /*
    * @brief Called on Master_reset or Factory_defaults
@@ -450,7 +448,7 @@ class ApplicationManager {
    * Resets Policy Table if applicable.
    */
   virtual void HeadUnitReset(
-	  mobile_api::AppInterfaceUnregisteredReason::eType reason) = 0;
+      mobile_api::AppInterfaceUnregisteredReason::eType reason) = 0;
 
   /**
    * @brief Checks HMI level and returns true if streaming is allowed
@@ -459,7 +457,7 @@ class ApplicationManager {
    * @return True if streaming is allowed, false in other case
    */
   virtual bool HMILevelAllowsStreaming(
-	  uint32_t app_id, protocol_handler::ServiceType service_type) const = 0;
+      uint32_t app_id, protocol_handler::ServiceType service_type) const = 0;
 
   /**
    * @brief Checks, if given RPC is allowed at current HMI level for specific
@@ -472,11 +470,11 @@ class ApplicationManager {
    * @return SUCCESS, if allowed, otherwise result code of check
    */
   virtual mobile_apis::Result::eType CheckPolicyPermissions(
-	  const std::string& policy_app_id,
-	  mobile_apis::HMILevel::eType hmi_level,
-	  mobile_apis::FunctionID::eType function_id,
-	  const RPCParams& rpc_params,
-	  CommandParametersPermissions* params_permissions = NULL) = 0;
+      const std::string& policy_app_id,
+      mobile_apis::HMILevel::eType hmi_level,
+      mobile_apis::FunctionID::eType function_id,
+      const RPCParams& rpc_params,
+      CommandParametersPermissions* params_permissions = NULL) = 0;
 
   /**
    * @brief IsApplicationForbidden allows to distinguish if application is
@@ -489,7 +487,7 @@ class ApplicationManager {
    * @return true in case application is allowed to register, false otherwise.
    */
   virtual bool IsApplicationForbidden(
-	  uint32_t connection_key, const std::string& policy_app_id) const = 0;
+      uint32_t connection_key, const std::string& policy_app_id) const = 0;
 
   virtual resumption::ResumeCtrl& resume_controller() = 0;
   /*
@@ -501,7 +499,7 @@ class ApplicationManager {
    * @return Corresponding HMI TransporType value
    */
   virtual hmi_apis::Common_TransportType::eType GetDeviceTransportType(
-	  const std::string& transport_type) = 0;
+      const std::string& transport_type) = 0;
 
   /**
    * @brief method adds application
@@ -519,7 +517,7 @@ class ApplicationManager {
   virtual uint32_t GenerateGrammarID() = 0;
 
   virtual policy::DeviceConsent GetUserConsentForDevice(
-	  const std::string& device_id) const = 0;
+      const std::string& device_id) const = 0;
 
   /**
   * @brief Handle sequence for unauthorized application
@@ -536,8 +534,8 @@ class ApplicationManager {
    * @param state Shows if streaming started or stopped
    */
   virtual void OnAppStreaming(uint32_t app_id,
-							  protocol_handler::ServiceType service_type,
-							  bool state) = 0;
+                              protocol_handler::ServiceType service_type,
+                              bool state) = 0;
 
   /**
    * @brief CreateRegularState create regular HMI state for application
@@ -548,13 +546,13 @@ class ApplicationManager {
    * @return new regular HMI state
    */
   virtual HmiStatePtr CreateRegularState(
-	  uint32_t app_id,
-	  mobile_apis::HMILevel::eType hmi_level,
-	  mobile_apis::AudioStreamingState::eType audio_state,
-	  mobile_apis::SystemContext::eType system_context) const = 0;
+      uint32_t app_id,
+      mobile_apis::HMILevel::eType hmi_level,
+      mobile_apis::AudioStreamingState::eType audio_state,
+      mobile_apis::SystemContext::eType system_context) const = 0;
 
   virtual void SendAudioPassThroughNotification(
-	  uint32_t session_key, std::vector<uint8_t>& binary_data) = 0;
+      uint32_t session_key, std::vector<uint8_t>& binary_data) = 0;
 
   /**
    * @brief Checks if application can stream (streaming service is started and
@@ -564,7 +562,7 @@ class ApplicationManager {
    * @return True if streaming is allowed, false in other case
    */
   virtual bool CanAppStream(
-	  uint32_t app_id, protocol_handler::ServiceType service_type) const = 0;
+      uint32_t app_id, protocol_handler::ServiceType service_type) const = 0;
 
   /**
    * @brief ForbidStreaming forbid the stream over the certain application.

--- a/src/components/application_manager/include/application_manager/application_manager.h
+++ b/src/components/application_manager/include/application_manager/application_manager.h
@@ -83,11 +83,26 @@ typedef std::vector<std::string> RPCParams;
 
 struct ApplicationsAppIdSorter {
   bool operator()(const ApplicationSharedPtr lhs,
-                  const ApplicationSharedPtr rhs) const {
-    return lhs->app_id() < rhs->app_id();
+				  const ApplicationSharedPtr rhs) const {
+	return lhs->app_id() < rhs->app_id();
   }
 };
+
+struct ApplicationsPolicyAppIdSorter {
+  bool operator()(const ApplicationSharedPtr lhs,
+				  const ApplicationSharedPtr rhs) {
+	if (lhs->policy_app_id() == rhs->policy_app_id()) {
+	  return lhs->device() < rhs->device();
+	}
+	return lhs->policy_app_id() < rhs->policy_app_id();
+  }
+};
+
 typedef std::set<ApplicationSharedPtr, ApplicationsAppIdSorter> ApplicationSet;
+
+typedef std::set<ApplicationSharedPtr, ApplicationsPolicyAppIdSorter>
+	AppsWaitRegistrationSet;
+
 
 // typedef for Applications list iterator
 typedef ApplicationSet::iterator ApplicationSetIt;
@@ -103,7 +118,7 @@ class ApplicationManager {
    * Inits application manager
    */
   virtual bool Init(resumption::LastState& last_state,
-                    media_manager::MediaManager* media_manager) = 0;
+					media_manager::MediaManager* media_manager) = 0;
 
   /**
    * @brief Stop work.
@@ -113,11 +128,11 @@ class ApplicationManager {
   virtual bool Stop() = 0;
 
   virtual void set_hmi_message_handler(
-      hmi_message_handler::HMIMessageHandler* handler) = 0;
+	  hmi_message_handler::HMIMessageHandler* handler) = 0;
   virtual void set_protocol_handler(
-      protocol_handler::ProtocolHandler* handler) = 0;
+	  protocol_handler::ProtocolHandler* handler) = 0;
   virtual void set_connection_handler(
-      connection_handler::ConnectionHandler* handler) = 0;
+	  connection_handler::ConnectionHandler* handler) = 0;
 
   virtual DataAccessor<ApplicationSet> applications() const = 0;
 
@@ -130,13 +145,13 @@ class ApplicationManager {
    * Don't use it inside Core
    */
   virtual ApplicationSharedPtr application_by_hmi_app(
-      uint32_t hmi_app_id) const = 0;
+	  uint32_t hmi_app_id) const = 0;
 
   virtual ApplicationSharedPtr application_by_policy_id(
-      const std::string& policy_app_id) const = 0;
+	  const std::string& policy_app_id) const = 0;
 
   virtual std::vector<ApplicationSharedPtr> applications_by_button(
-      uint32_t button) = 0;
+	  uint32_t button) = 0;
   virtual std::vector<ApplicationSharedPtr> applications_with_navi() = 0;
 
   /**
@@ -180,7 +195,7 @@ class ApplicationManager {
    * @param app_id Application ID
    */
   virtual void set_application_id(const int32_t correlation_id,
-                                  const uint32_t app_id) = 0;
+								  const uint32_t app_id) = 0;
 
   /**
    * @brief OnHMILevelChanged the callback that allows SDL to react when
@@ -192,8 +207,8 @@ class ApplicationManager {
    * @param to current HMILevel.
    */
   virtual void OnHMILevelChanged(uint32_t app_id,
-                                 mobile_apis::HMILevel::eType from,
-                                 mobile_apis::HMILevel::eType to) = 0;
+								 mobile_apis::HMILevel::eType from,
+								 mobile_apis::HMILevel::eType to) = 0;
 
   /**
    * @brief Sends HMI status notification to mobile
@@ -202,7 +217,7 @@ class ApplicationManager {
    *
    **/
   virtual void SendHMIStatusNotification(
-      const utils::SharedPtr<Application> app) = 0;
+	  const utils::SharedPtr<Application> app) = 0;
 
   /**
    * @brief Checks if Application is subscribed for way points
@@ -237,15 +252,15 @@ class ApplicationManager {
   virtual const std::set<int32_t> GetAppsSubscribedForWayPoints() const = 0;
 
   virtual void SendMessageToMobile(const commands::MessageSharedPtr message,
-                                   bool final_message = false) = 0;
+								   bool final_message = false) = 0;
 
   virtual void SendMessageToHMI(const commands::MessageSharedPtr message) = 0;
 
   virtual bool ManageHMICommand(const commands::MessageSharedPtr message) = 0;
   virtual bool ManageMobileCommand(const commands::MessageSharedPtr message,
-                                   commands::Command::CommandOrigin origin) = 0;
+								   commands::Command::CommandOrigin origin) = 0;
   virtual mobile_api::HMILevel::eType GetDefaultHmiLevel(
-      ApplicationConstSharedPtr application) const = 0;
+	  ApplicationConstSharedPtr application) const = 0;
   /**
    * @brief hmi_capabilities return capabilities of hmi
    * @return capabilities of hmi
@@ -255,7 +270,7 @@ class ApplicationManager {
   virtual const HMICapabilities& hmi_capabilities() const = 0;
 
   virtual void ProcessQueryApp(const smart_objects::SmartObject& sm_object,
-                               const uint32_t connection_key) = 0;
+							   const uint32_t connection_key) = 0;
 
   virtual bool is_attenuated_supported() const = 0;
 
@@ -269,7 +284,7 @@ class ApplicationManager {
    * @return true if exist otherwise false
    */
   virtual bool IsAppTypeExistsInFullOrLimited(
-      ApplicationConstSharedPtr app) const = 0;
+	  ApplicationConstSharedPtr app) const = 0;
 
   /**
    * @brief Sets default HMI level and configure application after its
@@ -317,27 +332,45 @@ class ApplicationManager {
    * @param new value (for integer values currently) of vehicle data
    */
   virtual std::vector<ApplicationSharedPtr> IviInfoUpdated(
-      VehicleDataType vehicle_info, int value) = 0;
+	  VehicleDataType vehicle_info, int value) = 0;
 
   virtual ApplicationSharedPtr RegisterApplication(const utils::SharedPtr<
-      smart_objects::SmartObject>& request_for_registration) = 0;
+	  smart_objects::SmartObject>& request_for_registration) = 0;
 
   virtual void SendUpdateAppList() = 0;
 
   virtual void MarkAppsGreyOut(const connection_handler::DeviceHandle handle,
-                               bool is_greyed_out) = 0;
+							   bool is_greyed_out) = 0;
+
+  /**
+   * @brief Returns pointer to application-to-be-registered (from QUERY_APP
+   * list)
+   * @param hmi_id HMI application id
+   * @return Pointer to application or uninitialized shared pointer
+   */
+  virtual ApplicationConstSharedPtr
+  app_to_be_registered(const uint32_t hmi_id) const = 0;
+
+  /**
+   * @brief Returns list of applications-to-be-registered (QUERY_APP list)
+   * @return Locked list of applications
+   */
+  virtual DataAccessor<AppsWaitRegistrationSet>
+  apps_waiting_for_registration() const = 0;
+
+
   virtual bool IsAppsQueriedFrom(
-      const connection_handler::DeviceHandle handle) const = 0;
+	  const connection_handler::DeviceHandle handle) const = 0;
 
   virtual bool IsStopping() const = 0;
 
   virtual void RemoveAppFromTTSGlobalPropertiesList(const uint32_t app_id) = 0;
 
   virtual mobile_apis::Result::eType SaveBinary(
-      const std::vector<uint8_t>& binary_data,
-      const std::string& file_path,
-      const std::string& file_name,
-      const int64_t offset) = 0;
+	  const std::vector<uint8_t>& binary_data,
+	  const std::string& file_path,
+	  const std::string& file_name,
+	  const int64_t offset) = 0;
   /*
    * @brief Sets SDL access to all mobile apps
    *
@@ -363,11 +396,11 @@ class ApplicationManager {
    * @param audio_type      Type of audio data
    */
   virtual void StartAudioPassThruThread(int32_t session_key,
-                                        int32_t correlation_id,
-                                        int32_t max_duration,
-                                        int32_t sampling_rate,
-                                        int32_t bits_per_sample,
-                                        int32_t audio_type) = 0;
+										int32_t correlation_id,
+										int32_t max_duration,
+										int32_t sampling_rate,
+										int32_t bits_per_sample,
+										int32_t audio_type) = 0;
 
   virtual void StartDevicesDiscovery() = 0;
 
@@ -391,9 +424,9 @@ class ApplicationManager {
    * Indicates if connection was unexpectedly lost(TM layer, HB)
    */
   virtual void UnregisterApplication(const uint32_t& app_id,
-                                     mobile_apis::Result::eType reason,
-                                     bool is_resuming = false,
-                                     bool is_unexpected_disconnect = false) = 0;
+									 mobile_apis::Result::eType reason,
+									 bool is_resuming = false,
+									 bool is_unexpected_disconnect = false) = 0;
 
   /**
    * @ Updates request timeout
@@ -403,13 +436,13 @@ class ApplicationManager {
    * @param new_timeout_value New timeout in milliseconds to be set
    */
   virtual void updateRequestTimeout(uint32_t connection_key,
-                                    uint32_t mobile_correlation_id,
-                                    uint32_t new_timeout_value) = 0;
+									uint32_t mobile_correlation_id,
+									uint32_t new_timeout_value) = 0;
 
   virtual StateController& state_controller() = 0;
 
   virtual void SetUnregisterAllApplicationsReason(
-      mobile_api::AppInterfaceUnregisteredReason::eType reason) = 0;
+	  mobile_api::AppInterfaceUnregisteredReason::eType reason) = 0;
 
   /*
    * @brief Called on Master_reset or Factory_defaults
@@ -417,7 +450,7 @@ class ApplicationManager {
    * Resets Policy Table if applicable.
    */
   virtual void HeadUnitReset(
-      mobile_api::AppInterfaceUnregisteredReason::eType reason) = 0;
+	  mobile_api::AppInterfaceUnregisteredReason::eType reason) = 0;
 
   /**
    * @brief Checks HMI level and returns true if streaming is allowed
@@ -426,7 +459,7 @@ class ApplicationManager {
    * @return True if streaming is allowed, false in other case
    */
   virtual bool HMILevelAllowsStreaming(
-      uint32_t app_id, protocol_handler::ServiceType service_type) const = 0;
+	  uint32_t app_id, protocol_handler::ServiceType service_type) const = 0;
 
   /**
    * @brief Checks, if given RPC is allowed at current HMI level for specific
@@ -439,11 +472,11 @@ class ApplicationManager {
    * @return SUCCESS, if allowed, otherwise result code of check
    */
   virtual mobile_apis::Result::eType CheckPolicyPermissions(
-      const std::string& policy_app_id,
-      mobile_apis::HMILevel::eType hmi_level,
-      mobile_apis::FunctionID::eType function_id,
-      const RPCParams& rpc_params,
-      CommandParametersPermissions* params_permissions = NULL) = 0;
+	  const std::string& policy_app_id,
+	  mobile_apis::HMILevel::eType hmi_level,
+	  mobile_apis::FunctionID::eType function_id,
+	  const RPCParams& rpc_params,
+	  CommandParametersPermissions* params_permissions = NULL) = 0;
 
   /**
    * @brief IsApplicationForbidden allows to distinguish if application is
@@ -456,7 +489,7 @@ class ApplicationManager {
    * @return true in case application is allowed to register, false otherwise.
    */
   virtual bool IsApplicationForbidden(
-      uint32_t connection_key, const std::string& policy_app_id) const = 0;
+	  uint32_t connection_key, const std::string& policy_app_id) const = 0;
 
   virtual resumption::ResumeCtrl& resume_controller() = 0;
   /*
@@ -468,7 +501,7 @@ class ApplicationManager {
    * @return Corresponding HMI TransporType value
    */
   virtual hmi_apis::Common_TransportType::eType GetDeviceTransportType(
-      const std::string& transport_type) = 0;
+	  const std::string& transport_type) = 0;
 
   /**
    * @brief method adds application
@@ -486,7 +519,7 @@ class ApplicationManager {
   virtual uint32_t GenerateGrammarID() = 0;
 
   virtual policy::DeviceConsent GetUserConsentForDevice(
-      const std::string& device_id) const = 0;
+	  const std::string& device_id) const = 0;
 
   /**
   * @brief Handle sequence for unauthorized application
@@ -503,8 +536,8 @@ class ApplicationManager {
    * @param state Shows if streaming started or stopped
    */
   virtual void OnAppStreaming(uint32_t app_id,
-                              protocol_handler::ServiceType service_type,
-                              bool state) = 0;
+							  protocol_handler::ServiceType service_type,
+							  bool state) = 0;
 
   /**
    * @brief CreateRegularState create regular HMI state for application
@@ -515,13 +548,13 @@ class ApplicationManager {
    * @return new regular HMI state
    */
   virtual HmiStatePtr CreateRegularState(
-      uint32_t app_id,
-      mobile_apis::HMILevel::eType hmi_level,
-      mobile_apis::AudioStreamingState::eType audio_state,
-      mobile_apis::SystemContext::eType system_context) const = 0;
+	  uint32_t app_id,
+	  mobile_apis::HMILevel::eType hmi_level,
+	  mobile_apis::AudioStreamingState::eType audio_state,
+	  mobile_apis::SystemContext::eType system_context) const = 0;
 
   virtual void SendAudioPassThroughNotification(
-      uint32_t session_key, std::vector<uint8_t>& binary_data) = 0;
+	  uint32_t session_key, std::vector<uint8_t>& binary_data) = 0;
 
   /**
    * @brief Checks if application can stream (streaming service is started and
@@ -531,7 +564,7 @@ class ApplicationManager {
    * @return True if streaming is allowed, false in other case
    */
   virtual bool CanAppStream(
-      uint32_t app_id, protocol_handler::ServiceType service_type) const = 0;
+	  uint32_t app_id, protocol_handler::ServiceType service_type) const = 0;
 
   /**
    * @brief ForbidStreaming forbid the stream over the certain application.

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -113,7 +113,7 @@ enum VRTTSSessionChanging { kVRSessionChanging = 0, kTTSSessionChanging };
 
 struct CommandParametersPermissions;
 typedef std::map<std::string, hmi_apis::Common_TransportType::eType>
-    DeviceTypes;
+	DeviceTypes;
 
 namespace impl {
 using namespace threads;
@@ -131,21 +131,21 @@ using namespace threads;
 struct MessageFromMobile : public utils::SharedPtr<Message> {
   MessageFromMobile() {}
   explicit MessageFromMobile(const utils::SharedPtr<Message>& message)
-      : utils::SharedPtr<Message>(message) {}
+	  : utils::SharedPtr<Message>(message) {}
   // PrioritizedQueue requres this method to decide which priority to assign
   size_t PriorityOrder() const {
-    return (*this)->Priority().OrderingValue();
+	return (*this)->Priority().OrderingValue();
   }
 };
 
 struct MessageToMobile : public utils::SharedPtr<Message> {
   MessageToMobile() : is_final(false) {}
   explicit MessageToMobile(const utils::SharedPtr<Message>& message,
-                           bool final_message)
-      : utils::SharedPtr<Message>(message), is_final(final_message) {}
+						   bool final_message)
+	  : utils::SharedPtr<Message>(message), is_final(final_message) {}
   // PrioritizedQueue requres this method to decide which priority to assign
   size_t PriorityOrder() const {
-    return (*this)->Priority().OrderingValue();
+	return (*this)->Priority().OrderingValue();
   }
   // Signals if connection to mobile must be closed after sending this message
   bool is_final;
@@ -154,32 +154,32 @@ struct MessageToMobile : public utils::SharedPtr<Message> {
 struct MessageFromHmi : public utils::SharedPtr<Message> {
   MessageFromHmi() {}
   explicit MessageFromHmi(const utils::SharedPtr<Message>& message)
-      : utils::SharedPtr<Message>(message) {}
+	  : utils::SharedPtr<Message>(message) {}
   // PrioritizedQueue requres this method to decide which priority to assign
   size_t PriorityOrder() const {
-    return (*this)->Priority().OrderingValue();
+	return (*this)->Priority().OrderingValue();
   }
 };
 
 struct MessageToHmi : public utils::SharedPtr<Message> {
   MessageToHmi() {}
   explicit MessageToHmi(const utils::SharedPtr<Message>& message)
-      : utils::SharedPtr<Message>(message) {}
+	  : utils::SharedPtr<Message>(message) {}
   // PrioritizedQueue requres this method to decide which priority to assign
   size_t PriorityOrder() const {
-    return (*this)->Priority().OrderingValue();
+	return (*this)->Priority().OrderingValue();
   }
 };
 
 // Short type names for prioritized message queues
 typedef threads::MessageLoopThread<utils::PrioritizedQueue<MessageFromMobile> >
-    FromMobileQueue;
+	FromMobileQueue;
 typedef threads::MessageLoopThread<utils::PrioritizedQueue<MessageToMobile> >
-    ToMobileQueue;
+	ToMobileQueue;
 typedef threads::MessageLoopThread<utils::PrioritizedQueue<MessageFromHmi> >
-    FromHmiQueue;
+	FromHmiQueue;
 typedef threads::MessageLoopThread<utils::PrioritizedQueue<MessageToHmi> >
-    ToHmiQueue;
+	ToHmiQueue;
 
 // AudioPassThru
 typedef struct {
@@ -194,38 +194,38 @@ typedef std::vector<std::string> RPCParams;
 typedef utils::SharedPtr<timer::Timer> TimerSPtr;
 
 class ApplicationManagerImpl
-    : public ApplicationManager,
-      public hmi_message_handler::HMIMessageObserver,
-      public protocol_handler::ProtocolObserver,
-      public connection_handler::ConnectionHandlerObserver,
-      public policy::PolicyHandlerObserver,
+	: public ApplicationManager,
+	  public hmi_message_handler::HMIMessageObserver,
+	  public protocol_handler::ProtocolObserver,
+	  public connection_handler::ConnectionHandlerObserver,
+	  public policy::PolicyHandlerObserver,
 #ifdef ENABLE_SECURITY
-      public security_manager::SecurityManagerListener,
+	  public security_manager::SecurityManagerListener,
 #endif  // ENABLE_SECURITY
-      public impl::FromMobileQueue::Handler,
-      public impl::ToMobileQueue::Handler,
-      public impl::FromHmiQueue::Handler,
-      public impl::ToHmiQueue::Handler,
-      public impl::AudioPassThruQueue::Handler
+	  public impl::FromMobileQueue::Handler,
+	  public impl::ToMobileQueue::Handler,
+	  public impl::FromHmiQueue::Handler,
+	  public impl::ToHmiQueue::Handler,
+	  public impl::AudioPassThruQueue::Handler
 #ifdef TELEMETRY_MONITOR
-      ,
-      public telemetry_monitor::TelemetryObservable<AMTelemetryObserver>
+	  ,
+	  public telemetry_monitor::TelemetryObservable<AMTelemetryObserver>
 #endif  // TELEMETRY_MONITOR
-      {
+	  {
 
   friend class ResumeCtrl;
   friend class CommandImpl;
 
  public:
   ApplicationManagerImpl(const ApplicationManagerSettings& am_settings,
-                         const policy::PolicySettings& policy_settings);
+						 const policy::PolicySettings& policy_settings);
   ~ApplicationManagerImpl();
 
   /**
    * Inits application manager
    */
   bool Init(resumption::LastState& last_state,
-            media_manager::MediaManager* media_manager) OVERRIDE;
+			media_manager::MediaManager* media_manager) OVERRIDE;
 
   /**
    * @brief Stop work.
@@ -240,12 +240,12 @@ class ApplicationManagerImpl
   ApplicationSharedPtr active_application() const OVERRIDE;
 
   ApplicationSharedPtr application_by_hmi_app(
-      uint32_t hmi_app_id) const OVERRIDE;
+	  uint32_t hmi_app_id) const OVERRIDE;
   ApplicationSharedPtr application_by_policy_id(
-      const std::string& policy_app_id) const OVERRIDE;
+	  const std::string& policy_app_id) const OVERRIDE;
 
   std::vector<ApplicationSharedPtr> applications_by_button(
-      uint32_t button) OVERRIDE;
+	  uint32_t button) OVERRIDE;
   std::vector<ApplicationSharedPtr> applications_with_navi() OVERRIDE;
 
   ApplicationSharedPtr get_limited_media_application() const OVERRIDE;
@@ -254,14 +254,14 @@ class ApplicationManagerImpl
 
   uint32_t application_id(const int32_t correlation_id) OVERRIDE;
   void set_application_id(const int32_t correlation_id,
-                          const uint32_t app_id) OVERRIDE;
+						  const uint32_t app_id) OVERRIDE;
 
   void OnHMILevelChanged(uint32_t app_id,
-                         mobile_apis::HMILevel::eType from,
-                         mobile_apis::HMILevel::eType to) OVERRIDE;
+						 mobile_apis::HMILevel::eType from,
+						 mobile_apis::HMILevel::eType to) OVERRIDE;
 
   void SendHMIStatusNotification(
-      const utils::SharedPtr<Application> app) OVERRIDE;
+	  const utils::SharedPtr<Application> app) OVERRIDE;
   /**
    * @brief Checks if application with the same HMI type
    *        (media, voice communication or navi) exists
@@ -313,7 +313,7 @@ class ApplicationManagerImpl
    * @param new value (for integer values currently) of vehicle data
    */
   std::vector<ApplicationSharedPtr> IviInfoUpdated(VehicleDataType vehicle_info,
-                                                   int value) OVERRIDE;
+												   int value) OVERRIDE;
 
   void OnApplicationRegistered(ApplicationSharedPtr app) OVERRIDE;
 
@@ -328,7 +328,7 @@ class ApplicationManagerImpl
    * @param connection_key connection key for app, which sent system request
    */
   void ProcessQueryApp(const smart_objects::SmartObject& sm_object,
-                       const uint32_t connection_key) OVERRIDE;
+					   const uint32_t connection_key) OVERRIDE;
 
   bool is_attenuated_supported() const OVERRIDE;
 
@@ -342,7 +342,7 @@ class ApplicationManagerImpl
 #endif  // TELEMETRY_MONITOR
 
   ApplicationSharedPtr RegisterApplication(const utils::SharedPtr<
-      smart_objects::SmartObject>& request_for_registration) OVERRIDE;
+	  smart_objects::SmartObject>& request_for_registration) OVERRIDE;
   /*
    * @brief Closes application by id
    *
@@ -354,9 +354,9 @@ class ApplicationManagerImpl
    * Indicates if connection was unexpectedly lost(TM layer, HB)
    */
   void UnregisterApplication(const uint32_t& app_id,
-                             mobile_apis::Result::eType reason,
-                             bool is_resuming = false,
-                             bool is_unexpected_disconnect = false) OVERRIDE;
+							 mobile_apis::Result::eType reason,
+							 bool is_resuming = false,
+							 bool is_unexpected_disconnect = false) OVERRIDE;
 
   /**
   * @brief Handle sequence for unauthorized application
@@ -371,7 +371,7 @@ class ApplicationManagerImpl
    * @param reason Describes the reason for HU switching off
    */
   void SetUnregisterAllApplicationsReason(
-      mobile_api::AppInterfaceUnregisteredReason::eType reason) OVERRIDE;
+	  mobile_api::AppInterfaceUnregisteredReason::eType reason) OVERRIDE;
 
   /*
    * @brief Called on Master_reset or Factory_defaults
@@ -379,7 +379,7 @@ class ApplicationManagerImpl
    * Resets Policy Table if applicable.
    */
   void HeadUnitReset(
-      mobile_api::AppInterfaceUnregisteredReason::eType reason) OVERRIDE;
+	  mobile_api::AppInterfaceUnregisteredReason::eType reason) OVERRIDE;
 
   /*
    * @brief Closes all registered applications
@@ -473,10 +473,10 @@ class ApplicationManagerImpl
    * @return new regular HMI state
    */
   HmiStatePtr CreateRegularState(
-      uint32_t app_id,
-      mobile_apis::HMILevel::eType hmi_level,
-      mobile_apis::AudioStreamingState::eType audio_state,
-      mobile_apis::SystemContext::eType system_context) const OVERRIDE;
+	  uint32_t app_id,
+	  mobile_apis::HMILevel::eType hmi_level,
+	  mobile_apis::AudioStreamingState::eType audio_state,
+	  mobile_apis::SystemContext::eType system_context) const OVERRIDE;
 
   /**
    * @brief SetState set regular audio state
@@ -484,14 +484,14 @@ class ApplicationManagerImpl
    * @param audio_state aaudio streaming state
    */
   void SetState(uint32_t app_id,
-                mobile_apis::AudioStreamingState::eType audio_state) {
-    ApplicationSharedPtr app = application(app_id);
-    if (!app) {
-      LOG4CXX_ERROR(logger_,
-                    "Application with appID=" << app_id << " does not exist");
-      return;
-    }
-    state_ctrl_.SetRegularState(app, audio_state);
+				mobile_apis::AudioStreamingState::eType audio_state) {
+	ApplicationSharedPtr app = application(app_id);
+	if (!app) {
+	  LOG4CXX_ERROR(logger_,
+					"Application with appID=" << app_id << " does not exist");
+	  return;
+	}
+	state_ctrl_.SetRegularState(app, audio_state);
   }
 
   /**
@@ -502,13 +502,13 @@ class ApplicationManagerImpl
    */
   template <bool SendActivateApp>
   void SetState(uint32_t app_id, HmiStatePtr new_state) {
-    ApplicationSharedPtr app = application(app_id);
-    if (!app) {
-      LOG4CXX_ERROR(logger_,
-                    "Application with appID=" << app_id << " does not exist");
-      return;
-    }
-    state_ctrl_.SetRegularState(app, new_state, SendActivateApp);
+	ApplicationSharedPtr app = application(app_id);
+	if (!app) {
+	  LOG4CXX_ERROR(logger_,
+					"Application with appID=" << app_id << " does not exist");
+	  return;
+	}
+	state_ctrl_.SetRegularState(app, new_state, SendActivateApp);
   }
 
   /**
@@ -518,13 +518,13 @@ class ApplicationManagerImpl
    */
   template <bool SendActivateApp>
   void SetState(uint32_t app_id, mobile_apis::HMILevel::eType hmi_level) {
-    ApplicationSharedPtr app = application(app_id);
-    if (!app) {
-      LOG4CXX_ERROR(logger_,
-                    "Application with appID=" << app_id << " does not exist");
-      return;
-    }
-    state_ctrl_.SetRegularState(app, hmi_level, SendActivateApp);
+	ApplicationSharedPtr app = application(app_id);
+	if (!app) {
+	  LOG4CXX_ERROR(logger_,
+					"Application with appID=" << app_id << " does not exist");
+	  return;
+	}
+	state_ctrl_.SetRegularState(app, hmi_level, SendActivateApp);
   }
 
   /**
@@ -536,15 +536,15 @@ class ApplicationManagerImpl
    */
   template <bool SendActivateApp>
   void SetState(uint32_t app_id,
-                mobile_apis::HMILevel::eType hmi_level,
-                mobile_apis::AudioStreamingState::eType audio_state) {
-    ApplicationSharedPtr app = application(app_id);
-    if (!app) {
-      LOG4CXX_ERROR(logger_,
-                    "Application with appID=" << app_id << " does not exist");
-      return;
-    }
-    state_ctrl_.SetRegularState(app, hmi_level, audio_state, SendActivateApp);
+				mobile_apis::HMILevel::eType hmi_level,
+				mobile_apis::AudioStreamingState::eType audio_state) {
+	ApplicationSharedPtr app = application(app_id);
+	if (!app) {
+	  LOG4CXX_ERROR(logger_,
+					"Application with appID=" << app_id << " does not exist");
+	  return;
+	}
+	state_ctrl_.SetRegularState(app, hmi_level, audio_state, SendActivateApp);
   }
 
   /**
@@ -556,17 +556,17 @@ class ApplicationManagerImpl
    */
   template <bool SendActivateApp>
   void SetState(uint32_t app_id,
-                mobile_apis::HMILevel::eType hmi_level,
-                mobile_apis::AudioStreamingState::eType audio_state,
-                mobile_apis::SystemContext::eType system_context) {
-    ApplicationSharedPtr app = application(app_id);
-    if (!app) {
-      LOG4CXX_ERROR(logger_,
-                    "Application with appID=" << app_id << " does not exist");
-      return;
-    }
-    state_ctrl_.SetRegularState(
-        app, hmi_level, audio_state, system_context, SendActivateApp);
+				mobile_apis::HMILevel::eType hmi_level,
+				mobile_apis::AudioStreamingState::eType audio_state,
+				mobile_apis::SystemContext::eType system_context) {
+	ApplicationSharedPtr app = application(app_id);
+	if (!app) {
+	  LOG4CXX_ERROR(logger_,
+					"Application with appID=" << app_id << " does not exist");
+	  return;
+	}
+	state_ctrl_.SetRegularState(
+		app, hmi_level, audio_state, system_context, SendActivateApp);
   }
 
   /**
@@ -575,14 +575,14 @@ class ApplicationManagerImpl
    * @param system_context of new regular state
    */
   void SetState(uint32_t app_id,
-                mobile_apis::SystemContext::eType system_context) {
-    ApplicationSharedPtr app = application(app_id);
-    if (!app) {
-      LOG4CXX_ERROR(logger_,
-                    "Application with appID=" << app_id << " does not exist");
-      return;
-    }
-    state_ctrl_.SetRegularState(app, system_context);
+				mobile_apis::SystemContext::eType system_context) {
+	ApplicationSharedPtr app = application(app_id);
+	if (!app) {
+	  LOG4CXX_ERROR(logger_,
+					"Application with appID=" << app_id << " does not exist");
+	  return;
+	}
+	state_ctrl_.SetRegularState(app, system_context);
   }
 
   /**
@@ -591,13 +591,13 @@ class ApplicationManagerImpl
    * @param hmi_level hmi level of new regular state
    */
   void SetHmiState(uint32_t app_id, mobile_apis::HMILevel::eType hmi_level) {
-    ApplicationSharedPtr app = application(app_id);
-    if (!app) {
-      LOG4CXX_ERROR(logger_,
-                    "Application with appID=" << app_id << " does not exist");
-      return;
-    }
-    state_ctrl_.SetRegularState(app, hmi_level);
+	ApplicationSharedPtr app = application(app_id);
+	if (!app) {
+	  LOG4CXX_ERROR(logger_,
+					"Application with appID=" << app_id << " does not exist");
+	  return;
+	}
+	state_ctrl_.SetRegularState(app, hmi_level);
   }
 
   /**
@@ -606,13 +606,13 @@ class ApplicationManagerImpl
    * @param state new regular hmi state
    */
   void SetState(uint32_t app_id, HmiStatePtr state) {
-    ApplicationSharedPtr app = application(app_id);
-    if (!app) {
-      LOG4CXX_ERROR(logger_,
-                    "Application with appID=" << app_id << " does not exist");
-      return;
-    }
-    state_ctrl_.SetRegularState(app, state);
+	ApplicationSharedPtr app = application(app_id);
+	if (!app) {
+	  LOG4CXX_ERROR(logger_,
+					"Application with appID=" << app_id << " does not exist");
+	  return;
+	}
+	state_ctrl_.SetRegularState(app, state);
   }
 
   /**
@@ -635,7 +635,7 @@ class ApplicationManagerImpl
    * for app with HMI level BACKGROUND.
    */
   void OnUpdateHMIAppType(
-      std::map<std::string, std::vector<std::string> > app_hmi_types) OVERRIDE;
+	  std::map<std::string, std::vector<std::string> > app_hmi_types) OVERRIDE;
 
   /*
    * @brief Starts audio pass thru thread
@@ -648,11 +648,11 @@ class ApplicationManagerImpl
    * @param audio_type      Type of audio data
    */
   void StartAudioPassThruThread(int32_t session_key,
-                                int32_t correlation_id,
-                                int32_t max_duration,
-                                int32_t sampling_rate,
-                                int32_t bits_per_sample,
-                                int32_t audio_type) OVERRIDE;
+								int32_t correlation_id,
+								int32_t max_duration,
+								int32_t sampling_rate,
+								int32_t bits_per_sample,
+								int32_t audio_type) OVERRIDE;
 
   /*
    * @brief Terminates audio pass thru thread
@@ -671,7 +671,7 @@ class ApplicationManagerImpl
    * @param binary_data AudioPassThru data chunk
    */
   void SendAudioPassThroughNotification(
-      uint32_t session_key, std::vector<uint8_t>& binary_data) OVERRIDE;
+	  uint32_t session_key, std::vector<uint8_t>& binary_data) OVERRIDE;
 
   std::string GetDeviceName(connection_handler::DeviceHandle handle);
 
@@ -684,7 +684,7 @@ class ApplicationManagerImpl
    * @return Corresponding HMI TransporType value
    */
   hmi_apis::Common_TransportType::eType GetDeviceTransportType(
-      const std::string& transport_type);
+	  const std::string& transport_type);
 
   void set_hmi_message_handler(hmi_message_handler::HMIMessageHandler* handler);
   void set_connection_handler(connection_handler::ConnectionHandler* handler);
@@ -696,12 +696,12 @@ class ApplicationManagerImpl
   // if |final_message| parameter is set connection to mobile will be closed
   // after processing this message
   void SendMessageToMobile(const commands::MessageSharedPtr message,
-                           bool final_message = false) OVERRIDE;
+						   bool final_message = false) OVERRIDE;
 
   void SendMessageToHMI(const commands::MessageSharedPtr message) OVERRIDE;
 
   bool ManageMobileCommand(const commands::MessageSharedPtr message,
-                           commands::Command::CommandOrigin origin) OVERRIDE;
+						   commands::Command::CommandOrigin origin) OVERRIDE;
   bool ManageHMICommand(const commands::MessageSharedPtr message) OVERRIDE;
 
   /**
@@ -712,41 +712,41 @@ class ApplicationManagerImpl
   void TerminateRequest(uint32_t connection_key, uint32_t corr_id) OVERRIDE;
   // Overriden ProtocolObserver method
   void OnMessageReceived(
-      const ::protocol_handler::RawMessagePtr message) OVERRIDE;
+	  const ::protocol_handler::RawMessagePtr message) OVERRIDE;
   void OnMobileMessageSent(
-      const ::protocol_handler::RawMessagePtr message) OVERRIDE;
+	  const ::protocol_handler::RawMessagePtr message) OVERRIDE;
 
   // Overriden HMIMessageObserver method
   void OnMessageReceived(
-      hmi_message_handler::MessageSharedPointer message) OVERRIDE;
+	  hmi_message_handler::MessageSharedPointer message) OVERRIDE;
   void OnErrorSending(
-      hmi_message_handler::MessageSharedPointer message) OVERRIDE;
+	  hmi_message_handler::MessageSharedPointer message) OVERRIDE;
 
   // Overriden ConnectionHandlerObserver method
   void OnDeviceListUpdated(
-      const connection_handler::DeviceMap& device_list) OVERRIDE;
+	  const connection_handler::DeviceMap& device_list) OVERRIDE;
   void OnFindNewApplicationsRequest() OVERRIDE;
   void RemoveDevice(
-      const connection_handler::DeviceHandle& device_handle) OVERRIDE;
+	  const connection_handler::DeviceHandle& device_handle) OVERRIDE;
   bool OnServiceStartedCallback(
-      const connection_handler::DeviceHandle& device_handle,
-      const int32_t& session_key,
-      const protocol_handler::ServiceType& type) OVERRIDE;
+	  const connection_handler::DeviceHandle& device_handle,
+	  const int32_t& session_key,
+	  const protocol_handler::ServiceType& type) OVERRIDE;
   void OnServiceEndedCallback(
-      const int32_t& session_key,
-      const protocol_handler::ServiceType& type,
-      const connection_handler::CloseSessionReason& close_reason) OVERRIDE;
+	  const int32_t& session_key,
+	  const protocol_handler::ServiceType& type,
+	  const connection_handler::CloseSessionReason& close_reason) OVERRIDE;
 
 #ifdef ENABLE_SECURITY
   // Overriden SecurityManagerListener method
   bool OnHandshakeDone(
-      uint32_t connection_key,
-      security_manager::SSLContext::HandshakeResult result) OVERRIDE FINAL;
+	  uint32_t connection_key,
+	  security_manager::SSLContext::HandshakeResult result) OVERRIDE FINAL;
 
   void OnCertificateUpdateRequired() OVERRIDE FINAL;
 
   security_manager::SSLContext::HandshakeContext GetHandshakeContext(
-      uint32_t key) const OVERRIDE FINAL;
+	  uint32_t key) const OVERRIDE FINAL;
 #endif  // ENABLE_SECURITY
 
   /**
@@ -771,8 +771,8 @@ class ApplicationManagerImpl
    * @param new_timeout_value New timeout in milliseconds to be set
    */
   void updateRequestTimeout(uint32_t connection_key,
-                            uint32_t mobile_correlation_id,
-                            uint32_t new_timeout_value) OVERRIDE;
+							uint32_t mobile_correlation_id,
+							uint32_t new_timeout_value) OVERRIDE;
 
   /**
    * @brief AddPolicyObserver allows to subscribe needed component to events
@@ -796,8 +796,8 @@ class ApplicationManagerImpl
    * @return True if streaming is allowed, false in other case
    */
   bool HMILevelAllowsStreaming(
-      uint32_t app_id,
-      protocol_handler::ServiceType service_type) const OVERRIDE;
+	  uint32_t app_id,
+	  protocol_handler::ServiceType service_type) const OVERRIDE;
 
   /**
    * @brief Checks if application can stream (streaming service is started and
@@ -807,7 +807,7 @@ class ApplicationManagerImpl
    * @return True if streaming is allowed, false in other case
    */
   bool CanAppStream(uint32_t app_id,
-                    protocol_handler::ServiceType service_type) const OVERRIDE;
+					protocol_handler::ServiceType service_type) const OVERRIDE;
 
   /**
    * @brief Ends opened navi services (audio/video) for application
@@ -828,18 +828,18 @@ class ApplicationManagerImpl
    * @param state Shows if streaming started or stopped
    */
   void OnAppStreaming(uint32_t app_id,
-                      protocol_handler::ServiceType service_type,
-                      bool state) OVERRIDE;
+					  protocol_handler::ServiceType service_type,
+					  bool state) OVERRIDE;
 
   mobile_api::HMILevel::eType GetDefaultHmiLevel(
-      ApplicationConstSharedPtr application) const;
+	  ApplicationConstSharedPtr application) const;
 
   /**
-    * Getter for resume_controller
-    * @return Resume Controller
-    */
+	* Getter for resume_controller
+	* @return Resume Controller
+	*/
   resumption::ResumeCtrl& resume_controller() OVERRIDE {
-    return resume_ctrl_;
+	return resume_ctrl_;
   }
 
   /**
@@ -883,9 +883,9 @@ class ApplicationManagerImpl
    * @return SUCCESS if file was saved, other code otherwise
    */
   mobile_apis::Result::eType SaveBinary(const std::vector<uint8_t>& binary_data,
-                                        const std::string& file_path,
-                                        const std::string& file_name,
-                                        const int64_t offset) OVERRIDE;
+										const std::string& file_path,
+										const std::string& file_name,
+										const int64_t offset) OVERRIDE;
 
   /**
    * @brief Get available app space
@@ -940,7 +940,7 @@ class ApplicationManagerImpl
   protocol_handler::ProtocolHandler& protocol_handler() const OVERRIDE;
 
   virtual policy::PolicyHandlerInterface& GetPolicyHandler() OVERRIDE {
-    return policy_handler_;
+	return policy_handler_;
   }
   /**
    * @brief Checks, if given RPC is allowed at current HMI level for specific
@@ -953,11 +953,11 @@ class ApplicationManagerImpl
    * @return SUCCESS, if allowed, otherwise result code of check
    */
   mobile_apis::Result::eType CheckPolicyPermissions(
-      const std::string& policy_app_id,
-      mobile_apis::HMILevel::eType hmi_level,
-      mobile_apis::FunctionID::eType function_id,
-      const RPCParams& rpc_params,
-      CommandParametersPermissions* params_permissions = NULL) OVERRIDE;
+	  const std::string& policy_app_id,
+	  mobile_apis::HMILevel::eType hmi_level,
+	  mobile_apis::FunctionID::eType function_id,
+	  const RPCParams& rpc_params,
+	  CommandParametersPermissions* params_permissions = NULL) OVERRIDE;
   /*
    * @brief Function Should be called when Low Voltage is occured
    */
@@ -979,104 +979,91 @@ class ApplicationManagerImpl
    * @return true in case application is allowed to register, false otherwise.
    */
   bool IsApplicationForbidden(uint32_t connection_key,
-                              const std::string& policy_app_id) const OVERRIDE;
+							  const std::string& policy_app_id) const OVERRIDE;
 
   policy::DeviceConsent GetUserConsentForDevice(
-      const std::string& device_id) const OVERRIDE;
+	  const std::string& device_id) const OVERRIDE;
 
   struct ApplicationsAppIdSorter {
-    bool operator()(const ApplicationSharedPtr lhs,
-                    const ApplicationSharedPtr rhs) {
-      return lhs->app_id() < rhs->app_id();
-    }
-  };
-
-  struct ApplicationsPolicyAppIdSorter {
-    bool operator()(const ApplicationSharedPtr lhs,
-                    const ApplicationSharedPtr rhs) {
-      if (lhs->policy_app_id() == rhs->policy_app_id()) {
-        return lhs->device() < rhs->device();
-      }
-      return lhs->policy_app_id() < rhs->policy_app_id();
-    }
+	bool operator()(const ApplicationSharedPtr lhs,
+					const ApplicationSharedPtr rhs) {
+	  return lhs->app_id() < rhs->app_id();
+	}
   };
 
   // typedef for Applications list
-  typedef std::set<ApplicationSharedPtr, ApplicationsPolicyAppIdSorter>
-      AppsWaitRegistrationSet;
-
   typedef std::set<std::string> ForbiddenApps;
 
   struct AppIdPredicate {
-    uint32_t app_id_;
-    AppIdPredicate(uint32_t app_id) : app_id_(app_id) {}
-    bool operator()(const ApplicationSharedPtr app) const {
-      return app ? app_id_ == app->app_id() : false;
-    }
+	uint32_t app_id_;
+	AppIdPredicate(uint32_t app_id) : app_id_(app_id) {}
+	bool operator()(const ApplicationSharedPtr app) const {
+	  return app ? app_id_ == app->app_id() : false;
+	}
   };
 
   struct HmiAppIdPredicate {
-    uint32_t hmi_app_id_;
-    HmiAppIdPredicate(uint32_t hmi_app_id) : hmi_app_id_(hmi_app_id) {}
-    bool operator()(const ApplicationSharedPtr app) const {
-      return app ? hmi_app_id_ == app->hmi_app_id() : false;
-    }
+	uint32_t hmi_app_id_;
+	HmiAppIdPredicate(uint32_t hmi_app_id) : hmi_app_id_(hmi_app_id) {}
+	bool operator()(const ApplicationSharedPtr app) const {
+	  return app ? hmi_app_id_ == app->hmi_app_id() : false;
+	}
   };
 
   struct PolicyAppIdPredicate {
-    std::string policy_app_id_;
-    PolicyAppIdPredicate(const std::string& policy_app_id)
-        : policy_app_id_(policy_app_id) {}
-    bool operator()(const ApplicationSharedPtr app) const {
-      return app ? policy_app_id_ == app->policy_app_id() : false;
-    }
+	std::string policy_app_id_;
+	PolicyAppIdPredicate(const std::string& policy_app_id)
+		: policy_app_id_(policy_app_id) {}
+	bool operator()(const ApplicationSharedPtr app) const {
+	  return app ? policy_app_id_ == app->policy_app_id() : false;
+	}
   };
 
   struct SubscribedToButtonPredicate {
-    mobile_apis::ButtonName::eType button_;
-    SubscribedToButtonPredicate(mobile_apis::ButtonName::eType button)
-        : button_(button) {}
-    bool operator()(const ApplicationSharedPtr app) const {
-      return app ? app->IsSubscribedToButton(button_) : false;
-    }
+	mobile_apis::ButtonName::eType button_;
+	SubscribedToButtonPredicate(mobile_apis::ButtonName::eType button)
+		: button_(button) {}
+	bool operator()(const ApplicationSharedPtr app) const {
+	  return app ? app->IsSubscribedToButton(button_) : false;
+	}
   };
 
   struct AppV4DevicePredicate {
-    connection_handler::DeviceHandle handle_;
-    AppV4DevicePredicate(const connection_handler::DeviceHandle handle)
-        : handle_(handle) {}
-    bool operator()(const ApplicationSharedPtr app) const {
-      return app
-                 ? handle_ == app->device() &&
-                       ProtocolVersion::kV4 == app->protocol_version()
-                 : false;
-    }
+	connection_handler::DeviceHandle handle_;
+	AppV4DevicePredicate(const connection_handler::DeviceHandle handle)
+		: handle_(handle) {}
+	bool operator()(const ApplicationSharedPtr app) const {
+	  return app
+				 ? handle_ == app->device() &&
+					   ProtocolVersion::kV4 == app->protocol_version()
+				 : false;
+	}
   };
 
   struct DevicePredicate {
-    connection_handler::DeviceHandle handle_;
-    DevicePredicate(const connection_handler::DeviceHandle handle)
-        : handle_(handle) {}
-    bool operator()(const ApplicationSharedPtr app) const {
-      return handle_ == app->device() ? true : false;
-    }
+	connection_handler::DeviceHandle handle_;
+	DevicePredicate(const connection_handler::DeviceHandle handle)
+		: handle_(handle) {}
+	bool operator()(const ApplicationSharedPtr app) const {
+	  return handle_ == app->device() ? true : false;
+	}
   };
 
   struct SubscribedToIVIPredicate {
-    int32_t vehicle_info_;
-    SubscribedToIVIPredicate(int32_t vehicle_info)
-        : vehicle_info_(vehicle_info) {}
-    bool operator()(const ApplicationSharedPtr app) const {
-      return app ? app->IsSubscribedToIVI(vehicle_info_) : false;
-    }
+	int32_t vehicle_info_;
+	SubscribedToIVIPredicate(int32_t vehicle_info)
+		: vehicle_info_(vehicle_info) {}
+	bool operator()(const ApplicationSharedPtr app) const {
+	  return app ? app->IsSubscribedToIVI(vehicle_info_) : false;
+	}
   };
 
   struct GrammarIdPredicate {
-    uint32_t grammar_id_;
-    GrammarIdPredicate(uint32_t grammar_id) : grammar_id_(grammar_id) {}
-    bool operator()(const ApplicationSharedPtr app) const {
-      return app ? grammar_id_ == app->get_grammar_id() : false;
-    }
+	uint32_t grammar_id_;
+	GrammarIdPredicate(uint32_t grammar_id) : grammar_id_(grammar_id) {}
+	bool operator()(const ApplicationSharedPtr app) const {
+	  return app ? grammar_id_ == app->get_grammar_id() : false;
+	}
   };
 
   /**
@@ -1091,7 +1078,13 @@ class ApplicationManagerImpl
    * @param handle, device handle
    */
   void MarkAppsGreyOut(const connection_handler::DeviceHandle handle,
-                       bool is_greyed_out) OVERRIDE;
+					   bool is_greyed_out) OVERRIDE;
+
+  ApplicationConstSharedPtr app_to_be_registered(
+	  const uint32_t hmi_id) const OVERRIDE;
+
+  DataAccessor<AppsWaitRegistrationSet> apps_waiting_for_registration()
+	  const OVERRIDE;
 
   /**
    * @brief Checks, if apps list had been queried already from certain device
@@ -1099,10 +1092,10 @@ class ApplicationManagerImpl
    * @return true, if list had been queried already, otherwise - false
    */
   bool IsAppsQueriedFrom(
-      const connection_handler::DeviceHandle handle) const OVERRIDE;
+	  const connection_handler::DeviceHandle handle) const OVERRIDE;
 
   bool IsStopping() const OVERRIDE {
-    return is_stopping_;
+	return is_stopping_;
   }
 
   StateController& state_controller() OVERRIDE;
@@ -1119,8 +1112,8 @@ class ApplicationManagerImpl
    * @param vrSynonym vr synonymus that should be filled.
    */
   void PullLanguagesInfo(const smart_objects::SmartObject& app_data,
-                         smart_objects::SmartObject& ttsName,
-                         smart_objects::SmartObject& vrSynonym);
+						 smart_objects::SmartObject& ttsName,
+						 smart_objects::SmartObject& vrSynonym);
 
   /**
    * @brief Method transforms string to AppHMIType
@@ -1136,17 +1129,17 @@ class ApplicationManagerImpl
    * @return return TRUE if arrays of appHMIType equal, otherwise return FALSE
    */
   bool CompareAppHMIType(const smart_objects::SmartObject& from_policy,
-                         const smart_objects::SmartObject& from_application);
+						 const smart_objects::SmartObject& from_application);
 
   hmi_apis::HMI_API& hmi_so_factory();
   mobile_apis::MOBILE_API& mobile_so_factory();
 
   bool ConvertMessageToSO(const Message& message,
-                          smart_objects::SmartObject& output);
+						  smart_objects::SmartObject& output);
   bool ConvertSOtoMessage(const smart_objects::SmartObject& message,
-                          Message& output);
+						  Message& output);
   utils::SharedPtr<Message> ConvertRawMsgToMessage(
-      const ::protocol_handler::RawMessagePtr message);
+	  const ::protocol_handler::RawMessagePtr message);
 
   void ProcessMessageFromMobile(const utils::SharedPtr<Message> message);
   void ProcessMessageFromHMI(const utils::SharedPtr<Message> message);
@@ -1173,36 +1166,36 @@ class ApplicationManagerImpl
 
   template <typename ApplicationList>
   void PrepareApplicationListSO(ApplicationList app_list,
-                                smart_objects::SmartObject& applications,
-                                ApplicationManager& app_mngr) {
-    CREATE_LOGGERPTR_LOCAL(logger_, "ApplicationManager");
+								smart_objects::SmartObject& applications,
+								ApplicationManager& app_mngr) {
+	CREATE_LOGGERPTR_LOCAL(logger_, "ApplicationManager");
 
-    smart_objects::SmartArray* app_array = applications.asArray();
-    uint32_t app_count = NULL == app_array ? 0 : app_array->size();
-    typename ApplicationList::const_iterator it;
-    for (it = app_list.begin(); it != app_list.end(); ++it) {
-      if (!it->valid()) {
-        LOG4CXX_ERROR(logger_, "Application not found ");
-        continue;
-      }
+	smart_objects::SmartArray* app_array = applications.asArray();
+	uint32_t app_count = NULL == app_array ? 0 : app_array->size();
+	typename ApplicationList::const_iterator it;
+	for (it = app_list.begin(); it != app_list.end(); ++it) {
+	  if (!it->valid()) {
+		LOG4CXX_ERROR(logger_, "Application not found ");
+		continue;
+	  }
 
-      smart_objects::SmartObject hmi_application(smart_objects::SmartType_Map);
-      const protocol_handler::SessionObserver& session_observer =
-          connection_handler().get_session_observer();
-      if (MessageHelper::CreateHMIApplicationStruct(*it,
-                                                    session_observer,
-                                                    GetPolicyHandler(),
-                                                    &hmi_application,
-                                                    app_mngr)) {
-        applications[app_count++] = hmi_application;
-      } else {
-        LOG4CXX_DEBUG(logger_, "Can't CreateHMIApplicationStruct ");
-      }
-    }
+	  smart_objects::SmartObject hmi_application(smart_objects::SmartType_Map);
+	  const protocol_handler::SessionObserver& session_observer =
+		  connection_handler().get_session_observer();
+	  if (MessageHelper::CreateHMIApplicationStruct(*it,
+													session_observer,
+													GetPolicyHandler(),
+													&hmi_application,
+													app_mngr)) {
+		applications[app_count++] = hmi_application;
+	  } else {
+		LOG4CXX_DEBUG(logger_, "Can't CreateHMIApplicationStruct ");
+	  }
+	}
 
-    if (0 == app_count) {
-      LOG4CXX_WARN(logger_, "Empty applications list");
-    }
+	if (0 == app_count) {
+	  LOG4CXX_WARN(logger_, "Empty applications list");
+	}
   }
 
   void OnApplicationListUpdateTimer();
@@ -1217,7 +1210,7 @@ class ApplicationManagerImpl
    * be created
    */
   void CreateApplications(smart_objects::SmartArray& obj_array,
-                          const uint32_t connection_key);
+						  const uint32_t connection_key);
 
   /*
    * @brief Function is called on IGN_OFF, Master_reset or Factory_defaults
@@ -1251,7 +1244,7 @@ class ApplicationManagerImpl
    * @return unique aplication identifier.
    */
   std::string GetHashedAppID(uint32_t connection_key,
-                             const std::string& policy_app_id) const;
+							 const std::string& policy_app_id) const;
 
   /**
    * @brief Removes suspended and stopped timers from timer pool
@@ -1279,7 +1272,7 @@ class ApplicationManagerImpl
    * @return True on success, false on fail
    */
   bool StartNaviService(uint32_t app_id,
-                        protocol_handler::ServiceType service_type);
+						protocol_handler::ServiceType service_type);
 
   /**
    * @brief Stops specified navi service for application
@@ -1287,7 +1280,7 @@ class ApplicationManagerImpl
    * @param service_type Type of service to stop
    */
   void StopNaviService(uint32_t app_id,
-                       protocol_handler::ServiceType service_type);
+					   protocol_handler::ServiceType service_type);
 
   /**
    * @brief Allows streaming for application if it was disallowed by
@@ -1346,7 +1339,7 @@ class ApplicationManagerImpl
    * @param handle, Device handle
    */
   void RemoveAppsWaitingForRegistration(
-      const connection_handler::DeviceHandle handle);
+	  const connection_handler::DeviceHandle handle);
 
   void ClearTTSGlobalPropertiesList();
 

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1080,10 +1080,10 @@ class ApplicationManagerImpl
   void MarkAppsGreyOut(const connection_handler::DeviceHandle handle,
                        bool is_greyed_out) OVERRIDE;
 
-  ApplicationConstSharedPtr app_to_be_registered(
+  ApplicationConstSharedPtr WaitingApplicationByID(
       const uint32_t hmi_id) const OVERRIDE;
 
-  DataAccessor<AppsWaitRegistrationSet> apps_waiting_for_registration()
+  DataAccessor<AppsWaitRegistrationSet> AppsWaitingForRegistration()
       const OVERRIDE;
 
   /**

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -113,7 +113,7 @@ enum VRTTSSessionChanging { kVRSessionChanging = 0, kTTSSessionChanging };
 
 struct CommandParametersPermissions;
 typedef std::map<std::string, hmi_apis::Common_TransportType::eType>
-	DeviceTypes;
+    DeviceTypes;
 
 namespace impl {
 using namespace threads;
@@ -131,21 +131,21 @@ using namespace threads;
 struct MessageFromMobile : public utils::SharedPtr<Message> {
   MessageFromMobile() {}
   explicit MessageFromMobile(const utils::SharedPtr<Message>& message)
-	  : utils::SharedPtr<Message>(message) {}
+      : utils::SharedPtr<Message>(message) {}
   // PrioritizedQueue requres this method to decide which priority to assign
   size_t PriorityOrder() const {
-	return (*this)->Priority().OrderingValue();
+    return (*this)->Priority().OrderingValue();
   }
 };
 
 struct MessageToMobile : public utils::SharedPtr<Message> {
   MessageToMobile() : is_final(false) {}
   explicit MessageToMobile(const utils::SharedPtr<Message>& message,
-						   bool final_message)
-	  : utils::SharedPtr<Message>(message), is_final(final_message) {}
+                           bool final_message)
+      : utils::SharedPtr<Message>(message), is_final(final_message) {}
   // PrioritizedQueue requres this method to decide which priority to assign
   size_t PriorityOrder() const {
-	return (*this)->Priority().OrderingValue();
+    return (*this)->Priority().OrderingValue();
   }
   // Signals if connection to mobile must be closed after sending this message
   bool is_final;
@@ -154,32 +154,32 @@ struct MessageToMobile : public utils::SharedPtr<Message> {
 struct MessageFromHmi : public utils::SharedPtr<Message> {
   MessageFromHmi() {}
   explicit MessageFromHmi(const utils::SharedPtr<Message>& message)
-	  : utils::SharedPtr<Message>(message) {}
+      : utils::SharedPtr<Message>(message) {}
   // PrioritizedQueue requres this method to decide which priority to assign
   size_t PriorityOrder() const {
-	return (*this)->Priority().OrderingValue();
+    return (*this)->Priority().OrderingValue();
   }
 };
 
 struct MessageToHmi : public utils::SharedPtr<Message> {
   MessageToHmi() {}
   explicit MessageToHmi(const utils::SharedPtr<Message>& message)
-	  : utils::SharedPtr<Message>(message) {}
+      : utils::SharedPtr<Message>(message) {}
   // PrioritizedQueue requres this method to decide which priority to assign
   size_t PriorityOrder() const {
-	return (*this)->Priority().OrderingValue();
+    return (*this)->Priority().OrderingValue();
   }
 };
 
 // Short type names for prioritized message queues
 typedef threads::MessageLoopThread<utils::PrioritizedQueue<MessageFromMobile> >
-	FromMobileQueue;
+    FromMobileQueue;
 typedef threads::MessageLoopThread<utils::PrioritizedQueue<MessageToMobile> >
-	ToMobileQueue;
+    ToMobileQueue;
 typedef threads::MessageLoopThread<utils::PrioritizedQueue<MessageFromHmi> >
-	FromHmiQueue;
+    FromHmiQueue;
 typedef threads::MessageLoopThread<utils::PrioritizedQueue<MessageToHmi> >
-	ToHmiQueue;
+    ToHmiQueue;
 
 // AudioPassThru
 typedef struct {
@@ -194,38 +194,38 @@ typedef std::vector<std::string> RPCParams;
 typedef utils::SharedPtr<timer::Timer> TimerSPtr;
 
 class ApplicationManagerImpl
-	: public ApplicationManager,
-	  public hmi_message_handler::HMIMessageObserver,
-	  public protocol_handler::ProtocolObserver,
-	  public connection_handler::ConnectionHandlerObserver,
-	  public policy::PolicyHandlerObserver,
+    : public ApplicationManager,
+      public hmi_message_handler::HMIMessageObserver,
+      public protocol_handler::ProtocolObserver,
+      public connection_handler::ConnectionHandlerObserver,
+      public policy::PolicyHandlerObserver,
 #ifdef ENABLE_SECURITY
-	  public security_manager::SecurityManagerListener,
+      public security_manager::SecurityManagerListener,
 #endif  // ENABLE_SECURITY
-	  public impl::FromMobileQueue::Handler,
-	  public impl::ToMobileQueue::Handler,
-	  public impl::FromHmiQueue::Handler,
-	  public impl::ToHmiQueue::Handler,
-	  public impl::AudioPassThruQueue::Handler
+      public impl::FromMobileQueue::Handler,
+      public impl::ToMobileQueue::Handler,
+      public impl::FromHmiQueue::Handler,
+      public impl::ToHmiQueue::Handler,
+      public impl::AudioPassThruQueue::Handler
 #ifdef TELEMETRY_MONITOR
-	  ,
-	  public telemetry_monitor::TelemetryObservable<AMTelemetryObserver>
+      ,
+      public telemetry_monitor::TelemetryObservable<AMTelemetryObserver>
 #endif  // TELEMETRY_MONITOR
-	  {
+      {
 
   friend class ResumeCtrl;
   friend class CommandImpl;
 
  public:
   ApplicationManagerImpl(const ApplicationManagerSettings& am_settings,
-						 const policy::PolicySettings& policy_settings);
+                         const policy::PolicySettings& policy_settings);
   ~ApplicationManagerImpl();
 
   /**
    * Inits application manager
    */
   bool Init(resumption::LastState& last_state,
-			media_manager::MediaManager* media_manager) OVERRIDE;
+            media_manager::MediaManager* media_manager) OVERRIDE;
 
   /**
    * @brief Stop work.
@@ -240,12 +240,12 @@ class ApplicationManagerImpl
   ApplicationSharedPtr active_application() const OVERRIDE;
 
   ApplicationSharedPtr application_by_hmi_app(
-	  uint32_t hmi_app_id) const OVERRIDE;
+      uint32_t hmi_app_id) const OVERRIDE;
   ApplicationSharedPtr application_by_policy_id(
-	  const std::string& policy_app_id) const OVERRIDE;
+      const std::string& policy_app_id) const OVERRIDE;
 
   std::vector<ApplicationSharedPtr> applications_by_button(
-	  uint32_t button) OVERRIDE;
+      uint32_t button) OVERRIDE;
   std::vector<ApplicationSharedPtr> applications_with_navi() OVERRIDE;
 
   ApplicationSharedPtr get_limited_media_application() const OVERRIDE;
@@ -254,14 +254,14 @@ class ApplicationManagerImpl
 
   uint32_t application_id(const int32_t correlation_id) OVERRIDE;
   void set_application_id(const int32_t correlation_id,
-						  const uint32_t app_id) OVERRIDE;
+                          const uint32_t app_id) OVERRIDE;
 
   void OnHMILevelChanged(uint32_t app_id,
-						 mobile_apis::HMILevel::eType from,
-						 mobile_apis::HMILevel::eType to) OVERRIDE;
+                         mobile_apis::HMILevel::eType from,
+                         mobile_apis::HMILevel::eType to) OVERRIDE;
 
   void SendHMIStatusNotification(
-	  const utils::SharedPtr<Application> app) OVERRIDE;
+      const utils::SharedPtr<Application> app) OVERRIDE;
   /**
    * @brief Checks if application with the same HMI type
    *        (media, voice communication or navi) exists
@@ -313,7 +313,7 @@ class ApplicationManagerImpl
    * @param new value (for integer values currently) of vehicle data
    */
   std::vector<ApplicationSharedPtr> IviInfoUpdated(VehicleDataType vehicle_info,
-												   int value) OVERRIDE;
+                                                   int value) OVERRIDE;
 
   void OnApplicationRegistered(ApplicationSharedPtr app) OVERRIDE;
 
@@ -328,7 +328,7 @@ class ApplicationManagerImpl
    * @param connection_key connection key for app, which sent system request
    */
   void ProcessQueryApp(const smart_objects::SmartObject& sm_object,
-					   const uint32_t connection_key) OVERRIDE;
+                       const uint32_t connection_key) OVERRIDE;
 
   bool is_attenuated_supported() const OVERRIDE;
 
@@ -342,7 +342,7 @@ class ApplicationManagerImpl
 #endif  // TELEMETRY_MONITOR
 
   ApplicationSharedPtr RegisterApplication(const utils::SharedPtr<
-	  smart_objects::SmartObject>& request_for_registration) OVERRIDE;
+      smart_objects::SmartObject>& request_for_registration) OVERRIDE;
   /*
    * @brief Closes application by id
    *
@@ -354,9 +354,9 @@ class ApplicationManagerImpl
    * Indicates if connection was unexpectedly lost(TM layer, HB)
    */
   void UnregisterApplication(const uint32_t& app_id,
-							 mobile_apis::Result::eType reason,
-							 bool is_resuming = false,
-							 bool is_unexpected_disconnect = false) OVERRIDE;
+                             mobile_apis::Result::eType reason,
+                             bool is_resuming = false,
+                             bool is_unexpected_disconnect = false) OVERRIDE;
 
   /**
   * @brief Handle sequence for unauthorized application
@@ -371,7 +371,7 @@ class ApplicationManagerImpl
    * @param reason Describes the reason for HU switching off
    */
   void SetUnregisterAllApplicationsReason(
-	  mobile_api::AppInterfaceUnregisteredReason::eType reason) OVERRIDE;
+      mobile_api::AppInterfaceUnregisteredReason::eType reason) OVERRIDE;
 
   /*
    * @brief Called on Master_reset or Factory_defaults
@@ -379,7 +379,7 @@ class ApplicationManagerImpl
    * Resets Policy Table if applicable.
    */
   void HeadUnitReset(
-	  mobile_api::AppInterfaceUnregisteredReason::eType reason) OVERRIDE;
+      mobile_api::AppInterfaceUnregisteredReason::eType reason) OVERRIDE;
 
   /*
    * @brief Closes all registered applications
@@ -473,10 +473,10 @@ class ApplicationManagerImpl
    * @return new regular HMI state
    */
   HmiStatePtr CreateRegularState(
-	  uint32_t app_id,
-	  mobile_apis::HMILevel::eType hmi_level,
-	  mobile_apis::AudioStreamingState::eType audio_state,
-	  mobile_apis::SystemContext::eType system_context) const OVERRIDE;
+      uint32_t app_id,
+      mobile_apis::HMILevel::eType hmi_level,
+      mobile_apis::AudioStreamingState::eType audio_state,
+      mobile_apis::SystemContext::eType system_context) const OVERRIDE;
 
   /**
    * @brief SetState set regular audio state
@@ -484,14 +484,14 @@ class ApplicationManagerImpl
    * @param audio_state aaudio streaming state
    */
   void SetState(uint32_t app_id,
-				mobile_apis::AudioStreamingState::eType audio_state) {
-	ApplicationSharedPtr app = application(app_id);
-	if (!app) {
-	  LOG4CXX_ERROR(logger_,
-					"Application with appID=" << app_id << " does not exist");
-	  return;
-	}
-	state_ctrl_.SetRegularState(app, audio_state);
+                mobile_apis::AudioStreamingState::eType audio_state) {
+    ApplicationSharedPtr app = application(app_id);
+    if (!app) {
+      LOG4CXX_ERROR(logger_,
+                    "Application with appID=" << app_id << " does not exist");
+      return;
+    }
+    state_ctrl_.SetRegularState(app, audio_state);
   }
 
   /**
@@ -502,13 +502,13 @@ class ApplicationManagerImpl
    */
   template <bool SendActivateApp>
   void SetState(uint32_t app_id, HmiStatePtr new_state) {
-	ApplicationSharedPtr app = application(app_id);
-	if (!app) {
-	  LOG4CXX_ERROR(logger_,
-					"Application with appID=" << app_id << " does not exist");
-	  return;
-	}
-	state_ctrl_.SetRegularState(app, new_state, SendActivateApp);
+    ApplicationSharedPtr app = application(app_id);
+    if (!app) {
+      LOG4CXX_ERROR(logger_,
+                    "Application with appID=" << app_id << " does not exist");
+      return;
+    }
+    state_ctrl_.SetRegularState(app, new_state, SendActivateApp);
   }
 
   /**
@@ -518,13 +518,13 @@ class ApplicationManagerImpl
    */
   template <bool SendActivateApp>
   void SetState(uint32_t app_id, mobile_apis::HMILevel::eType hmi_level) {
-	ApplicationSharedPtr app = application(app_id);
-	if (!app) {
-	  LOG4CXX_ERROR(logger_,
-					"Application with appID=" << app_id << " does not exist");
-	  return;
-	}
-	state_ctrl_.SetRegularState(app, hmi_level, SendActivateApp);
+    ApplicationSharedPtr app = application(app_id);
+    if (!app) {
+      LOG4CXX_ERROR(logger_,
+                    "Application with appID=" << app_id << " does not exist");
+      return;
+    }
+    state_ctrl_.SetRegularState(app, hmi_level, SendActivateApp);
   }
 
   /**
@@ -536,15 +536,15 @@ class ApplicationManagerImpl
    */
   template <bool SendActivateApp>
   void SetState(uint32_t app_id,
-				mobile_apis::HMILevel::eType hmi_level,
-				mobile_apis::AudioStreamingState::eType audio_state) {
-	ApplicationSharedPtr app = application(app_id);
-	if (!app) {
-	  LOG4CXX_ERROR(logger_,
-					"Application with appID=" << app_id << " does not exist");
-	  return;
-	}
-	state_ctrl_.SetRegularState(app, hmi_level, audio_state, SendActivateApp);
+                mobile_apis::HMILevel::eType hmi_level,
+                mobile_apis::AudioStreamingState::eType audio_state) {
+    ApplicationSharedPtr app = application(app_id);
+    if (!app) {
+      LOG4CXX_ERROR(logger_,
+                    "Application with appID=" << app_id << " does not exist");
+      return;
+    }
+    state_ctrl_.SetRegularState(app, hmi_level, audio_state, SendActivateApp);
   }
 
   /**
@@ -556,17 +556,17 @@ class ApplicationManagerImpl
    */
   template <bool SendActivateApp>
   void SetState(uint32_t app_id,
-				mobile_apis::HMILevel::eType hmi_level,
-				mobile_apis::AudioStreamingState::eType audio_state,
-				mobile_apis::SystemContext::eType system_context) {
-	ApplicationSharedPtr app = application(app_id);
-	if (!app) {
-	  LOG4CXX_ERROR(logger_,
-					"Application with appID=" << app_id << " does not exist");
-	  return;
-	}
-	state_ctrl_.SetRegularState(
-		app, hmi_level, audio_state, system_context, SendActivateApp);
+                mobile_apis::HMILevel::eType hmi_level,
+                mobile_apis::AudioStreamingState::eType audio_state,
+                mobile_apis::SystemContext::eType system_context) {
+    ApplicationSharedPtr app = application(app_id);
+    if (!app) {
+      LOG4CXX_ERROR(logger_,
+                    "Application with appID=" << app_id << " does not exist");
+      return;
+    }
+    state_ctrl_.SetRegularState(
+        app, hmi_level, audio_state, system_context, SendActivateApp);
   }
 
   /**
@@ -575,14 +575,14 @@ class ApplicationManagerImpl
    * @param system_context of new regular state
    */
   void SetState(uint32_t app_id,
-				mobile_apis::SystemContext::eType system_context) {
-	ApplicationSharedPtr app = application(app_id);
-	if (!app) {
-	  LOG4CXX_ERROR(logger_,
-					"Application with appID=" << app_id << " does not exist");
-	  return;
-	}
-	state_ctrl_.SetRegularState(app, system_context);
+                mobile_apis::SystemContext::eType system_context) {
+    ApplicationSharedPtr app = application(app_id);
+    if (!app) {
+      LOG4CXX_ERROR(logger_,
+                    "Application with appID=" << app_id << " does not exist");
+      return;
+    }
+    state_ctrl_.SetRegularState(app, system_context);
   }
 
   /**
@@ -591,13 +591,13 @@ class ApplicationManagerImpl
    * @param hmi_level hmi level of new regular state
    */
   void SetHmiState(uint32_t app_id, mobile_apis::HMILevel::eType hmi_level) {
-	ApplicationSharedPtr app = application(app_id);
-	if (!app) {
-	  LOG4CXX_ERROR(logger_,
-					"Application with appID=" << app_id << " does not exist");
-	  return;
-	}
-	state_ctrl_.SetRegularState(app, hmi_level);
+    ApplicationSharedPtr app = application(app_id);
+    if (!app) {
+      LOG4CXX_ERROR(logger_,
+                    "Application with appID=" << app_id << " does not exist");
+      return;
+    }
+    state_ctrl_.SetRegularState(app, hmi_level);
   }
 
   /**
@@ -606,13 +606,13 @@ class ApplicationManagerImpl
    * @param state new regular hmi state
    */
   void SetState(uint32_t app_id, HmiStatePtr state) {
-	ApplicationSharedPtr app = application(app_id);
-	if (!app) {
-	  LOG4CXX_ERROR(logger_,
-					"Application with appID=" << app_id << " does not exist");
-	  return;
-	}
-	state_ctrl_.SetRegularState(app, state);
+    ApplicationSharedPtr app = application(app_id);
+    if (!app) {
+      LOG4CXX_ERROR(logger_,
+                    "Application with appID=" << app_id << " does not exist");
+      return;
+    }
+    state_ctrl_.SetRegularState(app, state);
   }
 
   /**
@@ -635,7 +635,7 @@ class ApplicationManagerImpl
    * for app with HMI level BACKGROUND.
    */
   void OnUpdateHMIAppType(
-	  std::map<std::string, std::vector<std::string> > app_hmi_types) OVERRIDE;
+      std::map<std::string, std::vector<std::string> > app_hmi_types) OVERRIDE;
 
   /*
    * @brief Starts audio pass thru thread
@@ -648,11 +648,11 @@ class ApplicationManagerImpl
    * @param audio_type      Type of audio data
    */
   void StartAudioPassThruThread(int32_t session_key,
-								int32_t correlation_id,
-								int32_t max_duration,
-								int32_t sampling_rate,
-								int32_t bits_per_sample,
-								int32_t audio_type) OVERRIDE;
+                                int32_t correlation_id,
+                                int32_t max_duration,
+                                int32_t sampling_rate,
+                                int32_t bits_per_sample,
+                                int32_t audio_type) OVERRIDE;
 
   /*
    * @brief Terminates audio pass thru thread
@@ -671,7 +671,7 @@ class ApplicationManagerImpl
    * @param binary_data AudioPassThru data chunk
    */
   void SendAudioPassThroughNotification(
-	  uint32_t session_key, std::vector<uint8_t>& binary_data) OVERRIDE;
+      uint32_t session_key, std::vector<uint8_t>& binary_data) OVERRIDE;
 
   std::string GetDeviceName(connection_handler::DeviceHandle handle);
 
@@ -684,7 +684,7 @@ class ApplicationManagerImpl
    * @return Corresponding HMI TransporType value
    */
   hmi_apis::Common_TransportType::eType GetDeviceTransportType(
-	  const std::string& transport_type);
+      const std::string& transport_type);
 
   void set_hmi_message_handler(hmi_message_handler::HMIMessageHandler* handler);
   void set_connection_handler(connection_handler::ConnectionHandler* handler);
@@ -696,12 +696,12 @@ class ApplicationManagerImpl
   // if |final_message| parameter is set connection to mobile will be closed
   // after processing this message
   void SendMessageToMobile(const commands::MessageSharedPtr message,
-						   bool final_message = false) OVERRIDE;
+                           bool final_message = false) OVERRIDE;
 
   void SendMessageToHMI(const commands::MessageSharedPtr message) OVERRIDE;
 
   bool ManageMobileCommand(const commands::MessageSharedPtr message,
-						   commands::Command::CommandOrigin origin) OVERRIDE;
+                           commands::Command::CommandOrigin origin) OVERRIDE;
   bool ManageHMICommand(const commands::MessageSharedPtr message) OVERRIDE;
 
   /**
@@ -712,41 +712,41 @@ class ApplicationManagerImpl
   void TerminateRequest(uint32_t connection_key, uint32_t corr_id) OVERRIDE;
   // Overriden ProtocolObserver method
   void OnMessageReceived(
-	  const ::protocol_handler::RawMessagePtr message) OVERRIDE;
+      const ::protocol_handler::RawMessagePtr message) OVERRIDE;
   void OnMobileMessageSent(
-	  const ::protocol_handler::RawMessagePtr message) OVERRIDE;
+      const ::protocol_handler::RawMessagePtr message) OVERRIDE;
 
   // Overriden HMIMessageObserver method
   void OnMessageReceived(
-	  hmi_message_handler::MessageSharedPointer message) OVERRIDE;
+      hmi_message_handler::MessageSharedPointer message) OVERRIDE;
   void OnErrorSending(
-	  hmi_message_handler::MessageSharedPointer message) OVERRIDE;
+      hmi_message_handler::MessageSharedPointer message) OVERRIDE;
 
   // Overriden ConnectionHandlerObserver method
   void OnDeviceListUpdated(
-	  const connection_handler::DeviceMap& device_list) OVERRIDE;
+      const connection_handler::DeviceMap& device_list) OVERRIDE;
   void OnFindNewApplicationsRequest() OVERRIDE;
   void RemoveDevice(
-	  const connection_handler::DeviceHandle& device_handle) OVERRIDE;
+      const connection_handler::DeviceHandle& device_handle) OVERRIDE;
   bool OnServiceStartedCallback(
-	  const connection_handler::DeviceHandle& device_handle,
-	  const int32_t& session_key,
-	  const protocol_handler::ServiceType& type) OVERRIDE;
+      const connection_handler::DeviceHandle& device_handle,
+      const int32_t& session_key,
+      const protocol_handler::ServiceType& type) OVERRIDE;
   void OnServiceEndedCallback(
-	  const int32_t& session_key,
-	  const protocol_handler::ServiceType& type,
-	  const connection_handler::CloseSessionReason& close_reason) OVERRIDE;
+      const int32_t& session_key,
+      const protocol_handler::ServiceType& type,
+      const connection_handler::CloseSessionReason& close_reason) OVERRIDE;
 
 #ifdef ENABLE_SECURITY
   // Overriden SecurityManagerListener method
   bool OnHandshakeDone(
-	  uint32_t connection_key,
-	  security_manager::SSLContext::HandshakeResult result) OVERRIDE FINAL;
+      uint32_t connection_key,
+      security_manager::SSLContext::HandshakeResult result) OVERRIDE FINAL;
 
   void OnCertificateUpdateRequired() OVERRIDE FINAL;
 
   security_manager::SSLContext::HandshakeContext GetHandshakeContext(
-	  uint32_t key) const OVERRIDE FINAL;
+      uint32_t key) const OVERRIDE FINAL;
 #endif  // ENABLE_SECURITY
 
   /**
@@ -771,8 +771,8 @@ class ApplicationManagerImpl
    * @param new_timeout_value New timeout in milliseconds to be set
    */
   void updateRequestTimeout(uint32_t connection_key,
-							uint32_t mobile_correlation_id,
-							uint32_t new_timeout_value) OVERRIDE;
+                            uint32_t mobile_correlation_id,
+                            uint32_t new_timeout_value) OVERRIDE;
 
   /**
    * @brief AddPolicyObserver allows to subscribe needed component to events
@@ -796,8 +796,8 @@ class ApplicationManagerImpl
    * @return True if streaming is allowed, false in other case
    */
   bool HMILevelAllowsStreaming(
-	  uint32_t app_id,
-	  protocol_handler::ServiceType service_type) const OVERRIDE;
+      uint32_t app_id,
+      protocol_handler::ServiceType service_type) const OVERRIDE;
 
   /**
    * @brief Checks if application can stream (streaming service is started and
@@ -807,7 +807,7 @@ class ApplicationManagerImpl
    * @return True if streaming is allowed, false in other case
    */
   bool CanAppStream(uint32_t app_id,
-					protocol_handler::ServiceType service_type) const OVERRIDE;
+                    protocol_handler::ServiceType service_type) const OVERRIDE;
 
   /**
    * @brief Ends opened navi services (audio/video) for application
@@ -828,18 +828,18 @@ class ApplicationManagerImpl
    * @param state Shows if streaming started or stopped
    */
   void OnAppStreaming(uint32_t app_id,
-					  protocol_handler::ServiceType service_type,
-					  bool state) OVERRIDE;
+                      protocol_handler::ServiceType service_type,
+                      bool state) OVERRIDE;
 
   mobile_api::HMILevel::eType GetDefaultHmiLevel(
-	  ApplicationConstSharedPtr application) const;
+      ApplicationConstSharedPtr application) const;
 
   /**
-	* Getter for resume_controller
-	* @return Resume Controller
-	*/
+  * Getter for resume_controller
+  * @return Resume Controller
+  */
   resumption::ResumeCtrl& resume_controller() OVERRIDE {
-	return resume_ctrl_;
+    return resume_ctrl_;
   }
 
   /**
@@ -883,9 +883,9 @@ class ApplicationManagerImpl
    * @return SUCCESS if file was saved, other code otherwise
    */
   mobile_apis::Result::eType SaveBinary(const std::vector<uint8_t>& binary_data,
-										const std::string& file_path,
-										const std::string& file_name,
-										const int64_t offset) OVERRIDE;
+                                        const std::string& file_path,
+                                        const std::string& file_name,
+                                        const int64_t offset) OVERRIDE;
 
   /**
    * @brief Get available app space
@@ -940,7 +940,7 @@ class ApplicationManagerImpl
   protocol_handler::ProtocolHandler& protocol_handler() const OVERRIDE;
 
   virtual policy::PolicyHandlerInterface& GetPolicyHandler() OVERRIDE {
-	return policy_handler_;
+    return policy_handler_;
   }
   /**
    * @brief Checks, if given RPC is allowed at current HMI level for specific
@@ -953,11 +953,11 @@ class ApplicationManagerImpl
    * @return SUCCESS, if allowed, otherwise result code of check
    */
   mobile_apis::Result::eType CheckPolicyPermissions(
-	  const std::string& policy_app_id,
-	  mobile_apis::HMILevel::eType hmi_level,
-	  mobile_apis::FunctionID::eType function_id,
-	  const RPCParams& rpc_params,
-	  CommandParametersPermissions* params_permissions = NULL) OVERRIDE;
+      const std::string& policy_app_id,
+      mobile_apis::HMILevel::eType hmi_level,
+      mobile_apis::FunctionID::eType function_id,
+      const RPCParams& rpc_params,
+      CommandParametersPermissions* params_permissions = NULL) OVERRIDE;
   /*
    * @brief Function Should be called when Low Voltage is occured
    */
@@ -979,91 +979,91 @@ class ApplicationManagerImpl
    * @return true in case application is allowed to register, false otherwise.
    */
   bool IsApplicationForbidden(uint32_t connection_key,
-							  const std::string& policy_app_id) const OVERRIDE;
+                              const std::string& policy_app_id) const OVERRIDE;
 
   policy::DeviceConsent GetUserConsentForDevice(
-	  const std::string& device_id) const OVERRIDE;
+      const std::string& device_id) const OVERRIDE;
 
   struct ApplicationsAppIdSorter {
-	bool operator()(const ApplicationSharedPtr lhs,
-					const ApplicationSharedPtr rhs) {
-	  return lhs->app_id() < rhs->app_id();
-	}
+    bool operator()(const ApplicationSharedPtr lhs,
+                    const ApplicationSharedPtr rhs) {
+      return lhs->app_id() < rhs->app_id();
+    }
   };
 
   // typedef for Applications list
   typedef std::set<std::string> ForbiddenApps;
 
   struct AppIdPredicate {
-	uint32_t app_id_;
-	AppIdPredicate(uint32_t app_id) : app_id_(app_id) {}
-	bool operator()(const ApplicationSharedPtr app) const {
-	  return app ? app_id_ == app->app_id() : false;
-	}
+    uint32_t app_id_;
+    AppIdPredicate(uint32_t app_id) : app_id_(app_id) {}
+    bool operator()(const ApplicationSharedPtr app) const {
+      return app ? app_id_ == app->app_id() : false;
+    }
   };
 
   struct HmiAppIdPredicate {
-	uint32_t hmi_app_id_;
-	HmiAppIdPredicate(uint32_t hmi_app_id) : hmi_app_id_(hmi_app_id) {}
-	bool operator()(const ApplicationSharedPtr app) const {
-	  return app ? hmi_app_id_ == app->hmi_app_id() : false;
-	}
+    uint32_t hmi_app_id_;
+    HmiAppIdPredicate(uint32_t hmi_app_id) : hmi_app_id_(hmi_app_id) {}
+    bool operator()(const ApplicationSharedPtr app) const {
+      return app ? hmi_app_id_ == app->hmi_app_id() : false;
+    }
   };
 
   struct PolicyAppIdPredicate {
-	std::string policy_app_id_;
-	PolicyAppIdPredicate(const std::string& policy_app_id)
-		: policy_app_id_(policy_app_id) {}
-	bool operator()(const ApplicationSharedPtr app) const {
-	  return app ? policy_app_id_ == app->policy_app_id() : false;
-	}
+    std::string policy_app_id_;
+    PolicyAppIdPredicate(const std::string& policy_app_id)
+        : policy_app_id_(policy_app_id) {}
+    bool operator()(const ApplicationSharedPtr app) const {
+      return app ? policy_app_id_ == app->policy_app_id() : false;
+    }
   };
 
   struct SubscribedToButtonPredicate {
-	mobile_apis::ButtonName::eType button_;
-	SubscribedToButtonPredicate(mobile_apis::ButtonName::eType button)
-		: button_(button) {}
-	bool operator()(const ApplicationSharedPtr app) const {
-	  return app ? app->IsSubscribedToButton(button_) : false;
-	}
+    mobile_apis::ButtonName::eType button_;
+    SubscribedToButtonPredicate(mobile_apis::ButtonName::eType button)
+        : button_(button) {}
+    bool operator()(const ApplicationSharedPtr app) const {
+      return app ? app->IsSubscribedToButton(button_) : false;
+    }
   };
 
   struct AppV4DevicePredicate {
-	connection_handler::DeviceHandle handle_;
-	AppV4DevicePredicate(const connection_handler::DeviceHandle handle)
-		: handle_(handle) {}
-	bool operator()(const ApplicationSharedPtr app) const {
-	  return app
-				 ? handle_ == app->device() &&
-					   ProtocolVersion::kV4 == app->protocol_version()
-				 : false;
-	}
+    connection_handler::DeviceHandle handle_;
+    AppV4DevicePredicate(const connection_handler::DeviceHandle handle)
+        : handle_(handle) {}
+    bool operator()(const ApplicationSharedPtr app) const {
+      return app
+                 ? handle_ == app->device() &&
+                       ProtocolVersion::kV4 == app->protocol_version()
+                 : false;
+    }
   };
 
   struct DevicePredicate {
-	connection_handler::DeviceHandle handle_;
-	DevicePredicate(const connection_handler::DeviceHandle handle)
-		: handle_(handle) {}
-	bool operator()(const ApplicationSharedPtr app) const {
-	  return handle_ == app->device() ? true : false;
-	}
+    connection_handler::DeviceHandle handle_;
+    DevicePredicate(const connection_handler::DeviceHandle handle)
+        : handle_(handle) {}
+    bool operator()(const ApplicationSharedPtr app) const {
+      return handle_ == app->device() ? true : false;
+    }
   };
 
   struct SubscribedToIVIPredicate {
-	int32_t vehicle_info_;
-	SubscribedToIVIPredicate(int32_t vehicle_info)
-		: vehicle_info_(vehicle_info) {}
-	bool operator()(const ApplicationSharedPtr app) const {
-	  return app ? app->IsSubscribedToIVI(vehicle_info_) : false;
-	}
+    int32_t vehicle_info_;
+    SubscribedToIVIPredicate(int32_t vehicle_info)
+        : vehicle_info_(vehicle_info) {}
+    bool operator()(const ApplicationSharedPtr app) const {
+      return app ? app->IsSubscribedToIVI(vehicle_info_) : false;
+    }
   };
 
   struct GrammarIdPredicate {
-	uint32_t grammar_id_;
-	GrammarIdPredicate(uint32_t grammar_id) : grammar_id_(grammar_id) {}
-	bool operator()(const ApplicationSharedPtr app) const {
-	  return app ? grammar_id_ == app->get_grammar_id() : false;
-	}
+    uint32_t grammar_id_;
+    GrammarIdPredicate(uint32_t grammar_id) : grammar_id_(grammar_id) {}
+    bool operator()(const ApplicationSharedPtr app) const {
+      return app ? grammar_id_ == app->get_grammar_id() : false;
+    }
   };
 
   /**
@@ -1078,13 +1078,13 @@ class ApplicationManagerImpl
    * @param handle, device handle
    */
   void MarkAppsGreyOut(const connection_handler::DeviceHandle handle,
-					   bool is_greyed_out) OVERRIDE;
+                       bool is_greyed_out) OVERRIDE;
 
   ApplicationConstSharedPtr app_to_be_registered(
-	  const uint32_t hmi_id) const OVERRIDE;
+      const uint32_t hmi_id) const OVERRIDE;
 
   DataAccessor<AppsWaitRegistrationSet> apps_waiting_for_registration()
-	  const OVERRIDE;
+      const OVERRIDE;
 
   /**
    * @brief Checks, if apps list had been queried already from certain device
@@ -1092,10 +1092,10 @@ class ApplicationManagerImpl
    * @return true, if list had been queried already, otherwise - false
    */
   bool IsAppsQueriedFrom(
-	  const connection_handler::DeviceHandle handle) const OVERRIDE;
+      const connection_handler::DeviceHandle handle) const OVERRIDE;
 
   bool IsStopping() const OVERRIDE {
-	return is_stopping_;
+    return is_stopping_;
   }
 
   StateController& state_controller() OVERRIDE;
@@ -1112,8 +1112,8 @@ class ApplicationManagerImpl
    * @param vrSynonym vr synonymus that should be filled.
    */
   void PullLanguagesInfo(const smart_objects::SmartObject& app_data,
-						 smart_objects::SmartObject& ttsName,
-						 smart_objects::SmartObject& vrSynonym);
+                         smart_objects::SmartObject& ttsName,
+                         smart_objects::SmartObject& vrSynonym);
 
   /**
    * @brief Method transforms string to AppHMIType
@@ -1129,17 +1129,17 @@ class ApplicationManagerImpl
    * @return return TRUE if arrays of appHMIType equal, otherwise return FALSE
    */
   bool CompareAppHMIType(const smart_objects::SmartObject& from_policy,
-						 const smart_objects::SmartObject& from_application);
+                         const smart_objects::SmartObject& from_application);
 
   hmi_apis::HMI_API& hmi_so_factory();
   mobile_apis::MOBILE_API& mobile_so_factory();
 
   bool ConvertMessageToSO(const Message& message,
-						  smart_objects::SmartObject& output);
+                          smart_objects::SmartObject& output);
   bool ConvertSOtoMessage(const smart_objects::SmartObject& message,
-						  Message& output);
+                          Message& output);
   utils::SharedPtr<Message> ConvertRawMsgToMessage(
-	  const ::protocol_handler::RawMessagePtr message);
+      const ::protocol_handler::RawMessagePtr message);
 
   void ProcessMessageFromMobile(const utils::SharedPtr<Message> message);
   void ProcessMessageFromHMI(const utils::SharedPtr<Message> message);
@@ -1166,36 +1166,36 @@ class ApplicationManagerImpl
 
   template <typename ApplicationList>
   void PrepareApplicationListSO(ApplicationList app_list,
-								smart_objects::SmartObject& applications,
-								ApplicationManager& app_mngr) {
-	CREATE_LOGGERPTR_LOCAL(logger_, "ApplicationManager");
+                                smart_objects::SmartObject& applications,
+                                ApplicationManager& app_mngr) {
+    CREATE_LOGGERPTR_LOCAL(logger_, "ApplicationManager");
 
-	smart_objects::SmartArray* app_array = applications.asArray();
-	uint32_t app_count = NULL == app_array ? 0 : app_array->size();
-	typename ApplicationList::const_iterator it;
-	for (it = app_list.begin(); it != app_list.end(); ++it) {
-	  if (!it->valid()) {
-		LOG4CXX_ERROR(logger_, "Application not found ");
-		continue;
-	  }
+    smart_objects::SmartArray* app_array = applications.asArray();
+    uint32_t app_count = NULL == app_array ? 0 : app_array->size();
+    typename ApplicationList::const_iterator it;
+    for (it = app_list.begin(); it != app_list.end(); ++it) {
+      if (!it->valid()) {
+        LOG4CXX_ERROR(logger_, "Application not found ");
+        continue;
+      }
 
-	  smart_objects::SmartObject hmi_application(smart_objects::SmartType_Map);
-	  const protocol_handler::SessionObserver& session_observer =
-		  connection_handler().get_session_observer();
-	  if (MessageHelper::CreateHMIApplicationStruct(*it,
-													session_observer,
-													GetPolicyHandler(),
-													&hmi_application,
-													app_mngr)) {
-		applications[app_count++] = hmi_application;
-	  } else {
-		LOG4CXX_DEBUG(logger_, "Can't CreateHMIApplicationStruct ");
-	  }
-	}
+      smart_objects::SmartObject hmi_application(smart_objects::SmartType_Map);
+      const protocol_handler::SessionObserver& session_observer =
+          connection_handler().get_session_observer();
+      if (MessageHelper::CreateHMIApplicationStruct(*it,
+                                                    session_observer,
+                                                    GetPolicyHandler(),
+                                                    &hmi_application,
+                                                    app_mngr)) {
+        applications[app_count++] = hmi_application;
+      } else {
+        LOG4CXX_DEBUG(logger_, "Can't CreateHMIApplicationStruct ");
+      }
+    }
 
-	if (0 == app_count) {
-	  LOG4CXX_WARN(logger_, "Empty applications list");
-	}
+    if (0 == app_count) {
+      LOG4CXX_WARN(logger_, "Empty applications list");
+    }
   }
 
   void OnApplicationListUpdateTimer();
@@ -1210,7 +1210,7 @@ class ApplicationManagerImpl
    * be created
    */
   void CreateApplications(smart_objects::SmartArray& obj_array,
-						  const uint32_t connection_key);
+                          const uint32_t connection_key);
 
   /*
    * @brief Function is called on IGN_OFF, Master_reset or Factory_defaults
@@ -1244,7 +1244,7 @@ class ApplicationManagerImpl
    * @return unique aplication identifier.
    */
   std::string GetHashedAppID(uint32_t connection_key,
-							 const std::string& policy_app_id) const;
+                             const std::string& policy_app_id) const;
 
   /**
    * @brief Removes suspended and stopped timers from timer pool
@@ -1272,7 +1272,7 @@ class ApplicationManagerImpl
    * @return True on success, false on fail
    */
   bool StartNaviService(uint32_t app_id,
-						protocol_handler::ServiceType service_type);
+                        protocol_handler::ServiceType service_type);
 
   /**
    * @brief Stops specified navi service for application
@@ -1280,7 +1280,7 @@ class ApplicationManagerImpl
    * @param service_type Type of service to stop
    */
   void StopNaviService(uint32_t app_id,
-					   protocol_handler::ServiceType service_type);
+                       protocol_handler::ServiceType service_type);
 
   /**
    * @brief Allows streaming for application if it was disallowed by
@@ -1339,7 +1339,7 @@ class ApplicationManagerImpl
    * @param handle, Device handle
    */
   void RemoveAppsWaitingForRegistration(
-	  const connection_handler::DeviceHandle handle);
+      const connection_handler::DeviceHandle handle);
 
   void ClearTTSGlobalPropertiesList();
 

--- a/src/components/application_manager/include/application_manager/commands/hmi/sdl_activate_app_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/sdl_activate_app_request.h
@@ -45,7 +45,10 @@ namespace commands {
  **/
 class SDLActivateAppRequest : public RequestFromHMI {
  public:
-  typedef std::vector<application_manager::ApplicationSharedPtr> SDL4Apps;
+  /**
+   * @brief Applications registered over protocol v4
+   */
+  typedef std::vector<application_manager::ApplicationSharedPtr> V4ProtoApps;
 
   /**
    * @brief SDLActivateAppRequest class constructor
@@ -87,7 +90,8 @@ class SDLActivateAppRequest : public RequestFromHMI {
    * @param handle Device handle
    * @return List of applications registered over v4 protocol
    */
-  SDL4Apps get_sdl4_apps(const connection_handler::DeviceHandle handle) const;
+  V4ProtoApps get_v4_proto_apps(
+      const connection_handler::DeviceHandle handle) const;
 
   /**
    * @brief Get v4 protocol application reported as forgrounded on device

--- a/src/components/application_manager/include/application_manager/commands/hmi/sdl_activate_app_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/sdl_activate_app_request.h
@@ -40,13 +40,13 @@ namespace application_manager {
 
 namespace commands {
 
-typedef std::pair<ApplicationSharedPtr, std::vector<ApplicationSharedPtr> >
-    DevicesApps;
 /**
  * @brief SDLActivateAppRequest command class
  **/
 class SDLActivateAppRequest : public RequestFromHMI {
  public:
+  typedef std::vector<application_manager::ApplicationSharedPtr> SDL4Apps;
+
   /**
    * @brief SDLActivateAppRequest class constructor
    *
@@ -58,32 +58,45 @@ class SDLActivateAppRequest : public RequestFromHMI {
   /**
    * @brief SDLActivateAppRequest class destructor
    **/
-  virtual ~SDLActivateAppRequest();
+  ~SDLActivateAppRequest() OVERRIDE;
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() OVERRIDE;
 
   /**
    * @brief onTimeOut allows to process case when timeout has appeared
    * during request execution.
    */
-  virtual void onTimeOut();
+  void onTimeOut() OVERRIDE;
 
   /**
    * @brief on_event allows to handle events
    *
    * @param event event type that current request subscribed on.
    */
-  virtual void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) OVERRIDE;
 
  private:
   uint32_t app_id() const;
   uint32_t hmi_app_id(const smart_objects::SmartObject& so) const;
 
-  DevicesApps FindAllAppOnParticularDevice(
-      const connection_handler::DeviceHandle handle);
+  /**
+   * @brief Retrieves all v4 protocol applications for particular device
+   * @param handle Device handle
+   * @return List of applications registered over v4 protocol
+   */
+  SDL4Apps get_sdl4_apps(const connection_handler::DeviceHandle handle) const;
+
+  /**
+   * @brief Get v4 protocol application reported as forgrounded on device
+   * @param handle Device
+   * @return Pointer to application or empty pointer
+   */
+  ApplicationSharedPtr get_foreground_app(
+      const connection_handler::DeviceHandle handle) const;
+
   DISALLOW_COPY_AND_ASSIGN(SDLActivateAppRequest);
 };
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -834,6 +834,28 @@ void ApplicationManagerImpl::OnMessageReceived(
   messages_from_hmi_.PostMessage(impl::MessageFromHmi(message));
 }
 
+ApplicationConstSharedPtr
+ApplicationManagerImpl::app_to_be_registered(const uint32_t hmi_id) const {
+  AppsWaitRegistrationSet app_list = apps_waiting_for_registration().GetData();
+
+  AppsWaitRegistrationSet::const_iterator it_end = app_list.end();
+
+  HmiAppIdPredicate finder(hmi_id);
+  ApplicationSharedPtr result;
+  ApplicationSetConstIt it_app = std::find_if(app_list.begin(), it_end, finder);
+  if (it_app != it_end) {
+    result = *it_app;
+  }
+  return result;
+}
+
+DataAccessor<AppsWaitRegistrationSet>
+ApplicationManagerImpl::apps_waiting_for_registration() const {
+  return DataAccessor<AppsWaitRegistrationSet>(
+      apps_to_register_,
+      apps_to_register_list_lock_);
+}
+
 bool ApplicationManagerImpl::IsAppsQueriedFrom(
     const connection_handler::DeviceHandle handle) const {
   sync_primitives::AutoLock lock(apps_to_register_list_lock_);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -834,9 +834,9 @@ void ApplicationManagerImpl::OnMessageReceived(
   messages_from_hmi_.PostMessage(impl::MessageFromHmi(message));
 }
 
-ApplicationConstSharedPtr
-ApplicationManagerImpl::app_to_be_registered(const uint32_t hmi_id) const {
-  AppsWaitRegistrationSet app_list = apps_waiting_for_registration().GetData();
+ApplicationConstSharedPtr ApplicationManagerImpl::WaitingApplicationByID(
+    const uint32_t hmi_id) const {
+  AppsWaitRegistrationSet app_list = AppsWaitingForRegistration().GetData();
 
   AppsWaitRegistrationSet::const_iterator it_end = app_list.end();
 
@@ -850,10 +850,9 @@ ApplicationManagerImpl::app_to_be_registered(const uint32_t hmi_id) const {
 }
 
 DataAccessor<AppsWaitRegistrationSet>
-ApplicationManagerImpl::apps_waiting_for_registration() const {
-  return DataAccessor<AppsWaitRegistrationSet>(
-      apps_to_register_,
-      apps_to_register_list_lock_);
+ApplicationManagerImpl::AppsWaitingForRegistration() const {
+  return DataAccessor<AppsWaitRegistrationSet>(apps_to_register_,
+                                               apps_to_register_list_lock_);
 }
 
 bool ApplicationManagerImpl::IsAppsQueriedFrom(

--- a/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
@@ -56,24 +56,24 @@ struct ForegroundApp
                           bool> {
   bool operator()(
       const SDLActivateAppRequest::V4ProtoApps::value_type ptr) const {
-    return ptr.valid() ? ptr->is_foreground() : false;
+    return ptr ? ptr->is_foreground() : false;
   }
 };
 
 struct SendLaunchApp
     : std::unary_function<SDLActivateAppRequest::V4ProtoApps::value_type,
-                          bool> {
+                          void> {
   ApplicationConstSharedPtr app_to_launch_;
   ApplicationManager& application_manager_;
   SendLaunchApp(ApplicationConstSharedPtr app_to_launch, ApplicationManager& am)
       : app_to_launch_(app_to_launch), application_manager_(am) {}
-  bool operator()(
+  void operator()(
       const SDLActivateAppRequest::V4ProtoApps::value_type ptr) const {
     MessageHelper::SendLaunchApp((*ptr).app_id(),
                                  app_to_launch_->SchemaUrl(),
                                  app_to_launch_->PackageName(),
                                  application_manager_);
-    return true;
+    return;
   }
 };
 }
@@ -129,7 +129,7 @@ void SDLActivateAppRequest::Run() {
   ApplicationSharedPtr foreground_v4_app = get_foreground_app(device_handle);
   V4ProtoApps v4_proto_apps = get_v4_proto_apps(device_handle);
 
-  if (!foreground_v4_app.valid() && v4_proto_apps.empty()) {
+  if (!foreground_v4_app && v4_proto_apps.empty()) {
     LOG4CXX_ERROR(logger_,
                   "Can't find regular foreground app with the same "
                   "connection id:"
@@ -142,7 +142,7 @@ void SDLActivateAppRequest::Run() {
                 "Application is not registered yet. "
                 "Sending launch request.");
 
-  if (foreground_v4_app.valid()) {
+  if (foreground_v4_app) {
     LOG4CXX_DEBUG(logger_, "Sending request to foreground application.");
     MessageHelper::SendLaunchApp(foreground_v4_app->app_id(),
                                  app_to_activate->SchemaUrl(),

--- a/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
@@ -125,10 +125,10 @@ void SDLActivateAppRequest::Run() {
   }
 
   connection_handler::DeviceHandle device_handle = app_to_activate->device();
-  ApplicationSharedPtr foreground_sdl4_app = get_foreground_app(device_handle);
+  ApplicationSharedPtr foreground_v4_app = get_foreground_app(device_handle);
   V4ProtoApps v4_proto_apps = get_v4_proto_apps(device_handle);
 
-  if (!foreground_sdl4_app.valid() && v4_proto_apps.empty()) {
+  if (!foreground_v4_app.valid() && v4_proto_apps.empty()) {
     LOG4CXX_ERROR(logger_,
                   "Can't find regular foreground app with the same "
                   "connection id:"
@@ -141,9 +141,9 @@ void SDLActivateAppRequest::Run() {
                 "Application is not registered yet. "
                 "Sending launch request.");
 
-  if (foreground_sdl4_app.valid()) {
+  if (foreground_v4_app.valid()) {
     LOG4CXX_DEBUG(logger_, "Sending request to foreground application.");
-    MessageHelper::SendLaunchApp(foreground_sdl4_app->app_id(),
+    MessageHelper::SendLaunchApp(foreground_v4_app->app_id(),
                                  app_to_activate->SchemaUrl(),
                                  app_to_activate->PackageName(),
                                  application_manager_);

--- a/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
@@ -103,7 +103,8 @@ void SDLActivateAppRequest::Run() {
     // replaces it with connection_key only for normally registered apps, but
     // for apps_to_be_registered (waiting) it keeps original value (hmi_app_id)
     // so method does lookup for hmi_app_id
-    app_to_activate = application_manager_.app_to_be_registered(application_id);
+    app_to_activate =
+        application_manager_.WaitingApplicationByID(application_id);
 
     if (!app_to_activate) {
       LOG4CXX_WARN(

--- a/src/components/application_manager/test/include/application_manager/mock_application_manager.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application_manager.h
@@ -234,10 +234,10 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD0(IsAnyAppSubscribedForWayPoints, bool());
   MOCK_CONST_METHOD0(GetAppsSubscribedForWayPoints, const std::set<int32_t>());
   MOCK_CONST_METHOD1(
-      app_to_be_registered,
+      WaitingApplicationByID,
       application_manager::ApplicationConstSharedPtr(const uint32_t));
   MOCK_CONST_METHOD0(
-      apps_waiting_for_registration,
+      AppsWaitingForRegistration,
       DataAccessor<application_manager::AppsWaitRegistrationSet>());
 };
 

--- a/src/components/application_manager/test/include/application_manager/mock_application_manager.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application_manager.h
@@ -233,6 +233,12 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD1(UnsubscribeAppFromWayPoints, void(const uint32_t));
   MOCK_CONST_METHOD0(IsAnyAppSubscribedForWayPoints, bool());
   MOCK_CONST_METHOD0(GetAppsSubscribedForWayPoints, const std::set<int32_t>());
+  MOCK_CONST_METHOD1(
+      app_to_be_registered,
+      application_manager::ApplicationConstSharedPtr(const uint32_t));
+  MOCK_CONST_METHOD0(
+      apps_waiting_for_registration,
+      DataAccessor<application_manager::AppsWaitRegistrationSet>());
 };
 
 }  // namespace application_manager_test


### PR DESCRIPTION
On invoking of SDL.ActivateApp SDL has to search through the registered
and to-be-regisetered apps in order to find necessary app to launch.
In case of registered app SDL has just to start it.
In case of to-be-registered app SDL has to send LAUNCH_APP request via
foregrounded SDL4.0-enabled application. If there is no such app - request
has to be sent via all registered SDL4.0-enabled application on the same
device as application requested to be launched.