### PR TITLE
Fix_core_dump_due_to_connection_been_created_twice

### DIFF
--- a/src/components/transport_manager/src/tcp/tcp_connection_factory.cc
+++ b/src/components/transport_manager/src/tcp/tcp_connection_factory.cc
@@ -57,7 +57,6 @@ TransportAdapter::Error TcpConnectionFactory::CreateConnection(
   TcpServerOiginatedSocketConnection* connection(
       new TcpServerOiginatedSocketConnection(
           device_uid, app_handle, controller_));
-  controller_->ConnectionCreated(connection, device_uid, app_handle);
   if (connection->Start() == TransportAdapter::OK) {
     LOG4CXX_DEBUG(logger_, "TCP connection initialised");
     return TransportAdapter::OK;

--- a/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
+++ b/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
@@ -162,7 +162,7 @@ TransportAdapter::Error ThreadedSocketConnection::Disconnect() {
 
 void ThreadedSocketConnection::threadMain() {
   LOG4CXX_AUTO_TRACE(logger_);
-  controller_->ConnectionCreated(this, device_uid_, app_handle_);
+  controller_->ConnectionCreated(this, device_handle(), application_handle());
   ConnectError* connect_error = NULL;
   if (!Establish(&connect_error)) {
     LOG4CXX_ERROR(logger_, "Connection Establish failed");

--- a/src/components/transport_manager/test/CMakeLists.txt
+++ b/src/components/transport_manager/test/CMakeLists.txt
@@ -62,15 +62,16 @@ if (BUILD_BT_SUPPORT)
 endif()
 
 set(SOURCES
-  ${TM_TEST_DIR}/transport_manager_default_test.cc
   ${TM_TEST_DIR}/transport_manager_impl_test.cc
   ${TM_TEST_DIR}/transport_adapter_test.cc
   ${TM_TEST_DIR}/transport_adapter_listener_test.cc
   ${TM_TEST_DIR}/tcp_transport_adapter_test.cc
   ${TM_TEST_DIR}/tcp_device_test.cc
   ${TM_TEST_DIR}/tcp_client_listener_test.cc
+  ${TM_TEST_DIR}/transport_manager_default_test.cc
 )
 
 create_test("transport_manager_test" "${SOURCES}" "${LIBRARIES}")
 file(COPY smartDeviceLink_test.ini DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY app_info_storage2 DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 endif()

--- a/src/components/transport_manager/test/app_info_storage2
+++ b/src/components/transport_manager/test/app_info_storage2
@@ -1,0 +1,99 @@
+{
+   "TransportManager" : {
+      "BluetoothAdapter" : null,
+      "TcpAdapter" : {
+         "devices" : [
+            {
+               "address" : "57.48.0.1",
+               "applications" : [
+                  {
+                     "port" : "12345"
+                  }
+               ],
+               "name" : "unique_device_name0"
+            },
+            {
+               "address" : "57.48.0.2",
+               "applications" : [
+                  {
+                     "port" : "12345"
+                  }
+               ],
+               "name" : "unique_device_name1"
+            },
+            {
+               "address" : "57.48.0.3",
+               "applications" : [
+                  {
+                     "port" : "12345"
+                  }
+               ],
+               "name" : "unique_device_name2"
+            },
+            {
+               "address" : "57.48.0.4",
+               "applications" : [
+                  {
+                     "port" : "12345"
+                  }
+               ],
+               "name" : "unique_device_name3"
+            },
+            {
+               "address" : "57.48.0.5",
+               "applications" : [
+                  {
+                     "port" : "12345"
+                  }
+               ],
+               "name" : "unique_device_name4"
+            },
+            {
+               "address" : "57.48.0.6",
+               "applications" : [
+                  {
+                     "port" : "12345"
+                  }
+               ],
+               "name" : "unique_device_name5"
+            },
+            {
+               "address" : "57.48.0.7",
+               "applications" : [
+                  {
+                     "port" : "12345"
+                  }
+               ],
+               "name" : "unique_device_name6"
+            },
+            {
+               "address" : "57.48.0.8",
+               "applications" : [
+                  {
+                     "port" : "12345"
+                  }
+               ],
+               "name" : "unique_device_name7"
+            },
+            {
+               "address" : "57.48.0.9",
+               "applications" : [
+                  {
+                     "port" : "12345"
+                  }
+               ],
+               "name" : "unique_device_name8"
+            },
+            {
+               "address" : "57.48.0.10",
+               "applications" : [
+                  {
+                     "port" : "12345"
+                  }
+               ],
+               "name" : "unique_device_name9"
+            }
+         ]
+      }
+   }
+}

--- a/src/components/transport_manager/test/transport_manager_default_test.cc
+++ b/src/components/transport_manager/test/transport_manager_default_test.cc
@@ -41,11 +41,12 @@ namespace components {
 namespace transport_manager_test {
 
 using ::testing::Return;
+
 TEST(TestTransportManagerDefault, Init_LastStateNotUsed) {
   MockTransportManagerSettings transport_manager_settings;
   transport_manager::TransportManagerDefault transport_manager(
       transport_manager_settings);
-  resumption::LastState last_state("app_storage_folder", "app_info_storage");
+  resumption::LastState last_state("app_storage_folder", "app_info_storage2");
 
   EXPECT_CALL(transport_manager_settings, use_last_state())
       .WillRepeatedly(Return(false));
@@ -54,18 +55,19 @@ TEST(TestTransportManagerDefault, Init_LastStateNotUsed) {
   transport_manager.Init(last_state);
 }
 
-// TODO(VVeremjova) APPLINK-22021
-TEST(TestTransportManagerDefault, DISABLED_Init_LastStateUsed) {
+TEST(TestTransportManagerDefault, Init_LastStateUsed) {
   MockTransportManagerSettings transport_manager_settings;
   transport_manager::TransportManagerDefault transport_manager(
       transport_manager_settings);
-  resumption::LastState last_state("app_storage_folder", "app_info_storage");
+  resumption::LastState last_state("app_storage_folder", "app_info_storage2");
 
   EXPECT_CALL(transport_manager_settings, use_last_state())
       .WillRepeatedly(Return(true));
   EXPECT_CALL(transport_manager_settings, transport_manager_tcp_adapter_port())
       .WillRepeatedly(Return(1u));
+
   transport_manager.Init(last_state);
+  transport_manager.Stop();
 }
 
 }  // namespace transport_manager_test


### PR DESCRIPTION
The reason for the core dump, is that ConnectionCreated() is
been called twice, from parent and child threads while the
transport_adapter is restoring the last state.
First is called in tcp_connection_factory.cc then in
threaded_socket_connection.cc from the child threadMain() with
connection->Start().

Related-issues:
APPLINK-25379, APPLINK-22021