### PR TITLE
Fix WARNINGS response when AppHMIType received

### DIFF
--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -89,11 +89,8 @@ std::string AppHMITypeToString(mobile_apis::AppHMIType::eType type) {
 
   std::map<mobile_apis::AppHMIType::eType, std::string>::const_iterator iter =
       appHMITypeMap.find(type);
-  if (appHMITypeMap.end() == iter) {
-    return "";
-  } else {
-    return iter->second;
-  }
+  
+  return appHMITypeMap.end() == iter ? iter->second : std::string("");
 }
 
 struct AppHMITypeInserter {

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -36,7 +36,6 @@
 #include <unistd.h>
 #include <algorithm>
 #include <map>
-#include <stdexcept>
 #include <string.h>
 
 #include "application_manager/application_manager_impl.h"
@@ -87,11 +86,13 @@ std::string AppHMITypeToString(mobile_apis::AppHMIType::eType type) {
     {mobile_apis::AppHMIType::TESTING, "TESTING"},
     {mobile_apis::AppHMIType::SYSTEM, "SYSTEM"}
   };
-  try {
-    return appHMITypeMap.at(type);
-  }
-  catch (const std::out_of_range &ex) {
+
+  std::map<mobile_apis::AppHMIType::eType, std::string>::const_iterator iter =
+      appHMITypeMap.find(type);
+  if (appHMITypeMap.end() == iter) {
     return "";
+  } else {
+    return iter->second;
   }
 }
 
@@ -116,7 +117,8 @@ struct CheckMissedTypes {
       : policy_app_types_(policy_app_types), log_(log) {}
 
   bool operator()(const smart_objects::SmartArray::value_type &value) {
-    std::string app_type_str = AppHMITypeToString(static_cast<mobile_apis::AppHMIType::eType>(value.asInt()));
+    std::string app_type_str = AppHMITypeToString(
+        static_cast<mobile_apis::AppHMIType::eType>(value.asInt()));
     if (!app_type_str.empty()) {
       policy::StringArray::const_iterator it = policy_app_types_.begin();
       policy::StringArray::const_iterator it_end = policy_app_types_.end();

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -72,6 +72,32 @@ mobile_apis::AppHMIType::eType StringToAppHMIType(const std::string &str) {
   }
 }
 
+std::string AppHMITypeToString(mobile_apis::AppHMIType::eType type) {
+  if (mobile_apis::AppHMIType::DEFAULT == type) {
+    return "DEFAULT";
+  } else if (mobile_apis::AppHMIType::COMMUNICATION == type) {
+    return "COMMUNICATION";
+  } else if (mobile_apis::AppHMIType::MEDIA == type) {
+    return "MEDIA";
+  } else if (mobile_apis::AppHMIType::MESSAGING == type) {
+    return "MESSAGING";
+  } else if (mobile_apis::AppHMIType::NAVIGATION == type) {
+    return "NAVIGATION";
+  } else if (mobile_apis::AppHMIType::INFORMATION == type) {
+    return "INFORMATION";
+  } else if (mobile_apis::AppHMIType::SOCIAL == type) {
+    return "SOCIAL";
+  } else if (mobile_apis::AppHMIType::BACKGROUND_PROCESS == type) {
+    return "BACKGROUND_PROCESS";
+  } else if (mobile_apis::AppHMIType::TESTING == type) {
+    return "TESTING";
+  } else if (mobile_apis::AppHMIType::SYSTEM == type) {
+    return "SYSTEM";
+  } else {
+    return NULL;
+  }
+}
+
 struct AppHMITypeInserter {
   AppHMITypeInserter(smart_objects::SmartObject &so_array)
       : index_(0), so_array_(so_array) {}
@@ -93,7 +119,7 @@ struct CheckMissedTypes {
       : policy_app_types_(policy_app_types), log_(log) {}
 
   bool operator()(const smart_objects::SmartArray::value_type &value) {
-    std::string app_type_str = value.asString();
+    std::string app_type_str = AppHMITypeToString((mobile_apis::AppHMIType::eType)value.asUInt());
     policy::StringArray::const_iterator it = policy_app_types_.begin();
     policy::StringArray::const_iterator it_end = policy_app_types_.end();
     for (; it != it_end; ++it) {

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -36,6 +36,7 @@
 #include <unistd.h>
 #include <algorithm>
 #include <map>
+#include <stdexcept>
 #include <string.h>
 
 #include "application_manager/application_manager_impl.h"
@@ -89,7 +90,7 @@ std::string AppHMITypeToString(mobile_apis::AppHMIType::eType type) {
   try {
     return appHMITypeMap.at(type);
   }
-  catch (const std::out_of_range ex) {
+  catch (const std::out_of_range &ex) {
     return "";
   }
 }

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -73,28 +73,20 @@ mobile_apis::AppHMIType::eType StringToAppHMIType(const std::string &str) {
 }
 
 std::string AppHMITypeToString(mobile_apis::AppHMIType::eType type) {
-  if (mobile_apis::AppHMIType::DEFAULT == type) {
-    return "DEFAULT";
-  } else if (mobile_apis::AppHMIType::COMMUNICATION == type) {
-    return "COMMUNICATION";
-  } else if (mobile_apis::AppHMIType::MEDIA == type) {
-    return "MEDIA";
-  } else if (mobile_apis::AppHMIType::MESSAGING == type) {
-    return "MESSAGING";
-  } else if (mobile_apis::AppHMIType::NAVIGATION == type) {
-    return "NAVIGATION";
-  } else if (mobile_apis::AppHMIType::INFORMATION == type) {
-    return "INFORMATION";
-  } else if (mobile_apis::AppHMIType::SOCIAL == type) {
-    return "SOCIAL";
-  } else if (mobile_apis::AppHMIType::BACKGROUND_PROCESS == type) {
-    return "BACKGROUND_PROCESS";
-  } else if (mobile_apis::AppHMIType::TESTING == type) {
-    return "TESTING";
-  } else if (mobile_apis::AppHMIType::SYSTEM == type) {
-    return "SYSTEM";
-  } else {
-    return NULL;
+  switch(type) {
+    case mobile_apis::AppHMIType::DEFAULT:            return "DEFAULT";
+    case mobile_apis::AppHMIType::COMMUNICATION:      return "COMMUNICATION";
+    case mobile_apis::AppHMIType::MEDIA:              return "MEDIA";
+    case mobile_apis::AppHMIType::MESSAGING:          return "MESSAGING";
+    case mobile_apis::AppHMIType::NAVIGATION:         return "NAVIGATION";
+    case mobile_apis::AppHMIType::INFORMATION:        return "INFORMATION";
+    case mobile_apis::AppHMIType::SOCIAL:             return "SOCIAL";
+    case mobile_apis::AppHMIType::BACKGROUND_PROCESS: return "BACKGROUND_PROCESS";
+    case mobile_apis::AppHMIType::TESTING:            return "TESTING";
+    case mobile_apis::AppHMIType::SYSTEM:             return "SYSTEM";
+    default:
+      NOTREACHED();
+      return NULL;
   }
 }
 
@@ -119,7 +111,7 @@ struct CheckMissedTypes {
       : policy_app_types_(policy_app_types), log_(log) {}
 
   bool operator()(const smart_objects::SmartArray::value_type &value) {
-    std::string app_type_str = AppHMITypeToString((mobile_apis::AppHMIType::eType)value.asUInt());
+    std::string app_type_str = AppHMITypeToString(static_cast<mobile_apis::AppHMIType::eType>(value.asInt()));
     policy::StringArray::const_iterator it = policy_app_types_.begin();
     policy::StringArray::const_iterator it_end = policy_app_types_.end();
     for (; it != it_end; ++it) {

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -35,6 +35,7 @@
 
 #include <unistd.h>
 #include <algorithm>
+#include <map>
 #include <string.h>
 
 #include "application_manager/application_manager_impl.h"
@@ -73,20 +74,23 @@ mobile_apis::AppHMIType::eType StringToAppHMIType(const std::string &str) {
 }
 
 std::string AppHMITypeToString(mobile_apis::AppHMIType::eType type) {
-  switch(type) {
-    case mobile_apis::AppHMIType::DEFAULT:            return "DEFAULT";
-    case mobile_apis::AppHMIType::COMMUNICATION:      return "COMMUNICATION";
-    case mobile_apis::AppHMIType::MEDIA:              return "MEDIA";
-    case mobile_apis::AppHMIType::MESSAGING:          return "MESSAGING";
-    case mobile_apis::AppHMIType::NAVIGATION:         return "NAVIGATION";
-    case mobile_apis::AppHMIType::INFORMATION:        return "INFORMATION";
-    case mobile_apis::AppHMIType::SOCIAL:             return "SOCIAL";
-    case mobile_apis::AppHMIType::BACKGROUND_PROCESS: return "BACKGROUND_PROCESS";
-    case mobile_apis::AppHMIType::TESTING:            return "TESTING";
-    case mobile_apis::AppHMIType::SYSTEM:             return "SYSTEM";
-    default:
-      NOTREACHED();
-      return NULL;
+  const std::map<mobile_apis::AppHMIType::eType, std::string> appHMITypeMap = {
+    {mobile_apis::AppHMIType::DEFAULT, "DEFAULT"},
+    {mobile_apis::AppHMIType::COMMUNICATION, "COMMUNICATION"},
+    {mobile_apis::AppHMIType::MEDIA, "MEDIA"},
+    {mobile_apis::AppHMIType::MESSAGING, "MESSAGING"},
+    {mobile_apis::AppHMIType::NAVIGATION, "NAVIGATION"},
+    {mobile_apis::AppHMIType::INFORMATION, "INFORMATION"},
+    {mobile_apis::AppHMIType::SOCIAL, "SOCIAL"},
+    {mobile_apis::AppHMIType::BACKGROUND_PROCESS, "BACKGROUND_PROCESS"},
+    {mobile_apis::AppHMIType::TESTING, "TESTING"},
+    {mobile_apis::AppHMIType::SYSTEM, "SYSTEM"}
+  };
+  try {
+    return appHMITypeMap.at(type);
+  }
+  catch (const std::out_of_range ex) {
+    return "";
   }
 }
 
@@ -112,11 +116,13 @@ struct CheckMissedTypes {
 
   bool operator()(const smart_objects::SmartArray::value_type &value) {
     std::string app_type_str = AppHMITypeToString(static_cast<mobile_apis::AppHMIType::eType>(value.asInt()));
-    policy::StringArray::const_iterator it = policy_app_types_.begin();
-    policy::StringArray::const_iterator it_end = policy_app_types_.end();
-    for (; it != it_end; ++it) {
-      if (app_type_str == *it) {
-        return true;
+    if (!app_type_str.empty()) {
+      policy::StringArray::const_iterator it = policy_app_types_.begin();
+      policy::StringArray::const_iterator it_end = policy_app_types_.end();
+      for (; it != it_end; ++it) {
+        if (app_type_str == *it) {
+          return true;
+        }
       }
     }
 

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -74,7 +74,7 @@ mobile_apis::AppHMIType::eType StringToAppHMIType(const std::string &str) {
 }
 
 std::string AppHMITypeToString(mobile_apis::AppHMIType::eType type) {
-  const std::map<mobile_apis::AppHMIType::eType, std::string> appHMITypeMap = {
+  const std::map<mobile_apis::AppHMIType::eType, std::string> app_hmi_type_map = {
     {mobile_apis::AppHMIType::DEFAULT, "DEFAULT"},
     {mobile_apis::AppHMIType::COMMUNICATION, "COMMUNICATION"},
     {mobile_apis::AppHMIType::MEDIA, "MEDIA"},
@@ -88,9 +88,9 @@ std::string AppHMITypeToString(mobile_apis::AppHMIType::eType type) {
   };
 
   std::map<mobile_apis::AppHMIType::eType, std::string>::const_iterator iter =
-      appHMITypeMap.find(type);
-  
-  return appHMITypeMap.end() == iter ? iter->second : std::string("");
+      app_hmi_type_map.find(type);
+
+  return app_hmi_type_map.end() == iter ? iter->second : std::string("");
 }
 
 struct AppHMITypeInserter {


### PR DESCRIPTION
When comparing the lists of AppHMITypes from the policy table and RegisterAppInterface message, the values are mistakenly read from the message object as strings when they are actually in enum form, resulting in a warning even if both lists include the same AppHMIType. 

This PR changes this so that the enum values are converted to strings when comparing the two lists, so that they are compared correctly.

Fixes #647 