### PR TITLE
Cover UnregisterAppInterface and UnsubscribeButton (request/response) by Unit Tests

### DIFF
--- a/src/components/application_manager/src/commands/mobile/unsubscribe_button_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_button_request.cc
@@ -60,22 +60,16 @@ void UnsubscribeButtonRequest::Run() {
   const uint32_t btn_id =
       (*message_)[str::msg_params][str::button_name].asUInt();
 
-  if (!app->IsSubscribedToButton(
+  if (!app->UnsubscribeFromButton(
           static_cast<mobile_apis::ButtonName::eType>(btn_id))) {
-    SDL_ERROR("App doesn't subscibe to button " << btn_id);
+    SDL_ERROR("App is not subscribed to button " << btn_id);
     SendResponse(false, mobile_apis::Result::IGNORED);
     return;
   }
 
-  app->UnsubscribeFromButton(
-      static_cast<mobile_apis::ButtonName::eType>(btn_id));
-
   SendUnsubscribeButtonNotification();
-  const bool is_succedeed = true;
-  SendResponse(is_succedeed, mobile_apis::Result::SUCCESS);
-  if (is_succedeed) {
-    app->UpdateHash();
-  }
+  SendResponse(true, mobile_apis::Result::SUCCESS);
+  app->UpdateHash();
 }
 
 void UnsubscribeButtonRequest::SendUnsubscribeButtonNotification() {

--- a/src/components/application_manager/test/commands/mobile/simple_response_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/simple_response_commands_test.cc
@@ -49,16 +49,20 @@
 #include "mobile/end_audio_pass_thru_response.h"
 #include "mobile/get_dtcs_response.h"
 #include "mobile/get_vehicle_data_response.h"
+#include "mobile/unregister_app_interface_response.h"
+#include "mobile/unsubscribe_button_response.h"
 
 namespace test {
 namespace components {
 namespace commands_test {
 namespace mobile_commands_test {
 
+namespace commands = ::application_manager::commands;
+
 using ::testing::_;
 using ::testing::NotNull;
 using ::testing::Types;
-namespace commands = ::application_manager::commands;
+
 using commands::MessageSharedPtr;
 
 template <class Command>
@@ -79,7 +83,9 @@ typedef Types<commands::ListFilesResponse,
               commands::DialNumberResponse,
               commands::EndAudioPassThruResponse,
               commands::GetDTCsResponse,
-              commands::GetVehicleDataResponse> ResponseCommandsList;
+              commands::GetVehicleDataResponse,
+              commands::UnregisterAppInterfaceResponse,
+              commands::UnsubscribeButtonResponse> ResponseCommandsList;
 TYPED_TEST_CASE(MobileResponseCommandsTest, ResponseCommandsList);
 
 TYPED_TEST(MobileResponseCommandsTest, Run_SendResponseToMobile_SUCCESS) {

--- a/src/components/application_manager/test/commands/mobile/unregister_app_interface_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unregister_app_interface_request_test.cc
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_message_helper.h"
+#include "mobile/unregister_app_interface_request.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+namespace am = ::application_manager;
+namespace mobile_result = mobile_apis::Result;
+
+using ::testing::_;
+
+using am::commands::UnregisterAppInterfaceRequest;
+using am::commands::MessageSharedPtr;
+
+typedef ::utils::SharedPtr<UnregisterAppInterfaceRequest> CommandPtr;
+
+class UnregisterAppInterfaceRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(UnregisterAppInterfaceRequestTest, Run_AppNotRegistered_UNSUCCESS) {
+  CommandPtr command(CreateCommand<UnregisterAppInterfaceRequest>());
+
+  EXPECT_CALL(app_mngr_, application(_))
+      .WillOnce(Return(ApplicationSharedPtr()));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(
+          MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
+
+  command->Run();
+}
+
+TEST_F(UnregisterAppInterfaceRequestTest, Run_SUCCESS) {
+  const uint32_t kConnectionKey = 1u;
+
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  CommandPtr command(CreateCommand<UnregisterAppInterfaceRequest>(command_msg));
+
+  MockAppPtr mock_app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
+
+  const mobile_apis::AppInterfaceUnregisteredReason::eType kUnregisterReason =
+      mobile_apis::AppInterfaceUnregisteredReason::INVALID_ENUM;
+
+  MessageSharedPtr dummy_msg(CreateMessage());
+  EXPECT_CALL(*am::MockMessageHelper::message_helper_mock(),
+              GetOnAppInterfaceUnregisteredNotificationToMobile(
+                  kConnectionKey, kUnregisterReason))
+      .WillOnce(Return(dummy_msg));
+  {
+    ::testing::InSequence sequence;
+
+    EXPECT_CALL(app_mngr_, ManageMobileCommand(dummy_msg, _));
+
+    EXPECT_CALL(app_mngr_,
+                UnregisterApplication(
+                    kConnectionKey, mobile_apis::Result::SUCCESS, _, _));
+
+    EXPECT_CALL(app_mngr_,
+                ManageMobileCommand(
+                    MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
+  }
+
+  command->Run();
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/unsubscribe_button_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unsubscribe_button_request_test.cc
@@ -1,0 +1,103 @@
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_message_helper.h"
+#include "mobile/unsubscribe_button_request.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+namespace am = ::application_manager;
+namespace mobile_result = mobile_apis::Result;
+
+using ::testing::_;
+
+using am::commands::UnsubscribeButtonRequest;
+using am::commands::MessageSharedPtr;
+
+typedef ::utils::SharedPtr<UnsubscribeButtonRequest> CommandPtr;
+
+namespace {
+const uint32_t kConnectionKey = 1u;
+const mobile_apis::ButtonName::eType kButtonId = mobile_apis::ButtonName::OK;
+}  // namespace
+
+class UnsubscribeButtonRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(UnsubscribeButtonRequestTest, Run_AppNotRegistered_UNSUCCESS) {
+  CommandPtr command(CreateCommand<UnsubscribeButtonRequest>());
+
+  EXPECT_CALL(app_mngr_, application(_))
+      .WillOnce(Return(ApplicationSharedPtr()));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(
+          MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
+
+  command->Run();
+}
+
+TEST_F(UnsubscribeButtonRequestTest,
+       Run_UnsubscribeNotSubscribedButton_UNSUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*command_msg)[am::strings::msg_params][am::strings::button_name] = kButtonId;
+
+  CommandPtr command(CreateCommand<UnsubscribeButtonRequest>(command_msg));
+
+  MockAppPtr mock_app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
+
+  EXPECT_CALL(*mock_app, UnsubscribeFromButton(kButtonId))
+      .WillOnce(Return(false));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::IGNORED), _));
+
+  command->Run();
+}
+
+TEST_F(UnsubscribeButtonRequestTest, Run_SUCCESS) {
+  const mobile_apis::ButtonName::eType kButtonId = mobile_apis::ButtonName::OK;
+
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*command_msg)[am::strings::msg_params][am::strings::button_name] = kButtonId;
+
+  CommandPtr command(CreateCommand<UnsubscribeButtonRequest>(command_msg));
+
+  MockAppPtr mock_app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
+
+  EXPECT_CALL(*mock_app, UnsubscribeFromButton(kButtonId))
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::Buttons_OnButtonSubscription)));
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
+
+  EXPECT_CALL(*mock_app, UpdateHash());
+
+  command->Run();
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test


### PR DESCRIPTION
Has been done:
- Covered next commands:
  - `UnregisterAppInterfaceRequest`;
  - `UnregisterAppInterfaceResponse`;
  - `UnsubscribeButtonRequest`;
  - `UnsubscribeButtonResponse`;
- Removed redundant check form
  `UnsubscribeButtonRequest::Run()` method.

Related to: [APPLINK-26530](https://adc.luxoft.com/jira/browse/APPLINK-26530)

@AByzhynar, @okozlovlux, @Kozoriz, @LuxoftAKutsan, @vlantonov, @VVeremjova, please review.