### PR TITLE
Fix UT to use thread start()/join() correctly

### DIFF
--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -95,7 +95,7 @@ void RequestController::DestroyThreadpool() {
   }
   for (size_t i = 0; i < pool_.size(); i++) {
     threads::Thread* thread = pool_[i];
-    thread->join();
+    thread->join(threads::Thread::kForceStop);
     delete thread->delegate();
     threads::DeleteThread(thread);
   }

--- a/src/components/connection_handler/src/connection.cc
+++ b/src/components/connection_handler/src/connection.cc
@@ -93,7 +93,7 @@ Connection::Connection(ConnectionHandle connection_handle,
 
 Connection::~Connection() {
   SDL_AUTO_TRACE();
-  heart_beat_monitor_thread_->join();
+  heart_beat_monitor_thread_->join(threads::Thread::kForceStop);
   delete heartbeat_monitor_;
   threads::DeleteThread(heart_beat_monitor_thread_);
   sync_primitives::AutoLock lock(session_map_lock_);

--- a/src/components/hmi_message_handler/src/mqueue_adapter.cc
+++ b/src/components/hmi_message_handler/src/mqueue_adapter.cc
@@ -104,7 +104,7 @@ MqueueAdapter::MqueueAdapter(HMIMessageHandler* hmi_message_handler)
 }
 
 MqueueAdapter::~MqueueAdapter() {
-  receiver_thread_->join();
+  receiver_thread_->join(threads::Thread::kForceStop);
   delete receiver_thread_delegate_;
   threads::DeleteThread(receiver_thread_);
   if (-1 != hmi_to_sdl_mqueue_)

--- a/src/components/include/utils/threads/message_loop_thread.h
+++ b/src/components/include/utils/threads/message_loop_thread.h
@@ -158,7 +158,7 @@ void MessageLoopThread<Q>::PostMessage(const Message& message) {
 
 template <class Q>
 void MessageLoopThread<Q>::Shutdown() {
-  thread_->join();
+  thread_->join(threads::Thread::kForceStop);
 }
 
 template <class Q>

--- a/src/components/media_manager/src/audio/from_mic_recorder_adapter.cc
+++ b/src/components/media_manager/src/audio/from_mic_recorder_adapter.cc
@@ -49,7 +49,7 @@ FromMicRecorderAdapter::FromMicRecorderAdapter()
 FromMicRecorderAdapter::~FromMicRecorderAdapter() {
   SDL_AUTO_TRACE();
   if (recorder_thread_) {
-    recorder_thread_->join();
+    recorder_thread_->join(threads::Thread::kForceStop);
     delete recorder_thread_->delegate();
     threads::DeleteThread(recorder_thread_);
   }
@@ -83,7 +83,7 @@ void FromMicRecorderAdapter::StopActivity(int32_t application_key) {
   }
 
   if (recorder_thread_) {
-    recorder_thread_->join();
+    recorder_thread_->join(threads::Thread::kForceStop);
     delete recorder_thread_->delegate();
     threads::DeleteThread(recorder_thread_);
     recorder_thread_ = NULL;

--- a/src/components/media_manager/src/audio/from_mic_recorder_listener.cc
+++ b/src/components/media_manager/src/audio/from_mic_recorder_listener.cc
@@ -47,7 +47,7 @@ FromMicRecorderListener::FromMicRecorderListener(
 FromMicRecorderListener::~FromMicRecorderListener() {
   SDL_AUTO_TRACE();
   if (reader_) {
-    reader_->join();
+    reader_->join(threads::Thread::kForceStop);
     delete reader_->delegate();
     threads::DeleteThread(reader_);
   }
@@ -83,7 +83,7 @@ void FromMicRecorderListener::OnActivityEnded(int32_t application_key) {
     return;
   }
   if (reader_) {
-    reader_->join();
+    reader_->join(threads::Thread::kForceStop);
     delete reader_->delegate();
     threads::DeleteThread(reader_);
     reader_ = NULL;

--- a/src/components/media_manager/src/streamer_adapter.cc
+++ b/src/components/media_manager/src/streamer_adapter.cc
@@ -44,7 +44,7 @@ StreamerAdapter::StreamerAdapter(Streamer* const streamer)
 }
 
 StreamerAdapter::~StreamerAdapter() {
-  thread_->join();
+  thread_->join(threads::Thread::kForceStop);
   threads::DeleteThread(thread_);
   delete streamer_;
 }

--- a/src/components/policy/src/cache_manager.cc
+++ b/src/components/policy/src/cache_manager.cc
@@ -101,7 +101,7 @@ CacheManager::CacheManager(const std::string& app_storage_folder,
 CacheManager::~CacheManager() {
   SDL_AUTO_TRACE();
   sync_primitives::AutoLock lock(backuper_locker_);
-  backup_thread_->join();
+  backup_thread_->join(threads::Thread::kForceStop);
   delete backup_thread_->delegate();
   threads::DeleteThread(backup_thread_);
 }

--- a/src/components/policy/src/update_status_manager.cc
+++ b/src/components/policy/src/update_status_manager.cc
@@ -56,7 +56,7 @@ UpdateStatusManager::~UpdateStatusManager() {
   SDL_AUTO_TRACE();
   DCHECK(update_status_thread_delegate_);
   DCHECK(thread_);
-  thread_->join();
+  thread_->join(threads::Thread::kForceStop);
   delete update_status_thread_delegate_;
   threads::DeleteThread(thread_);
 }

--- a/src/components/telemetry_monitor/src/telemetry_monitor.cc
+++ b/src/components/telemetry_monitor/src/telemetry_monitor.cc
@@ -110,7 +110,7 @@ void TelemetryMonitor::Stop() {
   SDL_AUTO_TRACE();
   if (thread_) {
     thread_->stop();
-    thread_->join();
+    thread_->join(threads::Thread::kForceStop);
     threads::DeleteThread(thread_);
   }
   thread_ = NULL;

--- a/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner_posix.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner_posix.cc
@@ -137,7 +137,7 @@ BluetoothDeviceScanner::BluetoothDeviceScanner(
 }
 
 BluetoothDeviceScanner::~BluetoothDeviceScanner() {
-  thread_->join();
+  thread_->join(threads::Thread::kForceStop);
   delete thread_->delegate();
   threads::DeleteThread(thread_);
 }

--- a/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner_win.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner_win.cc
@@ -97,7 +97,7 @@ BluetoothDeviceScanner::BluetoothDeviceScanner(
 }
 
 BluetoothDeviceScanner::~BluetoothDeviceScanner() {
-  thread_->join();
+  thread_->join(threads::Thread::kForceStop);
   delete thread_->delegate();
   threads::DeleteThread(thread_);
 }

--- a/src/components/transport_manager/src/bluetooth/bluetooth_socket_connection_posix.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_socket_connection_posix.cc
@@ -95,7 +95,7 @@ BluetoothSocketConnection::BluetoothSocketConnection(
 BluetoothSocketConnection::~BluetoothSocketConnection() {
   SDL_AUTO_TRACE();
   Disconnect();
-  thread_->join();
+  thread_->join(threads::Thread::kForceStop);
   delete thread_->delegate();
   threads::DeleteThread(thread_);
 }

--- a/src/components/transport_manager/src/bluetooth/bluetooth_socket_connection_win.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_socket_connection_win.cc
@@ -93,7 +93,7 @@ BluetoothSocketConnection::BluetoothSocketConnection(
 BluetoothSocketConnection::~BluetoothSocketConnection() {
   SDL_AUTO_TRACE();
   Disconnect();
-  thread_->join();
+  thread_->join(threads::Thread::kForceStop);
   delete thread_->delegate();
   threads::DeleteThread(thread_);
 }

--- a/src/components/transport_manager/src/tcp/tcp_client_listener.cc
+++ b/src/components/transport_manager/src/tcp/tcp_client_listener.cc
@@ -182,7 +182,7 @@ TransportAdapter::Error TcpClientListener::StopListening() {
     return TransportAdapter::BAD_STATE;
   }
 
-  thread_->join();
+  thread_->join(threads::Thread::kForceStop);
 
   SDL_INFO("Tcp client listener has stopped successfully");
   return TransportAdapter::OK;

--- a/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
+++ b/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
@@ -65,7 +65,7 @@ ThreadedSocketConnection::ThreadedSocketConnection(
 ThreadedSocketConnection::~ThreadedSocketConnection() {
   SDL_AUTO_TRACE();
   Disconnect();
-  thread_->join();
+  thread_->join(threads::Thread::kForceStop);
   delete thread_->delegate();
   threads::DeleteThread(thread_);
 }

--- a/src/components/transport_manager/src/usb/libusb/usb_handler.cc
+++ b/src/components/transport_manager/src/usb/libusb/usb_handler.cc
@@ -101,7 +101,7 @@ UsbHandler::~UsbHandler() {
     libusb_exit(libusb_context_);
     libusb_context_ = 0;
   }
-  thread_->join();
+  thread_->join(threads::Thread::kForceStop);
   delete thread_->delegate();
   threads::DeleteThread(thread_);
 }

--- a/src/components/utils/src/threads/async_runner.cc
+++ b/src/components/utils/src/threads/async_runner.cc
@@ -54,12 +54,12 @@ void AsyncRunner::AsyncRun(ThreadDelegate* delegate) {
 
 void AsyncRunner::Stop() {
   SDL_AUTO_TRACE();
-  thread_->join();
+  thread_->join(threads::Thread::kForceStop);
 }
 
 AsyncRunner::~AsyncRunner() {
   SDL_AUTO_TRACE();
-  thread_->join();
+  thread_->join(threads::Thread::kForceStop);
   delete executor_;
   threads::DeleteThread(thread_);
 }

--- a/src/components/utils/src/threads/thread_win.cc
+++ b/src/components/utils/src/threads/thread_win.cc
@@ -61,46 +61,58 @@ size_t Thread::kMinStackSize = 0;
 void Thread::cleanup(void* arg) {
   SDL_AUTO_TRACE();
   Thread* thread = static_cast<Thread*>(arg);
-  thread->isThreadRunning_ = false;
+  thread->thread_state_ = kThreadStateNone;
+  thread->thread_command_ = kThreadCommandNone;
   thread->state_cond_.Broadcast();
 }
 
 void* Thread::threadFunc(void* arg) {
-  // 0 - state_lock unlocked
-  //     stopped   = 0
-  //     running   = 0
-  //     finalized = 0
-  // 4 - state_lock unlocked
-  //     stopped = 1
-  //     running = 1
-  //     finalized = 0
-  // 5 - state_lock unlocked
-  //     stopped = 1
-  //     running = 1
-  //     finalized = 1
   SDL_DEBUG("Thread #" << GetCurrentThreadId() << " started successfully");
 
   threads::Thread* thread = static_cast<Thread*>(arg);
   DCHECK(thread);
 
   thread->state_lock_.Acquire();
+  thread->thread_state_ = kThreadStateIdle;
   thread->state_cond_.Broadcast();
 
-  while (!thread->finalized_) {
+  // We have special variable for controlling iterations/exiting thread
+  // in order to separate decision logic (continue iterations or exit?)
+  // from controlling while cycle
+  bool continueIterations = true;
+
+  while (continueIterations) {
     SDL_DEBUG("Thread #" << GetCurrentThreadId() << " iteration");
-    thread->run_cond_.Wait(thread->state_lock_);
-    SDL_DEBUG("Thread #" << GetCurrentThreadId() << " execute. "
-                         << "stopped_ = " << thread->stopped_
-                         << "; finalized_ = " << thread->finalized_);
-    if (!thread->stopped_ && !thread->finalized_) {
-      thread->isThreadRunning_ = true;
-
-      thread->state_lock_.Release();
-      thread->delegate_->threadMain();
-      thread->state_lock_.Acquire();
-
-      thread->isThreadRunning_ = false;
+    while (kThreadCommandNone == thread->thread_command_) {
+      thread->run_cond_.Wait(thread->state_lock_);
     }
+    SDL_DEBUG("Thread #" << GetCurrentThreadId() << " execute. "
+                         << "thread_command_ = " << thread->thread_command_);
+
+    switch (thread->thread_command_) {
+      case kThreadCommandRun:
+        thread->thread_state_ = kThreadStateRunning;
+        thread->state_lock_.Release();
+        thread->delegate_->threadMain();
+        thread->state_lock_.Acquire();
+        thread->thread_state_ = kThreadStateIdle;
+        break;
+
+      case kThreadCommandFinalize:
+        continueIterations = false;
+        break;
+
+      default:
+        // check for not expected command:
+        if ((kThreadCommandNone > thread->thread_command_) &&
+            (kThreadCommandFinalize < thread->thread_command_)) {
+          SDL_ERROR("Incorrect thread command: " << thread->thread_command_);
+        }
+        // else - nothing to do
+        break;
+    }
+
+    thread->thread_command_ = kThreadCommandNone;  // consumed
     thread->state_cond_.Broadcast();
     SDL_DEBUG("Thread #" << GetCurrentThreadId() << " finished iteration");
   }
@@ -118,10 +130,8 @@ Thread::Thread(const char* name, ThreadDelegate* delegate)
     , delegate_(delegate)
     , handle_(NULL)
     , thread_options_()
-    , isThreadRunning_(false)
-    , stopped_(false)
-    , finalized_(false)
-    , thread_created_(false) {}
+    , thread_command_(kThreadCommandNone)
+    , thread_state_(kThreadStateNone) {}
 
 bool Thread::start() {
   return start(thread_options_);
@@ -149,7 +159,7 @@ bool Thread::start(const ThreadOptions& options) {
     return false;
   }
 
-  if (isThreadRunning_) {
+  if (kThreadStateRunning == thread_state_) {
     SDL_TRACE("EXIT thread " << name_ << " #" << handle_
                              << " is already running");
     return true;
@@ -157,7 +167,7 @@ bool Thread::start(const ThreadOptions& options) {
 
   thread_options_ = options;
 
-  if (!thread_created_) {
+  if (kThreadStateNone == thread_state_) {
     // state_lock 1
     handle_ = ::CreateThread(
         NULL, stack_size(), (LPTHREAD_START_ROUTINE)&threadFunc, this, 0, NULL);
@@ -165,13 +175,14 @@ bool Thread::start(const ThreadOptions& options) {
       SDL_DEBUG("Created thread: " << name_);
       // state_lock 0
       // possible concurrencies: stop and threadFunc
-      state_cond_.Wait(auto_lock);
-      thread_created_ = true;
+      while (kThreadStateNone == thread_state_) {
+        state_cond_.Wait(auto_lock);
+      }
     } else {
       SDL_ERROR("Couldn't create thread " << name_);
     }
   }
-  stopped_ = false;
+  thread_command_ = kThreadCommandRun;
   run_cond_.NotifyOne();
   SDL_DEBUG("Thread " << name_ << " #" << handle_ << " started");
   return NULL != handle_;
@@ -184,6 +195,33 @@ void Thread::yield() {
 void Thread::stop() {
   SDL_AUTO_TRACE();
   sync_primitives::AutoLock auto_lock(state_lock_);
+  StopUnsafe();
+}
+
+void Thread::join(const JoinOptionStop force_stop) {
+  SDL_AUTO_TRACE();
+  DCHECK_OR_RETURN_VOID(!IsCurrentThread());
+  sync_primitives::AutoLock auto_lock(state_lock_);
+  JoinUnsafe(force_stop);
+}
+
+void Thread::JoinUnsafe(const JoinOptionStop force_stop) {
+  SDL_AUTO_TRACE();
+  DCHECK_OR_RETURN_VOID(!IsCurrentThread());
+  // if thread still exist at all
+  if (kThreadStateNone != thread_state_) {
+    if (kForceStop == force_stop) {
+      StopUnsafe();
+    }
+    while ((kThreadStateRunning == thread_state_) ||
+           (kThreadCommandNone != thread_command_)) {
+      state_cond_.Wait(state_lock_);
+    }
+  }
+}
+
+void Thread::StopUnsafe() {
+  SDL_AUTO_TRACE();
 
   // We should check thread exit code for kThreadCancelledExitCode
   // because we need to perform cleanup in case thread has been terminated.
@@ -195,38 +233,30 @@ void Thread::stop() {
     cleanup(static_cast<void*>(this));
   }
 
-  stopped_ = true;
+  thread_command_ = kThreadCommandNone;  // cancel all active commands
   SDL_DEBUG("Stopping thread #" << handle_ << " \"" << name_ << " \"");
 
-  if (delegate_ && isThreadRunning_) {
+  if (delegate_ && (kThreadStateRunning == thread_state_)) {
     delegate_->exitThreadMain();
   }
 
   SDL_DEBUG("Stopped thread #" << handle_ << " \"" << name_ << " \"");
 }
 
-void Thread::join() {
-  SDL_AUTO_TRACE();
-  DCHECK_OR_RETURN_VOID(!IsCurrentThread());
-
-  stop();
-
-  sync_primitives::AutoLock auto_lock(state_lock_);
-  run_cond_.NotifyOne();
-  if (isThreadRunning_) {
-    state_cond_.Wait(auto_lock);
-  }
-}
-
 Thread::~Thread() {
-  finalized_ = true;
-  stopped_ = true;
-  join();
-
-  if (thread_options_.is_joinable()) {
-    WaitForSingleObject(handle_, INFINITE);
+  if (0 != handle_) {
+    state_lock_.Acquire();
+    if (kThreadStateNone != thread_state_) {
+      JoinUnsafe(kForceStop);
+      thread_command_ = kThreadCommandFinalize;
+      run_cond_.NotifyOne();
+    }
+    state_lock_.Release();
+    if (thread_options_.is_joinable()) {
+      WaitForSingleObject(handle_, INFINITE);
+    }
+    CloseHandle(handle_);
   }
-  CloseHandle(handle_);
 }
 
 Thread* CreateThread(const char* name, ThreadDelegate* delegate) {

--- a/src/components/utils/src/timer.cc
+++ b/src/components/utils/src/timer.cc
@@ -143,7 +143,7 @@ void timer::Timer::StopThread() {
     delegate_->set_finalized_flag(true);
     {
       sync_primitives::AutoUnlock auto_unlock(state_lock_);
-      thread_->join();
+      thread_->join(threads::Thread::kForceStop);
     }
     delegate_->set_finalized_flag(false);
   }

--- a/src/components/utils/test/conditional_variable_test.cc
+++ b/src/components/utils/test/conditional_variable_test.cc
@@ -118,7 +118,7 @@ TEST_F(ConditionalVariableTest,
   cond_var_.WaitFor(test_lock, 2000);
   std::string last_value("changed again by thread 1");
   EXPECT_EQ(last_value, test_value_);
-  thread->join();
+  thread->join(threads::Thread::kForceStop);
   threads::DeleteThread(thread);
 }
 

--- a/src/components/utils/test/message_queue_test.cc
+++ b/src/components/utils/test/message_queue_test.cc
@@ -129,12 +129,12 @@ TEST_F(MessageQueueTest, DefaultCtorTest_ExpectEmptyQueueCreated) {
 }
 
 TEST_F(MessageQueueTest,
-       DISABLED_MessageQueuePushThreeElementsTest_ExpectThreeElementsAdded) {
+       MessageQueuePushThreeElementsTest_ExpectThreeElementsAdded) {
   MessageQueue<std::string> test_queue1;
   threads::Thread* thread = threads::CreateThread(
       "test thread", new AddThreeElementsDelegate(test_queue1));
   thread->start();
-  thread->join();
+  thread->join(threads::Thread::kNoStop);
   ASSERT_EQ(3u, test_queue1.size());
   threads::DeleteThread(thread);
 }
@@ -152,17 +152,16 @@ TEST_F(MessageQueueTest, NotEmptyMessageQueueResetTest_ExpectEmptyQueue) {
   ASSERT_EQ(0u, test_queue.size());
 }
 
-TEST_F(
-    MessageQueueTest,
-    DISABLED_MessageQueuePopOneElementTest_ExpectOneElementRemovedFromQueue) {
+TEST_F(MessageQueueTest,
+       MessageQueuePopOneElementTest_ExpectOneElementRemovedFromQueue) {
   threads::Thread* thread1 =
       threads::CreateThread("test thread", new AddOneElementDelegate());
   threads::Thread* thread2 =
       threads::CreateThread("test thread", new ExtractFromQueueDelegate());
   thread1->start();
   thread2->start();
-  thread1->join();
-  thread2->join();
+  thread1->join(threads::Thread::kNoStop);
+  thread2->join(threads::Thread::kNoStop);
 
   // Check if first element was removed successfully
   ASSERT_EQ(test_val_1, test_line);
@@ -173,17 +172,17 @@ TEST_F(
 }
 
 TEST_F(MessageQueueTest,
-       DISABLED_MessageQueueShutdownTest_ExpectMessageQueueWillBeShutDown) {
+       MessageQueueShutdownTest_ExpectMessageQueueWillBeShutDown) {
   threads::Thread* thread1 =
       threads::CreateThread("test thread", new ShutDownQueueDelegate());
   thread1->start();
-  thread1->join();
-  threads::DeleteThread(thread1);
+  thread1->join(threads::Thread::kNoStop);
 
   // Primary thread sleeps until thread1 will make queue shutdown
   test_queue.wait();
   check_value = true;
   ASSERT_TRUE(check_value);
+  threads::DeleteThread(thread1);
 }
 
 }  // namespace utils_test

--- a/src/components/utils/test/rwlock_test.cc
+++ b/src/components/utils/test/rwlock_test.cc
@@ -50,7 +50,7 @@ class RWlockTest : public ::testing::Test {
       ASSERT_TRUE(thread[i]->CurrentId());
     }
     for (uint8_t i = 0; i < kNum_threads_; ++i) {
-      thread[i]->join();
+      thread[i]->join(threads::Thread::kForceStop);
       threads::DeleteThread(thread[i]);
     }
   }

--- a/src/components/utils/test/singleton_test.cc
+++ b/src/components/utils/test/singleton_test.cc
@@ -143,15 +143,15 @@ TEST(SingletonTest, CreateSingletonInDifferentThreads) {
       threads::CreateThread("test thread", new CreateSingletonDelegate());
   thread1->start();
   thread2->start();
-  thread1->join();
-  thread2->join();
-  threads::DeleteThread(thread1);
-  threads::DeleteThread(thread2);
+  thread1->join(threads::Thread::kNoStop);
+  thread2->join(threads::Thread::kNoStop);
 
   // act
   SingletonTest::destroy();
   // assert
   ASSERT_FALSE(SingletonTest::exists());
+  threads::DeleteThread(thread1);
+  threads::DeleteThread(thread2);
 }
 
 #if defined(OS_POSIX)
@@ -192,7 +192,7 @@ TEST(SingletonTest, CreateDeleteSingletonInDifferentThreads) {
 }
 #endif
 
-TEST(SingletonTest, DISABLED_DeleteSingletonInDifferentThread) {
+TEST(SingletonTest, DeleteSingletonInDifferentThread) {
   // arrange
   SingletonTest::instance();
   ASSERT_TRUE(SingletonTest::exists());
@@ -200,7 +200,7 @@ TEST(SingletonTest, DISABLED_DeleteSingletonInDifferentThread) {
   threads::Thread* thread1 = threads::CreateThread(
       "test thread", new DestroySingletonDelegate(SingletonTest::instance()));
   thread1->start();
-  thread1->join();
+  thread1->join(threads::Thread::kNoStop);
 
   // assert
   ASSERT_FALSE(SingletonTest::exists());


### PR DESCRIPTION
Fixed some tests (UT) in message_queue_test and singleton_test to wait for
worker thread to finish before join() otherwise it will be cancelled
in the middle of its task.

Related to APPLINK-25909.

[APPLINK-25909](https://adc.luxoft.com/jira/browse/APPLINK-25909)