### PR TITLE
Fix issues with freed string before use (CIDs 80093, 80094)

### DIFF
--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -195,8 +195,7 @@ void AlertManeuverRequest::on_event(const event_engine::Event& event) {
     if (result && hmi_apis::Common_Result::UNSUPPORTED_RESOURCE ==
         static_cast<hmi_apis::Common_Result::eType>(tts_speak_result_code_)) {
       result_code = mobile_apis::Result::WARNINGS;
-      return_info =
-          std::string("Unsupported phoneme type sent in a prompt").c_str();
+      return_info = "Unsupported phoneme type sent in a prompt";
     }
 
     SendResponse(result, result_code, return_info,

--- a/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
@@ -278,7 +278,7 @@ void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
     if (result) {
       if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == tts_result_) {
         result_code = mobile_apis::Result::WARNINGS;
-        return_info = std::string("Unsupported phoneme type sent in a prompt").c_str();
+        return_info = "Unsupported phoneme type sent in a prompt";
       } else {
         result_code = static_cast<mobile_apis::Result::eType>(
                         std::max(ui_result_, tts_result_));

--- a/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
@@ -344,12 +344,11 @@ void SetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
 
     mobile_apis::Result::eType result_code;
     const char* return_info = NULL;
-    const std::string return_string = "Unsupported phoneme type sent in a prompt";
 
     if (result) {
       if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == tts_result_) {
         result_code = mobile_apis::Result::WARNINGS;
-        return_info = return_string.c_str();
+        return_info = "Unsupported phoneme type sent in a prompt";
       } else {
         result_code = static_cast<mobile_apis::Result::eType>(
                         std::max(ui_result_, tts_result_));

--- a/src/components/application_manager/src/commands/mobile/speak_request.cc
+++ b/src/components/application_manager/src/commands/mobile/speak_request.cc
@@ -125,8 +125,7 @@ void SpeakRequest::ProcessTTSSpeakResponse(
   if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE ==
       static_cast<hmi_apis::Common_Result::eType>(result_code)) {
     result_code = mobile_apis::Result::WARNINGS;
-    return_info = std::string(
-        "Unsupported phoneme type sent in a prompt").c_str();
+    return_info = "Unsupported phoneme type sent in a prompt";
   }
 
   SendResponse(result, static_cast<mobile_apis::Result::eType>(result_code),

--- a/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -254,8 +254,7 @@ void SubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
   if (result) {
     if (IsAnythingAlreadySubscribed(message[strings::msg_params])) {
       result_code = mobile_apis::Result::IGNORED;
-      return_info =
-        std::string("Already subscribed on some provided VehicleData.").c_str();
+      return_info = "Already subscribed on some provided VehicleData.";
     }
   }
 

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -245,8 +245,7 @@ void UnsubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
   if (result) {
     if (IsAnythingAlreadyUnsubscribed(message[strings::msg_params])) {
       result_code = mobile_apis::Result::IGNORED;
-      return_info =
-          std::string("Some provided VehicleData was not subscribed.").c_str();
+      return_info = "Some provided VehicleData was not subscribed.";
     }
   }
 


### PR DESCRIPTION
The std::string was freed before its use, causing return_info to be a garbage string. This sets return_info to a constant value to ensure it is not freed before use.

Coverity reports:
https://scan9.coverity.com/reports.htm#v27037/p12036/fileInstanceId=3984235&defectInstanceId=777501&mergedDefectId=80093
https://scan9.coverity.com/reports.htm#v27037/p12036/fileInstanceId=3984247&defectInstanceId=777502&mergedDefectId=80094