### PR TITLE
Null terminate char buffer after strncpy (CID 79979)

### DIFF
--- a/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner.cc
@@ -230,9 +230,11 @@ void BluetoothDeviceScanner::CheckSDLServiceOnDevices(
 
     if (hci_read_remote_name_ret != 0) {
       LOG4CXX_ERROR_WITH_ERRNO(logger_, "hci_read_remote_name failed");
+      int name_len = sizeof(deviceName) / sizeof(deviceName[0]);
       strncpy(deviceName,
               BluetoothDevice::GetUniqueDeviceId(bd_address).c_str(),
-              sizeof(deviceName) / sizeof(deviceName[0]));
+              name_len - 1);
+      deviceName[name_len - 1] = '\0';
     }
 
     Device* bluetooth_device = new BluetoothDevice(bd_address, deviceName,


### PR DESCRIPTION
Add null char at the end of char array to fix Coverity ID 79979.  It is likely that an overflow could not occur since `BluetoothDevice::GetUniqueDeviceId(bd_address).c_str()` only returns a 35 char string, but this is safer.

Coverity report:
https://scan9.coverity.com/reports.htm#v27037/p12036/fileInstanceId=6520018&defectInstanceId=1296949&mergedDefectId=79979&fileStart=251&fileEnd=484