### PR TITLE
Move unit tests for  request info

### DIFF
--- a/src/components/application_manager/include/application_manager/request_info.h
+++ b/src/components/application_manager/include/application_manager/request_info.h
@@ -60,18 +60,18 @@ struct RequestInfo {
   virtual ~RequestInfo() {}
 
   RequestInfo(RequestPtr request,
-              const RequestType requst_type,
-              const uint64_t timeout_msec)
-      : request_(request), timeout_msec_(timeout_msec) {
-    start_time_ = date_time::DateTime::getCurrentTime();
+              const RequestType request_type,
+              const uint64_t timeout_msec,
+              const uint32_t app_id,
+              const uint32_t correlation_id)
+      : request_(request)
+      , start_time_(date_time::DateTime::getCurrentTime())
+      , timeout_msec_(timeout_msec)
+      , app_id_(app_id)
+      , requst_type_(request_type)
+      , correlation_id_(correlation_id) {
     updateEndTime();
-    requst_type_ = requst_type;
   }
-
-  RequestInfo(RequestPtr request,
-              const RequestType requst_type,
-              const TimevalStruct& start_time,
-              const uint64_t timeout_msec);
 
   void updateEndTime();
 
@@ -141,16 +141,10 @@ typedef utils::SharedPtr<RequestInfo> RequestInfoPtr;
 
 struct MobileRequestInfo : public RequestInfo {
   MobileRequestInfo(RequestPtr request, const uint64_t timeout_msec);
-  MobileRequestInfo(RequestPtr request,
-                    const TimevalStruct& start_time,
-                    const uint64_t timeout_msec);
 };
 
 struct HMIRequestInfo : public RequestInfo {
   HMIRequestInfo(RequestPtr request, const uint64_t timeout_msec);
-  HMIRequestInfo(RequestPtr request,
-                 const TimevalStruct& start_time,
-                 const uint64_t timeout_msec);
 };
 
 // Request info, for searching in request info set by log_n time

--- a/src/components/application_manager/src/request_info.cc
+++ b/src/components/application_manager/src/request_info.cc
@@ -55,7 +55,7 @@ HMIRequestInfo::HMIRequestInfo(RequestPtr request, const uint64_t timeout_msec)
                   HMIRequest,
                   timeout_msec,
                   RequestInfo::HmiConnectoinKey,
-                  request_->correlation_id()) {}
+                  request->correlation_id()) {}
 
 MobileRequestInfo::MobileRequestInfo(RequestPtr request,
                                      const uint64_t timeout_msec)

--- a/src/components/application_manager/src/request_info.cc
+++ b/src/components/application_manager/src/request_info.cc
@@ -36,6 +36,7 @@
 #include "application_manager/request_info.h"
 
 #include <algorithm>
+#include "utils/make_shared.h"
 
 #if defined(OS_WINDOWS)
 #define ssize_t SSIZE_T
@@ -50,44 +51,19 @@ SDL_CREATE_LOGGER("RequestController")
 uint32_t RequestInfo::HmiConnectoinKey = 0;
 
 HMIRequestInfo::HMIRequestInfo(RequestPtr request, const uint64_t timeout_msec)
-    : RequestInfo(request, HMIRequest, timeout_msec) {
-  correlation_id_ = request_->correlation_id();
-  app_id_ = RequestInfo::HmiConnectoinKey;
-}
-
-HMIRequestInfo::HMIRequestInfo(RequestPtr request,
-                               const TimevalStruct& start_time,
-                               const uint64_t timeout_msec)
-    : RequestInfo(request, HMIRequest, start_time, timeout_msec) {
-  correlation_id_ = request_->correlation_id();
-  app_id_ = RequestInfo::HmiConnectoinKey;
-}
+    : RequestInfo(request,
+                  HMIRequest,
+                  timeout_msec,
+                  RequestInfo::HmiConnectoinKey,
+                  request_->correlation_id()) {}
 
 MobileRequestInfo::MobileRequestInfo(RequestPtr request,
                                      const uint64_t timeout_msec)
-    : RequestInfo(request, MobileRequest, timeout_msec) {
-  correlation_id_ = request_.get()->correlation_id();
-  app_id_ = request_.get()->connection_key();
-}
-
-MobileRequestInfo::MobileRequestInfo(RequestPtr request,
-                                     const TimevalStruct& start_time,
-                                     const uint64_t timeout_msec)
-    : RequestInfo(request, MobileRequest, start_time, timeout_msec) {
-  correlation_id_ = request_.get()->correlation_id();
-  app_id_ = request_.get()->connection_key();
-}
-
-RequestInfo::RequestInfo(RequestPtr request,
-                         const RequestInfo::RequestType requst_type,
-                         const TimevalStruct& start_time,
-                         const uint64_t timeout_msec)
-    : request_(request), start_time_(start_time), timeout_msec_(timeout_msec) {
-  updateEndTime();
-  requst_type_ = requst_type;
-  correlation_id_ = request_->correlation_id();
-  app_id_ = request_->connection_key();
-}
+    : RequestInfo(request,
+                  MobileRequest,
+                  timeout_msec,
+                  request->connection_key(),
+                  request->correlation_id()) {}
 
 void application_manager::request_controller::RequestInfo::updateEndTime() {
   end_time_ = date_time::DateTime::getCurrentTime();
@@ -153,8 +129,8 @@ RequestInfoPtr RequestInfoSet::Find(const uint32_t connection_key,
   RequestInfoPtr result;
 
   // Request info for searching in request info set by log_n time
-  utils::SharedPtr<FakeRequestInfo> request_info_for_search(
-      new FakeRequestInfo(connection_key, correlation_id));
+  utils::SharedPtr<FakeRequestInfo> request_info_for_search =
+      utils::MakeShared<FakeRequestInfo>(connection_key, correlation_id);
 
   sync_primitives::AutoLock lock(this_lock_);
   HashSortedRequestInfoSet::iterator it =

--- a/src/components/application_manager/test/include/application_manager/test_request_info.h
+++ b/src/components/application_manager/test/include/application_manager/test_request_info.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_TEST_REQUEST_INFO_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_TEST_REQUEST_INFO_H_
+
+#include "application_manager/request_info.h"
+
+namespace test {
+namespace components {
+namespace application_manager_test {
+
+using ::application_manager::request_controller::RequestInfo;
+using ::application_manager::request_controller::RequestPtr;
+
+class RequestInfoForTesting : public RequestInfo {
+ public:
+  RequestInfoForTesting(RequestPtr request,
+                        const RequestType request_type,
+                        const uint64_t timeout_sec,
+                        const uint32_t app_id,
+                        const uint32_t correlarion_id)
+      : RequestInfo(
+            request, request_type, timeout_sec, app_id, correlarion_id) {}
+  void SetEndTime(const TimevalStruct& end_time) {
+    end_time_ = end_time;
+  }
+};
+
+}  // namespace application_manager_test
+}  // namespace components
+}  // namespace test
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_TEST_REQUEST_INFO_H_

--- a/src/components/application_manager/test/request_controller/request_info_test.cc
+++ b/src/components/application_manager/test/request_controller/request_info_test.cc
@@ -69,11 +69,11 @@ class MockRequest : public application_manager::commands::Command {
 };
 
 namespace {
-const uint32_t kCountOfRequestsForTest = 1000;
-const uint32_t kHmiConnectionKey = 0;
-const uint32_t kMobileConnectionKey1 = 65431;
-const uint32_t kMobileConnectionKey2 = 65123;
-const uint32_t kDefaultTimeout = 10;
+const uint32_t kCountOfRequestsForTest = 1000u;
+const uint32_t kHmiConnectionKey = 0u;
+const uint32_t kMobileConnectionKey1 = 65431u;
+const uint32_t kMobileConnectionKey2 = 65123u;
+const uint32_t kDefaultTimeout = 10u;
 }  // namespace
 
 class RequestInfoTest : public ::testing::Test {
@@ -160,12 +160,12 @@ TEST_F(RequestInfoTest, AddHMIRequests_RemoveAllRequests) {
 }
 
 TEST_F(RequestInfoTest, CheckRequestsMaxCount) {
-  const uint32_t app_hmi_level_time_scale = 100;
-  const uint32_t hmi_level_count = 1000;
+  const uint32_t kAppHmiLevelTimeScale = 100u;
+  const uint32_t kHmiLevelCount = 1000u;
 
   // Count of added requests is less than max possible
   std::vector<utils::SharedPtr<RequestInfoForTesting>> requests;
-  for (uint32_t i = 0; i < hmi_level_count - 1; ++i) {
+  for (uint32_t i = 0; i < kHmiLevelCount - 1; ++i) {
     utils::SharedPtr<RequestInfoForTesting> request =
         CreateTestInfo(kMobileConnectionKey1,
                        i,
@@ -176,46 +176,46 @@ TEST_F(RequestInfoTest, CheckRequestsMaxCount) {
     requests.push_back(request);
     EXPECT_TRUE(request_info_set_.Add(request));
   }
-  EXPECT_EQ(hmi_level_count - 1, request_info_set_.Size());
+  EXPECT_EQ(kHmiLevelCount - 1, request_info_set_.Size());
 
   EXPECT_TRUE(request_info_set_.CheckHMILevelTimeScaleMaxRequest(
       mobile_apis::HMILevel::HMI_FULL,
       kMobileConnectionKey1,
-      app_hmi_level_time_scale,
-      hmi_level_count));
+      kAppHmiLevelTimeScale,
+      kHmiLevelCount));
 
   // Adding new request is correct
   utils::SharedPtr<RequestInfoForTesting> new_request =
       CreateTestInfo(kMobileConnectionKey1,
-                     hmi_level_count,
+                     kHmiLevelCount,
                      request_info::RequestInfo::MobileRequest,
                      kDefaultTimeout);
   new_request->set_hmi_level(mobile_apis::HMILevel::HMI_FULL);
   EXPECT_TRUE(request_info_set_.Add(new_request));
-  EXPECT_EQ(hmi_level_count, request_info_set_.Size());
+  EXPECT_EQ(kHmiLevelCount, request_info_set_.Size());
 
   // Count of added requests is max
   EXPECT_FALSE(request_info_set_.CheckHMILevelTimeScaleMaxRequest(
       mobile_apis::HMILevel::HMI_FULL,
       kMobileConnectionKey1,
-      app_hmi_level_time_scale,
-      hmi_level_count));
+      kAppHmiLevelTimeScale,
+      kHmiLevelCount));
 
   utils::SharedPtr<RequestInfoForTesting> new_request2 =
       CreateTestInfo(kMobileConnectionKey1,
-                     hmi_level_count + 1,
+                     kHmiLevelCount + 1,
                      request_info::RequestInfo::MobileRequest,
                      kDefaultTimeout);
   EXPECT_TRUE(request_info_set_.Add(new_request2));
 }
 
 TEST_F(RequestInfoTest, CheckMaxCountOfRequest) {
-  const uint32_t app_hmi_level_time_scale = 100;
-  const uint32_t hmi_level_count = 1000;
+  const uint32_t kAppHmiLevelTimeScale = 100u;
+  const uint32_t kHmiLevelCount = 1000u;
 
   // Count of added requests is less than max possible
   std::vector<utils::SharedPtr<RequestInfoForTesting>> requests;
-  for (uint32_t i = 0; i < hmi_level_count - 1; ++i) {
+  for (uint32_t i = 0; i < kHmiLevelCount - 1; ++i) {
     utils::SharedPtr<RequestInfoForTesting> request =
         CreateTestInfo(kMobileConnectionKey1,
                        i,
@@ -225,28 +225,28 @@ TEST_F(RequestInfoTest, CheckMaxCountOfRequest) {
     requests.push_back(request);
     EXPECT_TRUE(request_info_set_.Add(request));
   }
-  EXPECT_EQ(hmi_level_count - 1, request_info_set_.Size());
+  EXPECT_EQ(kHmiLevelCount - 1, request_info_set_.Size());
 
   EXPECT_TRUE(request_info_set_.CheckTimeScaleMaxRequest(
-      kMobileConnectionKey1, app_hmi_level_time_scale, hmi_level_count));
+      kMobileConnectionKey1, kAppHmiLevelTimeScale, kHmiLevelCount));
 
   // Adding new request is correct
   utils::SharedPtr<RequestInfoForTesting> new_request =
       CreateTestInfo(kMobileConnectionKey1,
-                     hmi_level_count,
+                     kHmiLevelCount,
                      request_info::RequestInfo::MobileRequest,
                      kDefaultTimeout);
   new_request->set_hmi_level(mobile_apis::HMILevel::HMI_FULL);
   EXPECT_TRUE(request_info_set_.Add(new_request));
-  EXPECT_EQ(hmi_level_count, request_info_set_.Size());
+  EXPECT_EQ(kHmiLevelCount, request_info_set_.Size());
 
   // Count of added requests is max
   EXPECT_FALSE(request_info_set_.CheckTimeScaleMaxRequest(
-      kMobileConnectionKey1, app_hmi_level_time_scale, hmi_level_count));
+      kMobileConnectionKey1, kAppHmiLevelTimeScale, kHmiLevelCount));
 
   utils::SharedPtr<RequestInfoForTesting> new_request2 =
       CreateTestInfo(kMobileConnectionKey1,
-                     hmi_level_count + 1,
+                     kHmiLevelCount + 1,
                      request_info::RequestInfo::MobileRequest,
                      kDefaultTimeout);
   EXPECT_TRUE(request_info_set_.Add(new_request2));
@@ -272,9 +272,9 @@ TEST_F(RequestInfoTest, AddMobileRequests_RemoveMobileRequests) {
 
 TEST_F(RequestInfoTest, AddMobileRequests_RemoveMobileRequestsByConnectionKey) {
   std::vector<utils::SharedPtr<RequestInfoForTesting>> requests;
-  const uint32_t count_of_mobile_request1 = 200;
-  const uint32_t count_of_mobile_request2 = 100;
-  for (uint32_t i = 0; i < count_of_mobile_request1; ++i) {
+  const uint32_t kCountOfMobileequest1 = 200u;
+  const uint32_t kCountOfMobileequest2 = 100u;
+  for (uint32_t i = 0; i < kCountOfMobileequest1; ++i) {
     utils::SharedPtr<RequestInfoForTesting> mobile_request1 =
         CreateTestInfo(kMobileConnectionKey1,
                        i,
@@ -284,9 +284,9 @@ TEST_F(RequestInfoTest, AddMobileRequests_RemoveMobileRequestsByConnectionKey) {
     requests.push_back(mobile_request1);
     EXPECT_TRUE(request_info_set_.Add(mobile_request1));
   }
-  EXPECT_EQ(count_of_mobile_request1, request_info_set_.Size());
+  EXPECT_EQ(kCountOfMobileequest1, request_info_set_.Size());
 
-  for (uint32_t i = 0; i < count_of_mobile_request2; ++i) {
+  for (uint32_t i = 0; i < kCountOfMobileequest2; ++i) {
     utils::SharedPtr<RequestInfoForTesting> mobile_request2 =
         CreateTestInfo(kMobileConnectionKey2,
                        i,
@@ -296,12 +296,12 @@ TEST_F(RequestInfoTest, AddMobileRequests_RemoveMobileRequestsByConnectionKey) {
     requests.push_back(mobile_request2);
     EXPECT_TRUE(request_info_set_.Add(mobile_request2));
   }
-  EXPECT_EQ(count_of_mobile_request1 + count_of_mobile_request2,
+  EXPECT_EQ(kCountOfMobileequest1 + kCountOfMobileequest2,
             request_info_set_.Size());
 
-  EXPECT_EQ(count_of_mobile_request1,
+  EXPECT_EQ(kCountOfMobileequest1,
             request_info_set_.RemoveByConnectionKey(kMobileConnectionKey1));
-  EXPECT_EQ(count_of_mobile_request2,
+  EXPECT_EQ(kCountOfMobileequest2,
             request_info_set_.RemoveByConnectionKey(kMobileConnectionKey2));
   EXPECT_EQ(0u, request_info_set_.Size());
 }
@@ -362,11 +362,11 @@ TEST_F(RequestInfoTest, RequestInfoSetFind) {
 
 TEST_F(RequestInfoTest, RequestInfoSetEqualHash) {
   request_info::RequestInfoSet request_info_set;
-  const uint32_t connection_key = 65483;
-  const uint32_t corr_id = 65483;
+  const uint32_t kConnectionKey = 65483u;
+  const uint32_t kCorrId = 65483u;
   utils::SharedPtr<RequestInfoForTesting> request =
-      CreateTestInfo(connection_key,
-                     corr_id,
+      CreateTestInfo(kConnectionKey,
+                     kCorrId,
                      request_info::RequestInfo::HMIRequest,
                      kDefaultTimeout);
   EXPECT_TRUE(request_info_set.Add(request));
@@ -374,7 +374,7 @@ TEST_F(RequestInfoTest, RequestInfoSetEqualHash) {
   EXPECT_FALSE(request_info_set.Add(request));
   EXPECT_EQ(1u, request_info_set.Size());
   request_info::RequestInfoPtr found =
-      request_info_set.Find(connection_key, corr_id);
+      request_info_set.Find(kConnectionKey, kCorrId);
   EXPECT_TRUE(found.valid());
   EXPECT_TRUE(request_info_set.RemoveRequest(found));
   EXPECT_EQ(0u, request_info_set.Size());

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -1415,8 +1415,9 @@ TEST_F(ProtocolHandlerImplTest,
   protocol_handler_impl->SendMessageToMobileApp(message, is_final);
 }
 
+// TODO APPLINK-26716
 TEST_F(ProtocolHandlerImplTest,
-       SendMessageToMobileApp_SendSingleNonControlMessage) {
+       DISABLED_SendMessageToMobileApp_SendSingleNonControlMessage) {
   // Arrange
   AddSession();
   const bool is_final = true;


### PR DESCRIPTION
Commit was moved from PASA.

In commit  request_info.h and request_info.cc were changed (related to [APPLINK-22306](https://adc.luxoft.com/jira/browse/APPLINK-22306) ).
 Contructor  RequestInfo(RequestPtr request,  const RequestType request_type, conts TimevalStruct start_time, const uint64_t timeout_msec) was deleted as not used
  Contructor  RequestInfo(RequestPtr request,  const RequestType request_type, const uint64_t timeout_msec, const uint32_t app_id, const uint32_t correlation_id) was modified according[ #339](https://github.com/CustomSDL/sdl_panasonic/pull/339/)

Related to [APPLINK-22722](https://adc.luxoft.com/jira/browse/APPLINK-22722)


Please review @OHerasym, @okozlovlux, @LevchenkoS, @VProdanov, @dtrunov, @nk0leg

