### PR TITLE
Move unit tests for request controller

### DIFF
--- a/src/components/application_manager/include/application_manager/request_controller.h
+++ b/src/components/application_manager/include/application_manager/request_controller.h
@@ -262,8 +262,8 @@ class RequestController {
   uint32_t pool_size_;
   sync_primitives::ConditionalVariable cond_var_;
 
-  std::list<RequestPtr> mobile_request_list_;
-  sync_primitives::Lock mobile_request_list_lock_;
+  std::list<RequestInfoPtr> mobile_request_info_list_;
+  sync_primitives::Lock mobile_request_info_list_lock_;
 
   /*
    * Requests, that are waiting for responses
@@ -288,7 +288,7 @@ class RequestController {
 #ifdef BUILD_TESTS
  public:
   RequestInfoSet& get_waiting_for_response();
-  const std::list<RequestInfoPtr> get_mobile_request_info_list() const;
+  const std::list<RequestInfoPtr>& get_mobile_request_info_list() const;
   const std::list<RequestPtr>& get_notification_list() const;
 #endif  // BUILD_TESTS
 };

--- a/src/components/application_manager/include/application_manager/request_controller.h
+++ b/src/components/application_manager/include/application_manager/request_controller.h
@@ -285,6 +285,12 @@ class RequestController {
   bool is_low_voltage_;
   const RequestControlerSettings& settings_;
   DISALLOW_COPY_AND_ASSIGN(RequestController);
+#ifdef BUILD_TESTS
+ public:
+  RequestInfoSet& get_waiting_for_response();
+  const std::list<RequestInfoPtr> get_mobile_request_info_list() const;
+  const std::list<RequestPtr>& get_notification_list() const;
+#endif  // BUILD_TESTS
 };
 
 }  // namespace request_controller

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -88,7 +88,7 @@ void RequestController::InitializeThreadpool() {
 void RequestController::DestroyThreadpool() {
   SDL_AUTO_TRACE();
   {
-    AutoLock auto_lock(mobile_request_list_lock_);
+    AutoLock auto_lock(mobile_request_info_list_lock_);
     pool_state_ = TPoolState::STOPPED;
     SDL_DEBUG("Broadcasting STOP signal to all threads...");
     cond_var_.Broadcast();  // notify all threads we are shutting down
@@ -146,7 +146,7 @@ bool RequestController::CheckPendingRequestsAmount(
     const uint32_t& pending_requests_amount) {
   SDL_AUTO_TRACE();
   if (pending_requests_amount > 0) {
-    const size_t pending_requests_size = mobile_request_list_.size();
+    const size_t pending_requests_size = mobile_request_info_list_.size();
     const bool available_to_add =
         pending_requests_amount > pending_requests_size;
     if (!available_to_add) {
@@ -173,9 +173,14 @@ RequestController::TResult RequestController::addMobileRequest(
                                 << request->connection_key());
   RequestController::TResult result = CheckPosibilitytoAdd(request);
   if (SUCCESS == result) {
-    AutoLock auto_lock_list(mobile_request_list_lock_);
-    mobile_request_list_.push_back(request);
-    SDL_DEBUG("Waiting for execution: " << mobile_request_list_.size());
+    RequestInfoPtr request_info_ptr(utils::MakeShared<MobileRequestInfo>(
+        request, request->default_timeout()));
+    request_info_ptr->set_hmi_level(hmi_level);
+
+    AutoLock auto_lock_list(mobile_request_info_list_lock_);
+    mobile_request_info_list_.push_back(request_info_ptr);
+
+    SDL_DEBUG("Waiting for execution: " << mobile_request_info_list_.size());
     // wake up one thread that is waiting for a task to be available
   }
   cond_var_.NotifyOne();
@@ -266,18 +271,20 @@ void RequestController::terminateWaitingForExecutionAppRequests(
     const uint32_t& app_id) {
   SDL_AUTO_TRACE();
   SDL_DEBUG("app_id: " << app_id << "Waiting for execution"
-                       << mobile_request_list_.size());
-  AutoLock auto_lock(mobile_request_list_lock_);
-  std::list<RequestPtr>::iterator request_it = mobile_request_list_.begin();
-  while (mobile_request_list_.end() != request_it) {
-    RequestPtr request = (*request_it);
-    if ((request.valid()) && (request->connection_key() == app_id)) {
-      mobile_request_list_.erase(request_it++);
+                       << mobile_request_info_list_.size());
+  AutoLock auto_lock(mobile_request_info_list_lock_);
+  std::list<RequestInfoPtr>::iterator request_it =
+      mobile_request_info_list_.begin();
+  while (mobile_request_info_list_.end() != request_it) {
+    RequestInfoPtr request_info = (*request_it);
+    if ((request_info.valid()) &&
+        (request_info->request()->connection_key() == app_id)) {
+      mobile_request_info_list_.erase(request_it++);
     } else {
       ++request_it;
     }
   }
-  SDL_DEBUG("Waiting for execution " << mobile_request_list_.size());
+  SDL_DEBUG("Waiting for execution " << mobile_request_info_list_.size());
 }
 
 void RequestController::terminateWaitingForResponseAppRequests(
@@ -290,7 +297,7 @@ void RequestController::terminateWaitingForResponseAppRequests(
 void RequestController::terminateAppRequests(const uint32_t& app_id) {
   SDL_AUTO_TRACE();
   SDL_DEBUG("app_id : " << app_id << "Requests waiting for execution count : "
-                        << mobile_request_list_.size()
+                        << mobile_request_info_list_.size()
                         << "Requests waiting for response count : "
                         << waiting_for_response_.Size());
 
@@ -308,8 +315,8 @@ void RequestController::terminateAllMobileRequests() {
   SDL_AUTO_TRACE();
   waiting_for_response_.RemoveMobileRequests();
   SDL_DEBUG("Mobile Requests waiting for response cleared");
-  AutoLock waiting_execution_auto_lock(mobile_request_list_lock_);
-  mobile_request_list_.clear();
+  AutoLock waiting_execution_auto_lock(mobile_request_info_list_lock_);
+  mobile_request_info_list_.clear();
   SDL_DEBUG("Mobile Requests waiting for execution cleared");
   UpdateTimer();
 }
@@ -406,10 +413,10 @@ void RequestController::Worker::threadMain() {
   AutoLock auto_lock(thread_lock_);
   while (!stop_flag_) {
     // Try to pick a request
-    AutoLock auto_lock(request_controller_->mobile_request_list_lock_);
+    AutoLock auto_lock(request_controller_->mobile_request_info_list_lock_);
 
     while ((request_controller_->pool_state_ != TPoolState::STOPPED) &&
-           (request_controller_->mobile_request_list_.empty())) {
+           (request_controller_->mobile_request_info_list_.empty())) {
       // Wait until there is a task in the queue
       // Unlock mutex while wait, then lock it back when signaled
       SDL_INFO("Unlocking and waiting");
@@ -422,22 +429,24 @@ void RequestController::Worker::threadMain() {
       break;
     }
 
-    if (request_controller_->mobile_request_list_.empty()) {
+    if (request_controller_->mobile_request_info_list_.empty()) {
       SDL_WARN("Mobile request list is empty");
       break;
     }
 
-    RequestPtr request_ptr(request_controller_->mobile_request_list_.front());
-    request_controller_->mobile_request_list_.pop_front();
-
-    bool init_res = request_ptr->Init();  // to setup specific
-                                          // default timeout
-
-    const uint32_t timeout_in_mseconds = request_ptr->default_timeout();
     RequestInfoPtr request_info_ptr(
-        new MobileRequestInfo(request_ptr, timeout_in_mseconds));
+        request_controller_->mobile_request_info_list_.front());
+    request_controller_->mobile_request_info_list_.pop_front();
 
-    request_controller_->waiting_for_response_.Add(request_info_ptr);
+    bool init_res = request_info_ptr->request()->Init();  // to setup specific
+                                                          // default timeout
+
+    const uint32_t timeout_in_mseconds =
+        request_info_ptr->request()->default_timeout();
+    if (!request_controller_->waiting_for_response_.Add(request_info_ptr)) {
+      SDL_ERROR("Request has not been added. Execution skipped.");
+      continue;
+    }
     SDL_DEBUG("timeout_in_mseconds " << timeout_in_mseconds);
 
     if (0 != timeout_in_mseconds) {
@@ -453,11 +462,11 @@ void RequestController::Worker::threadMain() {
 
     // execute
     if ((false == request_controller_->IsLowVoltage()) &&
-        request_ptr->CheckPermissions() && init_res) {
+        request_info_ptr->request()->CheckPermissions() && init_res) {
       SDL_DEBUG("Execute MobileRequest corr_id = "
                 << request_info_ptr->requestId()
                 << " with timeout: " << timeout_in_mseconds);
-      request_ptr->Run();
+      request_info_ptr->request()->Run();
     }
   }
 }
@@ -503,9 +512,9 @@ RequestInfoSet& RequestController::get_waiting_for_response() {
   return waiting_for_response_;
 }
 
-const std::list<RequestInfoPtr>
+const std::list<RequestInfoPtr>&
 RequestController::get_mobile_request_info_list() const {
-  return mobile_request_list_;
+  return mobile_request_info_list_;
 }
 
 const std::list<RequestPtr>& RequestController::get_notification_list() const {

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -498,5 +498,20 @@ void RequestController::UpdateTimer() {
   }
 }
 
+#ifdef BUILD_TESTS
+RequestInfoSet& RequestController::get_waiting_for_response() {
+  return waiting_for_response_;
+}
+
+const std::list<RequestInfoPtr>
+RequestController::get_mobile_request_info_list() const {
+  return mobile_request_list_;
+}
+
+const std::list<RequestPtr>& RequestController::get_notification_list() const {
+  return notification_list_;
+}
+#endif  // BUILD_TESTS
+
 }  //  namespace request_controller
 }  //  namespace application_manager

--- a/src/components/application_manager/test/CMakeLists.txt
+++ b/src/components/application_manager/test/CMakeLists.txt
@@ -60,10 +60,10 @@ set(REQUEST_CONTROLLER_PATHS
 )
 # Temporary exclude some resumption tests from build due to compile errors APPLINK-26346
 set(REQUEST_CONTROLLER_SOURCES
- request_controller/request_info_test.cc
- request_controller/request_controller_test.cc
-
+  request_controller/request_info_test.cc
+  request_controller/request_controller_test.cc
 )
+
 #=============== RESUMPTION =====================
 set(RESUMPTION_PATHS
   ${CMAKE_CURRENT_SOURCE_DIR}/resumption

--- a/src/components/application_manager/test/CMakeLists.txt
+++ b/src/components/application_manager/test/CMakeLists.txt
@@ -59,11 +59,11 @@ set(REQUEST_CONTROLLER_PATHS
   ${CMAKE_CURRENT_SOURCE_DIR}/request_controller
 )
 # Temporary exclude some resumption tests from build due to compile errors APPLINK-26346
-set(REQUEST_CONTROLLER_EXCLUDE
-  zero_request_amount_test.cc
-)
-collect_sources(REQUEST_CONTROLLER_SOURCES "${REQUEST_CONTROLLER_PATHS}" "${REQUEST_CONTROLLER_EXCLUDE}")
+set(REQUEST_CONTROLLER_SOURCES
+ request_controller/request_info_test.cc
+ request_controller/request_controller_test.cc
 
+)
 #=============== RESUMPTION =====================
 set(RESUMPTION_PATHS
   ${CMAKE_CURRENT_SOURCE_DIR}/resumption

--- a/src/components/application_manager/test/CMakeLists.txt
+++ b/src/components/application_manager/test/CMakeLists.txt
@@ -60,7 +60,6 @@ set(REQUEST_CONTROLLER_PATHS
 )
 # Temporary exclude some resumption tests from build due to compile errors APPLINK-26346
 set(REQUEST_CONTROLLER_EXCLUDE
-  request_controller_test.cc
   zero_request_amount_test.cc
 )
 collect_sources(REQUEST_CONTROLLER_SOURCES "${REQUEST_CONTROLLER_PATHS}" "${REQUEST_CONTROLLER_EXCLUDE}")

--- a/src/components/application_manager/test/include/application_manager/mock_request.h
+++ b/src/components/application_manager/test/include/application_manager/mock_request.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_REQUEST_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_REQUEST_H_
+
+#include "gmock/gmock.h"
+#include "application_manager/commands/command.h"
+
+namespace test {
+namespace components {
+namespace application_manager_test {
+
+using ::testing::Return;
+
+class MockRequest : public application_manager::commands::Command {
+ public:
+  MockRequest(uint32_t connection_key, uint32_t correlation_id) {
+    ON_CALL(*this, correlation_id()).WillByDefault(Return(correlation_id));
+    ON_CALL(*this, connection_key()).WillByDefault(Return(connection_key));
+  }
+
+  MOCK_METHOD0(CheckPermissions, bool());
+  MOCK_METHOD0(Init, bool());
+  MOCK_METHOD0(Run, void());
+  MOCK_METHOD0(CleanUp, bool());
+  MOCK_CONST_METHOD0(default_timeout, uint32_t());
+  MOCK_CONST_METHOD0(function_id, int32_t());
+  MOCK_METHOD0(onTimeOut, void());
+  MOCK_METHOD0(AllowedToTerminate, bool());
+  MOCK_METHOD1(SetAllowedToTerminate, void(bool is_allowed));
+
+  MOCK_CONST_METHOD0(connection_key, uint32_t());
+  MOCK_CONST_METHOD0(correlation_id, uint32_t());
+};
+
+}  // namespace application_manager_test
+}  // namespace components
+}  // namespace test
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_REQUEST_H_

--- a/src/components/application_manager/test/request_controller/request_controller_test.cc
+++ b/src/components/application_manager/test/request_controller/request_controller_test.cc
@@ -80,6 +80,7 @@ const uint32_t kMaxRequestAmount = 2u;
 const uint32_t kDefaultCorrelationID = 1u;
 const uint32_t kDefaultConnectionKey = 0u;
 const uint32_t kDefaultTimeout = 100u;
+const uint32_t kThreadPoolSize = 1u;
 }  // namespace
 
 class RequestControllerTestClass : public ::testing::Test {
@@ -107,17 +108,17 @@ class RequestControllerTestClass : public ::testing::Test {
 
   RequestControllerTestClass() {
     ON_CALL(mock_request_controller_settings_, thread_pool_size())
-        .WillByDefault(Return(kThreadPoolSize_));
+        .WillByDefault(Return(kThreadPoolSize));
     request_ctrl_ =
         utils::MakeShared<RequestController>(mock_request_controller_settings_);
   }
 
   RequestPtr GetMockRequest(
       const uint32_t correlation_id = kDefaultCorrelationID,
-      const uint32_t connection_key = kDefaultConnectionKey,
+      const uint32_t kConnectionKey = kDefaultConnectionKey,
       const uint32_t default_timeout = kDefaultTimeout) {
     RequestPtr output =
-        utils::MakeShared<MRequest>(connection_key, correlation_id);
+        utils::MakeShared<MRequest>(kConnectionKey, correlation_id);
     ON_CALL(*output, default_timeout()).WillByDefault(Return(default_timeout));
     return output;
   }
@@ -179,7 +180,6 @@ class RequestControllerTestClass : public ::testing::Test {
   RequestControllerSPtr request_ctrl_;
   RequestPtr empty_mock_request_;
   const TestSettings kDefaultSettings_;
-  const uint32_t kThreadPoolSize_ = 1u;
 };
 
 TEST_F(RequestControllerTestClass,
@@ -368,7 +368,7 @@ TEST_F(RequestControllerTestClass,
   EXPECT_EQ(1u, waiting_for_response.Size());
 
   // Call is not expected because request termination will be forced
-  EXPECT_CALL(*mock_request, AllowedToTerminate()).Times(0u);
+  EXPECT_CALL(*mock_request, AllowedToTerminate()).Times(0);
 
   request_ctrl_->terminateRequest(
       kDefaultCorrelationID, kDefaultConnectionKey, force_terminate);
@@ -396,9 +396,9 @@ TEST_F(RequestControllerTestClass,
 
   // Trying to terminate request from not existing connection key
   const uint32_t correlation_id = 2u;
-  const uint32_t connection_key = 1u;
+  const uint32_t kConnectionKey = 1u;
   request_ctrl_->terminateRequest(
-      correlation_id, connection_key, force_terminate);
+      correlation_id, kConnectionKey, force_terminate);
 
   // Check if request is still in waiting_for_response list
   EXPECT_EQ(1u, waiting_for_response.Size());
@@ -448,16 +448,16 @@ TEST_F(RequestControllerTestClass, AddNotification_RemoveNotification_SUCCESS) {
 
 TEST_F(RequestControllerTestClass,
        TerminateWaitingForResponseAppRequests_SUCCESS) {
-  const uint32_t connection_key = RequestInfo::HmiConnectoinKey;
+  const uint32_t kConnectionKey = RequestInfo::HmiConnectoinKey;
 
   EXPECT_EQ(RequestController::SUCCESS,
             AddRequest(kDefaultSettings_,
-                       GetMockRequest(1u, connection_key),
+                       GetMockRequest(1u, kConnectionKey),
                        RequestInfo::RequestType::HMIRequest));
 
   EXPECT_EQ(RequestController::SUCCESS,
             AddRequest(kDefaultSettings_,
-                       GetMockRequest(2u, connection_key),
+                       GetMockRequest(2u, kConnectionKey),
                        RequestInfo::RequestType::HMIRequest));
 
   RequestInfoSet& waiting_for_response =
@@ -475,18 +475,18 @@ TEST_F(RequestControllerTestClass,
 
 TEST_F(RequestControllerTestClass,
        TerminateWaitingForExecutionAppRequests_SUCCESS) {
-  const uint32_t connection_key = 3u;
+  const uint32_t kConnectionKey = 3u;
 
   request_ctrl_->DestroyThreadpool();
 
   EXPECT_EQ(RequestController::SUCCESS,
             AddRequest(kDefaultSettings_,
-                       GetMockRequest(1u, connection_key),
+                       GetMockRequest(1u, kConnectionKey),
                        RequestInfo::RequestType::MobileRequest));
 
   EXPECT_EQ(RequestController::SUCCESS,
             AddRequest(kDefaultSettings_,
-                       GetMockRequest(2u, connection_key),
+                       GetMockRequest(2u, kConnectionKey),
                        RequestInfo::RequestType::MobileRequest));
 
   const RequestInfoPtrList& mobile_request_info_list =
@@ -495,7 +495,7 @@ TEST_F(RequestControllerTestClass,
   // Checking size of waiting_for_response list before terminating all requests
   EXPECT_EQ(2u, mobile_request_info_list.size());
 
-  request_ctrl_->terminateAppRequests(connection_key);
+  request_ctrl_->terminateAppRequests(kConnectionKey);
 
   // Expect empty mobile_request_info_list list
   EXPECT_EQ(0u, mobile_request_info_list.size());

--- a/src/components/application_manager/test/request_controller/request_controller_test.cc
+++ b/src/components/application_manager/test/request_controller/request_controller_test.cc
@@ -30,8 +30,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdint.h>
+
 #include "gtest/gtest.h"
 #include "application_manager/request_controller.h"
+#include "application_manager/request_info.h"
 #include "application_manager/mock_request.h"
 #include "utils/shared_ptr.h"
 #include "smart_objects/smart_object.h"
@@ -52,91 +55,232 @@ namespace test {
 namespace components {
 namespace request_controller_test {
 
-using application_manager::request_controller::RequestController;
-using application_manager::request_controller::RequestInfo;
+using ::application_manager::request_controller::RequestController;
+using ::application_manager::request_controller::RequestInfo;
+using ::application_manager::request_controller::HMIRequestInfo;
+using ::application_manager::request_controller::MobileRequestInfo;
 
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::NiceMock;
+using ::application_manager::request_controller::RequestInfoPtr;
+using ::application_manager::request_controller::RequestInfoSet;
 
-typedef utils::SharedPtr<application_manager_test::MockRequest> RequestPtr;
+typedef NiceMock<application_manager_test::MockRequest> MRequest;
+typedef utils::SharedPtr<MRequest> RequestPtr;
 typedef utils::SharedPtr<RequestController> RequestControllerSPtr;
+typedef std::list<RequestInfoPtr> RequestInfoPtrList;
+typedef std::list<::application_manager::request_controller::RequestPtr>
+    RequestPtrList;
+
+namespace {
+const size_t kNumberOfRequests = 10u;
+const uint32_t kTimeScale = 5000u;  // 5 seconds
+const uint32_t kMaxRequestAmount = 2u;
+const uint32_t kDefaultCorrelationID = 1u;
+const uint32_t kDefaultConnectionKey = 0u;
+const uint32_t kDefaultTimeout = 100u;
+}  // namespace
 
 class RequestControllerTestClass : public ::testing::Test {
  public:
-  RequestControllerTestClass()
-      : request_ctrl_(utils::MakeShared<RequestController>(
-            mock_request_controller_settings_)) {
-    register_request_ = GetMockRequest();
+  struct TestSettings {
+    uint32_t app_hmi_level_none_requests_time_scale_;
+    uint32_t app_hmi_level_none_time_scale_max_requests_;
+    uint32_t app_time_scale_max_requests_;
+    uint32_t app_requests_time_scale_;
+    uint32_t pending_requests_amount_;
+
+    TestSettings(const uint32_t app_hmi_level_none_requests_time_scale = 0u,
+                 const uint32_t app_hmi_level_none_time_scale_max_requests = 0u,
+                 const uint32_t app_time_scale_max_requests = 0u,
+                 const uint32_t app_requests_time_scale = 0u,
+                 const uint32_t pending_requests_amount = 0u)
+        : app_hmi_level_none_requests_time_scale_(
+              app_hmi_level_none_requests_time_scale)
+        , app_hmi_level_none_time_scale_max_requests_(
+              app_hmi_level_none_time_scale_max_requests)
+        , app_time_scale_max_requests_(app_time_scale_max_requests)
+        , app_requests_time_scale_(app_requests_time_scale)
+        , pending_requests_amount_(pending_requests_amount) {}
+  };
+
+  RequestControllerTestClass() {
+    ON_CALL(mock_request_controller_settings_, thread_pool_size())
+        .WillByDefault(Return(kThreadPoolSize_));
+    request_ctrl_ =
+        utils::MakeShared<RequestController>(mock_request_controller_settings_);
+  }
+
+  RequestPtr GetMockRequest(
+      const uint32_t correlation_id = kDefaultCorrelationID,
+      const uint32_t connection_key = kDefaultConnectionKey,
+      const uint32_t default_timeout = kDefaultTimeout) {
+    RequestPtr output =
+        utils::MakeShared<MRequest>(connection_key, correlation_id);
+    ON_CALL(*output, default_timeout()).WillByDefault(Return(default_timeout));
+    return output;
+  }
+
+  RequestInfoPtr GetRequestInfo(RequestPtr request,
+                                const RequestInfo::RequestType request_type =
+                                    RequestInfo::RequestType::HMIRequest,
+                                const mobile_apis::HMILevel::eType& hmi_level =
+                                    mobile_apis::HMILevel::INVALID_ENUM) {
+    RequestInfoPtr request_info_ptr;
+    if (request_type == RequestInfo::RequestType::HMIRequest) {
+      request_info_ptr = utils::MakeShared<HMIRequestInfo>(
+          request, request->default_timeout());
+    } else {
+      request_info_ptr = utils::MakeShared<MobileRequestInfo>(
+          request, request->default_timeout());
+    }
+    request_info_ptr->set_hmi_level(hmi_level);
+
+    return request_info_ptr;
   }
 
   RequestController::TResult AddRequest(
-      const RequestInfo::RequestType request_type,
-      const bool RegisterRequest = false,
+      const TestSettings& settings,
+      RequestPtr request,
+      const RequestInfo::RequestType request_type =
+          RequestInfo::RequestType::HMIRequest,
       const mobile_apis::HMILevel::eType& hmi_level =
           mobile_apis::HMILevel::INVALID_ENUM) {
-    RequestPtr request;
-    if (RegisterRequest) {
-      request = register_request_;
-      EXPECT_CALL(*register_request_, default_timeout()).WillOnce(Return(0));
-    } else {
-      request = empty_register_request_;
-    }
     if (RequestInfo::RequestType::HMIRequest == request_type) {
       return request_ctrl_->addHMIRequest(request);
     }
+    CallSettings(settings);
     return request_ctrl_->addMobileRequest(request, hmi_level);
   }
 
-  RequestPtr GetMockRequest(const uint32_t id = 1,
-                            const uint32_t connection_key = 0) {
-    return utils::MakeShared<application_manager_test::MockRequest>(
-        connection_key, id);
-  }
-  void CallSettings() {
-    EXPECT_CALL(mock_request_controller_settings_,
-                app_hmi_level_none_time_scale())
-        .WillOnce(ReturnRef(kDefaultAppHmiLevelNoneRequestsTimeScale));
-    EXPECT_CALL(mock_request_controller_settings_,
-                app_hmi_level_none_time_scale_max_requests())
-        .WillOnce(ReturnRef(kDefaultAppHmiLevelNoneTimeScaleMaxRequests));
+  void CallSettings(const TestSettings& settings) const {
+    ON_CALL(mock_request_controller_settings_, app_hmi_level_none_time_scale())
+        .WillByDefault(
+            ReturnRef(settings.app_hmi_level_none_requests_time_scale_));
 
-    EXPECT_CALL(mock_request_controller_settings_, app_time_scale())
-        .WillOnce(ReturnRef(kDefaultAppRequestsTimeScale));
-    EXPECT_CALL(mock_request_controller_settings_,
-                app_time_scale_max_requests())
-        .WillOnce(ReturnRef(kDefaultAppTimeScaleMaxRequests));
+    ON_CALL(mock_request_controller_settings_,
+            app_hmi_level_none_time_scale_max_requests())
+        .WillByDefault(
+            ReturnRef(settings.app_hmi_level_none_time_scale_max_requests_));
 
-    EXPECT_CALL(mock_request_controller_settings_, pending_requests_amount())
-        .WillOnce(ReturnRef(kDefaultPendingRequestsAmount));
+    ON_CALL(mock_request_controller_settings_, app_time_scale())
+        .WillByDefault(ReturnRef(settings.app_requests_time_scale_));
+
+    ON_CALL(mock_request_controller_settings_, app_time_scale_max_requests())
+        .WillByDefault(ReturnRef(settings.app_time_scale_max_requests_));
+
+    ON_CALL(mock_request_controller_settings_, pending_requests_amount())
+        .WillByDefault(ReturnRef(settings.pending_requests_amount_));
   }
 
-  application_manager_test::MockRequestControlerSettings
+  NiceMock<application_manager_test::MockRequestControlerSettings>
       mock_request_controller_settings_;
-  RequestPtr register_request_;
-  RequestPtr empty_register_request_;
   RequestControllerSPtr request_ctrl_;
-
-  const uint32_t kDefaultAppHmiLevelNoneRequestsTimeScale = 10;
-  const uint32_t kDefaultAppHmiLevelNoneTimeScaleMaxRequests = 100u;
-  const uint32_t kDefaultAppTimeScaleMaxRequests = 0;
-  const uint32_t kDefaultAppRequestsTimeScale = 0;
-  const uint32_t kDefaultPendingRequestsAmount = 0;
+  RequestPtr empty_mock_request_;
+  const TestSettings kDefaultSettings_;
+  const uint32_t kThreadPoolSize_ = 1u;
 };
 
-TEST_F(RequestControllerTestClass, CheckPosibilitytoAdd_HMI_FULL_SUCCESS) {
-  CallSettings();
-  EXPECT_EQ(RequestController::TResult::SUCCESS,
-            AddRequest(RequestInfo::RequestType::MobileRequest,
-                       true,
+TEST_F(RequestControllerTestClass,
+       CheckPosibilitytoAdd_ZeroValueLimiters_SUCCESS) {
+  // Test case than pending_requests_amount,
+  // app_time_scale_max_requests_ and
+  // app_hmi_level_none_time_scale_max_requests_ equals 0
+  // (in the default settings they setted to 0)
+  for (size_t i = 0; i < kMaxRequestAmount; ++i) {
+    EXPECT_EQ(RequestController::SUCCESS,
+              AddRequest(kDefaultSettings_,
+                         GetMockRequest(i),
+                         RequestInfo::RequestType::MobileRequest,
+                         mobile_apis::HMILevel::HMI_FULL));
+  }
+}
+
+TEST_F(
+    RequestControllerTestClass,
+    CheckPosibilitytoAdd_ExcessPendingRequestsAmount_TooManyPendingRequests) {
+  TestSettings settings;
+  settings.pending_requests_amount_ = kNumberOfRequests;
+
+  request_ctrl_->DestroyThreadpool();
+
+  // Adding requests to fit in pending_requests_amount_
+  for (size_t i = 0; i < kNumberOfRequests; ++i) {
+    EXPECT_EQ(RequestController::TResult::SUCCESS,
+              AddRequest(settings,
+                         GetMockRequest(),
+                         RequestInfo::RequestType::MobileRequest,
+                         mobile_apis::HMILevel::HMI_FULL));
+  }
+
+  // Trying to add one more extra request
+  // Expect overflow and TOO_MANY_PENDING_REQUESTS result
+  EXPECT_EQ(RequestController::TResult::TOO_MANY_PENDING_REQUESTS,
+            AddRequest(settings,
+                       GetMockRequest(),
+                       RequestInfo::RequestType::MobileRequest,
                        mobile_apis::HMILevel::HMI_FULL));
 }
 
-TEST_F(RequestControllerTestClass, CheckPosibilitytoAdd_HMI_NONE_SUCCESS) {
-  CallSettings();
-  EXPECT_EQ(RequestController::TResult::SUCCESS,
-            AddRequest(RequestInfo::RequestType::MobileRequest,
-                       true,
+TEST_F(
+    RequestControllerTestClass,
+    CheckPosibilitytoAdd_ExcessHMILevelNoneTimeScaleMaxRequests_NoneHMILevelManyRequests) {
+  TestSettings settings;
+  // Setting time scale and max requests amount per it
+  // for none HMILevel type of requests
+  settings.app_hmi_level_none_requests_time_scale_ = kTimeScale;
+  settings.app_hmi_level_none_time_scale_max_requests_ = kNumberOfRequests;
+
+  request_ctrl_->DestroyThreadpool();
+
+  RequestInfoSet& waiting_for_response =
+      request_ctrl_->get_waiting_for_response();
+
+  // Artificially adding requests to waiting_for_response list
+  size_t i = 0;
+  for (; i < kNumberOfRequests; ++i) {
+    waiting_for_response.Add(
+        GetRequestInfo(GetMockRequest(i),
+                       RequestInfo::RequestType::MobileRequest,
                        mobile_apis::HMILevel::HMI_NONE));
+  }
+  // Trying to add one more extra request
+  // Expect overflow and NONE_HMI_LEVEL_MANY_REQUESTS result
+  EXPECT_EQ(RequestController::TResult::NONE_HMI_LEVEL_MANY_REQUESTS,
+            AddRequest(settings,
+                       GetMockRequest(i),
+                       RequestInfo::RequestType::MobileRequest,
+                       mobile_apis::HMILevel::HMI_NONE));
+}
+
+TEST_F(RequestControllerTestClass,
+       CheckPosibilitytoAdd_ExcessTimeScaleMaxRequest_ToManyRequests) {
+  TestSettings settings;
+  // Setting time scale and max requests amount per it
+  settings.app_requests_time_scale_ = kTimeScale;
+  settings.app_time_scale_max_requests_ = kNumberOfRequests;
+
+  request_ctrl_->DestroyThreadpool();
+
+  RequestInfoSet& waiting_for_response =
+      request_ctrl_->get_waiting_for_response();
+
+  // Artificially adding requests to waiting_for_response list
+  size_t i = 0u;
+  for (; i < kNumberOfRequests; ++i) {
+    waiting_for_response.Add(
+        GetRequestInfo(GetMockRequest(i),
+                       RequestInfo::RequestType::MobileRequest,
+                       mobile_apis::HMILevel::INVALID_ENUM));
+  }
+  // Trying to add one more extra request
+  // Expect overflow and TOO_MANY_REQUESTS result
+  EXPECT_EQ(RequestController::TResult::TOO_MANY_REQUESTS,
+            AddRequest(settings,
+                       GetMockRequest(i),
+                       RequestInfo::RequestType::MobileRequest,
+                       mobile_apis::HMILevel::INVALID_ENUM));
 }
 
 TEST_F(RequestControllerTestClass, IsLowVoltage_SetOnLowVoltage_TRUE) {
@@ -151,34 +295,226 @@ TEST_F(RequestControllerTestClass, IsLowVoltage_SetOnWakeUp_FALSE) {
   EXPECT_EQ(result, request_ctrl_->IsLowVoltage());
 }
 
+TEST_F(RequestControllerTestClass, AddMobileRequest_SetValidData_SUCCESS) {
+  EXPECT_EQ(RequestController::SUCCESS,
+            AddRequest(kDefaultSettings_,
+                       GetMockRequest(),
+                       RequestInfo::RequestType::MobileRequest,
+                       mobile_apis::HMILevel::HMI_FULL));
+}
+
 TEST_F(RequestControllerTestClass,
        AddMobileRequest_SetInvalidData_INVALID_DATA) {
   EXPECT_EQ(RequestController::INVALID_DATA,
-            AddRequest(RequestInfo::RequestType::MobileRequest,
-                       false,
+            AddRequest(kDefaultSettings_,
+                       empty_mock_request_,
+                       RequestInfo::RequestType::MobileRequest,
                        mobile_apis::HMILevel::HMI_NONE));
 }
 
-TEST_F(RequestControllerTestClass, addHMIRequest_AddRequest_SUCCESS) {
+TEST_F(RequestControllerTestClass, AddHMIRequest_AddRequest_SUCCESS) {
   EXPECT_EQ(RequestController::SUCCESS,
-            AddRequest(RequestInfo::RequestType::HMIRequest, true));
+            AddRequest(kDefaultSettings_,
+                       GetMockRequest(),
+                       RequestInfo::RequestType::HMIRequest));
 }
 
-TEST_F(RequestControllerTestClass, addHMIRequest_AddInvalidData_INVALID_DATA) {
+TEST_F(RequestControllerTestClass, AddHMIRequest_AddInvalidData_INVALID_DATA) {
   EXPECT_EQ(RequestController::INVALID_DATA,
-            AddRequest(RequestInfo::RequestType::HMIRequest));
+            AddRequest(kDefaultSettings_,
+                       empty_mock_request_,
+                       RequestInfo::RequestType::HMIRequest));
 }
 
-TEST_F(RequestControllerTestClass, ZeroValuePendingRequestsAmount) {
-  // Bigger than pending_requests_amount count
-  const uint32_t big_count_of_requests_for_test_ = 10;
-  for (uint32_t i = 0; i < big_count_of_requests_for_test_; ++i) {
-    CallSettings();
-    EXPECT_EQ(RequestController::SUCCESS,
-              AddRequest(RequestInfo::RequestType::MobileRequest,
-                         true,
-                         mobile_apis::HMILevel::HMI_FULL));
+TEST_F(RequestControllerTestClass,
+       TerminateRequest_TerminateExistingRequest_SUCCESS) {
+  const bool force_terminate = false;
+  RequestPtr mock_request =
+      GetMockRequest(kDefaultCorrelationID, kDefaultConnectionKey);
+
+  RequestInfoSet& waiting_for_response =
+      request_ctrl_->get_waiting_for_response();
+
+  EXPECT_EQ(RequestController::SUCCESS,
+            AddRequest(kDefaultSettings_, mock_request));
+
+  // Check if request is added to waiting_for_response list
+  EXPECT_EQ(1u, waiting_for_response.Size());
+
+  // Expect call of 'AllowedToTerminate method' cause 'force_terminate' is
+  // 'false'
+  EXPECT_CALL(*mock_request, AllowedToTerminate()).WillOnce(Return(true));
+
+  request_ctrl_->terminateRequest(
+      kDefaultCorrelationID, kDefaultConnectionKey, force_terminate);
+
+  // Check if request is terminated
+  EXPECT_EQ(0u, waiting_for_response.Size());
+}
+
+TEST_F(RequestControllerTestClass,
+       TerminateRequest_ForceToTerminateExistingRequest_SUCCESS) {
+  const bool force_terminate = true;
+  RequestPtr mock_request =
+      GetMockRequest(kDefaultCorrelationID, kDefaultConnectionKey);
+
+  RequestInfoSet& waiting_for_response =
+      request_ctrl_->get_waiting_for_response();
+
+  EXPECT_EQ(RequestController::SUCCESS,
+            AddRequest(kDefaultSettings_, mock_request));
+
+  // Check if request is added to waiting_for_response list
+  EXPECT_EQ(1u, waiting_for_response.Size());
+
+  // Call is not expected because request termination will be forced
+  EXPECT_CALL(*mock_request, AllowedToTerminate()).Times(0u);
+
+  request_ctrl_->terminateRequest(
+      kDefaultCorrelationID, kDefaultConnectionKey, force_terminate);
+
+  // Check if request is terminated
+  EXPECT_EQ(0u, waiting_for_response.Size());
+}
+
+TEST_F(RequestControllerTestClass,
+       TerminateRequest_TerminateNotExistingRequest_UNSUCCESS) {
+  const bool force_terminate = false;
+  RequestPtr mock_request =
+      GetMockRequest(kDefaultCorrelationID, kDefaultConnectionKey);
+
+  RequestInfoSet& waiting_for_response =
+      request_ctrl_->get_waiting_for_response();
+
+  EXPECT_EQ(RequestController::SUCCESS,
+            AddRequest(kDefaultSettings_, mock_request));
+
+  // Check if request is added to waiting_for_response list
+  EXPECT_EQ(1u, waiting_for_response.Size());
+
+  EXPECT_CALL(*mock_request, AllowedToTerminate()).Times(0u);
+
+  // Trying to terminate request from not existing connection key
+  const uint32_t correlation_id = 2u;
+  const uint32_t connection_key = 1u;
+  request_ctrl_->terminateRequest(
+      correlation_id, connection_key, force_terminate);
+
+  // Check if request is still in waiting_for_response list
+  EXPECT_EQ(1u, waiting_for_response.Size());
+}
+
+TEST_F(RequestControllerTestClass,
+       UpdateRequestTimeout_UpdateTimeoutToExistingRequest_SUCCESS) {
+  const uint32_t default_timeout = 15u;
+  const uint32_t updated_timeout = 20u;
+  RequestPtr mock_request = GetMockRequest(
+      kDefaultCorrelationID, kDefaultConnectionKey, default_timeout);
+
+  EXPECT_EQ(RequestController::SUCCESS,
+            AddRequest(kDefaultSettings_, mock_request));
+
+  request_ctrl_->updateRequestTimeout(
+      kDefaultConnectionKey, kDefaultCorrelationID, updated_timeout);
+
+  // Getting updated request
+  RequestInfoSet& waiting_for_response =
+      request_ctrl_->get_waiting_for_response();
+  const RequestInfoPtr& request =
+      waiting_for_response.Find(kDefaultConnectionKey, kDefaultCorrelationID);
+
+  EXPECT_EQ(updated_timeout, request->timeout_msec());
+}
+
+TEST_F(RequestControllerTestClass, AddNotification_RemoveNotification_SUCCESS) {
+  RequestPtr mock_requests[kNumberOfRequests];
+
+  for (size_t i = 0u; i < kNumberOfRequests; ++i) {
+    mock_requests[i] = GetMockRequest(i);
+    request_ctrl_->addNotification(mock_requests[i]);
   }
+
+  const RequestPtrList& notification_list =
+      request_ctrl_->get_notification_list();
+
+  EXPECT_EQ(kNumberOfRequests, notification_list.size());
+
+  for (size_t i = 0u; i < kNumberOfRequests; ++i) {
+    request_ctrl_->removeNotification(mock_requests[i].get());
+  }
+
+  EXPECT_EQ(0u, notification_list.size());
+}
+
+TEST_F(RequestControllerTestClass,
+       TerminateWaitingForResponseAppRequests_SUCCESS) {
+  const uint32_t connection_key = RequestInfo::HmiConnectoinKey;
+
+  EXPECT_EQ(RequestController::SUCCESS,
+            AddRequest(kDefaultSettings_,
+                       GetMockRequest(1u, connection_key),
+                       RequestInfo::RequestType::HMIRequest));
+
+  EXPECT_EQ(RequestController::SUCCESS,
+            AddRequest(kDefaultSettings_,
+                       GetMockRequest(2u, connection_key),
+                       RequestInfo::RequestType::HMIRequest));
+
+  RequestInfoSet& waiting_for_response =
+      request_ctrl_->get_waiting_for_response();
+
+  // Checking size of waiting_for_response list before terminating all HMI
+  // requests
+  EXPECT_EQ(2u, waiting_for_response.Size());
+
+  request_ctrl_->terminateAllHMIRequests();
+
+  // Expect empty waiting_for_response list
+  EXPECT_EQ(0u, waiting_for_response.Size());
+}
+
+TEST_F(RequestControllerTestClass,
+       TerminateWaitingForExecutionAppRequests_SUCCESS) {
+  const uint32_t connection_key = 3u;
+
+  request_ctrl_->DestroyThreadpool();
+
+  EXPECT_EQ(RequestController::SUCCESS,
+            AddRequest(kDefaultSettings_,
+                       GetMockRequest(1u, connection_key),
+                       RequestInfo::RequestType::MobileRequest));
+
+  EXPECT_EQ(RequestController::SUCCESS,
+            AddRequest(kDefaultSettings_,
+                       GetMockRequest(2u, connection_key),
+                       RequestInfo::RequestType::MobileRequest));
+
+  const RequestInfoPtrList& mobile_request_info_list =
+      request_ctrl_->get_mobile_request_info_list();
+
+  // Checking size of waiting_for_response list before terminating all requests
+  EXPECT_EQ(2u, mobile_request_info_list.size());
+
+  request_ctrl_->terminateAppRequests(connection_key);
+
+  // Expect empty mobile_request_info_list list
+  EXPECT_EQ(0u, mobile_request_info_list.size());
+}
+
+TEST_F(RequestControllerTestClass, OnTimer_SUCCESS) {
+  const uint32_t request_timeout = 1u;
+  RequestPtr mock_request = GetMockRequest(
+      kDefaultCorrelationID, kDefaultConnectionKey, request_timeout);
+
+  EXPECT_EQ(RequestController::SUCCESS,
+            AddRequest(kDefaultSettings_,
+                       mock_request,
+                       RequestInfo::RequestType::MobileRequest));
+
+  EXPECT_CALL(*mock_request, onTimeOut());
+
+  // Waiting for call of `onTimeOut` for `kTimeScale` seconds
+  testing::Mock::AsyncVerifyAndClearExpectations(kTimeScale);
 }
 
 }  // namespace request_controller_test


### PR DESCRIPTION
Commit was moved from [PASA](https://github.com/CustomSDL/sdl_panasonic/pull/322).
Adding request info was moved from PASA - partially commit b8fb1d6.
Related to [APPLINK-22721](https://adc.luxoft.com/jira/browse/APPLINK-22721)

Please review @OHerasym, @okozlovlux, @LevchenkoS, @VProdanov, @dtrunov, @nk0leg