### PR TITLE
Fix uninitialized pointer and scalar fields (Coverity)

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -88,7 +88,10 @@ struct Version {
 
 struct AppFile {
     // need to use in std::map;
-    AppFile() {
+    AppFile()
+      : is_persistent(false),
+        is_download_complete(false),
+        file_type(mobile_apis::FileType::INVALID_ENUM) {
     }
     AppFile(const std::string& name, bool persistent, bool download_complete,
           mobile_apis::FileType::eType type)

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -367,7 +367,8 @@ class Application : public virtual InitialApplicationData,
     };
 
   public:
-    Application() :
+    Application() : app_state_(ApplicationState::kWaitingForRegistration),
+      connection_id_(0),
       is_greyed_out_(false) {
     }
 

--- a/src/components/application_manager/include/application_manager/commands/mobile/create_interaction_choice_set_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/create_interaction_choice_set_request.h
@@ -103,7 +103,9 @@ class CreateInteractionChoiceSetRequest : public CommandRequestImpl {
      * processing deleting sent commands if error from HMI received
      */
     struct VRCommandInfo {
-      VRCommandInfo() {}
+      VRCommandInfo():
+        cmd_id_(0),
+        succesful_response_received_(false) {}
       explicit VRCommandInfo(uint32_t cmd_id):
         cmd_id_(cmd_id),
         succesful_response_received_(false) {}

--- a/src/components/application_manager/include/application_manager/request_info.h
+++ b/src/components/application_manager/include/application_manager/request_info.h
@@ -55,16 +55,27 @@ namespace request_controller {
   typedef utils::SharedPtr<commands::Command> RequestPtr;
 
   struct RequestInfo {
-    enum RequestType {MobileRequest, HMIRequest};
+    enum RequestType {RequestNone, MobileRequest, HMIRequest};
 
-    RequestInfo() {}
+    RequestInfo()
+      : timeout_sec_(0),
+        app_id_(0),
+        hmi_level_(mobile_apis::HMILevel::INVALID_ENUM),
+        requst_type_(RequestNone),
+        correlation_id_(0) {
+          start_time_ = date_time::DateTime::getCurrentTime();
+          updateEndTime();
+        }
     virtual ~RequestInfo() {}
 
     RequestInfo(RequestPtr request,
                 const RequestType requst_type,
                 const uint64_t timeout_sec)
       : request_(request),
-        timeout_sec_(timeout_sec) {
+        timeout_sec_(timeout_sec),
+        app_id_(0),
+        hmi_level_(mobile_apis::HMILevel::INVALID_ENUM),
+        correlation_id_(0) {
         start_time_ = date_time::DateTime::getCurrentTime();
         updateEndTime();
         requst_type_ = requst_type;

--- a/src/components/application_manager/include/application_manager/state_controller.h
+++ b/src/components/application_manager/include/application_manager/state_controller.h
@@ -241,7 +241,7 @@ private:
     StateController *state_ctrl_;
     HmiLevelConflictResolver(ApplicationSharedPtr app, HmiStatePtr state,
                              StateController *state_ctrl)
-        : applied_(app), state_(state) {}
+        : applied_(app), state_(state), state_ctrl_(state_ctrl) {}
     void operator()(ApplicationSharedPtr to_resolve);
   };
 

--- a/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -47,9 +47,11 @@ namespace commands {
 CreateInteractionChoiceSetRequest::CreateInteractionChoiceSetRequest(
   const MessageSharedPtr& message)
   : CommandRequestImpl(message),
+    choice_set_id_(0),
     expected_chs_count_(0),
     received_chs_count_(0),
-    error_from_hmi_(false) {
+    error_from_hmi_(false),
+    is_timed_out_(false) {
 }
 
 CreateInteractionChoiceSetRequest::~CreateInteractionChoiceSetRequest() {

--- a/src/components/application_manager/src/message.cc
+++ b/src/components/application_manager/src/message.cc
@@ -68,7 +68,8 @@ Message::Message(protocol_handler::MessagePriority priority)
 }
 
 Message::Message(const Message& message)
-    : priority_(message.priority_) {
+    : priority_(message.priority_),
+      binary_data_(NULL) {
   *this = message;
 }
 

--- a/src/components/application_manager/src/policies/delegates/statistics_delegate.cc
+++ b/src/components/application_manager/src/policies/delegates/statistics_delegate.cc
@@ -38,6 +38,9 @@ namespace policy {
   StatisticsDelegate::StatisticsDelegate(usage_statistics::GlobalCounterId type)
     : type_(INCREMENT_GLOBAL),
       global_counter_(type),
+      app_counter_(usage_statistics::AppCounterId::APP_COUNTER_NONE),
+      app_info_(usage_statistics::AppInfoId::APP_INFO_NONE),
+      stop_watch_(usage_statistics::AppStopwatchId::STOPWATCH_NONE),
       app_id_(""),
       value_(""),
       timespan_seconds_(0) {
@@ -47,7 +50,10 @@ namespace policy {
   StatisticsDelegate::StatisticsDelegate(const std::string& app_id,
                                        usage_statistics::AppCounterId type)
     : type_(INCREMENT_APP),
+      global_counter_(usage_statistics::GlobalCounterId::GLOBAL_COUNTER_NONE),
       app_counter_(type),
+      app_info_(usage_statistics::AppInfoId::APP_INFO_NONE),
+      stop_watch_(usage_statistics::AppStopwatchId::STOPWATCH_NONE),
       app_id_(app_id),
       value_(""),
       timespan_seconds_(0) {
@@ -58,7 +64,10 @@ namespace policy {
                                        usage_statistics::AppInfoId type,
                                        const std::string& value)
     : type_(SET),
+      global_counter_(usage_statistics::GlobalCounterId::GLOBAL_COUNTER_NONE),
+      app_counter_(usage_statistics::AppCounterId::APP_COUNTER_NONE),
       app_info_(type),
+      stop_watch_(usage_statistics::AppStopwatchId::STOPWATCH_NONE),
       app_id_(app_id),
       value_(value),
       timespan_seconds_(0) {
@@ -69,6 +78,9 @@ namespace policy {
                                        usage_statistics::AppStopwatchId type,
                                        int32_t timespan_seconds)
     : type_(ADD),
+      global_counter_(usage_statistics::GlobalCounterId::GLOBAL_COUNTER_NONE),
+      app_counter_(usage_statistics::AppCounterId::APP_COUNTER_NONE),
+      app_info_(usage_statistics::AppInfoId::APP_INFO_NONE),
       stop_watch_(type),
       app_id_(app_id),
       value_(""),

--- a/src/components/application_manager/src/request_info.cc
+++ b/src/components/application_manager/src/request_info.cc
@@ -84,7 +84,8 @@ RequestInfo::RequestInfo(RequestPtr request,
                          const uint64_t timeout_sec):
   request_(request),
   start_time_(start_time),
-  timeout_sec_(timeout_sec) {
+  timeout_sec_(timeout_sec),
+  hmi_level_(mobile_apis::HMILevel::INVALID_ENUM) {
   updateEndTime();
   requst_type_ = requst_type;
   correlation_id_ = request_->correlation_id();

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -258,6 +258,7 @@ Profile::Profile()
       server_port_(kDefaultServerPort),
       video_streaming_port_(kDefaultVideoStreamingPort),
       audio_streaming_port_(kDefaultAudioStreamingPort),
+      stop_streaming_timeout_(kDefaultStopStreamingTimeout),
       time_testing_port_(kDefaultTimeTestingPort),
       hmi_capabilities_file_name_(kDefaultHmiCapabilitiesFileName),
       help_prompt_(),
@@ -268,6 +269,7 @@ Profile::Profile()
       max_cmd_id_(kDefaultMaxCmdId),
       default_timeout_(kDefaultTimeout),
       app_resuming_timeout_(kDefaultAppResumingTimeout),
+      app_resumption_save_persistent_data_timeout_(kDefaultAppSavePersistentDataTimeout),
       app_dir_quota_(kDefaultDirQuota),
       app_hmi_level_none_time_scale_max_requests_(
           kDefaultAppHmiLevelNoneTimeScaleMaxRequests),
@@ -298,6 +300,8 @@ Profile::Profile()
       recording_file_source_(kDefaultRecordingFileSourceName),
       recording_file_name_(kDefaultRecordingFileName),
       application_list_update_timeout_(kDefaultApplicationListUpdateTimeout),
+      max_thread_pool_size_(kDefaultMaxThreadPoolSize),
+      default_hub_protocol_index_(kDefaultHubProtocolIndex),
       iap_legacy_protocol_mask_(kDefaultLegacyProtocolMask),
       iap_hub_protocol_mask_(kDefaultHubProtocolMask),
       iap_pool_protocol_mask_(kDefaultPoolProtocolMask),
@@ -308,6 +312,8 @@ Profile::Profile()
       tts_global_properties_timeout_(kDefaultTTSGlobalPropertiesTimeout),
       attempts_to_open_policy_db_(kDefaultAttemptsToOpenPolicyDB),
       open_attempt_timeout_ms_(kDefaultAttemptsToOpenPolicyDB),
+      resumption_delay_before_ign_(kDefaultResumptionDelayBeforeIgn),
+      resumption_delay_after_ign_(kDefaultResumptionDelayAfterIgn),
       hash_string_size_(kDefaultHashStringSize) {
   ReadStringValue(&sdl_version_, kDefaultSDLVersion,
                   kMainSection, kSDLVersionKey);

--- a/src/components/connection_handler/include/connection_handler/connection.h
+++ b/src/components/connection_handler/include/connection_handler/connection.h
@@ -41,6 +41,7 @@
 #include "connection_handler/device.h"
 #include "connection_handler/heartbeat_monitor.h"
 #include "protocol/service_type.h"
+#include "protocol_handler/protocol_packet.h"
 
 #ifdef ENABLE_SECURITY
 namespace security_manager {
@@ -97,7 +98,8 @@ struct Session {
   security_manager::SSLContext *ssl_context;
 #endif  // ENABLE_SECURITY
   Session()
-    : service_list()
+    : service_list(),
+      protocol_version(::protocol_handler::PROTOCOL_VERSION_2)
 #ifdef ENABLE_SECURITY
     , ssl_context(NULL)
 #endif  // ENABLE_SECURITY

--- a/src/components/hmi_message_handler/src/mqueue_adapter.cc
+++ b/src/components/hmi_message_handler/src/mqueue_adapter.cc
@@ -78,6 +78,7 @@ MqueueAdapter::MqueueAdapter(HMIMessageHandler* hmi_message_handler)
     : HMIMessageAdapter(hmi_message_handler),
       sdl_to_hmi_mqueue_(-1),
       hmi_to_sdl_mqueue_(-1),
+      receiver_thread_delegate_(NULL),
       receiver_thread_(NULL) {
   mq_attr mq_attributes;
   mq_attributes.mq_maxmsg = kMqueueSize;

--- a/src/components/media_manager/src/audio/audio_stream_sender_thread.cc
+++ b/src/components/media_manager/src/audio/audio_stream_sender_thread.cc
@@ -63,6 +63,7 @@ AudioStreamSenderThread::AudioStreamSenderThread(
   const std::string fileName, uint32_t session_key)
   : session_key_(session_key),
     fileName_(fileName),
+    offset_(0),
     shouldBeStoped_(false),
     shouldBeStoped_lock_(),
     shouldBeStoped_cv_() {

--- a/src/components/media_manager/src/audio/from_mic_recorder_listener.cc
+++ b/src/components/media_manager/src/audio/from_mic_recorder_listener.cc
@@ -42,7 +42,8 @@ CREATE_LOGGERPTR_GLOBAL(logger_, "FromMicRecorderListener")
 FromMicRecorderListener::FromMicRecorderListener(
   const std::string& file_name)
   : reader_(NULL)
-  , file_name_(file_name) {
+  , file_name_(file_name)
+  , current_application_(0) {
 }
 
 FromMicRecorderListener::~FromMicRecorderListener() {

--- a/src/components/media_manager/src/socket_streamer_adapter.cc
+++ b/src/components/media_manager/src/socket_streamer_adapter.cc
@@ -49,7 +49,8 @@ namespace media_manager {
 CREATE_LOGGERPTR_GLOBAL(logger, "SocketStreamerAdapter")
 
 SocketStreamerAdapter::SocketStreamerAdapter()
-  : socket_fd_(0),
+  : port_(0),
+    socket_fd_(0),
     is_ready_(false),
     streamer_(new Streamer(this)),
     thread_(threads::CreateThread("SocketStreamer", streamer_)),

--- a/src/components/policy/src/policy/usage_statistics/include/usage_statistics/statistics_manager.h
+++ b/src/components/policy/src/policy/usage_statistics/include/usage_statistics/statistics_manager.h
@@ -39,17 +39,20 @@
 namespace usage_statistics {
 
 enum GlobalCounterId {
+  GLOBAL_COUNTER_NONE,
   IAP_BUFFER_FULL,
   SYNC_OUT_OF_MEMORY,
   SYNC_REBOOTS
 };
 
 enum AppInfoId {
+  APP_INFO_NONE,
   LANGUAGE_GUI,
   LANGUAGE_VUI
 };
 
 enum AppStopwatchId {
+  STOPWATCH_NONE,
   SECONDS_HMI_FULL,
   SECONDS_HMI_LIMITED,
   SECONDS_HMI_BACKGROUND,
@@ -57,6 +60,7 @@ enum AppStopwatchId {
 };
 
 enum AppCounterId {
+  APP_COUNTER_NONE,
   USER_SELECTIONS,
   REJECTIONS_SYNC_OUT_OF_MEMORY,
   REJECTIONS_NICKNAME_MISMATCH,

--- a/src/components/rpc_base/include/rpc_base/rpc_base_inl.h
+++ b/src/components/rpc_base/include/rpc_base/rpc_base_inl.h
@@ -574,13 +574,15 @@ void Nullable<T>::ReportErrors(ValidationReport* report) const {
  * Optional class
  */
 template<typename T>
-Optional<T>::Optional() {
+Optional<T>::Optional()
+    : policy_table_type_(policy_table_interface_base::INVALID_PT_TYPE) {
 }
 
 template<typename T>
 template<typename U>
 Optional<T>::Optional(const U& value)
-    : value_(value) {
+    : policy_table_type_(policy_table_interface_base::INVALID_PT_TYPE),
+      value_(value) {
 }
 
 template<typename T>

--- a/src/components/rpc_base/include/rpc_base/rpc_base_json_inl.h
+++ b/src/components/rpc_base/include/rpc_base/rpc_base_json_inl.h
@@ -356,7 +356,8 @@ inline Json::Value Nullable<T>::ToJsonValue() const {
 template<typename T>
 template<typename U>
 Optional<T>::Optional(const Json::Value* value, const U& def_value)
-  : value_(value, def_value) {
+  : policy_table_type_(policy_table_interface_base::INVALID_PT_TYPE),
+    value_(value, def_value) {
 }
 
 template<typename T>

--- a/src/components/security_manager/src/ssl_context_impl.cc
+++ b/src/components/security_manager/src/ssl_context_impl.cc
@@ -52,7 +52,8 @@ CryptoManagerImpl::SSLContextImpl::SSLContextImpl(SSL *conn, Mode mode)
     buffer_size_(1500),
     buffer_(new uint8_t[buffer_size_]),
     is_handshake_pending_(false),
-    mode_(mode) {
+    mode_(mode),
+    max_block_size_(0) {
   SSL_set_bio(connection_, bioIn_, bioOut_);
 }
 

--- a/src/components/time_tester/src/time_manager.cc
+++ b/src/components/time_tester/src/time_manager.cc
@@ -50,6 +50,7 @@ namespace time_tester {
 CREATE_LOGGERPTR_GLOBAL(logger_, "TimeManager")
 
 TimeManager::TimeManager():
+  is_ready_(false),
   thread_(NULL),
   streamer_(NULL),
   app_observer(this),


### PR DESCRIPTION
These commits address issues found in Coverity with uninitialized scalar and pointer fields.

Most were fixed and verified by initializing values to sane defaults.