### PR TITLE
Only send frames when POLLOUT set (CID 79995)

### DIFF
--- a/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
+++ b/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
@@ -244,7 +244,7 @@ void ThreadedSocketConnection::Transmit() {
   const bool is_queue_empty = IsFramesToSendQueueEmpty();
 
   // Send data if possible
-  if (!is_queue_empty && (poll_fds[0].revents | POLLOUT)) {
+  if (!is_queue_empty && (poll_fds[0].revents & POLLOUT)) {
     LOG4CXX_DEBUG(logger_, "frames_to_send_ not empty() ");
 
     // send data


### PR DESCRIPTION
The bitwise or (`|`) with `poll_fds[0].revents` and `POLLOUT` will always be true since `POLLOUT` is a positive value.  This causes frames to be sent regardless of the flags set in `poll_fds[0].revents`.

This needs to be a bitwise and (`&`) so that frames are only sent when `poll_fds[0].revents` has the `POLLOUT` flag set.

Coverity report:
https://scan9.coverity.com/reports.htm#v27037/p12036/fileInstanceId=6520000&defectInstanceId=1296981&mergedDefectId=79995&fileStart=251&fileEnd=354