### PR TITLE
Change socket close logic to prevent double close (CID 137866)

### DIFF
--- a/src/components/transport_manager/src/bluetooth/bluetooth_socket_connection.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_socket_connection.cc
@@ -103,14 +103,12 @@ bool BluetoothSocketConnection::Establish(ConnectError** error) {
     if (0 == connect_status) {
       LOG4CXX_DEBUG(logger_, "rfcomm Connect ok");
       break;
-    }
-    if (errno != 111 && errno != 104) {
-      LOG4CXX_DEBUG(logger_, "rfcomm Connect errno " << errno);
-      break;
-    }
-    if (errno) {
-      LOG4CXX_DEBUG(logger_, "rfcomm Connect errno " << errno);
-      close(rfcomm_socket);
+    } else { // If connect_status is not 0, an errno is returned
+      LOG4CXX_WARN_WITH_ERRNO(logger_, "rfcomm Connect failed");
+      close(rfcomm_socket); // Always close the socket upon error
+      if (errno != ECONNREFUSED && errno != ECONNRESET) {
+        break;
+      }
     }
     sleep(2);
   } while (--attempts > 0);
@@ -120,7 +118,6 @@ bool BluetoothSocketConnection::Establish(ConnectError** error) {
                   "Failed to Connect to remote device " << BluetoothDevice::GetUniqueDeviceId(
                     remoteSocketAddress.rc_bdaddr) << " for session " << this);
     *error = new ConnectError();
-    close(rfcomm_socket);
     LOG4CXX_TRACE(logger_, "exit with FALSE");
     return false;
   }


### PR DESCRIPTION
This simplifies the logic used to connect to bluetooth sockets. It
prevents the rfcomm_socket from being closed twice or being left
unclosed.

This fixes the double close Coverity issue introduced by f95d608893b6a537ec2e7e753a6b162f067c1c01 in pull request #714.

This pull request reverts changes introduced by f95d608893b6a537ec2e7e753a6b162f067c1c01 and fixes the resource leak issue mentioned in pull request #714.

Coverity report:
https://scan9.coverity.com/reports.htm#v27037/p12036/fileInstanceId=6754941&defectInstanceId=1342386&mergedDefectId=137886