### PR TITLE
Coverity fix unchecked return values

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2468,9 +2468,10 @@ void ApplicationManagerImpl::Handle(const impl::AudioData message) {
   LOG4CXX_INFO_EXT(logger_, "Send data");
   CommandSharedPtr command(MobileCommandFactory::CreateCommand(
       on_audio_pass, commands::Command::ORIGIN_SDL));
-  command->Init();
-  command->Run();
-  command->CleanUp();
+  if (command->Init()) {
+    command->Run();
+    command->CleanUp();
+  }
 }
 
 mobile_apis::Result::eType ApplicationManagerImpl::CheckPolicyPermissions(

--- a/src/components/config_profile/src/ini_file.cc
+++ b/src/components/config_profile/src/ini_file.cc
@@ -39,6 +39,8 @@
 #include <limits.h>
 #include <stdint.h>
 
+#include "utils/logger.h"
+
 #ifndef _WIN32
 #include <unistd.h>
 #else
@@ -52,6 +54,8 @@
 #include <string>
 
 namespace profile {
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "Profile")
 
 char* ini_write_inst(const char *fname, uint8_t flag) {
   FILE             *fp = 0;
@@ -270,9 +274,10 @@ char ini_write_value(const char *fname,
   fclose(wr_fp);
   fclose(rd_fp);
 
-  remove(fname);
   if (0 != rename(temp_fname, fname)) {
-    remove(temp_fname);
+    if (0 != remove(temp_fname)) {
+      LOG4CXX_WARN_WITH_ERRNO(logger_, "Unable to remove temp file: " << std::string(temp_fname));
+    }
     return FALSE;
   }
 

--- a/src/components/policy/src/policy/src/sql_pt_representation.cc
+++ b/src/components/policy/src/policy/src/sql_pt_representation.cc
@@ -372,7 +372,9 @@ InitResult SQLPTRepresentation::Init() {
                                         << check_first_run.GetBoolean(0));
               if (check_first_run.GetBoolean(0)) {
                 dbms::SQLQuery set_not_first_run(db());
-                set_not_first_run.Exec(sql_pt::kSetNotFirstRun);
+                if (!set_not_first_run.Exec(sql_pt::kSetNotFirstRun)) {
+                  LOG4CXX_WARN(logger_, "Failed update is_first_run");
+                }
                 return InitResult::SUCCESS;
               }
             } else {

--- a/src/components/transport_manager/src/tcp/tcp_client_listener.cc
+++ b/src/components/transport_manager/src/tcp/tcp_client_listener.cc
@@ -92,7 +92,9 @@ TransportAdapter::Error TcpClientListener::Init() {
   server_address.sin_addr.s_addr = INADDR_ANY;
 
   int optval = 1;
-  setsockopt(socket_, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+  if (0 != setsockopt(socket_, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval))) {
+    LOG4CXX_WARN_WITH_ERRNO(logger_, "setsockopt SO_REUSEADDR failed");
+  }
 
   if (bind(socket_, reinterpret_cast<sockaddr*>(&server_address),
            sizeof(server_address)) != 0) {
@@ -144,12 +146,24 @@ void SetKeepaliveOptions(const int fd) {
   int keepintvl = 1;
 #ifdef __linux__
   int user_timeout = 7000;  // milliseconds
-  setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes));
-  setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, sizeof(keepidle));
-  setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt));
-  setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl));
-  setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &user_timeout,
-             sizeof(user_timeout));
+  if (0 != setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes))) {
+    LOG4CXX_WARN_WITH_ERRNO(logger_, "setsockopt SO_KEEPALIVE failed");
+  }
+  if (0 != setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE,
+                      &keepidle, sizeof(keepidle))) {
+    LOG4CXX_WARN_WITH_ERRNO(logger_, "setsockopt TCP_KEEPIDLE failed");
+  }
+  if (0 != setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt))) {
+    LOG4CXX_WARN_WITH_ERRNO(logger_, "setsockopt TCP_KEEPCNT failed");
+  }
+  if (0 != setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL,
+                      &keepintvl, sizeof(keepintvl))) {
+    LOG4CXX_WARN_WITH_ERRNO(logger_, "setsockopt TCP_KEEPINTVL failed");
+  }
+  if (0 != setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT,
+                      &user_timeout, sizeof(user_timeout))) {
+    LOG4CXX_WARN_WITH_ERRNO(logger_, "setsockopt TCP_USER_TIMEOUT failed");
+  }
 #elif defined(__QNX__)  // __linux__
   // TODO(KKolodiy): Out of order!
   const int kMidLength = 4;
@@ -241,9 +255,15 @@ void TcpClientListener::StopLoop() {
   server_address.sin_family = AF_INET;
   server_address.sin_port = htons(port_);
   server_address.sin_addr.s_addr = INADDR_ANY;
-  connect(byesocket, reinterpret_cast<sockaddr*>(&server_address),
-          sizeof(server_address));
-  shutdown(byesocket, SHUT_RDWR);
+  if (0 != connect(byesocket, reinterpret_cast<sockaddr*>(&server_address),
+                   sizeof(server_address))) {
+    LOG4CXX_WARN_WITH_ERRNO(logger_, "Failed to connect byesocket");
+  } else {
+    // Can only shutdown socket if connected
+    if (0 != shutdown(byesocket, SHUT_RDWR)) {
+      LOG4CXX_WARN_WITH_ERRNO(logger_, "Failed to shutdown byesocket");
+    }
+  }
   close(byesocket);
 }
 

--- a/src/components/utils/src/file_system.cc
+++ b/src/components/utils/src/file_system.cc
@@ -59,8 +59,11 @@ uint64_t file_system::GetAvailableDiskSpace(const std::string& path) {
 int64_t file_system::FileSize(const std::string &path) {
   if (file_system::FileExists(path)) {
     struct stat file_info = { 0 };
-    stat(path.c_str(), &file_info);
-    return file_info.st_size;
+    if (0 != stat(path.c_str(), &file_info)) {
+      LOG4CXX_WARN_WITH_ERRNO(logger_, "Could not get file size: " << path);
+    } else {
+      return file_info.st_size;
+    }
   }
   return 0;
 }
@@ -94,8 +97,12 @@ size_t file_system::DirectorySize(const std::string& path) {
       if (file_system::IsDirectory(full_element_path)) {
         size += DirectorySize(full_element_path);
       } else {
-        stat(full_element_path.c_str(), &file_info);
-        size += file_info.st_size;
+        if (0 != stat(full_element_path.c_str(), &file_info)) {
+          LOG4CXX_WARN_WITH_ERRNO(logger_, "Could not get file info: "
+                                  << full_element_path);
+        } else {
+          size += file_info.st_size;
+        }
       }
     }
   }
@@ -108,7 +115,9 @@ size_t file_system::DirectorySize(const std::string& path) {
 
 std::string file_system::CreateDirectory(const std::string& name) {
   if (!DirectoryExists(name)) {
-    mkdir(name.c_str(), S_IRWXU);
+    if (0 != mkdir(name.c_str(), S_IRWXU)) {
+      LOG4CXX_WARN_WITH_ERRNO(logger_, "Unable to create directory: " << name);
+    }
   }
 
   return name;
@@ -254,7 +263,10 @@ void file_system::remove_directory_content(const std::string& directory_name) {
         remove_directory_content(full_element_path);
         rmdir(full_element_path.c_str());
       } else {
-        remove(full_element_path.c_str());
+        if (0 != remove(full_element_path.c_str())) {
+          LOG4CXX_WARN_WITH_ERRNO(logger_, "Unable to remove file: "
+                                  << full_element_path);
+        }
       }
     }
   }
@@ -416,7 +428,9 @@ bool file_system::CreateFile(const std::string& path) {
 
 uint64_t file_system::GetFileModificationTime(const std::string& path) {
   struct stat info;
-  stat(path.c_str(), &info);
+  if (0 != stat(path.c_str(), &info)) {
+    LOG4CXX_WARN_WITH_ERRNO(logger_, "Could not get file mod time: " << path);
+  }
 #ifndef __QNXNTO__
   return static_cast<uint64_t>(info.st_mtim.tv_nsec);
 #else


### PR DESCRIPTION
These commits are intended to address Coverity defects warning about unchecked return values.

In many instances, the return value was checked and an errno was logged.  Typically, no important logic was added as a result of the check.  This means that this pull request may not be critical but could be nice to have to increase logging verbosity and address Coverity issues.