### PR TITLE
Fix application add to app_level table

### DIFF
--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -766,7 +766,8 @@ void ConnectionHandlerImpl::CloseSession(ConnectionHandle connection_handle,
                                          uint8_t session_id,
                                          CloseSessionReason close_reason) {
   LOG4CXX_AUTO_TRACE(logger_);
-  LOG4CXX_DEBUG(logger_, "Closing session with id: " << session_id);
+  LOG4CXX_DEBUG(logger_,
+                "Closing session with id: " << static_cast<int>(session_id));
 
   // In case of malformed message the connection should be broke up without
   // any other notification to mobile.

--- a/src/components/policy/include/policy/policy_table/types.h
+++ b/src/components/policy/include/policy/policy_table/types.h
@@ -374,7 +374,6 @@ struct UsageAndErrorCounts : CompositeType {
 
 struct DeviceParams : CompositeType {
  public:
- public:
   DeviceParams();
   ~DeviceParams();
   explicit DeviceParams(const Json::Value* value__);


### PR DESCRIPTION
Required functionality to add the registered
application in the app_level table with
application name in column application_id.

Related issue: [APPLINK-17802](https://adc.luxoft.com/jira/browse/APPLINK-17802)