### PR TITLE
Coverity fix unnecessary mixing of enums (CID 80023, 80024, 80026, 80028, 80030)

### DIFF
--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -174,17 +174,15 @@ void AlertManeuverRequest::on_event(const event_engine::Event& event) {
 
   if (pending_requests_.IsFinal(event_id)) {
 
-    bool result = ((hmi_apis::Common_Result::SUCCESS ==
-        static_cast<hmi_apis::Common_Result::eType>(tts_speak_result_code_) ||
-        hmi_apis::Common_Result::UNSUPPORTED_RESOURCE ==
-            static_cast<hmi_apis::Common_Result::eType>(tts_speak_result_code_) ||
-            (hmi_apis::Common_Result::INVALID_ENUM ==
-                static_cast<hmi_apis::Common_Result::eType>(tts_speak_result_code_))) &&
-                (hmi_apis::Common_Result::SUCCESS ==
-                    static_cast<hmi_apis::Common_Result::eType>(navi_alert_maneuver_result_code_))) ||
-        (hmi_apis::Common_Result::SUCCESS == static_cast<hmi_apis::Common_Result::eType>(
-            tts_speak_result_code_) && hmi_apis::Common_Result::UNSUPPORTED_RESOURCE ==
-                static_cast<hmi_apis::Common_Result::eType>(navi_alert_maneuver_result_code_));
+    bool result = ((mobile_apis::Result::SUCCESS == tts_speak_result_code_ ||
+        mobile_apis::Result::UNSUPPORTED_RESOURCE == 
+          tts_speak_result_code_ ||
+        mobile_apis::Result::INVALID_ENUM == tts_speak_result_code_) &&
+        mobile_apis::Result::SUCCESS == 
+          navi_alert_maneuver_result_code_) ||
+            (mobile_apis::Result::SUCCESS == tts_speak_result_code_ && 
+            mobile_apis::Result::UNSUPPORTED_RESOURCE == 
+                navi_alert_maneuver_result_code_);
 
     mobile_apis::Result::eType result_code =
         static_cast<mobile_apis::Result::eType>(std::max(tts_speak_result_code_,
@@ -192,8 +190,8 @@ void AlertManeuverRequest::on_event(const event_engine::Event& event) {
 
     const char* return_info = NULL;
 
-    if (result && hmi_apis::Common_Result::UNSUPPORTED_RESOURCE ==
-        static_cast<hmi_apis::Common_Result::eType>(tts_speak_result_code_)) {
+    if (result && mobile_apis::Result::UNSUPPORTED_RESOURCE == 
+        tts_speak_result_code_) {
       result_code = mobile_apis::Result::WARNINGS;
       return_info = "Unsupported phoneme type sent in a prompt";
     }

--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -175,11 +175,9 @@ void AlertManeuverRequest::on_event(const event_engine::Event& event) {
   if (pending_requests_.IsFinal(event_id)) {
 
     bool result = ((mobile_apis::Result::SUCCESS == tts_speak_result_code_ ||
-        mobile_apis::Result::UNSUPPORTED_RESOURCE == 
-          tts_speak_result_code_ ||
+        mobile_apis::Result::UNSUPPORTED_RESOURCE == tts_speak_result_code_ ||
         mobile_apis::Result::INVALID_ENUM == tts_speak_result_code_) &&
-        mobile_apis::Result::SUCCESS == 
-          navi_alert_maneuver_result_code_) ||
+        mobile_apis::Result::SUCCESS == navi_alert_maneuver_result_code_) ||
             (mobile_apis::Result::SUCCESS == tts_speak_result_code_ && 
             mobile_apis::Result::UNSUPPORTED_RESOURCE == 
                 navi_alert_maneuver_result_code_);

--- a/src/components/application_manager/src/commands/mobile/get_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/get_vehicle_data_request.cc
@@ -259,8 +259,7 @@ void GetVehicleDataRequest::on_event(const event_engine::Event& event) {
               message[strings::params][hmi_response::code].asInt());
       bool result = false;
       if (mobile_apis::Result::SUCCESS == result_code ||
-          (hmi_apis::Common_Result::DATA_NOT_AVAILABLE ==
-              static_cast<hmi_apis::Common_Result::eType>(result_code)
+          (mobile_apis::Result::VEHICLE_DATA_NOT_AVAILABLE == result_code
                     && message[strings::msg_params].length() > 1)) {
         result = true;
       }

--- a/src/components/application_manager/src/commands/mobile/slider_request.cc
+++ b/src/components/application_manager/src/commands/mobile/slider_request.cc
@@ -130,10 +130,11 @@ void SliderRequest::on_event(const event_engine::Event& event) {
   //event_id == hmi_apis::FunctionID::UI_Slider:
   LOG4CXX_INFO(logger_, "Received UI_Slider event");
 
-  const int response_code =
-      message[strings::params][hmi_response::code].asInt();
+  const mobile_apis::Result::eType response_code = 
+      static_cast<mobile_apis::Result::eType>(
+        message[strings::params][hmi_response::code].asInt());
   smart_objects::SmartObject response_msg_params = message[strings::msg_params];
-  if (response_code == hmi_apis::Common_Result::ABORTED &&
+  if (response_code == mobile_apis::Result::ABORTED &&
       message[strings::params][strings::data].keyExists(strings::slider_position)) {
     //Copy slider_position info to msg_params section
 	response_msg_params[strings::slider_position] =

--- a/src/components/application_manager/src/commands/mobile/speak_request.cc
+++ b/src/components/application_manager/src/commands/mobile/speak_request.cc
@@ -113,8 +113,7 @@ void SpeakRequest::ProcessTTSSpeakResponse(
   mobile_apis::Result::eType result_code =
     static_cast<mobile_apis::Result::eType>(
       message[strings::params][hmi_response::code].asInt());
-  if (hmi_apis::Common_Result::SUCCESS ==
-      static_cast<hmi_apis::Common_Result::eType>(result_code)) {
+  if (mobile_apis::Result::SUCCESS == result_code) {
     result = true;
   }
   (*message_)[strings::params][strings::function_id] =
@@ -122,8 +121,7 @@ void SpeakRequest::ProcessTTSSpeakResponse(
 
   const char* return_info = NULL;
 
-  if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE ==
-      static_cast<hmi_apis::Common_Result::eType>(result_code)) {
+  if (mobile_apis::Result::UNSUPPORTED_RESOURCE == result_code) {
     result_code = mobile_apis::Result::WARNINGS;
     return_info = "Unsupported phoneme type sent in a prompt";
   }


### PR DESCRIPTION
Fixes several Coverity defects where the HMI result codes were compared against Mobile result codes unnecessarily.

While the enum values for both hmi_apis::Common_Result and mobile_apis::Result should theoretically be the same, it is more readable if the variables are simply compared against constants of the same type rather than casting them.