### PR TITLE
Change_VerifyPeer_parameter_in_ini_file_to_true

### DIFF
--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -156,7 +156,7 @@ SSLMode         = CLIENT
 ;CipherList      = AES256-GCM-SHA384
 CipherList      = ALL
 ; Verify Mobile app certificate (could be used in both SSLMode Server and Client)
-VerifyPeer  = false
+VerifyPeer  = true
 ; Preloaded CA certificates directory
 CACertificatePath = .
 ; Services which can not be started unprotected (could be id's from 0x01 to 0xFF)


### PR DESCRIPTION
By implementing this feature we fix secure service opening
without validation. The problem which is occuring is that
when we remove the server cridentials from SDL and start
secure service we succeed. The reason for that is the VerifyPeer
located in .ini file which by default was set false. As result
SSL_CTX_set_verify is called without SSL_VERIFY_PEER, 
which is the reason server`s cridentials to not be checked.

Requirement: APPLINK-22607
Fix-issue: APPLINK-17757