### PR TITLE
Feature/cover hmi commands with unit tests

### DIFF
--- a/src/components/application_manager/src/commands/hmi/close_popup_request.cc
+++ b/src/components/application_manager/src/commands/hmi/close_popup_request.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/components/application_manager/test/commands/hmi/close_popup_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/close_popup_response_test.cc
@@ -29,24 +29,42 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/command.h"
+#include "commands/commands_test.h"
+#include "application_manager/commands/hmi/response_from_hmi.h"
 #include "application_manager/commands/hmi/close_popup_response.h"
 
-namespace application_manager {
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
 
-namespace commands {
+using ::utils::SharedPtr;
+namespace am = ::application_manager;
+using am::commands::ResponseFromHMI;
+using am::commands::ClosePopupResponse;
+using am::commands::CommandImpl;
 
-ClosePopupResponse::ClosePopupResponse(const MessageSharedPtr& message,
-                                       ApplicationManager& application_manager)
-    : ResponseFromHMI(message, application_manager) {}
+typedef SharedPtr<ResponseFromHMI> ResponseFromHMIPtr;
 
-ClosePopupResponse::~ClosePopupResponse() {}
+class ClosePopupResponseTest : public CommandsTest<CommandsTestMocks::kIsNice> {
+};
 
-void ClosePopupResponse::Run() {
-  SDL_AUTO_TRACE();
+TEST_F(ClosePopupResponseTest, RUN_SUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  ResponseFromHMIPtr command(CreateCommand<ClosePopupResponse>(command_msg));
 
-  // TODO(VS): Process response from HMI
+  command->Run();
 }
-
-}  // namespace commands
-
-}  // namespace application_manager
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/get_system_info_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_system_info_request_test.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "commands/commands_test.h"
+#include "application_manager/application.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/commands/hmi/request_to_hmi.h"
+#include "application_manager/commands/hmi/get_system_info_request.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::utils::SharedPtr;
+namespace am = ::application_manager;
+namespace strings = ::application_manager::strings;
+using am::commands::RequestToHMI;
+using am::commands::GetSystemInfoRequest;
+using am::commands::CommandImpl;
+
+typedef SharedPtr<RequestToHMI> RequestToHMIPtr;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const uint32_t kCorrelationId = 1u;
+}  // namespace
+
+class GetSystemInfoRequestTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(GetSystemInfoRequestTest, RUN_SendRequest_SUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::msg_params][strings::number] = "123";
+  (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
+  (*command_msg)[strings::params][strings::correlation_id] = kCorrelationId;
+
+  RequestToHMIPtr command(CreateCommand<GetSystemInfoRequest>(command_msg));
+
+  const uint32_t kAppId = command->application_id();
+
+  EXPECT_CALL(app_mngr_, set_application_id(kCorrelationId, kAppId));
+
+  EXPECT_CALL(app_mngr_, SendMessageToHMI(command_msg));
+
+  command->Run();
+
+  EXPECT_EQ((*command_msg)[strings::msg_params][strings::app_id].asUInt(),
+            kAppId);
+  EXPECT_EQ((*command_msg)[strings::params][strings::correlation_id].asUInt(),
+            kCorrelationId);
+
+  EXPECT_EQ((*command_msg)[strings::params][strings::protocol_type].asInt(),
+            CommandImpl::hmi_protocol_type_);
+  EXPECT_EQ((*command_msg)[strings::params][strings::protocol_version].asInt(),
+            CommandImpl::protocol_version_);
+}
+
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/get_system_info_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_system_info_response_test.cc
@@ -51,7 +51,6 @@ namespace components {
 namespace commands_test {
 namespace hmi_commands_test {
 
-using ::testing::_;
 using ::testing::Return;
 using ::utils::SharedPtr;
 using ::testing::NiceMock;
@@ -100,7 +99,7 @@ class GetSystemInfoResponseTest
   SmartObject capabilities_;
 };
 
-TEST_F(GetSystemInfoResponseTest, RUN_SUCCESS) {
+TEST_F(GetSystemInfoResponseTest, GetSystemInfo_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
   (*command_msg)[strings::params][hmi_response::code] =
       hmi_apis::Common_Result::SUCCESS;

--- a/src/components/application_manager/test/commands/hmi/get_system_info_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_system_info_response_test.cc
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "commands/commands_test.h"
+#include "application_manager/application.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/commands/hmi/response_from_hmi.h"
+#include "application_manager/commands/hmi/get_system_info_response.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::testing::_;
+using ::testing::Return;
+using ::utils::SharedPtr;
+using ::testing::NiceMock;
+namespace am = ::application_manager;
+namespace strings = ::application_manager::strings;
+namespace hmi_response = am::hmi_response;
+using am::commands::ResponseFromHMI;
+using am::commands::GetSystemInfoResponse;
+using am::commands::CommandImpl;
+using am::commands::SystemInfo;
+
+typedef SharedPtr<ResponseFromHMI> ResponseFromHMIPtr;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const std::string ccpu_version("4.1.3.B_EB355B");
+const std::string wers_country_code("WAEGB");
+const uint32_t lang_code = 0u;
+const std::string kLanguage = "";
+}  // namespace
+
+class GetSystemInfoResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  MessageSharedPtr CreateCommandMsg() {
+    MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+    (*command_msg)[strings::msg_params][strings::number] = "123";
+    (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
+    (*command_msg)[strings::msg_params]["ccpu_version"] = ccpu_version;
+    (*command_msg)[strings::msg_params]["wersCountryCode"] = wers_country_code;
+    (*command_msg)[strings::msg_params]["language"] = lang_code;
+
+    return command_msg;
+  }
+
+  void SetUp() OVERRIDE {
+    message_helper_mock_ =
+        application_manager::MockMessageHelper::message_helper_mock();
+  }
+
+  am::MockMessageHelper* message_helper_mock_;
+  MockHMICapabilities mock_hmi_capabilities_;
+  SmartObject capabilities_;
+};
+
+TEST_F(GetSystemInfoResponseTest, RUN_SUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  (*command_msg)[strings::msg_params][hmi_response::capabilities] =
+      (capabilities_);
+
+  ResponseFromHMIPtr command(CreateCommand<GetSystemInfoResponse>(command_msg));
+  policy_test::MockPolicyHandlerInterface policy_handler;
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  std::string language;
+  EXPECT_CALL(*message_helper_mock_,
+              CommonLanguageToString(
+                  static_cast<hmi_apis::Common_Language::eType>(lang_code)))
+      .WillOnce(Return(language));
+  EXPECT_EQ(kLanguage, language);
+
+  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+      .WillOnce(ReturnRef(policy_handler));
+  EXPECT_CALL(policy_handler,
+              OnGetSystemInfo(ccpu_version, wers_country_code, kLanguage));
+
+  command->Run();
+}
+
+TEST_F(GetSystemInfoResponseTest, GetSystemInfo_UNSUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::WRONG_LANGUAGE;
+  (*command_msg)[strings::msg_params][hmi_response::capabilities] =
+      (capabilities_);
+
+  ResponseFromHMIPtr command(CreateCommand<GetSystemInfoResponse>(command_msg));
+  policy_test::MockPolicyHandlerInterface policy_handler;
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities()).Times(0);
+
+  EXPECT_CALL(*message_helper_mock_,
+              CommonLanguageToString(
+                  static_cast<hmi_apis::Common_Language::eType>(lang_code)))
+      .Times(0);
+
+  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+      .WillOnce(ReturnRef(policy_handler));
+  EXPECT_CALL(policy_handler, OnGetSystemInfo("", "", ""));
+
+  command->Run();
+}
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/get_urls_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_urls_response_test.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2016
+ * , Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/command.h"
+#include "commands/commands_test.h"
+#include "application_manager/application.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/commands/hmi/response_to_hmi.h"
+#include "application_manager/commands/hmi/get_urls_response.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::testing::_;
+using ::testing::Return;
+using ::utils::SharedPtr;
+namespace am = ::application_manager;
+namespace strings = ::application_manager::strings;
+using am::commands::ResponseToHMI;
+using am::commands::GetUrlsResponse;
+using am::commands::CommandImpl;
+
+typedef SharedPtr<ResponseToHMI> ResponseToHMIPtr;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+}  // namespace
+
+class GetUrlResponseTest : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(GetUrlResponseTest, RUN_SendRequest_SUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::msg_params][strings::number] = "123";
+  (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
+
+  ResponseToHMIPtr command(CreateCommand<GetUrlsResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, SendMessageToHMI(command_msg));
+
+  command->Run();
+
+  EXPECT_EQ((*command_msg)[strings::params][strings::protocol_type].asInt(),
+            CommandImpl::hmi_protocol_type_);
+  EXPECT_EQ((*command_msg)[strings::params][strings::protocol_version].asInt(),
+            CommandImpl::protocol_version_);
+}
+
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/get_urls_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_urls_test.cc
@@ -109,7 +109,6 @@ TEST_F(GetUrlsTest, RUN_SUCCESS) {
 
   ON_CALL(app_mngr_, event_dispatcher())
       .WillByDefault(ReturnRef(mock_event_dispatcher_));
-  ;
 
   RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
 
@@ -132,7 +131,6 @@ TEST_F(GetUrlsTest, RUN_PolicyNotEnabled_UNSUCCESS) {
 
   ON_CALL(app_mngr_, event_dispatcher())
       .WillByDefault(ReturnRef(mock_event_dispatcher_));
-  ;
 
   RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
 
@@ -160,7 +158,6 @@ TEST_F(GetUrlsTest, RUN_EmptyEndpoints_UNSUCCESS) {
 
   ON_CALL(app_mngr_, event_dispatcher())
       .WillByDefault(ReturnRef(mock_event_dispatcher_));
-  ;
 
   RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
 
@@ -192,7 +189,6 @@ TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_SUCCESS) {
 
   ON_CALL(app_mngr_, event_dispatcher())
       .WillByDefault(ReturnRef(mock_event_dispatcher_));
-  ;
 
   RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
 
@@ -208,18 +204,17 @@ TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_SUCCESS) {
   EXPECT_CALL(policy_handler_, GetServiceUrls(kPolicyService, _));
 
   MockAppPtr mock_app = CreateMockApp();
-  uint32_t app_id = 1u;
-  EXPECT_CALL(policy_handler_, GetAppIdForSending()).WillOnce(Return(app_id));
+
+  EXPECT_CALL(policy_handler_, GetAppIdForSending())
+      .WillOnce(Return(kAppIdForSending));
 
   EXPECT_CALL(app_mngr_, application(kAppIdForSending))
       .WillOnce(Return(mock_app));
-  EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(app_id));
+  EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kAppIdForSending));
   EXPECT_CALL(app_mngr_, ManageHMICommand(command_msg))
       .WillRepeatedly(Return(true));
 
   command->Run();
-
-  EXPECT_EQ(kAppIdForSending, app_id);
 
   EXPECT_FALSE((*command_msg)[am::strings::msg_params].keyExists(
       am::hmi_request::service));
@@ -252,7 +247,6 @@ TEST_F(GetUrlsTest, ProcessServiceURLs_SUCCESS) {
 
   ON_CALL(app_mngr_, event_dispatcher())
       .WillByDefault(ReturnRef(mock_event_dispatcher_));
-  ;
 
   RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
 
@@ -295,7 +289,6 @@ TEST_F(GetUrlsTest, ProcessServiceURLs_PolicyDefaultId_SUCCESS) {
 
   ON_CALL(app_mngr_, event_dispatcher())
       .WillByDefault(ReturnRef(mock_event_dispatcher_));
-  ;
 
   RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
 

--- a/src/components/application_manager/test/commands/hmi/get_urls_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_urls_test.cc
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "application_manager/message.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/mock_application_manager.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/command.h"
+#include "application_manager/commands/hmi/get_urls.h"
+#include "application_manager/policies/policy_handler.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
+#include "commands/commands_test.h"
+#include "commands/command_request_test.h"
+#include "hmi/request_from_hmi.h"
+#include "policy/mock_policy_manager.h"
+#include "application_manager/event_engine/event_dispatcher.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using namespace hmi_apis;
+using namespace policy;
+using ::utils::SharedPtr;
+using ::testing::NiceMock;
+using ::testing::SetArgReferee;
+using ::test::components::application_manager_test::MockApplication;
+namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
+namespace am = ::application_manager;
+namespace strings = ::application_manager::strings;
+using am::commands::RequestFromHMI;
+using am::commands::GetUrls;
+using am::commands::CommandImpl;
+using policy::PolicyHandler;
+using policy_test::MockPolicyHandlerInterface;
+
+typedef SharedPtr<RequestFromHMI> RequestFromHMIPtr;
+
+namespace {
+const uint32_t kInvalidAppId_ = 0u;
+const uint32_t kAppIdForSending = 1u;
+const uint32_t kConnectionKey = 2u;
+const std::string kInitialService = "0x0";
+const std::string kPolicyService = "7";
+const std::string kDefaultUrl = "URL is not found";
+const std::string kDefaultId = "default";
+}  // namespace
+
+class GetUrlsTest : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  policy_test::MockPolicyHandlerInterface policy_handler_;
+  utils::SharedPtr<policy_manager_test::MockPolicyManager> mock_policy_manager_;
+  NiceMock<event_engine_test::MockEventDispatcher> mock_event_dispatcher_;
+  ApplicationSharedPtr app;
+
+  virtual void SetUp() OVERRIDE {
+    ON_CALL(app_mngr_, GetPolicyHandler())
+        .WillByDefault(ReturnRef(policy_handler_));
+    mock_policy_manager_ =
+        utils::MakeShared<policy_manager_test::MockPolicyManager>();
+    ASSERT_TRUE(mock_policy_manager_);
+  }
+};
+
+TEST_F(GetUrlsTest, RUN_SUCCESS) {
+  MessageSharedPtr command_msg(
+      CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
+      kInitialService;
+
+  ON_CALL(app_mngr_, event_dispatcher())
+      .WillByDefault(ReturnRef(mock_event_dispatcher_));
+  ;
+
+  RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
+
+  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(2);
+
+  EXPECT_CALL(policy_handler_, GetServiceUrls(kInitialService, _));
+
+  EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+
+  command->Run();
+}
+TEST_F(GetUrlsTest, RUN_PolicyNotEnabled_UNSUCCESS) {
+  MessageSharedPtr command_msg(
+      CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
+      kInitialService;
+
+  ON_CALL(app_mngr_, event_dispatcher())
+      .WillByDefault(ReturnRef(mock_event_dispatcher_));
+  ;
+
+  RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
+
+  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+
+  EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(false));
+
+  EXPECT_CALL(app_mngr_, ManageHMICommand(command_msg)).WillOnce(Return(true));
+
+  command->Run();
+
+  EXPECT_EQ((*command_msg)[strings::params][strings::message_type].asInt(),
+            am::MessageType::kResponse);
+  EXPECT_EQ((*command_msg)[strings::params][am::hmi_response::code].asInt(),
+            Common_Result::DATA_NOT_AVAILABLE);
+}
+TEST_F(GetUrlsTest, RUN_EmptyEndpoints_UNSUCCESS) {
+  MessageSharedPtr command_msg(
+      CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
+      kInitialService;
+
+  ON_CALL(app_mngr_, event_dispatcher())
+      .WillByDefault(ReturnRef(mock_event_dispatcher_));
+  ;
+
+  RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
+
+  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(2);
+
+  EXPECT_CALL(policy_handler_, GetServiceUrls(kInitialService, _));
+
+  EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+
+  EXPECT_CALL(app_mngr_, ManageHMICommand(command_msg)).WillOnce(Return(true));
+
+  command->Run();
+
+  EXPECT_EQ((*command_msg)[strings::params][strings::message_type].asInt(),
+            am::MessageType::kResponse);
+  EXPECT_EQ((*command_msg)[strings::params][am::hmi_response::code].asInt(),
+            Common_Result::DATA_NOT_AVAILABLE);
+}
+
+#ifdef EXTENDED_POLICY
+TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_SUCCESS) {
+  MessageSharedPtr command_msg(
+      CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
+      kPolicyService;
+
+  ON_CALL(app_mngr_, event_dispatcher())
+      .WillByDefault(ReturnRef(mock_event_dispatcher_));
+  ;
+
+  RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
+
+  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(3);
+  EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+
+  EndpointUrls endpoints_;
+  EndpointData data(kDefaultUrl);
+  endpoints_.push_back(data);
+
+  ON_CALL(policy_handler_, GetServiceUrls(kPolicyService, _))
+      .WillByDefault(SetArgReferee<1>(endpoints_));
+  EXPECT_CALL(policy_handler_, GetServiceUrls(kPolicyService, _));
+
+  MockAppPtr mock_app = CreateMockApp();
+  uint32_t app_id = 1u;
+  EXPECT_CALL(policy_handler_, GetAppIdForSending()).WillOnce(Return(app_id));
+
+  EXPECT_CALL(app_mngr_, application(kAppIdForSending))
+      .WillOnce(Return(mock_app));
+  EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(app_id));
+  EXPECT_CALL(app_mngr_, ManageHMICommand(command_msg))
+      .WillRepeatedly(Return(true));
+
+  command->Run();
+
+  EXPECT_EQ(kAppIdForSending, app_id);
+
+  EXPECT_FALSE((*command_msg)[am::strings::msg_params].keyExists(
+      am::hmi_request::service));
+
+  EXPECT_EQ((*command_msg)[strings::params][strings::message_type].asInt(),
+            am::MessageType::kResponse);
+  EXPECT_EQ((*command_msg)[strings::params][am::hmi_response::code].asInt(),
+            Common_Result::SUCCESS);
+
+  EXPECT_EQ(kAppIdForSending,
+            (*command_msg)[am::strings::msg_params][am::hmi_response::urls][0]
+                          [strings::app_id].asInt());
+  EXPECT_EQ(kDefaultUrl,
+            (*command_msg)[am::strings::msg_params][am::hmi_response::urls][0]
+                          [strings::url].asString());
+}
+#endif
+TEST_F(GetUrlsTest, ProcessServiceURLs_SUCCESS) {
+  MessageSharedPtr command_msg(
+      CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
+      kInitialService;
+  (*command_msg)[am::strings::msg_params][am::hmi_response::urls][0] =
+      kDefaultUrl;
+  (*command_msg)[am::strings::msg_params][am::hmi_response::urls][0]
+                [am::hmi_response::policy_app_id].asString() = "1";
+
+  ON_CALL(app_mngr_, event_dispatcher())
+      .WillByDefault(ReturnRef(mock_event_dispatcher_));
+  ;
+
+  RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
+
+  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(2);
+  EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+
+  EndpointUrls endpoints_;
+  EndpointData data(kDefaultUrl);
+  data.app_id = "1";
+  endpoints_.push_back(data);
+
+  ON_CALL(policy_handler_, GetServiceUrls(kInitialService, _))
+      .WillByDefault(SetArgReferee<1>(endpoints_));
+  EXPECT_CALL(policy_handler_, GetServiceUrls(kInitialService, _));
+
+  command->Run();
+
+  EXPECT_FALSE((*command_msg)[am::strings::msg_params].keyExists(
+      am::hmi_request::service));
+  EXPECT_EQ((*command_msg)[am::strings::msg_params][am::hmi_response::urls][0]
+                          [am::strings::url].asString(),
+            kDefaultUrl);
+
+  EXPECT_EQ((*command_msg)[am::strings::msg_params][am::hmi_response::urls][0]
+                          [am::hmi_response::policy_app_id].asString(),
+            endpoints_[0].app_id);
+}
+TEST_F(GetUrlsTest, ProcessServiceURLs_PolicyDefaultId_SUCCESS) {
+  MessageSharedPtr command_msg(
+      CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
+      kInitialService;
+  (*command_msg)[am::strings::msg_params][am::hmi_response::urls][0] =
+      kDefaultUrl;
+  (*command_msg)[am::strings::msg_params][am::hmi_response::urls][0]
+                [am::hmi_response::policy_app_id].asString() = kDefaultId;
+
+  ON_CALL(app_mngr_, event_dispatcher())
+      .WillByDefault(ReturnRef(mock_event_dispatcher_));
+  ;
+
+  RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
+
+  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(2);
+  EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+
+  EndpointUrls endpoints_;
+  EndpointData data(kDefaultUrl);
+  endpoints_.push_back(data);
+
+  ON_CALL(policy_handler_, GetServiceUrls(kInitialService, _))
+      .WillByDefault(SetArgReferee<1>(endpoints_));
+  EXPECT_CALL(policy_handler_, GetServiceUrls(kInitialService, _));
+
+  command->Run();
+
+  EXPECT_FALSE((*command_msg)[am::strings::msg_params].keyExists(
+      am::hmi_request::service));
+  EXPECT_FALSE(
+      (*command_msg)[am::strings::msg_params][am::hmi_response::urls][0]
+          .keyExists(am::hmi_response::policy_app_id));
+}
+
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/mixing_audio_supported_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/mixing_audio_supported_request_test.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "commands/commands_test.h"
+#include "commands/command_request_test.h"
+#include "hmi/request_to_hmi.h"
+#include "application_manager/commands/hmi/mixing_audio_supported_request.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::testing::_;
+using ::testing::Return;
+using ::utils::SharedPtr;
+namespace am = ::application_manager;
+namespace strings = ::application_manager::strings;
+using am::commands::RequestToHMI;
+using am::commands::MixingAudioSupportedRequest;
+using am::commands::CommandImpl;
+
+typedef SharedPtr<RequestToHMI> RequestToHMIPtr;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+}  // namespace
+
+class MixingAudioSupportedRequestTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(MixingAudioSupportedRequestTest, RUN_SendRequest_SUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  RequestToHMIPtr command(
+      CreateCommand<MixingAudioSupportedRequest>(command_msg));
+
+  EXPECT_CALL(app_mngr_, SendMessageToHMI(command_msg));
+
+  command->Run();
+
+  EXPECT_EQ((*command_msg)[strings::params][strings::protocol_type].asInt(),
+            CommandImpl::hmi_protocol_type_);
+  EXPECT_EQ((*command_msg)[strings::params][strings::protocol_version].asInt(),
+            CommandImpl::protocol_version_);
+}
+
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/mixing_audio_supported_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/mixing_audio_supported_response_test.cc
@@ -52,7 +52,6 @@ namespace components {
 namespace commands_test {
 namespace hmi_commands_test {
 
-using ::testing::_;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::NiceMock;

--- a/src/components/application_manager/test/commands/hmi/mixing_audio_supported_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/mixing_audio_supported_response_test.cc
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/command.h"
+#include "commands/commands_test.h"
+#include "commands/command_request_test.h"
+#include "application_manager/commands/hmi/response_from_hmi.h"
+#include "interfaces/HMI_API.h"
+#include "interfaces/MOBILE_API.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/commands/hmi/mixing_audio_supported_response.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using ::testing::NiceMock;
+using ::utils::SharedPtr;
+namespace am = ::application_manager;
+namespace strings = ::application_manager::strings;
+using am::commands::ResponseFromHMI;
+using am::commands::MixingAudioSupportedResponse;
+using am::commands::CommandImpl;
+using am::HMICapabilities;
+namespace hmi_response = ::application_manager::hmi_response;
+
+typedef SharedPtr<ResponseFromHMI> ResponseFromHMIPtr;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+}  // namespace
+
+class MixingAudioSupportedResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(MixingAudioSupportedResponseTest, RUN_SUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  ResponseFromHMIPtr command(
+      CreateCommand<MixingAudioSupportedResponse>(command_msg));
+  MockHMICapabilities mock_hmi_capabilities;
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities));
+
+  const bool hmiResponse =
+      (*command_msg)[strings::msg_params][hmi_response::attenuated_supported]
+          .asBool();
+
+  EXPECT_CALL(mock_hmi_capabilities, set_attenuated_supported(hmiResponse));
+
+  command->Run();
+}
+
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test


### PR DESCRIPTION
Unit tests were added for the following HMI commands:
- close_popup_request
- close_popup_response
- dial_number_request
- dial_number_response
- get_system_info_request
- get_system_info_response
- get_urls
- get_urls_response
- mixing_audio_supported_request
- mixing_audio_supported_response

Related issue: APPLINK-25901