### PR TITLE
Cover HMI commands with Unit Tests. Part 8

### DIFF
--- a/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
@@ -41,6 +41,18 @@
 #include "hmi/vi_is_ready_request.h"
 #include "hmi/vi_read_did_request.h"
 #include "hmi/vi_subscribe_vehicle_data_request.h"
+#include "hmi/dial_number_request.h"
+#include "hmi/tts_is_ready_request.h"
+#include "hmi/tts_set_global_properties_request.h"
+#include "hmi/tts_speak_request.h"
+#include "hmi/tts_stop_speaking_request.h"
+#include "hmi/tts_get_supported_languages_request.h"
+#include "hmi/close_popup_request.h"
+#include "hmi/ui_add_command_request.h"
+#include "hmi/ui_add_submenu_request.h"
+#include "hmi/ui_alert_request.h"
+#include "hmi/ui_change_registration_request.h"
+#include "hmi/ui_delete_command_request.h"
 
 namespace test {
 namespace components {
@@ -87,7 +99,19 @@ class RequestToHMICommandsTest
 typedef Types<commands::VIIsReadyRequest,
               commands::VIGetVehicleTypeRequest,
               commands::VIReadDIDRequest,
-              commands::VISubscribeVehicleDataRequest> RequestCommandsList;
+              commands::VISubscribeVehicleDataRequest,
+              commands::hmi::DialNumberRequest,
+              commands::ClosePopupRequest,
+              commands::TTSIsReadyRequest,
+              commands::TTSSetGlobalPropertiesRequest,
+              commands::TTSSpeakRequest,
+              commands::TTSStopSpeakingRequest,
+              commands::TTSGetSupportedLanguagesRequest,
+              commands::UIAddCommandRequest,
+              commands::UIAddSubmenuRequest,
+              commands::UIAlertRequest,
+              commands::UIChangeRegistrationRequest,
+              commands::UIDeleteCommandRequest> RequestCommandsList;
 
 TYPED_TEST_CASE(RequestToHMICommandsTest, RequestCommandsList);
 

--- a/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
@@ -45,6 +45,17 @@
 #include "hmi/vi_subscribe_vehicle_data_response.h"
 #include "hmi/vi_get_vehicle_type_response.h"
 #include "hmi/vi_is_ready_response.h"
+#include "hmi/dial_number_response.h"
+#include "hmi/close_popup_response.h"
+#include "hmi/tts_set_global_properties_response.h"
+#include "hmi/tts_speak_response.h"
+#include "hmi/tts_stop_speaking_response.h"
+#include "hmi/ui_add_command_response.h"
+#include "hmi/ui_add_command_response.h"
+#include "hmi/ui_add_submenu_response.h"
+#include "hmi/ui_alert_response.h"
+#include "hmi/ui_change_registration_response.h"
+#include "hmi/ui_delete_command_response.h"
 
 namespace test {
 namespace components {
@@ -85,9 +96,24 @@ struct CommandData {
 typedef Types<
     CommandData<commands::VIReadDIDResponse,
                 hmi_apis::FunctionID::VehicleInfo_ReadDID>,
+    CommandData<commands::TTSSpeakResponse, hmi_apis::FunctionID::TTS_Speak>,
     CommandData<commands::VISubscribeVehicleDataResponse,
-                hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData> >
-    ResponseCommandsList;
+                hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData>,
+    CommandData<commands::hmi::DialNumberResponse,
+                hmi_apis::FunctionID::BasicCommunication_DialNumber>,
+    CommandData<commands::TTSSetGlobalPropertiesResponse,
+                hmi_apis::FunctionID::TTS_SetGlobalProperties>,
+    CommandData<commands::TTSStopSpeakingResponse,
+                hmi_apis::FunctionID::TTS_StopSpeaking>,
+    CommandData<commands::UIAddCommandResponse,
+                hmi_apis::FunctionID::UI_AddCommand>,
+    CommandData<commands::UIAddSubmenuResponse,
+                hmi_apis::FunctionID::UI_AddSubMenu>,
+    CommandData<commands::UIAlertResponse, hmi_apis::FunctionID::UI_Alert>,
+    CommandData<commands::UIChangeRegistratioResponse,
+                hmi_apis::FunctionID::UI_ChangeRegistration>,
+    CommandData<commands::UIDeleteCommandResponse,
+                hmi_apis::FunctionID::UI_DeleteCommand> > ResponseCommandsList;
 
 TYPED_TEST_CASE(ResponseFromHMICommandsTest, ResponseCommandsList);
 


### PR DESCRIPTION
Following HMI Covered With Unit Tests:

- ui_add_command_request
- ui_add_command_response
- ui_add_submenu_request
- ui_add_submenu_response
- ui_alert_request
- ui_alert_response
- ui_change_registration_request
- ui_change_registration_response
- ui_delete_command_request
- ui_delete_command_response

Related issue: APPLINK-25922