### PR TITLE
Send TIMED_OUT result code upon no HMI response

### DIFF
--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -108,7 +108,7 @@ void CommandRequestImpl::onTimeOut() {
 
   smart_objects::SmartObjectSPtr response =
     MessageHelper::CreateNegativeResponse(connection_key(), function_id(),
-    correlation_id(), mobile_api::Result::GENERIC_ERROR);
+    correlation_id(), mobile_api::Result::TIMED_OUT);
 
   ApplicationManagerImpl::instance()->ManageMobileCommand(response);
 }


### PR DESCRIPTION
When the HMI does not respond to a request within a certain amount of
time, a GENERIC_ERROR message was being created internally by SDL to be
sent to mobile.  This changes the GENERIC_ERROR to a more descriptive
TIMED_OUT.

This addresses the issue of GENERIC_ERRORs being created instead of timeouts for #479.  The cause of timeout for that issue appears to be due to HMI implementation and lack of response to SDL core.