### PR TITLE
Fix issue in HMI language handler

### DIFF
--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -424,6 +424,10 @@ class HMICapabilitiesImpl : public HMICapabilities {
 
   void Init(resumption::LastState* last_state) OVERRIDE;
 
+  HMILanguageHandler& get_hmi_language_handler() OVERRIDE {
+    return hmi_language_handler_;
+  }
+
  protected:
   /*
    * @brief Loads capabilities from local file in case SDL was launched

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -424,9 +424,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
 
   void Init(resumption::LastState* last_state) OVERRIDE;
 
-  HMILanguageHandler& get_hmi_language_handler() OVERRIDE {
-    return hmi_language_handler_;
-  }
+  HMILanguageHandler& get_hmi_language_handler() OVERRIDE;
 
  protected:
   /*

--- a/src/components/application_manager/include/application_manager/hmi_language_handler.h
+++ b/src/components/application_manager/include/application_manager/hmi_language_handler.h
@@ -98,6 +98,13 @@ class HMILanguageHandler : public event_engine::EventObserver {
                                           hmi_apis::Common_Language::eType tts);
   void Init(resumption::LastState* value);
 
+  /**
+   * @brief Removes application from container after
+   * removing application from core
+   * @param app_id id application for removing
+  */
+  void OnUnregisterApplication(const uint32_t app_id);
+
  private:
   void SendOnLanguageChangeToMobile(uint32_t connection_key);
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1645,11 +1645,6 @@ void ApplicationManagerImpl::SendMessageToHMI(
     return;
   }
 #endif  // HMI_DBUS_API
-  SDL_INFO("MESSAGE_APP_ID: " << message_to_send->correlation_id());
-  SDL_INFO("MESSAGE_POLICY_ID: " << message_to_send->connection_key());
-  SDL_INFO("MESSAGE_MSG_APP_ID: " << message_to_send->json_message());
-  SDL_INFO("MESSAGE_MSG_POLICY_ID: " << message_to_send->function_id());
-
   messages_to_hmi_.PostMessage(impl::MessageToHmi(message_to_send));
 }
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1645,6 +1645,10 @@ void ApplicationManagerImpl::SendMessageToHMI(
     return;
   }
 #endif  // HMI_DBUS_API
+  SDL_INFO("MESSAGE_APP_ID: " << message_to_send->correlation_id());
+  SDL_INFO("MESSAGE_POLICY_ID: " << message_to_send->connection_key());
+  SDL_INFO("MESSAGE_MSG_APP_ID: " << message_to_send->json_message());
+  SDL_INFO("MESSAGE_MSG_POLICY_ID: " << message_to_send->function_id());
 
   messages_to_hmi_.PostMessage(impl::MessageToHmi(message_to_send));
 }
@@ -2581,6 +2585,8 @@ void ApplicationManagerImpl::UnregisterApplication(
       resume_controller().RemoveApplicationFromSaved(app_to_remove);
     }
     applications_.erase(app_to_remove);
+    (hmi_capabilities_->get_hmi_language_handler())
+        .OnUnregisterApplication(app_id);
     AppV4DevicePredicate finder(handle);
     ApplicationSharedPtr app = FindApp(accessor, finder);
     if (!app) {

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -545,16 +545,24 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
       *(application.get()), resumption, need_restore_vr);
   SendResponse(true, result_code, add_info.c_str(), &response_params);
 
-  if (result_code != mobile_apis::Result::RESUME_FAILED) {
-    resumer.StartResumption(application, hash_id);
-  } else {
-    resumer.StartResumptionOnlyHMILevel(application);
-  }
+  // Check if application exists, because application might be unregestered
+  // during sending reponse to mobile.
+  application = application_manager_.application(key);
+  if (application) {
+    SDL_DEBUG("Application with app_id = " << key << " exists.");
+    if (result_code != mobile_apis::Result::RESUME_FAILED) {
+      resumer.StartResumption(application, hash_id);
+    } else {
+      resumer.StartResumptionOnlyHMILevel(application);
+    }
 
-  // By default app subscribed to CUSTOM_BUTTON
-  SendSubscribeCustomButtonNotification();
-  MessageHelper::SendChangeRegistrationRequestToHMI(application,
-                                                    application_manager_);
+    // By default app subscribed to CUSTOM_BUTTON
+    SendSubscribeCustomButtonNotification();
+    MessageHelper::SendChangeRegistrationRequestToHMI(application,
+                                                      application_manager_);
+  } else {
+    SDL_DEBUG("Application with app_id = " << key << " doesn't exist.");
+  }
 }
 
 void RegisterAppInterfaceRequest::SendOnAppRegisteredNotificationToHMI(

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -1204,4 +1204,8 @@ void HMICapabilitiesImpl::convert_json_languages_to_obj(
   }
 }
 
+HMILanguageHandler& HMICapabilitiesImpl::get_hmi_language_handler() {
+  return hmi_language_handler_;
+}
+
 }  //  namespace application_manager

--- a/src/components/application_manager/src/hmi_language_handler.cc
+++ b/src/components/application_manager/src/hmi_language_handler.cc
@@ -133,6 +133,10 @@ void HMILanguageHandler::on_event(const event_engine::Event& event) {
       is_tts_language_received_ = true;
       break;
     case hmi_apis::FunctionID::BasicCommunication_OnAppRegistered:
+      if (!(msg[strings::params].keyExists(strings::app_id))) {
+        SDL_INFO("Message doesn't contain parameter app_id");
+        return;
+      }
       CheckApplication(
           std::make_pair(msg[strings::params][strings::app_id].asUInt(), true));
       return;
@@ -274,13 +278,21 @@ void HMILanguageHandler::VerifyWithPersistedLanguages() {
 
 void HMILanguageHandler::HandleWrongLanguageApp(const Apps::value_type& app) {
   SDL_AUTO_TRACE();
-  Apps::iterator it = apps_.find(app.first);
-  if (apps_.end() == it) {
-    SDL_DEBUG("Application id "
-              << app.first << " is not found within apps with wrong language.");
-    return;
+  {
+    sync_primitives::AutoLock lock(apps_lock_);
+    Apps::iterator it = apps_.find(app.first);
+    if (apps_.end() == it) {
+      SDL_DEBUG("Application id "
+                << app.first
+                << " is not found within apps with wrong language.");
+      return;
+    }
+    apps_.erase(it);
+    if (0 == apps_.size()) {
+      SDL_DEBUG("HMILanguageHandler unsubscribed from all events.");
+      unsubscribe_from_all_events();
+    }
   }
-
   SDL_INFO("Unregistering application with app_id "
            << app.first << " because of HMI language(s) mismatch.");
 
@@ -292,24 +304,23 @@ void HMILanguageHandler::HandleWrongLanguageApp(const Apps::value_type& app) {
       commands::Command::ORIGIN_SDL);
   application_manager_.UnregisterApplication(
       app.first, mobile_apis::Result::SUCCESS, false);
-  apps_.erase(it);
-  if (0 == apps_.size()) {
-    SDL_DEBUG("All apps processed. Unsubscribing from all events.");
-    unsubscribe_from_all_events();
-  }
 }
 
 void HMILanguageHandler::CheckApplication(const Apps::value_type app) {
   SDL_AUTO_TRACE();
-  sync_primitives::AutoLock lock(apps_lock_);
-  Apps::iterator it = apps_.find(app.first);
-  if (apps_.end() == it) {
-    SDL_INFO("Adding application id "
-             << app.first << " Application registered: " << app.second);
-    apps_.insert(app);
-    return;
+  bool is_need_handle_wrong_language = false;
+  {
+    sync_primitives::AutoLock lock(apps_lock_);
+    Apps::iterator it = apps_.find(app.first);
+    if (apps_.end() == it) {
+      SDL_INFO("Adding application id "
+               << app.first << " Application registered: " << app.second);
+      apps_.insert(app);
+      return;
+    }
+    is_need_handle_wrong_language = apps_[app.first];
   }
-  if (apps_[app.first]) {
+  if (is_need_handle_wrong_language) {
     HandleWrongLanguageApp(app);
   }
 }
@@ -326,5 +337,11 @@ const HMILanguageHandler::Apps& HMILanguageHandler::get_apps() const {
   return apps_;
 }
 #endif  // BUILD_TESTS
+
+void HMILanguageHandler::OnUnregisterApplication(const uint32_t app_id) {
+  SDL_AUTO_TRACE();
+  sync_primitives::AutoLock lock(apps_lock_);
+  apps_.erase(app_id);
+}
 
 }  // namespace application_manager

--- a/src/components/application_manager/src/hmi_language_handler.cc
+++ b/src/components/application_manager/src/hmi_language_handler.cc
@@ -134,7 +134,7 @@ void HMILanguageHandler::on_event(const event_engine::Event& event) {
       break;
     case hmi_apis::FunctionID::BasicCommunication_OnAppRegistered:
       if (!(msg[strings::params].keyExists(strings::app_id))) {
-        SDL_INFO("Message doesn't contain parameter app_id");
+        SDL_WARN("Message doesn't contain parameter app_id");
         return;
       }
       CheckApplication(
@@ -288,7 +288,7 @@ void HMILanguageHandler::HandleWrongLanguageApp(const Apps::value_type& app) {
       return;
     }
     apps_.erase(it);
-    if (0 == apps_.size()) {
+    if (apps_.empty()) {
       SDL_DEBUG("HMILanguageHandler unsubscribed from all events.");
       unsubscribe_from_all_events();
     }

--- a/src/components/application_manager/test/hmi_language_handler_test.cc
+++ b/src/components/application_manager/test/hmi_language_handler_test.cc
@@ -356,6 +356,22 @@ TEST_F(HmiLanguageHandlerTest,
   EXPECT_EQ(kDefaultAppsSize, kApps.size());
 }
 
+TEST_F(HmiLanguageHandlerTest, OnUnregisterApp_SUCCESS) {
+  const uint32_t app_id = 5u;
+  smart_objects::SmartObject msg;
+  msg[am::strings::params][am::strings::app_id] = app_id;
+
+  Event event(hmi_apis::FunctionID::BasicCommunication_OnAppRegistered);
+  event.set_smart_object(msg);
+
+  hmi_language_handler_->on_event(event);
+
+  EXPECT_EQ(1u, hmi_language_handler_->get_apps().size());
+
+  hmi_language_handler_->OnUnregisterApplication(app_id);
+  EXPECT_EQ(kDefaultAppsSize, hmi_language_handler_->get_apps().size());
+}
+
 }  // namespace hmi_language_handler
 }  // namespace components
 }  // namespace test

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -159,6 +159,8 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
 
   MOCK_CONST_METHOD0(ccpu_version, const std::string&());
   MOCK_METHOD1(set_ccpu_version, void(const std::string& ccpu_version));
+  MOCK_METHOD0(get_hmi_language_handler,
+               application_manager::HMILanguageHandler&());
 
  protected:
   MOCK_CONST_METHOD2(check_existing_json_member,

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -418,6 +418,13 @@ class HMICapabilities {
 
   virtual void Init(resumption::LastState* last_state) = 0;
 
+  /**
+   * @brief return component which follows for correctness of
+   * languages
+   * @return HMI language handler
+   */
+  virtual HMILanguageHandler& get_hmi_language_handler() = 0;
+
  protected:
   /*
    * @brief function checks if json member exists


### PR DESCRIPTION
 with HMI language mismatch

  - fixed issue with unregistering app after it's
    registration because of HMI lang mismatch

Related to APPLINK-21931

@anosach-luxoft @LevchenkoS @Kozoriz @VVeremjova @wolfylambova22 @vlantonov @pvvasilev please review