### PR TITLE
Implement LogsEnabled option

### DIFF
--- a/src/appMain/main.cc
+++ b/src/appMain/main.cc
@@ -150,6 +150,11 @@ int32_t main(int32_t argc, char** argv) {
       profile::Profile::instance()->config_file_name("smartDeviceLink.ini");
   }
 
+  if (!profile::Profile::instance()->logs_enabled()) {
+    LOG4CXX_INFO(logger_, "Logging option is not enabled, disabling logger now");
+    DISABLE_LOGGER();
+  }
+
 #ifdef __QNX__
   if (profile::Profile::instance()->enable_policy()) {
     if (!utils::System("./init_policy.sh").Execute(true)) {

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -64,6 +64,11 @@ class Profile : public utils::Singleton<Profile> {
     const std::string& sdl_version() const;
 
     /**
+     * @brief Returns true if logging is enabled, otherwise false
+     */
+    bool logs_enabled() const;
+
+    /**
       * @brief Returns true if HMI should be started, otherwise false
       */
     bool launch_hmi() const;
@@ -625,6 +630,7 @@ class Profile : public utils::Singleton<Profile> {
 
 private:
     std::string                     sdl_version_;
+    bool                            logs_enabled_;
     bool                            launch_hmi_;
 #ifdef WEB_HMI
     std::string                     link_to_web_hmi_;

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -74,6 +74,7 @@ const char* kSDL4Section = "SDL4";
 const char* kResumptionSection = "Resumption";
 
 const char* kSDLVersionKey = "SDLVersion";
+const char* kLogsEnabledKey = "LogsEnabled";
 const char* kHmiCapabilitiesKey = "HMICapabilities";
 const char* kPathToSnapshotKey = "PathToSnapshot";
 const char* kPreloadedPTKey = "PreloadedPT";
@@ -242,6 +243,7 @@ CREATE_LOGGERPTR_GLOBAL(logger_, "Profile")
 
 Profile::Profile()
     : sdl_version_(kDefaultSDLVersion),
+      logs_enabled_(true),
       launch_hmi_(true),
 #ifdef WEB_HMI
       link_to_web_hmi_(kDefaultLinkToWebHMI),
@@ -331,6 +333,10 @@ const std::string& Profile::config_file_name() const {
 
 const std::string& Profile::sdl_version() const {
   return sdl_version_;
+}
+
+bool Profile::logs_enabled() const {
+  return logs_enabled_;
 }
 
 bool Profile::launch_hmi() const {
@@ -701,6 +707,17 @@ void Profile::UpdateValues() {
                   kMainSection, kSDLVersionKey);
 
   LOG_UPDATED_VALUE(sdl_version_, kSDLVersionKey, kMainSection);
+
+  // Logs Enabled Parameter
+  std::string logs_enabled;
+  if (ReadValue(&logs_enabled, kMainSection, kLogsEnabledKey) &&
+      0 == strcmp("true", logs_enabled.c_str())) {
+    logs_enabled_ = true;
+  } else {
+    logs_enabled_ = false;
+  }
+
+  LOG_UPDATED_BOOL_VALUE(logs_enabled_, kLogsEnabledKey, kMainSection);
 
   // Launch HMI parameter
   std::string launch_value;

--- a/src/components/config_profile/test/profile_test.cc
+++ b/src/components/config_profile/test/profile_test.cc
@@ -187,12 +187,14 @@ TEST_F(ProfileTest, UpdateIntValues) {
 TEST_F(ProfileTest, UpdateBoolValues) {
   // Default values
   EXPECT_EQ("smartDeviceLink.ini", Profile::instance()->config_file_name());
+  EXPECT_TRUE(profile::Profile::instance()->logs_enabled());
   EXPECT_TRUE(profile::Profile::instance()->launch_hmi());
   EXPECT_FALSE(profile::Profile::instance()->enable_policy());
 
   // Set config file
   Profile::instance()->config_file_name("smartDeviceLink.ini");
   // Check values
+  EXPECT_TRUE(profile::Profile::instance()->logs_enabled());
   EXPECT_TRUE(profile::Profile::instance()->launch_hmi());
   EXPECT_TRUE(profile::Profile::instance()->enable_policy());
   EXPECT_FALSE(profile::Profile::instance()->is_redecoding_enabled());
@@ -200,6 +202,7 @@ TEST_F(ProfileTest, UpdateBoolValues) {
   // Update config file again
   profile::Profile::instance()->UpdateValues();
   // Values are same
+  EXPECT_TRUE(profile::Profile::instance()->logs_enabled());
   EXPECT_TRUE(profile::Profile::instance()->launch_hmi());
   EXPECT_TRUE(profile::Profile::instance()->enable_policy());
   EXPECT_FALSE(profile::Profile::instance()->is_redecoding_enabled());
@@ -210,6 +213,7 @@ TEST_F(ProfileTest, UpdateBoolValues) {
             Profile::instance()->config_file_name());
 
   // Parameters after updating
+  EXPECT_FALSE(profile::Profile::instance()->logs_enabled());
   EXPECT_FALSE(profile::Profile::instance()->launch_hmi());
   EXPECT_FALSE(profile::Profile::instance()->enable_policy());
   EXPECT_TRUE(profile::Profile::instance()->is_redecoding_enabled());
@@ -218,6 +222,7 @@ TEST_F(ProfileTest, UpdateBoolValues) {
   profile::Profile::instance()->UpdateValues();
 
   // Parameters are same
+  EXPECT_FALSE(profile::Profile::instance()->logs_enabled());
   EXPECT_FALSE(profile::Profile::instance()->launch_hmi());
   EXPECT_FALSE(profile::Profile::instance()->enable_policy());
   EXPECT_TRUE(profile::Profile::instance()->is_redecoding_enabled());

--- a/src/components/config_profile/test/smartDeviceLink.ini
+++ b/src/components/config_profile/test/smartDeviceLink.ini
@@ -21,6 +21,7 @@ VideoStreamingPort = 5050
 AudioStreamingPort = 5080
 
 [MAIN]
+LogsEnabled = true
 ; Contains .json/.ini files
 AppConfigFolder =
 ; Contains output files, e.g. .wav

--- a/src/components/config_profile/test/smartDeviceLink_test.ini
+++ b/src/components/config_profile/test/smartDeviceLink_test.ini
@@ -23,6 +23,7 @@ VideoStreamingPort = 5050
 AudioStreamingPort = 5080
 
 [MAIN]
+LogsEnabled = false
 ; Contains .json/.ini files
 AppConfigFolder =
 ; Contains output files, e.g. .wav

--- a/src/components/include/utils/logger.h
+++ b/src/components/include/utils/logger.h
@@ -41,6 +41,7 @@
   #include <sstream>
   #include <log4cxx/propertyconfigurator.h>
   #include <log4cxx/spi/loggingevent.h>
+  #include <log4cxx/logmanager.h>
   #include "utils/push_log.h"
   #include "utils/logger_status.h"
   #include "utils/auto_trace.h"
@@ -63,6 +64,8 @@
     // without this deinitilization log4cxx threads continue using some instances destroyed by exit()
     void deinit_logger ();
     #define DEINIT_LOGGER() deinit_logger()
+
+    #define DISABLE_LOGGER() ::log4cxx::LogManager::getLoggerRepository()->setThreshold(::log4cxx::Level::getOff())
 
     #define LOG4CXX_IS_TRACE_ENABLED(logger) logger->isTraceEnabled()
 


### PR DESCRIPTION
The LogsEnabled option is included in the default smartDeviceLink.ini file, but wasn't implemented. This PR implements this option and includes tests for the option.

Fixes #704 

Related: APPLINK-21531