### PR TITLE
Complete covering of AppLaunch functionality by Unit Tests

### DIFF
--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -785,6 +785,30 @@ TEST_F(ResumeCtrlTest, CheckApplicationkHash_) {
   EXPECT_TRUE(res_ctrl->CheckApplicationHash(app_mock, kHash_));
 }
 
+TEST_F(ResumeCtrlTest, GetSavedAppHmiLevel_NoAskedApp_INVALID_ENUM) {
+  const std::string app_id = "test_app_id";
+  const std::string device_id = "test_device_id";
+  EXPECT_CALL(*mock_storage, GetSavedApplication(app_id, device_id, _))
+      .WillOnce(Return(false));
+  EXPECT_EQ(mobile_apis::HMILevel::INVALID_ENUM,
+            res_ctrl->GetSavedAppHmiLevel(app_id, device_id));
+}
+
+ACTION_P(SetHmiLevel, hmi_level) {
+  arg2[am::strings::hmi_level] = hmi_level;
+}
+
+TEST_F(ResumeCtrlTest, GetSavedAppHmiLevel_AskedAppFound_INVALID_ENUM) {
+  const std::string app_id = "test_app_id";
+  const std::string device_id = "test_device_id";
+  const mobile_apis::HMILevel::eType hmi_level =
+      mobile_apis::HMILevel::HMI_FULL;
+
+  EXPECT_CALL(*mock_storage, GetSavedApplication(app_id, device_id, _))
+      .WillOnce(DoAll(SetHmiLevel(hmi_level), Return(true)));
+  EXPECT_EQ(hmi_level, res_ctrl->GetSavedAppHmiLevel(app_id, device_id));
+}
+
 }  // namespace resumption_test
 }  // namespace components
 }  // namespace test

--- a/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
+++ b/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
@@ -414,6 +414,18 @@ class TransportAdapterImpl : public TransportAdapter,
    */
   std::string GetConnectionType() const OVERRIDE;
 
+  /**
+   * @brief RunAppOnDevice allows run specific application on the certain
+   *device.
+   *
+   * @param device_handle device identifier to run application on.
+   *
+   * @param bundle_id application id also known as bundle id on some devices to
+   *run.
+   */
+  void RunAppOnDevice(const DeviceUID& device_uid,
+                      const std::string& bundle_id) OVERRIDE;
+
 #ifdef TELEMETRY_MONITOR
   /**
    * @brief Setup observer for time metric.
@@ -477,18 +489,6 @@ class TransportAdapterImpl : public TransportAdapter,
    * @return Error information about connecting applications on device
    */
   TransportAdapter::Error ConnectDevice(DeviceSptr device);
-
-  /**
-   * @brief RunAppOnDevice allows run specific application on the certain
-   *device.
-   *
-   * @param device_handle device identifier to run application on.
-   *
-   * @param bundle_id application id alsow known as bundle id on some devices to
-   *run.
-   */
-  void RunAppOnDevice(const DeviceUID& device_uid,
-                      const std::string& bundle_id) OVERRIDE;
 
   /**
    * @brief Remove specified device

--- a/src/components/transport_manager/test/include/transport_manager/device_mock.h
+++ b/src/components/transport_manager/test/include/transport_manager/device_mock.h
@@ -48,6 +48,7 @@ class MockDevice : public ::transport_manager::transport_adapter::Device {
       : Device(name, unique_device_id) {}
   MOCK_CONST_METHOD1(IsSameAs, bool(const Device* other_device));
   MOCK_CONST_METHOD0(GetApplicationList, std::vector<int>());
+  MOCK_CONST_METHOD1(LaunchApp, void(const std::string& bundle_id));
   MOCK_METHOD0(Stop, void());
 };
 

--- a/src/components/transport_manager/test/transport_adapter_test.cc
+++ b/src/components/transport_manager/test/transport_adapter_test.cc
@@ -54,6 +54,7 @@ namespace components {
 namespace transport_manager_test {
 
 using ::testing::Return;
+using ::testing::ReturnRef;
 using ::testing::_;
 using ::testing::NiceMock;
 using namespace ::transport_manager;
@@ -737,6 +738,39 @@ TEST_F(TransportAdapterTest, FindEstablishedConnection) {
   EXPECT_EQ(mock_connection, conn);
 
   EXPECT_CALL(*serverMock, Terminate());
+}
+
+TEST_F(TransportAdapterTest, RunAppOnDevice_NoDeviseWithAskedId_UNSUCCESS) {
+  const std::string bundle_id = "test_bundle_id";
+
+  MockTransportAdapterImpl transport_adapter(
+      NULL, NULL, NULL, last_state_, transport_manager_settings);
+
+  utils::SharedPtr<MockDevice> mock_device =
+      utils::MakeShared<MockDevice>("test_device_name", "test_device_uid0");
+
+  transport_adapter.AddDevice(mock_device);
+
+  EXPECT_CALL(*mock_device, LaunchApp(bundle_id)).Times(0);
+
+  transport_adapter.RunAppOnDevice("test_device_uid1", bundle_id);
+}
+
+TEST_F(TransportAdapterTest, RunAppOnDevice_DeviseWithAskedIdWasFound_SUCCESS) {
+  const std::string bundle_id = "test_bundle_id";
+  const std::string device_uid = "test_device_uid";
+
+  MockTransportAdapterImpl transport_adapter(
+      NULL, NULL, NULL, last_state_, transport_manager_settings);
+
+  utils::SharedPtr<MockDevice> mock_device =
+      utils::MakeShared<MockDevice>("test_device_name", device_uid);
+
+  transport_adapter.AddDevice(mock_device);
+
+  EXPECT_CALL(*mock_device, LaunchApp(bundle_id));
+
+  transport_adapter.RunAppOnDevice(device_uid, bundle_id);
 }
 
 }  // namespace transport_manager_test

--- a/src/components/transport_manager/test/transport_manager_impl_test.cc
+++ b/src/components/transport_manager/test/transport_manager_impl_test.cc
@@ -52,6 +52,7 @@
 using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Return;
+using ::testing::ReturnRef;
 
 using ::protocol_handler::RawMessage;
 using ::protocol_handler::RawMessagePtr;
@@ -1067,6 +1068,13 @@ TEST_F(TransportManagerImplTest,
   // Act and Assert
   EXPECT_CALL(*tm_listener_, OnUnexpectedDisconnect(_, _)).Times(0);
   tm_.TestHandle(test_event);
+}
+
+TEST_F(TransportManagerImplTest, RunAppOnDevice_TransportAdapterFound_SUCCESS) {
+  HandleDeviceListUpdated();
+  const std::string bundle_id = "test_bundle_id";
+  EXPECT_CALL(*mock_adapter_, RunAppOnDevice(mac_address_, bundle_id));
+  tm_.RunAppOnDevice(device_handle_, bundle_id);
 }
 
 }  // namespace transport_manager_test


### PR DESCRIPTION
Has been covered:
- `ConnectionHandlerImpl::RunAppOnDevice`;
- `TransportManagerImpl::RunAppOnDevice`;
- `TransportAdapterImpl::RunAppOnDevice`;
- `ResumeCtrlImpl::GetSavedAppHmiLevel`.

Related to: [APPLINK-24895](https://adc.luxoft.com/jira/browse/APPLINK-24895)

@okozlovlux, @Kozoriz, @LuxoftAKutsan, @vlantonov, @VVeremjova, @pvvasilev, please review.