### PR TITLE
Cover HMI Commands With Unit Tests Part 9

### DIFF
--- a/src/components/application_manager/test/commands/hmi/get_urls_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_urls_response_test.cc
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2016
- * , Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
@@ -42,7 +42,17 @@
 #include "hmi/vi_read_did_request.h"
 #include "hmi/vi_subscribe_vehicle_data_request.h"
 #include "hmi/dial_number_request.h"
+#include "hmi/tts_is_ready_request.h"
+#include "hmi/tts_set_global_properties_request.h"
+#include "hmi/tts_speak_request.h"
+#include "hmi/tts_stop_speaking_request.h"
+#include "hmi/tts_get_supported_languages_request.h"
 #include "hmi/close_popup_request.h"
+#include "hmi/ui_add_command_request.h"
+#include "hmi/ui_add_submenu_request.h"
+#include "hmi/ui_alert_request.h"
+#include "hmi/ui_change_registration_request.h"
+#include "hmi/ui_delete_command_request.h"
 #include "hmi/ui_delete_submenu_request.h"
 #include "hmi/ui_end_audio_pass_thru_request.h"
 #include "hmi/ui_get_capabilities_request.h"
@@ -95,6 +105,16 @@ typedef Types<commands::VIIsReadyRequest,
               commands::VISubscribeVehicleDataRequest,
               commands::hmi::DialNumberRequest,
               commands::ClosePopupRequest,
+              commands::TTSIsReadyRequest,
+              commands::TTSSetGlobalPropertiesRequest,
+              commands::TTSSpeakRequest,
+              commands::TTSStopSpeakingRequest,
+              commands::TTSGetSupportedLanguagesRequest,
+              commands::UIAddCommandRequest,
+              commands::UIAddSubmenuRequest,
+              commands::UIAlertRequest,
+              commands::UIChangeRegistrationRequest,
+              commands::UIDeleteCommandRequest,
               commands::UIDeleteSubmenuRequest,
               commands::UIEndAudioPassThruRequest,
               commands::UIGetCapabilitiesRequest> RequestCommandsList;

--- a/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
@@ -42,17 +42,10 @@
 #include "hmi/vi_read_did_request.h"
 #include "hmi/vi_subscribe_vehicle_data_request.h"
 #include "hmi/dial_number_request.h"
-#include "hmi/tts_is_ready_request.h"
-#include "hmi/tts_set_global_properties_request.h"
-#include "hmi/tts_speak_request.h"
-#include "hmi/tts_stop_speaking_request.h"
-#include "hmi/tts_get_supported_languages_request.h"
 #include "hmi/close_popup_request.h"
-#include "hmi/ui_add_command_request.h"
-#include "hmi/ui_add_submenu_request.h"
-#include "hmi/ui_alert_request.h"
-#include "hmi/ui_change_registration_request.h"
-#include "hmi/ui_delete_command_request.h"
+#include "hmi/ui_delete_submenu_request.h"
+#include "hmi/ui_end_audio_pass_thru_request.h"
+#include "hmi/ui_get_capabilities_request.h"
 
 namespace test {
 namespace components {
@@ -102,16 +95,9 @@ typedef Types<commands::VIIsReadyRequest,
               commands::VISubscribeVehicleDataRequest,
               commands::hmi::DialNumberRequest,
               commands::ClosePopupRequest,
-              commands::TTSIsReadyRequest,
-              commands::TTSSetGlobalPropertiesRequest,
-              commands::TTSSpeakRequest,
-              commands::TTSStopSpeakingRequest,
-              commands::TTSGetSupportedLanguagesRequest,
-              commands::UIAddCommandRequest,
-              commands::UIAddSubmenuRequest,
-              commands::UIAlertRequest,
-              commands::UIChangeRegistrationRequest,
-              commands::UIDeleteCommandRequest> RequestCommandsList;
+              commands::UIDeleteSubmenuRequest,
+              commands::UIEndAudioPassThruRequest,
+              commands::UIGetCapabilitiesRequest> RequestCommandsList;
 
 TYPED_TEST_CASE(RequestToHMICommandsTest, RequestCommandsList);
 

--- a/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
@@ -46,6 +46,16 @@
 #include "hmi/vi_get_vehicle_type_response.h"
 #include "hmi/vi_is_ready_response.h"
 #include "hmi/dial_number_response.h"
+#include "hmi/close_popup_response.h"
+#include "hmi/tts_set_global_properties_response.h"
+#include "hmi/tts_speak_response.h"
+#include "hmi/tts_stop_speaking_response.h"
+#include "hmi/ui_add_command_response.h"
+#include "hmi/ui_add_command_response.h"
+#include "hmi/ui_add_submenu_response.h"
+#include "hmi/ui_alert_response.h"
+#include "hmi/ui_change_registration_response.h"
+#include "hmi/ui_delete_command_response.h"
 #include "hmi/ui_delete_submenu_response.h"
 #include "hmi/ui_end_audio_pass_thru_response.h"
 
@@ -88,6 +98,7 @@ struct CommandData {
 typedef Types<
     CommandData<commands::VIReadDIDResponse,
                 hmi_apis::FunctionID::VehicleInfo_ReadDID>,
+    CommandData<commands::TTSSpeakResponse, hmi_apis::FunctionID::TTS_Speak>,
     CommandData<commands::VISubscribeVehicleDataResponse,
                 hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData>,
     CommandData<commands::hmi::DialNumberResponse,
@@ -95,8 +106,20 @@ typedef Types<
     CommandData<commands::UIDeleteSubmenuResponse,
                 hmi_apis::FunctionID::UI_DeleteSubMenu>,
     CommandData<commands::UIEndAudioPassThruResponse,
-                hmi_apis::FunctionID::UI_EndAudioPassThru> >
-    ResponseCommandsList;
+                hmi_apis::FunctionID::UI_EndAudioPassThru>,
+    CommandData<commands::TTSSetGlobalPropertiesResponse,
+                hmi_apis::FunctionID::TTS_SetGlobalProperties>,
+    CommandData<commands::TTSStopSpeakingResponse,
+                hmi_apis::FunctionID::TTS_StopSpeaking>,
+    CommandData<commands::UIAddCommandResponse,
+                hmi_apis::FunctionID::UI_AddCommand>,
+    CommandData<commands::UIAddSubmenuResponse,
+                hmi_apis::FunctionID::UI_AddSubMenu>,
+    CommandData<commands::UIAlertResponse, hmi_apis::FunctionID::UI_Alert>,
+    CommandData<commands::UIChangeRegistratioResponse,
+                hmi_apis::FunctionID::UI_ChangeRegistration>,
+    CommandData<commands::UIDeleteCommandResponse,
+                hmi_apis::FunctionID::UI_DeleteCommand> > ResponseCommandsList;
 
 TYPED_TEST_CASE(ResponseFromHMICommandsTest, ResponseCommandsList);
 

--- a/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
@@ -46,16 +46,8 @@
 #include "hmi/vi_get_vehicle_type_response.h"
 #include "hmi/vi_is_ready_response.h"
 #include "hmi/dial_number_response.h"
-#include "hmi/close_popup_response.h"
-#include "hmi/tts_set_global_properties_response.h"
-#include "hmi/tts_speak_response.h"
-#include "hmi/tts_stop_speaking_response.h"
-#include "hmi/ui_add_command_response.h"
-#include "hmi/ui_add_command_response.h"
-#include "hmi/ui_add_submenu_response.h"
-#include "hmi/ui_alert_response.h"
-#include "hmi/ui_change_registration_response.h"
-#include "hmi/ui_delete_command_response.h"
+#include "hmi/ui_delete_submenu_response.h"
+#include "hmi/ui_end_audio_pass_thru_response.h"
 
 namespace test {
 namespace components {
@@ -96,24 +88,15 @@ struct CommandData {
 typedef Types<
     CommandData<commands::VIReadDIDResponse,
                 hmi_apis::FunctionID::VehicleInfo_ReadDID>,
-    CommandData<commands::TTSSpeakResponse, hmi_apis::FunctionID::TTS_Speak>,
     CommandData<commands::VISubscribeVehicleDataResponse,
                 hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData>,
     CommandData<commands::hmi::DialNumberResponse,
                 hmi_apis::FunctionID::BasicCommunication_DialNumber>,
-    CommandData<commands::TTSSetGlobalPropertiesResponse,
-                hmi_apis::FunctionID::TTS_SetGlobalProperties>,
-    CommandData<commands::TTSStopSpeakingResponse,
-                hmi_apis::FunctionID::TTS_StopSpeaking>,
-    CommandData<commands::UIAddCommandResponse,
-                hmi_apis::FunctionID::UI_AddCommand>,
-    CommandData<commands::UIAddSubmenuResponse,
-                hmi_apis::FunctionID::UI_AddSubMenu>,
-    CommandData<commands::UIAlertResponse, hmi_apis::FunctionID::UI_Alert>,
-    CommandData<commands::UIChangeRegistratioResponse,
-                hmi_apis::FunctionID::UI_ChangeRegistration>,
-    CommandData<commands::UIDeleteCommandResponse,
-                hmi_apis::FunctionID::UI_DeleteCommand> > ResponseCommandsList;
+    CommandData<commands::UIDeleteSubmenuResponse,
+                hmi_apis::FunctionID::UI_DeleteSubMenu>,
+    CommandData<commands::UIEndAudioPassThruResponse,
+                hmi_apis::FunctionID::UI_EndAudioPassThru> >
+    ResponseCommandsList;
 
 TYPED_TEST_CASE(ResponseFromHMICommandsTest, ResponseCommandsList);
 

--- a/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -195,7 +195,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetNavigation_SUCCESS) {
   command->Run();
 }
 
-TEST_F(UIGetCapabilitiesResponseTest, SePhoneCall_SUCCESS) {
+TEST_F(UIGetCapabilitiesResponseTest, SetPhoneCall_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
   (*command_msg)[strings::msg_params][strings::hmi_capabilities] =
       smart_objects::SmartObject(smart_objects::SmartType_Map);

--- a/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -40,7 +40,6 @@
 #include "smart_objects/smart_object.h"
 #include "interfaces/MOBILE_API.h"
 #include "application_manager/mock_hmi_capabilities.h"
-#include "application_manager/commands/command_request_test.h"
 #include "application_manager/smart_object_keys.h"
 #include "application_manager/commands/commands_test.h"
 #include "application_manager/commands/command_impl.h"
@@ -101,10 +100,11 @@ TEST_F(UIGetCapabilitiesResponseTest, RUN_SetDisplay_SUCCESSS) {
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
+  smart_objects::SmartObject display_capabilities_so =
+      (*command_msg)[strings::msg_params][hmi_response::display_capabilities];
+
   EXPECT_CALL(mock_hmi_capabilities_,
-              set_display_capabilities(
-                  (*command_msg)[strings::msg_params]
-                                [hmi_response::display_capabilities]));
+              set_display_capabilities(display_capabilities_so));
 
   command->Run();
 }
@@ -122,10 +122,11 @@ TEST_F(UIGetCapabilitiesResponseTest, SetSoftButton_SUCCESS) {
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
+  smart_objects::SmartObject soft_button_capabilities_so = (*command_msg)
+      [strings::msg_params][hmi_response::soft_button_capabilities];
+
   EXPECT_CALL(mock_hmi_capabilities_,
-              set_soft_button_capabilities(
-                  (*command_msg)[strings::msg_params]
-                                [hmi_response::soft_button_capabilities]));
+              set_soft_button_capabilities(soft_button_capabilities_so));
 
   command->Run();
 }
@@ -143,10 +144,11 @@ TEST_F(UIGetCapabilitiesResponseTest, SetHmiZone_SUCCESS) {
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
+  smart_objects::SmartObject hmi_zone_capabilities_so =
+      (*command_msg)[strings::msg_params][hmi_response::hmi_zone_capabilities];
+
   EXPECT_CALL(mock_hmi_capabilities_,
-              set_hmi_zone_capabilities(
-                  (*command_msg)[strings::msg_params]
-                                [hmi_response::hmi_zone_capabilities]));
+              set_hmi_zone_capabilities(hmi_zone_capabilities_so));
 
   command->Run();
 }
@@ -162,10 +164,11 @@ TEST_F(UIGetCapabilitiesResponseTest, SetAudioPassThru_SUCCESS) {
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
-  EXPECT_CALL(mock_hmi_capabilities_,
-              set_audio_pass_thru_capabilities(
-                  (*command_msg)[strings::msg_params]
-                                [strings::audio_pass_thru_capabilities]));
+  smart_objects::SmartObject audio_pass_thru_capabilities_so = (*command_msg)
+      [strings::msg_params][strings::audio_pass_thru_capabilities];
+  EXPECT_CALL(
+      mock_hmi_capabilities_,
+      set_audio_pass_thru_capabilities(audio_pass_thru_capabilities_so));
 
   command->Run();
 }
@@ -183,10 +186,11 @@ TEST_F(UIGetCapabilitiesResponseTest, SetNavigation_SUCCESS) {
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
+  smart_objects::SmartObject hmi_capabilities_so =
+      (*command_msg)[strings::msg_params][strings::hmi_capabilities];
   EXPECT_CALL(mock_hmi_capabilities_,
               set_navigation_supported(
-                  (*command_msg)[strings::msg_params][strings::hmi_capabilities]
-                                [strings::navigation].asBool()));
+                  hmi_capabilities_so[strings::navigation].asBool()));
 
   command->Run();
 }
@@ -204,10 +208,11 @@ TEST_F(UIGetCapabilitiesResponseTest, SePhoneCall_SUCCESS) {
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
+  smart_objects::SmartObject hmi_capabilities_so =
+      (*command_msg)[strings::msg_params][strings::hmi_capabilities];
   EXPECT_CALL(mock_hmi_capabilities_,
               set_phone_call_supported(
-                  (*command_msg)[strings::msg_params][strings::hmi_capabilities]
-                                [strings::phone_call].asBool()));
+                  hmi_capabilities_so[strings::phone_call].asBool()));
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+#include <set>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "utils/make_shared.h"
+#include "smart_objects/smart_object.h"
+#include "interfaces/MOBILE_API.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_impl.h"
+#include "application_manager/commands/hmi/ui_get_capabilities_response.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::utils::SharedPtr;
+using ::testing::NiceMock;
+namespace am = ::application_manager;
+namespace strings = am::strings;
+namespace hmi_response = am::hmi_response;
+using am::commands::ResponseFromHMI;
+using am::commands::UIGetCapabilitiesResponse;
+using am::commands::CommandImpl;
+
+typedef SharedPtr<ResponseFromHMI> ResponseFromHMIPtr;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+}  // namespace
+
+class UIGetCapabilitiesResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  MessageSharedPtr CreateCommandMsg() {
+    MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+    (*command_msg)[strings::msg_params][strings::number] = "123";
+    (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
+    (*command_msg)[strings::params][hmi_response::code] =
+        hmi_apis::Common_Result::SUCCESS;
+    (*command_msg)[strings::msg_params][hmi_response::capabilities] =
+        (capabilities_);
+
+    return command_msg;
+  }
+
+  MockHMICapabilities mock_hmi_capabilities_;
+  SmartObject capabilities_;
+};
+
+TEST_F(UIGetCapabilitiesResponseTest, RUN_SetDisplay_SUCCESSS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::msg_params][hmi_response::display_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  (*command_msg)[strings::msg_params][hmi_response::display_capabilities]
+                [hmi_response::display_type] = "GEN2_8_DMA";
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_display_capabilities(
+                  (*command_msg)[strings::msg_params]
+                                [hmi_response::display_capabilities]));
+
+  command->Run();
+}
+
+TEST_F(UIGetCapabilitiesResponseTest, SetSoftButton_SUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::msg_params][hmi_response::soft_button_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  (*command_msg)[strings::msg_params][hmi_response::soft_button_capabilities]
+                [hmi_response::image_supported] = true;
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_soft_button_capabilities(
+                  (*command_msg)[strings::msg_params]
+                                [hmi_response::soft_button_capabilities]));
+
+  command->Run();
+}
+
+TEST_F(UIGetCapabilitiesResponseTest, SetHmiZone_SUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::msg_params][hmi_response::hmi_zone_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  (*command_msg)[strings::msg_params][hmi_response::hmi_zone_capabilities][0] =
+      "FRONT";
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_hmi_zone_capabilities(
+                  (*command_msg)[strings::msg_params]
+                                [hmi_response::hmi_zone_capabilities]));
+
+  command->Run();
+}
+
+TEST_F(UIGetCapabilitiesResponseTest, SetAudioPassThru_SUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::msg_params][strings::audio_pass_thru_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_audio_pass_thru_capabilities(
+                  (*command_msg)[strings::msg_params]
+                                [strings::audio_pass_thru_capabilities]));
+
+  command->Run();
+}
+
+TEST_F(UIGetCapabilitiesResponseTest, SetNavigation_SUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::msg_params][strings::hmi_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  (*command_msg)[strings::msg_params][strings::hmi_capabilities]
+                [strings::navigation] = true;
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_navigation_supported(
+                  (*command_msg)[strings::msg_params][strings::hmi_capabilities]
+                                [strings::navigation].asBool()));
+
+  command->Run();
+}
+
+TEST_F(UIGetCapabilitiesResponseTest, SePhoneCall_SUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::msg_params][strings::hmi_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  (*command_msg)[strings::msg_params][strings::hmi_capabilities]
+                [strings::phone_call] = true;
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_phone_call_supported(
+                  (*command_msg)[strings::msg_params][strings::hmi_capabilities]
+                                [strings::phone_call].asBool()));
+
+  command->Run();
+}
+
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -31,8 +31,6 @@
  */
 
 #include <stdint.h>
-#include <string>
-#include <set>
 
 #include "gtest/gtest.h"
 #include "utils/shared_ptr.h"


### PR DESCRIPTION
 Unit tests were added for the following HMI commands:

- ui_delete_submenu_request
- ui_delete_submenu_response
- ui_end_audio_pass_thru_request
- ui_end_audio_pass_thru_response
- ui_get_capabilities_request
- ui_get_capabilities_response

 Related issue: APPLINK-25924
