### PR TITLE
VehicleInfo interface: SDL behavior in case HMI does not respond to IsReady request or respond with "available" = false

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager.h
+++ b/src/components/application_manager/include/application_manager/application_manager.h
@@ -496,13 +496,14 @@ class ApplicationManager {
   virtual resumption::ResumeCtrl& resume_controller() = 0;
 
   /**
- * @brief hmi_interfaces getter for hmi_interfaces component, that handle
- * hmi_instrfaces state
- * @return reference to hmi_interfaces component
- */
+  * @brief hmi_interfaces getter for hmi_interfaces component, that handle
+  * hmi_instrfaces state
+  * @return reference to hmi_interfaces component
+  */
   virtual HmiInterfaces& hmi_interfaces() = 0;
 
   virtual app_launch::AppLaunchCtrl& app_launch_ctrl() = 0;
+
   /*
    * @brief Converts connection string transport type representation
    * to HMI Common_TransportType

--- a/src/components/application_manager/include/application_manager/hmi_interfaces.h
+++ b/src/components/application_manager/include/application_manager/hmi_interfaces.h
@@ -1,36 +1,35 @@
 /*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
 
- Copyright (c) 2016, Ford Motor Company
- All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
-
- Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
-
- Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following
- disclaimer in the documentation and/or other materials provided with the
- distribution.
-
- Neither the name of the Ford Motor Company nor the names of its contributors
- may be used to endorse or promote products derived from this software
- without specific prior written permission.
-
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- POSSIBILITY OF SUCH DAMAGE.
  */
-
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_INTERFACES_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_INTERFACES_H_
 
@@ -39,8 +38,9 @@
 namespace application_manager {
 
 /**
- * @brief The HmiInterfacesImpl class handles
- *  hmi interfaces states
+ * @brief The class contains information about state HMI's interfaces
+ * (Buttons, BasicCommunication, VR, TTS, UI, Navigation,VehicleInfo,
+ *  SDL) and provides this information through public interfaces.
  */
 class HmiInterfaces {
  public:

--- a/src/components/application_manager/include/application_manager/hmi_interfaces_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_interfaces_impl.h
@@ -36,13 +36,12 @@
 #include "application_manager/hmi_interfaces.h"
 #include "utils/macro.h"
 #include "utils/lock.h"
-
-namespace application_manager {
-
 /**
  * @brief The HmiInterfacesImpl class handles
  *  hmi interfaces states
  */
+namespace application_manager {
+
 class HmiInterfacesImpl : public HmiInterfaces {
  public:
   HmiInterfacesImpl();

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -37,7 +37,6 @@
 #include "application_manager/application_manager.h"
 #include "application_manager/message_helper.h"
 #include "smart_objects/smart_object.h"
-
 namespace application_manager {
 
 namespace commands {

--- a/src/components/application_manager/src/commands/hmi/vi_is_ready_response.cc
+++ b/src/components/application_manager/src/commands/hmi/vi_is_ready_response.cc
@@ -48,17 +48,16 @@ void VIIsReadyResponse::Run() {
   bool is_available = false;
   if (object[strings::msg_params].keyExists(strings::available)) {
     is_available = object[strings::msg_params][strings::available].asBool();
+    const HmiInterfaces::InterfaceState interface_state =
+        is_available ? HmiInterfaces::STATE_AVAILABLE
+                     : HmiInterfaces::STATE_NOT_AVAILABLE;
+    HmiInterfaces& hmi_interfaces = application_manager_.hmi_interfaces();
+    hmi_interfaces.SetInterfaceState(HmiInterfaces::HMI_INTERFACE_VehicleInfo,
+                                     interface_state);
   }
 
   HMICapabilities& hmi_capabilities = application_manager_.hmi_capabilities();
   hmi_capabilities.set_is_ivi_cooperating(is_available);
-
-  const HmiInterfaces::InterfaceState interface_state =
-      is_available ? HmiInterfaces::STATE_AVAILABLE
-                   : HmiInterfaces::STATE_NOT_AVAILABLE;
-  HmiInterfaces& hmi_interfaces = application_manager_.hmi_interfaces();
-  hmi_interfaces.SetInterfaceState(HmiInterfaces::HMI_INTERFACE_VehicleInfo,
-                                   interface_state);
 
   application_manager_.GetPolicyHandler().OnVIIsReady();
 }

--- a/src/components/application_manager/src/commands/hmi/vr_is_ready_response.cc
+++ b/src/components/application_manager/src/commands/hmi/vr_is_ready_response.cc
@@ -48,17 +48,16 @@ void VRIsReadyResponse::Run() {
   bool is_available = false;
   if (object[strings::msg_params].keyExists(strings::available)) {
     is_available = object[strings::msg_params][strings::available].asBool();
+    const HmiInterfaces::InterfaceState interface_state =
+        is_available ? HmiInterfaces::STATE_AVAILABLE
+                     : HmiInterfaces::STATE_NOT_AVAILABLE;
+    HmiInterfaces& hmi_interfaces = application_manager_.hmi_interfaces();
+    hmi_interfaces.SetInterfaceState(HmiInterfaces::HMI_INTERFACE_VR,
+                                     interface_state);
   }
 
   HMICapabilities& hmi_capabilities = application_manager_.hmi_capabilities();
   hmi_capabilities.set_is_vr_cooperating(is_available);
-
-  const HmiInterfaces::InterfaceState interface_state =
-      is_available ? HmiInterfaces::STATE_AVAILABLE
-                   : HmiInterfaces::STATE_NOT_AVAILABLE;
-  HmiInterfaces& hmi_interfaces = application_manager_.hmi_interfaces();
-  hmi_interfaces.SetInterfaceState(HmiInterfaces::HMI_INTERFACE_VR,
-                                   interface_state);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -354,7 +354,6 @@ void CreateInteractionChoiceSetRequest::on_event(
         ProcessHmiError(result);
       }
     }
-
     CountReceivedVRResponses();
   }
 }

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -456,15 +456,15 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
     result_code = mobile_apis::Result::WRONG_LANGUAGE;
   }
 
-  if (application_manager_.hmi_interfaces().GetInterfaceState(
-          HmiInterfaces::HMI_INTERFACE_VR) !=
-      HmiInterfaces::STATE_NOT_AVAILABLE) {
+  if (HmiInterfaces::STATE_NOT_AVAILABLE !=
+      application_manager_.hmi_interfaces().GetInterfaceState(
+          HmiInterfaces::HMI_INTERFACE_VR)) {
     FillVRRelatedFields(response_params, hmi_capabilities);
   }
 
-  if (application_manager_.hmi_interfaces().GetInterfaceState(
-          HmiInterfaces::HMI_INTERFACE_UI) !=
-      HmiInterfaces::STATE_NOT_AVAILABLE) {
+  if (HmiInterfaces::STATE_NOT_AVAILABLE !=
+      application_manager_.hmi_interfaces().GetInterfaceState(
+          HmiInterfaces::HMI_INTERFACE_UI)) {
     FillUIRelatedFields(response_params, hmi_capabilities);
   }
 


### PR DESCRIPTION
Added logic for processing case when HMI does not respond to IsReady request or respond with
"available"=false.
 Based on implementation CRQ [APPLINK-20920](https://adc.luxoft.com/jira/browse/APPLINK-20920)
 
CRQ [APPLINK-25201](https://adc.luxoft.com/jira/browse/APPLINK-25201)