### PR TITLE
Cover HMI commands with Unit Tests Part 10

### DIFF
--- a/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
@@ -56,6 +56,11 @@
 #include "hmi/ui_delete_submenu_request.h"
 #include "hmi/ui_end_audio_pass_thru_request.h"
 #include "hmi/ui_get_capabilities_request.h"
+#include "hmi/ui_get_language_request.h"
+#include "hmi/ui_get_supported_languages_request.h"
+#include "hmi/ui_is_ready_request.h"
+#include "hmi/ui_perform_audio_pass_thru_request.h"
+#include "hmi/ui_perform_interaction_request.h"
 
 namespace test {
 namespace components {
@@ -117,7 +122,12 @@ typedef Types<commands::VIIsReadyRequest,
               commands::UIDeleteCommandRequest,
               commands::UIDeleteSubmenuRequest,
               commands::UIEndAudioPassThruRequest,
-              commands::UIGetCapabilitiesRequest> RequestCommandsList;
+              commands::UIGetCapabilitiesRequest,
+              commands::UIGetLanguageRequest,
+              commands::UIGetSupportedLanguagesRequest,
+              commands::UIIsReadyRequest,
+              commands::UIPerformAudioPassThruRequest,
+              commands::UIPerformInteractionRequest> RequestCommandsList;
 
 TYPED_TEST_CASE(RequestToHMICommandsTest, RequestCommandsList);
 

--- a/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
@@ -58,6 +58,8 @@
 #include "hmi/ui_delete_command_response.h"
 #include "hmi/ui_delete_submenu_response.h"
 #include "hmi/ui_end_audio_pass_thru_response.h"
+#include "hmi/ui_perform_audio_pass_thru_response.h"
+#include "hmi/ui_perform_interaction_response.h"
 
 namespace test {
 namespace components {
@@ -119,7 +121,12 @@ typedef Types<
     CommandData<commands::UIChangeRegistratioResponse,
                 hmi_apis::FunctionID::UI_ChangeRegistration>,
     CommandData<commands::UIDeleteCommandResponse,
-                hmi_apis::FunctionID::UI_DeleteCommand> > ResponseCommandsList;
+                hmi_apis::FunctionID::UI_DeleteCommand>,
+    CommandData<commands::UIPerformAudioPassThruResponse,
+                hmi_apis::FunctionID::UI_PerformAudioPassThru>,
+    CommandData<commands::UIPerformInteractionResponse,
+                hmi_apis::FunctionID::UI_PerformInteraction>>
+    ResponseCommandsList;
 
 TYPED_TEST_CASE(ResponseFromHMICommandsTest, ResponseCommandsList);
 

--- a/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
@@ -125,7 +125,11 @@ typedef Types<
     CommandData<commands::UIPerformAudioPassThruResponse,
                 hmi_apis::FunctionID::UI_PerformAudioPassThru>,
     CommandData<commands::UIPerformInteractionResponse,
-                hmi_apis::FunctionID::UI_PerformInteraction>>
+                hmi_apis::FunctionID::UI_PerformInteraction>,
+    CommandData<commands::UIDeleteSubmenuResponse,
+                hmi_apis::FunctionID::UI_DeleteSubMenu>,
+    CommandData<commands::UIEndAudioPassThruResponse,
+                hmi_apis::FunctionID::UI_EndAudioPassThru>>
     ResponseCommandsList;
 
 TYPED_TEST_CASE(ResponseFromHMICommandsTest, ResponseCommandsList);

--- a/src/components/application_manager/test/commands/hmi/ui_get_language_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_language_response_test.cc
@@ -45,7 +45,6 @@ namespace hmi_commands_test {
 
 using utils::SharedPtr;
 using application_manager::commands::UIGetLanguageResponse;
-// using test::components::application_manager_test::MockHMICapabilities;
 using test::components::event_engine_test::MockEventDispatcher;
 using testing::_;
 using testing::ReturnRef;
@@ -59,12 +58,16 @@ typedef NiceMock<
     ::test::components::application_manager_test::MockHMICapabilities>
     MockHMICapabilities;
 
+namespace {
+const hmi_apis::Common_Language::eType kLanguage = Common_Language::EN_GB;
+}  // namespace
+
 class UIGetLanguageResponseTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {};
 
 TEST_F(UIGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
-  (*msg)[strings::msg_params][hmi_response::language] = Common_Language::EN_GB;
+  (*msg)[strings::msg_params][hmi_response::language] = kLanguage;
 
   SharedPtr<UIGetLanguageResponse> command(
       CreateCommand<UIGetLanguageResponse>(msg));
@@ -72,8 +75,7 @@ TEST_F(UIGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
   MockHMICapabilities mock_hmi_capabilities;
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities));
-  EXPECT_CALL(mock_hmi_capabilities,
-              set_active_ui_language(Common_Language::EN_GB));
+  EXPECT_CALL(mock_hmi_capabilities, set_active_ui_language(kLanguage));
 
   MockEventDispatcher mock_event_dispatcher;
   EXPECT_CALL(app_mngr_, event_dispatcher())

--- a/src/components/application_manager/test/commands/hmi/ui_get_language_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_language_response_test.cc
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gtest/gtest.h"
+#include "application_manager/commands/hmi/ui_get_language_response.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/mock_event_dispatcher.h"
+#include "application_manager/mock_application_manager.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using utils::SharedPtr;
+using application_manager::commands::UIGetLanguageResponse;
+// using test::components::application_manager_test::MockHMICapabilities;
+using test::components::event_engine_test::MockEventDispatcher;
+using testing::_;
+using testing::ReturnRef;
+using ::testing::NiceMock;
+
+namespace strings = application_manager::strings;
+namespace hmi_response = application_manager::hmi_response;
+using namespace hmi_apis;
+
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+class UIGetLanguageResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(UIGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::msg_params][hmi_response::language] = Common_Language::EN_GB;
+
+  SharedPtr<UIGetLanguageResponse> command(
+      CreateCommand<UIGetLanguageResponse>(msg));
+
+  MockHMICapabilities mock_hmi_capabilities;
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities));
+  EXPECT_CALL(mock_hmi_capabilities,
+              set_active_ui_language(Common_Language::EN_GB));
+
+  MockEventDispatcher mock_event_dispatcher;
+  EXPECT_CALL(app_mngr_, event_dispatcher())
+      .WillOnce(ReturnRef(mock_event_dispatcher));
+  EXPECT_CALL(mock_event_dispatcher, raise_event(_));
+
+  command->Run();
+}
+
+TEST_F(UIGetLanguageResponseTest, Run_LanguageNotSet_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+
+  SharedPtr<UIGetLanguageResponse> command(
+      CreateCommand<UIGetLanguageResponse>(msg));
+
+  MockHMICapabilities mock_hmi_capabilities;
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities));
+  EXPECT_CALL(mock_hmi_capabilities,
+              set_active_ui_language(Common_Language::INVALID_ENUM));
+
+  MockEventDispatcher mock_event_dispatcher;
+  EXPECT_CALL(app_mngr_, event_dispatcher())
+      .WillOnce(ReturnRef(mock_event_dispatcher));
+  EXPECT_CALL(mock_event_dispatcher, raise_event(_));
+
+  command->Run();
+}
+
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/ui_get_supported_languages_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_supported_languages_response_test.cc
@@ -41,7 +41,6 @@
 #include "commands/commands_test.h"
 #include "application_manager/mock_hmi_capabilities.h"
 #include "application_manager/mock_application_manager.h"
-#include "application_manager/commands/hmi/response_from_hmi.h"
 #include "application_manager/commands/hmi/ui_get_supported_languages_response.h"
 #include "application_manager/policies/mock_policy_handler_interface.h"
 
@@ -50,18 +49,16 @@ namespace components {
 namespace commands_test {
 namespace hmi_commands_test {
 
-using ::testing::_;
 using ::testing::Return;
 using ::utils::SharedPtr;
 using ::testing::NiceMock;
 namespace am = ::application_manager;
 namespace strings = ::application_manager::strings;
 namespace hmi_response = am::hmi_response;
-using am::commands::ResponseFromHMI;
 using am::commands::UIGetSupportedLanguagesResponse;
-using am::commands::CommandImpl;
 
-typedef SharedPtr<ResponseFromHMI> ResponseFromHMIPtr;
+typedef SharedPtr<UIGetSupportedLanguagesResponse>
+    UIGetSupportedLanguagesResponsePtr;
 typedef NiceMock<
     ::test::components::application_manager_test::MockHMICapabilities>
     MockHMICapabilities;
@@ -91,15 +88,14 @@ TEST_F(UIGetSupportedLanguagesResponseTest, RUN_SUCCESS) {
   (*command_msg)[strings::msg_params][hmi_response::languages] =
       supported_languages;
 
-  ResponseFromHMIPtr command(
+  UIGetSupportedLanguagesResponsePtr command(
       CreateCommand<UIGetSupportedLanguagesResponse>(command_msg));
 
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   EXPECT_CALL(mock_hmi_capabilities_,
-              set_ui_supported_languages((
-                  *command_msg)[strings::msg_params][hmi_response::languages]));
+              set_ui_supported_languages((supported_languages)));
 
   command->Run();
 }
@@ -112,7 +108,7 @@ TEST_F(UIGetSupportedLanguagesResponseTest, RUN_UNSUCCESS) {
   (*command_msg)[strings::msg_params][hmi_response::capabilities] =
       (capabilities_);
 
-  ResponseFromHMIPtr command(
+  UIGetSupportedLanguagesResponsePtr command(
       CreateCommand<UIGetSupportedLanguagesResponse>(command_msg));
 
   EXPECT_CALL(mock_hmi_capabilities_,

--- a/src/components/application_manager/test/commands/hmi/ui_get_supported_languages_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_supported_languages_response_test.cc
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/application.h"
+#include "commands/commands_test.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/commands/hmi/response_from_hmi.h"
+#include "application_manager/commands/hmi/ui_get_supported_languages_response.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::testing::_;
+using ::testing::Return;
+using ::utils::SharedPtr;
+using ::testing::NiceMock;
+namespace am = ::application_manager;
+namespace strings = ::application_manager::strings;
+namespace hmi_response = am::hmi_response;
+using am::commands::ResponseFromHMI;
+using am::commands::UIGetSupportedLanguagesResponse;
+using am::commands::CommandImpl;
+
+typedef SharedPtr<ResponseFromHMI> ResponseFromHMIPtr;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+}  // namespace
+
+class UIGetSupportedLanguagesResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  MockHMICapabilities mock_hmi_capabilities_;
+  SmartObject capabilities_;
+};
+
+TEST_F(UIGetSupportedLanguagesResponseTest, RUN_SUCCESS) {
+  smart_objects::SmartObject supported_languages("EN_US");
+
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::msg_params][strings::number] = "123";
+  (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  (*command_msg)[strings::msg_params][hmi_response::capabilities] =
+      (capabilities_);
+  (*command_msg)[strings::msg_params][hmi_response::languages] =
+      supported_languages;
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetSupportedLanguagesResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_ui_supported_languages((
+                  *command_msg)[strings::msg_params][hmi_response::languages]));
+
+  command->Run();
+}
+TEST_F(UIGetSupportedLanguagesResponseTest, RUN_UNSUCCESS) {
+  smart_objects::SmartObject supported_languages("EN_US");
+
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::msg_params][strings::number] = "123";
+  (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::WRONG_LANGUAGE;
+  (*command_msg)[strings::msg_params][hmi_response::capabilities] =
+      (capabilities_);
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetSupportedLanguagesResponse>(command_msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_ui_supported_languages(supported_languages)).Times(0);
+
+  command->Run();
+
+  EXPECT_FALSE((*command_msg)[am::strings::msg_params].keyExists(
+      am::hmi_response::languages));
+}
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/ui_get_supported_languages_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_supported_languages_response_test.cc
@@ -68,6 +68,9 @@ typedef NiceMock<
 
 namespace {
 const uint32_t kConnectionKey = 2u;
+const std::string kStringNum = "123";
+const std::string kLanguage = "EN_US";
+const smart_objects::SmartObject supported_languages(kLanguage);
 }  // namespace
 
 class UIGetSupportedLanguagesResponseTest
@@ -78,10 +81,8 @@ class UIGetSupportedLanguagesResponseTest
 };
 
 TEST_F(UIGetSupportedLanguagesResponseTest, RUN_SUCCESS) {
-  smart_objects::SmartObject supported_languages("EN_US");
-
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
-  (*command_msg)[strings::msg_params][strings::number] = "123";
+  (*command_msg)[strings::msg_params][strings::number] = kStringNum;
   (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
   (*command_msg)[strings::params][hmi_response::code] =
       hmi_apis::Common_Result::SUCCESS;
@@ -103,10 +104,8 @@ TEST_F(UIGetSupportedLanguagesResponseTest, RUN_SUCCESS) {
   command->Run();
 }
 TEST_F(UIGetSupportedLanguagesResponseTest, RUN_UNSUCCESS) {
-  smart_objects::SmartObject supported_languages("EN_US");
-
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
-  (*command_msg)[strings::msg_params][strings::number] = "123";
+  (*command_msg)[strings::msg_params][strings::number] = kStringNum;
   (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
   (*command_msg)[strings::params][hmi_response::code] =
       hmi_apis::Common_Result::WRONG_LANGUAGE;

--- a/src/components/application_manager/test/commands/hmi/ui_is_ready_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_is_ready_response_test.cc
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "commands/commands_test.h"
+#include "application_manager/application.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/commands/hmi/response_from_hmi.h"
+#include "application_manager/commands/hmi/ui_is_ready_response.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::testing::_;
+using ::testing::Return;
+using ::utils::SharedPtr;
+using ::testing::NiceMock;
+namespace am = ::application_manager;
+namespace strings = ::application_manager::strings;
+namespace hmi_response = am::hmi_response;
+using am::commands::ResponseFromHMI;
+using am::commands::UIIsReadyResponse;
+using am::commands::CommandImpl;
+
+typedef SharedPtr<ResponseFromHMI> ResponseFromHMIPtr;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const bool kIsAvailable = true;
+const bool kIsNotAvailable = false;
+}  // namespace
+
+class UIIsReadyResponseTest : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  MockHMICapabilities mock_hmi_capabilities_;
+  SmartObject capabilities_;
+};
+
+TEST_F(UIIsReadyResponseTest, RUN_SUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::msg_params][strings::number] = "123";
+  (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  (*command_msg)[strings::msg_params][hmi_response::capabilities] =
+      (capabilities_);
+  (*command_msg)[strings::msg_params][strings::available] = kIsAvailable;
+
+  ResponseFromHMIPtr command(CreateCommand<UIIsReadyResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  EXPECT_CALL(mock_hmi_capabilities_, set_is_ui_cooperating(kIsAvailable));
+
+  command->Run();
+}
+
+TEST_F(UIIsReadyResponseTest, RUN_NoKeyAvailable) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::msg_params][strings::number] = "123";
+  (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  (*command_msg)[strings::msg_params][hmi_response::capabilities] =
+      (capabilities_);
+
+  ResponseFromHMIPtr command(CreateCommand<UIIsReadyResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  EXPECT_CALL(mock_hmi_capabilities_, set_is_ui_cooperating(kIsNotAvailable));
+
+  command->Run();
+
+  EXPECT_FALSE(
+      (*command_msg)[strings::msg_params].keyExists(strings::available));
+}
+
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/ui_is_ready_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_is_ready_response_test.cc
@@ -38,7 +38,6 @@
 #include "smart_objects/smart_object.h"
 #include "commands/commands_test.h"
 #include "application_manager/mock_hmi_capabilities.h"
-#include "application_manager/commands/hmi/response_from_hmi.h"
 #include "application_manager/commands/hmi/ui_is_ready_response.h"
 
 namespace test {
@@ -52,10 +51,9 @@ using ::testing::NiceMock;
 namespace am = ::application_manager;
 namespace strings = ::application_manager::strings;
 namespace hmi_response = am::hmi_response;
-using am::commands::ResponseFromHMI;
 using am::commands::UIIsReadyResponse;
 
-typedef SharedPtr<ResponseFromHMI> ResponseFromHMIPtr;
+typedef SharedPtr<UIIsReadyResponse> UIIsReadyResponsePtr;
 typedef NiceMock<
     ::test::components::application_manager_test::MockHMICapabilities>
     MockHMICapabilities;
@@ -83,7 +81,7 @@ TEST_F(UIIsReadyResponseTest, RUN_SUCCESS) {
       (capabilities_);
   (*command_msg)[strings::msg_params][strings::available] = kIsAvailable;
 
-  ResponseFromHMIPtr command(CreateCommand<UIIsReadyResponse>(command_msg));
+  UIIsReadyResponsePtr command(CreateCommand<UIIsReadyResponse>(command_msg));
 
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
@@ -102,7 +100,7 @@ TEST_F(UIIsReadyResponseTest, RUN_NoKeyAvailable) {
   (*command_msg)[strings::msg_params][hmi_response::capabilities] =
       (capabilities_);
 
-  ResponseFromHMIPtr command(CreateCommand<UIIsReadyResponse>(command_msg));
+  UIIsReadyResponsePtr command(CreateCommand<UIIsReadyResponse>(command_msg));
 
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));

--- a/src/components/application_manager/test/commands/hmi/ui_is_ready_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_is_ready_response_test.cc
@@ -36,22 +36,16 @@
 #include "gtest/gtest.h"
 #include "utils/shared_ptr.h"
 #include "smart_objects/smart_object.h"
-#include "application_manager/smart_object_keys.h"
 #include "commands/commands_test.h"
-#include "application_manager/application.h"
 #include "application_manager/mock_hmi_capabilities.h"
-#include "application_manager/mock_message_helper.h"
-#include "application_manager/mock_application_manager.h"
 #include "application_manager/commands/hmi/response_from_hmi.h"
 #include "application_manager/commands/hmi/ui_is_ready_response.h"
-#include "application_manager/policies/mock_policy_handler_interface.h"
 
 namespace test {
 namespace components {
 namespace commands_test {
 namespace hmi_commands_test {
 
-using ::testing::_;
 using ::testing::Return;
 using ::utils::SharedPtr;
 using ::testing::NiceMock;
@@ -60,7 +54,6 @@ namespace strings = ::application_manager::strings;
 namespace hmi_response = am::hmi_response;
 using am::commands::ResponseFromHMI;
 using am::commands::UIIsReadyResponse;
-using am::commands::CommandImpl;
 
 typedef SharedPtr<ResponseFromHMI> ResponseFromHMIPtr;
 typedef NiceMock<
@@ -69,6 +62,7 @@ typedef NiceMock<
 
 namespace {
 const uint32_t kConnectionKey = 2u;
+const std::string kStringNum = "123";
 const bool kIsAvailable = true;
 const bool kIsNotAvailable = false;
 }  // namespace
@@ -81,7 +75,7 @@ class UIIsReadyResponseTest : public CommandsTest<CommandsTestMocks::kIsNice> {
 
 TEST_F(UIIsReadyResponseTest, RUN_SUCCESS) {
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
-  (*command_msg)[strings::msg_params][strings::number] = "123";
+  (*command_msg)[strings::msg_params][strings::number] = kStringNum;
   (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
   (*command_msg)[strings::params][hmi_response::code] =
       hmi_apis::Common_Result::SUCCESS;
@@ -101,7 +95,7 @@ TEST_F(UIIsReadyResponseTest, RUN_SUCCESS) {
 
 TEST_F(UIIsReadyResponseTest, RUN_NoKeyAvailable) {
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
-  (*command_msg)[strings::msg_params][strings::number] = "123";
+  (*command_msg)[strings::msg_params][strings::number] = kStringNum;
   (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
   (*command_msg)[strings::params][hmi_response::code] =
       hmi_apis::Common_Result::SUCCESS;


### PR DESCRIPTION
Following HMI commands were coverd by unit tests:

- ui_get_language_request
- ui_get_language_response
- ui_get_supported_languages_request
- ui_get_supported_languages_response
- ui_is_ready_request
- ui_is_ready_response
- ui_perform_audio_pass_thru_request
- ui_perform_audio_pass_thru_response
- ui_perform_interaction_request
- ui_perform_interaction_response

Related issue: APPLINK-25914