### PR TITLE
SDL behaviour if VR is not avaliable

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager.h
+++ b/src/components/application_manager/include/application_manager/application_manager.h
@@ -47,6 +47,7 @@
 #include "application_manager/policies/policy_handler_interface.h"
 #include "application_manager/application_manager_settings.h"
 #include "application_manager/state_controller.h"
+#include "application_manager/hmi_interfaces.h"
 
 namespace resumption {
 class LastState;
@@ -493,6 +494,13 @@ class ApplicationManager {
       uint32_t connection_key, const std::string& policy_app_id) const = 0;
 
   virtual resumption::ResumeCtrl& resume_controller() = 0;
+
+  /**
+ * @brief hmi_interfaces getter for hmi_interfaces component, that handle
+ * hmi_instrfaces state
+ * @return reference to hmi_interfaces component
+ */
+  virtual HmiInterfaces& hmi_interfaces() = 0;
 
   virtual app_launch::AppLaunchCtrl& app_launch_ctrl() = 0;
   /*

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -53,6 +53,7 @@
 #include "application_manager/app_launch/app_launch_data.h"
 #include "application_manager/application_manager_settings.h"
 #include "application_manager/event_engine/event_dispatcher_impl.h"
+#include "application_manager/hmi_interfaces_impl.h"
 
 #include "protocol_handler/protocol_observer.h"
 #include "protocol_handler/protocol_handler.h"
@@ -844,6 +845,10 @@ class ApplicationManagerImpl
     return *resume_ctrl_.get();
   }
 
+  HmiInterfaces& hmi_interfaces() OVERRIDE {
+    return hmi_interfaces_;
+  }
+
   /**
    * Generate grammar ID
    *
@@ -1423,6 +1428,8 @@ class ApplicationManagerImpl
    * application in case INGITION_OFF or MASTER_RESSET
    */
   std::auto_ptr<resumption::ResumeCtrl> resume_ctrl_;
+
+  HmiInterfacesImpl hmi_interfaces_;
 
   NaviServiceStatusMap navi_service_status_;
   std::deque<uint32_t> navi_app_to_stop_;

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -182,6 +182,10 @@ class CommandRequestImpl : public CommandImpl,
    */
   void AddDisallowedParametersToInfo(
       smart_objects::SmartObject& response) const;
+
+  bool ProcessHMIInterfacesAvailability(
+      const uint32_t hmi_correlation_id,
+      const hmi_apis::FunctionID::eType& function_id);
 };
 
 }  // namespace commands

--- a/src/components/application_manager/include/application_manager/commands/mobile/add_command_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/add_command_request.h
@@ -33,6 +33,7 @@
 
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_ADD_COMMAND_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_ADD_COMMAND_REQUEST_H_
+#include <string>
 
 #include "application_manager/application.h"
 #include "application_manager/commands/command_request_impl.h"
@@ -141,6 +142,7 @@ class AddCommandRequest : public CommandRequestImpl {
 
   hmi_apis::Common_Result::eType ui_result_;
   hmi_apis::Common_Result::eType vr_result_;
+  std::string info_;
 };
 
 }  // namespace commands

--- a/src/components/application_manager/include/application_manager/commands/mobile/create_interaction_choice_set_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/create_interaction_choice_set_request.h
@@ -231,6 +231,30 @@ class CreateInteractionChoiceSetRequest : public CommandRequestImpl {
    */
   bool IsWhiteSpaceExist(const smart_objects::SmartObject& choice_set);
 
+  /**
+   * @brief ProcessHmiError process received error from HMI.
+   * This function id not thread safe. It should be protected with
+   * vr_commands_lock_
+   * @param vr_result ERROR type
+   */
+  void ProcessHmiError(const hmi_apis::Common_Result::eType vr_result);
+
+  /**
+   * @brief ProcessSuccesfulHMIResponse process succesful response from HMI\
+   * This function id not thread safe. It should be protected with
+   * vr_commands_lock_
+   * @param corr_id correlation id of received response
+   * @return true if resuest with corr_itd was sent on HMI, false otherwise
+   */
+  bool ProcessSuccesfulHMIResponse(const uint32_t corr_id);
+
+  /**
+   * @brief CountReceivedVRResponses counts received HMI responses. Updated
+   * request timeout if not all responses received
+   * Send response to mobile if all responses received.
+   */
+  void CountReceivedVRResponses();
+
   DISALLOW_COPY_AND_ASSIGN(CreateInteractionChoiceSetRequest);
 };
 

--- a/src/components/application_manager/include/application_manager/commands/mobile/delete_command_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/delete_command_request.h
@@ -33,6 +33,7 @@
 
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_DELETE_COMMAND_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_DELETE_COMMAND_REQUEST_H_
+#include <string>
 
 #include "application_manager/commands/command_request_impl.h"
 #include "utils/macro.h"
@@ -81,6 +82,13 @@ class DeleteCommandRequest : public CommandRequestImpl {
    */
   bool IsPendingResponseExist();
 
+  /**
+   * @brief CalculateResult calculate mobile result from received ui and vr
+   * results
+   * @return calculated mobile result
+  */
+  bool CalculateResult();
+
   bool is_ui_send_;
   bool is_vr_send_;
 
@@ -89,6 +97,7 @@ class DeleteCommandRequest : public CommandRequestImpl {
 
   hmi_apis::Common_Result::eType ui_result_;
   hmi_apis::Common_Result::eType vr_result_;
+  std::string info_;
 };
 
 }  // namespace commands

--- a/src/components/application_manager/include/application_manager/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/register_app_interface_request.h
@@ -87,6 +87,23 @@ class RegisterAppInterfaceRequest : public CommandRequestImpl {
 
  private:
   /**
+   * @brief SendChangeRegistration send ChangeRegistration on HMI
+   * @param function_id interface specific ChangeRegistration
+   * @param language language of registration
+   * @param app_id application to change registration
+   */
+  void SendChangeRegistration(const hmi_apis::FunctionID::eType function_id,
+                              const int32_t language,
+                              const uint32_t app_id);
+
+  /**
+   * @brief SendChangeRagistrationOnHMI send required SendChangeRagistration n
+   * HMI
+   * @param app application to change registration
+   */
+  void SendChangeRagistrationOnHMI(ApplicationConstSharedPtr app);
+
+  /**
    * @brief Sends OnAppRegistered notification to HMI
    *
    *@param application_impl application with changed HMI status

--- a/src/components/application_manager/include/application_manager/hmi_interfaces.h
+++ b/src/components/application_manager/include/application_manager/hmi_interfaces.h
@@ -1,0 +1,75 @@
+/*
+
+ Copyright (c) 2016, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_INTERFACES_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_INTERFACES_H_
+
+#include "interfaces/HMI_API.h"
+
+namespace application_manager {
+
+class HmiInterfaces {
+ public:
+  enum InterfaceID {
+    HMI_INTERFACE_INVALID_ENUM,
+    HMI_INTERFACE_Buttons,
+    HMI_INTERFACE_BasicCommunication,
+    HMI_INTERFACE_VR,
+    HMI_INTERFACE_TTS,
+    HMI_INTERFACE_UI,
+    HMI_INTERFACE_Navigation,
+    HMI_INTERFACE_VehicleInfo,
+    HMI_INTERFACE_SDL
+  };
+
+  /**
+   * @brief The InterfaceState enum handle possible states of HMI interfaces
+   * STATE_NOT_RESPONSE - HMI didn't not responsed IsReady on Inerface
+   * STATE_AVAILABLE - Hmi responsed IsReady(avaliable = true)
+   * STATE_NOT_AVAILABLE - Hmi responsed IsReady(avaliable = false)
+   */
+  enum InterfaceState {
+    STATE_NOT_RESPONSE,
+    STATE_AVAILABLE,
+    STATE_NOT_AVAILABLE
+  };
+
+  virtual InterfaceState GetInterfaceState(InterfaceID interface) const = 0;
+  virtual InterfaceID GetInterfaceFromFunction(
+      hmi_apis::FunctionID::eType function) const = 0;
+  virtual void SetInterfaceState(InterfaceID interface,
+                                 InterfaceState state) = 0;
+  virtual ~HmiInterfaces() {}
+};
+}  // namespace application_manager
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_INTERFACES_H_

--- a/src/components/application_manager/include/application_manager/hmi_interfaces_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_interfaces_impl.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_INTERFACES_IMPL_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_INTERFACES_IMPL_H_
+#include <map>
+#include "application_manager/hmi_interfaces.h"
+#include "utils/macro.h"
+
+namespace application_manager {
+class HmiInterfacesImpl : public HmiInterfaces {
+ public:
+  HmiInterfacesImpl();
+  ~HmiInterfacesImpl() {}
+  InterfaceState GetInterfaceState(InterfaceID interface) const OVERRIDE;
+  InterfaceID GetInterfaceFromFunction(
+      hmi_apis::FunctionID::eType function) const OVERRIDE;
+  void SetInterfaceState(InterfaceID interface, InterfaceState state) OVERRIDE;
+
+ private:
+  typedef std::map<InterfaceID, InterfaceState> InterfaceStatesMap;
+  InterfaceStatesMap interfaces_states_;
+};
+}  // namespace application_manager
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_INTERFACES_IMPL_H_

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -269,8 +269,6 @@ class MessageHelper {
    */
   static void SendUIChangeRegistrationRequestToHMI(
       ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
-  static void SendChangeRegistrationRequestToHMI(ApplicationConstSharedPtr app,
-                                                 ApplicationManager& app_mngr);
   static void SendAddVRCommandToHMI(
       uint32_t cmd_id,
       const smart_objects::SmartObject& vr_commands,

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <string>
+#include "utils/macro.h"
 #include "application_manager/commands/command_request_impl.h"
 #include "application_manager/application_manager.h"
 #include "application_manager/message_helper.h"
@@ -194,6 +195,59 @@ bool CommandRequestImpl::CheckSyntax(const std::string& str,
   return true;
 }
 
+smart_objects::SmartObject CreateUnsupportedResourceResponse(
+    const hmi_apis::FunctionID::eType function_id,
+    const uint32_t hmi_correlation_id,
+    HmiInterfaces::InterfaceID interface) {
+  smart_objects::SmartObject response(smart_objects::SmartType_Map);
+  smart_objects::SmartObject& params = response[strings::params];
+  params[strings::message_type] = MessageType::kResponse;
+  params[strings::correlation_id] = hmi_correlation_id;
+  params[strings::protocol_type] = CommandImpl::hmi_protocol_type_;
+  params[strings::protocol_version] = CommandImpl::protocol_version_;
+  params[strings::function_id] = function_id;
+  params[hmi_response::code] = hmi_apis::Common_Result::UNSUPPORTED_RESOURCE;
+  smart_objects::SmartObject& msg_params = response[strings::msg_params];
+
+  switch (interface) {
+    case HmiInterfaces::HMI_INTERFACE_VR: {
+      msg_params[strings::info] = "VR is not supported by system";
+      break;
+    }
+    case HmiInterfaces::HMI_INTERFACE_VehicleInfo: {
+      msg_params[strings::info] = "VehicleInfo is not supported by system";
+      break;
+    }
+    case HmiInterfaces::HMI_INTERFACE_UI: {
+      msg_params[strings::info] = "UI is not supported by system";
+      break;
+    }
+    default:
+      break;
+  }
+  return response;
+}
+
+bool CommandRequestImpl::ProcessHMIInterfacesAvailability(
+    const uint32_t hmi_correlation_id,
+    const hmi_apis::FunctionID::eType& function_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  HmiInterfaces& hmi_interfaces = application_manager_.hmi_interfaces();
+  HmiInterfaces::InterfaceID interface =
+      hmi_interfaces.GetInterfaceFromFunction(function_id);
+  DCHECK(interface != HmiInterfaces::HMI_INTERFACE_INVALID_ENUM);
+  const HmiInterfaces::InterfaceState state =
+      hmi_interfaces.GetInterfaceState(interface);
+  if (HmiInterfaces::STATE_NOT_AVAILABLE == state) {
+    event_engine::Event event(function_id);
+    event.set_smart_object(CreateUnsupportedResourceResponse(
+        function_id, hmi_correlation_id, interface));
+    event.raise(application_manager_.event_dispatcher());
+    return false;
+  }
+  return true;
+}
+
 uint32_t CommandRequestImpl::SendHMIRequest(
     const hmi_apis::FunctionID::eType& function_id,
     const smart_objects::SmartObject* msg_params,
@@ -202,12 +256,6 @@ uint32_t CommandRequestImpl::SendHMIRequest(
 
   const uint32_t hmi_correlation_id =
       application_manager_.GetNextHMICorrelationID();
-  if (use_events) {
-    LOG4CXX_DEBUG(logger_,
-                  "subscribe_on_event " << function_id << " "
-                                        << hmi_correlation_id);
-    subscribe_on_event(function_id, hmi_correlation_id);
-  }
 
   smart_objects::SmartObject& request = *result;
   request[strings::params][strings::message_type] = MessageType::kRequest;
@@ -222,9 +270,19 @@ uint32_t CommandRequestImpl::SendHMIRequest(
     request[strings::msg_params] = *msg_params;
   }
 
-  if (!application_manager_.ManageHMICommand(result)) {
-    LOG4CXX_ERROR(logger_, "Unable to send request");
-    SendResponse(false, mobile_apis::Result::OUT_OF_MEMORY);
+  if (use_events) {
+    LOG4CXX_DEBUG(logger_,
+                  "subscribe_on_event " << function_id << " "
+                                        << hmi_correlation_id);
+    subscribe_on_event(function_id, hmi_correlation_id);
+  }
+  if (ProcessHMIInterfacesAvailability(hmi_correlation_id, function_id)) {
+    if (!application_manager_.ManageHMICommand(result)) {
+      LOG4CXX_ERROR(logger_, "Unable to send request");
+      SendResponse(false, mobile_apis::Result::OUT_OF_MEMORY);
+    }
+  } else {
+    LOG4CXX_DEBUG(logger_, "Interface is not available");
   }
   return hmi_correlation_id;
 }

--- a/src/components/application_manager/src/commands/hmi/ui_is_ready_response.cc
+++ b/src/components/application_manager/src/commands/hmi/ui_is_ready_response.cc
@@ -53,6 +53,12 @@ void UIIsReadyResponse::Run() {
   HMICapabilities& hmi_capabilities = application_manager_.hmi_capabilities();
 
   hmi_capabilities.set_is_ui_cooperating(is_available);
+  const HmiInterfaces::InterfaceState inteface_state =
+      is_available ? HmiInterfaces::STATE_AVAILABLE
+                   : HmiInterfaces::STATE_NOT_AVAILABLE;
+  HmiInterfaces& hmi_interfaces = application_manager_.hmi_interfaces();
+  hmi_interfaces.SetInterfaceState(HmiInterfaces::HMI_INTERFACE_UI,
+                                   inteface_state);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/hmi/vi_is_ready_response.cc
+++ b/src/components/application_manager/src/commands/hmi/vi_is_ready_response.cc
@@ -53,6 +53,13 @@ void VIIsReadyResponse::Run() {
   HMICapabilities& hmi_capabilities = application_manager_.hmi_capabilities();
   hmi_capabilities.set_is_ivi_cooperating(is_available);
 
+  const HmiInterfaces::InterfaceState inteface_state =
+      is_available ? HmiInterfaces::STATE_AVAILABLE
+                   : HmiInterfaces::STATE_NOT_AVAILABLE;
+  HmiInterfaces& hmi_interfaces = application_manager_.hmi_interfaces();
+  hmi_interfaces.SetInterfaceState(HmiInterfaces::HMI_INTERFACE_VehicleInfo,
+                                   inteface_state);
+
   application_manager_.GetPolicyHandler().OnVIIsReady();
 }
 

--- a/src/components/application_manager/src/commands/hmi/vr_is_ready_response.cc
+++ b/src/components/application_manager/src/commands/hmi/vr_is_ready_response.cc
@@ -52,6 +52,13 @@ void VRIsReadyResponse::Run() {
 
   HMICapabilities& hmi_capabilities = application_manager_.hmi_capabilities();
   hmi_capabilities.set_is_vr_cooperating(is_available);
+
+  const HmiInterfaces::InterfaceState inteface_state =
+      is_available ? HmiInterfaces::STATE_AVAILABLE
+                   : HmiInterfaces::STATE_NOT_AVAILABLE;
+  HmiInterfaces& hmi_interfaces = application_manager_.hmi_interfaces();
+  hmi_interfaces.SetInterfaceState(HmiInterfaces::HMI_INTERFACE_VR,
+                                   inteface_state);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/read_did_request.cc
+++ b/src/components/application_manager/src/commands/mobile/read_did_request.cc
@@ -102,13 +102,7 @@ void ReadDIDRequest::on_event(const event_engine::Event& event) {
 
       bool result = mobile_apis::Result::SUCCESS == result_code;
 
-      const std::string return_info =
-          message[strings::msg_params][hmi_response::message].asString();
-
-      SendResponse(result,
-                   result_code,
-                   return_info.c_str(),
-                   &(message[strings::msg_params]));
+      SendResponse(result, result_code, NULL, &(message[strings::msg_params]));
       break;
     }
     default: {

--- a/src/components/application_manager/src/hmi_interfaces_impl.cc
+++ b/src/components/application_manager/src/hmi_interfaces_impl.cc
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/hmi_interfaces_impl.h"
+namespace application_manager {
+
+std::map<hmi_apis::FunctionID::eType, HmiInterfaces::InterfaceID>
+generate_function_to_interface_convert_map() {
+  using namespace hmi_apis::FunctionID;
+  std::map<hmi_apis::FunctionID::eType, HmiInterfaces::InterfaceID> convert_map;
+  convert_map[Buttons_GetCapabilities] = HmiInterfaces::HMI_INTERFACE_Buttons;
+  convert_map[Buttons_OnButtonEvent] = HmiInterfaces::HMI_INTERFACE_Buttons;
+  convert_map[Buttons_OnButtonPress] = HmiInterfaces::HMI_INTERFACE_Buttons;
+  convert_map[Buttons_OnButtonSubscription] =
+      HmiInterfaces::HMI_INTERFACE_Buttons;
+  convert_map[BasicCommunication_OnReady] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnStartDeviceDiscovery] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnUpdateDeviceList] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnPhoneCall] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnEmergencyEvent] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnResumeAudioSource] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnSDLPersistenceComplete] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_UpdateAppList] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_UpdateDeviceList] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnFileRemoved] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_AllowDeviceToConnect] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnDeviceChosen] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnFindApplications] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_ActivateApp] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnAppActivated] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnAppDeactivated] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnAppRegistered] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnAppUnregistered] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnExitApplication] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnExitAllApplications] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnAwakeSDL] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_MixingAudioSupported] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_DialNumber] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnSystemRequest] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_SystemRequest] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_PolicyUpdate] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnSDLClose] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnPutFile] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_GetSystemInfo] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnSystemInfoChanged] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnIgnitionCycleOver] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnDeactivateHMI] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnEventChanged] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[VR_IsReady] = HmiInterfaces::HMI_INTERFACE_VR;
+  convert_map[VR_Started] = HmiInterfaces::HMI_INTERFACE_VR;
+  convert_map[VR_Stopped] = HmiInterfaces::HMI_INTERFACE_VR;
+  convert_map[VR_AddCommand] = HmiInterfaces::HMI_INTERFACE_VR;
+  convert_map[VR_DeleteCommand] = HmiInterfaces::HMI_INTERFACE_VR;
+  convert_map[VR_PerformInteraction] = HmiInterfaces::HMI_INTERFACE_VR;
+  convert_map[VR_OnCommand] = HmiInterfaces::HMI_INTERFACE_VR;
+  convert_map[VR_ChangeRegistration] = HmiInterfaces::HMI_INTERFACE_VR;
+  convert_map[VR_OnLanguageChange] = HmiInterfaces::HMI_INTERFACE_VR;
+  convert_map[VR_GetSupportedLanguages] = HmiInterfaces::HMI_INTERFACE_VR;
+  convert_map[VR_GetLanguage] = HmiInterfaces::HMI_INTERFACE_VR;
+  convert_map[VR_GetCapabilities] = HmiInterfaces::HMI_INTERFACE_VR;
+  convert_map[TTS_GetCapabilities] = HmiInterfaces::HMI_INTERFACE_VR;
+  convert_map[TTS_Started] = HmiInterfaces::HMI_INTERFACE_TTS;
+  convert_map[TTS_Stopped] = HmiInterfaces::HMI_INTERFACE_TTS;
+  convert_map[TTS_IsReady] = HmiInterfaces::HMI_INTERFACE_TTS;
+  convert_map[TTS_Speak] = HmiInterfaces::HMI_INTERFACE_TTS;
+  convert_map[TTS_StopSpeaking] = HmiInterfaces::HMI_INTERFACE_TTS;
+  convert_map[TTS_ChangeRegistration] = HmiInterfaces::HMI_INTERFACE_TTS;
+  convert_map[TTS_OnLanguageChange] = HmiInterfaces::HMI_INTERFACE_TTS;
+  convert_map[TTS_GetSupportedLanguages] = HmiInterfaces::HMI_INTERFACE_TTS;
+  convert_map[TTS_GetLanguage] = HmiInterfaces::HMI_INTERFACE_TTS;
+  convert_map[TTS_SetGlobalProperties] = HmiInterfaces::HMI_INTERFACE_TTS;
+  convert_map[TTS_OnResetTimeout] = HmiInterfaces::HMI_INTERFACE_TTS;
+  convert_map[UI_Alert] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_Show] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_AddCommand] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_DeleteCommand] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_AddSubMenu] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_DeleteSubMenu] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_PerformInteraction] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_SetMediaClockTimer] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_SetGlobalProperties] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_OnCommand] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_OnSystemContext] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_GetCapabilities] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_ChangeRegistration] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_OnLanguageChange] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_GetSupportedLanguages] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_GetLanguage] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_OnDriverDistraction] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_SetAppIcon] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_SetDisplayLayout] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_ShowCustomForm] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_OnKeyboardInput] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_OnTouchEvent] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_Slider] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_ScrollableMessage] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_PerformAudioPassThru] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_EndAudioPassThru] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_IsReady] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_ClosePopUp] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_OnResetTimeout] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[Navigation_IsReady] = HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_SendLocation] =
+      HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_ShowConstantTBT] =
+      HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_AlertManeuver] =
+      HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_UpdateTurnList] =
+      HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_OnTBTClientState] =
+      HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_StartStream] = HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_StopStream] = HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_StartAudioStream] =
+      HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_StopAudioStream] =
+      HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_OnAudioDataStreaming] =
+      HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_OnVideoDataStreaming] =
+      HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_GetWayPoints] =
+      HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_OnWayPointChange] =
+      HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_SubscribeWayPoints] =
+      HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_UnsubscribeWayPoints] =
+      HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[VehicleInfo_IsReady] = HmiInterfaces::HMI_INTERFACE_VehicleInfo;
+  convert_map[VehicleInfo_GetVehicleType] =
+      HmiInterfaces::HMI_INTERFACE_VehicleInfo;
+  convert_map[VehicleInfo_ReadDID] = HmiInterfaces::HMI_INTERFACE_VehicleInfo;
+  convert_map[VehicleInfo_GetDTCs] = HmiInterfaces::HMI_INTERFACE_VehicleInfo;
+  convert_map[VehicleInfo_DiagnosticMessage] =
+      HmiInterfaces::HMI_INTERFACE_VehicleInfo;
+  convert_map[VehicleInfo_SubscribeVehicleData] =
+      HmiInterfaces::HMI_INTERFACE_VehicleInfo;
+  convert_map[VehicleInfo_UnsubscribeVehicleData] =
+      HmiInterfaces::HMI_INTERFACE_VehicleInfo;
+  convert_map[VehicleInfo_GetVehicleData] =
+      HmiInterfaces::HMI_INTERFACE_VehicleInfo;
+  convert_map[VehicleInfo_OnVehicleData] =
+      HmiInterfaces::HMI_INTERFACE_VehicleInfo;
+  convert_map[SDL_ActivateApp] = HmiInterfaces::HMI_INTERFACE_SDL;
+  convert_map[SDL_GetUserFriendlyMessage] = HmiInterfaces::HMI_INTERFACE_SDL;
+  convert_map[SDL_OnAllowSDLFunctionality] = HmiInterfaces::HMI_INTERFACE_SDL;
+  convert_map[SDL_OnReceivedPolicyUpdate] = HmiInterfaces::HMI_INTERFACE_SDL;
+  convert_map[SDL_OnPolicyUpdate] = HmiInterfaces::HMI_INTERFACE_SDL;
+  convert_map[SDL_GetListOfPermissions] = HmiInterfaces::HMI_INTERFACE_SDL;
+  convert_map[SDL_OnAppPermissionConsent] = HmiInterfaces::HMI_INTERFACE_SDL;
+  convert_map[SDL_OnAppPermissionChanged] = HmiInterfaces::HMI_INTERFACE_SDL;
+  convert_map[SDL_OnSDLConsentNeeded] = HmiInterfaces::HMI_INTERFACE_SDL;
+  convert_map[SDL_UpdateSDL] = HmiInterfaces::HMI_INTERFACE_SDL;
+  convert_map[SDL_GetStatusUpdate] = HmiInterfaces::HMI_INTERFACE_SDL;
+  convert_map[SDL_OnStatusUpdate] = HmiInterfaces::HMI_INTERFACE_SDL;
+  convert_map[SDL_OnSystemError] = HmiInterfaces::HMI_INTERFACE_SDL;
+  convert_map[SDL_AddStatisticsInfo] = HmiInterfaces::HMI_INTERFACE_SDL;
+  convert_map[SDL_GetURLS] = HmiInterfaces::HMI_INTERFACE_SDL;
+  return convert_map;
+}
+
+HmiInterfacesImpl::HmiInterfacesImpl() {
+  interfaces_states_[HmiInterfaces::HMI_INTERFACE_BasicCommunication] =
+      HmiInterfaces::STATE_NOT_RESPONSE;
+  interfaces_states_[HmiInterfaces::HMI_INTERFACE_Buttons] =
+      HmiInterfaces::STATE_NOT_RESPONSE;
+  interfaces_states_[HmiInterfaces::HMI_INTERFACE_Navigation] =
+      HmiInterfaces::STATE_NOT_RESPONSE;
+  interfaces_states_[HmiInterfaces::HMI_INTERFACE_SDL] =
+      HmiInterfaces::STATE_NOT_RESPONSE;
+  interfaces_states_[HmiInterfaces::HMI_INTERFACE_TTS] =
+      HmiInterfaces::STATE_NOT_RESPONSE;
+  interfaces_states_[HmiInterfaces::HMI_INTERFACE_UI] =
+      HmiInterfaces::STATE_NOT_RESPONSE;
+  interfaces_states_[HmiInterfaces::HMI_INTERFACE_VehicleInfo] =
+      HmiInterfaces::STATE_NOT_RESPONSE;
+  interfaces_states_[HmiInterfaces::HMI_INTERFACE_VR] =
+      HmiInterfaces::STATE_NOT_RESPONSE;
+}
+
+HmiInterfaces::InterfaceState HmiInterfacesImpl::GetInterfaceState(
+    HmiInterfaces::InterfaceID interface) const {
+  const InterfaceStatesMap::const_iterator it =
+      interfaces_states_.find(interface);
+  // all interfaces should be presented in interfaces_states_ map.
+  DCHECK_OR_RETURN(it != interfaces_states_.end(), STATE_NOT_RESPONSE);
+  return it->second;
+}
+
+void HmiInterfacesImpl::SetInterfaceState(HmiInterfaces::InterfaceID interface,
+                                          HmiInterfaces::InterfaceState state) {
+  DCHECK(interfaces_states_.find(interface) != interfaces_states_.end());
+  interfaces_states_[interface] = state;
+}
+
+HmiInterfaces::InterfaceID HmiInterfacesImpl::GetInterfaceFromFunction(
+    hmi_apis::FunctionID::eType function) const {
+  // TODO(AKutsan): APPLINK-26874: Generate map of functionid to inteface
+  // automaticaly from
+  // HMI_API.xml
+  static const std::map<hmi_apis::FunctionID::eType, InterfaceID> convert_map =
+      generate_function_to_interface_convert_map();
+  const std::map<hmi_apis::FunctionID::eType, InterfaceID>::const_iterator it =
+      convert_map.find(function);
+  return it != convert_map.end() ? it->second : HMI_INTERFACE_INVALID_ENUM;
+}
+}  // namespace application_manager

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1156,51 +1156,6 @@ void MessageHelper::SendUIChangeRegistrationRequestToHMI(
   }
 }
 
-void MessageHelper::SendChangeRegistrationRequestToHMI(
-    ApplicationConstSharedPtr app, ApplicationManager& app_mngr) {
-  if (!app.valid()) {
-    return;
-  }
-  if (mobile_apis::Language::INVALID_ENUM != app->language()) {
-    smart_objects::SmartObjectSPtr vr_command =
-        CreateChangeRegistration(hmi_apis::FunctionID::VR_ChangeRegistration,
-                                 app->language(),
-                                 app->app_id(),
-                                 NULL,
-                                 app_mngr);
-
-    if (vr_command) {
-      app_mngr.ManageHMICommand(vr_command);
-    }
-  }
-
-  if (mobile_apis::Language::INVALID_ENUM != app->language()) {
-    smart_objects::SmartObjectSPtr tts_command =
-        CreateChangeRegistration(hmi_apis::FunctionID::TTS_ChangeRegistration,
-                                 app->language(),
-                                 app->app_id(),
-                                 NULL,
-                                 app_mngr);
-
-    if (tts_command) {
-      app_mngr.ManageHMICommand(tts_command);
-    }
-  }
-
-  if (mobile_apis::Language::INVALID_ENUM != app->ui_language()) {
-    smart_objects::SmartObjectSPtr ui_command =
-        CreateChangeRegistration(hmi_apis::FunctionID::UI_ChangeRegistration,
-                                 app->ui_language(),
-                                 app->app_id(),
-                                 NULL,
-                                 app_mngr);
-
-    if (ui_command) {
-      app_mngr.ManageHMICommand(ui_command);
-    }
-  }
-}
-
 void MessageHelper::SendAddVRCommandToHMI(
     const uint32_t cmd_id,
     const smart_objects::SmartObject& vr_commands,

--- a/src/components/application_manager/test/include/application_manager/mock_application_manager.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application_manager.h
@@ -200,6 +200,7 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                      bool(uint32_t connection_key,
                           const std::string& policy_app_id));
   MOCK_METHOD0(resume_controller, resumption::ResumeCtrl&());
+  MOCK_METHOD0(hmi_interfaces, application_manager::HmiInterfaces&());
   MOCK_METHOD0(app_launch_ctrl, app_launch::AppLaunchCtrl&());
   MOCK_METHOD1(
       GetDeviceTransportType,

--- a/src/components/include/security_manager/crypto_manager.h
+++ b/src/components/include/security_manager/crypto_manager.h
@@ -58,7 +58,7 @@ class CryptoManager : public policy::PolicyHandlerObserver {
   /**
    * @brief Init allows to initialize cryptomanager with certain values.
    *
-   * @return true in case initialization was succesfull, false otherwise.
+   * @return true in case initialization was succesful, false otherwise.
    */
   virtual bool Init() = 0;
   virtual SSLContext* CreateSSLContext() = 0;

--- a/src/components/utils/include/utils/helpers.h
+++ b/src/components/utils/include/utils/helpers.h
@@ -117,6 +117,15 @@ bool Compare(T what, T to, T to1, T to2, T to3, T to4) {
       Compare<T, CompareType, CmpStrategy>(what, to4));
 }
 
+template <typename T,
+          bool (*CompareType)(T, T),
+          bool (*CmpStrategy)(bool, bool)>
+bool Compare(T what, T to, T to1, T to2, T to3, T to4, T to5) {
+  return CmpStrategy(
+      Compare<T, CompareType, CmpStrategy>(what, to, to1, to2, to3),
+      Compare<T, CompareType, CmpStrategy>(what, to4, to5));
+}
+
 template <typename Container>
 bool in_range(const Container& container,
               const typename Container::value_type& value) {


### PR DESCRIPTION
Is VR interface is not available SDL should process VR related requests according rules described in 
CRQ APPLINK-20918 [GENIVI] VR interface: SDL behavior in case HMI does not respond to IsReady_request or respond with "available" = false

