### PR TITLE
Fix WARNINGS response from RegisterAppInterface on valid AppHMIType received

### DIFF
--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -90,7 +90,7 @@ std::string AppHMITypeToString(mobile_apis::AppHMIType::eType type) {
   std::map<mobile_apis::AppHMIType::eType, std::string>::const_iterator iter =
       app_hmi_type_map.find(type);
 
-  return app_hmi_type_map.end() == iter ? iter->second : std::string("");
+  return app_hmi_type_map.end() != iter ? iter->second : std::string("");
 }
 
 struct AppHMITypeInserter {


### PR DESCRIPTION
After external pull request #702 has
been merged appears a problems with
`RegisterAppInterface`. If message contains
`AppHMIType` array, `RegisterAppInterface`
will return WARNING in any case
either it's valid or not.

Related to: [APPLINK-27096](https://adc.luxoft.com/jira/browse/APPLINK-27096)
Triggered by: [APPLINK-26912](https://adc.luxoft.com/jira/browse/APPLINK-26912)

@okozlovlux, @LuxoftAKutsan, @vlantonov, @wolfylambova22, @VVeremjova , @pvvasilev, please review.