### PR TITLE
Navigation interface sdl behavior in case hmi does not respond to is ready request or respond with available false

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -1,5 +1,5 @@
 ﻿/*
- Copyright (c) 2014, Ford Motor Company
+ Copyright (c) 2016, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -83,6 +83,23 @@ namespace NsSmart = NsSmartDeviceLink::NsSmartObjects;
  *         if both are not empty return empty first +", " + second
  */
 std::string MergeInfos(const std::string& first, const std::string& second);
+
+/**
+ * @brief MergeInfos merge 2 infos into one string with info
+ * @param first_info -contains result_code from HMI response and
+ * interface that returns response
+ * @param first_str - info string that should be first in result info
+ * @param second_info -contains result_code from HMI response and
+ * interface that returns response
+ * @param second_str - info string that should be second in result info
+ * @return if first_info is not available and second_str not empty return second
+ *         if second_info is not available and first_str not empty return first
+ *         other cases return result MergeInfos for 2 params
+ */
+std::string MergeInfos(const ResponseInfo& first_info,
+                       const std::string& first_str,
+                       const ResponseInfo& second_info,
+                       const std::string& second_str);
 
 /**
  * @brief MergeInfos merge 3 infos in one string

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -223,6 +223,7 @@ class CommandRequestImpl : public CommandImpl,
    */
   bool PrepareResultForMobileResponse(ResponseInfo& out_first,
                                       ResponseInfo& out_second) const;
+
   /**
    * @brief If message from HMI contains returns this info
    * or process result code from HMI and checks state of interface

--- a/src/components/application_manager/include/application_manager/commands/hmi/navi_is_ready_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/navi_is_ready_request.h
@@ -42,7 +42,8 @@ namespace commands {
 /**
  * @brief NaviIsReadyRequest command class
  **/
-class NaviIsReadyRequest : public RequestToHMI {
+class NaviIsReadyRequest : public RequestToHMI,
+                           public event_engine::EventObserver {
  public:
   /**
    * @brief NaviIsReadyRequest class constructor
@@ -60,7 +61,12 @@ class NaviIsReadyRequest : public RequestToHMI {
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() OVERRIDE;
+
+  /**
+   * @brief On event callback
+   **/
+  void on_event(const event_engine::Event& event) OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(NaviIsReadyRequest);

--- a/src/components/application_manager/include/application_manager/commands/hmi/request_to_hmi.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/request_to_hmi.h
@@ -48,6 +48,7 @@ namespace commands {
  */
 bool CheckAvailabilityHMIInterfaces(ApplicationManager& application_manager,
                                     HmiInterfaces::InterfaceID interface);
+
 /**
  * @brief Change interface state
  * @param application_manager contains ApplicationManager instance

--- a/src/components/application_manager/include/application_manager/commands/hmi/tts_is_ready_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/tts_is_ready_request.h
@@ -56,7 +56,7 @@ class TTSIsReadyRequest : public RequestToHMI,
   /**
    * @brief TTSIsReadyRequest class destructor
    **/
-  ~TTSIsReadyRequest() OVERRIDE;
+  virtual ~TTSIsReadyRequest();
 
   /**
    * @brief Execute command

--- a/src/components/application_manager/include/application_manager/commands/hmi/ui_is_ready_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/ui_is_ready_request.h
@@ -56,7 +56,7 @@ class UIIsReadyRequest : public RequestToHMI,
   /**
    * @brief UIIsReadyRequest class destructor
    **/
-  ~UIIsReadyRequest() OVERRIDE;
+  virtual ~UIIsReadyRequest();
 
   /**
    * @brief Execute command

--- a/src/components/application_manager/include/application_manager/commands/hmi/vi_is_ready_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/vi_is_ready_request.h
@@ -56,7 +56,7 @@ class VIIsReadyRequest : public RequestToHMI,
   /**
    * @brief VIIsReadyRequest class destructor
    **/
-  ~VIIsReadyRequest() OVERRIDE;
+  virtual ~VIIsReadyRequest();
 
   /**
    * @brief Execute command

--- a/src/components/application_manager/include/application_manager/commands/hmi/vr_is_ready_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/vr_is_ready_request.h
@@ -62,17 +62,17 @@ class VRIsReadyRequest : public RequestToHMI,
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() OVERRIDE;
 
   /**
    * @brief On event callback
    **/
-  virtual void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) OVERRIDE;
 
   /**
    * @brief onTimeOut from requrst Controller
    */
-  virtual void onTimeOut();
+  void onTimeOut() OVERRIDE;
 
   /**
    * @brief Send request to HMI for fetching of cappabilities

--- a/src/components/application_manager/include/application_manager/commands/mobile/alert_maneuver_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/alert_maneuver_request.h
@@ -74,14 +74,15 @@ class AlertManeuverRequest : public CommandRequestImpl {
   virtual void on_event(const event_engine::Event& event);
 
  private:
+
   /**
    * @brief Prepare parameters for  sending to mobile application
    * @param result_code contains result code for sending to mobile application
+   * @param return_info contains result result info for sending to mobil application
    * @return result for sending to mobile application.
    */
   bool PrepareResponseParameters(mobile_apis::Result::eType& result_code,
                                  std::string& return_info);
-
   /**
    * @brief Checks alert maneuver params(ttsChunks, ...).
    * When type is String there is a check on the contents \t\n \\t \\n

--- a/src/components/application_manager/include/application_manager/commands/mobile/alert_maneuver_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/alert_maneuver_request.h
@@ -74,11 +74,11 @@ class AlertManeuverRequest : public CommandRequestImpl {
   virtual void on_event(const event_engine::Event& event);
 
  private:
-
   /**
    * @brief Prepare parameters for  sending to mobile application
    * @param result_code contains result code for sending to mobile application
-   * @param return_info contains result result info for sending to mobil application
+   * @param return_info contains resulting info for sending to mobile
+   * application
    * @return result for sending to mobile application.
    */
   bool PrepareResponseParameters(mobile_apis::Result::eType& result_code,

--- a/src/components/application_manager/include/application_manager/hmi_interfaces.h
+++ b/src/components/application_manager/include/application_manager/hmi_interfaces.h
@@ -35,6 +35,7 @@
  * (Buttons, BasicCommunication, VR, TTS, UI, Navigation,VehicleInfo,
  *  SDL) and provides this information through public interfaces.
  */
+
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_INTERFACES_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_INTERFACES_H_
 

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2013, Ford Motor Company
+ Copyright (c) 2016, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,25 @@
 namespace application_manager {
 
 namespace commands {
+
+std::string MergeInfos(const ResponseInfo& first_info,
+                       const std::string& first_str,
+                       const ResponseInfo& second_info,
+                       const std::string& second_str) {
+  if ((first_info.interface_state == HmiInterfaces::STATE_NOT_AVAILABLE) &&
+      (second_info.interface_state != HmiInterfaces::STATE_NOT_AVAILABLE) &&
+      !second_str.empty()) {
+    return second_str;
+  }
+
+  if ((second_info.interface_state == HmiInterfaces::STATE_NOT_AVAILABLE) &&
+      (first_info.interface_state != HmiInterfaces::STATE_NOT_AVAILABLE) &&
+      !first_str.empty()) {
+    return first_str;
+  }
+
+  return MergeInfos(first_str, second_str);
+}
 
 std::string MergeInfos(const std::string& first, const std::string& second) {
   return first + ((!first.empty() && !second.empty()) ? ", " : "") + second;

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -651,7 +651,6 @@ bool CommandRequestImpl::PrepareResultForMobileResponse(
     hmi_apis::Common_Result::eType result_code,
     HmiInterfaces::InterfaceID interface) const {
   using namespace helpers;
-
   if (Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
           result_code,
           hmi_apis::Common_Result::SUCCESS,

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -37,7 +37,6 @@
 #include "application_manager/application_manager.h"
 #include "application_manager/message_helper.h"
 #include "smart_objects/smart_object.h"
-
 namespace application_manager {
 
 namespace commands {

--- a/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
@@ -58,7 +58,11 @@ AudioStartStreamRequest::~AudioStartStreamRequest() {}
 
 void AudioStartStreamRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
-
+  if (!CheckAvailabilityHMIInterfaces(
+          application_manager_, HmiInterfaces::HMI_INTERFACE_Navigation)) {
+    LOG4CXX_INFO(logger_, "Interface Navi is not supported by system");
+    return;
+  }
   SetAllowedToTerminate(false);
   subscribe_on_event(hmi_apis::FunctionID::Navigation_StartAudioStream,
                      correlation_id());

--- a/src/components/application_manager/src/commands/hmi/navi_audio_stop_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_audio_stop_stream_request.cc
@@ -43,7 +43,11 @@ AudioStopStreamRequest::~AudioStopStreamRequest() {}
 
 void AudioStopStreamRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
-
+  if (!CheckAvailabilityHMIInterfaces(
+          application_manager_, HmiInterfaces::HMI_INTERFACE_Navigation)) {
+    LOG4CXX_INFO(logger_, "Interface Navi is not supported by system");
+    return;
+  }
   SendRequest();
 }
 

--- a/src/components/application_manager/src/commands/hmi/navi_is_ready_response.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_is_ready_response.cc
@@ -48,6 +48,12 @@ void NaviIsReadyResponse::Run() {
   bool is_available = false;
   if (object[strings::msg_params].keyExists(strings::available)) {
     is_available = object[strings::msg_params][strings::available].asBool();
+    const HmiInterfaces::InterfaceState interface_state =
+        is_available ? HmiInterfaces::STATE_AVAILABLE
+                     : HmiInterfaces::STATE_NOT_AVAILABLE;
+    HmiInterfaces& hmi_interfaces = application_manager_.hmi_interfaces();
+    hmi_interfaces.SetInterfaceState(HmiInterfaces::HMI_INTERFACE_Navigation,
+                                     interface_state);
   }
 
   HMICapabilities& hmi_capabilities = application_manager_.hmi_capabilities();

--- a/src/components/application_manager/src/commands/hmi/navi_is_ready_response.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_is_ready_response.cc
@@ -43,22 +43,9 @@ NaviIsReadyResponse::~NaviIsReadyResponse() {}
 
 void NaviIsReadyResponse::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
-  smart_objects::SmartObject& object = *message_;
-
-  bool is_available = false;
-  if (object[strings::msg_params].keyExists(strings::available)) {
-    is_available = object[strings::msg_params][strings::available].asBool();
-    const HmiInterfaces::InterfaceState interface_state =
-        is_available ? HmiInterfaces::STATE_AVAILABLE
-                     : HmiInterfaces::STATE_NOT_AVAILABLE;
-    HmiInterfaces& hmi_interfaces = application_manager_.hmi_interfaces();
-    hmi_interfaces.SetInterfaceState(HmiInterfaces::HMI_INTERFACE_Navigation,
-                                     interface_state);
-  }
-
-  HMICapabilities& hmi_capabilities = application_manager_.hmi_capabilities();
-
-  hmi_capabilities.set_is_navi_cooperating(is_available);
+  event_engine::Event event(hmi_apis::FunctionID::Navigation_IsReady);
+  event.set_smart_object(*message_);
+  event.raise(application_manager_.event_dispatcher());
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
@@ -58,6 +58,11 @@ NaviStartStreamRequest::~NaviStartStreamRequest() {}
 
 void NaviStartStreamRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
+  if (!CheckAvailabilityHMIInterfaces(
+          application_manager_, HmiInterfaces::HMI_INTERFACE_Navigation)) {
+    LOG4CXX_INFO(logger_, "Interface Navi is not supported by system");
+    return;
+  }
 
   SetAllowedToTerminate(false);
   subscribe_on_event(hmi_apis::FunctionID::Navigation_StartStream,

--- a/src/components/application_manager/src/commands/hmi/navi_stop_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_stop_stream_request.cc
@@ -12,7 +12,11 @@ NaviStopStreamRequest::~NaviStopStreamRequest() {}
 
 void NaviStopStreamRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
-
+  if (!CheckAvailabilityHMIInterfaces(
+          application_manager_, HmiInterfaces::HMI_INTERFACE_Navigation)) {
+    LOG4CXX_INFO(logger_, "Interface Navi is not supported by system");
+    return;
+  }
   SendRequest();
 }
 

--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -179,7 +179,6 @@ void AlertManeuverRequest::on_event(const event_engine::Event& event) {
   std::string return_info;
   mobile_apis::Result::eType result_code;
   const bool result = PrepareResponseParameters(result_code, return_info);
-
   bool must_be_empty_info = false;
   if (return_info.find("\n") != std::string::npos ||
       return_info.find("\t") != std::string::npos) {

--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -213,7 +213,6 @@ bool AlertManeuverRequest::PrepareResponseParameters(
     return_info = std::string("Unsupported phoneme type sent in a prompt");
     return result;
   }
-
   result_code =
       PrepareResultCodeForResponse(navigation_alert_info, tts_alert_info);
   return_info = MergeInfos(info_navi_, info_tts_);

--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -200,7 +200,7 @@ bool AlertManeuverRequest::PrepareResponseParameters(
       HmiInterfaces::HMI_INTERFACE_Navigation);
 
   application_manager::commands::ResponseInfo tts_alert_info(
-      tts_speak_result_code_, HmiInterfaces::HMI_INTERFACE_Navigation);
+      tts_speak_result_code_, HmiInterfaces::HMI_INTERFACE_TTS);
   const bool result =
       PrepareResultForMobileResponse(navigation_alert_info, tts_alert_info);
 
@@ -215,7 +215,8 @@ bool AlertManeuverRequest::PrepareResponseParameters(
   }
   result_code =
       PrepareResultCodeForResponse(navigation_alert_info, tts_alert_info);
-  return_info = MergeInfos(info_navi_, info_tts_);
+  return_info =
+      MergeInfos(navigation_alert_info, info_navi_, tts_alert_info, info_tts_);
   return result;
 }
 

--- a/src/components/application_manager/src/commands/mobile/get_way_points_request.cc
+++ b/src/components/application_manager/src/commands/mobile/get_way_points_request.cc
@@ -1,5 +1,6 @@
 #include "application_manager/application_manager.h"
 #include "application_manager/commands/mobile/get_way_points_request.h"
+#include "application_manager/message_helper.h"
 
 namespace application_manager {
 
@@ -35,16 +36,24 @@ void GetWayPointsRequest::Run() {
 
 void GetWayPointsRequest::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
-  ApplicationSharedPtr app = application_manager_.application(connection_key());
   const smart_objects::SmartObject& message = event.smart_object();
   switch (event.id()) {
     case hmi_apis::FunctionID::Navigation_GetWayPoints: {
       LOG4CXX_INFO(logger_, "Received Navigation_GetWayPoints event");
-      mobile_apis::Result::eType result_code =
-          GetMobileResultCode(static_cast<hmi_apis::Common_Result::eType>(
-              message[strings::params][hmi_response::code].asUInt()));
-      bool result = mobile_apis::Result::SUCCESS == result_code;
-      SendResponse(result, result_code, NULL, &(message[strings::msg_params]));
+      const hmi_apis::Common_Result::eType result_code =
+          static_cast<hmi_apis::Common_Result::eType>(
+              message[strings::params][hmi_response::code].asInt());
+      std::string response_info;
+      GetInfo(HmiInterfaces::HMI_INTERFACE_Navigation,
+              result_code,
+              message,
+              response_info);
+      const bool result = PrepareResultForMobileResponse(
+          result_code, HmiInterfaces::HMI_INTERFACE_Navigation);
+      SendResponse(result,
+                   MessageHelper::HMIToMobileResult(result_code),
+                   response_info.empty() ? NULL : response_info.c_str(),
+                   &(message[strings::msg_params]));
       break;
     }
     default: {

--- a/src/components/application_manager/src/commands/mobile/send_location_request.cc
+++ b/src/components/application_manager/src/commands/mobile/send_location_request.cc
@@ -31,11 +31,8 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <algorithm>
-
 #include "application_manager/commands/mobile/send_location_request.h"
-
 #include "application_manager/message_helper.h"
-#include "utils/helpers.h"
 #include "utils/custom_string.h"
 
 namespace application_manager {
@@ -136,23 +133,23 @@ void SendLocationRequest::Run() {
 
 void SendLocationRequest::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
-  namespace Result = mobile_apis::Result;
-  using namespace helpers;
+  using namespace hmi_apis;
   const smart_objects::SmartObject& message = event.smart_object();
   if (hmi_apis::FunctionID::Navigation_SendLocation == event.id()) {
     LOG4CXX_INFO(logger_, "Received Navigation_SendLocation event");
-    mobile_apis::Result::eType result_code =
-        GetMobileResultCode(static_cast<hmi_apis::Common_Result::eType>(
-            message[strings::params][hmi_response::code].asUInt()));
-    bool result = Compare<Result::eType, EQ, ONE>(
-        result_code, Result::SAVED, Result::SUCCESS, Result::WARNINGS);
-    result =
-        result || (Result::UNSUPPORTED_RESOURCE == result &&
-                   HmiInterfaces::STATE_AVAILABLE ==
-                       application_manager_.hmi_interfaces().GetInterfaceState(
-                           HmiInterfaces::HMI_INTERFACE_Navigation));
-
-    SendResponse(result, result_code, NULL, &(message[strings::params]));
+    const Common_Result::eType result_code = static_cast<Common_Result::eType>(
+        message[strings::params][hmi_response::code].asInt());
+    std::string response_info;
+    GetInfo(HmiInterfaces::HMI_INTERFACE_Navigation,
+            result_code,
+            message,
+            response_info);
+    const bool result = PrepareResultForMobileResponse(
+        result_code, HmiInterfaces::HMI_INTERFACE_Navigation);
+    SendResponse(result,
+                 MessageHelper::HMIToMobileResult(result_code),
+                 response_info.empty() ? NULL : response_info.c_str(),
+                 &(message[strings::params]));
     return;
   }
   LOG4CXX_ERROR(logger_, "Received unknown event" << event.id());

--- a/src/components/application_manager/src/commands/mobile/send_location_request.cc
+++ b/src/components/application_manager/src/commands/mobile/send_location_request.cc
@@ -144,12 +144,14 @@ void SendLocationRequest::on_event(const event_engine::Event& event) {
     mobile_apis::Result::eType result_code =
         GetMobileResultCode(static_cast<hmi_apis::Common_Result::eType>(
             message[strings::params][hmi_response::code].asUInt()));
-    const bool result =
-        Compare<Result::eType, EQ, ONE>(result_code,
-                                        Result::SAVED,
-                                        Result::SUCCESS,
-                                        Result::WARNINGS,
-                                        Result::UNSUPPORTED_RESOURCE);
+    bool result = Compare<Result::eType, EQ, ONE>(
+        result_code, Result::SAVED, Result::SUCCESS, Result::WARNINGS);
+    result =
+        result || (Result::UNSUPPORTED_RESOURCE == result &&
+                   HmiInterfaces::STATE_AVAILABLE ==
+                       application_manager_.hmi_interfaces().GetInterfaceState(
+                           HmiInterfaces::HMI_INTERFACE_Navigation));
+
     SendResponse(result, result_code, NULL, &(message[strings::params]));
     return;
   }

--- a/src/components/application_manager/src/commands/mobile/show_constant_tbt_request.cc
+++ b/src/components/application_manager/src/commands/mobile/show_constant_tbt_request.cc
@@ -183,27 +183,17 @@ void ShowConstantTBTRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::Navigation_ShowConstantTBT: {
       LOG4CXX_INFO(logger_, "Received Navigation_ShowConstantTBT event");
-      std::string return_info;
 
       mobile_apis::Result::eType result_code =
           GetMobileResultCode(static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt()));
-      HMICapabilities& hmi_capabilities =
-          application_manager_.hmi_capabilities();
-      bool result = false;
-      if (mobile_apis::Result::SUCCESS == result_code) {
-        result = true;
-        return_info =
-            message[strings::msg_params][hmi_response::message].asString();
-      } else if ((mobile_apis::Result::UNSUPPORTED_RESOURCE == result_code) &&
-                 hmi_capabilities.is_ui_cooperating()) {
-        result = true;
-      }
-
-      SendResponse(result,
-                   result_code,
-                   return_info.empty() ? 0 : return_info.c_str(),
-                   &(message[strings::msg_params]));
+      bool result = mobile_apis::Result::SUCCESS == result_code;
+      result =
+          result || (mobile_apis::Result::UNSUPPORTED_RESOURCE == result_code &&
+                     (HmiInterfaces::STATE_AVAILABLE ==
+                      application_manager_.hmi_interfaces().GetInterfaceState(
+                          HmiInterfaces::HMI_INTERFACE_Navigation)));
+      SendResponse(result, result_code, NULL, &(message[strings::msg_params]));
       break;
     }
     default: {

--- a/src/components/application_manager/src/commands/mobile/subscribe_way_points_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_way_points_request.cc
@@ -1,5 +1,6 @@
 #include "application_manager/application_manager.h"
 #include "application_manager/commands/mobile/subscribe_way_points_request.h"
+#include "application_manager/message_helper.h"
 
 namespace application_manager {
 
@@ -47,14 +48,23 @@ void SubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::Navigation_SubscribeWayPoints: {
       LOG4CXX_INFO(logger_, "Received Navigation_SubscribeWayPoints event");
-      mobile_apis::Result::eType result_code =
-          GetMobileResultCode(static_cast<hmi_apis::Common_Result::eType>(
-              message[strings::params][hmi_response::code].asUInt()));
-      bool result = mobile_apis::Result::SUCCESS == result_code;
+      const hmi_apis::Common_Result::eType result_code =
+          static_cast<hmi_apis::Common_Result::eType>(
+              message[strings::params][hmi_response::code].asInt());
+      std::string response_info;
+      GetInfo(HmiInterfaces::HMI_INTERFACE_Navigation,
+              result_code,
+              message,
+              response_info);
+      const bool result = PrepareResultForMobileResponse(
+          result_code, HmiInterfaces::HMI_INTERFACE_Navigation);
       if (result) {
         application_manager_.SubscribeAppForWayPoints(app->app_id());
       }
-      SendResponse(result, result_code, NULL, &(message[strings::msg_params]));
+      SendResponse(result,
+                   MessageHelper::HMIToMobileResult(result_code),
+                   response_info.empty() ? NULL : response_info.c_str(),
+                   &(message[strings::msg_params]));
       if (result) {
         app->UpdateHash();
       }

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_way_points_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_way_points_request.cc
@@ -1,5 +1,6 @@
 #include "application_manager/application_manager.h"
 #include "application_manager/commands/mobile/unsubscribe_way_points_request.h"
+#include "application_manager/message_helper.h"
 
 namespace application_manager {
 
@@ -40,14 +41,23 @@ void UnSubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints: {
       LOG4CXX_INFO(logger_, "Received Navigation_UnSubscribeWayPoints event");
-      mobile_apis::Result::eType result_code =
-          GetMobileResultCode(static_cast<hmi_apis::Common_Result::eType>(
-              message[strings::params][hmi_response::code].asUInt()));
-      bool result = mobile_apis::Result::SUCCESS == result_code;
+      const hmi_apis::Common_Result::eType result_code =
+          static_cast<hmi_apis::Common_Result::eType>(
+              message[strings::params][hmi_response::code].asInt());
+      std::string response_info;
+      GetInfo(HmiInterfaces::HMI_INTERFACE_Navigation,
+              result_code,
+              message,
+              response_info);
+      const bool result = PrepareResultForMobileResponse(
+          result_code, HmiInterfaces::HMI_INTERFACE_Navigation);
       if (result) {
         application_manager_.UnsubscribeAppFromWayPoints(app->app_id());
       }
-      SendResponse(result, result_code, NULL, &(message[strings::msg_params]));
+      SendResponse(result,
+                   MessageHelper::HMIToMobileResult(result_code),
+                   response_info.empty() ? NULL : response_info.c_str(),
+                   &(message[strings::msg_params]));
       if (result) {
         app->UpdateHash();
       }

--- a/src/components/application_manager/src/commands/mobile/update_turn_list_request.cc
+++ b/src/components/application_manager/src/commands/mobile/update_turn_list_request.cc
@@ -158,14 +158,13 @@ void UpdateTurnListRequest::on_event(const event_engine::Event& event) {
       mobile_apis::Result::eType result_code =
           static_cast<mobile_apis::Result::eType>(
               message[strings::params][hmi_response::code].asInt());
-      HMICapabilities& hmi_capabilities =
-          application_manager_.hmi_capabilities();
 
-      bool result =
-          (mobile_apis::Result::SUCCESS == result_code) ||
-          ((mobile_apis::Result::UNSUPPORTED_RESOURCE == result_code) &&
-           (hmi_capabilities.is_ui_cooperating()));
-
+      bool result = mobile_apis::Result::SUCCESS == result_code;
+      result =
+          result || (mobile_apis::Result::UNSUPPORTED_RESOURCE == result_code &&
+                     (HmiInterfaces::STATE_AVAILABLE ==
+                      application_manager_.hmi_interfaces().GetInterfaceState(
+                          HmiInterfaces::HMI_INTERFACE_Navigation)));
       SendResponse(result, result_code, NULL, &(message[strings::msg_params]));
       break;
     }

--- a/src/components/application_manager/src/commands/mobile/update_turn_list_request.cc
+++ b/src/components/application_manager/src/commands/mobile/update_turn_list_request.cc
@@ -155,17 +155,20 @@ void UpdateTurnListRequest::on_event(const event_engine::Event& event) {
     case hmi_apis::FunctionID::Navigation_UpdateTurnList: {
       LOG4CXX_INFO(logger_, "Received Navigation_UpdateTurnList event");
 
-      mobile_apis::Result::eType result_code =
-          static_cast<mobile_apis::Result::eType>(
+      const hmi_apis::Common_Result::eType result_code =
+          static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());
-
-      bool result = mobile_apis::Result::SUCCESS == result_code;
-      result =
-          result || (mobile_apis::Result::UNSUPPORTED_RESOURCE == result_code &&
-                     (HmiInterfaces::STATE_AVAILABLE ==
-                      application_manager_.hmi_interfaces().GetInterfaceState(
-                          HmiInterfaces::HMI_INTERFACE_Navigation)));
-      SendResponse(result, result_code, NULL, &(message[strings::msg_params]));
+      std::string response_info;
+      GetInfo(HmiInterfaces::HMI_INTERFACE_Navigation,
+              result_code,
+              message,
+              response_info);
+      const bool result = PrepareResultForMobileResponse(
+          result_code, HmiInterfaces::HMI_INTERFACE_Navigation);
+      SendResponse(result,
+                   MessageHelper::HMIToMobileResult(result_code),
+                   response_info.empty() ? NULL : response_info.c_str(),
+                   &(message[strings::msg_params]));
       break;
     }
     default: {


### PR DESCRIPTION
Navigation interface: SDL behavior in case HMI does not respond to IsReady request or respond with "available" = false
    
    Added logic for processing case when HMI does not respond to IsReady request or respond with "available"=false.
    Changed processing of result code UNSUPPORTED_RESOURCE for navi commands.
    
    CRQ [APPLINK-25171](https://adc.luxoft.com/jira/browse/APPLINK-25171)