### PR TITLE
Cover HMI commands with Unit Tests. Part 16

### DIFF
--- a/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
@@ -142,7 +142,8 @@ typedef Types<commands::VIIsReadyRequest,
               commands::VRGetCapabilitiesRequest,
               commands::VRGetSupportedLanguagesRequest,
               commands::VRGetLanguageRequest,
-              commands::VRPerformInteractionRequest> RequestCommandsList;
+              commands::VRPerformInteractionRequest,
+              commands::VRIsReadyRequest> RequestCommandsList;
 
 TYPED_TEST_CASE(RequestToHMICommandsTest, RequestCommandsList);
 
@@ -156,7 +157,7 @@ TYPED_TEST(RequestToHMICommandsTest, Run_SendMessageToHMI_SUCCESS) {
   command->Run();
 }
 
-}  // hmi_commands_test
+}  // namespace hmi_commands_test
 }  // namespace commands_test
 }  // namespace components
 }  // namespace test

--- a/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
@@ -64,6 +64,11 @@
 #include "hmi/vi_diagnostic_message_request.h"
 #include "hmi/vi_get_dtcs_request.h"
 #include "hmi/vi_get_vehicle_data_request.h"
+#include "hmi/vr_get_capabilities_request.h"
+#include "hmi/vr_get_supported_languages_request.h"
+#include "hmi/vr_get_language_request.h"
+#include "hmi/vr_is_ready_request.h"
+#include "hmi/vr_perform_interaction_request.h"
 
 namespace test {
 namespace components {
@@ -133,7 +138,11 @@ typedef Types<commands::VIIsReadyRequest,
               commands::UIPerformInteractionRequest,
               commands::VIDiagnosticMessageRequest,
               commands::VIGetDTCsRequest,
-              commands::VIGetVehicleDataRequest> RequestCommandsList;
+              commands::VIGetVehicleDataRequest,
+              commands::VRGetCapabilitiesRequest,
+              commands::VRGetSupportedLanguagesRequest,
+              commands::VRGetLanguageRequest,
+              commands::VRPerformInteractionRequest> RequestCommandsList;
 
 TYPED_TEST_CASE(RequestToHMICommandsTest, RequestCommandsList);
 

--- a/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
@@ -62,6 +62,7 @@
 #include "hmi/ui_perform_interaction_response.h"
 #include "hmi/vi_diagnostic_message_response.h"
 #include "hmi/vi_get_dtcs_response.h"
+#include "hmi/vr_perform_interaction_response.h"
 
 namespace test {
 namespace components {
@@ -135,7 +136,9 @@ typedef Types<
     CommandData<commands::VIDiagnosticMessageResponse,
                 hmi_apis::FunctionID::VehicleInfo_DiagnosticMessage>,
     CommandData<commands::VIGetDTCsResponse,
-                hmi_apis::FunctionID::VehicleInfo_GetDTCs>>
+                hmi_apis::FunctionID::VehicleInfo_GetDTCs>,
+    CommandData<commands::VRPerformInteractionResponse,
+                hmi_apis::FunctionID::VR_PerformInteraction>>
     ResponseCommandsList;
 
 TYPED_TEST_CASE(ResponseFromHMICommandsTest, ResponseCommandsList);

--- a/src/components/application_manager/test/commands/hmi/vr_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_get_capabilities_response_test.cc
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "utils/make_shared.h"
+#include "smart_objects/smart_object.h"
+#include "interfaces/MOBILE_API.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_impl.h"
+#include "application_manager/commands/hmi/vr_get_capabilities_response.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::utils::SharedPtr;
+using ::testing::NiceMock;
+namespace am = ::application_manager;
+namespace strings = am::strings;
+namespace hmi_response = am::hmi_response;
+using am::commands::VRGetCapabilitiesResponse;
+using am::commands::CommandImpl;
+
+typedef SharedPtr<VRGetCapabilitiesResponse> VRGetCapabilitiesResponsePtr;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+}  // namespace
+
+class VRGetCapabilitiesResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  MessageSharedPtr CreateCommandMsg() {
+    MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+    (*command_msg)[strings::msg_params][strings::number] = "123";
+    (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
+    (*command_msg)[strings::params][hmi_response::code] =
+        hmi_apis::Common_Result::SUCCESS;
+    (*command_msg)[strings::msg_params][hmi_response::capabilities] =
+        (capabilities_);
+
+    return command_msg;
+  }
+
+  MockHMICapabilities mock_hmi_capabilities_;
+  SmartObject capabilities_;
+};
+
+TEST_F(VRGetCapabilitiesResponseTest, RUN_SetDisplay_SUCCESSS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::msg_params][strings::vr_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  (*command_msg)[strings::msg_params][strings::vr_capabilities][0] =
+      "vrCapabilities";
+
+  VRGetCapabilitiesResponsePtr command(
+      CreateCommand<VRGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  smart_objects::SmartObject vr_capabilities_so =
+      (*command_msg)[strings::msg_params][strings::vr_capabilities];
+
+  EXPECT_CALL(mock_hmi_capabilities_, set_vr_capabilities(vr_capabilities_so));
+
+  command->Run();
+}
+
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/vr_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_get_capabilities_response_test.cc
@@ -34,7 +34,6 @@
 
 #include "gtest/gtest.h"
 #include "utils/shared_ptr.h"
-#include "utils/make_shared.h"
 #include "smart_objects/smart_object.h"
 #include "interfaces/MOBILE_API.h"
 #include "application_manager/mock_hmi_capabilities.h"
@@ -84,7 +83,7 @@ class VRGetCapabilitiesResponseTest
   SmartObject capabilities_;
 };
 
-TEST_F(VRGetCapabilitiesResponseTest, RUN_SetDisplay_SUCCESSS) {
+TEST_F(VRGetCapabilitiesResponseTest, RUN_SUCCESSS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
   (*command_msg)[strings::msg_params][strings::vr_capabilities] =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
@@ -105,7 +104,7 @@ TEST_F(VRGetCapabilitiesResponseTest, RUN_SetDisplay_SUCCESSS) {
   command->Run();
 }
 
-}  // hmi_commands_test
+}  // namespace hmi_commands_test
 }  // namespace commands_test
 }  // namespace components
 }  // namespace test

--- a/src/components/application_manager/test/commands/hmi/vr_get_language_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_get_language_response_test.cc
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gtest/gtest.h"
+#include "application_manager/commands/hmi/vr_get_language_response.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/mock_event_dispatcher.h"
+#include "application_manager/mock_application_manager.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using utils::SharedPtr;
+using application_manager::commands::VRGetLanguageResponse;
+using test::components::event_engine_test::MockEventDispatcher;
+using testing::_;
+using testing::ReturnRef;
+using ::testing::NiceMock;
+
+namespace strings = application_manager::strings;
+namespace hmi_response = application_manager::hmi_response;
+using namespace hmi_apis;
+
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+namespace {
+const hmi_apis::Common_Language::eType kLanguage = Common_Language::EN_GB;
+}  // namespace
+
+class VRGetLanguageResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(VRGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::msg_params][hmi_response::language] = kLanguage;
+
+  SharedPtr<VRGetLanguageResponse> command(
+      CreateCommand<VRGetLanguageResponse>(msg));
+
+  MockHMICapabilities mock_hmi_capabilities;
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities));
+  EXPECT_CALL(mock_hmi_capabilities, set_active_vr_language(kLanguage));
+
+  MockEventDispatcher mock_event_dispatcher;
+  EXPECT_CALL(app_mngr_, event_dispatcher())
+      .WillOnce(ReturnRef(mock_event_dispatcher));
+  EXPECT_CALL(mock_event_dispatcher, raise_event(_));
+
+  command->Run();
+}
+
+TEST_F(VRGetLanguageResponseTest, Run_LanguageNotSet_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+
+  SharedPtr<VRGetLanguageResponse> command(
+      CreateCommand<VRGetLanguageResponse>(msg));
+
+  MockHMICapabilities mock_hmi_capabilities;
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities));
+  EXPECT_CALL(mock_hmi_capabilities,
+              set_active_vr_language(Common_Language::INVALID_ENUM));
+
+  MockEventDispatcher mock_event_dispatcher;
+  EXPECT_CALL(app_mngr_, event_dispatcher())
+      .WillOnce(ReturnRef(mock_event_dispatcher));
+  EXPECT_CALL(mock_event_dispatcher, raise_event(_));
+
+  command->Run();
+}
+
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/vr_get_language_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_get_language_response_test.cc
@@ -105,7 +105,7 @@ TEST_F(VRGetLanguageResponseTest, Run_LanguageNotSet_SUCCESS) {
   command->Run();
 }
 
-}  // hmi_commands_test
+}  // namespace hmi_commands_test
 }  // namespace commands_test
 }  // namespace components
 }  // namespace test

--- a/src/components/application_manager/test/commands/hmi/vr_get_supported_languages_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_get_supported_languages_response_test.cc
@@ -119,7 +119,7 @@ TEST_F(VRGetSupportedLanguagesResponseTest, RUN_UNSUCCESS) {
   EXPECT_FALSE((*command_msg)[am::strings::msg_params].keyExists(
       am::hmi_response::languages));
 }
-}  // hmi_commands_test
+}  // namespace hmi_commands_test
 }  // namespace commands_test
 }  // namespace components
 }  // namespace test

--- a/src/components/application_manager/test/commands/hmi/vr_get_supported_languages_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_get_supported_languages_response_test.cc
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/application.h"
+#include "commands/commands_test.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/commands/hmi/vr_get_supported_languages_response.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::testing::Return;
+using ::utils::SharedPtr;
+using ::testing::NiceMock;
+namespace am = ::application_manager;
+namespace strings = ::application_manager::strings;
+namespace hmi_response = am::hmi_response;
+using am::commands::VRGetSupportedLanguagesResponse;
+
+typedef SharedPtr<VRGetSupportedLanguagesResponse>
+    VRGetSupportedLanguagesResponsePtr;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const std::string kStringNum = "123";
+const std::string kLanguage = "EN_US";
+const smart_objects::SmartObject supported_languages(kLanguage);
+}  // namespace
+
+class VRGetSupportedLanguagesResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  MockHMICapabilities mock_hmi_capabilities_;
+  SmartObject capabilities_;
+};
+
+TEST_F(VRGetSupportedLanguagesResponseTest, RUN_SUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::msg_params][strings::number] = kStringNum;
+  (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  (*command_msg)[strings::msg_params][hmi_response::capabilities] =
+      (capabilities_);
+  (*command_msg)[strings::msg_params][hmi_response::languages] =
+      supported_languages;
+
+  VRGetSupportedLanguagesResponsePtr command(
+      CreateCommand<VRGetSupportedLanguagesResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_vr_supported_languages((supported_languages)));
+
+  command->Run();
+}
+TEST_F(VRGetSupportedLanguagesResponseTest, RUN_UNSUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::msg_params][strings::number] = kStringNum;
+  (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::WRONG_LANGUAGE;
+  (*command_msg)[strings::msg_params][hmi_response::capabilities] =
+      (capabilities_);
+
+  VRGetSupportedLanguagesResponsePtr command(
+      CreateCommand<VRGetSupportedLanguagesResponse>(command_msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_vr_supported_languages(supported_languages)).Times(0);
+
+  command->Run();
+
+  EXPECT_FALSE((*command_msg)[am::strings::msg_params].keyExists(
+      am::hmi_response::languages));
+}
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/vr_is_ready_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_is_ready_response_test.cc
@@ -113,7 +113,7 @@ TEST_F(VRIsReadyResponseTest, RUN_NoKeyAvailable) {
       (*command_msg)[strings::msg_params].keyExists(strings::available));
 }
 
-}  // hmi_commands_test
+}  // namespace hmi_commands_test
 }  // namespace commands_test
 }  // namespace components
 }  // namespace test

--- a/src/components/application_manager/test/commands/hmi/vr_is_ready_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_is_ready_response_test.cc
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "commands/commands_test.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/commands/hmi/vr_is_ready_response.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::testing::Return;
+using ::utils::SharedPtr;
+using ::testing::NiceMock;
+namespace am = ::application_manager;
+namespace strings = ::application_manager::strings;
+namespace hmi_response = am::hmi_response;
+using am::commands::VRIsReadyResponse;
+
+typedef SharedPtr<VRIsReadyResponse> VRIsReadyResponsePtr;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const std::string kStringNum = "123";
+const bool kIsAvailable = true;
+const bool kIsNotAvailable = false;
+}  // namespace
+
+class VRIsReadyResponseTest : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  MockHMICapabilities mock_hmi_capabilities_;
+  SmartObject capabilities_;
+};
+
+TEST_F(VRIsReadyResponseTest, RUN_SUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::msg_params][strings::number] = kStringNum;
+  (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  (*command_msg)[strings::msg_params][hmi_response::capabilities] =
+      (capabilities_);
+  (*command_msg)[strings::msg_params][strings::available] = kIsAvailable;
+
+  VRIsReadyResponsePtr command(CreateCommand<VRIsReadyResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  EXPECT_CALL(mock_hmi_capabilities_, set_is_vr_cooperating(kIsAvailable));
+
+  command->Run();
+}
+
+TEST_F(VRIsReadyResponseTest, RUN_NoKeyAvailable) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::msg_params][strings::number] = kStringNum;
+  (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  (*command_msg)[strings::msg_params][hmi_response::capabilities] =
+      (capabilities_);
+
+  VRIsReadyResponsePtr command(CreateCommand<VRIsReadyResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  EXPECT_CALL(mock_hmi_capabilities_, set_is_vr_cooperating(kIsNotAvailable));
+
+  command->Run();
+
+  EXPECT_FALSE(
+      (*command_msg)[strings::msg_params].keyExists(strings::available));
+}
+
+}  // hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test


### PR DESCRIPTION
Following HMI commands were coverd by unit tests:

- vr_get_capabilities_request
- vr_get_capabilities_response
- vr_get_language_request
- vr_get_language_response
- vr_get_supported_languages_request
- vr_get_supported_languages_response
- vr_is_ready_request
- vr_is_ready_response
- vr_perform_interaction_request
- vr_perform_interaction_response

Related issue: APPLINK-25902