### PR TITLE
Update logger properties to log to file only

### DIFF
--- a/src/appMain/log4cxx.properties
+++ b/src/appMain/log4cxx.properties
@@ -44,8 +44,8 @@ log4j.appender.ProtocolFordHandlingLogFile.layout=org.apache.log4j.PatternLayout
 log4j.appender.ProtocolFordHandlingLogFile.layout.ConversionPattern=%-5p [%d{dd MMM yyyy HH:mm:ss,SSS}][%c] %M: %m%n
 
 # Root logging settings
-# Set ALL logging levels to Console, main log file, Socket and Telnet
-log4j.rootLogger=ALL, Console, SmartDeviceLinkCoreLogFile, SmartDeviceLinkCoreSocketHub, TelnetLogging
+# Set ALL logging levels to main log file
+log4j.rootLogger=ALL, SmartDeviceLinkCoreLogFile
 
 # Components loggers with own logging levels
 log4j.logger.SDLMain            = ALL


### PR DESCRIPTION
Leave only logging to file in log4cxx.properties
due to slow printing to console/terminal.
Workaround for APPLINK-17599.

Related to [APPLINK-17599](https://adc.luxoft.com/jira/browse/APPLINK-17599).