### PR TITLE
Cover HMI commands with Unit Tests Part 12

### DIFF
--- a/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
@@ -64,10 +64,9 @@
 #include "hmi/vi_diagnostic_message_request.h"
 #include "hmi/vi_get_dtcs_request.h"
 #include "hmi/vi_get_vehicle_data_request.h"
-#include "hmi/vi_unsubscribe_vehicle_data_request.h"
-#include "hmi/vr_add_command_request.h"
-#include "hmi/vr_change_registration_request.h"
-#include "hmi/vr_delete_command_request.h"
+#include "hmi/ui_set_media_clock_timer_request.h"
+#include "hmi/ui_show_request.h"
+#include "hmi/ui_slider_request.h"
 
 namespace test {
 namespace components {
@@ -138,10 +137,9 @@ typedef Types<commands::VIIsReadyRequest,
               commands::VIDiagnosticMessageRequest,
               commands::VIGetDTCsRequest,
               commands::VIGetVehicleDataRequest,
-              commands::VIUnsubscribeVehicleDataRequest,
-              commands::VRAddCommandRequest,
-              commands::VRChangeRegistrationRequest,
-              commands::VRDeleteCommandRequest> RequestCommandsList;
+              commands::UISetMediaClockTimerRequest,
+              commands::UIShowRequest,
+              commands::UISliderRequest> RequestCommandsList;
 
 TYPED_TEST_CASE(RequestToHMICommandsTest, RequestCommandsList);
 

--- a/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
@@ -141,10 +141,9 @@ typedef Types<
                 hmi_apis::FunctionID::VehicleInfo_GetDTCs>,
     CommandData<commands::UISetMediaClockTimerResponse,
                 hmi_apis::FunctionID::UI_SetMediaClockTimer>,
-    CommandData<commands::UIShowResponse,
-                hmi_apis::FunctionID::UI_Show>,
-    CommandData<commands::UISliderResponse,
-                hmi_apis::FunctionID::UI_Slider>>ResponseCommandsList;
+    CommandData<commands::UIShowResponse, hmi_apis::FunctionID::UI_Show>,
+    CommandData<commands::UISliderResponse, hmi_apis::FunctionID::UI_Slider>>
+    ResponseCommandsList;
 
 TYPED_TEST_CASE(ResponseFromHMICommandsTest, ResponseCommandsList);
 

--- a/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
@@ -62,10 +62,9 @@
 #include "hmi/ui_perform_interaction_response.h"
 #include "hmi/vi_diagnostic_message_response.h"
 #include "hmi/vi_get_dtcs_response.h"
-#include "hmi/vi_unsubscribe_vehicle_data_response.h"
-#include "hmi/vr_add_command_response.h"
-#include "hmi/vr_change_registration_response.h"
-#include "hmi/vr_delete_command_response.h"
+#include "hmi/ui_set_media_clock_timer_response.h"
+#include "hmi/ui_show_response.h"
+#include "hmi/ui_slider_response.h"
 
 namespace test {
 namespace components {
@@ -140,14 +139,12 @@ typedef Types<
                 hmi_apis::FunctionID::VehicleInfo_DiagnosticMessage>,
     CommandData<commands::VIGetDTCsResponse,
                 hmi_apis::FunctionID::VehicleInfo_GetDTCs>,
-    CommandData<commands::VIUnsubscribeVehicleDataResponse,
-                hmi_apis::FunctionID::VehicleInfo_UnsubscribeVehicleData>,
-    CommandData<commands::VRAddCommandResponse,
-                hmi_apis::FunctionID::VR_AddCommand>,
-    CommandData<commands::VRChangeRegistrationResponse,
-                hmi_apis::FunctionID::VR_ChangeRegistration>,
-    CommandData<commands::VRDeleteCommandResponse,
-                hmi_apis::FunctionID::VR_DeleteCommand>> ResponseCommandsList;
+    CommandData<commands::UISetMediaClockTimerResponse,
+                hmi_apis::FunctionID::UI_SetMediaClockTimer>,
+    CommandData<commands::UIShowResponse,
+                hmi_apis::FunctionID::UI_Show>,
+    CommandData<commands::UISliderResponse,
+                hmi_apis::FunctionID::UI_Slider>>ResponseCommandsList;
 
 TYPED_TEST_CASE(ResponseFromHMICommandsTest, ResponseCommandsList);
 

--- a/src/components/application_manager/test/commands/hmi/update_device_list_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/update_device_list_request_test.cc
@@ -57,7 +57,6 @@ using ::utils::SharedPtr;
 using testing::_;
 using testing::ReturnRef;
 using testing::Return;
-using ::testing::NiceMock;
 using test::components::event_engine_test::MockEventDispatcher;
 using ::test::components::application_manager_test::
     MockApplicationManagerSettings;
@@ -88,15 +87,15 @@ class UpdateDeviceListRequestTest
   }
 
   MockApplicationManagerSettings settings_;
-  MockEventDispatcher mock_event_dispatcher;
+  MockEventDispatcher mock_event_dispatcher_;
 };
 
 TEST_F(UpdateDeviceListRequestTest, RUN_LaunchHMIReturnsFalse) {
   MessageSharedPtr command_msg = CreateCommandMsg();
 
   EXPECT_CALL(app_mngr_, event_dispatcher())
-      .WillOnce(ReturnRef(mock_event_dispatcher));
-  EXPECT_CALL(mock_event_dispatcher, remove_observer(_));
+      .WillOnce(ReturnRef(mock_event_dispatcher_));
+  EXPECT_CALL(mock_event_dispatcher_, remove_observer(_));
 
   UpdateDeviceListRequestPtr command(
       CreateCommand<UpdateDeviceListRequest>(command_msg));
@@ -121,8 +120,8 @@ TEST_F(UpdateDeviceListRequestTest, RUN_HMICooperatingReturnsTrue_SUCCESSS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
 
   EXPECT_CALL(app_mngr_, event_dispatcher())
-      .WillOnce(ReturnRef(mock_event_dispatcher));
-  EXPECT_CALL(mock_event_dispatcher, remove_observer(_));
+      .WillOnce(ReturnRef(mock_event_dispatcher_));
+  EXPECT_CALL(mock_event_dispatcher_, remove_observer(_));
 
   UpdateDeviceListRequestPtr command(
       CreateCommand<UpdateDeviceListRequest>(command_msg));
@@ -147,8 +146,8 @@ TEST_F(UpdateDeviceListRequestTest, OnEvent_WrongEventId_UNSUCCESS) {
   Event event(Event::EventID::INVALID_ENUM);
 
   EXPECT_CALL(app_mngr_, event_dispatcher())
-      .WillOnce(ReturnRef(mock_event_dispatcher));
-  EXPECT_CALL(mock_event_dispatcher, remove_observer(_));
+      .WillOnce(ReturnRef(mock_event_dispatcher_));
+  EXPECT_CALL(mock_event_dispatcher_, remove_observer(_));
 
   UpdateDeviceListRequestPtr command(CreateCommand<UpdateDeviceListRequest>());
 
@@ -159,8 +158,8 @@ TEST_F(UpdateDeviceListRequestTest, OnEvent_SUCCESS) {
   Event event(Event::EventID::BasicCommunication_OnReady);
 
   EXPECT_CALL(app_mngr_, event_dispatcher())
-      .WillOnce(ReturnRef(mock_event_dispatcher));
-  EXPECT_CALL(mock_event_dispatcher, remove_observer(_, _));
+      .WillOnce(ReturnRef(mock_event_dispatcher_));
+  EXPECT_CALL(mock_event_dispatcher_, remove_observer(_, _));
 
   UpdateDeviceListRequestPtr command(CreateCommand<UpdateDeviceListRequest>());
 

--- a/src/components/application_manager/test/commands/hmi/update_device_list_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/update_device_list_request_test.cc
@@ -59,14 +59,14 @@ using testing::ReturnRef;
 using testing::Return;
 using ::testing::NiceMock;
 using test::components::event_engine_test::MockEventDispatcher;
-using ::test::components::application_manager_test::MockApplicationManagerSettings;
+using ::test::components::application_manager_test::
+    MockApplicationManagerSettings;
 namespace am = ::application_manager;
 namespace strings = am::strings;
 namespace hmi_response = am::hmi_response;
 using am::event_engine::Event;
 using am::commands::UpdateDeviceListRequest;
 using am::commands::CommandImpl;
-
 
 typedef SharedPtr<UpdateDeviceListRequest> UpdateDeviceListRequestPtr;
 
@@ -94,15 +94,14 @@ class UpdateDeviceListRequestTest
 TEST_F(UpdateDeviceListRequestTest, RUN_LaunchHMIReturnsFalse) {
   MessageSharedPtr command_msg = CreateCommandMsg();
 
-    EXPECT_CALL(app_mngr_, event_dispatcher())
-        .WillOnce(ReturnRef(mock_event_dispatcher));
-     EXPECT_CALL(mock_event_dispatcher, remove_observer(_));
+  EXPECT_CALL(app_mngr_, event_dispatcher())
+      .WillOnce(ReturnRef(mock_event_dispatcher));
+  EXPECT_CALL(mock_event_dispatcher, remove_observer(_));
 
   UpdateDeviceListRequestPtr command(
       CreateCommand<UpdateDeviceListRequest>(command_msg));
 
-  EXPECT_CALL(app_mngr_, get_settings())
-      .WillOnce(ReturnRef(settings_));
+  EXPECT_CALL(app_mngr_, get_settings()).WillOnce(ReturnRef(settings_));
 
   EXPECT_CALL(settings_, launch_hmi()).WillOnce(Return(false));
 
@@ -118,19 +117,17 @@ TEST_F(UpdateDeviceListRequestTest, RUN_LaunchHMIReturnsFalse) {
             CommandImpl::protocol_version_);
 }
 
- TEST_F(UpdateDeviceListRequestTest, RUN_HMICooperatingReturnsTrue_SUCCESSS)
- {
+TEST_F(UpdateDeviceListRequestTest, RUN_HMICooperatingReturnsTrue_SUCCESSS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
 
   EXPECT_CALL(app_mngr_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
-   EXPECT_CALL(mock_event_dispatcher, remove_observer(_));
+  EXPECT_CALL(mock_event_dispatcher, remove_observer(_));
 
   UpdateDeviceListRequestPtr command(
       CreateCommand<UpdateDeviceListRequest>(command_msg));
 
-  EXPECT_CALL(app_mngr_, get_settings())
-      .WillOnce(ReturnRef(settings_));
+  EXPECT_CALL(app_mngr_, get_settings()).WillOnce(ReturnRef(settings_));
 
   EXPECT_CALL(settings_, launch_hmi()).WillOnce(Return(true));
 
@@ -146,33 +143,29 @@ TEST_F(UpdateDeviceListRequestTest, RUN_LaunchHMIReturnsFalse) {
             CommandImpl::protocol_version_);
 }
 
- TEST_F(UpdateDeviceListRequestTest, OnEvent_WrongEventId_UNSUCCESS) {
+TEST_F(UpdateDeviceListRequestTest, OnEvent_WrongEventId_UNSUCCESS) {
+  Event event(Event::EventID::INVALID_ENUM);
 
-   Event event(Event::EventID::INVALID_ENUM);
+  EXPECT_CALL(app_mngr_, event_dispatcher())
+      .WillOnce(ReturnRef(mock_event_dispatcher));
+  EXPECT_CALL(mock_event_dispatcher, remove_observer(_));
 
-   EXPECT_CALL(app_mngr_, event_dispatcher())
-         .WillOnce(ReturnRef(mock_event_dispatcher));
-   EXPECT_CALL(mock_event_dispatcher, remove_observer(_));
+  UpdateDeviceListRequestPtr command(CreateCommand<UpdateDeviceListRequest>());
 
-   UpdateDeviceListRequestPtr command(
-       CreateCommand<UpdateDeviceListRequest>());
+  command->on_event(event);
+}
 
-   command->on_event(event);
- }
+TEST_F(UpdateDeviceListRequestTest, OnEvent_SUCCESS) {
+  Event event(Event::EventID::BasicCommunication_OnReady);
 
- TEST_F(UpdateDeviceListRequestTest, OnEvent_SUCCESS) {
+  EXPECT_CALL(app_mngr_, event_dispatcher())
+      .WillOnce(ReturnRef(mock_event_dispatcher));
+  EXPECT_CALL(mock_event_dispatcher, remove_observer(_, _));
 
-   Event event(Event::EventID::BasicCommunication_OnReady);
+  UpdateDeviceListRequestPtr command(CreateCommand<UpdateDeviceListRequest>());
 
-   EXPECT_CALL(app_mngr_, event_dispatcher())
-         .WillOnce(ReturnRef(mock_event_dispatcher));
-   EXPECT_CALL(mock_event_dispatcher, remove_observer(_,_));
-
-   UpdateDeviceListRequestPtr command(
-       CreateCommand<UpdateDeviceListRequest>());
-
-   command->on_event(event);
- }
+  command->on_event(event);
+}
 }  // namespace hmi_commands_test
 }  // namespace commands_test
 }  // namespace components

--- a/src/components/application_manager/test/commands/hmi/update_device_list_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/update_device_list_request_test.cc
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "interfaces/HMI_API.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_impl.h"
+#include "application_manager/application_manager.h"
+#include "application_manager/application_manager_impl.h"
+#include "application_manager/mock_event_dispatcher.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/event_engine/event.h"
+#include "application_manager/request_controller_settings.h"
+#include "application_manager/mock_application_manager_settings.h"
+#include "application_manager/commands/hmi/update_device_list_request.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::utils::SharedPtr;
+using testing::_;
+using testing::ReturnRef;
+using testing::Return;
+using ::testing::NiceMock;
+using test::components::event_engine_test::MockEventDispatcher;
+using ::test::components::application_manager_test::MockApplicationManagerSettings;
+namespace am = ::application_manager;
+namespace strings = am::strings;
+namespace hmi_response = am::hmi_response;
+using am::event_engine::Event;
+using am::commands::UpdateDeviceListRequest;
+using am::commands::CommandImpl;
+
+
+typedef SharedPtr<UpdateDeviceListRequest> UpdateDeviceListRequestPtr;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+}  // namespace
+
+class UpdateDeviceListRequestTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  MessageSharedPtr CreateCommandMsg() {
+    MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+    (*command_msg)[strings::msg_params][strings::number] = "123";
+    (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
+    (*command_msg)[strings::params][hmi_response::code] =
+        hmi_apis::Common_Result::SUCCESS;
+
+    return command_msg;
+  }
+
+  MockApplicationManagerSettings settings_;
+  MockEventDispatcher mock_event_dispatcher;
+};
+
+TEST_F(UpdateDeviceListRequestTest, RUN_LaunchHMIReturnsFalse) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+
+    EXPECT_CALL(app_mngr_, event_dispatcher())
+        .WillOnce(ReturnRef(mock_event_dispatcher));
+     EXPECT_CALL(mock_event_dispatcher, remove_observer(_));
+
+  UpdateDeviceListRequestPtr command(
+      CreateCommand<UpdateDeviceListRequest>(command_msg));
+
+  EXPECT_CALL(app_mngr_, get_settings())
+      .WillOnce(ReturnRef(settings_));
+
+  EXPECT_CALL(settings_, launch_hmi()).WillOnce(Return(false));
+
+  EXPECT_CALL(app_mngr_, IsHMICooperating()).Times(0);
+
+  EXPECT_CALL(app_mngr_, SendMessageToHMI(command_msg));
+
+  command->Run();
+
+  EXPECT_EQ((*command_msg)[strings::params][strings::protocol_type].asInt(),
+            CommandImpl::hmi_protocol_type_);
+  EXPECT_EQ((*command_msg)[strings::params][strings::protocol_version].asInt(),
+            CommandImpl::protocol_version_);
+}
+
+ TEST_F(UpdateDeviceListRequestTest, RUN_HMICooperatingReturnsTrue_SUCCESSS)
+ {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+
+  EXPECT_CALL(app_mngr_, event_dispatcher())
+      .WillOnce(ReturnRef(mock_event_dispatcher));
+   EXPECT_CALL(mock_event_dispatcher, remove_observer(_));
+
+  UpdateDeviceListRequestPtr command(
+      CreateCommand<UpdateDeviceListRequest>(command_msg));
+
+  EXPECT_CALL(app_mngr_, get_settings())
+      .WillOnce(ReturnRef(settings_));
+
+  EXPECT_CALL(settings_, launch_hmi()).WillOnce(Return(true));
+
+  EXPECT_CALL(app_mngr_, IsHMICooperating()).WillOnce(Return(true));
+
+  EXPECT_CALL(app_mngr_, SendMessageToHMI(command_msg));
+
+  command->Run();
+
+  EXPECT_EQ((*command_msg)[strings::params][strings::protocol_type].asInt(),
+            CommandImpl::hmi_protocol_type_);
+  EXPECT_EQ((*command_msg)[strings::params][strings::protocol_version].asInt(),
+            CommandImpl::protocol_version_);
+}
+
+ TEST_F(UpdateDeviceListRequestTest, OnEvent_WrongEventId_UNSUCCESS) {
+
+   Event event(Event::EventID::INVALID_ENUM);
+
+   EXPECT_CALL(app_mngr_, event_dispatcher())
+         .WillOnce(ReturnRef(mock_event_dispatcher));
+   EXPECT_CALL(mock_event_dispatcher, remove_observer(_));
+
+   UpdateDeviceListRequestPtr command(
+       CreateCommand<UpdateDeviceListRequest>());
+
+   command->on_event(event);
+ }
+
+ TEST_F(UpdateDeviceListRequestTest, OnEvent_SUCCESS) {
+
+   Event event(Event::EventID::BasicCommunication_OnReady);
+
+   EXPECT_CALL(app_mngr_, event_dispatcher())
+         .WillOnce(ReturnRef(mock_event_dispatcher));
+   EXPECT_CALL(mock_event_dispatcher, remove_observer(_,_));
+
+   UpdateDeviceListRequestPtr command(
+       CreateCommand<UpdateDeviceListRequest>());
+
+   command->on_event(event);
+ }
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test


### PR DESCRIPTION
Following HMI commands were coverd by unit tests:

- ui_set_media_clock_timer_request
- ui_set_media_clock_timer_response
- ui_show_request
- ui_show_response
- ui_slider_request
- ui_slider_response
- update_app_list_request
- update_app_list_response
- update_device_list_request
- update_device_list_response

Related issue: APPLINK-25912