### PR TITLE
Test "device" and "pre_DataConsent" must be in PT

### DIFF
--- a/src/components/policy/test/CMakeLists.txt
+++ b/src/components/policy/test/CMakeLists.txt
@@ -53,7 +53,7 @@ set(testSources
   usage_statistics_test.cc    
   shared_library_test.cc    
   generated_code_test.cc 
-  #policy_manager_impl_test.cc
+  policy_manager_impl_test.cc
 )
 
   include_directories(${COMPONENTS_DIR}/policy/src/policy/policy_table/table_struct)
@@ -82,7 +82,7 @@ else ()
     generated_code_with_sqlite_test.cc   
 
     # TODO{ALeshin} AssertTrue in SetUpTestCase() return false
-    #policy_manager_impl_stress_test.cc
+    policy_manager_impl_stress_test.cc
   )
   list (APPEND testLibraries sqlite3)
 endif()

--- a/src/components/policy/test/policy_manager_impl_stress_test.cc
+++ b/src/components/policy/test/policy_manager_impl_stress_test.cc
@@ -47,8 +47,8 @@ namespace policy {
 class PolicyManagerImplStressTest : public ::testing::Test {
  protected:
   static const std::string kNameFile;
-  static const int kNumberGroups = 3;  //10;
-  static const int kNumberFuncs = 4;  //100;
+  static const int kNumberGroups = 3;  // 10;
+  static const int kNumberFuncs = 4;  // 100;
   static const int kNumberApps = 5;
   static const int kNumberAppGroups = 5;
   static PolicyManagerImpl* manager;
@@ -80,7 +80,7 @@ void PolicyManagerImplStressTest::SetUpTestCase() {
   mock_listener = new MockPolicyListener();
   manager->set_listener(mock_listener);
 
-  //TODO(AGaliuzov) APPLINK-10657
+  // TODO(AGaliuzov) APPLINK-10657
   ASSERT_TRUE(manager->InitPT(kNameFile));
 }
 
@@ -111,7 +111,8 @@ void PolicyManagerImplStressTest::CreateGroups(std::ofstream& ofs) {
 }
 
 void PolicyManagerImplStressTest::CreateFuncs(std::ofstream& ofs) {
-  std::string func = "{\n"
+  std::string func =
+      "{\n"
       "\t\t\"hmi_levels\":["
       "\"BACKGROUND\","
       "\"FULL\","
@@ -132,16 +133,32 @@ void PolicyManagerImplStressTest::CreateFuncs(std::ofstream& ofs) {
 }
 
 void PolicyManagerImplStressTest::CreateApps(std::ofstream& ofs) {
-
   ofs << "\"default\":{\n";
   ofs << "\"keep_context\": true,\n"
-      "\"steal_focus\": true,\n"
-      "\"priority\": \"NORMAL\",\n"
-      "\"default_hmi\": \"FULL\",\n";
+         "\"steal_focus\": true,\n"
+         "\"priority\": \"NORMAL\",\n"
+         "\"default_hmi\": \"FULL\",\n";
   ofs << "\"groups\":["
-      "\"Group-1\""
-      "]"
-      "},\n";
+         "\"Group-1\""
+         "]"
+         "},\n";
+
+  // Device app_policies object must be present and initialized for PT to be
+  // valid.
+  ofs << "\"device\":{\n";
+  ofs << "\"priority\": \"NONE\",\n";
+  ofs << "\"groups\":["
+         "\"Group-1\""
+         "]"
+         "},\n";
+
+  // preData app_policies must be present and initialized for PT to be valid.
+  ofs << "\"pre_DataConsent\":{\n";
+  ofs << "\"priority\": \"NONE\",\n";
+  ofs << "\"groups\":["
+         "\"Group-1\""
+         "]"
+         "},\n";
 
   std::stringstream ss;
   std::string number;
@@ -150,9 +167,9 @@ void PolicyManagerImplStressTest::CreateApps(std::ofstream& ofs) {
     ss >> number;
     ofs << "\"" << number << "\" : {";
     ofs << "\n\"keep_context\": true,\n"
-        "\"steal_focus\": true,\n"
-        "\"priority\": \"NORMAL\",\n"
-        "\"default_hmi\": \"FULL\",\n";
+           "\"steal_focus\": true,\n"
+           "\"priority\": \"NORMAL\",\n"
+           "\"default_hmi\": \"FULL\",\n";
 
     ofs << "\"groups\": ";
     CreateAppGroups(ofs);
@@ -162,9 +179,9 @@ void PolicyManagerImplStressTest::CreateApps(std::ofstream& ofs) {
   ss >> number;
   ofs << "\"" << number << "\" : {";
   ofs << "\n\"keep_context\": true,\n"
-      "\"steal_focus\": true,\n"
-      "\"priority\": \"NORMAL\",\n"
-      "\"default_hmi\": \"FULL\",\n";
+         "\"steal_focus\": true,\n"
+         "\"priority\": \"NORMAL\",\n"
+         "\"default_hmi\": \"FULL\",\n";
 
   ofs << "\"groups\": ";
   CreateAppGroups(ofs);
@@ -196,35 +213,35 @@ void PolicyManagerImplStressTest::CreateAppGroups(std::ofstream& ofs) {
 
 void PolicyManagerImplStressTest::CreateTable(std::ofstream& ofs) {
   ofs << "{"
-      "\"policy_table\":{\n"
-      "\"module_config\":{\n"
-      "\t\"preloaded_pt\":true,\n"
-      "\t\"endpoints\":{\n"
-      "\t\t\"default\": {\n"
-      "\t\t\t\"default\":["
-      "\"http://sdl.net/api\""
-      "]\n"
-      "\t\t}\n"
-      "\t},\n"
+         "\"policy_table\":{\n"
+         "\"module_config\":{\n"
+         "\t\"preloaded_pt\":true,\n"
+         "\t\"endpoints\":{\n"
+         "\t\t\"default\": {\n"
+         "\t\t\t\"default\":["
+         "\"http://sdl.net/api\""
+         "]\n"
+         "\t\t}\n"
+         "\t},\n"
 
-      "\"notifications_per_minute_by_priority\": {\n"
-      "\t\"EMERGENCY\": 60,\n"
-      "\t\"NAVIGATION\": 15,\n"
-      "\t\"COMMUNICATION\": 6,\n"
-      "\t\"NORMAL\": 4,\n"
-      "\t\"NONE\": 0\n"
-      "},\n"
+         "\"notifications_per_minute_by_priority\": {\n"
+         "\t\"EMERGENCY\": 60,\n"
+         "\t\"NAVIGATION\": 15,\n"
+         "\t\"COMMUNICATION\": 6,\n"
+         "\t\"NORMAL\": 4,\n"
+         "\t\"NONE\": 0\n"
+         "},\n"
 
-      "\"exchange_after_x_ignition_cycles\": 40,\n"
-      "\"exchange_after_x_kilometers\" : 2,\n"
-      "\"exchange_after_x_days\" : 23,\n"
-      "\"timeout_after_x_seconds\" : 20,\n"
-      "\"seconds_between_retries\" : [10, 7, 5, 3, 1]\n"
-      "},"
-      "\"consumer_friendly_messages\":{\n"
-      "\t\"version\":\"001.001.001\",\n"
-      "\t\"messages\":{} },\n"
-      "\"functional_groupings\":{\n";
+         "\"exchange_after_x_ignition_cycles\": 40,\n"
+         "\"exchange_after_x_kilometers\" : 2,\n"
+         "\"exchange_after_x_days\" : 23,\n"
+         "\"timeout_after_x_seconds\" : 20,\n"
+         "\"seconds_between_retries\" : [10, 7, 5, 3, 1]\n"
+         "},"
+         "\"consumer_friendly_messages\":{\n"
+         "\t\"version\":\"001.001.001\",\n"
+         "\t\"messages\":{} },\n"
+         "\"functional_groupings\":{\n";
 
   CreateGroups(ofs);
 
@@ -235,7 +252,8 @@ void PolicyManagerImplStressTest::CreateTable(std::ofstream& ofs) {
   ofs << "} } }";
 }
 
-TEST_F(PolicyManagerImplStressTest, OneCheck_AppAndFunctuionExisting_RpcAllowed) {
+TEST_F(PolicyManagerImplStressTest,
+       OneCheck_AppAndFunctuionExisting_RpcAllowed) {
   ::policy::RPCParams input_params;
   ::policy::CheckPermissionResult output;
   manager->CheckPermissions("2", "FULL", "Func-1", input_params, output);
@@ -263,8 +281,9 @@ TEST_F(PolicyManagerImplStressTest, NoHmi_HMIInLevelNone_RpcDissallowed) {
   EXPECT_EQ(::policy::kRpcDisallowed, output.hmi_level_permitted);
 }
 
-TEST_F(PolicyManagerImplStressTest, FewChecks_CheckSeveralFunctions_RpcAllowed) {
-  const int kNumberOfCheckings = kNumberFuncs;  //100;
+TEST_F(PolicyManagerImplStressTest,
+       FewChecks_CheckSeveralFunctions_RpcAllowed) {
+  const int kNumberOfCheckings = kNumberFuncs;  // 100;
   std::stringstream ss;
   int app, func;
   std::string app_number, func_number;
@@ -278,8 +297,8 @@ TEST_F(PolicyManagerImplStressTest, FewChecks_CheckSeveralFunctions_RpcAllowed) 
 
     ::policy::RPCParams input_params;
     ::policy::CheckPermissionResult output;
-    manager->CheckPermissions(app_number, "FULL", "Func-" + func_number,
-                              input_params, output);
+    manager->CheckPermissions(
+        app_number, "FULL", "Func-" + func_number, input_params, output);
     EXPECT_EQ(::policy::kRpcAllowed, output.hmi_level_permitted);
   }
 }


### PR DESCRIPTION
Enabled policy_manager_impl_stress_test.cc and
policy_manager_impl_test.cc.
Test updated to test device and pre_DataConsent
presence in PT. Also some other tests improved.

Related to APPLINK-26927.