### PR TITLE
Fix of SDL "SIGSEGV signal has been caught" when ending navi streaming

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3122,12 +3122,14 @@ void ApplicationManagerImpl::EndNaviStreaming() {
   using namespace mobile_apis::AppInterfaceUnregisteredReason;
   using namespace mobile_apis::Result;
 
-  uint32_t app_id = navi_app_to_end_stream_.front();
-  navi_app_to_end_stream_.pop_front();
+  if(!navi_app_to_end_stream_.empty()) {
+   const  uint32_t app_id = navi_app_to_end_stream_.front();
+    navi_app_to_end_stream_.pop_front();
 
-  if (navi_app_to_stop_.end() ==
-      std::find(navi_app_to_stop_.begin(), navi_app_to_stop_.end(), app_id)) {
-    DisallowStreaming(app_id);
+    if (navi_app_to_stop_.end() ==
+        std::find(navi_app_to_stop_.begin(), navi_app_to_stop_.end(), app_id)) {
+        DisallowStreaming(app_id);
+    }
   }
 }
 


### PR DESCRIPTION
Application gets Disallowed Status After SDL version 4 and SDL stops.

Related issue: [APPLINK-27161](https://adc.luxoft.com/jira/browse/APPLINK-27161)