### PR TITLE
Initialize state_ctrl_ to constructor parameter (CID 80054)

### DIFF
--- a/src/components/application_manager/include/application_manager/state_controller.h
+++ b/src/components/application_manager/include/application_manager/state_controller.h
@@ -241,7 +241,7 @@ private:
     StateController *state_ctrl_;
     HmiLevelConflictResolver(ApplicationSharedPtr app, HmiStatePtr state,
                              StateController *state_ctrl)
-        : applied_(app), state_(state) {}
+        : applied_(app), state_(state), state_ctrl_(state_ctrl) {}
     void operator()(ApplicationSharedPtr to_resolve);
   };
 


### PR DESCRIPTION
This hotfix fixes [`DCHECK_OR_RETURN_VOID(state_ctrl_);`](https://github.com/smartdevicelink/sdl_core/blob/master/src/components/application_manager/src/state_controller.cc#L82) failing due to the `HmiLevelConflictResolver` constructor missing its `state_ctrl_` initializer.

This commit was cherry-picked from the coverity branch.