### PR TITLE
Fix instruction about SDL_SQLITE_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ environment variable
 * Download and install [GStreamer SDK](http://docs.gstreamer.com/display/GstSDK/Installing+on+Windows). You will need both Runtime and Development files. Add path to **bin** folder to `PATH`. Create new environment variable `SDL_GSTREAMER_DIR` with path to SDK (e.g. `D:\gstreamer-sdk\0.10\x86_64`).
 
 ##### Steps for Windows platform
-* Download [sqlite3 sources](https://www.sqlite.org/2015/sqlite-amalgamation-3090200.zip) and extract them.
+* Download [sqlite3 sources](https://www.sqlite.org/2015/sqlite-amalgamation-3090200.zip) and extract them and add this folder to `PATH`.
 * Download [sqlite3 binaries](https://www.sqlite.org/2015/sqlite-dll-win64-x64-3090200.zip). Extract them and add this folder to `PATH`. Create new environment variable `SDL_SQLITE_DIR` and assign path where sqlite binaries were extracted to this variable.
 * Install [Windows SDK 7.1](https://www.microsoft.com/en-us/download/details.aspx?id=8442)
 * Install [Visual Studio 2013](https://www.microsoft.com/en-us/download/confirmation.aspx?id=44914)

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ environment variable
 * Download and install [GStreamer SDK](http://docs.gstreamer.com/display/GstSDK/Installing+on+Windows). You will need both Runtime and Development files. Add path to **bin** folder to `PATH`. Create new environment variable `SDL_GSTREAMER_DIR` with path to SDK (e.g. `D:\gstreamer-sdk\0.10\x86_64`).
 
 ##### Steps for Windows platform
-* Download [sqlite3 sources](https://www.sqlite.org/2015/sqlite-amalgamation-3090200.zip) and extract them and add this folder to `PATH`.
-* Download [sqlite3 binaries](https://www.sqlite.org/2015/sqlite-dll-win64-x64-3090200.zip). Extract them and add this folder to `PATH`. Create new environment variable `SDL_SQLITE_DIR` and assign path where sqlite binaries were extracted to this variable.
+* Download [sqlite3 sources](https://www.sqlite.org/2015/sqlite-amalgamation-3090200.zip) and extract them and add this folder to `PATH`. Create new environment variable `SDL_SQLITE_DIR` and assign path where sqlite binaries were extracted to this variable.
+* Download [sqlite3 binaries](https://www.sqlite.org/2015/sqlite-dll-win64-x64-3090200.zip). Extract them and add this folder to `PATH`. Create new environment variable `SDL_SQLITE_BIN_DIR` and assign path where sqlite binaries were extracted to this variable.
 * Install [Windows SDK 7.1](https://www.microsoft.com/en-us/download/details.aspx?id=8442)
 * Install [Visual Studio 2013](https://www.microsoft.com/en-us/download/confirmation.aspx?id=44914)
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ environment variable
 * Download and install [GStreamer SDK](http://docs.gstreamer.com/display/GstSDK/Installing+on+Windows). You will need both Runtime and Development files. Add path to **bin** folder to `PATH`. Create new environment variable `SDL_GSTREAMER_DIR` with path to SDK (e.g. `D:\gstreamer-sdk\0.10\x86_64`).
 
 ##### Steps for Windows platform
-* Download [sqlite3 sources](https://www.sqlite.org/2015/sqlite-amalgamation-3090200.zip) and extract them. Create new environment variable `SDL_SQLITE_DIR` and assign path where sqlite sources were extracted to this variable.
-* Download [sqlite3 binaries](https://www.sqlite.org/2015/sqlite-dll-win64-x64-3090200.zip). Extract them and add this folder to `PATH`.
+* Download [sqlite3 sources](https://www.sqlite.org/2015/sqlite-amalgamation-3090200.zip) and extract them.
+* Download [sqlite3 binaries](https://www.sqlite.org/2015/sqlite-dll-win64-x64-3090200.zip). Extract them and add this folder to `PATH`. Create new environment variable `SDL_SQLITE_DIR` and assign path where sqlite binaries were extracted to this variable.
 * Install [Windows SDK 7.1](https://www.microsoft.com/en-us/download/details.aspx?id=8442)
 * Install [Visual Studio 2013](https://www.microsoft.com/en-us/download/confirmation.aspx?id=44914)
 


### PR DESCRIPTION
There is an error in current instructions.
SDL_SQLITE_DIR is used in make_sqlite_lib.cmd to prepare sqlite3.lib in the binary folder by using sqlite3.dll.
So, it is not related to sqlite source folder but binary one.