### PR TITLE
Change SDL_SQLITE_DIR to SDL_SQLITE_BIN_DIR

### DIFF
--- a/tools/ms/make_sqlite_lib.cmd
+++ b/tools/ms/make_sqlite_lib.cmd
@@ -1,5 +1,5 @@
 @echo off
 
-pushd %SDL_SQLITE_DIR%
+pushd %SDL_SQLITE_BIN_DIR%
 lib /def:sqlite3.def /machine:x64
 popd


### PR DESCRIPTION
There is a contradiction in the installation instructions for windows about using SDL_SQLITE_DIR environment variable.
For example in file make_sqlite_lib.cmd is assumed it points to the sqlite binary directory but in other places it is expected to point to sqlite source directory (FindSDLSqlite3.cmake).
That's why it is better to use different environment variables. Instructions must be updated too.