### PR TITLE
Delete Connection instance on close

### DIFF
--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -722,6 +722,7 @@ void ConnectionHandlerImpl::CloseConnection(
   ConnectionList::iterator connection_list_itr =
       connection_list_.find(connection_uid);
   if (connection_list_.end() != connection_list_itr) {
+    delete connection_list_itr->second;
     connection_list_.erase(connection_list_itr);
   }
 }

--- a/src/components/include/utils/conditional_variable.h
+++ b/src/components/include/utils/conditional_variable.h
@@ -98,6 +98,16 @@ class ConditionalVariable {
  private:
   impl::PlatformConditionalVariable cond_var_;
 
+#ifndef NDEBUG
+  /**
+  * @brief Variable for debugging purposes that shows
+  * how much threads are waiting for condition variable currently.
+  * Allows detection of destroying condition variable
+  * while some threads are still waiting for it.
+  */
+  uint32_t waiting_threads_count_;
+#endif
+
  private:
   DISALLOW_COPY_AND_ASSIGN(ConditionalVariable);
 };


### PR DESCRIPTION
- Delete `Connection` instance in `ConnectionHandlerImpl::CloseConnection` method before erasing pointer from connections list
- Add debugging variable `waiting_threads_count_` to condition variable realization to catch the case when condition variable destroyed while some threads are still waiting for it

Closes-bug: [APPLINK-27474](https://adc.luxoft.com/jira/browse/APPLINK-27474), [APPLINK-27149](https://adc.luxoft.com/jira/browse/APPLINK-27149)

@AGaliuzov @dev-gh @nk0leg @LevchenkoS @LuxoftAKutsan please review