### PR TITLE
Reorder info message in add command if vr is not ready

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/add_command_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/add_command_request.h
@@ -134,6 +134,11 @@ class AddCommandRequest : public CommandRequestImpl {
 
   inline bool BothSend() const;
 
+  /**
+   * @brief GenerateMobileResponseInfo generated info for mobile response
+   * depends from UI and VR responses
+   * @return info for mobile response
+   */
   const std::string GenerateMobileResponseInfo();
   bool send_ui_;
   bool send_vr_;

--- a/src/components/application_manager/include/application_manager/commands/mobile/add_command_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/add_command_request.h
@@ -134,15 +134,18 @@ class AddCommandRequest : public CommandRequestImpl {
 
   inline bool BothSend() const;
 
+  const std::string GenerateMobileResponseInfo();
   bool send_ui_;
   bool send_vr_;
 
   bool is_ui_received_;
   bool is_vr_received_;
 
+  std::string ui_info_;
+  std::string vr_info_;
+
   hmi_apis::Common_Result::eType ui_result_;
   hmi_apis::Common_Result::eType vr_result_;
-  std::string info_;
 };
 
 }  // namespace commands

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3122,13 +3122,13 @@ void ApplicationManagerImpl::EndNaviStreaming() {
   using namespace mobile_apis::AppInterfaceUnregisteredReason;
   using namespace mobile_apis::Result;
 
-  if(!navi_app_to_end_stream_.empty()) {
-   const  uint32_t app_id = navi_app_to_end_stream_.front();
+  if (!navi_app_to_end_stream_.empty()) {
+    const uint32_t app_id = navi_app_to_end_stream_.front();
     navi_app_to_end_stream_.pop_front();
 
     if (navi_app_to_stop_.end() ==
         std::find(navi_app_to_stop_.begin(), navi_app_to_stop_.end(), app_id)) {
-        DisallowStreaming(app_id);
+      DisallowStreaming(app_id);
     }
   }
 }

--- a/src/components/application_manager/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_command_request.cc
@@ -526,7 +526,7 @@ bool AddCommandRequest::IsWhiteSpaceExist() {
 }
 
 bool AddCommandRequest::BothSend() const {
-    return send_vr_ && send_ui_;
+  return send_vr_ && send_ui_;
 }
 
 /**
@@ -543,14 +543,14 @@ std::string MergeInfos(const std::string& first, const std::string& second) {
 }
 
 const std::string AddCommandRequest::GenerateMobileResponseInfo() {
-    if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == vr_result_) {
-        return MergeInfos(vr_info_, ui_info_);
-    }
+  if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == vr_result_) {
+    return MergeInfos(vr_info_, ui_info_);
+  }
 
-    if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == ui_result_) {
-        return MergeInfos(ui_info_, vr_info_);
-    }
+  if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == ui_result_) {
     return MergeInfos(ui_info_, vr_info_);
+  }
+  return MergeInfos(ui_info_, vr_info_);
 }
 
 void AddCommandRequest::RemoveCommand() {

--- a/src/components/application_manager/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_command_request.cc
@@ -324,7 +324,6 @@ void AddCommandRequest::on_event(const event_engine::Event& event) {
     case hmi_apis::FunctionID::VR_AddCommand: {
       LOG4CXX_INFO(logger_, "Received VR_AddCommand event");
       is_vr_received_ = true;
-      MessageHelper::PrintSmartObject(message);
       vr_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
       vr_info_ = message[strings::msg_params][strings::info].asString();
@@ -531,15 +530,15 @@ bool AddCommandRequest::BothSend() const {
 
 /**
  * @brief MergeInfos merge 2 infos in one string
- * @param first first info string
- * @param second - second info string
- * @return if first is empty return second
- *         if second is empty return first
+ * @param lval - info string that should be first in result info
+ * @param rval - info string that should be second in result info
+ * @return if lval is empty return rval
+ *         if rval is empty return lval
  *         if both are empty return empty string
- *         if both are not empty return empty first +", " + second
+ *         if both are not empty return empty lval +", " + rval
  */
-std::string MergeInfos(const std::string& first, const std::string& second) {
-  return first + ((!first.empty() && !second.empty()) ? ", " : "") + second;
+std::string MergeInfos(const std::string& lval, const std::string& rval) {
+  return lval + ((!lval.empty() && !rval.empty()) ? ", " : "") + rval;
 }
 
 const std::string AddCommandRequest::GenerateMobileResponseInfo() {
@@ -550,6 +549,9 @@ const std::string AddCommandRequest::GenerateMobileResponseInfo() {
   // Other way order is doesn't matter
   if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == vr_result_) {
     return MergeInfos(vr_info_, ui_info_);
+  }
+  if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == ui_result_) {
+    return MergeInfos(ui_info_, vr_info_);
   }
   return MergeInfos(ui_info_, vr_info_);
 }

--- a/src/components/application_manager/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_command_request.cc
@@ -542,7 +542,7 @@ std::string MergeInfos(const std::string& first, const std::string& second) {
   return std::string();
 }
 
-const std::__cxx11::string AddCommandRequest::GenerateMobileResponseInfo() {
+const std::string AddCommandRequest::GenerateMobileResponseInfo() {
     if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == vr_result_) {
         return MergeInfos(vr_info_, ui_info_);
     }

--- a/src/components/application_manager/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_command_request.cc
@@ -529,17 +529,17 @@ bool AddCommandRequest::BothSend() const {
     return send_vr_ && send_ui_;
 }
 
+/**
+ * @brief MergeInfos merge 2 infos in one string
+ * @param first first info string
+ * @param second - second info string
+ * @return if first is empty return second
+ *         if second is empty return first
+ *         if both are empty return empty string
+ *         if both are not empty return empty first +", " + second
+ */
 std::string MergeInfos(const std::string& first, const std::string& second) {
-  if (!first.empty() && second.empty()) {
-    return first;
-  }
-  if (first.empty() && !second.empty()) {
-    return second;
-  }
-  if (!first.empty() && !second.empty()) {
-    return first + ", " + second;
-  }
-  return std::string();
+  return first + ((!first.empty() && !second.empty()) ? ", " : "") + second;
 }
 
 const std::string AddCommandRequest::GenerateMobileResponseInfo() {

--- a/src/components/application_manager/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_command_request.cc
@@ -543,12 +543,13 @@ std::string MergeInfos(const std::string& first, const std::string& second) {
 }
 
 const std::string AddCommandRequest::GenerateMobileResponseInfo() {
+  // In case if vr_result_ is UNSUPPORTED_RESOURCE vr_info should be on the
+  // first place
+  // In case if ui_result_ is UNSUPPORTED_RESOURCE ui_info should be on the
+  // first place
+  // Other way order is doesn't matter
   if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == vr_result_) {
     return MergeInfos(vr_info_, ui_info_);
-  }
-
-  if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == ui_result_) {
-    return MergeInfos(ui_info_, vr_info_);
   }
   return MergeInfos(ui_info_, vr_info_);
 }


### PR DESCRIPTION
In case if only one interface is available UI SDL should respond to HMI
info by pattern :

info = "VR is not supported by system, " + error message from other
interface

Related issue : [APPLINK-26900](https://adc.luxoft.com/jira/browse/APPLINK-26900)