### PR TITLE
Fix issue with throwing exception in ResumeCtrlTest

### DIFF
--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -797,10 +797,10 @@ TEST_F(ResumeCtrlTest, OnAppRegistrationStart) {
 }
 
 TEST_F(ResumeCtrlTest, OnAppRegistrationEnd) {
-  const uint32_t kTimeout = 10u;
+  const uint32_t timeout = 1000u;
   EXPECT_CALL(mock_application_manager_settings_,
               app_resumption_save_persistent_data_timeout())
-      .WillOnce(ReturnRef(kTimeout));
+      .WillOnce(ReturnRef(timeout));
   res_ctrl->OnAppRegistrationEnd();
 }
 
@@ -889,10 +889,10 @@ TEST_F(ResumeCtrlTest, OnSuspend_EmptyApplicationlist) {
 }
 
 TEST_F(ResumeCtrlTest, OnAwake) {
-  const uint32_t kTimeout = 10u;
+  const uint32_t timeout = 1000u;
   EXPECT_CALL(mock_application_manager_settings_,
               app_resumption_save_persistent_data_timeout())
-      .WillOnce(ReturnRef(kTimeout));
+      .WillOnce(ReturnRef(timeout));
   EXPECT_CALL(*mock_storage, OnAwake());
   res_ctrl->OnAwake();
 }


### PR DESCRIPTION
  -fixed issue with throwing exception in tests:
   OnAppRegistrationEnd, OnAwake

Related to APPLINK-27147, APPLINK-27616