### PR TITLE
Cover mobile commands with unit tests

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/create_interaction_choice_set_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/create_interaction_choice_set_request.h
@@ -71,7 +71,6 @@ class CreateInteractionChoiceSetRequest : public CommandRequestImpl {
    **/
   void Run() OVERRIDE;
 
- private:
   /**
    * @brief Interface method that is called whenever new event received
    *
@@ -84,6 +83,8 @@ class CreateInteractionChoiceSetRequest : public CommandRequestImpl {
    * has exceed it's limit
    */
   void onTimeOut() OVERRIDE;
+
+ private:
   /**
    * @brief DeleteChoices allows to walk through the sent commands collection
    * in order to sent appropriate DeleteCommand request.

--- a/src/components/application_manager/include/application_manager/commands/mobile/delete_sub_menu_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/delete_sub_menu_request.h
@@ -65,6 +65,13 @@ class DeleteSubMenuRequest : public CommandRequestImpl {
    **/
   void Run() OVERRIDE;
 
+  /**
+   * @brief Interface method that is called whenever new event received
+   *
+   * @param event The received event
+   */
+  void on_event(const event_engine::Event& event) OVERRIDE;
+
  private:
   /*
    * @brief Deletes VR commands from SDL for corresponding submenu ID
@@ -83,13 +90,6 @@ class DeleteSubMenuRequest : public CommandRequestImpl {
    * @return TRUE on success, otherwise FALSE
    */
   void DeleteSubMenuUICommands(ApplicationSharedPtr const app);
-
-  /**
-   * @brief Interface method that is called whenever new event received
-   *
-   * @param event The received event
-   */
-  void on_event(const event_engine::Event& event) OVERRIDE;
 
   DISALLOW_COPY_AND_ASSIGN(DeleteSubMenuRequest);
 };

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_interaction_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_interaction_request.h
@@ -79,7 +79,20 @@ class PerformInteractionRequest : public CommandRequestImpl {
    */
   virtual void on_event(const event_engine::Event& event) OVERRIDE;
 
- private:
+#if BUILD_TESTS
+  enum CheckMethod {
+    kCheckVrSynonyms = 0,
+    kCheckMenuNames,
+    kCheckVrHelpItem
+  };
+
+  /**
+   * @brief Method for easier check methods in unit tests.
+   * Needed because Run method have ways which cannot be validated.
+   */
+  bool CallCheckMethod(CheckMethod);
+#endif  // BUILD_TESTS
+
   /*
    * @brief Function is called by RequestController when request execution time
    * has exceed it's limit
@@ -87,6 +100,7 @@ class PerformInteractionRequest : public CommandRequestImpl {
    */
   void onTimeOut() OVERRIDE;
 
+ private:
   /*
    * @brief Function will be called when VR_OnCommand event
    * comes
@@ -179,6 +193,16 @@ class PerformInteractionRequest : public CommandRequestImpl {
    * FALSE otherwise
    */
   bool IsWhiteSpaceExist();
+
+  /**
+   * @brief Help function for IsWhiteSpaceExist, which validate one of fields
+   * for white space existence
+   * @param field_name - name for find field in message smart object.
+   * Field must have type Array of Strings
+   * and could have [image][value] field inside
+   * @return false if whitespace not exists and vice versa
+   */
+  bool IsFieldHaveWhiteSpaces(const std::string& field_name);
 
   /**
    * @brief Send HMI close PopUp and call DisablePerformInteraction

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_interaction_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_interaction_request.h
@@ -80,11 +80,7 @@ class PerformInteractionRequest : public CommandRequestImpl {
   virtual void on_event(const event_engine::Event& event) OVERRIDE;
 
 #if BUILD_TESTS
-  enum CheckMethod {
-    kCheckVrSynonyms = 0,
-    kCheckMenuNames,
-    kCheckVrHelpItem
-  };
+  enum CheckMethod { kCheckVrSynonyms = 0, kCheckMenuNames, kCheckVrHelpItem };
 
   /**
    * @brief Method for easier check methods in unit tests.

--- a/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
@@ -767,6 +767,8 @@ void PerformInteractionRequest::DisablePerformInteraction() {
 
 bool PerformInteractionRequest::IsFieldHaveWhiteSpaces(
     const std::string& field_name) {
+  SDL_AUTO_TRACE();
+
   if (!(*message_)[strings::msg_params].keyExists(field_name)) {
     return false;
   }

--- a/src/components/application_manager/test/commands/command_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_impl_test.cc
@@ -147,7 +147,7 @@ TEST_F(CommandImplTest, ReplaceMobileByHMIAppId_NoAppIdInMessage_UNSUCCESS) {
   MessageSharedPtr msg;
   UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
 
-  EXPECT_CALL(app_mngr_, application(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, application(_)).Times(0);
 
   command->ReplaceMobileByHMIAppId(*msg);
 }
@@ -160,7 +160,7 @@ TEST_F(CommandImplTest, ReplaceMobileByHMIAppId_SUCCESS) {
 
   MockAppPtr app = CreateMockApp();
 
-  EXPECT_CALL(app_mngr_, application(kAppId1_)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kAppId1_)).WillOnce(Return(app));
   ON_CALL(*app, hmi_app_id()).WillByDefault(Return(kAppId2_));
 
   command->ReplaceMobileByHMIAppId(*msg);
@@ -174,7 +174,7 @@ TEST_F(CommandImplTest, ReplaceMobileByHMIAppId_Array_SUCCESS) {
 
   MockAppPtr app = CreateMockApp();
 
-  EXPECT_CALL(app_mngr_, application(_))
+  EXPECT_CALL(mock_app_manager_, application(_))
       .Times(kDefaultMsgCount_)
       .WillRepeatedly(Return(app));
   ON_CALL(*app, hmi_app_id()).WillByDefault(Return(kAppId2_));
@@ -195,7 +195,7 @@ TEST_F(CommandImplTest, ReplaceMobileByHMIAppId_Map_SUCCESS) {
 
   MockAppPtr app = CreateMockApp();
 
-  EXPECT_CALL(app_mngr_, application(_))
+  EXPECT_CALL(mock_app_manager_, application(_))
       .Times(kDefaultMsgCount_)
       .WillRepeatedly(Return(app));
   ON_CALL(*app, hmi_app_id()).WillByDefault(Return(kAppId2_));
@@ -213,7 +213,7 @@ TEST_F(CommandImplTest, ReplaceHMIByMobileAppId_NoHMIAppIdInMessage_UNSUCCESS) {
   MessageSharedPtr msg;
   UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
 
-  EXPECT_CALL(app_mngr_, application_by_hmi_app(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(_)).Times(0);
 
   command->ReplaceHMIByMobileAppId(*msg);
 }
@@ -226,7 +226,7 @@ TEST_F(CommandImplTest, ReplaceHMIByMobileAppId_SUCCESS) {
 
   MockAppPtr app = CreateMockApp();
 
-  EXPECT_CALL(app_mngr_, application_by_hmi_app(kAppId1_))
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(kAppId1_))
       .WillOnce(Return(app));
   ON_CALL(*app, app_id()).WillByDefault(Return(kAppId2_));
 
@@ -241,7 +241,7 @@ TEST_F(CommandImplTest, ReplaceHMIByMobileAppId_Array_SUCCESS) {
   UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
   MockAppPtr app = CreateMockApp();
 
-  EXPECT_CALL(app_mngr_, application_by_hmi_app(_))
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(_))
       .Times(kDefaultMsgCount_)
       .WillRepeatedly(Return(app));
   ON_CALL(*app, app_id()).WillByDefault(Return(kAppId2_));
@@ -262,7 +262,7 @@ TEST_F(CommandImplTest, ReplaceHMIByMobileAppId_Map_SUCCESS) {
   UCommandImplPtr command = CreateCommand<UCommandImpl>(msg);
   MockAppPtr app = CreateMockApp();
 
-  EXPECT_CALL(app_mngr_, application_by_hmi_app(_))
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(_))
       .Times(kDefaultMsgCount_)
       .WillRepeatedly(Return(app));
   ON_CALL(*app, app_id()).WillByDefault(Return(kAppId2_));

--- a/src/components/application_manager/test/commands/command_response_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_response_impl_test.cc
@@ -77,7 +77,7 @@ TEST_F(CommandResponseImplTest, SendResponse_MessageWithResultCode_SUCCESS) {
   // then send message to mobile.
   (*msg)[strings::msg_params][strings::result_code] = kResultCode;
 
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, kFinalResponse));
 
   command->SendResponse(kSuccess, kResultCode, kFinalResponse);
 }
@@ -93,7 +93,7 @@ TEST_F(CommandResponseImplTest,
       mobile_apis::Result::eType::SUCCESS;
   const bool kFinalResponse = true;
 
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, kFinalResponse));
 
   // If `msg_params->result_code` does not exist in message
   // and arg `result_code` not equals `INVALID_ENUM`,
@@ -121,7 +121,7 @@ TEST_F(CommandResponseImplTest,
   // then set it to `msg_params->result_code` and send message to mobile.
   (*msg)[strings::params][hmi_response::code] = mobile_apis::Result::SUCCESS;
 
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, kFinalResponse));
 
   command->SendResponse(kSuccess, kResultCode, kFinalResponse);
 
@@ -146,7 +146,7 @@ TEST_F(CommandResponseImplTest,
   // then `msg_params->result_code` will be `SUCCESS`
   const bool kSuccess = true;
 
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, kFinalResponse));
 
   command->SendResponse(kSuccess, kResultCode, kFinalResponse);
 
@@ -171,7 +171,7 @@ TEST_F(CommandResponseImplTest,
   // then `msg_params->result_code` will be `INVALID_ENUM`
   const bool kSuccess = false;
 
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, kFinalResponse));
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, kFinalResponse));
 
   command->SendResponse(kSuccess, kResultCode, kFinalResponse);
 

--- a/src/components/application_manager/test/commands/hmi/dummy_hmi_commands_test.cc
+++ b/src/components/application_manager/test/commands/hmi/dummy_hmi_commands_test.cc
@@ -299,13 +299,13 @@ class HMICommandsTest : public components::commands_test::CommandRequestTest<
   void InitCommand(const uint32_t& timeout) OVERRIDE {
     stream_retry_.first = 0;
     stream_retry_.second = 0;
-    EXPECT_CALL(app_mngr_settings_, default_timeout())
+    EXPECT_CALL(mock_app_manager_settings_, default_timeout())
         .WillOnce(ReturnRef(timeout));
-    ON_CALL(app_mngr_, event_dispatcher())
+    ON_CALL(mock_app_manager_, event_dispatcher())
         .WillByDefault(ReturnRef(event_dispatcher_));
-    ON_CALL(app_mngr_, get_settings())
-        .WillByDefault(ReturnRef(app_mngr_settings_));
-    ON_CALL(app_mngr_settings_, start_stream_retry_amount())
+    ON_CALL(mock_app_manager_, get_settings())
+        .WillByDefault(ReturnRef(mock_app_manager_settings_));
+    ON_CALL(mock_app_manager_settings_, start_stream_retry_amount())
         .WillByDefault(ReturnRef(stream_retry_));
   }
 

--- a/src/components/application_manager/test/commands/hmi/get_system_info_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_system_info_request_test.cc
@@ -75,9 +75,9 @@ TEST_F(GetSystemInfoRequestTest, RUN_SendRequest_SUCCESS) {
 
   const uint32_t kAppId = command->application_id();
 
-  EXPECT_CALL(app_mngr_, set_application_id(kCorrelationId, kAppId));
+  EXPECT_CALL(mock_app_manager_, set_application_id(kCorrelationId, kAppId));
 
-  EXPECT_CALL(app_mngr_, SendMessageToHMI(command_msg));
+  EXPECT_CALL(mock_app_manager_, SendMessageToHMI(command_msg));
 
   command->Run();
 

--- a/src/components/application_manager/test/commands/hmi/get_system_info_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_system_info_response_test.cc
@@ -109,7 +109,7 @@ TEST_F(GetSystemInfoResponseTest, GetSystemInfo_SUCCESS) {
   ResponseFromHMIPtr command(CreateCommand<GetSystemInfoResponse>(command_msg));
   policy_test::MockPolicyHandlerInterface policy_handler;
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   std::string language;
@@ -119,7 +119,7 @@ TEST_F(GetSystemInfoResponseTest, GetSystemInfo_SUCCESS) {
       .WillOnce(Return(language));
   EXPECT_EQ(kLanguage, language);
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(policy_handler));
   EXPECT_CALL(policy_handler,
               OnGetSystemInfo(ccpu_version, wers_country_code, kLanguage));
@@ -137,14 +137,14 @@ TEST_F(GetSystemInfoResponseTest, GetSystemInfo_UNSUCCESS) {
   ResponseFromHMIPtr command(CreateCommand<GetSystemInfoResponse>(command_msg));
   policy_test::MockPolicyHandlerInterface policy_handler;
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities()).Times(0);
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities()).Times(0);
 
   EXPECT_CALL(*message_helper_mock_,
               CommonLanguageToString(
                   static_cast<hmi_apis::Common_Language::eType>(lang_code)))
       .Times(0);
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(policy_handler));
   EXPECT_CALL(policy_handler, OnGetSystemInfo("", "", ""));
 

--- a/src/components/application_manager/test/commands/hmi/get_urls_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_urls_response_test.cc
@@ -73,7 +73,7 @@ TEST_F(GetUrlResponseTest, RUN_SendRequest_SUCCESS) {
 
   ResponseToHMIPtr command(CreateCommand<GetUrlsResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, SendMessageToHMI(command_msg));
+  EXPECT_CALL(mock_app_manager_, SendMessageToHMI(command_msg));
 
   command->Run();
 

--- a/src/components/application_manager/test/commands/hmi/get_urls_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_urls_test.cc
@@ -90,7 +90,7 @@ class GetUrlsTest : public CommandsTest<CommandsTestMocks::kIsNice> {
   ApplicationSharedPtr app;
 
   virtual void SetUp() OVERRIDE {
-    ON_CALL(app_mngr_, GetPolicyHandler())
+    ON_CALL(mock_app_manager_, GetPolicyHandler())
         .WillByDefault(ReturnRef(policy_handler_));
     mock_policy_manager_ =
         utils::MakeShared<policy_manager_test::MockPolicyManager>();
@@ -107,12 +107,12 @@ TEST_F(GetUrlsTest, RUN_SUCCESS) {
   (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
       kInitialService;
 
-  ON_CALL(app_mngr_, event_dispatcher())
+  ON_CALL(mock_app_manager_, event_dispatcher())
       .WillByDefault(ReturnRef(mock_event_dispatcher_));
 
   RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(2);
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(2);
 
   EXPECT_CALL(policy_handler_, GetServiceUrls(kInitialService, _));
 
@@ -129,16 +129,17 @@ TEST_F(GetUrlsTest, RUN_PolicyNotEnabled_UNSUCCESS) {
   (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
       kInitialService;
 
-  ON_CALL(app_mngr_, event_dispatcher())
+  ON_CALL(mock_app_manager_, event_dispatcher())
       .WillByDefault(ReturnRef(mock_event_dispatcher_));
 
   RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
 
   EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(false));
 
-  EXPECT_CALL(app_mngr_, ManageHMICommand(command_msg)).WillOnce(Return(true));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(command_msg))
+      .WillOnce(Return(true));
 
   command->Run();
 
@@ -156,18 +157,19 @@ TEST_F(GetUrlsTest, RUN_EmptyEndpoints_UNSUCCESS) {
   (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
       kInitialService;
 
-  ON_CALL(app_mngr_, event_dispatcher())
+  ON_CALL(mock_app_manager_, event_dispatcher())
       .WillByDefault(ReturnRef(mock_event_dispatcher_));
 
   RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(2);
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(2);
 
   EXPECT_CALL(policy_handler_, GetServiceUrls(kInitialService, _));
 
   EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
 
-  EXPECT_CALL(app_mngr_, ManageHMICommand(command_msg)).WillOnce(Return(true));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(command_msg))
+      .WillOnce(Return(true));
 
   command->Run();
 
@@ -187,12 +189,12 @@ TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_SUCCESS) {
   (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
       kPolicyService;
 
-  ON_CALL(app_mngr_, event_dispatcher())
+  ON_CALL(mock_app_manager_, event_dispatcher())
       .WillByDefault(ReturnRef(mock_event_dispatcher_));
 
   RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(3);
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(3);
   EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
 
   EndpointUrls endpoints_;
@@ -208,10 +210,10 @@ TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_SUCCESS) {
   EXPECT_CALL(policy_handler_, GetAppIdForSending())
       .WillOnce(Return(kAppIdForSending));
 
-  EXPECT_CALL(app_mngr_, application(kAppIdForSending))
+  EXPECT_CALL(mock_app_manager_, application(kAppIdForSending))
       .WillOnce(Return(mock_app));
   EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kAppIdForSending));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(command_msg))
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(command_msg))
       .WillRepeatedly(Return(true));
 
   command->Run();
@@ -245,12 +247,12 @@ TEST_F(GetUrlsTest, ProcessServiceURLs_SUCCESS) {
   (*command_msg)[am::strings::msg_params][am::hmi_response::urls][0]
                 [am::hmi_response::policy_app_id].asString() = "1";
 
-  ON_CALL(app_mngr_, event_dispatcher())
+  ON_CALL(mock_app_manager_, event_dispatcher())
       .WillByDefault(ReturnRef(mock_event_dispatcher_));
 
   RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(2);
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(2);
   EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
 
   EndpointUrls endpoints_;
@@ -287,12 +289,12 @@ TEST_F(GetUrlsTest, ProcessServiceURLs_PolicyDefaultId_SUCCESS) {
   (*command_msg)[am::strings::msg_params][am::hmi_response::urls][0]
                 [am::hmi_response::policy_app_id].asString() = kDefaultId;
 
-  ON_CALL(app_mngr_, event_dispatcher())
+  ON_CALL(mock_app_manager_, event_dispatcher())
       .WillByDefault(ReturnRef(mock_event_dispatcher_));
 
   RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(2);
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(2);
   EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
 
   EndpointUrls endpoints_;

--- a/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
+++ b/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
@@ -242,15 +242,16 @@ class HMICommandsNotificationsTest
 
   void InitCommand(const uint32_t& default_timeout) OVERRIDE {
     app_ = ConfigureApp(&app_ptr_, kAppId_, NOT_MEDIA, NOT_NAVI, NOT_VC);
-    EXPECT_CALL(app_mngr_, get_settings())
-        .WillOnce(ReturnRef(app_mngr_settings_));
-    EXPECT_CALL(app_mngr_settings_, default_timeout())
+    EXPECT_CALL(mock_app_manager_, get_settings())
+        .WillOnce(ReturnRef(mock_app_manager_settings_));
+    EXPECT_CALL(mock_app_manager_settings_, default_timeout())
         .WillOnce(ReturnRef(default_timeout));
-    ON_CALL(app_mngr_, event_dispatcher())
+    ON_CALL(mock_app_manager_, event_dispatcher())
         .WillByDefault(ReturnRef(mock_event_dispatcher_));
-    ON_CALL(app_mngr_, GetPolicyHandler())
+    ON_CALL(mock_app_manager_, GetPolicyHandler())
         .WillByDefault(ReturnRef(policy_interface_));
-    ON_CALL(app_mngr_, application_by_hmi_app(_)).WillByDefault(Return(app_));
+    ON_CALL(mock_app_manager_, application_by_hmi_app(_))
+        .WillByDefault(Return(app_));
     ON_CALL(*app_ptr_, app_id()).WillByDefault(Return(kAppId_));
   }
 
@@ -374,7 +375,7 @@ TYPED_TEST(HMIOnViNotifications, CommandsSendNotificationToMobile) {
       commands_test::CommandsTest<kIsNice>::CreateMessage();
   utils::SharedPtr<typename TestFixture::CommandType> command =
       this->template CreateCommand<typename TestFixture::CommandType>(message);
-  EXPECT_CALL(commands_test::CommandsTest<kIsNice>::app_mngr_,
+  EXPECT_CALL(commands_test::CommandsTest<kIsNice>::mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   command->Run();
   EXPECT_EQ(
@@ -389,7 +390,7 @@ TYPED_TEST(HMIOnNotificationsListToHMI, CommandsSendNotificationToHmi) {
       commands_test::CommandsTest<kIsNice>::CreateMessage();
   utils::SharedPtr<typename TestFixture::CommandType> command =
       this->template CreateCommand<typename TestFixture::CommandType>(message);
-  EXPECT_CALL(commands_test::CommandsTest<kIsNice>::app_mngr_,
+  EXPECT_CALL(commands_test::CommandsTest<kIsNice>::mock_app_manager_,
               SendMessageToHMI(_));
   command->Run();
   EXPECT_EQ(
@@ -408,7 +409,7 @@ TYPED_TEST(HMIOnNotificationsEventDispatcher,
   utils::SharedPtr<typename TestFixture::CommandType::CommandType> command =
       this->template CreateCommand<
           typename TestFixture::CommandType::CommandType>(message);
-  EXPECT_CALL(commands_test::CommandsTest<kIsNice>::app_mngr_,
+  EXPECT_CALL(commands_test::CommandsTest<kIsNice>::mock_app_manager_,
               event_dispatcher())
       .WillOnce(ReturnRef(this->mock_event_dispatcher_));
   EXPECT_CALL(this->mock_event_dispatcher_, raise_event(_))
@@ -423,7 +424,7 @@ TEST_F(HMICommandsNotificationsTest, OnButtonEventSendNotificationToMobile) {
   utils::SharedPtr<Command> command =
       CreateCommand<hmi::OnButtonEventNotification>(message);
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   command->Run();
   EXPECT_EQ(static_cast<int32_t>(mobile_apis::FunctionID::OnButtonEventID),
@@ -437,7 +438,7 @@ TEST_F(HMICommandsNotificationsTest, OnNaviTBTClientSendNotificationToMobile) {
   utils::SharedPtr<Command> command =
       CreateCommand<OnNaviTBTClientStateNotification>(message);
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   command->Run();
   EXPECT_EQ(static_cast<int32_t>(mobile_apis::FunctionID::OnTBTClientStateID),
@@ -452,7 +453,7 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnNaviWayPointChangeNotification>(message);
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   command->Run();
   EXPECT_EQ(static_cast<int32_t>(mobile_apis::FunctionID::OnWayPointChangeID),
@@ -466,7 +467,7 @@ TEST_F(HMICommandsNotificationsTest, OnUICommandSendNotificationToMobile) {
   utils::SharedPtr<Command> command =
       CreateCommand<OnUICommandNotification>(message);
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   command->Run();
   EXPECT_EQ(static_cast<int32_t>(mobile_apis::FunctionID::eType::OnCommandID),
@@ -484,7 +485,7 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<hmi::OnUIKeyBoardInputNotification>(message);
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   command->Run();
   EXPECT_EQ(static_cast<int32_t>(mobile_apis::FunctionID::OnKeyboardInputID),
@@ -498,7 +499,7 @@ TEST_F(HMICommandsNotificationsTest, OnUITouchEventSendNotificationToMobile) {
   utils::SharedPtr<Command> command =
       CreateCommand<hmi::OnUITouchEventNotification>(message);
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   command->Run();
   EXPECT_EQ(static_cast<int32_t>(mobile_apis::FunctionID::OnTouchEventID),
@@ -514,8 +515,8 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnAppRegisteredNotification>(message);
 
-  EXPECT_CALL(app_mngr_, SendMessageToHMI(_));
-  EXPECT_CALL(app_mngr_, event_dispatcher());
+  EXPECT_CALL(mock_app_manager_, SendMessageToHMI(_));
+  EXPECT_CALL(mock_app_manager_, event_dispatcher());
   EXPECT_CALL(mock_event_dispatcher_, raise_event(_))
       .WillOnce(GetEventId(&event_id));
   command->Run();
@@ -537,8 +538,8 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnAppUnregisteredNotification>(message);
 
-  EXPECT_CALL(app_mngr_, SendMessageToHMI(_));
-  EXPECT_CALL(app_mngr_, event_dispatcher());
+  EXPECT_CALL(mock_app_manager_, SendMessageToHMI(_));
+  EXPECT_CALL(mock_app_manager_, event_dispatcher());
   EXPECT_CALL(mock_event_dispatcher_, raise_event(_))
       .WillOnce(GetEventId(&event_id));
   command->Run();
@@ -559,9 +560,9 @@ TEST_F(HMICommandsNotificationsTest, OnButtonPressNotificationEventDispatcher) {
   utils::SharedPtr<Command> command =
       CreateCommand<hmi::OnButtonPressNotification>(message);
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
-  EXPECT_CALL(app_mngr_, event_dispatcher());
+  EXPECT_CALL(mock_app_manager_, event_dispatcher());
   EXPECT_CALL(mock_event_dispatcher_, raise_event(_))
       .WillOnce(GetEventId(&event_id));
   command->Run();
@@ -577,8 +578,8 @@ TEST_F(HMICommandsNotificationsTest, OnReadyNotificationEventDispatcher) {
   utils::SharedPtr<Command> command =
       CreateCommand<OnReadyNotification>(message);
 
-  EXPECT_CALL(app_mngr_, OnHMIStartedCooperation());
-  EXPECT_CALL(app_mngr_, event_dispatcher());
+  EXPECT_CALL(mock_app_manager_, OnHMIStartedCooperation());
+  EXPECT_CALL(mock_app_manager_, event_dispatcher());
   EXPECT_CALL(mock_event_dispatcher_, raise_event(_))
       .WillOnce(GetEventId(&event_id));
   command->Run();
@@ -592,7 +593,7 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnIgnitionCycleOverNotification>(message);
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, OnIgnitionCycleOver());
   command->Run();
 }
@@ -601,7 +602,7 @@ TEST_F(HMICommandsNotificationsTest, OnPolicyUpdateNotificationPolicyHandler) {
   MessageSharedPtr message = CreateMessage();
   utils::SharedPtr<Command> command = CreateCommand<OnPolicyUpdate>(message);
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, OnPTExchangeNeeded());
   command->Run();
 }
@@ -619,7 +620,7 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnReceivedPolicyUpdate>(message);
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, ReceiveMessageFromSDK(kFile, data));
   command->Run();
   EXPECT_TRUE(file_system::DeleteFile(kFile));
@@ -631,7 +632,7 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnReceivedPolicyUpdate>(message);
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
   EXPECT_CALL(policy_interface_, ReceiveMessageFromSDK(_, _)).Times(0);
   command->Run();
 }
@@ -652,7 +653,7 @@ TEST_F(HMICommandsNotificationsTest,
       CreateCommand<OnAppPermissionConsentNotification>(message);
 
   int32_t connection_id = -1;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, OnAppPermissionConsent(_, _))
       .WillOnce(GetArg(&connection_id));
   command->Run();
@@ -676,7 +677,7 @@ TEST_F(HMICommandsNotificationsTest,
 
   int32_t connection_id = -1;
   policy::PermissionConsent permission_consent;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, OnAppPermissionConsent(_, _))
       .WillOnce(
           GetConnectIdPermissionConsent(&connection_id, &permission_consent));
@@ -711,7 +712,7 @@ TEST_F(HMICommandsNotificationsTest,
 
   int32_t connection_id = -1;
   policy::PermissionConsent permission_consent;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, OnAppPermissionConsent(_, _))
       .WillOnce(
           GetConnectIdPermissionConsent(&connection_id, &permission_consent));
@@ -750,7 +751,7 @@ TEST_F(HMICommandsNotificationsTest,
 
   int32_t connection_id = -1;
   policy::PermissionConsent permission_consent;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, OnAppPermissionConsent(_, _))
       .WillOnce(
           GetConnectIdPermissionConsent(&connection_id, &permission_consent));
@@ -777,7 +778,7 @@ TEST_F(HMICommandsNotificationsTest,
       CreateCommand<OnSystemErrorNotification>(message);
 
   int32_t code = hmi_apis::Common_SystemError::INVALID_ENUM;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, OnSystemError(_)).WillOnce(GetArg(&code));
   command->Run();
   EXPECT_EQ(static_cast<int32_t>(hmi_apis::Common_SystemError::SYNC_REBOOTED),
@@ -794,7 +795,7 @@ TEST_F(HMICommandsNotificationsTest,
       CreateCommand<OnSystemInfoChangedNotification>(message);
 
   EXPECT_CALL(*message_helper_mock_, CommonLanguageToString(_));
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, OnSystemInfoChanged(_));
   command->Run();
 }
@@ -809,7 +810,7 @@ TEST_F(HMICommandsNotificationsTest,
 
   bool value = false;
   std::string str;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, OnAllowSDLFunctionalityNotification(_, _))
       .WillOnce(GetBoolValueAndString(&value, &str));
   command->Run();
@@ -828,7 +829,7 @@ TEST_F(HMICommandsNotificationsTest,
 
   bool value;
   std::string str;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, OnAllowSDLFunctionalityNotification(_, _))
       .WillOnce(GetBoolValueAndString(&value, &str));
   command->Run();
@@ -844,7 +845,7 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnDeviceStateChangedNotification>(message);
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
   EXPECT_CALL(policy_interface_, RemoveDevice(_)).Times(0);
   command->Run();
 }
@@ -861,7 +862,7 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnDeviceStateChangedNotification>(message);
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, RemoveDevice(_));
   command->Run();
 }
@@ -878,7 +879,7 @@ TEST_F(HMICommandsNotificationsTest,
       CreateCommand<OnDeviceStateChangedNotification>(message);
 
   std::string device_id = "default_id";
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, RemoveDevice(_)).WillOnce(GetArg(&device_id));
   command->Run();
   EXPECT_EQ(empty_device_id, device_id);
@@ -898,7 +899,7 @@ TEST_F(HMICommandsNotificationsTest,
       CreateCommand<OnDeviceStateChangedNotification>(message);
 
   std::string device_id = "default_id";
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, RemoveDevice(_)).WillOnce(GetArg(&device_id));
   command->Run();
   EXPECT_EQ(id, device_id);
@@ -916,9 +917,9 @@ TEST_F(HMICommandsNotificationsTest,
 #if defined(OS_POSIX)
   am::mobile_api::AppInterfaceUnregisteredReason::eType mob_reason;
 
-  EXPECT_CALL(app_mngr_, SetUnregisterAllApplicationsReason(_))
+  EXPECT_CALL(mock_app_manager_, SetUnregisterAllApplicationsReason(_))
       .WillOnce(GetArg(&mob_reason));
-  EXPECT_CALL(app_mngr_, HeadUnitReset(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, HeadUnitReset(_)).Times(0);
 
   SubscribeForSignal();
   command->Run();
@@ -959,8 +960,9 @@ TEST_F(HMICommandsNotificationsTest,
     am::mobile_api::AppInterfaceUnregisteredReason::eType mob_reason =
         *it_mob_reason;
 
-    EXPECT_CALL(app_mngr_, SetUnregisterAllApplicationsReason(mob_reason));
-    EXPECT_CALL(app_mngr_, HeadUnitReset(mob_reason));
+    EXPECT_CALL(mock_app_manager_,
+                SetUnregisterAllApplicationsReason(mob_reason));
+    EXPECT_CALL(mock_app_manager_, HeadUnitReset(mob_reason));
 
     SubscribeForSignal();
     command->Run();
@@ -988,9 +990,9 @@ TEST_F(HMICommandsNotificationsTest,
       kCorrelationId_;
   MessageSharedPtr temp_message = CreateMessage();
 
-  EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())
+  EXPECT_CALL(mock_app_manager_, GetNextHMICorrelationID())
       .WillOnce(Return(kCorrelationId_));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_))
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
       .WillOnce(GetMessage(temp_message));
   command->Run();
   EXPECT_EQ(
@@ -1014,10 +1016,11 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnExitAllApplicationsNotification>(message);
 
-  EXPECT_CALL(app_mngr_, SetUnregisterAllApplicationsReason(_)).Times(0);
-  EXPECT_CALL(app_mngr_, HeadUnitReset(_)).Times(0);
-  EXPECT_CALL(app_mngr_, GetNextHMICorrelationID()).Times(0);
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, SetUnregisterAllApplicationsReason(_))
+      .Times(0);
+  EXPECT_CALL(mock_app_manager_, HeadUnitReset(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, GetNextHMICorrelationID()).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
   command->Run();
 }
 
@@ -1060,13 +1063,14 @@ TEST_F(HMICommandsNotificationsTest,
     (*notification)[am::strings::msg_params][am::strings::reason] =
         static_cast<int32_t>(*it_mobile_reason);
 
-    EXPECT_CALL(app_mngr_, application(kAppId_)).WillRepeatedly(Return(app_));
+    EXPECT_CALL(mock_app_manager_, application(kAppId_))
+        .WillRepeatedly(Return(app_));
     EXPECT_CALL(*message_helper_mock_,
                 GetOnAppInterfaceUnregisteredNotificationToMobile(
                     kAppId_, *it_mobile_reason)).WillOnce(Return(notification));
-    EXPECT_CALL(app_mngr_,
+    EXPECT_CALL(mock_app_manager_,
                 ManageMobileCommand(notification, Command::ORIGIN_SDL));
-    EXPECT_CALL(app_mngr_,
+    EXPECT_CALL(mock_app_manager_,
                 UnregisterApplication(
                     kAppId_, mobile_apis::Result::SUCCESS, false, false));
     command->Run();
@@ -1084,11 +1088,11 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnExitApplicationNotification>(message);
 
-  EXPECT_CALL(app_mngr_, application(_)).Times(0);
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
-  EXPECT_CALL(app_mngr_, UnregisterApplication(_, _, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, state_controller()).Times(0);
-  EXPECT_CALL(app_mngr_, application(kAppId_)).WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_, application(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, UnregisterApplication(_, _, _, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, state_controller()).Times(0);
+  EXPECT_CALL(mock_app_manager_, application(kAppId_)).WillOnce(Return(app_));
   command->Run();
 }
 
@@ -1100,11 +1104,12 @@ TEST_F(HMICommandsNotificationsTest, OnExitApplicationNotificationInvalidApp) {
       CreateCommand<OnExitApplicationNotification>(message);
 
   am::ApplicationSharedPtr invalid_app;
-  EXPECT_CALL(app_mngr_, application(_)).Times(0);
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
-  EXPECT_CALL(app_mngr_, UnregisterApplication(_, _, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, state_controller()).Times(0);
-  EXPECT_CALL(app_mngr_, application(kAppId_)).WillOnce(Return(invalid_app));
+  EXPECT_CALL(mock_app_manager_, application(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, UnregisterApplication(_, _, _, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, state_controller()).Times(0);
+  EXPECT_CALL(mock_app_manager_, application(kAppId_))
+      .WillOnce(Return(invalid_app));
   command->Run();
 }
 
@@ -1129,17 +1134,18 @@ TEST_F(HMICommandsNotificationsTest,
       static_cast<int32_t>(mobile_apis::AppInterfaceUnregisteredReason::
                                DRIVER_DISTRACTION_VIOLATION);
 
-  EXPECT_CALL(app_mngr_, application(kAppId_)).WillRepeatedly(Return(app_));
+  EXPECT_CALL(mock_app_manager_, application(kAppId_))
+      .WillRepeatedly(Return(app_));
   EXPECT_CALL(*message_helper_mock_,
               GetOnAppInterfaceUnregisteredNotificationToMobile(
                   kAppId_,
                   mobile_apis::AppInterfaceUnregisteredReason::
                       DRIVER_DISTRACTION_VIOLATION))
       .WillOnce(Return(notification));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(notification, Command::ORIGIN_SDL));
 
-  EXPECT_CALL(app_mngr_, state_controller())
+  EXPECT_CALL(mock_app_manager_, state_controller())
       .WillOnce(ReturnRef(mock_state_controller_));
   EXPECT_CALL(mock_state_controller_,
               SetRegularState(app_,
@@ -1172,17 +1178,19 @@ TEST_F(HMICommandsNotificationsTest,
 
   am::ApplicationSharedPtr invalid_app;
   InSequence seq;
-  EXPECT_CALL(app_mngr_, application(kAppId_)).WillRepeatedly(Return(app_));
+  EXPECT_CALL(mock_app_manager_, application(kAppId_))
+      .WillRepeatedly(Return(app_));
   EXPECT_CALL(*message_helper_mock_,
               GetOnAppInterfaceUnregisteredNotificationToMobile(
                   kAppId_,
                   mobile_apis::AppInterfaceUnregisteredReason::
                       DRIVER_DISTRACTION_VIOLATION))
       .WillOnce(Return(notification));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(notification, Command::ORIGIN_SDL));
-  EXPECT_CALL(app_mngr_, application(kAppId_)).WillOnce(Return(invalid_app));
-  EXPECT_CALL(app_mngr_, state_controller()).Times(0);
+  EXPECT_CALL(mock_app_manager_, application(kAppId_))
+      .WillOnce(Return(invalid_app));
+  EXPECT_CALL(mock_app_manager_, state_controller()).Times(0);
   command->Run();
 }
 
@@ -1195,10 +1203,11 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnExitApplicationNotification>(message);
 
-  EXPECT_CALL(app_mngr_, application(kAppId_)).WillRepeatedly(Return(app_));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
-  EXPECT_CALL(app_mngr_, UnregisterApplication(_, _, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, state_controller())
+  EXPECT_CALL(mock_app_manager_, application(kAppId_))
+      .WillRepeatedly(Return(app_));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, UnregisterApplication(_, _, _, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, state_controller())
       .WillOnce(ReturnRef(mock_state_controller_));
   EXPECT_CALL(mock_state_controller_,
               SetRegularState(app_,
@@ -1218,15 +1227,16 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnVRCommandNotification>(message);
 
-  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(app_));
-  EXPECT_CALL(app_mngr_, state_controller())
+  EXPECT_CALL(mock_app_manager_, application(_)).WillRepeatedly(Return(app_));
+  EXPECT_CALL(mock_app_manager_, state_controller())
       .WillOnce(ReturnRef(mock_state_controller_));
   EXPECT_CALL(mock_state_controller_,
               SetRegularState(_, mobile_apis::HMILevel::HMI_FULL, true));
 
-  EXPECT_CALL(app_mngr_, get_settings())
-      .WillOnce(ReturnRef(app_mngr_settings_));
-  EXPECT_CALL(app_mngr_settings_, max_cmd_id()).WillOnce(ReturnRef(max_cmd_id));
+  EXPECT_CALL(mock_app_manager_, get_settings())
+      .WillOnce(ReturnRef(mock_app_manager_settings_));
+  EXPECT_CALL(mock_app_manager_settings_, max_cmd_id())
+      .WillOnce(ReturnRef(max_cmd_id));
   command->Run();
 }
 
@@ -1241,11 +1251,13 @@ TEST_F(HMICommandsNotificationsTest,
       CreateCommand<OnVRCommandNotification>(message);
 
   am::ApplicationSharedPtr invalid_app;
-  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(invalid_app));
-  EXPECT_CALL(app_mngr_, state_controller()).Times(0);
-  EXPECT_CALL(app_mngr_, get_settings())
-      .WillOnce(ReturnRef(app_mngr_settings_));
-  EXPECT_CALL(app_mngr_settings_, max_cmd_id()).WillOnce(ReturnRef(kMaxCmdId));
+  EXPECT_CALL(mock_app_manager_, application(_))
+      .WillRepeatedly(Return(invalid_app));
+  EXPECT_CALL(mock_app_manager_, state_controller()).Times(0);
+  EXPECT_CALL(mock_app_manager_, get_settings())
+      .WillOnce(ReturnRef(mock_app_manager_settings_));
+  EXPECT_CALL(mock_app_manager_settings_, max_cmd_id())
+      .WillOnce(ReturnRef(kMaxCmdId));
   command->Run();
 }
 
@@ -1259,10 +1271,11 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnVRCommandNotification>(message);
 
-  EXPECT_CALL(app_mngr_, application(_)).Times(0);
-  EXPECT_CALL(app_mngr_settings_, max_cmd_id()).WillOnce(ReturnRef(kMaxCmdId));
-  EXPECT_CALL(app_mngr_, get_settings())
-      .WillOnce(ReturnRef(app_mngr_settings_));
+  EXPECT_CALL(mock_app_manager_, application(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_settings_, max_cmd_id())
+      .WillOnce(ReturnRef(kMaxCmdId));
+  EXPECT_CALL(mock_app_manager_, get_settings())
+      .WillOnce(ReturnRef(mock_app_manager_settings_));
   command->Run();
 }
 
@@ -1277,12 +1290,13 @@ TEST_F(HMICommandsNotificationsTest,
       CreateCommand<OnVRCommandNotification>(message);
 
   am::ApplicationSharedPtr invalid_app;
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(invalid_app));
-  EXPECT_CALL(app_mngr_settings_, max_cmd_id()).WillOnce(ReturnRef(kMaxCmdId));
-  EXPECT_CALL(app_mngr_, get_settings())
-      .WillOnce(ReturnRef(app_mngr_settings_));
-  EXPECT_CALL(app_mngr_, event_dispatcher()).Times(0);
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(invalid_app));
+  EXPECT_CALL(mock_app_manager_settings_, max_cmd_id())
+      .WillOnce(ReturnRef(kMaxCmdId));
+  EXPECT_CALL(mock_app_manager_, get_settings())
+      .WillOnce(ReturnRef(mock_app_manager_settings_));
+  EXPECT_CALL(mock_app_manager_, event_dispatcher()).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
   command->Run();
 }
 
@@ -1297,16 +1311,17 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnVRCommandNotification>(message);
 
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app_));
-  EXPECT_CALL(app_mngr_settings_, max_cmd_id()).WillOnce(ReturnRef(kMaxCmdId));
-  EXPECT_CALL(app_mngr_, get_settings())
-      .WillOnce(ReturnRef(app_mngr_settings_));
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_settings_, max_cmd_id())
+      .WillOnce(ReturnRef(kMaxCmdId));
+  EXPECT_CALL(mock_app_manager_, get_settings())
+      .WillOnce(ReturnRef(mock_app_manager_settings_));
   EXPECT_CALL(*app_ptr_, is_perform_interaction_active())
       .WillOnce(Return(kIsPerformInteractionActive));
-  EXPECT_CALL(app_mngr_, event_dispatcher());
+  EXPECT_CALL(mock_app_manager_, event_dispatcher());
   EXPECT_CALL(mock_event_dispatcher_, raise_event(_))
       .WillOnce(GetEventId(&event_id));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
   command->Run();
   EXPECT_EQ(hmi_apis::FunctionID::VR_OnCommand, event_id);
 }
@@ -1323,15 +1338,16 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnVRCommandNotification>(message);
 
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app_));
-  EXPECT_CALL(app_mngr_settings_, max_cmd_id()).WillOnce(ReturnRef(kMaxCmdId));
-  EXPECT_CALL(app_mngr_, get_settings())
-      .WillOnce(ReturnRef(app_mngr_settings_));
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_settings_, max_cmd_id())
+      .WillOnce(ReturnRef(kMaxCmdId));
+  EXPECT_CALL(mock_app_manager_, get_settings())
+      .WillOnce(ReturnRef(mock_app_manager_settings_));
   EXPECT_CALL(*app_ptr_, is_perform_interaction_active())
       .WillOnce(Return(kIsPerformInteractionActive));
 
-  EXPECT_CALL(app_mngr_, event_dispatcher()).Times(0);
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_, event_dispatcher()).Times(0);
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   command->Run();
   EXPECT_EQ(static_cast<int32_t>(mobile_apis::FunctionID::eType::OnCommandID),
@@ -1353,10 +1369,11 @@ TEST_F(HMICommandsNotificationsTest, OnVRLanguageChangeNotificationEmptyData) {
   EXPECT_CALL(mock_hmi_capabilities_, active_ui_language())
       .WillOnce(Return(hmi_apis::Common_Language::EN_AU));
   EXPECT_CALL(mock_hmi_capabilities_, set_active_vr_language(_));
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
   EXPECT_CALL(*app_ptr_, app_id()).Times(0);
   EXPECT_CALL(*app_ptr_, language()).Times(0);
   command->Run();
@@ -1371,13 +1388,14 @@ TEST_F(HMICommandsNotificationsTest,
       CreateCommand<OnVRLanguageChangeNotification>(message);
 
   application_set_.insert(app_);
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
   EXPECT_CALL(mock_hmi_capabilities_, active_ui_language())
       .WillOnce(Return(hmi_apis::Common_Language::EN_AU));
   EXPECT_CALL(mock_hmi_capabilities_, set_active_vr_language(_));
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   EXPECT_CALL(*app_ptr_, app_id()).WillOnce(Return(kAppId_));
   EXPECT_CALL(*app_ptr_, language()).WillRepeatedly(ReturnRef(kLang));
@@ -1417,17 +1435,18 @@ TEST_F(HMICommandsNotificationsTest,
       static_cast<int32_t>(
           mobile_apis::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE);
 
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
   EXPECT_CALL(mock_hmi_capabilities_, active_ui_language())
       .WillOnce(Return(hmi_apis::Common_Language::EN_AU));
   EXPECT_CALL(mock_hmi_capabilities_, set_active_vr_language(_));
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   EXPECT_CALL(*app_ptr_, app_id()).WillRepeatedly(Return(kAppId_));
   EXPECT_CALL(*app_ptr_, language()).WillRepeatedly(ReturnRef(kLang));
-  EXPECT_CALL(app_mngr_, state_controller())
+  EXPECT_CALL(mock_app_manager_, state_controller())
       .WillOnce(ReturnRef(mock_state_controller_));
   EXPECT_CALL(mock_state_controller_,
               SetRegularState(app_, mobile_apis::HMILevel::HMI_NONE, false));
@@ -1436,9 +1455,9 @@ TEST_F(HMICommandsNotificationsTest,
                   kAppId_,
                   mobile_apis::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE))
       .WillOnce(Return(notification));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(notification, Command::ORIGIN_SDL));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               UnregisterApplication(
                   kAppId_, mobile_apis::Result::SUCCESS, false, false));
   command->Run();
@@ -1459,7 +1478,7 @@ TEST_F(HMICommandsNotificationsTest, OnStartDeviceDiscoveryRun) {
   MessageSharedPtr message = CreateMessage();
   utils::SharedPtr<Command> command =
       CreateCommand<OnStartDeviceDiscovery>(message);
-  EXPECT_CALL(app_mngr_, StartDevicesDiscovery());
+  EXPECT_CALL(mock_app_manager_, StartDevicesDiscovery());
   command->Run();
 }
 
@@ -1470,7 +1489,7 @@ TEST_F(HMICommandsNotificationsTest,
             [am::strings::id] = "2014";
   utils::SharedPtr<Command> command =
       CreateCommand<OnDeviceChosenNotification>(message);
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ConnectToDevice(
                   (*message)[am::strings::msg_params][am::strings::device_info]
                             [am::strings::id].asString()));
@@ -1482,7 +1501,7 @@ TEST_F(HMICommandsNotificationsTest,
   MessageSharedPtr message = CreateMessage();
   utils::SharedPtr<Command> command =
       CreateCommand<OnDeviceChosenNotification>(message);
-  EXPECT_CALL(app_mngr_, ConnectToDevice(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ConnectToDevice(_)).Times(0);
   command->Run();
 }
 
@@ -1503,8 +1522,8 @@ TEST_F(HMICommandsNotificationsTest,
         *it;
     utils::SharedPtr<Command> command =
         CreateCommand<OnSystemContextNotification>(message);
-    EXPECT_CALL(app_mngr_, active_application()).WillOnce(Return(app_));
-    EXPECT_CALL(app_mngr_, state_controller())
+    EXPECT_CALL(mock_app_manager_, active_application()).WillOnce(Return(app_));
+    EXPECT_CALL(mock_app_manager_, state_controller())
         .WillOnce(ReturnRef(mock_state_controller_));
     EXPECT_CALL(mock_state_controller_, SetRegularState(app_, *it));
     command->Run();
@@ -1519,8 +1538,9 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnSystemContextNotification>(message);
   ApplicationSharedPtr invalid_app;
-  EXPECT_CALL(app_mngr_, active_application()).WillOnce(Return(invalid_app));
-  EXPECT_CALL(app_mngr_, state_controller()).Times(0);
+  EXPECT_CALL(mock_app_manager_, active_application())
+      .WillOnce(Return(invalid_app));
+  EXPECT_CALL(mock_app_manager_, state_controller()).Times(0);
   command->Run();
 }
 
@@ -1531,9 +1551,9 @@ TEST_F(HMICommandsNotificationsTest,
       am::mobile_api::SystemContext::INVALID_ENUM;
   utils::SharedPtr<Command> command =
       CreateCommand<OnSystemContextNotification>(message);
-  EXPECT_CALL(app_mngr_, active_application()).Times(0);
-  EXPECT_CALL(app_mngr_, application(_)).Times(0);
-  EXPECT_CALL(app_mngr_, state_controller()).Times(0);
+  EXPECT_CALL(mock_app_manager_, active_application()).Times(0);
+  EXPECT_CALL(mock_app_manager_, application(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, state_controller()).Times(0);
   command->Run();
 }
 
@@ -1552,8 +1572,8 @@ TEST_F(HMICommandsNotificationsTest,
         *it;
     utils::SharedPtr<Command> command =
         CreateCommand<OnSystemContextNotification>(message);
-    EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app_));
-    EXPECT_CALL(app_mngr_, state_controller())
+    EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+    EXPECT_CALL(mock_app_manager_, state_controller())
         .WillOnce(ReturnRef(mock_state_controller_));
     EXPECT_CALL(mock_state_controller_, SetRegularState(app_, *it));
     command->Run();
@@ -1567,8 +1587,8 @@ TEST_F(HMICommandsNotificationsTest,
       am::mobile_api::SystemContext::SYSCTXT_ALERT;
   utils::SharedPtr<Command> command =
       CreateCommand<OnSystemContextNotification>(message);
-  EXPECT_CALL(app_mngr_, application(_)).Times(0);
-  EXPECT_CALL(app_mngr_, state_controller()).Times(0);
+  EXPECT_CALL(mock_app_manager_, application(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, state_controller()).Times(0);
   command->Run();
 }
 
@@ -1579,9 +1599,9 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnSystemRequestNotification>(message);
 
-  EXPECT_CALL(app_mngr_, application(kAppId_)).WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_, application(kAppId_)).WillOnce(Return(app_));
   EXPECT_CALL(*app_ptr_, app_id()).WillOnce(Return(kAppId_));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   command->Run();
   EXPECT_EQ(static_cast<int32_t>(am::MessageType::kNotification),
@@ -1601,9 +1621,10 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnSystemRequestNotification>(message);
   ApplicationSharedPtr invalid_app;
-  EXPECT_CALL(app_mngr_, application(kAppId_)).WillOnce(Return(invalid_app));
+  EXPECT_CALL(mock_app_manager_, application(kAppId_))
+      .WillOnce(Return(invalid_app));
   EXPECT_CALL(*app_ptr_, app_id()).Times(0);
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
   command->Run();
   EXPECT_EQ(
       static_cast<int32_t>(mobile_apis::FunctionID::eType::OnSystemRequestID),
@@ -1615,11 +1636,11 @@ TEST_F(HMICommandsNotificationsTest,
   MessageSharedPtr message = CreateMessage();
   utils::SharedPtr<Command> command =
       CreateCommand<OnSystemRequestNotification>(message);
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, GetAppIdForSending())
       .WillOnce(Return(kAppId_));
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app_));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   command->Run();
   EXPECT_EQ(static_cast<int32_t>(am::MessageType::kNotification),
@@ -1638,11 +1659,11 @@ TEST_F(HMICommandsNotificationsTest,
   MessageSharedPtr message = CreateMessage();
   utils::SharedPtr<Command> command =
       CreateCommand<OnSystemRequestNotification>(message);
-  EXPECT_CALL(app_mngr_, GetPolicyHandler());
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, GetAppIdForSending())
       .WillOnce(Return(kNullApppId));
-  EXPECT_CALL(app_mngr_, application(_)).Times(0);
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, application(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
   command->Run();
 }
 
@@ -1657,10 +1678,11 @@ TEST_F(HMICommandsNotificationsTest, OnTTSLanguageChangeNotificationEmptyData) {
   EXPECT_CALL(mock_hmi_capabilities_, set_active_vr_language(_));
   EXPECT_CALL(mock_hmi_capabilities_, active_ui_language())
       .WillOnce(Return(hmi_apis::Common_Language::EN_AU));
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
   EXPECT_CALL(*app_ptr_, app_id()).Times(0);
   EXPECT_CALL(*app_ptr_, language()).Times(0);
   command->Run();
@@ -1675,14 +1697,15 @@ TEST_F(HMICommandsNotificationsTest,
       CreateCommand<OnTTSLanguageChangeNotification>(message);
 
   application_set_.insert(app_);
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
   EXPECT_CALL(mock_hmi_capabilities_, active_ui_language())
       .WillOnce(Return(hmi_apis::Common_Language::EN_AU));
   EXPECT_CALL(mock_hmi_capabilities_, set_active_vr_language(_));
   EXPECT_CALL(mock_hmi_capabilities_, set_active_tts_language(_));
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   EXPECT_CALL(*app_ptr_, app_id()).WillOnce(Return(kAppId_));
   EXPECT_CALL(*app_ptr_, language()).WillRepeatedly(ReturnRef(kLang));
@@ -1722,14 +1745,15 @@ TEST_F(HMICommandsNotificationsTest,
       static_cast<int32_t>(
           mobile_apis::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE);
 
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
   EXPECT_CALL(mock_hmi_capabilities_, active_ui_language())
       .WillOnce(Return(hmi_apis::Common_Language::EN_AU));
   EXPECT_CALL(mock_hmi_capabilities_, set_active_vr_language(_));
   EXPECT_CALL(mock_hmi_capabilities_, set_active_tts_language(_));
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   EXPECT_CALL(*app_ptr_, app_id()).WillRepeatedly(Return(kAppId_));
   EXPECT_CALL(*app_ptr_, language()).WillRepeatedly(ReturnRef(kLang));
@@ -1738,9 +1762,9 @@ TEST_F(HMICommandsNotificationsTest,
                   kAppId_,
                   mobile_apis::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE))
       .WillOnce(Return(notification));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(notification, Command::ORIGIN_SDL));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               UnregisterApplication(
                   kAppId_, mobile_apis::Result::SUCCESS, false, false));
   command->Run();
@@ -1767,10 +1791,11 @@ TEST_F(HMICommandsNotificationsTest, OnUILanguageChangeNotificationEmptyData) {
   EXPECT_CALL(mock_hmi_capabilities_, set_active_ui_language(_));
   EXPECT_CALL(mock_hmi_capabilities_, active_vr_language())
       .WillOnce(Return(hmi_apis::Common_Language::EN_AU));
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
   EXPECT_CALL(*app_ptr_, app_id()).Times(0);
   EXPECT_CALL(*app_ptr_, ui_language()).Times(0);
   command->Run();
@@ -1785,13 +1810,14 @@ TEST_F(HMICommandsNotificationsTest,
       CreateCommand<OnUILanguageChangeNotification>(message);
 
   application_set_.insert(app_);
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
   EXPECT_CALL(mock_hmi_capabilities_, active_vr_language())
       .WillOnce(Return(hmi_apis::Common_Language::EN_AU));
   EXPECT_CALL(mock_hmi_capabilities_, set_active_ui_language(_));
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   EXPECT_CALL(*app_ptr_, app_id()).WillOnce(Return(kAppId_));
   EXPECT_CALL(*app_ptr_, ui_language()).WillRepeatedly(ReturnRef(kLang));
@@ -1831,13 +1857,14 @@ TEST_F(HMICommandsNotificationsTest,
       static_cast<int32_t>(
           mobile_apis::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE);
 
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
   EXPECT_CALL(mock_hmi_capabilities_, active_vr_language())
       .WillOnce(Return(hmi_apis::Common_Language::EN_AU));
   EXPECT_CALL(mock_hmi_capabilities_, set_active_ui_language(_));
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   EXPECT_CALL(*app_ptr_, app_id()).WillRepeatedly(Return(kAppId_));
   EXPECT_CALL(*app_ptr_, ui_language()).WillRepeatedly(ReturnRef(kLang));
@@ -1846,9 +1873,9 @@ TEST_F(HMICommandsNotificationsTest,
                   kAppId_,
                   mobile_apis::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE))
       .WillOnce(Return(notification));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(notification, Command::ORIGIN_SDL));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               UnregisterApplication(
                   kAppId_, mobile_apis::Result::SUCCESS, false, false));
   command->Run();
@@ -1873,10 +1900,11 @@ TEST_F(HMICommandsNotificationsTest, OnDriverDistractionNotificationEmptyData) {
   utils::SharedPtr<Command> command =
       CreateCommand<hmi::OnDriverDistractionNotification>(message);
 
-  EXPECT_CALL(app_mngr_, set_driver_distraction(kState));
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
+  EXPECT_CALL(mock_app_manager_, set_driver_distraction(kState));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
   EXPECT_CALL(*app_ptr_, app_id()).Times(0);
   command->Run();
 }
@@ -1892,9 +1920,10 @@ TEST_F(HMICommandsNotificationsTest,
 
   ApplicationSharedPtr invalid_app;
   application_set_.insert(invalid_app);
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
   EXPECT_CALL(*app_ptr_, app_id()).Times(0);
   command->Run();
 }
@@ -1909,8 +1938,9 @@ TEST_F(HMICommandsNotificationsTest, OnDriverDistractionNotificationValidApp) {
 
   application_set_.insert(app_);
 
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL))
       .WillOnce(GetMessage(message));
   EXPECT_CALL(*app_ptr_, app_id()).WillRepeatedly(Return(kAppId_));

--- a/src/components/application_manager/test/commands/hmi/mixing_audio_supported_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/mixing_audio_supported_request_test.cc
@@ -74,7 +74,7 @@ TEST_F(MixingAudioSupportedRequestTest, RUN_SendRequest_SUCCESS) {
   RequestToHMIPtr command(
       CreateCommand<MixingAudioSupportedRequest>(command_msg));
 
-  EXPECT_CALL(app_mngr_, SendMessageToHMI(command_msg));
+  EXPECT_CALL(mock_app_manager_, SendMessageToHMI(command_msg));
 
   command->Run();
 

--- a/src/components/application_manager/test/commands/hmi/mixing_audio_supported_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/mixing_audio_supported_response_test.cc
@@ -86,7 +86,7 @@ TEST_F(MixingAudioSupportedResponseTest, RUN_SUCCESS) {
       CreateCommand<MixingAudioSupportedResponse>(command_msg));
   MockHMICapabilities mock_hmi_capabilities;
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities));
 
   const bool hmiResponse =

--- a/src/components/application_manager/test/commands/hmi/response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/response_from_hmi_test.cc
@@ -76,9 +76,9 @@ TEST_F(ResponseFromHMITest, SendResponseToMobile_SUCCESS) {
 
   MessageSharedPtr msg(CreateMessage(smart_objects::SmartType_Map));
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(msg, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(msg, _));
 
-  command->SendResponseToMobile(msg, app_mngr_);
+  command->SendResponseToMobile(msg, mock_app_manager_);
 
   const application_manager::MessageType kReceivedMessageType =
       static_cast<application_manager::MessageType>(
@@ -91,7 +91,7 @@ TEST_F(ResponseFromHMITest, CreateHMIRequest_SUCCESS) {
   ResponseFromHMIPtr command(CreateCommand<ResponseFromHMI>());
 
   MessageSharedPtr result_msg;
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_))
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
       .WillOnce(DoAll(SaveArg<0>(&result_msg), Return(true)));
 
   const hmi_apis::FunctionID::eType kPostedFunctionId =

--- a/src/components/application_manager/test/commands/hmi/sdl_get_user_friendly_message_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/sdl_get_user_friendly_message_request_test.cc
@@ -84,7 +84,7 @@ class SDLGetUserFriendlyMessageRequestTest
   void InitCommand(const uint32_t& timeout) OVERRIDE {
     CommandRequestTest<CommandsTestMocks::kIsNice>::InitCommand(timeout);
     ON_CALL((*mock_app_), app_id()).WillByDefault(Return(kAppID));
-    EXPECT_CALL(app_mngr_, application_by_hmi_app(kAppID))
+    EXPECT_CALL(mock_app_manager_, application_by_hmi_app(kAppID))
         .WillOnce(Return(mock_app_));
   }
   MockAppPtr mock_app_;
@@ -109,7 +109,7 @@ TEST_F(SDLGetUserFriendlyMessageRequestTest, Run_LanguageSet_SUCCESS) {
 
   EXPECT_CALL(mock_message_helper_, CommonLanguageToString(kLanguage))
       .WillOnce(Return(kLanguageEn));
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler_));
   std::vector<std::string> msg_codes;
   msg_codes.push_back(kLanguageDe);
@@ -134,13 +134,13 @@ TEST_F(SDLGetUserFriendlyMessageRequestTest, Run_LanguageNotSet_SUCCESS) {
       CreateCommand<SDLGetUserFriendlyMessageRequest>(msg));
 
   MockHMICapabilities mock_hmi_capabilities;
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities));
   EXPECT_CALL(mock_hmi_capabilities, active_ui_language())
       .WillOnce(Return(kLanguage));
   EXPECT_CALL(mock_message_helper_, CommonLanguageToString(kLanguage))
       .WillOnce(Return(kLanguageEn));
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler_));
   std::vector<std::string> msg_codes;
   msg_codes.push_back(kLanguageDe);
@@ -160,7 +160,7 @@ TEST_F(SDLGetUserFriendlyMessageRequestTest, Run_NoMsgCodes_Canceled) {
       CreateCommand<SDLGetUserFriendlyMessageRequest>(msg));
 
   EXPECT_CALL(mock_message_helper_, CommonLanguageToString(_)).Times(0);
-  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
   EXPECT_CALL(mock_policy_handler_, OnGetUserFriendlyMessage(_, _, _)).Times(0);
 
   command->Run();

--- a/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
@@ -223,7 +223,7 @@ TYPED_TEST(RequestToHMICommandsTest2, Run_SendMessageToHMI_SUCCESS) {
 
   SharedPtr<CommandType> command = this->template CreateCommand<CommandType>();
 
-  EXPECT_CALL(this->app_mngr_, SendMessageToHMI(NotNull()));
+  EXPECT_CALL(this->mock_app_manager_, SendMessageToHMI(NotNull()));
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
@@ -131,7 +131,7 @@ TEST_F(RequestToHMITest, SendRequest_SUCCESS) {
   SharedPtr<commands::RequestToHMI> command(
       CreateCommand<commands::RequestToHMI>());
 
-  EXPECT_CALL(app_mngr_, SendMessageToHMI(NotNull()));
+  EXPECT_CALL(mock_app_manager_, SendMessageToHMI(NotNull()));
 
   command->SendRequest();
 }
@@ -213,7 +213,7 @@ TYPED_TEST(RequestToHMICommandsTest, Run_SendMessageToHMI_SUCCESS) {
 
   SharedPtr<CommandType> command = this->template CreateCommand<CommandType>();
 
-  EXPECT_CALL(this->app_mngr_, SendMessageToHMI(NotNull()));
+  EXPECT_CALL(this->mock_app_manager_, SendMessageToHMI(NotNull()));
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
@@ -112,7 +112,7 @@ class ResponseFromHMICommandsTest
   MockEventDispatcher event_dispatcher_;
 
   ResponseFromHMICommandsTest() {
-    ON_CALL(app_mngr_, event_dispatcher())
+    ON_CALL(mock_app_manager_, event_dispatcher())
         .WillByDefault(ReturnRef(event_dispatcher_));
   }
 };
@@ -244,7 +244,7 @@ TEST_F(OtherResponseFromHMICommandsTest, VIGetVehicleTypeResponse_Run_SUCCESS) {
       CreateCommand<commands::VIGetVehicleTypeResponse>(command_msg));
 
   application_manager_test::MockHMICapabilities hmi_capabilities;
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(hmi_capabilities));
 
   EXPECT_CALL(hmi_capabilities,
@@ -261,13 +261,13 @@ TEST_F(OtherResponseFromHMICommandsTest, VIIsReadyResponse_Run_SUCCESS) {
       CreateCommand<commands::VIIsReadyResponse>(command_msg));
 
   application_manager_test::MockHMICapabilities hmi_capabilities;
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(hmi_capabilities));
 
   EXPECT_CALL(hmi_capabilities, set_is_ivi_cooperating(Eq(true)));
 
   policy_test::MockPolicyHandlerInterface policy_handler;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(policy_handler));
 
   EXPECT_CALL(policy_handler, OnVIIsReady());

--- a/src/components/application_manager/test/commands/hmi/simple_response_to_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_response_to_hmi_test.cc
@@ -74,7 +74,7 @@ TYPED_TEST(ResponseToHMICommandsTest, Run_SendMessageToHMI_SUCCESS) {
 
   SharedPtr<CommandType> command = this->template CreateCommand<CommandType>();
 
-  EXPECT_CALL(this->app_mngr_, SendMessageToHMI(NotNull()));
+  EXPECT_CALL(this->mock_app_manager_, SendMessageToHMI(NotNull()));
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/hmi/tts_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/tts_get_capabilities_response_test.cc
@@ -68,7 +68,7 @@ TEST_F(TTSGetCapabilitiesResponseTest, Run_BothExist_SUCCESS) {
   (*msg)[strings::msg_params][hmi_response::prerecorded_speech_capabilities] =
       kText;
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
   EXPECT_CALL(mock_hmi_capabilities_,
               set_speech_capabilities(SmartObject(kText)));
@@ -85,7 +85,7 @@ TEST_F(TTSGetCapabilitiesResponseTest, Run_OnlySpeech_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
   (*msg)[strings::msg_params][hmi_response::speech_capabilities] = kText;
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
   EXPECT_CALL(mock_hmi_capabilities_,
               set_speech_capabilities(SmartObject(kText)));
@@ -102,7 +102,7 @@ TEST_F(TTSGetCapabilitiesResponseTest, Run_OnlyPrerecorded_SUCCESS) {
   (*msg)[strings::msg_params][hmi_response::prerecorded_speech_capabilities] =
       kText;
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
   EXPECT_CALL(mock_hmi_capabilities_, set_speech_capabilities(_)).Times(0);
   EXPECT_CALL(mock_hmi_capabilities_,
@@ -117,7 +117,7 @@ TEST_F(TTSGetCapabilitiesResponseTest, Run_OnlyPrerecorded_SUCCESS) {
 TEST_F(TTSGetCapabilitiesResponseTest, Run_Nothing_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
   EXPECT_CALL(mock_hmi_capabilities_, set_speech_capabilities(_)).Times(0);
   EXPECT_CALL(mock_hmi_capabilities_, set_prerecorded_speech(_)).Times(0);

--- a/src/components/application_manager/test/commands/hmi/tts_get_language_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/tts_get_language_response_test.cc
@@ -69,12 +69,12 @@ TEST_F(TTSGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
       CreateCommand<TTSGetLanguageResponse>(msg));
 
   MockHMICapabilities mock_hmi_capabilities;
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities));
   EXPECT_CALL(mock_hmi_capabilities, set_active_tts_language(kLanguage));
 
   MockEventDispatcher mock_event_dispatcher;
-  EXPECT_CALL(app_mngr_, event_dispatcher())
+  EXPECT_CALL(mock_app_manager_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
 
@@ -88,13 +88,13 @@ TEST_F(TTSGetLanguageResponseTest, Run_LanguageNotSet_SUCCESS) {
       CreateCommand<TTSGetLanguageResponse>(msg));
 
   MockHMICapabilities mock_hmi_capabilities;
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities));
   EXPECT_CALL(mock_hmi_capabilities,
               set_active_tts_language(Common_Language::INVALID_ENUM));
 
   MockEventDispatcher mock_event_dispatcher;
-  EXPECT_CALL(app_mngr_, event_dispatcher())
+  EXPECT_CALL(mock_app_manager_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
 

--- a/src/components/application_manager/test/commands/hmi/tts_get_supported_languages_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/tts_get_supported_languages_response_test.cc
@@ -94,7 +94,7 @@ TEST_F(TTSGetSupportedLanguageResponseTest, RUN_SUCCESS) {
   ResponseFromHMIPtr command(
       CreateCommand<TTSGetSupportedLanguagesResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   EXPECT_CALL(mock_hmi_capabilities_,

--- a/src/components/application_manager/test/commands/hmi/tts_is_ready_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/tts_is_ready_response_test.cc
@@ -91,7 +91,7 @@ TEST_F(TTSIsReadyResponseTest, RUN_SUCCESS) {
 
   ResponseFromHMIPtr command(CreateCommand<TTSIsReadyResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   EXPECT_CALL(mock_hmi_capabilities_, set_is_tts_cooperating(kIsAvailable));
@@ -110,7 +110,7 @@ TEST_F(TTSIsReadyResponseTest, RUN_NoKeyAvailable) {
 
   ResponseFromHMIPtr command(CreateCommand<TTSIsReadyResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   EXPECT_CALL(mock_hmi_capabilities_, set_is_tts_cooperating(kIsNotAvailable));

--- a/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -95,7 +95,7 @@ TEST_F(UIGetCapabilitiesResponseTest, RUN_SetDisplay_SUCCESSS) {
   ResponseFromHMIPtr command(
       CreateCommand<UIGetCapabilitiesResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   smart_objects::SmartObject display_capabilities_so =
@@ -117,7 +117,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetSoftButton_SUCCESS) {
   ResponseFromHMIPtr command(
       CreateCommand<UIGetCapabilitiesResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   smart_objects::SmartObject soft_button_capabilities_so = (*command_msg)
@@ -139,7 +139,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetHmiZone_SUCCESS) {
   ResponseFromHMIPtr command(
       CreateCommand<UIGetCapabilitiesResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   smart_objects::SmartObject hmi_zone_capabilities_so =
@@ -159,7 +159,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetAudioPassThru_SUCCESS) {
   ResponseFromHMIPtr command(
       CreateCommand<UIGetCapabilitiesResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   smart_objects::SmartObject audio_pass_thru_capabilities_so = (*command_msg)
@@ -181,7 +181,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetNavigation_SUCCESS) {
   ResponseFromHMIPtr command(
       CreateCommand<UIGetCapabilitiesResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   smart_objects::SmartObject hmi_capabilities_so =
@@ -203,7 +203,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetPhoneCall_SUCCESS) {
   ResponseFromHMIPtr command(
       CreateCommand<UIGetCapabilitiesResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   smart_objects::SmartObject hmi_capabilities_so =

--- a/src/components/application_manager/test/commands/hmi/ui_get_language_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_language_response_test.cc
@@ -73,12 +73,12 @@ TEST_F(UIGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
       CreateCommand<UIGetLanguageResponse>(msg));
 
   MockHMICapabilities mock_hmi_capabilities;
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities));
   EXPECT_CALL(mock_hmi_capabilities, set_active_ui_language(kLanguage));
 
   MockEventDispatcher mock_event_dispatcher;
-  EXPECT_CALL(app_mngr_, event_dispatcher())
+  EXPECT_CALL(mock_app_manager_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
 
@@ -92,13 +92,13 @@ TEST_F(UIGetLanguageResponseTest, Run_LanguageNotSet_SUCCESS) {
       CreateCommand<UIGetLanguageResponse>(msg));
 
   MockHMICapabilities mock_hmi_capabilities;
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities));
   EXPECT_CALL(mock_hmi_capabilities,
               set_active_ui_language(Common_Language::INVALID_ENUM));
 
   MockEventDispatcher mock_event_dispatcher;
-  EXPECT_CALL(app_mngr_, event_dispatcher())
+  EXPECT_CALL(mock_app_manager_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
 

--- a/src/components/application_manager/test/commands/hmi/ui_get_supported_languages_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_supported_languages_response_test.cc
@@ -91,7 +91,7 @@ TEST_F(UIGetSupportedLanguagesResponseTest, RUN_SUCCESS) {
   UIGetSupportedLanguagesResponsePtr command(
       CreateCommand<UIGetSupportedLanguagesResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   EXPECT_CALL(mock_hmi_capabilities_,

--- a/src/components/application_manager/test/commands/hmi/ui_is_ready_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_is_ready_response_test.cc
@@ -83,7 +83,7 @@ TEST_F(UIIsReadyResponseTest, RUN_SUCCESS) {
 
   UIIsReadyResponsePtr command(CreateCommand<UIIsReadyResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   EXPECT_CALL(mock_hmi_capabilities_, set_is_ui_cooperating(kIsAvailable));
@@ -102,7 +102,7 @@ TEST_F(UIIsReadyResponseTest, RUN_NoKeyAvailable) {
 
   UIIsReadyResponsePtr command(CreateCommand<UIIsReadyResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   EXPECT_CALL(mock_hmi_capabilities_, set_is_ui_cooperating(kIsNotAvailable));

--- a/src/components/application_manager/test/commands/hmi/update_device_list_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/update_device_list_request_test.cc
@@ -93,20 +93,20 @@ class UpdateDeviceListRequestTest
 TEST_F(UpdateDeviceListRequestTest, RUN_LaunchHMIReturnsFalse) {
   MessageSharedPtr command_msg = CreateCommandMsg();
 
-  EXPECT_CALL(app_mngr_, event_dispatcher())
+  EXPECT_CALL(mock_app_manager_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher_));
   EXPECT_CALL(mock_event_dispatcher_, remove_observer(_));
 
   UpdateDeviceListRequestPtr command(
       CreateCommand<UpdateDeviceListRequest>(command_msg));
 
-  EXPECT_CALL(app_mngr_, get_settings()).WillOnce(ReturnRef(settings_));
+  EXPECT_CALL(mock_app_manager_, get_settings()).WillOnce(ReturnRef(settings_));
 
   EXPECT_CALL(settings_, launch_hmi()).WillOnce(Return(false));
 
-  EXPECT_CALL(app_mngr_, IsHMICooperating()).Times(0);
+  EXPECT_CALL(mock_app_manager_, IsHMICooperating()).Times(0);
 
-  EXPECT_CALL(app_mngr_, SendMessageToHMI(command_msg));
+  EXPECT_CALL(mock_app_manager_, SendMessageToHMI(command_msg));
 
   command->Run();
 
@@ -119,20 +119,20 @@ TEST_F(UpdateDeviceListRequestTest, RUN_LaunchHMIReturnsFalse) {
 TEST_F(UpdateDeviceListRequestTest, RUN_HMICooperatingReturnsTrue_SUCCESSS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
 
-  EXPECT_CALL(app_mngr_, event_dispatcher())
+  EXPECT_CALL(mock_app_manager_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher_));
   EXPECT_CALL(mock_event_dispatcher_, remove_observer(_));
 
   UpdateDeviceListRequestPtr command(
       CreateCommand<UpdateDeviceListRequest>(command_msg));
 
-  EXPECT_CALL(app_mngr_, get_settings()).WillOnce(ReturnRef(settings_));
+  EXPECT_CALL(mock_app_manager_, get_settings()).WillOnce(ReturnRef(settings_));
 
   EXPECT_CALL(settings_, launch_hmi()).WillOnce(Return(true));
 
-  EXPECT_CALL(app_mngr_, IsHMICooperating()).WillOnce(Return(true));
+  EXPECT_CALL(mock_app_manager_, IsHMICooperating()).WillOnce(Return(true));
 
-  EXPECT_CALL(app_mngr_, SendMessageToHMI(command_msg));
+  EXPECT_CALL(mock_app_manager_, SendMessageToHMI(command_msg));
 
   command->Run();
 
@@ -145,7 +145,7 @@ TEST_F(UpdateDeviceListRequestTest, RUN_HMICooperatingReturnsTrue_SUCCESSS) {
 TEST_F(UpdateDeviceListRequestTest, OnEvent_WrongEventId_UNSUCCESS) {
   Event event(Event::EventID::INVALID_ENUM);
 
-  EXPECT_CALL(app_mngr_, event_dispatcher())
+  EXPECT_CALL(mock_app_manager_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher_));
   EXPECT_CALL(mock_event_dispatcher_, remove_observer(_));
 
@@ -157,7 +157,7 @@ TEST_F(UpdateDeviceListRequestTest, OnEvent_WrongEventId_UNSUCCESS) {
 TEST_F(UpdateDeviceListRequestTest, OnEvent_SUCCESS) {
   Event event(Event::EventID::BasicCommunication_OnReady);
 
-  EXPECT_CALL(app_mngr_, event_dispatcher())
+  EXPECT_CALL(mock_app_manager_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher_));
   EXPECT_CALL(mock_event_dispatcher_, remove_observer(_, _));
 

--- a/src/components/application_manager/test/commands/hmi/update_sdl_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/update_sdl_request_test.cc
@@ -73,7 +73,7 @@ TEST_F(UpdateSDLRequestTest, RUN_SUCCESS) {
   UpdateSDLRequestPtr command(CreateCommand<UpdateSDLRequest>(command_msg));
   policy_test::MockPolicyHandlerInterface policy_handler;
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(policy_handler));
   EXPECT_CALL(policy_handler, PTExchangeAtUserRequest(kCorrelationId));
 

--- a/src/components/application_manager/test/commands/hmi/update_sdl_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/update_sdl_response_test.cc
@@ -69,7 +69,7 @@ TEST_F(UpdateSDLResponseTest, RUN_SendRequest_SUCCESS) {
 
   UpdateSDLResponsePtr command(CreateCommand<UpdateSDLResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, SendMessageToHMI(command_msg));
+  EXPECT_CALL(mock_app_manager_, SendMessageToHMI(command_msg));
 
   command->Run();
 

--- a/src/components/application_manager/test/commands/hmi/vi_get_vehicle_data_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vi_get_vehicle_data_response_test.cc
@@ -90,12 +90,12 @@ TEST_F(VIGetVehicleDataResponseTest, RUN_SUCCESS) {
   event.set_smart_object(*command_msg);
 
   policy_test::MockPolicyHandlerInterface policy_handler;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(policy_handler));
   EXPECT_CALL(policy_handler, OnVehicleDataUpdated(*command_msg));
 
   MockEventDispatcher mock_event_dispatcher;
-  EXPECT_CALL(app_mngr_, event_dispatcher())
+  EXPECT_CALL(mock_app_manager_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
 
@@ -141,7 +141,7 @@ TEST_F(VIGetVehicleDataResponseTest, ErrorResponse_SUCCESS) {
   event.set_smart_object(result);
 
   MockEventDispatcher mock_event_dispatcher;
-  EXPECT_CALL(app_mngr_, event_dispatcher())
+  EXPECT_CALL(mock_app_manager_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
 

--- a/src/components/application_manager/test/commands/hmi/vr_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_get_capabilities_response_test.cc
@@ -93,7 +93,7 @@ TEST_F(VRGetCapabilitiesResponseTest, RUN_SUCCESSS) {
   VRGetCapabilitiesResponsePtr command(
       CreateCommand<VRGetCapabilitiesResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   smart_objects::SmartObject vr_capabilities_so =

--- a/src/components/application_manager/test/commands/hmi/vr_get_language_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_get_language_response_test.cc
@@ -73,12 +73,12 @@ TEST_F(VRGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
       CreateCommand<VRGetLanguageResponse>(msg));
 
   MockHMICapabilities mock_hmi_capabilities;
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities));
   EXPECT_CALL(mock_hmi_capabilities, set_active_vr_language(kLanguage));
 
   MockEventDispatcher mock_event_dispatcher;
-  EXPECT_CALL(app_mngr_, event_dispatcher())
+  EXPECT_CALL(mock_app_manager_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
 
@@ -92,13 +92,13 @@ TEST_F(VRGetLanguageResponseTest, Run_LanguageNotSet_SUCCESS) {
       CreateCommand<VRGetLanguageResponse>(msg));
 
   MockHMICapabilities mock_hmi_capabilities;
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities));
   EXPECT_CALL(mock_hmi_capabilities,
               set_active_vr_language(Common_Language::INVALID_ENUM));
 
   MockEventDispatcher mock_event_dispatcher;
-  EXPECT_CALL(app_mngr_, event_dispatcher())
+  EXPECT_CALL(mock_app_manager_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
 

--- a/src/components/application_manager/test/commands/hmi/vr_get_supported_languages_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_get_supported_languages_response_test.cc
@@ -91,7 +91,7 @@ TEST_F(VRGetSupportedLanguagesResponseTest, RUN_SUCCESS) {
   VRGetSupportedLanguagesResponsePtr command(
       CreateCommand<VRGetSupportedLanguagesResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   EXPECT_CALL(mock_hmi_capabilities_,

--- a/src/components/application_manager/test/commands/hmi/vr_is_ready_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_is_ready_response_test.cc
@@ -83,7 +83,7 @@ TEST_F(VRIsReadyResponseTest, RUN_SUCCESS) {
 
   VRIsReadyResponsePtr command(CreateCommand<VRIsReadyResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   EXPECT_CALL(mock_hmi_capabilities_, set_is_vr_cooperating(kIsAvailable));
@@ -102,7 +102,7 @@ TEST_F(VRIsReadyResponseTest, RUN_NoKeyAvailable) {
 
   VRIsReadyResponsePtr command(CreateCommand<VRIsReadyResponse>(command_msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   EXPECT_CALL(mock_hmi_capabilities_, set_is_vr_cooperating(kIsNotAvailable));

--- a/src/components/application_manager/test/commands/mobile/add_command_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/add_command_request_test.cc
@@ -133,7 +133,7 @@ TEST_F(AddCommandRequestTest, GetRunMethods_SUCCESS) {
       CreateCommand<AddCommandRequest>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  ON_CALL(app_mngr_, application(kConnectionKey))
+  ON_CALL(mock_app_manager_, application(kConnectionKey))
       .WillByDefault(Return(mock_app));
 
   MockMessageHelper* mock_message_helper =
@@ -153,7 +153,7 @@ TEST_F(AddCommandRequestTest, GetRunMethods_SUCCESS) {
 
   MessageSharedPtr ui_command_result;
   {
-    EXPECT_CALL(app_mngr_, ManageHMICommand(_))
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
         .WillOnce(DoAll(SaveArg<0>(&ui_command_result), Return(true)));
   }
 
@@ -173,7 +173,7 @@ TEST_F(AddCommandRequestTest, OnEvent_UI_SUCCESS) {
       hmi_apis::Common_Result::SUCCESS;
 
   MockAppPtr mock_app = CreateMockApp();
-  ON_CALL(app_mngr_, application(kConnectionKey))
+  ON_CALL(mock_app_manager_, application(kConnectionKey))
       .WillByDefault(Return(mock_app));
   ON_CALL(*mock_app, app_id()).WillByDefault(Return(1));
 
@@ -198,7 +198,7 @@ TEST_F(AddCommandRequestTest, OnEvent_UI_SUCCESS) {
 
   MessageSharedPtr ui_command_result;
   {
-    EXPECT_CALL(app_mngr_, ManageHMICommand(_))
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
         .WillOnce(DoAll(SaveArg<0>(&ui_command_result), Return(true)));
   }
 
@@ -206,7 +206,7 @@ TEST_F(AddCommandRequestTest, OnEvent_UI_SUCCESS) {
 
   ASSERT_TRUE(ui_command_result);
 
-  ON_CALL(app_mngr_, application(kConnectionKey))
+  ON_CALL(mock_app_manager_, application(kConnectionKey))
       .WillByDefault(Return(mock_app));
   ON_CALL(*mock_app, app_id()).WillByDefault(Return(1));
 
@@ -226,7 +226,7 @@ TEST_F(AddCommandRequestTest, OnEvent_VR_SUCCESS) {
       CreateCommand<AddCommandRequest>(msg_vr);
 
   MockAppPtr mock_app = CreateMockApp();
-  ON_CALL(app_mngr_, application(kConnectionKey))
+  ON_CALL(mock_app_manager_, application(kConnectionKey))
       .WillByDefault(Return(mock_app));
   ON_CALL(*mock_app, app_id()).WillByDefault(Return(1));
 
@@ -259,7 +259,7 @@ TEST_F(AddCommandRequestTest, OnEvent_VR_SUCCESS) {
 
   MessageSharedPtr vr_command_result;
   {
-    EXPECT_CALL(app_mngr_, ManageHMICommand(_))
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
         .WillOnce(DoAll(SaveArg<0>(&vr_command_result), Return(true)));
   }
 
@@ -305,7 +305,7 @@ TEST_F(AddCommandRequestTest, OnEvent_BothSend_SUCCESS) {
   event_vr.set_smart_object(*msg1);
 
   MockAppPtr mock_app = CreateMockApp();
-  ON_CALL(app_mngr_, application(kConnectionKey))
+  ON_CALL(mock_app_manager_, application(kConnectionKey))
       .WillByDefault(Return(mock_app));
   ON_CALL(*mock_app, app_id()).WillByDefault(Return(1));
 
@@ -323,9 +323,9 @@ TEST_F(AddCommandRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
       CreateCommand<AddCommandRequest>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(mock_app));
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   request->on_event(event);
 }

--- a/src/components/application_manager/test/commands/mobile/add_sub_menu_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/add_sub_menu_request_test.cc
@@ -75,7 +75,7 @@ TEST_F(AddSubMenuRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
   Event event(hmi_apis::FunctionID::INVALID_ENUM);
   AddSubMenuPtr command(CreateCommand<AddSubMenuRequest>());
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   command->on_event(event);
 }
@@ -96,7 +96,8 @@ TEST_F(AddSubMenuRequestTest, OnEvent_SUCCESS) {
   AddSubMenuPtr command(CreateCommand<AddSubMenuRequest>(command_msg));
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
 
   MessageSharedPtr result_msg(
       CatchMobileCommandResult(CallOnEvent(*command, event)));
@@ -110,7 +111,7 @@ TEST_F(AddSubMenuRequestTest, OnEvent_SUCCESS) {
 TEST_F(AddSubMenuRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
   AddSubMenuPtr command(CreateCommand<AddSubMenuRequest>());
 
-  EXPECT_CALL(app_mngr_, application(_))
+  EXPECT_CALL(mock_app_manager_, application(_))
       .WillOnce(Return(ApplicationSharedPtr()));
 
   MessageSharedPtr result_msg(CatchMobileCommandResult(CallRun(*command)));
@@ -131,7 +132,8 @@ TEST_F(AddSubMenuRequestTest, Run_InvalidSubMenuId_UNSUCCESS) {
 
   MockAppPtr app(CreateMockApp());
   MessageSharedPtr dummy_sub_menu(CreateMessage(smart_objects::SmartType_Null));
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
   EXPECT_CALL(*app, FindSubMenu(kMenuId))
       .WillOnce(Return(dummy_sub_menu.get()));
 
@@ -153,7 +155,8 @@ TEST_F(AddSubMenuRequestTest, Run_DuplicatedSubMenuName_UNSUCCESS) {
 
   MockAppPtr app(CreateMockApp());
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
   EXPECT_CALL(*app, FindSubMenu(kMenuId))
       .WillOnce(Return(static_cast<SmartObject*>(NULL)));
   EXPECT_CALL(*app, IsSubMenuNameAlreadyExist(_)).WillOnce(Return(true));
@@ -177,7 +180,8 @@ TEST_F(AddSubMenuRequestTest, Run_NotValidSubMenuName_UNSUCCESS) {
   AddSubMenuPtr command(CreateCommand<AddSubMenuRequest>(command_msg));
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
   EXPECT_CALL(*app, FindSubMenu(kMenuId))
       .WillOnce(Return(static_cast<SmartObject*>(NULL)));
 
@@ -202,7 +206,8 @@ TEST_F(AddSubMenuRequestTest, Run_SUCCESS) {
   AddSubMenuPtr command(CreateCommand<AddSubMenuRequest>(command_msg));
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
   EXPECT_CALL(*app, FindSubMenu(kMenuId))
       .WillOnce(Return(static_cast<SmartObject*>(NULL)));
 

--- a/src/components/application_manager/test/commands/mobile/alert_maneuver_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/alert_maneuver_request_test.cc
@@ -68,7 +68,7 @@ class AlertManeuverRequestTest
 
 TEST_F(AlertManeuverRequestTest, Run_RequiredFieldsDoesNotExist_UNSUCCESS) {
   CommandPtr command(CreateCommand<AlertManeuverRequest>());
-  EXPECT_CALL(app_mngr_, application(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, application(_)).Times(0);
   MessageSharedPtr result_msg(CatchMobileCommandResult(CallRun(*command)));
   EXPECT_EQ(mobile_apis::Result::INVALID_DATA,
             static_cast<mobile_apis::Result::eType>(
@@ -83,7 +83,7 @@ TEST_F(AlertManeuverRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
 
   CommandPtr command(CreateCommand<AlertManeuverRequest>(msg));
 
-  ON_CALL(app_mngr_, application(_))
+  ON_CALL(mock_app_manager_, application(_))
       .WillByDefault(Return(ApplicationSharedPtr()));
 
   MessageSharedPtr result_msg(CatchMobileCommandResult(CallRun(*command)));
@@ -100,9 +100,9 @@ TEST_F(AlertManeuverRequestTest, Run_ProcessingResult_UNSUCCESS) {
   CommandPtr command(CreateCommand<AlertManeuverRequest>(msg));
 
   MockAppPtr app(CreateMockApp());
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
 
-  ON_CALL(app_mngr_, GetPolicyHandler())
+  ON_CALL(mock_app_manager_, GetPolicyHandler())
       .WillByDefault(
           ReturnRef(*static_cast<policy::PolicyHandlerInterface*>(NULL)));
 
@@ -135,7 +135,7 @@ TEST_F(AlertManeuverRequestTest, Run_IsWhiteSpaceExist_UNSUCCESS) {
   CommandPtr command(CreateCommand<AlertManeuverRequest>(msg));
 
   MockAppPtr app(CreateMockApp());
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
 
   MessageSharedPtr result_msg(CatchMobileCommandResult(CallRun(*command)));
   EXPECT_EQ(mobile_apis::Result::INVALID_DATA,
@@ -151,9 +151,9 @@ TEST_F(AlertManeuverRequestTest, Run_ProcessingResult_SUCCESS) {
   CommandPtr command(CreateCommand<AlertManeuverRequest>(msg));
 
   MockAppPtr app(CreateMockApp());
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
 
-  ON_CALL(app_mngr_, GetPolicyHandler())
+  ON_CALL(mock_app_manager_, GetPolicyHandler())
       .WillByDefault(
           ReturnRef(*static_cast<policy::PolicyHandlerInterface*>(NULL)));
 

--- a/src/components/application_manager/test/commands/mobile/alert_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/alert_request_test.cc
@@ -85,7 +85,7 @@ TEST_F(AlertRequestTest, OnTimeOut_UNSUCCESS) {
   CommandPtr command(CreateCommand<AlertRequest>(msg));
 
   command->onTimeOut();
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 }
 
 TEST_F(AlertRequestTest, OnTimeOut_SUCCESS) {
@@ -106,7 +106,7 @@ TEST_F(AlertRequestTest, OnTimeOut_SUCCESS) {
 TEST_F(AlertRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
   CommandPtr command(CreateCommand<AlertRequest>());
 
-  ON_CALL(app_mngr_, application(_))
+  ON_CALL(mock_app_manager_, application(_))
       .WillByDefault(Return(ApplicationSharedPtr()));
 
   MessageSharedPtr result_msg(CatchMobileCommandResult(CallRun(*command)));
@@ -120,7 +120,7 @@ TEST_F(AlertRequestTest, Run_AlertFrequencyIsTooHigh_UNSUCCESS) {
   CommandPtr command(CreateCommand<AlertRequest>());
 
   MockAppPtr app(CreateMockApp());
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
 
   ON_CALL(*app, hmi_level())
       .WillByDefault(Return(mobile_apis::HMILevel::HMI_BACKGROUND));
@@ -140,12 +140,12 @@ TEST_F(AlertRequestTest, Run_FailToProcessSoftButtons_UNSUCCESS) {
   CommandPtr command(CreateCommand<AlertRequest>());
 
   MockAppPtr app(CreateMockApp());
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
   ON_CALL(*app, hmi_level())
       .WillByDefault(Return(mobile_apis::HMILevel::HMI_BACKGROUND));
   ON_CALL(*app, AreCommandLimitsExceeded(_, _)).WillByDefault(Return(false));
 
-  ON_CALL(app_mngr_, GetPolicyHandler())
+  ON_CALL(mock_app_manager_, GetPolicyHandler())
       .WillByDefault(
           ReturnRef(*static_cast<policy::PolicyHandlerInterface*>(NULL)));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
@@ -162,12 +162,12 @@ TEST_F(AlertRequestTest, Run_MandatoryParametersAreMissed_UNSUCCESS) {
   CommandPtr command(CreateCommand<AlertRequest>());
 
   MockAppPtr app(CreateMockApp());
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
   ON_CALL(*app, hmi_level())
       .WillByDefault(Return(mobile_apis::HMILevel::HMI_BACKGROUND));
   ON_CALL(*app, AreCommandLimitsExceeded(_, _)).WillByDefault(Return(false));
 
-  ON_CALL(app_mngr_, GetPolicyHandler())
+  ON_CALL(mock_app_manager_, GetPolicyHandler())
       .WillByDefault(
           ReturnRef(*static_cast<policy::PolicyHandlerInterface*>(NULL)));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
@@ -190,7 +190,7 @@ TEST_F(AlertRequestTest, Run_MandatoryParametersAreInvalid_UNSUCCESS) {
   CommandPtr command(CreateCommand<AlertRequest>(msg));
 
   MockAppPtr app(CreateMockApp());
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
   ON_CALL(*app, hmi_level())
       .WillByDefault(Return(mobile_apis::HMILevel::HMI_BACKGROUND));
   ON_CALL(*app, AreCommandLimitsExceeded(_, _)).WillByDefault(Return(false));
@@ -212,19 +212,19 @@ TEST_F(AlertRequestTest, Run_SUCCESS) {
   CommandPtr command(CreateCommand<AlertRequest>(msg));
 
   MockAppPtr app(CreateMockApp());
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
   ON_CALL(*app, hmi_level())
       .WillByDefault(Return(mobile_apis::HMILevel::HMI_BACKGROUND));
   ON_CALL(*app, AreCommandLimitsExceeded(_, _)).WillByDefault(Return(false));
 
-  ON_CALL(app_mngr_, GetPolicyHandler())
+  ON_CALL(mock_app_manager_, GetPolicyHandler())
       .WillByDefault(
           ReturnRef(*static_cast<policy::PolicyHandlerInterface*>(NULL)));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               ProcessSoftButtons(_, _, _, _))
       .WillOnce(Return(mobile_apis::Result::SUCCESS));
 
-  EXPECT_CALL(this->app_mngr_, ManageHMICommand(_))
+  EXPECT_CALL(this->mock_app_manager_, ManageHMICommand(_))
       .Times(AtLeast(1))
       .WillRepeatedly(Return(true));
 

--- a/src/components/application_manager/test/commands/mobile/change_registration_test.cc
+++ b/src/components/application_manager/test/commands/mobile/change_registration_test.cc
@@ -49,7 +49,7 @@
 #include "application_manager/mock_message_helper.h"
 #include "application_manager/event_engine/event.h"
 #include "application_manager/mock_hmi_capabilities.h"
-#include "application_manager/mock_policy_handler_interface.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
 
 namespace test {
 namespace components {

--- a/src/components/application_manager/test/commands/mobile/change_registration_test.cc
+++ b/src/components/application_manager/test/commands/mobile/change_registration_test.cc
@@ -1,0 +1,627 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <vector>
+#include <string>
+#include <map>
+
+#include "mobile/change_registration_request.h"
+#include "mobile/change_registration_response.h"
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/event_engine/event.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/mock_policy_handler_interface.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::ReturnRef;
+
+namespace am = ::application_manager;
+
+using am::commands::ChangeRegistrationRequest;
+using am::commands::ChangeRegistrationResponse;
+using am::commands::MessageSharedPtr;
+using am::event_engine::Event;
+
+typedef SharedPtr<ChangeRegistrationRequest> ChangeRegistrationRequestPtr;
+typedef SharedPtr<ChangeRegistrationResponse> ChangeRegistrationResponsePtr;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+ACTION_TEMPLATE(SetArgPointer,
+                HAS_1_TEMPLATE_PARAMS(int, k),
+                AND_1_VALUE_PARAMS(vec)) {
+  *std::tr1::get<k>(args) = *vec;
+}
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const int32_t kMenuId = 5;
+const std::string kAppName1 = "app_name_1";
+const std::string kAppName2 = "app_name_2";
+const std::string kVrSynonyms1 = "vr_synonyms_1";
+const std::string kVrSynonyms2 = "vr_synonyms_2";
+}  // namespace
+
+class ChangeRegistrationRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  ChangeRegistrationRequestTest()
+      : applications_(application_set_, applications_lock_) {}
+
+  void CreateDefaultMessage(MessageSharedPtr message) {
+    (*message)[am::strings::msg_params][am::strings::app_name] = kAppName1;
+    (*message)[am::strings::params][am::strings::connection_key] =
+        kConnectionKey;
+    (*message)[am::strings::msg_params][am::strings::vr_synonyms][0] =
+        kVrSynonyms1;
+    (*message)[am::strings::msg_params][am::strings::hmi_display_language] = 1;
+  }
+
+ protected:
+  void SetUp() OVERRIDE {
+    message_ = CreateMessage();
+    command_ = CreateCommand<ChangeRegistrationRequest>(message_);
+    app_ = CreateMockApp();
+  }
+
+  ChangeRegistrationRequestPtr command_;
+  MessageSharedPtr message_;
+  MockAppPtr app_;
+
+  am::ApplicationSet application_set_;
+  sync_primitives::Lock applications_lock_;
+  DataAccessor<am::ApplicationSet> applications_;
+  MockHMICapabilities mock_hmi_capabilities_;
+  NiceMock<policy_test::MockPolicyHandlerInterface> policy_interface_;
+};
+
+class ChangeRegistrationResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(ChangeRegistrationRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
+  Event event(hmi_apis::FunctionID::INVALID_ENUM);
+  EXPECT_CALL(mock_app_manager_, application(_)).Times(0);
+  command_->on_event(event);
+}
+
+TEST_F(ChangeRegistrationRequestTest, OnEvent_InvalidApp_UNSUCCESS) {
+  std::vector<hmi_apis::FunctionID::eType> function_id_vector;
+  function_id_vector.push_back(hmi_apis::FunctionID::UI_ChangeRegistration);
+  function_id_vector.push_back(hmi_apis::FunctionID::VR_ChangeRegistration);
+  function_id_vector.push_back(hmi_apis::FunctionID::TTS_ChangeRegistration);
+
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  MockAppPtr invalid_app;
+  std::vector<hmi_apis::FunctionID::eType>::iterator it =
+      function_id_vector.begin();
+  for (; it != function_id_vector.end(); ++it) {
+    MessageSharedPtr event_message(CreateMessage());
+    (*event_message)[am::strings::params][am::hmi_response::code] = 1;
+    (*event_message)[am::strings::msg_params] = 0;
+    Event event(*it);
+    event.set_smart_object(*event_message);
+    EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+        .WillOnce(Return(invalid_app));
+    command_->on_event(event);
+  }
+}
+
+TEST_F(ChangeRegistrationRequestTest, OnEvent_ValidApp_SUCCESS) {
+  std::vector<hmi_apis::FunctionID::eType> function_id_vector;
+  function_id_vector.push_back(hmi_apis::FunctionID::UI_ChangeRegistration);
+  function_id_vector.push_back(hmi_apis::FunctionID::VR_ChangeRegistration);
+  function_id_vector.push_back(hmi_apis::FunctionID::TTS_ChangeRegistration);
+
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  std::vector<hmi_apis::FunctionID::eType>::iterator it =
+      function_id_vector.begin();
+  for (; it != function_id_vector.end(); ++it) {
+    MessageSharedPtr event_message(CreateMessage());
+    (*event_message)[am::strings::params][am::hmi_response::code] =
+        hmi_apis::Common_Result::SUCCESS;
+    (*event_message)[am::strings::msg_params] = 0;
+    Event event(*it);
+    event.set_smart_object(*event_message);
+    EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+        .WillOnce(Return(app_));
+    EXPECT_CALL(*app_, set_ui_language(_));
+    command_->on_event(event);
+    EXPECT_EQ(
+        (*message_)[am::strings::params][am::strings::function_id].asInt(),
+        static_cast<mobile_apis::FunctionID::eType>(
+            mobile_apis::FunctionID::eType::ChangeRegistrationID));
+  }
+}
+
+TEST_F(ChangeRegistrationRequestTest, Run_InvalidApp_UNSUCCESS) {
+  MockAppPtr invalid_app;
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(invalid_app));
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+  EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating()).Times(0);
+  command_->Run();
+}
+
+TEST_F(ChangeRegistrationRequestTest,
+       Run_IsWhiteSpaceExist_InvalidAppNameAndScreenName_UNSUCCESS) {
+  std::map<const std::string, const std::string> params;
+  params.insert(std::pair<std::string, std::string>(
+      std::string("appName"), std::string("application_name\n")));
+  params.insert(std::pair<std::string, std::string>(
+      std::string("ngnMediaScreenAppName"),
+      std::string("ngn_media_screen_app_name\n")));
+
+  std::map<const std::string, const std::string>::iterator it = params.begin();
+  for (; it != params.end(); ++it) {
+    MessageSharedPtr message(CreateMessage());
+    (*message)[am::strings::msg_params][(it->first).c_str()] = it->second;
+    ChangeRegistrationRequestPtr command(
+        CreateCommand<ChangeRegistrationRequest>(message));
+
+    MockAppPtr app(CreateMockApp());
+    EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app));
+    EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+        .WillOnce(ReturnRef(mock_hmi_capabilities_));
+    EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating()).Times(0);
+    command->Run();
+  }
+}
+
+TEST_F(ChangeRegistrationRequestTest,
+       Run_IsWhiteSpaceExist_InvalidTTS_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::tts_name][0]
+             [am::strings::text] = "tts_name_1\n";
+  (*message_)[am::strings::msg_params][am::strings::tts_name][1]
+             [am::strings::text] = "tts_name_2\n";
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+  EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating()).Times(0);
+  command_->Run();
+}
+
+TEST_F(ChangeRegistrationRequestTest,
+       Run_IsWhiteSpaceExist_InvalidVrSynonyms_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::vr_synonyms][0] =
+      "vr_synonyms_1\n";
+  (*message_)[am::strings::msg_params][am::strings::vr_synonyms][1] =
+      "vr_synonyms_2\n";
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+  EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating()).Times(0);
+  command_->Run();
+}
+
+TEST_F(ChangeRegistrationRequestTest,
+       Run_CheckCoincidence_InvalidAppName_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::app_name] = kAppName1;
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  const utils::custom_string::CustomString kName(kAppName1);
+  app_->set_name(kName);
+  application_set_.insert(app_);
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
+  EXPECT_CALL(*app_, name()).WillOnce(ReturnRef(kName));
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+  EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating()).Times(0);
+  command_->Run();
+}
+
+TEST_F(ChangeRegistrationRequestTest,
+       Run_CheckCoincidence_InvalidNameSynonyms_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::app_name] = kAppName1;
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  application_set_.insert(app_);
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
+
+  const utils::custom_string::CustomString kName(kAppName2);
+  EXPECT_CALL(*app_, name()).WillOnce(ReturnRef(kName));
+
+  MessageSharedPtr name_synonyms_message(CreateMessage());
+  (*name_synonyms_message)[am::strings::msg_params][am::strings::app_name][0] =
+      kAppName1;
+  smart_objects::SmartObject& name_synonyms =
+      (*name_synonyms_message)[am::strings::msg_params][am::strings::app_name];
+  EXPECT_CALL(*app_, vr_synonyms())
+      .WillOnce(
+          Return(static_cast<smart_objects::SmartObject*>(&name_synonyms)));
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+  EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating()).Times(0);
+  command_->Run();
+}
+
+TEST_F(ChangeRegistrationRequestTest,
+       Run_CheckCoincidence_InvalidVrSynonyms_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::app_name] = kAppName1;
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*message_)[am::strings::msg_params][am::strings::vr_synonyms][0] = kAppName2;
+
+  const utils::custom_string::CustomString name(kAppName2);
+  application_set_.insert(app_);
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
+  EXPECT_CALL(*app_, name()).WillOnce(ReturnRef(name));
+
+  MessageSharedPtr vr_synonyms_message(CreateMessage());
+  (*vr_synonyms_message)[am::strings::msg_params][am::strings::vr_synonyms][0] =
+      kVrSynonyms1;
+  smart_objects::SmartObject& vr_synonyms =
+      (*vr_synonyms_message)[am::strings::msg_params][am::strings::vr_synonyms];
+  EXPECT_CALL(*app_, vr_synonyms())
+      .WillOnce(Return(static_cast<smart_objects::SmartObject*>(&vr_synonyms)));
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+  EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating()).Times(0);
+  command_->Run();
+}
+
+TEST_F(ChangeRegistrationRequestTest, Run_IsLanguageSupportedByUI_UNSUCCESS) {
+  CreateDefaultMessage(message_);
+  const utils::custom_string::CustomString kName(kAppName2);
+  application_set_.insert(app_);
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
+  EXPECT_CALL(*app_, name()).WillOnce(ReturnRef(kName));
+
+  MessageSharedPtr vr_synonyms_message(CreateMessage());
+  (*vr_synonyms_message)[am::strings::msg_params][am::strings::vr_synonyms][0] =
+      kVrSynonyms2;
+  smart_objects::SmartObject& vr_synonyms =
+      (*vr_synonyms_message)[am::strings::msg_params][am::strings::vr_synonyms];
+  EXPECT_CALL(*app_, vr_synonyms())
+      .WillOnce(Return(static_cast<smart_objects::SmartObject*>(&vr_synonyms)));
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+      .WillRepeatedly(ReturnRef(mock_hmi_capabilities_));
+  smart_objects::SmartObject* ui_languages = NULL;
+  EXPECT_CALL(mock_hmi_capabilities_, ui_supported_languages())
+      .WillOnce(Return(ui_languages));
+
+  EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating())
+      .WillOnce(Return(false));
+  EXPECT_CALL(mock_hmi_capabilities_, is_vr_cooperating())
+      .WillOnce(Return(false));
+  EXPECT_CALL(mock_hmi_capabilities_, is_tts_cooperating())
+      .WillOnce(Return(false));
+  EXPECT_CALL(mock_app_manager_, GetNextHMICorrelationID()).Times(0);
+  command_->Run();
+}
+
+TEST_F(ChangeRegistrationRequestTest, Run_IsLanguageSupportedByUITrue_SUCCESS) {
+  CreateDefaultMessage(message_);
+  const utils::custom_string::CustomString kName(kAppName2);
+  application_set_.insert(app_);
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
+  EXPECT_CALL(*app_, name()).WillOnce(ReturnRef(kName));
+
+  MessageSharedPtr vr_synonyms_message(CreateMessage());
+  (*vr_synonyms_message)[am::strings::msg_params][am::strings::vr_synonyms][0] =
+      kVrSynonyms2;
+  smart_objects::SmartObject& vr_synonyms =
+      (*vr_synonyms_message)[am::strings::msg_params][am::strings::vr_synonyms];
+  EXPECT_CALL(*app_, vr_synonyms())
+      .WillOnce(Return(static_cast<smart_objects::SmartObject*>(&vr_synonyms)));
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+      .WillRepeatedly(ReturnRef(mock_hmi_capabilities_));
+
+  (*vr_synonyms_message)[am::strings::msg_params]
+                        [am::strings::hmi_display_language][0] = 1;
+  (*vr_synonyms_message)[am::strings::msg_params]
+                        [am::strings::hmi_display_language][1] = 2;
+  smart_objects::SmartObject* ui_languages =
+      &((*vr_synonyms_message)[am::strings::msg_params]
+                              [am::strings::hmi_display_language]);
+  EXPECT_CALL(mock_hmi_capabilities_, ui_supported_languages())
+      .WillOnce(Return(ui_languages));
+
+  smart_objects::SmartObject* vr_languages = NULL;
+  EXPECT_CALL(mock_hmi_capabilities_, vr_supported_languages())
+      .WillOnce(Return(vr_languages));
+
+  EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating())
+      .WillOnce(Return(false));
+  EXPECT_CALL(mock_hmi_capabilities_, is_vr_cooperating())
+      .WillOnce(Return(false));
+  EXPECT_CALL(mock_hmi_capabilities_, is_tts_cooperating())
+      .WillOnce(Return(false));
+  EXPECT_CALL(mock_app_manager_, GetNextHMICorrelationID()).Times(0);
+  command_->Run();
+}
+
+TEST_F(ChangeRegistrationRequestTest, Run_IsLanguageSupportedByVrTrue_SUCCESS) {
+  CreateDefaultMessage(message_);
+  (*message_)[am::strings::msg_params][am::strings::language] = 1;
+
+  const utils::custom_string::CustomString kName(kAppName2);
+  application_set_.insert(app_);
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
+  EXPECT_CALL(*app_, name()).WillOnce(ReturnRef(kName));
+
+  MessageSharedPtr vr_synonyms_message(CreateMessage());
+  (*vr_synonyms_message)[am::strings::msg_params][am::strings::vr_synonyms][0] =
+      kVrSynonyms2;
+  smart_objects::SmartObject& vr_synonyms =
+      (*vr_synonyms_message)[am::strings::msg_params][am::strings::vr_synonyms];
+  EXPECT_CALL(*app_, vr_synonyms())
+      .WillOnce(Return(static_cast<smart_objects::SmartObject*>(&vr_synonyms)));
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+      .WillRepeatedly(ReturnRef(mock_hmi_capabilities_));
+
+  (*vr_synonyms_message)[am::strings::msg_params]
+                        [am::strings::hmi_display_language][0] = 1;
+  (*vr_synonyms_message)[am::strings::msg_params]
+                        [am::strings::hmi_display_language][1] = 2;
+  smart_objects::SmartObject* ui_languages =
+      &((*vr_synonyms_message)[am::strings::msg_params]
+                              [am::strings::hmi_display_language]);
+  EXPECT_CALL(mock_hmi_capabilities_, ui_supported_languages())
+      .WillOnce(Return(ui_languages));
+
+  (*vr_synonyms_message)[am::strings::msg_params][am::hmi_response::languages]
+                        [0] = 1;
+  (*vr_synonyms_message)[am::strings::msg_params][am::hmi_response::languages]
+                        [1] = 2;
+  smart_objects::SmartObject* vr_languages =
+      &((*vr_synonyms_message)[am::strings::msg_params]
+                              [am::hmi_response::languages]);
+  EXPECT_CALL(mock_hmi_capabilities_, vr_supported_languages())
+      .WillOnce(Return(vr_languages));
+
+  smart_objects::SmartObject* tts_languages = NULL;
+  EXPECT_CALL(mock_hmi_capabilities_, tts_supported_languages())
+      .WillOnce(Return(tts_languages));
+  EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating())
+      .WillOnce(Return(false));
+  EXPECT_CALL(mock_hmi_capabilities_, is_vr_cooperating())
+      .WillOnce(Return(false));
+  EXPECT_CALL(mock_hmi_capabilities_, is_tts_cooperating())
+      .WillOnce(Return(false));
+  EXPECT_CALL(mock_app_manager_, GetNextHMICorrelationID()).Times(0);
+  command_->Run();
+}
+
+TEST_F(ChangeRegistrationRequestTest, Run_IsNicknameAllowedFalse_UNSUCCESS) {
+  CreateDefaultMessage(message_);
+  (*message_)[am::strings::msg_params][am::strings::language] = 1;
+
+  const utils::custom_string::CustomString kName(kAppName2);
+  application_set_.insert(app_);
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillRepeatedly(Return(app_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
+  EXPECT_CALL(*app_, name()).WillOnce(ReturnRef(kName));
+
+  MessageSharedPtr vr_synonyms_message(CreateMessage());
+  (*vr_synonyms_message)[am::strings::msg_params][am::strings::vr_synonyms][0] =
+      kVrSynonyms2;
+  smart_objects::SmartObject& vr_synonyms =
+      (*vr_synonyms_message)[am::strings::msg_params][am::strings::vr_synonyms];
+  EXPECT_CALL(*app_, vr_synonyms())
+      .WillOnce(Return(static_cast<smart_objects::SmartObject*>(&vr_synonyms)));
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+      .WillRepeatedly(ReturnRef(mock_hmi_capabilities_));
+
+  (*vr_synonyms_message)[am::strings::msg_params]
+                        [am::strings::hmi_display_language][0] = 1;
+  (*vr_synonyms_message)[am::strings::msg_params]
+                        [am::strings::hmi_display_language][1] = 2;
+  smart_objects::SmartObject* ui_languages =
+      &((*vr_synonyms_message)[am::strings::msg_params]
+                              [am::strings::hmi_display_language]);
+  EXPECT_CALL(mock_hmi_capabilities_, ui_supported_languages())
+      .WillOnce(Return(ui_languages));
+
+  (*vr_synonyms_message)[am::strings::msg_params][am::hmi_response::languages]
+                        [0] = 1;
+  (*vr_synonyms_message)[am::strings::msg_params][am::hmi_response::languages]
+                        [1] = 2;
+  smart_objects::SmartObject* vr_languages =
+      &((*vr_synonyms_message)[am::strings::msg_params]
+                              [am::hmi_response::languages]);
+  EXPECT_CALL(mock_hmi_capabilities_, vr_supported_languages())
+      .WillOnce(Return(vr_languages));
+
+  EXPECT_CALL(mock_hmi_capabilities_, tts_supported_languages())
+      .WillOnce(Return(vr_languages));
+  EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating())
+      .WillOnce(Return(false));
+  EXPECT_CALL(mock_hmi_capabilities_, is_vr_cooperating())
+      .WillOnce(Return(false));
+  EXPECT_CALL(mock_hmi_capabilities_, is_tts_cooperating())
+      .WillOnce(Return(false));
+
+  const std::string kPolicyAppId = "policy_app_id";
+  EXPECT_CALL(*app_, policy_app_id()).WillOnce(Return(kPolicyAppId));
+
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
+      .WillRepeatedly(ReturnRef(policy_interface_));
+
+  policy::StringArray app_nicknames;
+
+  app_nicknames.push_back(kPolicyAppId);
+
+  EXPECT_CALL(policy_interface_, GetInitialAppData(kPolicyAppId, _, _))
+      .WillOnce(DoAll(SetArgPointer<1>(&app_nicknames),
+                      SetArgPointer<2>(&app_nicknames),
+                      Return(true)));
+  utils::SharedPtr<usage_statistics::StatisticsManager> manager;
+  EXPECT_CALL(policy_interface_, GetStatisticManager())
+      .WillOnce(Return(manager));
+  EXPECT_CALL(mock_app_manager_, GetNextHMICorrelationID()).Times(0);
+  command_->Run();
+}
+
+TEST_F(ChangeRegistrationRequestTest, Run_SUCCESS) {
+  CreateDefaultMessage(message_);
+  (*message_)[am::strings::msg_params][am::strings::language] = 1;
+
+  (*message_)[am::strings::msg_params][am::strings::app_name] =
+      utils::custom_string::CustomString("app_name");
+  (*message_)[am::strings::msg_params][am::strings::ngn_media_screen_app_name] =
+      "ngn_media_screen_app_name";
+  (*message_)[am::strings::msg_params][am::strings::vr_synonyms][0] =
+      "vr_synonyms";
+  (*message_)[am::strings::msg_params][am::strings::tts_name][0] = "tts_name";
+
+  application_set_.insert(app_);
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillRepeatedly(Return(app_));
+  EXPECT_CALL(mock_app_manager_, applications())
+      .WillOnce(Return(applications_));
+
+  MessageSharedPtr vr_synonyms_message(CreateMessage());
+  (*vr_synonyms_message)[am::strings::msg_params][am::strings::vr_synonyms][0] =
+      kVrSynonyms2;
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+      .WillRepeatedly(ReturnRef(mock_hmi_capabilities_));
+
+  (*vr_synonyms_message)[am::strings::msg_params]
+                        [am::strings::hmi_display_language][0] = 1;
+  (*vr_synonyms_message)[am::strings::msg_params]
+                        [am::strings::hmi_display_language][1] = 2;
+  smart_objects::SmartObject* ui_languages =
+      &((*vr_synonyms_message)[am::strings::msg_params]
+                              [am::strings::hmi_display_language]);
+  EXPECT_CALL(mock_hmi_capabilities_, ui_supported_languages())
+      .WillOnce(Return(ui_languages));
+
+  (*vr_synonyms_message)[am::strings::msg_params][am::hmi_response::languages]
+                        [0] = 1;
+  (*vr_synonyms_message)[am::strings::msg_params][am::hmi_response::languages]
+                        [1] = 2;
+  smart_objects::SmartObject* vr_languages =
+      &((*vr_synonyms_message)[am::strings::msg_params]
+                              [am::hmi_response::languages]);
+  EXPECT_CALL(mock_hmi_capabilities_, vr_supported_languages())
+      .WillOnce(Return(vr_languages));
+
+  EXPECT_CALL(mock_hmi_capabilities_, tts_supported_languages())
+      .WillOnce(Return(vr_languages));
+  EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating())
+      .WillOnce(Return(false));
+  EXPECT_CALL(mock_hmi_capabilities_, is_vr_cooperating())
+      .WillOnce(Return(false));
+  EXPECT_CALL(mock_hmi_capabilities_, is_tts_cooperating())
+      .WillOnce(Return(false));
+
+  const std::string kPolicyAppId = "policy_app_id";
+  EXPECT_CALL(*app_, policy_app_id()).WillOnce(Return(kPolicyAppId));
+
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
+      .WillRepeatedly(ReturnRef(policy_interface_));
+
+  policy::StringArray app_nicknames;
+
+  EXPECT_CALL(policy_interface_, GetInitialAppData(kPolicyAppId, _, _))
+      .WillOnce(DoAll(SetArgPointer<1>(&app_nicknames),
+                      SetArgPointer<2>(&app_nicknames),
+                      Return(true)));
+  EXPECT_CALL(policy_interface_, GetStatisticManager()).Times(0);
+
+  EXPECT_CALL(*app_, app_id()).WillRepeatedly(Return(kConnectionKey));
+  EXPECT_CALL(*app_, set_name(_));
+  EXPECT_CALL(*app_, set_ngn_media_screen_name(_));
+  EXPECT_CALL(*app_, set_vr_synonyms(_));
+  EXPECT_CALL(*app_, set_tts_name(_));
+  EXPECT_CALL(mock_app_manager_, GetNextHMICorrelationID())
+      .WillRepeatedly(Return(0));
+  command_->Run();
+}
+
+TEST_F(ChangeRegistrationResponseTest, Run_SUCCESS) {
+  MessageSharedPtr message(CreateMessage());
+
+  ChangeRegistrationResponsePtr command(
+      CreateCommand<ChangeRegistrationResponse>(message));
+
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(message, false));
+  command->Run();
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/create_interaction_choice_set_test.cc
+++ b/src/components/application_manager/test/commands/mobile/create_interaction_choice_set_test.cc
@@ -47,7 +47,7 @@
 #include "application_manager/mock_message_helper.h"
 #include "application_manager/event_engine/event.h"
 #include "application_manager/mock_hmi_capabilities.h"
-#include "application_manager/mock_policy_handler_interface.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
 
 static application_manager::MockMessageHelper* message_helper_mock_;
 
@@ -190,7 +190,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   (*message_)[am::strings::msg_params][am::strings::choice_set][1]
              [am::strings::vr_commands][0] = kVrCommands1;
   (*message_)[am::strings::msg_params][am::strings::choice_set][1]
-             [am::strings::vr_commands][1] = kVrCommands2;
+             [am::strings::vr_commands][1] = " kVrCommands2\t";
 
   EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
 
@@ -201,34 +201,6 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(choice_set_id));
 
-  EXPECT_CALL(mock_app_manager_, GenerateGrammarID()).Times(0);
-  command_->Run();
-}
-
-TEST_F(CreateInteractionChoiceSetRequestTest,
-       Run_CheckChoiceSet_InvalidAmountVrCommands_UNSUCCESS) {
-  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
-             [am::strings::menu_name] = kMenuName;
-  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
-             [am::strings::image][am::strings::value] = kImage;
-  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
-             [am::strings::choice_id] = kChoiceId1;
-  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
-             [am::strings::secondary_image][am::strings::value] = kSecondImage;
-
-  FillMessageFieldsItem2(message_);
-  (*message_)[am::strings::msg_params][am::strings::choice_set][1]
-             [am::strings::vr_commands][0] = kVrCommands1;
-  (*message_)[am::strings::msg_params][am::strings::choice_set][1]
-             [am::strings::vr_commands][1] = kVrCommands2;
-
-  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
-  EXPECT_CALL(*message_helper_mock_, VerifyImage(_, _, _))
-      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
-
-  smart_objects::SmartObject* choice_set_id = NULL;
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
-      .WillOnce(Return(choice_set_id));
   EXPECT_CALL(mock_app_manager_, GenerateGrammarID()).Times(0);
   command_->Run();
 }
@@ -373,7 +345,6 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
       .WillOnce(Return(choice_set_id));
 
   EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
-  EXPECT_CALL(*app_, UpdateHash());
   command_->Run();
 }
 

--- a/src/components/application_manager/test/commands/mobile/create_interaction_choice_set_test.cc
+++ b/src/components/application_manager/test/commands/mobile/create_interaction_choice_set_test.cc
@@ -1,0 +1,612 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "mobile/create_interaction_choice_set_request.h"
+#include "mobile/create_interaction_choice_set_response.h"
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/event_engine/event.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/mock_policy_handler_interface.h"
+
+static application_manager::MockMessageHelper* message_helper_mock_;
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using ::testing::AtLeast;
+
+namespace am = ::application_manager;
+
+using am::commands::CreateInteractionChoiceSetRequest;
+using am::commands::CreateInteractionChoiceSetResponse;
+using am::commands::MessageSharedPtr;
+using am::event_engine::Event;
+using am::MockMessageHelper;
+
+typedef SharedPtr<CreateInteractionChoiceSetRequest>
+    CreateInteractionChoiceSetRequestPtr;
+typedef SharedPtr<CreateInteractionChoiceSetResponse>
+    CreateInteractionChoiceSetResponsePtr;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const uint32_t kCorrelationId = 10u;
+const uint32_t kGrammarId = 10u;
+const int32_t kMenuId = 5;
+const uint32_t kChoiceSetId = 1u;
+const uint32_t kChoiceId1 = 2u;
+const uint32_t kChoiceId2 = 3u;
+const std::string kImage = "image";
+const std::string kSecondImage = "second_image";
+const std::string kVrCommands1 = "vr_commands_1";
+const std::string kVrCommands2 = "vr_commands_2";
+const std::string kMenuName = "menu_name";
+}  // namespace
+
+class CreateInteractionChoiceSetRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ protected:
+  void SetUp() OVERRIDE {
+    message_helper_mock_ = am::MockMessageHelper::message_helper_mock();
+    message_ = CreateMessage();
+    command_ = CreateCommand<CreateInteractionChoiceSetRequest>(message_);
+    app_ = CreateMockApp();
+  }
+  CreateInteractionChoiceSetRequestPtr command_;
+  MessageSharedPtr message_;
+  MockAppPtr app_;
+
+  void FillMessageFieldsItem1(MessageSharedPtr message) {
+    (*message)[am::strings::msg_params][am::strings::choice_set][0]
+              [am::strings::menu_name] = kMenuName;
+    (*message)[am::strings::msg_params][am::strings::choice_set][0]
+              [am::strings::image][am::strings::value] = kImage;
+    (*message)[am::strings::msg_params][am::strings::choice_set][0]
+              [am::strings::choice_id] = kChoiceId1;
+    (*message)[am::strings::msg_params][am::strings::choice_set][0]
+              [am::strings::vr_commands][0] = kVrCommands1;
+    (*message)[am::strings::msg_params][am::strings::choice_set][0]
+              [am::strings::secondary_image][am::strings::value] = kSecondImage;
+  }
+  void FillMessageFieldsItem2(MessageSharedPtr message) {
+    (*message)[am::strings::msg_params][am::strings::choice_set][1]
+              [am::strings::choice_id] = kChoiceId2;
+    (*message)[am::strings::msg_params][am::strings::choice_set][1]
+              [am::strings::menu_name] = kMenuName;
+    (*message)[am::strings::msg_params][am::strings::choice_set][1]
+              [am::strings::vr_commands][0] = kVrCommands2;
+    (*message)[am::strings::msg_params]
+              [am::strings::interaction_choice_set_id] = kChoiceSetId;
+  }
+};
+
+class CreateInteractionChoiceSetResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(CreateInteractionChoiceSetRequestTest, Run_InvalidApp_UNSUCCESS) {
+  MockAppPtr invalid_app;
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(invalid_app));
+  EXPECT_CALL(mock_app_manager_, GenerateGrammarID()).Times(0);
+
+  command_->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest, Run_VerifyImageFail_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::image] = kImage;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::secondary_image] = kSecondImage;
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(*message_helper_mock_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::INVALID_DATA));
+  EXPECT_CALL(mock_app_manager_, GenerateGrammarID()).Times(0);
+
+  command_->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest, Run_FindChoiceSetFail_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::image] = kImage;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::secondary_image] = kSecondImage;
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(*message_helper_mock_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* invalid_choice_set_id =
+      &((*message_)[am::strings::msg_params]
+                   [am::strings::interaction_choice_set_id]);
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(invalid_choice_set_id));
+  EXPECT_CALL(mock_app_manager_, GenerateGrammarID()).Times(0);
+  command_->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       Run_CheckChoiceSet_InvalidChoiceId_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::menu_name] = kMenuName;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::image][am::strings::value] = kImage;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::choice_id] = kChoiceId1;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::secondary_image][am::strings::value] = kSecondImage;
+
+  FillMessageFieldsItem2(message_);
+  (*message_)[am::strings::msg_params][am::strings::choice_set][1]
+             [am::strings::vr_commands][0] = kVrCommands1;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][1]
+             [am::strings::vr_commands][1] = kVrCommands2;
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+
+  EXPECT_CALL(*message_helper_mock_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(mock_app_manager_, GenerateGrammarID()).Times(0);
+  command_->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       Run_CheckChoiceSet_InvalidAmountVrCommands_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::menu_name] = kMenuName;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::image][am::strings::value] = kImage;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::choice_id] = kChoiceId1;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::secondary_image][am::strings::value] = kSecondImage;
+
+  FillMessageFieldsItem2(message_);
+  (*message_)[am::strings::msg_params][am::strings::choice_set][1]
+             [am::strings::vr_commands][0] = kVrCommands1;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][1]
+             [am::strings::vr_commands][1] = kVrCommands2;
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(*message_helper_mock_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+  EXPECT_CALL(mock_app_manager_, GenerateGrammarID()).Times(0);
+  command_->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       Run_IsWhiteSpaceVRCommandsExist_InvalidMenuName_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::menu_name] = "menu_name\t";
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::secondary_text] = "secondary_text\t";
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::tertiary_text] = "tertiary_text\t";
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::image][am::strings::value] = "image\t";
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::choice_id] = kChoiceId1;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::secondary_image][am::strings::value] =
+                 "second_image\t";
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::vr_commands][0] = "vr_commands_1\t";
+
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillRepeatedly(Return(choice_set_id));
+  EXPECT_CALL(mock_app_manager_, application(_)).WillRepeatedly(Return(app_));
+
+  EXPECT_CALL(*message_helper_mock_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  if ((*message_)[am::strings::msg_params][am::strings::choice_set][0]
+          .keyExists(am::strings::menu_name)) {
+    CreateInteractionChoiceSetRequestPtr command(
+        CreateCommand<CreateInteractionChoiceSetRequest>(message_));
+
+    EXPECT_CALL(mock_app_manager_, GenerateGrammarID()).Times(0);
+    command->Run();
+  }
+  if ((*message_)[am::strings::msg_params][am::strings::choice_set][0]
+          .keyExists(am::strings::secondary_text)) {
+    (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+               [am::strings::menu_name] = kMenuName;
+    CreateInteractionChoiceSetRequestPtr command(
+        CreateCommand<CreateInteractionChoiceSetRequest>(message_));
+
+    EXPECT_CALL(mock_app_manager_, GenerateGrammarID()).Times(0);
+    command->Run();
+  }
+  if ((*message_)[am::strings::msg_params][am::strings::choice_set][0]
+          .keyExists(am::strings::tertiary_text)) {
+    (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+               [am::strings::secondary_text] = "secondary_text";
+    CreateInteractionChoiceSetRequestPtr command(
+        CreateCommand<CreateInteractionChoiceSetRequest>(message_));
+
+    EXPECT_CALL(mock_app_manager_, GenerateGrammarID()).Times(0);
+    command->Run();
+  }
+  if ((*message_)[am::strings::msg_params][am::strings::choice_set][0]
+          .keyExists(am::strings::vr_commands)) {
+    (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+               [am::strings::tertiary_text] = "tertiary_text";
+    CreateInteractionChoiceSetRequestPtr command(
+        CreateCommand<CreateInteractionChoiceSetRequest>(message_));
+
+    EXPECT_CALL(mock_app_manager_, GenerateGrammarID()).Times(0);
+    command->Run();
+  }
+  if ((*message_)[am::strings::msg_params][am::strings::choice_set][0]
+          .keyExists(am::strings::image)) {
+    (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+               [am::strings::vr_commands][0] = "vr_commands";
+    CreateInteractionChoiceSetRequestPtr command(
+        CreateCommand<CreateInteractionChoiceSetRequest>(message_));
+
+    EXPECT_CALL(mock_app_manager_, GenerateGrammarID()).Times(0);
+    command->Run();
+  }
+  if ((*message_)[am::strings::msg_params][am::strings::choice_set][0]
+          .keyExists(am::strings::secondary_image)) {
+    (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+               [am::strings::image][am::strings::value] = kImage;
+    CreateInteractionChoiceSetRequestPtr command(
+        CreateCommand<CreateInteractionChoiceSetRequest>(message_));
+
+    EXPECT_CALL(mock_app_manager_, GenerateGrammarID()).Times(0);
+    command->Run();
+  }
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       Run_ValidAmountVrCommands_SUCCESS) {
+  FillMessageFieldsItem1(message_);
+  FillMessageFieldsItem2(message_);
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+
+  EXPECT_CALL(*message_helper_mock_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(mock_app_manager_, GenerateGrammarID())
+      .WillOnce(Return(kGrammarId));
+  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  EXPECT_CALL(mock_app_manager_, GetNextHMICorrelationID())
+      .Times(AtLeast(2))
+      .WillOnce(Return(kConnectionKey))
+      .WillOnce(Return(kConnectionKey));
+  command_->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       Run_EmptyAmountVrCommands_SUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::menu_name] = kMenuName;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::image][am::strings::value] = kImage;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::choice_id] = kChoiceId1;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::secondary_image][am::strings::value] = kSecondImage;
+
+  (*message_)[am::strings::msg_params][am::strings::choice_set][1]
+             [am::strings::choice_id] = kChoiceId2;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][1]
+             [am::strings::menu_name] = kMenuName;
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+
+  EXPECT_CALL(*message_helper_mock_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  EXPECT_CALL(*app_, UpdateHash());
+  command_->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       OnEvent_InvalidEventId_UNSUCCESS) {
+  Event event(hmi_apis::FunctionID::INVALID_ENUM);
+
+  EXPECT_CALL(mock_app_manager_, TerminateRequest(_, _)).Times(0);
+  command_->on_event(event);
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       OnEvent_InvalidVrCommand_UNSUCCESS) {
+  Event event(hmi_apis::FunctionID::VR_AddCommand);
+
+  (*message_)[am::strings::params][am::strings::correlation_id] =
+      kCorrelationId;
+  EXPECT_CALL(mock_app_manager_, TerminateRequest(_, _)).Times(0);
+  command_->on_event(event);
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest, OnEvent_ValidVrNoError_SUCCESS) {
+  Event event(hmi_apis::FunctionID::VR_AddCommand);
+
+  (*message_)[am::strings::params][am::strings::correlation_id] =
+      kCorrelationId;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::WARNINGS;
+
+  FillMessageFieldsItem1(message_);
+  FillMessageFieldsItem2(message_);
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+
+  EXPECT_CALL(*message_helper_mock_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(mock_app_manager_, GenerateGrammarID())
+      .WillOnce(Return(kGrammarId));
+  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  ON_CALL(mock_app_manager_, GetNextHMICorrelationID())
+      .WillByDefault(Return(kCorrelationId));
+  command_->Run();
+
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _));
+  EXPECT_CALL(mock_app_manager_, TerminateRequest(_, _)).Times(0);
+  event.set_smart_object(*message_);
+
+  command_->on_event(event);
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       OnEvent_InValidVrNoError_UNSUCCESS) {
+  Event event(hmi_apis::FunctionID::VR_AddCommand);
+
+  (*message_)[am::strings::params][am::strings::correlation_id] =
+      kCorrelationId;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::INVALID_DATA;
+
+  FillMessageFieldsItem1(message_);
+  FillMessageFieldsItem2(message_);
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+
+  EXPECT_CALL(*message_helper_mock_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(mock_app_manager_, GenerateGrammarID())
+      .WillOnce(Return(kGrammarId));
+  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  ON_CALL(mock_app_manager_, GetNextHMICorrelationID())
+      .WillByDefault(Return(kCorrelationId));
+  command_->Run();
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _));
+  EXPECT_CALL(mock_app_manager_, TerminateRequest(_, _)).Times(0);
+  event.set_smart_object(*message_);
+
+  command_->on_event(event);
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       OnEvent_ValidVrNoErrorAndExpectedChoiceLessThanReceiveChoice_SUCCESS) {
+  Event event(hmi_apis::FunctionID::VR_AddCommand);
+
+  (*message_)[am::strings::params][am::strings::correlation_id] =
+      kCorrelationId;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::WARNINGS;
+
+  FillMessageFieldsItem1(message_);
+
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app_));
+
+  EXPECT_CALL(*message_helper_mock_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(mock_app_manager_, GenerateGrammarID())
+      .WillOnce(Return(kGrammarId));
+  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  ON_CALL(mock_app_manager_, GetNextHMICorrelationID())
+      .WillByDefault(Return(kCorrelationId));
+  command_->Run();
+
+  FillMessageFieldsItem2(message_);
+
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, TerminateRequest(_, _));
+  event.set_smart_object(*message_);
+  command_->on_event(event);
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       OnTimeOut_InvalidErrorFromHMI_UNSUCCESS) {
+  Event event(hmi_apis::FunctionID::VR_AddCommand);
+
+  (*message_)[am::strings::params][am::strings::correlation_id] =
+      kCorrelationId;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::SUCCESS;
+
+  FillMessageFieldsItem1(message_);
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app_));
+
+  EXPECT_CALL(*message_helper_mock_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(mock_app_manager_, GenerateGrammarID())
+      .WillOnce(Return(kGrammarId));
+  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  ON_CALL(mock_app_manager_, GetNextHMICorrelationID())
+      .WillByDefault(Return(kCorrelationId));
+  command_->Run();
+
+  FillMessageFieldsItem2(message_);
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, TerminateRequest(_, _));
+  event.set_smart_object(*message_);
+  command_->on_event(event);
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_,
+              ManageMobileCommand(_, am::commands::Command::ORIGIN_SDL))
+      .Times(2);
+  EXPECT_CALL(mock_app_manager_, TerminateRequest(_, _));
+  command_->onTimeOut();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       OnTimeOut_ValidErrorFromHMI_SUCCESS) {
+  (*message_)[am::strings::params][am::strings::correlation_id] =
+      kCorrelationId;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::INVALID_ENUM;
+
+  FillMessageFieldsItem1(message_);
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app_));
+
+  EXPECT_CALL(*message_helper_mock_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(mock_app_manager_, GenerateGrammarID())
+      .WillOnce(Return(kGrammarId));
+  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  ON_CALL(mock_app_manager_, GetNextHMICorrelationID())
+      .WillByDefault(Return(kCorrelationId));
+  command_->Run();
+
+  FillMessageFieldsItem2(message_);
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, TerminateRequest(_, _));
+  Event event(hmi_apis::FunctionID::VR_AddCommand);
+  event.set_smart_object(*message_);
+  command_->on_event(event);
+
+  EXPECT_CALL(*app_, RemoveChoiceSet(kChoiceSetId));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, TerminateRequest(_, _));
+  command_->onTimeOut();
+}
+
+TEST_F(CreateInteractionChoiceSetResponseTest, Run_SuccessFalse_UNSUCCESS) {
+  MessageSharedPtr message(CreateMessage());
+  (*message)[am::strings::msg_params][am::strings::success] = false;
+  (*message)[am::strings::msg_params][am::strings::result_code] =
+      mobile_apis::Result::INVALID_ENUM;
+  CreateInteractionChoiceSetResponsePtr command(
+      CreateCommand<CreateInteractionChoiceSetResponse>(message));
+
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(message, false));
+  command->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetResponseTest, Run_SuccessTrue_SUCCESS) {
+  MessageSharedPtr message(CreateMessage());
+  (*message)[am::strings::msg_params][am::strings::success] = true;
+  (*message)[am::strings::msg_params][am::strings::result_code] =
+      mobile_apis::Result::SUCCESS;
+  CreateInteractionChoiceSetResponsePtr command(
+      CreateCommand<CreateInteractionChoiceSetResponse>(message));
+
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(message, false));
+  command->Run();
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/delete_command_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_command_request_test.cc
@@ -72,7 +72,7 @@ class DeleteCommandRequestTest
 TEST_F(DeleteCommandRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
   DeleteCommandPtr command(CreateCommand<DeleteCommandRequest>());
 
-  EXPECT_CALL(app_mngr_, application(_))
+  EXPECT_CALL(mock_app_manager_, application(_))
       .WillOnce(Return(ApplicationSharedPtr()));
 
   MessageSharedPtr result_msg(CatchMobileCommandResult(CallRun(*command)));
@@ -95,7 +95,8 @@ TEST_F(DeleteCommandRequestTest, Run_InvalidCommandId_UNSUCCESS) {
   DeleteCommandPtr command(CreateCommand<DeleteCommandRequest>(command_msg));
 
   MockAppPtr app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
   EXPECT_CALL(*app, FindCommand(kCommandId))
       .WillOnce(Return(static_cast<SmartObject*>(NULL)));
 
@@ -119,7 +120,8 @@ TEST_F(DeleteCommandRequestTest, Run_SUCCESS) {
   DeleteCommandPtr command(CreateCommand<DeleteCommandRequest>(command_msg));
 
   MockAppPtr app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
 
   MessageSharedPtr test_msg(CreateMessage(smart_objects::SmartType_Map));
   (*test_msg)[am::strings::menu_params] = 0;
@@ -131,9 +133,9 @@ TEST_F(DeleteCommandRequestTest, Run_SUCCESS) {
   MessageSharedPtr vr_command_result;
   {
     ::testing::InSequence sequence;
-    EXPECT_CALL(app_mngr_, ManageHMICommand(_))
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
         .WillOnce(DoAll(SaveArg<0>(&menu_params_result), Return(true)));
-    EXPECT_CALL(app_mngr_, ManageHMICommand(_))
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
         .WillOnce(DoAll(SaveArg<0>(&vr_command_result), Return(true)));
   }
 
@@ -160,7 +162,7 @@ TEST_F(DeleteCommandRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
 
   DeleteCommandPtr command(CreateCommand<DeleteCommandRequest>());
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   command->on_event(event);
 }
@@ -174,7 +176,7 @@ TEST_F(DeleteCommandRequestTest, OnEvent_UiDeleteCommand_SUCCESS) {
   DeleteCommandPtr command(CreateCommand<DeleteCommandRequest>(command_msg));
 
   MockAppPtr app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillRepeatedly(Return(app));
 
   MessageSharedPtr test_msg(CreateMessage(smart_objects::SmartType_Map));
@@ -217,7 +219,7 @@ TEST_F(DeleteCommandRequestTest, OnEvent_VrDeleteCommand_SUCCESS) {
   DeleteCommandPtr command(CreateCommand<DeleteCommandRequest>(command_msg));
 
   MockAppPtr app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillRepeatedly(Return(app));
 
   MessageSharedPtr test_msg(CreateMessage(smart_objects::SmartType_Map));

--- a/src/components/application_manager/test/commands/mobile/delete_file_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_file_test.cc
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <vector>
+#include <string>
+#include <map>
+
+#include "mobile/delete_file_request.h"
+#include "mobile/delete_file_response.h"
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "utils/file_system.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/application.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/event_engine/event.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/mock_policy_handler_interface.h"
+#include "application_manager/mock_application_manager_settings.h"
+
+#include "interfaces/MOBILE_API.h"
+#include "application_manager/policies/policy_handler_interface.h"
+#include "application_manager/policies/policy_handler.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using ::testing::_;
+using ::testing::Test;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using ::testing::SetArgReferee;
+using ::testing::AtLeast;
+namespace am = ::application_manager;
+using am::commands::DeleteFileRequest;
+using am::commands::DeleteFileResponse;
+using am::commands::MessageSharedPtr;
+using am::event_engine::Event;
+using am::MockMessageHelper;
+
+typedef SharedPtr<DeleteFileRequest> DeleteFileRequestPtr;
+typedef SharedPtr<DeleteFileResponse> DeleteFileResponsePtr;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+ACTION_TEMPLATE(SetArgPointer,
+                HAS_1_TEMPLATE_PARAMS(int, k),
+                AND_1_VALUE_PARAMS(vec)) {
+  *std::tr1::get<k>(args) = *vec;
+}
+
+MATCHER_P(CheckMessageResultCode, result_code, "") {
+  return (*arg)[am::strings::msg_params][am::strings::result_code].asInt() ==
+         result_code;
+}
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const uint32_t kCorrelationId = 10u;
+const int32_t kMenuId = 5;
+}  // namespace
+
+class DeleteFileRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ protected:
+  void SetUp() OVERRIDE {
+    message_ = CreateMessage();
+    command_ = CreateCommand<DeleteFileRequest>(message_);
+    app_ = CreateMockApp();
+  }
+  DeleteFileRequestPtr command_;
+  MessageSharedPtr message_;
+  MockAppPtr app_;
+};
+
+class DeleteFileResponseTest : public CommandsTest<CommandsTestMocks::kIsNice> {
+};
+
+TEST_F(DeleteFileRequestTest, Run_InvalidApp_UNSUCCESS) {
+  MockAppPtr invalid_app;
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(invalid_app));
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL));
+  EXPECT_CALL(mock_app_manager_, get_settings()).Times(0);
+
+  command_->Run();
+}
+
+TEST_F(DeleteFileRequestTest, Run_HMILevelNone_UNSUCCESS) {
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(*app_, hmi_level())
+      .WillOnce(Return(am::mobile_api::HMILevel::HMI_NONE));
+
+  EXPECT_CALL(mock_app_manager_, get_settings())
+      .WillOnce(ReturnRef(mock_app_manager_settings_));
+  const uint32_t kNum = 0;
+  EXPECT_CALL(mock_app_manager_settings_, delete_file_in_none())
+      .WillOnce(ReturnRef(kNum));
+  EXPECT_CALL(*app_, delete_file_in_none_count()).WillOnce(Return(1));
+
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(CheckMessageResultCode(mobile_apis::Result::REJECTED),
+                          am::commands::Command::CommandOrigin::ORIGIN_SDL));
+
+  command_->Run();
+}
+
+TEST_F(DeleteFileRequestTest, Run_InvalidFileName_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::sync_file_name] =
+      "invalid_file_name/";
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(*app_, hmi_level())
+      .WillOnce(Return(am::mobile_api::HMILevel::HMI_FULL));
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(CheckMessageResultCode(mobile_apis::Result::REJECTED),
+                          am::commands::Command::CommandOrigin::ORIGIN_SDL));
+  command_->Run();
+}
+
+TEST_F(DeleteFileRequestTest, Run_ValidFileName_SUCCESS) {
+  const std::string kFileName = "test_file.txt";
+  EXPECT_TRUE(file_system::CreateFile(kFileName));
+  (*message_)[am::strings::msg_params][am::strings::sync_file_name] = kFileName;
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(*app_, hmi_level())
+      .WillOnce(Return(am::mobile_api::HMILevel::HMI_FULL));
+
+  EXPECT_CALL(mock_app_manager_, get_settings())
+      .WillOnce(ReturnRef(mock_app_manager_settings_));
+  const std::string kFullFilePath = file_system::CurrentWorkingDirectory();
+  EXPECT_CALL(mock_app_manager_settings_, app_storage_folder())
+      .WillOnce(ReturnRef(kFullFilePath));
+
+  am::AppFile kFile;
+  kFile.file_name = kFileName;
+  kFile.file_type = mobile_apis::FileType::BINARY;
+
+  EXPECT_CALL(*app_, GetFile(_)).WillOnce(Return(&kFile));
+  EXPECT_CALL(*app_, DeleteFile(_));
+  EXPECT_CALL(*app_, increment_delete_file_in_none_count());
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(CheckMessageResultCode(mobile_apis::Result::SUCCESS),
+                          am::commands::Command::CommandOrigin::ORIGIN_SDL));
+
+  command_->Run();
+}
+
+TEST_F(DeleteFileRequestTest, Run_InvalidFile_UNSUCCESS) {
+  const std::string kFileName = "test_file.txt";
+  (*message_)[am::strings::msg_params][am::strings::sync_file_name] = kFileName;
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(*app_, hmi_level())
+      .WillOnce(Return(am::mobile_api::HMILevel::HMI_FULL));
+
+  EXPECT_CALL(mock_app_manager_, get_settings())
+      .WillOnce(ReturnRef(mock_app_manager_settings_));
+  const std::string kFullFilePath = file_system::CurrentWorkingDirectory();
+  EXPECT_CALL(mock_app_manager_settings_, app_storage_folder())
+      .WillOnce(ReturnRef(kFullFilePath));
+  EXPECT_CALL(mock_app_manager_,
+              ManageMobileCommand(
+                  CheckMessageResultCode(mobile_apis::Result::INVALID_DATA),
+                  am::commands::Command::CommandOrigin::ORIGIN_SDL));
+  command_->Run();
+}
+
+TEST_F(DeleteFileResponseTest, Run_InvalidApp_UNSUCCESS) {
+  MessageSharedPtr message = CreateMessage();
+  (*message)[am::strings::params][am::strings::connection_key] = kConnectionKey;
+  DeleteFileResponsePtr command = CreateCommand<DeleteFileResponse>(message);
+  MockAppPtr invalid_app;
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(invalid_app));
+  EXPECT_CALL(
+      mock_app_manager_,
+      SendMessageToMobile(CheckMessageResultCode(
+                              mobile_apis::Result::APPLICATION_NOT_REGISTERED),
+                          false));
+
+  command->Run();
+}
+
+TEST_F(DeleteFileResponseTest, Run_ValidApp_SUCCESS) {
+  MessageSharedPtr message = CreateMessage();
+  (*message)[am::strings::params][am::strings::connection_key] = kConnectionKey;
+  (*message)[am::strings::msg_params][am::strings::success] = true;
+
+  DeleteFileResponsePtr command = CreateCommand<DeleteFileResponse>(message);
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
+  const uint32_t kAvailableDiskSpace = 10u;
+  EXPECT_CALL(*app, GetAvailableDiskSpace())
+      .WillOnce(Return(kAvailableDiskSpace));
+
+  EXPECT_CALL(mock_app_manager_,
+              SendMessageToMobile(
+                  CheckMessageResultCode(mobile_apis::Result::SUCCESS), _));
+
+  command->Run();
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/delete_file_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_file_test.cc
@@ -51,7 +51,7 @@
 #include "application_manager/mock_message_helper.h"
 #include "application_manager/event_engine/event.h"
 #include "application_manager/mock_hmi_capabilities.h"
-#include "application_manager/mock_policy_handler_interface.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
 #include "application_manager/mock_application_manager_settings.h"
 
 #include "interfaces/MOBILE_API.h"
@@ -143,20 +143,6 @@ TEST_F(DeleteFileRequestTest, Run_HMILevelNone_UNSUCCESS) {
       ManageMobileCommand(CheckMessageResultCode(mobile_apis::Result::REJECTED),
                           am::commands::Command::CommandOrigin::ORIGIN_SDL));
 
-  command_->Run();
-}
-
-TEST_F(DeleteFileRequestTest, Run_InvalidFileName_UNSUCCESS) {
-  (*message_)[am::strings::msg_params][am::strings::sync_file_name] =
-      "invalid_file_name/";
-
-  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
-  EXPECT_CALL(*app_, hmi_level())
-      .WillOnce(Return(am::mobile_api::HMILevel::HMI_FULL));
-  EXPECT_CALL(
-      mock_app_manager_,
-      ManageMobileCommand(CheckMessageResultCode(mobile_apis::Result::REJECTED),
-                          am::commands::Command::CommandOrigin::ORIGIN_SDL));
   command_->Run();
 }
 

--- a/src/components/application_manager/test/commands/mobile/delete_interaction_choice_set_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_interaction_choice_set_test.cc
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <map>
+
+#include "mobile/delete_interaction_choice_set_request.h"
+#include "mobile/delete_interaction_choice_set_response.h"
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/event_engine/event.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using ::testing::_;
+using ::testing::Mock;
+using ::testing::Return;
+using ::testing::InSequence;
+
+namespace am = ::application_manager;
+
+using am::commands::DeleteInteractionChoiceSetRequest;
+using am::commands::DeleteInteractionChoiceSetResponse;
+using am::commands::MessageSharedPtr;
+using am::event_engine::Event;
+
+typedef SharedPtr<DeleteInteractionChoiceSetRequest>
+    DeleteInteractionChoiceSetRequestPtr;
+typedef SharedPtr<DeleteInteractionChoiceSetResponse>
+    DeleteInteractionChoiceSetResponsePtr;
+
+MATCHER_P(CheckMessageSuccess, success, "") {
+  return success ==
+         (*arg)[am::strings::msg_params][am::strings::success].asBool();
+}
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const uint32_t kChoiceSetId = 11u;
+const uint32_t kChoiceId = 110u;
+const uint32_t kGrammarId = 101u;
+}  // namespace
+
+class DeleteInteractionChoiceSetRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  DeleteInteractionChoiceSetRequestTest()
+      : accessor_(choice_set_map_, performinteraction_choice_set_lock_) {}
+
+  am::PerformChoiceSetMap choice_set_map_;
+  mutable sync_primitives::Lock performinteraction_choice_set_lock_;
+  DataAccessor<am::PerformChoiceSetMap> accessor_;
+
+ protected:
+  void SetUp() OVERRIDE {
+    message_ = CreateMessage();
+    command_ = CreateCommand<DeleteInteractionChoiceSetRequest>(message_);
+    app_ = CreateMockApp();
+  }
+  DeleteInteractionChoiceSetRequestPtr command_;
+  MessageSharedPtr message_;
+  MockAppPtr app_;
+};
+
+class DeleteInteractionChoiceSetResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {
+ protected:
+  void SetUp() OVERRIDE {
+    message_ = CreateMessage();
+    command_ = CreateCommand<DeleteInteractionChoiceSetResponse>(message_);
+    app_ = CreateMockApp();
+  }
+  DeleteInteractionChoiceSetResponsePtr command_;
+  MessageSharedPtr message_;
+  MockAppPtr app_;
+};
+
+TEST_F(DeleteInteractionChoiceSetRequestTest, Run_InvalidApp_UNSUCCESS) {
+  MockAppPtr invalid_app;
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(invalid_app));
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL));
+  EXPECT_CALL(*app_, FindChoiceSet(_)).Times(0);
+  command_->Run();
+}
+
+TEST_F(DeleteInteractionChoiceSetRequestTest, Run_FindChoiceSetFail_UNSUCCESS) {
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app_));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL));
+
+  command_->Run();
+}
+
+TEST_F(DeleteInteractionChoiceSetRequestTest, Run_ChoiceSetInUse_SUCCESS) {
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app_));
+
+  smart_objects::SmartObject* choice_set_id =
+      &((*message_)[am::strings::msg_params]
+                   [am::strings::interaction_choice_set_id]);
+
+  choice_set_map_[0].insert(
+      std::make_pair(kChoiceSetId,
+                     &((*message_)[am::strings::msg_params]
+                                  [am::strings::interaction_choice_set_id])));
+
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+  EXPECT_CALL(*app_, is_perform_interaction_active()).WillOnce(Return(true));
+  EXPECT_CALL(*app_, performinteraction_choice_set_map())
+      .WillOnce(Return(accessor_));
+
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL));
+
+  command_->Run();
+}
+
+TEST_F(DeleteInteractionChoiceSetRequestTest,
+       Run_SendVrDeleteCommand_PerformInteractionFalse_UNSUCCESS) {
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+  smart_objects::SmartObject* choice_set_id =
+      &((*message_)[am::strings::msg_params]
+                   [am::strings::interaction_choice_set_id]);
+  smart_objects::SmartObject* invalid_choice_set_id = NULL;
+
+  InSequence seq;
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app_));
+
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+  EXPECT_CALL(*app_, is_perform_interaction_active()).WillOnce(Return(false));
+  EXPECT_CALL(*app_, performinteraction_choice_set_map()).Times(0);
+
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(invalid_choice_set_id));
+
+  EXPECT_CALL(*app_, app_id()).WillOnce(Return(kConnectionKey));
+  EXPECT_CALL(*app_, RemoveChoiceSet(kChoiceSetId));
+  EXPECT_CALL(*app_, UpdateHash());
+
+  command_->Run();
+  EXPECT_TRUE(Mock::VerifyAndClearExpectations(app_.get()));
+}
+
+TEST_F(DeleteInteractionChoiceSetRequestTest, Run_SendVrDeleteCommand_SUCCESS) {
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+  (*message_)[am::strings::msg_params][am::strings::grammar_id] = kGrammarId;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::choice_id] = kChoiceId;
+  smart_objects::SmartObject* choice_set_id =
+      &((*message_)[am::strings::msg_params]);
+
+  InSequence seq;
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app_));
+
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+  EXPECT_CALL(*app_, is_perform_interaction_active()).WillOnce(Return(false));
+  EXPECT_CALL(*app_, performinteraction_choice_set_map()).Times(0);
+
+  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(*app_, app_id())
+      .WillOnce(Return(kConnectionKey))
+      .WillOnce(Return(kConnectionKey));
+  EXPECT_CALL(*app_, RemoveChoiceSet(kChoiceSetId));
+  EXPECT_CALL(*app_, UpdateHash());
+
+  command_->Run();
+  EXPECT_TRUE(Mock::VerifyAndClearExpectations(app_.get()));
+}
+
+TEST_F(DeleteInteractionChoiceSetResponseTest, Run_SuccessFalse_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::success] = false;
+
+  EXPECT_CALL(mock_app_manager_,
+              SendMessageToMobile(CheckMessageSuccess(false), false));
+  command_->Run();
+}
+
+TEST_F(DeleteInteractionChoiceSetResponseTest, Run_ValidResultCode_SUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::result_code] =
+      hmi_apis::Common_Result::SUCCESS;
+
+  EXPECT_CALL(mock_app_manager_,
+              SendMessageToMobile(CheckMessageSuccess(true), false));
+  command_->Run();
+}
+
+TEST_F(DeleteInteractionChoiceSetResponseTest,
+       Run_InvalidResultCode_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::result_code] =
+      hmi_apis::Common_Result::INVALID_ENUM;
+
+  EXPECT_CALL(mock_app_manager_,
+              SendMessageToMobile(CheckMessageSuccess(false), false));
+  command_->Run();
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/delete_sub_menu_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_sub_menu_test.cc
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <map>
+
+#include "mobile/delete_sub_menu_request.h"
+#include "mobile/delete_sub_menu_response.h"
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/event_engine/event.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using ::testing::_;
+using ::testing::Mock;
+using ::testing::Return;
+using ::testing::InSequence;
+
+namespace am = ::application_manager;
+
+using am::commands::DeleteSubMenuRequest;
+using am::commands::DeleteSubMenuResponse;
+using am::commands::MessageSharedPtr;
+using am::event_engine::Event;
+
+typedef SharedPtr<DeleteSubMenuRequest> DeleteSubMenuRequestPtr;
+typedef SharedPtr<DeleteSubMenuResponse> DeleteSubMenuResponsePtr;
+
+MATCHER_P(CheckMessageResultCode, result_code, "") {
+  return (*arg)[am::strings::msg_params][am::strings::result_code].asInt() ==
+         result_code;
+}
+
+MATCHER_P(CheckMessageConnectionKey, connection_key, "") {
+  return (*arg)[am::strings::msg_params][am::strings::connection_key].asInt() ==
+         connection_key;
+}
+
+ACTION_P(DeleteCommand, commands_map) {
+  am::CommandsMap::iterator it = (*commands_map).begin();
+  if ((*commands_map).end() != it) {
+    (*commands_map).erase(it);
+  }
+}
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const uint32_t kCorrelationId = 10u;
+const uint32_t kMenuId = 100u;
+const uint32_t kGrammarId = 101u;
+const int32_t kCmdId = 102;
+}  // namespace
+
+class DeleteSubMenuRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  DeleteSubMenuRequestTest() : accessor_(commands_map_, commands_lock_) {}
+
+  am::CommandsMap commands_map_;
+  mutable sync_primitives::Lock commands_lock_;
+  DataAccessor<am::CommandsMap> accessor_;
+
+ protected:
+  void SetUp() OVERRIDE {
+    message_ = CreateMessage();
+    command_ = CreateCommand<DeleteSubMenuRequest>(message_);
+    app_ = CreateMockApp();
+  }
+  DeleteSubMenuRequestPtr command_;
+  MessageSharedPtr message_;
+  MockAppPtr app_;
+};
+
+class DeleteSubMenuResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(DeleteSubMenuRequestTest, Run_InvalidApp_UNSUCCESS) {
+  MockAppPtr invalid_app;
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(invalid_app));
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(CheckMessageResultCode(
+                              mobile_apis::Result::APPLICATION_NOT_REGISTERED),
+                          am::commands::Command::CommandOrigin::ORIGIN_SDL));
+  EXPECT_CALL(*app_, FindSubMenu(_)).Times(0);
+  command_->Run();
+}
+
+TEST_F(DeleteSubMenuRequestTest, Run_FindSubMenuFalse_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::menu_id] = kMenuId;
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  smart_objects::SmartObject* invalid_sub_menu = NULL;
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app_));
+  EXPECT_CALL(*app_, FindSubMenu(kMenuId)).WillOnce(Return(invalid_sub_menu));
+
+  EXPECT_CALL(mock_app_manager_,
+              ManageMobileCommand(
+                  CheckMessageResultCode(mobile_apis::Result::INVALID_ID),
+                  am::commands::Command::CommandOrigin::ORIGIN_SDL));
+  EXPECT_CALL(*app_, app_id()).Times(0);
+  command_->Run();
+}
+
+TEST_F(DeleteSubMenuRequestTest, Run_SendHMIRequest_SUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::menu_id] = kMenuId;
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  smart_objects::SmartObject* sub_menu =
+      &((*message_)[am::strings::msg_params][am::strings::menu_id]);
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app_));
+  EXPECT_CALL(*app_, FindSubMenu(kMenuId)).WillOnce(Return(sub_menu));
+
+  EXPECT_CALL(*app_, app_id()).WillOnce(Return(kConnectionKey));
+  EXPECT_CALL(mock_app_manager_, GetNextHMICorrelationID())
+      .WillOnce(Return(kCorrelationId));
+
+  command_->Run();
+}
+
+TEST_F(DeleteSubMenuRequestTest, OnEvent_UnknownEventId_UNSUCCESS) {
+  Event event(hmi_apis::FunctionID::INVALID_ENUM);
+  EXPECT_CALL(mock_app_manager_, application(_)).Times(0);
+  command_->on_event(event);
+}
+
+TEST_F(DeleteSubMenuRequestTest, OnEvent_InvalidApp_UNSUCCESS) {
+  Event event(hmi_apis::FunctionID::UI_DeleteSubMenu);
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      am::mobile_api::Result::SUCCESS;
+  event.set_smart_object(*message_);
+
+  MockAppPtr invalid_app;
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(invalid_app));
+  EXPECT_CALL(*app_, RemoveSubMenu(_)).Times(0);
+  command_->on_event(event);
+}
+
+TEST_F(DeleteSubMenuRequestTest, OnEvent_DeleteSubmenu_SUCCESS) {
+  Event event(hmi_apis::FunctionID::UI_DeleteSubMenu);
+  (*message_)[am::strings::msg_params][am::strings::menu_id] = kMenuId;
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*message_)[am::strings::msg_params][am::strings::vr_commands] =
+      "vr_commands";
+  (*message_)[am::strings::msg_params][am::strings::cmd_id] = kCmdId;
+  (*message_)[am::strings::msg_params][am::strings::menu_params]
+             [am::hmi_request::parent_id] = kMenuId;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      am::mobile_api::Result::SUCCESS;
+  event.set_smart_object(*message_);
+
+  commands_map_.insert(
+      std::make_pair(0, &((*message_)[am::strings::msg_params])));
+
+  InSequence seq;
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(*app_, commands_map()).WillOnce(Return(accessor_));
+  EXPECT_CALL(*app_, app_id()).WillOnce(Return(kConnectionKey));
+  EXPECT_CALL(*app_, get_grammar_id()).WillOnce(Return(kGrammarId));
+
+  EXPECT_CALL(*app_, commands_map()).WillOnce(Return(accessor_));
+  EXPECT_CALL(*app_, app_id()).WillOnce(Return(kConnectionKey));
+  EXPECT_CALL(*app_, RemoveCommand(_)).WillOnce(DeleteCommand(&commands_map_));
+
+  EXPECT_CALL(*app_, RemoveSubMenu(_));
+  EXPECT_CALL(*app_, UpdateHash());
+  command_->on_event(event);
+  EXPECT_TRUE(Mock::VerifyAndClearExpectations(app_.get()));
+}
+
+TEST_F(DeleteSubMenuResponseTest, Run_SUCCESS) {
+  MessageSharedPtr message(CreateMessage());
+  (*message)[am::strings::msg_params][am::strings::connection_key] =
+      kConnectionKey;
+  DeleteSubMenuResponsePtr command(
+      CreateCommand<DeleteSubMenuResponse>(message));
+  EXPECT_CALL(
+      mock_app_manager_,
+      SendMessageToMobile(CheckMessageConnectionKey(kConnectionKey), _));
+  command->Run();
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/diagnostic_message_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/diagnostic_message_request_test.cc
@@ -79,11 +79,11 @@ TEST_F(DiagnosticMessageRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
   DiagnosticMessageRequestPtr command(
       CreateCommand<DiagnosticMessageRequest>(command_msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(ApplicationSharedPtr()));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
 
@@ -101,17 +101,18 @@ TEST_F(DiagnosticMessageRequestTest, Run_NotSupportedDiagnosticMode_UNSUCCESS) {
       CreateCommand<DiagnosticMessageRequest>(command_msg));
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
 
-  EXPECT_CALL(app_mngr_, get_settings())
-      .WillOnce(ReturnRef(app_mngr_settings_));
+  EXPECT_CALL(mock_app_manager_, get_settings())
+      .WillOnce(ReturnRef(mock_app_manager_settings_));
 
   const std::vector<uint32_t> empty_supported_diag_modes;
-  EXPECT_CALL(app_mngr_settings_, supported_diag_modes())
+  EXPECT_CALL(mock_app_manager_settings_, supported_diag_modes())
       .WillOnce(ReturnRef(empty_supported_diag_modes));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::REJECTED), _));
 
   command->Run();
@@ -128,18 +129,19 @@ TEST_F(DiagnosticMessageRequestTest, Run_SUCCESS) {
       CreateCommand<DiagnosticMessageRequest>(command_msg));
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
 
-  EXPECT_CALL(app_mngr_, get_settings())
-      .WillOnce(ReturnRef(app_mngr_settings_));
+  EXPECT_CALL(mock_app_manager_, get_settings())
+      .WillOnce(ReturnRef(mock_app_manager_settings_));
 
   std::vector<uint32_t> supported_diag_modes;
   supported_diag_modes.push_back(kDiagnosticMode);
 
-  EXPECT_CALL(app_mngr_settings_, supported_diag_modes())
+  EXPECT_CALL(mock_app_manager_settings_, supported_diag_modes())
       .WillOnce(ReturnRef(supported_diag_modes));
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::VehicleInfo_DiagnosticMessage)));
 
@@ -152,7 +154,7 @@ TEST_F(DiagnosticMessageRequestTest, OnEvent_UNSUCCESS) {
   DiagnosticMessageRequestPtr command(
       CreateCommand<DiagnosticMessageRequest>());
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   command->on_event(event);
 }
@@ -170,7 +172,7 @@ TEST_F(DiagnosticMessageRequestTest, OnEvent_SUCCESS) {
       CreateCommand<DiagnosticMessageRequest>());
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
 
   command->on_event(event);

--- a/src/components/application_manager/test/commands/mobile/dial_number_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/dial_number_request_test.cc
@@ -72,11 +72,11 @@ class DialNumberRequestTest
 TEST_F(DialNumberRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
   DialNumberRequestPtr command(CreateCommand<DialNumberRequest>());
 
-  EXPECT_CALL(app_mngr_, application(_))
+  EXPECT_CALL(mock_app_manager_, application(_))
       .WillOnce(Return(ApplicationSharedPtr()));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
 
@@ -92,10 +92,11 @@ TEST_F(DialNumberRequestTest, Run_InvalidNumber_UNSUCCESS) {
   DialNumberRequestPtr command(CreateCommand<DialNumberRequest>(command_msg));
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
 
   command->Run();
@@ -110,10 +111,11 @@ TEST_F(DialNumberRequestTest, Run_EmptyNumber_UNSUCCESS) {
   DialNumberRequestPtr command(CreateCommand<DialNumberRequest>(command_msg));
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
 
   command->Run();
@@ -128,9 +130,10 @@ TEST_F(DialNumberRequestTest, Run_SUCCESS) {
   DialNumberRequestPtr command(CreateCommand<DialNumberRequest>(command_msg));
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::BasicCommunication_DialNumber)));
 
@@ -145,11 +148,12 @@ TEST_F(DialNumberRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
   DialNumberRequestPtr command(CreateCommand<DialNumberRequest>(command_msg));
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
 
   Event event(hmi_apis::FunctionID::INVALID_ENUM);
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   command->on_event(event);
 }
@@ -162,7 +166,8 @@ TEST_F(DialNumberRequestTest, OnEvent_SUCCESS) {
   DialNumberRequestPtr command(CreateCommand<DialNumberRequest>(command_msg));
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
 
   MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
   (*event_msg)[am::strings::params][am::hmi_response::code] =
@@ -173,7 +178,7 @@ TEST_F(DialNumberRequestTest, OnEvent_SUCCESS) {
   event.set_smart_object(*event_msg);
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
 
   command->on_event(event);

--- a/src/components/application_manager/test/commands/mobile/dummy_mobile_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/dummy_mobile_commands_test.cc
@@ -178,13 +178,13 @@ class MobileCommandsTest : public components::commands_test::CommandRequestTest<
   typedef Command CommandType;
 
   void InitCommand(const uint32_t& timeout) OVERRIDE {
-    EXPECT_CALL(app_mngr_settings_, default_timeout())
+    EXPECT_CALL(mock_app_manager_settings_, default_timeout())
         .WillOnce(ReturnRef(timeout));
-    ON_CALL(app_mngr_, event_dispatcher())
+    ON_CALL(mock_app_manager_, event_dispatcher())
         .WillByDefault(ReturnRef(event_dispatcher_));
-    ON_CALL(app_mngr_, get_settings())
-        .WillByDefault(ReturnRef(app_mngr_settings_));
-    ON_CALL(app_mngr_settings_, app_icons_folder())
+    ON_CALL(mock_app_manager_, get_settings())
+        .WillByDefault(ReturnRef(mock_app_manager_settings_));
+    ON_CALL(mock_app_manager_settings_, app_icons_folder())
         .WillByDefault(ReturnRef(kEmptyString_));
   }
 };

--- a/src/components/application_manager/test/commands/mobile/end_audio_pass_thru_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/end_audio_pass_thru_request_test.cc
@@ -67,7 +67,7 @@ class EndAudioPassThruRequestTest
 TEST_F(EndAudioPassThruRequestTest, Run_SUCCESS) {
   EndAudioPassThruRequestPtr command(CreateCommand<EndAudioPassThruRequest>());
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageHMICommand(
                   HMIResultCodeIs(hmi_apis::FunctionID::UI_EndAudioPassThru)));
 
@@ -79,7 +79,7 @@ TEST_F(EndAudioPassThruRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
 
   Event event(hmi_apis::FunctionID::INVALID_ENUM);
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   command->on_event(event);
 }
@@ -102,11 +102,11 @@ TEST_F(EndAudioPassThruRequestTest, OnEvent_SUCCESS) {
   Event event(hmi_apis::FunctionID::UI_EndAudioPassThru);
   event.set_smart_object(*event_msg);
 
-  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(true));
-  EXPECT_CALL(app_mngr_, StopAudioPassThru(kConnectionKey));
+  EXPECT_CALL(mock_app_manager_, EndAudioPassThrough()).WillOnce(Return(true));
+  EXPECT_CALL(mock_app_manager_, StopAudioPassThru(kConnectionKey));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
 
   command->on_event(event);

--- a/src/components/application_manager/test/commands/mobile/get_dtcs_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/get_dtcs_request_test.cc
@@ -68,11 +68,11 @@ class GetDTCsRequestTest
 TEST_F(GetDTCsRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
   GetDTCsRequestPtr command(CreateCommand<GetDTCsRequest>());
 
-  EXPECT_CALL(app_mngr_, application(_))
+  EXPECT_CALL(mock_app_manager_, application(_))
       .WillOnce(Return(ApplicationSharedPtr()));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
 
@@ -89,9 +89,10 @@ TEST_F(GetDTCsRequestTest, Run_SUCCESS) {
   GetDTCsRequestPtr command(CreateCommand<GetDTCsRequest>(command_msg));
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageHMICommand(
                   HMIResultCodeIs(hmi_apis::FunctionID::VehicleInfo_GetDTCs)));
 
@@ -103,7 +104,7 @@ TEST_F(GetDTCsRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
 
   Event event(hmi_apis::FunctionID::INVALID_ENUM);
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   command->on_event(event);
 }
@@ -120,7 +121,7 @@ TEST_F(GetDTCsRequestTest, OnEvent_SUCCESS) {
   event.set_smart_object(*event_msg);
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
 
   command->on_event(event);

--- a/src/components/application_manager/test/commands/mobile/get_vehicle_data_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/get_vehicle_data_request_test.cc
@@ -91,11 +91,11 @@ class UnwrappedGetVehicleDataRequest : public GetVehicleDataRequest {
 TEST_F(GetVehicleDataRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
   GetVehicleDataRequestPtr command(CreateCommand<GetVehicleDataRequest>());
 
-  EXPECT_CALL(app_mngr_, application(_))
+  EXPECT_CALL(mock_app_manager_, application(_))
       .WillOnce(Return(ApplicationSharedPtr()));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
 
@@ -114,7 +114,8 @@ TEST_F(GetVehicleDataRequestTest, Run_TooHighFrequency_UNSUCCESS) {
       CreateCommand<GetVehicleDataRequest>(command_msg));
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
 
   EXPECT_CALL(
       *app,
@@ -122,7 +123,7 @@ TEST_F(GetVehicleDataRequestTest, Run_TooHighFrequency_UNSUCCESS) {
       .WillOnce(Return(true));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::REJECTED), _));
 
   command->Run();
@@ -141,10 +142,11 @@ TEST_F(GetVehicleDataRequestTest, Run_EmptyMsgParams_UNSUCCESS) {
       .WillOnce(ReturnRef(kEmptyVehicleData));
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
 
   command->Run();
@@ -168,10 +170,11 @@ TEST_F(GetVehicleDataRequestTest,
   disallowed_params.push_back("test_param");
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::DISALLOWED), _));
 
   command->Run();
@@ -195,9 +198,10 @@ TEST_F(GetVehicleDataRequestTest, Run_SUCCESS) {
       .WillOnce(ReturnRef(vehicle_data));
 
   MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(app));
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::VehicleInfo_GetVehicleData)));
 
@@ -214,7 +218,7 @@ TEST_F(GetVehicleDataRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
 
   Event event(hmi_apis::FunctionID::INVALID_ENUM);
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   command->on_event(event);
 }
@@ -237,7 +241,7 @@ TEST_F(GetVehicleDataRequestTest, OnEvent_DataNotAvailable_SUCCESS) {
   event.set_smart_object(*event_msg);
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResultCodeIs(mobile_result::VEHICLE_DATA_NOT_AVAILABLE), _));
 

--- a/src/components/application_manager/test/commands/mobile/get_way_points_test.cc
+++ b/src/components/application_manager/test/commands/mobile/get_way_points_test.cc
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "application_manager/commands/command_request_test.h"
+
+#include "mobile/get_way_points_request.h"
+
+#include "utils/shared_ptr.h"
+#include "utils/make_shared.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using namespace application_manager;
+
+using ::testing::Return;
+using ::testing::_;
+
+namespace {
+const uint32_t kCorrelationId = 2u;
+const uint32_t kAppId = 3u;
+const uint32_t kConnectionKey = kAppId;
+const std::string kMethodName = "Navigation.GetWayPoints";
+}
+
+class GetWayPointsRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  void SetUp() OVERRIDE {
+    message_ = utils::MakeShared<SmartObject>(::smart_objects::SmartType_Map);
+    (*message_)[strings::msg_params] =
+        ::smart_objects::SmartObject(::smart_objects::SmartType_Map);
+
+    command_sptr_ =
+        CreateCommand<application_manager::commands::GetWayPointsRequest>(
+            CommandsTest::kDefaultTimeout_, message_);
+  }
+
+  MessageSharedPtr message_;
+  utils::SharedPtr<commands::GetWayPointsRequest> command_sptr_;
+};
+
+TEST_F(GetWayPointsRequestTest,
+       Run_InvalidApp_ApplicationNotRegisteredResponce) {
+  const int32_t kConnectionKey = 1;
+
+  (*message_)[strings::params][strings::connection_key] = kConnectionKey;
+
+  utils::SharedPtr<Application> null_application_sptr;
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(null_application_sptr));
+
+  CallRun caller(*command_sptr_);
+
+  MessageSharedPtr result_message = CatchMobileCommandResult(caller);
+
+  const mobile_api::Result::eType kResult =
+      static_cast<mobile_api::Result::eType>(
+          (*result_message)[strings::msg_params][strings::result_code].asInt());
+
+  EXPECT_EQ(mobile_api::Result::APPLICATION_NOT_REGISTERED, kResult);
+}
+
+TEST_F(GetWayPointsRequestTest, Run_ApplicationRegistered_Success) {
+  (*message_)[strings::params][strings::connection_key] = kConnectionKey;
+
+  MockAppPtr application_sptr = CreateMockApp();
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(application_sptr));
+  EXPECT_CALL(*application_sptr, app_id()).WillOnce(Return(1));
+
+  EXPECT_CALL(mock_app_manager_, GetNextHMICorrelationID())
+      .WillOnce(Return(kCorrelationId));
+
+  CallRun caller(*command_sptr_);
+
+  MessageSharedPtr result_message = CatchHMICommandResult(caller);
+
+  const hmi_apis::FunctionID::eType kResultFunctionId =
+      static_cast<hmi_apis::FunctionID::eType>(
+          (*result_message)[strings::params][strings::function_id].asInt());
+
+  EXPECT_EQ(hmi_apis::FunctionID::Navigation_GetWayPoints, kResultFunctionId);
+  EXPECT_EQ(
+      kCorrelationId,
+      (*result_message)[strings::params][strings::correlation_id].asUInt());
+}
+
+TEST_F(GetWayPointsRequestTest,
+       OnEvent_NavigationGetWayPointsEvent_SendResponce) {
+  event_engine::Event event(hmi_apis::FunctionID::Navigation_GetWayPoints);
+
+  (*message_)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+
+  event.set_smart_object(*message_);
+
+  CallOnEvent caller(*command_sptr_, event);
+
+  MessageSharedPtr result_message = CatchMobileCommandResult(caller);
+
+  const mobile_api::Result::eType kResult =
+      static_cast<mobile_api::Result::eType>(
+          (*result_message)[strings::msg_params][strings::result_code].asInt());
+
+  EXPECT_EQ(mobile_api::Result::SUCCESS, kResult);
+}
+
+TEST_F(GetWayPointsRequestTest, OnEvent_ResetTimeoutEvent_UpdateTimeout) {
+  event_engine::Event event(hmi_apis::FunctionID::UI_OnResetTimeout);
+
+  (*message_)[strings::params][strings::connection_key] = kConnectionKey;
+  (*message_)[strings::params][strings::correlation_id] = kCorrelationId;
+  (*message_)[strings::msg_params][strings::app_id] = kAppId;
+  (*message_)[strings::msg_params][strings::method_name] = kMethodName;
+
+  event.set_smart_object(*message_);
+
+  EXPECT_CALL(mock_app_manager_,
+              updateRequestTimeout(kConnectionKey, kCorrelationId, _));
+
+  CallOnEvent caller(*command_sptr_, event);
+  caller();
+}
+
+TEST_F(GetWayPointsRequestTest,
+       OnEvent_ResetTimeoutEventAndIncerrectConnectionKey_NotUpdateTimeout) {
+  event_engine::Event event(hmi_apis::FunctionID::UI_OnResetTimeout);
+
+  const uint32_t kConnectionKey = 1u;
+
+  (*message_)[strings::params][strings::connection_key] = kConnectionKey;
+  (*message_)[strings::params][strings::correlation_id] = kCorrelationId;
+  (*message_)[strings::msg_params][strings::app_id] = kAppId;
+  (*message_)[strings::msg_params][strings::method_name] = kMethodName;
+
+  event.set_smart_object(*message_);
+
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _)).Times(0);
+
+  CallOnEvent caller(*command_sptr_, event);
+  caller();
+}
+
+TEST_F(GetWayPointsRequestTest, OnEvent_DefaultCase) {
+  event_engine::Event event(hmi_apis::FunctionID::INVALID_ENUM);
+
+  event.set_smart_object(*message_);
+
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
+
+  CallOnEvent caller(*command_sptr_, event);
+  caller();
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/get_way_points_test.cc
+++ b/src/components/application_manager/test/commands/mobile/get_way_points_test.cc
@@ -69,7 +69,7 @@ class GetWayPointsRequestTest
 
     command_sptr_ =
         CreateCommand<application_manager::commands::GetWayPointsRequest>(
-            CommandsTest::kDefaultTimeout_, message_);
+            message_);
     mock_app_ = CreateMockApp();
     ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(mock_app_));
   }
@@ -81,8 +81,6 @@ class GetWayPointsRequestTest
 
 TEST_F(GetWayPointsRequestTest,
        Run_InvalidApp_ApplicationNotRegisteredResponce) {
-  const int32_t kConnectionKey = 1;
-
   (*message_)[strings::params][strings::connection_key] = kConnectionKey;
 
   utils::SharedPtr<Application> null_application_sptr;
@@ -93,11 +91,11 @@ TEST_F(GetWayPointsRequestTest,
 
   MessageSharedPtr result_message = CatchMobileCommandResult(caller);
 
-  const mobile_api::Result::eType kResult =
+  const mobile_api::Result::eType result =
       static_cast<mobile_api::Result::eType>(
           (*result_message)[strings::msg_params][strings::result_code].asInt());
 
-  EXPECT_EQ(mobile_api::Result::APPLICATION_NOT_REGISTERED, kResult);
+  EXPECT_EQ(mobile_api::Result::APPLICATION_NOT_REGISTERED, result);
 }
 
 TEST_F(GetWayPointsRequestTest, Run_ApplicationRegistered_Success) {
@@ -116,11 +114,11 @@ TEST_F(GetWayPointsRequestTest, Run_ApplicationRegistered_Success) {
 
   MessageSharedPtr result_message = CatchHMICommandResult(caller);
 
-  const hmi_apis::FunctionID::eType kResultFunctionId =
+  const hmi_apis::FunctionID::eType result_function_id =
       static_cast<hmi_apis::FunctionID::eType>(
           (*result_message)[strings::params][strings::function_id].asInt());
 
-  EXPECT_EQ(hmi_apis::FunctionID::Navigation_GetWayPoints, kResultFunctionId);
+  EXPECT_EQ(hmi_apis::FunctionID::Navigation_GetWayPoints, result_function_id);
   EXPECT_EQ(
       kCorrelationId,
       (*result_message)[strings::params][strings::correlation_id].asUInt());
@@ -139,11 +137,11 @@ TEST_F(GetWayPointsRequestTest,
 
   MessageSharedPtr result_message = CatchMobileCommandResult(caller);
 
-  const mobile_api::Result::eType kResult =
+  const mobile_api::Result::eType result =
       static_cast<mobile_api::Result::eType>(
           (*result_message)[strings::msg_params][strings::result_code].asInt());
 
-  EXPECT_EQ(mobile_api::Result::SUCCESS, kResult);
+  EXPECT_EQ(mobile_api::Result::SUCCESS, result);
 }
 
 TEST_F(GetWayPointsRequestTest, OnEvent_DefaultCase) {

--- a/src/components/application_manager/test/commands/mobile/list_files_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/list_files_request_test.cc
@@ -65,7 +65,7 @@ class ListFilesRequestTest
 TEST_F(ListFilesRequestTest, Run_AppNotRegistered_UNSUCCESS) {
   SharedPtr<ListFilesRequest> command(CreateCommand<ListFilesRequest>());
 
-  ON_CALL(app_mngr_, application(_))
+  ON_CALL(mock_app_manager_, application(_))
       .WillByDefault(Return(SharedPtr<am::Application>()));
 
   MessageSharedPtr result_msg(CatchMobileCommandResult(CallRun(*command)));
@@ -79,16 +79,16 @@ TEST_F(ListFilesRequestTest, Run_TooManyHmiNone_UNSUCCESS) {
   MockAppPtr app(CreateMockApp());
   SharedPtr<ListFilesRequest> command(CreateCommand<ListFilesRequest>());
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
   ON_CALL(*app, hmi_level())
       .WillByDefault(Return(mobile_apis::HMILevel::HMI_NONE));
 
   const uint32_t kListFilesInNoneAllowed = 1u;
   const uint32_t kListFilesInNoneCount = 2u;
 
-  EXPECT_CALL(app_mngr_, get_settings())
-      .WillOnce(ReturnRef(app_mngr_settings_));
-  ON_CALL(app_mngr_settings_, list_files_in_none())
+  EXPECT_CALL(mock_app_manager_, get_settings())
+      .WillOnce(ReturnRef(mock_app_manager_settings_));
+  ON_CALL(mock_app_manager_settings_, list_files_in_none())
       .WillByDefault(ReturnRef(kListFilesInNoneAllowed));
   ON_CALL(*app, list_files_in_none_count())
       .WillByDefault(Return(kListFilesInNoneCount));
@@ -104,7 +104,7 @@ TEST_F(ListFilesRequestTest, Run_SUCCESS) {
   MockAppPtr app(CreateMockApp());
   SharedPtr<ListFilesRequest> command(CreateCommand<ListFilesRequest>());
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
   ON_CALL(*app, hmi_level())
       .WillByDefault(Return(mobile_apis::HMILevel::HMI_FULL));
 

--- a/src/components/application_manager/test/commands/mobile/on_button_event_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_button_event_notification_test.cc
@@ -88,12 +88,12 @@ class OnButtonEventNotificationTest
     subscribedApps.push_back(subscribed);
 
     if (is_app_id_valid) {
-      EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app));
+      EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(mock_app));
     } else {
-      EXPECT_CALL(app_mngr_, application(_))
+      EXPECT_CALL(mock_app_manager_, application(_))
           .WillOnce(Return(ApplicationSharedPtr()));
     }
-    EXPECT_CALL(app_mngr_, applications_by_button(_))
+    EXPECT_CALL(mock_app_manager_, applications_by_button(_))
         .WillOnce(Return(subscribedApps));
     EXPECT_CALL(*subscribed, hmi_level()).WillRepeatedly(Return(app_hmi_level));
     EXPECT_CALL(*subscribed, app_id()).WillRepeatedly(Return(app_id1));
@@ -102,7 +102,7 @@ class OnButtonEventNotificationTest
       EXPECT_CALL(*subscribed, IsFullscreen()).WillOnce(Return(true));
     }
     if (is_send_message_expected) {
-      EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _));
+      EXPECT_CALL(mock_app_manager_, SendMessageToMobile(_, _));
     }
 
     command_->Run();

--- a/src/components/application_manager/test/commands/mobile/on_button_notification_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_button_notification_commands_test.cc
@@ -131,7 +131,7 @@ TYPED_TEST(OnButtonNotificationCommandsTest,
   SharedPtr<Notification> command(
       this->template CreateCommand<Notification>(notification_msg));
 
-  EXPECT_CALL(this->app_mngr_, SendMessageToMobile(_, _)).Times(0);
+  EXPECT_CALL(this->mock_app_manager_, SendMessageToMobile(_, _)).Times(0);
 
   command->Run();
 }
@@ -150,7 +150,7 @@ TYPED_TEST(OnButtonNotificationCommandsTest,
   SharedPtr<Notification> command(
       this->template CreateCommand<Notification>(notification_msg));
 
-  EXPECT_CALL(this->app_mngr_, SendMessageToMobile(_, _)).Times(0);
+  EXPECT_CALL(this->mock_app_manager_, SendMessageToMobile(_, _)).Times(0);
 
   command->Run();
 }
@@ -171,10 +171,10 @@ TYPED_TEST(OnButtonNotificationCommandsTest,
   SharedPtr<Notification> command(
       this->template CreateCommand<Notification>(notification_msg));
 
-  EXPECT_CALL(this->app_mngr_, application(kAppId))
+  EXPECT_CALL(this->mock_app_manager_, application(kAppId))
       .WillOnce(Return(ApplicationSharedPtr()));
 
-  EXPECT_CALL(this->app_mngr_, SendMessageToMobile(_, _)).Times(0);
+  EXPECT_CALL(this->mock_app_manager_, SendMessageToMobile(_, _)).Times(0);
 
   command->Run();
 }
@@ -196,12 +196,13 @@ TYPED_TEST(OnButtonNotificationCommandsTest,
       this->template CreateCommand<Notification>(notification_msg));
 
   typename TestFixture::MockAppPtr mock_app = this->CreateMockApp();
-  EXPECT_CALL(this->app_mngr_, application(kAppId)).WillOnce(Return(mock_app));
+  EXPECT_CALL(this->mock_app_manager_, application(kAppId))
+      .WillOnce(Return(mock_app));
 
   EXPECT_CALL(*mock_app, IsSubscribedToSoftButton(kCustomButtonId))
       .WillOnce(Return(false));
 
-  EXPECT_CALL(this->app_mngr_, SendMessageToMobile(_, _)).Times(0);
+  EXPECT_CALL(this->mock_app_manager_, SendMessageToMobile(_, _)).Times(0);
 
   command->Run();
 }
@@ -222,12 +223,13 @@ TYPED_TEST(OnButtonNotificationCommandsTest, Run_CustomButton_SUCCESS) {
       this->template CreateCommand<Notification>(notification_msg));
 
   typename TestFixture::MockAppPtr mock_app = this->CreateMockApp();
-  EXPECT_CALL(this->app_mngr_, application(kAppId)).WillOnce(Return(mock_app));
+  EXPECT_CALL(this->mock_app_manager_, application(kAppId))
+      .WillOnce(Return(mock_app));
 
   EXPECT_CALL(*mock_app, IsSubscribedToSoftButton(kCustomButtonId))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(this->app_mngr_,
+  EXPECT_CALL(this->mock_app_manager_,
               SendMessageToMobile(
                   CheckNotificationMessage(TestFixture::kFunctionId), _));
 
@@ -247,10 +249,10 @@ TYPED_TEST(OnButtonNotificationCommandsTest, Run_NoSubscribedApps_UNSUCCESS) {
       this->template CreateCommand<Notification>(notification_msg));
 
   const std::vector<ApplicationSharedPtr> empty_subscribed_apps_list;
-  EXPECT_CALL(this->app_mngr_, applications_by_button(kButtonName))
+  EXPECT_CALL(this->mock_app_manager_, applications_by_button(kButtonName))
       .WillOnce(Return(empty_subscribed_apps_list));
 
-  EXPECT_CALL(this->app_mngr_, SendMessageToMobile(_, _)).Times(0);
+  EXPECT_CALL(this->mock_app_manager_, SendMessageToMobile(_, _)).Times(0);
 
   command->Run();
 }
@@ -274,10 +276,10 @@ TYPED_TEST(OnButtonNotificationCommandsTest, Run_InvalidHmiLevel_UNSUCCESS) {
   EXPECT_CALL(*mock_app, hmi_level())
       .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_NONE));
 
-  EXPECT_CALL(this->app_mngr_, applications_by_button(kButtonName))
+  EXPECT_CALL(this->mock_app_manager_, applications_by_button(kButtonName))
       .WillOnce(Return(subscribed_apps_list));
 
-  EXPECT_CALL(this->app_mngr_, SendMessageToMobile(_, _)).Times(0);
+  EXPECT_CALL(this->mock_app_manager_, SendMessageToMobile(_, _)).Times(0);
 
   command->Run();
 }
@@ -302,10 +304,10 @@ TYPED_TEST(OnButtonNotificationCommandsTest,
   EXPECT_CALL(*mock_app, hmi_level())
       .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_LIMITED));
 
-  EXPECT_CALL(this->app_mngr_, applications_by_button(kButtonName))
+  EXPECT_CALL(this->mock_app_manager_, applications_by_button(kButtonName))
       .WillOnce(Return(subscribed_apps_list));
 
-  EXPECT_CALL(this->app_mngr_, SendMessageToMobile(_, _)).Times(0);
+  EXPECT_CALL(this->mock_app_manager_, SendMessageToMobile(_, _)).Times(0);
 
   command->Run();
 }
@@ -329,10 +331,10 @@ TYPED_TEST(OnButtonNotificationCommandsTest, Run_SUCCESS) {
   EXPECT_CALL(*mock_app, hmi_level())
       .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
 
-  EXPECT_CALL(this->app_mngr_, applications_by_button(kButtonName))
+  EXPECT_CALL(this->mock_app_manager_, applications_by_button(kButtonName))
       .WillOnce(Return(subscribed_apps_list));
 
-  EXPECT_CALL(this->app_mngr_,
+  EXPECT_CALL(this->mock_app_manager_,
               SendMessageToMobile(
                   CheckNotificationMessage(TestFixture::kFunctionId), _));
 

--- a/src/components/application_manager/test/commands/mobile/on_button_press_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_button_press_notification_test.cc
@@ -88,12 +88,12 @@ class OnButtonPressNotificationTest
     subscribedApps.push_back(subscribed);
 
     if (is_app_id_valid) {
-      EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app));
+      EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(mock_app));
     } else {
-      EXPECT_CALL(app_mngr_, application(_))
+      EXPECT_CALL(mock_app_manager_, application(_))
           .WillOnce(Return(ApplicationSharedPtr()));
     }
-    EXPECT_CALL(app_mngr_, applications_by_button(_))
+    EXPECT_CALL(mock_app_manager_, applications_by_button(_))
         .WillOnce(Return(subscribedApps));
     EXPECT_CALL(*subscribed, hmi_level()).WillRepeatedly(Return(app_hmi_level));
     EXPECT_CALL(*subscribed, app_id()).WillRepeatedly(Return(app_id1));
@@ -103,7 +103,7 @@ class OnButtonPressNotificationTest
     }
 
     if (is_send_message_expected) {
-      EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _));
+      EXPECT_CALL(mock_app_manager_, SendMessageToMobile(_, _));
     }
 
     command_->Run();

--- a/src/components/application_manager/test/commands/mobile/on_command_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_command_notification_test.cc
@@ -67,10 +67,10 @@ class OnCommandNotificationTest
 TEST_F(OnCommandNotificationTest, Run_AppNotRegistered_UNSUCCESS) {
   CommandPtr command(CreateCommand<OnCommandNotification>());
 
-  EXPECT_CALL(app_mngr_, application(_))
+  EXPECT_CALL(mock_app_manager_, application(_))
       .WillOnce(Return(ApplicationSharedPtr()));
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   command->Run();
 }
@@ -83,12 +83,13 @@ TEST_F(OnCommandNotificationTest, Run_NoAppsForTheCommand_UNSUCCESS) {
   CommandPtr command(CreateCommand<OnCommandNotification>(command_msg));
 
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kAppId)).WillOnce(Return(mock_app));
+  EXPECT_CALL(mock_app_manager_, application(kAppId))
+      .WillOnce(Return(mock_app));
 
   EXPECT_CALL(*mock_app, FindCommand(kCommandId))
       .WillOnce(Return(static_cast<SmartObject*>(NULL)));
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   command->Run();
 }
@@ -118,13 +119,15 @@ TEST_F(OnCommandNotificationTest, Run_SUCCESS) {
   CommandPtr command(CreateCommand<OnCommandNotification>(command_msg));
 
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kAppId)).WillOnce(Return(mock_app));
+  EXPECT_CALL(mock_app_manager_, application(kAppId))
+      .WillOnce(Return(mock_app));
 
   MessageSharedPtr dummy_msg(CreateMessage());
   EXPECT_CALL(*mock_app, FindCommand(kCommandId))
       .WillOnce(Return(dummy_msg.get()));
 
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(CheckNotificationMessage(), _));
+  EXPECT_CALL(mock_app_manager_,
+              SendMessageToMobile(CheckNotificationMessage(), _));
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/mobile/on_hash_change_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_hash_change_notification_test.cc
@@ -79,11 +79,11 @@ TEST_F(OnHashChangeNotificationTest, Run_ValidApp_SUCCESS) {
 
   std::string return_string = "1234";
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
   EXPECT_CALL(*mock_app, curHash()).WillOnce(ReturnRef(return_string));
   EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _));
 
   command->Run();
 
@@ -108,11 +108,11 @@ TEST_F(OnHashChangeNotificationTest, Run_InvalidApp_NoNotification) {
   std::string return_string;
   MockAppPtr mock_app = CreateMockApp();
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(MockAppPtr()));
   EXPECT_CALL(*mock_app, curHash()).Times(0);
   EXPECT_CALL(message_helper_, PrintSmartObject(_)).Times(0);
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _)).Times(0);
 
   command->Run();
 

--- a/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_from_mobile_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_from_mobile_test.cc
@@ -79,15 +79,16 @@ TEST_F(OnHMIStatusNotificationFromMobileTest,
       CreateCommand<OnHMIStatusNotificationFromMobile>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
   EXPECT_CALL(*mock_app, set_foreground(true));
 
   EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
-  EXPECT_CALL(app_mngr_, IsAppsQueriedFrom(kHandle)).WillOnce(Return(true));
+  EXPECT_CALL(mock_app_manager_, IsAppsQueriedFrom(kHandle))
+      .WillOnce(Return(true));
 
   DataAccessor<ApplicationSet> accessor(app_set_, lock_);
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
 
   EXPECT_CALL(*mock_app, protocol_version())
       .WillRepeatedly(Return(ProtocolVersion::kV4));
@@ -106,14 +107,14 @@ TEST_F(OnHMIStatusNotificationFromMobileTest, Run_InvalidApp_NoNotification) {
       CreateCommand<OnHMIStatusNotificationFromMobile>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(MockAppPtr()));
   EXPECT_CALL(*mock_app, set_foreground(true)).Times(0);
 
   EXPECT_CALL(*mock_app, device()).Times(0);
-  EXPECT_CALL(app_mngr_, IsAppsQueriedFrom(kHandle)).Times(0);
+  EXPECT_CALL(mock_app_manager_, IsAppsQueriedFrom(kHandle)).Times(0);
 
-  EXPECT_CALL(app_mngr_, applications()).Times(0);
+  EXPECT_CALL(mock_app_manager_, applications()).Times(0);
 
   EXPECT_CALL(*mock_app, protocol_version()).Times(0);
   EXPECT_CALL(*mock_app, is_foreground()).Times(0);
@@ -132,15 +133,16 @@ TEST_F(OnHMIStatusNotificationFromMobileTest,
       CreateCommand<OnHMIStatusNotificationFromMobile>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
   EXPECT_CALL(*mock_app, set_foreground(false));
 
   EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
-  EXPECT_CALL(app_mngr_, IsAppsQueriedFrom(kHandle)).WillOnce(Return(true));
+  EXPECT_CALL(mock_app_manager_, IsAppsQueriedFrom(kHandle))
+      .WillOnce(Return(true));
 
   DataAccessor<ApplicationSet> accessor(app_set_, lock_);
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
 
   EXPECT_CALL(*mock_app, protocol_version())
       .WillRepeatedly(Return(ProtocolVersion::kV4));
@@ -160,15 +162,16 @@ TEST_F(OnHMIStatusNotificationFromMobileTest,
       CreateCommand<OnHMIStatusNotificationFromMobile>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
   EXPECT_CALL(*mock_app, set_foreground(false));
 
   EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
-  EXPECT_CALL(app_mngr_, IsAppsQueriedFrom(kHandle)).WillOnce(Return(true));
+  EXPECT_CALL(mock_app_manager_, IsAppsQueriedFrom(kHandle))
+      .WillOnce(Return(true));
 
   DataAccessor<ApplicationSet> accessor(app_set_, lock_);
-  EXPECT_CALL(app_mngr_, applications()).Times(0);
+  EXPECT_CALL(mock_app_manager_, applications()).Times(0);
 
   EXPECT_CALL(*mock_app, protocol_version())
       .WillOnce(Return(ProtocolVersion::kV3));
@@ -188,14 +191,15 @@ TEST_F(OnHMIStatusNotificationFromMobileTest,
       CreateCommand<OnHMIStatusNotificationFromMobile>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
   EXPECT_CALL(*mock_app, set_foreground(true));
 
   EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
-  EXPECT_CALL(app_mngr_, IsAppsQueriedFrom(kHandle)).WillOnce(Return(false));
+  EXPECT_CALL(mock_app_manager_, IsAppsQueriedFrom(kHandle))
+      .WillOnce(Return(false));
 
-  EXPECT_CALL(app_mngr_, applications()).Times(0);
+  EXPECT_CALL(mock_app_manager_, applications()).Times(0);
 
   EXPECT_CALL(*mock_app, protocol_version())
       .WillOnce(Return(ProtocolVersion::kV3));
@@ -215,17 +219,18 @@ TEST_F(OnHMIStatusNotificationFromMobileTest,
       CreateCommand<OnHMIStatusNotificationFromMobile>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
   EXPECT_CALL(*mock_app, set_foreground(true));
 
   EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
-  EXPECT_CALL(app_mngr_, IsAppsQueriedFrom(kHandle)).WillOnce(Return(false));
+  EXPECT_CALL(mock_app_manager_, IsAppsQueriedFrom(kHandle))
+      .WillOnce(Return(false));
 
   EXPECT_CALL(*mock_app, protocol_version())
       .WillOnce(Return(ProtocolVersion::kV4));
 
-  EXPECT_CALL(app_mngr_, applications()).Times(0);
+  EXPECT_CALL(mock_app_manager_, applications()).Times(0);
 
   EXPECT_CALL(*mock_app, is_foreground()).WillOnce(Return(true));
 
@@ -249,22 +254,23 @@ TEST_F(OnHMIStatusNotificationFromMobileTest,
       CreateCommand<OnHMIStatusNotificationFromMobile>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
   EXPECT_CALL(*mock_app, set_foreground(true));
 
   EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
-  EXPECT_CALL(app_mngr_, IsAppsQueriedFrom(kHandle)).WillOnce(Return(true));
+  EXPECT_CALL(mock_app_manager_, IsAppsQueriedFrom(kHandle))
+      .WillOnce(Return(true));
 
   DataAccessor<ApplicationSet> accessor(app_set_, lock_);
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
 
   EXPECT_CALL(*mock_app, protocol_version())
       .WillRepeatedly(Return(ProtocolVersion::kV4));
   EXPECT_CALL(*mock_app, is_foreground()).WillRepeatedly(Return(false));
 
-  EXPECT_CALL(app_mngr_, MarkAppsGreyOut(kHandle, false));
-  EXPECT_CALL(app_mngr_, SendUpdateAppList());
+  EXPECT_CALL(mock_app_manager_, MarkAppsGreyOut(kHandle, false));
+  EXPECT_CALL(mock_app_manager_, SendUpdateAppList());
 
   command->Run();
 

--- a/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_test.cc
@@ -76,7 +76,7 @@ class OnHMIStatusNotificationTest
   void SetSendNotificationExpectations(MessageSharedPtr& msg) {
     Mock::VerifyAndClearExpectations(&message_helper_);
     EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
-    EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+    EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _));
   }
 
   void VerifySendNotificationData(MessageSharedPtr& msg) {
@@ -98,14 +98,14 @@ TEST_F(OnHMIStatusNotificationTest, Run_InvalidApp_NoNotification) {
       CreateCommand<OnHMIStatusNotification>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(MockAppPtr()));
 
   EXPECT_CALL(*mock_app, tts_properties_in_full()).Times(0);
   EXPECT_CALL(*mock_app, set_tts_properties_in_full(_)).Times(0);
   EXPECT_CALL(*mock_app, app_id()).Times(0);
-  EXPECT_CALL(app_mngr_, AddAppToTTSGlobalPropertiesList(kConnectionKey))
-      .Times(0);
+  EXPECT_CALL(mock_app_manager_,
+              AddAppToTTSGlobalPropertiesList(kConnectionKey)).Times(0);
 
   command->Run();
 }
@@ -117,7 +117,7 @@ TEST_F(OnHMIStatusNotificationTest, Run_InvalidEnum_SUCCESS) {
       CreateCommand<OnHMIStatusNotification>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   SetSendNotificationExpectations(msg);
@@ -135,7 +135,7 @@ TEST_F(OnHMIStatusNotificationTest, Run_BackgroundAndFalseProperties_SUCCESS) {
       CreateCommand<OnHMIStatusNotification>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(*mock_app, tts_properties_in_none()).WillOnce(Return(false));
@@ -154,7 +154,7 @@ TEST_F(OnHMIStatusNotificationTest, Run_BackgroundAndTrueProperties_SUCCESS) {
       CreateCommand<OnHMIStatusNotification>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(*mock_app, tts_properties_in_none()).WillOnce(Return(true));
@@ -173,13 +173,14 @@ TEST_F(OnHMIStatusNotificationTest, Run_FullAndFalseProperties_SUCCESS) {
       CreateCommand<OnHMIStatusNotification>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(*mock_app, tts_properties_in_full()).WillOnce(Return(false));
   EXPECT_CALL(*mock_app, set_tts_properties_in_full(true));
   EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kConnectionKey));
-  EXPECT_CALL(app_mngr_, AddAppToTTSGlobalPropertiesList(kConnectionKey));
+  EXPECT_CALL(mock_app_manager_,
+              AddAppToTTSGlobalPropertiesList(kConnectionKey));
 
   SetSendNotificationExpectations(msg);
 
@@ -195,7 +196,7 @@ TEST_F(OnHMIStatusNotificationTest, Run_FullAndTrueProperties_SUCCESS) {
       CreateCommand<OnHMIStatusNotification>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(*mock_app, tts_properties_in_full()).WillOnce(Return(true));

--- a/src/components/application_manager/test/commands/mobile/on_keyboard_input_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_keyboard_input_notification_test.cc
@@ -65,7 +65,7 @@ class OnKeyBoardInputNotificationTest
 
   void SetSendNotificationExpectations(MessageSharedPtr msg) {
     EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
-    EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+    EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _));
   }
 
   void SetSendNotificationVariables(MessageSharedPtr msg) {
@@ -89,7 +89,7 @@ class OnKeyBoardInputNotificationTest
     app_set = (!app_set ? ::utils::MakeShared<ApplicationSet>() : app_set);
     MockAppPtr app(CreateMockApp());
     app_set->insert(app);
-    EXPECT_CALL(app_mngr_, applications())
+    EXPECT_CALL(mock_app_manager_, applications())
         .WillOnce(Return(DataAccessor<ApplicationSet>(*app_set, lock_)));
     return app;
   }
@@ -160,7 +160,7 @@ TEST_F(OnKeyBoardInputNotificationTest, Run_InvalidApp_NoNotification) {
       .WillOnce(Return(mobile_apis::HMILevel::eType::HMI_BACKGROUND));
 
   EXPECT_CALL(message_helper_, PrintSmartObject(_)).Times(0);
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _)).Times(0);
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
@@ -148,10 +148,10 @@ TEST_F(OnSystemRequestNotificationTest, DISABLED_Run_ProprietaryType_SUCCESS) {
       CreateCommand<OnSystemRequestNotification>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
   MockPolicyHandlerInterface mock_policy_handler;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillRepeatedly(ReturnRef(mock_policy_handler));
   std::string policy_app_id;
   EXPECT_CALL(*mock_app, policy_app_id()).WillOnce(Return(policy_app_id));
@@ -159,14 +159,14 @@ TEST_F(OnSystemRequestNotificationTest, DISABLED_Run_ProprietaryType_SUCCESS) {
       .WillOnce(Return(true));
 
 #ifdef EXTENDED_POLICY
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .Times(2)
       .WillRepeatedly(ReturnRef(mock_policy_handler));
   EXPECT_CALL(mock_policy_handler, TimeoutExchange()).WillOnce(Return(5u));
 #endif  // EXTENDED_POLICY
 
   EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _));
 
   command->Run();
 
@@ -194,10 +194,10 @@ TEST_F(OnSystemRequestNotificationTest, Run_HTTPType_SUCCESS) {
       CreateCommand<OnSystemRequestNotification>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
   MockPolicyHandlerInterface mock_policy_handler;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler));
   std::string policy_app_id;
   EXPECT_CALL(*mock_app, policy_app_id()).WillOnce(Return(policy_app_id));
@@ -205,7 +205,7 @@ TEST_F(OnSystemRequestNotificationTest, Run_HTTPType_SUCCESS) {
       .WillOnce(Return(true));
 
   EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _));
 
   command->Run();
 
@@ -230,15 +230,15 @@ TEST_F(OnSystemRequestNotificationTest, Run_InvalidApp_NoNotification) {
       CreateCommand<OnSystemRequestNotification>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(MockAppPtr()));
-  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
   EXPECT_CALL(*mock_app, policy_app_id()).Times(0);
   MockPolicyHandlerInterface mock_policy_handler;
   EXPECT_CALL(mock_policy_handler, IsRequestTypeAllowed(_, _)).Times(0);
 
   EXPECT_CALL(message_helper_, PrintSmartObject(_)).Times(0);
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _)).Times(0);
 
   command->Run();
 }
@@ -254,10 +254,10 @@ TEST_F(OnSystemRequestNotificationTest, Run_RequestNotAllowed_NoNotification) {
       CreateCommand<OnSystemRequestNotification>(msg);
 
   MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
   MockPolicyHandlerInterface mock_policy_handler;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler));
   std::string policy_app_id;
   EXPECT_CALL(*mock_app, policy_app_id()).WillOnce(Return(policy_app_id));
@@ -265,7 +265,7 @@ TEST_F(OnSystemRequestNotificationTest, Run_RequestNotAllowed_NoNotification) {
       .WillOnce(Return(false));
 
   EXPECT_CALL(message_helper_, PrintSmartObject(_)).Times(0);
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _)).Times(0);
   ;
 
   command->Run();

--- a/src/components/application_manager/test/commands/mobile/on_tbt_client_state_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_tbt_client_state_notification_test.cc
@@ -75,7 +75,7 @@ TEST_F(OnTBTClientStateNotificationTest, Run_HmiLevelNone_UNSUCCESS) {
   std::vector<ApplicationSharedPtr> applications_with_navi;
   applications_with_navi.push_back(mock_app);
 
-  EXPECT_CALL(app_mngr_, applications_with_navi())
+  EXPECT_CALL(mock_app_manager_, applications_with_navi())
       .WillOnce(Return(applications_with_navi));
 
   EXPECT_CALL(*mock_app, hmi_level())
@@ -83,7 +83,7 @@ TEST_F(OnTBTClientStateNotificationTest, Run_HmiLevelNone_UNSUCCESS) {
 
   EXPECT_CALL(*mock_app, app_id()).Times(0);
 
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(_, _)).Times(0);
 
   command_->Run();
 }
@@ -119,7 +119,7 @@ TEST_F(OnTBTClientStateNotificationTest,
   std::vector<ApplicationSharedPtr> applications_with_navi;
   applications_with_navi.push_back(mock_app);
 
-  EXPECT_CALL(app_mngr_, applications_with_navi())
+  EXPECT_CALL(mock_app_manager_, applications_with_navi())
       .WillOnce(Return(applications_with_navi));
 
   EXPECT_CALL(*mock_app, hmi_level())
@@ -127,7 +127,7 @@ TEST_F(OnTBTClientStateNotificationTest,
 
   EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kAppId));
 
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(CheckMessageData(), _));
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(CheckMessageData(), _));
 
   command_->Run();
 }

--- a/src/components/application_manager/test/commands/mobile/on_touch_event_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_touch_event_notification_test.cc
@@ -75,14 +75,14 @@ TEST_F(OnTouchEventNotificationTest, Run_AppIsNotFullscreen_UNSUCCESS) {
   std::vector<ApplicationSharedPtr> applications_with_navi;
   applications_with_navi.push_back(mock_app);
 
-  EXPECT_CALL(app_mngr_, applications_with_navi())
+  EXPECT_CALL(mock_app_manager_, applications_with_navi())
       .WillOnce(Return(applications_with_navi));
 
   EXPECT_CALL(*mock_app, IsFullscreen()).WillOnce(Return(false));
 
   EXPECT_CALL(*mock_app, app_id()).Times(0);
 
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(_, _)).Times(0);
 
   command_->Run();
 }
@@ -117,14 +117,14 @@ TEST_F(OnTouchEventNotificationTest, Run_NotEmptyListOfAppsWithNavi_SUCCESS) {
   std::vector<ApplicationSharedPtr> applications_with_navi;
   applications_with_navi.push_back(mock_app);
 
-  EXPECT_CALL(app_mngr_, applications_with_navi())
+  EXPECT_CALL(mock_app_manager_, applications_with_navi())
       .WillOnce(Return(applications_with_navi));
 
   EXPECT_CALL(*mock_app, IsFullscreen()).WillOnce(Return(true));
 
   EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kAppId));
 
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(CheckMessageData(), _));
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(CheckMessageData(), _));
 
   command_->Run();
 }

--- a/src/components/application_manager/test/commands/mobile/on_vehicle_data_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_vehicle_data_notification_test.cc
@@ -125,7 +125,7 @@ TEST_F(OnVehicleDataNotificationTest,
   std::vector<ApplicationSharedPtr> applications;
   applications.push_back(mock_app);
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               IviInfoUpdated(am::VehicleDataType::FUELLEVEL, kFuelLevel))
       .WillOnce(Return(applications));
 
@@ -133,7 +133,7 @@ TEST_F(OnVehicleDataNotificationTest,
   ::utils::custom_string::CustomString dummy_name("test_app");
   ON_CALL(*mock_app, name()).WillByDefault(ReturnRef(dummy_name));
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               SendMessageToMobile(
                   CheckMessageData(am::strings::fuel_level, kFuelLevel), _));
 

--- a/src/components/application_manager/test/commands/mobile/on_way_point_change_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_way_point_change_notification_test.cc
@@ -100,10 +100,10 @@ TEST_F(OnWayPointChangeNotificationTest,
   std::set<int32_t> apps_subscribed_for_way_points;
   apps_subscribed_for_way_points.insert(kAppId);
 
-  EXPECT_CALL(app_mngr_, GetAppsSubscribedForWayPoints())
+  EXPECT_CALL(mock_app_manager_, GetAppsSubscribedForWayPoints())
       .WillOnce(Return(apps_subscribed_for_way_points));
 
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(CheckMessageData(), _));
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(CheckMessageData(), _));
 
   command_->Run();
 }

--- a/src/components/application_manager/test/commands/mobile/perform_audio_path_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_path_thru_test.cc
@@ -62,11 +62,10 @@ class PerformAudioPassThruRequestTest
  public:
   PerformAudioPassThruRequestTest()
       : message_(utils::MakeShared<SmartObject>(::smart_objects::SmartType_Map))
-      , kMsgParams_((*message_)[strings::msg_params]) {}
+      , msg_params_((*message_)[strings::msg_params]) {}
   void SetUp() OVERRIDE {
     command_sptr_ = CreateCommand<
-        application_manager::commands::PerformAudioPassThruRequest>(
-        CommandsTest::kDefaultTimeout_, message_);
+        application_manager::commands::PerformAudioPassThruRequest>(message_);
 
     application_sptr_ = CreateMockApp();
     ON_CALL(mock_app_manager_, application(_))
@@ -76,9 +75,9 @@ class PerformAudioPassThruRequestTest
  protected:
   void TestWrongSyntaxInField(const std::string& field) {
     if (field == strings::initial_prompt) {
-      kMsgParams_[field][0][strings::text] = "prompt\\n";
+      msg_params_[field][0][strings::text] = "prompt\\n";
     } else {
-      kMsgParams_[field] = "prompt\\n";
+      msg_params_[field] = "prompt\\n";
     }
 
     EXPECT_CALL(*application_sptr_, hmi_level())
@@ -96,7 +95,7 @@ class PerformAudioPassThruRequestTest
   }
 
   MessageSharedPtr message_;
-  ::smart_objects::SmartObject& kMsgParams_;
+  ::smart_objects::SmartObject& msg_params_;
   utils::SharedPtr<commands::PerformAudioPassThruRequest> command_sptr_;
   MockAppPtr application_sptr_;
 };

--- a/src/components/application_manager/test/commands/mobile/perform_audio_path_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_path_thru_test.cc
@@ -1,0 +1,413 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "application_manager/commands/command_request_test.h"
+
+#include "mobile/perform_audio_pass_thru_request.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using namespace application_manager;
+
+using ::testing::Return;
+using ::testing::_;
+using ::testing::InSequence;
+
+namespace {
+const std::string kCorrectPrompt = "CorrectPrompt";
+const std::string kCorrectType = "CorrectType";
+const std::string kCorrectDisplayText1 = "CorrectDisplayText1";
+const std::string kCorrectDisplayText2 = "CorrectDisplayText2";
+}
+
+class PerformAudioPassThruRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  PerformAudioPassThruRequestTest()
+      : message_(utils::MakeShared<SmartObject>(::smart_objects::SmartType_Map))
+      , kMsgParams_((*message_)[strings::msg_params]) {}
+  void SetUp() OVERRIDE {
+    command_sptr_ = CreateCommand<
+        application_manager::commands::PerformAudioPassThruRequest>(
+        CommandsTest::kDefaultTimeout_, message_);
+
+    application_sptr_ = CreateMockApp();
+    ON_CALL(mock_app_manager_, application(_))
+        .WillByDefault(Return(application_sptr_));
+  }
+
+ protected:
+  void TestWrongSyntaxInField(const std::string& field) {
+    if (field == strings::initial_prompt) {
+      kMsgParams_[field][0][strings::text] = "prompt\\n";
+    } else {
+      kMsgParams_[field] = "prompt\\n";
+    }
+
+    EXPECT_CALL(*application_sptr_, hmi_level())
+        .WillOnce(Return(mobile_api::HMILevel::HMI_FULL));
+
+    CallRun caller(*command_sptr_);
+    MessageSharedPtr result_message = CatchMobileCommandResult(caller);
+
+    const mobile_api::Result::eType kResult =
+        static_cast<mobile_api::Result::eType>(
+            (*result_message)[strings::msg_params][strings::result_code]
+                .asInt());
+
+    EXPECT_EQ(mobile_api::Result::INVALID_DATA, kResult);
+  }
+
+  MessageSharedPtr message_;
+  ::smart_objects::SmartObject& kMsgParams_;
+  utils::SharedPtr<commands::PerformAudioPassThruRequest> command_sptr_;
+  MockAppPtr application_sptr_;
+};
+
+TEST_F(PerformAudioPassThruRequestTest,
+       Run_InvalidApp_ApplicationNotRegisteredResponce) {
+  utils::SharedPtr<Application> null_application_sptr;
+  EXPECT_CALL(mock_app_manager_, application(_))
+      .WillOnce(Return(null_application_sptr));
+
+  CallRun caller(*command_sptr_);
+  MessageSharedPtr result_message = CatchMobileCommandResult(caller);
+
+  const mobile_api::Result::eType kResult =
+      static_cast<mobile_api::Result::eType>(
+          (*result_message)[strings::msg_params][strings::result_code].asInt());
+  EXPECT_EQ(mobile_api::Result::APPLICATION_NOT_REGISTERED, kResult);
+}
+
+TEST_F(PerformAudioPassThruRequestTest, Run_HmiLevelNone_Rejected) {
+  EXPECT_CALL(*application_sptr_, hmi_level())
+      .WillOnce(Return(mobile_api::HMILevel::HMI_NONE));
+
+  CallRun caller(*command_sptr_);
+  MessageSharedPtr result_message = CatchMobileCommandResult(caller);
+
+  const mobile_api::Result::eType kResult =
+      static_cast<mobile_api::Result::eType>(
+          (*result_message)[strings::msg_params][strings::result_code].asInt());
+  EXPECT_EQ(mobile_api::Result::REJECTED, kResult);
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       Run_WhitespaceInInitialPrompt_InvalidData) {
+  TestWrongSyntaxInField(strings::initial_prompt);
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       Run_WhitespaceInAudioPassDisplayText1_InvalidData) {
+  TestWrongSyntaxInField(strings::audio_pass_display_text1);
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       Run_WhitespaceInAudioPassDisplayText2_InvalidData) {
+  TestWrongSyntaxInField(strings::audio_pass_display_text2);
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       Run_InitPromptCorrect_SpeakAndPerformAPTRequestsSendMuteTrue) {
+  EXPECT_CALL(*application_sptr_, hmi_level())
+      .WillOnce(Return(mobile_api::HMILevel::HMI_FULL));
+
+  kMsgParams_[strings::initial_prompt][0][strings::text] = kCorrectPrompt;
+  kMsgParams_[strings::initial_prompt][0][strings::type] = kCorrectType;
+  kMsgParams_[strings::audio_pass_display_text1] = kCorrectDisplayText1;
+  kMsgParams_[strings::audio_pass_display_text2] = kCorrectDisplayText2;
+
+  MessageSharedPtr speak_reqeust_result_msg;
+  MessageSharedPtr perform_result_msg;
+  {
+    InSequence dummy;
+    // Send speak request sending
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+        .WillOnce(DoAll(SaveArg<0>(&speak_reqeust_result_msg), Return(true)));
+
+    // Perform audio path thru request sending
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+        .WillOnce(DoAll(SaveArg<0>(&perform_result_msg), Return(true)));
+  }
+  CallRun caller(*command_sptr_);
+  caller();
+
+  const ::smart_objects::SmartObject& kSpeakMsgParams_ =
+      (*speak_reqeust_result_msg)[strings::msg_params];
+  const ::smart_objects::SmartObject& kPerformMsgParams =
+      (*perform_result_msg)[strings::msg_params];
+
+  const std::string& kResultInitialPrompt =
+      kSpeakMsgParams_[hmi_request::tts_chunks][0][strings::text].asString();
+  const std::string& kResultPromptType =
+      kSpeakMsgParams_[hmi_request::tts_chunks][0][strings::type].asString();
+  const std::string& kResultDisplayText1 =
+      kPerformMsgParams[hmi_request::audio_pass_display_texts][0]
+                       [hmi_request::field_text].asString();
+  const std::string& kResultDisplayText2 =
+      kPerformMsgParams[hmi_request::audio_pass_display_texts][1]
+                       [hmi_request::field_text].asString();
+
+  EXPECT_EQ(kCorrectPrompt, kResultInitialPrompt);
+  EXPECT_EQ(kCorrectType, kResultPromptType);
+  EXPECT_EQ(kCorrectDisplayText1, kResultDisplayText1);
+  EXPECT_EQ(kCorrectDisplayText2, kResultDisplayText2);
+
+  EXPECT_EQ(true, kPerformMsgParams[strings::mute_audio].asBool());
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       Run_InitPromptCorrect_SpeakAndPerformAPTRequestsSendMuteFalse) {
+  EXPECT_CALL(*application_sptr_, hmi_level())
+      .WillOnce(Return(mobile_api::HMILevel::HMI_FULL));
+
+  kMsgParams_[strings::initial_prompt][0][strings::text] = kCorrectPrompt;
+  kMsgParams_[strings::initial_prompt][0][strings::type] = kCorrectType;
+
+  const bool kMuted = false;
+
+  kMsgParams_[strings::mute_audio] = kMuted;
+
+  MessageSharedPtr speak_reqeust_result_msg;
+  MessageSharedPtr perform_result_msg;
+  {
+    InSequence dummy;
+    // Send speak request sending
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+        .WillOnce(DoAll(SaveArg<0>(&speak_reqeust_result_msg), Return(true)));
+
+    // Perform audio path thru request sending
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+        .WillOnce(DoAll(SaveArg<0>(&perform_result_msg), Return(true)));
+  }
+  CallRun caller(*command_sptr_);
+  caller();
+
+  EXPECT_EQ(
+      kMuted,
+      (*perform_result_msg)[strings::msg_params][strings::mute_audio].asBool());
+}
+
+TEST_F(
+    PerformAudioPassThruRequestTest,
+    Run_InitPromptEmpty_PerformAndRecordStartNotificationsAndStartRecording) {
+  EXPECT_CALL(*application_sptr_, hmi_level())
+      .WillOnce(Return(mobile_api::HMILevel::HMI_FULL));
+
+  MessageSharedPtr start_record_result_msg;
+  MessageSharedPtr perform_result_msg;
+  {
+    InSequence dummy;
+    // Perform audio path thru request sending
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+        .WillOnce(DoAll(SaveArg<0>(&perform_result_msg), Return(true)));
+
+    // Start recording notification sending
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+        .WillOnce(DoAll(SaveArg<0>(&start_record_result_msg), Return(true)));
+  }
+
+  // Start microphone recording cals
+  EXPECT_CALL(mock_app_manager_, BeginAudioPassThrough());
+  EXPECT_CALL(mock_app_manager_, StartAudioPassThruThread(_, _, _, _, _, _));
+
+  CallRun caller(*command_sptr_);
+  caller();
+
+  const hmi_apis::FunctionID::eType kStartRecordResultFunctionId =
+      static_cast<hmi_apis::FunctionID::eType>(
+          (*start_record_result_msg)[strings::params][strings::function_id]
+              .asInt());
+  EXPECT_EQ(hmi_apis::FunctionID::UI_OnRecordStart,
+            kStartRecordResultFunctionId);
+}
+
+TEST_F(PerformAudioPassThruRequestTest, OnEvent_UIPAPT_Rejected) {
+  event_engine::Event event(hmi_apis::FunctionID::UI_PerformAudioPassThru);
+
+  (*message_)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::REJECTED;
+  event.set_smart_object(*message_);
+
+  CallOnEvent caller(*command_sptr_, event);
+
+  MessageSharedPtr result_message = CatchMobileCommandResult(caller);
+
+  const mobile_apis::Result::eType kResultCode =
+      static_cast<mobile_api::Result::eType>(
+          (*result_message)[strings::msg_params][strings::result_code].asInt());
+
+  EXPECT_EQ(mobile_apis::Result::REJECTED, kResultCode);
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       OnEvent_TTSSpeakSuccess_UpdateRequestTimeout) {
+  event_engine::Event event(hmi_apis::FunctionID::TTS_Speak);
+
+  (*message_)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  event.set_smart_object(*message_);
+
+  // Start recording notification sending
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).WillOnce(Return(true));
+
+  // Start microphone recording cals
+  EXPECT_CALL(mock_app_manager_, BeginAudioPassThrough());
+  EXPECT_CALL(mock_app_manager_, StartAudioPassThruThread(_, _, _, _, _, _));
+
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _));
+
+  CallOnEvent caller(*command_sptr_, event);
+  caller();
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       OnEvent_PAPTunsupportedResource_CorrectInfo) {
+  const std::string kReturnInfo = "Unsupported phoneme type sent in a prompt";
+
+  event_engine::Event event_speak(hmi_apis::FunctionID::TTS_Speak);
+  event_engine::Event event_perform(
+      hmi_apis::FunctionID::UI_PerformAudioPassThru);
+
+  (*message_)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE;
+  event_speak.set_smart_object(*message_);
+
+  (*message_)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  event_perform.set_smart_object(*message_);
+
+  // First call on_event for setting result_tts_speak_ to UNSUPPORTED_RESOURCE
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _)).Times(0);
+  CallOnEvent caller_speak(*command_sptr_, event_speak);
+  caller_speak();
+
+  // Second call for test correct behavior of UI_PerformAudioPassThru event
+  EXPECT_CALL(mock_app_manager_, EndAudioPassThrough()).WillOnce(Return(false));
+  EXPECT_CALL(mock_app_manager_, StopAudioPassThru(_)).Times(0);
+
+  CallOnEvent caller_perform(*command_sptr_, event_perform);
+
+  MessageSharedPtr perform_event_result =
+      CatchMobileCommandResult(caller_perform);
+
+  EXPECT_EQ(
+      kReturnInfo,
+      (*perform_event_result)[strings::msg_params][strings::info].asString());
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       OnEvent_TTSOnResetTimeout_UpdateTimeout) {
+  event_engine::Event event(hmi_apis::FunctionID::TTS_Speak);
+
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _));
+
+  CallOnEvent caller(*command_sptr_, event);
+  caller();
+}
+
+TEST_F(PerformAudioPassThruRequestTest, OnEvent_DefaultCase) {
+  event_engine::Event event(hmi_apis::FunctionID::INVALID_ENUM);
+
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, EndAudioPassThrough()).Times(0);
+
+  CallOnEvent caller(*command_sptr_, event);
+  caller();
+}
+
+TEST_F(PerformAudioPassThruRequestTest, Init_CorrectTimeout) {
+  const uint32_t kDefaultTimeout = command_sptr_->default_timeout();
+  const uint32_t kMaxDuration = 10000u;
+
+  kMsgParams_[strings::max_duration] = kMaxDuration;
+
+  command_sptr_->Init();
+
+  EXPECT_EQ(kDefaultTimeout + kMaxDuration, command_sptr_->default_timeout());
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       onTimeOut_ttsSpeakNotActive_DontSendHMIReqeust) {
+  EXPECT_CALL(mock_app_manager_, EndAudioPassThrough()).WillOnce(Return(true));
+  EXPECT_CALL(mock_app_manager_, StopAudioPassThru(_));
+
+  // For setting current_state_ -> kCompleted
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
+  command_sptr_->SendResponse(true, mobile_api::Result::SUCCESS);
+
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
+
+  command_sptr_->onTimeOut();
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       onTimeOut_ttsSpeakActive_SendHMIReqeust) {
+  EXPECT_CALL(mock_app_manager_, EndAudioPassThrough()).WillOnce(Return(true));
+  EXPECT_CALL(mock_app_manager_, StopAudioPassThru(_));
+
+  EXPECT_CALL(*application_sptr_, hmi_level())
+      .WillOnce(Return(mobile_api::HMILevel::HMI_FULL));
+
+  kMsgParams_[strings::initial_prompt][0][strings::text] = kCorrectPrompt;
+  kMsgParams_[strings::initial_prompt][0][strings::type] = kCorrectType;
+
+  // For setting is_active_tts_speak -> true
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+      .Times(2)
+      .WillRepeatedly(Return(true));
+  CallRun caller(*command_sptr_);
+  caller();
+
+  // For setting current_state_ -> kCompleted
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
+  command_sptr_->SendResponse(true, mobile_api::Result::SUCCESS);
+
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::TTS_StopSpeaking)))
+      .WillOnce(Return(true));
+  command_sptr_->onTimeOut();
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
@@ -70,8 +70,8 @@ class PerformInteractionRequestTest
       : message_(utils::MakeShared<SmartObject>(::smart_objects::SmartType_Map))
       , kMsgParams_((*message_)[strings::msg_params]) {}
   void SetUp() OVERRIDE {
-    command_sptr_ = CreateCommand<commands::PerformInteractionRequest>(
-        CommandsTest::kDefaultTimeout_, message_);
+    command_sptr_ =
+        CreateCommand<commands::PerformInteractionRequest>(message_);
 
     mock_application_sptr_ = CreateMockApp();
     ON_CALL(mock_app_manager_, application(_))
@@ -714,22 +714,22 @@ TEST_F(PerformInteractionRequestTest,
 
 TEST_F(
     PerformInteractionRequestTest,
-    OnEvent_VRResponcVRPIcodeGenericError_TerminatePIAndGenericErrorResponce) {
+    OnEvent_VRResponceRPIcodeGenericError_TerminatePIAndGenericErrorResponce) {
   TestVRResponceResultCode(mobile_apis::Result::GENERIC_ERROR);
 }
 
 TEST_F(PerformInteractionRequestTest,
-       OnEvent_VRResponcVRPIcodeAbortedVrOnly_TerminatePIAndAbortedResponce) {
+       OnEvent_VRResponceRPIcodeAbortedVrOnly_TerminatePIAndAbortedResponce) {
   TestVRResponceResultCode(mobile_apis::Result::ABORTED);
 }
 
 TEST_F(PerformInteractionRequestTest,
-       OnEvent_VRResponcVRPIcodeTimeout_TerminatePIAndTimeoutResponce) {
+       OnEvent_VRResponceRPIcodeTimeout_TerminatePIAndTimeoutResponce) {
   TestVRResponceResultCode(mobile_apis::Result::TIMED_OUT);
 }
 
 TEST_F(PerformInteractionRequestTest,
-       OnEvent_VRResponcVRPIcodeTimeOut_ResetTimeout) {
+       OnEvent_VRResponceRPIcodeTimeOut_ResetTimeout) {
   event_engine::Event event(hmi_apis::FunctionID::VR_PerformInteraction);
   CallOnEvent caller(*command_sptr_, event);
 
@@ -745,23 +745,23 @@ TEST_F(PerformInteractionRequestTest,
 }
 
 TEST_F(PerformInteractionRequestTest,
-       OnEvent_VRResponcVRPIcodeRejected_TerminatePIAndRejectedResponce) {
+       OnEvent_VRResponceRPIcodeRejected_TerminatePIAndRejectedResponce) {
   TestVRResponceResultCode(mobile_apis::Result::REJECTED);
 }
 
 TEST_F(
     PerformInteractionRequestTest,
-    OnEvent_VRResponcVRPIcodeUnsupportedRequest_TerminatePIAndWarningsResponce) {
+    OnEvent_VRResponceRPIcodeUnsupportedRequest_TerminatePIAndWarningsResponce) {
   TestVRResponceResultCode(mobile_apis::Result::UNSUPPORTED_REQUEST);
 }
 
 TEST_F(PerformInteractionRequestTest,
-       OnEvent_VRResponcVRPIcodeWarnings_TerminatePIAndWarningsResponce) {
+       OnEvent_VRResponceRPIcodeWarnings_TerminatePIAndWarningsResponce) {
   TestVRResponceResultCode(mobile_apis::Result::WARNINGS);
 }
 
 TEST_F(PerformInteractionRequestTest,
-       OnEvent_VRResponcVRPIcodeSuccessManualOnly_Return) {
+       OnEvent_VRResponceRPIcodeSuccessManualOnly_Return) {
   event_engine::Event event(hmi_apis::FunctionID::VR_PerformInteraction);
   CallOnEvent caller(*command_sptr_, event);
 
@@ -780,7 +780,7 @@ TEST_F(PerformInteractionRequestTest,
 }
 
 TEST_F(PerformInteractionRequestTest,
-       OnEvent_VRResponcVRPIWrongChoiset_ResponceGenericError) {
+       OnEvent_VRResponceRPIWrongChoiset_ResponceGenericError) {
   event_engine::Event event(hmi_apis::FunctionID::VR_PerformInteraction);
   CallOnEvent caller(*command_sptr_, event);
 
@@ -823,7 +823,7 @@ TEST_F(PerformInteractionRequestTest,
 }
 
 TEST_F(PerformInteractionRequestTest,
-       OnEvent_VRResponcVRPICorrectChoiSet_ResponceSuccess) {
+       OnEvent_VRResponceRPICorrectChoiSet_ResponceSuccess) {
   event_engine::Event event(hmi_apis::FunctionID::VR_PerformInteraction);
   CallOnEvent caller(*command_sptr_, event);
 

--- a/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
@@ -1,0 +1,889 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/helpers.h"
+
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_message_helper.h"
+
+#include "mobile/perform_interaction_request.h"
+
+#include "utils/data_accessor.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using namespace application_manager;
+
+using ::testing::Return;
+using ::testing::ReturnNull;
+using ::testing::ReturnPointee;
+using ::testing::_;
+
+namespace {
+const std::string kNotValidText = "wrong prompt\n";
+const std::string kValidText = "correct prompt";
+const uint32_t kCorrelationId = 666u;
+const int32_t kSomeNumber = 1;
+const int32_t kSomeAnotherNumber = 666;
+}
+
+class PerformInteractionRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  PerformInteractionRequestTest()
+      : message_(utils::MakeShared<SmartObject>(::smart_objects::SmartType_Map))
+      , kMsgParams_((*message_)[strings::msg_params]) {}
+  void SetUp() OVERRIDE {
+    command_sptr_ = CreateCommand<commands::PerformInteractionRequest>(
+        CommandsTest::kDefaultTimeout_, message_);
+
+    mock_application_sptr_ = CreateMockApp();
+    ON_CALL(mock_app_manager_, application(_))
+        .WillByDefault(Return(mock_application_sptr_));
+    ON_CALL(*mock_application_sptr_, is_perform_interaction_active())
+        .WillByDefault(Return(false));
+  }
+
+ protected:
+  void ExpectMobileResult(mobile_api::Result::eType result) {
+    CallRun caller(*command_sptr_);
+    MessageSharedPtr result_message = CatchMobileCommandResult(caller);
+
+    const mobile_api::Result::eType kResult =
+        static_cast<mobile_api::Result::eType>(
+            (*result_message)[strings::msg_params][strings::result_code]
+                .asInt());
+    EXPECT_EQ(result, kResult);
+  }
+
+  void TestPromptFieldValidation(const std::string& field) {
+    kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+
+    ::smart_objects::SmartObject choise_sets;
+    choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+    EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
+        .WillOnce(Return(&choise_sets));
+
+    kMsgParams_[strings::initial_text] = kValidText;
+    kMsgParams_[field][0][strings::text] = kNotValidText;
+
+    ExpectMobileResult(mobile_api::Result::INVALID_DATA);
+  }
+
+  void TestVRResponceResultCode(mobile_apis::Result::eType code) {
+    using namespace helpers;
+    event_engine::Event event(hmi_apis::FunctionID::VR_PerformInteraction);
+    CallOnEvent caller(*command_sptr_, event);
+
+    (*message_)[strings::params][hmi_response::code] = code;
+
+    const bool is_vr_aborted_timeout =
+        Compare<mobile_apis::Result::eType, EQ, ONE>(
+            code, mobile_apis::Result::ABORTED, mobile_apis::Result::TIMED_OUT);
+
+    if (is_vr_aborted_timeout) {
+      (*message_)[strings::msg_params][strings::interaction_mode] =
+          mobile_api::InteractionMode::VR_ONLY;
+      command_sptr_->Init();
+    }
+
+    if (mobile_api::Result::UNSUPPORTED_REQUEST == code) {
+      // Because in case UNSUPPORTED_REQUEST we will send WARNINGS
+      code = mobile_api::Result::WARNINGS;
+    }
+
+    event.set_smart_object(*message_);
+
+    MessageSharedPtr hmi_result_msg;
+    MessageSharedPtr mobile_result_msg;
+
+    {
+      ::testing::InSequence dummy;
+      EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+          .WillOnce(DoAll(SaveArg<0>(&hmi_result_msg), Return(true)));
+
+      EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _))
+          .WillOnce(DoAll(SaveArg<0>(&mobile_result_msg), Return(true)));
+
+      if (!is_vr_aborted_timeout) {
+        EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+            .WillOnce(Return(true));
+
+        EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _))
+            .WillOnce(Return(true));
+      }
+    }
+
+    caller();
+
+    const hmi_apis::FunctionID::eType kHmiResult =
+        static_cast<hmi_apis::FunctionID::eType>(
+            (*hmi_result_msg)[strings::params][strings::function_id].asInt());
+    const mobile_api::Result::eType kMobileResult =
+        static_cast<mobile_api::Result::eType>(
+            (*mobile_result_msg)[strings::msg_params][strings::result_code]
+                .asInt());
+
+    EXPECT_EQ(hmi_apis::FunctionID::UI_ClosePopUp, kHmiResult);
+    EXPECT_EQ(code, kMobileResult);
+  }
+
+  sync_primitives::Lock test_lock_;
+  MessageSharedPtr message_;
+  ::smart_objects::SmartObject& kMsgParams_;
+  utils::SharedPtr<commands::PerformInteractionRequest> command_sptr_;
+  MockAppPtr mock_application_sptr_;
+};
+
+TEST_F(PerformInteractionRequestTest, Init_CorrectTimeout) {
+  const uint32_t kNewTimeOut = 1000u;
+  kMsgParams_[strings::timeout] = kNewTimeOut;
+  kMsgParams_[strings::interaction_mode] =
+      mobile_api::InteractionMode::MANUAL_ONLY;
+
+  EXPECT_EQ(kDefaultTimeout_, command_sptr_->default_timeout());
+
+  command_sptr_->Init();
+  EXPECT_EQ(kNewTimeOut * 2, command_sptr_->default_timeout());
+}
+
+TEST_F(PerformInteractionRequestTest,
+       Run_InvalidApp_ApplicationNotRegisteredResponce) {
+  utils::SharedPtr<Application> null_application_sptr;
+  EXPECT_CALL(mock_app_manager_, application(_))
+      .WillOnce(Return(null_application_sptr));
+
+  ExpectMobileResult(mobile_api::Result::APPLICATION_NOT_REGISTERED);
+}
+
+TEST_F(PerformInteractionRequestTest, Run_VROnlyAndKeyboardLayout_InvalidData) {
+  kMsgParams_[hmi_request::interaction_layout] =
+      mobile_api::LayoutMode::KEYBOARD;
+  kMsgParams_[strings::interaction_mode] = mobile_api::InteractionMode::VR_ONLY;
+  command_sptr_->Init();
+
+  ExpectMobileResult(mobile_api::Result::INVALID_DATA);
+}
+
+TEST_F(PerformInteractionRequestTest, Run_BothAndKeyboardLayout_InvalidData) {
+  kMsgParams_[hmi_request::interaction_layout] =
+      mobile_api::LayoutMode::KEYBOARD;
+  kMsgParams_[strings::interaction_mode] = mobile_api::InteractionMode::BOTH;
+  command_sptr_->Init();
+
+  ExpectMobileResult(mobile_api::Result::INVALID_DATA);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       Run_SetIdsEmptyAndLayoutNotKeyboard_InvalidData) {
+  kMsgParams_[hmi_request::interaction_layout] =
+      mobile_api::LayoutMode::ICON_ONLY;
+
+  ExpectMobileResult(mobile_api::Result::INVALID_DATA);
+}
+
+TEST_F(PerformInteractionRequestTest, Run_FoundInvalidChouiseSet_InvalidId) {
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_)).WillOnce(ReturnNull());
+
+  ExpectMobileResult(mobile_api::Result::INVALID_ID);
+}
+
+TEST_F(PerformInteractionRequestTest, Run_TwoSameChoisesetIds_InvalidId) {
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+
+  ::smart_objects::SmartObject choise_sets;
+  choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+  choise_sets[strings::choice_set][1][strings::choice_id] = kSomeNumber;
+
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
+      .WillOnce(Return(&choise_sets));
+
+  ExpectMobileResult(mobile_api::Result::INVALID_ID);
+}
+
+TEST_F(PerformInteractionRequestTest, Run_InvalidImageVrHelpItems_InvalidData) {
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+
+  ::smart_objects::SmartObject choise_sets;
+  choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
+      .WillOnce(Return(&choise_sets));
+
+  kMsgParams_[strings::vr_help] = "vr_help";
+  EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
+              VerifyImageVrHelpItems(_, _, _))
+      .WillOnce(Return(mobile_api::Result::INVALID_ENUM));
+
+  ExpectMobileResult(mobile_api::Result::INVALID_DATA);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       Run_WhiteSpaceExistsInInitialText_InvalidData) {
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+
+  ::smart_objects::SmartObject choise_sets;
+  choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
+      .WillOnce(Return(&choise_sets));
+
+  kMsgParams_[strings::initial_text] = kNotValidText;
+
+  ExpectMobileResult(mobile_api::Result::INVALID_DATA);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       Run_WhiteSpaceExistsInInitialPrompt_InvalidData) {
+  TestPromptFieldValidation(strings::initial_prompt);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       Run_WhiteSpaceExistsInHelpPrompt_InvalidData) {
+  TestPromptFieldValidation(strings::help_prompt);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       Run_WhiteSpaceExistsInTimeoutPrompt_InvalidData) {
+  TestPromptFieldValidation(strings::timeout_prompt);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       Run_WhiteSpaceExistsInVrHelpText_InvalidData) {
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+
+  ::smart_objects::SmartObject choise_sets;
+  choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
+      .WillOnce(Return(&choise_sets));
+
+  EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
+              VerifyImageVrHelpItems(_, _, _))
+      .WillOnce(Return(mobile_api::Result::SUCCESS));
+
+  kMsgParams_[strings::initial_text] = kValidText;
+  kMsgParams_[strings::vr_help][0][strings::text] = kNotValidText;
+
+  ExpectMobileResult(mobile_api::Result::INVALID_DATA);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       Run_WhiteSpaceExistsInVrHelpImageValue_InvalidData) {
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+
+  ::smart_objects::SmartObject choise_sets;
+  choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
+      .WillOnce(Return(&choise_sets));
+
+  EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
+              VerifyImageVrHelpItems(_, _, _))
+      .WillOnce(Return(mobile_api::Result::SUCCESS));
+
+  kMsgParams_[strings::initial_text] = kValidText;
+  kMsgParams_[strings::vr_help][0][strings::text] = kValidText;
+  kMsgParams_[strings::vr_help][0][strings::image][strings::value] =
+      kNotValidText;
+
+  ExpectMobileResult(mobile_api::Result::INVALID_DATA);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       ChecVrSynonyms_InvalidChoiseSet_InvalidId) {
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = 1u;
+  kMsgParams_[strings::interaction_choice_set_id_list][1] = 1u;
+  kMsgParams_[strings::interaction_choice_set_id_list][2] = 1u;
+
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
+      .WillRepeatedly(ReturnNull());
+  EXPECT_CALL(mock_app_manager_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_apis::Result::INVALID_ID), _));
+
+  command_sptr_->CallCheckMethod(
+      commands::PerformInteractionRequest::CheckMethod::kCheckVrSynonyms);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       ChecVrSynonyms_TwoSameVrCommands_DuplicateName) {
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][1] = kSomeNumber;
+  ::smart_objects::SmartObject choise_sets;
+  choise_sets[strings::grammar_id] = kSomeNumber;
+  choise_sets[strings::choice_set][0][strings::vr_commands][0] = kSomeNumber;
+  choise_sets[strings::choice_set][0][strings::vr_commands][1] = kSomeNumber;
+
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
+      .WillRepeatedly(Return(&choise_sets));
+
+  EXPECT_CALL(mock_app_manager_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_apis::Result::DUPLICATE_NAME), _));
+
+  const bool kResult = command_sptr_->CallCheckMethod(
+      commands::PerformInteractionRequest::CheckMethod::kCheckVrSynonyms);
+
+  EXPECT_FALSE(kResult);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       CheckMenuNames_InvalidListOfNames_InvalidId) {
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][1] = kSomeNumber;
+
+  EXPECT_CALL(
+      *mock_application_sptr_,
+      FindChoiceSet(
+          kMsgParams_[strings::interaction_choice_set_id_list][0].asInt()))
+      .Times(3)
+      .WillRepeatedly(ReturnNull());
+  EXPECT_CALL(mock_app_manager_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_apis::Result::INVALID_ID), _));
+
+  const bool kResult = command_sptr_->CallCheckMethod(
+      commands::PerformInteractionRequest::CheckMethod::kCheckMenuNames);
+
+  EXPECT_FALSE(kResult);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       CheckMenuNames_TwoSameNames_DuplicateName) {
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][1] = kSomeNumber;
+
+  ::smart_objects::SmartObject choise_set_1;
+  ::smart_objects::SmartObject choise_set_2;
+  choise_set_1[strings::choice_set][0][strings::menu_name] = "MenuName";
+  choise_set_2[strings::choice_set][0][strings::menu_name] = "MenuName";
+
+  EXPECT_CALL(
+      *mock_application_sptr_,
+      FindChoiceSet(
+          kMsgParams_[strings::interaction_choice_set_id_list][0].asInt()))
+      .Times(3)
+      .WillOnce(Return(&choise_set_1))
+      // Second call will be scipped in method cycles
+      .WillOnce(ReturnNull())
+      // Third call value will be compared to value from first call
+      .WillOnce(Return(&choise_set_2));
+
+  EXPECT_CALL(mock_app_manager_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_apis::Result::DUPLICATE_NAME), _));
+
+  const bool kResult = command_sptr_->CallCheckMethod(
+      commands::PerformInteractionRequest::CheckMethod::kCheckMenuNames);
+
+  EXPECT_FALSE(kResult);
+}
+
+TEST_F(PerformInteractionRequestTest, CheckMenuNames_AllRight_Success) {
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][1] = kSomeNumber;
+
+  ::smart_objects::SmartObject choise_set_1;
+  ::smart_objects::SmartObject choise_set_2;
+  choise_set_1[strings::choice_set][0][strings::menu_name] = "MenuName";
+  choise_set_2[strings::choice_set][0][strings::menu_name] = "AnotherMenuName";
+
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
+      .Times(6)
+      .WillOnce(Return(&choise_set_1))
+      // Second call will be scipped in method cycles
+      .WillOnce(ReturnNull())
+      // Third call value will be compared to value from first call
+      .WillOnce(Return(&choise_set_2))
+      // First cycle second iteration
+      .WillOnce(Return(&choise_set_2))
+      // Second cycle first iteration
+      .WillOnce(Return(&choise_set_1))
+      // Second cycle second iteration will be skipped
+      .WillOnce(ReturnNull());
+
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
+
+  const bool kResult = command_sptr_->CallCheckMethod(
+      commands::PerformInteractionRequest::CheckMethod::kCheckMenuNames);
+
+  EXPECT_TRUE(kResult);
+}
+
+TEST_F(PerformInteractionRequestTest, CheckVrHelpItem_VrHelpNotExists_Success) {
+  const bool kResult = command_sptr_->CallCheckMethod(
+      commands::PerformInteractionRequest::CheckMethod::kCheckVrHelpItem);
+
+  EXPECT_TRUE(kResult);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       CheckVrHelpItem_IncorrectPosition_Rejected) {
+  kMsgParams_[strings::vr_help][0][strings::position] = kSomeNumber;
+  kMsgParams_[strings::vr_help][1][strings::position] = kSomeAnotherNumber;
+
+  EXPECT_CALL(mock_app_manager_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_apis::Result::REJECTED), _));
+
+  const bool kResult = command_sptr_->CallCheckMethod(
+      commands::PerformInteractionRequest::CheckMethod::kCheckVrHelpItem);
+
+  EXPECT_FALSE(kResult);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       CheckVrHelpItem_CorrectPositions_Success) {
+  kMsgParams_[strings::vr_help][0][strings::position] = kSomeNumber;
+  kMsgParams_[strings::vr_help][1][strings::position] = kSomeNumber + 1;
+
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
+
+  const bool kResult = command_sptr_->CallCheckMethod(
+      commands::PerformInteractionRequest::CheckMethod::kCheckVrHelpItem);
+
+  EXPECT_TRUE(kResult);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       Run_InvalidInteractionMode_StopProcessing) {
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+  kMsgParams_[strings::interaction_mode] =
+      mobile_api::InteractionMode::INVALID_ENUM;
+  kMsgParams_[strings::initial_text] = kValidText;
+
+  ::smart_objects::SmartObject choise_sets;
+  choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
+      .WillOnce(Return(&choise_sets));
+
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
+
+  CallRun caller(*command_sptr_);
+  caller();
+}
+
+TEST_F(PerformInteractionRequestTest, Run_AllRight_SendVRAndUIRequests) {
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = 1u;
+  kMsgParams_[strings::interaction_mode] = mobile_api::InteractionMode::VR_ONLY;
+  kMsgParams_[strings::initial_text] = kValidText;
+  kMsgParams_[strings::help_prompt][0][strings::text] = "Prompt";
+
+  ::smart_objects::SmartObject choise_sets;
+  choise_sets[strings::grammar_id] = kSomeNumber;
+  choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+  choise_sets[strings::choice_set][0][strings::vr_commands][0] = kSomeNumber;
+
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
+      .WillRepeatedly(Return(&choise_sets));
+
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
+
+  command_sptr_->Init();
+  CallRun caller(*command_sptr_);
+
+  MessageSharedPtr first_msg;
+  MessageSharedPtr second_msg;
+  {
+    ::testing::InSequence dummy;
+    EXPECT_CALL(this->mock_app_manager_, ManageHMICommand(_))
+        .WillOnce(DoAll(SaveArg<0>(&first_msg), Return(true)));
+    EXPECT_CALL(this->mock_app_manager_, ManageHMICommand(_))
+        .WillOnce(DoAll(SaveArg<0>(&second_msg), Return(true)));
+  }
+  caller();
+
+  const hmi_apis::FunctionID::eType kFirstResult =
+      static_cast<hmi_apis::FunctionID::eType>(
+          (*first_msg)[strings::params][strings::function_id].asInt());
+  EXPECT_EQ(hmi_apis::FunctionID::VR_PerformInteraction, kFirstResult);
+
+  const hmi_apis::FunctionID::eType kSecondResult =
+      static_cast<hmi_apis::FunctionID::eType>(
+          (*second_msg)[strings::params][strings::function_id].asInt());
+  EXPECT_EQ(hmi_apis::FunctionID::UI_PerformInteraction, kSecondResult);
+}
+
+TEST_F(PerformInteractionRequestTest, OnEvent_OnResetTimeout_UpdateTimeout) {
+  event_engine::Event event(hmi_apis::FunctionID::UI_OnResetTimeout);
+  CallOnEvent caller(*command_sptr_, event);
+
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _));
+
+  caller();
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_PerformInteractionResponce_Unsuccess) {
+  event_engine::Event event(hmi_apis::FunctionID::UI_PerformInteraction);
+  CallOnEvent caller(*command_sptr_, event);
+
+  ApplicationSharedPtr null_application;
+  EXPECT_CALL(mock_app_manager_, application(_))
+      .WillOnce(Return(null_application));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
+
+  caller();
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_PerformInteractionResponceUnsupportedResource_CorrectCode) {
+  event_engine::Event event(hmi_apis::FunctionID::UI_PerformInteraction);
+  CallOnEvent caller(*command_sptr_, event);
+  const std::string kExpectedInfo =
+      "Unsupported phoneme type was sent in an item";
+  const std::string kExpectedData = "some data";
+
+  (*message_)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE;
+  (*message_)[strings::params][strings::data]["some_field"] = kExpectedData;
+
+  event.set_smart_object(*message_);
+
+  EXPECT_CALL(*mock_application_sptr_, DeletePerformInteractionChoiceSet(_))
+      .Times(2);
+
+  MessageSharedPtr result_msg = CatchMobileCommandResult(caller);
+
+  const mobile_api::Result::eType kResult =
+      static_cast<mobile_api::Result::eType>(
+          (*result_msg)[strings::msg_params][strings::result_code].asInt());
+  const std::string& kResultInfo =
+      (*result_msg)[strings::msg_params][strings::info].asString();
+
+  EXPECT_EQ(mobile_api::Result::UNSUPPORTED_RESOURCE, kResult);
+  EXPECT_EQ(kExpectedInfo, kResultInfo);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_PerformInteractionResponceInvalidChoiseId_GenericError) {
+  event_engine::Event event(hmi_apis::FunctionID::UI_PerformInteraction);
+  CallOnEvent caller(*command_sptr_, event);
+  const std::string kExpectedInfo = "Wrong choiceID was received from HMI";
+
+  ::smart_objects::SmartObject message;
+  message[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  message[strings::msg_params][strings::choice_id] = kSomeNumber;
+
+  event.set_smart_object(message);
+
+  PerformChoiceSetMap empty_choice_set_map;
+  const DataAccessor<PerformChoiceSetMap> empty_data_accessor(
+      empty_choice_set_map, test_lock_);
+  EXPECT_CALL(*mock_application_sptr_, performinteraction_choice_set_map())
+      .WillOnce(Return(empty_data_accessor));
+
+  EXPECT_CALL(*mock_application_sptr_, DeletePerformInteractionChoiceSet(_))
+      .Times(2);
+
+  MessageSharedPtr result_msg = CatchMobileCommandResult(caller);
+
+  const mobile_api::Result::eType kResult =
+      static_cast<mobile_api::Result::eType>(
+          (*result_msg)[strings::msg_params][strings::result_code].asInt());
+  const std::string& kResultInfo =
+      (*result_msg)[strings::msg_params][strings::info].asString();
+
+  EXPECT_EQ(mobile_api::Result::GENERIC_ERROR, kResult);
+  EXPECT_EQ(kExpectedInfo, kResultInfo);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_PerformInteractionResponceCorrectChoiseSet_TriggerSourceTsMenu) {
+  event_engine::Event event(hmi_apis::FunctionID::UI_PerformInteraction);
+  CallOnEvent caller(*command_sptr_, event);
+  const std::string kExpectedInfo = "";
+
+  (*message_)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  (*message_)[strings::params][strings::correlation_id] = kCorrelationId;
+  (*message_)[strings::msg_params][strings::choice_id] = kCorrelationId;
+
+  event.set_smart_object(*message_);
+
+  ::smart_objects::SmartObject choise_set;
+  choise_set[strings::choice_set][0][strings::choice_id] = kCorrelationId;
+
+  PerformChoice perform_choise_map;
+  perform_choise_map[kCorrelationId] = &choise_set;
+
+  PerformChoiceSetMap choice_set_map;
+  choice_set_map[kCorrelationId] = perform_choise_map;
+
+  const DataAccessor<PerformChoiceSetMap> data_accessor(choice_set_map,
+                                                        test_lock_);
+  EXPECT_CALL(*mock_application_sptr_, performinteraction_choice_set_map())
+      .WillOnce(Return(data_accessor));
+
+  EXPECT_CALL(*mock_application_sptr_, DeletePerformInteractionChoiceSet(_))
+      .Times(2);
+
+  MessageSharedPtr result_msg = CatchMobileCommandResult(caller);
+
+  const mobile_api::Result::eType kResult =
+      static_cast<mobile_api::Result::eType>(
+          (*result_msg)[strings::msg_params][strings::result_code].asInt());
+  const std::string& kResultInfo =
+      (*result_msg)[strings::msg_params][strings::info].asString();
+
+  EXPECT_EQ(mobile_api::Result::SUCCESS, kResult);
+  EXPECT_EQ(kExpectedInfo, kResultInfo);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_PerformInteractionResponceEmptyTextEntry_TriggerSourceKeyboard) {
+  event_engine::Event event(hmi_apis::FunctionID::UI_PerformInteraction);
+  CallOnEvent caller(*command_sptr_, event);
+  const std::string kExpectedInfo = "";
+
+  (*message_)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  (*message_)[strings::params][strings::correlation_id] = kCorrelationId;
+  (*message_)[strings::msg_params][strings::manual_text_entry] = "";
+
+  event.set_smart_object(*message_);
+
+  EXPECT_CALL(*mock_application_sptr_, DeletePerformInteractionChoiceSet(_)).Times(2);
+
+  MessageSharedPtr result_msg = CatchMobileCommandResult(caller);
+
+  const mobile_api::Result::eType kResult =
+      static_cast<mobile_api::Result::eType>(
+          (*result_msg)[strings::msg_params][strings::result_code].asInt());
+  const std::string& kResultInfo =
+      (*result_msg)[strings::msg_params][strings::info].asString();
+  const bool kTextEntryExists =
+      (*result_msg)[strings::msg_params].keyExists(strings::manual_text_entry);
+
+  EXPECT_FALSE(kTextEntryExists);
+  EXPECT_EQ(mobile_api::Result::SUCCESS, kResult);
+  EXPECT_EQ(kExpectedInfo, kResultInfo);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_VRResponceIncorrectApp_NoResponces) {
+  event_engine::Event event(hmi_apis::FunctionID::VR_PerformInteraction);
+  CallOnEvent caller(*command_sptr_, event);
+
+  ApplicationSharedPtr null_application;
+  EXPECT_CALL(mock_app_manager_, application(_))
+      .WillRepeatedly(Return(null_application));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
+
+  caller();
+}
+
+TEST_F(
+    PerformInteractionRequestTest,
+    OnEvent_VRResponcVRPIcodeGenericError_TerminatePIAndGenericErrorResponce) {
+  TestVRResponceResultCode(mobile_apis::Result::GENERIC_ERROR);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_VRResponcVRPIcodeAbortedVrOnly_TerminatePIAndAbortedResponce) {
+  TestVRResponceResultCode(mobile_apis::Result::ABORTED);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_VRResponcVRPIcodeTimeout_TerminatePIAndTimeoutResponce) {
+  TestVRResponceResultCode(mobile_apis::Result::TIMED_OUT);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_VRResponcVRPIcodeTimeOut_ResetTimeout) {
+  event_engine::Event event(hmi_apis::FunctionID::VR_PerformInteraction);
+  CallOnEvent caller(*command_sptr_, event);
+
+  (*message_)[strings::params][hmi_response::code] =
+      mobile_apis::Result::TIMED_OUT;
+
+  event.set_smart_object(*message_);
+
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
+
+  caller();
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_VRResponcVRPIcodeRejected_TerminatePIAndRejectedResponce) {
+  TestVRResponceResultCode(mobile_apis::Result::REJECTED);
+}
+
+TEST_F(
+    PerformInteractionRequestTest,
+    OnEvent_VRResponcVRPIcodeUnsupportedRequest_TerminatePIAndWarningsResponce) {
+  TestVRResponceResultCode(mobile_apis::Result::UNSUPPORTED_REQUEST);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_VRResponcVRPIcodeWarnings_TerminatePIAndWarningsResponce) {
+  TestVRResponceResultCode(mobile_apis::Result::WARNINGS);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_VRResponcVRPIcodeSuccessManualOnly_Return) {
+  event_engine::Event event(hmi_apis::FunctionID::VR_PerformInteraction);
+  CallOnEvent caller(*command_sptr_, event);
+
+  (*message_)[strings::params][hmi_response::code] =
+      mobile_apis::Result::SUCCESS;
+
+  event.set_smart_object(*message_);
+
+  (*message_)[strings::msg_params][strings::interaction_mode] =
+      mobile_api::InteractionMode::MANUAL_ONLY;
+  command_sptr_->Init();
+
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
+
+  caller();
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_VRResponcVRPIWrongChoiset_ResponceGenericError) {
+  event_engine::Event event(hmi_apis::FunctionID::VR_PerformInteraction);
+  CallOnEvent caller(*command_sptr_, event);
+
+  (*message_)[strings::msg_params][strings::choice_id] = kSomeNumber;
+  (*message_)[strings::params][hmi_response::code] =
+      mobile_apis::Result::SUCCESS;
+
+  event.set_smart_object(*message_);
+
+  PerformChoiceSetMap empty_choice_set_map;
+  const DataAccessor<PerformChoiceSetMap> empty_data_accessor(
+      empty_choice_set_map, test_lock_);
+  EXPECT_CALL(*mock_application_sptr_, performinteraction_choice_set_map())
+      .WillOnce(Return(empty_data_accessor));
+
+  MessageSharedPtr hmi_result_msg;
+  MessageSharedPtr mobile_result_msg;
+
+  {
+    ::testing::InSequence dummy;
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+        .WillOnce(DoAll(SaveArg<0>(&hmi_result_msg), Return(true)));
+
+    EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _))
+        .WillOnce(DoAll(SaveArg<0>(&mobile_result_msg), Return(true)));
+  }
+
+  caller();
+
+  const hmi_apis::FunctionID::eType kHmiResult =
+      static_cast<hmi_apis::FunctionID::eType>(
+          (*hmi_result_msg)[strings::params][strings::function_id].asInt());
+  const mobile_api::Result::eType kMobileResult =
+      static_cast<mobile_api::Result::eType>(
+          (*mobile_result_msg)[strings::msg_params][strings::result_code]
+              .asInt());
+
+  EXPECT_EQ(hmi_apis::FunctionID::UI_ClosePopUp, kHmiResult);
+  EXPECT_EQ(mobile_apis::Result::GENERIC_ERROR, kMobileResult);
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_VRResponcVRPICorrectChoiSet_ResponceSuccess) {
+  event_engine::Event event(hmi_apis::FunctionID::VR_PerformInteraction);
+  CallOnEvent caller(*command_sptr_, event);
+
+  (*message_)[strings::msg_params][strings::result_code] =
+      mobile_api::Result::SUCCESS;
+
+  (*message_)[strings::params][strings::correlation_id] = kCorrelationId;
+  (*message_)[strings::msg_params][strings::choice_id] = kSomeNumber;
+
+  event.set_smart_object(*message_);
+
+  ::smart_objects::SmartObject choise_set;
+  choise_set[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+
+  PerformChoice perform_choise_map;
+  perform_choise_map[kCorrelationId] = &choise_set;
+
+  PerformChoiceSetMap choice_set_map;
+  choice_set_map[kCorrelationId] = perform_choise_map;
+
+  const DataAccessor<PerformChoiceSetMap> data_accessor(choice_set_map,
+                                                        test_lock_);
+  EXPECT_CALL(*mock_application_sptr_, performinteraction_choice_set_map())
+      .WillOnce(Return(data_accessor));
+
+  MessageSharedPtr hmi_result_msg;
+  MessageSharedPtr mobile_result_msg;
+  {
+    ::testing::InSequence dummy;
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+        .WillOnce(DoAll(SaveArg<0>(&hmi_result_msg), Return(true)));
+
+    EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _))
+        .WillOnce(DoAll(SaveArg<0>(&mobile_result_msg), Return(true)));
+  }
+
+  caller();
+
+  const hmi_apis::FunctionID::eType kHmiResult =
+      static_cast<hmi_apis::FunctionID::eType>(
+          (*hmi_result_msg)[strings::params][strings::function_id].asInt());
+  const mobile_api::Result::eType kMobileResult =
+      static_cast<mobile_api::Result::eType>(
+          (*mobile_result_msg)[strings::msg_params][strings::result_code]
+              .asInt());
+
+  const int32_t kResultChoiseId =
+      (*mobile_result_msg)[strings::msg_params][strings::choice_id].asInt();
+  const mobile_api::TriggerSource::eType ts_result =
+      static_cast<mobile_api::TriggerSource::eType>(
+          (*mobile_result_msg)[strings::msg_params][strings::trigger_source]
+              .asInt());
+
+  EXPECT_EQ(hmi_apis::FunctionID::UI_ClosePopUp, kHmiResult);
+
+  EXPECT_EQ(mobile_api::TriggerSource::TS_VR, ts_result);
+  EXPECT_EQ(kSomeNumber, kResultChoiseId);
+  EXPECT_EQ(mobile_apis::Result::SUCCESS, kMobileResult);
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
@@ -680,7 +680,8 @@ TEST_F(PerformInteractionRequestTest,
 
   event.set_smart_object(*message_);
 
-  EXPECT_CALL(*mock_application_sptr_, DeletePerformInteractionChoiceSet(_)).Times(2);
+  EXPECT_CALL(*mock_application_sptr_, DeletePerformInteractionChoiceSet(_))
+      .Times(2);
 
   MessageSharedPtr result_msg = CatchMobileCommandResult(caller);
 

--- a/src/components/application_manager/test/commands/mobile/put_file_test.cc
+++ b/src/components/application_manager/test/commands/mobile/put_file_test.cc
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "application_manager/commands/commands_test.h"
+
+#include "mobile/put_file_response.h"
+#include "mobile/put_file_request.h"
+
+#include "utils/make_shared.h"
+#include "smart_objects/smart_object.h"
+
+#include "application_manager/mock_application.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using namespace application_manager;
+
+using ::testing::Return;
+using ::testing::_;
+
+class PutFileResponceTest : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  void SetUp() OVERRIDE {
+    message_ = utils::MakeShared<SmartObject>(::smart_objects::SmartType_Map);
+    (*message_)[strings::msg_params] =
+        ::smart_objects::SmartObject(::smart_objects::SmartType_Map);
+
+    command_sptr_ =
+        CreateCommand<application_manager::commands::PutFileResponse>(
+            CommandsTest::kDefaultTimeout_, message_);
+  }
+
+  MessageSharedPtr message_;
+  utils::SharedPtr<commands::PutFileResponse> command_sptr_;
+};
+
+TEST_F(PutFileResponceTest, Run_InvalidApp_ApplicationNotRegisteredResponce) {
+  const int32_t kConnectionKey = 1;
+  ::smart_objects::SmartObject& message_ref = *message_;
+
+  message_ref[strings::params][strings::connection_key] = kConnectionKey;
+
+  utils::SharedPtr<Application> null_application_sptr;
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(null_application_sptr));
+  EXPECT_CALL(
+      mock_app_manager_,
+      SendMessageToMobile(
+          MobileResultCodeIs(mobile_api::Result::APPLICATION_NOT_REGISTERED),
+          _)).Times(1);
+  command_sptr_->Run();
+}
+
+TEST_F(PutFileResponceTest, Run_ApplicationRegistered_Success) {
+  const int32_t kConnectionKey = 1;
+  ::smart_objects::SmartObject& message_ref = *message_;
+
+  message_ref[strings::params][strings::connection_key] = kConnectionKey;
+  message_ref[strings::msg_params][strings::success] = true;
+
+  utils::SharedPtr<Application> application_sptr =
+      utils::MakeShared<MockApplication>();
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(application_sptr));
+  EXPECT_CALL(
+      mock_app_manager_,
+      SendMessageToMobile(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _))
+      .Times(1);
+  command_sptr_->Run();
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/put_file_test.cc
+++ b/src/components/application_manager/test/commands/mobile/put_file_test.cc
@@ -55,6 +55,10 @@ using namespace application_manager;
 using ::testing::Return;
 using ::testing::_;
 
+namespace {
+const int32_t kConnectionKey = 1;
+}
+
 class PutFileResponceTest : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
   void SetUp() OVERRIDE {
@@ -63,8 +67,7 @@ class PutFileResponceTest : public CommandsTest<CommandsTestMocks::kIsNice> {
         ::smart_objects::SmartObject(::smart_objects::SmartType_Map);
 
     command_sptr_ =
-        CreateCommand<application_manager::commands::PutFileResponse>(
-            CommandsTest::kDefaultTimeout_, message_);
+        CreateCommand<application_manager::commands::PutFileResponse>(message_);
   }
 
   MessageSharedPtr message_;
@@ -72,7 +75,6 @@ class PutFileResponceTest : public CommandsTest<CommandsTestMocks::kIsNice> {
 };
 
 TEST_F(PutFileResponceTest, Run_InvalidApp_ApplicationNotRegisteredResponce) {
-  const int32_t kConnectionKey = 1;
   ::smart_objects::SmartObject& message_ref = *message_;
 
   message_ref[strings::params][strings::connection_key] = kConnectionKey;
@@ -84,12 +86,11 @@ TEST_F(PutFileResponceTest, Run_InvalidApp_ApplicationNotRegisteredResponce) {
       mock_app_manager_,
       SendMessageToMobile(
           MobileResultCodeIs(mobile_api::Result::APPLICATION_NOT_REGISTERED),
-          _)).Times(1);
+          _));
   command_sptr_->Run();
 }
 
 TEST_F(PutFileResponceTest, Run_ApplicationRegistered_Success) {
-  const int32_t kConnectionKey = 1;
   ::smart_objects::SmartObject& message_ref = *message_;
 
   message_ref[strings::params][strings::connection_key] = kConnectionKey;
@@ -102,8 +103,7 @@ TEST_F(PutFileResponceTest, Run_ApplicationRegistered_Success) {
       .WillOnce(Return(application_sptr));
   EXPECT_CALL(
       mock_app_manager_,
-      SendMessageToMobile(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _))
-      .Times(1);
+      SendMessageToMobile(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
   command_sptr_->Run();
 }
 

--- a/src/components/application_manager/test/commands/mobile/read_did_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/read_did_request_test.cc
@@ -69,7 +69,7 @@ TEST_F(ReadDIDRequestTest, OnEvent_WrongEventId_UNSUCCESS) {
   Event event(Event::EventID::INVALID_ENUM);
   SharedPtr<ReadDIDRequest> command(CreateCommand<ReadDIDRequest>());
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
   command->on_event(event);
 }
 
@@ -96,7 +96,7 @@ TEST_F(ReadDIDRequestTest, OnEvent_SUCCESS) {
 TEST_F(ReadDIDRequestTest, Run_AppNotRegistered_UNSUCCESS) {
   SharedPtr<ReadDIDRequest> command(CreateCommand<ReadDIDRequest>());
 
-  ON_CALL(app_mngr_, application(_))
+  ON_CALL(mock_app_manager_, application(_))
       .WillByDefault(Return(SharedPtr<am::Application>()));
 
   MessageSharedPtr result_msg(CatchMobileCommandResult(CallRun(*command)));
@@ -110,7 +110,7 @@ TEST_F(ReadDIDRequestTest, Run_CommandLimitsExceeded_UNSUCCESS) {
   SharedPtr<ReadDIDRequest> command(CreateCommand<ReadDIDRequest>());
 
   MockAppPtr app(CreateMockApp());
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
 
   ON_CALL(*app, AreCommandLimitsExceeded(_, _)).WillByDefault(Return(true));
 
@@ -125,7 +125,7 @@ TEST_F(ReadDIDRequestTest, Run_EmptyDidLocation_UNSUCCESS) {
   MockAppPtr app(CreateMockApp());
   SharedPtr<ReadDIDRequest> command(CreateCommand<ReadDIDRequest>());
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
 
   ON_CALL(*app, AreCommandLimitsExceeded(_, _)).WillByDefault(Return(false));
 
@@ -142,7 +142,7 @@ TEST_F(ReadDIDRequestTest, Run_SUCCESS) {
   (*msg)[am::strings::msg_params][am::strings::did_location]["SomeData"] = 0;
   SharedPtr<ReadDIDRequest> command(CreateCommand<ReadDIDRequest>(msg));
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
 
   ON_CALL(*app, AreCommandLimitsExceeded(_, _)).WillByDefault(Return(false));
 

--- a/src/components/application_manager/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/register_app_interface_request_test.cc
@@ -122,27 +122,27 @@ class RegisterAppInterfaceRequestTest
   }
 
   void InitGetters() {
-    ON_CALL(app_mngr_, GetPolicyHandler())
+    ON_CALL(mock_app_manager_, GetPolicyHandler())
         .WillByDefault(ReturnRef(mock_policy_handler_));
-    ON_CALL(app_mngr_, resume_controller())
+    ON_CALL(mock_app_manager_, resume_controller())
         .WillByDefault(ReturnRef(mock_resume_crt_));
-    ON_CALL(app_mngr_, connection_handler())
+    ON_CALL(mock_app_manager_, connection_handler())
         .WillByDefault(ReturnRef(mock_connection_handler_));
     ON_CALL(mock_connection_handler_, get_session_observer())
         .WillByDefault(ReturnRef(mock_session_observer_));
-    ON_CALL(app_mngr_, hmi_capabilities())
+    ON_CALL(mock_app_manager_, hmi_capabilities())
         .WillByDefault(ReturnRef(mock_hmi_capabilities_));
-    ON_CALL(app_mngr_settings_, sdl_version())
+    ON_CALL(mock_app_manager_settings_, sdl_version())
         .WillByDefault(ReturnRef(kDummyString));
     ON_CALL(mock_hmi_capabilities_, ccpu_version())
         .WillByDefault(ReturnRef(kDummyString));
-    ON_CALL(app_mngr_settings_, supported_diag_modes())
+    ON_CALL(mock_app_manager_settings_, supported_diag_modes())
         .WillByDefault(ReturnRef(kDummyDiagModes));
     ON_CALL(mock_policy_handler_, GetAppRequestTypes(_))
         .WillByDefault(Return(std::vector<std::string>()));
     ON_CALL(mock_policy_handler_, GetUserConsentForDevice(_))
         .WillByDefault(Return(policy::DeviceConsent::kDeviceAllowed));
-    ON_CALL(app_mngr_, GetDeviceTransportType(_))
+    ON_CALL(mock_app_manager_, GetDeviceTransportType(_))
         .WillByDefault(Return(hmi_apis::Common_TransportType::WIFI));
   }
 
@@ -182,30 +182,31 @@ TEST_F(RegisterAppInterfaceRequestTest, Run_MinimalData_SUCCESS) {
   InitLanguage();
   InitBasicMessage();
 
-  ON_CALL(app_mngr_, IsHMICooperating()).WillByDefault(Return(true));
+  ON_CALL(mock_app_manager_, IsHMICooperating()).WillByDefault(Return(true));
 
   MockAppPtr mock_app = CreateBasicMockedApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(ApplicationSharedPtr()))
       .WillRepeatedly(Return(mock_app));
 
-  ON_CALL(app_mngr_, applications())
+  ON_CALL(mock_app_manager_, applications())
       .WillByDefault(Return(DataAccessor<am::ApplicationSet>(app_set_, lock_)));
   ON_CALL(mock_policy_handler_, PolicyEnabled()).WillByDefault(Return(true));
   ON_CALL(mock_policy_handler_, GetInitialAppData(kAppId, _, _))
       .WillByDefault(Return(true));
 
-  EXPECT_CALL(app_mngr_, RegisterApplication(msg_)).WillOnce(Return(mock_app));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_, RegisterApplication(msg_))
+      .WillOnce(Return(mock_app));
+  EXPECT_CALL(mock_app_manager_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::BasicCommunication_OnAppRegistered)))
       .WillOnce(Return(true));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::Buttons_OnButtonSubscription)))
       .WillOnce(Return(true));
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
   EXPECT_CALL(mock_message_helper_,
               SendChangeRegistrationRequestToHMI(testing::Eq(mock_app), _));
@@ -228,30 +229,31 @@ TEST_F(RegisterAppInterfaceRequestTest, DISABLED_Run_AppHmiTypes_SUCCESS) {
 
   (*msg_)[am::strings::msg_params][am::strings::app_hmi_type][0] = app_hmi_type;
 
-  ON_CALL(app_mngr_, IsHMICooperating()).WillByDefault(Return(true));
+  ON_CALL(mock_app_manager_, IsHMICooperating()).WillByDefault(Return(true));
 
   MockAppPtr mock_app = CreateBasicMockedApp();
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(ApplicationSharedPtr()))
       .WillRepeatedly(Return(mock_app));
 
-  ON_CALL(app_mngr_, applications())
+  ON_CALL(mock_app_manager_, applications())
       .WillByDefault(Return(DataAccessor<am::ApplicationSet>(app_set_, lock_)));
   ON_CALL(mock_policy_handler_, PolicyEnabled()).WillByDefault(Return(true));
   ON_CALL(mock_policy_handler_, GetInitialAppData(kAppId, _, _))
       .WillByDefault(DoAll(SetHmiType(app_hmi_type_str), Return(true)));
 
-  EXPECT_CALL(app_mngr_, RegisterApplication(msg_)).WillOnce(Return(mock_app));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_, RegisterApplication(msg_))
+      .WillOnce(Return(mock_app));
+  EXPECT_CALL(mock_app_manager_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::BasicCommunication_OnAppRegistered)))
       .WillOnce(Return(true));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::Buttons_OnButtonSubscription)))
       .WillOnce(Return(true));
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
   EXPECT_CALL(mock_message_helper_,
               SendChangeRegistrationRequestToHMI(testing::Eq(mock_app), _));

--- a/src/components/application_manager/test/commands/mobile/register_app_interface_test.cc
+++ b/src/components/application_manager/test/commands/mobile/register_app_interface_test.cc
@@ -55,6 +55,10 @@ using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::_;
 
+namespace {
+const std::string kPolicyAppId = "id";
+}
+
 class RegisterAppInterfaceResponceTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
@@ -63,8 +67,7 @@ class RegisterAppInterfaceResponceTest
     (*message_)[strings::msg_params] =
         ::smart_objects::SmartObject(::smart_objects::SmartType_Map);
     command_sptr_ = CreateCommand<
-        application_manager::commands::RegisterAppInterfaceResponse>(
-        CommandsTest::kDefaultTimeout_, message_);
+        application_manager::commands::RegisterAppInterfaceResponse>(message_);
   }
 
   MessageSharedPtr message_;
@@ -82,14 +85,14 @@ TEST_F(RegisterAppInterfaceResponceTest,
               SendMessageToMobile(
                   MobileResultCodeIs(
                       mobile_apis::Result::APPLICATION_REGISTERED_ALREADY),
-                  false)).Times(1);
+                  false));
 
   EXPECT_CALL(mock_app_manager_, application(_)).Times(0);
   command_sptr_->Run();
 }
 
 TEST_F(RegisterAppInterfaceResponceTest, Run_WrongConnectionKey_Unsuccess) {
-  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(_, _)).Times(1);
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(_, _));
 
   ApplicationSharedPtr null_application;
   EXPECT_CALL(mock_app_manager_, application(_))
@@ -101,8 +104,7 @@ TEST_F(RegisterAppInterfaceResponceTest, Run_WrongConnectionKey_Unsuccess) {
 
 TEST_F(RegisterAppInterfaceResponceTest,
        Run_PolicyEnabled_SetHeartbeatTimeout) {
-  const std::string kPolicyAppId = "id";
-  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(_, _)).Times(1);
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(_, _));
 
   utils::SharedPtr<NiceMock<MockApplication> > mock_application =
       utils::MakeShared<NiceMock<MockApplication> >();
@@ -120,7 +122,7 @@ TEST_F(RegisterAppInterfaceResponceTest,
   connection_handler_test::MockConnectionHandler mock_connection_handler;
   EXPECT_CALL(mock_app_manager_, connection_handler())
       .WillOnce(ReturnRef(mock_connection_handler));
-  EXPECT_CALL(mock_connection_handler, SetHeartBeatTimeout(_, _)).Times(1);
+  EXPECT_CALL(mock_connection_handler, SetHeartBeatTimeout(_, _));
 
   EXPECT_CALL(mock_app_manager_, OnApplicationRegistered(_));
   EXPECT_CALL(mock_policy_handler_, OnAppRegisteredOnMobile(kPolicyAppId));
@@ -130,8 +132,7 @@ TEST_F(RegisterAppInterfaceResponceTest,
 
 TEST_F(RegisterAppInterfaceResponceTest,
        Run_PolicyDisabled_DontSetHeartbeatTimeout) {
-  const std::string kPolicyAppId = "id";
-  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(_, _)).Times(1);
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(_, _));
 
   utils::SharedPtr<NiceMock<MockApplication> > mock_application =
       utils::MakeShared<NiceMock<MockApplication> >();

--- a/src/components/application_manager/test/commands/mobile/register_app_interface_test.cc
+++ b/src/components/application_manager/test/commands/mobile/register_app_interface_test.cc
@@ -39,7 +39,7 @@
 
 #include "application_manager/commands/commands_test.h"
 #include "application_manager/commands/command_request_test.h"
-#include "application_manager/mock_policy_handler_interface.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
 #include "connection_handler/mock_connection_handler.h"
 
 #include "mobile/register_app_interface_response.h"

--- a/src/components/application_manager/test/commands/mobile/register_app_interface_test.cc
+++ b/src/components/application_manager/test/commands/mobile/register_app_interface_test.cc
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "utils/shared_ptr.h"
+
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_policy_handler_interface.h"
+#include "connection_handler/mock_connection_handler.h"
+
+#include "mobile/register_app_interface_response.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+
+using namespace application_manager;
+
+using ::testing::Return;
+using ::testing::ReturnRef;
+using ::testing::_;
+
+class RegisterAppInterfaceResponceTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  void SetUp() OVERRIDE {
+    message_ = utils::MakeShared<SmartObject>(::smart_objects::SmartType_Map);
+    (*message_)[strings::msg_params] =
+        ::smart_objects::SmartObject(::smart_objects::SmartType_Map);
+    command_sptr_ = CreateCommand<
+        application_manager::commands::RegisterAppInterfaceResponse>(
+        CommandsTest::kDefaultTimeout_, message_);
+  }
+
+  MessageSharedPtr message_;
+  utils::SharedPtr<commands::RegisterAppInterfaceResponse> command_sptr_;
+  policy_test::MockPolicyHandlerInterface mock_policy_handler_;
+};
+
+TEST_F(RegisterAppInterfaceResponceTest,
+       Run_ApplicationRegisteredAlready_Unsuccess) {
+  (*message_)[strings::msg_params][strings::success] = false;
+  (*message_)[strings::msg_params][strings::result_code] =
+      mobile_apis::Result::APPLICATION_REGISTERED_ALREADY;
+
+  EXPECT_CALL(mock_app_manager_,
+              SendMessageToMobile(
+                  MobileResultCodeIs(
+                      mobile_apis::Result::APPLICATION_REGISTERED_ALREADY),
+                  false)).Times(1);
+
+  EXPECT_CALL(mock_app_manager_, application(_)).Times(0);
+  command_sptr_->Run();
+}
+
+TEST_F(RegisterAppInterfaceResponceTest, Run_WrongConnectionKey_Unsuccess) {
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(_, _)).Times(1);
+
+  ApplicationSharedPtr null_application;
+  EXPECT_CALL(mock_app_manager_, application(_))
+      .WillOnce(Return(null_application));
+
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
+  command_sptr_->Run();
+}
+
+TEST_F(RegisterAppInterfaceResponceTest,
+       Run_PolicyEnabled_SetHeartbeatTimeout) {
+  const std::string kPolicyAppId = "id";
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(_, _)).Times(1);
+
+  utils::SharedPtr<NiceMock<MockApplication> > mock_application =
+      utils::MakeShared<NiceMock<MockApplication> >();
+  EXPECT_CALL(mock_app_manager_, application(_))
+      .WillOnce(Return(mock_application));
+  ON_CALL(*mock_application, policy_app_id())
+      .WillByDefault(Return(kPolicyAppId));
+
+  ON_CALL(mock_app_manager_, GetPolicyHandler())
+      .WillByDefault(ReturnRef(mock_policy_handler_));
+  EXPECT_CALL(mock_policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+  EXPECT_CALL(mock_policy_handler_, HeartBeatTimeout(_))
+      .WillOnce(Return(CommandsTest::kDefaultTimeout_));
+
+  connection_handler_test::MockConnectionHandler mock_connection_handler;
+  EXPECT_CALL(mock_app_manager_, connection_handler())
+      .WillOnce(ReturnRef(mock_connection_handler));
+  EXPECT_CALL(mock_connection_handler, SetHeartBeatTimeout(_, _)).Times(1);
+
+  EXPECT_CALL(mock_app_manager_, OnApplicationRegistered(_));
+  EXPECT_CALL(mock_policy_handler_, OnAppRegisteredOnMobile(kPolicyAppId));
+
+  command_sptr_->Run();
+}
+
+TEST_F(RegisterAppInterfaceResponceTest,
+       Run_PolicyDisabled_DontSetHeartbeatTimeout) {
+  const std::string kPolicyAppId = "id";
+  EXPECT_CALL(mock_app_manager_, SendMessageToMobile(_, _)).Times(1);
+
+  utils::SharedPtr<NiceMock<MockApplication> > mock_application =
+      utils::MakeShared<NiceMock<MockApplication> >();
+  EXPECT_CALL(mock_app_manager_, application(_))
+      .WillOnce(Return(mock_application));
+  ON_CALL(*mock_application, policy_app_id())
+      .WillByDefault(Return(kPolicyAppId));
+
+  ON_CALL(mock_app_manager_, GetPolicyHandler())
+      .WillByDefault(ReturnRef(mock_policy_handler_));
+  EXPECT_CALL(mock_policy_handler_, PolicyEnabled()).WillOnce(Return(false));
+  EXPECT_CALL(mock_policy_handler_, HeartBeatTimeout(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, connection_handler()).Times(0);
+
+  EXPECT_CALL(mock_app_manager_, OnApplicationRegistered(_));
+  EXPECT_CALL(mock_policy_handler_, OnAppRegisteredOnMobile(kPolicyAppId));
+
+  command_sptr_->Run();
+}
+
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/simple_notification_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/simple_notification_commands_test.cc
@@ -84,7 +84,7 @@ TYPED_TEST_CASE(MobileNotificationCommandsTest, NotificationCommandsList);
 TYPED_TEST(MobileNotificationCommandsTest, Run_SendMessageToMobile_SUCCESS) {
   ::utils::SharedPtr<typename TestFixture::CommandType> command =
       this->template CreateCommand<typename TestFixture::CommandType>();
-  EXPECT_CALL(this->app_mngr_,
+  EXPECT_CALL(this->mock_app_manager_,
               SendMessageToMobile(CheckNotificationMessage(), _));
   command->Run();
 }

--- a/src/components/application_manager/test/commands/mobile/simple_response_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/simple_response_commands_test.cc
@@ -120,7 +120,7 @@ TYPED_TEST_CASE(MobileResponseCommandsTest, ResponseCommandsList);
 TYPED_TEST(MobileResponseCommandsTest, Run_SendResponseToMobile_SUCCESS) {
   ::utils::SharedPtr<typename TestFixture::CommandType> command =
       this->template CreateCommand<typename TestFixture::CommandType>();
-  EXPECT_CALL(this->app_mngr_, SendMessageToMobile(NotNull(), _));
+  EXPECT_CALL(this->mock_app_manager_, SendMessageToMobile(NotNull(), _));
   command->Run();
 }
 

--- a/src/components/application_manager/test/commands/mobile/subscribe_button_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/subscribe_button_request_test.cc
@@ -76,7 +76,7 @@ typedef SubscribeButtonRequestTest::MockHMICapabilities MockHMICapabilities;
 TEST_F(SubscribeButtonRequestTest, Run_AppNotRegistered_UNSUCCESS) {
   CommandPtr command(CreateCommand<SubscribeButtonRequest>());
 
-  ON_CALL(app_mngr_, application(_))
+  ON_CALL(mock_app_manager_, application(_))
       .WillByDefault(Return(SharedPtr<am::Application>()));
 
   MessageSharedPtr result_msg(CatchMobileCommandResult(CallRun(*command)));
@@ -93,7 +93,7 @@ TEST_F(SubscribeButtonRequestTest, Run_SubscriptionNotAllowed_UNSUCCESS) {
   CommandPtr command(CreateCommand<SubscribeButtonRequest>(msg));
 
   MockAppPtr app(CreateMockApp());
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
   ON_CALL(*app, is_media_application()).WillByDefault(Return(false));
 
   MessageSharedPtr result_msg(CatchMobileCommandResult(CallRun(*command)));
@@ -107,10 +107,10 @@ TEST_F(SubscribeButtonRequestTest, Run_UiIsNotSupported_UNSUCCESS) {
   CommandPtr command(CreateCommand<SubscribeButtonRequest>());
 
   MockAppPtr app(CreateMockApp());
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
 
   MockHMICapabilities hmi_capabilities;
-  ON_CALL(app_mngr_, hmi_capabilities())
+  ON_CALL(mock_app_manager_, hmi_capabilities())
       .WillByDefault(ReturnRef(hmi_capabilities));
   ON_CALL(hmi_capabilities, is_ui_cooperating()).WillByDefault(Return(false));
 
@@ -130,11 +130,11 @@ TEST_F(SubscribeButtonRequestTest, Run_IsSubscribedToButton_UNSUCCESS) {
   CommandPtr command(CreateCommand<SubscribeButtonRequest>(msg));
 
   MockAppPtr app(CreateMockApp());
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
   ON_CALL(*app, is_media_application()).WillByDefault(Return(true));
 
   MockHMICapabilities hmi_capabilities;
-  ON_CALL(app_mngr_, hmi_capabilities())
+  ON_CALL(mock_app_manager_, hmi_capabilities())
       .WillByDefault(ReturnRef(hmi_capabilities));
   ON_CALL(hmi_capabilities, is_ui_cooperating()).WillByDefault(Return(true));
 
@@ -162,11 +162,11 @@ TEST_F(SubscribeButtonRequestTest, Run_SUCCESS) {
   CommandPtr command(CreateCommand<SubscribeButtonRequest>(msg));
 
   MockAppPtr app(CreateMockApp());
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app));
   ON_CALL(*app, is_media_application()).WillByDefault(Return(true));
 
   MockHMICapabilities hmi_capabilities;
-  ON_CALL(app_mngr_, hmi_capabilities())
+  ON_CALL(mock_app_manager_, hmi_capabilities())
       .WillByDefault(ReturnRef(hmi_capabilities));
   ON_CALL(hmi_capabilities, is_ui_cooperating()).WillByDefault(Return(true));
 
@@ -179,7 +179,7 @@ TEST_F(SubscribeButtonRequestTest, Run_SUCCESS) {
   ON_CALL(*app, IsSubscribedToButton(_)).WillByDefault(Return(false));
 
   MessageSharedPtr hmi_result_msg;
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_))
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
       .WillOnce(DoAll(SaveArg<0>(&hmi_result_msg), Return(true)));
 
   MessageSharedPtr mobile_result_msg(

--- a/src/components/application_manager/test/commands/mobile/unregister_app_interface_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unregister_app_interface_request_test.cc
@@ -61,11 +61,11 @@ class UnregisterAppInterfaceRequestTest
 TEST_F(UnregisterAppInterfaceRequestTest, Run_AppNotRegistered_UNSUCCESS) {
   CommandPtr command(CreateCommand<UnregisterAppInterfaceRequest>());
 
-  EXPECT_CALL(app_mngr_, application(_))
+  EXPECT_CALL(mock_app_manager_, application(_))
       .WillOnce(Return(ApplicationSharedPtr()));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
 
@@ -82,7 +82,7 @@ TEST_F(UnregisterAppInterfaceRequestTest, Run_SUCCESS) {
   CommandPtr command(CreateCommand<UnregisterAppInterfaceRequest>(command_msg));
 
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   const mobile_apis::AppInterfaceUnregisteredReason::eType kUnregisterReason =
@@ -96,13 +96,13 @@ TEST_F(UnregisterAppInterfaceRequestTest, Run_SUCCESS) {
   {
     ::testing::InSequence sequence;
 
-    EXPECT_CALL(app_mngr_, ManageMobileCommand(dummy_msg, _));
+    EXPECT_CALL(mock_app_manager_, ManageMobileCommand(dummy_msg, _));
 
-    EXPECT_CALL(app_mngr_,
+    EXPECT_CALL(mock_app_manager_,
                 UnregisterApplication(
                     kConnectionKey, mobile_apis::Result::SUCCESS, _, _));
 
-    EXPECT_CALL(app_mngr_,
+    EXPECT_CALL(mock_app_manager_,
                 ManageMobileCommand(
                     MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
   }

--- a/src/components/application_manager/test/commands/mobile/unsubscribe_button_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unsubscribe_button_request_test.cc
@@ -34,11 +34,11 @@ class UnsubscribeButtonRequestTest
 TEST_F(UnsubscribeButtonRequestTest, Run_AppNotRegistered_UNSUCCESS) {
   CommandPtr command(CreateCommand<UnsubscribeButtonRequest>());
 
-  EXPECT_CALL(app_mngr_, application(_))
+  EXPECT_CALL(mock_app_manager_, application(_))
       .WillOnce(Return(ApplicationSharedPtr()));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
 
@@ -55,14 +55,14 @@ TEST_F(UnsubscribeButtonRequestTest,
   CommandPtr command(CreateCommand<UnsubscribeButtonRequest>(command_msg));
 
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(*mock_app, UnsubscribeFromButton(kButtonId))
       .WillOnce(Return(false));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::IGNORED), _));
 
   command->Run();
@@ -79,17 +79,17 @@ TEST_F(UnsubscribeButtonRequestTest, Run_SUCCESS) {
   CommandPtr command(CreateCommand<UnsubscribeButtonRequest>(command_msg));
 
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(*mock_app, UnsubscribeFromButton(kButtonId))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::Buttons_OnButtonSubscription)));
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
 
   EXPECT_CALL(*mock_app, UpdateHash());

--- a/src/components/application_manager/test/commands/mobile/unsubscribe_vehicle_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unsubscribe_vehicle_request_test.cc
@@ -70,11 +70,11 @@ class UnsubscribeVehicleRequestTest
 
 TEST_F(UnsubscribeVehicleRequestTest, Run_AppNotRegistered_UNSUCCESS) {
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>());
-  EXPECT_CALL(app_mngr_, application(_))
+  EXPECT_CALL(mock_app_manager_, application(_))
       .WillOnce(Return(ApplicationSharedPtr()));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
 
@@ -95,11 +95,11 @@ TEST_F(UnsubscribeVehicleRequestTest,
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
 
   command->Run();
@@ -119,11 +119,11 @@ TEST_F(UnsubscribeVehicleRequestTest,
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::IGNORED), _));
 
   command->Run();
@@ -143,11 +143,11 @@ TEST_F(UnsubscribeVehicleRequestTest,
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::IGNORED), _));
 
   command->Run();
@@ -165,11 +165,11 @@ TEST_F(UnsubscribeVehicleRequestTest, Run_UnsubscribeDataDisabled_UNSUCCESS) {
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
 
   command->Run();
@@ -190,9 +190,9 @@ void UnsubscribeVehicleRequestTest::UnsubscribeSuccessfully() {
   MockAppPtr mock_app(CreateMockApp());
   application_set_.insert(mock_app);
   DataAccessor<am::ApplicationSet> accessor(application_set_, app_set_lock_);
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
 
   EXPECT_CALL(*mock_app, IsSubscribedToIVI(kVehicleType))
       .WillRepeatedly(Return(true));
@@ -200,7 +200,7 @@ void UnsubscribeVehicleRequestTest::UnsubscribeSuccessfully() {
       .WillRepeatedly(Return(true));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
 
   command->Run();
@@ -219,7 +219,7 @@ TEST_F(UnsubscribeVehicleRequestTest, OnEvent_DataNotSubscribed_IGNORED) {
 
   am::VehicleData vehicle_data;
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillRepeatedly(Return(mock_app));
   vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
   EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()), vehicle_data())
@@ -227,7 +227,7 @@ TEST_F(UnsubscribeVehicleRequestTest, OnEvent_DataNotSubscribed_IGNORED) {
   EXPECT_CALL(*mock_app, IsSubscribedToIVI(kVehicleType))
       .WillRepeatedly(Return(false));
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::IGNORED), _));
   command->Run();
 
@@ -244,7 +244,7 @@ TEST_F(UnsubscribeVehicleRequestTest, OnEvent_DataNotSubscribed_IGNORED) {
               HMIToMobileResult(hmi_result)).WillOnce(Return(mob_result));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::IGNORED), _));
   EXPECT_CALL(*mock_app, UpdateHash());
 
@@ -273,11 +273,11 @@ TEST_F(UnsubscribeVehicleRequestTest, OnEvent_DataUnsubscribed_SUCCESS) {
   EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()),
               HMIToMobileResult(hmi_result)).WillOnce(Return(mob_result));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
 
   EXPECT_CALL(*mock_app, UpdateHash());

--- a/src/components/application_manager/test/commands/mobile/unsubscribe_vehicle_response_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unsubscribe_vehicle_response_test.cc
@@ -70,7 +70,7 @@ TEST_F(UnsubscribeVehicleResponseTest,
   ::utils::SharedPtr<commands::UnsubscribeVehicleDataResponse> command =
       CreateCommand<commands::UnsubscribeVehicleDataResponse>(command_msg);
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       SendMessageToMobile(ResultCodeIs(mobile_apis::Result::INVALID_ENUM), _));
   command->Run();
 }
@@ -83,7 +83,7 @@ TEST_F(UnsubscribeVehicleResponseTest,
   ::utils::SharedPtr<commands::UnsubscribeVehicleDataResponse> command =
       CreateCommand<commands::UnsubscribeVehicleDataResponse>(command_msg);
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       SendMessageToMobile(ResultCodeIs(mobile_apis::Result::SUCCESS), _));
   command->Run();
 }
@@ -99,7 +99,8 @@ TEST_F(UnsubscribeVehicleResponseTest,
       result_type;
   ::utils::SharedPtr<commands::UnsubscribeVehicleDataResponse> command =
       CreateCommand<commands::UnsubscribeVehicleDataResponse>(command_msg);
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(ResultCodeIs(result_type), _));
+  EXPECT_CALL(mock_app_manager_,
+              SendMessageToMobile(ResultCodeIs(result_type), _));
   command->Run();
 }
 

--- a/src/components/application_manager/test/commands/mobile/unsubscribe_way_points_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unsubscribe_way_points_request_test.cc
@@ -81,11 +81,11 @@ class UnSubscribeWayPointsRequestTest
 
 TEST_F(UnSubscribeWayPointsRequestTest,
        Run_ApplicationIsNotRegistered_UNSUCCESS) {
-  EXPECT_CALL(app_mngr_, application(_))
+  EXPECT_CALL(mock_app_manager_, application(_))
       .WillOnce(Return(ApplicationSharedPtr()));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
 
@@ -95,16 +95,16 @@ TEST_F(UnSubscribeWayPointsRequestTest,
 TEST_F(UnSubscribeWayPointsRequestTest,
        Run_AppIsNotSubscribedForWayPoints_UNSUCCESS) {
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kAppId));
 
-  EXPECT_CALL(app_mngr_, IsAppSubscribedForWayPoints(kAppId))
+  EXPECT_CALL(mock_app_manager_, IsAppSubscribedForWayPoints(kAppId))
       .WillOnce(Return(false));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::IGNORED), _));
 
   command_->Run();
@@ -112,15 +112,15 @@ TEST_F(UnSubscribeWayPointsRequestTest,
 
 TEST_F(UnSubscribeWayPointsRequestTest, Run_AppSubscribedForWayPoints_SUCCESS) {
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kAppId));
 
-  EXPECT_CALL(app_mngr_, IsAppSubscribedForWayPoints(kAppId))
+  EXPECT_CALL(mock_app_manager_, IsAppSubscribedForWayPoints(kAppId))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints)));
 
@@ -129,10 +129,10 @@ TEST_F(UnSubscribeWayPointsRequestTest, Run_AppSubscribedForWayPoints_SUCCESS) {
 
 TEST_F(UnSubscribeWayPointsRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   Event event(hmi_apis::FunctionID::INVALID_ENUM);
 
@@ -142,7 +142,7 @@ TEST_F(UnSubscribeWayPointsRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
 TEST_F(UnSubscribeWayPointsRequestTest,
        OnEvent_ReceivedNavigationUnSubscribeWayPointsEvent_SUCCESS) {
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
@@ -154,10 +154,10 @@ TEST_F(UnSubscribeWayPointsRequestTest,
 
   EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kAppId));
 
-  EXPECT_CALL(app_mngr_, UnsubscribeAppFromWayPoints(kAppId));
+  EXPECT_CALL(mock_app_manager_, UnsubscribeAppFromWayPoints(kAppId));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
 
   command_->on_event(event);

--- a/src/components/application_manager/test/commands/mobile/update_turn_list_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/update_turn_list_request_test.cc
@@ -96,11 +96,11 @@ class UpdateTurnListRequestTest
 };
 
 TEST_F(UpdateTurnListRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(ApplicationSharedPtr()));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
 
@@ -112,11 +112,11 @@ TEST_F(UpdateTurnListRequestTest, Run_InvalidNavigationText_UNSUCCESS) {
                  [am::strings::navigation_text] = "invalid_navigation_text\t\n";
 
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
 
   command_->Run();
@@ -130,11 +130,11 @@ TEST_F(UpdateTurnListRequestTest, Run_InvalidTurnIcon_UNSUCCESS) {
                      "invalid_turn_icon\t\n";
 
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
 
   command_->Run();
@@ -149,10 +149,10 @@ TEST_F(UpdateTurnListRequestTest,
                      "valid_turn_icon";
 
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler_));
 
   const mobile_result::eType kExpectedResult = mobile_result::INVALID_ENUM;
@@ -160,10 +160,10 @@ TEST_F(UpdateTurnListRequestTest,
               ProcessSoftButtons((*command_msg_)[am::strings::msg_params],
                                  Eq(mock_app),
                                  Ref(mock_policy_handler_),
-                                 Ref(app_mngr_)))
+                                 Ref(mock_app_manager_)))
       .WillOnce(Return(kExpectedResult));
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(MobileResultCodeIs(kExpectedResult), _));
 
   command_->Run();
@@ -171,21 +171,21 @@ TEST_F(UpdateTurnListRequestTest,
 
 TEST_F(UpdateTurnListRequestTest, Run_NoTurnList_UNSUCCESS) {
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler_));
 
   EXPECT_CALL(mock_message_helper_,
               ProcessSoftButtons((*command_msg_)[am::strings::msg_params],
                                  Eq(mock_app),
                                  Ref(mock_policy_handler_),
-                                 Ref(app_mngr_)))
+                                 Ref(mock_app_manager_)))
       .WillOnce(Return(mobile_result::SUCCESS));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
 
   command_->Run();
@@ -202,17 +202,17 @@ TEST_F(UpdateTurnListRequestTest, Run_ValidTurnList_SUCCESS) {
   (*command_msg_)[am::strings::msg_params][am::strings::soft_buttons] = 0;
 
   MockAppPtr mock_app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler_));
 
   EXPECT_CALL(mock_message_helper_,
               ProcessSoftButtons((*command_msg_)[am::strings::msg_params],
                                  Eq(mock_app),
                                  Ref(mock_policy_handler_),
-                                 Ref(app_mngr_)))
+                                 Ref(mock_app_manager_)))
       .WillOnce(Return(mobile_result::SUCCESS));
 
   EXPECT_CALL(
@@ -221,7 +221,7 @@ TEST_F(UpdateTurnListRequestTest, Run_ValidTurnList_SUCCESS) {
           (*command_msg_)[am::strings::msg_params][am::strings::turn_list][0]
                          [am::strings::turn_icon],
           Eq(mock_app),
-          Ref(app_mngr_))).WillOnce(Return(mobile_result::SUCCESS));
+          Ref(mock_app_manager_))).WillOnce(Return(mobile_result::SUCCESS));
 
   EXPECT_CALL(mock_message_helper_,
               SubscribeApplicationToSoftButton(_, _, kFunctionId));
@@ -257,7 +257,7 @@ TEST_F(UpdateTurnListRequestTest, Run_ValidTurnList_SUCCESS) {
 TEST_F(UpdateTurnListRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
   Event event(hmi_apis::FunctionID::INVALID_ENUM);
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   command_->on_event(event);
 }
@@ -272,13 +272,13 @@ TEST_F(UpdateTurnListRequestTest, OnEvent_UnsupportedResource_SUCCESS) {
   event.set_smart_object(*event_msg);
 
   MockHMICapabilities mock_hmi_capabilities;
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities));
 
   EXPECT_CALL(mock_hmi_capabilities, is_ui_cooperating())
       .WillOnce(Return(true));
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(
                   MobileResultCodeIs(mobile_result::UNSUPPORTED_RESOURCE), _));
 
@@ -296,13 +296,13 @@ TEST_F(UpdateTurnListRequestTest,
   event.set_smart_object(*event_msg);
 
   MockHMICapabilities mock_hmi_capabilities;
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities));
 
   EXPECT_CALL(mock_hmi_capabilities, is_ui_cooperating()).Times(0);
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
 
   command_->on_event(event);

--- a/src/components/application_manager/test/include/application_manager/commands/command_request_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/command_request_test.h
@@ -122,28 +122,6 @@ class CommandRequestTest : public CommandsTest<kIsNice> {
   }
 };
 
-MATCHER_P(MobileResultCodeIs, result_code, "") {
-  return result_code ==
-         static_cast<mobile_apis::Result::eType>(
-             (*arg)[am::strings::msg_params][am::strings::result_code].asInt());
-}
-
-MATCHER_P(HMIResultCodeIs, result_code, "") {
-  return result_code ==
-         static_cast<hmi_apis::FunctionID::eType>(
-             (*arg)[am::strings::params][am::strings::function_id].asInt());
-}
-
-MATCHER_P3(MobileResponseIs, result_code, result_info, result_success, "") {
-  mobile_apis::Result::eType code = static_cast<mobile_apis::Result::eType>(
-      (*arg)[am::strings::msg_params][am::strings::result_code].asInt());
-  std::string info =
-      (*arg)[am::strings::msg_params][am::strings::info].asString();
-  bool success = (*arg)[am::strings::msg_params][am::strings::success].asBool();
-  return result_code == code && result_info == info &&
-         result_success == success;
-}
-
 }  // namespace commands_test
 }  // namespace components
 }  // namespace test

--- a/src/components/application_manager/test/include/application_manager/commands/command_request_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/command_request_test.h
@@ -94,7 +94,7 @@ class CommandRequestTest : public CommandsTest<kIsNice> {
   MessageSharedPtr CatchMobileCommandResult(CallableT delegate,
                                             bool call_return = true) {
     MessageSharedPtr result_msg;
-    EXPECT_CALL(this->app_mngr_, ManageMobileCommand(_, _))
+    EXPECT_CALL(this->mock_app_manager_, ManageMobileCommand(_, _))
         .WillOnce(DoAll(SaveArg<0>(&result_msg), Return(call_return)));
     delegate();
     return result_msg;
@@ -104,7 +104,7 @@ class CommandRequestTest : public CommandsTest<kIsNice> {
   MessageSharedPtr CatchHMICommandResult(CallableT delegate,
                                          bool call_return = true) {
     MessageSharedPtr result_msg;
-    EXPECT_CALL(this->app_mngr_, ManageHMICommand(_))
+    EXPECT_CALL(this->mock_app_manager_, ManageHMICommand(_))
         .WillOnce(DoAll(SaveArg<0>(&result_msg), Return(call_return)));
     delegate();
     return result_msg;
@@ -117,7 +117,7 @@ class CommandRequestTest : public CommandsTest<kIsNice> {
 
   virtual void InitCommand(const uint32_t& default_timeout) OVERRIDE {
     CommandsTest<kIsNice>::InitCommand(default_timeout);
-    ON_CALL(CommandsTest<kIsNice>::app_mngr_, event_dispatcher())
+    ON_CALL(CommandsTest<kIsNice>::mock_app_manager_, event_dispatcher())
         .WillByDefault(ReturnRef(event_dispatcher_));
   }
 };

--- a/src/components/application_manager/test/include/application_manager/commands/commands_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/commands_test.h
@@ -112,7 +112,7 @@ class CommandsTest : public ::testing::Test {
                                    MessageSharedPtr& msg) {
     InitCommand(timeout);
     return ::utils::MakeShared<Command>((msg ? msg : msg = CreateMessage()),
-                                        app_mngr_);
+                                        mock_app_manager_);
   }
 
   template <class Command>
@@ -124,19 +124,19 @@ class CommandsTest : public ::testing::Test {
   SharedPtr<Command> CreateCommand(const uint32_t timeout = kDefaultTimeout_) {
     InitCommand(timeout);
     MessageSharedPtr msg = CreateMessage();
-    return ::utils::MakeShared<Command>(msg, app_mngr_);
+    return ::utils::MakeShared<Command>(msg, mock_app_manager_);
   }
 
   enum { kDefaultTimeout_ = 100 };
 
-  MockAppManager app_mngr_;
-  MockAppManagerSettings app_mngr_settings_;
+  MockAppManager mock_app_manager_;
+  MockAppManagerSettings mock_app_manager_settings_;
 
  protected:
   virtual void InitCommand(const uint32_t& timeout) {
-    ON_CALL(app_mngr_, get_settings())
-        .WillByDefault(ReturnRef(app_mngr_settings_));
-    ON_CALL(app_mngr_settings_, default_timeout())
+    ON_CALL(mock_app_manager_, get_settings())
+        .WillByDefault(ReturnRef(mock_app_manager_settings_));
+    ON_CALL(mock_app_manager_settings_, default_timeout())
         .WillByDefault(ReturnRef(timeout));
   }
 

--- a/src/components/application_manager/test/include/application_manager/commands/commands_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/commands_test.h
@@ -48,6 +48,8 @@ namespace test {
 namespace components {
 namespace commands_test {
 
+namespace am = ::application_manager;
+
 using ::testing::ReturnRef;
 using ::testing::NiceMock;
 
@@ -140,6 +142,30 @@ class CommandsTest : public ::testing::Test {
 
   CommandsTest() {}
 };
+
+MATCHER_P(MobileResultCodeIs, result_code, "") {
+  return result_code ==
+         static_cast<mobile_apis::Result::eType>(
+             (*arg)[application_manager::strings::msg_params]
+                   [application_manager::strings::result_code].asInt());
+}
+
+MATCHER_P(HMIResultCodeIs, result_code, "") {
+  return result_code ==
+         static_cast<hmi_apis::FunctionID::eType>(
+             (*arg)[application_manager::strings::params]
+                   [application_manager::strings::function_id].asInt());
+}
+
+MATCHER_P3(MobileResponseIs, result_code, result_info, result_success, "") {
+  mobile_apis::Result::eType code = static_cast<mobile_apis::Result::eType>(
+      (*arg)[am::strings::msg_params][am::strings::result_code].asInt());
+  std::string info =
+      (*arg)[am::strings::msg_params][am::strings::info].asString();
+  bool success = (*arg)[am::strings::msg_params][am::strings::success].asBool();
+  return result_code == code && result_info == info &&
+         result_success == success;
+}
 
 }  // namespace commands_test
 }  // namespace components


### PR DESCRIPTION
Covered : 
- change_registration
- create_interaction_choice_set
- delete_file
- delete_interaction_choice_set
- delete_sub_menu
- put_file
- register_app_interface
- get_way_points
- perform_audio_path_thru
- perform_interaction
Fixed some buildability errors.

Please review : @OHerasym , @anosach-luxoft , @okozlovlux , @LevchenkoS , @VProdanov , @orhan-mehmedov 

Related task : APPLINK-26076