### PR TITLE
Fix defects found by rpc_base_test

### DIFF
--- a/src/components/utils/src/json_utils_qt.cc
+++ b/src/components/utils/src/json_utils_qt.cc
@@ -136,6 +136,8 @@ utils::json::ValueType::Type GetType(const QVariant& value) {
       return ValueType::UINT_VALUE;
     } else if (type == QVariant::Int) {
       return ValueType::INT_VALUE;
+    } else if (type == QVariant::LongLong) {
+      return ValueType::INT_VALUE;
     } else if (type == QVariant::Double) {
       // Handling of the numeric types is tricky since Qt stores
       // all json number values as double during parsing


### PR DESCRIPTION
  - fixed defect found by rpc_base_test about
    json type convertation

In json_utils_qt.cc in func `GetType(const QVariant& value)` added case when `QVariant& value` is `long long int`. Returning value in this case is  `ValueType::INT_VALUE` which is `long long int`.

Related to [APPLINK-27814](https://adc.luxoft.com/jira/browse/APPLINK-27814) 
Related to [APPLINK-27154](https://adc.luxoft.com/jira/browse/APPLINK-27154)