### PR TITLE
Update README to reflect run changes for 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Once SDL Core is compiled and installed you can start it from the executable in 
 
 ```
 %cd bin/
-%./smartDeviceLinkCore
+%LD_LIBRARY_PATH=. ./smartDeviceLinkCore
 ```
 
 ## Start WEB HMI

--- a/README.md
+++ b/README.md
@@ -41,15 +41,13 @@ A quick guide to installing, configuring, and running an instance of the SDL Cor
 ```
 %make
 %make install
-%cp bin/mykey.pem src/appMain
-%cp bin/mycert.pem src/appMain
 ```
 
 ## Start SDL Core
 Once SDL Core is compiled and installed you can start it from the executable in the bin folder
 
 ```
-%cd src/appMain
+%cd bin/
 %./smartDeviceLinkCore
 ```
 


### PR DESCRIPTION
For the most recent master, smartDeviceLinkCore now needs to be run from build/bin to work correctly.  This pull request updates the README to reflect this.  Also, the keys do not need to be copied over to src/appMain since the executable can now be run from the build/bin directory.