### PR TITLE
Fix message helper methods behavior

### DIFF
--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -2298,22 +2298,21 @@ mobile_apis::Result::eType MessageHelper::VerifyImage(
         app_mngr.get_settings().app_storage_folder();
     if (!app_storage_folder.empty()) {
       // TODO(nvaganov@luxoft.com): APPLINK-11293
-      if (!file_system::IsRelativePath(app_storage_folder)) {  // absolute path
-        full_file_path = app_storage_folder + path_delimeter;
-      } else {  // relative path
-        full_file_path = file_system::CurrentWorkingDirectory() +
-                         path_delimeter + app_storage_folder + path_delimeter;
+      if (file_system::IsRelativePath(app_storage_folder)) {  // relative path
+        full_file_path = file_system::ConcatPath(
+            file_system::CurrentWorkingDirectory(), app_storage_folder);
+      } else {  // absolute path
+        full_file_path = app_storage_folder;
       }
     } else {  // empty app storage folder
-      full_file_path = file_system::CurrentWorkingDirectory() + path_delimeter;
+      full_file_path = file_system::CurrentWorkingDirectory();
     }
 
     const std::string app_folder_name = app->folder_name();
     if (!app_folder_name.empty()) {
-      full_file_path += app_folder_name;
-      full_file_path += path_delimeter;
+      full_file_path = file_system::ConcatPath(full_file_path, app_folder_name);
     }
-    full_file_path += file_name;
+    full_file_path = file_system::ConcatPath(full_file_path, file_name);
   }
 
   if (!file_system::FileExists(full_file_path)) {

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -2290,25 +2290,29 @@ mobile_apis::Result::eType MessageHelper::VerifyImage(
   }
 
   std::string full_file_path;
-  if (file_name.size() > 0 && file_name[0] == '/') {
+  const std::string path_delimeter = file_system::GetPathDelimiter();
+  if (file_name.size() > 0 && !file_system::IsRelativePath(file_name)) {
     full_file_path = file_name;
   } else {
     const std::string& app_storage_folder =
         app_mngr.get_settings().app_storage_folder();
     if (!app_storage_folder.empty()) {
       // TODO(nvaganov@luxoft.com): APPLINK-11293
-      if (app_storage_folder[0] == '/') {  // absolute path
-        full_file_path = app_storage_folder + "/";
+      if (!file_system::IsRelativePath(app_storage_folder)) {  // absolute path
+        full_file_path = app_storage_folder + path_delimeter;
       } else {  // relative path
-        full_file_path = file_system::CurrentWorkingDirectory() + "/" +
-                         app_storage_folder + "/";
+        full_file_path = file_system::CurrentWorkingDirectory() +
+                         path_delimeter + app_storage_folder + path_delimeter;
       }
     } else {  // empty app storage folder
-      full_file_path = file_system::CurrentWorkingDirectory() + "/";
+      full_file_path = file_system::CurrentWorkingDirectory() + path_delimeter;
     }
 
-    full_file_path += app->folder_name();
-    full_file_path += "/";
+    const std::string app_folder_name = app->folder_name();
+    if (!app_folder_name.empty()) {
+      full_file_path += app_folder_name;
+      full_file_path += path_delimeter;
+    }
     full_file_path += file_name;
   }
 

--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -34,7 +34,6 @@
 #include <vector>
 #include <set>
 #include <algorithm>
-#include <iostream>
 
 #include "gmock/gmock.h"
 #include "application_manager/message_helper.h"
@@ -61,6 +60,15 @@ namespace application_manager_test {
 namespace {
 const uint32_t kCorrelationId = 1;
 const uint32_t kAppId = 123;
+#ifdef OS_WINDOWS
+const std::string full_file_path = "C:\\file.txt";
+const std::string relative_file_path = "file.txt";
+const std::string app_storage_folder = "";
+#else
+const std::string full_file_path = "/file.txt";
+const std::string relative_file_path = "./file.txt";
+const std::string app_storage_folder = "./";
+#endif
 }  // namespace
 
 namespace HmiLanguage = hmi_apis::Common_Language;
@@ -1341,43 +1349,40 @@ TEST_F(MessageHelperTest,
       utils::MakeShared<MockApplication>();
   smart_objects::SmartObject image;
   image[strings::image_type] = mobile_apis::ImageType::DYNAMIC;
-  image[strings::value] = "/file.dat";
+  image[strings::value] = full_file_path;
   mobile_apis::Result::eType result = MessageHelper::VerifyImage(
       image, app_shared_mock, mock_application_manager_);
   EXPECT_EQ(mobile_apis::Result::INVALID_DATA, result);
 }
 
 TEST_F(MessageHelperTest, VerifyImage_FullFilePathFileExists_InvalidData) {
-  const std::string kFile = "/file.txt";
-  EXPECT_FALSE(file_system::CreateFile(kFile));
+  EXPECT_FALSE(file_system::CreateFile(full_file_path));
   MockApplicationSharedPtr app_shared_mock =
       utils::MakeShared<MockApplication>();
   smart_objects::SmartObject image;
   image[strings::image_type] = mobile_apis::ImageType::DYNAMIC;
-  image[strings::value] = kFile;
+  image[strings::value] = full_file_path;
   mobile_apis::Result::eType result = MessageHelper::VerifyImage(
       image, app_shared_mock, mock_application_manager_);
   EXPECT_EQ(mobile_apis::Result::INVALID_DATA, result);
 }
 
 TEST_F(MessageHelperTest, VerifyImage_CurrentFilePath_SUCCESS) {
-  const std::string kFile = "./file.txt";
-  const std::string kFolder = "./";
-  EXPECT_TRUE(file_system::CreateFile(kFile));
+  EXPECT_TRUE(file_system::CreateFile(relative_file_path));
   MockApplicationSharedPtr app_shared_mock =
       utils::MakeShared<MockApplication>();
   MockApplicationManagerSettings app_mngr_settings;
   smart_objects::SmartObject image;
   image[strings::image_type] = mobile_apis::ImageType::DYNAMIC;
-  image[strings::value] = kFile;
+  image[strings::value] = relative_file_path;
   EXPECT_CALL(mock_application_manager_, get_settings())
       .WillOnce(ReturnRef(app_mngr_settings));
   EXPECT_CALL(app_mngr_settings, app_storage_folder())
-      .WillOnce(ReturnRef(kFolder));
+      .WillOnce(ReturnRef(app_storage_folder));
   mobile_apis::Result::eType result = MessageHelper::VerifyImage(
       image, app_shared_mock, mock_application_manager_);
   EXPECT_EQ(mobile_apis::Result::SUCCESS, result);
-  EXPECT_TRUE(file_system::DeleteFile(kFile));
+  EXPECT_TRUE(file_system::DeleteFile(relative_file_path));
 }
 
 TEST_F(MessageHelperTest, VerifyImage_AbsoluteFolderPath_InvalidData) {

--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -61,13 +61,13 @@ namespace {
 const uint32_t kCorrelationId = 1;
 const uint32_t kAppId = 123;
 #ifdef OS_WINDOWS
-const std::string full_file_path = "C:\\file.txt";
-const std::string relative_file_path = "file.txt";
-const std::string app_storage_folder = "";
+const std::string kFullFilePath = "C:\\file.txt";
+const std::string kRelativeFilePath = "file.txt";
+const std::string kAppStorageFolder = "";
 #else
-const std::string full_file_path = "/file.txt";
-const std::string relative_file_path = "./file.txt";
-const std::string app_storage_folder = "./";
+const std::string kFullFilePath = "/file.txt";
+const std::string kRelativeFilePath = "./file.txt";
+const std::string kAppStorageFolder = "./";
 #endif
 }  // namespace
 
@@ -1349,40 +1349,40 @@ TEST_F(MessageHelperTest,
       utils::MakeShared<MockApplication>();
   smart_objects::SmartObject image;
   image[strings::image_type] = mobile_apis::ImageType::DYNAMIC;
-  image[strings::value] = full_file_path;
+  image[strings::value] = kFullFilePath;
   mobile_apis::Result::eType result = MessageHelper::VerifyImage(
       image, app_shared_mock, mock_application_manager_);
   EXPECT_EQ(mobile_apis::Result::INVALID_DATA, result);
 }
 
 TEST_F(MessageHelperTest, VerifyImage_FullFilePathFileExists_InvalidData) {
-  EXPECT_FALSE(file_system::CreateFile(full_file_path));
+  EXPECT_FALSE(file_system::CreateFile(kFullFilePath));
   MockApplicationSharedPtr app_shared_mock =
       utils::MakeShared<MockApplication>();
   smart_objects::SmartObject image;
   image[strings::image_type] = mobile_apis::ImageType::DYNAMIC;
-  image[strings::value] = full_file_path;
+  image[strings::value] = kFullFilePath;
   mobile_apis::Result::eType result = MessageHelper::VerifyImage(
       image, app_shared_mock, mock_application_manager_);
   EXPECT_EQ(mobile_apis::Result::INVALID_DATA, result);
 }
 
 TEST_F(MessageHelperTest, VerifyImage_CurrentFilePath_SUCCESS) {
-  EXPECT_TRUE(file_system::CreateFile(relative_file_path));
+  EXPECT_TRUE(file_system::CreateFile(kRelativeFilePath));
   MockApplicationSharedPtr app_shared_mock =
       utils::MakeShared<MockApplication>();
   MockApplicationManagerSettings app_mngr_settings;
   smart_objects::SmartObject image;
   image[strings::image_type] = mobile_apis::ImageType::DYNAMIC;
-  image[strings::value] = relative_file_path;
+  image[strings::value] = kRelativeFilePath;
   EXPECT_CALL(mock_application_manager_, get_settings())
       .WillOnce(ReturnRef(app_mngr_settings));
   EXPECT_CALL(app_mngr_settings, app_storage_folder())
-      .WillOnce(ReturnRef(app_storage_folder));
+      .WillOnce(ReturnRef(kAppStorageFolder));
   mobile_apis::Result::eType result = MessageHelper::VerifyImage(
       image, app_shared_mock, mock_application_manager_);
   EXPECT_EQ(mobile_apis::Result::SUCCESS, result);
-  EXPECT_TRUE(file_system::DeleteFile(relative_file_path));
+  EXPECT_TRUE(file_system::DeleteFile(kRelativeFilePath));
 }
 
 TEST_F(MessageHelperTest, VerifyImage_AbsoluteFolderPath_InvalidData) {

--- a/src/components/include/policy/policy_types.h
+++ b/src/components/include/policy/policy_types.h
@@ -218,6 +218,7 @@ struct AppPermissions {
       , appRevoked(false)
       , appPermissionsConsentNeeded(false)
       , appUnauthorized(false)
+	  , isSDLAllowed(false)
       , requestTypeChanged(false) {}
 
   std::string application_id;

--- a/src/components/include/policy/policy_types.h
+++ b/src/components/include/policy/policy_types.h
@@ -218,7 +218,7 @@ struct AppPermissions {
       , appRevoked(false)
       , appPermissionsConsentNeeded(false)
       , appUnauthorized(false)
-	  , isSDLAllowed(false)
+      , isSDLAllowed(false)
       , requestTypeChanged(false) {}
 
   std::string application_id;


### PR DESCRIPTION
Corrected behavior of : 
- VerifyImage (incorrect path`s processing, for Win platform)
- SendSDLActivateAppResponce (possible undefined behavior with uninitialized AppPermissions::isSDLAllowed bool field)

Corrected tests according corrected behavior. 