### PR TITLE
Update build dependencies in CMakeLists.txt files

### DIFF
--- a/src/components/application_manager/CMakeLists.txt
+++ b/src/components/application_manager/CMakeLists.txt
@@ -107,6 +107,7 @@ set(LIBRARIES
   formatters
   dbms
   ${SQLITE3_LIBRARIES}
+  utils
 )
 
 get_os(OS)

--- a/src/components/connection_handler/CMakeLists.txt
+++ b/src/components/connection_handler/CMakeLists.txt
@@ -52,6 +52,7 @@ set(LIBRARIES
   protocol
   encryption
   ${OPENSSL_LIBRARIES}
+  utils
 )
 
 collect_sources(SOURCES "${PATHS}")

--- a/src/components/dbus/CMakeLists.txt
+++ b/src/components/dbus/CMakeLists.txt
@@ -46,7 +46,9 @@ set(PATHS
 collect_sources(SOURCES "${PATHS}")
 
 set(LIBRARIES
+  HMI_API
   dbus-1
+  utils
   ${DBUS_LIBRARIES}
 )
 

--- a/src/components/media_manager/CMakeLists.txt
+++ b/src/components/media_manager/CMakeLists.txt
@@ -54,8 +54,10 @@ set(PATHS
 set(EXCLUDE_PATHS)
 
 set(LIBRARIES
+  MOBILE_API
   protocol
   application_manager
+  utils
 )
 
 if(EXTENDED_MEDIA_MODE)

--- a/src/components/resumption/CMakeLists.txt
+++ b/src/components/resumption/CMakeLists.txt
@@ -41,9 +41,15 @@ set(PATHS
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
+
+set(LIBRARIES
+  utils
+)
+
 collect_sources(SOURCES "${PATHS}")
 
 add_library(resumption ${SOURCES} )
+target_link_libraries(resumption ${LIBRARIES})
 
 if(BUILD_TESTS)
   add_subdirectory(test)

--- a/src/components/security_manager/CMakeLists.txt
+++ b/src/components/security_manager/CMakeLists.txt
@@ -51,6 +51,7 @@ set(PATHS
 collect_sources(SOURCES "${PATHS}")
 
 set(LIBRARIES
+  utils
   protocol
   protocol_handler
   jsoncpp

--- a/src/components/transport_manager/CMakeLists.txt
+++ b/src/components/transport_manager/CMakeLists.txt
@@ -56,6 +56,7 @@ set(EXCLUDE_PATHS
 
 set(LIBRARIES
   protocol
+  utils
 )
 
 if(BUILD_BT_SUPPORT)

--- a/src/plugins/appenders/CMakeLists.txt
+++ b/src/plugins/appenders/CMakeLists.txt
@@ -43,6 +43,8 @@ set(LIBRARIES
 add_library(appenders SHARED ${SOURCES})
 target_link_libraries(appenders ${LIBRARIES})
 
+add_dependencies(appenders install-3rd_party_logger)
+
 install(TARGETS appenders
   DESTINATION ${INSTALL_DIRECTORY}
   PERMISSIONS


### PR DESCRIPTION
Update build dependencies in order to be able
to build in parallel mode, for example:
make -j4
No source code changed.

Related to [APPLINK-25547](https://adc.luxoft.com/jira/browse/APPLINK-25547).