### PR TITLE
Move applicable Unit Tests for commands Part 1

### DIFF
--- a/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
@@ -30,6 +30,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <utility>
 #include "application_manager/commands/hmi/navi_start_stream_request.h"
 #include "application_manager/message_helper.h"
 #include "protocol_handler/protocol_handler.h"

--- a/src/components/application_manager/test/CMakeLists.txt
+++ b/src/components/application_manager/test/CMakeLists.txt
@@ -166,8 +166,7 @@ list(APPEND LIBRARIES
 
 create_test(am_hmi_capabilities_test "${AM_HMI_CAPABILITIES_SOURCES}" "${LIBRARIES}")
 create_test(am_application_test "${APPLICATION_SOURCES}" "${LIBRARIES}")
-# TODO(AKutsan) APPLINK-25547 Uncoment command tests when sdl will support multithreading build
-#create_test(am_commands_test "${COMMANDS_SOURCES}" "${LIBRARIES}")
+create_test(am_commands_test "${COMMANDS_SOURCES}" "${LIBRARIES}")
 create_test(am_resumption_test "${RESUMPTION_SOURCES}" "${LIBRARIES}")
 create_test(am_state_controller_test "${STATE_CONTROLLER_SOURCES}" "${LIBRARIES}")
 create_test(am_hmi_language_handler_test "${AM_HMI_LANGUAGE_HANDLER}" "${LIBRARIES}")

--- a/src/components/application_manager/test/commands/hmi/allow_all_apps_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/allow_all_apps_response_test.cc
@@ -31,54 +31,45 @@
  */
 
 #include "gtest/gtest.h"
+#include "application_manager/commands/hmi/allow_all_apps_response.h"
 #include "utils/shared_ptr.h"
 #include "smart_objects/smart_object.h"
-#include "application_manager/smart_object_keys.h"
-#include "application_manager/commands/commands_test.h"
-#include "application_manager/commands/command.h"
-#include "application_manager/commands/hmi/sdl_activate_app_response.h"
-#include "application_manager/commands/hmi/sdl_get_list_of_permissions_response.h"
-#include "application_manager/commands/hmi/sdl_get_status_update_response.h"
-#include "application_manager/commands/hmi/sdl_get_user_friendly_message_response.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/commands/command_impl.h"
+#include "commands/commands_test.h"
 
 namespace test {
 namespace components {
 namespace commands_test {
 namespace hmi_commands_test {
 
-using ::testing::_;
-using ::testing::Types;
-using ::testing::NotNull;
-using ::utils::SharedPtr;
+using application_manager::commands::MessageSharedPtr;
+using application_manager::commands::AllowAllAppsResponse;
 
-namespace commands = ::application_manager::commands;
-using commands::MessageSharedPtr;
+namespace strings = ::application_manager::strings;
+namespace hmi_response = ::application_manager::hmi_response;
 
-template <class Command>
-class ResponseToHMICommandsTest
-    : public CommandsTest<CommandsTestMocks::kIsNice> {
- public:
-  typedef Command CommandType;
-};
+typedef ::utils::SharedPtr<AllowAllAppsResponse> ResponsePtr;
 
-typedef Types<commands::SDLActivateAppResponse,
-              commands::SDLGetListOfPermissionsResponse,
-              commands::SDLGetStatusUpdateResponse,
-              commands::SDLGetUserFriendlyMessageResponse> ResponseCommandsList;
+namespace {
+const bool kResponseIsAllowed = true;
+}  //
 
-TYPED_TEST_CASE(ResponseToHMICommandsTest, ResponseCommandsList);
+class AllowAllAppsResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
 
-TYPED_TEST(ResponseToHMICommandsTest, Run_SendMessageToHMI_SUCCESS) {
-  typedef typename TestFixture::CommandType CommandType;
+TEST_F(AllowAllAppsResponseTest, Run_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::msg_params][hmi_response::allowed] = kResponseIsAllowed;
 
-  SharedPtr<CommandType> command = this->template CreateCommand<CommandType>();
+  ResponsePtr command(CreateCommand<AllowAllAppsResponse>(msg));
 
-  EXPECT_CALL(this->mock_app_manager_, SendMessageToHMI(NotNull()));
+  EXPECT_CALL(mock_app_manager_, SetAllAppsAllowed(kResponseIsAllowed));
 
   command->Run();
 }
 
-}  // hmi_commands_test
+}  // namespace hmi_commands_test
 }  // namespace commands_test
 }  // namespace components
 }  // namespace test

--- a/src/components/application_manager/test/commands/hmi/button_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/button_get_capabilities_response_test.cc
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gtest/gtest.h"
+#include "application_manager/commands/hmi/button_get_capabilities_response.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "commands/commands_test.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using application_manager::commands::MessageSharedPtr;
+using application_manager::commands::ButtonGetCapabilitiesResponse;
+using ::testing::ReturnRef;
+using ::testing::NiceMock;
+
+namespace strings = ::application_manager::strings;
+namespace hmi_response = ::application_manager::hmi_response;
+
+typedef ::utils::SharedPtr<ButtonGetCapabilitiesResponse> ResponsePtr;
+
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+class ButtonGetCapabilitiesResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  MessageSharedPtr CreateMsgParams() {
+    capabilities_[strings::name] = hmi_apis::Common_ButtonName::OK;
+    preset_bank_capabilities_ = true;
+
+    MessageSharedPtr msg = CreateMessage();
+    (*msg)[strings::msg_params][hmi_response::capabilities] = (capabilities_);
+    (*msg)[strings::msg_params][hmi_response::preset_bank_capabilities] =
+        (preset_bank_capabilities_);
+
+    return msg;
+  }
+
+  MockHMICapabilities mock_hmi_capabilities_;
+  SmartObject capabilities_;
+  SmartObject preset_bank_capabilities_;
+};
+
+TEST_F(ButtonGetCapabilitiesResponseTest, Run_CodeSuccess_SUCCESS) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+
+  ResponsePtr command(CreateCommand<ButtonGetCapabilitiesResponse>(msg));
+
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+  EXPECT_CALL(mock_hmi_capabilities_, set_button_capabilities(capabilities_));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_preset_bank_capabilities(preset_bank_capabilities_));
+
+  command->Run();
+}
+
+TEST_F(ButtonGetCapabilitiesResponseTest, Run_CodeAborted_SUCCESS) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::ABORTED;
+
+  ResponsePtr command(CreateCommand<ButtonGetCapabilitiesResponse>(msg));
+
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities()).Times(0);
+  EXPECT_CALL(mock_hmi_capabilities_, set_button_capabilities(capabilities_))
+      .Times(0);
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_preset_bank_capabilities(preset_bank_capabilities_)).Times(0);
+
+  command->Run();
+}
+
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/dummy_hmi_commands_test.cc
+++ b/src/components/application_manager/test/commands/hmi/dummy_hmi_commands_test.cc
@@ -45,7 +45,6 @@
 #include "application_manager/commands/hmi/navi_audio_start_stream_response.h"
 #include "application_manager/commands/hmi/navi_audio_stop_stream_request.h"
 #include "application_manager/commands/hmi/navi_audio_stop_stream_response.h"
-
 #include "application_manager/commands/hmi/update_device_list_request.h"
 #include "application_manager/commands/hmi/update_device_list_response.h"
 #include "application_manager/commands/hmi/on_update_device_list.h"

--- a/src/components/application_manager/test/commands/hmi/navi_start_stream_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_start_stream_request_test.cc
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+#include <utility>
+
+#include "hmi/navi_start_stream_request.h"
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "commands/commands_test.h"
+#include "commands/command_request_test.h"
+#include "application_manager/application.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_application_manager_settings.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/event_engine/event.h"
+#include "application_manager/mock_event_dispatcher.h"
+#include "interfaces/MOBILE_API.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+namespace am = ::application_manager;
+namespace mobile_result = mobile_apis::Result;
+
+using ::utils::SharedPtr;
+using ::testing::_;
+using ::testing::Return;
+using ::testing::InSequence;
+using test::components::event_engine_test::MockEventDispatcher;
+using am::commands::NaviStartStreamRequest;
+using am::commands::MessageSharedPtr;
+using am::event_engine::Event;
+
+typedef SharedPtr<NaviStartStreamRequest> NaviStartStreamRequestPtr;
+
+namespace {
+const int32_t kConnectionKey = 2;
+const uint32_t kAppId = 3u;
+const uint32_t kCorId = 5u;
+}  // namespace
+
+class NaviStartStreamRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ protected:
+  void SetUp() OVERRIDE {
+    command_msg = CreateMessage(smart_objects::SmartType_Map);
+    (*command_msg)[am::strings::params][am::strings::connection_key] =
+        kConnectionKey;
+    (*command_msg)[am::strings::params][am::strings::correlation_id] = kCorId;
+    app = CreateMockApp();
+
+    ON_CALL(mock_app_manager_settings_, start_stream_retry_amount())
+        .WillByDefault(ReturnRef(stream_retry));
+  }
+
+  MockAppPtr app;
+  MessageSharedPtr command_msg;
+  std::pair<uint32_t, int32_t> stream_retry;
+  MockEventDispatcher mock_event_dispatcher_;
+};
+
+MATCHER_P(CheckSendRequest, connection_key, "") {
+  return connection_key ==
+         (*arg)[am::strings::params][am::strings::connection_key].asInt();
+}
+
+TEST_F(NaviStartStreamRequestTest, Run_ApplicationNotExists_RequestNotSend) {
+  NaviStartStreamRequestPtr command(
+      CreateCommand<NaviStartStreamRequest>(command_msg));
+
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(_))
+      .WillOnce(Return(ApplicationSharedPtr()));
+  EXPECT_CALL(mock_app_manager_, SendMessageToHMI(_)).Times(0);
+
+  command->Run();
+}
+
+TEST_F(NaviStartStreamRequestTest,
+       Run_AppIDGivenAndApplicationExists_RequestSend) {
+  (*command_msg)[am::strings::msg_params][am::strings::app_id] = kAppId;
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app));
+  EXPECT_CALL(*app, hmi_app_id())
+      .WillOnce(Return(kAppId))
+      .WillOnce(Return(kAppId));
+  NaviStartStreamRequestPtr command(
+      CreateCommand<NaviStartStreamRequest>(command_msg));
+
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(kAppId))
+      .WillOnce(Return(app));
+  EXPECT_CALL(*app, set_video_streaming_allowed(true));
+
+  EXPECT_CALL(mock_app_manager_, SendMessageToHMI(command_msg));
+
+  command->Run();
+}
+
+TEST_F(NaviStartStreamRequestTest,
+       Run_AppNotGivenApplicationExists_RequestSend) {
+  // AppId is not given
+  EXPECT_CALL(mock_app_manager_, application(_)).Times(0);
+  EXPECT_CALL(*app, hmi_app_id()).Times(0);
+  NaviStartStreamRequestPtr command(
+      CreateCommand<NaviStartStreamRequest>(command_msg));
+
+  // Get default app id
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(0))
+      .WillOnce(Return(app));
+
+  EXPECT_CALL(*app, set_video_streaming_allowed(true));
+
+  EXPECT_CALL(mock_app_manager_,
+              SendMessageToHMI(CheckSendRequest(kConnectionKey)));
+
+  command->Run();
+}
+
+TEST_F(NaviStartStreamRequestTest,
+       OnEvent_StartStreamingSuccessful_StreamingApproved) {
+  const hmi_apis::Common_Result::eType code = hmi_apis::Common_Result::SUCCESS;
+
+  (*command_msg)[am::strings::msg_params][am::strings::app_id] = kAppId;
+  MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
+
+  (*event_msg)[am::strings::params][am::hmi_response::code] = code;
+
+  Event event(hmi_apis::FunctionID::Navigation_StartStream);
+  event.set_smart_object(*event_msg);
+  // AppId is given
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app));
+  EXPECT_CALL(*app, hmi_app_id())
+      .WillOnce(Return(kAppId))
+      .WillOnce(Return(kAppId));
+  NaviStartStreamRequestPtr command(
+      CreateCommand<NaviStartStreamRequest>(command_msg));
+
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(kAppId))
+      .WillOnce(Return(app));
+  EXPECT_CALL(*app, app_id()).WillOnce(Return(kAppId));
+  EXPECT_CALL(mock_app_manager_,
+              HMILevelAllowsStreaming(
+                  kAppId, protocol_handler::ServiceType::kMobileNav))
+      .WillOnce(Return(true));
+  EXPECT_CALL(*app, set_video_streaming_approved(true));
+
+  command->on_event(event);
+}
+
+TEST_F(NaviStartStreamRequestTest,
+       OnEvent_StartStreamingRejected_StreamingNotStarted) {
+  const hmi_apis::Common_Result::eType code = hmi_apis::Common_Result::REJECTED;
+
+  (*command_msg)[am::strings::msg_params][am::strings::app_id] = kAppId;
+  MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
+
+  (*event_msg)[am::strings::params][am::hmi_response::code] = code;
+
+  Event event(hmi_apis::FunctionID::Navigation_StartStream);
+  event.set_smart_object(*event_msg);
+
+  // AppId is given
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app));
+  EXPECT_CALL(*app, hmi_app_id())
+      .WillOnce(Return(kAppId))
+      .WillOnce(Return(kAppId));
+  NaviStartStreamRequestPtr command(
+      CreateCommand<NaviStartStreamRequest>(command_msg));
+
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(kAppId))
+      .WillOnce(Return(app))
+      .WillOnce(Return(app));
+
+  EXPECT_CALL(mock_app_manager_, HMILevelAllowsStreaming(_, _)).Times(0);
+  // Streaming is not approved
+  EXPECT_CALL(*app, set_video_streaming_approved(_)).Times(0);
+
+  EXPECT_CALL(mock_app_manager_, TerminateRequest(kConnectionKey, kCorId));
+
+  command->on_event(event);
+}
+TEST_F(NaviStartStreamRequestTest,
+       OnEvent_StartStreamingNotRejectedAndNotSuccessful_StreamingNotStarted) {
+  const hmi_apis::Common_Result::eType code = hmi_apis::Common_Result::ABORTED;
+
+  (*command_msg)[am::strings::msg_params][am::strings::app_id] = kAppId;
+  MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*event_msg)[am::strings::params][am::hmi_response::code] = code;
+
+  Event event(hmi_apis::FunctionID::Navigation_StartStream);
+  event.set_smart_object(*event_msg);
+
+  // AppId is given
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app));
+  EXPECT_CALL(*app, hmi_app_id())
+      .WillOnce(Return(kAppId))
+      .WillOnce(Return(kAppId));
+  NaviStartStreamRequestPtr command(
+      CreateCommand<NaviStartStreamRequest>(command_msg));
+
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(kAppId))
+      .WillOnce(Return(app));
+
+  EXPECT_CALL(mock_app_manager_, HMILevelAllowsStreaming(_, _)).Times(0);
+  // Streaming is not approved
+  EXPECT_CALL(*app, set_video_streaming_approved(_)).Times(0);
+
+  // Send nothing
+  EXPECT_CALL(mock_app_manager_, SendMessageToHMI(_)).Times(0);
+  command->on_event(event);
+}
+
+TEST_F(NaviStartStreamRequestTest, OnTimeOut_VideoStreamingApproved) {
+  (*command_msg)[am::strings::msg_params][am::strings::app_id] = kAppId;
+
+  const int32_t retry_number = 10;
+  stream_retry.first = retry_number;
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app));
+  EXPECT_CALL(*app, hmi_app_id())
+      .WillOnce(Return(kAppId))
+      .WillOnce(Return(kAppId));
+  NaviStartStreamRequestPtr command(
+      CreateCommand<NaviStartStreamRequest>(command_msg));
+
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(_))
+      .WillOnce(Return(app));
+  EXPECT_CALL(*app, video_streaming_allowed()).WillOnce(Return(true));
+  EXPECT_CALL(*app, video_streaming_approved()).WillOnce(Return(true));
+  EXPECT_CALL(*app, set_video_stream_retry_number(0));
+
+  EXPECT_CALL(mock_app_manager_, TerminateRequest(kConnectionKey, kCorId));
+  command->onTimeOut();
+}
+
+TEST_F(NaviStartStreamRequestTest,
+       OnTimeOut_VideoStreamingNotApproved_RetryVideo) {
+  (*command_msg)[am::strings::msg_params][am::strings::app_id] = kAppId;
+
+  const int32_t retry_number = 10;
+  stream_retry.first = retry_number;
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app));
+  EXPECT_CALL(*app, hmi_app_id())
+      .WillOnce(Return(kAppId))
+      .WillOnce(Return(kAppId));
+  NaviStartStreamRequestPtr command(
+      CreateCommand<NaviStartStreamRequest>(command_msg));
+
+  ON_CALL(*app, app_id()).WillByDefault(Return(kAppId));
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(_))
+      .WillOnce(Return(app));
+  EXPECT_CALL(*app, video_streaming_allowed()).WillOnce(Return(true));
+  // Video has not approved yet
+  EXPECT_CALL(*app, video_streaming_approved()).WillOnce(Return(false));
+  EXPECT_CALL(*app, set_video_stream_retry_number(0)).Times(0);
+
+  EXPECT_CALL(*am::MockMessageHelper::message_helper_mock(),
+              SendNaviStartStream(kAppId, _));
+
+  // Retry number increased
+  EXPECT_CALL(*app, set_video_stream_retry_number(1));
+
+  EXPECT_CALL(mock_app_manager_, TerminateRequest(kConnectionKey, kCorId));
+  command->onTimeOut();
+}
+
+TEST_F(NaviStartStreamRequestTest,
+       OnTimeOut_VideoStreamingNotApproved_RetryNumberExceeded_VideoStopped) {
+  (*command_msg)[am::strings::msg_params][am::strings::app_id] = kAppId;
+
+  const int32_t retry_number = 10;
+  stream_retry.first = retry_number;
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app));
+  EXPECT_CALL(*app, hmi_app_id())
+      .WillOnce(Return(kAppId))
+      .WillOnce(Return(kAppId));
+  NaviStartStreamRequestPtr command(
+      CreateCommand<NaviStartStreamRequest>(command_msg));
+
+  ON_CALL(*app, app_id()).WillByDefault(Return(kAppId));
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(_))
+      .WillRepeatedly(Return(app));
+  EXPECT_CALL(*app, video_streaming_allowed()).WillRepeatedly(Return(true));
+  // Video has not approved yet
+  EXPECT_CALL(*app, video_streaming_approved()).WillRepeatedly(Return(false));
+  EXPECT_CALL(*app, set_video_stream_retry_number(0)).Times(0);
+
+  // Retry number exceeded
+  EXPECT_CALL(*app, video_stream_retry_number()).WillOnce(Return(retry_number));
+
+  EXPECT_CALL(*am::MockMessageHelper::message_helper_mock(),
+              SendNaviStartStream(kAppId, _)).Times(0);
+  EXPECT_CALL(*app, set_video_stream_retry_number(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, EndNaviServices(kAppId));
+  EXPECT_CALL(mock_app_manager_, TerminateRequest(kConnectionKey, kCorId));
+  command->onTimeOut();
+}
+
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/sdl_activate_app_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/sdl_activate_app_request_test.cc
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+
+#include "gtest/gtest.h"
+#include "utils/lock.h"
+#include "application_manager/commands/hmi/sdl_activate_app_request.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/application_manager.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
+#include "commands/command_request_test.h"
+#include "application_manager/mock_message_helper.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+namespace am = ::application_manager;
+namespace strings = am::strings;
+namespace hmi_response = am::hmi_response;
+using am::commands::MessageSharedPtr;
+using am::commands::SDLActivateAppRequest;
+using am::ApplicationSet;
+using testing::Return;
+using testing::ReturnRef;
+using am::MockMessageHelper;
+using policy_test::MockPolicyHandlerInterface;
+
+namespace {
+const uint32_t kCorrelationID = 1u;
+const uint32_t kAppID = 2u;
+const uint32_t kAppIDFirst = 1u;
+const connection_handler::DeviceHandle kHandle = 2u;
+}  // namespace
+
+class SDLActivateAppRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ protected:
+  SDLActivateAppRequestTest()
+      : message_helper_mock_(am::MockMessageHelper::message_helper_mock()) {}
+
+  void InitCommand(const uint32_t& timeout) OVERRIDE {
+    MockAppPtr mock_app = CreateMockApp();
+    CommandRequestTest<CommandsTestMocks::kIsNice>::InitCommand(timeout);
+    ON_CALL((*mock_app), app_id()).WillByDefault(Return(kAppID));
+    EXPECT_CALL(mock_app_manager_, application_by_hmi_app(kAppID))
+        .WillOnce(Return(mock_app));
+  }
+
+  ApplicationSet app_list_;
+  ::sync_primitives::Lock lock_;
+  am::MockMessageHelper* message_helper_mock_;
+  policy_test::MockPolicyHandlerInterface policy_handler_;
+};
+
+TEST_F(SDLActivateAppRequestTest, FindAppToRegister_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
+  (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
+
+  SharedPtr<SDLActivateAppRequest> command(
+      CreateCommand<SDLActivateAppRequest>(msg));
+
+  MockAppPtr mock_app(CreateMockApp());
+  EXPECT_CALL(mock_app_manager_, application(kAppID))
+      .WillOnce(Return(ApplicationSharedPtr()));
+  EXPECT_CALL(mock_app_manager_, FindAppToRegister(kAppID))
+      .WillOnce(Return(mock_app));
+  EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
+
+  MockAppPtr mock_app_first(CreateMockApp());
+  ON_CALL(*mock_app_first, device()).WillByDefault(Return(kHandle));
+  ON_CALL(*mock_app_first, is_foreground()).WillByDefault(Return(false));
+
+  app_list_.insert(mock_app_first);
+  DataAccessor<ApplicationSet> accessor(app_list_, lock_);
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
+
+  EXPECT_CALL(*mock_app_first, device()).WillOnce(Return(kHandle));
+  EXPECT_CALL(*mock_app_first, is_foreground()).WillOnce(Return(false));
+
+  EXPECT_CALL(*message_helper_mock_, SendLaunchApp(_, _, _, _));
+
+  command->Run();
+}
+
+TEST_F(SDLActivateAppRequestTest, AppIdNotFound_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
+  (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
+
+  SharedPtr<SDLActivateAppRequest> command(
+      CreateCommand<SDLActivateAppRequest>(msg));
+
+  EXPECT_CALL(mock_app_manager_, application(kAppID))
+      .WillOnce(Return(ApplicationSharedPtr()));
+  EXPECT_CALL(mock_app_manager_, FindAppToRegister(kAppID))
+      .WillOnce(Return(ApplicationSharedPtr()));
+
+  command->Run();
+}
+
+TEST_F(SDLActivateAppRequestTest, DevicesAppsEmpty_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
+  (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
+
+  SharedPtr<SDLActivateAppRequest> command(
+      CreateCommand<SDLActivateAppRequest>(msg));
+
+  MockAppPtr mock_app(CreateMockApp());
+  ON_CALL(mock_app_manager_, application(kAppID))
+      .WillByDefault(Return(mock_app));
+
+  DataAccessor<ApplicationSet> accessor(app_list_, lock_);
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
+  app_list_ = accessor.GetData();
+
+  command->Run();
+}
+
+TEST_F(SDLActivateAppRequestTest, FirstAppActive_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
+  (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
+
+  SharedPtr<SDLActivateAppRequest> command(
+      CreateCommand<SDLActivateAppRequest>(msg));
+
+  MockAppPtr mock_app(CreateMockApp());
+  ON_CALL(mock_app_manager_, application(kAppID))
+      .WillByDefault(Return(mock_app));
+
+  EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
+
+  DataAccessor<ApplicationSet> accessor(app_list_, lock_);
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
+
+  app_list_ = accessor.GetData();
+
+  MockAppPtr mock_app_first(CreateMockApp());
+  ON_CALL(mock_app_manager_, application(kAppIDFirst))
+      .WillByDefault(Return(mock_app_first));
+
+  app_list_.insert(mock_app_first);
+
+  EXPECT_CALL(*mock_app_first, device()).WillOnce(Return(kHandle));
+  EXPECT_CALL(*mock_app_first, is_foreground()).WillRepeatedly(Return(true));
+
+  EXPECT_CALL(*message_helper_mock_, SendLaunchApp(_, _, _, _));
+
+  command->Run();
+}
+
+TEST_F(SDLActivateAppRequestTest, FirstAppNotActive_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
+  (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
+
+  SharedPtr<SDLActivateAppRequest> command(
+      CreateCommand<SDLActivateAppRequest>(msg));
+
+  MockAppPtr mock_app(CreateMockApp());
+  ON_CALL(mock_app_manager_, application(kAppID))
+      .WillByDefault(Return(mock_app));
+
+  EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
+
+  MockAppPtr mock_app_first(CreateMockApp());
+  ON_CALL(*mock_app_first, device()).WillByDefault(Return(kHandle));
+  ON_CALL(*mock_app_first, is_foreground()).WillByDefault(Return(false));
+
+  app_list_.insert(mock_app_first);
+  DataAccessor<ApplicationSet> accessor(app_list_, lock_);
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
+
+  EXPECT_CALL(*mock_app, IsRegistered()).WillOnce(Return(true));
+  EXPECT_CALL(*mock_app_first, device()).WillOnce(Return(kHandle));
+  EXPECT_CALL(*mock_app_first, is_foreground()).WillOnce(Return(false));
+
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
+      .WillOnce(ReturnRef(policy_handler_));
+  EXPECT_CALL(policy_handler_, OnActivateApp(kAppID, kCorrelationID));
+
+  command->Run();
+}
+
+TEST_F(SDLActivateAppRequestTest, FirstAppNotRegisteredAndEmpty_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
+  (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
+
+  SharedPtr<SDLActivateAppRequest> command(
+      CreateCommand<SDLActivateAppRequest>(msg));
+
+  MockAppPtr mock_app(CreateMockApp());
+  ON_CALL(mock_app_manager_, application(kAppID))
+      .WillByDefault(Return(mock_app));
+  EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
+
+  MockAppPtr mock_app_first(CreateMockApp());
+  ON_CALL(*mock_app_first, device()).WillByDefault(Return(kHandle));
+  ON_CALL(*mock_app_first, is_foreground()).WillByDefault(Return(false));
+
+  app_list_.insert(mock_app_first);
+  DataAccessor<ApplicationSet> accessor(app_list_, lock_);
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
+
+  EXPECT_CALL(*mock_app_first, device()).WillOnce(Return(kHandle));
+  EXPECT_CALL(*mock_app_first, is_foreground()).WillOnce(Return(false));
+
+  EXPECT_CALL(*message_helper_mock_, SendLaunchApp(_, _, _, _));
+
+  command->Run();
+}
+
+TEST_F(SDLActivateAppRequestTest, FirstAppNotRegistered_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
+  (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
+
+  SharedPtr<SDLActivateAppRequest> command(
+      CreateCommand<SDLActivateAppRequest>(msg));
+
+  MockAppPtr mock_app(CreateMockApp());
+  ON_CALL(mock_app_manager_, application(kAppID))
+      .WillByDefault(Return(mock_app));
+  EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
+
+  DataAccessor<ApplicationSet> accessor(app_list_, lock_);
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
+
+  app_list_ = accessor.GetData();
+
+  MockAppPtr mock_app_first(CreateMockApp());
+  ON_CALL(*mock_app_first, device()).WillByDefault(Return(kHandle));
+  ON_CALL(*mock_app_first, is_foreground()).WillByDefault(Return(false));
+
+  app_list_.insert(mock_app_first);
+
+  EXPECT_CALL(*mock_app_first, device()).WillOnce(Return(kHandle));
+  EXPECT_CALL(*mock_app_first, is_foreground()).WillRepeatedly(Return(true));
+
+  EXPECT_CALL(*message_helper_mock_, SendLaunchApp(_, _, _, _));
+
+  command->Run();
+}
+
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/sdl_get_list_of_permisssions_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/sdl_get_list_of_permisssions_request_test.cc
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+
+#include "gtest/gtest.h"
+#include "application_manager/commands/hmi/sdl_get_list_of_permissions_request.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
+#include "commands/command_request_test.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using application_manager::commands::MessageSharedPtr;
+using application_manager::commands::SDLGetListOfPermissionsRequest;
+using test::components::policy_test::MockPolicyHandlerInterface;
+using smart_objects::SmartObject;
+using testing::Return;
+using testing::ReturnRef;
+
+namespace {
+const uint32_t kCorrelationID = 1u;
+const uint32_t kAppID = 2u;
+const uint32_t kConnectionKey = 0u;
+}  // namespace
+
+namespace strings = ::application_manager::strings;
+namespace hmi_response = ::application_manager::hmi_response;
+
+class SDLGetListOfPermissionsRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ protected:
+  void SetUp() OVERRIDE {
+    mock_app_ = CreateMockApp();
+  }
+
+  void InitCommand(const uint32_t& timeout) OVERRIDE {
+    CommandRequestTest<CommandsTestMocks::kIsNice>::InitCommand(timeout);
+    ON_CALL((*mock_app_), app_id()).WillByDefault(Return(kAppID));
+  }
+  MockAppPtr mock_app_;
+};
+
+TEST_F(SDLGetListOfPermissionsRequestTest, Run_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::correlation_id] = kCorrelationID;
+  (*msg)[strings::msg_params][strings::app_id] = kAppID;
+
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(kAppID))
+      .WillOnce(Return(mock_app_));
+
+  SharedPtr<SDLGetListOfPermissionsRequest> command(
+      CreateCommand<SDLGetListOfPermissionsRequest>(msg));
+
+  MockPolicyHandlerInterface policy_handler;
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
+      .WillOnce(ReturnRef(policy_handler));
+  EXPECT_CALL(policy_handler, OnGetListOfPermissions(kAppID, kCorrelationID));
+
+  command->Run();
+}
+
+TEST_F(SDLGetListOfPermissionsRequestTest, Run_KeyDoesntExist_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Binary);
+  (*msg)[strings::params][strings::correlation_id] = kCorrelationID;
+
+  SharedPtr<SDLGetListOfPermissionsRequest> command(
+      CreateCommand<SDLGetListOfPermissionsRequest>(msg));
+
+  MockPolicyHandlerInterface policy_handler;
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
+      .WillOnce(ReturnRef(policy_handler));
+  EXPECT_CALL(policy_handler,
+              OnGetListOfPermissions(kConnectionKey, kCorrelationID));
+
+  command->Run();
+}
+
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
@@ -100,6 +100,16 @@
 #include "hmi/vr_get_language_request.h"
 #include "hmi/vr_is_ready_request.h"
 #include "hmi/vr_perform_interaction_request.h"
+#include "hmi/allow_all_apps_request.h"
+#include "hmi/basic_communication_system_request.h"
+#include "hmi/button_get_capabilities_request.h"
+#include "hmi/allow_app_request.h"
+#include "hmi/navi_send_location_request.h"
+#include "hmi/navi_unsubscribe_way_points_request.h"
+#include "hmi/navi_update_turn_list_request.h"
+#include "hmi/navi_show_constant_tbt_request.h"
+#include "hmi/navi_stop_stream_request.h"
+#include "hmi/navi_subscribe_way_points_request.h"
 
 namespace test {
 namespace components {
@@ -187,17 +197,19 @@ typedef Types<commands::VIIsReadyRequest,
               commands::BasicCommunicationSystemRequest,
               commands::ButtonGetCapabilitiesRequest,
               commands::NaviSendLocationRequest,
+              commands::NaviUnSubscribeWayPointsRequest,
+              commands::NaviUpdateTurnListRequest,
               commands::NaviShowConstantTBTRequest,
               commands::NaviStopStreamRequest,
               commands::NaviSubscribeWayPointsRequest,
               commands::NaviAlertManeuverRequest,
               commands::AudioStopStreamRequest,
               commands::NaviGetWayPointsRequest,
-              commands::NaviIsReadyRequest,
-              commands::UIScrollableMessageRequest,
               commands::UISetGlobalPropertiesRequest> RequestCommandsList;
 
-typedef Types<commands::VRGetCapabilitiesRequest,
+typedef Types<commands::NaviIsReadyRequest,
+              commands::UIScrollableMessageRequest,
+              commands::VRGetCapabilitiesRequest,
               commands::UISetAppIconRequest,
               commands::UiSetDisplayLayoutRequest,
               commands::VRGetSupportedLanguagesRequest,

--- a/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
@@ -86,6 +86,14 @@
 #include "hmi/vr_change_registration_response.h"
 #include "hmi/vr_delete_command_response.h"
 #include "hmi/vr_perform_interaction_response.h"
+#include "hmi/activate_app_response.h"
+#include "hmi/basic_communication_system_response.h"
+#include "hmi/navi_unsubscribe_way_points_response.h"
+#include "hmi/navi_update_turn_list_response.h"
+#include "hmi/navi_send_location_response.h"
+#include "hmi/navi_show_constant_tbt_response.h"
+#include "hmi/navi_start_stream_response.h"
+#include "hmi/navi_subscribe_way_points_response.h"
 
 namespace test {
 namespace components {

--- a/src/components/application_manager/test/commands/mobile/perform_audio_path_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_path_thru_test.cc
@@ -148,10 +148,10 @@ TEST_F(PerformAudioPassThruRequestTest,
   EXPECT_CALL(*application_sptr_, hmi_level())
       .WillOnce(Return(mobile_api::HMILevel::HMI_FULL));
 
-  kMsgParams_[strings::initial_prompt][0][strings::text] = kCorrectPrompt;
-  kMsgParams_[strings::initial_prompt][0][strings::type] = kCorrectType;
-  kMsgParams_[strings::audio_pass_display_text1] = kCorrectDisplayText1;
-  kMsgParams_[strings::audio_pass_display_text2] = kCorrectDisplayText2;
+  msg_params_[strings::initial_prompt][0][strings::text] = kCorrectPrompt;
+  msg_params_[strings::initial_prompt][0][strings::type] = kCorrectType;
+  msg_params_[strings::audio_pass_display_text1] = kCorrectDisplayText1;
+  msg_params_[strings::audio_pass_display_text2] = kCorrectDisplayText2;
 
   MessageSharedPtr speak_reqeust_result_msg;
   MessageSharedPtr perform_result_msg;
@@ -197,12 +197,12 @@ TEST_F(PerformAudioPassThruRequestTest,
   EXPECT_CALL(*application_sptr_, hmi_level())
       .WillOnce(Return(mobile_api::HMILevel::HMI_FULL));
 
-  kMsgParams_[strings::initial_prompt][0][strings::text] = kCorrectPrompt;
-  kMsgParams_[strings::initial_prompt][0][strings::type] = kCorrectType;
+  msg_params_[strings::initial_prompt][0][strings::text] = kCorrectPrompt;
+  msg_params_[strings::initial_prompt][0][strings::type] = kCorrectType;
 
   const bool kMuted = false;
 
-  kMsgParams_[strings::mute_audio] = kMuted;
+  msg_params_[strings::mute_audio] = kMuted;
 
   MessageSharedPtr speak_reqeust_result_msg;
   MessageSharedPtr perform_result_msg;
@@ -356,7 +356,7 @@ TEST_F(PerformAudioPassThruRequestTest, Init_CorrectTimeout) {
   const uint32_t kDefaultTimeout = command_sptr_->default_timeout();
   const uint32_t kMaxDuration = 10000u;
 
-  kMsgParams_[strings::max_duration] = kMaxDuration;
+  msg_params_[strings::max_duration] = kMaxDuration;
 
   command_sptr_->Init();
 
@@ -385,8 +385,8 @@ TEST_F(PerformAudioPassThruRequestTest,
   EXPECT_CALL(*application_sptr_, hmi_level())
       .WillOnce(Return(mobile_api::HMILevel::HMI_FULL));
 
-  kMsgParams_[strings::initial_prompt][0][strings::text] = kCorrectPrompt;
-  kMsgParams_[strings::initial_prompt][0][strings::type] = kCorrectType;
+  msg_params_[strings::initial_prompt][0][strings::text] = kCorrectPrompt;
+  msg_params_[strings::initial_prompt][0][strings::type] = kCorrectType;
 
   // For setting is_active_tts_speak -> true
   EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
@@ -405,7 +405,6 @@ TEST_F(PerformAudioPassThruRequestTest,
       .WillOnce(Return(true));
   command_sptr_->onTimeOut();
 }
-
 }  // namespace mobile_commands_test
 }  // namespace commands_test
 }  // namespace components

--- a/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
@@ -59,7 +59,7 @@ using utils::custom_string::CustomString;
 using smart_objects::SmartObject;
 using testing::_;
 using testing::Return;
-
+/*
 namespace strings = application_manager::strings;
 namespace hmi_request = application_manager::hmi_request;
 namespace hmi_response = application_manager::hmi_response;
@@ -94,7 +94,7 @@ class SetGlobalPropertiesRequestTest
     vr_help_array[0][strings::text] = kText;
     vr_help_array[0][strings::position] = kPosition;
     (*msg)[strings::msg_params][strings::vr_help] = vr_help_array;
-    EXPECT_CALL(app_mngr_, application(kConnectionKey))
+    EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
         .WillOnce(Return(mock_app_));
   }
 
@@ -106,7 +106,7 @@ class SetGlobalPropertiesRequestTest
     EXPECT_CALL(mock_message_helper_,
                 VerifyImageVrHelpItems(vr_help_array, _, _))
         .WillOnce((Return(mobile_apis::Result::SUCCESS)));
-    EXPECT_CALL(app_mngr_,
+    EXPECT_CALL(mock_app_manager_,
                 RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
     EXPECT_CALL(*mock_app_, set_vr_help_title(vr_help_title));
     EXPECT_CALL(*mock_app_, set_vr_help(vr_help_array));
@@ -129,10 +129,10 @@ class SetGlobalPropertiesRequestTest
     timeout_prompt[0][strings::text] = "Timeout_Prompt_One";
     (*msg)[strings::msg_params][strings::timeout_prompt] = timeout_prompt;
 
-    EXPECT_CALL(app_mngr_, application(kConnectionKey))
+    EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
         .WillOnce(Return(mock_app_));
     EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-    EXPECT_CALL(app_mngr_,
+    EXPECT_CALL(mock_app_manager_,
                 RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
     SmartObject vr_help_title("title");
     EXPECT_CALL(*mock_app_, vr_help_title()).WillOnce(Return(&vr_help_title));
@@ -189,7 +189,8 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_VRWithMenuAndKeyboard_SUCCESS) {
       .WillOnce((Return(mobile_apis::Result::SUCCESS)));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(vr_help_array, _, _))
       .WillOnce((Return(mobile_apis::Result::SUCCESS)));
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   EXPECT_CALL(*mock_app_, set_vr_help_title(vr_help_title));
   EXPECT_CALL(*mock_app_, set_vr_help(vr_help_array));
   EXPECT_CALL(*mock_app_, vr_help_title()).WillOnce(Return(&vr_help_title));
@@ -213,12 +214,13 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_VRBrokenMenuIcon_Canceled) {
   menu_icon[strings::value] = "1";
   (*msg)[strings::msg_params][hmi_request::menu_icon] = menu_icon;
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImage(menu_icon, _, _))
       .WillOnce((Return(mobile_apis::Result::ABORTED)));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -240,7 +242,8 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_VRBrokenVRHelp_Canceled) {
       .WillOnce((Return(mobile_apis::Result::SUCCESS)));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(vr_help_array, _, _))
       .WillOnce((Return(mobile_apis::Result::ABORTED)));
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -264,7 +267,8 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_VRIncorrectSyntax_Canceled) {
       .WillOnce((Return(mobile_apis::Result::SUCCESS)));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(vr_help_array, _, _))
       .WillOnce((Return(mobile_apis::Result::SUCCESS)));
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -281,11 +285,12 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_VRMissingTitle_Canceled) {
   vr_help_array[0][strings::position] = kPosition;
   (*msg)[strings::msg_params][strings::vr_help] = vr_help_array;
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(vr_help_array, _, _))
       .WillOnce((Return(mobile_apis::Result::SUCCESS)));
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -299,10 +304,11 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_VRMissingArray_Canceled) {
   SmartObject vr_help_title("yes");
   (*msg)[strings::msg_params][strings::vr_help_title] = vr_help_title;
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -323,7 +329,8 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_VRWrongOrder_Canceled) {
 
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(vr_help_array, _, _))
       .WillOnce((Return(mobile_apis::Result::SUCCESS)));
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -340,10 +347,11 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_NoVR_SUCCESS) {
   SmartObject menu_title("Menu_Title");
   (*msg)[strings::msg_params][hmi_request::menu_title] = menu_title;
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   SmartObject vr_help_title("Menu_Title");
   EXPECT_CALL(*mock_app_, vr_help_title()).WillOnce(Return(&vr_help_title));
   EXPECT_CALL(*mock_app_, set_menu_title(menu_title));
@@ -363,10 +371,11 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_NoVRNoDataNoDefault_Canceled) {
   (*msg)[strings::msg_params][hmi_request::keyboard_properties] =
       keyboard_properties;
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   SmartObject vr_help_title(smart_objects::SmartType_Null);
   EXPECT_CALL(*mock_app_, vr_help_title()).WillOnce(Return(&vr_help_title));
 
@@ -391,10 +400,11 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_NoVRNoDataDefaultCreated_SUCCESS) {
   (*msg)[strings::msg_params][hmi_request::keyboard_properties] =
       keyboard_properties;
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   SmartObject vr_help_title(smart_objects::SmartType_Null);
   EXPECT_CALL(*mock_app_, vr_help_title())
       .Times(2)
@@ -429,10 +439,11 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_NoVRNoDataFromSynonyms_SUCCESS) {
   (*msg)[strings::msg_params][hmi_request::keyboard_properties] =
       keyboard_properties;
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   SmartObject vr_help_title(smart_objects::SmartType_Null);
   EXPECT_CALL(*mock_app_, vr_help_title())
       .Times(2)
@@ -473,10 +484,11 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_TTSHelpAndTimeout_SUCCESS) {
   timeout_prompt[0][strings::text] = "Timeout_Prompt_One";
   (*msg)[strings::msg_params][strings::timeout_prompt] = timeout_prompt;
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   SmartObject vr_help_title("title");
   EXPECT_CALL(*mock_app_, vr_help_title()).WillOnce(Return(&vr_help_title));
   EXPECT_CALL(*mock_app_, set_help_prompt(help_prompt));
@@ -497,10 +509,11 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_TTSOnlyHelp_SUCCESS) {
   help_prompt[0][strings::text] = "Help_Prompt_One";
   (*msg)[strings::msg_params][strings::help_prompt] = help_prompt;
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   SmartObject vr_help_title("title");
   EXPECT_CALL(*mock_app_, vr_help_title()).WillOnce(Return(&vr_help_title));
   EXPECT_CALL(*mock_app_, set_help_prompt(help_prompt));
@@ -521,10 +534,11 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_TTSOnlyTimeout_SUCCESS) {
   timeout_prompt[0][strings::text] = "Timeout_Prompt_One";
   (*msg)[strings::msg_params][strings::timeout_prompt] = timeout_prompt;
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   SmartObject vr_help_title("title");
   EXPECT_CALL(*mock_app_, vr_help_title()).WillOnce(Return(&vr_help_title));
   EXPECT_CALL(*mock_app_, set_help_prompt(_)).Times(0);
@@ -545,10 +559,11 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_TTSIncorrectSyntax_Canceled) {
   timeout_prompt[0][strings::text] = "Timeout_Prompt_One\\n";
   (*msg)[strings::msg_params][strings::timeout_prompt] = timeout_prompt;
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
   SmartObject vr_help_title("title");
   EmptyExpectationsSetupHelper();
 
@@ -561,10 +576,11 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_TTSIncorrectSyntax_Canceled) {
 TEST_F(SetGlobalPropertiesRequestTest, Run_NoData_Canceled) {
   MessageSharedPtr msg = CreateMsgParams();
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -577,10 +593,11 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidApp_Canceled) {
   MessageSharedPtr msg = CreateMessage();
   (*msg)[strings::params][strings::connection_key] = kConnectionKey;
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(MockAppPtr()));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_,
+RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -602,7 +619,7 @@ TEST_F(SetGlobalPropertiesRequestTest, OnEvent_UIAndSuccessResultCode_SUCCESS) {
 
   EXPECT_CALL(mock_message_helper_, HMIToMobileResult(response_code))
       .WillOnce(Return(mobile_apis::Result::SUCCESS));
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_app_, UpdateHash());
 
@@ -624,7 +641,7 @@ TEST_F(SetGlobalPropertiesRequestTest, OnEvent_UIAndWarningResultCode_SUCCESS) {
   OnEventUISetupHelper(msg, command);
 
   EXPECT_CALL(mock_message_helper_, HMIToMobileResult(_)).Times(0);
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_app_, UpdateHash());
 
@@ -646,7 +663,7 @@ TEST_F(SetGlobalPropertiesRequestTest, OnEvent_InvalidApp_Canceled) {
   OnEventUISetupHelper(msg, command);
 
   EXPECT_CALL(mock_message_helper_, HMIToMobileResult(_)).Times(0);
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(MockAppPtr()));
   EXPECT_CALL(*mock_app_, UpdateHash()).Times(0);
 
@@ -663,7 +680,7 @@ TEST_F(SetGlobalPropertiesRequestTest, OnEvent_InvalidEventID_Canceled) {
       CreateCommand<SetGlobalPropertiesRequest>(msg));
 
   EXPECT_CALL(mock_message_helper_, HMIToMobileResult(_)).Times(0);
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).Times(0);
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey)).Times(0);
   EXPECT_CALL(*mock_app_, UpdateHash()).Times(0);
 
   Event event(hmi_apis::FunctionID::TTS_Stopped);
@@ -686,7 +703,7 @@ TEST_F(SetGlobalPropertiesRequestTest,
 
   EXPECT_CALL(mock_message_helper_, HMIToMobileResult(response_code))
       .WillOnce(Return(mobile_apis::Result::SUCCESS));
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_app_, UpdateHash());
 
@@ -709,7 +726,7 @@ TEST_F(SetGlobalPropertiesRequestTest,
   OnEventTTSSetupHelper(msg, command);
 
   EXPECT_CALL(mock_message_helper_, HMIToMobileResult(_)).Times(0);
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_app_, UpdateHash());
 
@@ -717,7 +734,7 @@ TEST_F(SetGlobalPropertiesRequestTest,
   event.set_smart_object(*msg);
 
   command->on_event(event);
-}
+}*/
 
 }  // namespace mobile_commands_test
 }  // namespace commands_test

--- a/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
@@ -59,7 +59,7 @@ using utils::custom_string::CustomString;
 using smart_objects::SmartObject;
 using testing::_;
 using testing::Return;
-/*
+
 namespace strings = application_manager::strings;
 namespace hmi_request = application_manager::hmi_request;
 namespace hmi_response = application_manager::hmi_response;
@@ -190,7 +190,7 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_VRWithMenuAndKeyboard_SUCCESS) {
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(vr_help_array, _, _))
       .WillOnce((Return(mobile_apis::Result::SUCCESS)));
   EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+              RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   EXPECT_CALL(*mock_app_, set_vr_help_title(vr_help_title));
   EXPECT_CALL(*mock_app_, set_vr_help(vr_help_array));
   EXPECT_CALL(*mock_app_, vr_help_title()).WillOnce(Return(&vr_help_title));
@@ -219,8 +219,8 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_VRBrokenMenuIcon_Canceled) {
   EXPECT_CALL(mock_message_helper_, VerifyImage(menu_icon, _, _))
       .WillOnce((Return(mobile_apis::Result::ABORTED)));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, RemoveAppFromTTSGlobalPropertiesList(_))
+      .Times(0);
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -242,8 +242,8 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_VRBrokenVRHelp_Canceled) {
       .WillOnce((Return(mobile_apis::Result::SUCCESS)));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(vr_help_array, _, _))
       .WillOnce((Return(mobile_apis::Result::ABORTED)));
-  EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, RemoveAppFromTTSGlobalPropertiesList(_))
+      .Times(0);
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -267,8 +267,8 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_VRIncorrectSyntax_Canceled) {
       .WillOnce((Return(mobile_apis::Result::SUCCESS)));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(vr_help_array, _, _))
       .WillOnce((Return(mobile_apis::Result::SUCCESS)));
-  EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, RemoveAppFromTTSGlobalPropertiesList(_))
+      .Times(0);
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -290,7 +290,7 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_VRMissingTitle_Canceled) {
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(vr_help_array, _, _))
       .WillOnce((Return(mobile_apis::Result::SUCCESS)));
   EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+              RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -308,7 +308,7 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_VRMissingArray_Canceled) {
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
   EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+              RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -330,7 +330,7 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_VRWrongOrder_Canceled) {
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(vr_help_array, _, _))
       .WillOnce((Return(mobile_apis::Result::SUCCESS)));
   EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+              RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -351,7 +351,7 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_NoVR_SUCCESS) {
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
   EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+              RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   SmartObject vr_help_title("Menu_Title");
   EXPECT_CALL(*mock_app_, vr_help_title()).WillOnce(Return(&vr_help_title));
   EXPECT_CALL(*mock_app_, set_menu_title(menu_title));
@@ -375,18 +375,22 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_NoVRNoDataNoDefault_Canceled) {
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
   EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+              RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   SmartObject vr_help_title(smart_objects::SmartType_Null);
-  EXPECT_CALL(*mock_app_, vr_help_title()).WillOnce(Return(&vr_help_title));
+  EXPECT_CALL(*mock_app_, vr_help_title())
+      .WillOnce(Return(&vr_help_title))
+      .WillOnce(Return(&vr_help_title));
 
   CommandsMap commands_map;
   DataAccessor<CommandsMap> accessor(commands_map, lock_);
   EXPECT_CALL(*mock_app_, commands_map()).WillOnce(Return(accessor));
-  EXPECT_CALL(*mock_app_, vr_synonyms()).WillOnce(Return(&vr_help_title));
+  const CustomString name("name");
+  EXPECT_CALL(*mock_app_, name()).WillOnce(ReturnRef(name));
+  EXPECT_CALL(*mock_app_, set_vr_help_title(SmartObject(name)));
   EXPECT_CALL(*mock_app_, set_menu_title(_)).Times(0);
   EXPECT_CALL(*mock_app_, set_menu_icon(_)).Times(0);
-  EXPECT_CALL(*mock_app_, set_keyboard_props(_)).Times(0);
-  EXPECT_CALL(*mock_app_, app_id()).Times(0);
+  EXPECT_CALL(*mock_app_, set_keyboard_props(_));
+  EXPECT_CALL(*mock_app_, app_id());
 
   SharedPtr<SetGlobalPropertiesRequest> command(
       CreateCommand<SetGlobalPropertiesRequest>(msg));
@@ -404,7 +408,7 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_NoVRNoDataDefaultCreated_SUCCESS) {
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
   EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+              RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   SmartObject vr_help_title(smart_objects::SmartType_Null);
   EXPECT_CALL(*mock_app_, vr_help_title())
       .Times(2)
@@ -443,7 +447,7 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_NoVRNoDataFromSynonyms_SUCCESS) {
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
   EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+              RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   SmartObject vr_help_title(smart_objects::SmartType_Null);
   EXPECT_CALL(*mock_app_, vr_help_title())
       .Times(2)
@@ -458,12 +462,9 @@ RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   vr_help_array[0][strings::position] = kPosition;
   SmartObject vr_synonyms(smart_objects::SmartType_Array);
   vr_synonyms[0] = vr_help_array;
-  EXPECT_CALL(*mock_app_, vr_synonyms()).WillOnce(Return(&vr_synonyms));
-  EXPECT_CALL(*mock_app_, set_vr_help(vr_help_array));
   const CustomString name("name");
   EXPECT_CALL(*mock_app_, name()).WillOnce(ReturnRef(name));
   EXPECT_CALL(*mock_app_, set_vr_help_title(SmartObject(name)));
-  EXPECT_CALL(*mock_app_, vr_help()).WillOnce(Return(&vr_help_array));
   EXPECT_CALL(*mock_app_, set_menu_title(_)).Times(0);
   EXPECT_CALL(*mock_app_, set_menu_icon(_)).Times(0);
   EXPECT_CALL(*mock_app_, set_keyboard_props(keyboard_properties));
@@ -488,7 +489,7 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_TTSHelpAndTimeout_SUCCESS) {
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
   EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+              RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   SmartObject vr_help_title("title");
   EXPECT_CALL(*mock_app_, vr_help_title()).WillOnce(Return(&vr_help_title));
   EXPECT_CALL(*mock_app_, set_help_prompt(help_prompt));
@@ -513,7 +514,7 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_TTSOnlyHelp_SUCCESS) {
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
   EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+              RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   SmartObject vr_help_title("title");
   EXPECT_CALL(*mock_app_, vr_help_title()).WillOnce(Return(&vr_help_title));
   EXPECT_CALL(*mock_app_, set_help_prompt(help_prompt));
@@ -538,7 +539,7 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_TTSOnlyTimeout_SUCCESS) {
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
   EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+              RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
   SmartObject vr_help_title("title");
   EXPECT_CALL(*mock_app_, vr_help_title()).WillOnce(Return(&vr_help_title));
   EXPECT_CALL(*mock_app_, set_help_prompt(_)).Times(0);
@@ -562,8 +563,8 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_TTSIncorrectSyntax_Canceled) {
   EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, RemoveAppFromTTSGlobalPropertiesList(_))
+      .Times(0);
   SmartObject vr_help_title("title");
   EmptyExpectationsSetupHelper();
 
@@ -579,8 +580,8 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_NoData_Canceled) {
   EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, RemoveAppFromTTSGlobalPropertiesList(_))
+      .Times(0);
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -596,8 +597,8 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidApp_Canceled) {
   EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(MockAppPtr()));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(mock_app_manager_,
-RemoveAppFromTTSGlobalPropertiesList(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, RemoveAppFromTTSGlobalPropertiesList(_))
+      .Times(0);
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -734,7 +735,7 @@ TEST_F(SetGlobalPropertiesRequestTest,
   event.set_smart_object(*msg);
 
   command->on_event(event);
-}*/
+}
 
 }  // namespace mobile_commands_test
 }  // namespace commands_test

--- a/src/components/application_manager/test/commands/mobile/set_media_clock_timer_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_media_clock_timer_request_test.cc
@@ -73,11 +73,11 @@ class SetMediaClockRequestTest
   }
 
   void ExpectationsSetupHelper(bool is_media) {
-    EXPECT_CALL(app_mngr_, application(kConnectionKey))
+    EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
         .WillOnce(Return(mock_app_));
     EXPECT_CALL(*mock_app_, is_media_application()).WillOnce(Return(is_media));
     EXPECT_CALL(*mock_app_, app_id()).Times(0);
-    EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+    EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
   }
 
   MockAppPtr mock_app_;
@@ -95,7 +95,7 @@ TEST_F(SetMediaClockRequestTest, Run_UpdateCountUp_SUCCESS) {
   SharedPtr<SetMediaClockRequest> command(
       CreateCommand<SetMediaClockRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_app_, is_media_application()).WillOnce(Return(true));
   EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppID));
@@ -115,7 +115,7 @@ TEST_F(SetMediaClockRequestTest, Run_UpdateCountDown_SUCCESS) {
   SharedPtr<SetMediaClockRequest> command(
       CreateCommand<SetMediaClockRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_app_, is_media_application()).WillOnce(Return(true));
   EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppID));
@@ -152,11 +152,11 @@ TEST_F(SetMediaClockRequestTest, Run_UpdateCountDownWrongTime_Canceled) {
   SharedPtr<SetMediaClockRequest> command(
       CreateCommand<SetMediaClockRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_app_, is_media_application()).WillOnce(Return(true));
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
 
   command->Run();
 }
@@ -201,11 +201,11 @@ TEST_F(SetMediaClockRequestTest, Run_InvalidApp_Canceled) {
   SharedPtr<SetMediaClockRequest> command(
       CreateCommand<SetMediaClockRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(MockAppPtr()));
   EXPECT_CALL(*mock_app_, is_media_application()).Times(0);
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
 
   command->Run();
 }
@@ -218,7 +218,7 @@ TEST_F(SetMediaClockRequestTest, OnEvent_Success) {
   SharedPtr<SetMediaClockRequest> command(
       CreateCommand<SetMediaClockRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
 
   Event event(hmi_apis::FunctionID::UI_SetMediaClockTimer);
   event.set_smart_object(*msg);
@@ -232,7 +232,7 @@ TEST_F(SetMediaClockRequestTest, OnEvent_Canceled) {
   SharedPtr<SetMediaClockRequest> command(
       CreateCommand<SetMediaClockRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   Event event(hmi_apis::FunctionID::UI_Slider);
   event.set_smart_object(*msg);

--- a/src/components/application_manager/test/commands/mobile/show_constant_tbt_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/show_constant_tbt_request_test.cc
@@ -79,9 +79,9 @@ class ShowConstantTBTRequestTest
   }
 
   void GeneralExpectationsSetupHelper(SmartObject& msg_params) {
-    EXPECT_CALL(app_mngr_, application(kConnectionKey))
+    EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
         .WillOnce(Return(mock_app_));
-    EXPECT_CALL(app_mngr_, GetPolicyHandler())
+    EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
         .WillOnce(ReturnRef(mock_policy_handler_));
     EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(msg_params, _, _, _))
         .WillOnce(Return(mobile_apis::Result::SUCCESS));
@@ -144,9 +144,9 @@ TEST_F(ShowConstantTBTRequestTest, Run_TurnIcon_Canceled) {
   SharedPtr<ShowConstantTBTRequest> command(
       CreateCommand<ShowConstantTBTRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler_));
   EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(msg_params, _, _, _))
       .WillOnce(Return(mobile_apis::Result::SUCCESS));
@@ -154,7 +154,7 @@ TEST_F(ShowConstantTBTRequestTest, Run_TurnIcon_Canceled) {
       .WillOnce(Return(mobile_apis::Result::REJECTED));
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
   EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
 
   command->Run();
 }
@@ -193,9 +193,9 @@ TEST_F(ShowConstantTBTRequestTest, Run_NextTurnIcon_Canceled) {
   SharedPtr<ShowConstantTBTRequest> command(
       CreateCommand<ShowConstantTBTRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler_));
   EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(msg_params, _, _, _))
       .WillOnce(Return(mobile_apis::Result::SUCCESS));
@@ -203,7 +203,7 @@ TEST_F(ShowConstantTBTRequestTest, Run_NextTurnIcon_Canceled) {
       .WillOnce(Return(mobile_apis::Result::REJECTED));
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
   EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
 
   command->Run();
 }
@@ -331,10 +331,10 @@ TEST_F(ShowConstantTBTRequestTest, Run_InvalidApp_Canceled) {
   SharedPtr<ShowConstantTBTRequest> command(
       CreateCommand<ShowConstantTBTRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(MockAppPtr()));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
-  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
   EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
 
@@ -349,10 +349,10 @@ TEST_F(ShowConstantTBTRequestTest, Run_EmptyMsgParams_Canceled) {
   SharedPtr<ShowConstantTBTRequest> command(
       CreateCommand<ShowConstantTBTRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
-  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
   EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
 
@@ -368,10 +368,10 @@ TEST_F(ShowConstantTBTRequestTest, Run_WrongSyntax_Canceled) {
   SharedPtr<ShowConstantTBTRequest> command(
       CreateCommand<ShowConstantTBTRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
-  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
   EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
 
@@ -387,13 +387,13 @@ TEST_F(ShowConstantTBTRequestTest, Run_UnsuccessfulProcessing_Canceled) {
   SharedPtr<ShowConstantTBTRequest> command(
       CreateCommand<ShowConstantTBTRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler_));
   EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _))
       .WillOnce(Return(mobile_apis::Result::ABORTED));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
 
   EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
@@ -410,9 +410,9 @@ TEST_F(ShowConstantTBTRequestTest, OnEvent_SuccessResultCode_SUCCESS) {
   SharedPtr<ShowConstantTBTRequest> command(
       CreateCommand<ShowConstantTBTRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
 
   Event event(hmi_apis::FunctionID::Navigation_ShowConstantTBT);
   event.set_smart_object(*msg);
@@ -429,11 +429,11 @@ TEST_F(ShowConstantTBTRequestTest, OnEvent_UnsupportedRCAndUICoop_SUCCESS) {
   SharedPtr<ShowConstantTBTRequest> command(
       CreateCommand<ShowConstantTBTRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
   EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating())
       .WillOnce(Return(true));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
 
   Event event(hmi_apis::FunctionID::Navigation_ShowConstantTBT);
   event.set_smart_object(*msg);
@@ -450,11 +450,11 @@ TEST_F(ShowConstantTBTRequestTest, OnEvent_UnsupportedRCAndUINotCoop_SUCCESS) {
   SharedPtr<ShowConstantTBTRequest> command(
       CreateCommand<ShowConstantTBTRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
   EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating())
       .WillOnce(Return(false));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
 
   Event event(hmi_apis::FunctionID::Navigation_ShowConstantTBT);
   event.set_smart_object(*msg);
@@ -471,10 +471,10 @@ TEST_F(ShowConstantTBTRequestTest, OnEvent_AbortedResponseCode_SUCCESS) {
   SharedPtr<ShowConstantTBTRequest> command(
       CreateCommand<ShowConstantTBTRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
   EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating()).Times(0);
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
 
   Event event(hmi_apis::FunctionID::Navigation_ShowConstantTBT);
   event.set_smart_object(*msg);
@@ -488,9 +488,9 @@ TEST_F(ShowConstantTBTRequestTest, OnEvent_WrongFunctionID_SUCCESS) {
   SharedPtr<ShowConstantTBTRequest> command(
       CreateCommand<ShowConstantTBTRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities()).Times(0);
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities()).Times(0);
   EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating()).Times(0);
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   Event event(hmi_apis::FunctionID::UI_SetGlobalProperties);
   event.set_smart_object(*msg);

--- a/src/components/application_manager/test/commands/mobile/show_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/show_request_test.cc
@@ -91,7 +91,7 @@ class ShowRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
     msg_params[field] = text_field_;
     (*msg)[strings::msg_params] = msg_params;
 
-    EXPECT_CALL(app_mngr_, application(kConnectionKey))
+    EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
         .WillOnce(Return(mock_app_));
     EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppID));
 
@@ -104,7 +104,7 @@ class ShowRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
     msg_params[hmi_request::show_strings][0][hmi_request::field_text] =
         text_field_;
 
-    EXPECT_CALL(app_mngr_, ManageHMICommand(_));
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_));
     EXPECT_CALL(*mock_app_, set_show_command(msg_params));
   }
 
@@ -117,12 +117,12 @@ class ShowRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
     msg_params[field] = text_field_;
     (*msg)[strings::msg_params] = msg_params;
 
-    EXPECT_CALL(app_mngr_, application(kConnectionKey))
+    EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
         .WillOnce(Return(mock_app_));
-    EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+    EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
     EXPECT_CALL(*mock_app_, app_id()).Times(0);
 
-    EXPECT_CALL(app_mngr_, ManageHMICommand(_)).Times(0);
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
     EXPECT_CALL(*mock_app_, set_show_command(_)).Times(0);
   }
 
@@ -142,10 +142,10 @@ TEST_F(ShowRequestTest, Run_SoftButtonExists_SUCCESS) {
   SmartObject creation_msg_params(msg_params);
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   MockPolicyHandlerInterface mock_policy_handler;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler));
   EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(msg_params, _, _, _))
       .WillOnce(Return(mobile_apis::Result::SUCCESS));
@@ -158,7 +158,7 @@ TEST_F(ShowRequestTest, Run_SoftButtonExists_SUCCESS) {
   EXPECT_CALL(
       mock_message_helper_,
       SubscribeApplicationToSoftButton(creation_msg_params, _, kFunctionID));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_));
   EXPECT_CALL(*mock_app_, set_show_command(msg_params));
 
   command->Run();
@@ -176,10 +176,10 @@ TEST_F(ShowRequestTest, Run_SoftButtonNotExists_SUCCESS) {
   (*msg)[strings::msg_params] = msg_params;
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   MockPolicyHandlerInterface mock_policy_handler;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
   EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
   EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppID));
 
@@ -188,7 +188,7 @@ TEST_F(ShowRequestTest, Run_SoftButtonNotExists_SUCCESS) {
       smart_objects::SmartObject(smart_objects::SmartType_Array);
 
   EXPECT_CALL(*mock_app_, UnsubscribeFromSoftButtons(kFunctionID));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_));
   EXPECT_CALL(*mock_app_, set_show_command(msg_params));
 
   command->Run();
@@ -207,21 +207,21 @@ TEST_F(ShowRequestTest, Run_SoftButtonExists_Canceled) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   MockPolicyHandlerInterface mock_policy_handler;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler));
   EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(msg_params, _, _, _))
       .WillOnce(Return(mobile_apis::Result::ABORTED));
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
 
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
 
   EXPECT_CALL(mock_message_helper_, SubscribeApplicationToSoftButton(_, _, _))
       .Times(0);
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
   EXPECT_CALL(*mock_app_, set_show_command(_)).Times(0);
 
   command->Run();
@@ -242,7 +242,7 @@ TEST_F(ShowRequestTest, Run_Graphic_SUCCESS) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImage(graphic, _, _))
       .WillOnce(Return(mobile_apis::Result::SUCCESS));
@@ -252,7 +252,7 @@ TEST_F(ShowRequestTest, Run_Graphic_SUCCESS) {
   msg_params[hmi_request::show_strings] =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
 
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_));
   EXPECT_CALL(*mock_app_, set_show_command(msg_params));
 
   command->Run();
@@ -273,14 +273,14 @@ TEST_F(ShowRequestTest, Run_Graphic_Canceled) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImage(graphic, _, _))
       .WillOnce(Return(mobile_apis::Result::ABORTED));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
 
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
   EXPECT_CALL(*mock_app_, set_show_command(msg_params)).Times(0);
 
   command->Run();
@@ -301,13 +301,13 @@ TEST_F(ShowRequestTest, Run_Graphic_WrongSyntax) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
 
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
   EXPECT_CALL(*mock_app_, set_show_command(msg_params)).Times(0);
 
   command->Run();
@@ -328,7 +328,7 @@ TEST_F(ShowRequestTest, Run_SecondaryGraphic_SUCCESS) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImage(graphic, _, _))
       .WillOnce(Return(mobile_apis::Result::SUCCESS));
@@ -338,7 +338,7 @@ TEST_F(ShowRequestTest, Run_SecondaryGraphic_SUCCESS) {
   msg_params[hmi_request::show_strings] =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
 
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_));
   EXPECT_CALL(*mock_app_, set_show_command(msg_params));
 
   command->Run();
@@ -359,14 +359,14 @@ TEST_F(ShowRequestTest, Run_SecondaryGraphic_Canceled) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImage(graphic, _, _))
       .WillOnce(Return(mobile_apis::Result::ABORTED));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
 
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
   EXPECT_CALL(*mock_app_, set_show_command(msg_params)).Times(0);
 
   command->Run();
@@ -387,13 +387,13 @@ TEST_F(ShowRequestTest, Run_SecondaryGraphic_WrongSyntax) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImage(graphic, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
 
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
   EXPECT_CALL(*mock_app_, set_show_command(msg_params)).Times(0);
 
   command->Run();
@@ -565,7 +565,7 @@ TEST_F(ShowRequestTest, Run_Alignment_SUCCESS) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppID));
 
@@ -573,7 +573,7 @@ TEST_F(ShowRequestTest, Run_Alignment_SUCCESS) {
   msg_params[hmi_request::show_strings] =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
 
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_));
   EXPECT_CALL(*mock_app_, set_show_command(msg_params));
 
   command->Run();
@@ -589,7 +589,7 @@ TEST_F(ShowRequestTest, Run_CustomPresets_SUCCESS) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppID));
 
@@ -597,7 +597,7 @@ TEST_F(ShowRequestTest, Run_CustomPresets_SUCCESS) {
   msg_params[hmi_request::show_strings] =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
 
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_));
   EXPECT_CALL(*mock_app_, set_show_command(msg_params));
 
   command->Run();
@@ -613,12 +613,12 @@ TEST_F(ShowRequestTest, Run_CustomPresets_WrongSyntax) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
 
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
   EXPECT_CALL(*mock_app_, set_show_command(_)).Times(0);
 
   command->Run();
@@ -629,11 +629,11 @@ TEST_F(ShowRequestTest, Run_InvalidApp_Canceled) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(MockAppPtr()));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
   EXPECT_CALL(*mock_app_, set_show_command(_)).Times(0);
 
   command->Run();
@@ -644,11 +644,11 @@ TEST_F(ShowRequestTest, Run_EmptyParams_Canceled) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
   EXPECT_CALL(*mock_app_, set_show_command(_)).Times(0);
 
   command->Run();
@@ -661,7 +661,7 @@ TEST_F(ShowRequestTest, OnEvent_SuccessResultCode_SUCCESS) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
 
   Event event(hmi_apis::FunctionID::UI_Show);
   event.set_smart_object(*msg);
@@ -677,7 +677,7 @@ TEST_F(ShowRequestTest, OnEvent_WarningsResultCode_SUCCESS) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
 
   Event event(hmi_apis::FunctionID::UI_Show);
   event.set_smart_object(*msg);
@@ -691,7 +691,7 @@ TEST_F(ShowRequestTest, OnEvent_WrongFunctionID_Canceled) {
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   Event event(hmi_apis::FunctionID::UI_Alert);
   event.set_smart_object(*msg);

--- a/src/components/application_manager/test/commands/mobile/speaker_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/speaker_request_test.cc
@@ -78,11 +78,11 @@ class SpeakRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
 TEST_F(SpeakRequestTest, Run_ApplicationIsNotRegistered) {
   CommandPtr command(CreateCommand<SpeakRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(_))
+  ON_CALL(mock_app_manager_, application(_))
       .WillByDefault(Return(ApplicationSharedPtr()));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
 
@@ -94,10 +94,10 @@ TEST_F(SpeakRequestTest, Run_MsgWithWhiteSpace_InvalidData) {
          [am::strings::text] = " ";
   CommandPtr command(CreateCommand<SpeakRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app_));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
 
   command->Run();
@@ -108,10 +108,10 @@ TEST_F(SpeakRequestTest, Run_MsgWithIncorrectChar1_InvalidData) {
          [am::strings::text] = "sd\\t";
   CommandPtr command(CreateCommand<SpeakRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app_));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
 
   command->Run();
@@ -122,10 +122,10 @@ TEST_F(SpeakRequestTest, Run_MsgWithIncorrectChar2_InvalidData) {
          [am::strings::text] = "sd\\n";
   CommandPtr command(CreateCommand<SpeakRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app_));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
 
   command->Run();
@@ -136,10 +136,10 @@ TEST_F(SpeakRequestTest, Run_MsgWithIncorrectChar3_InvalidData) {
          [am::strings::text] = "sd\tdf";
   CommandPtr command(CreateCommand<SpeakRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app_));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
 
   command->Run();
@@ -150,10 +150,10 @@ TEST_F(SpeakRequestTest, Run_MsgWithIncorrectChar4_InvalidData) {
          [am::strings::text] = "sd\n rer";
   CommandPtr command(CreateCommand<SpeakRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app_));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
 
   command->Run();
@@ -164,10 +164,10 @@ TEST_F(SpeakRequestTest, Run_MsgWithIncorrectCharInfirstPlace_InvalidData) {
          [am::strings::text] = "\n";
   CommandPtr command(CreateCommand<SpeakRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app_));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::INVALID_DATA), _));
 
   command->Run();
@@ -178,11 +178,11 @@ TEST_F(SpeakRequestTest, Run_MsgWithEmptyString_Success) {
          [am::strings::text] = "";
   CommandPtr command(CreateCommand<SpeakRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app_));
   ON_CALL(*app_, app_id()).WillByDefault(Return(kAppId));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::TTS_Speak)));
 
   command->Run();
@@ -193,11 +193,11 @@ TEST_F(SpeakRequestTest, Run_MsgCorrect_Success) {
          [am::strings::text] = "asda";
   CommandPtr command(CreateCommand<SpeakRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app_));
   ON_CALL(*app_, app_id()).WillByDefault(Return(kAppId));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::TTS_Speak)));
 
   command->Run();
@@ -207,7 +207,7 @@ TEST_F(SpeakRequestTest, OnEvent_WrongEventId_UNSUCCESS) {
   Event event(Event::EventID::INVALID_ENUM);
   CommandPtr command(CreateCommand<SpeakRequest>());
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
   command->on_event(event);
 }
 
@@ -223,13 +223,13 @@ TEST_F(SpeakRequestTest, OnEvent_TTS_Speak_SUCCESS) {
   event.set_smart_object(*event_msg);
   CommandPtr command(CreateCommand<SpeakRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app_));
 
   EXPECT_CALL((*am::MockMessageHelper::message_helper_mock()),
               HMIToMobileResult(hmi_result))
       .WillOnce(Return(am::mobile_api::Result::SUCCESS));
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
   command->on_event(event);
 }
@@ -244,13 +244,13 @@ TEST_F(SpeakRequestTest, OnEvent_TTS_SpeakWithWarning_WarningWithSuccess) {
   event.set_smart_object(*event_msg);
   CommandPtr command(CreateCommand<SpeakRequest>());
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app_));
 
   const std::string info = "Unsupported phoneme type sent in a prompt";
   EXPECT_CALL((*am::MockMessageHelper::message_helper_mock()),
               HMIToMobileResult(hmi_result))
       .WillOnce(Return(am::mobile_api::Result::WARNINGS));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(
                   MobileResponseIs(mobile_result::WARNINGS, info, true), _));
   command->on_event(event);
@@ -268,13 +268,13 @@ TEST_F(SpeakRequestTest,
   event.set_smart_object(*event_msg);
   CommandPtr command(CreateCommand<SpeakRequest>());
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(_)).WillByDefault(Return(app_));
 
   const std::string info = "Unsupported phoneme type sent in a prompt";
   EXPECT_CALL((*am::MockMessageHelper::message_helper_mock()),
               HMIToMobileResult(hmi_result))
       .WillOnce(Return(am::mobile_api::Result::UNSUPPORTED_RESOURCE));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(
                   MobileResponseIs(mobile_result::WARNINGS, info, false), _));
   command->on_event(event);
@@ -286,7 +286,7 @@ TEST_F(SpeakRequestTest, OnEvent_TTS_OnResetTimeout_UpdateTimeout) {
   (*msg_)[am::strings::params][am::strings::correlation_id] = kAppId;
   CommandPtr command(CreateCommand<SpeakRequest>(msg_));
 
-  EXPECT_CALL(app_mngr_, updateRequestTimeout(kKey, kAppId, _));
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(kKey, kAppId, _));
 
   command->on_event(event);
 }

--- a/src/components/application_manager/test/commands/mobile/subscribe_vehicle_data_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/subscribe_vehicle_data_request_test.cc
@@ -119,11 +119,11 @@ MATCHER_P6(CheckResponseWithKeyParams,
 TEST_F(SubscribeVehicleDataRequestTest, Run_ApplicationIsNotRegistered) {
   CommandPtr command(CreateCommand<SubscribeVehicleDataRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(_))
+  ON_CALL(mock_app_manager_, application(_))
       .WillByDefault(Return(ApplicationSharedPtr()));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
 
@@ -134,9 +134,9 @@ TEST_F(SubscribeVehicleDataRequestTest, Run_NoDataInRequest_InvalidData) {
   (*msg_)[am::strings::params][am::strings::connection_key] = kKey;
   CommandPtr command(CreateCommand<SubscribeVehicleDataRequest>(msg_));
   const std::string info = "No data in the request";
-  ON_CALL(app_mngr_, application(kKey)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(kKey)).WillByDefault(Return(app_));
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResponseIs(mobile_result::INVALID_DATA, info, false), _));
 
@@ -148,12 +148,12 @@ TEST_F(SubscribeVehicleDataRequestTest, Run_DataAlreadySubscribed_IGNORED) {
   (*msg_)[am::strings::msg_params][kKeyName] = true;
   CommandPtr command(CreateCommand<SubscribeVehicleDataRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(kKey)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(kKey)).WillByDefault(Return(app_));
   // Data is subscribed
   EXPECT_CALL(*app_, IsSubscribedToIVI(data_type)).WillOnce(Return(true));
 
   const std::string info = "Already subscribed on some provided VehicleData.";
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(
                   MobileResponseIs(mobile_result::IGNORED, info, true), _));
 
@@ -166,7 +166,7 @@ TEST_F(SubscribeVehicleDataRequestTest,
   (*msg_)[am::strings::msg_params][kKeyName] = true;
   CommandPtr command(CreateCommand<SubscribeVehicleDataRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(kKey)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(kKey)).WillByDefault(Return(app_));
   // Data is not subscribed
   EXPECT_CALL(*app_, IsSubscribedToIVI(data_type)).WillOnce(Return(false));
 
@@ -176,13 +176,13 @@ TEST_F(SubscribeVehicleDataRequestTest,
 
   DataAccessor<am::ApplicationSet> accessor(app_set, app_set_lock_);
 
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
   EXPECT_CALL(*app2_, IsSubscribedToIVI(data_type)).WillOnce(Return(true));
 
   EXPECT_CALL(*app_, SubscribeToIVI(static_cast<uint32_t>(data_type)))
       .WillOnce(Return(true));
   const std::string info = "";
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(
                   MobileResponseIs(mobile_result::SUCCESS, info, true), _));
   command->Run();
@@ -194,7 +194,7 @@ TEST_F(SubscribeVehicleDataRequestTest,
   (*msg_)[am::strings::msg_params][kKeyName] = true;
   CommandPtr command(CreateCommand<SubscribeVehicleDataRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(kKey)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(kKey)).WillByDefault(Return(app_));
   // Data is not subscribed
   EXPECT_CALL(*app_, IsSubscribedToIVI(data_type)).WillOnce(Return(false));
 
@@ -204,14 +204,14 @@ TEST_F(SubscribeVehicleDataRequestTest,
 
   DataAccessor<am::ApplicationSet> accessor(app_set, app_set_lock_);
 
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
 
   EXPECT_CALL(*app2_, IsSubscribedToIVI(data_type)).WillOnce(Return(true));
   // Key could not be subscribed
   EXPECT_CALL(*app_, SubscribeToIVI(static_cast<uint32_t>(data_type)))
       .WillOnce(Return(false));
   const std::string info = "Already subscribed on provided VehicleData.";
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(
                   MobileResponseIs(mobile_result::IGNORED, info, false), _));
   command->Run();
@@ -223,7 +223,7 @@ TEST_F(SubscribeVehicleDataRequestTest,
   (*msg_)[am::strings::msg_params][kKeyName] = true;
   CommandPtr command(CreateCommand<SubscribeVehicleDataRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(kKey)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(kKey)).WillByDefault(Return(app_));
   // Data is not subscribed
   EXPECT_CALL(*app_, IsSubscribedToIVI(data_type)).WillOnce(Return(false));
 
@@ -233,7 +233,7 @@ TEST_F(SubscribeVehicleDataRequestTest,
 
   DataAccessor<am::ApplicationSet> accessor(app_set, app_set_lock_);
 
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
   EXPECT_CALL(*app2_, IsSubscribedToIVI(data_type)).WillOnce(Return(false));
 
   EXPECT_CALL(*app_, SubscribeToIVI(static_cast<uint32_t>(data_type)))
@@ -242,7 +242,7 @@ TEST_F(SubscribeVehicleDataRequestTest,
       event_dispatcher_,
       add_observer(
           hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData, _, _));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData)))
       .WillOnce(Return(true));
@@ -255,7 +255,7 @@ TEST_F(SubscribeVehicleDataRequestTest,
   (*msg_)[am::strings::msg_params][kKeyName] = true;
   CommandPtr command(CreateCommand<SubscribeVehicleDataRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(kKey)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(kKey)).WillByDefault(Return(app_));
   // Data is not subscribed
   EXPECT_CALL(*app_, IsSubscribedToIVI(data_type)).WillOnce(Return(false));
 
@@ -265,7 +265,7 @@ TEST_F(SubscribeVehicleDataRequestTest,
 
   DataAccessor<am::ApplicationSet> accessor(app_set, app_set_lock_);
 
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
   EXPECT_CALL(*app2_, IsSubscribedToIVI(data_type)).WillOnce(Return(false));
 
   EXPECT_CALL(*app_, SubscribeToIVI(static_cast<uint32_t>(data_type)))
@@ -277,13 +277,13 @@ TEST_F(SubscribeVehicleDataRequestTest,
       add_observer(
           hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData, _, _));
   // Manage unsuccessful
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData)))
       .WillOnce(Return(false));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResponseIs(mobile_result::OUT_OF_MEMORY, info, false), _));
   command->Run();
@@ -304,13 +304,13 @@ TEST_F(SubscribeVehicleDataRequestTest,
   (*msg_)[am::strings::params][am::strings::connection_key] = kKey;
   CommandPtr command(CreateCommand<SubscribeVehicleDataRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(kKey)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(kKey)).WillByDefault(Return(app_));
 
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
               HMIToMobileResult(hmi_code)).WillOnce(Return(mobile_code));
 
   const std::string info = "";
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(
                   MobileResponseIs(mobile_result::SUCCESS, info, true), _));
   EXPECT_CALL(*app_, UpdateHash());
@@ -332,14 +332,14 @@ TEST_F(SubscribeVehicleDataRequestTest,
   (*msg_)[am::strings::params][am::strings::connection_key] = kKey;
   CommandPtr command(CreateCommand<SubscribeVehicleDataRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(kKey)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(kKey)).WillByDefault(Return(app_));
   // Expect unsibscribe from unsuccessful subscription
   EXPECT_CALL(*app_, UnsubscribeFromIVI(data_type));
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
               HMIToMobileResult(hmi_code)).WillOnce(Return(mobile_code));
 
   const std::string info = "";
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(
                   MobileResponseIs(mobile_result::SUCCESS, info, true), _));
   EXPECT_CALL(*app_, UpdateHash());
@@ -351,12 +351,12 @@ TEST_F(SubscribeVehicleDataRequestTest, OnEvent_AppAlreadySubscribed_Ignored) {
   (*msg_)[am::strings::msg_params][kKeyName] = true;
   CommandPtr command(CreateCommand<SubscribeVehicleDataRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(kKey)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(kKey)).WillByDefault(Return(app_));
   // Data is subscribed
   EXPECT_CALL(*app_, IsSubscribedToIVI(data_type)).WillOnce(Return(true));
 
   const std::string info = "Already subscribed on some provided VehicleData.";
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(
                   MobileResponseIs(mobile_result::IGNORED, info, true), _));
 
@@ -375,7 +375,7 @@ TEST_F(SubscribeVehicleDataRequestTest, OnEvent_AppAlreadySubscribed_Ignored) {
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
               HMIToMobileResult(hmi_code)).WillOnce(Return(mobile_code));
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           CheckResponseWithKeyParams(
               mobile_result::IGNORED,

--- a/src/components/application_manager/test/commands/mobile/subscribe_way_points_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/subscribe_way_points_request_test.cc
@@ -84,11 +84,11 @@ class SubscribeWayPointsRequestTest
 TEST_F(SubscribeWayPointsRequestTest, Run_ApplicationIsNotRegistered) {
   CommandPtr command(CreateCommand<SubscribeWayPointsRequest>(msg_));
 
-  ON_CALL(app_mngr_, application(_))
+  ON_CALL(mock_app_manager_, application(_))
       .WillByDefault(Return(ApplicationSharedPtr()));
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
 
@@ -97,11 +97,11 @@ TEST_F(SubscribeWayPointsRequestTest, Run_ApplicationIsNotRegistered) {
 
 TEST_F(SubscribeWayPointsRequestTest, Run_WayPointsSubscribedBefore_Ignored) {
   CommandPtr command(CreateCommand<SubscribeWayPointsRequest>(msg_));
-  ON_CALL(app_mngr_, application(kKey)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(kKey)).WillByDefault(Return(app_));
 
-  EXPECT_CALL(app_mngr_, IsAppSubscribedForWayPoints(kAppId))
+  EXPECT_CALL(mock_app_manager_, IsAppSubscribedForWayPoints(kAppId))
       .WillOnce(Return(true));
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(
                   MobileResponseIs(mobile_result::IGNORED, info_, false), _));
 
@@ -110,16 +110,16 @@ TEST_F(SubscribeWayPointsRequestTest, Run_WayPointsSubscribedBefore_Ignored) {
 
 TEST_F(SubscribeWayPointsRequestTest, Run_SomeAppSubscribedBefore_Success) {
   CommandPtr command(CreateCommand<SubscribeWayPointsRequest>(msg_));
-  ON_CALL(app_mngr_, application(kKey)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(kKey)).WillByDefault(Return(app_));
 
-  EXPECT_CALL(app_mngr_, IsAppSubscribedForWayPoints(kAppId))
+  EXPECT_CALL(mock_app_manager_, IsAppSubscribedForWayPoints(kAppId))
       .WillOnce(Return(false));
-  EXPECT_CALL(app_mngr_, IsAnyAppSubscribedForWayPoints())
+  EXPECT_CALL(mock_app_manager_, IsAnyAppSubscribedForWayPoints())
       .WillOnce(Return(true));
-  EXPECT_CALL(app_mngr_, SubscribeAppForWayPoints(kAppId));
+  EXPECT_CALL(mock_app_manager_, SubscribeAppForWayPoints(kAppId));
   EXPECT_CALL(*app_, UpdateHash());
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(
                   MobileResponseIs(mobile_result::SUCCESS, info_, true), _));
 
@@ -129,27 +129,27 @@ TEST_F(SubscribeWayPointsRequestTest, Run_SomeAppSubscribedBefore_Success) {
 TEST_F(SubscribeWayPointsRequestTest,
        Run_AnyAppSubscribedBefore_SuccessSubscribe) {
   CommandPtr command(CreateCommand<SubscribeWayPointsRequest>(msg_));
-  ON_CALL(app_mngr_, application(kKey)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(kKey)).WillByDefault(Return(app_));
 
-  EXPECT_CALL(app_mngr_, IsAppSubscribedForWayPoints(kAppId))
+  EXPECT_CALL(mock_app_manager_, IsAppSubscribedForWayPoints(kAppId))
       .WillOnce(Return(false));
-  EXPECT_CALL(app_mngr_, IsAnyAppSubscribedForWayPoints())
+  EXPECT_CALL(mock_app_manager_, IsAnyAppSubscribedForWayPoints())
       .WillOnce(Return(false));
   // App is not subscribed now
-  EXPECT_CALL(app_mngr_, SubscribeAppForWayPoints(kAppId)).Times(0);
+  EXPECT_CALL(mock_app_manager_, SubscribeAppForWayPoints(kAppId)).Times(0);
 
   // Subscribe on Navigation_SubscribeWayPoints
   EXPECT_CALL(
       event_dispatcher_,
       add_observer(hmi_apis::FunctionID::Navigation_SubscribeWayPoints, _, _));
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::Navigation_SubscribeWayPoints)))
       .WillOnce(Return(true));
 
   // Response to mobile is not sending
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
   command->Run();
 }
@@ -168,13 +168,13 @@ TEST_F(SubscribeWayPointsRequestTest, OnEvent_SuccessResult_SubscribeApp) {
   event.set_smart_object(*event_msg);
 
   CommandPtr command(CreateCommand<SubscribeWayPointsRequest>(msg_));
-  ON_CALL(app_mngr_, application(kKey)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(kKey)).WillByDefault(Return(app_));
 
-  EXPECT_CALL(app_mngr_, SubscribeAppForWayPoints(kAppId));
+  EXPECT_CALL(mock_app_manager_, SubscribeAppForWayPoints(kAppId));
 
   EXPECT_CALL(*app_, UpdateHash());
 
-  EXPECT_CALL(app_mngr_,
+  EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(
                   MobileResponseIs(mobile_result::SUCCESS, info_, true), _));
   command->on_event(event);
@@ -194,14 +194,14 @@ TEST_F(SubscribeWayPointsRequestTest, OnEvent_UnsuccessResult_NotSubscribeApp) {
   event.set_smart_object(*event_msg);
 
   CommandPtr command(CreateCommand<SubscribeWayPointsRequest>(msg_));
-  ON_CALL(app_mngr_, application(kKey)).WillByDefault(Return(app_));
+  ON_CALL(mock_app_manager_, application(kKey)).WillByDefault(Return(app_));
 
-  EXPECT_CALL(app_mngr_, SubscribeAppForWayPoints(kAppId)).Times(0);
+  EXPECT_CALL(mock_app_manager_, SubscribeAppForWayPoints(kAppId)).Times(0);
 
   EXPECT_CALL(*app_, UpdateHash()).Times(0);
 
   EXPECT_CALL(
-      app_mngr_,
+      mock_app_manager_,
       ManageMobileCommand(
           MobileResponseIs(mobile_result::GENERIC_ERROR, info_, false), _));
   command->on_event(event);

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -66,9 +66,9 @@ class HMICapabilitiesTest : public ::testing::Test {
       : last_state_("app_storage_folder", "app_info_data")
       , kFileName("hmi_capabilities.json") {}
   virtual void SetUp() OVERRIDE {
-    EXPECT_CALL(app_mngr_, event_dispatcher())
+    EXPECT_CALL(mock_app_manager_, event_dispatcher())
         .WillOnce(ReturnRef(mock_event_dispatcher));
-    EXPECT_CALL(app_mngr_, get_settings())
+    EXPECT_CALL(mock_app_manager_, get_settings())
         .WillRepeatedly(ReturnRef(mock_application_manager_settings_));
     EXPECT_CALL(mock_application_manager_settings_,
                 hmi_capabilities_file_name()).WillOnce(ReturnRef(kFileName));
@@ -77,7 +77,7 @@ class HMICapabilitiesTest : public ::testing::Test {
     EXPECT_CALL(mock_application_manager_settings_, launch_hmi())
         .WillOnce(Return(false));
     hmi_capabilities_test =
-        utils::MakeShared<HMICapabilitiesForTesting>(app_mngr_);
+        utils::MakeShared<HMICapabilitiesForTesting>(mock_app_manager_);
     hmi_capabilities_test->Init(&last_state_);
   }
 
@@ -91,7 +91,7 @@ class HMICapabilitiesTest : public ::testing::Test {
   }
 
   void SetCooperating();
-  MockApplicationManager app_mngr_;
+  MockApplicationManager mock_app_manager_;
   event_engine_test::MockEventDispatcher mock_event_dispatcher;
   resumption::LastState last_state_;
   MockApplicationManagerSettings mock_application_manager_settings_;
@@ -413,7 +413,8 @@ void HMICapabilitiesTest::SetCooperating() {
   smart_objects::SmartObjectSPtr test_so;
   EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
               CreateModuleInfoSO(_, _)).WillRepeatedly(Return(test_so));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillRepeatedly(Return(true));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+      .WillRepeatedly(Return(true));
 }
 
 TEST_F(HMICapabilitiesTest, SetVRCooperating) {
@@ -424,19 +425,19 @@ TEST_F(HMICapabilitiesTest, SetVRCooperating) {
   EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
               CreateModuleInfoSO(hmi_apis::FunctionID::VR_GetLanguage, _))
       .WillOnce(Return(language));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(language));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(language));
 
   smart_objects::SmartObjectSPtr support_language;
   EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
               CreateModuleInfoSO(hmi_apis::FunctionID::VR_GetSupportedLanguages,
                                  _)).WillOnce(Return(support_language));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(support_language));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(support_language));
 
   smart_objects::SmartObjectSPtr capabilities;
   EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
               CreateModuleInfoSO(hmi_apis::FunctionID::VR_GetCapabilities, _))
       .WillOnce(Return(capabilities));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(capabilities));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(capabilities));
 
   hmi_capabilities_test->set_is_vr_cooperating(true);
 }
@@ -448,20 +449,20 @@ TEST_F(HMICapabilitiesTest, SetTTSCooperating) {
   EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
               CreateModuleInfoSO(hmi_apis::FunctionID::TTS_GetLanguage, _))
       .WillOnce(Return(language));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(language));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(language));
 
   smart_objects::SmartObjectSPtr support_language;
   EXPECT_CALL(
       *(MockMessageHelper::message_helper_mock()),
       CreateModuleInfoSO(hmi_apis::FunctionID::TTS_GetSupportedLanguages, _))
       .WillOnce(Return(support_language));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(support_language));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(support_language));
 
   smart_objects::SmartObjectSPtr capabilities;
   EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
               CreateModuleInfoSO(hmi_apis::FunctionID::TTS_GetCapabilities, _))
       .WillOnce(Return(capabilities));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(capabilities));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(capabilities));
 
   hmi_capabilities_test->set_is_tts_cooperating(true);
 }
@@ -473,19 +474,19 @@ TEST_F(HMICapabilitiesTest, SetUICooperating) {
   EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
               CreateModuleInfoSO(hmi_apis::FunctionID::UI_GetLanguage, _))
       .WillOnce(Return(language));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(language));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(language));
 
   smart_objects::SmartObjectSPtr support_language;
   EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
               CreateModuleInfoSO(hmi_apis::FunctionID::UI_GetSupportedLanguages,
                                  _)).WillOnce(Return(support_language));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(support_language));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(support_language));
 
   smart_objects::SmartObjectSPtr capabilities;
   EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
               CreateModuleInfoSO(hmi_apis::FunctionID::UI_GetCapabilities, _))
       .WillOnce(Return(capabilities));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(capabilities));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(capabilities));
 
   hmi_capabilities_test->set_is_ui_cooperating(true);
 }
@@ -496,7 +497,7 @@ TEST_F(HMICapabilitiesTest, SetIviCooperating) {
       *(MockMessageHelper::message_helper_mock()),
       CreateModuleInfoSO(hmi_apis::FunctionID::VehicleInfo_GetVehicleType, _))
       .WillOnce(Return(ivi_type));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(ivi_type));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(ivi_type));
 
   hmi_capabilities_test->set_is_ivi_cooperating(true);
 }

--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -727,23 +727,23 @@ class MessageHelperTest : public ::testing::Test {
       const std::string& video_server_type,
       const std::string& server_path,
       const uint16_t port = 0) {
-    MockApplicationManagerSettings mock_app_mngr_settings;
+    MockApplicationManagerSettings mock_mock_app_manager_settings;
     EXPECT_CALL(mock_application_manager_, GetNextHMICorrelationID())
         .WillOnce(Return(kCorrelationId));
     EXPECT_CALL(mock_application_manager_, get_settings())
-        .WillRepeatedly(ReturnRef(mock_app_mngr_settings));
-    EXPECT_CALL(mock_app_mngr_settings, video_server_type())
+        .WillRepeatedly(ReturnRef(mock_mock_app_manager_settings));
+    EXPECT_CALL(mock_mock_app_manager_settings, video_server_type())
         .WillRepeatedly(ReturnRef(video_server_type));
     if (video_server_type == "socket") {
-      EXPECT_CALL(mock_app_mngr_settings, server_address())
+      EXPECT_CALL(mock_mock_app_manager_settings, server_address())
           .WillOnce(ReturnRef(server_path));
-      EXPECT_CALL(mock_app_mngr_settings, video_streaming_port())
+      EXPECT_CALL(mock_mock_app_manager_settings, video_streaming_port())
           .WillOnce(Return(port));
     } else if (video_server_type == "pipe") {
-      EXPECT_CALL(mock_app_mngr_settings, named_video_pipe_path())
+      EXPECT_CALL(mock_mock_app_manager_settings, named_video_pipe_path())
           .WillOnce(ReturnRef(server_path));
     } else {
-      EXPECT_CALL(mock_app_mngr_settings, video_stream_file())
+      EXPECT_CALL(mock_mock_app_manager_settings, video_stream_file())
           .WillOnce(ReturnRef(server_path));
     }
     smart_objects::SmartObjectSPtr result;
@@ -1371,13 +1371,13 @@ TEST_F(MessageHelperTest, VerifyImage_CurrentFilePath_SUCCESS) {
   EXPECT_TRUE(file_system::CreateFile(kRelativeFilePath));
   MockApplicationSharedPtr app_shared_mock =
       utils::MakeShared<MockApplication>();
-  MockApplicationManagerSettings app_mngr_settings;
+  MockApplicationManagerSettings mock_app_manager_settings;
   smart_objects::SmartObject image;
   image[strings::image_type] = mobile_apis::ImageType::DYNAMIC;
   image[strings::value] = kRelativeFilePath;
   EXPECT_CALL(mock_application_manager_, get_settings())
-      .WillOnce(ReturnRef(app_mngr_settings));
-  EXPECT_CALL(app_mngr_settings, app_storage_folder())
+      .WillOnce(ReturnRef(mock_app_manager_settings));
+  EXPECT_CALL(mock_app_manager_settings, app_storage_folder())
       .WillOnce(ReturnRef(kAppStorageFolder));
   mobile_apis::Result::eType result = MessageHelper::VerifyImage(
       image, app_shared_mock, mock_application_manager_);
@@ -1391,13 +1391,13 @@ TEST_F(MessageHelperTest, VerifyImage_AbsoluteFolderPath_InvalidData) {
   EXPECT_TRUE(file_system::CreateFile(kFile));
   MockApplicationSharedPtr app_shared_mock =
       utils::MakeShared<MockApplication>();
-  MockApplicationManagerSettings app_mngr_settings;
+  MockApplicationManagerSettings mock_app_manager_settings;
   smart_objects::SmartObject image;
   image[strings::image_type] = mobile_apis::ImageType::DYNAMIC;
   image[strings::value] = kFile;
   EXPECT_CALL(mock_application_manager_, get_settings())
-      .WillOnce(ReturnRef(app_mngr_settings));
-  EXPECT_CALL(app_mngr_settings, app_storage_folder())
+      .WillOnce(ReturnRef(mock_app_manager_settings));
+  EXPECT_CALL(mock_app_manager_settings, app_storage_folder())
       .WillOnce(ReturnRef(kFolder));
   mobile_apis::Result::eType result = MessageHelper::VerifyImage(
       image, app_shared_mock, mock_application_manager_);
@@ -1410,13 +1410,13 @@ TEST_F(MessageHelperTest, VerifyImage_EmptyFolder_InvalidData) {
   const std::string kEmptyFolder = "";
   MockApplicationSharedPtr app_shared_mock =
       utils::MakeShared<MockApplication>();
-  MockApplicationManagerSettings app_mngr_settings;
+  MockApplicationManagerSettings mock_app_manager_settings;
   smart_objects::SmartObject image;
   image[strings::image_type] = mobile_apis::ImageType::DYNAMIC;
   image[strings::value] = kFile;
   EXPECT_CALL(mock_application_manager_, get_settings())
-      .WillOnce(ReturnRef(app_mngr_settings));
-  EXPECT_CALL(app_mngr_settings, app_storage_folder())
+      .WillOnce(ReturnRef(mock_app_manager_settings));
+  EXPECT_CALL(mock_app_manager_settings, app_storage_folder())
       .WillOnce(ReturnRef(kEmptyFolder));
   mobile_apis::Result::eType result = MessageHelper::VerifyImage(
       image, app_shared_mock, mock_application_manager_);
@@ -2615,17 +2615,17 @@ TEST_F(MessageHelperTest,
 }
 
 TEST_F(MessageHelperTest, SendAudioStartStream_SUCCESS) {
-  MockApplicationManagerSettings app_mngr_settings;
+  MockApplicationManagerSettings mock_app_manager_settings;
 
   ON_CALL(mock_application_manager_, get_settings())
-      .WillByDefault(ReturnRef(app_mngr_settings));
+      .WillByDefault(ReturnRef(mock_app_manager_settings));
 
   const std::string kAudioServerType("test_audio_server_type");
-  ON_CALL(app_mngr_settings, audio_server_type())
+  ON_CALL(mock_app_manager_settings, audio_server_type())
       .WillByDefault(ReturnRef(kAudioServerType));
 
   const std::string kAudioStreamFile("test_audio_stream_file");
-  ON_CALL(app_mngr_settings, audio_stream_file())
+  ON_CALL(mock_app_manager_settings, audio_stream_file())
       .WillByDefault(ReturnRef(kAudioStreamFile));
 
   smart_objects::SmartObjectSPtr result;

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -84,18 +84,18 @@ class ResumeCtrlTest : public ::testing::Test {
       , kTestTimeStamp_(1452074434) {}
 
   virtual void SetUp() OVERRIDE {
-    ON_CALL(mock_app_mngr_, event_dispatcher())
+    ON_CALL(mock_mock_app_manager_, event_dispatcher())
         .WillByDefault(ReturnRef(mock_event_dispatcher_));
     mock_storage =
         ::utils::MakeShared<NiceMock<resumption_test::MockResumptionData> >(
             mock_application_manager_settings_);
     app_mock = utils::MakeShared<NiceMock<MockApplication> >();
-    res_ctrl = utils::MakeShared<ResumeCtrlImpl>(mock_app_mngr_);
+    res_ctrl = utils::MakeShared<ResumeCtrlImpl>(mock_mock_app_manager_);
     res_ctrl->set_resumption_storage(mock_storage);
 
-    ON_CALL(mock_app_mngr_, state_controller())
+    ON_CALL(mock_mock_app_manager_, state_controller())
         .WillByDefault(ReturnRef(state_controller_));
-    ON_CALL(mock_app_mngr_, get_settings())
+    ON_CALL(mock_mock_app_manager_, get_settings())
         .WillByDefault(ReturnRef(mock_application_manager_settings_));
 
     ON_CALL(mock_application_manager_settings_, use_db_for_resumption())
@@ -114,7 +114,7 @@ class ResumeCtrlTest : public ::testing::Test {
   NiceMock<event_engine_test::MockEventDispatcher> mock_event_dispatcher_;
   application_manager_test::MockApplicationManagerSettings
       mock_application_manager_settings_;
-  application_manager_test::MockApplicationManager mock_app_mngr_;
+  application_manager_test::MockApplicationManager mock_mock_app_manager_;
   MockStateController state_controller_;
   utils::SharedPtr<ResumeCtrlImpl> res_ctrl;
   utils::SharedPtr<NiceMock<resumption_test::MockResumptionData> > mock_storage;
@@ -145,7 +145,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithGrammarId) {
 
   // Check RestoreApplicationData
   GetInfoFromApp();
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_))
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
       .WillRepeatedly(Return(kDefaultTestLevel_));
   EXPECT_CALL(*mock_storage,
               GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
@@ -169,7 +169,7 @@ TEST_F(ResumeCtrlTest, StartResumption_WithoutGrammarId) {
   saved_app[application_manager::strings::hash_id] = kHash_;
 
   GetInfoFromApp();
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_))
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
       .WillRepeatedly(Return(kDefaultTestLevel_));
   // Check RestoreApplicationData
   EXPECT_CALL(*mock_storage, GetSavedApplication(_, _, _))
@@ -216,7 +216,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithFiles) {
       test_application_files;
 
   // Check RestoreApplicationData
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_))
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
       .WillRepeatedly(Return(kDefaultTestLevel_));
   EXPECT_CALL(*mock_storage, GetSavedApplication(_, _, _))
       .WillRepeatedly(DoAll(SetArgReferee<2>(saved_app), Return(true)));
@@ -253,7 +253,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubmenues) {
       test_application_submenues;
 
   // Check RestoreApplicationData
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_))
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
       .WillRepeatedly(Return(kDefaultTestLevel_));
   EXPECT_CALL(*mock_storage, GetSavedApplication(_, _, _))
       .WillRepeatedly(DoAll(SetArgReferee<2>(saved_app), Return(true)));
@@ -265,7 +265,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubmenues) {
   }
   smart_objects::SmartObjectList requests;
 
-  EXPECT_CALL(mock_app_mngr_, GetNextHMICorrelationID())
+  EXPECT_CALL(mock_mock_app_manager_, GetNextHMICorrelationID())
       .WillRepeatedly(Return(kCorId_));
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
               CreateAddSubMenuRequestToHMI(_, kCorId_))
@@ -293,7 +293,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithCommands) {
   saved_app[application_manager::strings::application_commands] =
       test_application_commands;
 
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_))
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
       .WillRepeatedly(Return(kDefaultTestLevel_));
   // Check RestoreApplicationData
   EXPECT_CALL(*mock_storage, GetSavedApplication(_, _, _))
@@ -344,7 +344,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithChoiceSet) {
       application_choice_sets;
 
   // Check RestoreApplicationData
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_))
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
       .WillRepeatedly(Return(kDefaultTestLevel_));
   GetInfoFromApp();
   EXPECT_CALL(*mock_storage, GetSavedApplication(_, _, _))
@@ -375,7 +375,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithGlobalProperties) {
       test_global_properties;
 
   // Check RestoreApplicationData
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_))
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
       .WillRepeatedly(Return(kDefaultTestLevel_));
   GetInfoFromApp();
   EXPECT_CALL(*mock_storage, GetSavedApplication(_, _, _))
@@ -413,7 +413,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscribeOnButtons) {
       test_subscriptions;
 
   // Check RestoreApplicationData
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_))
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
       .WillRepeatedly(Return(kDefaultTestLevel_));
   GetInfoFromApp();
   EXPECT_CALL(*mock_storage, GetSavedApplication(_, _, _))
@@ -457,7 +457,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToIVI) {
       test_subscriptions;
 
   // Check RestoreApplicationData
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_))
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
       .WillRepeatedly(Return(kDefaultTestLevel_));
   GetInfoFromApp();
   EXPECT_CALL(*mock_storage, GetSavedApplication(_, _, _))
@@ -493,8 +493,9 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToWayPoints) {
       .Times(2)
       .WillRepeatedly(DoAll(SetArgReferee<2>(saved_app), Return(true)));
   EXPECT_CALL(*app_mock, set_grammar_id(kTestGrammarId_));
-  EXPECT_CALL(mock_app_mngr_, SubscribeAppForWayPoints(_));
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_)).WillOnce(Return(HMI_FULL));
+  EXPECT_CALL(mock_mock_app_manager_, SubscribeAppForWayPoints(_));
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
+      .WillOnce(Return(HMI_FULL));
 
   const bool kResult = res_ctrl->StartResumption(app_mock, kHash_);
   EXPECT_TRUE(kResult);
@@ -503,7 +504,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToWayPoints) {
 TEST_F(ResumeCtrlTest, StartResumptionOnlyHMILevel) {
   smart_objects::SmartObject saved_app;
 
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_))
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
       .WillOnce(Return(kDefaultTestLevel_));
   GetInfoFromApp();
   EXPECT_CALL(*mock_storage, GetSavedApplication(kTestPolicyAppId_, _, _))
@@ -528,7 +529,7 @@ TEST_F(ResumeCtrlTest, StartAppHmiStateResumption_AppInFull) {
   EXPECT_CALL(*mock_storage, RemoveApplicationFromSaved(_, _))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(mock_app_mngr_, GetUserConsentForDevice(kMacAddress_))
+  EXPECT_CALL(mock_mock_app_manager_, GetUserConsentForDevice(kMacAddress_))
       .WillRepeatedly(Return(policy::kDeviceAllowed));
   res_ctrl->StartAppHmiStateResumption(app_mock);
 }
@@ -541,7 +542,7 @@ TEST_F(ResumeCtrlTest, StartAppHmiStateResumption_AppInBackground) {
   saved_app[application_manager::strings::ign_off_count] = ign_off_count;
   saved_app[application_manager::strings::hmi_level] = restored_test_type;
 
-  EXPECT_CALL(mock_app_mngr_, state_controller()).Times(0);
+  EXPECT_CALL(mock_mock_app_manager_, state_controller()).Times(0);
   GetInfoFromApp();
   EXPECT_CALL(*mock_storage, GetSavedApplication(kTestPolicyAppId_, _, _))
       .WillRepeatedly(DoAll(SetArgReferee<2>(saved_app), Return(true)));
@@ -567,7 +568,7 @@ TEST_F(ResumeCtrlTest, RestoreAppHMIState_RestoreHMILevelFull) {
   EXPECT_CALL(*mock_storage, GetSavedApplication(_, _, _))
       .WillOnce(DoAll(SetArgReferee<2>(saved_app), Return(true)));
 
-  EXPECT_CALL(mock_app_mngr_, GetUserConsentForDevice(kMacAddress_))
+  EXPECT_CALL(mock_mock_app_manager_, GetUserConsentForDevice(kMacAddress_))
       .WillOnce(Return(policy::kDeviceAllowed));
   EXPECT_CALL(*app_mock, set_is_resuming(true));
 
@@ -580,12 +581,13 @@ TEST_F(ResumeCtrlTest, SetupDefaultHMILevel) {
 
   saved_app[application_manager::strings::hmi_level] = kDefaultTestLevel_;
 
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_))
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
       .WillRepeatedly(Return(kDefaultTestLevel_));
   GetInfoFromApp();
-  EXPECT_CALL(mock_app_mngr_, GetUserConsentForDevice(kMacAddress_)).Times(0);
+  EXPECT_CALL(mock_mock_app_manager_, GetUserConsentForDevice(kMacAddress_))
+      .Times(0);
 
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_))
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
       .WillOnce(Return(kDefaultTestLevel_));
 
   EXPECT_CALL(state_controller_, SetRegularState(_, kDefaultTestLevel_))
@@ -595,7 +597,8 @@ TEST_F(ResumeCtrlTest, SetupDefaultHMILevel) {
 }
 
 TEST_F(ResumeCtrlTest, ApplicationResumptiOnTimer_AppInFull) {
-  EXPECT_CALL(mock_app_mngr_, application(_)).WillRepeatedly(Return(app_mock));
+  EXPECT_CALL(mock_mock_app_manager_, application(_))
+      .WillRepeatedly(Return(app_mock));
 
   mobile_apis::HMILevel::eType restored_test_type = eType::HMI_FULL;
   const uint32_t ign_off_count = 0;
@@ -604,7 +607,7 @@ TEST_F(ResumeCtrlTest, ApplicationResumptiOnTimer_AppInFull) {
   saved_app[application_manager::strings::hmi_level] = restored_test_type;
 
   MockStateController state_controller_;
-  EXPECT_CALL(mock_app_mngr_, state_controller())
+  EXPECT_CALL(mock_mock_app_manager_, state_controller())
       .WillOnce(ReturnRef(state_controller_));
   EXPECT_CALL(state_controller_, SetRegularState(_, restored_test_type))
       .Times(AtLeast(1));
@@ -616,7 +619,7 @@ TEST_F(ResumeCtrlTest, ApplicationResumptiOnTimer_AppInFull) {
   EXPECT_CALL(*mock_storage, RemoveApplicationFromSaved(_, _))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(mock_app_mngr_, GetUserConsentForDevice(kMacAddress_))
+  EXPECT_CALL(mock_mock_app_manager_, GetUserConsentForDevice(kMacAddress_))
       .WillRepeatedly(Return(policy::kDeviceAllowed));
   res_ctrl->StartAppHmiStateResumption(app_mock);
 }
@@ -628,7 +631,8 @@ TEST_F(ResumeCtrlTest, ApplicationResumptiOnTimer_AppInFull) {
 TEST_F(ResumeCtrlTest, SetAppHMIState_HMINone_WithoutCheckPolicy) {
   GetInfoFromApp();
 
-  EXPECT_CALL(mock_app_mngr_, GetUserConsentForDevice(kMacAddress_)).Times(0);
+  EXPECT_CALL(mock_mock_app_manager_, GetUserConsentForDevice(kMacAddress_))
+      .Times(0);
 
   EXPECT_CALL(*app_mock, set_is_resuming(true));
   EXPECT_CALL(state_controller_, SetRegularState(_, kDefaultTestLevel_))
@@ -641,7 +645,8 @@ TEST_F(ResumeCtrlTest, SetAppHMIState_HMINone_WithoutCheckPolicy) {
 TEST_F(ResumeCtrlTest, SetAppHMIState_HMILimited_WithoutCheckPolicy) {
   mobile_apis::HMILevel::eType test_type = eType::HMI_LIMITED;
   GetInfoFromApp();
-  EXPECT_CALL(mock_app_mngr_, GetUserConsentForDevice(kMacAddress_)).Times(0);
+  EXPECT_CALL(mock_mock_app_manager_, GetUserConsentForDevice(kMacAddress_))
+      .Times(0);
 
   EXPECT_CALL(*app_mock, set_is_resuming(true));
   EXPECT_CALL(state_controller_, SetRegularState(_, test_type))
@@ -654,8 +659,9 @@ TEST_F(ResumeCtrlTest, SetAppHMIState_HMIFull_WithoutCheckPolicy) {
   mobile_apis::HMILevel::eType test_type = eType::HMI_FULL;
   GetInfoFromApp();
   // GetDefaultHmiLevel should not be called
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_)).Times(0);
-  EXPECT_CALL(mock_app_mngr_, GetUserConsentForDevice(kMacAddress_)).Times(0);
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_)).Times(0);
+  EXPECT_CALL(mock_mock_app_manager_, GetUserConsentForDevice(kMacAddress_))
+      .Times(0);
 
   EXPECT_CALL(*app_mock, set_is_resuming(true));
   EXPECT_CALL(state_controller_, SetRegularState(_, test_type))
@@ -669,7 +675,7 @@ TEST_F(ResumeCtrlTest, SetAppHMIState_HMIFull_WithPolicy_DevAllowed) {
   mobile_apis::HMILevel::eType test_type = eType::HMI_FULL;
 
   GetInfoFromApp();
-  EXPECT_CALL(mock_app_mngr_, GetUserConsentForDevice(kMacAddress_))
+  EXPECT_CALL(mock_mock_app_manager_, GetUserConsentForDevice(kMacAddress_))
       .WillOnce(Return(policy::kDeviceAllowed));
 
   EXPECT_CALL(*app_mock, set_is_resuming(true));
@@ -684,11 +690,11 @@ TEST_F(ResumeCtrlTest, SetAppHMIState_HMIFull_WithPolicy_DevDisallowed) {
   mobile_apis::HMILevel::eType test_type = eType::HMI_FULL;
 
   GetInfoFromApp();
-  EXPECT_CALL(mock_app_mngr_, GetUserConsentForDevice(kMacAddress_))
+  EXPECT_CALL(mock_mock_app_manager_, GetUserConsentForDevice(kMacAddress_))
       .WillOnce(Return(policy::kDeviceDisallowed));
 
   EXPECT_CALL(*app_mock, set_is_resuming(true));
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_))
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
       .WillOnce(Return(kDefaultTestLevel_));
   EXPECT_CALL(state_controller_, SetRegularState(_, kDefaultTestLevel_))
       .Times(AtLeast(1));
@@ -706,7 +712,8 @@ TEST_F(ResumeCtrlTest, SaveAllApplications) {
   DataAccessor<application_manager::ApplicationSet> accessor(app_set,
                                                              app_set_lock_);
 
-  EXPECT_CALL(mock_app_mngr_, applications()).WillRepeatedly(Return(accessor));
+  EXPECT_CALL(mock_mock_app_manager_, applications())
+      .WillRepeatedly(Return(accessor));
   EXPECT_CALL(*mock_storage, SaveApplication(app_sh_mock)).Times(1);
   res_ctrl->SaveAllApplications();
 }
@@ -720,7 +727,8 @@ TEST_F(ResumeCtrlTest, SaveAllApplications_EmptyApplicationlist) {
   DataAccessor<application_manager::ApplicationSet> accessor(app_set,
                                                              app_set_lock_);
 
-  EXPECT_CALL(mock_app_mngr_, applications()).WillRepeatedly(Return(accessor));
+  EXPECT_CALL(mock_mock_app_manager_, applications())
+      .WillRepeatedly(Return(accessor));
   EXPECT_CALL(*mock_storage, SaveApplication(app_sh_mock)).Times(0);
   res_ctrl->SaveAllApplications();
 }
@@ -737,7 +745,7 @@ TEST_F(ResumeCtrlTest, OnAppActivated_ResumptionHasStarted) {
   smart_objects::SmartObject saved_app;
   GetInfoFromApp();
 
-  EXPECT_CALL(mock_app_mngr_, GetDefaultHmiLevel(_))
+  EXPECT_CALL(mock_mock_app_manager_, GetDefaultHmiLevel(_))
       .WillOnce(Return(kDefaultTestLevel_));
   EXPECT_CALL(*mock_storage, GetSavedApplication(kTestPolicyAppId_, _, _))
       .WillOnce(DoAll(SetArgReferee<2>(saved_app), Return(true)));
@@ -863,7 +871,8 @@ TEST_F(ResumeCtrlTest, OnSuspend) {
   DataAccessor<application_manager::ApplicationSet> accessor(app_set,
                                                              app_set_lock_);
 
-  EXPECT_CALL(mock_app_mngr_, applications()).WillRepeatedly(Return(accessor));
+  EXPECT_CALL(mock_mock_app_manager_, applications())
+      .WillRepeatedly(Return(accessor));
   EXPECT_CALL(*mock_storage, SaveApplication(app_sh_mock)).Times(1);
 
   EXPECT_CALL(*mock_storage, OnSuspend());
@@ -880,7 +889,8 @@ TEST_F(ResumeCtrlTest, OnSuspend_EmptyApplicationlist) {
   DataAccessor<application_manager::ApplicationSet> accessor(app_set,
                                                              app_set_lock_);
 
-  EXPECT_CALL(mock_app_mngr_, applications()).WillRepeatedly(Return(accessor));
+  EXPECT_CALL(mock_mock_app_manager_, applications())
+      .WillRepeatedly(Return(accessor));
   EXPECT_CALL(*mock_storage, SaveApplication(app_sh_mock)).Times(0);
 
   EXPECT_CALL(*mock_storage, OnSuspend());


### PR DESCRIPTION
   Following HMI commands were covered by Unit Tests:

    activate_app_request
    activate_app_response
    add_statistics_info_notification
    allow_all_apps_request
    allow_all_apps_response
    allow_app_request
    allow_app_response
    basic_communication_system_request
    basic_communication_system_response
    button_get_capabilities_request
    button_get_capabilities_response
    navi_send_location_request
    navi_send_location_response
    navi_show_constant_tbt_request
    navi_show_constant_tbt_response
    navi_start_stream_request
    navi_start_stream_response
    navi_stop_stream_request
    navi_stop_stream_response
    navi_subscribe_way_points_request
    navi_subscribe_way_points_response
    navi_unsubscribe_way_points_request
    navi_unsubscribe_way_points_response
    navi_update_turn_list_request
    navi_update_turn_list_response
    sdl_activate_app_request
    sdl_activate_app_response
    sdl_get_list_of_permissions_request
    sdl_get_list_of_permissions_response
    sdl_get_status_update_request
    sdl_get_status_update_response
    
  **Additional UTs were added to sdl_activate_app_request.cc

    Related issue: APPLINK-26069
