### PR TITLE
Fix Security and unit tests crashes

### DIFF
--- a/src/components/security_manager/src/crypto_manager_impl.cc
+++ b/src/components/security_manager/src/crypto_manager_impl.cc
@@ -274,13 +274,14 @@ bool CryptoManagerImpl::set_certificate(const std::string& cert_data) {
     SDL_WARN("Empty certificate");
     return false;
   }
+  const size_t cert_data_len = cert_data.length();
 
   BIO* bio = BIO_new(BIO_f_base64());
-  BIO* bmem = BIO_new_mem_buf((char*)cert_data.c_str(), cert_data.length());
+  BIO* bmem = BIO_new_mem_buf((char*)cert_data.c_str(), cert_data_len);
   bmem = BIO_push(bio, bmem);
 
-  char* buf = new char[cert_data.length()];
-  int len = BIO_read(bmem, buf, cert_data.length());
+  char* buf = new char[cert_data_len];
+  const int len = BIO_read(bmem, buf, cert_data_len);
 
   BIO* bio_cert = BIO_new(BIO_s_mem());
   if (NULL == bio_cert) {

--- a/src/components/security_manager/src/crypto_manager_impl.cc
+++ b/src/components/security_manager/src/crypto_manager_impl.cc
@@ -160,6 +160,16 @@ bool CryptoManagerImpl::Init() {
     free_ctx(&context_);
   }
   context_ = SSL_CTX_new(method);
+  if (!context_) {
+    const unsigned long error = ERR_get_error();
+    UNUSED(error);
+    SDL_ERROR("Could not create \""
+              << (is_server ? "server" : "client") << "\" SSL method \"'"
+              << get_settings().security_manager_protocol_name()
+              << "\"', err 0x" << std::hex << error << " \""
+              << ERR_reason_error_string(error) << '"');
+    return false;
+  }
 
   utils::ScopeGuard guard = utils::MakeGuard(free_ctx, &context_);
 

--- a/src/components/security_manager/src/security_manager_impl.cc
+++ b/src/components/security_manager/src/security_manager_impl.cc
@@ -31,12 +31,16 @@
  */
 
 #include "security_manager/security_manager_impl.h"
-#include "security_manager/crypto_manager_impl.h"
-#include "protocol_handler/protocol_packet.h"
+
+#include <string.h>
+
 #include "utils/logger.h"
 #include "utils/byte_order.h"
 #include "utils/json_utils.h"
 #include "utils/convert_utils.h"
+
+#include "security_manager/crypto_manager_impl.h"
+#include "protocol_handler/protocol_packet.h"
 
 namespace security_manager {
 

--- a/src/components/security_manager/src/ssl_context_impl.cc
+++ b/src/components/security_manager/src/ssl_context_impl.cc
@@ -327,8 +327,8 @@ SSLContext::HandshakeResult CryptoManagerImpl::SSLContextImpl::DoHandshakeStep(
     const uint8_t** const out_data,
     size_t* out_data_size) {
   SDL_AUTO_TRACE();
-  DCHECK(out_data);
-  DCHECK(out_data_size);
+  DCHECK_OR_RETURN(out_data, Handshake_Result_Fail);
+  DCHECK_OR_RETURN(out_data_size, Handshake_Result_Fail);
   *out_data = NULL;
   *out_data_size = 0;
 

--- a/src/components/security_manager/test/ssl_context_test.cc
+++ b/src/components/security_manager/test/ssl_context_test.cc
@@ -54,7 +54,8 @@ namespace {
 const std::string kCaPath = "";
 const uint8_t* kServerBuf;
 const uint8_t* kClientBuf;
-const std::string kAllCiphers = "ALL";
+const std::string kAllCiphers = SSL_TXT_ALL;
+const std::string kNullCiphers = SSL_TXT_NULL;
 size_t server_buf_len;
 size_t client_buf_len;
 #ifdef __QNXNTO__
@@ -89,15 +90,26 @@ struct ProtocolAndCipher {
 class SSLTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
-    std::ifstream certificate_file("server/spt_credential_unsigned.p12");
+    std::ifstream certificate_file("server/spt_credential_unsigned.p12.enc");
+    ASSERT_TRUE(certificate_file.is_open())
+        << "Could not open certificate data file";
     std::stringstream certificate;
-    if (certificate_file.is_open()) {
-      certificate << certificate_file.rdbuf();
-    }
+    certificate << certificate_file.rdbuf();
     certificate_file.close();
-    certificate_data_base64_ = certificate.str();
-    ASSERT_FALSE(certificate_data_base64_.empty())
-        << "Certificate data file is empty";
+    server_certificate_data_base64_ = certificate.str();
+    ASSERT_FALSE(server_certificate_data_base64_.empty())
+        << "Server certificate data file is empty";
+
+    certificate.clear();
+
+    certificate_file.open("client/client_credential_unsigned.p12.enc");
+    ASSERT_TRUE(certificate_file.is_open())
+        << "Could not open certificate data file";
+    certificate << certificate_file.rdbuf();
+    certificate_file.close();
+    client_certificate_data_base64_ = certificate.str();
+    ASSERT_FALSE(client_certificate_data_base64_.empty())
+        << "Client certificate data file is empty";
   }
 
   virtual void SetUp() OVERRIDE {
@@ -113,13 +125,13 @@ class SSLTest : public testing::Test {
                 security_manager_protocol_name())
         .WillOnce(Return(security_manager::TLSv1_2));
     EXPECT_CALL(*mock_crypto_manager_settings_, certificate_data())
-        .WillOnce(ReturnRef(certificate_data_base64_));
+        .WillOnce(ReturnRef(server_certificate_data_base64_));
     EXPECT_CALL(*mock_crypto_manager_settings_, ciphers_list())
-        .WillRepeatedly(ReturnRef(kAllCiphers));
+        .WillRepeatedly(ReturnRef(kNullCiphers));
     EXPECT_CALL(*mock_crypto_manager_settings_, ca_cert_path())
         .WillRepeatedly(ReturnRef(kCaPath));
     EXPECT_CALL(*mock_crypto_manager_settings_, verify_peer())
-        .WillOnce(Return(false));
+        .WillRepeatedly(Return(false));
     const bool crypto_manager_initialization = crypto_manager_->Init();
     EXPECT_TRUE(crypto_manager_initialization);
 
@@ -135,14 +147,13 @@ class SSLTest : public testing::Test {
                 security_manager_protocol_name())
         .WillOnce(Return(security_manager::TLSv1_2));
     EXPECT_CALL(*mock_client_manager_settings_, certificate_data())
-        .WillOnce(ReturnRef(certificate_data_base64_));
+        .WillOnce(ReturnRef(client_certificate_data_base64_));
     EXPECT_CALL(*mock_client_manager_settings_, ciphers_list())
-        .WillRepeatedly(ReturnRef(kAllCiphers));
+        .WillRepeatedly(ReturnRef(kNullCiphers));
     EXPECT_CALL(*mock_client_manager_settings_, ca_cert_path())
-        .Times(2)
         .WillRepeatedly(ReturnRef(kCaPath));
     EXPECT_CALL(*mock_client_manager_settings_, verify_peer())
-        .WillOnce(Return(false));
+        .WillRepeatedly(Return(false));
     const bool client_manager_initialization = client_manager_->Init();
     EXPECT_TRUE(client_manager_initialization);
 
@@ -190,9 +201,11 @@ class SSLTest : public testing::Test {
   security_manager::SSLContext* server_ctx;
   security_manager::SSLContext* client_ctx;
 
-  static std::string certificate_data_base64_;
+  static std::string client_certificate_data_base64_;
+  static std::string server_certificate_data_base64_;
 };
-std::string SSLTest::certificate_data_base64_;
+std::string SSLTest::client_certificate_data_base64_;
+std::string SSLTest::server_certificate_data_base64_;
 
 // StartHandshake() fails when client and server protocols are not TLSv1_2
 class SSLTestParam : public testing::TestWithParam<ProtocolAndCipher> {
@@ -385,7 +398,7 @@ TEST_F(SSLTest, DISABLED_OnTSL2Protocol_Positive) {
             security_manager::SSLContext::Handshake_Result_Success);
   ASSERT_FALSE(NULL == kClientBuf);
   ASSERT_LT(0u, client_buf_len);
-  EXPECT_TRUE(server_ctx->IsInitCompleted());
+  EXPECT_FALSE(server_ctx->IsInitCompleted());
 
   while (true) {
     const security_manager::SSLContext::HandshakeResult server_result =
@@ -416,9 +429,11 @@ TEST_F(SSLTest, DISABLED_OnTSL2Protocol_Positive) {
   EXPECT_TRUE(server_ctx->IsInitCompleted());
 
   // Encrypt text on client side
-  const uint8_t* text = reinterpret_cast<const uint8_t*>("abra");
+  const std::string input_string =
+      std::string("abrakadabra") + std::string(1024, 'Z');
+  const uint8_t* text = reinterpret_cast<const uint8_t*>(input_string.c_str());
   const uint8_t* encrypted_text = 0;
-  size_t text_len = 4;
+  size_t text_len = input_string.size();
   size_t encrypted_text_len;
   EXPECT_TRUE(client_ctx->Encrypt(
       text, text_len, &encrypted_text, &encrypted_text_len));
@@ -432,7 +447,9 @@ TEST_F(SSLTest, DISABLED_OnTSL2Protocol_Positive) {
   ASSERT_NE(reinterpret_cast<void*>(NULL), text);
   ASSERT_LT(0u, text_len);
 
-  ASSERT_EQ(strncmp(reinterpret_cast<const char*>(text), "abra", 4), 0);
+  const std::string output_str =
+      std::string(reinterpret_cast<const char*>(text), text_len);
+  ASSERT_EQ(input_string, output_str);
 }
 
 TEST_F(SSLTest, DISABLED_OnTSL2Protocol_EcncryptionFail) {

--- a/src/components/security_manager/test/ssl_context_test.cc
+++ b/src/components/security_manager/test/ssl_context_test.cc
@@ -381,7 +381,7 @@ INSTANTIATE_TEST_CASE_P(
                                         kFordCipher)));
 
 // TODO(OHerasym) : ReleaseSSLContext fails
-TEST_F(SSLTest, DISABLED_OnTSL2Protocol_BrokenHandshake) {
+TEST_F(SSLTest, OnTSL2Protocol_BrokenHandshake) {
   ASSERT_EQ(security_manager::SSLContext::Handshake_Result_Success,
             client_ctx->StartHandshake(&kClientBuf, &client_buf_len));
   ASSERT_FALSE(NULL == kClientBuf);
@@ -400,7 +400,7 @@ TEST_F(SSLTest, DISABLED_OnTSL2Protocol_BrokenHandshake) {
 // TODO {AKozoriz} : Unexpected uncomplited init of SSL component.
 // In this and next tests.
 // Must be fixed after merge to develop.
-TEST_F(SSLTest, DISABLED_OnTSL2Protocol_Positive) {
+TEST_F(SSLTest, OnTSL2Protocol_Positive) {
   ASSERT_EQ(client_ctx->StartHandshake(&kClientBuf, &client_buf_len),
             security_manager::SSLContext::Handshake_Result_Success);
   ASSERT_FALSE(NULL == kClientBuf);
@@ -459,7 +459,7 @@ TEST_F(SSLTest, DISABLED_OnTSL2Protocol_Positive) {
   ASSERT_EQ(input_string, output_str);
 }
 
-TEST_F(SSLTest, DISABLED_OnTSL2Protocol_EcncryptionFail) {
+TEST_F(SSLTest, OnTSL2Protocol_EcncryptionFail) {
   ASSERT_EQ(security_manager::SSLContext::Handshake_Result_Success,
             client_ctx->StartHandshake(&kClientBuf, &client_buf_len));
 

--- a/src/components/security_manager/test/ssl_context_test.cc
+++ b/src/components/security_manager/test/ssl_context_test.cc
@@ -211,6 +211,10 @@ std::string SSLTest::server_certificate_data_base64_;
 class SSLTestParam : public testing::TestWithParam<ProtocolAndCipher> {
  protected:
   virtual void SetUp() OVERRIDE {
+    crypto_manager = NULL;
+    client_manager = NULL;
+    server_ctx = NULL;
+    client_ctx = NULL;
     std::ifstream certificate_file("server/spt_credential.p12");
     ASSERT_TRUE(certificate_file.is_open())
         << "Could not open certificate data file";
@@ -248,7 +252,10 @@ class SSLTestParam : public testing::TestWithParam<ProtocolAndCipher> {
     EXPECT_TRUE(client_manager_initialization);
 
     server_ctx = crypto_manager->CreateSSLContext();
+    ASSERT_TRUE(server_ctx) << " Server SSL Contect is not created";
+
     client_ctx = client_manager->CreateSSLContext();
+    ASSERT_TRUE(client_ctx) << " Client SSL Contect is not created";
 
     security_manager::SSLContext::HandshakeContext ctx;
     ctx.make_context(custom_str::CustomString("SPT"),


### PR DESCRIPTION
Security component:
* Add local variable for debugging
* Update includes
* Change DCHECK to RETURN
* Fixed Crash for SSL3

Unittests:
* Fix security tests
* Set correct certificate paths
* Fixed expectations
* Add checking decrypted string
* Fix crash in case no Context creation