### PR TITLE
Fix deadlock on thread termination 

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_retry_sequence.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_retry_sequence.h
@@ -42,7 +42,8 @@ class PolicyHandler;
 class RetrySequence : public threads::ThreadDelegate {
  public:
   explicit RetrySequence(PolicyHandler* const policy_handler);
-  void threadMain();
+  void threadMain() OVERRIDE;
+  void exitThreadMain() OVERRIDE;
 
  private:
   PolicyHandler* const policy_handler_;

--- a/src/components/include/utils/threads/thread_delegate.h
+++ b/src/components/include/utils/threads/thread_delegate.h
@@ -68,7 +68,9 @@ class ThreadDelegate {
    * Should be called to free all resources allocated in threadMain
    * and exiting threadMain
    * This function should be blocking and return only when threadMain() will be
-   * finished in other case segmantation failes are possible
+   * finished in other case segmentation faults are possible.
+   * WARNING: The use of the thread cancellation should be avoided
+   * as it can cause deadlocks under Windows!
    */
   virtual void exitThreadMain();
 

--- a/src/components/transport_manager/include/transport_manager/bluetooth/bluetooth_device_scanner.h
+++ b/src/components/transport_manager/include/transport_manager/bluetooth/bluetooth_device_scanner.h
@@ -53,6 +53,7 @@
 #include "utils/conditional_variable.h"
 #include "utils/lock.h"
 #include "utils/threads/thread_delegate.h"
+#include "utils/atomic_object.h"
 
 class Thread;
 
@@ -118,6 +119,7 @@ class BluetoothDeviceScanner : public DeviceScanner {
    public:
     explicit BluetoothDeviceScannerDelegate(BluetoothDeviceScanner* scanner);
     void threadMain() OVERRIDE;
+    void exitThreadMain() OVERRIDE;
 
    private:
     BluetoothDeviceScanner* scanner_;
@@ -196,9 +198,9 @@ class BluetoothDeviceScanner : public DeviceScanner {
 #endif
   TransportAdapterController* controller_;
   threads::Thread* thread_;
-  bool shutdown_requested_;
+  sync_primitives::atomic_bool shutdown_requested_;
   bool ready_;
-  bool device_scan_requested_;
+  volatile bool device_scan_requested_;
   sync_primitives::Lock device_scan_requested_lock_;
   sync_primitives::ConditionalVariable device_scan_requested_cv_;
 

--- a/src/components/transport_manager/include/transport_manager/usb/libusb/usb_handler.h
+++ b/src/components/transport_manager/include/transport_manager/usb/libusb/usb_handler.h
@@ -47,6 +47,7 @@
 #include "transport_manager/usb/usb_control_transfer.h"
 
 #include "utils/threads/thread.h"
+#include "utils/atomic_object.h"
 
 class Thread;
 
@@ -81,12 +82,13 @@ class UsbHandler {
    public:
     explicit UsbHandlerDelegate(UsbHandler* handler);
     void threadMain() OVERRIDE;
+    void exitThreadMain() OVERRIDE;
 
    private:
     UsbHandler* handler_;
   };
 
-  bool shutdown_requested_;
+  sync_primitives::atomic_bool shutdown_requested_;
   threads::Thread* thread_;
 
   friend class UsbDeviceListener;

--- a/src/components/transport_manager/src/tcp/tcp_connection_factory.cc
+++ b/src/components/transport_manager/src/tcp/tcp_connection_factory.cc
@@ -60,7 +60,6 @@ TransportAdapter::Error TcpConnectionFactory::CreateConnection(
   TcpServerOiginatedSocketConnection* connection(
       new TcpServerOiginatedSocketConnection(
           device_uid, app_handle, controller_));
-  controller_->ConnectionCreated(connection, device_uid, app_handle);
   if (connection->Start() == TransportAdapter::OK) {
     SDL_DEBUG("TCP connection initialised");
     return TransportAdapter::OK;

--- a/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
+++ b/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
@@ -127,7 +127,7 @@ TransportAdapter::Error ThreadedSocketConnection::Disconnect() {
 
 void ThreadedSocketConnection::threadMain() {
   SDL_AUTO_TRACE();
-  controller_->ConnectionCreated(this, device_uid_, app_handle_);
+  controller_->ConnectionCreated(this, device_handle(), application_handle());
   ConnectError* connect_error = NULL;
   if (!Establish(&connect_error)) {
     SDL_ERROR("Connection Establish failed");
@@ -229,6 +229,7 @@ void ThreadedSocketConnection::SocketConnectionDelegate::threadMain() {
 
 void ThreadedSocketConnection::SocketConnectionDelegate::exitThreadMain() {
   SDL_AUTO_TRACE();
+  connection_->Abort();
 }
 
 }  // namespace transport_adapter

--- a/src/components/transport_manager/test/CMakeLists.txt
+++ b/src/components/transport_manager/test/CMakeLists.txt
@@ -59,3 +59,4 @@ set(LIBRARIES
 create_test(transport_manager_test "${SOURCES}" "${LIBRARIES}")
 
 file(COPY smartDeviceLink_test.ini DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY app_info_storage2.txt DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/components/transport_manager/test/app_info_storage2.txt
+++ b/src/components/transport_manager/test/app_info_storage2.txt
@@ -1,0 +1,99 @@
+{
+   "TransportManager" : {
+      "BluetoothAdapter" : null,
+      "TcpAdapter" : {
+         "devices" : [
+            {
+               "address" : "57.48.0.1",
+               "applications" : [
+                  {
+                     "port" : 12345
+                  }
+               ],
+               "name" : "unique_device_name0"
+            },
+            {
+               "address" : "57.48.0.2",
+               "applications" : [
+                  {
+                     "port" : 12345
+                  }
+               ],
+               "name" : "unique_device_name1"
+            },
+            {
+               "address" : "57.48.0.3",
+               "applications" : [
+                  {
+                     "port" : 12345
+                  }
+               ],
+               "name" : "unique_device_name2"
+            },
+            {
+               "address" : "57.48.0.4",
+               "applications" : [
+                  {
+                     "port" : 12345
+                  }
+               ],
+               "name" : "unique_device_name3"
+            },
+            {
+               "address" : "57.48.0.5",
+               "applications" : [
+                  {
+                     "port" : 12345
+                  }
+               ],
+               "name" : "unique_device_name4"
+            },
+            {
+               "address" : "57.48.0.6",
+               "applications" : [
+                  {
+                     "port" : 12345
+                  }
+               ],
+               "name" : "unique_device_name5"
+            },
+            {
+               "address" : "57.48.0.7",
+               "applications" : [
+                  {
+                     "port" : 12345
+                  }
+               ],
+               "name" : "unique_device_name6"
+            },
+            {
+               "address" : "57.48.0.8",
+               "applications" : [
+                  {
+                     "port" : 12345
+                  }
+               ],
+               "name" : "unique_device_name7"
+            },
+            {
+               "address" : "57.48.0.9",
+               "applications" : [
+                  {
+                     "port" : 12345
+                  }
+               ],
+               "name" : "unique_device_name8"
+            },
+            {
+               "address" : "57.48.0.10",
+               "applications" : [
+                  {
+                     "port" : 12345
+                  }
+               ],
+               "name" : "unique_device_name9"
+            }
+         ]
+      }
+   }
+}

--- a/src/components/transport_manager/test/transport_manager_default_test.cc
+++ b/src/components/transport_manager/test/transport_manager_default_test.cc
@@ -41,31 +41,40 @@ namespace components {
 namespace transport_manager_test {
 
 using ::testing::Return;
+
+namespace {
+const std::string kAppStorageFolder = "app_storage_folder";
+const std::string kAppInfoStorage = "app_info_storage2.txt";
+}  // namespace
+
 TEST(TestTransportManagerDefault, Init_LastStateNotUsed) {
   MockTransportManagerSettings transport_manager_settings;
   transport_manager::TransportManagerDefault transport_manager(
       transport_manager_settings);
-  resumption::LastState last_state("app_storage_folder", "app_info_storage");
+  resumption::LastState last_state(kAppStorageFolder, kAppInfoStorage);
 
   EXPECT_CALL(transport_manager_settings, use_last_state())
       .WillRepeatedly(Return(false));
   EXPECT_CALL(transport_manager_settings, transport_manager_tcp_adapter_port())
       .WillRepeatedly(Return(1u));
   transport_manager.Init(last_state);
+  transport_manager.Stop();
 }
 
-// TODO(VVeremjova) APPLINK-22021
+// TODO(VlAntonov) APPLINK-27939
 TEST(TestTransportManagerDefault, DISABLED_Init_LastStateUsed) {
   MockTransportManagerSettings transport_manager_settings;
   transport_manager::TransportManagerDefault transport_manager(
       transport_manager_settings);
-  resumption::LastState last_state("app_storage_folder", "app_info_storage");
+  resumption::LastState last_state(kAppStorageFolder, kAppInfoStorage);
 
   EXPECT_CALL(transport_manager_settings, use_last_state())
       .WillRepeatedly(Return(true));
   EXPECT_CALL(transport_manager_settings, transport_manager_tcp_adapter_port())
       .WillRepeatedly(Return(1u));
+
   transport_manager.Init(last_state);
+  transport_manager.Stop();
 }
 
 }  // namespace transport_manager_test

--- a/src/components/transport_manager/test/transport_manager_impl_test.cc
+++ b/src/components/transport_manager/test/transport_manager_impl_test.cc
@@ -70,6 +70,7 @@ class TransportManagerImplTest : public ::testing::Test {
  protected:
   TransportManagerImplTest()
       : tm_(settings)
+      , mock_adapter_(NULL)
       , device_handle_(1)
       , mac_address_("MA:CA:DR:ES:S")
       , dev_info_(device_handle_, mac_address_, "TestDeviceName", "BTMAC") {}
@@ -507,6 +508,7 @@ TEST_F(TransportManagerImplTest, SendMessageToDevice) {
   EXPECT_CALL(mock_metric_observer_, StartRawMsg(test_message_.get()));
 #endif  // TELEMETRY_MONITOR
   EXPECT_EQ(E_SUCCESS, tm_.SendMessageToDevice(test_message_));
+
   testing::Mock::AsyncVerifyAndClearExpectations(kAsyncExpectationsTimeout);
 }
 
@@ -640,7 +642,8 @@ TEST_F(TransportManagerImplTest, UpdateDeviceList_AddNewDevice) {
 
 struct DeviceInfoComparator {
   const transport_manager::DeviceInfo& val_;
-  DeviceInfoComparator(const transport_manager::DeviceInfo& val) : val_(val) {}
+  explicit DeviceInfoComparator(const transport_manager::DeviceInfo& val)
+      : val_(val) {}
 
   bool operator()(const transport_manager::DeviceInfo& val) const {
     return val_.name() == val.name() &&
@@ -689,6 +692,7 @@ TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_OnSearchDeviceDone) {
   EXPECT_CALL(*tm_listener_, OnScanDevicesFinished());
 
   tm_.ReceiveEventFromDevice(test_event);
+
   testing::Mock::AsyncVerifyAndClearExpectations(kAsyncExpectationsTimeout);
 }
 
@@ -707,6 +711,7 @@ TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_OnSearchDeviceFail) {
   EXPECT_CALL(*tm_listener_, OnScanDevicesFailed(_));
 
   tm_.ReceiveEventFromDevice(test_event);
+
   testing::Mock::AsyncVerifyAndClearExpectations(kAsyncExpectationsTimeout);
 }
 
@@ -741,6 +746,7 @@ TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_DeviceListUpdated) {
 
   tm_.ReceiveEventFromDevice(test_event);
   device_list_.pop_back();
+
   testing::Mock::AsyncVerifyAndClearExpectations(kAsyncExpectationsTimeout);
 }
 

--- a/src/components/utils/src/threads/thread_delegate_posix.cc
+++ b/src/components/utils/src/threads/thread_delegate_posix.cc
@@ -49,6 +49,7 @@ void ThreadDelegate::exitThreadMain() {
     if (thread_->IsCurrentThread()) {
       pthread_exit(NULL);
     } else {
+      DCHECK(!"Thread termination by force should be avoided!")
       pthread_cancel(thread_->thread_handle());
     }
   }

--- a/src/components/utils/src/threads/thread_delegate_qt.cc
+++ b/src/components/utils/src/threads/thread_delegate_qt.cc
@@ -47,6 +47,7 @@ void ThreadDelegate::exitThreadMain() {
     if (thread_->IsCurrentThread()) {
       DCHECK(!"Cannot terminate self");
     } else {
+      DCHECK(!"Thread termination by force should be avoided!")
       emit TerminateThread();
     }
   }

--- a/src/components/utils/src/threads/thread_delegate_win.cc
+++ b/src/components/utils/src/threads/thread_delegate_win.cc
@@ -47,6 +47,7 @@ void ThreadDelegate::exitThreadMain() {
     if (thread_->IsCurrentThread()) {
       ExitThread(kThreadCancelledExitCode);
     } else {
+      DCHECK(!"Thread termination by force should be avoided!")
       TerminateThread(thread_->thread_handle(), kThreadCancelledExitCode);
     }
   }

--- a/src/components/utils/test/async_runner_test.cc
+++ b/src/components/utils/test/async_runner_test.cc
@@ -37,6 +37,7 @@
 
 #include "utils/lock.h"
 #include "utils/conditional_variable.h"
+#include "utils/atomic_object.h"
 #include "utils/threads/async_runner.h"
 
 namespace test {
@@ -53,9 +54,10 @@ uint32_t check_value = 0;
 // ThreadDelegate successor
 class TestThreadDelegate : public ThreadDelegate {
  public:
-  void threadMain() {
+  void threadMain() OVERRIDE {
     ++check_value;
   }
+  void exitThreadMain() OVERRIDE {}
 };
 
 class AsyncRunnerTest : public ::testing::Test {


### PR DESCRIPTION
- Added overrides of exitThreadMain method in derived delegates instead of base implementation.
- Added warning and assertinon in the ThreadDelegate to avoid the force termination of threads.

Related issue: [APPLINK-27410](https://adc.luxoft.com/jira/browse/APPLINK-27410)