### PR TITLE
Activate TestTransportManagerDefault_Init_LastStateUsed test

### DIFF
--- a/src/components/hmi_message_handler/src/mqueue_adapter.cc
+++ b/src/components/hmi_message_handler/src/mqueue_adapter.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,6 +29,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include <time.h>
 
 #include "hmi_message_handler/mqueue_adapter.h"
 #include "hmi_message_handler/hmi_message_handler.h"

--- a/src/components/transport_manager/test/transport_manager_default_test.cc
+++ b/src/components/transport_manager/test/transport_manager_default_test.cc
@@ -61,8 +61,7 @@ TEST(TestTransportManagerDefault, Init_LastStateNotUsed) {
   transport_manager.Stop();
 }
 
-// TODO(VlAntonov) APPLINK-27939
-TEST(TestTransportManagerDefault, DISABLED_Init_LastStateUsed) {
+TEST(TestTransportManagerDefault, Init_LastStateUsed) {
   MockTransportManagerSettings transport_manager_settings;
   transport_manager::TransportManagerDefault transport_manager(
       transport_manager_settings);


### PR DESCRIPTION
The reported deadlock on thread create under Windows Qt was not reproduced.

Related issue: [APPLINK-27939](https://adc.luxoft.com/jira/browse/APPLINK-27939)