### PR TITLE
Fix HMI resumption after activation

### DIFF
--- a/src/components/application_manager/src/resumption/resume_ctrl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl.cc
@@ -300,7 +300,6 @@ bool ResumeCtrl::StartResumption(ApplicationSharedPtr application,
                           << " hmi_app_id = " << application->hmi_app_id()
                           << " policy_id = " << application->policy_app_id()
                           << " received hash = " << hash);
-  SetupDefaultHMILevel(application);
   smart_objects::SmartObject saved_app;
   const std::string& device_mac = application->mac_address();
   bool result = resumption_storage_->GetSavedApplication(
@@ -326,7 +325,6 @@ bool ResumeCtrl::StartResumptionOnlyHMILevel(ApplicationSharedPtr application) {
                     << application->app_id() << "with hmi_app_id "
                     << application->hmi_app_id() << ", policy_app_id "
                     << application->policy_app_id());
-  SetupDefaultHMILevel(application);
   const std::string& device_mac = application->mac_address();
   smart_objects::SmartObject saved_app;
   bool result = resumption_storage_->GetSavedApplication(


### PR DESCRIPTION
This pull request is a fix for issue #805.

If an HMI application is activated to HMI level FULL, it could still be
resumed which causes the application to then receive HMI level NONE.

This is because the HMI level is set during the initial resumption
function using `SetupDefaultHMILevel` which currently only sets the HMI
level to NONE.

The HMI level should only be set if resumption is still needed.  This
occurs in the `StartAppHmiStateResumption` function. If the app is
activated, it is removed from the resumption queue in
`RemoveFromResumption`. This ensures that the HMI is not set during
resumption when the app is already active.

Therefore, there is no need to have `SetupDefaultHMILevel` in the
initial resume function since `SetupDefaultHMILevel` should only be
called when the app actually needs resumption.