### PR TITLE
Fix compile errors when ENABLE_LOG is 0

### DIFF
--- a/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -32,6 +32,7 @@
  */
 
 #include <string>
+#include <cstring>
 #include <algorithm>
 #include <vector>
 #include "application_manager/commands/mobile/create_interaction_choice_set_request.h"

--- a/src/components/application_manager/src/resumption/resume_ctrl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl.cc
@@ -658,7 +658,6 @@ bool ResumeCtrl::CheckAppRestrictions(
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK_OR_RETURN(saved_app.keyExists(strings::hmi_level), false);
 
-  const bool is_media_app = application->is_media_application();
   const HMILevel::eType hmi_level =
       static_cast<HMILevel::eType>(saved_app[strings::hmi_level].asInt());
   const bool result = Compare<HMILevel::eType, EQ, ONE>(
@@ -666,8 +665,9 @@ bool ResumeCtrl::CheckAppRestrictions(
                           ? true
                           : false;
   LOG4CXX_DEBUG(logger_,
-                "is_media_app " << is_media_app << "; hmi_level " << hmi_level
-                                << " result " << result);
+                "is_media_app " << application->is_media_application()
+                                << "; hmi_level " << hmi_level << " result "
+                                << result);
   return result;
 }
 

--- a/src/components/include/utils/logger.h
+++ b/src/components/include/utils/logger.h
@@ -137,9 +137,11 @@ log4cxx_time_t time_now();
 
 #define CREATE_LOGGERPTR_LOCAL(logger_var, logger_name)
 
-#define INIT_LOGGER(file_name)
+#define INIT_LOGGER(file_name, logs_enabled)
 
-#define DEINIT_LOGGER(file_name)
+#define DEINIT_LOGGER()
+
+#define FLUSH_LOGGER()
 
 #define LOG4CXX_IS_TRACE_ENABLED(logger) false
 

--- a/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
+++ b/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
@@ -751,21 +751,20 @@ void TransportAdapterImpl::ConnectFailed(const DeviceUID& device_handle,
 void TransportAdapterImpl::RemoveFinalizedConnection(
     const DeviceUID& device_handle, const ApplicationHandle& app_handle) {
   const DeviceUID device_uid = device_handle;
-  const ApplicationHandle app_uid = app_handle;
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoWriteLock lock(connections_lock_);
   ConnectionMap::iterator it_conn =
       connections_.find(std::make_pair(device_uid, app_handle));
   if (it_conn == connections_.end()) {
     LOG4CXX_WARN(logger_,
-                 "Device_id: " << &device_uid << ", app_handle: " << &app_uid
+                 "Device_id: " << &device_uid << ", app_handle: " << &app_handle
                                << " connection not found");
     return;
   }
   const ConnectionInfo& info = it_conn->second;
   if (info.state != ConnectionInfo::FINALISING) {
     LOG4CXX_WARN(logger_,
-                 "Device_id: " << &device_uid << ", app_handle: " << &app_uid
+                 "Device_id: " << &device_uid << ", app_handle: " << &app_handle
                                << " connection not finalized");
     return;
   }

--- a/src/components/utils/src/custom_string.cc
+++ b/src/components/utils/src/custom_string.cc
@@ -37,6 +37,7 @@
 #include <cwctype>
 #include <new>
 #include <algorithm>
+#include <vector>
 #include <string.h>
 #include "utils/logger.h"
 #include "utils/macro.h"


### PR DESCRIPTION
After running cmake with flag -DENABLE_LOG=0, sdl_core fails to build with make.

This pull request fixes the issues that occur so that sdl_core can now be compiled with ENABLE_LOG=0.