### PR TITLE
Fix HMI NONE after activation

### DIFF
--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -590,9 +590,9 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
                                             application->mac_address());
   }
 
+  SendResponse(true, result_code, add_info.c_str(), &response_params);
   SendOnAppRegisteredNotificationToHMI(
       *(application.get()), resumption, need_restore_vr);
-  SendResponse(true, result_code, add_info.c_str(), &response_params);
 
   // Check if application exists, because application might be unregestered
   // during sending reponse to mobile.


### PR DESCRIPTION
This is a different fix for issue #805. The other fix is pull request #829, which may not conform to requirements.  This fix still allows default HMI to be immediately assigned on resumption.  This change allows resumption to occur immediately after the HMI is notified of an app registration.

If an HMI activates an application immediately after receving a
register app notification, then the mobile application could receive a
HMI FULL notification from the activation and then an HMI NONE
notification. The HMI NONE notification comes from the resumption
function following the HMI and mobile responses.

By sending the HMI notification last, we can ensure that resumption will
follow before the HMI sends an `ActivateApp`. With this commit, the
mobile application will first be notified of successful registration and
then the HMI will be notified.