### PR TITLE
Fix for activate app hanging

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -959,7 +959,9 @@ void PolicyHandler::OnIgnitionCycleOver() {
 void PolicyHandler::OnActivateApp(uint32_t connection_key,
                                   uint32_t correlation_id) {
   LOG4CXX_AUTO_TRACE(logger_);
-  POLICY_LIB_CHECK_VOID();
+  if(PolicyEnabled()) {
+    POLICY_LIB_CHECK_VOID();
+  }
   ApplicationSharedPtr app = application_manager_.application(connection_key);
   if (!app.valid()) {
     LOG4CXX_WARN(logger_, "Activated App failed: no app found.");


### PR DESCRIPTION
POLICY_LIB_CHECK_VOID() crashes the policy handler thread when policies are disabled.
