### PR TITLE
Enable code coverage count for commands

### DIFF
--- a/tools/infrastructure/collect_coverage.sh
+++ b/tools/infrastructure/collect_coverage.sh
@@ -18,7 +18,7 @@ rm -rf $REPORTS_DIR -
 
 mkdir $COVERAGE_DIR
 lcov --quiet --capture --directory . --output-file $COVERAGE_DIR/full_report.info
-lcov --quiet --remove $COVERAGE_DIR/full_report.info '/usr/*' '*/test/*' '*/commands/*' '*/src/3rd*' '*/build/src/*'  --output-file $COVERAGE_DIR/coverage.info
+lcov --quiet --remove $COVERAGE_DIR/full_report.info '/usr/*' '*/test/*'  '*/src/3rd*' '*/build/src/*'  --output-file $COVERAGE_DIR/coverage.info
 
 mkdir $REPORTS_DIR
 genhtml --quiet $COVERAGE_DIR/coverage.info --output-directory $REPORTS_DIR


### PR DESCRIPTION
Enable code coverage count for commands in collect_coverage.sh

Related:[APPLINK-28144](https://adc.luxoft.com/jira/browse/APPLINK-28144)

Please rewiev @AByzhynar @LuxoftAKutsan 