### PR TITLE
Fix/validate response from hmi in get way points genivi

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/get_way_points_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/get_way_points_request.h
@@ -44,6 +44,7 @@ namespace commands {
  **/
 class GetWayPointsRequest : public CommandRequestImpl {
  public:
+  typedef std::set<std::string>::const_iterator ConstSetIter;
   /**
    * \brief GetWayPointsRequest class constructor
    **/
@@ -66,11 +67,6 @@ class GetWayPointsRequest : public CommandRequestImpl {
    */
   virtual void on_event(const event_engine::Event& event) OVERRIDE;
 
-  /**
-   * @brief Will caled by request controller, when default will be expired.
-   */
-  void onTimeOut() OVERRIDE;
-
  private:
   /**
    * @brief Validate response from HMI
@@ -90,7 +86,7 @@ class GetWayPointsRequest : public CommandRequestImpl {
    * @param message from HMI to check
    */
   bool ValidateSmartMapResponse(const smart_objects::SmartObject& obj,
-                                std::set<std::string>::const_iterator key);
+                                ConstSetIter key);
   DISALLOW_COPY_AND_ASSIGN(GetWayPointsRequest);
 };
 

--- a/src/components/application_manager/include/application_manager/commands/mobile/get_way_points_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/get_way_points_request.h
@@ -66,7 +66,31 @@ class GetWayPointsRequest : public CommandRequestImpl {
    */
   virtual void on_event(const event_engine::Event& event) OVERRIDE;
 
+  /**
+   * @brief Will caled by request controller, when default will be expired.
+   */
+  void onTimeOut() OVERRIDE;
+
  private:
+  /**
+   * @brief Validate response from HMI
+   *
+   * @param message from HMI to check
+   */
+  bool ValidateResponseFromHMI(const smart_objects::SmartObject& obj);
+  /**
+   * @brief Check message syntax
+   *
+   * @param message from HMI to check
+   */
+  bool CheckResponseSyntax(const smart_objects::SmartObject& obj);
+  /**
+   * @brief Validate SmartMap message from HMI
+   *
+   * @param message from HMI to check
+   */
+  bool ValidateSmartMapResponse(const smart_objects::SmartObject& obj,
+                                std::set<std::string>::const_iterator key);
   DISALLOW_COPY_AND_ASSIGN(GetWayPointsRequest);
 };
 

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -158,6 +158,7 @@ extern const char* speech_capabilities;
 extern const char* vr_capabilities;
 extern const char* audio_pass_thru_capabilities;
 extern const char* pcm_stream_capabilities;
+extern const char* way_points;
 
 // PutFile
 extern const char* sync_file_name;

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1785,7 +1785,7 @@ bool HandleWrongMessageType(smart_objects::SmartObject& output) {
       output[strings::params][hmi_response::code] =
           hmi_apis::Common_Result::GENERIC_ERROR;
       output[strings::msg_params][strings::info] =
-          std::string("Invalid message received from vehicle");
+          "Invalid message received from vehicle";
       SDL_ERROR("Received invalid data on HMI response");
     }
   }

--- a/src/components/application_manager/src/commands/mobile/get_way_points_request.cc
+++ b/src/components/application_manager/src/commands/mobile/get_way_points_request.cc
@@ -5,6 +5,13 @@ namespace application_manager {
 
 namespace commands {
 
+namespace {
+using NsSmartDeviceLink::NsSmartObjects::SmartType_Map;
+using NsSmartDeviceLink::NsSmartObjects::SmartType_String;
+using NsSmartDeviceLink::NsSmartObjects::SmartType_Array;
+typedef std::set<std::string>::const_iterator ConstSetIter;
+}
+
 GetWayPointsRequest::GetWayPointsRequest(
     const MessageSharedPtr& message, ApplicationManager& application_manager)
     : CommandRequestImpl(message, application_manager) {}
@@ -32,18 +39,104 @@ void GetWayPointsRequest::Run() {
                  true);
 }
 
+bool GetWayPointsRequest::CheckResponseSyntax(
+    const smart_objects::SmartObject& obj) {
+  const char* str = obj.asCharArray();
+  const bool is_str_empty = str && !str[0];
+  return is_str_empty || CheckSyntax(str);
+}
+
+bool GetWayPointsRequest::ValidateSmartMapResponse(
+    const smart_objects::SmartObject& obj, ConstSetIter key) {
+  const smart_objects::SmartObject& value = obj[*key];
+  switch (value.getType()) {
+    case SmartType_Array:
+    case SmartType_Map: {
+      return ValidateResponseFromHMI(value);
+    }
+    case SmartType_String: {
+      return CheckResponseSyntax(value);
+    }
+    default:
+      // Catch SmartType_Integer or SmartType_Double
+      break;
+  }
+  return true;
+}
+
+bool GetWayPointsRequest::ValidateResponseFromHMI(
+    const smart_objects::SmartObject& obj) {
+  switch (obj.getType()) {
+    case SmartType_Array: {
+      for (uint32_t i = 0; i < obj.length(); ++i) {
+        if (!ValidateResponseFromHMI(obj[i])) {
+          return false;
+        }
+      }
+      break;
+    }
+    case SmartType_Map: {
+      const std::set<std::string> keys = obj.enumerate();
+      for (ConstSetIter key = keys.begin(); key != keys.end(); key++) {
+        if (!ValidateSmartMapResponse(obj, key)) {
+          return false;
+        }
+      }
+      break;
+    }
+    case SmartType_String: {
+      return CheckResponseSyntax(obj);
+    }
+    default:
+      // Catch SmartType_Integer or SmartType_Double
+      break;
+  }
+  return true;
+}
+
+void GetWayPointsRequest::onTimeOut() {
+  SDL_AUTO_TRACE();
+  SendResponse(false,
+               mobile_apis::Result::GENERIC_ERROR,
+               "Invalid response from system");
+}
+
 void GetWayPointsRequest::on_event(const event_engine::Event& event) {
   SDL_AUTO_TRACE();
-  ApplicationSharedPtr app = application_manager_.application(connection_key());
-  const smart_objects::SmartObject& message = event.smart_object();
+  smart_objects::SmartObject message = event.smart_object();
   switch (event.id()) {
     case hmi_apis::FunctionID::Navigation_GetWayPoints: {
       SDL_INFO("Received Navigation_GetWayPoints event");
+      const bool all_checks_passed = ValidateResponseFromHMI(
+          message[strings::msg_params][strings::way_points]);
+      const char* response_info =
+          message[strings::params][hmi_response::message].asCharArray();
       mobile_apis::Result::eType result_code =
           GetMobileResultCode(static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asUInt()));
-      bool result = mobile_apis::Result::SUCCESS == result_code;
-      SendResponse(result, result_code, NULL, &(message[strings::msg_params]));
+      const bool result = mobile_apis::Result::SUCCESS == result_code;
+
+      if(!result) {
+        SendResponse(false,
+                     result_code,
+                     "Invalid response from system");
+        return;
+      }
+      if (!CheckSyntax(response_info)) {
+        response_info = NULL;
+      }
+
+      message[strings::msg_params].erase(strings::info);
+      if (all_checks_passed) {
+        SendResponse(result,
+                     result_code,
+                     response_info,
+                     &(message[strings::msg_params]));
+      } else {
+        SendResponse(false,
+                     mobile_apis::Result::GENERIC_ERROR,
+                     "Invalid response from system");
+      }
       break;
     }
     default: {

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -125,6 +125,7 @@ const char* speech_capabilities = "speechCapabilities";
 const char* vr_capabilities = "vrCapabilities";
 const char* audio_pass_thru_capabilities = "audioPassThruCapabilities";
 const char* pcm_stream_capabilities = "pcmStreamCapabilities";
+const char* way_points = "wayPoints";
 // PutFile
 const char* sync_file_name = "syncFileName";
 const char* file_name = "fileName";

--- a/src/components/application_manager/test/commands/mobile/get_way_points_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/get_way_points_request_test.cc
@@ -82,13 +82,14 @@ class GetWayPointsRequestTest
 
   MockAppPtr mock_app_;
   MessageSharedPtr message_;
-  utils::SharedPtr<application_manager::commands::GetWayPointsRequest> command_sptr_;
+  utils::SharedPtr<application_manager::commands::GetWayPointsRequest>
+      command_sptr_;
 };
 
-class GetWayPointsRequestTest2
+class GetWayPointsRequestOnEventTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  GetWayPointsRequestTest2() : app_(CreateMockApp()) {}
+  GetWayPointsRequestOnEventTest() : app_(CreateMockApp()) {}
 
   void CheckOnEventResponse(const std::string& wayPointsParam,
                             const MobileResult ResultCode,
@@ -124,7 +125,8 @@ class GetWayPointsRequestTest2
 
 TEST_F(GetWayPointsRequestTest,
        Run_InvalidApp_ApplicationNotRegisteredResponce) {
-  (*message_)[am::strings::params][am::strings::connection_key] = kConnectionKey;
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
 
   utils::SharedPtr<am::Application> null_application_sptr;
   EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
@@ -136,13 +138,15 @@ TEST_F(GetWayPointsRequestTest,
 
   const mobile_apis::Result::eType result =
       static_cast<mobile_apis::Result::eType>(
-          (*result_message)[am::strings::msg_params][am::strings::result_code].asInt());
+          (*result_message)[am::strings::msg_params][am::strings::result_code]
+              .asInt());
 
   EXPECT_EQ(mobile_apis::Result::APPLICATION_NOT_REGISTERED, result);
 }
 
 TEST_F(GetWayPointsRequestTest, Run_ApplicationRegistered_Success) {
-  (*message_)[am::strings::params][am::strings::connection_key] = kConnectionKey;
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
 
   MockAppPtr application_sptr = CreateMockApp();
 
@@ -159,12 +163,13 @@ TEST_F(GetWayPointsRequestTest, Run_ApplicationRegistered_Success) {
 
   const hmi_apis::FunctionID::eType result_function_id =
       static_cast<hmi_apis::FunctionID::eType>(
-          (*result_message)[am::strings::params][am::strings::function_id].asInt());
+          (*result_message)[am::strings::params][am::strings::function_id]
+              .asInt());
 
   EXPECT_EQ(hmi_apis::FunctionID::Navigation_GetWayPoints, result_function_id);
-  EXPECT_EQ(
-      kCorrelationId,
-      (*result_message)[am::strings::params][am::strings::correlation_id].asUInt());
+  EXPECT_EQ(kCorrelationId,
+            (*result_message)[am::strings::params][am::strings::correlation_id]
+                .asUInt());
 }
 
 TEST_F(GetWayPointsRequestTest,
@@ -182,7 +187,8 @@ TEST_F(GetWayPointsRequestTest,
 
   const mobile_apis::Result::eType result =
       static_cast<mobile_apis::Result::eType>(
-          (*result_message)[am::strings::msg_params][am::strings::result_code].asInt());
+          (*result_message)[am::strings::msg_params][am::strings::result_code]
+              .asInt());
 
   EXPECT_EQ(mobile_apis::Result::SUCCESS, result);
 }
@@ -199,7 +205,7 @@ TEST_F(GetWayPointsRequestTest, OnEvent_DefaultCase) {
   caller();
 }
 
-TEST_F(GetWayPointsRequestTest2, OnEvent_WrongEventId_UNSUCCESS) {
+TEST_F(GetWayPointsRequestOnEventTest, OnEvent_WrongEventId_UNSUCCESS) {
   Event event(Event::EventID::INVALID_ENUM);
   CommandPtr command(CreateCommand<GetWayPointsRequest>());
 
@@ -207,31 +213,31 @@ TEST_F(GetWayPointsRequestTest2, OnEvent_WrongEventId_UNSUCCESS) {
   command->on_event(event);
 }
 
-TEST_F(GetWayPointsRequestTest2, OnEvent_Expect_SUCCESS_Case1) {
+TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_SUCCESS_Case1) {
   CheckOnEventResponse("0", SUCCESS, true);
 }
 
-TEST_F(GetWayPointsRequestTest2, OnEvent_Expect_SUCCESS_Case2) {
+TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_SUCCESS_Case2) {
   CheckOnEventResponse("", SUCCESS, true);
 }
 
-TEST_F(GetWayPointsRequestTest2, OnEvent_Expect_SUCCESS_Case3) {
+TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_SUCCESS_Case3) {
   CheckOnEventResponse("test", SUCCESS, true);
 }
 
-TEST_F(GetWayPointsRequestTest2, OnEvent_Expect_GENERIC_ERROR_Case1) {
+TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_GENERIC_ERROR_Case1) {
   CheckOnEventResponse("    ", GENERIC_ERROR, false);
 }
 
-TEST_F(GetWayPointsRequestTest2, OnEvent_Expect_GENERIC_ERROR_Case2) {
+TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_GENERIC_ERROR_Case2) {
   CheckOnEventResponse("test\t", GENERIC_ERROR, false);
 }
 
-TEST_F(GetWayPointsRequestTest2, OnEvent_Expect_GENERIC_ERROR_Case3) {
+TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_GENERIC_ERROR_Case3) {
   CheckOnEventResponse("test\n", GENERIC_ERROR, false);
 }
 
-TEST_F(GetWayPointsRequestTest2, OnEvent_Expect_GENERIC_ERROR_Case4) {
+TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_GENERIC_ERROR_Case4) {
   CheckOnEventResponse("test\t\n", GENERIC_ERROR, false);
 }
 


### PR DESCRIPTION
###Pull request changes:
- Move  Fix message validation from HMI in GetWayPoints
- Move  Fix Send GENERIC_ERROR in case invalid HMI's response
- Move related Unit tests

Related: [APPLINK-28150](https://adc.luxoft.com/jira/browse/APPLINK-28150)

