### PR TITLE
Fix TestObject classes in the same namespace

### DIFF
--- a/src/components/utils/test/scope_guard_test.cc
+++ b/src/components/utils/test/scope_guard_test.cc
@@ -44,7 +44,7 @@ using ::utils::MakeGuard;
 using ::utils::MakeObjGuard;
 using ::testing::Mock;
 
-class TestObject {
+class ScopeGuardTestObject {
  public:
   MOCK_METHOD0(function_to_call, void());
   MOCK_METHOD1(function_to_call_with_param, void(void*));
@@ -69,22 +69,23 @@ TEST(ScopeGuardTest, CallFreeFunctionWithParam) {
 }
 
 TEST(ScopeGuardTest, CallObjectFunction) {
-  TestObject obj;
+  ScopeGuardTestObject obj;
   Mock::AllowLeak(&obj);  // Google tests bug
   EXPECT_CALL(obj, function_to_call()).Times(1);
   {
-    ScopeGuard guard = MakeObjGuard(obj, &TestObject::function_to_call);
+    ScopeGuard guard =
+        MakeObjGuard(obj, &ScopeGuardTestObject::function_to_call);
     UNUSED(guard);
   }
 }
 
 TEST(ScopeGuardTest, CallObjectFunctionWithParam) {
-  TestObject obj;
+  ScopeGuardTestObject obj;
   Mock::AllowLeak(&obj);  // Google tests bug
   EXPECT_CALL(obj, function_to_call_with_param(&obj)).Times(1);
   {
-    ScopeGuard guard =
-        MakeObjGuard(obj, &TestObject::function_to_call_with_param, &obj);
+    ScopeGuard guard = MakeObjGuard(
+        obj, &ScopeGuardTestObject::function_to_call_with_param, &obj);
     UNUSED(guard);
   }
 }
@@ -100,20 +101,21 @@ TEST(ScopeGuardTest, DismissCallFreeFunctionWithParam) {
 }
 
 TEST(ScopeGuardTest, DismissCallObjectFunction) {
-  TestObject obj;
+  ScopeGuardTestObject obj;
   EXPECT_CALL(obj, function_to_call()).Times(0);
   {
-    ScopeGuard guard = MakeObjGuard(obj, &TestObject::function_to_call);
+    ScopeGuard guard =
+        MakeObjGuard(obj, &ScopeGuardTestObject::function_to_call);
     guard.Dismiss();
   }
 }
 
 TEST(ScopeGuardTest, DismissCallObjectFunctionWithParam) {
-  TestObject obj;
+  ScopeGuardTestObject obj;
   EXPECT_CALL(obj, function_to_call_with_param(&obj)).Times(0);
   {
-    ScopeGuard guard =
-        MakeObjGuard(obj, &TestObject::function_to_call_with_param, &obj);
+    ScopeGuard guard = MakeObjGuard(
+        obj, &ScopeGuardTestObject::function_to_call_with_param, &obj);
     guard.Dismiss();
   }
 }

--- a/src/components/utils/test/stl_utils_test.cc
+++ b/src/components/utils/test/stl_utils_test.cc
@@ -42,17 +42,17 @@ namespace utils_test {
 using ::utils::StlCollectionDeleter;
 using ::utils::StlMapDeleter;
 
-class TestObject {
+class STLTestObject {
  public:
-  ~TestObject() {}
+  ~STLTestObject() {}
 };
 
-typedef std::map<int, TestObject*> TestMap;
-typedef std::vector<TestObject*> TestVector;
+typedef std::map<int, STLTestObject*> TestMap;
+typedef std::vector<STLTestObject*> TestVector;
 
 TEST(StlDeleter, DestructMapWithOneElement) {
   TestMap test_map;
-  test_map[1] = new TestObject();
+  test_map[1] = new STLTestObject();
 
   EXPECT_EQ(1u, test_map.size());
   { StlMapDeleter<TestMap> test_list_deleter_(&test_map); }
@@ -62,8 +62,8 @@ TEST(StlDeleter, DestructMapWithOneElement) {
 
 TEST(StlDeleter, DestructMapWithSeveralElements) {
   TestMap test_map;
-  test_map[1] = new TestObject();
-  test_map[2] = new TestObject();
+  test_map[1] = new STLTestObject();
+  test_map[2] = new STLTestObject();
 
   EXPECT_EQ(2u, test_map.size());
   { StlMapDeleter<TestMap> test_list_deleter_(&test_map); }
@@ -74,7 +74,7 @@ TEST(StlDeleter, DestructMapWithSeveralElements) {
 
 TEST(StlDeleter, DestructVectorWithOneElement) {
   TestVector test_vector;
-  test_vector.push_back(new TestObject());
+  test_vector.push_back(new STLTestObject());
 
   EXPECT_EQ(1u, test_vector.size());
   { StlCollectionDeleter<TestVector> test_list_deleter_(&test_vector); }
@@ -84,8 +84,8 @@ TEST(StlDeleter, DestructVectorWithOneElement) {
 
 TEST(StlDeleter, DestructVectorWithSeveralElements) {
   TestVector test_vector;
-  test_vector.push_back(new TestObject());
-  test_vector.push_back(new TestObject());
+  test_vector.push_back(new STLTestObject());
+  test_vector.push_back(new STLTestObject());
 
   EXPECT_EQ(2u, test_vector.size());
   { StlCollectionDeleter<TestVector> test_list_deleter_(&test_vector); }


### PR DESCRIPTION
There are two TestObject classes in the same namespace.
This can cause problems at linking.
This PR will rename them.

Related issue: [APPLINK-28224](https://adc.luxoft.com/jira/browse/APPLINK-28224)