### PR TITLE
Cover commands with unit tests

### DIFF
--- a/src/components/application_manager/src/commands/hmi/response_from_hmi.cc
+++ b/src/components/application_manager/src/commands/hmi/response_from_hmi.cc
@@ -32,6 +32,7 @@
 
 #include "application_manager/commands/hmi/response_from_hmi.h"
 #include "smart_objects/smart_object.h"
+#include "utils/make_shared.h"
 
 namespace application_manager {
 
@@ -72,12 +73,8 @@ void ResponseFromHMI::SendResponseToMobile(
 void ResponseFromHMI::CreateHMIRequest(
     const hmi_apis::FunctionID::eType& function_id,
     const smart_objects::SmartObject& msg_params) const {
-  smart_objects::SmartObjectSPtr result = new smart_objects::SmartObject;
-
-  if (!result) {
-    SDL_ERROR("Memory allocation failed.");
-    return;
-  }
+  smart_objects::SmartObjectSPtr result =
+      utils::MakeShared<smart_objects::SmartObject>();
 
   // get hmi correlation id for chaining further request from this object
   const uint32_t hmi_correlation_id_ =

--- a/src/components/application_manager/src/commands/mobile/on_button_event_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_button_event_notification.cc
@@ -35,6 +35,8 @@
 #include "application_manager/application_impl.h"
 #include "interfaces/MOBILE_API.h"
 
+#include "utils/make_shared.h"
+
 namespace application_manager {
 
 namespace commands {
@@ -123,18 +125,8 @@ void OnButtonEventNotification::Run() {
 }
 
 void OnButtonEventNotification::SendButtonEvent(ApplicationConstSharedPtr app) {
-  if (!app) {
-    SDL_ERROR("OnButtonEvent NULL pointer");
-    return;
-  }
-
   smart_objects::SmartObjectSPtr on_btn_event =
-      new smart_objects::SmartObject();
-
-  if (!on_btn_event) {
-    SDL_ERROR("OnButtonEvent NULL pointer");
-    return;
-  }
+      utils::MakeShared<smart_objects::SmartObject>();
 
   (*on_btn_event)[strings::params][strings::connection_key] = app->app_id();
 

--- a/src/components/application_manager/src/commands/mobile/on_button_event_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_button_event_notification.cc
@@ -125,6 +125,11 @@ void OnButtonEventNotification::Run() {
 }
 
 void OnButtonEventNotification::SendButtonEvent(ApplicationConstSharedPtr app) {
+  if (!app) {
+    SDL_ERROR("OnButtonEvent NULL pointer");
+    return;
+  }
+
   smart_objects::SmartObjectSPtr on_btn_event =
       utils::MakeShared<smart_objects::SmartObject>();
 

--- a/src/components/application_manager/src/commands/mobile/on_button_press_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_button_press_notification.cc
@@ -125,6 +125,11 @@ void OnButtonPressNotification::Run() {
 }
 
 void OnButtonPressNotification::SendButtonPress(ApplicationConstSharedPtr app) {
+  if (!app) {
+    SDL_ERROR("OnButtonPress NULL pointer");
+    return;
+  }
+
   smart_objects::SmartObjectSPtr on_btn_press =
       utils::MakeShared<smart_objects::SmartObject>();
 

--- a/src/components/application_manager/src/commands/mobile/on_button_press_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_button_press_notification.cc
@@ -35,6 +35,8 @@
 #include "application_manager/application_impl.h"
 #include "interfaces/MOBILE_API.h"
 
+#include "utils/make_shared.h"
+
 namespace application_manager {
 
 namespace commands {
@@ -123,18 +125,8 @@ void OnButtonPressNotification::Run() {
 }
 
 void OnButtonPressNotification::SendButtonPress(ApplicationConstSharedPtr app) {
-  if (!app) {
-    SDL_ERROR("OnButtonPress NULL pointer");
-    return;
-  }
-
   smart_objects::SmartObjectSPtr on_btn_press =
-      new smart_objects::SmartObject();
-
-  if (!on_btn_press) {
-    SDL_ERROR("OnButtonPress NULL pointer");
-    return;
-  }
+      utils::MakeShared<smart_objects::SmartObject>();
 
   (*on_btn_press)[strings::params][strings::connection_key] = app->app_id();
 

--- a/src/components/application_manager/test/commands/hmi/response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/response_from_hmi_test.cc
@@ -116,6 +116,21 @@ TEST_F(ResponseFromHMITest, CreateHMIRequest_SUCCESS) {
   EXPECT_EQ(kPostedFunctionId, kReceivedFunctionId);
 }
 
+TEST_F(ResponseFromHMITest, CreateHMIRequest_CantManageCommand_Covering) {
+  ResponseFromHMIPtr command(CreateCommand<ResponseFromHMI>());
+
+  MessageSharedPtr result_msg;
+  ON_CALL(mock_app_manager_, GetNextHMICorrelationID())
+      .WillByDefault(Return(1u));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&result_msg), Return(false)));
+
+  const hmi_apis::FunctionID::eType kPostedFunctionId =
+      hmi_apis::FunctionID::INVALID_ENUM;
+  MessageSharedPtr dummy_msg_params = CreateMessage();
+  command->CreateHMIRequest(kPostedFunctionId, *dummy_msg_params);
+}
+
 }  // namespace response_from_hmi
 }  // namespace hmi_commands_test
 }  // namespace commands_test

--- a/src/components/application_manager/test/commands/hmi/response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/response_from_hmi_test.cc
@@ -81,11 +81,11 @@ TEST_F(ResponseFromHMITest, SendResponseToMobile_SUCCESS) {
 
   command->SendResponseToMobile(msg, mock_app_manager_);
 
-  const application_manager::MessageType kReceivedMessageType =
+  const application_manager::MessageType received_message_tipe =
       static_cast<application_manager::MessageType>(
           (*msg)[am::strings::params][am::strings::message_type].asInt());
 
-  EXPECT_EQ(application_manager::MessageType::kResponse, kReceivedMessageType);
+  EXPECT_EQ(application_manager::MessageType::kResponse, received_message_tipe);
 }
 
 TEST_F(ResponseFromHMITest, CreateHMIRequest_SUCCESS) {
@@ -95,25 +95,25 @@ TEST_F(ResponseFromHMITest, CreateHMIRequest_SUCCESS) {
   EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
       .WillOnce(DoAll(SaveArg<0>(&result_msg), Return(true)));
 
-  const hmi_apis::FunctionID::eType kPostedFunctionId =
+  const hmi_apis::FunctionID::eType posted_function_id =
       hmi_apis::FunctionID::INVALID_ENUM;
   MessageSharedPtr dummy_msg_params = CreateMessage();
-  command->CreateHMIRequest(kPostedFunctionId, *dummy_msg_params);
+  command->CreateHMIRequest(posted_function_id, *dummy_msg_params);
 
   ASSERT_TRUE(result_msg);
 
-  const application_manager::MessageType kReceivedMessageType =
+  const application_manager::MessageType received_message_tipe =
       static_cast<application_manager::MessageType>(
           (*result_msg)[am::strings::params][am::strings::message_type]
               .asInt());
 
-  EXPECT_EQ(am::MessageType::kRequest, kReceivedMessageType);
+  EXPECT_EQ(am::MessageType::kRequest, received_message_tipe);
 
-  const hmi_apis::FunctionID::eType kReceivedFunctionId =
+  const hmi_apis::FunctionID::eType received_function_id =
       static_cast<hmi_apis::FunctionID::eType>(
           (*result_msg)[am::strings::params][am::strings::function_id].asInt());
 
-  EXPECT_EQ(kPostedFunctionId, kReceivedFunctionId);
+  EXPECT_EQ(posted_function_id, received_function_id);
 }
 
 TEST_F(ResponseFromHMITest, CreateHMIRequest_CantManageCommand_Covering) {
@@ -125,10 +125,10 @@ TEST_F(ResponseFromHMITest, CreateHMIRequest_CantManageCommand_Covering) {
   EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
       .WillOnce(DoAll(SaveArg<0>(&result_msg), Return(false)));
 
-  const hmi_apis::FunctionID::eType kPostedFunctionId =
+  const hmi_apis::FunctionID::eType posted_function_id =
       hmi_apis::FunctionID::INVALID_ENUM;
   MessageSharedPtr dummy_msg_params = CreateMessage();
-  command->CreateHMIRequest(kPostedFunctionId, *dummy_msg_params);
+  command->CreateHMIRequest(posted_function_id, *dummy_msg_params);
 }
 
 }  // namespace response_from_hmi

--- a/src/components/application_manager/test/commands/hmi/simple_notifications_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_notifications_test.cc
@@ -54,8 +54,8 @@ class SimpleNotificationsTest
   typedef Command CommandType;
 };
 
-typedef Types<commands::CommandNotificationImpl,
-              commands::NotificationToHMI> CommandsList;
+typedef Types<commands::CommandNotificationImpl, commands::NotificationToHMI>
+    CommandsList;
 
 TYPED_TEST_CASE(SimpleNotificationsTest, CommandsList);
 

--- a/src/components/application_manager/test/commands/hmi/simple_notifications_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_notifications_test.cc
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gtest/gtest.h"
+
+#include "commands/commands_test.h"
+
+#include "hmi/notification_to_hmi.h"
+#include "application_manager/commands/command_notification_impl.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+namespace simple_notifications_test {
+
+using namespace application_manager;
+
+using ::testing::Types;
+
+template <typename Command>
+class SimpleNotificationsTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  typedef Command CommandType;
+};
+
+typedef Types<commands::CommandNotificationImpl,
+              commands::NotificationToHMI> CommandsList;
+
+TYPED_TEST_CASE(SimpleNotificationsTest, CommandsList);
+
+TYPED_TEST(SimpleNotificationsTest, Run_SendMessageToHMI_SUCCESS) {
+  typedef typename TestFixture::CommandType CommandType;
+
+  SharedPtr<CommandType> command = this->template CreateCommand<CommandType>();
+
+  // Current implementation always return `true`
+  EXPECT_TRUE(command->Init());
+  EXPECT_NO_THROW(command->Run());
+  EXPECT_TRUE(command->CleanUp());
+}
+
+}  // namespace simple_notifications_test
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/delete_sub_menu_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_sub_menu_test.cc
@@ -226,6 +226,49 @@ TEST_F(DeleteSubMenuResponseTest, Run_SUCCESS) {
   command->Run();
 }
 
+TEST_F(DeleteSubMenuRequestTest,
+       DeleteSubmenu_CommandhaventVrCommadsAndMenuParams_DontSendHMIRequest) {
+  Event event(hmi_apis::FunctionID::UI_DeleteSubMenu);
+  (*message_)[am::strings::msg_params][am::strings::menu_id] = kMenuId;
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      am::mobile_api::Result::SUCCESS;
+  event.set_smart_object(*message_);
+
+  commands_map_.insert(
+      std::make_pair(0, &((*message_)[am::strings::msg_params])));
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(*app_, commands_map()).Times(2).WillRepeatedly(Return(accessor_));
+  EXPECT_CALL(*app_, RemoveCommand(_)).Times(0);
+
+  command_->on_event(event);
+}
+
+TEST_F(DeleteSubMenuRequestTest,
+       DeleteSubmenu_NotAChildOfMenupartam_DontSendHMIRequest) {
+  Event event(hmi_apis::FunctionID::UI_DeleteSubMenu);
+  (*message_)[am::strings::msg_params][am::strings::menu_id] = kMenuId;
+  (*message_)[am::strings::msg_params][am::strings::menu_params]
+             [am::hmi_request::parent_id] = kMenuId + 1;
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      am::mobile_api::Result::SUCCESS;
+  event.set_smart_object(*message_);
+
+  commands_map_.insert(
+      std::make_pair(0, &((*message_)[am::strings::msg_params])));
+
+  EXPECT_CALL(mock_app_manager_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(*app_, commands_map()).Times(2).WillRepeatedly(Return(accessor_));
+  EXPECT_CALL(*app_, RemoveCommand(_)).Times(0);
+
+  command_->on_event(event);
+}
 }  // namespace delete_sub_menu
 }  // namespace mobile_commands_test
 }  // namespace commands_test

--- a/src/components/application_manager/test/commands/mobile/on_button_notification_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_button_notification_commands_test.cc
@@ -342,6 +342,31 @@ TYPED_TEST(OnButtonNotificationCommandsTest, Run_SUCCESS) {
   command->Run();
 }
 
+TYPED_TEST(OnButtonNotificationCommandsTest,
+           Run_InvalidAppInSubscribed_UNSUCCESS) {
+  typedef typename TestFixture::Notification Notification;
+
+  MessageSharedPtr notification_msg(
+      this->CreateMessage(smart_objects::SmartType_Map));
+
+  (*notification_msg)[am::strings::msg_params][am::hmi_response::button_name] =
+      kButtonName;
+
+  SharedPtr<Notification> command(
+      this->template CreateCommand<Notification>(notification_msg));
+
+  typename TestFixture::MockAppPtr mock_app;
+  std::vector<ApplicationSharedPtr> subscribed_apps_list;
+  subscribed_apps_list.push_back(mock_app);
+
+  EXPECT_CALL(this->mock_app_manager_, applications_by_button(kButtonName))
+      .WillOnce(Return(subscribed_apps_list));
+
+  EXPECT_CALL(this->mock_app_manager_, SendMessageToMobile(_, _)).Times(0);
+
+  command->Run();
+}
+
 }  // namespace on_button_notification {
 }  // namespace mobile_commands_test
 }  // namespace commands_test

--- a/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_from_mobile_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_from_mobile_test.cc
@@ -248,7 +248,7 @@ TEST_F(OnHMIStatusNotificationFromMobileTest,
 }
 
 TEST_F(OnHMIStatusNotificationFromMobileTest,
-       Run_AnotherForegroundSDLApp_SUCCESS) {
+       Run_NotAnotherForegroundSDLApp_SendUpdateAppList) {
   MessageSharedPtr msg = CreateMsgParams(mobile_apis::HMILevel::HMI_FULL);
 
   SharedPtr<OnHMIStatusNotificationFromMobile> command =
@@ -272,6 +272,44 @@ TEST_F(OnHMIStatusNotificationFromMobileTest,
 
   EXPECT_CALL(mock_app_manager_, MarkAppsGreyOut(kHandle, false));
   EXPECT_CALL(mock_app_manager_, SendUpdateAppList());
+
+  command->Run();
+
+  ASSERT_EQ(application_manager::MessageType::kNotification,
+            (*msg)[strings::params][strings::message_type].asInt());
+}
+
+TEST_F(OnHMIStatusNotificationFromMobileTest,
+       Run_AnotherForegroundSDLApp_DontSendUpdateAppList) {
+  MessageSharedPtr msg = CreateMsgParams(mobile_apis::HMILevel::HMI_FULL);
+
+  SharedPtr<OnHMIStatusNotificationFromMobile> command =
+      CreateCommand<OnHMIStatusNotificationFromMobile>(msg);
+
+  MockAppPtr mock_app = CreateMockApp();
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
+  EXPECT_CALL(*mock_app, set_foreground(true));
+
+  EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
+  EXPECT_CALL(mock_app_manager_, IsAppsQueriedFrom(kHandle))
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(*mock_app, protocol_version())
+      .WillOnce(Return(ProtocolVersion::kV4));
+
+  MockAppPtr mock_another_app_sptr = CreateMockApp();
+  app_set_.insert(mock_another_app_sptr);
+  DataAccessor<ApplicationSet> accessor(app_set_, lock_);
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
+
+  EXPECT_CALL(*mock_another_app_sptr, app_id()).WillOnce(Return(2u));
+  EXPECT_CALL(*mock_another_app_sptr, protocol_version())
+      .WillOnce(Return(ProtocolVersion::kV4));
+  EXPECT_CALL(*mock_another_app_sptr, is_foreground()).WillOnce(Return(true));
+
+  EXPECT_CALL(mock_app_manager_, MarkAppsGreyOut(kHandle, false)).Times(0);
+  EXPECT_CALL(mock_app_manager_, SendUpdateAppList()).Times(0);
 
   command->Run();
 

--- a/src/components/application_manager/test/commands/mobile/simple_response_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/simple_response_commands_test.cc
@@ -71,6 +71,8 @@
 #include "mobile/set_app_icon_response.h"
 #include "mobile/set_display_layout_response.h"
 #include "mobile/generic_response.h"
+#include "mobile/set_app_icon_response.h"
+#include "mobile/set_icon_response.h"
 
 namespace test {
 namespace components {
@@ -126,7 +128,8 @@ typedef Types<commands::ListFilesResponse,
               commands::AddCommandResponse,
               commands::SendLocationResponse,
               commands::SetAppIconResponse,
-              commands::SetDisplayLayoutResponse> ResponseCommandsList;
+              commands::SetDisplayLayoutResponse,
+              commands::SetIconResponse> ResponseCommandsList;
 
 TYPED_TEST_CASE(MobileResponseCommandsTest, ResponseCommandsList);
 

--- a/src/components/include/utils/make_shared.h
+++ b/src/components/include/utils/make_shared.h
@@ -67,25 +67,25 @@ SharedPtr<T> Initialize(T* object) {
 
 template <typename T>
 SharedPtr<T> MakeShared() {
-  T* t = new (std::nothrow) T;
+  T* t = new T;
   return Initialize(t);
 }
 
 template <typename T, typename Arg1>
 SharedPtr<T> MakeShared(Arg1& arg1) {
-  T* t = new (std::nothrow) T(arg1);
+  T* t = new T(arg1);
   return Initialize(t);
 }
 
 template <typename T, typename Arg1, typename Arg2>
 SharedPtr<T> MakeShared(Arg1& arg1, Arg2& arg2) {
-  T* t = new (std::nothrow) T(arg1, arg2);
+  T* t = new T(arg1, arg2);
   return Initialize(t);
 }
 
 template <typename T, typename Arg1, typename Arg2, typename Arg3>
 SharedPtr<T> MakeShared(Arg1& arg1, Arg2& arg2, Arg3& arg3) {
-  T* t = new (std::nothrow) T(arg1, arg2, arg3);
+  T* t = new T(arg1, arg2, arg3);
   return Initialize(t);
 }
 
@@ -95,7 +95,7 @@ template <typename T,
           typename Arg3,
           typename Arg4>
 SharedPtr<T> MakeShared(Arg1& arg1, Arg2& arg2, Arg3& arg3, Arg4& arg4) {
-  T* t = new (std::nothrow) T(arg1, arg2, arg3, arg4);
+  T* t = new T(arg1, arg2, arg3, arg4);
   return Initialize(t);
 }
 
@@ -107,7 +107,7 @@ template <typename T,
           typename Arg5>
 SharedPtr<T> MakeShared(
     Arg1& arg1, Arg2& arg2, Arg3& arg3, Arg4& arg4, Arg5& arg5) {
-  T* t = new (std::nothrow) T(arg1, arg2, arg3, arg4, arg5);
+  T* t = new T(arg1, arg2, arg3, arg4, arg5);
   return Initialize(t);
 }
 
@@ -120,25 +120,25 @@ template <typename T,
           typename Arg6>
 SharedPtr<T> MakeShared(
     Arg1& arg1, Arg2& arg2, Arg3& arg3, Arg4& arg4, Arg5& arg5, Arg6& arg6) {
-  T* t = new (std::nothrow) T(arg1, arg2, arg3, arg4, arg5, arg6);
+  T* t = new T(arg1, arg2, arg3, arg4, arg5, arg6);
   return Initialize(t);
 }
 
 template <typename T, typename Arg1>
 SharedPtr<T> MakeShared(const Arg1& arg1) {
-  T* t = new (std::nothrow) T(arg1);
+  T* t = new T(arg1);
   return Initialize(t);
 }
 
 template <typename T, typename Arg1, typename Arg2>
 SharedPtr<T> MakeShared(const Arg1& arg1, const Arg2& arg2) {
-  T* t = new (std::nothrow) T(arg1, arg2);
+  T* t = new T(arg1, arg2);
   return Initialize(t);
 }
 
 template <typename T, typename Arg1, typename Arg2, typename Arg3>
 SharedPtr<T> MakeShared(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3) {
-  T* t = new (std::nothrow) T(arg1, arg2, arg3);
+  T* t = new T(arg1, arg2, arg3);
   return Initialize(t);
 }
 
@@ -151,7 +151,7 @@ SharedPtr<T> MakeShared(const Arg1& arg1,
                         const Arg2& arg2,
                         const Arg3& arg3,
                         const Arg4& arg4) {
-  T* t = new (std::nothrow) T(arg1, arg2, arg3, arg4);
+  T* t = new T(arg1, arg2, arg3, arg4);
   return Initialize(t);
 }
 
@@ -166,7 +166,7 @@ SharedPtr<T> MakeShared(const Arg1& arg1,
                         const Arg3& arg3,
                         const Arg4& arg4,
                         const Arg5& arg5) {
-  T* t = new (std::nothrow) T(arg1, arg2, arg3, arg4, arg5);
+  T* t = new T(arg1, arg2, arg3, arg4, arg5);
   return Initialize(t);
 }
 
@@ -183,7 +183,7 @@ SharedPtr<T> MakeShared(const Arg1& arg1,
                         const Arg4& arg4,
                         const Arg5& arg5,
                         const Arg6& arg6) {
-  T* t = new (std::nothrow) T(arg1, arg2, arg3, arg4, arg5, arg6);
+  T* t = new T(arg1, arg2, arg3, arg4, arg5, arg6);
   return Initialize(t);
 }
 


### PR DESCRIPTION
 - set_icon_response
 - response_from_hmi
 - delete_sub_menu_request
 - command_notification_impl
 - on_hmi_status_notification_from_mobile
 - notification_to_hmi
 - on_button_event_notification
 - on_button_press_notification

Related task : [APPLINK-28072)](https://adc.luxoft.com/jira/browse/APPLINK-28072)