### PR TITLE
Fix SystemRequestTest fails on repeatedly run

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/system_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/system_request.h
@@ -80,6 +80,18 @@ class SystemRequest : public CommandRequestImpl {
    */
   virtual void on_event(const event_engine::Event& event) OVERRIDE;
 
+#ifdef BUILD_TESTS
+  /**
+   * @brief To avoid override of existing file,
+   * command append index as a suffix to
+   * the file name and increment it, each time
+   * when command saves a file.
+   **/
+  static uint32_t file_index() {
+    return index;
+  }
+#endif  // BUILD_TESTS
+
  private:
   /**
    * @brief Validates data coming within QueryApps response


### PR DESCRIPTION
Fixed `SystemRequestTest` failure on repeatedly run

`SystemRequestTest` fails because `SystemRequest
every new call, change save file name.
In test provided only one name for save file.
As an result, in repeat mode, `SystemRequest`
change file name, and it mismatch name provided in test.

-
Closes bug: [APPLINK-28272](https://adc.luxoft.com/jira/browse/APPLINK-28272)

@AGaliuzov, @Kozoriz, @LuxoftAKutsan, @VProdanov, @wolfylambova22, please, review.