### PR TITLE
Fix defects found by am_commands_test under WinQt

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -92,7 +92,10 @@ struct Version {
 
 struct AppFile {
   // need to use in std::map;
-  AppFile() {}
+  AppFile()
+      : is_persistent(false)
+      , is_download_complete(false)
+      , file_type(mobile_apis::FileType::INVALID_ENUM) {}
   AppFile(const std::string& name,
           bool persistent,
           bool download_complete,

--- a/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
@@ -265,7 +265,7 @@ void SetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
                 (is_ui_invalid_unsupported && is_tts_succeeded);
 
   mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
-  const char* return_info = NULL;
+  std::string return_info;
 
   const bool is_ui_or_tts_warning =
       Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
@@ -274,8 +274,7 @@ void SetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
   if (result && (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == tts_result_ ||
                  is_ui_or_tts_warning)) {
     result_code = mobile_apis::Result::WARNINGS;
-    return_info =
-        std::string("Unsupported phoneme type sent in a prompt").c_str();
+    return_info = "Unsupported phoneme type sent in a prompt";
   } else {
     result_code =
         MessageHelper::HMIToMobileResult(std::max(ui_result_, tts_result_));
@@ -285,8 +284,10 @@ void SetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
   ApplicationSharedPtr application =
       application_manager_.application(connection_key());
 
-  SendResponse(
-      result, result_code, return_info, &(message[strings::msg_params]));
+  SendResponse(result,
+               result_code,
+               return_info.empty() ? NULL : return_info.c_str(),
+               &(message[strings::msg_params]));
 
   if (!application) {
     SDL_DEBUG("NULL pointer.");

--- a/src/components/application_manager/src/commands/mobile/speak_request.cc
+++ b/src/components/application_manager/src/commands/mobile/speak_request.cc
@@ -125,7 +125,7 @@ void SpeakRequest::ProcessTTSSpeakResponse(
   (*message_)[strings::params][strings::function_id] =
       mobile_apis::FunctionID::SpeakID;
 
-  const char* return_info = NULL;
+  std::string return_info;
 
   const bool is_result_ok = Compare<mobile_api::Result::eType, EQ, ONE>(
       result_code,
@@ -137,13 +137,14 @@ void SpeakRequest::ProcessTTSSpeakResponse(
     return_info = "Unsupported phoneme type sent in a prompt";
   }
 
-  SendResponse(
-      result, result_code, return_info, &(message[strings::msg_params]));
+  SendResponse(result,
+               result_code,
+               return_info.empty() ? NULL : return_info.c_str(),
+               &(message[strings::msg_params]));
 }
 
 bool SpeakRequest::IsWhiteSpaceExist() {
   SDL_AUTO_TRACE();
-  const char* str = NULL;
 
   if ((*message_)[strings::msg_params].keyExists(strings::tts_chunks)) {
     const smart_objects::SmartArray* tc_array =
@@ -153,7 +154,7 @@ bool SpeakRequest::IsWhiteSpaceExist() {
     smart_objects::SmartArray::const_iterator it_tc_end = tc_array->end();
 
     for (; it_tc != it_tc_end; ++it_tc) {
-      str = (*it_tc)[strings::text].asCharArray();
+      const char* str = (*it_tc)[strings::text].asCharArray();
       if (strlen(str) && !CheckSyntax(str)) {
         SDL_ERROR("Invalid tts_chunks syntax check failed");
         return true;

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -63,6 +63,7 @@ using ::testing::_;
 using ::testing::Return;
 using ::testing::SaveArg;
 using ::testing::DoAll;
+using ::testing::Mock;
 
 using ::utils::SharedPtr;
 using am::commands::MessageSharedPtr;
@@ -123,8 +124,12 @@ class CommandRequestImplTest
 
   CommandRequestImplTest() {
     mock_message_helper_ = am::MockMessageHelper::message_helper_mock();
+    Mock::VerifyAndClearExpectations(mock_message_helper_);
   }
   ~CommandRequestImplTest() {
+    // Fix DataAccessor release and WinQt crash
+    Mock::VerifyAndClearExpectations(&mock_app_manager_);
+    Mock::VerifyAndClearExpectations(mock_message_helper_);
     mock_message_helper_ = NULL;
   }
 

--- a/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
+++ b/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
@@ -219,7 +219,17 @@ class HMICommandsNotificationsTest
           CommandsTestMocks::kIsNice> {
  public:
   HMICommandsNotificationsTest()
-      : applications_(application_set_, applications_lock_) {}
+      : applications_(application_set_, applications_lock_), app_ptr_(NULL) {
+    message_helper_mock_ =
+        application_manager::MockMessageHelper::message_helper_mock();
+    Mock::VerifyAndClearExpectations(message_helper_mock_);
+  }
+
+  ~HMICommandsNotificationsTest() {
+    // Fix DataAccessor release and WinQt crash
+    Mock::VerifyAndClearExpectations(&mock_app_manager_);
+    Mock::VerifyAndClearExpectations(message_helper_mock_);
+  }
   typedef Command CommandType;
 
  protected:
@@ -235,11 +245,6 @@ class HMICommandsNotificationsTest
 
   am::ApplicationSharedPtr app_;
   NiceMock<MockApplication>* app_ptr_;
-
-  void SetUp() OVERRIDE {
-    message_helper_mock_ =
-        application_manager::MockMessageHelper::message_helper_mock();
-  }
 
   void InitCommand(const uint32_t& default_timeout) OVERRIDE {
     app_ = ConfigureApp(&app_ptr_, kAppId_, NOT_MEDIA, NOT_NAVI, NOT_VC);

--- a/src/components/application_manager/test/commands/hmi/sdl_activate_app_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/sdl_activate_app_request_test.cc
@@ -55,6 +55,7 @@ using am::commands::SDLActivateAppRequest;
 using am::ApplicationSet;
 using testing::Return;
 using testing::ReturnRef;
+using testing::Mock;
 using am::MockMessageHelper;
 using policy_test::MockPolicyHandlerInterface;
 
@@ -69,7 +70,15 @@ class SDLActivateAppRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  protected:
   SDLActivateAppRequestTest()
-      : message_helper_mock_(am::MockMessageHelper::message_helper_mock()) {}
+      : message_helper_mock_(am::MockMessageHelper::message_helper_mock()) {
+    Mock::VerifyAndClearExpectations(message_helper_mock_);
+  }
+
+  ~SDLActivateAppRequestTest() {
+    // Fix DataAccessor release and WinQt crash
+    Mock::VerifyAndClearExpectations(&mock_app_manager_);
+    Mock::VerifyAndClearExpectations(message_helper_mock_);
+  }
 
   void InitCommand(const uint32_t& timeout) OVERRIDE {
     MockAppPtr mock_app = CreateMockApp();

--- a/src/components/application_manager/test/commands/hmi/update_device_list_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/update_device_list_request_test.cc
@@ -161,6 +161,7 @@ TEST_F(UpdateDeviceListRequestTest, OnEvent_SUCCESS) {
   EXPECT_CALL(mock_app_manager_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher_));
   EXPECT_CALL(mock_event_dispatcher_, remove_observer(_, _));
+  EXPECT_CALL(mock_event_dispatcher_, remove_observer(_));
 
   UpdateDeviceListRequestPtr command(CreateCommand<UpdateDeviceListRequest>());
 

--- a/src/components/application_manager/test/commands/mobile/change_registration_test.cc
+++ b/src/components/application_manager/test/commands/mobile/change_registration_test.cc
@@ -60,6 +60,7 @@ namespace change_registration {
 using ::testing::_;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::Mock;
 
 namespace am = ::application_manager;
 
@@ -96,6 +97,11 @@ class ChangeRegistrationRequestTest
  public:
   ChangeRegistrationRequestTest()
       : applications_(application_set_, applications_lock_) {}
+
+  ~ChangeRegistrationRequestTest() {
+    // Fix DataAccessor release and WinQt crash
+    Mock::VerifyAndClearExpectations(&mock_app_manager_);
+  }
 
   void CreateDefaultMessage(MessageSharedPtr message) {
     (*message)[am::strings::msg_params][am::strings::app_name] = kAppName1;

--- a/src/components/application_manager/test/commands/mobile/delete_command_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_command_request_test.cc
@@ -42,6 +42,7 @@
 #include "application_manager/application.h"
 #include "application_manager/mock_application_manager.h"
 #include "application_manager/mock_application.h"
+#include "application_manager/mock_message_helper.h"
 #include "application_manager/event_engine/event.h"
 #include "mobile/delete_command_request.h"
 #include "interfaces/MOBILE_API.h"
@@ -55,6 +56,7 @@ namespace delete_command_request {
 using ::testing::_;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::Mock;
 namespace am = ::application_manager;
 using am::commands::DeleteCommandRequest;
 using am::commands::MessageSharedPtr;
@@ -65,10 +67,23 @@ typedef SharedPtr<DeleteCommandRequest> DeleteCommandPtr;
 namespace {
 const uint32_t kConnectionKey = 2u;
 const int32_t kCommandId = 5;
+const hmi_apis::Common_Result::eType kHmiResponse =
+    hmi_apis::Common_Result::WARNINGS;
 }  // namespace
 
 class DeleteCommandRequestTest
-    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ protected:
+  DeleteCommandRequestTest() {
+    mock_message_helper_ = am::MockMessageHelper::message_helper_mock();
+    Mock::VerifyAndClearExpectations(mock_message_helper_);
+  }
+  ~DeleteCommandRequestTest() {
+    Mock::VerifyAndClearExpectations(mock_message_helper_);
+  }
+
+  am::MockMessageHelper* mock_message_helper_;
+};
 
 TEST_F(DeleteCommandRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
   DeleteCommandPtr command(CreateCommand<DeleteCommandRequest>());
@@ -189,14 +204,16 @@ TEST_F(DeleteCommandRequestTest, OnEvent_UiDeleteCommand_SUCCESS) {
   command->Run();
 
   MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
-  (*event_msg)[am::strings::params][am::hmi_response::code] =
-      hmi_apis::Common_Result::WARNINGS;
+  (*event_msg)[am::strings::params][am::hmi_response::code] = kHmiResponse;
   Event event(hmi_apis::FunctionID::UI_DeleteCommand);
   event.set_smart_object(*event_msg);
 
   EXPECT_CALL(*app, RemoveCommand(kCommandId));
 
   EXPECT_CALL(*app, UpdateHash());
+
+  EXPECT_CALL(*mock_message_helper_, HMIResultToString(kHmiResponse))
+      .WillOnce(Return(std::string()));
 
   MessageSharedPtr result_msg(
       CatchMobileCommandResult(CallOnEvent(*command, event)));
@@ -232,14 +249,16 @@ TEST_F(DeleteCommandRequestTest, OnEvent_VrDeleteCommand_SUCCESS) {
   command->Run();
 
   MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
-  (*event_msg)[am::strings::params][am::hmi_response::code] =
-      hmi_apis::Common_Result::WARNINGS;
+  (*event_msg)[am::strings::params][am::hmi_response::code] = kHmiResponse;
   Event event(hmi_apis::FunctionID::VR_DeleteCommand);
   event.set_smart_object(*event_msg);
 
   EXPECT_CALL(*app, RemoveCommand(kCommandId));
 
   EXPECT_CALL(*app, UpdateHash());
+
+  EXPECT_CALL(*mock_message_helper_, HMIResultToString(kHmiResponse))
+      .WillOnce(Return(std::string()));
 
   MessageSharedPtr result_msg(
       CatchMobileCommandResult(CallOnEvent(*command, event)));

--- a/src/components/application_manager/test/commands/mobile/delete_interaction_choice_set_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_interaction_choice_set_test.cc
@@ -87,6 +87,11 @@ class DeleteInteractionChoiceSetRequestTest
   DeleteInteractionChoiceSetRequestTest()
       : accessor_(choice_set_map_, performinteraction_choice_set_lock_) {}
 
+  ~DeleteInteractionChoiceSetRequestTest() {
+    // Fix DataAccessor release and WinQt crash
+    Mock::VerifyAndClearExpectations(&mock_app_manager_);
+  }
+
   am::PerformChoiceSetMap choice_set_map_;
   mutable sync_primitives::Lock performinteraction_choice_set_lock_;
   DataAccessor<am::PerformChoiceSetMap> accessor_;
@@ -97,6 +102,7 @@ class DeleteInteractionChoiceSetRequestTest
     command_ = CreateCommand<DeleteInteractionChoiceSetRequest>(message_);
     app_ = CreateMockApp();
   }
+
   DeleteInteractionChoiceSetRequestPtr command_;
   MessageSharedPtr message_;
   MockAppPtr app_;

--- a/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_from_mobile_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_from_mobile_test.cc
@@ -61,6 +61,12 @@ using testing::_;
 class OnHMIStatusNotificationFromMobileTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
+  ~OnHMIStatusNotificationFromMobileTest() {
+    // Fix DataAccessor release and WinQt crash
+    Mock::VerifyAndClearExpectations(&mock_app_manager_);
+  }
+
+ protected:
   MessageSharedPtr CreateMsgParams(
       const mobile_apis::HMILevel::eType kHMIState) {
     MessageSharedPtr msg = CreateMessage();

--- a/src/components/application_manager/test/commands/mobile/on_keyboard_input_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_keyboard_input_notification_test.cc
@@ -62,7 +62,15 @@ class OnKeyBoardInputNotificationTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
   OnKeyBoardInputNotificationTest()
-      : message_helper_(*MockMessageHelper::message_helper_mock()) {}
+      : message_helper_(*MockMessageHelper::message_helper_mock()) {
+    Mock::VerifyAndClearExpectations(&message_helper_);
+  }
+
+  ~OnKeyBoardInputNotificationTest() {
+    // Fix DataAccessor release and WinQt crash
+    Mock::VerifyAndClearExpectations(&mock_app_manager_);
+    Mock::VerifyAndClearExpectations(&message_helper_);
+  }
 
   void SetSendNotificationExpectations(MessageSharedPtr msg) {
     EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
@@ -76,14 +84,6 @@ class OnKeyBoardInputNotificationTest
               (*msg)[strings::params][strings::protocol_type].asInt());
     ASSERT_EQ(CommandImpl::protocol_version_,
               (*msg)[strings::params][strings::protocol_version].asInt());
-  }
-
-  void SetUp() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&message_helper_);
-  }
-
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&message_helper_);
   }
 
   MockAppPtr InitAppSetDataAccessor(SharedPtr<ApplicationSet>& app_set) {

--- a/src/components/application_manager/test/commands/mobile/on_tbt_client_state_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_tbt_client_state_notification_test.cc
@@ -38,6 +38,7 @@
 #include "utils/shared_ptr.h"
 #include "smart_objects/smart_object.h"
 #include "application_manager/smart_object_keys.h"
+#include "application_manager/mock_message_helper.h"
 #include "application_manager/commands/commands_test.h"
 #include "application_manager/commands/command_impl.h"
 #include "utils/helpers.h"
@@ -52,7 +53,9 @@ namespace am = ::application_manager;
 
 using ::testing::_;
 using ::testing::Return;
+using ::testing::Mock;
 
+using am::MockMessageHelper;
 using am::commands::MessageSharedPtr;
 using am::commands::OnTBTClientStateNotification;
 
@@ -66,9 +69,18 @@ class OnTBTClientStateNotificationTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
   OnTBTClientStateNotificationTest()
-      : command_(CreateCommand<OnTBTClientStateNotification>()) {}
+      : command_(CreateCommand<OnTBTClientStateNotification>())
+      , message_helper_(*MockMessageHelper::message_helper_mock()) {
+    Mock::VerifyAndClearExpectations(&message_helper_);
+  }
 
+  ~OnTBTClientStateNotificationTest() {
+    Mock::VerifyAndClearExpectations(&message_helper_);
+  }
+
+ protected:
   NotificationPtr command_;
+  MockMessageHelper& message_helper_;
 };
 
 TEST_F(OnTBTClientStateNotificationTest, Run_HmiLevelNone_UNSUCCESS) {
@@ -129,6 +141,8 @@ TEST_F(OnTBTClientStateNotificationTest,
   EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kAppId));
 
   EXPECT_CALL(mock_app_manager_, SendMessageToMobile(CheckMessageData(), _));
+
+  EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
 
   command_->Run();
 }

--- a/src/components/application_manager/test/commands/mobile/on_vehicle_data_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_vehicle_data_notification_test.cc
@@ -57,6 +57,7 @@ namespace am = ::application_manager;
 using ::testing::_;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::Mock;
 
 using am::commands::MessageSharedPtr;
 using am::commands::OnVehicleDataNotification;
@@ -73,8 +74,15 @@ class OnVehicleDataNotificationTest
   OnVehicleDataNotificationTest()
       : mock_message_helper_(*am::MockMessageHelper::message_helper_mock())
       , command_msg_(CreateMessage(smart_objects::SmartType_Map))
-      , command_(CreateCommand<OnVehicleDataNotification>(command_msg_)) {}
+      , command_(CreateCommand<OnVehicleDataNotification>(command_msg_)) {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
 
+  ~OnVehicleDataNotificationTest() {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+
+ protected:
   am::MockMessageHelper& mock_message_helper_;
   MessageSharedPtr command_msg_;
   NotificationPtr command_;
@@ -139,6 +147,9 @@ TEST_F(OnVehicleDataNotificationTest,
   EXPECT_CALL(mock_app_manager_,
               SendMessageToMobile(
                   CheckMessageData(am::strings::fuel_level, fuel_level), _));
+
+  EXPECT_CALL(mock_message_helper_, PrintSmartObject(_))
+      .WillOnce(Return(false));
 
   command_->Run();
 }

--- a/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
@@ -54,6 +54,7 @@ using namespace application_manager;
 using ::testing::Return;
 using ::testing::ReturnNull;
 using ::testing::ReturnPointee;
+using ::testing::Mock;
 using ::testing::_;
 
 namespace {
@@ -70,6 +71,12 @@ class PerformInteractionRequestTest
   PerformInteractionRequestTest()
       : message_(utils::MakeShared<SmartObject>(::smart_objects::SmartType_Map))
       , kMsgParams_((*message_)[strings::msg_params]) {}
+
+  ~PerformInteractionRequestTest() {
+    // Fix DataAccessor release and WinQt crash
+    Mock::VerifyAndClearExpectations(mock_application_sptr_.get());
+  }
+
   void SetUp() OVERRIDE {
     command_sptr_ =
         CreateCommand<commands::PerformInteractionRequest>(message_);

--- a/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
@@ -60,6 +60,7 @@ using utils::custom_string::CustomString;
 using smart_objects::SmartObject;
 using testing::_;
 using testing::Return;
+using testing::Mock;
 
 namespace strings = application_manager::strings;
 namespace hmi_request = application_manager::hmi_request;
@@ -77,6 +78,17 @@ class SetGlobalPropertiesRequestTest
  public:
   SetGlobalPropertiesRequestTest()
       : mock_message_helper_(*MockMessageHelper::message_helper_mock()) {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+
+  ~SetGlobalPropertiesRequestTest() {
+    // Fix DataAccessor release and WinQt crash
+    Mock::VerifyAndClearExpectations(mock_app_.get());
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+
+ protected:
+  void SetUp() OVERRIDE {
     mock_app_ = CreateMockApp();
   }
 

--- a/src/components/application_manager/test/commands/mobile/simple_notification_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/simple_notification_commands_test.cc
@@ -37,6 +37,7 @@
 #include "utils/shared_ptr.h"
 #include "smart_objects/smart_object.h"
 #include "application_manager/smart_object_keys.h"
+#include "application_manager/mock_message_helper.h"
 #include "command_impl.h"
 #include "commands/commands_test.h"
 #include "mobile/on_app_interface_unregistered_notification.h"
@@ -56,12 +57,29 @@ namespace commands = am::commands;
 
 using ::testing::_;
 using ::testing::Types;
+using ::testing::Return;
+using ::testing::Mock;
+
+using am::MockMessageHelper;
 
 template <class Command>
 class MobileNotificationCommandsTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
   typedef Command CommandType;
+
+ public:
+  MobileNotificationCommandsTest()
+      : message_helper_(*MockMessageHelper::message_helper_mock()) {
+    Mock::VerifyAndClearExpectations(&message_helper_);
+  }
+
+  ~MobileNotificationCommandsTest() {
+    Mock::VerifyAndClearExpectations(&message_helper_);
+  }
+
+ protected:
+  MockMessageHelper& message_helper_;
 };
 
 typedef Types<commands::OnAppInterfaceUnregisteredNotification,
@@ -87,6 +105,8 @@ TYPED_TEST(MobileNotificationCommandsTest, Run_SendMessageToMobile_SUCCESS) {
       this->template CreateCommand<typename TestFixture::CommandType>();
   EXPECT_CALL(this->mock_app_manager_,
               SendMessageToMobile(CheckNotificationMessage(), _));
+  EXPECT_CALL(this->message_helper_, PrintSmartObject(_))
+      .WillOnce(Return(false));
   command->Run();
 }
 

--- a/src/components/application_manager/test/commands/mobile/simple_response_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/simple_response_commands_test.cc
@@ -143,13 +143,13 @@ class GenericResponseFromHMICommandsTest
 MATCHER_P2(CheckMessageParams, success, result, "") {
   const bool is_msg_type_correct =
       (am::MessageType::kResponse) ==
-      static_cast<uint32_t>(
+      static_cast<int32_t>(
           (*arg)[am::strings::params][am::strings::message_type].asInt());
   const bool is_success_correct =
       success == (*arg)[am::strings::msg_params][am::strings::success].asBool();
   const bool is_result_code_correct =
       result ==
-      static_cast<uint32_t>(
+      static_cast<int32_t>(
           (*arg)[am::strings::msg_params][am::strings::result_code].asInt());
 
   using namespace helpers;

--- a/src/components/application_manager/test/commands/mobile/subscribe_vehicle_data_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/subscribe_vehicle_data_request_test.cc
@@ -53,6 +53,7 @@ namespace subscribe_vehicle_data_request {
 
 using application_manager::commands::SubscribeVehicleDataRequest;
 using ::testing::DefaultValue;
+using ::testing::Mock;
 using application_manager::MockMessageHelper;
 
 namespace mobile_result = mobile_apis::Result;
@@ -68,19 +69,22 @@ const std::string kKeyName = "key_name";
 
 class SubscribeVehicleDataRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
- protected:
+ public:
   SubscribeVehicleDataRequestTest() : app_(CreateMockApp()) {
     msg_ = CreateMessage(smart_objects::SmartType_Map);
     data_type = am::VehicleDataType::SPEED;
     vehicle_data.insert(
         std::pair<std::string, am::VehicleDataType>(kKeyName, data_type));
-  }
-
-  void SetUp() OVERRIDE {
     EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
                 vehicle_data()).WillRepeatedly(ReturnRef(vehicle_data));
   }
 
+  ~SubscribeVehicleDataRequestTest() {
+    // Fix DataAccessor release and WinQt crash
+    Mock::VerifyAndClearExpectations(&mock_app_manager_);
+  }
+
+ protected:
   void AlreadySubscribedByThisApp();
   MockAppPtr app_;
   MessageSharedPtr msg_;

--- a/src/components/application_manager/test/commands/mobile/unsubscribe_vehicle_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unsubscribe_vehicle_request_test.cc
@@ -49,6 +49,7 @@ namespace unsubscribe_vehicle_data_request {
 namespace am = ::application_manager;
 namespace mobile_result = mobile_apis::Result;
 
+using ::testing::Mock;
 using ::testing::_;
 
 using am::commands::UnsubscribeVehicleDataRequest;
@@ -64,6 +65,12 @@ const am::VehicleDataType kVehicleType = am::VehicleDataType::SPEED;
 
 class UnsubscribeVehicleRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  ~UnsubscribeVehicleRequestTest() {
+    // Fix DataAccessor release and WinQt crash
+    Mock::VerifyAndClearExpectations(&mock_app_manager_);
+  }
+
  protected:
   void UnsubscribeSuccessfully();
   sync_primitives::Lock app_set_lock_;

--- a/src/components/utils/src/file_system_win.cc
+++ b/src/components/utils/src/file_system_win.cc
@@ -530,7 +530,11 @@ std::string file_system::GetPathDelimiter() {
 
 std::string file_system::ConcatPath(const std::string& utf8_path1,
                                     const std::string& utf8_path2) {
-  return utf8_path1 + GetPathDelimiter() + utf8_path2;
+  if (utf8_path1.empty() || utf8_path2.empty()) {
+    return utf8_path1 + utf8_path2;
+  } else {
+    return utf8_path1 + GetPathDelimiter() + utf8_path2;
+  }
 }
 
 std::string file_system::ConcatPath(const std::string& utf8_path1,


### PR DESCRIPTION
Fixed memory leaks.
Fixed Windows path creation.
Fixed Unit test output.
Fixed DataAccessor expectation release.
Refactored AddCommandRequestTest.

Related issue: [APPLINK-27667](https://adc.luxoft.com/jira/browse/APPLINK-27667)