### PR TITLE
Completely cover commands with unit tests

### DIFF
--- a/src/components/application_manager/test/commands/hmi/get_urls_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_urls_test.cc
@@ -98,12 +98,34 @@ class GetUrlsTest : public CommandsTest<CommandsTestMocks::kIsNice> {
         utils::MakeShared<policy_manager_test::MockPolicyManager>();
     ASSERT_TRUE(mock_policy_manager_);
   }
+
+  MessageSharedPtr CreateCommandMsg() {
+    MessageSharedPtr command_msg(
+        CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
+    (*command_msg)[am::strings::params][am::strings::connection_key] =
+        kConnectionKey;
+    (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
+        kPolicyService;
+
+    return command_msg;
+  }
+
+  RequestFromHMIPtr PrepareRunFlowAndCreateCommandRequestFromHMI(
+      MessageSharedPtr command_msg) {
+    ON_CALL(mock_app_manager_, event_dispatcher())
+        .WillByDefault(ReturnRef(mock_event_dispatcher_));
+
+    RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
+
+    EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(3);
+    EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+    return command;
+  }
 };
 
 TEST_F(GetUrlsTest, RUN_SUCCESS) {
   MessageSharedPtr command_msg(
       CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
-  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
   (*command_msg)[am::strings::params][am::strings::connection_key] =
       kConnectionKey;
   (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
@@ -125,7 +147,6 @@ TEST_F(GetUrlsTest, RUN_SUCCESS) {
 TEST_F(GetUrlsTest, RUN_PolicyNotEnabled_UNSUCCESS) {
   MessageSharedPtr command_msg(
       CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
-  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
   (*command_msg)[am::strings::params][am::strings::connection_key] =
       kConnectionKey;
   (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
@@ -153,7 +174,6 @@ TEST_F(GetUrlsTest, RUN_PolicyNotEnabled_UNSUCCESS) {
 TEST_F(GetUrlsTest, RUN_EmptyEndpoints_UNSUCCESS) {
   MessageSharedPtr command_msg(
       CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
-  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
   (*command_msg)[am::strings::params][am::strings::connection_key] =
       kConnectionKey;
   (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
@@ -183,21 +203,9 @@ TEST_F(GetUrlsTest, RUN_EmptyEndpoints_UNSUCCESS) {
 
 #ifdef EXTENDED_POLICY
 TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_SUCCESS) {
-  MessageSharedPtr command_msg(
-      CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
-  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
-  (*command_msg)[am::strings::params][am::strings::connection_key] =
-      kConnectionKey;
-  (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
-      kPolicyService;
-
-  ON_CALL(mock_app_manager_, event_dispatcher())
-      .WillByDefault(ReturnRef(mock_event_dispatcher_));
-
-  RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
-
-  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(3);
-  EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  RequestFromHMIPtr command =
+      PrepareRunFlowAndCreateCommandRequestFromHMI(command_msg);
 
   EndpointUrls endpoints_;
   EndpointData data(kDefaultUrl);
@@ -236,21 +244,9 @@ TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_SUCCESS) {
                           [strings::url].asString());
 }
 TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_IncorrectIdForSending_UNSUCCESS) {
-  MessageSharedPtr command_msg(
-      CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
-  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
-  (*command_msg)[am::strings::params][am::strings::connection_key] =
-      kConnectionKey;
-  (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
-      kPolicyService;
-
-  ON_CALL(mock_app_manager_, event_dispatcher())
-      .WillByDefault(ReturnRef(mock_event_dispatcher_));
-
-  RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
-
-  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(3);
-  EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  RequestFromHMIPtr command =
+      PrepareRunFlowAndCreateCommandRequestFromHMI(command_msg);
 
   EndpointUrls endpoints_;
   EndpointData data(kDefaultUrl);
@@ -271,21 +267,9 @@ TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_IncorrectIdForSending_UNSUCCESS) {
   command->Run();
 }
 TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_ApplicationIsNotValid_UNSUCCESS) {
-  MessageSharedPtr command_msg(
-      CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
-  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
-  (*command_msg)[am::strings::params][am::strings::connection_key] =
-      kConnectionKey;
-  (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
-      kPolicyService;
-
-  ON_CALL(mock_app_manager_, event_dispatcher())
-      .WillByDefault(ReturnRef(mock_event_dispatcher_));
-
-  RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
-
-  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(3);
-  EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  RequestFromHMIPtr command =
+      PrepareRunFlowAndCreateCommandRequestFromHMI(command_msg);
 
   EndpointUrls endpoints_;
   EndpointData data(kDefaultUrl);
@@ -314,21 +298,9 @@ TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_ApplicationIsNotValid_UNSUCCESS) {
             Common_Result::DATA_NOT_AVAILABLE);
 }
 TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_FoundURLForApplication_SUCCESS) {
-  MessageSharedPtr command_msg(
-      CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
-  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
-  (*command_msg)[am::strings::params][am::strings::connection_key] =
-      kConnectionKey;
-  (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
-      kPolicyService;
-
-  ON_CALL(mock_app_manager_, event_dispatcher())
-      .WillByDefault(ReturnRef(mock_event_dispatcher_));
-
-  RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
-
-  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(3);
-  EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  RequestFromHMIPtr command =
+      PrepareRunFlowAndCreateCommandRequestFromHMI(command_msg);
 
   EndpointUrls endpoints_;
   EndpointData data(kDefaultUrl);
@@ -369,7 +341,6 @@ TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_FoundURLForApplication_SUCCESS) {
 TEST_F(GetUrlsTest, ProcessServiceURLs_SUCCESS) {
   MessageSharedPtr command_msg(
       CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
-  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
   (*command_msg)[am::strings::params][am::strings::connection_key] =
       kConnectionKey;
   (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
@@ -411,7 +382,6 @@ TEST_F(GetUrlsTest, ProcessServiceURLs_SUCCESS) {
 TEST_F(GetUrlsTest, ProcessServiceURLs_PolicyDefaultId_SUCCESS) {
   MessageSharedPtr command_msg(
       CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
-  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
   (*command_msg)[am::strings::params][am::strings::connection_key] =
       kConnectionKey;
   (*command_msg)[am::strings::msg_params][am::hmi_request::service] =

--- a/src/components/application_manager/test/commands/hmi/get_urls_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_urls_test.cc
@@ -81,6 +81,7 @@ const std::string kInitialService = "0x0";
 const std::string kPolicyService = "7";
 const std::string kDefaultUrl = "URL is not found";
 const std::string kDefaultId = "default";
+const std::string kPolicyAppId = "policy_app_id";
 }  // namespace
 
 class GetUrlsTest : public CommandsTest<CommandsTestMocks::kIsNice> {
@@ -234,7 +235,137 @@ TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_SUCCESS) {
             (*command_msg)[am::strings::msg_params][am::hmi_response::urls][0]
                           [strings::url].asString());
 }
+TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_IncorrectIdForSending_UNSUCCESS) {
+  MessageSharedPtr command_msg(
+      CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
+      kPolicyService;
+
+  ON_CALL(mock_app_manager_, event_dispatcher())
+      .WillByDefault(ReturnRef(mock_event_dispatcher_));
+
+  RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
+
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(3);
+  EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+
+  EndpointUrls endpoints_;
+  EndpointData data(kDefaultUrl);
+  endpoints_.push_back(data);
+
+  ON_CALL(policy_handler_, GetServiceUrls(kPolicyService, _))
+      .WillByDefault(SetArgReferee<1>(endpoints_));
+  EXPECT_CALL(policy_handler_, GetServiceUrls(kPolicyService, _));
+
+  EXPECT_CALL(policy_handler_, GetAppIdForSending())
+      .WillOnce(Return(kInvalidAppId_));
+
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(command_msg))
+      .WillRepeatedly(Return(true));
+
+  EXPECT_CALL(mock_app_manager_, application(kInvalidAppId_)).Times(0);
+
+  command->Run();
+}
+TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_ApplicationIsNotValid_UNSUCCESS) {
+  MessageSharedPtr command_msg(
+      CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
+      kPolicyService;
+
+  ON_CALL(mock_app_manager_, event_dispatcher())
+      .WillByDefault(ReturnRef(mock_event_dispatcher_));
+
+  RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
+
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(3);
+  EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+
+  EndpointUrls endpoints_;
+  EndpointData data(kDefaultUrl);
+  endpoints_.push_back(data);
+
+  ON_CALL(policy_handler_, GetServiceUrls(kPolicyService, _))
+      .WillByDefault(SetArgReferee<1>(endpoints_));
+  EXPECT_CALL(policy_handler_, GetServiceUrls(kPolicyService, _));
+
+  MockAppPtr mock_app;
+
+  EXPECT_CALL(policy_handler_, GetAppIdForSending())
+      .WillOnce(Return(kAppIdForSending));
+
+  EXPECT_CALL(mock_app_manager_, application(kAppIdForSending))
+      .WillOnce(Return(mock_app));
+
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(command_msg))
+      .WillRepeatedly(Return(true));
+
+  command->Run();
+
+  EXPECT_EQ((*command_msg)[strings::params][strings::message_type].asInt(),
+            am::MessageType::kResponse);
+  EXPECT_EQ((*command_msg)[strings::params][am::hmi_response::code].asInt(),
+            Common_Result::DATA_NOT_AVAILABLE);
+}
+TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_FoundURLForApplication_SUCCESS) {
+  MessageSharedPtr command_msg(
+      CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = "123";
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*command_msg)[am::strings::msg_params][am::hmi_request::service] =
+      kPolicyService;
+
+  ON_CALL(mock_app_manager_, event_dispatcher())
+      .WillByDefault(ReturnRef(mock_event_dispatcher_));
+
+  RequestFromHMIPtr command(CreateCommand<GetUrls>(command_msg));
+
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(3);
+  EXPECT_CALL(policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+
+  EndpointUrls endpoints_;
+  EndpointData data(kDefaultUrl);
+  data.app_id = kPolicyAppId;
+  endpoints_.push_back(data);
+
+  ON_CALL(policy_handler_, GetServiceUrls(kPolicyService, _))
+      .WillByDefault(SetArgReferee<1>(endpoints_));
+  EXPECT_CALL(policy_handler_, GetServiceUrls(kPolicyService, _));
+
+  MockAppPtr mock_app = CreateMockApp();
+
+  EXPECT_CALL(policy_handler_, GetAppIdForSending())
+      .WillOnce(Return(kAppIdForSending));
+
+  EXPECT_CALL(mock_app_manager_, application(kAppIdForSending))
+      .WillOnce(Return(mock_app));
+
+  EXPECT_CALL(*mock_app, policy_app_id()).WillOnce(Return(kPolicyAppId));
+
+  EXPECT_CALL(mock_app_manager_, ManageHMICommand(command_msg))
+      .WillRepeatedly(Return(true));
+
+  EXPECT_CALL(*mock_app, app_id()).Times(0);
+
+  command->Run();
+
+  EXPECT_FALSE((*command_msg)[am::strings::msg_params].keyExists(
+      am::hmi_request::service));
+
+  EXPECT_EQ((*command_msg)[strings::params][strings::message_type].asInt(),
+            am::MessageType::kResponse);
+  EXPECT_EQ((*command_msg)[strings::params][am::hmi_response::code].asInt(),
+            Common_Result::SUCCESS);
+}
 #endif
+
 TEST_F(GetUrlsTest, ProcessServiceURLs_SUCCESS) {
   MessageSharedPtr command_msg(
       CreateMessage(NsSmartDeviceLink::NsSmartObjects::SmartType_Map));

--- a/src/components/application_manager/test/commands/hmi/navi_is_ready_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_is_ready_response_test.cc
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_event_dispatcher.h"
+#include "application_manager/commands/hmi/navi_is_ready_response.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+namespace navi_is_ready_responce {
+
+namespace am = ::application_manager;
+namespace commands = am::commands;
+
+using ::testing::ReturnRef;
+using ::testing::Eq;
+using ::utils::SharedPtr;
+using commands::MessageSharedPtr;
+
+namespace {
+const bool kNaviIsAvailable = true;
+const bool kNaviIsNotAvailable = false;
+}  // namespace
+
+class NaviIsReadyResponseTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  NaviIsReadyResponseTest() {}
+  void SetUp() OVERRIDE {}
+
+ protected:
+  void TestRunWithSpecificNaviState(const bool is_available) {
+    application_manager_test::MockApplicationManager mock_app_manager;
+    application_manager_test::MockHMICapabilities mock_hmi_capabilities;
+    application_manager_test::MockApplicationManagerSettings mock_settings;
+
+    MessageSharedPtr command_msg(utils::MakeShared<smart_objects::SmartObject>(
+        smart_objects::SmartType_Map));
+
+    (*command_msg)[am::strings::msg_params][am::strings::available] =
+        is_available;
+    uint32_t timeout = CommandsTest::kDefaultTimeout_;
+
+    EXPECT_CALL(mock_app_manager, get_settings())
+        .WillOnce(ReturnRef(mock_settings));
+    EXPECT_CALL(mock_settings, default_timeout()).WillOnce(ReturnRef(timeout));
+
+    SharedPtr<commands::NaviIsReadyResponse> command(
+        ::utils::MakeShared<commands::NaviIsReadyResponse>(command_msg,
+                                                           mock_app_manager));
+
+    EXPECT_CALL(mock_app_manager, hmi_capabilities())
+        .WillOnce(ReturnRef(mock_hmi_capabilities));
+    EXPECT_CALL(mock_hmi_capabilities,
+                set_is_navi_cooperating(Eq(is_available)));
+
+    command->Run();
+  }
+};
+
+TEST_F(NaviIsReadyResponseTest, NaviIsReadyResponse_Run_SUCCESS) {
+  TestRunWithSpecificNaviState(kNaviIsAvailable);
+}
+
+TEST_F(NaviIsReadyResponseTest, NaviIsReadyResponse_Run_UNSUCCESS) {
+  TestRunWithSpecificNaviState(kNaviIsNotAvailable);
+}
+
+}  // namespace navi_is_ready_responce
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
@@ -112,6 +112,7 @@
 #include "hmi/navi_subscribe_way_points_request.h"
 #include "hmi/sdl_policy_update.h"
 #include "hmi/ui_set_icon_request.h"
+#include "hmi/dial_number_request.h"
 
 namespace test {
 namespace components {
@@ -221,7 +222,8 @@ typedef Types<commands::NaviIsReadyRequest,
               commands::VRIsReadyRequest,
               commands::AllowAppRequest,
               commands::SDLPolicyUpdate,
-              commands::UISetIconRequest> RequestCommandsList2;
+              commands::UISetIconRequest,
+              commands::hmi::DialNumberRequest> RequestCommandsList2;
 
 TYPED_TEST_CASE(RequestToHMICommandsTest, RequestCommandsList);
 TYPED_TEST_CASE(RequestToHMICommandsTest2, RequestCommandsList2);

--- a/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
@@ -96,7 +96,6 @@
 #include "hmi/navi_show_constant_tbt_response.h"
 #include "hmi/navi_start_stream_response.h"
 #include "hmi/navi_subscribe_way_points_response.h"
-#include "hmi/navi_is_ready_response.h"
 #include "hmi/on_find_applications.h"
 #include "hmi/on_update_device_list.h"
 #include "hmi/sdl_policy_update_response.h"
@@ -111,7 +110,6 @@ namespace simple_response_from_hmi_test {
 
 using ::testing::_;
 using ::testing::ReturnRef;
-using ::testing::Return;
 using ::testing::Types;
 using ::testing::Eq;
 
@@ -316,32 +314,6 @@ TEST_F(OtherResponseFromHMICommandsTest, VIIsReadyResponse_Run_SUCCESS) {
       .WillOnce(ReturnRef(policy_handler));
 
   EXPECT_CALL(policy_handler, OnVIIsReady());
-
-  command->Run();
-}
-
-TEST(NaviIsReadyResponseTest, NaviIsReadyResponse_Run_SUCCESS) {
-  application_manager_test::MockApplicationManager mock_app_manager;
-  application_manager_test::MockHMICapabilities mock_hmi_capabilities;
-  application_manager_test::MockApplicationManagerSettings mock_settings;
-
-  MessageSharedPtr command_msg(utils::MakeShared<smart_objects::SmartObject>(
-      smart_objects::SmartType_Map));
-
-  (*command_msg)[am::strings::msg_params][am::strings::available] = true;
-  uint32_t timeout = 1u;
-
-  EXPECT_CALL(mock_app_manager, get_settings())
-      .WillOnce(ReturnRef(mock_settings));
-  EXPECT_CALL(mock_settings, default_timeout()).WillOnce(ReturnRef(timeout));
-
-  SharedPtr<commands::NaviIsReadyResponse> command(
-      ::utils::MakeShared<commands::NaviIsReadyResponse>(command_msg,
-                                                         mock_app_manager));
-
-  EXPECT_CALL(mock_app_manager, hmi_capabilities())
-      .WillOnce(ReturnRef(mock_hmi_capabilities));
-  EXPECT_CALL(mock_hmi_capabilities, set_is_navi_cooperating(Eq(true)));
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_response_from_hmi_test.cc
@@ -96,6 +96,7 @@
 #include "hmi/navi_show_constant_tbt_response.h"
 #include "hmi/navi_start_stream_response.h"
 #include "hmi/navi_subscribe_way_points_response.h"
+#include "hmi/navi_is_ready_response.h"
 #include "hmi/on_find_applications.h"
 #include "hmi/on_update_device_list.h"
 #include "hmi/sdl_policy_update_response.h"
@@ -110,6 +111,7 @@ namespace simple_response_from_hmi_test {
 
 using ::testing::_;
 using ::testing::ReturnRef;
+using ::testing::Return;
 using ::testing::Types;
 using ::testing::Eq;
 
@@ -314,6 +316,32 @@ TEST_F(OtherResponseFromHMICommandsTest, VIIsReadyResponse_Run_SUCCESS) {
       .WillOnce(ReturnRef(policy_handler));
 
   EXPECT_CALL(policy_handler, OnVIIsReady());
+
+  command->Run();
+}
+
+TEST(NaviIsReadyResponseTest, NaviIsReadyResponse_Run_SUCCESS) {
+  application_manager_test::MockApplicationManager mock_app_manager;
+  application_manager_test::MockHMICapabilities mock_hmi_capabilities;
+  application_manager_test::MockApplicationManagerSettings mock_settings;
+
+  MessageSharedPtr command_msg(utils::MakeShared<smart_objects::SmartObject>(
+      smart_objects::SmartType_Map));
+
+  (*command_msg)[am::strings::msg_params][am::strings::available] = true;
+  uint32_t timeout = 1u;
+
+  EXPECT_CALL(mock_app_manager, get_settings())
+      .WillOnce(ReturnRef(mock_settings));
+  EXPECT_CALL(mock_settings, default_timeout()).WillOnce(ReturnRef(timeout));
+
+  SharedPtr<commands::NaviIsReadyResponse> command(
+      ::utils::MakeShared<commands::NaviIsReadyResponse>(command_msg,
+                                                         mock_app_manager));
+
+  EXPECT_CALL(mock_app_manager, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities));
+  EXPECT_CALL(mock_hmi_capabilities, set_is_navi_cooperating(Eq(true)));
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/mobile/perform_audio_path_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_path_thru_test.cc
@@ -145,6 +145,76 @@ TEST_F(PerformAudioPassThruRequestTest,
 }
 
 TEST_F(PerformAudioPassThruRequestTest,
+       Run_InitPromptCorrect_TTSSpeakIsAbsent) {
+  EXPECT_CALL(*application_sptr_, hmi_level())
+      .WillOnce(Return(mobile_api::HMILevel::HMI_FULL));
+
+  msg_params_[strings::initial_prompt][0][strings::text] = kCorrectPrompt;
+  msg_params_[strings::initial_prompt][0][strings::type] = kCorrectType;
+  msg_params_[strings::audio_pass_display_text1] = kCorrectDisplayText1;
+  msg_params_[strings::audio_pass_display_text2] = kCorrectDisplayText2;
+
+  MessageSharedPtr speak_reqeust_result_msg;
+  MessageSharedPtr perform_result_msg;
+  {
+    InSequence dummy;
+    // Send speak request sending
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+        .WillOnce(DoAll(SaveArg<0>(&speak_reqeust_result_msg), Return(true)));
+
+    // Perform audio path thru request sending
+    EXPECT_CALL(mock_app_manager_, ManageHMICommand(_))
+        .WillOnce(DoAll(SaveArg<0>(&perform_result_msg), Return(true)));
+  }
+  CallRun run_caller(*command_sptr_);
+  run_caller();
+
+  const ::smart_objects::SmartObject& kSpeakMsgParams_ =
+      (*speak_reqeust_result_msg)[strings::msg_params];
+  const ::smart_objects::SmartObject& kPerformMsgParams =
+      (*perform_result_msg)[strings::msg_params];
+
+  const std::string& kResultInitialPrompt =
+      kSpeakMsgParams_[hmi_request::tts_chunks][0][strings::text].asString();
+  const std::string& kResultPromptType =
+      kSpeakMsgParams_[hmi_request::tts_chunks][0][strings::type].asString();
+  const std::string& kResultDisplayText1 =
+      kPerformMsgParams[hmi_request::audio_pass_display_texts][0]
+                       [hmi_request::field_text].asString();
+  const std::string& kResultDisplayText2 =
+      kPerformMsgParams[hmi_request::audio_pass_display_texts][1]
+                       [hmi_request::field_text].asString();
+
+  EXPECT_EQ(kCorrectPrompt, kResultInitialPrompt);
+  EXPECT_EQ(kCorrectType, kResultPromptType);
+  EXPECT_EQ(kCorrectDisplayText1, kResultDisplayText1);
+  EXPECT_EQ(kCorrectDisplayText2, kResultDisplayText2);
+
+  EXPECT_EQ(true, kPerformMsgParams[strings::mute_audio].asBool());
+
+  // now we recieve on_event:
+
+  application_manager_test::MockApplicationManagerSettings mock_settings;
+  uint32_t default_timeout_msec = 1u;
+  event_engine::Event event(hmi_apis::FunctionID::UI_PerformAudioPassThru);
+  (*message_)[strings::params][hmi_response::code] =
+      mobile_apis::Result::eType::GENERIC_ERROR;
+  event.set_smart_object(*message_);
+  CallOnEvent on_event_caller(*command_sptr_, event);
+
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::TTS_StopSpeaking)))
+      .WillOnce(Return(true));
+  EXPECT_CALL(mock_app_manager_, get_settings())
+      .WillOnce(ReturnRef(mock_settings));
+  EXPECT_CALL(mock_settings, default_timeout())
+      .WillOnce(ReturnRef(default_timeout_msec));
+
+  CatchMobileCommandResult(on_event_caller);
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
        Run_InitPromptCorrect_SpeakAndPerformAPTRequestsSendMuteTrue) {
   EXPECT_CALL(*application_sptr_, hmi_level())
       .WillOnce(Return(mobile_api::HMILevel::HMI_FULL));
@@ -333,9 +403,18 @@ TEST_F(PerformAudioPassThruRequestTest,
       (*perform_event_result)[strings::msg_params][strings::info].asString());
 }
 
+TEST_F(PerformAudioPassThruRequestTest, OnEvent_TTSSpeak_UpdateTimeout) {
+  event_engine::Event event(hmi_apis::FunctionID::TTS_Speak);
+
+  EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _));
+
+  CallOnEvent caller(*command_sptr_, event);
+  caller();
+}
+
 TEST_F(PerformAudioPassThruRequestTest,
        OnEvent_TTSOnResetTimeout_UpdateTimeout) {
-  event_engine::Event event(hmi_apis::FunctionID::TTS_Speak);
+  event_engine::Event event(hmi_apis::FunctionID::TTS_OnResetTimeout);
 
   EXPECT_CALL(mock_app_manager_, updateRequestTimeout(_, _, _));
 

--- a/src/components/application_manager/test/commands/mobile/perform_audio_path_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_path_thru_test.cc
@@ -195,7 +195,7 @@ TEST_F(PerformAudioPassThruRequestTest,
   // now we recieve on_event:
 
   application_manager_test::MockApplicationManagerSettings mock_settings;
-  uint32_t default_timeout_msec = 1u;
+  uint32_t default_timeout_msec = CommandsTest::kDefaultTimeout_;
   event_engine::Event event(hmi_apis::FunctionID::UI_PerformAudioPassThru);
   (*message_)[strings::params][hmi_response::code] =
       mobile_apis::Result::eType::GENERIC_ERROR;

--- a/src/components/application_manager/test/commands/mobile/show_constant_tbt_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/show_constant_tbt_request_test.cc
@@ -160,6 +160,27 @@ TEST_F(ShowConstantTBTRequestTest, Run_TurnIcon_Canceled) {
   command->Run();
 }
 
+TEST_F(ShowConstantTBTRequestTest, Run_TurnIcon_WrongSyntax) {
+  MessageSharedPtr msg = CreateMsgParams();
+  SmartObject turn_icon(smart_objects::SmartType_Map);
+  turn_icon[strings::value] = "Wrong Syntax\\n";
+  (*msg)[strings::msg_params][strings::turn_icon] = turn_icon;
+
+  SharedPtr<ShowConstantTBTRequest> command(
+      CreateCommand<ShowConstantTBTRequest>(msg));
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app_));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
+  EXPECT_CALL(*mock_app_, app_id()).Times(0);
+
+  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
+
+  command->Run();
+}
+
 TEST_F(ShowConstantTBTRequestTest, Run_NextTurnIcon_SUCCESS) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -209,6 +230,27 @@ TEST_F(ShowConstantTBTRequestTest, Run_NextTurnIcon_Canceled) {
   command->Run();
 }
 
+TEST_F(ShowConstantTBTRequestTest, Run_NextTurnIcon_WrongSyntax) {
+  MessageSharedPtr msg = CreateMsgParams();
+  SmartObject next_turn_icon(smart_objects::SmartType_Map);
+  next_turn_icon[strings::value] = "Wrong Syntax\\n";
+  (*msg)[strings::msg_params][strings::next_turn_icon] = next_turn_icon;
+
+  SharedPtr<ShowConstantTBTRequest> command(
+      CreateCommand<ShowConstantTBTRequest>(msg));
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app_));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
+  EXPECT_CALL(*mock_app_, app_id()).Times(0);
+
+  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
+
+  command->Run();
+}
+
 TEST_F(ShowConstantTBTRequestTest, Run_NavigationText1_SUCCESS) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -224,6 +266,25 @@ TEST_F(ShowConstantTBTRequestTest, Run_NavigationText1_SUCCESS) {
   MsgParamsSetupHelper(msg_params,
                        strings::navigation_text_1,
                        hmi_apis::Common_TextFieldName::navigationText1);
+
+  command->Run();
+}
+
+TEST_F(ShowConstantTBTRequestTest, Run_NavigationText1_WrongSyntax) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::msg_params][strings::navigation_text_1] = "Wrong Syntax\\n";
+
+  SharedPtr<ShowConstantTBTRequest> command(
+      CreateCommand<ShowConstantTBTRequest>(msg));
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app_));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
+  EXPECT_CALL(*mock_app_, app_id()).Times(0);
+
+  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
 
   command->Run();
 }
@@ -247,6 +308,25 @@ TEST_F(ShowConstantTBTRequestTest, Run_NavigationText2_SUCCESS) {
   command->Run();
 }
 
+TEST_F(ShowConstantTBTRequestTest, Run_NavigationText2_WrongSyntax) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::msg_params][strings::navigation_text_2] = "Wrong Syntax\\n";
+
+  SharedPtr<ShowConstantTBTRequest> command(
+      CreateCommand<ShowConstantTBTRequest>(msg));
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app_));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
+  EXPECT_CALL(*mock_app_, app_id()).Times(0);
+
+  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
+
+  command->Run();
+}
+
 TEST_F(ShowConstantTBTRequestTest, Run_ETA_SUCCESS) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -261,6 +341,25 @@ TEST_F(ShowConstantTBTRequestTest, Run_ETA_SUCCESS) {
 
   MsgParamsSetupHelper(
       msg_params, strings::eta, hmi_apis::Common_TextFieldName::ETA);
+
+  command->Run();
+}
+
+TEST_F(ShowConstantTBTRequestTest, Run_ETA_WrongSyntax) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::msg_params][strings::eta] = "Wrong Syntax\\n";
+
+  SharedPtr<ShowConstantTBTRequest> command(
+      CreateCommand<ShowConstantTBTRequest>(msg));
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app_));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
+  EXPECT_CALL(*mock_app_, app_id()).Times(0);
+
+  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
 
   command->Run();
 }
@@ -284,6 +383,25 @@ TEST_F(ShowConstantTBTRequestTest, Run_TotalDistance_SUCCESS) {
   command->Run();
 }
 
+TEST_F(ShowConstantTBTRequestTest, Run_TotalDistance_WrongSyntax) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::msg_params][strings::total_distance] = "Wrong Syntax\\n";
+
+  SharedPtr<ShowConstantTBTRequest> command(
+      CreateCommand<ShowConstantTBTRequest>(msg));
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app_));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
+  EXPECT_CALL(*mock_app_, app_id()).Times(0);
+
+  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
+
+  command->Run();
+}
+
 TEST_F(ShowConstantTBTRequestTest, Run_TimeToDistanation_SUCCESS) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -299,6 +417,25 @@ TEST_F(ShowConstantTBTRequestTest, Run_TimeToDistanation_SUCCESS) {
   MsgParamsSetupHelper(msg_params,
                        strings::time_to_destination,
                        hmi_apis::Common_TextFieldName::timeToDestination);
+
+  command->Run();
+}
+
+TEST_F(ShowConstantTBTRequestTest, Run_TimeToDistanation_WrongSyntax) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::msg_params][strings::time_to_destination] = "Wrong Syntax\\n";
+
+  SharedPtr<ShowConstantTBTRequest> command(
+      CreateCommand<ShowConstantTBTRequest>(msg));
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app_));
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
+  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
+  EXPECT_CALL(*mock_app_, app_id()).Times(0);
+
+  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
 
   command->Run();
 }
@@ -346,25 +483,6 @@ TEST_F(ShowConstantTBTRequestTest, Run_InvalidApp_Canceled) {
 
 TEST_F(ShowConstantTBTRequestTest, Run_EmptyMsgParams_Canceled) {
   MessageSharedPtr msg = CreateMsgParams();
-
-  SharedPtr<ShowConstantTBTRequest> command(
-      CreateCommand<ShowConstantTBTRequest>(msg));
-
-  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
-      .WillOnce(Return(mock_app_));
-  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
-  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
-  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
-  EXPECT_CALL(*mock_app_, app_id()).Times(0);
-
-  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
-
-  command->Run();
-}
-
-TEST_F(ShowConstantTBTRequestTest, Run_WrongSyntax_Canceled) {
-  MessageSharedPtr msg = CreateMsgParams();
-  (*msg)[strings::msg_params][strings::navigation_text_1] = "Wrong Syntax\\n";
 
   SharedPtr<ShowConstantTBTRequest> command(
       CreateCommand<ShowConstantTBTRequest>(msg));

--- a/src/components/application_manager/test/commands/mobile/show_constant_tbt_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/show_constant_tbt_request_test.cc
@@ -63,6 +63,7 @@ namespace hmi_response = application_manager::hmi_response;
 namespace {
 const uint32_t kConnectionKey = 1u;
 const uint32_t kAppID = 2u;
+const std::string kWrongSyntax = "Wrong Syntax\\n";
 }  // namespace
 
 class ShowConstantTBTRequestTest
@@ -102,6 +103,22 @@ class ShowConstantTBTRequestTest
         navi_text_;
 
     EXPECT_CALL(*mock_app_, set_tbt_show_command(msg_params));
+  }
+
+  void WrongSyntaxBehavior(MessageSharedPtr msg) {
+    SharedPtr<ShowConstantTBTRequest> command(
+        CreateCommand<ShowConstantTBTRequest>(msg));
+
+    EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+        .WillOnce(Return(mock_app_));
+    EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
+    EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
+    EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
+    EXPECT_CALL(*mock_app_, app_id()).Times(0);
+
+    EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
+
+    command->Run();
   }
 
   MockAppPtr mock_app_;
@@ -163,22 +180,9 @@ TEST_F(ShowConstantTBTRequestTest, Run_TurnIcon_Canceled) {
 TEST_F(ShowConstantTBTRequestTest, Run_TurnIcon_WrongSyntax) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject turn_icon(smart_objects::SmartType_Map);
-  turn_icon[strings::value] = "Wrong Syntax\\n";
+  turn_icon[strings::value] = kWrongSyntax;
   (*msg)[strings::msg_params][strings::turn_icon] = turn_icon;
-
-  SharedPtr<ShowConstantTBTRequest> command(
-      CreateCommand<ShowConstantTBTRequest>(msg));
-
-  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
-      .WillOnce(Return(mock_app_));
-  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
-  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
-  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
-  EXPECT_CALL(*mock_app_, app_id()).Times(0);
-
-  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
-
-  command->Run();
+  WrongSyntaxBehavior(msg);
 }
 
 TEST_F(ShowConstantTBTRequestTest, Run_NextTurnIcon_SUCCESS) {
@@ -233,22 +237,9 @@ TEST_F(ShowConstantTBTRequestTest, Run_NextTurnIcon_Canceled) {
 TEST_F(ShowConstantTBTRequestTest, Run_NextTurnIcon_WrongSyntax) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject next_turn_icon(smart_objects::SmartType_Map);
-  next_turn_icon[strings::value] = "Wrong Syntax\\n";
+  next_turn_icon[strings::value] = kWrongSyntax;
   (*msg)[strings::msg_params][strings::next_turn_icon] = next_turn_icon;
-
-  SharedPtr<ShowConstantTBTRequest> command(
-      CreateCommand<ShowConstantTBTRequest>(msg));
-
-  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
-      .WillOnce(Return(mock_app_));
-  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
-  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
-  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
-  EXPECT_CALL(*mock_app_, app_id()).Times(0);
-
-  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
-
-  command->Run();
+  WrongSyntaxBehavior(msg);
 }
 
 TEST_F(ShowConstantTBTRequestTest, Run_NavigationText1_SUCCESS) {
@@ -272,21 +263,8 @@ TEST_F(ShowConstantTBTRequestTest, Run_NavigationText1_SUCCESS) {
 
 TEST_F(ShowConstantTBTRequestTest, Run_NavigationText1_WrongSyntax) {
   MessageSharedPtr msg = CreateMsgParams();
-  (*msg)[strings::msg_params][strings::navigation_text_1] = "Wrong Syntax\\n";
-
-  SharedPtr<ShowConstantTBTRequest> command(
-      CreateCommand<ShowConstantTBTRequest>(msg));
-
-  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
-      .WillOnce(Return(mock_app_));
-  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
-  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
-  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
-  EXPECT_CALL(*mock_app_, app_id()).Times(0);
-
-  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
-
-  command->Run();
+  (*msg)[strings::msg_params][strings::navigation_text_1] = kWrongSyntax;
+  WrongSyntaxBehavior(msg);
 }
 
 TEST_F(ShowConstantTBTRequestTest, Run_NavigationText2_SUCCESS) {
@@ -310,21 +288,8 @@ TEST_F(ShowConstantTBTRequestTest, Run_NavigationText2_SUCCESS) {
 
 TEST_F(ShowConstantTBTRequestTest, Run_NavigationText2_WrongSyntax) {
   MessageSharedPtr msg = CreateMsgParams();
-  (*msg)[strings::msg_params][strings::navigation_text_2] = "Wrong Syntax\\n";
-
-  SharedPtr<ShowConstantTBTRequest> command(
-      CreateCommand<ShowConstantTBTRequest>(msg));
-
-  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
-      .WillOnce(Return(mock_app_));
-  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
-  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
-  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
-  EXPECT_CALL(*mock_app_, app_id()).Times(0);
-
-  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
-
-  command->Run();
+  (*msg)[strings::msg_params][strings::navigation_text_2] = kWrongSyntax;
+  WrongSyntaxBehavior(msg);
 }
 
 TEST_F(ShowConstantTBTRequestTest, Run_ETA_SUCCESS) {
@@ -347,21 +312,8 @@ TEST_F(ShowConstantTBTRequestTest, Run_ETA_SUCCESS) {
 
 TEST_F(ShowConstantTBTRequestTest, Run_ETA_WrongSyntax) {
   MessageSharedPtr msg = CreateMsgParams();
-  (*msg)[strings::msg_params][strings::eta] = "Wrong Syntax\\n";
-
-  SharedPtr<ShowConstantTBTRequest> command(
-      CreateCommand<ShowConstantTBTRequest>(msg));
-
-  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
-      .WillOnce(Return(mock_app_));
-  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
-  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
-  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
-  EXPECT_CALL(*mock_app_, app_id()).Times(0);
-
-  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
-
-  command->Run();
+  (*msg)[strings::msg_params][strings::eta] = kWrongSyntax;
+  WrongSyntaxBehavior(msg);
 }
 
 TEST_F(ShowConstantTBTRequestTest, Run_TotalDistance_SUCCESS) {
@@ -385,21 +337,8 @@ TEST_F(ShowConstantTBTRequestTest, Run_TotalDistance_SUCCESS) {
 
 TEST_F(ShowConstantTBTRequestTest, Run_TotalDistance_WrongSyntax) {
   MessageSharedPtr msg = CreateMsgParams();
-  (*msg)[strings::msg_params][strings::total_distance] = "Wrong Syntax\\n";
-
-  SharedPtr<ShowConstantTBTRequest> command(
-      CreateCommand<ShowConstantTBTRequest>(msg));
-
-  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
-      .WillOnce(Return(mock_app_));
-  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
-  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
-  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
-  EXPECT_CALL(*mock_app_, app_id()).Times(0);
-
-  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
-
-  command->Run();
+  (*msg)[strings::msg_params][strings::total_distance] = kWrongSyntax;
+  WrongSyntaxBehavior(msg);
 }
 
 TEST_F(ShowConstantTBTRequestTest, Run_TimeToDistanation_SUCCESS) {
@@ -423,21 +362,8 @@ TEST_F(ShowConstantTBTRequestTest, Run_TimeToDistanation_SUCCESS) {
 
 TEST_F(ShowConstantTBTRequestTest, Run_TimeToDistanation_WrongSyntax) {
   MessageSharedPtr msg = CreateMsgParams();
-  (*msg)[strings::msg_params][strings::time_to_destination] = "Wrong Syntax\\n";
-
-  SharedPtr<ShowConstantTBTRequest> command(
-      CreateCommand<ShowConstantTBTRequest>(msg));
-
-  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
-      .WillOnce(Return(mock_app_));
-  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
-  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
-  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
-  EXPECT_CALL(*mock_app_, app_id()).Times(0);
-
-  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
-
-  command->Run();
+  (*msg)[strings::msg_params][strings::time_to_destination] = kWrongSyntax;
+  WrongSyntaxBehavior(msg);
 }
 
 TEST_F(ShowConstantTBTRequestTest, Run_SoftButtons_SUCCESS) {


### PR DESCRIPTION
Covered code lines for following files:
 - navi_is_ready_response;
 - dial_number_request;
 - get_urls;
 - perform_audio_pass_thru_request;
 - show_constant_tbt_request.

Related task : APPLINK-28075