### PR TITLE
Cover commands with unit tests

### DIFF
--- a/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/src/commands/hmi/sdl_activate_app_request.cc
@@ -149,7 +149,7 @@ uint32_t SDLActivateAppRequest::app_id() const {
 
 uint32_t SDLActivateAppRequest::hmi_app_id(
     const smart_objects::SmartObject& so) const {
-  if (so.keyExists(strings::params)) {
+  if (so.keyExists(strings::msg_params)) {
     if (so[strings::msg_params].keyExists(strings::application)) {
       if (so[strings::msg_params][strings::application].keyExists(
               strings::app_id)) {

--- a/src/components/application_manager/test/commands/hmi/sdl_activate_app_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/sdl_activate_app_request_test.cc
@@ -34,12 +34,15 @@
 
 #include "gtest/gtest.h"
 #include "utils/lock.h"
+#include "utils/helpers.h"
 #include "application_manager/commands/hmi/sdl_activate_app_request.h"
 #include "application_manager/mock_application.h"
 #include "application_manager/application_manager.h"
 #include "application_manager/policies/mock_policy_handler_interface.h"
 #include "commands/command_request_test.h"
 #include "application_manager/mock_message_helper.h"
+#include "application_manager/event_engine/event.h"
+#include "application_manager/mock_event_dispatcher.h"
 
 namespace test {
 namespace components {
@@ -53,10 +56,12 @@ namespace hmi_response = am::hmi_response;
 using am::commands::MessageSharedPtr;
 using am::commands::SDLActivateAppRequest;
 using am::ApplicationSet;
+using testing::Mock;
 using testing::Return;
 using testing::ReturnRef;
 using am::MockMessageHelper;
 using policy_test::MockPolicyHandlerInterface;
+using am::event_engine::Event;
 
 namespace {
 const uint32_t kCorrelationID = 1u;
@@ -64,6 +69,33 @@ const uint32_t kAppID = 2u;
 const uint32_t kAppIDFirst = 1u;
 const connection_handler::DeviceHandle kHandle = 2u;
 }  // namespace
+
+MATCHER_P2(CheckMsgParams, result, corr_id, "") {
+  const bool is_func_id_valid =
+      hmi_apis::FunctionID::SDL_ActivateApp ==
+      static_cast<int32_t>(
+          (*arg)[am::strings::params][am::strings::function_id].asInt());
+
+  const bool is_result_code_valid =
+      hmi_apis::Common_Result::APPLICATION_NOT_REGISTERED ==
+      static_cast<int32_t>(
+          (*arg)[am::strings::msg_params][am::strings::result_code].asInt());
+
+  const bool is_result_valid =
+      result == (*arg)[am::strings::msg_params][am::strings::success].asBool();
+
+  const bool is_corr_id_valid =
+      corr_id ==
+      static_cast<int32_t>(
+          (*arg)[am::strings::params][am::strings::correlation_id].asInt());
+
+  using namespace helpers;
+  return Compare<bool, EQ, ALL>(true,
+                                is_func_id_valid,
+                                is_result_code_valid,
+                                is_result_valid,
+                                is_corr_id_valid);
+}
 
 class SDLActivateAppRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
@@ -75,8 +107,12 @@ class SDLActivateAppRequestTest
     MockAppPtr mock_app = CreateMockApp();
     CommandRequestTest<CommandsTestMocks::kIsNice>::InitCommand(timeout);
     ON_CALL((*mock_app), app_id()).WillByDefault(Return(kAppID));
-    EXPECT_CALL(mock_app_manager_, application_by_hmi_app(kAppID))
-        .WillOnce(Return(mock_app));
+    ON_CALL(mock_app_manager_, application_by_hmi_app(kAppID))
+        .WillByDefault(Return(mock_app));
+  }
+  void SetCorrelationAndAppID(MessageSharedPtr msg) {
+    (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
+    (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
   }
 
   ApplicationSet app_list_;
@@ -87,8 +123,7 @@ class SDLActivateAppRequestTest
 
 TEST_F(SDLActivateAppRequestTest, FindAppToRegister_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
-  (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
-  (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
+  SetCorrelationAndAppID(msg);
 
   SharedPtr<SDLActivateAppRequest> command(
       CreateCommand<SDLActivateAppRequest>(msg));
@@ -118,8 +153,7 @@ TEST_F(SDLActivateAppRequestTest, FindAppToRegister_SUCCESS) {
 
 TEST_F(SDLActivateAppRequestTest, AppIdNotFound_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
-  (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
-  (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
+  SetCorrelationAndAppID(msg);
 
   SharedPtr<SDLActivateAppRequest> command(
       CreateCommand<SDLActivateAppRequest>(msg));
@@ -134,8 +168,7 @@ TEST_F(SDLActivateAppRequestTest, AppIdNotFound_SUCCESS) {
 
 TEST_F(SDLActivateAppRequestTest, DevicesAppsEmpty_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
-  (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
-  (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
+  SetCorrelationAndAppID(msg);
 
   SharedPtr<SDLActivateAppRequest> command(
       CreateCommand<SDLActivateAppRequest>(msg));
@@ -153,8 +186,7 @@ TEST_F(SDLActivateAppRequestTest, DevicesAppsEmpty_SUCCESS) {
 
 TEST_F(SDLActivateAppRequestTest, FirstAppActive_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
-  (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
-  (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
+  SetCorrelationAndAppID(msg);
 
   SharedPtr<SDLActivateAppRequest> command(
       CreateCommand<SDLActivateAppRequest>(msg));
@@ -186,8 +218,7 @@ TEST_F(SDLActivateAppRequestTest, FirstAppActive_SUCCESS) {
 
 TEST_F(SDLActivateAppRequestTest, FirstAppNotActive_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
-  (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
-  (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
+  SetCorrelationAndAppID(msg);
 
   SharedPtr<SDLActivateAppRequest> command(
       CreateCommand<SDLActivateAppRequest>(msg));
@@ -217,10 +248,47 @@ TEST_F(SDLActivateAppRequestTest, FirstAppNotActive_SUCCESS) {
   command->Run();
 }
 
+TEST_F(SDLActivateAppRequestTest, FirstAppIsForeground_SUCCESS) {
+  Mock::VerifyAndClearExpectations(&message_helper_mock_);
+  MessageSharedPtr msg = CreateMessage();
+  SetCorrelationAndAppID(msg);
+
+  SharedPtr<SDLActivateAppRequest> command(
+      CreateCommand<SDLActivateAppRequest>(msg));
+
+  MockAppPtr mock_app(CreateMockApp());
+
+  const std::string schema("schema");
+  mock_app->SetShemaUrl(schema);
+  const std::string package_name("package_name");
+  mock_app->SetPackageName(package_name);
+
+  ON_CALL(mock_app_manager_, application(kAppID))
+      .WillByDefault(Return(mock_app));
+
+  EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
+
+  MockAppPtr mock_app_first(CreateMockApp());
+  ON_CALL(*mock_app_first, device()).WillByDefault(Return(kHandle));
+  ON_CALL(*mock_app_first, is_foreground()).WillByDefault(Return(false));
+
+  app_list_.insert(mock_app_first);
+  DataAccessor<ApplicationSet> accessor(app_list_, lock_);
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
+
+  EXPECT_CALL(*mock_app, IsRegistered()).WillOnce(Return(true));
+  EXPECT_CALL(*mock_app_first, device()).WillOnce(Return(kHandle));
+  EXPECT_CALL(*mock_app_first, is_foreground()).WillOnce(Return(true));
+
+  EXPECT_CALL(*message_helper_mock_, SendLaunchApp(_, schema, package_name, _));
+
+  command->Run();
+  Mock::VerifyAndClearExpectations(&message_helper_mock_);
+}
+
 TEST_F(SDLActivateAppRequestTest, FirstAppNotRegisteredAndEmpty_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
-  (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
-  (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
+  SetCorrelationAndAppID(msg);
 
   SharedPtr<SDLActivateAppRequest> command(
       CreateCommand<SDLActivateAppRequest>(msg));
@@ -248,8 +316,7 @@ TEST_F(SDLActivateAppRequestTest, FirstAppNotRegisteredAndEmpty_SUCCESS) {
 
 TEST_F(SDLActivateAppRequestTest, FirstAppNotRegistered_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
-  (*msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
-  (*msg)[am::strings::msg_params][strings::app_id] = kAppID;
+  SetCorrelationAndAppID(msg);
 
   SharedPtr<SDLActivateAppRequest> command(
       CreateCommand<SDLActivateAppRequest>(msg));
@@ -276,6 +343,77 @@ TEST_F(SDLActivateAppRequestTest, FirstAppNotRegistered_SUCCESS) {
   EXPECT_CALL(*message_helper_mock_, SendLaunchApp(_, _, _, _));
 
   command->Run();
+}
+
+TEST_F(SDLActivateAppRequestTest, OnTimeout_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  SetCorrelationAndAppID(msg);
+
+  SharedPtr<SDLActivateAppRequest> command(
+      CreateCommand<SDLActivateAppRequest>(msg));
+
+  EXPECT_CALL(mock_app_manager_,
+              ManageHMICommand(CheckMsgParams(false, kCorrelationID)))
+      .WillOnce(Return(true));
+
+  command->onTimeOut();
+}
+
+TEST_F(SDLActivateAppRequestTest, OnEvent_InvalidEventId_UNSUCCESS) {
+  MessageSharedPtr event_msg = CreateMessage();
+  (*event_msg)[am::strings::params][strings::correlation_id] = kCorrelationID;
+
+  SharedPtr<SDLActivateAppRequest> command(
+      CreateCommand<SDLActivateAppRequest>());
+
+  Event event(hmi_apis::FunctionID::INVALID_ENUM);
+  event.set_smart_object(*event_msg);
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(_)).Times(0);
+
+  command->on_event(event);
+}
+
+TEST_F(SDLActivateAppRequestTest, OnEvent_InvalidAppId_UNSUCCESS) {
+  MessageSharedPtr event_msg = CreateMessage();
+  (*event_msg)[strings::msg_params][strings::application][strings::app_id] =
+      kAppID;
+
+  SharedPtr<SDLActivateAppRequest> command(
+      CreateCommand<SDLActivateAppRequest>());
+
+  Event event(hmi_apis::FunctionID::BasicCommunication_OnAppRegistered);
+  event.set_smart_object(*event_msg);
+
+  MockAppPtr invalid_mock_app;
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(kAppID))
+      .WillOnce(Return(invalid_mock_app));
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
+
+  command->on_event(event);
+}
+
+TEST_F(SDLActivateAppRequestTest, OnEvent_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::correlation_id] = kCorrelationID;
+  SharedPtr<SDLActivateAppRequest> command(
+      CreateCommand<SDLActivateAppRequest>(msg));
+
+  MessageSharedPtr event_msg = CreateMessage();
+  (*event_msg)[strings::msg_params][strings::application][strings::app_id] =
+      kAppID;
+
+  Event event(hmi_apis::FunctionID::BasicCommunication_OnAppRegistered);
+  event.set_smart_object(*event_msg);
+
+  MockAppPtr mock_app(CreateMockApp());
+  EXPECT_CALL(mock_app_manager_, application_by_hmi_app(kAppID))
+      .WillOnce(Return(mock_app));
+  EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kAppID));
+  EXPECT_CALL(mock_app_manager_, GetPolicyHandler())
+      .WillOnce(ReturnRef(policy_handler_));
+  EXPECT_CALL(policy_handler_, OnActivateApp(kAppID, kCorrelationID));
+
+  command->on_event(event);
 }
 
 }  // namespace sdl_activate_app_request

--- a/src/components/application_manager/test/commands/mobile/unsubscribe_vehicle_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unsubscribe_vehicle_request_test.cc
@@ -50,23 +50,47 @@ namespace am = ::application_manager;
 namespace mobile_result = mobile_apis::Result;
 
 using ::testing::_;
+using ::testing::Mock;
 
 using am::commands::UnsubscribeVehicleDataRequest;
 using am::commands::MessageSharedPtr;
-
+using am::MockMessageHelper;
 typedef ::utils::SharedPtr<UnsubscribeVehicleDataRequest> CommandPtr;
 
 namespace {
 const uint32_t kConnectionKey = 1u;
+const uint32_t kCorrelationKey = 2u;
 const std::string kMsgParamKey = "test_key";
 const am::VehicleDataType kVehicleType = am::VehicleDataType::SPEED;
 }  // namespace
 
+MATCHER_P(CheckMsgCorrelationKey, correlation_key, "") {
+  return correlation_key ==
+         static_cast<uint32_t>(
+             (*arg)[am::strings::params][am::strings::correlation_id].asUInt());
+}
+
 class UnsubscribeVehicleRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  protected:
+  UnsubscribeVehicleRequestTest()
+      : message_helper_mock_(am::MockMessageHelper::message_helper_mock()) {}
+
   void UnsubscribeSuccessfully();
+  void SetMsgParamsAndVehicleData(MessageSharedPtr msg) {
+    (*msg)[am::strings::params][am::strings::connection_key] = kConnectionKey;
+    (*msg)[am::strings::msg_params][kMsgParamKey] = kVehicleType;
+
+    vehicle_data_.insert(
+        am::VehicleData::value_type(kMsgParamKey, kVehicleType));
+  }
+  void TearDown() OVERRIDE {
+    Mock::VerifyAndClearExpectations(&message_helper_mock_);
+  }
+
   sync_primitives::Lock app_set_lock_;
+  am::VehicleData vehicle_data_;
+  am::MockMessageHelper* message_helper_mock_;
 };
 
 TEST_F(UnsubscribeVehicleRequestTest, Run_AppNotRegistered_UNSUCCESS) {
@@ -89,10 +113,9 @@ TEST_F(UnsubscribeVehicleRequestTest,
       kConnectionKey;
   (*command_msg)[am::strings::msg_params][am::strings::button_name] =
       kVehicleType;
-
-  am::VehicleData data;
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()), vehicle_data())
-      .WillOnce(ReturnRef(data));
+  am::VehicleData empty_vehicle_data;
+  EXPECT_CALL(*message_helper_mock_, vehicle_data())
+      .WillOnce(ReturnRef(empty_vehicle_data));
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
   MockAppPtr mock_app(CreateMockApp());
@@ -109,14 +132,10 @@ TEST_F(UnsubscribeVehicleRequestTest,
 TEST_F(UnsubscribeVehicleRequestTest,
        Run_UnsubscribeNotSubscribedBeforeData_IGNORED) {
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
-  (*command_msg)[am::strings::params][am::strings::connection_key] =
-      kConnectionKey;
-  (*command_msg)[am::strings::msg_params][kMsgParamKey] = kVehicleType;
 
-  am::VehicleData vehicle_data;
-  vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()), vehicle_data())
-      .WillOnce(ReturnRef(vehicle_data));
+  SetMsgParamsAndVehicleData(command_msg);
+  EXPECT_CALL(*message_helper_mock_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data_));
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
   MockAppPtr mock_app(CreateMockApp());
@@ -133,14 +152,11 @@ TEST_F(UnsubscribeVehicleRequestTest,
 TEST_F(UnsubscribeVehicleRequestTest,
        Run_UnsubscribeNotSubscribedBeforeData_UNSUCCESS) {
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
-  (*command_msg)[am::strings::params][am::strings::connection_key] =
-      kConnectionKey;
-  (*command_msg)[am::strings::msg_params][kMsgParamKey] = true;
 
-  am::VehicleData vehicle_data;
-  vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()), vehicle_data())
-      .WillOnce(ReturnRef(vehicle_data));
+  SetMsgParamsAndVehicleData(command_msg);
+
+  EXPECT_CALL(*message_helper_mock_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data_));
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
   MockAppPtr mock_app(CreateMockApp());
@@ -161,7 +177,7 @@ TEST_F(UnsubscribeVehicleRequestTest, Run_UnsubscribeDataDisabled_UNSUCCESS) {
 
   am::VehicleData vehicle_data;
   vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()), vehicle_data())
+  EXPECT_CALL(*message_helper_mock_, vehicle_data())
       .WillOnce(ReturnRef(vehicle_data));
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
@@ -178,13 +194,10 @@ TEST_F(UnsubscribeVehicleRequestTest, Run_UnsubscribeDataDisabled_UNSUCCESS) {
 
 void UnsubscribeVehicleRequestTest::UnsubscribeSuccessfully() {
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
-  (*command_msg)[am::strings::params][am::strings::connection_key] =
-      kConnectionKey;
-  (*command_msg)[am::strings::msg_params][kMsgParamKey] = true;
-  am::VehicleData vehicle_data;
-  vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()), vehicle_data())
-      .WillOnce(ReturnRef(vehicle_data));
+
+  SetMsgParamsAndVehicleData(command_msg);
+  EXPECT_CALL(*message_helper_mock_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data_));
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
   am::ApplicationSet application_set_;
@@ -207,24 +220,151 @@ void UnsubscribeVehicleRequestTest::UnsubscribeSuccessfully() {
   command->Run();
 }
 
+TEST_F(UnsubscribeVehicleRequestTest, Run_UnsubscribedKeyType_UNSUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+
+  SetMsgParamsAndVehicleData(command_msg);
+  EXPECT_CALL(*message_helper_mock_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data_));
+  CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
+
+  MockAppPtr mock_app(CreateMockApp());
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
+
+  EXPECT_CALL(*mock_app, IsSubscribedToIVI(kVehicleType))
+      .WillOnce(Return(true));
+  EXPECT_CALL(*mock_app, UnsubscribeFromIVI(kVehicleType))
+      .WillOnce(Return(false));
+
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::IGNORED), _));
+
+  command->Run();
+}
+
+TEST_F(UnsubscribeVehicleRequestTest, Run_SubscribedKeyType_SUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+
+  SetMsgParamsAndVehicleData(command_msg);
+  EXPECT_CALL(*message_helper_mock_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data_));
+  CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
+
+  am::ApplicationSet application_set_;
+  MockAppPtr mock_app(CreateMockApp());
+  application_set_.insert(mock_app);
+  DataAccessor<am::ApplicationSet> accessor(application_set_, app_set_lock_);
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
+
+  EXPECT_CALL(*mock_app, IsSubscribedToIVI(kVehicleType))
+      .WillOnce(Return(true))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*mock_app, UnsubscribeFromIVI(kVehicleType))
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(mock_app_manager_, GetNextHMICorrelationID())
+      .WillOnce(Return(kCorrelationKey));
+
+  EXPECT_CALL(mock_app_manager_,
+              ManageHMICommand(CheckMsgCorrelationKey(kCorrelationKey)))
+      .WillOnce(Return(false));
+
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::OUT_OF_MEMORY), _));
+
+  command->Run();
+}
+
 TEST_F(UnsubscribeVehicleRequestTest, Run_UnsubscribeData_SUCCESS) {
   UnsubscribeSuccessfully();
 }
 
-TEST_F(UnsubscribeVehicleRequestTest, OnEvent_DataNotSubscribed_IGNORED) {
+TEST_F(UnsubscribeVehicleRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
+  CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>());
+  am::event_engine::Event test_event(hmi_apis::FunctionID::INVALID_ENUM);
+  SmartObject message(smart_objects::SmartType_Map);
+  const hmi_apis::Common_Result::eType hmi_result =
+      hmi_apis::Common_Result::SUCCESS;
+  message[am::strings::params][am::hmi_response::code] = hmi_result;
+  message[am::strings::msg_params][kMsgParamKey] = true;
+  test_event.set_smart_object(message);
+  EXPECT_CALL(*message_helper_mock_, HMIToMobileResult(hmi_result)).Times(0);
+
+  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
+
+  command->on_event(test_event);
+}
+
+TEST_F(UnsubscribeVehicleRequestTest,
+       OnEvent_AddAlreadyUnsubscribedVI_SUCCESS) {
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
-  (*command_msg)[am::strings::params][am::strings::connection_key] =
-      kConnectionKey;
-  (*command_msg)[am::strings::msg_params][kMsgParamKey] = true;
+
+  SetMsgParamsAndVehicleData(command_msg);
+  EXPECT_CALL(*message_helper_mock_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data_));
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
-  am::VehicleData vehicle_data;
+  am::ApplicationSet application_set_;
+  MockAppPtr mock_app(CreateMockApp());
+  application_set_.insert(mock_app);
+  DataAccessor<am::ApplicationSet> accessor(application_set_, app_set_lock_);
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
+  EXPECT_CALL(mock_app_manager_, applications()).WillOnce(Return(accessor));
+
+  EXPECT_CALL(*mock_app, IsSubscribedToIVI(kVehicleType))
+      .WillOnce(Return(true))
+      .WillOnce(Return(true));
+  EXPECT_CALL(*mock_app, UnsubscribeFromIVI(kVehicleType))
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
+
+  command->Run();
+
+  am::event_engine::Event test_event(
+      hmi_apis::FunctionID::VehicleInfo_UnsubscribeVehicleData);
+  SmartObject message(smart_objects::SmartType_Map);
+  const hmi_apis::Common_Result::eType hmi_result =
+      hmi_apis::Common_Result::SUCCESS;
+  const mobile_apis::Result::eType mob_result = mobile_apis::Result::SUCCESS;
+  message[am::strings::params][am::hmi_response::code] = hmi_result;
+  message[am::strings::msg_params][kMsgParamKey] = true;
+  test_event.set_smart_object(message);
+
+  EXPECT_CALL(*message_helper_mock_, HMIToMobileResult(hmi_result))
+      .WillOnce(Return(mob_result));
+
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
+  MockAppPtr invalid_app;
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(invalid_app));
+  EXPECT_CALL(*mock_app, UpdateHash()).Times(0);
+
+  command->on_event(test_event);
+}
+
+TEST_F(UnsubscribeVehicleRequestTest, OnEvent_DataNotSubscribed_IGNORED) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+
+  SetMsgParamsAndVehicleData(command_msg);
+
+  CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
+
   MockAppPtr mock_app(CreateMockApp());
   EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillRepeatedly(Return(mock_app));
-  vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()), vehicle_data())
-      .WillOnce(ReturnRef(vehicle_data));
+  EXPECT_CALL(*message_helper_mock_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data_));
   EXPECT_CALL(*mock_app, IsSubscribedToIVI(kVehicleType))
       .WillRepeatedly(Return(false));
   EXPECT_CALL(
@@ -241,8 +381,8 @@ TEST_F(UnsubscribeVehicleRequestTest, OnEvent_DataNotSubscribed_IGNORED) {
   message[am::strings::params][am::hmi_response::code] = hmi_result;
   message[am::strings::msg_params][kMsgParamKey] = true;
   test_event.set_smart_object(message);
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()),
-              HMIToMobileResult(hmi_result)).WillOnce(Return(mob_result));
+  EXPECT_CALL(*message_helper_mock_, HMIToMobileResult(hmi_result))
+      .WillOnce(Return(mob_result));
 
   EXPECT_CALL(
       mock_app_manager_,
@@ -255,9 +395,8 @@ TEST_F(UnsubscribeVehicleRequestTest, OnEvent_DataNotSubscribed_IGNORED) {
 TEST_F(UnsubscribeVehicleRequestTest, OnEvent_DataUnsubscribed_SUCCESS) {
   UnsubscribeSuccessfully();
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
-  (*command_msg)[am::strings::params][am::strings::connection_key] =
-      kConnectionKey;
-  (*command_msg)[am::strings::msg_params][kMsgParamKey] = true;
+
+  SetMsgParamsAndVehicleData(command_msg);
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
   MockAppPtr mock_app(CreateMockApp());
 
@@ -271,8 +410,8 @@ TEST_F(UnsubscribeVehicleRequestTest, OnEvent_DataUnsubscribed_SUCCESS) {
   message[am::strings::msg_params][kMsgParamKey] = true;
   test_event.set_smart_object(message);
 
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()),
-              HMIToMobileResult(hmi_result)).WillOnce(Return(mob_result));
+  EXPECT_CALL(*message_helper_mock_, HMIToMobileResult(hmi_result))
+      .WillOnce(Return(mob_result));
 
   EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));


### PR DESCRIPTION
- Fixed issue with validation of message params in SDLActivateAppRequest. 
- covered next commands with UT:
   UnsubscribeVehicleDataRequest, 
   OnSystemRequestNotification, 
   NotificationFromHmi, 
   SdlActivateAppRequest

Related to [APPLINK-28482](https://adc.luxoft.com/jira/browse/APPLINK-28482) , [APPLINK-28078](https://adc.luxoft.com/jira/browse/APPLINK-28078)