### PR TITLE
Fix defects found by am_resumption_test under WinQt

### DIFF
--- a/src/components/utils/src/timer.cc
+++ b/src/components/utils/src/timer.cc
@@ -60,11 +60,10 @@ timer::Timer::Timer(const std::string& name, TimerTask* task)
 timer::Timer::~Timer() {
   SDL_AUTO_TRACE();
   sync_primitives::AutoLock auto_lock(state_lock_);
-  StopThread();
   StopDelegate();
+  StopThread();
   single_shot_ = true;
 
-  thread_->set_delegate(NULL);
   delegate_.reset();
   DeleteThread(thread_);
   DCHECK(task_);


### PR DESCRIPTION
Fixed Unit test output.
Fixed DataAccessor expectation release.
Fixed Timer ThreadDelegate release.

Related issue: [APPLINK-27159](https://adc.luxoft.com/jira/browse/APPLINK-27159)