### PR TITLE
	Fix defects found by application_manager_test under WinQt

### DIFF
--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -199,7 +199,6 @@ TEST_F(ApplicationManagerImplTest,
     }
   }
 
-  EXPECT_CALL(mock_hmi_mess_handler_, SendMessageToHMI(_)).Times(AtLeast(0));
   EXPECT_TRUE(app_manager_impl_->FindAppToRegister(hmi_app_id_).valid());
 }
 
@@ -229,7 +228,6 @@ TEST_F(ApplicationManagerImplTest,
     }
   }
 
-  EXPECT_CALL(mock_hmi_mess_handler_, SendMessageToHMI(_)).Times(AtLeast(0));
   hmi_app_id_ += 100;  // change hmi_id
   EXPECT_FALSE(app_manager_impl_->FindAppToRegister(hmi_app_id_).valid());
 }

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -112,7 +112,7 @@ class ApplicationManagerImplTest : public ::testing::Test {
     app_manager_impl_->resume_controller().set_resumption_storage(
         mock_storage_);
     app_manager_impl_->set_connection_handler(&mock_connection_handler_);
-    app_manager_impl_->set_hmi_message_handler(&mock_hmi_mess_handler_);
+    app_manager_impl_->set_hmi_message_handler(&mock_hmi_msg_handler_);
   }
 
   void CreateAppManager() {
@@ -144,7 +144,7 @@ class ApplicationManagerImplTest : public ::testing::Test {
   NiceMock<con_test::MockConnectionHandler> mock_connection_handler_;
   NiceMock<protocol_handler_test::MockSessionObserver> mock_session_observer_;
   NiceMock<hmi_message_handler_test::MockHMIMessageHandler>
-      mock_hmi_mess_handler_;
+      mock_hmi_msg_handler_;
   NiceMock<MockApplicationManagerSettings> mock_application_manager_settings_;
   std::auto_ptr<am::ApplicationManagerImpl> app_manager_impl_;
 };
@@ -186,7 +186,7 @@ TEST_F(ApplicationManagerImplTest,
   smart_objects::SmartObject sm_object(SmartType_Map);
   sm_object[am::json::response][0] = app_data;
 
-  EXPECT_CALL(mock_hmi_mess_handler_, SendMessageToHMI(Truly(AppIdExtractor())))
+  EXPECT_CALL(mock_hmi_msg_handler_, SendMessageToHMI(Truly(AppIdExtractor())))
       .Times(AtLeast(1u));
 
   app_manager_impl_->ProcessQueryApp(sm_object, connection_key);
@@ -215,7 +215,7 @@ TEST_F(ApplicationManagerImplTest,
   smart_objects::SmartObject sm_object(SmartType_Map);
   sm_object[am::json::response][0] = app_data;
 
-  EXPECT_CALL(mock_hmi_mess_handler_, SendMessageToHMI(Truly(AppIdExtractor())))
+  EXPECT_CALL(mock_hmi_msg_handler_, SendMessageToHMI(Truly(AppIdExtractor())))
       .Times(AtLeast(1u));
 
   app_manager_impl_->ProcessQueryApp(sm_object, connection_key);

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -76,7 +76,14 @@ const uint32_t kThreadPoolSize = 1;
 const bool kHmiLaunch = false;
 const uint32_t kStopStreamingTimeout = 10000;
 const uint32_t kWaitFreeQueue = 2000;
-const std::string directory_name = "./test_storage";
+const std::string kDirectoryName = "./test_storage";
+const uint32_t kTimeout = 10000u;
+const std::string kFolderName = "app";
+const std::string kTestPath =
+    file_system::ConcatPath(kDirectoryName, kFolderName);
+const std::string kTestFileName =
+    file_system::ConcatPath(kTestPath, "test_file2.bmp");
+const std::string kMacAddr_("kMacAddr_ess");
 
 bool is_called_ = false;
 uint32_t hmi_app_id_ = 0u;
@@ -91,47 +98,39 @@ class ApplicationManagerImplTest : public ::testing::Test {
 
     CreateAppManager();
 
-    const std::string kMacAddr_("kMacAddr_ess");
-
-    ON_CALL(mock_session_observer, GetDataOnDeviceID(_, _, _, _, _))
+    ON_CALL(mock_session_observer_, GetDataOnDeviceID(_, _, _, _, _))
         .WillByDefault(DoAll(SetArgPointee<3u>(kMacAddr_), Return(0)));
-    ON_CALL(mock_connection_handler, GetDataOnSessionKey(_, _, _, _))
+    ON_CALL(mock_connection_handler_, GetDataOnSessionKey(_, _, _, _))
         .WillByDefault(DoAll(SetArgPointee<3u>(app_id_), Return(0)));
-    ON_CALL(mock_connection_handler, get_session_observer())
-        .WillByDefault(ReturnRef(mock_session_observer));
+    ON_CALL(mock_connection_handler_, get_session_observer())
+        .WillByDefault(ReturnRef(mock_session_observer_));
 
-    mock_storage =
+    mock_storage_ =
         ::utils::MakeShared<NiceMock<resumption_test::MockResumptionData> >(
             mock_application_manager_settings_);
 
-    app_manager_impl_->resume_controller().set_resumption_storage(mock_storage);
-    app_manager_impl_->set_connection_handler(&mock_connection_handler);
-    app_manager_impl_->set_hmi_message_handler(&mock_hmi_mess_handler);
+    app_manager_impl_->resume_controller().set_resumption_storage(
+        mock_storage_);
+    app_manager_impl_->set_connection_handler(&mock_connection_handler_);
+    app_manager_impl_->set_hmi_message_handler(&mock_hmi_mess_handler_);
   }
 
   void CreateAppManager() {
-    const uint32_t timeout = 10000u;
-    const std::string folder_name = "app";
-    const std::string test_path =
-        file_system::ConcatPath(directory_name, folder_name);
-    const std::string file1 =
-        file_system::ConcatPath(test_path, "test_file2.bmp");
-
-    ASSERT_TRUE(file_system::CreateDirectoryRecursively(test_path));
-    ASSERT_TRUE(file_system::CreateFile(file1));
+    ASSERT_TRUE(file_system::CreateDirectoryRecursively(kTestPath));
+    ASSERT_TRUE(file_system::CreateFile(kTestFileName));
 
     ON_CALL(mock_application_manager_settings_, thread_pool_size())
         .WillByDefault(Return(2u));
     ON_CALL(mock_application_manager_settings_, app_icons_folder())
-        .WillByDefault(ReturnRef(directory_name));
+        .WillByDefault(ReturnRef(kDirectoryName));
     ON_CALL(mock_application_manager_settings_, app_storage_folder())
-        .WillByDefault(ReturnRef(directory_name));
+        .WillByDefault(ReturnRef(kDirectoryName));
     ON_CALL(mock_application_manager_settings_, launch_hmi())
         .WillByDefault(Return(true));
     ON_CALL(mock_application_manager_settings_, stop_streaming_timeout())
         .WillByDefault(Return(1u));
     ON_CALL(mock_application_manager_settings_, default_timeout())
-        .WillByDefault(ReturnRef(timeout));
+        .WillByDefault(ReturnRef(kTimeout));
     app_manager_impl_.reset(new am::ApplicationManagerImpl(
         mock_application_manager_settings_, mock_policy_settings_));
 
@@ -140,11 +139,12 @@ class ApplicationManagerImplTest : public ::testing::Test {
 
   uint32_t app_id_;
   NiceMock<policy_test::MockPolicySettings> mock_policy_settings_;
-  utils::SharedPtr<NiceMock<resumption_test::MockResumptionData> > mock_storage;
-  NiceMock<con_test::MockConnectionHandler> mock_connection_handler;
-  NiceMock<protocol_handler_test::MockSessionObserver> mock_session_observer;
+  utils::SharedPtr<NiceMock<resumption_test::MockResumptionData> >
+      mock_storage_;
+  NiceMock<con_test::MockConnectionHandler> mock_connection_handler_;
+  NiceMock<protocol_handler_test::MockSessionObserver> mock_session_observer_;
   NiceMock<hmi_message_handler_test::MockHMIMessageHandler>
-      mock_hmi_mess_handler;
+      mock_hmi_mess_handler_;
   NiceMock<MockApplicationManagerSettings> mock_application_manager_settings_;
   std::auto_ptr<am::ApplicationManagerImpl> app_manager_impl_;
 };
@@ -186,7 +186,7 @@ TEST_F(ApplicationManagerImplTest,
   smart_objects::SmartObject sm_object(SmartType_Map);
   sm_object[am::json::response][0] = app_data;
 
-  EXPECT_CALL(mock_hmi_mess_handler, SendMessageToHMI(Truly(AppIdExtractor())))
+  EXPECT_CALL(mock_hmi_mess_handler_, SendMessageToHMI(Truly(AppIdExtractor())))
       .Times(AtLeast(1u));
 
   app_manager_impl_->ProcessQueryApp(sm_object, connection_key);
@@ -199,7 +199,7 @@ TEST_F(ApplicationManagerImplTest,
     }
   }
 
-  EXPECT_CALL(mock_hmi_mess_handler, SendMessageToHMI(_)).Times(AtLeast(0));
+  EXPECT_CALL(mock_hmi_mess_handler_, SendMessageToHMI(_)).Times(AtLeast(0));
   EXPECT_TRUE(app_manager_impl_->FindAppToRegister(hmi_app_id_).valid());
 }
 
@@ -216,7 +216,7 @@ TEST_F(ApplicationManagerImplTest,
   smart_objects::SmartObject sm_object(SmartType_Map);
   sm_object[am::json::response][0] = app_data;
 
-  EXPECT_CALL(mock_hmi_mess_handler, SendMessageToHMI(Truly(AppIdExtractor())))
+  EXPECT_CALL(mock_hmi_mess_handler_, SendMessageToHMI(Truly(AppIdExtractor())))
       .Times(AtLeast(1u));
 
   app_manager_impl_->ProcessQueryApp(sm_object, connection_key);
@@ -229,7 +229,7 @@ TEST_F(ApplicationManagerImplTest,
     }
   }
 
-  EXPECT_CALL(mock_hmi_mess_handler, SendMessageToHMI(_)).Times(AtLeast(0));
+  EXPECT_CALL(mock_hmi_mess_handler_, SendMessageToHMI(_)).Times(AtLeast(0));
   hmi_app_id_ += 100;  // change hmi_id
   EXPECT_FALSE(app_manager_impl_->FindAppToRegister(hmi_app_id_).valid());
 }

--- a/src/components/utils/src/threads/thread_qt.cc
+++ b/src/components/utils/src/threads/thread_qt.cc
@@ -126,6 +126,11 @@ Thread::Thread(const char* name, ThreadDelegate* delegate, QObject* parent)
     , thread_command_(kThreadCommandNone)
     , thread_state_(kThreadStateNone) {
   qRegisterMetaType<QThread*>("QThread*");
+  // The number of the threads was set to the number
+  // of threads used in SDL according to ListOfThreads.
+  // This is done in order to prevent the blocking
+  // of thread at start due to insufficient pool size.
+  QThreadPool::globalInstance()->setMaxThreadCount(45);
 #ifdef THREAD_COUNT
   ThreadCounter::Increment();
 #endif  // THREAD_COUNT

--- a/src/components/utils/src/threads/thread_qt.cc
+++ b/src/components/utils/src/threads/thread_qt.cc
@@ -128,6 +128,7 @@ Thread::Thread(const char* name, ThreadDelegate* delegate, QObject* parent)
   qRegisterMetaType<QThread*>("QThread*");
   // The number of the threads was set to the number
   // of threads used in SDL according to ListOfThreads.
+  // See APPLINK-27148 for details.
   // This is done in order to prevent the blocking
   // of thread at start due to insufficient pool size.
   QThreadPool::globalInstance()->setMaxThreadCount(45);


### PR DESCRIPTION
Refactored application_manager_test.
Fixed thread pool size under WinQt.

Related issue: [APPLINK-27148](https://adc.luxoft.com/jira/browse/APPLINK-27148)