### PR TITLE
Remove all incorrect usages of std::string

### DIFF
--- a/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
@@ -275,13 +275,12 @@ void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
          (hmi_apis::Common_Result::SUCCESS == tts_result_));
 
     mobile_apis::Result::eType result_code;
-    const char* return_info = NULL;
+    std::string return_info;
 
     if (result) {
       if (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == tts_result_) {
         result_code = mobile_apis::Result::WARNINGS;
-        return_info =
-            std::string("Unsupported phoneme type sent in a prompt").c_str();
+        return_info = "Unsupported phoneme type sent in a prompt";
       } else {
         result_code = static_cast<mobile_apis::Result::eType>(
             std::max(ui_result_, tts_result_));
@@ -293,7 +292,7 @@ void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
 
     SendResponse(result,
                  static_cast<mobile_apis::Result::eType>(result_code),
-                 return_info,
+                 return_info.empty() ? NULL : return_info.c_str(),
                  &(message[strings::msg_params]));
 
     if (!application) {

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -2500,7 +2500,7 @@ bool MessageHelper::PrintSmartObject(const smart_objects::SmartObject& object) {
         ++tab;
 
         SDL_INFO(tab_buffer << (*key) << ": ");
-        if (!PrintSmartObject(object[(*key).c_str()])) {
+        if (!PrintSmartObject(object[*key])) {
           return false;
         }
       }

--- a/src/components/application_manager/test/commands/hmi/sdl_activate_app_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/sdl_activate_app_request_test.cc
@@ -87,8 +87,7 @@ MATCHER_P2(CheckMsgParams, result, corr_id, "") {
 
   const bool is_corr_id_valid =
       corr_id ==
-      static_cast<int32_t>(
-          (*arg)[am::strings::params][am::strings::correlation_id].asInt());
+      (*arg)[am::strings::params][am::strings::correlation_id].asUInt();
 
   using namespace helpers;
   return Compare<bool, EQ, ALL>(true,

--- a/src/components/application_manager/test/commands/mobile/change_registration_test.cc
+++ b/src/components/application_manager/test/commands/mobile/change_registration_test.cc
@@ -219,7 +219,7 @@ TEST_F(ChangeRegistrationRequestTest,
   std::map<const std::string, const std::string>::iterator it = params.begin();
   for (; it != params.end(); ++it) {
     MessageSharedPtr message(CreateMessage());
-    (*message)[am::strings::msg_params][(it->first).c_str()] = it->second;
+    (*message)[am::strings::msg_params][it->first] = it->second;
     ChangeRegistrationRequestPtr command(
         CreateCommand<ChangeRegistrationRequest>(message));
 

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -522,7 +522,8 @@ DevicesDiscoveryStarter& ConnectionHandlerImpl::get_device_discovery_starter() {
 struct CompareMAC {
   explicit CompareMAC(const std::string& mac) : mac_(mac) {}
   bool operator()(const DeviceMap::value_type& device) {
-    return strcasecmp(device.second.mac_address().c_str(), mac_.c_str()) == 0;
+    std::string mac_address = device.second.mac_address();
+    return strcasecmp(mac_address.c_str(), mac_.c_str()) == 0;
   }
 
  private:

--- a/src/components/formatters/include/formatters/formatter_json_rpc.h
+++ b/src/components/formatters/include/formatters/formatter_json_rpc.h
@@ -481,8 +481,9 @@ int32_t FormatterJsonRpc::ParseFunctionId(
   } else {
     FunctionId function_id;
 
+    const std::string method_value_str = method_value.AsString();
     if (!NsSmartObjects::EnumConversionHelper<FunctionId>::CStringToEnum(
-            method_value.AsString().c_str(), &function_id)) {
+            method_value_str.c_str(), &function_id)) {
       result |= kUnknownMethod;
     } else {
       namespace strings = NsSmartDeviceLink::NsJSONHandler::strings;

--- a/src/components/media_manager/src/audio/from_mic_to_file_recorder_thread.cc
+++ b/src/components/media_manager/src/audio/from_mic_to_file_recorder_thread.cc
@@ -118,20 +118,22 @@ media_manager::FromMicToFileRecorderThread::Impl::Impl(
   argc_ = 5;
   argv_ = new gchar* [argc_];
 
-  std::stringstream stringStream;
-  stringStream << duration / 1000;
-  std::string durationString = stringStream.str();
+  std::stringstream string_stream;
+  string_stream << duration / 1000;
+  const std::string duration_string = string_stream.str();
+  const std::string audio_manager = "AudioManager";
+
   argv_[0] = new gchar[14];
   argv_[1] = new gchar[3];
   argv_[2] = new gchar[outputFileName.length() + 1];
   argv_[3] = new gchar[3];
-  argv_[4] = new gchar[durationString.length() + 1];
+  argv_[4] = new gchar[duration_string.length() + 1];
 
-  argv_[0] = const_cast<gchar*>(std::string("AudioManager").c_str());
+  argv_[0] = const_cast<gchar*>(audio_manager.c_str());
   argv_[1] = const_cast<gchar*>(oKey_.c_str());
   argv_[2] = const_cast<gchar*>(outputFileName.c_str());
   argv_[3] = const_cast<gchar*>(tKey_.c_str());
-  argv_[4] = const_cast<gchar*>(durationString.c_str());
+  argv_[4] = const_cast<gchar*>(duration_string.c_str());
 }
 
 media_manager::FromMicToFileRecorderThread::Impl::~Impl() {}

--- a/src/components/telemetry_monitor/src/telemetry_monitor.cc
+++ b/src/components/telemetry_monitor/src/telemetry_monitor.cc
@@ -202,7 +202,7 @@ void Streamer::Start() {
   if (-1 == bind(server_socket_fd_,
                  reinterpret_cast<struct sockaddr*>(&serv_addr_),
                  sizeof(serv_addr_))) {
-    SDL_ERROR("Unable to bind server " << kserver_->ip().c_str() << ':'
+    SDL_ERROR("Unable to bind server " << kserver_->ip() << ':'
                                        << kserver_->port());
     return;
   }

--- a/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner_win.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner_win.cc
@@ -222,12 +222,13 @@ void BluetoothDeviceScanner::CheckSDLServiceOnDevices(
     }
 
     const BLUETOOTH_DEVICE_INFO bd_address = bd_addresses[i];
-    char deviceName[256];
+    const size_t device_name_size = 256u;
+    char device_name[device_name_size];
     char servInfo[NI_MAXSERV];
     DWORD hci_read_remote_name_ret =
         getnameinfo((struct sockaddr*)device_handle,
                     sizeof(struct sockaddr),
-                    deviceName,
+                    device_name,
                     NI_MAXHOST,
                     servInfo,
                     NI_MAXSERV,
@@ -235,19 +236,19 @@ void BluetoothDeviceScanner::CheckSDLServiceOnDevices(
 
     if (hci_read_remote_name_ret != 0) {
       SDL_ERROR_WITH_ERRNO("hci_read_remote_name failed");
-      strncpy(deviceName,
-              BluetoothDevice::GetUniqueDeviceId(bd_address).c_str(),
-              sizeof(deviceName) / sizeof(deviceName[0]));
+      const std::string unique_device_id =
+          BluetoothDevice::GetUniqueDeviceId(bd_address);
+      strncpy(device_name, unique_device_id.c_str(), device_name_size);
     }
 
     Device* bluetooth_device = new BluetoothDevice(
-        bd_address, deviceName, sdl_rfcomm_channels[i], sock_addr_bth_server_);
+        bd_address, device_name, sdl_rfcomm_channels[i], sock_addr_bth_server_);
 
     if (bluetooth_device) {
       SDL_INFO("Bluetooth device created successfully");
       discovered_devices->push_back(bluetooth_device);
     } else {
-      SDL_WARN("Can't create bluetooth device " << deviceName);
+      SDL_WARN("Can't create bluetooth device " << device_name);
     }
   }
 }

--- a/src/components/utils/src/file_system_posix.cc
+++ b/src/components/utils/src/file_system_posix.cc
@@ -112,8 +112,9 @@ bool file_system::CreateDirectoryRecursively(const std::string& utf8_path) {
 
   while (ret_val == true && pos <= utf8_path.length()) {
     pos = utf8_path.find(GetPathDelimiter(), pos + 1);
+    const std::string path = utf8_path.substr(0, pos);
     if (!DirectoryExists(utf8_path.substr(0, pos))) {
-      if (0 != mkdir(utf8_path.substr(0, pos).c_str(), S_IRWXU)) {
+      if (0 != mkdir(path.c_str(), S_IRWXU)) {
         ret_val = false;
       }
     }

--- a/src/components/utils/src/file_system_qt.cc
+++ b/src/components/utils/src/file_system_qt.cc
@@ -64,7 +64,7 @@ std::wstring ConvertUTF8ToWString(const std::string& utf8_str) {
     return std::wstring();
   }
   QString extended_utf8_str =
-      QString::fromUtf8(utils::ReplaceString(utf8_str, "/", "\\").c_str());
+      QString::fromStdString(utils::ReplaceString(utf8_str, "/", "\\"));
   if (!file_system::IsRelativePath(utf8_str)) {
     extended_utf8_str = kPlatformPathPrefix + extended_utf8_str;
   }

--- a/src/components/utils/src/log_message_loop_thread_qt.cc
+++ b/src/components/utils/src/log_message_loop_thread_qt.cc
@@ -91,17 +91,18 @@ void LogMessageHandler::Handle(const LogMessage message) {
   // will be the same for all messages. So the question is next, how to inject
   // correct thread id
   // to the qlogger.
-  (qlogger.*log_func)(
-      "%s [%s][%d][%s] %s:%d %s: %s",
-      type_str.c_str(),
-      message.time_.toString("yyyy:MM:dd hh:mm:ss.zzz").toStdString().c_str(),
-      message.thread_id_,
-      message.logger_.c_str(),
-      file_system::RetrieveFileNameFromPath(message.location_.file_name_)
-          .c_str(),
-      message.location_.line_number_,
-      message.location_.function_name_,
-      message.entry_.c_str());
+  const std::string time =
+      message.time_.toString("yyyy:MM:dd hh:mm:ss.zzz").toStdString();
+  (qlogger.*log_func)("%s [%s][%d][%s] %s:%d %s: %s",
+                      type_str.c_str(),
+                      time.c_str(),
+                      message.thread_id_,
+                      message.logger_.c_str(),
+                      file_system::RetrieveFileNameFromPath(
+                          message.location_.file_name_).c_str(),
+                      message.location_.line_number_,
+                      message.location_.function_name_,
+                      message.entry_.c_str());
 }
 
 }  // namespace logger

--- a/src/components/utils/src/log_message_loop_thread_win.cc
+++ b/src/components/utils/src/log_message_loop_thread_win.cc
@@ -88,11 +88,12 @@ void LogMessageHandler::Handle(const LogMessage message) {
         << utils::ReplaceString(message.entry_, "%", "%%");
 
   // dump log string to console
-  printf(entry.str().c_str());
+  const std::string entry_str = entry.str();
+  printf(entry_str.c_str());
   printf("\n");
   // dump log string to file
   if (message.output_file_) {
-    fprintf(message.output_file_, entry.str().c_str());
+    fprintf(message.output_file_, entry_str.c_str());
     fprintf(message.output_file_, "\n");
     fflush(message.output_file_);
   }

--- a/src/components/utils/src/pipe_qt.cc
+++ b/src/components/utils/src/pipe_qt.cc
@@ -33,6 +33,7 @@
 #include <cstdint>
 #include <cstddef>
 #include <QtNetwork>
+#include <QString>
 
 #include "utils/winhdr.h"
 #include "utils/pipe.h"
@@ -154,8 +155,8 @@ bool utils::Pipe::Impl::Write(const uint8_t* buffer,
 ////////////////////////////////////////////////////////////////////////////////
 
 utils::Pipe::Pipe(const std::string& name) {
-  impl_->name_ = (kPlatformPipePrefix +
-                  file_system::RetrieveFileNameFromPath(name)).c_str();
+  impl_->name_ = QString::fromStdString(
+      kPlatformPipePrefix + file_system::RetrieveFileNameFromPath(name));
 }
 
 bool utils::Pipe::Open() {

--- a/src/components/utils/src/socket_qt.cc
+++ b/src/components/utils/src/socket_qt.cc
@@ -324,9 +324,8 @@ void utils::TcpSocketConnection::Impl::Wait() {
 }
 
 void utils::TcpSocketConnection::Impl::OnErrorSlot() {
-  SDL_DEBUG("Socket error code:#["
-            << tcp_socket_->error() << "]. "
-            << tcp_socket_->errorString().toStdString().c_str());
+  SDL_DEBUG("Socket error code:#[" << tcp_socket_->error() << "]. "
+                                   << tcp_socket_->errorString().toStdString());
   if (tcp_socket_->error() != QAbstractSocket::RemoteHostClosedError) {
     OnError(tcp_socket_->error());
   }

--- a/src/components/utils/src/sql_qt_wrapper/sql_database_impl.cc
+++ b/src/components/utils/src/sql_qt_wrapper/sql_database_impl.cc
@@ -45,7 +45,8 @@ SQLDatabaseImpl::SQLDatabaseImpl() : database_path_() {}
 
 SQLDatabaseImpl::SQLDatabaseImpl(const std::string& database_path,
                                  const std::string& connection_name)
-    : database_path_((database_path + kDatabaseExtension.toStdString()).c_str())
+    : database_path_(QString::fromStdString(database_path +
+                                            kDatabaseExtension.toStdString()))
     , connection_name_(connection_name.c_str()) {
   db_ = QSqlDatabase::addDatabase("QSQLITE", connection_name_);
 }

--- a/src/components/utils/test/generated_code_with_sqlite_test.cc
+++ b/src/components/utils/test/generated_code_with_sqlite_test.cc
@@ -41,7 +41,8 @@ class GeneratedCodeTest : public ::testing::Test {
  public:
   static void SetUpTestCase() {
     sqlite3* conn;
-    sqlite3_open((kDatabaseName + ".sqlite").c_str(), &conn);
+    const std::string database_name = kDatabaseName + ".sqlite";
+    sqlite3_open(database_name.c_str(), &conn);
     sqlite3_exec(conn, kEndpointsCreation.c_str(), NULL, NULL, NULL);
     sqlite3_exec(conn, kEndpointsContent.c_str(), NULL, NULL, NULL);
     sqlite3_exec(conn, kAppPoliciesCreation.c_str(), NULL, NULL, NULL);
@@ -50,7 +51,8 @@ class GeneratedCodeTest : public ::testing::Test {
   }
 
   static void TearDownTestCase() {
-    remove((kDatabaseName + ".sqlite").c_str());
+    const std::string database_name = kDatabaseName + ".sqlite";
+    remove(database_name.c_str());
   }
 
   static const std::string kDatabaseName;

--- a/src/components/utils/test/sqlite_wrapper/sql_query_test.cc
+++ b/src/components/utils/test/sqlite_wrapper/sql_query_test.cc
@@ -56,7 +56,8 @@ class SQLQueryTest : public ::testing::Test {
   SQLDatabaseImpl db_;
 
   static void SetUpTestCase() {
-    sqlite3_open((kDatabaseName_ + ".sqlite").c_str(), &conn_);
+    const std::string database_name = kDatabaseName_ + ".sqlite";
+    sqlite3_open(database_name.c_str(), &conn_);
     sqlite3_exec(conn_,
                  "CREATE TABLE testTable (integerValue INTEGER,"
                  " doubleValue REAL, stringValue TEXT)",
@@ -67,7 +68,8 @@ class SQLQueryTest : public ::testing::Test {
 
   static void TearDownTestCase() {
     sqlite3_close(conn_);
-    remove((kDatabaseName_ + ".sqlite").c_str());
+    const std::string database_name = kDatabaseName_ + ".sqlite";
+    remove(database_name.c_str());
   }
 
   void SetUp() {


### PR DESCRIPTION
Currently, in code present incorrect usage
 of std::string like this:
`std::string("Some string").c_str();`
It causes undefined behavior, and should
be deprecated.

-
Related to: [APPLINK-28458](https://adc.luxoft.com/jira/browse/APPLINK-28458)

@AGaliuzov, @Kozoriz, @LuxoftAKutsan, @VProdanov, @wolfylambova22, please, review.