### PR TITLE
Add logger include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,10 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/components/include
 )
 
+include_directories(
+  $ENV{THIRD_PARTY_INSTALL_PREFIX}/include
+)
+
 if(BUILD_TESTS)
   enable_testing()
   add_definitions(-DBUILD_TESTS)

--- a/src/components/application_manager/test/commands/mobile/simple_response_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/simple_response_commands_test.cc
@@ -152,7 +152,7 @@ MATCHER_P2(CheckMessageParams, success, result, "") {
       success == (*arg)[am::strings::msg_params][am::strings::success].asBool();
   const bool is_result_code_correct =
       result ==
-      static_cast<uint32_t>(
+      static_cast<int32_t>(
           (*arg)[am::strings::msg_params][am::strings::result_code].asInt());
 
   using namespace helpers;


### PR DESCRIPTION
In case if log4cxx is not installed in the system, SDL should specify
include path for log4cxx

Fix signed\unsigned compare

Related issue : APPLINK-28469