### PR TITLE
Cover commands with UT

### DIFF
--- a/src/components/application_manager/test/commands/mobile/set_display_layout_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_display_layout_request_test.cc
@@ -87,10 +87,10 @@ TEST_F(SetDisplayLayoutRequestTest, Run_InvalidApp_UNSUCCESS) {
   EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(invalid_mock_app));
 
-  EXPECT_CALL(
-      mock_app_manager_,
-      ManageMobileCommand(
-          MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
+  EXPECT_CALL(mock_app_manager_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED),
+                  am::commands::Command::CommandOrigin::ORIGIN_SDL));
 
   command->Run();
 }
@@ -148,7 +148,8 @@ TEST_F(SetDisplayLayoutRequestTest, OnEvent_SUCCESS) {
 
   EXPECT_CALL(
       mock_app_manager_,
-      ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS),
+                          am::commands::Command::CommandOrigin::ORIGIN_SDL));
 
   command->on_event(event);
 }

--- a/src/components/application_manager/test/commands/mobile/set_display_layout_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_display_layout_request_test.cc
@@ -1,0 +1,160 @@
+/*
+ Copyright (c) 2016, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "mobile/set_display_layout_request.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+namespace set_display_layout_request {
+
+namespace am = ::application_manager;
+namespace mobile_result = mobile_apis::Result;
+
+using ::testing::Mock;
+using ::testing::_;
+
+using am::commands::SetDisplayLayoutRequest;
+using am::commands::MessageSharedPtr;
+
+typedef ::utils::SharedPtr<SetDisplayLayoutRequest> CommandPtr;
+
+namespace {
+const uint32_t kConnectionKey = 1u;
+const uint32_t kCorrelationKey = 2u;
+const uint32_t kAppId = 3u;
+}  // namespace
+
+MATCHER_P(CheckMshCorrId, corr_id, "") {
+  return (*arg)[am::strings::params][am::strings::correlation_id].asUInt() ==
+         corr_id;
+}
+
+class SetDisplayLayoutRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  typedef TypeIf<kMocksAreNice,
+                 NiceMock<application_manager_test::MockHMICapabilities>,
+                 application_manager_test::MockHMICapabilities>::Result
+      MockHMICapabilities;
+};
+typedef SetDisplayLayoutRequestTest::MockHMICapabilities MockHMICapabilities;
+
+TEST_F(SetDisplayLayoutRequestTest, Run_InvalidApp_UNSUCCESS) {
+  MessageSharedPtr msg(CreateMessage(smart_objects::SmartType_Map));
+  (*msg)[am::strings::params][am::strings::connection_key] = kConnectionKey;
+  CommandPtr command(CreateCommand<SetDisplayLayoutRequest>(msg));
+  MockAppPtr invalid_mock_app;
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(invalid_mock_app));
+
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(
+          MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
+
+  command->Run();
+}
+
+TEST_F(SetDisplayLayoutRequestTest, Run_SUCCESS) {
+  MessageSharedPtr msg(CreateMessage(smart_objects::SmartType_Map));
+  (*msg)[am::strings::params][am::strings::connection_key] = kConnectionKey;
+  CommandPtr command(CreateCommand<SetDisplayLayoutRequest>(msg));
+  MockAppPtr mock_app(CreateMockApp());
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
+  EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kAppId));
+
+  EXPECT_CALL(mock_app_manager_, GetNextHMICorrelationID())
+      .WillOnce(Return(kCorrelationKey));
+  EXPECT_CALL(mock_app_manager_,
+              ManageHMICommand(CheckMshCorrId(kCorrelationKey)))
+      .WillOnce(Return(true));
+
+  command->Run();
+}
+
+TEST_F(SetDisplayLayoutRequestTest, OnEvent_InvalidEventId_UNSUCCESS) {
+  CommandPtr command(CreateCommand<SetDisplayLayoutRequest>());
+  am::event_engine::Event event(hmi_apis::FunctionID::INVALID_ENUM);
+  SmartObject msg(smart_objects::SmartType_Map);
+
+  event.set_smart_object(msg);
+
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities()).Times(0);
+  command->on_event(event);
+}
+
+TEST_F(SetDisplayLayoutRequestTest, OnEvent_SUCCESS) {
+  CommandPtr command(CreateCommand<SetDisplayLayoutRequest>());
+
+  am::event_engine::Event event(hmi_apis::FunctionID::UI_SetDisplayLayout);
+  MessageSharedPtr msg = CreateMessage();
+
+  (*msg)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  (*msg)[am::strings::msg_params][am::hmi_response::display_capabilities] = 0;
+  event.set_smart_object(*msg);
+
+  MockHMICapabilities hmi_capabilities;
+  MessageSharedPtr dispaly_capabilities_msg = CreateMessage();
+  (*dispaly_capabilities_msg)[am::hmi_response::templates_available] =
+      "templates_available";
+
+  EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+      .WillOnce(ReturnRef(hmi_capabilities));
+
+  EXPECT_CALL(hmi_capabilities, display_capabilities())
+      .WillOnce(Return(dispaly_capabilities_msg.get()));
+
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
+
+  command->on_event(event);
+}
+
+}  // namespace set_display_layout_request
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
@@ -59,6 +59,7 @@ using utils::SharedPtr;
 using utils::custom_string::CustomString;
 using smart_objects::SmartObject;
 using testing::_;
+using testing::Mock;
 using testing::Return;
 
 namespace strings = application_manager::strings;
@@ -155,6 +156,43 @@ class SetGlobalPropertiesRequestTest
     EXPECT_CALL(*mock_app_, set_menu_icon(_)).Times(0);
     EXPECT_CALL(*mock_app_, set_keyboard_props(_)).Times(0);
     EXPECT_CALL(*mock_app_, app_id()).Times(0);
+  }
+
+  void ExpectInvalidData() {
+    EXPECT_CALL(mock_app_manager_,
+                ManageMobileCommand(
+                    MobileResultCodeIs(mobile_apis::Result::INVALID_DATA),
+                    am::commands::Command::ORIGIN_SDL));
+  }
+
+  void ExpectVerifyImageVrHelpSuccess(SmartObject& smart_obj) {
+    EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+        .WillOnce(Return(mock_app_));
+    EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(smart_obj, _, _))
+        .WillOnce(Return(mobile_apis::Result::SUCCESS));
+    EXPECT_CALL(mock_app_manager_, RemoveAppFromTTSGlobalPropertiesList(_))
+        .Times(0);
+  }
+
+  void ExpectVerifyImageVrHelpUnsuccess() {
+    EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+        .WillOnce(Return(mock_app_));
+    EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
+    EXPECT_CALL(mock_app_manager_, RemoveAppFromTTSGlobalPropertiesList(_))
+        .Times(0);
+  }
+
+  void ExpectVerifyImageSuccess(SmartObject& smart_obj) {
+    EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+        .WillOnce(Return(mock_app_));
+    EXPECT_CALL(mock_message_helper_, VerifyImage(smart_obj, _, _))
+        .WillOnce(Return(mobile_apis::Result::SUCCESS));
+    EXPECT_CALL(mock_app_manager_, RemoveAppFromTTSGlobalPropertiesList(_))
+        .Times(0);
+  }
+
+  void TearDown() OVERRIDE {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }
 
   MockAppPtr mock_app_;
@@ -366,6 +404,39 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_NoVR_SUCCESS) {
   command->Run();
 }
 
+TEST_F(SetGlobalPropertiesRequestTest, Run_VRCouldNotGenerate_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  SmartObject keyboard_properties(smart_objects::SmartType_Map);
+  (*msg)[strings::msg_params][hmi_request::keyboard_properties] =
+      keyboard_properties;
+  SmartObject menu_title("Menu_Title");
+  (*msg)[strings::msg_params][hmi_request::menu_title] = menu_title;
+
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app_));
+  EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
+  EXPECT_CALL(mock_app_manager_,
+              RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+  SmartObject* vr_help_title = NULL;
+  CommandsMap commands_map;
+  SmartObject empty_msg(smart_objects::SmartType_Map);
+  commands_map.insert(std::pair<uint32_t, SmartObject*>(1u, &empty_msg));
+  DataAccessor<CommandsMap> accessor(commands_map, lock_);
+  EXPECT_CALL(*mock_app_, commands_map()).WillOnce(Return(accessor));
+  EXPECT_CALL(*mock_app_, vr_help_title()).WillOnce(Return(vr_help_title));
+  EXPECT_CALL(*mock_app_, set_menu_title(_)).Times(0);
+
+  SharedPtr<SetGlobalPropertiesRequest> command(
+      CreateCommand<SetGlobalPropertiesRequest>(msg));
+
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::INVALID_DATA),
+                          am::commands::Command::ORIGIN_SDL));
+
+  command->Run();
+}
+
 TEST_F(SetGlobalPropertiesRequestTest, Run_NoVRNoDataNoDefault_Canceled) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject keyboard_properties(smart_objects::SmartType_Map);
@@ -564,9 +635,6 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_TTSIncorrectSyntax_Canceled) {
   EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(mock_app_manager_, RemoveAppFromTTSGlobalPropertiesList(_))
-      .Times(0);
-  SmartObject vr_help_title("title");
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -575,14 +643,134 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_TTSIncorrectSyntax_Canceled) {
   command->Run();
 }
 
+TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidHelpPromptText_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  SmartObject help_prompt(smart_objects::SmartType_Array);
+  help_prompt[0][strings::text] = "help_prompt\\n";
+  (*msg)[strings::msg_params][strings::help_prompt] = help_prompt;
+
+  ExpectVerifyImageVrHelpUnsuccess();
+  EmptyExpectationsSetupHelper();
+
+  SharedPtr<SetGlobalPropertiesRequest> command(
+      CreateCommand<SetGlobalPropertiesRequest>(msg));
+
+  ExpectInvalidData();
+
+  command->Run();
+}
+
+TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidVrHelpText_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  SmartObject vr_help(smart_objects::SmartType_Array);
+  vr_help[0][strings::text] = "vr_help\\n";
+  (*msg)[strings::msg_params][strings::vr_help] = vr_help;
+
+  ExpectVerifyImageVrHelpSuccess(vr_help);
+  EmptyExpectationsSetupHelper();
+
+  SharedPtr<SetGlobalPropertiesRequest> command(
+      CreateCommand<SetGlobalPropertiesRequest>(msg));
+
+  ExpectInvalidData();
+
+  command->Run();
+}
+
+TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidImageValue_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  SmartObject vr_help(smart_objects::SmartType_Array);
+  vr_help[0][strings::text] = "vr_help";
+  vr_help[0][strings::image][strings::value] = "value\\n";
+  (*msg)[strings::msg_params][strings::vr_help] = vr_help;
+
+  ExpectVerifyImageVrHelpSuccess(vr_help);
+  EmptyExpectationsSetupHelper();
+
+  SharedPtr<SetGlobalPropertiesRequest> command(
+      CreateCommand<SetGlobalPropertiesRequest>(msg));
+
+  ExpectInvalidData();
+
+  command->Run();
+}
+
+TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidMenuIcon_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  SmartObject menu_icon(smart_objects::SmartType_Array);
+  menu_icon[strings::value] = "meun_icon\\n";
+  (*msg)[strings::msg_params][strings::menu_icon] = menu_icon;
+
+  ExpectVerifyImageSuccess(menu_icon);
+  EmptyExpectationsSetupHelper();
+
+  SharedPtr<SetGlobalPropertiesRequest> command(
+      CreateCommand<SetGlobalPropertiesRequest>(msg));
+
+  ExpectInvalidData();
+
+  command->Run();
+}
+
+TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidMenuTitle_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  SmartObject menu_title(smart_objects::SmartType_Array);
+  menu_title = "menu_title\\n";
+  (*msg)[strings::msg_params][strings::menu_title] = menu_title;
+
+  ExpectVerifyImageVrHelpUnsuccess();
+  EmptyExpectationsSetupHelper();
+
+  SharedPtr<SetGlobalPropertiesRequest> command(
+      CreateCommand<SetGlobalPropertiesRequest>(msg));
+
+  ExpectInvalidData();
+
+  command->Run();
+}
+
+TEST_F(SetGlobalPropertiesRequestTest,
+       Run_InvalidLimitedCharacterList_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  SmartObject limited_character_list(smart_objects::SmartType_Array);
+  limited_character_list[0] = "limited_character_list\\n";
+  (*msg)[strings::msg_params][strings::keyboard_properties]
+        [strings::limited_character_list] = limited_character_list;
+
+  ExpectVerifyImageVrHelpUnsuccess();
+  EmptyExpectationsSetupHelper();
+
+  SharedPtr<SetGlobalPropertiesRequest> command(
+      CreateCommand<SetGlobalPropertiesRequest>(msg));
+
+  ExpectInvalidData();
+
+  command->Run();
+}
+
+TEST_F(SetGlobalPropertiesRequestTest,
+       Run_InvalidAutoCompleteText_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  SmartObject auto_complete_text(smart_objects::SmartType_Array);
+  auto_complete_text = "auto_complete_text\\n";
+  (*msg)[strings::msg_params][strings::keyboard_properties]
+        [strings::auto_complete_text] = auto_complete_text;
+
+  ExpectVerifyImageVrHelpUnsuccess();
+  EmptyExpectationsSetupHelper();
+
+  SharedPtr<SetGlobalPropertiesRequest> command(
+      CreateCommand<SetGlobalPropertiesRequest>(msg));
+
+  ExpectInvalidData();
+
+  command->Run();
+}
+
 TEST_F(SetGlobalPropertiesRequestTest, Run_NoData_Canceled) {
   MessageSharedPtr msg = CreateMsgParams();
 
-  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
-      .WillOnce(Return(mock_app_));
-  EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(mock_app_manager_, RemoveAppFromTTSGlobalPropertiesList(_))
-      .Times(0);
+  ExpectVerifyImageVrHelpUnsuccess();
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
@@ -595,17 +783,31 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidApp_Canceled) {
   MessageSharedPtr msg = CreateMessage();
   (*msg)[strings::params][strings::connection_key] = kConnectionKey;
 
-  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
-      .WillOnce(Return(MockAppPtr()));
-  EXPECT_CALL(mock_message_helper_, VerifyImageVrHelpItems(_, _, _)).Times(0);
-  EXPECT_CALL(mock_app_manager_, RemoveAppFromTTSGlobalPropertiesList(_))
-      .Times(0);
+  ExpectVerifyImageVrHelpUnsuccess();
+
   EmptyExpectationsSetupHelper();
 
   SharedPtr<SetGlobalPropertiesRequest> command(
       CreateCommand<SetGlobalPropertiesRequest>(msg));
 
   command->Run();
+}
+
+TEST_F(SetGlobalPropertiesRequestTest, OnEvent_PendingRequest_UNSUCCESS) {
+  MessageSharedPtr msg = CreateMsgParams();
+  hmi_apis::Common_Result::eType response_code =
+      hmi_apis::Common_Result::SUCCESS;
+  (*msg)[strings::params][hmi_response::code] = response_code;
+
+  SharedPtr<SetGlobalPropertiesRequest> command(
+      CreateCommand<SetGlobalPropertiesRequest>(msg));
+
+  EXPECT_CALL(mock_message_helper_, HMIToMobileResult(_)).Times(0);
+
+  Event event(hmi_apis::FunctionID::UI_SetGlobalProperties);
+  event.set_smart_object(*msg);
+
+  command->on_event(event);
 }
 
 TEST_F(SetGlobalPropertiesRequestTest, OnEvent_UIAndSuccessResultCode_SUCCESS) {

--- a/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
@@ -646,7 +646,8 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_TTSIncorrectSyntax_Canceled) {
 TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidHelpPromptText_INVALID_DATA) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject help_prompt(smart_objects::SmartType_Array);
-  help_prompt[0][strings::text] = "help_prompt\\n";
+  help_prompt[0][strings::text] =
+      "invalid help prompt text with empty line in the end\\n";
   (*msg)[strings::msg_params][strings::help_prompt] = help_prompt;
 
   ExpectVerifyImageVrHelpUnsuccess();
@@ -663,7 +664,8 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidHelpPromptText_INVALID_DATA) {
 TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidVrHelpText_INVALID_DATA) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject vr_help(smart_objects::SmartType_Array);
-  vr_help[0][strings::text] = "vr_help\\n";
+  vr_help[0][strings::text] =
+      "invalid vr_help text with empty line in the end\\n";
   (*msg)[strings::msg_params][strings::vr_help] = vr_help;
 
   ExpectVerifyImageVrHelpSuccess(vr_help);
@@ -681,7 +683,8 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidImageValue_INVALID_DATA) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject vr_help(smart_objects::SmartType_Array);
   vr_help[0][strings::text] = "vr_help";
-  vr_help[0][strings::image][strings::value] = "value\\n";
+  vr_help[0][strings::image][strings::value] =
+      "invalid value text with empty line in the end\\n";
   (*msg)[strings::msg_params][strings::vr_help] = vr_help;
 
   ExpectVerifyImageVrHelpSuccess(vr_help);
@@ -698,7 +701,8 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidImageValue_INVALID_DATA) {
 TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidMenuIcon_INVALID_DATA) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject menu_icon(smart_objects::SmartType_Array);
-  menu_icon[strings::value] = "meun_icon\\n";
+  menu_icon[strings::value] =
+      "invalid menu icon text with empty line in the end\\n";
   (*msg)[strings::msg_params][strings::menu_icon] = menu_icon;
 
   ExpectVerifyImageSuccess(menu_icon);
@@ -715,7 +719,7 @@ TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidMenuIcon_INVALID_DATA) {
 TEST_F(SetGlobalPropertiesRequestTest, Run_InvalidMenuTitle_INVALID_DATA) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject menu_title(smart_objects::SmartType_Array);
-  menu_title = "menu_title\\n";
+  menu_title = "invalid menu title text with empty line in the end\\n";
   (*msg)[strings::msg_params][strings::menu_title] = menu_title;
 
   ExpectVerifyImageVrHelpUnsuccess();
@@ -733,7 +737,8 @@ TEST_F(SetGlobalPropertiesRequestTest,
        Run_InvalidLimitedCharacterList_INVALID_DATA) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject limited_character_list(smart_objects::SmartType_Array);
-  limited_character_list[0] = "limited_character_list\\n";
+  limited_character_list[0] =
+      "invalid limited character list text with empty line in the end\\n";
   (*msg)[strings::msg_params][strings::keyboard_properties]
         [strings::limited_character_list] = limited_character_list;
 
@@ -752,7 +757,8 @@ TEST_F(SetGlobalPropertiesRequestTest,
        Run_InvalidAutoCompleteText_INVALID_DATA) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject auto_complete_text(smart_objects::SmartType_Array);
-  auto_complete_text = "auto_complete_text\\n";
+  auto_complete_text =
+      "invalid auto completetext with empty line in the end\\n";
   (*msg)[strings::msg_params][strings::keyboard_properties]
         [strings::auto_complete_text] = auto_complete_text;
 

--- a/src/components/application_manager/test/commands/mobile/set_icon_reques_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_icon_reques_test.cc
@@ -78,8 +78,8 @@ class SetIconRequestTest
         .WillByDefault(ReturnRef(mock_app_manager_settings_));
   }
   void TearDown() OVERRIDE {
-    if (file_system::FileExists("./" + kFileName)) {
-      EXPECT_TRUE(file_system::DeleteFile("./" + kFileName));
+    if (file_system::FileExists(kFileName)) {
+      EXPECT_TRUE(file_system::DeleteFile(kFileName));
     }
   }
 };
@@ -92,10 +92,10 @@ TEST_F(SetIconRequestTest, Run_InvalidApp_UNSUCCESS) {
   EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(invalid_mock_app));
 
-  EXPECT_CALL(
-      mock_app_manager_,
-      ManageMobileCommand(
-          MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
+  EXPECT_CALL(mock_app_manager_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED),
+                  am::commands::Command::CommandOrigin::ORIGIN_SDL));
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/mobile/set_icon_reques_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_icon_reques_test.cc
@@ -1,0 +1,193 @@
+/*
+ Copyright (c) 2016, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "utils/file_system.h"
+#include "commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "mobile/set_icon_request.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+namespace set_icon_request {
+
+namespace am = ::application_manager;
+namespace mobile_result = mobile_apis::Result;
+
+using ::testing::Mock;
+using ::testing::_;
+
+using am::commands::SetIconRequest;
+using am::commands::MessageSharedPtr;
+
+typedef ::utils::SharedPtr<SetIconRequest> CommandPtr;
+
+namespace {
+const uint32_t kConnectionKey = 1u;
+const std::string kFileName = "file.txt";
+}  // namespace
+
+MATCHER_P(CheckMsgType, msg_type, "") {
+  return msg_type ==
+         static_cast<int32_t>(
+             (*arg)[am::strings::params][am::strings::message_type].asInt());
+}
+
+class SetIconRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ protected:
+  void SetUp() OVERRIDE {
+    ON_CALL(mock_app_manager_, get_settings())
+        .WillByDefault(ReturnRef(mock_app_manager_settings_));
+  }
+  void TearDown() OVERRIDE {
+    if (file_system::FileExists("./" + kFileName)) {
+      EXPECT_TRUE(file_system::DeleteFile("./" + kFileName));
+    }
+  }
+};
+
+TEST_F(SetIconRequestTest, Run_InvalidApp_UNSUCCESS) {
+  MessageSharedPtr msg(CreateMessage(smart_objects::SmartType_Map));
+  (*msg)[am::strings::params][am::strings::connection_key] = kConnectionKey;
+  CommandPtr command(CreateCommand<SetIconRequest>(msg));
+  MockAppPtr invalid_mock_app;
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(invalid_mock_app));
+
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(
+          MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
+
+  command->Run();
+}
+
+TEST_F(SetIconRequestTest, Run_InvalidFile_UNSUCCESS) {
+  MessageSharedPtr msg(CreateMessage(smart_objects::SmartType_Map));
+  (*msg)[am::strings::params][am::strings::connection_key] = kConnectionKey;
+  (*msg)[am::strings::msg_params][am::strings::sync_file_name] = kFileName;
+
+  CommandPtr command(CreateCommand<SetIconRequest>(msg));
+  MockAppPtr mock_app(CreateMockApp());
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
+  const std::string folder_path = file_system::CurrentWorkingDirectory();
+  EXPECT_CALL(mock_app_manager_settings_, app_storage_folder())
+      .WillOnce(ReturnRef(folder_path));
+  EXPECT_CALL(*mock_app, folder_name()).WillOnce(Return("./"));
+
+  EXPECT_CALL(
+      mock_app_manager_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::INVALID_DATA),
+                          am::commands::Command::CommandOrigin::ORIGIN_SDL));
+
+  command->Run();
+}
+
+TEST_F(SetIconRequestTest, Run_SUCCESS) {
+  MessageSharedPtr msg(CreateMessage(smart_objects::SmartType_Map));
+  (*msg)[am::strings::params][am::strings::connection_key] = kConnectionKey;
+  (*msg)[am::strings::msg_params][am::strings::sync_file_name] = kFileName;
+
+  file_system::CreateFile("./" + kFileName);
+  CommandPtr command(CreateCommand<SetIconRequest>(msg));
+  MockAppPtr mock_app(CreateMockApp());
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
+  const std::string folder_path = file_system::CurrentWorkingDirectory();
+  EXPECT_CALL(mock_app_manager_settings_, app_storage_folder())
+      .WillOnce(ReturnRef(folder_path));
+  EXPECT_CALL(*mock_app, folder_name()).WillOnce(Return("./"));
+  EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kConnectionKey));
+
+  EXPECT_CALL(mock_app_manager_,
+              ManageHMICommand(CheckMsgType(am::MessageType::kRequest)))
+      .WillOnce(Return(true));
+
+  command->Run();
+}
+
+TEST_F(SetIconRequestTest, OnEvent_InvalidEventId_UNSUCCESS) {
+  CommandPtr command(CreateCommand<SetIconRequest>());
+  am::event_engine::Event event(hmi_apis::FunctionID::INVALID_ENUM);
+  SmartObject msg(smart_objects::SmartType_Map);
+
+  event.set_smart_object(msg);
+
+  EXPECT_CALL(mock_app_manager_, application(_)).Times(0);
+  command->on_event(event);
+}
+
+TEST_F(SetIconRequestTest, OnEvent_SUCCESS) {
+  const std::string file_path = "./file.txt";
+  MessageSharedPtr message = CreateMessage();
+  (*message)[am::strings::msg_params][am::strings::sync_file_name]
+            [am::strings::value] = file_path;
+  (*message)[am::strings::params][am::strings::connection_key] = kConnectionKey;
+
+  CommandPtr command(CreateCommand<SetIconRequest>(message));
+
+  am::event_engine::Event event(hmi_apis::FunctionID::UI_SetAppIcon);
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[am::strings::msg_params] = 0;
+  (*msg)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  event.set_smart_object(*msg);
+
+  MockAppPtr mock_app = CreateMockApp();
+  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
+
+  EXPECT_CALL(*mock_app, set_app_icon_path(file_path)).WillOnce(Return(true));
+  EXPECT_CALL(*mock_app, app_icon_path()).WillOnce(ReturnRef(file_path));
+
+  EXPECT_CALL(mock_app_manager_,
+              ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS),
+                                  am::commands::Command::ORIGIN_SDL));
+
+  command->on_event(event);
+}
+
+}  // namespace set_display_layout_request
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test


### PR DESCRIPTION
Covered next commands:
    - SetDisplayLayoutRequest,
    - SetGlobalPopertiesRequest,
    - SetIconRequest

Related to [APPLINK-28079](https://adc.luxoft.com/jira/browse/APPLINK-28079)