### PR TITLE
Add logger include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,10 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/components/include
 )
 
+include_directories(
+  $ENV{THIRD_PARTY_INSTALL_PREFIX}/include
+)
+
 if(BUILD_TESTS)
   enable_testing()
   add_definitions(-DBUILD_TESTS)

--- a/tools/policy_table_validator/CMakeLists.txt
+++ b/tools/policy_table_validator/CMakeLists.txt
@@ -16,6 +16,7 @@ link_directories (
 set(LIBRARIES
   policy_struct
   rpc_base
+  Utils
 )
 
 set (SOURCES


### PR DESCRIPTION
In case if logger is not installed to the system SDL should include directories from environment variables 