### PR TITLE
Cover commands with unit tests

### DIFF
--- a/src/components/application_manager/test/commands/hmi/navi_is_ready_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_is_ready_response_test.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_event_dispatcher.h"
+#include "application_manager/commands/hmi/navi_is_ready_response.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+namespace navi_is_ready_responce {
+
+namespace am = ::application_manager;
+namespace commands = am::commands;
+
+using ::testing::ReturnRef;
+using ::testing::Eq;
+using ::utils::SharedPtr;
+using commands::MessageSharedPtr;
+using commands::ResponseFromHMI;
+
+typedef SharedPtr<ResponseFromHMI> ResponseFromHMIPtr;
+
+namespace {
+const bool kNaviIsAvailable = true;
+const bool kNaviIsNotAvailable = false;
+}  // namespace
+
+class NaviIsReadyResponseTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  void TestRunWithSpecificNaviState(const bool is_available) {
+    application_manager_test::MockHMICapabilities mock_hmi_capabilities;
+    MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+    (*command_msg)[am::strings::msg_params][am::strings::available] =
+        is_available;
+
+    ResponseFromHMIPtr command(
+        CreateCommand<commands::NaviIsReadyResponse>(command_msg));
+
+    EXPECT_CALL(mock_app_manager_, hmi_capabilities())
+        .WillOnce(ReturnRef(mock_hmi_capabilities));
+    EXPECT_CALL(mock_hmi_capabilities, set_is_navi_cooperating(is_available));
+
+    command->Run();
+  }
+};
+
+TEST_F(NaviIsReadyResponseTest, NaviIsReadyResponse_Run_SUCCESS) {
+  TestRunWithSpecificNaviState(kNaviIsAvailable);
+}
+
+TEST_F(NaviIsReadyResponseTest, NaviIsReadyResponse_Run_UNSUCCESS) {
+  TestRunWithSpecificNaviState(kNaviIsNotAvailable);
+}
+
+}  // namespace navi_is_ready_responce
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
+++ b/src/components/application_manager/test/commands/hmi/simple_requests_to_hmi_test.cc
@@ -112,6 +112,7 @@
 #include "hmi/navi_subscribe_way_points_request.h"
 #include "hmi/sdl_policy_update.h"
 #include "hmi/ui_set_icon_request.h"
+#include "hmi/dial_number_request.h"
 
 namespace test {
 namespace components {
@@ -221,7 +222,8 @@ typedef Types<commands::NaviIsReadyRequest,
               commands::VRIsReadyRequest,
               commands::AllowAppRequest,
               commands::SDLPolicyUpdate,
-              commands::UISetIconRequest> RequestCommandsList2;
+              commands::UISetIconRequest,
+              commands::hmi::DialNumberRequest> RequestCommandsList2;
 
 TYPED_TEST_CASE(RequestToHMICommandsTest, RequestCommandsList);
 TYPED_TEST_CASE(RequestToHMICommandsTest2, RequestCommandsList2);

--- a/src/components/application_manager/test/commands/mobile/show_constant_tbt_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/show_constant_tbt_request_test.cc
@@ -59,10 +59,12 @@ using testing::ReturnRef;
 namespace strings = application_manager::strings;
 namespace hmi_request = application_manager::hmi_request;
 namespace hmi_response = application_manager::hmi_response;
+namespace mobile_result = mobile_apis::Result;
 
 namespace {
 const uint32_t kConnectionKey = 1u;
 const uint32_t kAppID = 2u;
+const std::string kWrongSyntax = "Wrong Syntax\\n";
 }  // namespace
 
 class ShowConstantTBTRequestTest
@@ -102,6 +104,19 @@ class ShowConstantTBTRequestTest
         navi_text_;
 
     EXPECT_CALL(*mock_app_, set_tbt_show_command(msg_params));
+  }
+
+  void WrongSyntaxBehavior(MessageSharedPtr msg) {
+    SharedPtr<ShowConstantTBTRequest> command(
+        CreateCommand<ShowConstantTBTRequest>(msg));
+
+    EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
+        .WillOnce(Return(mock_app_));
+    EXPECT_CALL(mock_app_manager_,
+                ManageMobileCommand(
+                    MobileResultCodeIs(mobile_result::INVALID_DATA), _));
+
+    command->Run();
   }
 
   MockAppPtr mock_app_;
@@ -160,6 +175,12 @@ TEST_F(ShowConstantTBTRequestTest, Run_TurnIcon_Canceled) {
   command->Run();
 }
 
+TEST_F(ShowConstantTBTRequestTest, Run_TurnIcon_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::msg_params][strings::turn_icon] = kWrongSyntax;
+  WrongSyntaxBehavior(msg);
+}
+
 TEST_F(ShowConstantTBTRequestTest, Run_NextTurnIcon_SUCCESS) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -209,6 +230,12 @@ TEST_F(ShowConstantTBTRequestTest, Run_NextTurnIcon_Canceled) {
   command->Run();
 }
 
+TEST_F(ShowConstantTBTRequestTest, Run_NextTurnIcon_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::msg_params][strings::next_turn_icon] = kWrongSyntax;
+  WrongSyntaxBehavior(msg);
+}
+
 TEST_F(ShowConstantTBTRequestTest, Run_NavigationText1_SUCCESS) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -226,6 +253,12 @@ TEST_F(ShowConstantTBTRequestTest, Run_NavigationText1_SUCCESS) {
                        hmi_apis::Common_TextFieldName::navigationText1);
 
   command->Run();
+}
+
+TEST_F(ShowConstantTBTRequestTest, Run_NavigationText1_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::msg_params][strings::navigation_text_1] = kWrongSyntax;
+  WrongSyntaxBehavior(msg);
 }
 
 TEST_F(ShowConstantTBTRequestTest, Run_NavigationText2_SUCCESS) {
@@ -247,6 +280,12 @@ TEST_F(ShowConstantTBTRequestTest, Run_NavigationText2_SUCCESS) {
   command->Run();
 }
 
+TEST_F(ShowConstantTBTRequestTest, Run_NavigationText2_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::msg_params][strings::navigation_text_2] = kWrongSyntax;
+  WrongSyntaxBehavior(msg);
+}
+
 TEST_F(ShowConstantTBTRequestTest, Run_ETA_SUCCESS) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -263,6 +302,12 @@ TEST_F(ShowConstantTBTRequestTest, Run_ETA_SUCCESS) {
       msg_params, strings::eta, hmi_apis::Common_TextFieldName::ETA);
 
   command->Run();
+}
+
+TEST_F(ShowConstantTBTRequestTest, Run_ETA_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::msg_params][strings::eta] = kWrongSyntax;
+  WrongSyntaxBehavior(msg);
 }
 
 TEST_F(ShowConstantTBTRequestTest, Run_TotalDistance_SUCCESS) {
@@ -284,6 +329,12 @@ TEST_F(ShowConstantTBTRequestTest, Run_TotalDistance_SUCCESS) {
   command->Run();
 }
 
+TEST_F(ShowConstantTBTRequestTest, Run_TotalDistance_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::msg_params][strings::total_distance] = kWrongSyntax;
+  WrongSyntaxBehavior(msg);
+}
+
 TEST_F(ShowConstantTBTRequestTest, Run_TimeToDistanation_SUCCESS) {
   MessageSharedPtr msg = CreateMsgParams();
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -301,6 +352,12 @@ TEST_F(ShowConstantTBTRequestTest, Run_TimeToDistanation_SUCCESS) {
                        hmi_apis::Common_TextFieldName::timeToDestination);
 
   command->Run();
+}
+
+TEST_F(ShowConstantTBTRequestTest, Run_TimeToDistanation_INVALID_DATA) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::msg_params][strings::time_to_destination] = kWrongSyntax;
+  WrongSyntaxBehavior(msg);
 }
 
 TEST_F(ShowConstantTBTRequestTest, Run_SoftButtons_SUCCESS) {
@@ -346,25 +403,6 @@ TEST_F(ShowConstantTBTRequestTest, Run_InvalidApp_Canceled) {
 
 TEST_F(ShowConstantTBTRequestTest, Run_EmptyMsgParams_Canceled) {
   MessageSharedPtr msg = CreateMsgParams();
-
-  SharedPtr<ShowConstantTBTRequest> command(
-      CreateCommand<ShowConstantTBTRequest>(msg));
-
-  EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
-      .WillOnce(Return(mock_app_));
-  EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _));
-  EXPECT_CALL(mock_app_manager_, GetPolicyHandler()).Times(0);
-  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _)).Times(0);
-  EXPECT_CALL(*mock_app_, app_id()).Times(0);
-
-  EXPECT_CALL(*mock_app_, set_tbt_show_command(_)).Times(0);
-
-  command->Run();
-}
-
-TEST_F(ShowConstantTBTRequestTest, Run_WrongSyntax_Canceled) {
-  MessageSharedPtr msg = CreateMsgParams();
-  (*msg)[strings::msg_params][strings::navigation_text_1] = "Wrong Syntax\\n";
 
   SharedPtr<ShowConstantTBTRequest> command(
       CreateCommand<ShowConstantTBTRequest>(msg));


### PR DESCRIPTION
Covered code lines for following files:
 - navi_is_ready_response;
 - dial_number_request;
 - get_urls;
 - perform_audio_pass_thru_request; 
 - show_constant_tbt_request.

Related task : APPLINK-28075
Reopened #862 