### PR TITLE
Fix problem with saving VI subscribtion when vi interface isn't available

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
@@ -130,7 +130,7 @@ class SubscribeVehicleDataRequest : public CommandRequestImpl {
                             mobile_apis::Result::eType& out_result_code,
                             smart_objects::SmartObject& out_response_params,
                             smart_objects::SmartObject& out_request_params,
-                            bool& result);
+                            bool& out_result);
 
   /**
    * @brief VI parameters which had been already subscribed by another apps

--- a/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
@@ -113,6 +113,26 @@ class SubscribeVehicleDataRequest : public CommandRequestImpl {
       const smart_objects::SmartObject& msg_params) const;
 
   /**
+   * @brief Checks if current application and other applications
+   * were subscribed to VI, prepare data that need to send to mobile app
+   * or HMI.
+   * @param app contains application
+   * @param out_info contains resulting info for sending to mobile app
+   * @param out_result_code contains result code for sending to mobile app
+   * @param out_response_params contains parameters that SDL sends to
+   * mobile application
+   * @param out_request_params contains parameters that SDL sends to
+   * HMI
+   * @param result contains result that SDL sends to mobile app.
+   */
+  void CheckVISubscribtions(ApplicationSharedPtr app,
+                            std::string& out_info,
+                            mobile_apis::Result::eType& out_result_code,
+                            smart_objects::SmartObject& out_response_params,
+                            smart_objects::SmartObject& out_request_params,
+                            bool& result);
+
+  /**
    * @brief VI parameters which had been already subscribed by another apps
    * befor particular app subscribed for these parameters
    */

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -68,6 +68,9 @@ const std::string CreateInfoForUnsupportedResult(
     case (HmiInterfaces::InterfaceID::HMI_INTERFACE_Navigation): {
       return "Navi is not supported by system";
     }
+    case (HmiInterfaces::InterfaceID::HMI_INTERFACE_VehicleInfo): {
+      return "VehicleInfo is not supported by system";
+    }
     default:
 #ifdef ENABLE_LOG
       CREATE_LOGGERPTR_LOCAL(logger, "Commands");

--- a/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -109,115 +109,21 @@ void SubscribeVehicleDataRequest::Run() {
     SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
     return;
   }
-
-  // counter for items to subscribe
-  int32_t items_to_subscribe = 0;
-  // counter for subscribed items by application
-  int32_t subscribed_items = 0;
-
-  const VehicleData& vehicle_data = MessageHelper::vehicle_data();
-  VehicleData::const_iterator it = vehicle_data.begin();
-
+  std::string info;
+  mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
   smart_objects::SmartObject msg_params =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
-
   smart_objects::SmartObject response_params =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
+  bool result = false;
+  CheckVISubscribtions(
+      app, info, result_code, response_params, msg_params, result);
 
-  for (; vehicle_data.end() != it; ++it) {
-    const std::string& key_name = it->first;
-    if ((*message_)[strings::msg_params].keyExists(key_name)) {
-      bool is_key_enabled = (*message_)[strings::msg_params][key_name].asBool();
-      if (is_key_enabled) {
-        ++items_to_subscribe;
-
-        VehicleDataType key_type = it->second;
-        if (app->IsSubscribedToIVI(key_type)) {
-          LOG4CXX_DEBUG(logger_,
-                        "App with connection key "
-                            << connection_key()
-                            << " is subscribed already for VehicleDataType: "
-                            << key_type);
-          ++subscribed_items;
-          vi_already_subscribed_by_this_app_.insert(key_type);
-          response_params[key_name][strings::data_type] = key_type;
-          response_params[key_name][strings::result_code] =
-              mobile_apis::VehicleDataResultCode::VDRC_DATA_ALREADY_SUBSCRIBED;
-          continue;
-        }
-
-        if (IsSomeoneSubscribedFor(key_type)) {
-          LOG4CXX_DEBUG(logger_,
-                        "There are apps subscribed already for "
-                        "VehicleDataType: "
-                            << key_type);
-          if (!app->SubscribeToIVI(static_cast<uint32_t>(key_type))) {
-            LOG4CXX_ERROR(
-                logger_,
-                "Unable to subscribe for VehicleDataType: " << key_type);
-            continue;
-          }
-          LOG4CXX_DEBUG(
-              logger_,
-              "App with connection key "
-                  << connection_key()
-                  << " have been subscribed for VehicleDataType: " << key_type);
-          ++subscribed_items;
-          vi_already_subscribed_by_another_apps_.insert(key_type);
-          response_params[key_name][strings::data_type] = key_type;
-          response_params[key_name][strings::result_code] =
-              mobile_apis::VehicleDataResultCode::VDRC_SUCCESS;
-          continue;
-        }
-
-        msg_params[key_name] = is_key_enabled;
-
-        if (app->SubscribeToIVI(static_cast<uint32_t>(key_type))) {
-          LOG4CXX_DEBUG(
-              logger_,
-              "App with connection key "
-                  << connection_key()
-                  << " have been subscribed for VehicleDataType: " << key_type);
-          ++subscribed_items;
-        }
-      }
-    }
-  }
-
-  bool is_everything_already_subscribed =
-      static_cast<uint32_t>(items_to_subscribe) ==
-      vi_already_subscribed_by_another_apps_.size() +
-          vi_already_subscribed_by_this_app_.size();
-
-  if (0 == items_to_subscribe) {
-    if (HasDisallowedParams()) {
-      SendResponse(false, mobile_apis::Result::DISALLOWED);
-    } else {
-      SendResponse(
-          false, mobile_apis::Result::INVALID_DATA, "No data in the request");
-    }
-    return;
-  }
-
-  if (0 == subscribed_items) {
-    SendResponse(false,
-                 mobile_apis::Result::IGNORED,
-                 "Already subscribed on provided VehicleData.",
-                 &response_params);
-    return;
-  }
-
-  if (is_everything_already_subscribed) {
-    mobile_apis::Result::eType result_code =
-        vi_already_subscribed_by_this_app_.size()
-            ? mobile_apis::Result::IGNORED
-            : mobile_apis::Result::SUCCESS;
-
-    const char* info = vi_already_subscribed_by_this_app_.size()
-                           ? "Already subscribed on some provided VehicleData."
-                           : NULL;
-
-    SendResponse(true, result_code, info, &response_params);
+  if (mobile_apis::Result::INVALID_ENUM != result_code) {
+    SendResponse(result,
+                 result_code,
+                 info.empty() ? NULL : info.c_str(),
+                 response_params.empty() ? NULL : &response_params);
     return;
   }
 
@@ -427,6 +333,121 @@ bool SubscribeVehicleDataRequest::IsSomeoneSubscribedFor(
   ApplicationSetConstIt it = std::find_if(
       accessor.GetData().begin(), accessor.GetData().end(), finder);
   return it != accessor.GetData().end();
+}
+
+void SubscribeVehicleDataRequest::CheckVISubscribtions(
+    ApplicationSharedPtr app,
+    std::string& out_info,
+    mobile_apis::Result::eType& out_result_code,
+    smart_objects::SmartObject& out_response_params,
+    smart_objects::SmartObject& out_request_params,
+    bool& result) {
+  // counter for items to subscribe
+  int32_t items_to_subscribe = 0;
+  // counter for subscribed items by application
+  int32_t subscribed_items = 0;
+
+  const VehicleData& vehicle_data = MessageHelper::vehicle_data();
+  VehicleData::const_iterator it = vehicle_data.begin();
+
+  HmiInterfaces::InterfaceState interface_state =
+      application_manager_.hmi_interfaces().GetInterfaceState(
+          HmiInterfaces::HMI_INTERFACE_VehicleInfo);
+
+  const bool is_interface_not_available =
+      interface_state == HmiInterfaces::STATE_NOT_AVAILABLE;
+
+  for (; vehicle_data.end() != it; ++it) {
+    const std::string& key_name = it->first;
+    if ((*message_)[strings::msg_params].keyExists(key_name)) {
+      bool is_key_enabled = (*message_)[strings::msg_params][key_name].asBool();
+      if (is_key_enabled) {
+        ++items_to_subscribe;
+      }
+      if (!is_interface_not_available && is_key_enabled) {
+        VehicleDataType key_type = it->second;
+        if (app->IsSubscribedToIVI(key_type)) {
+          LOG4CXX_DEBUG(logger_,
+                        "App with connection key "
+                            << connection_key()
+                            << " is subscribed already for VehicleDataType: "
+                            << key_type);
+          ++subscribed_items;
+          vi_already_subscribed_by_this_app_.insert(key_type);
+          out_response_params[key_name][strings::data_type] = key_type;
+          out_response_params[key_name][strings::result_code] =
+              mobile_apis::VehicleDataResultCode::VDRC_DATA_ALREADY_SUBSCRIBED;
+          continue;
+        }
+
+        if (IsSomeoneSubscribedFor(key_type)) {
+          LOG4CXX_DEBUG(logger_,
+                        "There are apps subscribed already for "
+                        "VehicleDataType: "
+                            << key_type);
+          if (!app->SubscribeToIVI(static_cast<uint32_t>(key_type))) {
+            LOG4CXX_ERROR(
+                logger_,
+                "Unable to subscribe for VehicleDataType: " << key_type);
+            continue;
+          }
+          LOG4CXX_DEBUG(
+              logger_,
+              "App with connection key "
+                  << connection_key()
+                  << " have been subscribed for VehicleDataType: " << key_type);
+          ++subscribed_items;
+          vi_already_subscribed_by_another_apps_.insert(key_type);
+          out_response_params[key_name][strings::data_type] = key_type;
+          out_response_params[key_name][strings::result_code] =
+              mobile_apis::VehicleDataResultCode::VDRC_SUCCESS;
+          continue;
+        }
+
+        out_request_params[key_name] = is_key_enabled;
+
+        if (app->SubscribeToIVI(static_cast<uint32_t>(key_type))) {
+          LOG4CXX_DEBUG(
+              logger_,
+              "App with connection key "
+                  << connection_key()
+                  << " have been subscribed for VehicleDataType: " << key_type);
+          ++subscribed_items;
+        }
+      }
+    }
+  }
+
+  const bool is_everything_already_subscribed =
+      static_cast<uint32_t>(items_to_subscribe) ==
+      vi_already_subscribed_by_another_apps_.size() +
+          vi_already_subscribed_by_this_app_.size();
+
+  if (0 == items_to_subscribe) {
+    if (HasDisallowedParams()) {
+      out_result_code = mobile_apis::Result::DISALLOWED;
+    } else {
+      out_result_code = mobile_apis::Result::INVALID_DATA;
+      out_info = "No data in the request";
+    }
+    result = false;
+  }
+
+  if (0 == subscribed_items && !is_interface_not_available) {
+    out_result_code = mobile_apis::Result::IGNORED;
+    out_info = "Already subscribed on provided VehicleData.";
+    result = false;
+  }
+
+  if (is_everything_already_subscribed) {
+    out_result_code = vi_already_subscribed_by_this_app_.size()
+                          ? mobile_apis::Result::IGNORED
+                          : mobile_apis::Result::SUCCESS;
+    if (vi_already_subscribed_by_this_app_.size()) {
+      out_info = "Already subscribed on some provided VehicleData.";
+    }
+    result = true;
+  }
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -341,11 +341,11 @@ void SubscribeVehicleDataRequest::CheckVISubscribtions(
     mobile_apis::Result::eType& out_result_code,
     smart_objects::SmartObject& out_response_params,
     smart_objects::SmartObject& out_request_params,
-    bool& result) {
+    bool& out_result) {
   // counter for items to subscribe
-  int32_t items_to_subscribe = 0;
+  VehicleInfoSubscriptions::size_type items_to_subscribe = 0;
   // counter for subscribed items by application
-  int32_t subscribed_items = 0;
+  uint32_t subscribed_items = 0;
 
   const VehicleData& vehicle_data = MessageHelper::vehicle_data();
   VehicleData::const_iterator it = vehicle_data.begin();
@@ -360,7 +360,8 @@ void SubscribeVehicleDataRequest::CheckVISubscribtions(
   for (; vehicle_data.end() != it; ++it) {
     const std::string& key_name = it->first;
     if ((*message_)[strings::msg_params].keyExists(key_name)) {
-      bool is_key_enabled = (*message_)[strings::msg_params][key_name].asBool();
+      const bool is_key_enabled =
+          (*message_)[strings::msg_params][key_name].asBool();
       if (is_key_enabled) {
         ++items_to_subscribe;
       }
@@ -419,7 +420,7 @@ void SubscribeVehicleDataRequest::CheckVISubscribtions(
   }
 
   const bool is_everything_already_subscribed =
-      static_cast<uint32_t>(items_to_subscribe) ==
+      items_to_subscribe ==
       vi_already_subscribed_by_another_apps_.size() +
           vi_already_subscribed_by_this_app_.size();
 
@@ -430,23 +431,23 @@ void SubscribeVehicleDataRequest::CheckVISubscribtions(
       out_result_code = mobile_apis::Result::INVALID_DATA;
       out_info = "No data in the request";
     }
-    result = false;
+    out_result = false;
   }
 
   if (0 == subscribed_items && !is_interface_not_available) {
     out_result_code = mobile_apis::Result::IGNORED;
     out_info = "Already subscribed on provided VehicleData.";
-    result = false;
+    out_result = false;
   }
 
   if (is_everything_already_subscribed) {
     out_result_code = vi_already_subscribed_by_this_app_.size()
                           ? mobile_apis::Result::IGNORED
                           : mobile_apis::Result::SUCCESS;
-    if (vi_already_subscribed_by_this_app_.size()) {
+    if (!(vi_already_subscribed_by_this_app_.empty())) {
       out_info = "Already subscribed on some provided VehicleData.";
     }
-    result = true;
+    out_result = true;
   }
 }
 


### PR DESCRIPTION
Forbid ability to save vi subscribtion if vi interface isn't available

Closes defect [APPLINK-28726](https://adc.luxoft.com/jira/browse/APPLINK-28726)