### PR TITLE
Add “SDL_GENERIC” Display Type Enum

### DIFF
--- a/src/components/application_manager/src/hmi_capabilities.cc
+++ b/src/components/application_manager/src/hmi_capabilities.cc
@@ -196,7 +196,8 @@ const std::map<std::string, hmi_apis::Common_DisplayType::eType>
         {"MFD3", hmi_apis::Common_DisplayType::MFD3},
         {"MFD4", hmi_apis::Common_DisplayType::MFD4},
         {"MFD5", hmi_apis::Common_DisplayType::MFD5},
-        {"GEN3_8_INCH", hmi_apis::Common_DisplayType::GEN3_8_INCH}};
+        {"GEN3_8_INCH", hmi_apis::Common_DisplayType::GEN3_8_INCH},
+        {"SDL_GENERIC", hmi_apis::Common_DisplayType::SDL_GENERIC}};
 
 const std::map<std::string, hmi_apis::Common_CharacterSet::eType>
     character_set_enum = {{"TYPE2SET", hmi_apis::Common_CharacterSet::TYPE2SET},

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -382,6 +382,7 @@
     <description> 5 inch GEN1.1 display </description>
     </element>
     <element name="GEN3_8_INCH"/>
+    <element name="SDL_GENERIC" />
   </enum>
 
 <enum name="ImageType">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -580,6 +580,7 @@
     <element name="MFD4" />
     <element name="MFD5" />
     <element name="GEN3_8-INCH" internal_name="GEN3_8_INCH" />
+    <element name="SDL_GENERIC" />
   </enum>
 
   <enum name="TextFieldName">

--- a/src/components/utils/test/test_generator/MOBILE_API.xml
+++ b/src/components/utils/test/test_generator/MOBILE_API.xml
@@ -584,6 +584,7 @@
     <element name="MFD4" />
     <element name="MFD5" />
     <element name="GEN3_8-INCH" internal_name="GEN3_8_INCH" />
+    <element name="SDL_GENERIC" />
   </enum>
 
   <enum name="TextFieldName">


### PR DESCRIPTION
All display types included in the API specs are Ford specific. Other Parties integrating SDL need this enum supported ASAP.

#626 