### PR TITLE
Add Unit Tests to TTS IsReady false

### DIFF
--- a/src/components/application_manager/test/commands/mobile/CMakeLists.txt
+++ b/src/components/application_manager/test/commands/mobile/CMakeLists.txt
@@ -45,6 +45,9 @@ set (SOURCES
   ${COMMANDS_TEST_SOURCE_DIR}/mobile/change_registration_test.cc
   ${COMMANDS_TEST_SOURCE_DIR}/mobile/create_interaction_choice_set_test.cc
   ${COMMANDS_TEST_SOURCE_DIR}/mobile/register_app_interface_request_test.cc
+  ${COMMANDS_TEST_SOURCE_DIR}/mobile/speak_request_test.cc
+  ${COMMANDS_TEST_SOURCE_DIR}/mobile/set_global_properties_request_test.cc
+  ${COMMANDS_TEST_SOURCE_DIR}/mobile/alert_maneuver_request_test.cc
 )
 
 set(LIBRARIES

--- a/src/components/application_manager/test/commands/mobile/change_registration_test.cc
+++ b/src/components/application_manager/test/commands/mobile/change_registration_test.cc
@@ -141,8 +141,10 @@ class ChangeRegistrationRequestTest
                          const mobile_apis::Result::eType mobile_response,
                          const am::HmiInterfaces::InterfaceState state,
                          const bool success,
-                         const hmi_apis::Common_Result::eType ui_hmi_response = hmi_apis::Common_Result::WARNINGS,
-                         const hmi_apis::Common_Result::eType vr_hmi_response = hmi_apis::Common_Result::UNSUPPORTED_RESOURCE) {
+                         const hmi_apis::Common_Result::eType ui_hmi_response =
+                             hmi_apis::Common_Result::WARNINGS,
+                         const hmi_apis::Common_Result::eType vr_hmi_response =
+                             hmi_apis::Common_Result::UNSUPPORTED_RESOURCE) {
     MessageSharedPtr msg_from_mobile = CreateMsgFromMobile();
 
     utils::SharedPtr<ChangeRegistrationRequest> command =
@@ -167,11 +169,8 @@ class ChangeRegistrationRequestTest
     MessageSharedPtr ui_response = CreateMessage(smart_objects::SmartType_Map);
     MessageSharedPtr vr_response = CreateMessage(smart_objects::SmartType_Map);
     MessageSharedPtr tts_response = CreateMessage(smart_objects::SmartType_Map);
-    CreateResponseFromHMI(
-        ui_response, ui_hmi_response, "ui_info");
-    CreateResponseFromHMI(vr_response,
-                          vr_hmi_response,
-                          "unsupported_resource");
+    CreateResponseFromHMI(ui_response, ui_hmi_response, "ui_info");
+    CreateResponseFromHMI(vr_response, vr_hmi_response, "unsupported_resource");
 
     (*tts_response)[strings::params][hmi_response::code] = hmi_response;
     (*tts_response)[strings::msg_params] = 0;
@@ -179,7 +178,8 @@ class ChangeRegistrationRequestTest
     MockHmiInterfaces hmi_interfaces;
     EXPECT_CALL(app_mngr_, hmi_interfaces())
         .WillRepeatedly(ReturnRef(hmi_interfaces));
-    EXPECT_CALL(hmi_interfaces, GetInterfaceState(_)).WillRepeatedly(Return(state));
+    EXPECT_CALL(hmi_interfaces, GetInterfaceState(_))
+        .WillRepeatedly(Return(state));
 
     am::event_engine::Event event_ui(
         hmi_apis::FunctionID::UI_ChangeRegistration);
@@ -293,53 +293,68 @@ TEST_F(ChangeRegistrationRequestTest, OnEvent_VR_UNSUPPORTED_RESOURCE) {
       static_cast<int32_t>(mobile_apis::Result::UNSUPPORTED_RESOURCE));
 }
 
-TEST_F(ChangeRegistrationRequestTest, OnEvent_TTS_UNSUPPORTED_RESOURCE_STATE_NOT_AVAILABLE_Expect_true) {
+TEST_F(ChangeRegistrationRequestTest,
+       OnEvent_TTS_UNSUPPORTED_RESOURCE_STATE_NOT_AVAILABLE_Expect_true) {
   CheckExpectations(hmi_apis::Common_Result::SUCCESS,
                     mobile_apis::Result::UNSUPPORTED_RESOURCE,
                     am::HmiInterfaces::STATE_NOT_AVAILABLE,
                     true);
 }
 
-TEST_F(ChangeRegistrationRequestTest, OnEvent_TTS_UNSUPPORTED_RESOURCE_STATE_NOT_RESPONSE_Expect_false) {
+TEST_F(ChangeRegistrationRequestTest,
+       OnEvent_TTS_UNSUPPORTED_RESOURCE_STATE_NOT_RESPONSE_Expect_false) {
   CheckExpectations(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
                     mobile_apis::Result::UNSUPPORTED_RESOURCE,
                     am::HmiInterfaces::STATE_NOT_RESPONSE,
                     false);
 }
 
-TEST_F(ChangeRegistrationRequestTest, OnEvent_TTS_UNSUPPORTED_RESOURCE_STATE_AVAILABLE_Expect_false) {
+TEST_F(ChangeRegistrationRequestTest,
+       OnEvent_TTS_UNSUPPORTED_RESOURCE_STATE_AVAILABLE_Expect_false) {
   CheckExpectations(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
                     mobile_apis::Result::UNSUPPORTED_RESOURCE,
                     am::HmiInterfaces::STATE_AVAILABLE,
                     false);
 }
 
-TEST_F(ChangeRegistrationRequestTest, OnEvent_TTS_UNSUPPORTED_RESOURCE_SUCCESS_STATE_AVAILABLE_Expect_false) {
+TEST_F(ChangeRegistrationRequestTest,
+       OnEvent_TTS_UNSUPPORTED_RESOURCE_SUCCESS_STATE_AVAILABLE_Expect_false) {
   CheckExpectations(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
                     mobile_apis::Result::UNSUPPORTED_RESOURCE,
                     am::HmiInterfaces::STATE_AVAILABLE,
-                    false, hmi_apis::Common_Result::SUCCESS, hmi_apis::Common_Result::SUCCESS);
+                    false,
+                    hmi_apis::Common_Result::SUCCESS,
+                    hmi_apis::Common_Result::SUCCESS);
 }
 
-TEST_F(ChangeRegistrationRequestTest, OnEvent_TTS_SUCCESS_STATE_AVAILABLE_Expect_false) {
+TEST_F(ChangeRegistrationRequestTest,
+       OnEvent_TTS_SUCCESS_STATE_AVAILABLE_Expect_false) {
   CheckExpectations(hmi_apis::Common_Result::SUCCESS,
                     mobile_apis::Result::SUCCESS,
                     am::HmiInterfaces::STATE_AVAILABLE,
-                    true, hmi_apis::Common_Result::SUCCESS, hmi_apis::Common_Result::SUCCESS);
+                    true,
+                    hmi_apis::Common_Result::SUCCESS,
+                    hmi_apis::Common_Result::SUCCESS);
 }
 
-TEST_F(ChangeRegistrationRequestTest, OnEvent_TTS_WRONG_LANGUAGE_STATE_AVAILABLE_Expect_true) {
+TEST_F(ChangeRegistrationRequestTest,
+       OnEvent_TTS_WRONG_LANGUAGE_STATE_AVAILABLE_Expect_true) {
   CheckExpectations(hmi_apis::Common_Result::WRONG_LANGUAGE,
                     mobile_apis::Result::SUCCESS,
                     am::HmiInterfaces::STATE_AVAILABLE,
-                    true, hmi_apis::Common_Result::SUCCESS, hmi_apis::Common_Result::SUCCESS);
+                    true,
+                    hmi_apis::Common_Result::SUCCESS,
+                    hmi_apis::Common_Result::SUCCESS);
 }
 
-TEST_F(ChangeRegistrationRequestTest, OnEvent_TTS_INVALID_DATA_STATE_AVAILABLE_Expect_false) {
+TEST_F(ChangeRegistrationRequestTest,
+       OnEvent_TTS_INVALID_DATA_STATE_AVAILABLE_Expect_false) {
   CheckExpectations(hmi_apis::Common_Result::INVALID_DATA,
                     mobile_apis::Result::SUCCESS,
                     am::HmiInterfaces::STATE_AVAILABLE,
-                    false, hmi_apis::Common_Result::SUCCESS, hmi_apis::Common_Result::SUCCESS);
+                    false,
+                    hmi_apis::Common_Result::SUCCESS,
+                    hmi_apis::Common_Result::SUCCESS);
 }
 
 }  // namespace commands_test

--- a/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+#include <set>
+
+#include "application_manager/commands/mobile/set_global_properties_request.h"
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "utils/helpers.h"
+#include "utils/make_shared.h"
+#include "utils/custom_string.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/smart_object_keys.h"
+#include "policy/usage_statistics/mock_statistics_manager.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/event_engine/event.h"
+#include "application_manager/mock_hmi_interface.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+
+namespace am = application_manager;
+namespace hmi_response = ::application_manager::hmi_response;
+namespace strings = ::application_manager::strings;
+using am::commands::CommandImpl;
+using am::ApplicationManager;
+using am::commands::MessageSharedPtr;
+using am::ApplicationSharedPtr;
+using am::MockMessageHelper;
+using am::MockHmiInterfaces;
+using ::testing::_;
+using ::utils::SharedPtr;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using am::commands::SetGlobalPropertiesRequest;
+using ::test::components::application_manager_test::MockApplication;
+
+class SetGlobalPropertiesRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+};
+
+TEST_F(SetGlobalPropertiesRequestTest, Test1) {
+  MessageSharedPtr response = CreateMessage(smart_objects::SmartType_Map);
+  (*response)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  (*response)[am::strings::msg_params][am::strings::info] = "test";
+
+  am::event_engine::Event event(hmi_apis::FunctionID::TTS_SetGlobalProperties);
+  event.set_smart_object(*response);
+
+  utils::SharedPtr<SetGlobalPropertiesRequest> command =
+      CreateCommand<SetGlobalPropertiesRequest>(response);
+
+  MockAppPtr mock_app(CreateMockApp());
+  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
+      .Times(0);
+  command->on_event(event);
+}
+
+TEST_F(SetGlobalPropertiesRequestTest, Test2) {
+  MessageSharedPtr response = CreateMessage(smart_objects::SmartType_Map);
+  (*response)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  (*response)[am::strings::msg_params][am::strings::info] = "qwe";
+
+  am::event_engine::Event event_tts(
+      hmi_apis::FunctionID::TTS_SetGlobalProperties);
+  event_tts.set_smart_object(*response);
+  am::event_engine::Event event_ui(
+      hmi_apis::FunctionID::UI_SetGlobalProperties);
+  event_tts.set_smart_object(*response);
+  utils::SharedPtr<SetGlobalPropertiesRequest> command =
+      CreateCommand<SetGlobalPropertiesRequest>(response);
+
+  MockAppPtr mock_app(CreateMockApp());
+  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app));
+
+  MockMessageHelper* mock_message_helper =
+      MockMessageHelper::message_helper_mock();
+  EXPECT_CALL(*mock_message_helper, HMIToMobileResult(_))
+      .WillOnce(Return(mobile_apis::Result::UNSUPPORTED_RESOURCE));
+
+  MockHmiInterfaces hmi_interfaces;
+  EXPECT_CALL(app_mngr_, hmi_interfaces())
+      .WillRepeatedly(ReturnRef(hmi_interfaces));
+  EXPECT_CALL(hmi_interfaces, GetInterfaceState(_))
+      .WillRepeatedly(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+
+  MessageSharedPtr response_to_mobile;
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&response_to_mobile), Return(true)));
+  command->Run();
+  command->on_event(event_ui);
+  command->on_event(event_tts);
+
+  EXPECT_EQ((*response_to_mobile)[am::strings::msg_params][am::strings::success]
+                .asBool(),
+            false);
+  EXPECT_EQ(
+      (*response_to_mobile)[am::strings::msg_params][am::strings::result_code]
+          .asInt(),
+      static_cast<int32_t>(mobile_apis::Result::INVALID_DATA));
+}
+
+}  // namespace commands_test
+}  // namespace components
+}  // namespace tests

--- a/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
@@ -77,7 +77,7 @@ class SetGlobalPropertiesRequestTest
  public:
 };
 
-TEST_F(SetGlobalPropertiesRequestTest, Test1) {
+TEST_F(SetGlobalPropertiesRequestTest, OnEvent_SUCCESS_Expect_MessageNotSend) {
   MessageSharedPtr response = CreateMessage(smart_objects::SmartType_Map);
   (*response)[am::strings::params][am::hmi_response::code] =
       hmi_apis::Common_Result::SUCCESS;
@@ -99,7 +99,7 @@ TEST_F(SetGlobalPropertiesRequestTest, Test1) {
   command->on_event(event);
 }
 
-TEST_F(SetGlobalPropertiesRequestTest, Test2) {
+TEST_F(SetGlobalPropertiesRequestTest, OnEvent_UNSUPPORTED_RESOURCE_Expect_false) {
   MessageSharedPtr response = CreateMessage(smart_objects::SmartType_Map);
   (*response)[am::strings::params][am::hmi_response::code] =
       hmi_apis::Common_Result::SUCCESS;

--- a/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_global_properties_request_test.cc
@@ -99,7 +99,8 @@ TEST_F(SetGlobalPropertiesRequestTest, OnEvent_SUCCESS_Expect_MessageNotSend) {
   command->on_event(event);
 }
 
-TEST_F(SetGlobalPropertiesRequestTest, OnEvent_UNSUPPORTED_RESOURCE_Expect_false) {
+TEST_F(SetGlobalPropertiesRequestTest,
+       OnEvent_UNSUPPORTED_RESOURCE_Expect_false) {
   MessageSharedPtr response = CreateMessage(smart_objects::SmartType_Map);
   (*response)[am::strings::params][am::hmi_response::code] =
       hmi_apis::Common_Result::SUCCESS;

--- a/src/components/application_manager/test/commands/mobile/speak_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/speak_request_test.cc
@@ -1,0 +1,186 @@
+/*
+
+ Copyright (c) 2016, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string>
+#include "gtest/gtest.h"
+#include "mobile/speak_request.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_request_test.h"
+#include "interfaces/HMI_API.h"
+#include "interfaces/MOBILE_API.h"
+#include "utils/shared_ptr.h"
+#include "utils/helpers.h"
+#include "utils/make_shared.h"
+#include "smart_objects/smart_object.h"
+#include "utils/custom_string.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/event_engine/event.h"
+#include "application_manager/mock_hmi_interface.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+
+namespace am = application_manager;
+namespace hmi_response = ::application_manager::hmi_response;
+namespace strings = ::application_manager::strings;
+using am::commands::CommandImpl;
+using am::ApplicationManager;
+using am::commands::MessageSharedPtr;
+using am::ApplicationSharedPtr;
+using am::MockMessageHelper;
+using am::MockHmiInterfaces;
+using ::testing::_;
+using ::utils::SharedPtr;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using am::commands::SpeakRequest;
+using ::test::components::application_manager_test::MockApplication;
+
+class SpeakRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  SpeakRequestTest()
+      : request_(CreateMessage(smart_objects::SmartType_Map))
+      , response_(CreateMessage(smart_objects::SmartType_Map)) {}
+
+  MessageSharedPtr ManageResponse() {
+    return response_;
+  }
+  MessageSharedPtr ManageRequest() {
+    return request_;
+  }
+
+  void CheckExpectations(const hmi_apis::Common_Result::eType hmi_response,
+                         const mobile_apis::Result::eType mobile_response,
+                         const am::HmiInterfaces::InterfaceState state,
+                         const bool success) {
+    utils::SharedPtr<SpeakRequest> command =
+        CreateCommand<SpeakRequest>(ManageRequest());
+
+    (*ManageResponse())[strings::params][hmi_response::code] = hmi_response;
+    (*ManageResponse())[strings::msg_params] = 0;
+
+    am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+    event_tts.set_smart_object(*ManageResponse());
+
+    MockAppPtr mock_app(CreateMockApp());
+    ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app));
+
+    MessageSharedPtr response_to_mobile;
+    MockHmiInterfaces hmi_interfaces;
+    EXPECT_CALL(app_mngr_, hmi_interfaces())
+        .WillOnce(ReturnRef(hmi_interfaces));
+    EXPECT_CALL(hmi_interfaces, GetInterfaceState(_)).WillOnce(Return(state));
+    MockMessageHelper* mock_message_helper =
+        MockMessageHelper::message_helper_mock();
+    EXPECT_CALL(*mock_message_helper, HMIToMobileResult(_))
+        .WillOnce(Return(mobile_response));
+
+    EXPECT_CALL(app_mngr_,
+                ManageMobileCommand(
+                    _, am::commands::Command::CommandOrigin::ORIGIN_SDL))
+        .WillOnce(DoAll(SaveArg<0>(&response_to_mobile), Return(true)));
+
+    command->on_event(event_tts);
+
+    EXPECT_EQ(
+        (*response_to_mobile)[strings::msg_params][strings::success].asBool(),
+        success);
+    EXPECT_EQ((*response_to_mobile)[strings::msg_params][strings::result_code]
+                  .asInt(),
+              static_cast<int32_t>(mobile_response));
+  }
+
+ private:
+  MessageSharedPtr request_;
+  MessageSharedPtr response_;
+};
+
+TEST_F(SpeakRequestTest, OnEvent_SUCCESS_Expect_true) {
+  utils::SharedPtr<SpeakRequest> command =
+      CreateCommand<SpeakRequest>(ManageRequest());
+
+  (*ManageResponse())[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  (*ManageResponse())[strings::msg_params] = 0;
+
+  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  event_tts.set_smart_object(*ManageResponse());
+
+  MockAppPtr mock_app(CreateMockApp());
+  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app));
+
+  MessageSharedPtr response_to_mobile;
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&response_to_mobile), Return(true)));
+
+  command->on_event(event_tts);
+
+  EXPECT_EQ(
+      (*response_to_mobile)[strings::msg_params][strings::success].asBool(),
+      true);
+  EXPECT_EQ(
+      (*response_to_mobile)[strings::msg_params][strings::result_code].asInt(),
+      static_cast<int32_t>(mobile_apis::Result::SUCCESS));
+}
+
+TEST_F(SpeakRequestTest, OnEvent_UNSUPPORTED_RESOURCE_Case1) {
+  CheckExpectations(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
+                    mobile_apis::Result::UNSUPPORTED_RESOURCE,
+                    am::HmiInterfaces::STATE_AVAILABLE,
+                    true);
+}
+
+TEST_F(SpeakRequestTest, OnEvent_UNSUPPORTED_RESOURCE_Case2) {
+  CheckExpectations(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
+                    mobile_apis::Result::UNSUPPORTED_RESOURCE,
+                    am::HmiInterfaces::STATE_NOT_AVAILABLE,
+                    false);
+}
+
+TEST_F(SpeakRequestTest, OnEvent_UNSUPPORTED_RESOURCE_Case3) {
+  CheckExpectations(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
+                    mobile_apis::Result::UNSUPPORTED_RESOURCE,
+                    am::HmiInterfaces::STATE_NOT_RESPONSE,
+                    true);
+}
+
+}  // namespace commands_test
+}  // namespace component
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/speak_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/speak_request_test.cc
@@ -160,21 +160,21 @@ TEST_F(SpeakRequestTest, OnEvent_SUCCESS_Expect_true) {
       static_cast<int32_t>(mobile_apis::Result::SUCCESS));
 }
 
-TEST_F(SpeakRequestTest, OnEvent_UNSUPPORTED_RESOURCE_Case1) {
+TEST_F(SpeakRequestTest, OnEvent_UNSUPPORTED_RESOURCE_STATE_AVAILABLE_Expect_true) {
   CheckExpectations(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
                     mobile_apis::Result::UNSUPPORTED_RESOURCE,
                     am::HmiInterfaces::STATE_AVAILABLE,
                     true);
 }
 
-TEST_F(SpeakRequestTest, OnEvent_UNSUPPORTED_RESOURCE_Case2) {
+TEST_F(SpeakRequestTest, OnEvent_UNSUPPORTED_RESOURCE_STATE_NOT_AVAILABLE_Expect_false) {
   CheckExpectations(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
                     mobile_apis::Result::UNSUPPORTED_RESOURCE,
                     am::HmiInterfaces::STATE_NOT_AVAILABLE,
                     false);
 }
 
-TEST_F(SpeakRequestTest, OnEvent_UNSUPPORTED_RESOURCE_Case3) {
+TEST_F(SpeakRequestTest, OnEvent_UNSUPPORTED_RESOURCE_STATE_NOT_RESPONSE_Expect_true) {
   CheckExpectations(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
                     mobile_apis::Result::UNSUPPORTED_RESOURCE,
                     am::HmiInterfaces::STATE_NOT_RESPONSE,

--- a/src/components/application_manager/test/commands/mobile/speak_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/speak_request_test.cc
@@ -160,21 +160,24 @@ TEST_F(SpeakRequestTest, OnEvent_SUCCESS_Expect_true) {
       static_cast<int32_t>(mobile_apis::Result::SUCCESS));
 }
 
-TEST_F(SpeakRequestTest, OnEvent_UNSUPPORTED_RESOURCE_STATE_AVAILABLE_Expect_true) {
+TEST_F(SpeakRequestTest,
+       OnEvent_UNSUPPORTED_RESOURCE_STATE_AVAILABLE_Expect_true) {
   CheckExpectations(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
                     mobile_apis::Result::UNSUPPORTED_RESOURCE,
                     am::HmiInterfaces::STATE_AVAILABLE,
                     true);
 }
 
-TEST_F(SpeakRequestTest, OnEvent_UNSUPPORTED_RESOURCE_STATE_NOT_AVAILABLE_Expect_false) {
+TEST_F(SpeakRequestTest,
+       OnEvent_UNSUPPORTED_RESOURCE_STATE_NOT_AVAILABLE_Expect_false) {
   CheckExpectations(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
                     mobile_apis::Result::UNSUPPORTED_RESOURCE,
                     am::HmiInterfaces::STATE_NOT_AVAILABLE,
                     false);
 }
 
-TEST_F(SpeakRequestTest, OnEvent_UNSUPPORTED_RESOURCE_STATE_NOT_RESPONSE_Expect_true) {
+TEST_F(SpeakRequestTest,
+       OnEvent_UNSUPPORTED_RESOURCE_STATE_NOT_RESPONSE_Expect_true) {
   CheckExpectations(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
                     mobile_apis::Result::UNSUPPORTED_RESOURCE,
                     am::HmiInterfaces::STATE_NOT_RESPONSE,


### PR DESCRIPTION
### Pull request changes:
- Add unit tests for CRQ TTS IsReady false

Related: [APPLINK-25122](https://adc.luxoft.com/jira/browse/APPLINK-25122)