### PR TITLE
Remove all redundant local redefinitions of `smart_objects` namespace

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -39,6 +39,7 @@
 #include <list>
 #include "utils/shared_ptr.h"
 #include "utils/data_accessor.h"
+#include "smart_objects/smart_object.h"
 #include "interfaces/MOBILE_API.h"
 #include "connection_handler/device.h"
 #include "application_manager/message.h"
@@ -51,18 +52,10 @@
 #elif defined(OS_WINDOWS)
 #define strcasecmp _stricmp
 #endif
-namespace NsSmartDeviceLink {
-namespace NsSmartObjects {
-
-class SmartObject;
-}
-}
 
 namespace application_manager {
 
 namespace mobile_api = mobile_apis;
-
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 namespace custom_str = utils::custom_string;
 

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <memory>
 
+#include "smart_objects/smart_object.h"
 #include "application_manager/hmi_command_factory.h"
 #include "application_manager/application_manager.h"
 #include "application_manager/hmi_capabilities.h"
@@ -88,13 +89,6 @@
 #include "utils/lock.h"
 #include "utils/data_accessor.h"
 #include "utils/timer.h"
-
-namespace NsSmartDeviceLink {
-namespace NsSmartObjects {
-class SmartObject;
-}
-}
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 namespace threads {
 class Thread;

--- a/src/components/application_manager/include/application_manager/commands/command.h
+++ b/src/components/application_manager/include/application_manager/commands/command.h
@@ -38,7 +38,6 @@
 #include "utils/shared_ptr.h"
 
 namespace application_manager {
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 namespace commands {
 

--- a/src/components/application_manager/include/application_manager/commands/hmi/notification_from_hmi.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/notification_from_hmi.h
@@ -33,20 +33,13 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_NOTIFICATION_FROM_HMI_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_NOTIFICATION_FROM_HMI_H_
 
+#include "smart_objects/smart_object.h"
 #include "application_manager/commands/command_impl.h"
 #include "interfaces/HMI_API.h"
-
-namespace NsSmartDeviceLink {
-namespace NsSmartObjects {
-class CSmartObject;
-}
-}
 
 namespace application_manager {
 
 namespace commands {
-
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 class NotificationFromHMI : public CommandImpl {
  public:

--- a/src/components/application_manager/include/application_manager/commands/hmi/response_from_hmi.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/response_from_hmi.h
@@ -33,21 +33,14 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_RESPONSE_FROM_HMI_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_RESPONSE_FROM_HMI_H_
 
+#include "smart_objects/smart_object.h"
 #include "application_manager/commands/command_impl.h"
 #include "application_manager/application_manager.h"
 #include "interfaces/HMI_API.h"
 
-namespace NsSmartDeviceLink {
-namespace NsSmartObjects {
-class SmartObject;
-}
-}
-
 namespace application_manager {
 
 namespace commands {
-
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 class ResponseFromHMI : public CommandImpl {
  public:

--- a/src/components/application_manager/include/application_manager/event_engine/event.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event.h
@@ -43,8 +43,6 @@ namespace event_engine {
 
 class EventDispatcher;
 
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
-
 class Event {
  public:
   // Typedef for possible Event ID's from mobile_apis functionID enum

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -33,6 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_IMPL_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_HMI_CAPABILITIES_IMPL_H_
 
+#include "smart_objects/smart_object.h"
 #include "application_manager/hmi_capabilities.h"
 #include "interfaces/HMI_API.h"
 #include "interfaces/MOBILE_API.h"
@@ -41,17 +42,9 @@
 #include "utils/json_utils.h"
 #include "application_manager/hmi_language_handler.h"
 
-namespace NsSmartDeviceLink {
-namespace NsSmartObjects {
-class SmartObject;
-}  // namespace NsSmartObjects
-}  // namespace NsSmartDeviceLink
-
 namespace resumption {
 class LastState;
 }  // namespace resumption
-
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 namespace application_manager {
 class ApplicationManager;

--- a/src/components/application_manager/include/application_manager/hmi_language_handler.h
+++ b/src/components/application_manager/include/application_manager/hmi_language_handler.h
@@ -84,8 +84,7 @@ class HMILanguageHandler : public event_engine::EventObserver {
    * @brief Trigger waiting for response
    * @param request Request object
    */
-  void set_handle_response_for(
-      const event_engine::smart_objects::SmartObject& request);
+  void set_handle_response_for(const smart_objects::SmartObject& request);
 
   /**
    * @brief Sets default languages from HMI capabilities

--- a/src/components/application_manager/include/application_manager/message.h
+++ b/src/components/application_manager/include/application_manager/message.h
@@ -41,8 +41,6 @@
 #include "protocol/rpc_type.h"
 #include "smart_objects/smart_object.h"
 
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
-
 namespace application_manager {
 
 typedef std::vector<uint8_t> BinaryData;

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -40,6 +40,7 @@
 #include "interfaces/MOBILE_API.h"
 #include "interfaces/HMI_API.h"
 #include "utils/macro.h"
+#include "smart_objects/smart_object.h"
 #include "connection_handler/device.h"
 #include "application_manager/application.h"
 #include "application_manager/vehicle_info_data.h"
@@ -47,19 +48,12 @@
 #include "protocol_handler/session_observer.h"
 #include "application_manager/policies/policy_handler_interface.h"
 
-namespace NsSmartDeviceLink {
-namespace NsSmartObjects {
-class SmartObject;
-}
-}
-
 namespace policy {
 class PolicyHandlerInterface;
 }
 
 namespace application_manager {
 namespace mobile_api = mobile_apis;
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 /*
  * @brief Typedef for VehicleData

--- a/src/components/application_manager/include/application_manager/policies/policy_event_observer.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_event_observer.h
@@ -33,11 +33,11 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_POLICIES_POLICY_EVENT_OBSERVER_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_POLICIES_POLICY_EVENT_OBSERVER_H_
 
+#include "smart_objects/smart_object.h"
 #include "application_manager/event_engine/event_observer.h"
 #include "utils/lock.h"
 
 namespace policy {
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 class PolicyHandlerInterface;
 

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data.h
@@ -46,7 +46,6 @@ class ApplicationManagerSettings;
 
 namespace resumption {
 
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 namespace app_mngr = application_manager;
 
 /**

--- a/src/components/application_manager/include/application_manager/telemetry_observer.h
+++ b/src/components/application_manager/include/application_manager/telemetry_observer.h
@@ -39,7 +39,6 @@
 #include "utils/shared_ptr.h"
 #include "utils/date_time.h"
 
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 namespace application_manager {
 
 class AMTelemetryObserver {

--- a/src/components/application_manager/src/commands/mobile/alert_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_request.cc
@@ -35,6 +35,7 @@
 
 #include <string.h>
 
+#include "smart_objects/smart_object.h"
 #include "application_manager/message_helper.h"
 #include "application_manager/application_impl.h"
 #include "application_manager/policies/policy_handler.h"
@@ -43,8 +44,6 @@
 namespace application_manager {
 
 namespace commands {
-
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 AlertRequest::AlertRequest(const MessageSharedPtr& message,
                            ApplicationManager& application_manager)

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_button_response.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_button_response.cc
@@ -31,6 +31,7 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "smart_objects/smart_object.h"
 #include "application_manager/commands/mobile/unsubscribe_button_response.h"
 
 namespace application_manager {
@@ -45,8 +46,6 @@ UnsubscribeButtonResponse::~UnsubscribeButtonResponse() {}
 
 void UnsubscribeButtonResponse::Run() {
   SDL_AUTO_TRACE();
-
-  namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
   // check if response false
   if (true == (*message_)[strings::msg_params].keyExists(strings::success)) {

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_response.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_response.cc
@@ -31,6 +31,7 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "smart_objects/smart_object.h"
 #include "application_manager/commands/mobile/unsubscribe_vehicle_data_response.h"
 
 namespace application_manager {
@@ -44,9 +45,6 @@ UnsubscribeVehicleDataResponse::~UnsubscribeVehicleDataResponse() {}
 
 void UnsubscribeVehicleDataResponse::Run() {
   SDL_AUTO_TRACE();
-
-  namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
-
   // check if response false
   if (true == (*message_)[strings::msg_params].keyExists(strings::success)) {
     if ((*message_)[strings::msg_params][strings::success].asBool() == false) {

--- a/src/components/application_manager/src/hmi_language_handler.cc
+++ b/src/components/application_manager/src/hmi_language_handler.cc
@@ -30,6 +30,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include "smart_objects/smart_object.h"
 #include "application_manager/hmi_language_handler.h"
 #include "application_manager/application_manager.h"
 #include "application_manager/message_helper.h"
@@ -152,7 +153,7 @@ void HMILanguageHandler::on_event(const event_engine::Event& event) {
 }
 
 void HMILanguageHandler::set_handle_response_for(
-    const event_engine::smart_objects::SmartObject& request) {
+    const smart_objects::SmartObject& request) {
   SDL_AUTO_TRACE();
   using namespace helpers;
   if (!request.keyExists(strings::params)) {

--- a/src/components/application_manager/src/policies/policy_event_observer.cc
+++ b/src/components/application_manager/src/policies/policy_event_observer.cc
@@ -37,7 +37,6 @@
 #include "smart_objects/smart_object.h"
 
 namespace policy {
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 using namespace application_manager;
 class PolicyHandler;
 

--- a/src/components/application_manager/test/application_impl/application_impl_test.cc
+++ b/src/components/application_manager/test/application_impl/application_impl_test.cc
@@ -56,7 +56,6 @@ namespace application_manager_test {
 using namespace application_manager;
 
 using namespace mobile_apis;
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 namespace custom_str = utils::custom_string;
 
 using ::testing::_;

--- a/src/components/application_manager/test/commands/hmi/get_urls_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_urls_test.cc
@@ -62,7 +62,6 @@ using ::utils::SharedPtr;
 using ::testing::NiceMock;
 using ::testing::SetArgReferee;
 using ::test::components::application_manager_test::MockApplication;
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 namespace am = ::application_manager;
 namespace strings = ::application_manager::strings;
 using am::commands::RequestFromHMI;

--- a/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
+++ b/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
@@ -621,7 +621,7 @@ TEST_F(HMICommandsNotificationsTest,
   std::vector<uint8_t> data(tmp, tmp + 4);
   EXPECT_TRUE(file_system::WriteBinaryFile(kFile, data));
 
-  MessageSharedPtr message = CreateMessage(am::smart_objects::SmartType_String);
+  MessageSharedPtr message = CreateMessage(smart_objects::SmartType_String);
   (*message)[am::strings::msg_params][am::hmi_notification::policyfile] = kFile;
   utils::SharedPtr<Command> command =
       CreateCommand<OnReceivedPolicyUpdate>(message);
@@ -634,7 +634,7 @@ TEST_F(HMICommandsNotificationsTest,
 
 TEST_F(HMICommandsNotificationsTest,
        OnReceivePolicyUpdateNotification_UNSUCCESS) {
-  MessageSharedPtr message = CreateMessage(am::smart_objects::SmartType_String);
+  MessageSharedPtr message = CreateMessage(smart_objects::SmartType_String);
   utils::SharedPtr<Command> command =
       CreateCommand<OnReceivedPolicyUpdate>(message);
 
@@ -645,14 +645,13 @@ TEST_F(HMICommandsNotificationsTest,
 
 TEST_F(HMICommandsNotificationsTest,
        OnAppPermissionConsentNotificationPolicyHandlerNoAppId) {
-  MessageSharedPtr message = CreateMessage(am::smart_objects::SmartType_Map);
+  MessageSharedPtr message = CreateMessage(smart_objects::SmartType_Map);
   (*message)[am::strings::msg_params][am::strings::consented_functions] =
-      am::smart_objects::SmartObject(am::smart_objects::SmartType_Array);
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
   SmartObject& applications =
       (*message)[am::strings::msg_params][am::strings::consented_functions];
 
-  am::smart_objects::SmartObject hmi_application_temp(
-      am::smart_objects::SmartType_Map);
+  smart_objects::SmartObject hmi_application_temp(smart_objects::SmartType_Map);
   applications[0] = hmi_application_temp;
 
   utils::SharedPtr<Command> command =
@@ -668,13 +667,13 @@ TEST_F(HMICommandsNotificationsTest,
 
 TEST_F(HMICommandsNotificationsTest,
        OnAppPermissionConsentNotificationPolicyHandlerWithAppId) {
-  MessageSharedPtr message = CreateMessage(am::smart_objects::SmartType_Map);
+  MessageSharedPtr message = CreateMessage(smart_objects::SmartType_Map);
   (*message)[am::strings::msg_params][am::strings::app_id] = kAppId_;
   (*message)[am::strings::msg_params][am::strings::consented_functions] =
-      am::smart_objects::SmartObject(am::smart_objects::SmartType_Array);
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
 
-  am::smart_objects::SmartObjectSPtr consented_function =
-      utils::MakeShared<am::smart_objects::SmartObject>();
+  smart_objects::SmartObjectSPtr consented_function =
+      utils::MakeShared<smart_objects::SmartObject>();
   (*message)[am::strings::msg_params][am::strings::consented_functions][0] =
       *consented_function;
 
@@ -698,15 +697,15 @@ TEST_F(HMICommandsNotificationsTest,
 
 TEST_F(HMICommandsNotificationsTest,
        OnAppPermissionConsentNotificationPolicyHandlerAppIdAllowTrue) {
-  MessageSharedPtr message = CreateMessage(am::smart_objects::SmartType_Map);
+  MessageSharedPtr message = CreateMessage(smart_objects::SmartType_Map);
   (*message)[am::strings::msg_params][am::strings::consented_functions] =
-      am::smart_objects::SmartObject(am::smart_objects::SmartType_Array);
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
   (*message)[am::strings::msg_params][am::strings::app_id] = kAppId_;
   (*message)[am::strings::msg_params][am::strings::consent_source] =
       "test_content_source";
 
-  am::smart_objects::SmartObjectSPtr consented_function =
-      utils::MakeShared<am::smart_objects::SmartObject>();
+  smart_objects::SmartObjectSPtr consented_function =
+      utils::MakeShared<smart_objects::SmartObject>();
   (*consented_function)[am::strings::allowed] = true;
   (*consented_function)[am::strings::id] = 999;
   (*consented_function)[am::strings::name] = "test_group_alias";
@@ -737,15 +736,15 @@ TEST_F(HMICommandsNotificationsTest,
 
 TEST_F(HMICommandsNotificationsTest,
        OnAppPermissionConsentNotificationPolicyHandlerAppIdAllowFalse) {
-  MessageSharedPtr message = CreateMessage(am::smart_objects::SmartType_Map);
+  MessageSharedPtr message = CreateMessage(smart_objects::SmartType_Map);
   (*message)[am::strings::msg_params][am::strings::consented_functions] =
-      am::smart_objects::SmartObject(am::smart_objects::SmartType_Array);
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
   (*message)[am::strings::msg_params][am::strings::app_id] = kAppId_;
   (*message)[am::strings::msg_params][am::strings::consent_source] =
       "test_content_source";
 
-  am::smart_objects::SmartObjectSPtr consented_function =
-      utils::MakeShared<am::smart_objects::SmartObject>();
+  smart_objects::SmartObjectSPtr consented_function =
+      utils::MakeShared<smart_objects::SmartObject>();
   (*consented_function)[am::strings::allowed] = false;
   (*consented_function)[am::strings::id] = 999;
   (*consented_function)[am::strings::name] = "test_group_alias";
@@ -987,7 +986,7 @@ TEST_F(HMICommandsNotificationsTest,
       CreateCommand<OnExitAllApplicationsNotification>(message);
 
   MessageSharedPtr ethalon_message =
-      CreateMessage(am::smart_objects::SmartType_Map);
+      CreateMessage(smart_objects::SmartType_Map);
   (*ethalon_message)[am::strings::params][am::strings::function_id] =
       hmi_apis::FunctionID::BasicCommunication_OnSDLPersistenceComplete;
   (*ethalon_message)[am::strings::params][am::strings::message_type] =
@@ -1034,8 +1033,8 @@ TEST_F(HMICommandsNotificationsTest,
        OnExitApplicationNotificationManageMobileCommand) {
   MessageSharedPtr message = CreateMessage();
   (*message)[am::strings::msg_params][am::strings::app_id] = kAppId_;
-  am::smart_objects::SmartObjectSPtr notification =
-      utils::MakeShared<am::smart_objects::SmartObject>();
+  smart_objects::SmartObjectSPtr notification =
+      utils::MakeShared<smart_objects::SmartObject>();
   (*notification)[am::strings::params][am::strings::function_id] =
       static_cast<int32_t>(
           mobile_apis::FunctionID::OnAppInterfaceUnregisteredID);
@@ -1128,8 +1127,8 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnExitApplicationNotification>(message);
 
-  am::smart_objects::SmartObjectSPtr notification =
-      utils::MakeShared<am::smart_objects::SmartObject>();
+  smart_objects::SmartObjectSPtr notification =
+      utils::MakeShared<smart_objects::SmartObject>();
   (*notification)[am::strings::params][am::strings::function_id] =
       static_cast<int32_t>(
           mobile_apis::FunctionID::OnAppInterfaceUnregisteredID);
@@ -1170,8 +1169,8 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnExitApplicationNotification>(message);
 
-  am::smart_objects::SmartObjectSPtr notification =
-      utils::MakeShared<am::smart_objects::SmartObject>();
+  smart_objects::SmartObjectSPtr notification =
+      utils::MakeShared<smart_objects::SmartObject>();
   (*notification)[am::strings::params][am::strings::function_id] =
       static_cast<int32_t>(
           mobile_apis::FunctionID::OnAppInterfaceUnregisteredID);
@@ -1430,8 +1429,8 @@ TEST_F(HMICommandsNotificationsTest,
       CreateCommand<OnVRLanguageChangeNotification>(message);
 
   application_set_.insert(app_);
-  am::smart_objects::SmartObjectSPtr notification =
-      utils::MakeShared<am::smart_objects::SmartObject>();
+  smart_objects::SmartObjectSPtr notification =
+      utils::MakeShared<smart_objects::SmartObject>();
   (*notification)[am::strings::params][am::strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);
   (*notification)[am::strings::params][am::strings::message_type] =
@@ -1740,8 +1739,8 @@ TEST_F(HMICommandsNotificationsTest,
       CreateCommand<OnTTSLanguageChangeNotification>(message);
 
   application_set_.insert(app_);
-  am::smart_objects::SmartObjectSPtr notification =
-      utils::MakeShared<am::smart_objects::SmartObject>();
+  smart_objects::SmartObjectSPtr notification =
+      utils::MakeShared<smart_objects::SmartObject>();
   (*notification)[am::strings::params][am::strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);
   (*notification)[am::strings::params][am::strings::message_type] =
@@ -1852,8 +1851,8 @@ TEST_F(HMICommandsNotificationsTest,
       CreateCommand<OnUILanguageChangeNotification>(message);
 
   application_set_.insert(app_);
-  am::smart_objects::SmartObjectSPtr notification =
-      utils::MakeShared<am::smart_objects::SmartObject>();
+  smart_objects::SmartObjectSPtr notification =
+      utils::MakeShared<smart_objects::SmartObject>();
   (*notification)[am::strings::params][am::strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);
   (*notification)[am::strings::params][am::strings::message_type] =

--- a/src/components/application_manager/test/event_engine/event_engine_test.cc
+++ b/src/components/application_manager/test/event_engine/event_engine_test.cc
@@ -45,7 +45,6 @@ namespace test {
 namespace components {
 namespace event_engine_test {
 
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 using application_manager::event_engine::EventDispatcherImpl;
 using application_manager::event_engine::Event;
 using application_manager::event_engine::EventObserver;

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -57,7 +57,6 @@ using ::testing::AtLeast;
 using ::testing::Invoke;
 using ::testing::InSequence;
 
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 using namespace application_manager;
 
 class HMICapabilitiesTest : public ::testing::Test {

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -42,7 +42,6 @@ namespace components {
 namespace application_manager_test {
 
 namespace custom_str = utils::custom_string;
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 class MockApplication : public ::application_manager::Application {
  public:
   MockApplication() {}

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -33,6 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_MESSAGE_HELPER_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_MESSAGE_HELPER_H_
 #include "gmock/gmock.h"
+#include "smart_objects/smart_object.h"
 #include "application_manager/application.h"
 #include "application_manager/message_helper.h"
 #include "interfaces/HMI_API.h"
@@ -42,7 +43,6 @@
 
 namespace application_manager {
 
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 class MockMessageHelper {
  public:
   MOCK_METHOD1(GetHashUpdateNotification,

--- a/src/components/application_manager/test/include/application_manager/mock_resumption_data.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resumption_data.h
@@ -33,6 +33,7 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_RESUMPTION_DATA_H_
 #include <string>
 #include "gmock/gmock.h"
+#include "smart_objects/smart_object.h"
 #include "application_manager/resumption/resumption_data.h"
 #include "application_manager/application.h"
 #include "application_manager/mock_application_manager_settings.h"
@@ -43,7 +44,6 @@ namespace components {
 namespace resumption_test {
 
 namespace app_mngr = application_manager;
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 class MockResumptionData : public ::resumption::ResumptionData {
  public:

--- a/src/components/application_manager/test/policies/policy_event_observer_test.cc
+++ b/src/components/application_manager/test/policies/policy_event_observer_test.cc
@@ -42,7 +42,6 @@ namespace test {
 namespace components {
 namespace policy_test {
 
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 using application_manager::event_engine::Event;
 using namespace policy;
 

--- a/src/components/application_manager/test/resumption/resumption_data_db_test.cc
+++ b/src/components/application_manager/test/resumption/resumption_data_db_test.cc
@@ -40,6 +40,7 @@
 #include "utils/sqlite_wrapper/sql_query.h"
 #include "utils/make_shared.h"
 #include "utils/file_system.h"
+#include "smart_objects/smart_object.h"
 #include "application_manager/resumption_data_test.h"
 #include "application_manager/test_resumption_data_db.h"
 
@@ -68,7 +69,6 @@ using application_manager_test::MockApplication;
 using ::test::components::utils::dbms::MockSQLDatabase;
 
 namespace am = application_manager;
-namespace smart_objects = ::NsSmartDeviceLink::NsSmartObjects;
 using namespace file_system;
 
 using namespace resumption;
@@ -1262,7 +1262,7 @@ TEST_F(ResumptionDataDBTest, DropAppResumptionData) {
 
   EXPECT_TRUE(res_db()->DropAppDataResumption(kMacAddress_, policy_app_id_));
 
-  am::smart_objects::SmartObject app;
+  ::smart_objects::SmartObject app;
   EXPECT_TRUE(res_db()->GetSavedApplication(policy_app_id_, kMacAddress_, app));
 
   EXPECT_TRUE(app.keyExists(am::strings::application_commands) &&

--- a/src/components/dbus/include/dbus/dbus_adapter.h
+++ b/src/components/dbus/include/dbus/dbus_adapter.h
@@ -42,8 +42,6 @@ struct DBusMessageIter;
 
 namespace dbus {
 
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
-
 /**
  * \brief class for work with DBus
  */

--- a/src/components/dbus/include/dbus/dbus_message_controller.h
+++ b/src/components/dbus/include/dbus/dbus_message_controller.h
@@ -35,11 +35,10 @@
 
 #include <string>
 #include <map>
+#include "smart_objects/smart_object.h"
 #include "dbus/dbus_adapter.h"
 
 namespace dbus {
-
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 class DBusMessageController : public DBusAdapter {
  public:

--- a/src/components/dbus/src/dbus_adapter.cc
+++ b/src/components/dbus/src/dbus_adapter.cc
@@ -33,12 +33,12 @@
 #include "dbus/dbus_adapter.h"
 #include <dbus/dbus.h>
 #include <sstream>
+#include "smart_objects/smart_object.h"
 #include "formatters/CSmartFactory.hpp"
 #include "utils/logger.h"
 
 using ford_message_descriptions::ParameterDescription;
 namespace sos = NsSmartDeviceLink::NsJSONHandler::strings;
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 extern char introspection_xml[];
 

--- a/src/components/formatters/test/CMakeLists.txt
+++ b/src/components/formatters/test/CMakeLists.txt
@@ -41,9 +41,9 @@ set(LIBRARIES
   gmock 
   HMI_API
   MOBILE_API
+  jsoncpp
   smart_object
   formatters
-  jsoncpp
 )
 
 collect_sources(SOURCES "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/src/components/hmi_message_handler/include/hmi_message_handler/dbus_message_adapter.h
+++ b/src/components/hmi_message_handler/include/hmi_message_handler/dbus_message_adapter.h
@@ -40,8 +40,6 @@
 
 namespace hmi_message_handler {
 
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
-
 /**
  * \brief adapter for DBus
  */

--- a/src/components/hmi_message_handler/src/dbus_message_adapter.cc
+++ b/src/components/hmi_message_handler/src/dbus_message_adapter.cc
@@ -30,12 +30,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "hmi_message_handler/dbus_message_adapter.h"
 #include <sstream>
+#include "smart_objects/smart_object.h"
+#include "hmi_message_handler/dbus_message_adapter.h"
 #include "utils/logger.h"
 #include "formatters/CSmartFactory.h"
 
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 namespace sos = NsSmartDeviceLink::NsJSONHandler::strings;
 
 namespace hmi_message_handler {

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -39,17 +39,11 @@
 #include "utils/macro.h"
 #include "utils/json_utils.h"
 #include "application_manager/hmi_language_handler.h"
+#include "smart_objects/smart_object.h"
 
-namespace NsSmartDeviceLink {
-namespace NsSmartObjects {
-class SmartObject;
-}
-}
 namespace resumption {
 class LastState;
 }
-
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 namespace application_manager {
 class ApplicationManager;

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -47,7 +47,7 @@
 #include "smart_objects/smart_object.h"
 
 namespace policy {
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
+
 class PolicyHandlerInterface {
  public:
   virtual ~PolicyHandlerInterface() {}

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -36,6 +36,7 @@
 #include <string>
 #include <vector>
 #include "gmock/gmock.h"
+#include "smart_objects/smart_object.h"
 #include "application_manager/application_manager.h"
 #include "application_manager/application_manager_impl.h"
 #include "application_manager/application_manager_settings.h"
@@ -49,7 +50,6 @@
 namespace test {
 namespace components {
 namespace application_manager_test {
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 
 class MockApplicationManager : public application_manager::ApplicationManager {
  public:

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -36,12 +36,12 @@
 #include "application_manager/policies/policy_handler_interface.h"
 #include "gmock/gmock.h"
 #include "policy/policy_types.h"
+#include "smart_objects/smart_object.h"
 
 namespace test {
 namespace components {
 namespace policy_test {
 
-namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
 class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
  public:
   MOCK_METHOD0(LoadPolicyLibrary, bool());

--- a/src/components/smart_objects/include/smart_objects/smart_object.h
+++ b/src/components/smart_objects/include/smart_objects/smart_object.h
@@ -1016,4 +1016,7 @@ static SmartObject invalid_object_value(SmartType_Invalid);
 static const SmartBinary invalid_binary_value;
 }  // namespace NsSmartObjects
 }  // namespace NsSmartDeviceLink
+
+namespace smart_objects = NsSmartDeviceLink::NsSmartObjects;
+
 #endif  // SRC_COMPONENTS_SMART_OBJECTS_INCLUDE_SMART_OBJECTS_SMART_OBJECT_H_


### PR DESCRIPTION
Has been removed all redundant local
redefinitions of `smart_objects` namespace.

-
Related to: [APPLINK-28796](https://adc.luxoft.com/jira/browse/APPLINK-28796)

@AGaliuzov, @Kozoriz, @LuxoftAKutsan, @VProdanov, @wolfylambova22, @VVeremjova, please, review.