### PR TITLE
Add function_id check in request controller

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager.h
+++ b/src/components/application_manager/include/application_manager/application_manager.h
@@ -413,7 +413,9 @@ class ApplicationManager {
    * @param connection_key - application id of request
    * @param corr_id correlation id of request
    */
-  virtual void TerminateRequest(uint32_t connection_key, uint32_t corr_id) = 0;
+  virtual void TerminateRequest(uint32_t connection_key,
+                                uint32_t corr_id,
+                                const int32_t function_id) = 0;
 
   /*
    * @brief Closes application by id

--- a/src/components/application_manager/include/application_manager/application_manager.h
+++ b/src/components/application_manager/include/application_manager/application_manager.h
@@ -412,9 +412,10 @@ class ApplicationManager {
    * @brief TerminateRequest forces termination of request
    * @param connection_key - application id of request
    * @param corr_id correlation id of request
+   * @param function_id function id of request
    */
-  virtual void TerminateRequest(uint32_t connection_key,
-                                uint32_t corr_id,
+  virtual void TerminateRequest(const uint32_t connection_key,
+                                const uint32_t corr_id,
                                 const int32_t function_id) = 0;
 
   /*

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -711,6 +711,7 @@ class ApplicationManagerImpl
    * @brief TerminateRequest forces termination of request
    * @param connection_key - application id of request
    * @param corr_id correlation id of request
+   * @param function_id function id of request
    */
   void TerminateRequest(const uint32_t connection_key,
                         const uint32_t corr_id,

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -712,7 +712,9 @@ class ApplicationManagerImpl
    * @param connection_key - application id of request
    * @param corr_id correlation id of request
    */
-  void TerminateRequest(uint32_t connection_key, uint32_t corr_id) OVERRIDE;
+  void TerminateRequest(const uint32_t connection_key,
+                        const uint32_t corr_id,
+                        const int32_t function_id) OVERRIDE;
   // Overriden ProtocolObserver method
   void OnMessageReceived(
       const ::protocol_handler::RawMessagePtr message) OVERRIDE;

--- a/src/components/application_manager/include/application_manager/request_controller.h
+++ b/src/components/application_manager/include/application_manager/request_controller.h
@@ -143,7 +143,7 @@ class RequestController {
   * @param force_terminate if true, request controller will terminate
   * even if not allowed by request
   */
-  void terminateRequest(const uint32_t correlation_id,
+  void TerminateRequest(const uint32_t correlation_id,
                         const uint32_t connection_key,
                         const int32_t function_id,
                         bool force_terminate = false);

--- a/src/components/application_manager/include/application_manager/request_controller.h
+++ b/src/components/application_manager/include/application_manager/request_controller.h
@@ -139,6 +139,7 @@ class RequestController {
   *
   * @param correlation_id Active request correlation ID,
   * @param connection_key Active request connection key (0 for HMI requersts)
+  * @param function_id Active request  function id
   * @param force_terminate if true, request controller will terminate
   * even if not allowed by request
   */

--- a/src/components/application_manager/include/application_manager/request_controller.h
+++ b/src/components/application_manager/include/application_manager/request_controller.h
@@ -142,8 +142,9 @@ class RequestController {
   * @param force_terminate if true, request controller will terminate
   * even if not allowed by request
   */
-  void terminateRequest(const uint32_t& correlation_id,
-                        const uint32_t& connection_key,
+  void terminateRequest(const uint32_t correlation_id,
+                        const uint32_t connection_key,
+                        const int32_t function_id,
                         bool force_terminate = false);
 
   /**
@@ -152,8 +153,9 @@ class RequestController {
   * @param mobile_correlation_id Active mobile request correlation ID
   *
   */
-  void OnMobileResponse(const uint32_t& mobile_correlation_id,
-                        const uint32_t& connection_key);
+  void OnMobileResponse(const uint32_t mobile_correlation_id,
+                        const uint32_t connection_key,
+                        const int32_t function_id);
 
   /**
   * @brief Removes request from queue
@@ -161,7 +163,7 @@ class RequestController {
   * @param mobile_correlation_id Active mobile request correlation ID
   *
   */
-  void OnHMIResponse(const uint32_t& correlation_id);
+  void OnHMIResponse(const uint32_t correlation_id, const int32_t function_id);
 
   /**
   * @ Add notification to collection

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1442,7 +1442,7 @@ void ApplicationManagerImpl::SendMessageToMobile(
 void ApplicationManagerImpl::TerminateRequest(const uint32_t connection_key,
                                               const uint32_t corr_id,
                                               const int32_t function_id) {
-  request_ctrl_.terminateRequest(corr_id, connection_key, function_id, true);
+  request_ctrl_.TerminateRequest(corr_id, connection_key, function_id, true);
 }
 
 bool ApplicationManagerImpl::ManageMobileCommand(

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1387,8 +1387,8 @@ void ApplicationManagerImpl::SendMessageToMobile(
   // checked against policy permissions
   if (msg_to_mobile[strings::params].keyExists(strings::correlation_id)) {
     request_ctrl_.OnMobileResponse(
-        msg_to_mobile[strings::params][strings::correlation_id].asInt(),
-        msg_to_mobile[strings::params][strings::connection_key].asInt(),
+        msg_to_mobile[strings::params][strings::correlation_id].asUInt(),
+        msg_to_mobile[strings::params][strings::connection_key].asUInt(),
         msg_to_mobile[strings::params][strings::function_id].asInt());
   } else if (app) {
     mobile_apis::FunctionID::eType function_id =
@@ -1695,7 +1695,7 @@ bool ApplicationManagerImpl::ManageHMICommand(
     command->Run();
     if (kResponse == message_type) {
       const uint32_t correlation_id =
-          (*(message.get()))[strings::params][strings::correlation_id].asInt();
+          (*(message.get()))[strings::params][strings::correlation_id].asUInt();
       const int32_t function_id =
           (*(message.get()))[strings::params][strings::function_id].asInt();
       request_ctrl_.OnHMIResponse(correlation_id, function_id);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1388,7 +1388,8 @@ void ApplicationManagerImpl::SendMessageToMobile(
   if (msg_to_mobile[strings::params].keyExists(strings::correlation_id)) {
     request_ctrl_.OnMobileResponse(
         msg_to_mobile[strings::params][strings::correlation_id].asInt(),
-        msg_to_mobile[strings::params][strings::connection_key].asInt());
+        msg_to_mobile[strings::params][strings::connection_key].asInt(),
+        msg_to_mobile[strings::params][strings::function_id].asInt());
   } else if (app) {
     mobile_apis::FunctionID::eType function_id =
         static_cast<mobile_apis::FunctionID::eType>(
@@ -1438,9 +1439,10 @@ void ApplicationManagerImpl::SendMessageToMobile(
       impl::MessageToMobile(message_to_send, final_message));
 }
 
-void ApplicationManagerImpl::TerminateRequest(uint32_t connection_key,
-                                              uint32_t corr_id) {
-  request_ctrl_.terminateRequest(corr_id, connection_key, true);
+void ApplicationManagerImpl::TerminateRequest(const uint32_t connection_key,
+                                              const uint32_t corr_id,
+                                              const int32_t function_id) {
+  request_ctrl_.terminateRequest(corr_id, connection_key, function_id, true);
 }
 
 bool ApplicationManagerImpl::ManageMobileCommand(
@@ -1694,7 +1696,9 @@ bool ApplicationManagerImpl::ManageHMICommand(
     if (kResponse == message_type) {
       const uint32_t correlation_id =
           (*(message.get()))[strings::params][strings::correlation_id].asInt();
-      request_ctrl_.OnHMIResponse(correlation_id);
+      const int32_t function_id =
+          (*(message.get()))[strings::params][strings::function_id].asInt();
+      request_ctrl_.OnHMIResponse(correlation_id, function_id);
     }
     return true;
   }

--- a/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
@@ -124,7 +124,8 @@ void AudioStartStreamRequest::on_event(const event_engine::Event& event) {
 void AudioStartStreamRequest::onTimeOut() {
   RetryStartSession();
 
-  application_manager_.TerminateRequest(connection_key(), correlation_id());
+  application_manager_.TerminateRequest(
+      connection_key(), correlation_id(), function_id());
 }
 
 void AudioStartStreamRequest::RetryStartSession() {

--- a/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
@@ -124,7 +124,8 @@ void NaviStartStreamRequest::on_event(const event_engine::Event& event) {
 void NaviStartStreamRequest::onTimeOut() {
   RetryStartSession();
 
-  application_manager_.TerminateRequest(connection_key(), correlation_id());
+  application_manager_.TerminateRequest(
+      connection_key(), correlation_id(), function_id());
 }
 
 void NaviStartStreamRequest::RetryStartSession() {

--- a/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -370,7 +370,8 @@ void CreateInteractionChoiceSetRequest::onTimeOut() {
   // according to SDLAQ-CRS-2976
   sync_primitives::AutoLock timeout_lock_(is_timed_out_lock_);
   is_timed_out_ = true;
-  application_manager_.TerminateRequest(connection_key(), correlation_id());
+  application_manager_.TerminateRequest(
+      connection_key(), correlation_id(), function_id());
 }
 
 void CreateInteractionChoiceSetRequest::DeleteChoices() {
@@ -420,7 +421,8 @@ void CreateInteractionChoiceSetRequest::OnAllHMIResponsesReceived() {
     DeleteChoices();
   }
 
-  application_manager_.TerminateRequest(connection_key(), correlation_id());
+  application_manager_.TerminateRequest(
+      connection_key(), correlation_id(), function_id());
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -403,7 +403,8 @@ void UnsubscribeVehicleDataRequest::UpdateHash() const {
                   "Application with connection_key = " << connection_key()
                                                        << " doesn't exist.");
   }
-  application_manager_.TerminateRequest(connection_key(), correlation_id());
+  application_manager_.TerminateRequest(
+      connection_key(), correlation_id(), function_id());
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -227,7 +227,7 @@ void RequestController::removeNotification(
   LOG4CXX_DEBUG(logger_, "Cant find notification");
 }
 
-void RequestController::terminateRequest(const uint32_t correlation_id,
+void RequestController::TerminateRequest(const uint32_t correlation_id,
                                          const uint32_t connection_key,
                                          const int32_t function_id,
                                          bool force_terminate) {
@@ -240,11 +240,11 @@ void RequestController::terminateRequest(const uint32_t correlation_id,
   RequestInfoPtr request =
       waiting_for_response_.Find(connection_key, correlation_id);
   if (!request) {
-    LOG4CXX_WARN(logger_, "Request not found in waiting_for_response");
+    LOG4CXX_WARN(logger_, "Request was not found in waiting_for_response");
     return;
   }
   if (request->request()->function_id() != function_id) {
-    LOG4CXX_ERROR(logger_, "Request and response funciton_id's does not match");
+    LOG4CXX_ERROR(logger_, "Request and response function_id's don't match");
     return;
   }
   if (force_terminate || request->request()->AllowedToTerminate()) {
@@ -259,13 +259,13 @@ void RequestController::OnMobileResponse(const uint32_t mobile_correlation_id,
                                          const uint32_t connection_key,
                                          const int32_t function_id) {
   LOG4CXX_AUTO_TRACE(logger_);
-  terminateRequest(mobile_correlation_id, connection_key, function_id);
+  TerminateRequest(mobile_correlation_id, connection_key, function_id);
 }
 
 void RequestController::OnHMIResponse(const uint32_t correlation_id,
                                       const int32_t function_id) {
   LOG4CXX_AUTO_TRACE(logger_);
-  terminateRequest(correlation_id, RequestInfo::HmiConnectoinKey, function_id);
+  TerminateRequest(correlation_id, RequestInfo::HmiConnectoinKey, function_id);
 }
 
 void RequestController::terminateWaitingForExecutionAppRequests(

--- a/src/components/application_manager/test/include/application_manager/mock_application_manager.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application_manager.h
@@ -174,7 +174,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD0(StartDevicesDiscovery, void());
   MOCK_METHOD1(StopAudioPassThru, void(int32_t application_key));
   MOCK_METHOD2(TerminateRequest,
-               void(uint32_t connection_key, uint32_t corr_id));
+               void(uint32_t connection_key,
+                    uint32_t corr_id,
+                    int32_t function_id));
   MOCK_METHOD4(UnregisterApplication,
                void(const uint32_t&, mobile_apis::Result::eType, bool, bool));
   MOCK_METHOD3(updateRequestTimeout,

--- a/src/components/application_manager/test/include/application_manager/mock_application_manager.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application_manager.h
@@ -174,9 +174,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD0(StartDevicesDiscovery, void());
   MOCK_METHOD1(StopAudioPassThru, void(int32_t application_key));
   MOCK_METHOD2(TerminateRequest,
-               void(uint32_t connection_key,
-                    uint32_t corr_id,
-                    int32_t function_id));
+               void(const uint32_t connection_key,
+                    const uint32_t corr_id,
+                    const int32_t function_id));
   MOCK_METHOD4(UnregisterApplication,
                void(const uint32_t&, mobile_apis::Result::eType, bool, bool));
   MOCK_METHOD3(updateRequestTimeout,

--- a/src/components/application_manager/test/include/application_manager/mock_application_manager.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application_manager.h
@@ -173,7 +173,7 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                     int32_t audio_type));
   MOCK_METHOD0(StartDevicesDiscovery, void());
   MOCK_METHOD1(StopAudioPassThru, void(int32_t application_key));
-  MOCK_METHOD2(TerminateRequest,
+  MOCK_METHOD3(TerminateRequest,
                void(const uint32_t connection_key,
                     const uint32_t corr_id,
                     const int32_t function_id));


### PR DESCRIPTION
Request controller should not terminate request in case if function id
does not match.

Related issue :  APPLINK-28636