### PR TITLE
Fix problem with incorrect success result

### DIFF
--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -102,11 +102,8 @@ const std::string CreateInfoForUnsupportedResult(
 }
 
 bool CheckResultCode(const ResponseInfo& first, const ResponseInfo& second) {
-  if (first.is_ok && second.is_unsupported_resource) {
-    return true;
-  }
-  if (first.is_invalid_enum && second.is_unsupported_resource &&
-      HmiInterfaces::STATE_NOT_AVAILABLE != second.interface_state) {
+  if (first.is_ok && second.is_unsupported_resource &&
+      second.interface_state == HmiInterfaces::STATE_NOT_AVAILABLE) {
     return true;
   }
   return false;

--- a/src/components/application_manager/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_command_request.cc
@@ -1,6 +1,6 @@
 /*
 
- Copyright (c) 2013, Ford Motor Company
+ Copyright (c) 2016, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -313,7 +313,7 @@ void RegisterAppInterfaceRequest::Run() {
 }
 
 void FillTTSRelatedFields(smart_objects::SmartObject& response_params,
-                         const HMICapabilities& hmi_capabilities) {
+                          const HMICapabilities& hmi_capabilities) {
   response_params[strings::language] = hmi_capabilities.active_tts_language();
 }
 

--- a/src/components/application_manager/test/commands/mobile/delete_command_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_command_request_test.cc
@@ -134,10 +134,6 @@ TEST_F(DeleteCommandRequestTest, OnEvent_VrDeleteCommand_UNSUPPORTED_RESOURCE) {
   Event event_vr(hmi_apis::FunctionID::VR_DeleteCommand);
   event_vr.set_smart_object(*event_msg);
 
-  EXPECT_CALL(*app, RemoveCommand(kCommandId));
-
-  EXPECT_CALL(*app, UpdateHash());
-
   MessageSharedPtr result_msg(
       CatchMobileCommandResult(CallOnEvent(*command, event_vr)));
 
@@ -145,7 +141,7 @@ TEST_F(DeleteCommandRequestTest, OnEvent_VrDeleteCommand_UNSUPPORTED_RESOURCE) {
 
   EXPECT_EQ(
       (*result_msg)[am::strings::msg_params][am::strings::success].asBool(),
-      true);
+      false);
   EXPECT_EQ(
       hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
       (*result_msg)[am::strings::msg_params][am::strings::result_code].asInt());


### PR DESCRIPTION
HMI send erronius result code and after that SDL answers with success=true. I fix this problem.

Closes bug [APPLINK-28762](https://adc.luxoft.com/jira/browse/APPLINK-28762)