### PR TITLE
Cover by UT navigation interface behavior

### DIFF
--- a/src/components/application_manager/test/commands/hmi/CMakeLists.txt
+++ b/src/components/application_manager/test/commands/hmi/CMakeLists.txt
@@ -36,12 +36,11 @@ include_directories(
   ${COMPONENTS_DIR}/application_manager/test/include/application_manager/commands/
 )
 
-set (SOURCES
+file(GLOB SOURCES
   ${AM_SOURCE_DIR}/src/smart_object_keys.cc
   ${AM_SOURCE_DIR}/test/mock_message_helper.cc
-  ${COMMANDS_TEST_SOURCE_DIR}/hmi/vi_is_ready_request_test.cc
-  ${COMMANDS_TEST_SOURCE_DIR}/hmi/vr_is_ready_request_test.cc
-  )
+  ${COMMANDS_TEST_SOURCE_DIR}/hmi/*
+)
 
 set(LIBRARIES
   gmock

--- a/src/components/application_manager/test/commands/hmi/navi_audio_start_stream_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_audio_start_stream_request_test.cc
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <utility>
+
+#include "application_manager/commands/hmi/navi_audio_start_stream_request.h"
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/hmi_interfaces.h"
+#include "application_manager/mock_hmi_interface.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::testing::_;
+using ::testing::ReturnRef;
+namespace am = ::application_manager;
+namespace commands = am::commands;
+using commands::MessageSharedPtr;
+using commands::AudioStartStreamRequest;
+using am::event_engine::Event;
+
+namespace {
+const uint32_t kHmiAppId = 13u;
+const am::HmiInterfaces::InterfaceID kHmiInterface =
+    am::HmiInterfaces::HMI_INTERFACE_Navigation;
+}  // namespace
+
+class AudioStartStreamRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  AudioStartStreamRequestTest() {
+    ON_CALL(app_mngr_, hmi_interfaces())
+        .WillByDefault(ReturnRef(mock_hmi_interfaces_));
+    ON_CALL(app_mngr_settings_, start_stream_retry_amount())
+        .WillByDefault(ReturnRef(start_stream_retry_amount_));
+    msg_ = CreateMessage();
+    command_ = CreateCommand<AudioStartStreamRequest>(msg_);
+  }
+
+  std::pair<uint32_t, int32_t> start_stream_retry_amount_;
+  MessageSharedPtr msg_;
+  SharedPtr<AudioStartStreamRequest> command_;
+  MOCK(am::MockHmiInterfaces) mock_hmi_interfaces_;
+};
+
+TEST_F(AudioStartStreamRequestTest, Run_HmiInterfaceNotAvailable_NoRequest) {
+  EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(kHmiInterface))
+      .WillOnce(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+  EXPECT_CALL(app_mngr_, SendMessageToHMI(_)).Times(0);
+
+  command_->Run();
+}
+
+TEST_F(AudioStartStreamRequestTest,
+       Run_HmiInterfaceAvailableButNoApp_NoRequest) {
+  (*msg_)[am::strings::msg_params][am::strings::app_id] = kHmiAppId;
+  EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(kHmiInterface))
+      .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  EXPECT_CALL(app_mngr_, application_by_hmi_app(kHmiAppId))
+      .WillOnce(Return(ApplicationSharedPtr()));
+  EXPECT_CALL(app_mngr_, SendMessageToHMI(_)).Times(0);
+
+  command_->Run();
+}
+
+TEST_F(AudioStartStreamRequestTest, Run_HmiInterfaceAvailable_SentRequest) {
+  (*msg_)[am::strings::msg_params][am::strings::app_id] = kHmiAppId;
+  EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(kHmiInterface))
+      .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  MockAppPtr mock_app = CreateMockApp();
+  EXPECT_CALL(app_mngr_, application_by_hmi_app(kHmiAppId))
+      .WillOnce(Return(mock_app));
+  EXPECT_CALL(*mock_app, set_audio_streaming_allowed(true));
+  EXPECT_CALL(app_mngr_, SendMessageToHMI(msg_));
+
+  command_->Run();
+}
+
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/navi_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_is_ready_request_test.cc
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/commands/hmi/navi_is_ready_request.h"
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/hmi_interfaces.h"
+#include "application_manager/mock_hmi_interface.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/event_engine/event.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::testing::_;
+using ::testing::ReturnRef;
+namespace am = ::application_manager;
+using am::commands::MessageSharedPtr;
+using am::commands::NaviIsReadyRequest;
+using am::event_engine::Event;
+
+namespace {
+const hmi_apis::FunctionID::eType kEventID =
+    hmi_apis::FunctionID::Navigation_IsReady;
+}  // namespace
+
+typedef SharedPtr<NaviIsReadyRequest> NaviIsReadyRequestPtr;
+
+class NaviIsReadyRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  NaviIsReadyRequestTest() : command_(CreateCommand<NaviIsReadyRequest>()) {
+    ON_CALL(app_mngr_, hmi_capabilities())
+        .WillByDefault(ReturnRef(mock_hmi_capabilities_));
+    ON_CALL(app_mngr_, hmi_interfaces())
+        .WillByDefault(ReturnRef(mock_hmi_interfaces_));
+  }
+
+  NaviIsReadyRequestPtr command_;
+  MOCK(am::MockHmiInterfaces) mock_hmi_interfaces_;
+  MOCK(application_manager_test::MockHMICapabilities) mock_hmi_capabilities_;
+};
+
+TEST_F(NaviIsReadyRequestTest,
+       OnEvent_HmiInterfaceIsAvailable_NaviCooperatingIsAvailable) {
+  const bool is_hmi_interface_available = true;
+
+  MessageSharedPtr event_msg = CreateMessage();
+  (*event_msg)[am::strings::msg_params][am::strings::available] =
+      is_hmi_interface_available;
+
+  Event event(kEventID);
+  event.set_smart_object(*event_msg);
+
+  EXPECT_CALL(mock_hmi_interfaces_,
+              SetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_Navigation,
+                                am::HmiInterfaces::STATE_AVAILABLE));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_is_navi_cooperating(is_hmi_interface_available));
+
+  command_->on_event(event);
+}
+
+TEST_F(NaviIsReadyRequestTest,
+       OnEvent_HmiInterfaceIsNotAvailable_NaviCooperatingIsNotAvailable) {
+  const bool is_hmi_interface_available = false;
+
+  MessageSharedPtr event_msg = CreateMessage();
+  (*event_msg)[am::strings::msg_params][am::strings::available] =
+      is_hmi_interface_available;
+
+  Event event(kEventID);
+  event.set_smart_object(*event_msg);
+
+  EXPECT_CALL(mock_hmi_interfaces_,
+              SetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_Navigation,
+                                am::HmiInterfaces::STATE_NOT_AVAILABLE));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_is_navi_cooperating(is_hmi_interface_available));
+
+  command_->on_event(event);
+}
+
+TEST_F(NaviIsReadyRequestTest,
+       OnEvent_AvailabilityFieldMissing_NaviCooperatingIsNotAvailable) {
+  const bool is_hmi_interface_available = false;
+
+  MessageSharedPtr event_msg = CreateMessage();
+  Event event(kEventID);
+  event.set_smart_object(*event_msg);
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_is_navi_cooperating(is_hmi_interface_available));
+
+  command_->on_event(event);
+}
+
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/navi_start_stream_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_start_stream_request_test.cc
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <utility>
+
+#include "application_manager/commands/hmi/navi_start_stream_request.h"
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/hmi_interfaces.h"
+#include "application_manager/mock_hmi_interface.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::testing::_;
+using ::testing::ReturnRef;
+namespace am = ::application_manager;
+namespace commands = am::commands;
+using commands::MessageSharedPtr;
+using commands::NaviStartStreamRequest;
+using am::event_engine::Event;
+
+namespace {
+const uint32_t kHmiAppId = 13u;
+const am::HmiInterfaces::InterfaceID kHmiInterface =
+    am::HmiInterfaces::HMI_INTERFACE_Navigation;
+}  // namespace
+
+class NaviStartStreamRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  NaviStartStreamRequestTest() {
+    ON_CALL(app_mngr_, hmi_interfaces())
+        .WillByDefault(ReturnRef(mock_hmi_interfaces_));
+    ON_CALL(app_mngr_settings_, start_stream_retry_amount())
+        .WillByDefault(ReturnRef(start_stream_retry_amount_));
+    msg_ = CreateMessage();
+    command_ = CreateCommand<NaviStartStreamRequest>(msg_);
+  }
+
+  std::pair<uint32_t, int32_t> start_stream_retry_amount_;
+  MessageSharedPtr msg_;
+  SharedPtr<NaviStartStreamRequest> command_;
+  MOCK(am::MockHmiInterfaces) mock_hmi_interfaces_;
+};
+
+TEST_F(NaviStartStreamRequestTest, Run_HmiInterfaceNotAvailable_NoRequest) {
+  EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(kHmiInterface))
+      .WillOnce(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+  EXPECT_CALL(app_mngr_, SendMessageToHMI(_)).Times(0);
+
+  command_->Run();
+}
+
+TEST_F(NaviStartStreamRequestTest,
+       Run_HmiInterfaceAvailableButNoApp_NoRequest) {
+  (*msg_)[am::strings::msg_params][am::strings::app_id] = kHmiAppId;
+  EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(kHmiInterface))
+      .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  EXPECT_CALL(app_mngr_, application_by_hmi_app(kHmiAppId))
+      .WillOnce(Return(ApplicationSharedPtr()));
+  EXPECT_CALL(app_mngr_, SendMessageToHMI(_)).Times(0);
+
+  command_->Run();
+}
+
+TEST_F(NaviStartStreamRequestTest, Run_HmiInterfaceAvailable_SentRequest) {
+  (*msg_)[am::strings::msg_params][am::strings::app_id] = kHmiAppId;
+  EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(kHmiInterface))
+      .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  MockAppPtr mock_app = CreateMockApp();
+  EXPECT_CALL(app_mngr_, application_by_hmi_app(kHmiAppId))
+      .WillOnce(Return(mock_app));
+  EXPECT_CALL(*mock_app, set_video_streaming_allowed(true));
+  EXPECT_CALL(app_mngr_, SendMessageToHMI(msg_));
+
+  command_->Run();
+}
+
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/navi_stop_stream_requests_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_stop_stream_requests_test.cc
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/commands/hmi/navi_stop_stream_request.h"
+#include "application_manager/commands/hmi/navi_audio_stop_stream_request.h"
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/hmi_interfaces.h"
+#include "application_manager/mock_hmi_interface.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+
+using ::testing::_;
+using ::testing::ReturnRef;
+namespace am = ::application_manager;
+namespace commands = am::commands;
+using commands::MessageSharedPtr;
+using am::event_engine::Event;
+
+namespace {
+const am::HmiInterfaces::InterfaceID kHmiInterface =
+    am::HmiInterfaces::HMI_INTERFACE_Navigation;
+}  // namespace
+
+template <typename Command>
+class NaviStopStreamRequestsTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  NaviStopStreamRequestsTest() {
+    ON_CALL(this->app_mngr_, hmi_interfaces())
+        .WillByDefault(ReturnRef(mock_hmi_interfaces_));
+    msg_ = CreateMessage();
+    command_ = CreateCommand<Command>(msg_);
+  }
+
+  MessageSharedPtr msg_;
+  SharedPtr<Command> command_;
+  MOCK(am::MockHmiInterfaces) mock_hmi_interfaces_;
+};
+
+typedef testing::Types<commands::AudioStopStreamRequest,
+                       commands::NaviStopStreamRequest> RequestCommandsList;
+TYPED_TEST_CASE(NaviStopStreamRequestsTest, RequestCommandsList);
+
+TYPED_TEST(NaviStopStreamRequestsTest, Run_HmiInterfaceNotAvailable_NoRequest) {
+  EXPECT_CALL(TestFixture::mock_hmi_interfaces_,
+              GetInterfaceState(kHmiInterface))
+      .WillOnce(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+  EXPECT_CALL(TestFixture::app_mngr_, SendMessageToHMI(_)).Times(0);
+
+  TestFixture::command_->Run();
+}
+
+TYPED_TEST(NaviStopStreamRequestsTest, Run_HmiInterfaceAvailable_SentRequest) {
+  EXPECT_CALL(TestFixture::mock_hmi_interfaces_,
+              GetInterfaceState(kHmiInterface))
+      .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(TestFixture::app_mngr_, SendMessageToHMI(TestFixture::msg_));
+
+  TestFixture::command_->Run();
+}
+
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/include/application_manager/commands/commands_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/commands_test.h
@@ -74,6 +74,8 @@ template <class MockT, bool kIsNice>
 struct IsNiceMock : public TypeIf<kIsNice, ::testing::NiceMock<MockT>, MockT> {
 };
 
+#define MOCK(Type) typename IsNiceMock<Type, kMocksAreNice>::Result
+
 // If `kIsNice` is `true` then all used mock types
 // will be wrapped by a `NiceMock`
 


### PR DESCRIPTION
Has been covered `SDL` commands
behavior in case `HMI` does
not respond to `IsReadyRequest`,
or respond with `available == false`.

-
Related to: [APPLINK-25174](https://adc.luxoft.com/jira/browse/APPLINK-25174)

@AGaliuzov, @Kozoriz, @LuxoftAKutsan, @VProdanov, @wolfylambova22, @VVeremjova, please, review.