### PR TITLE
Fix EXTENDED_MEDIA_MODE build and runtime failures

### DIFF
--- a/src/appMain/CMakeLists.txt
+++ b/src/appMain/CMakeLists.txt
@@ -45,6 +45,7 @@ cmake_policy(POP)
 if (EXTENDED_MEDIA_MODE)
 set(default_media_inc
 ${GSTREAMER_gst_INCLUDE_DIR}
+${GSTREAMER_gstconfig_INCLUDE_DIR}
 )
 else(EXTENDED_MEDIA_MODE)
 set(default_media_inc

--- a/src/components/media_manager/CMakeLists.txt
+++ b/src/components/media_manager/CMakeLists.txt
@@ -37,6 +37,7 @@ pkg_check_modules(GLIB2 REQUIRED glib-2.0)
 add_definitions(${GLIB2_CFLAGS})
 set(default_includes
     ${GSTREAMER_gst_INCLUDE_DIR}
+    ${GSTREAMER_gstconfig_INCLUDE_DIR}
     ${GLIB_glib_2_INCLUDE_DIR}
 )
 set(default_sources
@@ -63,6 +64,8 @@ set(LIBRARIES
     glib-2.0
 )
 else(EXTENDED_MEDIA_MODE)
+set(default_includes
+)
 
 set(default_sources
     ${COMPONENTS_DIR}/media_manager/src/audio/socket_audio_streamer_adapter.cc
@@ -96,6 +99,7 @@ include_directories (
     ${JSONCPP_INCLUDE_DIRECTORY}
     ${CMAKE_BINARY_DIR}/src/components/
     ${COMPONENTS_DIR}/policy/include/
+    ${default_includes}
     ${LOG4CXX_INCLUDE_DIRECTORY}
 )
 

--- a/src/components/media_manager/src/media_manager_impl.cc
+++ b/src/components/media_manager/src/media_manager_impl.cc
@@ -114,8 +114,6 @@ void MediaManagerImpl::Init() {
 
 #if defined(EXTENDED_MEDIA_MODE)
   LOG4CXX_INFO(logger_, "Called Init with default configuration.");
-  a2dp_player_ =
-      new A2DPSourcePlayerAdapter(protocol_handler_->get_session_observer());
   from_mic_recorder_ = new FromMicRecorderAdapter();
 #endif
 
@@ -157,6 +155,14 @@ void MediaManagerImpl::Init() {
 
 void MediaManagerImpl::PlayA2DPSource(int32_t application_key) {
   LOG4CXX_AUTO_TRACE(logger_);
+
+#if defined(EXTENDED_MEDIA_MODE)
+  if (!a2dp_player_ && protocol_handler_) {
+    a2dp_player_ =
+        new A2DPSourcePlayerAdapter(protocol_handler_->get_session_observer());
+  }
+#endif
+
   if (a2dp_player_) {
     a2dp_player_->StartActivity(application_key);
   }


### PR DESCRIPTION
The build for SDL Core currently fails if EXTENDED_MEDIA_MODE=ON, this is partially due to a mistake made in a large CMake refactoring commit which removes the GStreamer include directories ([here](https://github.com/smartdevicelink/sdl_core/commit/9dba2aecd2a4c7b4054067deb413311c44c80cac#diff-d4aa18259c54c5324255aa1f61777fb3L66)). 

In addition, the GStreamer config directory is not included in the build, which is used by some of the headers in the gst directory which are included in the Media Manager. Unfortunately, FindGStreamer-1.0.cmake cannot find the config directory automatically, so the GSTREAMER_DIR environment variable still needs to be set manually for these changes to work (for Ubuntu 16.04 64-bit, this path should be /usr/lib/x86_64-linux-gnu/gstreamer-1.0):

```
export GSTREAMER_DIR=$PATH_TO_GSTREAMER
```

Finally, once Core is built with this feature, a SEGFAULT occurs in media_manager_impl.cc due to the code attempting to access a member of protocol_handler_ before it is set.

PR Changes
  * Edits Media Manager and appMain CMakeLists to fix build errors with Extended Media Mode
  * Fixes SEGFAULT error which occurs when the Media Manager is being initialized with Extended Media Mode