### PR TITLE
Fix that StartStreamRequest may hang forever in case of app absence

### DIFF
--- a/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
@@ -63,20 +63,19 @@ void AudioStartStreamRequest::Run() {
     LOG4CXX_INFO(logger_, "Interface Navi is not supported by system");
     return;
   }
-  SetAllowedToTerminate(false);
-  subscribe_on_event(hmi_apis::FunctionID::Navigation_StartAudioStream,
-                     correlation_id());
-
   ApplicationSharedPtr app =
       application_manager_.application_by_hmi_app(application_id());
-  if (app) {
-    app->set_audio_streaming_allowed(true);
-    SendRequest();
-  } else {
+  if (!app) {
     LOG4CXX_ERROR(logger_,
                   "Applcation with hmi_app_id " << application_id()
                                                 << " does not exist");
+    return;
   }
+  SetAllowedToTerminate(false);
+  subscribe_on_event(hmi_apis::FunctionID::Navigation_StartAudioStream,
+                     correlation_id());
+  app->set_audio_streaming_allowed(true);
+  SendRequest();
 }
 
 void AudioStartStreamRequest::on_event(const event_engine::Event& event) {

--- a/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
@@ -63,21 +63,19 @@ void NaviStartStreamRequest::Run() {
     LOG4CXX_INFO(logger_, "Interface Navi is not supported by system");
     return;
   }
-
-  SetAllowedToTerminate(false);
-  subscribe_on_event(hmi_apis::FunctionID::Navigation_StartStream,
-                     correlation_id());
-
   ApplicationSharedPtr app =
       application_manager_.application_by_hmi_app(application_id());
-  if (app) {
-    app->set_video_streaming_allowed(true);
-    SendRequest();
-  } else {
+  if (!app) {
     LOG4CXX_ERROR(logger_,
                   "Applcation with hmi_app_id " << application_id()
                                                 << "does not exist");
+    return;
   }
+  SetAllowedToTerminate(false);
+  subscribe_on_event(hmi_apis::FunctionID::Navigation_StartStream,
+                     correlation_id());
+  app->set_video_streaming_allowed(true);
+  SendRequest();
 }
 
 void NaviStartStreamRequest::on_event(const event_engine::Event& event) {


### PR DESCRIPTION
In `AudioStartStreamRequest`
and `NaviStartStreamRequest`,
subscription to event and
disabling of `AllowedToTerminate`
flag, has been moved after checking
for applications presence.

-
Closes bug: [APPLINK-28988](https://adc.luxoft.com/jira/browse/APPLINK-28988)

@AGaliuzov, @Kozoriz, @LuxoftAKutsan, @VProdanov, @wolfylambova22, @VVeremjova, please, review.