### PR TITLE
Set policy db path to storage folder

### DIFF
--- a/src/components/policy/src/sql_pt_representation.cc
+++ b/src/components/policy/src/sql_pt_representation.cc
@@ -320,6 +320,10 @@ InitResult SQLPTRepresentation::Init(const PolicySettings* settings) {
 #ifdef BUILD_TESTS
   open_counter_ = 0;
 #endif  // BUILD_TESTS
+  std::string path = get_settings().app_storage_folder();
+  if (!path.empty()) {
+    db_->set_path(path + "/");
+  }
   if (!db_->Open()) {
     LOG4CXX_ERROR(logger_, "Failed opening database.");
     LOG4CXX_INFO(logger_, "Starting opening retries.");

--- a/src/components/utils/include/utils/sqlite_wrapper/sql_database.h
+++ b/src/components/utils/include/utils/sqlite_wrapper/sql_database.h
@@ -131,6 +131,11 @@ class SQLDatabase {
   sync_primitives::Lock conn_lock_;
 
   /**
+   * The file path of database
+   */
+  std::string path_;
+
+  /**
    * The filename of database
    */
   std::string databasename_;

--- a/src/components/utils/src/sqlite_wrapper/sql_database.cc
+++ b/src/components/utils/src/sqlite_wrapper/sql_database.cc
@@ -53,7 +53,8 @@ bool SQLDatabase::Open() {
   sync_primitives::AutoLock auto_lock(conn_lock_);
   if (conn_)
     return true;
-  error_ = sqlite3_open(databasename_.c_str(), &conn_);
+  error_ = sqlite3_open(get_path().c_str(), &conn_);
+  printf("OPEN SQLDATABASE: %i\n", error_);
   return error_ == SQLITE_OK;
 }
 
@@ -101,11 +102,11 @@ sqlite3* SQLDatabase::conn() const {
 }
 
 void SQLDatabase::set_path(const std::string& path) {
-  databasename_ = path + databasename_;
+  path_ = path;
 }
 
 std::string SQLDatabase::get_path() const {
-  return databasename_;
+  return path_ + databasename_;
 }
 
 bool SQLDatabase::Backup() {


### PR DESCRIPTION
Quick change which sets the path for `policy.sqlite` to the app storage folder defined in smartDeviceLink.ini

Fixes #905 