### PR TITLE
Remove PrintSmartObject

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -576,8 +576,6 @@ class MessageHelper {
       ApplicationSharedPtr app,
       const int32_t function_id);
 
-  static bool PrintSmartObject(const smart_objects::SmartObject& object);
-
   template <typename From, typename To>
   static To ConvertEnumAPINoCheck(const From& input) {
     return static_cast<To>(input);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1041,7 +1041,6 @@ uint32_t ApplicationManagerImpl::GenerateNewHMIAppID() {
 
 void ApplicationManagerImpl::ReplaceMobileByHMIAppId(
     smart_objects::SmartObject& message) {
-  MessageHelper::PrintSmartObject(message);
   if (message.keyExists(strings::app_id)) {
     ApplicationSharedPtr application_ptr =
         application(message[strings::app_id].asUInt());
@@ -1452,9 +1451,6 @@ bool ApplicationManagerImpl::ManageMobileCommand(
     SDL_WARN("Low Voltage is active");
     return false;
   }
-#ifdef DEBUG
-  MessageHelper::PrintSmartObject(*message);
-#endif
 
   SDL_DEBUG("Trying to create message in mobile factory.");
   utils::SharedPtr<commands::Command> command(
@@ -1661,8 +1657,6 @@ bool ApplicationManagerImpl::ManageHMICommand(
     SDL_WARN("Low Voltage is active");
     return false;
   }
-
-  MessageHelper::PrintSmartObject(*message);
 
   CommandSharedPtr command = HMICommandFactory::CreateCommand(message, *this);
   if (!command) {

--- a/src/components/application_manager/src/commands/command_notification_from_mobile_impl.cc
+++ b/src/components/application_manager/src/commands/command_notification_from_mobile_impl.cc
@@ -61,7 +61,6 @@ void CommandNotificationFromMobileImpl::SendNotification() {
       static_cast<int32_t>(application_manager::MessageType::kNotification);
 
   SDL_INFO("SendNotification");
-  MessageHelper::PrintSmartObject(*message_);
 
   application_manager_.SendMessageToMobile(message_);
 }

--- a/src/components/application_manager/src/commands/command_notification_impl.cc
+++ b/src/components/application_manager/src/commands/command_notification_impl.cc
@@ -61,7 +61,6 @@ void CommandNotificationImpl::SendNotification() {
       static_cast<int32_t>(application_manager::MessageType::kNotification);
 
   SDL_INFO("SendNotification");
-  MessageHelper::PrintSmartObject(*message_);
 
   application_manager_.SendMessageToMobile(message_);
 }

--- a/src/components/application_manager/src/commands/mobile/send_location_request.cc
+++ b/src/components/application_manager/src/commands/mobile/send_location_request.cc
@@ -159,7 +159,6 @@ void SendLocationRequest::on_event(const event_engine::Event& event) {
 bool SendLocationRequest::CheckFieldsCompatibility() {
   const smart_objects::SmartObject& msg_params =
       (*message_)[strings::msg_params];
-  MessageHelper::PrintSmartObject(msg_params);
   const bool longitude_degrees_exist =
       msg_params.keyExists(strings::longitude_degrees);
   const bool latitude_degrees_exist =

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -293,7 +293,6 @@ void MessageHelper::SendHashUpdateNotification(const uint32_t app_id,
     return;
   }
   smart_objects::SmartObjectSPtr so = CreateHashUpdateNotification(app_id);
-  PrintSmartObject(*so);
   if (!app_mngr.ManageMobileCommand(so, commands::Command::ORIGIN_SDL)) {
     SDL_ERROR("Failed to send HashUpdate notification.");
     return;
@@ -1888,10 +1887,6 @@ void MessageHelper::SendSystemRequestNotification(
 
   content[strings::params][strings::connection_key] = connection_key;
 
-#ifdef DEBUG
-  PrintSmartObject(content);
-#endif
-
   DCHECK(app_mngr.ManageMobileCommand(
       utils::MakeShared<smart_objects::SmartObject>(content),
       commands::Command::ORIGIN_SDL));
@@ -2464,75 +2459,6 @@ void MessageHelper::SubscribeApplicationToSoftButton(
     softbuttons_id.insert(soft_buttons[i][strings::soft_button_id].asUInt());
   }
   app->SubscribeToSoftButtons(function_id, softbuttons_id);
-}
-
-bool MessageHelper::PrintSmartObject(const smart_objects::SmartObject& object) {
-#ifdef ENABLE_LOG
-  static uint32_t tab = 0;
-  std::string tab_buffer;
-
-  if (tab == 0) {
-    SDL_INFO("-------------------------------------------------------------");
-  }
-
-  for (uint32_t i = 0; i < tab; ++i) {
-    tab_buffer += "\t";
-  }
-
-  switch (object.getType()) {
-    case NsSmartDeviceLink::NsSmartObjects::SmartType_Array: {
-      for (size_t i = 0; i < object.length(); i++) {
-        ++tab;
-
-        SDL_INFO(tab_buffer << i << ": ");
-        if (!PrintSmartObject(object.getElement(i))) {
-          return false;
-        }
-      }
-      break;
-    }
-    case NsSmartDeviceLink::NsSmartObjects::SmartType_Map: {
-      std::set<std::string> keys = object.enumerate();
-
-      for (std::set<std::string>::const_iterator key = keys.begin();
-           key != keys.end();
-           key++) {
-        ++tab;
-
-        SDL_INFO(tab_buffer << (*key) << ": ");
-        if (!PrintSmartObject(object[*key])) {
-          return false;
-        }
-      }
-      break;
-    }
-    case NsSmartDeviceLink::NsSmartObjects::SmartType_Boolean:
-      SDL_INFO(std::boolalpha << object.asBool());
-      break;
-    case NsSmartDeviceLink::NsSmartObjects::SmartType_Double: {
-      SDL_INFO(object.asDouble());
-      break;
-    }
-    case NsSmartDeviceLink::NsSmartObjects::SmartType_Integer:
-      break;
-    case NsSmartDeviceLink::NsSmartObjects::SmartType_String:
-      SDL_INFO(object.asString());
-      break;
-    case NsSmartDeviceLink::NsSmartObjects::SmartType_Character:
-      SDL_INFO(object.asChar());
-      break;
-    default:
-      SDL_INFO("PrintSmartObject - default case\n");
-      break;
-  }
-
-  if (0 != tab) {
-    --tab;
-  } else {
-    SDL_INFO("-------------------------------------------------------------");
-  }
-#endif
-  return true;
 }
 
 }  //  namespace application_manager

--- a/src/components/application_manager/test/commands/mobile/on_button_notification_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_button_notification_commands_test.cc
@@ -250,9 +250,6 @@ TYPED_TEST(OnButtonNotificationCommandsTest, Run_CustomButton_SUCCESS) {
               SendMessageToMobile(
                   CheckNotificationMessage(TestFixture::kFunctionId), _));
 
-  EXPECT_CALL(this->message_helper_, PrintSmartObject(_))
-      .WillOnce(Return(false));
-
   command->Run();
 }
 
@@ -357,9 +354,6 @@ TYPED_TEST(OnButtonNotificationCommandsTest, Run_SUCCESS) {
   EXPECT_CALL(this->mock_app_manager_,
               SendMessageToMobile(
                   CheckNotificationMessage(TestFixture::kFunctionId), _));
-
-  EXPECT_CALL(this->message_helper_, PrintSmartObject(_))
-      .WillOnce(Return(false));
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/mobile/on_command_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_command_notification_test.cc
@@ -149,7 +149,6 @@ TEST_F(OnCommandNotificationTest, Run_SUCCESS) {
   EXPECT_CALL(mock_app_manager_, application(kAppId))
       .WillOnce(Return(mock_app));
   EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(0u));
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
 
   MessageSharedPtr dummy_msg(CreateMessage());
   EXPECT_CALL(*mock_app, FindCommand(kCommandId))

--- a/src/components/application_manager/test/commands/mobile/on_hash_change_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_hash_change_notification_test.cc
@@ -83,7 +83,6 @@ TEST_F(OnHashChangeNotificationTest, Run_ValidApp_SUCCESS) {
   EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
   EXPECT_CALL(*mock_app, curHash()).WillOnce(ReturnRef(return_string));
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
   EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _));
 
   command->Run();
@@ -112,7 +111,6 @@ TEST_F(OnHashChangeNotificationTest, Run_InvalidApp_NoNotification) {
   EXPECT_CALL(mock_app_manager_, application(kConnectionKey))
       .WillOnce(Return(MockAppPtr()));
   EXPECT_CALL(*mock_app, curHash()).Times(0);
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).Times(0);
   EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _)).Times(0);
 
   command->Run();

--- a/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_test.cc
@@ -76,7 +76,6 @@ class OnHMIStatusNotificationTest
 
   void SetSendNotificationExpectations(MessageSharedPtr& msg) {
     Mock::VerifyAndClearExpectations(&message_helper_);
-    EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
     EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _));
   }
 

--- a/src/components/application_manager/test/commands/mobile/on_keyboard_input_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_keyboard_input_notification_test.cc
@@ -73,7 +73,6 @@ class OnKeyBoardInputNotificationTest
   }
 
   void SetSendNotificationExpectations(MessageSharedPtr msg) {
-    EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
     EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _));
   }
 
@@ -160,7 +159,6 @@ TEST_F(OnKeyBoardInputNotificationTest, Run_InvalidApp_NoNotification) {
   EXPECT_CALL(*mock_app, hmi_level())
       .WillOnce(Return(mobile_apis::HMILevel::eType::HMI_BACKGROUND));
 
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).Times(0);
   EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _)).Times(0);
 
   command->Run();

--- a/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
@@ -163,7 +163,6 @@ TEST_F(OnSystemRequestNotificationTest, Run_ProprietaryType_SUCCESS) {
   EXPECT_CALL(mock_policy_handler_, TimeoutExchange()).WillOnce(Return(5u));
 #endif  // EXTENDED_POLICY
 
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
   EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _));
 
   command->Run();
@@ -203,7 +202,6 @@ TEST_F(OnSystemRequestNotificationTest, Run_EmptyMessage_UNSUCCESS) {
   EXPECT_CALL(mock_policy_handler_, TimeoutExchange()).WillOnce(Return(NULL));
 #endif  // EXTENDED_POLICY
 
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
   EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _));
 
   command->Run();
@@ -239,7 +237,6 @@ TEST_F(OnSystemRequestNotificationTest, Run_HTTPType_SUCCESS) {
   EXPECT_CALL(mock_policy_handler_, IsRequestTypeAllowed(_, _))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
   EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _));
 
   command->Run();
@@ -271,7 +268,6 @@ TEST_F(OnSystemRequestNotificationTest, Run_InvalidApp_NoNotification) {
   EXPECT_CALL(*mock_app, policy_app_id()).Times(0);
   EXPECT_CALL(mock_policy_handler_, IsRequestTypeAllowed(_, _)).Times(0);
 
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).Times(0);
   EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _)).Times(0);
 
   command->Run();
@@ -295,9 +291,7 @@ TEST_F(OnSystemRequestNotificationTest, Run_RequestNotAllowed_NoNotification) {
   EXPECT_CALL(mock_policy_handler_, IsRequestTypeAllowed(_, _))
       .WillOnce(Return(false));
 
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).Times(0);
   EXPECT_CALL(mock_app_manager_, SendMessageToMobile(msg, _)).Times(0);
-  ;
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/mobile/on_tbt_client_state_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_tbt_client_state_notification_test.cc
@@ -142,8 +142,6 @@ TEST_F(OnTBTClientStateNotificationTest,
 
   EXPECT_CALL(mock_app_manager_, SendMessageToMobile(CheckMessageData(), _));
 
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
-
   command_->Run();
 }
 

--- a/src/components/application_manager/test/commands/mobile/on_touch_event_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_touch_event_notification_test.cc
@@ -139,8 +139,6 @@ TEST_F(OnTouchEventNotificationTest, Run_NotEmptyListOfAppsWithNavi_SUCCESS) {
 
   EXPECT_CALL(mock_app_manager_, SendMessageToMobile(CheckMessageData(), _));
 
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
-
   command_->Run();
 }
 

--- a/src/components/application_manager/test/commands/mobile/on_vehicle_data_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_vehicle_data_notification_test.cc
@@ -148,9 +148,6 @@ TEST_F(OnVehicleDataNotificationTest,
               SendMessageToMobile(
                   CheckMessageData(am::strings::fuel_level, fuel_level), _));
 
-  EXPECT_CALL(mock_message_helper_, PrintSmartObject(_))
-      .WillOnce(Return(false));
-
   command_->Run();
 }
 

--- a/src/components/application_manager/test/commands/mobile/on_way_point_change_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_way_point_change_notification_test.cc
@@ -118,8 +118,6 @@ TEST_F(OnWayPointChangeNotificationTest,
 
   EXPECT_CALL(mock_app_manager_, SendMessageToMobile(CheckMessageData(), _));
 
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
-
   command_->Run();
 }
 

--- a/src/components/application_manager/test/commands/mobile/simple_notification_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/simple_notification_commands_test.cc
@@ -105,8 +105,7 @@ TYPED_TEST(MobileNotificationCommandsTest, Run_SendMessageToMobile_SUCCESS) {
       this->template CreateCommand<typename TestFixture::CommandType>();
   EXPECT_CALL(this->mock_app_manager_,
               SendMessageToMobile(CheckNotificationMessage(), _));
-  EXPECT_CALL(this->message_helper_, PrintSmartObject(_))
-      .WillOnce(Return(false));
+
   command->Run();
 }
 

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -237,8 +237,6 @@ class MockMessageHelper {
 
   MOCK_METHOD1(GetPriorityCode, const uint32_t(const std::string& priority));
 
-  MOCK_METHOD1(PrintSmartObject,
-               bool(const smart_objects::SmartObject& object));
   MOCK_METHOD3(SendTTSGlobalProperties,
                void(ApplicationSharedPtr app,
                     const bool default_help_prompt,

--- a/src/components/application_manager/test/message_helper/mock_message_helper.cc
+++ b/src/components/application_manager/test/message_helper/mock_message_helper.cc
@@ -443,10 +443,6 @@ void MessageHelper::SendTTSGlobalProperties(ApplicationSharedPtr app,
       app, default_help_prompt, app_man);
 }
 
-bool MessageHelper::PrintSmartObject(const smart_objects::SmartObject& object) {
-  return MockMessageHelper::message_helper_mock()->PrintSmartObject(object);
-}
-
 void MessageHelper::SendSetAppIcon(const uint32_t app_id,
                                    const std::string& icon_path,
                                    ApplicationManager& application_manager) {

--- a/src/components/smart_objects/include/smart_objects/smart_object.h
+++ b/src/components/smart_objects/include/smart_objects/smart_object.h
@@ -36,6 +36,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <iostream>
 #include <map>
 
 #include "smart_objects/smart_schema.h"
@@ -163,7 +164,7 @@ class SmartObject FINAL {
    * @param pointer
    **/
   template <typename UnknownType>
-  SmartObject(const UnknownType&);
+  explicit SmartObject(const UnknownType&);
 
   /**
    * @brief Constructor for creating object of given primitive type.
@@ -449,6 +450,18 @@ class SmartObject FINAL {
    * @return std::string
    **/
   std::string asString() const;
+
+  /**
+   * @brief Writes smart object to stream
+   *
+   * @param out_stream reference to a stream
+   * in which smart_object will be recorded
+   * @param smart_object object which will be
+   * written to the out_stream
+   * @return reference to out_stream
+   **/
+  friend std::iostream& operator<<(std::iostream& out_stream,
+                                   const SmartObject& smart_object);
 
   /**
    * @brief Returns char array from SmartObject data if exist. Otherwise returns
@@ -841,14 +854,6 @@ class SmartObject FINAL {
   inline void set_value_cstr(const char* NewValue);
 
   /**
-   * @brief Converts object to string type
-   *
-   * @return int32_t Converted value or invalid_string_value if conversion not
-   *possible
-   **/
-  inline std::string convert_string() const;
-
-  /**
    * @brief Converts object to CustomString type
    *
    * @return CustomString Converted value or
@@ -1014,6 +1019,7 @@ static SmartObject invalid_object_value(SmartType_Invalid);
  * @brief Value that is used as invalid value for object type
  **/
 static const SmartBinary invalid_binary_value;
+
 }  // namespace NsSmartObjects
 }  // namespace NsSmartDeviceLink
 

--- a/src/components/smart_objects/test/SmartObjectUnit_test.cc
+++ b/src/components/smart_objects/test/SmartObjectUnit_test.cc
@@ -304,7 +304,7 @@ TEST(FromBool, TypeConversion) {
 
   obj = true;
 
-  ASSERT_EQ(invalid_string_value, obj.asString());
+  ASSERT_EQ("true", obj.asString());
   ASSERT_TRUE(obj.asBool());
   ASSERT_EQ(1, obj.asInt());
   ASSERT_EQ(invalid_char_value, obj.asChar());
@@ -315,7 +315,7 @@ TEST(FromBool, TypeConversion) {
 
   obj = false;
 
-  ASSERT_EQ(invalid_string_value, obj.asString());
+  ASSERT_EQ("false", obj.asString());
   ASSERT_FALSE(obj.asBool());
   ASSERT_EQ(0, obj.asBool());
   ASSERT_EQ(invalid_char_value, obj.asChar());
@@ -413,7 +413,7 @@ TEST(FromMap, TypeConversion) {
 
   obj["key1"] = 123;
 
-  ASSERT_EQ(invalid_string_value, obj.asString());
+  ASSERT_EQ("{\"key1\": 123}", obj.asString());
   ASSERT_EQ(invalid_int_value, obj.asInt());
   ASSERT_EQ(invalid_char_value, obj.asChar());
   ASSERT_EQ(invalid_double_value, obj.asDouble());
@@ -428,7 +428,7 @@ TEST(FromArray, TypeConversion) {
   obj[0] = 'A';
   obj[1] = -123;
 
-  ASSERT_EQ(invalid_string_value, obj.asString());
+  ASSERT_EQ("[A, -123]", obj.asString());
   ASSERT_EQ(invalid_int_value, obj.asInt());
   ASSERT_EQ(invalid_char_value, obj.asChar());
   ASSERT_EQ(invalid_double_value, obj.asDouble());


### PR DESCRIPTION
`MessageHelper::PrintSmartObject()`
method has been removed as redundant.

-
`SmartObject::asString()` method has
been improved, to support conversion
from major amount of `SmartTypes`.

-
Related to: [APPLINK-29319](https://adc.luxoft.com/jira/browse/APPLINK-29319)

@AGaliuzov, @Kozoriz, @LuxoftAKutsan, @VProdanov, @wolfylambova22, @VVeremjova, please, review.