### PR TITLE
CreateInteraction/PerformInteraction: case with the same MenuName or vrCommands between the different ChoiceSets

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -95,7 +95,8 @@ class CommandRequestImpl : public CommandImpl,
    * @param allow_empty_string if true methods allow empty sting
    * @return true if success otherwise return false
    */
-  bool CheckSyntax(const std::string& str, bool allow_empty_line = false);
+  static bool CheckSyntax(const std::string& str,
+                          bool allow_empty_line = false);
 
   /*
    * @brief Sends HMI request

--- a/src/components/application_manager/include/application_manager/commands/mobile/create_interaction_choice_set_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/create_interaction_choice_set_request.h
@@ -143,11 +143,10 @@ class CreateInteractionChoiceSetRequest : public CommandRequestImpl {
 
   /**
    * @brief Checks incoming choiseSet params.
-   * @param app Registred mobile application
    *
    * @return Mobile result code
    */
-  mobile_apis::Result::eType CheckChoiceSet(ApplicationConstSharedPtr app);
+  mobile_apis::Result::eType CheckChoiceSet();
 
   /**
    * @brief Checks choice set params(menuName, tertiaryText, ...)

--- a/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -45,6 +45,12 @@ namespace application_manager {
 
 namespace commands {
 
+/**
+ * @brief The UniqueParamChecker class
+ * helps to check, whether incoming string
+ * is unique compared to previous ones, or not.
+ * Also checks syntax correctness.
+ */
 class UniqueParamChecker {
  public:
   UniqueParamChecker(const char* const name) : name_(name) {}

--- a/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -106,23 +106,59 @@ void CreateInteractionChoiceSetRequest::Run() {
     return;
   }
 
-  Result::eType result = CheckChoiceSet(app);
+  Result::eType result = CheckChoiceSet();
   if (Result::SUCCESS != result) {
     SendResponse(false, result);
     return;
   }
   uint32_t grammar_id = application_manager_.GenerateGrammarID();
   (*message_)[strings::msg_params][strings::grammar_id] = grammar_id;
-  app->AddChoiceSet(choice_set_id_, (*message_)[strings::msg_params]);
   SendVRAddCommandRequests(app);
+  app->AddChoiceSet(choice_set_id_, (*message_)[strings::msg_params]);
 }
 
-mobile_apis::Result::eType CreateInteractionChoiceSetRequest::CheckChoiceSet(
-    ApplicationConstSharedPtr app) {
+template <typename T>
+bool InsertData(std::set<T>& out_set, const T& data) {
+  typedef std::pair<typename std::set<T>::iterator, bool> InsertResult;
+  InsertResult ins_res = out_set.insert(data);
+  return ins_res.second;
+}
+
+class UniqueParamChecker {
+ public:
+  UniqueParamChecker(const char* const name) : name_(name) {}
+
+  mobile_apis::Result::eType operator()(const std::string& param) {
+    if (!InsertData(hash_set_, utils::Djb2HashFromString(param))) {
+      error_msg_ = "Choise with " + name_ + " " + param + " already exists";
+      return mobile_apis::Result::DUPLICATE_NAME;
+    }
+    if (!CommandRequestImpl::CheckSyntax(param)) {
+      error_msg_ = "Invalid " + name_ + " syntax check failed";
+      return mobile_apis::Result::INVALID_DATA;
+    }
+
+    return mobile_apis::Result::SUCCESS;
+  }
+
+  const std::string error_msg() const {
+    return error_msg_;
+  }
+
+ private:
+  std::string error_msg_;
+  std::set<int32_t> hash_set_;
+  const std::string name_;
+};
+
+mobile_apis::Result::eType CreateInteractionChoiceSetRequest::CheckChoiceSet() {
   using namespace smart_objects;
+
   SDL_AUTO_TRACE();
 
   std::set<uint32_t> choice_id_set;
+  UniqueParamChecker choice_menu_name_checker(strings::menu_name);
+  UniqueParamChecker choice_vr_command_checker(strings::vr_commands);
 
   const SmartArray* choice_set =
       (*message_)[strings::msg_params][strings::choice_set].asArray();
@@ -130,17 +166,34 @@ mobile_apis::Result::eType CreateInteractionChoiceSetRequest::CheckChoiceSet(
   SmartArray::const_iterator choice_set_it = choice_set->begin();
 
   for (; choice_set->end() != choice_set_it; ++choice_set_it) {
-    std::pair<std::set<uint32_t>::iterator, bool> ins_res =
-        choice_id_set.insert((*choice_set_it)[strings::choice_id].asInt());
-    if (!ins_res.second) {
-      SDL_ERROR("Choise with ID "
-                << (*choice_set_it)[strings::choice_id].asInt()
-                << " already exists");
+    const uint32_t choice_id = (*choice_set_it)[strings::choice_id].asUInt();
+    if (!InsertData(choice_id_set, choice_id)) {
+      SDL_ERROR("Choise with ID " << choice_id << " already exists");
       return mobile_apis::Result::INVALID_ID;
     }
 
+    mobile_apis::Result::eType result_code = mobile_apis::Result::SUCCESS;
+
+    const std::string choice_menu_name =
+        (*choice_set_it)[strings::menu_name].asString();
+    if ((result_code = choice_menu_name_checker(choice_menu_name))) {
+      SDL_ERROR(choice_menu_name_checker.error_msg());
+      return result_code;
+    }
+
+    const SmartObject& vr_commands_array =
+        (*choice_set_it)[strings::vr_commands];
+
+    for (size_t i = 0; i < vr_commands_array.length(); ++i) {
+      const std::string choice_vr_command = vr_commands_array[i].asString();
+      if ((result_code = choice_vr_command_checker(choice_vr_command))) {
+        SDL_ERROR(choice_vr_command_checker.error_msg());
+        return result_code;
+      }
+    }
+
     if (IsWhiteSpaceExist(*choice_set_it)) {
-      SDL_ERROR("Incoming choice set has contains \t\n \\t \\n");
+      SDL_ERROR("Incoming choice set has contains \\t\\n \\t \\n");
       return mobile_apis::Result::INVALID_DATA;
     }
   }
@@ -148,54 +201,36 @@ mobile_apis::Result::eType CreateInteractionChoiceSetRequest::CheckChoiceSet(
 }
 
 bool CreateInteractionChoiceSetRequest::IsWhiteSpaceExist(
-    const smart_objects::SmartObject& choice_set) {
+    const smart_objects::SmartObject& choice) {
   SDL_AUTO_TRACE();
   const char* str = NULL;
 
-  str = choice_set[strings::menu_name].asCharArray();
-  if (!CheckSyntax(str)) {
-    SDL_ERROR("Invalid menu_name syntax check failed");
-    return true;
-  }
-
-  if (choice_set.keyExists(strings::secondary_text)) {
-    str = choice_set[strings::secondary_text].asCharArray();
+  if (choice.keyExists(strings::secondary_text)) {
+    str = choice[strings::secondary_text].asCharArray();
     if (!CheckSyntax(str)) {
       SDL_ERROR("Invalid secondary_text syntax check failed");
       return true;
     }
   }
 
-  if (choice_set.keyExists(strings::tertiary_text)) {
-    str = choice_set[strings::tertiary_text].asCharArray();
+  if (choice.keyExists(strings::tertiary_text)) {
+    str = choice[strings::tertiary_text].asCharArray();
     if (!CheckSyntax(str)) {
       SDL_ERROR("Invalid tertiary_text syntax check failed");
       return true;
     }
   }
 
-  if (choice_set.keyExists(strings::vr_commands)) {
-    const size_t len = choice_set[strings::vr_commands].length();
-
-    for (size_t i = 0; i < len; ++i) {
-      str = choice_set[strings::vr_commands][i].asCharArray();
-      if (!CheckSyntax(str)) {
-        SDL_ERROR("Invalid vr_commands syntax check failed");
-        return true;
-      }
-    }
-  }
-
-  if (choice_set.keyExists(strings::image)) {
-    str = choice_set[strings::image][strings::value].asCharArray();
+  if (choice.keyExists(strings::image)) {
+    str = choice[strings::image][strings::value].asCharArray();
     if (!CheckSyntax(str)) {
       SDL_ERROR("Invalid image value syntax check failed");
       return true;
     }
   }
 
-  if (choice_set.keyExists(strings::secondary_image)) {
-    str = choice_set[strings::secondary_image][strings::value].asCharArray();
+  if (choice.keyExists(strings::secondary_image)) {
+    str = choice[strings::secondary_image][strings::value].asCharArray();
     if (!CheckSyntax(str)) {
       SDL_ERROR(
           "Invalid secondary_image value. "
@@ -204,6 +239,38 @@ bool CreateInteractionChoiceSetRequest::IsWhiteSpaceExist(
     }
   }
   return false;
+}
+
+bool InsertVrCommand(std::set<int32_t>& vr_commands_hash,
+                     const smart_objects::SmartObject& vr_commands) {
+  using namespace smart_objects;
+  const SmartArray* vr_commands_array = vr_commands.asArray();
+
+  SmartArray::const_iterator vr_it = vr_commands_array->begin();
+
+  bool result = true;
+  for (; vr_commands_array->end() != vr_it; ++vr_it) {
+    const std::string vr_command = (*vr_it).asString();
+    result = result && InsertData(vr_commands_hash,
+                                  utils::Djb2HashFromString(vr_command));
+  }
+  return result;
+}
+
+std::set<int32_t> CollectVRCommands(
+    DataAccessor<application_manager::ChoiceSetMap> data_accessor) {
+  using namespace application_manager;
+  using namespace smart_objects;
+  std::set<int32_t> vr_commands_set;
+  const ChoiceSetMap& choice_set_map = data_accessor.GetData();
+
+  ChoiceSetMap::const_iterator choice_set_it = choice_set_map.begin();
+  const ChoiceSetMap::const_iterator choice_set_end = choice_set_map.end();
+  for (; choice_set_it != choice_set_end; ++choice_set_it) {
+    InsertVrCommand(vr_commands_set,
+                    (*choice_set_it->second)[strings::vr_commands]);
+  }
+  return vr_commands_set;
 }
 
 void CreateInteractionChoiceSetRequest::SendVRAddCommandRequests(
@@ -219,6 +286,8 @@ void CreateInteractionChoiceSetRequest::SendVRAddCommandRequests(
   const uint32_t choice_count = choice_set[strings::choice_set].length();
   SetAllowedToTerminate(false);
 
+  std::set<int32_t> vr_commands_hash(CollectVRCommands(app->choice_set_map()));
+
   expected_chs_count_ = choice_count;
   size_t chs_num = 0;
   for (; chs_num < choice_count; ++chs_num) {
@@ -233,9 +302,27 @@ void CreateInteractionChoiceSetRequest::SendVRAddCommandRequests(
     msg_params[strings::cmd_id] =
         choice_set[strings::choice_set][chs_num][strings::choice_id];
     msg_params[strings::vr_commands] =
-        smart_objects::SmartObject(smart_objects::SmartType_Array);
-    msg_params[strings::vr_commands] =
         choice_set[strings::choice_set][chs_num][strings::vr_commands];
+
+    if (!msg_params[strings::vr_commands].asArray() ||
+        msg_params[strings::vr_commands].empty()) {
+      --expected_chs_count_;
+      SDL_DEBUG("Choice with cmd_id "
+                << msg_params[strings::cmd_id].asString()
+                << "was skipped because it have no vr_commands");
+      continue;
+    }
+
+    if (!InsertVrCommand(vr_commands_hash, msg_params[strings::vr_commands])) {
+      --expected_chs_count_;
+      SDL_DEBUG("Choice with cmd_id "
+                << msg_params[strings::cmd_id].asString()
+                << "was skipped because some of vr_commands already be sent to "
+                   "HMI. vr_commands: "
+                << msg_params[strings::vr_commands].asString());
+
+      continue;
+    }
 
     sync_primitives::AutoLock commands_lock(vr_commands_lock_);
     const uint32_t vr_cmd_id = msg_params[strings::cmd_id].asUInt();
@@ -247,7 +334,7 @@ void CreateInteractionChoiceSetRequest::SendVRAddCommandRequests(
     SDL_DEBUG("VR_command sent corr_id " << vr_corr_id << " cmd_id "
                                          << vr_corr_id);
   }
-  expected_chs_count_ = chs_num;
+
   SDL_DEBUG("expected_chs_count_ = " << expected_chs_count_);
 }
 

--- a/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
@@ -42,6 +42,7 @@
 #include "utils/helpers.h"
 #include "utils/custom_string.h"
 #include "utils/gen_hash.h"
+#include "utils/stl_utils.h"
 
 namespace application_manager {
 
@@ -87,13 +88,6 @@ bool PerformInteractionRequest::Init() {
   return true;
 }
 
-template <typename T>
-bool InsertData(std::set<T>& out_set, const T& data) {
-  typedef std::pair<typename std::set<T>::iterator, bool> InsertResult;
-  InsertResult ins_res = out_set.insert(data);
-  return ins_res.second;
-}
-
 class CheckMenuNames {
  public:
   CheckMenuNames()
@@ -102,7 +96,8 @@ class CheckMenuNames {
 
   bool operator()(const smart_objects::SmartObject& choice) {
     const std::string& menu_name = choice[strings::menu_name].asString();
-    return InsertData(hash_set_, utils::Djb2HashFromString(menu_name));
+    return utils::InsertIntoSet(utils::Djb2HashFromString(menu_name),
+                                hash_set_);
   }
 
   const mobile_apis::Result::eType result_code_;
@@ -124,7 +119,8 @@ class CheckVRSynonyms {
     for (size_t vr_command_i = 0; vr_command_i < vr_commands.length();
          ++vr_command_i) {
       const std::string& vr_command = vr_commands[vr_command_i].asString();
-      if (!InsertData(hash_set_, utils::Djb2HashFromString(vr_command))) {
+      if (!utils::InsertIntoSet(utils::Djb2HashFromString(vr_command),
+                                hash_set_)) {
         return false;
       }
     }

--- a/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
@@ -88,6 +88,11 @@ bool PerformInteractionRequest::Init() {
   return true;
 }
 
+/**
+ * @brief The MenuNamesChecker class helps
+ * to check, whether incoming menu name
+ * is unique compared to previous ones, or not.
+ */
 class MenuNamesChecker {
  public:
   MenuNamesChecker()
@@ -107,6 +112,11 @@ class MenuNamesChecker {
   std::set<int32_t> hash_set_;
 };
 
+/**
+ * @brief The VRSynonymsChecker class helps
+ * to check, whether incoming vr synonyms
+ * is unique compared to previous ones, or not.
+ */
 class VRSynonymsChecker {
  public:
   VRSynonymsChecker()

--- a/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
@@ -88,9 +88,9 @@ bool PerformInteractionRequest::Init() {
   return true;
 }
 
-class CheckMenuNames {
+class MenuNamesChecker {
  public:
-  CheckMenuNames()
+  MenuNamesChecker()
       : result_code_(mobile_apis::Result::DUPLICATE_NAME)
       , error_msg_("Choice set has duplicated menu name") {}
 
@@ -107,11 +107,11 @@ class CheckMenuNames {
   std::set<int32_t> hash_set_;
 };
 
-class CheckVRSynonyms {
+class VRSynonymsChecker {
  public:
-  CheckVRSynonyms()
+  VRSynonymsChecker()
       : result_code_(mobile_apis::Result::DUPLICATE_NAME)
-      , error_msg_("Choice set has duplicated VR synonym") {}
+      , error_msg_("Choice set has duplicated VR synonyms") {}
 
   bool operator()(const smart_objects::SmartObject& choice) {
     const smart_objects::SmartObject& vr_commands =
@@ -221,8 +221,8 @@ void PerformInteractionRequest::Run() {
   switch (interaction_mode_) {
     case mobile_apis::InteractionMode::BOTH: {
       SDL_DEBUG("Interaction Mode: BOTH");
-      if (!CheckChoiceSet(app, CheckVRSynonyms()) ||
-          !CheckChoiceSet(app, CheckMenuNames()) ||
+      if (!ProcessChoiceSet(app, VRSynonymsChecker()) ||
+          !ProcessChoiceSet(app, MenuNamesChecker()) ||
           !CheckVrHelpItemPositions(app)) {
         return;
       }
@@ -230,8 +230,8 @@ void PerformInteractionRequest::Run() {
     }
     case mobile_apis::InteractionMode::MANUAL_ONLY: {
       SDL_DEBUG("Interaction Mode: MANUAL_ONLY");
-      if (!CheckChoiceSet(app, CheckVRSynonyms()) ||
-          !CheckChoiceSet(app, CheckMenuNames()) ||
+      if (!ProcessChoiceSet(app, VRSynonymsChecker()) ||
+          !ProcessChoiceSet(app, MenuNamesChecker()) ||
           !CheckVrHelpItemPositions(app)) {
         return;
       }
@@ -239,7 +239,7 @@ void PerformInteractionRequest::Run() {
     }
     case mobile_apis::InteractionMode::VR_ONLY: {
       SDL_DEBUG("Interaction Mode: VR_ONLY");
-      if (!CheckChoiceSet(app, CheckVRSynonyms()) ||
+      if (!ProcessChoiceSet(app, VRSynonymsChecker()) ||
           !CheckVrHelpItemPositions(app)) {
         return;
       }
@@ -883,10 +883,10 @@ bool PerformInteractionRequest::CallCheckMethod(CheckMethod method) {
   ApplicationSharedPtr app = application_manager_.application(connection_key());
   switch (method) {
     case CheckMethod::kCheckVrSynonyms: {
-      return CheckChoiceSet(app, CheckVRSynonyms());
+      return ProcessChoiceSet(app, VRSynonymsChecker());
     }
     case CheckMethod::kCheckMenuNames: {
-      return CheckChoiceSet(app, CheckMenuNames());
+      return ProcessChoiceSet(app, MenuNamesChecker());
     }
     case CheckMethod::kCheckVrHelpItem: {
       return CheckVrHelpItemPositions(app);

--- a/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
@@ -464,7 +464,7 @@ TEST_F(PerformInteractionRequestTest,
 TEST_F(PerformInteractionRequestTest,
        CheckVrHelpItem_CorrectPositions_Success) {
   kMsgParams_[strings::vr_help][0][strings::position] = kChoiceSetId0;
-  kMsgParams_[strings::vr_help][1][strings::position] = kChoiceSetId0 + 1;
+  kMsgParams_[strings::vr_help][1][strings::position] = kChoiceSetId1;
 
   EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 

--- a/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
@@ -60,8 +60,15 @@ using ::testing::_;
 namespace {
 const std::string kNotValidText = "wrong prompt\n";
 const std::string kValidText = "correct prompt";
+const std::string kVrCommand0 = "vr_command_0";
+const std::string kVrCommand1 = "vr_command_1";
 const uint32_t kCorrelationId = 666u;
-const int32_t kSomeNumber = 1;
+const uint32_t kChoiceId0 = 1;
+const uint32_t kChoiceId1 = 2;
+const uint32_t kChoiceSetId0 = 1;
+const uint32_t kChoiceSetId1 = 2;
+const uint32_t kGrammarId = 10u;
+
 const int32_t kSomeAnotherNumber = 666;
 }
 
@@ -101,10 +108,10 @@ class PerformInteractionRequestTest
   }
 
   void TestPromptFieldValidation(const std::string& field) {
-    kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+    kMsgParams_[strings::interaction_choice_set_id_list][0] = kChoiceSetId0;
 
     ::smart_objects::SmartObject choise_sets;
-    choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+    choise_sets[strings::choice_set][0][strings::choice_id] = kChoiceId0;
     EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
         .WillOnce(Return(&choise_sets));
 
@@ -227,18 +234,18 @@ TEST_F(PerformInteractionRequestTest,
 }
 
 TEST_F(PerformInteractionRequestTest, Run_FoundInvalidChouiseSet_InvalidId) {
-  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kChoiceSetId0;
   EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_)).WillOnce(ReturnNull());
 
   ExpectMobileResult(mobile_api::Result::INVALID_ID);
 }
 
 TEST_F(PerformInteractionRequestTest, Run_TwoSameChoisesetIds_InvalidId) {
-  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kChoiceSetId0;
 
   ::smart_objects::SmartObject choise_sets;
-  choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
-  choise_sets[strings::choice_set][1][strings::choice_id] = kSomeNumber;
+  choise_sets[strings::choice_set][0][strings::choice_id] = kChoiceId0;
+  choise_sets[strings::choice_set][1][strings::choice_id] = kChoiceId0;
 
   EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
       .WillOnce(Return(&choise_sets));
@@ -247,10 +254,10 @@ TEST_F(PerformInteractionRequestTest, Run_TwoSameChoisesetIds_InvalidId) {
 }
 
 TEST_F(PerformInteractionRequestTest, Run_InvalidImageVrHelpItems_InvalidData) {
-  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kChoiceSetId0;
 
   ::smart_objects::SmartObject choise_sets;
-  choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+  choise_sets[strings::choice_set][0][strings::choice_id] = kChoiceId0;
   EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
       .WillOnce(Return(&choise_sets));
 
@@ -264,10 +271,10 @@ TEST_F(PerformInteractionRequestTest, Run_InvalidImageVrHelpItems_InvalidData) {
 
 TEST_F(PerformInteractionRequestTest,
        Run_WhiteSpaceExistsInInitialText_InvalidData) {
-  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kChoiceSetId0;
 
   ::smart_objects::SmartObject choise_sets;
-  choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+  choise_sets[strings::choice_set][0][strings::choice_id] = kChoiceId0;
   EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
       .WillOnce(Return(&choise_sets));
 
@@ -293,10 +300,10 @@ TEST_F(PerformInteractionRequestTest,
 
 TEST_F(PerformInteractionRequestTest,
        Run_WhiteSpaceExistsInVrHelpText_InvalidData) {
-  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kChoiceSetId0;
 
   ::smart_objects::SmartObject choise_sets;
-  choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+  choise_sets[strings::choice_set][0][strings::choice_id] = kChoiceId0;
   EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
       .WillOnce(Return(&choise_sets));
 
@@ -312,10 +319,10 @@ TEST_F(PerformInteractionRequestTest,
 
 TEST_F(PerformInteractionRequestTest,
        Run_WhiteSpaceExistsInVrHelpImageValue_InvalidData) {
-  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kChoiceSetId0;
 
   ::smart_objects::SmartObject choise_sets;
-  choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+  choise_sets[strings::choice_set][0][strings::choice_id] = kChoiceId0;
   EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
       .WillOnce(Return(&choise_sets));
 
@@ -349,12 +356,12 @@ TEST_F(PerformInteractionRequestTest,
 
 TEST_F(PerformInteractionRequestTest,
        ChecVrSynonyms_TwoSameVrCommands_DuplicateName) {
-  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
-  kMsgParams_[strings::interaction_choice_set_id_list][1] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kChoiceSetId0;
+  kMsgParams_[strings::interaction_choice_set_id_list][1] = kChoiceSetId0;
   ::smart_objects::SmartObject choise_sets;
-  choise_sets[strings::grammar_id] = kSomeNumber;
-  choise_sets[strings::choice_set][0][strings::vr_commands][0] = kSomeNumber;
-  choise_sets[strings::choice_set][0][strings::vr_commands][1] = kSomeNumber;
+  choise_sets[strings::grammar_id] = kGrammarId;
+  choise_sets[strings::choice_set][0][strings::vr_commands][0] = kVrCommand0;
+  choise_sets[strings::choice_set][0][strings::vr_commands][1] = kVrCommand1;
 
   EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
       .WillRepeatedly(Return(&choise_sets));
@@ -371,14 +378,9 @@ TEST_F(PerformInteractionRequestTest,
 
 TEST_F(PerformInteractionRequestTest,
        CheckMenuNames_InvalidListOfNames_InvalidId) {
-  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
-  kMsgParams_[strings::interaction_choice_set_id_list][1] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kChoiceSetId0;
 
-  EXPECT_CALL(
-      *mock_application_sptr_,
-      FindChoiceSet(
-          kMsgParams_[strings::interaction_choice_set_id_list][0].asInt()))
-      .Times(3)
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(kChoiceSetId0))
       .WillRepeatedly(ReturnNull());
   EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(
@@ -392,24 +394,18 @@ TEST_F(PerformInteractionRequestTest,
 
 TEST_F(PerformInteractionRequestTest,
        CheckMenuNames_TwoSameNames_DuplicateName) {
-  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
-  kMsgParams_[strings::interaction_choice_set_id_list][1] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kChoiceSetId0;
+  kMsgParams_[strings::interaction_choice_set_id_list][1] = kChoiceSetId1;
 
+  ::smart_objects::SmartObject choise_set_0;
   ::smart_objects::SmartObject choise_set_1;
-  ::smart_objects::SmartObject choise_set_2;
+  choise_set_0[strings::choice_set][0][strings::menu_name] = "MenuName";
   choise_set_1[strings::choice_set][0][strings::menu_name] = "MenuName";
-  choise_set_2[strings::choice_set][0][strings::menu_name] = "MenuName";
 
-  EXPECT_CALL(
-      *mock_application_sptr_,
-      FindChoiceSet(
-          kMsgParams_[strings::interaction_choice_set_id_list][0].asInt()))
-      .Times(3)
-      .WillOnce(Return(&choise_set_1))
-      // Second call will be scipped in method cycles
-      .WillOnce(ReturnNull())
-      // Third call value will be compared to value from first call
-      .WillOnce(Return(&choise_set_2));
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(kChoiceSetId0))
+      .WillOnce(Return(&choise_set_0));
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(kChoiceSetId1))
+      .WillOnce(Return(&choise_set_1));
 
   EXPECT_CALL(mock_app_manager_,
               ManageMobileCommand(
@@ -422,27 +418,18 @@ TEST_F(PerformInteractionRequestTest,
 }
 
 TEST_F(PerformInteractionRequestTest, CheckMenuNames_AllRight_Success) {
-  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
-  kMsgParams_[strings::interaction_choice_set_id_list][1] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kChoiceSetId0;
+  kMsgParams_[strings::interaction_choice_set_id_list][1] = kChoiceSetId1;
 
+  ::smart_objects::SmartObject choise_set_0;
   ::smart_objects::SmartObject choise_set_1;
-  ::smart_objects::SmartObject choise_set_2;
-  choise_set_1[strings::choice_set][0][strings::menu_name] = "MenuName";
-  choise_set_2[strings::choice_set][0][strings::menu_name] = "AnotherMenuName";
+  choise_set_0[strings::choice_set][0][strings::menu_name] = "MenuName";
+  choise_set_1[strings::choice_set][0][strings::menu_name] = "AnotherMenuName";
 
-  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
-      .Times(6)
-      .WillOnce(Return(&choise_set_1))
-      // Second call will be scipped in method cycles
-      .WillOnce(ReturnNull())
-      // Third call value will be compared to value from first call
-      .WillOnce(Return(&choise_set_2))
-      // First cycle second iteration
-      .WillOnce(Return(&choise_set_2))
-      // Second cycle first iteration
-      .WillOnce(Return(&choise_set_1))
-      // Second cycle second iteration will be skipped
-      .WillOnce(ReturnNull());
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(kChoiceSetId0))
+      .WillOnce(Return(&choise_set_0));
+  EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(kChoiceSetId1))
+      .WillOnce(Return(&choise_set_1));
 
   EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
@@ -461,7 +448,7 @@ TEST_F(PerformInteractionRequestTest, CheckVrHelpItem_VrHelpNotExists_Success) {
 
 TEST_F(PerformInteractionRequestTest,
        CheckVrHelpItem_IncorrectPosition_Rejected) {
-  kMsgParams_[strings::vr_help][0][strings::position] = kSomeNumber;
+  kMsgParams_[strings::vr_help][0][strings::position] = kChoiceSetId0;
   kMsgParams_[strings::vr_help][1][strings::position] = kSomeAnotherNumber;
 
   EXPECT_CALL(mock_app_manager_,
@@ -476,8 +463,8 @@ TEST_F(PerformInteractionRequestTest,
 
 TEST_F(PerformInteractionRequestTest,
        CheckVrHelpItem_CorrectPositions_Success) {
-  kMsgParams_[strings::vr_help][0][strings::position] = kSomeNumber;
-  kMsgParams_[strings::vr_help][1][strings::position] = kSomeNumber + 1;
+  kMsgParams_[strings::vr_help][0][strings::position] = kChoiceSetId0;
+  kMsgParams_[strings::vr_help][1][strings::position] = kChoiceSetId0 + 1;
 
   EXPECT_CALL(mock_app_manager_, ManageMobileCommand(_, _)).Times(0);
 
@@ -489,13 +476,13 @@ TEST_F(PerformInteractionRequestTest,
 
 TEST_F(PerformInteractionRequestTest,
        Run_InvalidInteractionMode_StopProcessing) {
-  kMsgParams_[strings::interaction_choice_set_id_list][0] = kSomeNumber;
+  kMsgParams_[strings::interaction_choice_set_id_list][0] = kChoiceSetId0;
   kMsgParams_[strings::interaction_mode] =
       mobile_api::InteractionMode::INVALID_ENUM;
   kMsgParams_[strings::initial_text] = kValidText;
 
   ::smart_objects::SmartObject choise_sets;
-  choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+  choise_sets[strings::choice_set][0][strings::choice_id] = kChoiceSetId0;
 
   EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
       .WillOnce(Return(&choise_sets));
@@ -514,9 +501,9 @@ TEST_F(PerformInteractionRequestTest, Run_AllRight_SendVRAndUIRequests) {
   kMsgParams_[strings::help_prompt][0][strings::text] = "Prompt";
 
   ::smart_objects::SmartObject choise_sets;
-  choise_sets[strings::grammar_id] = kSomeNumber;
-  choise_sets[strings::choice_set][0][strings::choice_id] = kSomeNumber;
-  choise_sets[strings::choice_set][0][strings::vr_commands][0] = kSomeNumber;
+  choise_sets[strings::grammar_id] = kGrammarId;
+  choise_sets[strings::choice_set][0][strings::choice_id] = kChoiceId0;
+  choise_sets[strings::choice_set][0][strings::vr_commands][0] = kVrCommand0;
 
   EXPECT_CALL(*mock_application_sptr_, FindChoiceSet(_))
       .WillRepeatedly(Return(&choise_sets));
@@ -608,7 +595,7 @@ TEST_F(PerformInteractionRequestTest,
   ::smart_objects::SmartObject message;
   message[strings::params][hmi_response::code] =
       hmi_apis::Common_Result::SUCCESS;
-  message[strings::msg_params][strings::choice_id] = kSomeNumber;
+  message[strings::msg_params][strings::choice_id] = kChoiceId0;
 
   event.set_smart_object(message);
 
@@ -792,7 +779,7 @@ TEST_F(PerformInteractionRequestTest,
   event_engine::Event event(hmi_apis::FunctionID::VR_PerformInteraction);
   CallOnEvent caller(*command_sptr_, event);
 
-  (*message_)[strings::msg_params][strings::choice_id] = kSomeNumber;
+  (*message_)[strings::msg_params][strings::choice_id] = kChoiceId0;
   (*message_)[strings::params][hmi_response::code] =
       mobile_apis::Result::SUCCESS;
 
@@ -839,12 +826,12 @@ TEST_F(PerformInteractionRequestTest,
       mobile_api::Result::SUCCESS;
 
   (*message_)[strings::params][strings::correlation_id] = kCorrelationId;
-  (*message_)[strings::msg_params][strings::choice_id] = kSomeNumber;
+  (*message_)[strings::msg_params][strings::choice_id] = kChoiceId0;
 
   event.set_smart_object(*message_);
 
   ::smart_objects::SmartObject choise_set;
-  choise_set[strings::choice_set][0][strings::choice_id] = kSomeNumber;
+  choise_set[strings::choice_set][0][strings::choice_id] = kChoiceId0;
 
   PerformChoice perform_choise_map;
   perform_choise_map[kCorrelationId] = &choise_set;
@@ -878,8 +865,8 @@ TEST_F(PerformInteractionRequestTest,
           (*mobile_result_msg)[strings::msg_params][strings::result_code]
               .asInt());
 
-  const int32_t kResultChoiseId =
-      (*mobile_result_msg)[strings::msg_params][strings::choice_id].asInt();
+  const uint32_t kResultChoiseId =
+      (*mobile_result_msg)[strings::msg_params][strings::choice_id].asUInt();
   const mobile_api::TriggerSource::eType ts_result =
       static_cast<mobile_api::TriggerSource::eType>(
           (*mobile_result_msg)[strings::msg_params][strings::trigger_source]
@@ -888,7 +875,7 @@ TEST_F(PerformInteractionRequestTest,
   EXPECT_EQ(hmi_apis::FunctionID::UI_ClosePopUp, kHmiResult);
 
   EXPECT_EQ(mobile_api::TriggerSource::TS_VR, ts_result);
-  EXPECT_EQ(kSomeNumber, kResultChoiseId);
+  EXPECT_EQ(kChoiceId0, kResultChoiseId);
   EXPECT_EQ(mobile_apis::Result::SUCCESS, kMobileResult);
 }
 

--- a/src/components/utils/include/utils/stl_utils.h
+++ b/src/components/utils/include/utils/stl_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,6 +32,7 @@
 #ifndef SRC_COMPONENTS_UTILS_INCLUDE_UTILS_STL_UTILS_H_
 #define SRC_COMPONENTS_UTILS_INCLUDE_UTILS_STL_UTILS_H_
 
+#include <set>
 #include "utils/macro.h"
 
 namespace utils {
@@ -81,6 +82,13 @@ class StlMapDeleter {
  private:
   Collection* collection_;
 };
+
+template <typename T>
+bool InsertIntoSet(const T& data, std::set<T>& out_set) {
+  typedef std::pair<typename std::set<T>::iterator, bool> InsertResult;
+  InsertResult ins_res = out_set.insert(data);
+  return ins_res.second;
+}
 
 }  // namespace utils
 


### PR DESCRIPTION
CreateInteractionChoiceSet: SUCCESS the same menuName or vrCommand in different choiceSets
---
Functional requirement: [APPLINK-16940](https://adc.luxoft.com/jira/browse/APPLINK-16940)
Implements: [APPLINK-29256](https://adc.luxoft.com/jira/browse/APPLINK-29256)
Related to: [APPLINK-29259](https://adc.luxoft.com/jira/browse/APPLINK-29259)

---
Unit tests has been updated
for `CreateInteractionRequest`.

---
Related to: [APPLINK-29262](https://adc.luxoft.com/jira/browse/APPLINK-29262)

PerformInteraction: DUPLICATE_NAME MenuName or/and vrSynonyms within ChoiceSets
-
Functional requirement: [APPLINK-17385](https://adc.luxoft.com/jira/browse/APPLINK-17385)
Implements: [APPLINK-29256](https://adc.luxoft.com/jira/browse/APPLINK-29256)
Related to: [APPLINK-29259](https://adc.luxoft.com/jira/browse/APPLINK-29259)

---
Unit tests has been updated
for `PerformInteractionRequest`.

---
Related to: [APPLINK-29262](https://adc.luxoft.com/jira/browse/APPLINK-29262)

@AGaliuzov, @Kozoriz, @LuxoftAKutsan, @VProdanov, @wolfylambova22, @VVeremjova, @dtrunov, please, review.