### PR TITLE
Make navi timer singleshot

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2998,7 +2998,7 @@ void ApplicationManagerImpl::EndNaviServices(uint32_t app_id) {
         "CloseNaviAppTimer",
         new TimerTaskImpl<ApplicationManagerImpl>(
             this, &ApplicationManagerImpl::CloseNaviApp)));
-    close_timer->Start(navi_close_app_timeout_, timer::kPeriodic);
+    close_timer->Start(navi_close_app_timeout_, timer::kSingleShot);
 
     sync_primitives::AutoLock lock(timer_pool_lock_);
     timer_pool_.push_back(close_timer);
@@ -3103,7 +3103,7 @@ void ApplicationManagerImpl::CloseNaviApp() {
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace mobile_apis::AppInterfaceUnregisteredReason;
   using namespace mobile_apis::Result;
-
+  DCHECK_OR_RETURN_VOID(!navi_app_to_stop_.empty());
   uint32_t app_id = navi_app_to_stop_.front();
   navi_app_to_stop_.pop_front();
 


### PR DESCRIPTION
Navi timer should shot one time after insertion of application
Related issue : APPLINK-29350
Review performed on https://github.com/smartdevicelink/sdl_core/pull/918 