### PR TITLE
Inclusion of PLAY_PAUSE as a subscribable button

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -422,6 +422,12 @@
 	    		"upDownAvailable"    :true
 	    	},
 	    	{
+	    		"name":"PLAY_PAUSE",
+	    		"shortPressAvailable":true,
+	    		"longPressAvailable" :true,
+	    		"upDownAvailable"    :true
+	    	},
+	    	{
 	    		"name":"SEEKLEFT",
 	    		"shortPressAvailable":true,
 	    		"longPressAvailable" :true,

--- a/src/components/application_manager/src/commands/mobile/subscribe_button_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_button_request.cc
@@ -95,7 +95,8 @@ void SubscribeButtonRequest::Run() {
 bool SubscribeButtonRequest::IsSubscriptionAllowed(
     ApplicationSharedPtr app, mobile_apis::ButtonName::eType btn_id) {
   if (!app->is_media_application() &&
-      ((mobile_apis::ButtonName::SEEKLEFT == btn_id) ||
+      ((mobile_apis::ButtonName::PLAY_PAUSE == btn_id) ||
+       (mobile_apis::ButtonName::SEEKLEFT == btn_id) ||
        (mobile_apis::ButtonName::SEEKRIGHT == btn_id) ||
        (mobile_apis::ButtonName::TUNEUP == btn_id) ||
        (mobile_apis::ButtonName::TUNEDOWN == btn_id))) {

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -74,6 +74,8 @@ void InitCapabilities() {
   button_enum_name.insert(
       std::make_pair(std::string("OK"), hmi_apis::Common_ButtonName::OK));
   button_enum_name.insert(std::make_pair(
+      std::string("PLAY_PAUSE"), hmi_apis::Common_ButtonName::PLAY_PAUSE));
+  button_enum_name.insert(std::make_pair(
       std::string("SEEKLEFT"), hmi_apis::Common_ButtonName::SEEKLEFT));
   button_enum_name.insert(std::make_pair(
       std::string("SEEKRIGHT"), hmi_apis::Common_ButtonName::SEEKRIGHT));

--- a/src/components/application_manager/test/hmi_capabilities.json
+++ b/src/components/application_manager/test/hmi_capabilities.json
@@ -422,6 +422,12 @@
                 "upDownAvailable"    :true
             },
             {
+                "name":"PLAY_PAUSE", 
+                "shortPressAvailable":true,
+                "longPressAvailable" :true,
+                "upDownAvailable"    :true
+            },
+            {
                 "name":"SEEKLEFT",
                 "shortPressAvailable":true,
                 "longPressAvailable" :true,

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -236,7 +236,7 @@ TEST_F(HMICapabilitiesTest, LoadCapabilitiesFromFile) {
 
   // Count of buttons in json file
   const uint32_t btn_length = buttons_capabilities_so.length();
-  EXPECT_EQ(15u, btn_length);
+  EXPECT_EQ(16u, btn_length);
   for (uint32_t i = 0; i < btn_length; ++i) {
     EXPECT_TRUE((buttons_capabilities_so[i]).keyExists(strings::name));
     EXPECT_TRUE((buttons_capabilities_so[i]).keyExists("shortPressAvailable"));

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -76,6 +76,7 @@
 <enum name="ButtonName">
     <description>Defines the hard (physical) and soft (touchscreen) buttons available from SYNC</description>
     <element name="OK"/>
+    <element name="PLAY_PAUSE"/>
     <element name="SEEKLEFT"/>
     <element name="SEEKRIGHT"/>
     <element name="TUNEUP"/>

--- a/src/components/interfaces/Json_HMI_message_specification.txt
+++ b/src/components/interfaces/Json_HMI_message_specification.txt
@@ -267,6 +267,13 @@ Notifications:
 			
 			{
 				"longPressAvailable" : true,
+				"name" : "PLAY_PAUSE",
+				"shortPressAvailable" : true,
+				"upDownAvailable" : true
+			},
+
+			{
+				"longPressAvailable" : true,
 				"name" : "SEEKLEFT",
 				"shortPressAvailable" : true,
 				"upDownAvailable" : true

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -489,6 +489,7 @@
   <enum name="ButtonName">
     <description>Defines the hard (physical) and soft (touchscreen) buttons available from SYNC</description>
     <element name="OK" />
+    <element name="PLAY_PAUSE" />
     <element name="SEEKLEFT" />
     <element name="SEEKRIGHT" />
     <element name="TUNEUP" />

--- a/src/components/interfaces/QT_HMI_API.xml
+++ b/src/components/interfaces/QT_HMI_API.xml
@@ -70,6 +70,7 @@
     <enum name="ButtonName">
       <description>Defines the hard (physical) and soft (touchscreen) buttons available from SYNC</description>
       <element name="OK"/>
+      <element name="PLAY_PAUSE"/>
       <element name="SEEKLEFT"/>
       <element name="SEEKRIGHT"/>
       <element name="TUNEUP"/>

--- a/src/components/utils/test/test_generator/MOBILE_API.xml
+++ b/src/components/utils/test/test_generator/MOBILE_API.xml
@@ -493,6 +493,7 @@
   <enum name="ButtonName">
     <description>Defines the hard (physical) and soft (touchscreen) buttons available from SYNC</description>
     <element name="OK" />
+    <element name="PLAY_PAUSE" />
     <element name="SEEKLEFT" />
     <element name="SEEKRIGHT" />
     <element name="TUNEUP" />

--- a/tools/intergen/test/test_hmi_interface.xml
+++ b/tools/intergen/test/test_hmi_interface.xml
@@ -66,6 +66,7 @@
 <enum name="ButtonName">
     <description>Defines the hard (physical) and soft (touchscreen) buttons available from SYNC</description>
     <element name="OK"/>
+    <element name="PLAY_PAUSE"/>
     <element name="SEEKLEFT"/>
     <element name="SEEKRIGHT"/>
     <element name="TUNEUP"/>


### PR DESCRIPTION
Adds the PLAY_PAUSE button name enum value to the Mobile and HMI APIs, as well as the default HMI capabilities.