### PR TITLE
Add new parameters to .ini file to read them by SDL

### DIFF
--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -211,6 +211,10 @@ ApplicationListUpdateTimeout = 2000
 ThreadPoolSize = 1
 ; The max size of hash which is used by OnHashUpdated
 HashStringSize = 32
+; Menu title default text
+MenuTitle = MENU
+; Path to default menu icon
+MenuIcon = 
 
 [SDL4]
 ; Enables SDL 4.0 support

--- a/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
@@ -76,7 +76,7 @@ void ResetGlobalPropertiesRequest::Run() {
   bool helpt_promt = false;
   bool timeout_prompt = false;
   bool vr_help_title_items = false;
-  bool menu_name = false;
+  bool menu_title = false;
   bool menu_icon = false;
   bool is_key_board_properties = false;
   int number_of_reset_vr = 0;
@@ -98,7 +98,7 @@ void ResetGlobalPropertiesRequest::Run() {
       ++number_of_reset_vr;
       vr_help_title_items = ResetVrHelpTitleItems(app);
     } else if (mobile_apis::GlobalProperty::MENUNAME == global_property) {
-      menu_name = true;
+      menu_title = true;
     } else if (mobile_apis::GlobalProperty::MENUICON == global_property) {
       menu_icon = true;
     } else if (mobile_apis::GlobalProperty::KEYBOARDPROPERTIES ==
@@ -107,7 +107,7 @@ void ResetGlobalPropertiesRequest::Run() {
     }
   }
 
-  if (vr_help_title_items || menu_name || menu_icon ||
+  if (vr_help_title_items || menu_title || menu_icon ||
       is_key_board_properties) {
     is_ui_send_ = true;
   }
@@ -118,7 +118,7 @@ void ResetGlobalPropertiesRequest::Run() {
 
   app->set_reset_global_properties_active(true);
 
-  if (vr_help_title_items || menu_name || menu_icon ||
+  if (vr_help_title_items || menu_title || menu_icon ||
       is_key_board_properties) {
     smart_objects::SmartObject msg_params =
         smart_objects::SmartObject(smart_objects::SmartType_Map);
@@ -131,13 +131,18 @@ void ResetGlobalPropertiesRequest::Run() {
       }
       msg_params = *vr_help;
     }
-    if (menu_name) {
-      msg_params[hmi_request::menu_title] = "";
+    if (menu_title) {
+      msg_params[hmi_request::menu_title] =
+          application_manager_.get_settings().menu_title();
       app->set_menu_title(msg_params[hmi_request::menu_title]);
     }
-    // TODO(DT): clarify the sending parameter menuIcon
-    // if (menu_icon) {
-    //}
+    if (menu_icon) {
+      smart_objects::SmartObject so_menu_icon(smart_objects::SmartType_Map);
+      so_menu_icon[strings::value] =
+          application_manager_.get_settings().menu_icon();
+      msg_params[hmi_request::menu_icon] = so_menu_icon;
+      app->set_menu_icon(msg_params[hmi_request::menu_icon]);
+    }
     if (is_key_board_properties) {
       smart_objects::SmartObject key_board_properties =
           smart_objects::SmartObject(smart_objects::SmartType_Map);

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -581,6 +581,16 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
    */
   uint16_t open_attempt_timeout_ms_resumption_db() const OVERRIDE;
 
+  /**
+   * @brief Returns menu title
+   */
+  const std::string& menu_title() const;
+
+  /**
+   * @brief Returns path to menu icon
+   */
+  const std::string& menu_icon() const;
+
   /*
    * @brief Updates all related values from ini file
    */
@@ -796,6 +806,8 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   bool use_db_for_resumption_;
   uint16_t attempts_to_open_resumption_db_;
   uint16_t open_attempt_timeout_ms_resumption_db_;
+  std::string menu_title_;
+  std::string menu_icon_;
 
   DISALLOW_COPY_AND_ASSIGN(Profile);
 };

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -193,6 +193,8 @@ const char* kUseDBForResumptionKey = "UseDBForResumption";
 const char* kAttemptsToOpenResumptionDBKey = "AttemptsToOpenResumptionDB";
 const char* kOpenAttemptTimeoutMsResumptionDBKey =
     "OpenAttemptTimeoutMsResumptionDB";
+const char* kMenuTitleKey = "MenuTitle";
+const char* kMenuIconKey = "MenuIcon";
 
 #ifdef WEB_HMI
 const char* kDefaultLinkToWebHMI = "HMI/index.html";
@@ -216,6 +218,8 @@ const char* kDefaultHubProtocolMask = "com.smartdevicelink.prot";
 const char* kDefaultPoolProtocolMask = "com.smartdevicelink.prot";
 const char* kDefaultIAPSystemConfig = "/fs/mp/etc/mm/ipod.cfg";
 const char* kDefaultIAP2SystemConfig = "/fs/mp/etc/mm/iap2.cfg";
+const char* kDefaultMenuTitle = "MENU";
+const char* kDefaultMenuIcon = "";
 
 #ifdef ENABLE_SECURITY
 const char* kDefaultSecurityProtocol = "TLSv1.2";
@@ -357,7 +361,9 @@ Profile::Profile()
     , use_db_for_resumption_(false)
     , attempts_to_open_resumption_db_(kDefaultAttemptsToOpenResumptionDB)
     , open_attempt_timeout_ms_resumption_db_(
-          kDefaultOpenAttemptTimeoutMsResumptionDB) {
+          kDefaultOpenAttemptTimeoutMsResumptionDB)
+    , menu_title_(kDefaultMenuTitle)
+    , menu_icon_(kDefaultMenuIcon) {
 }
 
 Profile::~Profile() {}
@@ -818,6 +824,14 @@ uint16_t Profile::attempts_to_open_resumption_db() const {
 
 uint16_t Profile::open_attempt_timeout_ms_resumption_db() const {
   return open_attempt_timeout_ms_resumption_db_;
+}
+
+const std::string& Profile::menu_title() const {
+  return menu_title_;
+}
+
+const std::string& Profile::menu_icon() const {
+  return menu_icon_;
 }
 
 void Profile::UpdateValues() {
@@ -1680,6 +1694,20 @@ void Profile::UpdateValues() {
   LOG_UPDATED_VALUE(open_attempt_timeout_ms_resumption_db_,
                     kOpenAttemptTimeoutMsResumptionDBKey,
                     kResumptionSection);
+
+  // Menu title
+  ReadStringValue(&menu_title_,
+                  kDefaultMenuTitle,
+                  kApplicationManagerSection,
+                  kMenuTitleKey);
+
+  LOG_UPDATED_VALUE(menu_title_, kMenuTitleKey, kApplicationManagerSection);
+
+  // Menu icon
+  ReadStringValue(
+      &menu_icon_, kDefaultMenuIcon, kApplicationManagerSection, kMenuIconKey);
+
+  LOG_UPDATED_VALUE(menu_icon_, kMenuIconKey, kApplicationManagerSection);
 }
 
 bool Profile::ReadValue(bool* value,

--- a/src/components/config_profile/test/profile_test.cc
+++ b/src/components/config_profile/test/profile_test.cc
@@ -201,10 +201,12 @@ TEST_F(ProfileTest, UpdateBoolValues) {
 TEST_F(ProfileTest, UpdateStringValue) {
   // Default values
   std::string recording_file_name = "record.wav";
+  std::string server_address = "127.0.0.1";
+  std::string app_resource_folder = "";
   std::string tts_delimiter_ = "";
   std::string vr_help_title_ = "";
-  std::string app_resource_folder = "";
-  std::string server_address = "127.0.0.1";
+  std::string menu_title = "";
+  std::string menu_icon = "";
 
   EXPECT_EQ(recording_file_name, profile_.recording_file_name());
   EXPECT_EQ(server_address, profile_.server_address());
@@ -219,7 +221,9 @@ TEST_F(ProfileTest, UpdateStringValue) {
   EXPECT_EQ(tts_delimiter_, profile_.tts_delimiter());
   vr_help_title_ = "Available Vr Commands List";
   EXPECT_EQ(vr_help_title_, profile_.vr_help_title());
-  EXPECT_EQ(server_address, profile_.server_address());
+  menu_title = "MENU";
+  EXPECT_EQ(menu_title, profile_.menu_title());
+  EXPECT_EQ(menu_icon, profile_.menu_icon());
 
   // Update config file
   profile_.UpdateValues();
@@ -228,6 +232,8 @@ TEST_F(ProfileTest, UpdateStringValue) {
   EXPECT_EQ(tts_delimiter_, profile_.tts_delimiter());
   EXPECT_EQ(vr_help_title_, profile_.vr_help_title());
   EXPECT_EQ(server_address, profile_.server_address());
+  EXPECT_EQ(menu_title, profile_.menu_title());
+  EXPECT_EQ(menu_icon, profile_.menu_icon());
 }
 
 TEST_F(ProfileTest, UpdateInt_ValueAppearsInFileTwice) {

--- a/src/components/config_profile/test/smartDeviceLink.ini
+++ b/src/components/config_profile/test/smartDeviceLink.ini
@@ -168,6 +168,10 @@ FrequencyTime = 1000
 ApplicationListUpdateTimeout = 2
 ; Max allowed threads for handling mobile requests. Currently max allowed is 2
 ThreadPoolSize = 1
+; Menu title default text
+MenuTitle = MENU
+; Path to default menu icon
+MenuIcon =
 
 [Resumption]
 

--- a/src/components/include/application_manager/application_manager_settings.h
+++ b/src/components/include/application_manager/application_manager_settings.h
@@ -86,6 +86,8 @@ class ApplicationManagerSettings : public RequestControlerSettings {
   virtual const uint32_t& app_resuming_timeout() const = 0;
   virtual uint16_t attempts_to_open_resumption_db() const = 0;
   virtual uint16_t open_attempt_timeout_ms_resumption_db() const = 0;
+  virtual const std::string& menu_title() const = 0;
+  virtual const std::string& menu_icon() const = 0;
   virtual void config_file_name(const std::string& fileName) = 0;
   virtual const std::pair<uint32_t, int32_t>& start_stream_retry_amount()
       const = 0;

--- a/src/components/include/test/application_manager/mock_application_manager_settings.h
+++ b/src/components/include/test/application_manager/mock_application_manager_settings.h
@@ -94,6 +94,8 @@ class MockApplicationManagerSettings
   MOCK_CONST_METHOD0(app_resuming_timeout, const uint32_t&());
   MOCK_CONST_METHOD0(attempts_to_open_resumption_db, uint16_t());
   MOCK_CONST_METHOD0(open_attempt_timeout_ms_resumption_db, uint16_t());
+  MOCK_CONST_METHOD0(menu_title, const std::string&());
+  MOCK_CONST_METHOD0(menu_icon, const std::string&());
   MOCK_METHOD1(config_file_name, void(const std::string& fileName));
   // The following line won't really compile, as the return
   // type has multiple template arguments.  To fix it, use a


### PR DESCRIPTION
Added new parameters 'menuIcon' and 'menuTitle' to the .ini file.
Added to SDL ability to read default values for those parameters from ini file.
Also added to SDL resetting of those parameters in ResetGlobalProperties request.

Related tasks: [APPLINK-28166](https://adc.luxoft.com/jira/browse/APPLINK-28166), [APPLINK-28169](https://adc.luxoft.com/jira/browse/APPLINK-28169)