### PR TITLE
Remove Ford specific policy endpoint

### DIFF
--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -13,10 +13,10 @@
             625],
             "endpoints": {
                 "0x07": {
-                    "default": ["https://policies.smartdevicelink.com/api/1/policies/proprietary"]
+                    "default": ["http://localhost:3000/api/1/policies/proprietary"]
                 },
                 "0x04": {
-                    "default": ["http://ivsu.smartdevicelink.com/api/getsoftwareupdates"]
+                    "default": ["http://localhost:3000/api/1/softwareUpdate"]
                 },
                 "queryAppsUrl": {
                     "default": ["http://sdl.shaid.server"]

--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -16,7 +16,7 @@
                     "default": ["https://policies.smartdevicelink.com/api/1/policies/proprietary"]
                 },
                 "0x04": {
-                    "default": ["http://ivsu.software.ford.com/api/getsoftwareupdates"]
+                    "default": ["http://ivsu.smartdevicelink.com/api/getsoftwareupdates"]
                 },
                 "queryAppsUrl": {
                     "default": ["http://sdl.shaid.server"]

--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -13,7 +13,7 @@
             625],
             "endpoints": {
                 "0x07": {
-                    "default": ["http://policies.telematics.ford.com/api/policies"]
+                    "default": ["https://policies.smartdevicelink.com/api/1/policies/proprietary"]
                 },
                 "0x04": {
                     "default": ["http://ivsu.software.ford.com/api/getsoftwareupdates"]


### PR DESCRIPTION
New endpoint points to a develpment instance of sdl server that will return a policy table snapshot.