### PR TITLE
Remove Policy_lib_check_void() for activate app

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -959,7 +959,7 @@ void PolicyHandler::OnIgnitionCycleOver() {
 void PolicyHandler::OnActivateApp(uint32_t connection_key,
                                   uint32_t correlation_id) {
   LOG4CXX_AUTO_TRACE(logger_);
-  POLICY_LIB_CHECK_VOID();
+
   ApplicationSharedPtr app = application_manager_.application(connection_key);
   if (!app.valid()) {
     LOG4CXX_WARN(logger_, "Activated App failed: no app found.");


### PR DESCRIPTION
In the event policies are disabled, this policy lib check void would return before sdl has the opportunity to tell the hmi to activate the app. When this function returns because of policy lib check void, an app could never be activated and no warnings or errors are reported.

This check of policies is not needed either since there are the appropriate checks in this function for if policies are enabled, and handles either setting appropriately.

Fixes #842 