### PR TITLE
[WiP] CreateInteraction/PerformInteraction: case with the same MenuName or vrCommands between the different ChoiceSets

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -158,7 +158,8 @@ class CommandRequestImpl : public CommandImpl,
    * @param allow_empty_string if true methods allow empty sting
    * @return true if success otherwise return false
    */
-  bool CheckSyntax(const std::string& str, bool allow_empty_line = false);
+  static bool CheckSyntax(const std::string& str,
+                          bool allow_empty_line = false);
 
   /*
    * @brief Sends HMI request

--- a/src/components/application_manager/include/application_manager/commands/mobile/create_interaction_choice_set_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/create_interaction_choice_set_request.h
@@ -142,11 +142,10 @@ class CreateInteractionChoiceSetRequest : public CommandRequestImpl {
 
   /*
    * @brief Checks incoming choiseSet params.
-   * @param app Registred mobile application
    *
    * @return Mobile result code
    */
-  mobile_apis::Result::eType CheckChoiceSet(ApplicationConstSharedPtr app);
+  mobile_apis::Result::eType CheckChoiceSet();
 
   /*
   * @brief Predicate for using with CheckChoiceSet method to compare choice ID

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_interaction_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_interaction_request.h
@@ -35,6 +35,8 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_PERFORM_INTERACTION_REQUEST_H_
 #include <string>
 
+#include <algorithm>
+
 #include "application_manager/commands/command_request_impl.h"
 #include "application_manager/application.h"
 #include "utils/macro.h"
@@ -87,6 +89,16 @@ class PerformInteractionRequest : public CommandRequestImpl {
    */
   virtual void onTimeOut();
 
+#if BUILD_TESTS
+  enum CheckMethod { kCheckVrSynonyms = 0, kCheckMenuNames, kCheckVrHelpItem };
+
+  /**
+   * @brief Method for easier check methods in unit tests.
+   * Needed because Run method have ways which cannot be validated.
+   */
+  bool CallCheckMethod(CheckMethod);
+#endif  // BUILD_TESTS
+
  private:
   /**
    * @brief Function will be called when VR_OnCommand event
@@ -131,26 +143,18 @@ class PerformInteractionRequest : public CommandRequestImpl {
   void SendUIShowVRHelpRequest(ApplicationSharedPtr const app);
 
   /*
-   * @brief Checks if incoming choice set doesn't has similar menu names.
+   * @brief Checks incoming choice set by checker.
    *
-   * @param app_id Application ID
+   * @param app shared pointer to Application
+   * @param checker a functor which checks choises;
    *
-   * return Return TRUE if there are no similar menu names in choice set,
+   * return Return TRUE if checker returned TRUE
+   * for each choice in a choice set form the list,
    * otherwise FALSE
    */
-  bool CheckChoiceSetMenuNames(
-      application_manager::ApplicationSharedPtr const app);
-
-  /*
-   * @brief Checks if incoming choice set doesn't has similar VR synonyms.
-   *
-   * @param app_id Application ID
-   *
-   * return Return TRUE if there are no similar VR synonyms in choice set,
-   * otherwise FALSE
-   */
-  bool CheckChoiceSetVRSynonyms(
-      application_manager::ApplicationSharedPtr const app);
+  template <typename FunctorT>
+  bool ProcessChoiceSet(const application_manager::ApplicationSharedPtr app,
+                        FunctorT checker);
 
   /*
    * @brief Checks if request with non-sequential positions of vrHelpItems
@@ -233,6 +237,38 @@ class PerformInteractionRequest : public CommandRequestImpl {
 
   DISALLOW_COPY_AND_ASSIGN(PerformInteractionRequest);
 };
+
+template <typename FunctorT>
+bool PerformInteractionRequest::ProcessChoiceSet(
+    const application_manager::ApplicationSharedPtr app, FunctorT checker) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  using smart_objects::SmartObject;
+  using smart_objects::SmartArray;
+  SmartObject& choice_set_list =
+      (*message_)[strings::msg_params][strings::interaction_choice_set_id_list];
+
+  for (size_t choice_set_i = 0; choice_set_i < choice_set_list.length();
+       ++choice_set_i) {
+    const SmartObject* const choice_set_ptr =
+        app->FindChoiceSet(choice_set_list[choice_set_i].asInt());
+    if (!choice_set_ptr) {
+      LOG4CXX_ERROR(logger_, "Invalid choice set ID");
+      SendResponse(false, mobile_apis::Result::INVALID_ID);
+      return false;
+    }
+
+    const SmartObject& choice_set = (*choice_set_ptr)[strings::choice_set];
+
+    for (size_t choice_i = 0; choice_i < choice_set.length(); ++choice_i) {
+      if (!checker(choice_set[choice_i])) {
+        LOG4CXX_ERROR(logger_, checker.error_msg_);
+        SendResponse(false, checker.result_code_, checker.error_msg_);
+        return false;
+      }
+    }
+  }
+  return true;
+}
 
 }  // namespace commands
 }  // namespace application_manager

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_interaction_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_interaction_request.h
@@ -146,15 +146,15 @@ class PerformInteractionRequest : public CommandRequestImpl {
    * @brief Checks incoming choice set by checker.
    *
    * @param app shared pointer to Application
-   * @param checker a functor which checks choises;
+   * @param checker a functor which checks choices;
    *
    * return Return TRUE if checker returned TRUE
    * for each choice in a choice set form the list,
    * otherwise FALSE
    */
-  template <typename FunctorT>
+  template <typename CheckerT>
   bool ProcessChoiceSet(const application_manager::ApplicationSharedPtr app,
-                        FunctorT checker);
+                        CheckerT checker);
 
   /*
    * @brief Checks if request with non-sequential positions of vrHelpItems
@@ -238,19 +238,19 @@ class PerformInteractionRequest : public CommandRequestImpl {
   DISALLOW_COPY_AND_ASSIGN(PerformInteractionRequest);
 };
 
-template <typename FunctorT>
+template <typename CheckerT>
 bool PerformInteractionRequest::ProcessChoiceSet(
-    const application_manager::ApplicationSharedPtr app, FunctorT checker) {
+    const application_manager::ApplicationSharedPtr app, CheckerT checker) {
   LOG4CXX_AUTO_TRACE(logger_);
   using smart_objects::SmartObject;
   using smart_objects::SmartArray;
-  SmartObject& choice_set_list =
+  SmartObject& choice_set_id_list =
       (*message_)[strings::msg_params][strings::interaction_choice_set_id_list];
 
-  for (size_t choice_set_i = 0; choice_set_i < choice_set_list.length();
+  for (size_t choice_set_i = 0; choice_set_i < choice_set_id_list.length();
        ++choice_set_i) {
     const SmartObject* const choice_set_ptr =
-        app->FindChoiceSet(choice_set_list[choice_set_i].asInt());
+        app->FindChoiceSet(choice_set_id_list[choice_set_i].asInt());
     if (!choice_set_ptr) {
       LOG4CXX_ERROR(logger_, "Invalid choice set ID");
       SendResponse(false, mobile_apis::Result::INVALID_ID);

--- a/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -47,6 +47,12 @@ namespace application_manager {
 
 namespace commands {
 
+/**
+ * @brief The UniqueParamChecker class
+ * helps to check, whether incoming string
+ * is unique compared to previous ones, or not.
+ * Also checks syntax correctness.
+ */
 class UniqueParamChecker {
  public:
   UniqueParamChecker(const char* const name) : name_(name) {}

--- a/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
@@ -88,6 +88,11 @@ bool PerformInteractionRequest::Init() {
   return true;
 }
 
+/**
+ * @brief The MenuNamesChecker class helps
+ * to check, whether incoming menu name
+ * is unique compared to previous ones, or not.
+ */
 class MenuNamesChecker {
  public:
   MenuNamesChecker()
@@ -107,6 +112,11 @@ class MenuNamesChecker {
   std::set<int32_t> hash_set_;
 };
 
+/**
+ * @brief The VRSynonymsChecker class helps
+ * to check, whether incoming vr synonyms
+ * is unique compared to previous ones, or not.
+ */
 class VRSynonymsChecker {
  public:
   VRSynonymsChecker()

--- a/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
@@ -891,26 +891,6 @@ void PerformInteractionRequest::SendBothModeResponse(
                response_params);
 }
 
-#if BUILD_TESTS
-bool PerformInteractionRequest::CallCheckMethod(CheckMethod method) {
-  ApplicationSharedPtr app = application_manager_.application(connection_key());
-  switch (method) {
-    case CheckMethod::kCheckVrSynonyms: {
-      return ProcessChoiceSet(app, VRSynonymsChecker());
-    }
-    case CheckMethod::kCheckMenuNames: {
-      return ProcessChoiceSet(app, MenuNamesChecker());
-    }
-    case CheckMethod::kCheckVrHelpItem: {
-      return CheckVrHelpItemPositions(app);
-    }
-    default:
-      break;
-  }
-  return false;
-}
-#endif
-
 }  // namespace commands
 
 }  // namespace application_manager

--- a/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
@@ -44,6 +44,7 @@
 #include "utils/helpers.h"
 #include "utils/custom_string.h"
 #include "utils/gen_hash.h"
+#include "utils/stl_utils.h"
 
 namespace application_manager {
 
@@ -86,6 +87,52 @@ bool PerformInteractionRequest::Init() {
   }
   return true;
 }
+
+class MenuNamesChecker {
+ public:
+  MenuNamesChecker()
+      : result_code_(mobile_apis::Result::DUPLICATE_NAME)
+      , error_msg_("Choice set has duplicated menu name") {}
+
+  bool operator()(const smart_objects::SmartObject& choice) {
+    const std::string& menu_name = choice[strings::menu_name].asString();
+    return utils::InsertIntoSet(utils::Djb2HashFromString(menu_name),
+                                hash_set_);
+  }
+
+  const mobile_apis::Result::eType result_code_;
+  const char* const error_msg_;
+
+ private:
+  std::set<int32_t> hash_set_;
+};
+
+class VRSynonymsChecker {
+ public:
+  VRSynonymsChecker()
+      : result_code_(mobile_apis::Result::DUPLICATE_NAME)
+      , error_msg_("Choice set has duplicated VR synonyms") {}
+
+  bool operator()(const smart_objects::SmartObject& choice) {
+    const smart_objects::SmartObject& vr_commands =
+        choice[strings::vr_commands];
+    for (size_t vr_command_i = 0; vr_command_i < vr_commands.length();
+         ++vr_command_i) {
+      const std::string& vr_command = vr_commands[vr_command_i].asString();
+      if (!utils::InsertIntoSet(utils::Djb2HashFromString(vr_command),
+                                hash_set_)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  const mobile_apis::Result::eType result_code_;
+  const char* const error_msg_;
+
+ private:
+  std::set<int32_t> hash_set_;
+};
 
 void PerformInteractionRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
@@ -176,7 +223,8 @@ void PerformInteractionRequest::Run() {
   switch (interaction_mode_) {
     case mobile_apis::InteractionMode::BOTH: {
       LOG4CXX_DEBUG(logger_, "Interaction Mode: BOTH");
-      if (!CheckChoiceSetVRSynonyms(app) || !CheckChoiceSetMenuNames(app) ||
+      if (!ProcessChoiceSet(app, VRSynonymsChecker()) ||
+          !ProcessChoiceSet(app, MenuNamesChecker()) ||
           !CheckVrHelpItemPositions(app)) {
         return;
       }
@@ -184,7 +232,8 @@ void PerformInteractionRequest::Run() {
     }
     case mobile_apis::InteractionMode::MANUAL_ONLY: {
       LOG4CXX_DEBUG(logger_, "Interaction Mode: MANUAL_ONLY");
-      if (!CheckChoiceSetVRSynonyms(app) || !CheckChoiceSetMenuNames(app) ||
+      if (!ProcessChoiceSet(app, VRSynonymsChecker()) ||
+          !ProcessChoiceSet(app, MenuNamesChecker()) ||
           !CheckVrHelpItemPositions(app)) {
         return;
       }
@@ -192,7 +241,8 @@ void PerformInteractionRequest::Run() {
     }
     case mobile_apis::InteractionMode::VR_ONLY: {
       LOG4CXX_DEBUG(logger_, "Interaction Mode: VR_ONLY");
-      if (!CheckChoiceSetVRSynonyms(app) || !CheckVrHelpItemPositions(app)) {
+      if (!ProcessChoiceSet(app, VRSynonymsChecker()) ||
+          !CheckVrHelpItemPositions(app)) {
         return;
       }
       break;
@@ -598,119 +648,6 @@ void PerformInteractionRequest::SendVRPerformInteractionRequest(
       hmi_apis::FunctionID::VR_PerformInteraction, &msg_params, true);
 }
 
-bool PerformInteractionRequest::CheckChoiceSetMenuNames(
-    application_manager::ApplicationSharedPtr const app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  smart_objects::SmartObject& choice_list =
-      (*message_)[strings::msg_params][strings::interaction_choice_set_id_list];
-
-  for (size_t i = 0; i < choice_list.length(); ++i) {
-    // choice_set contains SmartObject msg_params
-    smart_objects::SmartObject* i_choice_set =
-        app->FindChoiceSet(choice_list[i].asInt());
-
-    for (size_t j = 0; j < choice_list.length(); ++j) {
-      smart_objects::SmartObject* j_choice_set =
-          app->FindChoiceSet(choice_list[j].asInt());
-
-      if (i == j) {
-        // skip check the same element
-        continue;
-      }
-
-      if (!i_choice_set || !j_choice_set) {
-        LOG4CXX_ERROR(logger_, "Invalid ID");
-        SendResponse(false, mobile_apis::Result::INVALID_ID);
-        return false;
-      }
-
-      size_t ii = 0;
-      size_t jj = 0;
-      for (; ii < (*i_choice_set)[strings::choice_set].length(); ++ii) {
-        for (; jj < (*j_choice_set)[strings::choice_set].length(); ++jj) {
-          const std::string& ii_menu_name =
-              (*i_choice_set)[strings::choice_set][ii][strings::menu_name]
-                  .asString();
-          const std::string& jj_menu_name =
-              (*j_choice_set)[strings::choice_set][jj][strings::menu_name]
-                  .asString();
-
-          if (ii_menu_name == jj_menu_name) {
-            LOG4CXX_ERROR(logger_, "Choice set has duplicated menu name");
-            SendResponse(false,
-                         mobile_apis::Result::DUPLICATE_NAME,
-                         "Choice set has duplicated menu name");
-            return false;
-          }
-        }
-      }
-    }
-  }
-
-  return true;
-}
-
-bool PerformInteractionRequest::CheckChoiceSetVRSynonyms(
-    application_manager::ApplicationSharedPtr const app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  smart_objects::SmartObject& choice_list =
-      (*message_)[strings::msg_params][strings::interaction_choice_set_id_list];
-
-  for (size_t i = 0; i < choice_list.length(); ++i) {
-    // choice_set contains SmartObject msg_params
-    smart_objects::SmartObject* i_choice_set =
-        app->FindChoiceSet(choice_list[i].asInt());
-
-    for (size_t j = 0; j < choice_list.length(); ++j) {
-      smart_objects::SmartObject* j_choice_set =
-          app->FindChoiceSet(choice_list[j].asInt());
-
-      if (i == j) {
-        // skip check the same element
-        continue;
-      }
-
-      if ((!i_choice_set) || (!j_choice_set)) {
-        LOG4CXX_ERROR(logger_, "Invalid ID");
-        SendResponse(false, mobile_apis::Result::INVALID_ID);
-        return false;
-      }
-
-      size_t ii = 0;
-      size_t jj = 0;
-      for (; ii < (*i_choice_set)[strings::choice_set].length(); ++ii) {
-        for (; jj < (*j_choice_set)[strings::choice_set].length(); ++jj) {
-          // choice_set pointer contains SmartObject msg_params
-          smart_objects::SmartObject& ii_vr_commands =
-              (*i_choice_set)[strings::choice_set][ii][strings::vr_commands];
-
-          smart_objects::SmartObject& jj_vr_commands =
-              (*j_choice_set)[strings::choice_set][jj][strings::vr_commands];
-
-          for (size_t iii = 0; iii < ii_vr_commands.length(); ++iii) {
-            for (size_t jjj = 0; jjj < jj_vr_commands.length(); ++jjj) {
-              const custom_str::CustomString& vr_cmd_i =
-                  ii_vr_commands[iii].asCustomString();
-              const custom_str::CustomString& vr_cmd_j =
-                  jj_vr_commands[jjj].asCustomString();
-              if (vr_cmd_i.CompareIgnoreCase(vr_cmd_j)) {
-                LOG4CXX_ERROR(logger_, "Choice set has duplicated VR synonym");
-                SendResponse(false,
-                             mobile_apis::Result::DUPLICATE_NAME,
-                             "Choice set has duplicated VR synonym");
-                return false;
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  return true;
-}
-
 bool PerformInteractionRequest::CheckVrHelpItemPositions(
     application_manager::ApplicationSharedPtr const app) {
   LOG4CXX_AUTO_TRACE(logger_);
@@ -937,12 +874,32 @@ void PerformInteractionRequest::SendBothModeResponse(
       msg_param.empty() ? NULL : &msg_param;
   std::string info =
       MergeInfos(ui_perform_info, ui_info_, vr_perform_info, vr_info_);
-  DisablePerformInteraction();
+  TerminatePerformInteraction();
   SendResponse(result,
                perform_interaction_result_code,
                info.empty() ? NULL : info.c_str(),
                response_params);
 }
+
+#if BUILD_TESTS
+bool PerformInteractionRequest::CallCheckMethod(CheckMethod method) {
+  ApplicationSharedPtr app = application_manager_.application(connection_key());
+  switch (method) {
+    case CheckMethod::kCheckVrSynonyms: {
+      return ProcessChoiceSet(app, VRSynonymsChecker());
+    }
+    case CheckMethod::kCheckMenuNames: {
+      return ProcessChoiceSet(app, MenuNamesChecker());
+    }
+    case CheckMethod::kCheckVrHelpItem: {
+      return CheckVrHelpItemPositions(app);
+    }
+    default:
+      break;
+  }
+  return false;
+}
+#endif
 
 }  // namespace commands
 

--- a/src/components/application_manager/test/commands/mobile/create_interaction_choice_set_test.cc
+++ b/src/components/application_manager/test/commands/mobile/create_interaction_choice_set_test.cc
@@ -34,77 +34,143 @@
 #include <string>
 #include <set>
 
-#include "application_manager/commands/mobile/create_interaction_choice_set_request.h"
+#include "mobile/create_interaction_choice_set_request.h"
+#include "mobile/create_interaction_choice_set_response.h"
 
 #include "gtest/gtest.h"
 #include "utils/shared_ptr.h"
 #include "utils/helpers.h"
 #include "utils/make_shared.h"
 #include "smart_objects/smart_object.h"
-#include "utils/custom_string.h"
 #include "application_manager/commands/command_request_test.h"
 #include "application_manager/smart_object_keys.h"
 #include "application_manager/mock_application.h"
 #include "application_manager/mock_application_manager.h"
 #include "application_manager/mock_message_helper.h"
 #include "application_manager/event_engine/event.h"
+#include "application_manager/hmi_interfaces.h"
 #include "application_manager/mock_hmi_interface.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
+#include "utils/lock.h"
 
 namespace test {
 namespace components {
 namespace commands_test {
+namespace mobile_commands_test {
 namespace create_interaction_choice_set_request {
 
 namespace am = application_manager;
-using am::commands::CommandImpl;
-using am::ApplicationManager;
-using am::commands::MessageSharedPtr;
-using am::ApplicationSharedPtr;
-using am::MockMessageHelper;
-using am::MockHmiInterfaces;
+namespace strings = am::strings;
+namespace hmi_response = am::hmi_response;
+
 using ::testing::_;
 using ::testing::Mock;
-using ::utils::SharedPtr;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::AtLeast;
+using ::utils::SharedPtr;
+using am::commands::MessageSharedPtr;
+using am::MockMessageHelper;
 using am::commands::CreateInteractionChoiceSetRequest;
-using ::test::components::application_manager_test::MockApplication;
+using am::commands::CreateInteractionChoiceSetResponse;
 
-namespace custom_str = utils::custom_string;
-namespace strings = ::application_manager::strings;
-namespace hmi_response = ::application_manager::hmi_response;
+typedef SharedPtr<CreateInteractionChoiceSetRequest>
+    CreateInteractionChoiceSetRequestPtr;
+typedef SharedPtr<CreateInteractionChoiceSetResponse>
+    CreateInteractionChoiceSetResponsePtr;
 
 namespace {
-const hmi_apis::FunctionID::eType kInvalidFunctionId =
-    hmi_apis::FunctionID::INVALID_ENUM;
-const int32_t kCommandId = 1;
-const uint32_t kAppId = 1u;
-const uint32_t kCmdId = 1u;
+const uint32_t kCommandId = 1u;
 const uint32_t kConnectionKey = 2u;
+const uint32_t kCorrelationId = 10u;
+const uint32_t kGrammarId = 10u;
+const uint32_t kChoiceSetId = 1u;
+const uint32_t kChoiceId0 = 2u;
+const uint32_t kChoiceId1 = 3u;
+const std::string kImage = "image";
+const std::string kSecondImage = "second_image";
+const std::string kVrCommand0 = "vr_command_0";
+const std::string kVrCommand1 = "vr_command_1";
+const std::string kMenuName0 = "menu_name_0";
+const std::string kMenuName1 = "menu_name_1";
+const am::HmiInterfaces::InterfaceID kHmiInterface =
+    am::HmiInterfaces::HMI_INTERFACE_SDL;
 }  // namespace
 
 class CreateInteractionChoiceSetRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  sync_primitives::Lock lock_;
+  CreateInteractionChoiceSetRequestTest()
+      : mock_message_helper_(am::MockMessageHelper::message_helper_mock())
+      , message_(CreateMessage())
+      , command_(CreateCommand<CreateInteractionChoiceSetRequest>(message_))
+      , mock_app_(CreateMockApp()) {
+    ON_CALL(*mock_app_, choice_set_map())
+        .WillByDefault(Return(
+            DataAccessor<am::ChoiceSetMap>(dummy_choice_set_map_, lock_)));
+    ON_CALL(app_mngr_, hmi_interfaces())
+        .WillByDefault(ReturnRef(mock_hmi_interfaces_));
+    ON_CALL(mock_hmi_interfaces_, GetInterfaceFromFunction(_))
+        .WillByDefault(Return(kHmiInterface));
+    ON_CALL(mock_hmi_interfaces_, GetInterfaceState(kHmiInterface))
+        .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+
+  ~CreateInteractionChoiceSetRequestTest() {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+
+  void FillMessageFieldsItem1(MessageSharedPtr message) {
+    (*message)[am::strings::msg_params][am::strings::choice_set][0]
+              [am::strings::menu_name] = kMenuName0;
+    (*message)[am::strings::msg_params][am::strings::choice_set][0]
+              [am::strings::image][am::strings::value] = kImage;
+    (*message)[am::strings::msg_params][am::strings::choice_set][0]
+              [am::strings::choice_id] = kChoiceId0;
+    (*message)[am::strings::msg_params][am::strings::choice_set][0]
+              [am::strings::vr_commands][0] = kVrCommand0;
+    (*message)[am::strings::msg_params][am::strings::choice_set][0]
+              [am::strings::secondary_image][am::strings::value] = kSecondImage;
+  }
+  void FillMessageFieldsItem2(MessageSharedPtr message) {
+    (*message)[am::strings::msg_params][am::strings::choice_set][1]
+              [am::strings::choice_id] = kChoiceId1;
+    (*message)[am::strings::msg_params][am::strings::choice_set][1]
+              [am::strings::menu_name] = kMenuName1;
+    (*message)[am::strings::msg_params][am::strings::choice_set][1]
+              [am::strings::vr_commands][0] = kVrCommand1;
+    (*message)[am::strings::msg_params]
+              [am::strings::interaction_choice_set_id] = kChoiceSetId;
+  }
 
   MessageSharedPtr CreateFullParamsVRSO() {
     MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
     (*msg)[strings::params][strings::connection_key] = kConnectionKey;
     smart_objects::SmartObject msg_params =
         smart_objects::SmartObject(smart_objects::SmartType_Map);
-    msg_params[strings::cmd_id] = kCmdId;
+    msg_params[strings::cmd_id] = kCommandId;
     msg_params[strings::vr_commands] =
         smart_objects::SmartObject(smart_objects::SmartType_Array);
     msg_params[strings::vr_commands][0] = "lamer";
     msg_params[strings::type] = 34;
     msg_params[strings::grammar_id] = 12;
-    msg_params[strings::app_id] = kAppId;
+    msg_params[strings::app_id] = kConnectionKey;
     (*msg)[strings::msg_params] = msg_params;
 
     return msg;
   }
+
+  am::MockMessageHelper* mock_message_helper_;
+  MessageSharedPtr message_;
+  CreateInteractionChoiceSetRequestPtr command_;
+  MockAppPtr mock_app_;
+  am::MockHmiInterfaces mock_hmi_interfaces_;
+  am::ChoiceSetMap dummy_choice_set_map_;
+  sync_primitives::Lock lock_;
 };
+
 TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeout_GENERIC_ERROR) {
   MessageSharedPtr msg_vr = CreateMessage(smart_objects::SmartType_Map);
   (*msg_vr)[strings::msg_params][strings::result_code] =
@@ -114,11 +180,10 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeout_GENERIC_ERROR) {
   utils::SharedPtr<CreateInteractionChoiceSetRequest> req_vr =
       CreateCommand<CreateInteractionChoiceSetRequest>();
 
-  MockAppPtr mock_app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app));
-  ON_CALL(*mock_app, app_id()).WillByDefault(Return(kConnectionKey));
-  ON_CALL(*mock_app, get_grammar_id()).WillByDefault(Return(kConnectionKey));
-  ON_CALL(*mock_app, RemoveCommand(_)).WillByDefault(Return());
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
+  ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
+  ON_CALL(*mock_app_, get_grammar_id()).WillByDefault(Return(kConnectionKey));
+  ON_CALL(*mock_app_, RemoveCommand(_)).WillByDefault(Return());
 
   MessageSharedPtr vr_command_result;
   EXPECT_CALL(
@@ -145,11 +210,10 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnEvent_VR_UNSUPPORTED_RESOURCE) {
   utils::SharedPtr<CreateInteractionChoiceSetRequest> req_vr =
       CreateCommand<CreateInteractionChoiceSetRequest>(msg_vr);
 
-  MockAppPtr mock_app = CreateMockApp();
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app));
-  ON_CALL(*mock_app, app_id()).WillByDefault(Return(kConnectionKey));
+  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
+  ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
   smart_objects::SmartObject* null_obj = NULL;
-  ON_CALL(*mock_app, FindChoiceSet(_)).WillByDefault(Return(null_obj));
+  ON_CALL(*mock_app_, FindChoiceSet(_)).WillByDefault(Return(null_obj));
 
   MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
   (*msg)[strings::params][hmi_response::code] =
@@ -161,26 +225,13 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnEvent_VR_UNSUPPORTED_RESOURCE) {
   event.set_smart_object(*msg);
 
   smart_objects::SmartObject* ptr = NULL;
-  ON_CALL(*mock_app, FindCommand(kCmdId)).WillByDefault(Return(ptr));
+  ON_CALL(*mock_app_, FindCommand(kCommandId)).WillByDefault(Return(ptr));
   EXPECT_EQ(NULL, ptr);
 
   MockMessageHelper* mock_message_helper =
       MockMessageHelper::message_helper_mock();
   ON_CALL(*mock_message_helper, HMIToMobileResult(_))
       .WillByDefault(Return(mobile_apis::Result::SUCCESS));
-
-  am::CommandsMap commands_map;
-  ON_CALL(*mock_app, commands_map())
-      .WillByDefault(
-          Return(DataAccessor<am::CommandsMap>(commands_map, lock_)));
-  MockHmiInterfaces hmi_interfaces;
-  ON_CALL(app_mngr_, hmi_interfaces()).WillByDefault(ReturnRef(hmi_interfaces));
-  ON_CALL(hmi_interfaces, GetInterfaceFromFunction(_))
-      .WillByDefault(
-          Return(am::HmiInterfaces::HMI_INTERFACE_BasicCommunication));
-  ON_CALL(hmi_interfaces, GetInterfaceState(_))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
-  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
 
   req_vr->Run();
 
@@ -205,7 +256,539 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnEvent_VR_UNSUPPORTED_RESOURCE) {
   }
 }
 
-}  // namespace create_interaction_choice_set_request
+class CreateInteractionChoiceSetResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(CreateInteractionChoiceSetRequestTest, Run_InvalidApp_UNSUCCESS) {
+  MockAppPtr invalid_app;
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(invalid_app));
+  EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
+
+  command_->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest, Run_VerifyImageFail_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::image] = kImage;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::secondary_image] = kSecondImage;
+
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
+  EXPECT_CALL(*mock_message_helper_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::INVALID_DATA));
+  EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
+
+  command_->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest, Run_FindChoiceSetFail_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::image] = kImage;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::secondary_image] = kSecondImage;
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
+  EXPECT_CALL(*mock_message_helper_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* invalid_choice_set_id =
+      &((*message_)[am::strings::msg_params]
+                   [am::strings::interaction_choice_set_id]);
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(invalid_choice_set_id));
+  EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
+  command_->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       Run_CheckChoiceSet_InvalidChoiceId_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::menu_name] = kMenuName0;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::image][am::strings::value] = kImage;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::choice_id] = kChoiceId0;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::secondary_image][am::strings::value] = kSecondImage;
+
+  FillMessageFieldsItem2(message_);
+  (*message_)[am::strings::msg_params][am::strings::choice_set][1]
+             [am::strings::vr_commands][0] = kVrCommand0;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][1]
+             [am::strings::vr_commands][1] = " kVrCommand1\t";
+
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
+
+  EXPECT_CALL(*mock_message_helper_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
+  command_->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       Run_IsWhiteSpaceVRCommandsExist_InvalidMenuName_UNSUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::menu_name] = "menu_name\t";
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::secondary_text] = "secondary_text\t";
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::tertiary_text] = "tertiary_text\t";
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::image][am::strings::value] = "image\t";
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::choice_id] = kChoiceId0;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::secondary_image][am::strings::value] =
+                 "second_image\t";
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::vr_commands][0] = "vr_commands_1\t";
+
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
+      .WillRepeatedly(Return(choice_set_id));
+  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(mock_app_));
+
+  EXPECT_CALL(*mock_message_helper_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  if ((*message_)[am::strings::msg_params][am::strings::choice_set][0]
+          .keyExists(am::strings::menu_name)) {
+    CreateInteractionChoiceSetRequestPtr command(
+        CreateCommand<CreateInteractionChoiceSetRequest>(message_));
+
+    EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
+    command->Run();
+  }
+  if ((*message_)[am::strings::msg_params][am::strings::choice_set][0]
+          .keyExists(am::strings::secondary_text)) {
+    (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+               [am::strings::menu_name] = kMenuName0;
+    CreateInteractionChoiceSetRequestPtr command(
+        CreateCommand<CreateInteractionChoiceSetRequest>(message_));
+
+    EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
+    command->Run();
+  }
+  if ((*message_)[am::strings::msg_params][am::strings::choice_set][0]
+          .keyExists(am::strings::tertiary_text)) {
+    (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+               [am::strings::secondary_text] = "secondary_text";
+    CreateInteractionChoiceSetRequestPtr command(
+        CreateCommand<CreateInteractionChoiceSetRequest>(message_));
+
+    EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
+    command->Run();
+  }
+  if ((*message_)[am::strings::msg_params][am::strings::choice_set][0]
+          .keyExists(am::strings::vr_commands)) {
+    (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+               [am::strings::tertiary_text] = "tertiary_text";
+    CreateInteractionChoiceSetRequestPtr command(
+        CreateCommand<CreateInteractionChoiceSetRequest>(message_));
+
+    EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
+    command->Run();
+  }
+  if ((*message_)[am::strings::msg_params][am::strings::choice_set][0]
+          .keyExists(am::strings::image)) {
+    (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+               [am::strings::vr_commands][0] = "vr_commands";
+    CreateInteractionChoiceSetRequestPtr command(
+        CreateCommand<CreateInteractionChoiceSetRequest>(message_));
+
+    EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
+    command->Run();
+  }
+  if ((*message_)[am::strings::msg_params][am::strings::choice_set][0]
+          .keyExists(am::strings::secondary_image)) {
+    (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+               [am::strings::image][am::strings::value] = kImage;
+    CreateInteractionChoiceSetRequestPtr command(
+        CreateCommand<CreateInteractionChoiceSetRequest>(message_));
+
+    EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
+    command->Run();
+  }
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       Run_ValidAmountVrCommands_SUCCESS) {
+  FillMessageFieldsItem1(message_);
+  FillMessageFieldsItem2(message_);
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
+
+  EXPECT_CALL(*mock_message_helper_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(app_mngr_, GenerateGrammarID()).WillOnce(Return(kGrammarId));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
+  EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())
+      .Times(AtLeast(2))
+      .WillOnce(Return(kConnectionKey))
+      .WillOnce(Return(kConnectionKey));
+  command_->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       Run_EmptyAmountVrCommands_SUCCESS) {
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::menu_name] = kMenuName0;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::image][am::strings::value] = kImage;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::choice_id] = kChoiceId0;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][0]
+             [am::strings::secondary_image][am::strings::value] = kSecondImage;
+
+  (*message_)[am::strings::msg_params][am::strings::choice_set][1]
+             [am::strings::choice_id] = kChoiceId1;
+  (*message_)[am::strings::msg_params][am::strings::choice_set][1]
+             [am::strings::menu_name] = kMenuName1;
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
+
+  EXPECT_CALL(*mock_message_helper_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
+  command_->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       OnEvent_InvalidEventId_UNSUCCESS) {
+  Event event(hmi_apis::FunctionID::INVALID_ENUM);
+
+  EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _)).Times(0);
+  command_->on_event(event);
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest, OnEvent_ValidVrNoError_SUCCESS) {
+  Event event(hmi_apis::FunctionID::VR_AddCommand);
+
+  (*message_)[am::strings::params][am::strings::correlation_id] =
+      kCorrelationId;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::WARNINGS;
+
+  FillMessageFieldsItem1(message_);
+  FillMessageFieldsItem2(message_);
+
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
+
+  EXPECT_CALL(*mock_message_helper_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(app_mngr_, GenerateGrammarID()).WillOnce(Return(kGrammarId));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
+  ON_CALL(app_mngr_, GetNextHMICorrelationID())
+      .WillByDefault(Return(kCorrelationId));
+  command_->Run();
+
+  EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
+  EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _)).Times(0);
+  event.set_smart_object(*message_);
+
+  command_->on_event(event);
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       OnEvent_InValidVrNoError_UNSUCCESS) {
+  Event event(hmi_apis::FunctionID::VR_AddCommand);
+
+  (*message_)[am::strings::params][am::strings::correlation_id] =
+      kCorrelationId;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::INVALID_DATA;
+
+  FillMessageFieldsItem1(message_);
+  FillMessageFieldsItem2(message_);
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
+
+  EXPECT_CALL(*mock_message_helper_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(app_mngr_, GenerateGrammarID()).WillOnce(Return(kGrammarId));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
+  ON_CALL(app_mngr_, GetNextHMICorrelationID())
+      .WillByDefault(Return(kCorrelationId));
+  command_->Run();
+  EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
+  EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _)).Times(0);
+  event.set_smart_object(*message_);
+
+  command_->on_event(event);
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       OnEvent_ValidVrNoErrorAndExpectedChoiceLessThanReceiveChoice_SUCCESS) {
+  Event event(hmi_apis::FunctionID::VR_AddCommand);
+
+  (*message_)[am::strings::params][am::strings::correlation_id] =
+      kCorrelationId;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::WARNINGS;
+
+  FillMessageFieldsItem1(message_);
+
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
+
+  EXPECT_CALL(*mock_message_helper_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(app_mngr_, GenerateGrammarID()).WillOnce(Return(kGrammarId));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
+  ON_CALL(app_mngr_, GetNextHMICorrelationID())
+      .WillByDefault(Return(kCorrelationId));
+  command_->Run();
+
+  FillMessageFieldsItem2(message_);
+
+  EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _)).Times(0);
+  EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
+  event.set_smart_object(*message_);
+  command_->on_event(event);
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       OnTimeOut_InvalidErrorFromHMI_UNSUCCESS) {
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
+
+  EXPECT_CALL(app_mngr_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_apis::Result::GENERIC_ERROR),
+                  am::commands::Command::ORIGIN_SDL));
+
+  EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
+  command_->onTimeOut();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       OnTimeOut_ValidErrorFromHMI_SUCCESS) {
+  (*message_)[am::strings::params][am::strings::correlation_id] =
+      kCorrelationId;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::INVALID_ENUM;
+
+  FillMessageFieldsItem1(message_);
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+
+  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
+
+  EXPECT_CALL(*mock_message_helper_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(app_mngr_, GenerateGrammarID()).WillOnce(Return(kGrammarId));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
+  ON_CALL(app_mngr_, GetNextHMICorrelationID())
+      .WillByDefault(Return(kCorrelationId));
+  command_->Run();
+
+  FillMessageFieldsItem2(message_);
+  EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _)).Times(0);
+  EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
+  Event event(hmi_apis::FunctionID::VR_AddCommand);
+  event.set_smart_object(*message_);
+  command_->on_event(event);
+
+  EXPECT_CALL(*mock_app_, RemoveChoiceSet(kChoiceSetId));
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
+  command_->onTimeOut();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeOut_InvalidApp_UNSUCCESS) {
+  (*message_)[am::strings::params][am::strings::correlation_id] =
+      kCorrelationId;
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::INVALID_ENUM;
+
+  FillMessageFieldsItem1(message_);
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+
+  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(mock_app_));
+
+  EXPECT_CALL(*mock_message_helper_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(app_mngr_, GenerateGrammarID()).WillOnce(Return(kGrammarId));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
+  ON_CALL(app_mngr_, GetNextHMICorrelationID())
+      .WillByDefault(Return(kCorrelationId));
+  command_->Run();
+
+  FillMessageFieldsItem2(message_);
+  EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _)).Times(0);
+  EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _)).Times(2);
+  Event event(hmi_apis::FunctionID::VR_AddCommand);
+  event.set_smart_object(*message_);
+  command_->on_event(event);
+
+  MockAppPtr invalid_app;
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(invalid_app));
+  EXPECT_CALL(*mock_app_, RemoveChoiceSet(_)).Times(0);
+  command_->onTimeOut();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest,
+       OnTimeOut_SuccessfulResponseReceived_UNSUCCESS) {
+  (*message_)[am::strings::params][am::strings::correlation_id] =
+      kCorrelationId;
+  (*message_)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::SUCCESS;
+
+  FillMessageFieldsItem1(message_);
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(mock_app_));
+
+  EXPECT_CALL(*mock_message_helper_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
+      .WillOnce(Return(choice_set_id));
+
+  EXPECT_CALL(app_mngr_, GenerateGrammarID()).WillOnce(Return(kGrammarId));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
+  ON_CALL(app_mngr_, GetNextHMICorrelationID())
+      .WillByDefault(Return(kCorrelationId));
+  command_->Run();
+
+  FillMessageFieldsItem2(message_);
+  EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _)).Times(0);
+  EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
+  Event event(hmi_apis::FunctionID::VR_AddCommand);
+  event.set_smart_object(*message_);
+
+  MockAppPtr invalid_app;
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(invalid_app));
+  command_->on_event(event);
+
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(mock_app_));
+  EXPECT_CALL(*mock_app_, RemoveChoiceSet(_));
+  command_->onTimeOut();
+}
+
+TEST_F(CreateInteractionChoiceSetResponseTest, Run_SuccessFalse_UNSUCCESS) {
+  MessageSharedPtr message(CreateMessage());
+  (*message)[am::strings::msg_params][am::strings::success] = false;
+  (*message)[am::strings::msg_params][am::strings::result_code] =
+      mobile_apis::Result::INVALID_ENUM;
+  CreateInteractionChoiceSetResponsePtr command(
+      CreateCommand<CreateInteractionChoiceSetResponse>(message));
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(message, false));
+  command->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetResponseTest, Run_SuccessTrue_SUCCESS) {
+  MessageSharedPtr message(CreateMessage());
+  (*message)[am::strings::msg_params][am::strings::success] = true;
+  (*message)[am::strings::msg_params][am::strings::result_code] =
+      mobile_apis::Result::SUCCESS;
+  CreateInteractionChoiceSetResponsePtr command(
+      CreateCommand<CreateInteractionChoiceSetResponse>(message));
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(message, false));
+  command->Run();
+}
+
+TEST_F(CreateInteractionChoiceSetRequestTest, Run_ErrorFromHmiFalse_UNSUCCESS) {
+  Event event(hmi_apis::FunctionID::VR_AddCommand);
+
+  (*message_)[am::strings::params][am::strings::correlation_id] =
+      kCorrelationId;
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::GENERIC_ERROR;
+
+  FillMessageFieldsItem1(message_);
+
+  (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
+      kChoiceSetId;
+  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
+
+  EXPECT_CALL(*mock_message_helper_, VerifyImage(_, _, _))
+      .WillRepeatedly(Return(mobile_apis::Result::GENERIC_ERROR));
+
+  smart_objects::SmartObject* choice_set_id = NULL;
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
+      .WillRepeatedly(Return(choice_set_id));
+
+  EXPECT_CALL(app_mngr_, GenerateGrammarID())
+      .WillRepeatedly(Return(kGrammarId));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _)).Times(2);
+  ON_CALL(app_mngr_, GetNextHMICorrelationID())
+      .WillByDefault(Return(kCorrelationId));
+  command_->Run();
+
+  FillMessageFieldsItem2(message_);
+
+  EXPECT_CALL(app_mngr_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_apis::Result::GENERIC_ERROR),
+                  am::commands::Command::ORIGIN_SDL));
+  EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _)).Times(0);
+  EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
+  event.set_smart_object(*message_);
+  command_->on_event(event);
+  command_->Run();
+}
+
+}  // namespace create_interaction_choice_set
+}  // namespace mobile_commands_test
 }  // namespace commands_test
 }  // namespace components
-}  // namespace tests
+}  // namespace test

--- a/src/components/utils/include/utils/stl_utils.h
+++ b/src/components/utils/include/utils/stl_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,6 +32,7 @@
 #ifndef SRC_COMPONENTS_UTILS_INCLUDE_UTILS_STL_UTILS_H_
 #define SRC_COMPONENTS_UTILS_INCLUDE_UTILS_STL_UTILS_H_
 
+#include <set>
 #include "utils/macro.h"
 
 namespace utils {
@@ -81,6 +82,13 @@ class StlMapDeleter {
  private:
   Collection* collection_;
 };
+
+template <typename T>
+bool InsertIntoSet(const T& data, std::set<T>& out_set) {
+  typedef std::pair<typename std::set<T>::iterator, bool> InsertResult;
+  InsertResult ins_res = out_set.insert(data);
+  return ins_res.second;
+}
 
 }  // namespace utils
 


### PR DESCRIPTION
CreateInteractionChoiceSet: SUCCESS the same menuName or vrCommand in different choiceSets

---
Functional requirement: [APPLINK-16940](https://adc.luxoft.com/jira/browse/APPLINK-16940)
Implements: [APPLINK-29256](https://adc.luxoft.com/jira/browse/APPLINK-29256)
Related to: [APPLINK-29259](https://adc.luxoft.com/jira/browse/APPLINK-29259)

---
Unit tests has been updated
for `CreateInteractionRequest`.

---
Related to: [APPLINK-29262](https://adc.luxoft.com/jira/browse/APPLINK-29262)

PerformInteraction: DUPLICATE_NAME MenuName or/and vrSynonyms within ChoiceSets
-
Functional requirement: [APPLINK-17385](https://adc.luxoft.com/jira/browse/APPLINK-17385)
Implements: [APPLINK-29256](https://adc.luxoft.com/jira/browse/APPLINK-29256)
Related to: [APPLINK-29259](https://adc.luxoft.com/jira/browse/APPLINK-29259)

---
Unit tests has been updated
for `PerformInteractionRequest`.

---
Related to: [APPLINK-29262](https://adc.luxoft.com/jira/browse/APPLINK-29262)
Recreated #923 

@AGaliuzov, @Kozoriz, @LuxoftAKutsan, @VProdanov, @wolfylambova22, @VVeremjova, @dtrunov, please, review.