### PR TITLE
[WiP][Testing] Add new parameters to .ini file to read them by SDL

### DIFF
--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -212,6 +212,10 @@ ApplicationListUpdateTimeout = 2000
 ThreadPoolSize = 1
 ; The max size of hash which is used by OnHashUpdated
 HashStringSize = 32
+; Menu title default text
+MenuTitle = MENU
+; Default path to menu icon, if this parameter is empty - the icon does not exist and no icon should be displayed
+MenuIcon = 
 
 [SDL4]
 ; Enables SDL 4.0 support

--- a/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
@@ -78,7 +78,7 @@ void ResetGlobalPropertiesRequest::Run() {
   bool helpt_promt = false;
   bool timeout_prompt = false;
   bool vr_help_title_items = false;
-  bool menu_name = false;
+  bool menu_title = false;
   bool menu_icon = false;
   bool is_key_board_properties = false;
   int number_of_reset_vr = 0;
@@ -100,7 +100,7 @@ void ResetGlobalPropertiesRequest::Run() {
       ++number_of_reset_vr;
       vr_help_title_items = ResetVrHelpTitleItems(app);
     } else if (mobile_apis::GlobalProperty::MENUNAME == global_property) {
-      menu_name = true;
+      menu_title = true;
     } else if (mobile_apis::GlobalProperty::MENUICON == global_property) {
       menu_icon = true;
     } else if (mobile_apis::GlobalProperty::KEYBOARDPROPERTIES ==
@@ -109,7 +109,7 @@ void ResetGlobalPropertiesRequest::Run() {
     }
   }
 
-  if (vr_help_title_items || menu_name || menu_icon ||
+  if (vr_help_title_items || menu_title || menu_icon ||
       is_key_board_properties) {
     is_ui_send_ = true;
   }
@@ -120,7 +120,7 @@ void ResetGlobalPropertiesRequest::Run() {
 
   app->set_reset_global_properties_active(true);
 
-  if (vr_help_title_items || menu_name || menu_icon ||
+  if (vr_help_title_items || menu_title || menu_icon ||
       is_key_board_properties) {
     smart_objects::SmartObject msg_params =
         smart_objects::SmartObject(smart_objects::SmartType_Map);
@@ -133,13 +133,18 @@ void ResetGlobalPropertiesRequest::Run() {
       }
       msg_params = *vr_help;
     }
-    if (menu_name) {
-      msg_params[hmi_request::menu_title] = "";
+    if (menu_title) {
+      msg_params[hmi_request::menu_title] =
+          application_manager_.get_settings().menu_title();
       app->set_menu_title(msg_params[hmi_request::menu_title]);
     }
-    // TODO(DT): clarify the sending parameter menuIcon
-    // if (menu_icon) {
-    //}
+    if (menu_icon) {
+      smart_objects::SmartObject so_menu_icon(smart_objects::SmartType_Map);
+      so_menu_icon[strings::value] =
+          application_manager_.get_settings().menu_icon();
+      msg_params[hmi_request::menu_icon] = so_menu_icon;
+      app->set_menu_icon(so_menu_icon);
+    }
     if (is_key_board_properties) {
       smart_objects::SmartObject key_board_properties =
           smart_objects::SmartObject(smart_objects::SmartType_Map);

--- a/src/components/application_manager/test/commands/mobile/reset_global_properties_test.cc
+++ b/src/components/application_manager/test/commands/mobile/reset_global_properties_test.cc
@@ -1,0 +1,474 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#include "mobile/reset_global_properties_request.h"
+#include "mobile/reset_global_properties_response.h"
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "utils/make_shared.h"
+#include "smart_objects/smart_object.h"
+#include "interfaces/HMI_API.h"
+#include "interfaces/MOBILE_API.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/mock_hmi_interface.h"
+#include "application_manager/event_engine/event.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+namespace reset_global_properties {
+
+using ::testing::_;
+using ::testing::Mock;
+using ::testing::Return;
+using ::testing::ReturnRef;
+
+namespace am = ::application_manager;
+
+using am::commands::ResetGlobalPropertiesRequest;
+using am::commands::ResetGlobalPropertiesResponse;
+using am::commands::MessageSharedPtr;
+using am::event_engine::Event;
+using am::MockMessageHelper;
+using am::MockHmiInterfaces;
+
+typedef SharedPtr<ResetGlobalPropertiesRequest> ResetGlobalPropertiesRequestPtr;
+typedef SharedPtr<ResetGlobalPropertiesResponse>
+    ResetGlobalPropertiesResponsePtr;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const uint32_t kCorrelationId = 10u;
+const std::string kTimeOutPromptTestValue = "time_out";
+const std::string kMenuTitleTestValue = "MENU";
+const std::string kMenuIconTestValue = "icon_path";
+}  // namespace
+
+class ResetGlobalPropertiesRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ protected:
+  ResetGlobalPropertiesRequestTest()
+      : mock_message_helper_(MockMessageHelper::message_helper_mock())
+      , msg_(CreateMessage())
+      , mock_app_(CreateMockApp()) {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+    InitTestParamsAndGetters();
+  }
+
+  ~ResetGlobalPropertiesRequestTest() {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+
+  void InitTestParamsAndGetters() {
+    (*msg_)[am::strings::params][am::strings::connection_key] = kConnectionKey;
+    (*msg_)[am::strings::params][am::strings::correlation_id] = kCorrelationId;
+
+    command_ = CreateCommand<ResetGlobalPropertiesRequest>(msg_);
+
+    ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
+    ON_CALL(app_mngr_, application(kConnectionKey))
+        .WillByDefault(Return(mock_app_));
+    ON_CALL(app_mngr_, GetNextHMICorrelationID())
+        .WillByDefault(Return(kCorrelationId));
+    ON_CALL(app_mngr_, application(kConnectionKey))
+        .WillByDefault(Return(mock_app_));
+
+    ON_CALL(app_mngr_, hmi_interfaces())
+        .WillByDefault(ReturnRef(mock_hmi_interfaces_));
+    ON_CALL(mock_hmi_interfaces_, GetInterfaceFromFunction(_))
+        .WillByDefault(
+            Return(am::HmiInterfaces::HMI_INTERFACE_BasicCommunication));
+    ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
+        .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  }
+
+  MockMessageHelper* mock_message_helper_;
+  MessageSharedPtr msg_;
+  MockAppPtr mock_app_;
+  NiceMock<MockHmiInterfaces> mock_hmi_interfaces_;
+  ResetGlobalPropertiesRequestPtr command_;
+};
+
+class ResetGlobalPropertiesResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidApp_UNSUCCESS) {
+  MockAppPtr invalid_app;
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(invalid_app));
+
+  MessageSharedPtr command_result;
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&command_result), Return(true)));
+
+  command_->Run();
+  EXPECT_FALSE((*command_result)[am::strings::msg_params][am::strings::success]
+                   .asBool());
+  EXPECT_EQ(
+      (*command_result)[am::strings::msg_params][am::strings::result_code]
+          .asInt(),
+      static_cast<int32_t>(mobile_apis::Result::APPLICATION_NOT_REGISTERED));
+}
+
+TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidVrHelp_UNSUCCESS) {
+  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+
+  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
+      mobile_apis::GlobalProperty::HELPPROMPT;
+  (*msg_)[am::strings::msg_params][am::strings::properties][1] =
+      mobile_apis::GlobalProperty::TIMEOUTPROMPT;
+  (*msg_)[am::strings::msg_params][am::strings::properties][2] =
+      mobile_apis::GlobalProperty::VRHELPTITLE;
+
+  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  // mobile_apis::GlobalProperty::HELPPROMPT:
+  smart_objects::SmartObject help_prompt_array =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  EXPECT_CALL(*mock_app_, set_help_prompt(help_prompt_array));
+
+  // mobile_apis::GlobalProperty::TIMEOUTPROMPT:
+  std::vector<std::string> time_out_prompt_default_vector;
+  time_out_prompt_default_vector.push_back(kTimeOutPromptTestValue);
+  EXPECT_CALL(app_mngr_settings_, time_out_promt())
+      .WillOnce(ReturnRef(time_out_prompt_default_vector));
+
+  smart_objects::SmartObject time_out_prompt_map =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  time_out_prompt_map[am::strings::text] = time_out_prompt_default_vector[0];
+  time_out_prompt_map[am::strings::type] =
+      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+
+  smart_objects::SmartObject time_out_prompt_array =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  time_out_prompt_array[0] = time_out_prompt_map;
+  EXPECT_CALL(*mock_app_, set_timeout_prompt(time_out_prompt_array));
+
+  // mobile_apis::GlobalProperty::VRHELPTITLE:
+  EXPECT_CALL(*mock_app_, reset_vr_help_title());
+  EXPECT_CALL(*mock_app_, reset_vr_help());
+
+  smart_objects::SmartObjectSPtr invalid_vr_help;  // = NULL;
+  EXPECT_CALL(*mock_message_helper_, CreateAppVrHelp(_))
+      .WillOnce(Return(invalid_vr_help));
+
+  EXPECT_CALL(app_mngr_, ManageHMICommand(_)).Times(0);
+
+  command_->Run();
+}
+
+TEST_F(ResetGlobalPropertiesRequestTest, Run_SUCCESS) {
+  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+
+  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
+      mobile_apis::GlobalProperty::HELPPROMPT;
+  (*msg_)[am::strings::msg_params][am::strings::properties][1] =
+      mobile_apis::GlobalProperty::TIMEOUTPROMPT;
+  (*msg_)[am::strings::msg_params][am::strings::properties][2] =
+      mobile_apis::GlobalProperty::VRHELPTITLE;
+  (*msg_)[am::strings::msg_params][am::strings::properties][3] =
+      mobile_apis::GlobalProperty::MENUNAME;
+  (*msg_)[am::strings::msg_params][am::strings::properties][4] =
+      mobile_apis::GlobalProperty::MENUICON;
+  (*msg_)[am::strings::msg_params][am::strings::properties][5] =
+      mobile_apis::GlobalProperty::KEYBOARDPROPERTIES;
+
+  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  smart_objects::SmartObject ui_msg_params =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  // mobile_apis::GlobalProperty::HELPPROMPT:
+  smart_objects::SmartObject help_prompt_array =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  EXPECT_CALL(*mock_app_, set_help_prompt(help_prompt_array));
+
+  const smart_objects::SmartObjectSPtr so_help_prompt =
+      ::utils::MakeShared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  EXPECT_CALL(*mock_app_, help_prompt()).WillOnce(Return(so_help_prompt.get()));
+
+  // mobile_apis::GlobalProperty::TIMEOUTPROMPT:
+  std::vector<std::string> time_out_prompt_default_vector;
+  time_out_prompt_default_vector.push_back(kTimeOutPromptTestValue);
+  EXPECT_CALL(app_mngr_settings_, time_out_promt())
+      .WillOnce(ReturnRef(time_out_prompt_default_vector));
+
+  smart_objects::SmartObject time_out_prompt_map =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  time_out_prompt_map[am::strings::text] = time_out_prompt_default_vector[0];
+  time_out_prompt_map[am::strings::type] =
+      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+
+  smart_objects::SmartObject time_out_prompt_array =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  time_out_prompt_array[0] = time_out_prompt_map;
+  EXPECT_CALL(*mock_app_, set_timeout_prompt(time_out_prompt_array));
+
+  const smart_objects::SmartObjectSPtr so_time_out_prompt =
+      ::utils::MakeShared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  EXPECT_CALL(*mock_app_, timeout_prompt())
+      .WillOnce(Return(so_time_out_prompt.get()));
+
+  // mobile_apis::GlobalProperty::VRHELPTITLE:
+  EXPECT_CALL(*mock_app_, reset_vr_help_title());
+  EXPECT_CALL(*mock_app_, reset_vr_help());
+
+  const smart_objects::SmartObjectSPtr vr_help =
+      ::utils::MakeShared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  EXPECT_CALL(*mock_message_helper_, CreateAppVrHelp(_))
+      .WillOnce(Return(vr_help));
+
+  // mobile_apis::GlobalProperty::MENUNAME:
+  EXPECT_CALL(app_mngr_settings_, menu_title())
+      .WillOnce(ReturnRef(kMenuTitleTestValue));
+  ui_msg_params[am::hmi_request::menu_title] = kMenuTitleTestValue;
+  EXPECT_CALL(*mock_app_,
+              set_menu_title(ui_msg_params[am::hmi_request::menu_title]));
+
+  // mobile_apis::GlobalProperty::MENUICON:
+  smart_objects::SmartObject so_menu_icon =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  EXPECT_CALL(app_mngr_settings_, menu_icon())
+      .WillOnce(ReturnRef(kMenuIconTestValue));
+  so_menu_icon[am::strings::value] = kMenuIconTestValue;
+  ui_msg_params[am::hmi_request::menu_icon] = so_menu_icon;
+  EXPECT_CALL(*mock_app_, set_menu_icon(so_menu_icon));
+
+  // mobile_apis::GlobalProperty::KEYBOARDPROPERTIES:
+  smart_objects::SmartObject key_board_properties =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  key_board_properties[am::strings::language] =
+      static_cast<int32_t>(hmi_apis::Common_Language::EN_US);
+  key_board_properties[am::hmi_request::keyboard_layout] =
+      static_cast<int32_t>(hmi_apis::Common_KeyboardLayout::QWERTY);
+  key_board_properties[am::hmi_request::auto_complete_text] = "";
+  ui_msg_params[am::hmi_request::keyboard_properties] = key_board_properties;
+
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::UI_SetGlobalProperties)))
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::TTS_SetGlobalProperties)))
+      .WillOnce(Return(true));
+
+  command_->Run();
+}
+
+TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_InvalidEventId_UNSUCCESS) {
+  Event event(hmi_apis::FunctionID::INVALID_ENUM);
+
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  command_->on_event(event);
+}
+
+TEST_F(ResetGlobalPropertiesRequestTest,
+       OnEvent_UI_SetGlobalProperties_SUCCESS) {
+  Event event(hmi_apis::FunctionID::UI_SetGlobalProperties);
+  (*msg_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::SUCCESS;
+
+  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
+      mobile_apis::GlobalProperty::VRHELPTITLE;
+
+  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  // mobile_apis::GlobalProperty::VRHELPTITLE:
+  EXPECT_CALL(*mock_app_, reset_vr_help_title());
+  EXPECT_CALL(*mock_app_, reset_vr_help());
+
+  const smart_objects::SmartObjectSPtr vr_help =
+      utils::MakeShared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  EXPECT_CALL(*mock_message_helper_, CreateAppVrHelp(_))
+      .WillOnce(Return(vr_help));
+
+  command_->Run();
+
+  event.set_smart_object(*msg_);
+
+  EXPECT_CALL(app_mngr_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_apis::Result::eType::SUCCESS),
+                  am::commands::Command::ORIGIN_SDL));
+  EXPECT_CALL(*mock_app_, UpdateHash());
+
+  command_->on_event(event);
+}
+
+TEST_F(ResetGlobalPropertiesRequestTest,
+       OnEvent_TTS_SetGlobalProperties_SUCCESS) {
+  Event event(hmi_apis::FunctionID::TTS_SetGlobalProperties);
+  (*msg_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::UNSUPPORTED_RESOURCE;
+
+  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
+      mobile_apis::GlobalProperty::TIMEOUTPROMPT;
+  (*msg_)[am::strings::msg_params][am::strings::properties][1] =
+      mobile_apis::GlobalProperty::MENUNAME;
+
+  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  smart_objects::SmartObject ui_msg_params =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  // mobile_apis::GlobalProperty::TIMEOUTPROMPT:
+  std::vector<std::string> time_out_prompt_default_vector;
+  time_out_prompt_default_vector.push_back(kTimeOutPromptTestValue);
+  EXPECT_CALL(app_mngr_settings_, time_out_promt())
+      .WillOnce(ReturnRef(time_out_prompt_default_vector));
+
+  smart_objects::SmartObject time_out_prompt_map =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  time_out_prompt_map[am::strings::text] = time_out_prompt_default_vector[0];
+  time_out_prompt_map[am::strings::type] =
+      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+
+  smart_objects::SmartObject time_out_prompt_array =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  time_out_prompt_array[0] = time_out_prompt_map;
+  EXPECT_CALL(*mock_app_, set_timeout_prompt(time_out_prompt_array));
+
+  const smart_objects::SmartObjectSPtr so_time_out_prompt =
+      ::utils::MakeShared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  EXPECT_CALL(*mock_app_, timeout_prompt())
+      .WillOnce(Return(so_time_out_prompt.get()));
+
+  // mobile_apis::GlobalProperty::MENUNAME:
+  EXPECT_CALL(app_mngr_settings_, menu_title())
+      .WillOnce(ReturnRef(kMenuTitleTestValue));
+  ui_msg_params[am::hmi_request::menu_title] = kMenuTitleTestValue;
+  EXPECT_CALL(*mock_app_,
+              set_menu_title(ui_msg_params[am::hmi_request::menu_title]));
+
+  MessageSharedPtr ui_msg = CreateMessage();
+  (*ui_msg)[am::strings::params][am::strings::correlation_id] = kCorrelationId;
+  (*ui_msg)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::SUCCESS;
+  (*ui_msg)[am::strings::params][am::strings::msg_params] = ui_msg_params;
+
+  Event ui_event(hmi_apis::FunctionID::UI_SetGlobalProperties);
+  ui_event.set_smart_object(*ui_msg);
+
+  command_->Run();
+  command_->on_event(ui_event);
+  event.set_smart_object(*msg_);
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::WARNINGS),
+                          am::commands::Command::ORIGIN_SDL));
+  EXPECT_CALL(*mock_app_, UpdateHash());
+
+  command_->on_event(event);
+}
+
+TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_PendingRequest_UNSUCCESS) {
+  Event event(hmi_apis::FunctionID::UI_SetGlobalProperties);
+  event.set_smart_object(*msg_);
+
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
+  EXPECT_CALL(*mock_app_, UpdateHash()).Times(0);
+
+  command_->on_event(event);
+}
+
+TEST_F(ResetGlobalPropertiesResponseTest, Run_Sendmsg_SUCCESS) {
+  MessageSharedPtr message(CreateMessage());
+  ResetGlobalPropertiesResponsePtr command(
+      CreateCommand<ResetGlobalPropertiesResponse>(message));
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(message, _));
+  command->Run();
+}
+
+TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_InvalidApp_UNSUCCESS) {
+  Event event(hmi_apis::FunctionID::UI_SetGlobalProperties);
+  (*msg_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::SUCCESS;
+
+  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
+      mobile_apis::GlobalProperty::VRHELPTITLE;
+
+  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  // mobile_apis::GlobalProperty::VRHELPTITLE:
+  EXPECT_CALL(*mock_app_, reset_vr_help_title());
+  EXPECT_CALL(*mock_app_, reset_vr_help());
+
+  const smart_objects::SmartObjectSPtr vr_help =
+      utils::MakeShared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  EXPECT_CALL(*mock_message_helper_, CreateAppVrHelp(_))
+      .WillOnce(Return(vr_help));
+
+  command_->Run();
+
+  event.set_smart_object(*msg_);
+
+  EXPECT_CALL(app_mngr_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_apis::Result::eType::SUCCESS),
+                  am::commands::Command::ORIGIN_SDL));
+
+  MockAppPtr invalid_app;
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(invalid_app));
+
+  EXPECT_CALL(*mock_app_, UpdateHash()).Times(0);
+
+  command_->on_event(event);
+}
+
+}  // namespace reset_global_properties
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -632,6 +632,16 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   const bool enable_app_launch_ios() const OVERRIDE;
 
   /**
+   * @brief Returns menu title
+   */
+  const std::string& menu_title() const OVERRIDE;
+
+  /**
+   * @brief Returns path to menu icon
+   */
+  const std::string& menu_icon() const OVERRIDE;
+
+  /*
    * @brief Updates all related values from ini file
    */
   void UpdateValues();
@@ -887,6 +897,8 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   uint16_t max_number_of_ios_device_;
   uint16_t wait_time_between_apps_;
   bool enable_app_launch_ios_;
+  std::string menu_title_;
+  std::string menu_icon_;
   bool error_occured_;
   std::string error_description_;
 

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -199,7 +199,6 @@ const char* kUseDBForResumptionKey = "UseDBForResumption";
 const char* kAttemptsToOpenResumptionDBKey = "AttemptsToOpenResumptionDB";
 const char* kOpenAttemptTimeoutMsResumptionDBKey =
     "OpenAttemptTimeoutMsResumptionDB";
-
 const char* kAppLaunchWaitTimeKey = "AppLaunchWaitTime";
 const char* kAppLaunchMaxRetryAttemptKey = "AppLaunchMaxRetryAttempt";
 const char* kAppLaunchRetryWaitTimeKey = "AppLaunchRetryWaitTime";
@@ -207,6 +206,8 @@ const char* kRemoveBundleIDattemptsKey = "RemoveBundleIDattempts";
 const char* kMaxNumberOfiOSDeviceKey = "MaxNumberOfiOSDevice";
 const char* kWaitTimeBetweenAppsKey = "WaitTimeBetweenApps";
 const char* kEnableAppLaunchIOSKey = "EnableAppLaunchIOS";
+const char* kMenuTitleKey = "MenuTitle";
+const char* kMenuIconKey = "MenuIcon";
 #ifdef WEB_HMI
 const char* kDefaultLinkToWebHMI = "HMI/index.html";
 #endif  // WEB_HMI
@@ -230,6 +231,8 @@ const char* kDefaultHubProtocolMask = "com.smartdevicelink.prot";
 const char* kDefaultPoolProtocolMask = "com.smartdevicelink.prot";
 const char* kDefaultIAPSystemConfig = "/fs/mp/etc/mm/ipod.cfg";
 const char* kDefaultIAP2SystemConfig = "/fs/mp/etc/mm/iap2.cfg";
+const char* kDefaultMenuTitle = "MENU";
+const char* kDefaultMenuIcon = "";
 
 #ifdef ENABLE_SECURITY
 const char* kDefaultSecurityProtocol = "TLSv1.2";
@@ -387,6 +390,8 @@ Profile::Profile()
     , max_number_of_ios_device_(kDefaultMaxNumberOfiOSDevice)
     , wait_time_between_apps_(kDefaultWaitTimeBetweenApps)
     , enable_app_launch_ios_(kDefaultEnableAppLaunchIOS)
+    , menu_title_(kDefaultMenuTitle)
+    , menu_icon_(kDefaultMenuIcon)
     , error_occured_(false)
     , error_description_() {
   // SDL version
@@ -871,6 +876,14 @@ const uint16_t Profile::app_launch_wait_time() const {
 
 const bool Profile::enable_app_launch_ios() const {
   return enable_app_launch_ios_;
+}
+
+const std::string& Profile::menu_title() const {
+  return menu_title_;
+}
+
+const std::string& Profile::menu_icon() const {
+  return menu_icon_;
 }
 
 const uint16_t Profile::max_number_of_ios_device() const {
@@ -1829,6 +1842,20 @@ void Profile::UpdateValues() {
 
   LOG_UPDATED_BOOL_VALUE(
       enable_app_launch_ios_, kEnableAppLaunchIOSKey, kAppLaunchSection);
+
+  // Menu title
+  ReadStringValue(&menu_title_,
+                  kDefaultMenuTitle,
+                  kApplicationManagerSection,
+                  kMenuTitleKey);
+
+  LOG_UPDATED_VALUE(menu_title_, kMenuTitleKey, kApplicationManagerSection);
+
+  // Menu icon
+  ReadStringValue(
+      &menu_icon_, kDefaultMenuIcon, kApplicationManagerSection, kMenuIconKey);
+
+  LOG_UPDATED_VALUE(menu_icon_, kMenuIconKey, kApplicationManagerSection);
 }
 
 bool Profile::ReadValue(bool* value,

--- a/src/components/config_profile/test/profile_test.cc
+++ b/src/components/config_profile/test/profile_test.cc
@@ -200,10 +200,12 @@ TEST_F(ProfileTest, UpdateBoolValues) {
 TEST_F(ProfileTest, UpdateStringValue) {
   // Default values
   std::string recording_file_name = "record.wav";
+  std::string server_address = "127.0.0.1";
+  std::string app_resource_folder = "";
   std::string tts_delimiter_ = "";
   std::string vr_help_title_ = "";
-  std::string app_resource_folder = "";
-  std::string server_address = "127.0.0.1";
+  std::string menu_title = "";
+  std::string menu_icon;
 
   EXPECT_EQ(recording_file_name, profile_.recording_file_name());
   EXPECT_EQ(server_address, profile_.server_address());
@@ -218,7 +220,9 @@ TEST_F(ProfileTest, UpdateStringValue) {
   EXPECT_EQ(tts_delimiter_, profile_.tts_delimiter());
   vr_help_title_ = "Available Vr Commands List";
   EXPECT_EQ(vr_help_title_, profile_.vr_help_title());
-  EXPECT_EQ(server_address, profile_.server_address());
+  menu_title = "MENU";
+  EXPECT_EQ(menu_title, profile_.menu_title());
+  EXPECT_EQ(menu_icon, profile_.menu_icon());
 
   // Update config file
   profile_.UpdateValues();
@@ -227,6 +231,8 @@ TEST_F(ProfileTest, UpdateStringValue) {
   EXPECT_EQ(tts_delimiter_, profile_.tts_delimiter());
   EXPECT_EQ(vr_help_title_, profile_.vr_help_title());
   EXPECT_EQ(server_address, profile_.server_address());
+  EXPECT_EQ(menu_title, profile_.menu_title());
+  EXPECT_EQ(menu_icon, profile_.menu_icon());
 }
 
 TEST_F(ProfileTest, UpdateInt_ValueAppearsInFileTwice) {

--- a/src/components/config_profile/test/smartDeviceLink.ini
+++ b/src/components/config_profile/test/smartDeviceLink.ini
@@ -168,6 +168,10 @@ FrequencyTime = 1000
 ApplicationListUpdateTimeout = 2
 ; Max allowed threads for handling mobile requests. Currently max allowed is 2
 ThreadPoolSize = 1
+; Menu title default text
+MenuTitle = MENU
+; Default path to menu icon, if this parameter is empty - the icon does not exist and no icon should be displayed
+MenuIcon =
 
 [Resumption]
 

--- a/src/components/include/application_manager/application_manager_settings.h
+++ b/src/components/include/application_manager/application_manager_settings.h
@@ -86,6 +86,8 @@ class ApplicationManagerSettings : public RequestControlerSettings,
   virtual const uint32_t& app_resuming_timeout() const = 0;
   virtual uint16_t attempts_to_open_resumption_db() const = 0;
   virtual uint16_t open_attempt_timeout_ms_resumption_db() const = 0;
+  virtual const std::string& menu_title() const = 0;
+  virtual const std::string& menu_icon() const = 0;
   virtual void set_config_file_name(const std::string& fileName) = 0;
   virtual const std::pair<uint32_t, int32_t>& start_stream_retry_amount()
       const = 0;

--- a/src/components/include/test/application_manager/mock_application_manager_settings.h
+++ b/src/components/include/test/application_manager/mock_application_manager_settings.h
@@ -94,6 +94,8 @@ class MockApplicationManagerSettings
   MOCK_CONST_METHOD0(app_resuming_timeout, const uint32_t&());
   MOCK_CONST_METHOD0(attempts_to_open_resumption_db, uint16_t());
   MOCK_CONST_METHOD0(open_attempt_timeout_ms_resumption_db, uint16_t());
+  MOCK_CONST_METHOD0(menu_title, const std::string&());
+  MOCK_CONST_METHOD0(menu_icon, const std::string&());
   MOCK_METHOD1(set_config_file_name, void(const std::string& fileName));
   // The following line won't really compile, as the return
   // type has multiple template arguments.  To fix it, use a


### PR DESCRIPTION
Added new parameters 'menuIcon' and 'menuTitle' to the .ini file.
Added to SDL ability to read default values for those parameters from ini file.
Also added to SDL resetting of those parameters in ResetGlobalProperties request.

Reopened from PR: #931 (Moved feature from branch "feature/pre_5.0" to branch "develop")
