### PR TITLE
Fix issues related to UTs on CI 

### DIFF
--- a/src/components/application_manager/test/commands/mobile/speak_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/speak_request_test.cc
@@ -75,8 +75,15 @@ using ::test::components::application_manager_test::MockApplication;
 class SpeakRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
   SpeakRequestTest()
-      : request_(CreateMessage(smart_objects::SmartType_Map))
-      , response_(CreateMessage(smart_objects::SmartType_Map)) {}
+      : mock_message_helper_(*am::MockMessageHelper::message_helper_mock())
+      , request_(CreateMessage(smart_objects::SmartType_Map))
+      , response_(CreateMessage(smart_objects::SmartType_Map)) {
+    testing::Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+
+  ~SpeakRequestTest() {
+    testing::Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
 
   MessageSharedPtr ManageResponse() {
     return response_;
@@ -126,6 +133,8 @@ class SpeakRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
               static_cast<int32_t>(mobile_response));
   }
 
+  am::MockMessageHelper& mock_message_helper_;
+
  private:
   MessageSharedPtr request_;
   MessageSharedPtr response_;
@@ -147,6 +156,9 @@ TEST_F(SpeakRequestTest, OnEvent_SUCCESS_Expect_true) {
 
   MessageSharedPtr response_to_mobile;
 
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
   EXPECT_CALL(
       app_mngr_,
       ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))

--- a/src/components/transport_manager/src/bluetooth/bluetooth_connection_factory.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_connection_factory.cc
@@ -59,6 +59,8 @@ TransportAdapter::Error BluetoothConnectionFactory::CreateConnection(
                                       << ", app_handle: " << &app_handle);
   BluetoothSocketConnection* connection(
       new BluetoothSocketConnection(device_uid, app_handle, controller_));
+  controller_->ConnectionCreated(connection, device_uid, app_handle);
+
   TransportAdapter::Error error = connection->Start();
   if (TransportAdapter::OK != error) {
     LOG4CXX_ERROR(logger_, "connection::Start() failed");

--- a/src/components/transport_manager/src/tcp/tcp_connection_factory.cc
+++ b/src/components/transport_manager/src/tcp/tcp_connection_factory.cc
@@ -57,6 +57,8 @@ TransportAdapter::Error TcpConnectionFactory::CreateConnection(
   TcpServerOiginatedSocketConnection* connection(
       new TcpServerOiginatedSocketConnection(
           device_uid, app_handle, controller_));
+  controller_->ConnectionCreated(connection, device_uid, app_handle);
+
   if (connection->Start() == TransportAdapter::OK) {
     LOG4CXX_DEBUG(logger_, "TCP connection initialised");
     return TransportAdapter::OK;

--- a/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
+++ b/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
@@ -162,7 +162,6 @@ TransportAdapter::Error ThreadedSocketConnection::Disconnect() {
 
 void ThreadedSocketConnection::threadMain() {
   LOG4CXX_AUTO_TRACE(logger_);
-  controller_->ConnectionCreated(this, device_handle(), application_handle());
   ConnectError* connect_error = NULL;
   if (!Establish(&connect_error)) {
     LOG4CXX_ERROR(logger_, "Connection Establish failed");

--- a/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
+++ b/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
@@ -281,9 +281,11 @@ TransportAdapter::Error TransportAdapterImpl::DisconnectDevice(
        j != to_disconnect.end();
        ++j) {
     ConnectionInfo info = *j;
-    if (OK != info.connection->Disconnect()) {
-      error = FAIL;
-      LOG4CXX_ERROR(logger_, "Error on disconnect " << error);
+    if (info.connection) {
+      if (OK != info.connection->Disconnect()) {
+        error = FAIL;
+        LOG4CXX_ERROR(logger_, "Error on disconnect " << error);
+      }
     }
   }
 

--- a/src/components/utils/src/push_log.cc
+++ b/src/components/utils/src/push_log.cc
@@ -92,11 +92,13 @@ void delete_log_message_loop_thread() {
 }
 
 void flush_logger() {
-  logger::LoggerStatus old_status = logger::logger_status;
   // Stop pushing new messages to the log queue
-  logger::logger_status = logger::DeletingLoggerThread;
-  log_message_loop_thread->WaitDumpQueue();
-  logger::logger_status = old_status;
+  if (logger::logger_status != LoggerThreadNotCreated) {
+    logger::LoggerStatus old_status = logger::logger_status;
+    logger::logger_status = logger::DeletingLoggerThread;
+    log_message_loop_thread->WaitDumpQueue();
+    logger::logger_status = old_status;
+  }
 }
 
 }  // namespace logger


### PR DESCRIPTION
Added missed MockMessageHelper expectations into SpeakRequestTest;
Added check if logger is available during call of flush_logger method;
Eliminated possibility to try stopping uninitialized connection in TransportManager UT.

Related to: [APPLINK-30284](https://adc.luxoft.com/jira/browse/APPLINK-30284)