### PR TITLE
Fixes policy update status changing

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1418,6 +1418,18 @@ void ApplicationManagerImpl::SendMessageToMobile(
                                  << ") not allowed by policy");
       return;
     }
+
+#ifdef EXTERNAL_PROPRIETARY
+    if (function_id == mobile_apis::FunctionID::OnSystemRequestID) {
+      mobile_apis::RequestType::eType request_type =
+          static_cast<mobile_apis::RequestType::eType>(
+              (*message)[strings::msg_params][strings::request_type].asUInt());
+      if (mobile_apis::RequestType::PROPRIETARY == request_type ||
+          mobile_apis::RequestType::HTTP == request_type) {
+        GetPolicyHandler().OnUpdateRequestSentToMobile();
+      }
+    }
+#endif  // EXTERNAL_PROPRIETARY
   }
 
   if (message_to_send->binary_data()) {


### PR DESCRIPTION
During sending out of snapshot with OnSystemRequest policy has set status UPDATING and notify HMI in case prior state was different.

Closes-bug: APPLINK-30383