### PR TITLE
Add appID in SystemRequest to HMI

### DIFF
--- a/src/components/application_manager/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/src/commands/mobile/system_request.cc
@@ -578,9 +578,9 @@ void SystemRequest::Run() {
     msg_params[strings::file_name] = file_dst_path;
   }
 
-  if (mobile_apis::RequestType::PROPRIETARY != request_type) {
-    msg_params[strings::app_id] = (application->policy_app_id());
-  }
+  // expected int, mandatory=true, all Policies flow (HTTP,Proprietary,External)
+  msg_params[strings::app_id] = application->hmi_app_id();
+
   msg_params[strings::request_type] =
       (*message_)[strings::msg_params][strings::request_type];
   SendHMIRequest(hmi_apis::FunctionID::BasicCommunication_SystemRequest,

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -2130,7 +2130,7 @@
     </function>
 </interface>
 
-<interface name="BasicCommunication" version="1.0" date="2013-04-12">
+<interface name="BasicCommunication" version="1.1" date="2016-12-01">
     <function name="OnReady" messagetype="notification">
       <description>HMI must notify SDL about its readiness to start communication. In fact, this has to be the first message between SDL and HMI.</description>
     </function>
@@ -2356,8 +2356,8 @@
       <param name="fileName" type="String" maxlength="255" minlength="1" mandatory="true">
           <description>The path to file.</description>
       </param>
-      <param name="appID" type="Integer" mandatory="false">
-        <description>ID of application that requested this RPC.</description>
+      <param name="appID" type="Integer" mandatory="true">
+        <description>Internal ID of the application that requested this RPC.</description>
       </param>
     </function>
     <function name="SystemRequest" messagetype="response">


### PR DESCRIPTION
Added hmi_appID as appID in SystemRequest to HMI.
Made appID mandatory=true in SystemRequest in HMI_API.xml.

Related to [APPLINK-30384](https://adc.luxoft.com/jira/browse/APPLINK-30384).