### PR TITLE
Fixes policy update status in case of non-consented device

### DIFF
--- a/src/components/policy/policy_external/include/policy/update_status_manager.h
+++ b/src/components/policy/policy_external/include/policy/update_status_manager.h
@@ -96,13 +96,19 @@ class UpdateStatusManager {
   /**
    * @brief Update status handler on new application registering
    */
-  void OnNewApplicationAdded();
+  void OnNewApplicationAdded(const DeviceConsent consent);
 
   /**
    * @brief Update status handler for policy initialization
    * @param is_update_required Update necessity flag
    */
   void OnPolicyInit(bool is_update_required);
+
+  /**
+   * @brief In case application from non-consented device has been registered
+   * before and and no updated happened then triggers status change
+   */
+  void OnDeviceConsented();
 
   /**
    * @brief IsUpdateRequired allows to distiguish if update is required
@@ -198,6 +204,7 @@ class UpdateStatusManager {
   bool update_scheduled_;
   bool exchange_pending_;
   bool apps_search_in_progress_;
+  bool app_registered_from_non_consented_device_;
   sync_primitives::Lock exchange_in_progress_lock_;
   sync_primitives::Lock update_required_lock_;
   sync_primitives::Lock exchange_pending_lock_;

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -548,6 +548,9 @@ void PolicyManagerImpl::SetUserConsentForDevice(const std::string& device_id,
                  "Event listener is not initialized. "
                  "Can't call OnDeviceConsentChanged");
   }
+  if (is_allowed) {
+    update_status_manager_.OnDeviceConsented();
+  }
   StartPTExchange();
 }
 
@@ -1194,7 +1197,7 @@ void PolicyManagerImpl::AddApplication(const std::string& application_id) {
 
   if (IsNewApplication(application_id)) {
     AddNewApplication(application_id, device_consent);
-    update_status_manager_.OnNewApplicationAdded();
+    update_status_manager_.OnNewApplicationAdded(device_consent);
   } else {
     PromoteExistedApplication(application_id, device_consent);
   }

--- a/src/components/policy/policy_external/src/update_status_manager.cc
+++ b/src/components/policy/policy_external/src/update_status_manager.cc
@@ -45,7 +45,7 @@ UpdateStatusManager::UpdateStatusManager()
     , update_scheduled_(false)
     , exchange_pending_(false)
     , apps_search_in_progress_(false)
-    , app_registered_from_non_consented_device_(false)
+    , app_registered_from_non_consented_device_(true)
     , last_update_status_(policy::StatusUnknown) {
   update_status_thread_delegate_ = new UpdateThreadDelegate(this);
   thread_ = threads::CreateThread("UpdateStatusThread",

--- a/src/components/policy/policy_external/test/include/policy/mock_update_status_manager.h
+++ b/src/components/policy/policy_external/test/include/policy/mock_update_status_manager.h
@@ -49,7 +49,7 @@ class MockUpdateStatusManager : public ::policy::UpdateStatusManager {
   MOCK_METHOD0(OnWrongUpdateReceived, void());
   MOCK_METHOD1(OnResetDefaultPT, void(bool is_update_required));
   MOCK_METHOD0(OnResetRetrySequence, void());
-  MOCK_METHOD0(OnNewApplicationAdded, void());
+  MOCK_METHOD1(OnNewApplicationAdded, void(const DeviceConsent));
   MOCK_METHOD1(OnPolicyInit, void(bool is_update_required));
   MOCK_METHOD0(GetUpdateStatus, PolicyTableStatus());
 };

--- a/src/components/policy/policy_external/test/policy_manager_impl_user_consent_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_user_consent_test.cc
@@ -68,9 +68,9 @@ TEST_F(
   // To set UP_TO_DATE before registration
   GetPTU(kValidSdlPtUpdateJson);
 
-  TimevalStruct current_time = date_time::DateTime::getCurrentTime();
+  const TimevalStruct current_time = date_time::DateTime::getCurrentTime();
   const int kSecondsInDay = 60 * 60 * 24;
-  int days_after_epoch = current_time.tv_sec / kSecondsInDay;
+  const int days_after_epoch = current_time.tv_sec / kSecondsInDay;
 
   manager_->PTUpdatedAt(DAYS_AFTER_EPOCH, days_after_epoch);
   manager_->PTUpdatedAt(KILOMETERS, 1000);

--- a/src/components/policy/policy_external/test/update_status_manager_test.cc
+++ b/src/components/policy/policy_external/test/update_status_manager_test.cc
@@ -150,7 +150,7 @@ TEST_F(UpdateStatusManagerTest,
   manager_->OnUpdateSentOut(k_timeout_);
   status_ = manager_->GetLastUpdateStatus();
   EXPECT_EQ(StatusUpdatePending, status_);
-  manager_->OnNewApplicationAdded();
+  manager_->OnNewApplicationAdded(kDeviceAllowed);
   status_ = manager_->GetLastUpdateStatus();
   // Checks
   EXPECT_EQ(StatusUpdatePending, status_);


### PR DESCRIPTION
In case application is registered on non-consented device SDL does not
have to set UPDATE_NEEDED status, but only after device is consented.

Relates-to: APPLINK-30368