### PR TITLE
Fix behavior get user friendly message

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -583,8 +583,18 @@ void PolicyHandler::OnGetUserFriendlyMessage(
     uint32_t correlation_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK_VOID();
-  std::vector<UserFriendlyMessage> result =
+
+#ifdef EXTERNAL_PROPRIETARY
+  const std::string active_hmi_language =
+      application_manager::MessageHelper::CommonLanguageToString(
+          application_manager_.hmi_capabilities().active_ui_language());
+  const std::vector<UserFriendlyMessage> result =
+      policy_manager_->GetUserFriendlyMessages(
+          message_codes, language, active_hmi_language);
+#else
+  const std::vector<UserFriendlyMessage> result =
       policy_manager_->GetUserFriendlyMessages(message_codes, language);
+#endif  // EXTERNAL_PROPRIETARY
   // Send response to HMI with gathered data
   MessageHelper::SendGetUserFriendlyMessageResponse(
       result, correlation_id, application_manager_);

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -281,7 +281,8 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    */
   virtual std::vector<UserFriendlyMessage> GetUserFriendlyMessages(
       const std::vector<std::string>& message_code,
-      const std::string& language) = 0;
+      const std::string& language,
+      const std::string& active_hmi_language) = 0;
 
   /**
    * Checks if the application is revoked

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -116,10 +116,11 @@ class MockPolicyManager : public PolicyManager {
   MOCK_CONST_METHOD2(GetPriority,
                      bool(const std::string& policy_app_id,
                           std::string* priority));
-  MOCK_METHOD2(GetUserFriendlyMessages,
+  MOCK_METHOD3(GetUserFriendlyMessages,
                std::vector<policy::UserFriendlyMessage>(
                    const std::vector<std::string>& message_code,
-                   const std::string& language));
+                   const std::string& language,
+                   const std::string& active_hmi_language));
   MOCK_CONST_METHOD1(IsApplicationRevoked, bool(const std::string& app_id));
   MOCK_METHOD3(
       GetPermissionsForApp,

--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -145,11 +145,15 @@ class CacheManager : public CacheManagerInterface {
    * dependent on language and context.
    * @param msg_codes Context of message (Driver distraction, Grant permission
    * etc)
-   * @param language Language of the message
+   * @param language Requested language of the message
+   * @param active_hmi_language Last language has been received
+   * via UI.GetLanguage (used as first fallback language)
    * @return Array of appropriate messages parameters
    */
   std::vector<UserFriendlyMessage> GetUserFriendlyMsg(
-      const std::vector<std::string>& msg_codes, const std::string& language);
+      const std::vector<std::string>& msg_codes,
+      const std::string& language,
+      const std::string& active_hmi_language);
 
   /**
    * @brief GetLockScreenIcon allows to obtain lock screen icon url;

--- a/src/components/policy/policy_external/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager_interface.h
@@ -144,7 +144,8 @@ class CacheManagerInterface {
    */
   virtual std::vector<UserFriendlyMessage> GetUserFriendlyMsg(
       const std::vector<std::string>& msg_codes,
-      const std::string& language) = 0;
+      const std::string& language,
+      const std::string& active_hmi_language) = 0;
 
   /**
    * @brief Get list of URL to send PTS to

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -118,7 +118,8 @@ class PolicyManagerImpl : public PolicyManager {
 
   virtual std::vector<UserFriendlyMessage> GetUserFriendlyMessages(
       const std::vector<std::string>& message_code,
-      const std::string& language);
+      const std::string& language,
+      const std::string& active_hmi_language);
 
   virtual bool IsApplicationRevoked(const std::string& app_id) const;
 

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -772,8 +772,11 @@ bool PolicyManagerImpl::GetPriority(const std::string& policy_app_id,
 }
 
 std::vector<UserFriendlyMessage> PolicyManagerImpl::GetUserFriendlyMessages(
-    const std::vector<std::string>& message_code, const std::string& language) {
-  return cache_->GetUserFriendlyMsg(message_code, language);
+    const std::vector<std::string>& message_code,
+    const std::string& language,
+    const std::string& active_hmi_language) {
+  return cache_->GetUserFriendlyMsg(
+      message_code, language, active_hmi_language);
 }
 
 void PolicyManagerImpl::GetUserConsentForApp(

--- a/src/components/policy/policy_external/test/include/policy/mock_cache_manager.h
+++ b/src/components/policy/policy_external/test/include/policy/mock_cache_manager.h
@@ -83,10 +83,11 @@ class MockCacheManagerInterface : public ::policy::CacheManagerInterface {
   MOCK_CONST_METHOD1(GetCachedDeviceConsent,
                      DeviceConsent(const std::string& device_id));
   MOCK_METHOD1(SetVINValue, bool(const std::string& value));
-  MOCK_METHOD2(GetUserFriendlyMsg,
+  MOCK_METHOD3(GetUserFriendlyMsg,
                std::vector<UserFriendlyMessage>(
                    const std::vector<std::string>& msg_codes,
-                   const std::string& language));
+                   const std::string& language,
+                   const std::string& active_hmi_language));
   MOCK_METHOD2(GetUpdateUrls,
                void(const std::string& service_type,
                     EndpointUrls& out_end_points));

--- a/src/components/policy/policy_external/test/policy_manager_impl_user_consent_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_user_consent_test.cc
@@ -368,8 +368,10 @@ TEST_F(PolicyManagerImplTest2,
   message_code.push_back("SettingEnableUpdates");
   message_code.push_back("AppPermissions");
   const std::string language = "en-us";
+  const std::string active_hmi_language = language;
   std::vector< ::policy::UserFriendlyMessage> result =
-      manager_->GetUserFriendlyMessages(message_code, language);
+      manager_->GetUserFriendlyMessages(
+          message_code, language, active_hmi_language);
   uint32_t size = result.size();
   EXPECT_GT(size, 0u);
   std::vector< ::policy::UserFriendlyMessage>::iterator result_iter;

--- a/src/components/policy/policy_external/test/sql_pt_representation_test.cc
+++ b/src/components/policy/policy_external/test/sql_pt_representation_test.cc
@@ -1095,7 +1095,7 @@ TEST(SQLPTRepresentationTest3,
      Init_TryInitNotExistingDataBase_ExpectResultFail) {
   // Arrange
   NiceMock<policy_handler_test::MockPolicySettings> policy_settings_;
-  const std::string not_existing_path = "/not/existing/path"
+  const std::string not_existing_path = "/not/existing/path";
   ON_CALL(policy_settings_, app_storage_folder())
       .WillByDefault(ReturnRef(not_existing_path));
   SQLPTRepresentation reps;


### PR DESCRIPTION
SDL must use language which was got via UI.GetLanguage response from HMI

Updated policy_manager, cache_manager for external_policy
Added processing of active hmi language to cache_mamanager impl.

Related defect : [APPLINK-30398](https://adc.luxoft.com/jira/browse/APPLINK-30398)