### PR TITLE
Fixed double calling of UpdateDeviceList

### DIFF
--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -173,6 +173,7 @@ void ConnectionHandlerImpl::OnDeviceRemoved(
   sync_primitives::AutoReadLock read_lock(connection_handler_observer_lock_);
   if (connection_handler_observer_) {
     connection_handler_observer_->RemoveDevice(device_info.device_handle());
+    connection_handler_observer_->OnDeviceListUpdated(device_list_);
   }
 }
 

--- a/src/components/transport_manager/src/transport_manager_impl.cc
+++ b/src/components/transport_manager/src/transport_manager_impl.cc
@@ -693,7 +693,6 @@ void TransportManagerImpl::OnDeviceListUpdated(TransportAdapter* ta) {
     device_infos.push_back(it->second);
   }
   device_list_lock_.Release();
-  RaiseEvent(&TransportManagerListener::OnDeviceListUpdated, device_infos);
   LOG4CXX_TRACE(logger_, "exit");
 }
 

--- a/src/components/transport_manager/test/transport_manager_impl_test.cc
+++ b/src/components/transport_manager/test/transport_manager_impl_test.cc
@@ -126,7 +126,6 @@ class TransportManagerImplTest : public ::testing::Test {
 
     EXPECT_CALL(*tm_listener_, OnDeviceFound(dev_info_));
     EXPECT_CALL(*tm_listener_, OnDeviceAdded(dev_info_));
-    EXPECT_CALL(*tm_listener_, OnDeviceListUpdated(vector_dev_info));
 
     tm_.TestHandle(test_event);
     device_list_.pop_back();
@@ -717,7 +716,6 @@ TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_DeviceListUpdated) {
 
   EXPECT_CALL(*tm_listener_, OnDeviceFound(dev_info_));
   EXPECT_CALL(*tm_listener_, OnDeviceAdded(dev_info_));
-  EXPECT_CALL(*tm_listener_, OnDeviceListUpdated(vector_dev_info));
 
   tm_.ReceiveEventFromDevice(test_event);
   device_list_.pop_back();


### PR DESCRIPTION
Removed triggered event from TransportManager
UpdateDeviceList will be called from AddDevice, RemoveDevice in ConnectionHandlerImpl

Fixed defect :[ APPLINK-30437](https://adc.luxoft.com/jira/browse/APPLINK-30437)


