### PR TITLE
Fix SDL BC.ActivateApp for NONE level

### DIFF
--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -95,9 +95,7 @@ void StateControllerImpl::SetRegularState(ApplicationSharedPtr app,
       static_cast<hmi_apis::Common_HMILevel::eType>(
           resolved_state->hmi_level());
 
-  const bool is_full_allowed = (hmi_apis::Common_HMILevel::FULL == hmi_level);
-
-  if (send_activate_app && is_full_allowed) {
+  if (send_activate_app) {
     const int64_t corr_id = SendBCActivateApp(app, hmi_level, true);
     if (-1 != corr_id) {
       subscribe_on_event(hmi_apis::FunctionID::BasicCommunication_ActivateApp,


### PR DESCRIPTION
Fixed problem that _SDL BC.ActivateApp_ wasn't sent in case of user replies
"NO" for data consent prompt.
The problem was in additional check that _SDL BC.ActivateApp_ could be sent only if
HMI level was **FULL**. But in case of negative user reply HMI level must be **NONE**.
Therefore this check was deleted.

Related: [APPLINK-30617](https://adc.luxoft.com/jira/browse/APPLINK-30617)