### PR TITLE
Fix HMI level resumption for COMMUNICATION apps

### DIFF
--- a/src/components/application_manager/src/hmi_state.cc
+++ b/src/components/application_manager/src/hmi_state.cc
@@ -175,7 +175,7 @@ mobile_apis::HMILevel::eType AudioSource::hmi_level() const {
                                         HMILevel::HMI_NONE)) {
     return parent()->hmi_level();
   }
-  if (is_navi_app(app_id_)) {
+  if (is_navi_app(app_id_) || is_voice_communication_app(app_id_)) {
     return HMILevel::HMI_LIMITED;
   }
   return HMILevel::HMI_BACKGROUND;


### PR DESCRIPTION
After COMMUNICATION application resumption due
to lost Wi-Fi connection from LIMITED HMI level,
the application resumes in BACKGROUND HMI level

When an AudioSource HMI state is created, if the
application is of type COMMUNICATIONS, it gets
LIMITED HMI level.

Related Issue: [APPLINK-24767](https://adc.luxoft.com/jira/browse/APPLINK-24767)