### PR TITLE
Fixes status changing sequence

### DIFF
--- a/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
@@ -100,12 +100,12 @@ TEST_F(OnSystemRequestNotificationTest, Run_ProprietaryType_SUCCESS) {
   EXPECT_CALL(mock_policy_handler, IsRequestTypeAllowed(_, _))
       .WillOnce(Return(true));
 
-#if defined(EXTENDED_POLICY) || defined(EXTERNAL_PROPRIETARY)
+#if defined(EXTENDED_POLICY)
   EXPECT_CALL(app_mngr_, GetPolicyHandler())
       .Times(2)
       .WillRepeatedly(ReturnRef(mock_policy_handler));
   EXPECT_CALL(mock_policy_handler, TimeoutExchange()).WillOnce(Return(5u));
-#endif  // EXTENDED_POLICY || EXTERNAL_PROPRIETARY
+#endif  // EXTENDED_POLICY
 
   EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
   EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));

--- a/src/components/policy/policy_external/src/update_status_manager.cc
+++ b/src/components/policy/policy_external/src/update_status_manager.cc
@@ -89,8 +89,17 @@ void UpdateStatusManager::OnUpdateTimeoutOccurs() {
 void UpdateStatusManager::OnValidUpdateReceived() {
   LOG4CXX_AUTO_TRACE(logger_);
   update_status_thread_delegate_->updateTimeOut(0);  // Stop Timer
+  const bool is_another_update_planned = IsUpdateRequired();
+  if (is_another_update_planned) {
+    set_update_required(false);
+  }
+
   set_exchange_pending(false);
   set_exchange_in_progress(false);
+
+  if (is_another_update_planned) {
+    set_update_required(true);
+  }
 }
 
 void UpdateStatusManager::OnWrongUpdateReceived() {

--- a/src/components/policy/policy_external/test/update_status_manager_test.cc
+++ b/src/components/policy/policy_external/test/update_status_manager_test.cc
@@ -34,24 +34,38 @@
 #include "policy/mock_policy_listener.h"
 #include "policy/policy_manager_impl.h"
 #include "policy/update_status_manager.h"
+#include "utils/make_shared.h"
 
 namespace test {
 namespace components {
 namespace policy_test {
 
 using namespace ::policy;
+using ::testing::_;
+using ::testing::Return;
 
 class UpdateStatusManagerTest : public ::testing::Test {
  protected:
   UpdateStatusManager* manager_;
   PolicyTableStatus status_;
   const uint32_t k_timeout_;
+  utils::SharedPtr<MockPolicyListener> listener_;
+  const std::string up_to_date_status_;
+  const std::string update_needed_status_;
+  const std::string updating_status_;
 
  public:
-  UpdateStatusManagerTest() : k_timeout_(1) {}
+  UpdateStatusManagerTest()
+      : k_timeout_(1)
+      , listener_(utils::MakeShared<MockPolicyListener>())
+      , up_to_date_status_("UP_TO_DATE")
+      , update_needed_status_("UPDATE_NEEDED")
+      , updating_status_("UPDATING") {}
 
   void SetUp() {
     manager_ = new UpdateStatusManager();
+    manager_->set_listener(listener_.get());
+    ON_CALL(*listener_, OnUpdateStatusChanged(_)).WillByDefault(Return());
   }
 
   void TearDown() {
@@ -86,13 +100,37 @@ TEST_F(UpdateStatusManagerTest,
 TEST_F(UpdateStatusManagerTest,
        OnValidUpdateReceived_SetValidUpdateReceived_ExpectStatusUpToDate) {
   // Arrange
+  EXPECT_CALL(*listener_, OnUpdateStatusChanged(updating_status_));
   manager_->OnUpdateSentOut(k_timeout_);
   status_ = manager_->GetLastUpdateStatus();
   EXPECT_EQ(StatusUpdatePending, status_);
+
+  EXPECT_CALL(*listener_, OnUpdateStatusChanged(up_to_date_status_));
   manager_->OnValidUpdateReceived();
   status_ = manager_->GetLastUpdateStatus();
   // Check
   EXPECT_EQ(StatusUpToDate, status_);
+}
+
+TEST_F(
+    UpdateStatusManagerTest,
+    SheduledUpdate_OnValidUpdateReceived_ExpectStatusUpToDateThanUpdateNeeded) {
+  using ::testing::InSequence;
+  // Arrange
+  EXPECT_CALL(*listener_, OnUpdateStatusChanged(updating_status_));
+  manager_->OnUpdateSentOut(k_timeout_);
+  status_ = manager_->GetLastUpdateStatus();
+  EXPECT_EQ(StatusUpdatePending, status_);
+  manager_->ScheduleUpdate();
+
+  InSequence s;
+  EXPECT_CALL(*listener_, OnUpdateStatusChanged(up_to_date_status_));
+  EXPECT_CALL(*listener_, OnUpdateStatusChanged(update_needed_status_));
+
+  manager_->OnValidUpdateReceived();
+  status_ = manager_->GetLastUpdateStatus();
+  // Check
+  EXPECT_EQ(StatusUpdateRequired, status_);
 }
 
 TEST_F(UpdateStatusManagerTest,

--- a/src/components/policy/policy_external/test/update_status_manager_test.cc
+++ b/src/components/policy/policy_external/test/update_status_manager_test.cc
@@ -46,7 +46,7 @@ using ::testing::Return;
 
 class UpdateStatusManagerTest : public ::testing::Test {
  protected:
-  UpdateStatusManager* manager_;
+  utils::SharedPtr<UpdateStatusManager> manager_;
   PolicyTableStatus status_;
   const uint32_t k_timeout_;
   utils::SharedPtr<MockPolicyListener> listener_;
@@ -56,21 +56,19 @@ class UpdateStatusManagerTest : public ::testing::Test {
 
  public:
   UpdateStatusManagerTest()
-      : k_timeout_(1)
+      : manager_(utils::MakeShared<UpdateStatusManager>())
+      , k_timeout_(1)
       , listener_(utils::MakeShared<MockPolicyListener>())
       , up_to_date_status_("UP_TO_DATE")
       , update_needed_status_("UPDATE_NEEDED")
       , updating_status_("UPDATING") {}
 
-  void SetUp() {
-    manager_ = new UpdateStatusManager();
+  void SetUp() OVERRIDE {
     manager_->set_listener(listener_.get());
     ON_CALL(*listener_, OnUpdateStatusChanged(_)).WillByDefault(Return());
   }
 
-  void TearDown() {
-    delete manager_;
-  }
+  void TearDown() OVERRIDE {}
 };
 
 TEST_F(UpdateStatusManagerTest,


### PR DESCRIPTION
After successfull policy update SDL must send up-to-date status to system
even if there is another update planned already.

Closes-bug: APPLINK-30399