### PR TITLE
Fixes order of notification sending during application registration

### DIFF
--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -638,6 +638,15 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
   SendOnAppRegisteredNotificationToHMI(
       *(application.get()), resumption, need_restore_vr);
 
+  // Default HMI level should be set before any permissions validation, since it
+  // relies on HMI level.
+  application_manager_.OnApplicationRegistered(application);
+
+  // Sends OnPermissionChange notification to mobile right after RAI response
+  // and HMI level set-up
+  application_manager_.GetPolicyHandler().OnAppRegisteredOnMobile(
+      application->policy_app_id());
+
   if (result_code != mobile_apis::Result::RESUME_FAILED) {
     resumer.StartResumption(application, hash_id);
   } else {

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
@@ -77,15 +77,6 @@ void RegisterAppInterfaceResponse::Run() {
   }
 
   SetHeartBeatTimeout(connection_key(), application->policy_app_id());
-
-  // Default HMI level should be set before any permissions validation, since it
-  // relies on HMI level.
-  application_manager_.OnApplicationRegistered(application);
-
-  // Sends OnPermissionChange notification to mobile right after RAI response
-  // and HMI level set-up
-  application_manager_.GetPolicyHandler().OnAppRegisteredOnMobile(
-      application->policy_app_id());
 }
 
 void RegisterAppInterfaceResponse::SetHeartBeatTimeout(


### PR DESCRIPTION
According to requirement OnAppRegistered notification must be sent before
OnHMIStatus and OnPermissionsChanged

Closes-bug: APPLINK-30566