### PR TITLE
Fix EXTERNAL_PROPRIETARY implementation of commands.

### DIFF
--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2477,6 +2477,7 @@ bool MessageHelper::PrintSmartObject(const smart_objects::SmartObject& object) {
       break;
     }
     case NsSmartDeviceLink::NsSmartObjects::SmartType_Integer:
+      printf("%lld", static_cast<long long int>(object.asInt()));
       break;
     case NsSmartDeviceLink::NsSmartObjects::SmartType_String:
       printf("%s", object.asString().c_str());

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -224,12 +224,12 @@ void RequestController::removeNotification(
     if (it->get() == notification) {
       notification_list_.erase(it++);
       LOG4CXX_DEBUG(logger_, "Notification removed");
-      break;
+      return;
     } else {
       ++it;
     }
   }
-  LOG4CXX_DEBUG(logger_, "Cant find notification");
+  LOG4CXX_DEBUG(logger_, "Cannot find notification");
 }
 
 void RequestController::TerminateRequest(const uint32_t correlation_id,

--- a/src/components/application_manager/test/commands/mobile/subscribe_way_points_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/subscribe_way_points_request_test.cc
@@ -39,6 +39,7 @@
 #include "application_manager/mock_application_manager.h"
 #include "application_manager/mock_application.h"
 #include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/mock_message_helper.h"
 #include "application_manager/include/application_manager/commands/mobile/subscribe_way_points_request.h"
 #include "interfaces/MOBILE_API.h"
 #include "application_manager/smart_object_keys.h"
@@ -55,9 +56,11 @@ using ::testing::ReturnRef;
 using ::testing::DoAll;
 using ::testing::SaveArg;
 using ::testing::InSequence;
+using ::testing::Mock;
 namespace am = ::application_manager;
 using am::commands::SubscribeWayPointsRequest;
 using am::commands::MessageSharedPtr;
+using am::MockMessageHelper;
 
 typedef SharedPtr<SubscribeWayPointsRequest> CommandPtr;
 
@@ -95,22 +98,31 @@ TEST_F(SubscribeWayPointsRequestTest, OnEvent_SUCCESS) {
   Event event(hmi_apis::FunctionID::Navigation_SubscribeWayPoints);
 
   MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
-  (*event_msg)[am::strings::params][am::hmi_response::code] =
-      mobile_apis::Result::SUCCESS;
+  const hmi_apis::Common_Result::eType result_code =
+      hmi_apis::Common_Result::SUCCESS;
+  (*event_msg)[am::strings::params][am::hmi_response::code] = result_code;
   (*event_msg)[am::strings::msg_params] = 0;
 
   event.set_smart_object(*event_msg);
+
+  MockMessageHelper* mock_message_helper =
+      MockMessageHelper::message_helper_mock();
+  Mock::VerifyAndClearExpectations(mock_message_helper);
 
   ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
 
   {
     InSequence dummy;
     EXPECT_CALL(app_mngr_, SubscribeAppForWayPoints(_));
+    EXPECT_CALL(*mock_message_helper, HMIToMobileResult(result_code))
+        .WillOnce(Return(mobile_apis::Result::SUCCESS));
     EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
     EXPECT_CALL(*app, UpdateHash());
   }
 
   command->on_event(event);
+
+  Mock::VerifyAndClearExpectations(mock_message_helper);
 }
 
 }  // namespace subscribe_way_points_request

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -102,7 +102,14 @@ class PolicyHandlerTest : public ::testing::Test {
       , app_set(test_app, app_lock)
       , kAppId_(10u)
       , kSnapshotFile_("snapshot")
-      , kSnapshotStorage_("snapshot_storage") {}
+      , kSnapshotStorage_("snapshot_storage") {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+
+  ~PolicyHandlerTest() {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+    Mock::VerifyAndClearExpectations(&app_manager_);
+  }
 
  protected:
   NiceMock<MockPolicySettings> policy_settings_;
@@ -1319,7 +1326,6 @@ TEST_F(PolicyHandlerTest, OnSnapshotCreated_UrlAdded) {
 
   ExtendedPolicyExpectations();
 
-  EXPECT_CALL(mock_message_helper_, SendPolicySnapshotNotification(_, _, _, _));
   EXPECT_CALL(app_manager_, application(kAppId_))
       .WillRepeatedly(Return(mock_app_));
 

--- a/src/components/hmi_message_handler/src/hmi_message_handler_impl.cc
+++ b/src/components/hmi_message_handler/src/hmi_message_handler_impl.cc
@@ -68,7 +68,7 @@ void HMIMessageHandlerImpl::OnMessageReceived(MessageSharedPointer message) {
 }
 
 void HMIMessageHandlerImpl::SendMessageToHMI(MessageSharedPointer message) {
-  LOG4CXX_INFO(logger_, "HMIMessageHandlerImpl::~sendMessageToHMI()");
+  LOG4CXX_INFO(logger_, "SendMessageToHMI");
   messages_to_hmi_.PostMessage(impl::MessageToHmi(message));
 }
 

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -163,7 +163,7 @@ bool PolicyManagerImpl::LoadPT(const std::string& file,
       LOG4CXX_INFO(logger_, "app_hmi_types is full calling OnUpdateHMIAppType");
       listener_->OnUpdateHMIAppType(app_hmi_types);
     } else {
-      LOG4CXX_INFO(logger_, "app_hmi_types empty" << pt_content.size());
+      LOG4CXX_INFO(logger_, "app_hmi_types empty");
     }
   }
 


### PR DESCRIPTION
- Fixed implementation of hmi::GetUrls and mobile::OnSystemRequestNotification in case of defined EXTERNAL_PROPRIETARY.
- Improved memory handling of HandleOutgoingMessageProtocolV2.    
- Added minor fixes in logic and log messages.
- Fixed PolicyHandler and SubscribeWayPointsRequest tests.

Related Issue: [APPLINK-30609](https://adc.luxoft.com/jira/browse/APPLINK-30609)
