### PR TITLE
Fix invalid PT after update

### DIFF
--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -400,7 +400,7 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * @param policy_app_id Unique application id
    * @return true, if policy assigned w/o data consent, otherwise -false
    */
-  virtual bool IsPredataPolicy(const std::string& policy_app_id) = 0;
+  virtual bool IsPredataPolicy(const std::string& policy_app_id) const = 0;
 
   /**
    * Returns heart beat timeout

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -148,7 +148,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_CONST_METHOD1(GetNotificationsNumber,
                      uint32_t(const std::string& priority));
   MOCK_METHOD1(SetVINValue, void(const std::string& value));
-  MOCK_METHOD1(IsPredataPolicy, bool(const std::string& policy_app_id));
+  MOCK_CONST_METHOD1(IsPredataPolicy, bool(const std::string& policy_app_id));
   MOCK_CONST_METHOD1(HeartBeatTimeout, uint32_t(const std::string& app_id));
   MOCK_METHOD1(SaveUpdateStatusRequired, void(bool is_update_needed));
   MOCK_METHOD0(OnAppsSearchStarted, void());

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -147,7 +147,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_CONST_METHOD1(GetNotificationsNumber,
                      uint32_t(const std::string& priority));
   MOCK_METHOD1(SetVINValue, void(const std::string& value));
-  MOCK_METHOD1(IsPredataPolicy, bool(const std::string& policy_app_id));
+  MOCK_CONST_METHOD1(IsPredataPolicy, bool(const std::string& policy_app_id));
   MOCK_CONST_METHOD1(HeartBeatTimeout, uint32_t(const std::string& app_id));
   MOCK_METHOD1(SaveUpdateStatusRequired, void(bool is_update_needed));
   MOCK_METHOD0(OnAppsSearchStarted, void());

--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -280,7 +280,7 @@ class CacheManager : public CacheManagerInterface {
    * @param app_id application id
    * @return true if application has default policy
    */
-  bool IsDefaultPolicy(const std::string& app_id);
+  bool IsDefaultPolicy(const std::string& app_id) const OVERRIDE;
 
   /**
    * @brief SetIsDefault Sets is_default flag for application
@@ -301,7 +301,7 @@ class CacheManager : public CacheManagerInterface {
    * @param app_id application id
    * @return true if application has pre_data policy
    */
-  bool IsPredataPolicy(const std::string& app_id);
+  bool IsPredataPolicy(const std::string& app_id) const OVERRIDE;
 
   /**
    * Sets default policy for application

--- a/src/components/policy/policy_external/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager_interface.h
@@ -274,7 +274,7 @@ class CacheManagerInterface {
    * @param app_id application id
    * @return true if application has default policy
    */
-  virtual bool IsDefaultPolicy(const std::string& app_id) = 0;
+  virtual bool IsDefaultPolicy(const std::string& app_id) const = 0;
 
   /**
    * @brief SetIsDefault Sets is_default flag for application
@@ -295,7 +295,7 @@ class CacheManagerInterface {
    * @param app_id application id
    * @return true if application has pre_data policy
    */
-  virtual bool IsPredataPolicy(const std::string& app_id) = 0;
+  virtual bool IsPredataPolicy(const std::string& app_id) const = 0;
 
   /**
    * Sets default policy for application

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -175,7 +175,7 @@ class PolicyManagerImpl : public PolicyManager {
 
   virtual void SaveUpdateStatusRequired(bool is_update_needed);
 
-  virtual bool IsPredataPolicy(const std::string& policy_app_id);
+  virtual bool IsPredataPolicy(const std::string& policy_app_id) const OVERRIDE;
   void set_cache_manager(CacheManagerInterface* cache_manager);
 
   virtual void OnAppsSearchStarted();

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -115,7 +115,7 @@ bool PolicyManagerImpl::LoadPT(const std::string& file,
   // Parse message into table struct
   utils::SharedPtr<policy_table::Table> pt_update = Parse(pt_content);
   if (!pt_update) {
-    LOG4CXX_WARN(logger_, "Parsed table pointer is 0.");
+    LOG4CXX_WARN(logger_, "Parsed table pointer is NULL.");
     update_status_manager_.OnWrongUpdateReceived();
     return false;
   }
@@ -1211,7 +1211,8 @@ void PolicyManagerImpl::RemoveAppConsentForGroup(
   cache_->RemoveAppConsentForGroup(app_id, group_name);
 }
 
-bool PolicyManagerImpl::IsPredataPolicy(const std::string& policy_app_id) {
+bool PolicyManagerImpl::IsPredataPolicy(
+    const std::string& policy_app_id) const {
   LOG4CXX_INFO(logger_, "IsPredataApp");
   return cache_->IsPredataPolicy(policy_app_id);
 }

--- a/src/components/policy/policy_external/test/include/policy/mock_cache_manager.h
+++ b/src/components/policy/policy_external/test/include/policy/mock_cache_manager.h
@@ -116,10 +116,10 @@ class MockCacheManagerInterface : public ::policy::CacheManagerInterface {
   MOCK_METHOD1(GetFunctionalGroupings,
                bool(policy_table::FunctionalGroupings& groups));
   MOCK_CONST_METHOD1(IsApplicationRepresented, bool(const std::string& app_id));
-  MOCK_METHOD1(IsDefaultPolicy, bool(const std::string& app_id));
+  MOCK_CONST_METHOD1(IsDefaultPolicy, bool(const std::string& app_id));
   MOCK_METHOD1(SetIsDefault, bool(const std::string& app_id));
   MOCK_METHOD1(SetIsPredata, bool(const std::string& app_id));
-  MOCK_METHOD1(IsPredataPolicy, bool(const std::string& app_id));
+  MOCK_CONST_METHOD1(IsPredataPolicy, bool(const std::string& app_id));
   MOCK_METHOD1(SetDefaultPolicy, bool(const std::string& app_id));
   MOCK_CONST_METHOD1(CanAppKeepContext, bool(const std::string& app_id));
   MOCK_CONST_METHOD1(CanAppStealFocus, bool(const std::string& app_id));

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -266,7 +266,7 @@ class CacheManager : public CacheManagerInterface {
    * @param app_id application id
    * @return true if application has default policy
    */
-  bool IsDefaultPolicy(const std::string& app_id);
+  bool IsDefaultPolicy(const std::string& app_id) const OVERRIDE;
 
   /**
    * @brief SetIsDefault Sets is_default flag for application
@@ -280,7 +280,7 @@ class CacheManager : public CacheManagerInterface {
    * @param app_id application id
    * @return true if application has pre_data policy
    */
-  bool IsPredataPolicy(const std::string& app_id);
+  bool IsPredataPolicy(const std::string& app_id) const OVERRIDE;
 
   /**
    * Sets default policy for application

--- a/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
@@ -263,7 +263,7 @@ class CacheManagerInterface {
    * @param app_id application id
    * @return true if application has default policy
    */
-  virtual bool IsDefaultPolicy(const std::string& app_id) = 0;
+  virtual bool IsDefaultPolicy(const std::string& app_id) const = 0;
 
   /**
    * @brief SetIsDefault Sets is_default flag for application
@@ -277,7 +277,7 @@ class CacheManagerInterface {
    * @param app_id application id
    * @return true if application has pre_data policy
    */
-  virtual bool IsPredataPolicy(const std::string& app_id) = 0;
+  virtual bool IsPredataPolicy(const std::string& app_id) const = 0;
 
   /**
    * Sets default policy for application

--- a/src/components/policy/policy_regular/include/policy/policy_manager.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager.h
@@ -398,7 +398,7 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * @param policy_app_id Unique application id
    * @return true, if policy assigned w/o data consent, otherwise -false
    */
-  virtual bool IsPredataPolicy(const std::string& policy_app_id) = 0;
+  virtual bool IsPredataPolicy(const std::string& policy_app_id) const = 0;
 
   /**
    * Returns heart beat timeout

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -180,7 +180,7 @@ class PolicyManagerImpl : public PolicyManager {
 
   virtual void SaveUpdateStatusRequired(bool is_update_needed);
 
-  virtual bool IsPredataPolicy(const std::string& policy_app_id);
+  virtual bool IsPredataPolicy(const std::string& policy_app_id) const OVERRIDE;
   void set_cache_manager(CacheManagerInterface* cache_manager);
 
   virtual void OnAppsSearchStarted();

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -109,13 +109,16 @@ bool CacheManager::CanAppKeepContext(const std::string& app_id) const {
 uint32_t CacheManager::HeartBeatTimeout(const std::string& app_id) const {
   CACHE_MANAGER_CHECK(0);
   uint32_t result = 0;
-  if (AppExists(app_id)) {
-    if (pt_->policy_table.app_policies_section.apps[app_id]
-            .heart_beat_timeout_ms.is_initialized()) {
-      result = *(pt_->policy_table.app_policies_section.apps[app_id]
-                     .heart_beat_timeout_ms);
-    }
+  if (!AppExists(app_id)) {
+    return result;
   }
+
+  const policy_table::ApplicationPolicies::mapped_type& app =
+      pt_->policy_table.app_policies_section.apps[app_id];
+  if (app.heart_beat_timeout_ms.is_initialized()) {
+    result = *(app.heart_beat_timeout_ms);
+  }
+
   return result;
 }
 
@@ -823,6 +826,10 @@ void CacheManager::CheckSnapshotInitialization() {
         (*it).second.count_of_removals_for_bad_behavior = 0;
       }
 
+      if (!(*it).second.count_of_tls_errors.is_initialized()) {
+        (*it).second.count_of_tls_errors = 0;
+      }
+
       if (!(*it).second.count_of_run_attempts_while_revoked.is_initialized()) {
         (*it).second.count_of_run_attempts_while_revoked = 0;
       }
@@ -1173,7 +1180,7 @@ bool CacheManager::SetDefaultPolicy(const std::string& app_id) {
   return true;
 }
 
-bool CacheManager::IsDefaultPolicy(const std::string& app_id) {
+bool CacheManager::IsDefaultPolicy(const std::string& app_id) const {
   CACHE_MANAGER_CHECK(false);
   const bool result =
       pt_->policy_table.app_policies_section.apps.end() !=
@@ -1217,13 +1224,19 @@ bool CacheManager::SetPredataPolicy(const std::string& app_id) {
   return true;
 }
 
-bool CacheManager::IsPredataPolicy(const std::string& app_id) {
+bool CacheManager::IsPredataPolicy(const std::string& app_id) const {
   // TODO(AOleynik): Maybe change for comparison with pre_DataConsent
   // permissions or check string value from get_string()
-  policy_table::ApplicationParams& pre_data_app =
-      pt_->policy_table.app_policies_section.apps[kPreDataConsentId];
-  policy_table::ApplicationParams& specific_app =
-      pt_->policy_table.app_policies_section.apps[app_id];
+  if (!IsApplicationRepresented(app_id)) {
+    return false;
+  }
+
+  policy_table::ApplicationPolicies& apps =
+      pt_->policy_table.app_policies_section.apps;
+  const policy_table::ApplicationPolicies::mapped_type& pre_data_app =
+      apps[kPreDataConsentId];
+  const policy_table::ApplicationPolicies::mapped_type& specific_app =
+      apps[app_id];
 
   policy_table::Strings res;
   std::set_intersection(pre_data_app.groups.begin(),
@@ -1232,9 +1245,8 @@ bool CacheManager::IsPredataPolicy(const std::string& app_id) {
                         specific_app.groups.end(),
                         std::back_inserter(res));
 
-  bool is_marked_as_predata =
-      kPreDataConsentId ==
-      pt_->policy_table.app_policies_section.apps[app_id].get_string();
+  const bool is_marked_as_predata =
+      (kPreDataConsentId == specific_app.get_string());
 
   return !res.empty() && is_marked_as_predata;
 }
@@ -1387,9 +1399,6 @@ bool CacheManager::ResetPT(const std::string& file_name) {
 
 bool CacheManager::AppExists(const std::string& app_id) const {
   CACHE_MANAGER_CHECK(false);
-  if (kDeviceId == app_id) {
-    return true;
-  }
   policy_table::ApplicationPolicies::iterator policy_iter =
       pt_->policy_table.app_policies_section.apps.find(app_id);
   return pt_->policy_table.app_policies_section.apps.end() != policy_iter;
@@ -1415,6 +1424,11 @@ void CacheManager::GetAppRequestTypes(
     std::vector<std::string>& request_types) const {
   LOG4CXX_AUTO_TRACE(logger_);
   CACHE_MANAGER_CHECK_VOID();
+  if (kDeviceId == policy_app_id) {
+    LOG4CXX_DEBUG(logger_,
+                  "Request types not applicable for app_id " << kDeviceId);
+    return;
+  }
   policy_table::ApplicationPolicies::iterator policy_iter =
       pt_->policy_table.app_policies_section.apps.find(policy_app_id);
   if (pt_->policy_table.app_policies_section.apps.end() == policy_iter) {

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -918,7 +918,8 @@ void PolicyManagerImpl::RemoveAppConsentForGroup(
   cache_->RemoveAppConsentForGroup(app_id, group_name);
 }
 
-bool PolicyManagerImpl::IsPredataPolicy(const std::string& policy_app_id) {
+bool PolicyManagerImpl::IsPredataPolicy(
+    const std::string& policy_app_id) const {
   LOG4CXX_INFO(logger_, "IsPredataApp");
   return cache_->IsPredataPolicy(policy_app_id);
 }

--- a/src/components/policy/policy_regular/test/include/policy/mock_cache_manager.h
+++ b/src/components/policy/policy_regular/test/include/policy/mock_cache_manager.h
@@ -94,9 +94,9 @@ class MockCacheManagerInterface : public CacheManagerInterface {
   MOCK_METHOD1(GetFunctionalGroupings,
                bool(policy_table::FunctionalGroupings& groups));
   MOCK_CONST_METHOD1(IsApplicationRepresented, bool(const std::string& app_id));
-  MOCK_METHOD1(IsDefaultPolicy, bool(const std::string& app_id));
+  MOCK_CONST_METHOD1(IsDefaultPolicy, bool(const std::string& app_id));
   MOCK_METHOD1(SetIsDefault, bool(const std::string& app_id));
-  MOCK_METHOD1(IsPredataPolicy, bool(const std::string& app_id));
+  MOCK_CONST_METHOD1(IsPredataPolicy, bool(const std::string& app_id));
   MOCK_METHOD1(SetDefaultPolicy, bool(const std::string& app_id));
   MOCK_CONST_METHOD1(CanAppKeepContext, bool(const std::string& app_id));
   MOCK_CONST_METHOD1(CanAppStealFocus, bool(const std::string& app_id));

--- a/src/components/policy/policy_regular/test/include/policy/mock_policy_manager.h
+++ b/src/components/policy/policy_regular/test/include/policy/mock_policy_manager.h
@@ -145,7 +145,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_CONST_METHOD1(GetNotificationsNumber,
                      uint32_t(const std::string& priority));
   MOCK_METHOD1(SetVINValue, void(const std::string& value));
-  MOCK_METHOD1(IsPredataPolicy, bool(const std::string& policy_app_id));
+  MOCK_CONST_METHOD1(IsPredataPolicy, bool(const std::string& policy_app_id));
   MOCK_CONST_METHOD1(HeartBeatTimeout, uint32_t(const std::string& app_id));
   MOCK_METHOD1(SaveUpdateStatusRequired, void(bool is_update_needed));
   MOCK_METHOD0(OnAppsSearchStarted, void());


### PR DESCRIPTION
- The calls to CheckSnapshotInitialization, IsPredataPolicy and IsDefaultPolicy methods of the PolicyManager introduced uninitialized values in the local Policy Table which in turn became invalid.
- This failed the following Policy Table Updates.
- The adding of uninitialized values was removed.

Related Issue: [APPLINK-30706](https://adc.luxoft.com/jira/browse/APPLINK-30706)