### PR TITLE
Fixing incorrect counting retry StartStream

### DIFF
--- a/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
@@ -156,7 +156,7 @@ void AudioStartStreamRequest::RetryStartSession() {
   }
 
   uint32_t curr_retry_number = app->audio_stream_retry_number();
-  if (curr_retry_number < retry_number_ - 1) {
+  if (curr_retry_number < retry_number_) {
     LOG4CXX_DEBUG(
         logger_,
         "Send AudioStartStream retry. retry_number = " << curr_retry_number);

--- a/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
@@ -113,7 +113,7 @@ void NaviStartStreamRequest::on_event(const event_engine::Event& event) {
       }
       if (hmi_apis::Common_Result::REJECTED == code) {
         LOG4CXX_INFO(logger_, "StartStream response REJECTED ");
-        SendRequest();
+        RetryStartSession();
         break;
       }
     }
@@ -156,7 +156,7 @@ void NaviStartStreamRequest::RetryStartSession() {
   }
 
   uint32_t curr_retry_number = app->video_stream_retry_number();
-  if (curr_retry_number < retry_number_ - 1) {
+  if (curr_retry_number < retry_number_) {
     LOG4CXX_DEBUG(
         logger_,
         "Send NaviStartStream retry. retry_number = " << curr_retry_number);


### PR DESCRIPTION
 Fix incorrect counting retry StartStream
 and sending message to HMI every time when HMI reject previous StartStream

 Related task APPLINK-22263