### PR TITLE
Update status logic rework

### DIFF
--- a/src/components/policy/policy_external/CMakeLists.txt
+++ b/src/components/policy/policy_external/CMakeLists.txt
@@ -53,6 +53,7 @@ set(SOURCES
   ${POLICY_PATH}/src/sql_pt_queries.cc
   ${POLICY_PATH}/src/sql_pt_representation.cc
   ${POLICY_PATH}/src/update_status_manager.cc
+  ${POLICY_PATH}/src/status.cc
   ${POLICY_PATH}/src/cache_manager.cc
   ${COMPONENTS_DIR}/rpc_base/src/rpc_base/rpc_base.cc
 )

--- a/src/components/policy/policy_external/include/policy/status.h
+++ b/src/components/policy/policy_external/include/policy/status.h
@@ -1,0 +1,200 @@
+/*
+ Copyright (c) 2016, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_POLICY_POLICY_EXTERNAL_INCLUDE_POLICY_STATUS_H_
+#define SRC_COMPONENTS_POLICY_POLICY_EXTERNAL_INCLUDE_POLICY_STATUS_H_
+
+#include <string>
+#include "policy/policy_types.h"
+#include "utils/macro.h"
+
+namespace policy {
+
+/**
+ * @brief The UpdateEvent enum defines system events which can change update
+ * status
+ */
+enum UpdateEvent {
+  kOnNewAppRegistered,
+  kOnValidUpdateReceived,
+  kOnWrongUpdateReceived,
+  kOnUpdateSentOut,
+  kOnUpdateTimeout,
+  kOnResetPolicyTableRequireUpdate,
+  kOnResetPolicyTableNoUpdate,
+  kScheduleUpdate,
+  kOnResetRetrySequence
+};
+
+class UpdateStatusManager;
+
+/**
+ * @brief The Status class defines base implementation of update status
+ */
+class Status {
+ public:
+  /**
+ * @brief Destructor
+ */
+  virtual ~Status();
+
+  /**
+ * @brief Process event by setting next status in case event can affect
+ * current status or ignores the event
+ * @param mng Status manager pointer
+ * @param event Event which needs to be processed
+ */
+  virtual void ProcessEvent(UpdateStatusManager* mng, UpdateEvent event) = 0;
+
+  /**
+ * @brief Return current status as string value
+ * @return Status as string
+ */
+  virtual const std::string get_status_string() const = 0;
+
+  /**
+ * @brief Return status as enum value
+ * @return Status as enum value
+ */
+  virtual PolicyTableStatus get_status() const = 0;
+
+  /**
+ * @brief Check whether update is required in terms of status
+ * @return True if update is required, otherwise - false
+ */
+  virtual bool IsUpdateRequired() const;
+
+  /**
+ * @brief Check whether update is pending in terms of status
+ * @return True if update is pending, otherwise - false
+ */
+  virtual bool IsUpdatePending() const;
+};
+
+/**
+ * @brief The UpToDateStatus class represents 'up-to-date' status
+ */
+class UpToDateStatus : public Status {
+ public:
+  /**
+ * @brief Process event by setting next status in case event can affect
+ * current status or ignores the event
+ * @param mng Status manager pointer
+ * @param event Event which needs to be processed
+ */
+  void ProcessEvent(UpdateStatusManager* mng, UpdateEvent event) OVERRIDE;
+
+  /**
+ * @brief Return current status as string value
+ * @return Status as string
+ */
+  const std::string get_status_string() const OVERRIDE;
+
+  /**
+ * @brief Return status as enum value
+ * @return Status as enum value
+ */
+  PolicyTableStatus get_status() const OVERRIDE;
+};
+
+/**
+ * @brief The UpdateNeededStatus class represents 'update needed' status
+ */
+class UpdateNeededStatus : public Status {
+ public:
+  /**
+ * @brief Process event by setting next status in case event can affect
+ * current status or ignores the event
+ * @param mng Status manager pointer
+ * @param event Event which needs to be processed
+ */
+  void ProcessEvent(UpdateStatusManager* mng, UpdateEvent event) OVERRIDE;
+
+  /**
+ * @brief Return current status as string value
+ * @return Status as string
+ */
+  const std::string get_status_string() const OVERRIDE;
+
+  /**
+ * @brief Return status as enum value
+ * @return Status as enum value
+ */
+  PolicyTableStatus get_status() const OVERRIDE;
+
+  /**
+ * @brief Check whether update is required in terms of status
+ * @return True if update is required, otherwise - false
+ */
+  bool IsUpdateRequired() const OVERRIDE;
+};
+
+/**
+ * @brief The UpdatingStatus class represents 'updating' status
+ */
+class UpdatingStatus : public Status {
+ public:
+  /**
+ * @brief Process event by setting next status in case event can affect
+ * current status or ignores the event
+ * @param mng Status manager pointer
+ * @param event Event which needs to be processed
+ */
+  void ProcessEvent(UpdateStatusManager* mng, UpdateEvent event) OVERRIDE;
+
+  /**
+ * @brief Return current status as string value
+ * @return Status as string
+ */
+  const std::string get_status_string() const OVERRIDE;
+
+  /**
+ * @brief Return status as enum value
+ * @return Status as enum value
+ */
+  PolicyTableStatus get_status() const OVERRIDE;
+
+  /**
+ * @brief Check whether update is required in terms of status
+ * @return True if update is required, otherwise - false
+ */
+  bool IsUpdateRequired() const OVERRIDE;
+
+  /**
+ * @brief Check whether update is pending in terms of status
+ * @return True if update is pending, otherwise - false
+ */
+  bool IsUpdatePending() const OVERRIDE;
+};
+}
+
+#endif  // SRC_COMPONENTS_POLICY_POLICY_EXTERNAL_INCLUDE_POLICY_STATUS_H_

--- a/src/components/policy/policy_external/include/policy/status.h
+++ b/src/components/policy/policy_external/include/policy/status.h
@@ -86,13 +86,13 @@ class Status {
  * @brief Return current status as string value
  * @return Status as string
  */
-  virtual const std::string get_status_string() const;
+  const std::string get_status_string() const;
 
   /**
  * @brief Return status as enum value
  * @return Status as enum value
  */
-  virtual PolicyTableStatus get_status() const;
+  PolicyTableStatus get_status() const;
 
   /**
  * @brief Check whether update is required in terms of status

--- a/src/components/policy/policy_external/include/policy/status.h
+++ b/src/components/policy/policy_external/include/policy/status.h
@@ -63,6 +63,12 @@ class UpdateStatusManager;
 class Status {
  public:
   /**
+   * @brief Constructor
+   */
+  Status(const std::string& string_status,
+         const policy::PolicyTableStatus enum_status);
+
+  /**
  * @brief Destructor
  */
   virtual ~Status();
@@ -70,22 +76,23 @@ class Status {
   /**
  * @brief Process event by setting next status in case event can affect
  * current status or ignores the event
- * @param mng Status manager pointer
+ * @param manager Status manager pointer
  * @param event Event which needs to be processed
  */
-  virtual void ProcessEvent(UpdateStatusManager* mng, UpdateEvent event) = 0;
+  virtual void ProcessEvent(UpdateStatusManager* manager,
+                            UpdateEvent event) = 0;
 
   /**
  * @brief Return current status as string value
  * @return Status as string
  */
-  virtual const std::string get_status_string() const = 0;
+  virtual const std::string get_status_string() const;
 
   /**
  * @brief Return status as enum value
  * @return Status as enum value
  */
-  virtual PolicyTableStatus get_status() const = 0;
+  virtual PolicyTableStatus get_status() const;
 
   /**
  * @brief Check whether update is required in terms of status
@@ -98,6 +105,10 @@ class Status {
  * @return True if update is pending, otherwise - false
  */
   virtual bool IsUpdatePending() const;
+
+ private:
+  const std::string string_status_;
+  const PolicyTableStatus enum_status_;
 };
 
 /**
@@ -106,24 +117,17 @@ class Status {
 class UpToDateStatus : public Status {
  public:
   /**
+   * @brief Constructor
+   */
+  UpToDateStatus();
+
+  /**
  * @brief Process event by setting next status in case event can affect
  * current status or ignores the event
- * @param mng Status manager pointer
+ * @param manager Status manager pointer
  * @param event Event which needs to be processed
  */
-  void ProcessEvent(UpdateStatusManager* mng, UpdateEvent event) OVERRIDE;
-
-  /**
- * @brief Return current status as string value
- * @return Status as string
- */
-  const std::string get_status_string() const OVERRIDE;
-
-  /**
- * @brief Return status as enum value
- * @return Status as enum value
- */
-  PolicyTableStatus get_status() const OVERRIDE;
+  void ProcessEvent(UpdateStatusManager* manager, UpdateEvent event) FINAL;
 };
 
 /**
@@ -132,30 +136,23 @@ class UpToDateStatus : public Status {
 class UpdateNeededStatus : public Status {
  public:
   /**
+   * @brief Constructor
+   */
+  UpdateNeededStatus();
+
+  /**
  * @brief Process event by setting next status in case event can affect
  * current status or ignores the event
- * @param mng Status manager pointer
+ * @param manager Status manager pointer
  * @param event Event which needs to be processed
  */
-  void ProcessEvent(UpdateStatusManager* mng, UpdateEvent event) OVERRIDE;
-
-  /**
- * @brief Return current status as string value
- * @return Status as string
- */
-  const std::string get_status_string() const OVERRIDE;
-
-  /**
- * @brief Return status as enum value
- * @return Status as enum value
- */
-  PolicyTableStatus get_status() const OVERRIDE;
+  void ProcessEvent(UpdateStatusManager* manager, UpdateEvent event) FINAL;
 
   /**
  * @brief Check whether update is required in terms of status
  * @return True if update is required, otherwise - false
  */
-  bool IsUpdateRequired() const OVERRIDE;
+  bool IsUpdateRequired() const FINAL;
 };
 
 /**
@@ -164,36 +161,29 @@ class UpdateNeededStatus : public Status {
 class UpdatingStatus : public Status {
  public:
   /**
+   * @brief Constructor
+   */
+  UpdatingStatus();
+
+  /**
  * @brief Process event by setting next status in case event can affect
  * current status or ignores the event
- * @param mng Status manager pointer
+ * @param manager Status manager pointer
  * @param event Event which needs to be processed
  */
-  void ProcessEvent(UpdateStatusManager* mng, UpdateEvent event) OVERRIDE;
-
-  /**
- * @brief Return current status as string value
- * @return Status as string
- */
-  const std::string get_status_string() const OVERRIDE;
-
-  /**
- * @brief Return status as enum value
- * @return Status as enum value
- */
-  PolicyTableStatus get_status() const OVERRIDE;
+  void ProcessEvent(UpdateStatusManager* manager, UpdateEvent event) FINAL;
 
   /**
  * @brief Check whether update is required in terms of status
  * @return True if update is required, otherwise - false
  */
-  bool IsUpdateRequired() const OVERRIDE;
+  bool IsUpdateRequired() const FINAL;
 
   /**
  * @brief Check whether update is pending in terms of status
  * @return True if update is pending, otherwise - false
  */
-  bool IsUpdatePending() const OVERRIDE;
+  bool IsUpdatePending() const FINAL;
 };
 }
 

--- a/src/components/policy/policy_external/include/policy/update_status_manager.h
+++ b/src/components/policy/policy_external/include/policy/update_status_manager.h
@@ -41,6 +41,7 @@
 #include "utils/lock.h"
 #include "utils/logger.h"
 #include "utils/macro.h"
+#include "policy/status.h"
 
 namespace policy {
 
@@ -54,6 +55,25 @@ class UpdateStatusManager {
   UpdateStatusManager();
 
   ~UpdateStatusManager();
+
+  /**
+   * @brief Process event by current status implementations
+   * @param event Event
+   */
+  void ProcessEvent(UpdateEvent event);
+
+  /**
+   * @brief Set next status during event processing
+   * @param status Status shared pointer
+   */
+  void SetNextStatus(utils::SharedPtr<Status> status);
+
+  /**
+   * @brief Set postponed status (will be set after next status) during event
+   * processing
+   * @param status Status shared pointer
+   */
+  void SetPostponedStatus(utils::SharedPtr<Status> status);
 
   /**
    * @brief Sets listener pointer
@@ -131,11 +151,6 @@ class UpdateStatusManager {
   void ScheduleUpdate();
 
   /**
-   * @brief ResetUpdateSchedule allows to reset all scheduled updates.
-   */
-  void ResetUpdateSchedule();
-
-  /**
    * @brief StringifiedUpdateStatus allows to obtain update status as a string.
    *
    * @return stringified update status.
@@ -160,59 +175,39 @@ class UpdateStatusManager {
 
 #ifdef BUILD_TESTS
   PolicyTableStatus GetLastUpdateStatus() const {
-    return GetUpdateStatus();
+    return current_status_->get_status();
   }
 #endif  // BUILD_TESTS
 
  private:
-  /*
-   * @brief Sets flag for update progress
-   *
-   * @param value
-   */
-  void set_exchange_in_progress(bool value);
-
-  /*
-   * @brief Sets flag for pending update
-   *
-   * @param value
-   */
-  void set_exchange_pending(bool value);
-
-  /*
-   * @brief Sets flag for update necessity
-   *
-   * @param value
-   */
-  void set_update_required(bool value);
-
   /**
-   * @brief Check update status and notify HMI on changes
+   * @brief Does statuses transitions after event handling and notifies the
+   * system
    */
-  void CheckUpdateStatus();
+  void DoTransition();
 
  private:
-  /**
-   * @brief Returns current policy update status
-   * @return
-   */
-  PolicyTableStatus GetUpdateStatus() const;
-
   PolicyListener* listener_;
-  bool exchange_in_progress_;
-  bool update_required_;
-  bool update_scheduled_;
-  bool exchange_pending_;
+
+  /**
+   * @brief Current update status
+   */
+  utils::SharedPtr<Status> current_status_;
+
+  /**
+   * @brief Next status after current to be set
+   */
+  utils::SharedPtr<Status> next_status_;
+
+  /**
+   * @brief Status to be set after 'next' status
+   */
+  utils::SharedPtr<Status> postponed_status_;
+  sync_primitives::Lock status_lock_;
+
   bool apps_search_in_progress_;
   bool app_registered_from_non_consented_device_;
-  sync_primitives::Lock exchange_in_progress_lock_;
-  sync_primitives::Lock update_required_lock_;
-  sync_primitives::Lock exchange_pending_lock_;
   sync_primitives::Lock apps_search_in_progress_lock_;
-  /**
-   * @brief Last status of policy table update
-   */
-  PolicyTableStatus last_update_status_;
 
   class UpdateThreadDelegate : public threads::ThreadDelegate {
    public:

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -237,10 +237,6 @@ void PolicyManagerImpl::RequestPTUpdate() {
 
     listener_->OnSnapshotCreated(
         update, RetrySequenceDelaysSeconds(), TimeoutExchange());
-
-    // Need to reset update schedule since all currently registered applications
-    // were already added to the snapshot so no update for them required.
-    update_status_manager_.ResetUpdateSchedule();
   } else {
     LOG4CXX_ERROR(logger_, "Invalid Policy table snapshot - PTUpdate failed");
   }

--- a/src/components/policy/policy_external/src/status.cc
+++ b/src/components/policy/policy_external/src/status.cc
@@ -1,0 +1,140 @@
+/*
+ Copyright (c) 2016, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "policy/status.h"
+#include "policy/update_status_manager.h"
+#include "utils/make_shared.h"
+
+void policy::UpToDateStatus::ProcessEvent(UpdateStatusManager* mng,
+                                          policy::UpdateEvent event) {
+  switch (event) {
+    case kOnNewAppRegistered:
+    case kOnResetPolicyTableRequireUpdate:
+    case kScheduleUpdate:
+    case kOnResetRetrySequence:
+      mng->SetNextStatus(new UpdateNeededStatus());
+      break;
+    default:
+      break;
+  }
+}
+
+const std::string policy::UpToDateStatus::get_status_string() const {
+  return "UP_TO_DATE";
+}
+
+policy::PolicyTableStatus policy::UpToDateStatus::get_status() const {
+  return PolicyTableStatus::StatusUpToDate;
+}
+
+void policy::UpdateNeededStatus::ProcessEvent(policy::UpdateStatusManager* mng,
+                                              policy::UpdateEvent event) {
+  switch (event) {
+    case kOnUpdateSentOut:
+      mng->SetNextStatus(utils::MakeShared<UpdatingStatus>());
+      break;
+    case kOnResetPolicyTableRequireUpdate:
+      mng->SetNextStatus(utils::MakeShared<UpToDateStatus>());
+      mng->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
+      break;
+    case kOnResetPolicyTableNoUpdate:
+      mng->SetNextStatus(utils::MakeShared<UpToDateStatus>());
+      break;
+    default:
+      break;
+  }
+}
+
+const std::string policy::UpdateNeededStatus::get_status_string() const {
+  return "UPDATE_NEEDED";
+}
+
+policy::PolicyTableStatus policy::UpdateNeededStatus::get_status() const {
+  return PolicyTableStatus::StatusUpdateRequired;
+}
+
+bool policy::UpdateNeededStatus::IsUpdateRequired() const {
+  return true;
+}
+
+void policy::UpdatingStatus::ProcessEvent(policy::UpdateStatusManager* mng,
+                                          policy::UpdateEvent event) {
+  switch (event) {
+    case kOnValidUpdateReceived:
+    case kOnResetPolicyTableNoUpdate:
+      mng->SetNextStatus(utils::MakeShared<UpToDateStatus>());
+      break;
+    case kOnNewAppRegistered:
+      mng->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
+      break;
+    case kOnWrongUpdateReceived:
+    case kOnUpdateTimeout:
+      mng->SetNextStatus(utils::MakeShared<UpdateNeededStatus>());
+      break;
+    case kOnResetPolicyTableRequireUpdate:
+      mng->SetNextStatus(utils::MakeShared<UpToDateStatus>());
+      mng->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
+      break;
+    case kScheduleUpdate:
+    case kOnResetRetrySequence:
+      mng->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
+      break;
+    default:
+      break;
+  }
+}
+
+const std::string policy::UpdatingStatus::get_status_string() const {
+  return "UPDATING";
+}
+
+policy::PolicyTableStatus policy::UpdatingStatus::get_status() const {
+  return PolicyTableStatus::StatusUpdatePending;
+}
+
+bool policy::UpdatingStatus::IsUpdatePending() const {
+  return true;
+}
+
+bool policy::UpdatingStatus::IsUpdateRequired() const {
+  return true;
+}
+
+policy::Status::~Status() {}
+
+bool policy::Status::IsUpdateRequired() const {
+  return false;
+}
+
+bool policy::Status::IsUpdatePending() const {
+  return false;
+}

--- a/src/components/policy/policy_external/src/update_status_manager.cc
+++ b/src/components/policy/policy_external/src/update_status_manager.cc
@@ -33,6 +33,7 @@
 #include "policy/update_status_manager.h"
 #include "policy/policy_listener.h"
 #include "utils/logger.h"
+#include "utils/make_shared.h"
 
 namespace policy {
 
@@ -40,7 +41,7 @@ CREATE_LOGGERPTR_GLOBAL(logger_, "Policy")
 
 UpdateStatusManager::UpdateStatusManager()
     : listener_(NULL)
-    , current_status_(new UpToDateStatus())
+    , current_status_(utils::MakeShared<UpToDateStatus>())
     , apps_search_in_progress_(false)
     , app_registered_from_non_consented_device_(true) {
   update_status_thread_delegate_ = new UpdateThreadDelegate(this);

--- a/src/components/policy/policy_external/src/update_status_manager.cc
+++ b/src/components/policy/policy_external/src/update_status_manager.cc
@@ -40,13 +40,9 @@ CREATE_LOGGERPTR_GLOBAL(logger_, "Policy")
 
 UpdateStatusManager::UpdateStatusManager()
     : listener_(NULL)
-    , exchange_in_progress_(false)
-    , update_required_(false)
-    , update_scheduled_(false)
-    , exchange_pending_(false)
+    , current_status_(new UpToDateStatus())
     , apps_search_in_progress_(false)
-    , app_registered_from_non_consented_device_(true)
-    , last_update_status_(policy::StatusUnknown) {
+    , app_registered_from_non_consented_device_(true) {
   update_status_thread_delegate_ = new UpdateThreadDelegate(this);
   thread_ = threads::CreateThread("UpdateStatusThread",
                                   update_status_thread_delegate_);
@@ -62,6 +58,20 @@ UpdateStatusManager::~UpdateStatusManager() {
   threads::DeleteThread(thread_);
 }
 
+void UpdateStatusManager::ProcessEvent(UpdateEvent event) {
+  sync_primitives::AutoLock lock(status_lock_);
+  current_status_->ProcessEvent(this, event);
+  DoTransition();
+}
+
+void UpdateStatusManager::SetNextStatus(utils::SharedPtr<Status> status) {
+  next_status_ = status;
+}
+
+void UpdateStatusManager::SetPostponedStatus(utils::SharedPtr<Status> status) {
+  postponed_status_ = status;
+}
+
 void UpdateStatusManager::set_listener(PolicyListener* listener) {
   listener_ = listener;
 }
@@ -72,16 +82,12 @@ void UpdateStatusManager::OnUpdateSentOut(uint32_t update_timeout) {
   const unsigned milliseconds_in_second = 1000;
   update_status_thread_delegate_->updateTimeOut(update_timeout *
                                                 milliseconds_in_second);
-  set_exchange_in_progress(true);
-  set_exchange_pending(true);
-  set_update_required(false);
+  ProcessEvent(kOnUpdateSentOut);
 }
 
 void UpdateStatusManager::OnUpdateTimeoutOccurs() {
   LOG4CXX_AUTO_TRACE(logger_);
-  set_update_required(true);
-  set_exchange_in_progress(false);
-  set_exchange_pending(false);
+  ProcessEvent(kOnUpdateTimeout);
   DCHECK(update_status_thread_delegate_);
   update_status_thread_delegate_->updateTimeOut(0);  // Stop Timer
 }
@@ -89,41 +95,27 @@ void UpdateStatusManager::OnUpdateTimeoutOccurs() {
 void UpdateStatusManager::OnValidUpdateReceived() {
   LOG4CXX_AUTO_TRACE(logger_);
   update_status_thread_delegate_->updateTimeOut(0);  // Stop Timer
-  const bool is_another_update_planned = IsUpdateRequired();
-  if (is_another_update_planned) {
-    set_update_required(false);
-  }
-
-  set_exchange_pending(false);
-  set_exchange_in_progress(false);
-
-  if (is_another_update_planned) {
-    set_update_required(true);
-  }
+  ProcessEvent(kOnValidUpdateReceived);
 }
 
 void UpdateStatusManager::OnWrongUpdateReceived() {
   LOG4CXX_AUTO_TRACE(logger_);
   update_status_thread_delegate_->updateTimeOut(0);  // Stop Timer
-  set_update_required(true);
-  set_exchange_in_progress(false);
-  set_exchange_pending(false);
+  ProcessEvent(kOnWrongUpdateReceived);
 }
 
 void UpdateStatusManager::OnResetDefaultPT(bool is_update_required) {
   LOG4CXX_AUTO_TRACE(logger_);
-  exchange_in_progress_ = false;
-  update_required_ = is_update_required;
-  exchange_pending_ = false;
-  last_update_status_ = policy::StatusUnknown;
+  if (is_update_required) {
+    ProcessEvent(kOnResetPolicyTableRequireUpdate);
+    return;
+  }
+  ProcessEvent(kOnResetPolicyTableNoUpdate);
 }
 
 void UpdateStatusManager::OnResetRetrySequence() {
   LOG4CXX_AUTO_TRACE(logger_);
-  if (exchange_in_progress_) {
-    set_exchange_pending(true);
-  }
-  set_update_required(true);
+  ProcessEvent(kOnResetRetrySequence);
 }
 
 void UpdateStatusManager::OnNewApplicationAdded(const DeviceConsent consent) {
@@ -133,61 +125,38 @@ void UpdateStatusManager::OnNewApplicationAdded(const DeviceConsent consent) {
     return;
   }
   app_registered_from_non_consented_device_ = false;
-  set_update_required(true);
+  ProcessEvent(kOnNewAppRegistered);
 }
 
 void UpdateStatusManager::OnPolicyInit(bool is_update_required) {
   LOG4CXX_AUTO_TRACE(logger_);
-  update_required_ = is_update_required;
+  if (is_update_required) {
+    current_status_.reset(new UpToDateStatus());
+    ProcessEvent(kScheduleUpdate);
+  }
 }
 
 void UpdateStatusManager::OnDeviceConsented() {
   LOG4CXX_AUTO_TRACE(logger_);
   if (app_registered_from_non_consented_device_) {
-    set_update_required(true);
+    ProcessEvent(kOnNewAppRegistered);
   }
-}
-
-PolicyTableStatus UpdateStatusManager::GetUpdateStatus() const {
-  LOG4CXX_AUTO_TRACE(logger_);
-  if (!exchange_in_progress_ && !exchange_pending_ && !update_required_) {
-    return PolicyTableStatus::StatusUpToDate;
-  }
-
-  if (update_required_ && !exchange_in_progress_ && !exchange_pending_) {
-    return PolicyTableStatus::StatusUpdateRequired;
-  }
-
-  return PolicyTableStatus::StatusUpdatePending;
 }
 
 bool UpdateStatusManager::IsUpdateRequired() const {
-  return update_required_ || update_scheduled_;
+  return current_status_->IsUpdateRequired();
 }
 
 bool UpdateStatusManager::IsUpdatePending() const {
-  return exchange_pending_;
+  return current_status_->IsUpdatePending();
 }
 
 void UpdateStatusManager::ScheduleUpdate() {
-  update_scheduled_ = true;
-  update_required_ = true;
-}
-
-void UpdateStatusManager::ResetUpdateSchedule() {
-  update_scheduled_ = false;
+  ProcessEvent(kScheduleUpdate);
 }
 
 std::string UpdateStatusManager::StringifiedUpdateStatus() const {
-  switch (GetUpdateStatus()) {
-    case policy::StatusUpdatePending:
-      return "UPDATING";
-    case policy::StatusUpdateRequired:
-      return "UPDATE_NEEDED";
-    case policy::StatusUpToDate:
-      return "UP_TO_DATE";
-    default: { return "UNKNOWN"; }
-  }
+  return current_status_->get_status_string();
 }
 
 void policy::UpdateStatusManager::OnAppsSearchStarted() {
@@ -208,40 +177,23 @@ bool policy::UpdateStatusManager::IsAppsSearchInProgress() {
   return apps_search_in_progress_;
 }
 
-void UpdateStatusManager::CheckUpdateStatus() {
-  LOG4CXX_AUTO_TRACE(logger_);
-  policy::PolicyTableStatus status = GetUpdateStatus();
-  if (listener_ && last_update_status_ != status) {
-    LOG4CXX_INFO(logger_, "Send OnUpdateStatusChanged");
-    listener_->OnUpdateStatusChanged(StringifiedUpdateStatus());
+void UpdateStatusManager::DoTransition() {
+  DCHECK_OR_RETURN_VOID(listener_);
+  if (!next_status_) {
+    return;
   }
-  last_update_status_ = status;
-}
 
-void UpdateStatusManager::set_exchange_in_progress(bool value) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  sync_primitives::AutoLock lock(exchange_in_progress_lock_);
-  LOG4CXX_INFO(logger_,
-               "Exchange in progress value is:" << std::boolalpha << value);
-  exchange_in_progress_ = value;
-  CheckUpdateStatus();
-}
+  current_status_ = next_status_;
+  next_status_.reset();
+  listener_->OnUpdateStatusChanged(current_status_->get_status_string());
 
-void UpdateStatusManager::set_exchange_pending(bool value) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  sync_primitives::AutoLock lock(exchange_pending_lock_);
-  LOG4CXX_INFO(logger_,
-               "Exchange pending value is:" << std::boolalpha << value);
-  exchange_pending_ = value;
-  CheckUpdateStatus();
-}
+  if (!postponed_status_) {
+    return;
+  }
 
-void UpdateStatusManager::set_update_required(bool value) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  sync_primitives::AutoLock lock(update_required_lock_);
-  LOG4CXX_INFO(logger_, "Update required value is:" << std::boolalpha << value);
-  update_required_ = value;
-  CheckUpdateStatus();
+  current_status_ = postponed_status_;
+  listener_->OnUpdateStatusChanged(current_status_->get_status_string());
+  postponed_status_.reset();
 }
 
 UpdateStatusManager::UpdateThreadDelegate::UpdateThreadDelegate(

--- a/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
@@ -87,6 +87,8 @@ TEST_F(PolicyManagerImplTest2, GetNotificationsNumberAfterPTUpdate) {
   // Arrange
 
   Json::Value table = createPTforLoad();
+  manager_->ForcePTExchange();
+  manager_->OnUpdateStarted();
   policy_table::Table update(&table);
   update.SetPolicyTableType(rpc::policy_table_interface_base::PT_UPDATE);
   // Act
@@ -792,6 +794,8 @@ TEST_F(PolicyManagerImplTest2,
 
 TEST_F(PolicyManagerImplTest, LoadPT_SetInvalidUpdatePT_PTIsNotLoaded) {
   // Arrange
+  manager_->ForcePTExchange();
+  manager_->OnUpdateStarted();
   Json::Value table(Json::objectValue);
 
   policy_table::Table update(&table);

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -127,6 +127,8 @@ TEST_F(PolicyManagerImplTest, ResetPT) {
 
 TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
   // Arrange
+  manager_->ForcePTExchange();
+  manager_->OnUpdateStarted();
   Json::Value table = createPTforLoad();
 
   policy_table::Table update(&table);
@@ -280,6 +282,7 @@ TEST_F(PolicyManagerImplTest2, GetPolicyTableStatus_ExpectUpToDate) {
 TEST_F(PolicyManagerImplTest,
        SetUpdateStarted_GetPolicyTableStatus_Expect_Updating) {
   // Arrange
+  manager_->ForcePTExchange();
   EXPECT_CALL(*cache_manager_, SaveUpdateRequired(true));
   manager_->OnUpdateStarted();
   // Check
@@ -311,6 +314,7 @@ TEST_F(PolicyManagerImplTest2,
        OnExceededTimeout_GetPolicyTableStatus_ExpectUpdateNeeded) {
   // Arrange
   CreateLocalPT(preloadet_pt_filename_);
+  manager_->ForcePTExchange();
   manager_->OnExceededTimeout();
   // Check
   EXPECT_EQ("UPDATE_NEEDED", manager_->GetPolicyTableStatus());

--- a/src/components/policy/policy_external/test/update_status_manager_test.cc
+++ b/src/components/policy/policy_external/test/update_status_manager_test.cc
@@ -74,6 +74,7 @@ class UpdateStatusManagerTest : public ::testing::Test {
 TEST_F(UpdateStatusManagerTest,
        OnUpdateSentOut_WaitForTimeoutExpired_ExpectStatusUpdateNeeded) {
   // Arrange
+  manager_->ScheduleUpdate();
   manager_->OnUpdateSentOut(k_timeout_);
   status_ = manager_->GetLastUpdateStatus();
   EXPECT_EQ(StatusUpdatePending, status_);
@@ -89,6 +90,7 @@ TEST_F(UpdateStatusManagerTest,
   // Arrange
   status_ = manager_->GetLastUpdateStatus();
   EXPECT_EQ(StatusUpToDate, status_);
+  manager_->ScheduleUpdate();
   manager_->OnUpdateTimeoutOccurs();
   status_ = manager_->GetLastUpdateStatus();
   // Check
@@ -98,6 +100,9 @@ TEST_F(UpdateStatusManagerTest,
 TEST_F(UpdateStatusManagerTest,
        OnValidUpdateReceived_SetValidUpdateReceived_ExpectStatusUpToDate) {
   // Arrange
+  EXPECT_CALL(*listener_, OnUpdateStatusChanged(update_needed_status_));
+  manager_->ScheduleUpdate();
+  EXPECT_EQ(StatusUpdateRequired, status_);
   EXPECT_CALL(*listener_, OnUpdateStatusChanged(updating_status_));
   manager_->OnUpdateSentOut(k_timeout_);
   status_ = manager_->GetLastUpdateStatus();
@@ -115,6 +120,10 @@ TEST_F(
     SheduledUpdate_OnValidUpdateReceived_ExpectStatusUpToDateThanUpdateNeeded) {
   using ::testing::InSequence;
   // Arrange
+  EXPECT_CALL(*listener_, OnUpdateStatusChanged(update_needed_status_));
+  manager_->ScheduleUpdate();
+  status_ = manager_->GetLastUpdateStatus();
+  EXPECT_EQ(StatusUpdateRequired, status_);
   EXPECT_CALL(*listener_, OnUpdateStatusChanged(updating_status_));
   manager_->OnUpdateSentOut(k_timeout_);
   status_ = manager_->GetLastUpdateStatus();
@@ -134,6 +143,9 @@ TEST_F(
 TEST_F(UpdateStatusManagerTest,
        OnWrongUpdateReceived_SetWrongUpdateReceived_ExpectStatusUpdateNeeded) {
   // Arrange
+  manager_->ScheduleUpdate();
+  status_ = manager_->GetLastUpdateStatus();
+  EXPECT_EQ(StatusUpdateRequired, status_);
   manager_->OnUpdateSentOut(k_timeout_);
   status_ = manager_->GetLastUpdateStatus();
   EXPECT_EQ(StatusUpdatePending, status_);
@@ -146,6 +158,9 @@ TEST_F(UpdateStatusManagerTest,
 TEST_F(UpdateStatusManagerTest,
        OnResetDefaulPT_ResetPTtoDefaultState_ExpectPTinDefaultState) {
   // Arrange
+  manager_->ScheduleUpdate();
+  status_ = manager_->GetLastUpdateStatus();
+  EXPECT_EQ(StatusUpdateRequired, status_);
   manager_->OnUpdateSentOut(k_timeout_);
   status_ = manager_->GetLastUpdateStatus();
   EXPECT_EQ(StatusUpdatePending, status_);
@@ -159,6 +174,9 @@ TEST_F(UpdateStatusManagerTest,
 TEST_F(UpdateStatusManagerTest,
        OnResetDefaulPT2_ResetPTtoDefaultState_ExpectPTinDefaultState) {
   // Arrange
+  manager_->ScheduleUpdate();
+  status_ = manager_->GetLastUpdateStatus();
+  EXPECT_EQ(StatusUpdateRequired, status_);
   manager_->OnUpdateSentOut(k_timeout_);
   status_ = manager_->GetLastUpdateStatus();
   EXPECT_EQ(StatusUpdatePending, status_);
@@ -171,6 +189,9 @@ TEST_F(UpdateStatusManagerTest,
 
 TEST_F(UpdateStatusManagerTest, OnResetRetrySequence_ExpectStatusUpToDate) {
   // Arrange
+  manager_->ScheduleUpdate();
+  status_ = manager_->GetLastUpdateStatus();
+  EXPECT_EQ(StatusUpdateRequired, status_);
   manager_->OnUpdateSentOut(k_timeout_);
   status_ = manager_->GetLastUpdateStatus();
   EXPECT_EQ(StatusUpdatePending, status_);
@@ -183,6 +204,9 @@ TEST_F(UpdateStatusManagerTest, OnResetRetrySequence_ExpectStatusUpToDate) {
 TEST_F(UpdateStatusManagerTest,
        OnNewApplicationAdded_ExpectStatusUpdateNeeded) {
   // Arrange
+  manager_->ScheduleUpdate();
+  status_ = manager_->GetLastUpdateStatus();
+  EXPECT_EQ(StatusUpdateRequired, status_);
   manager_->OnUpdateSentOut(k_timeout_);
   status_ = manager_->GetLastUpdateStatus();
   EXPECT_EQ(StatusUpdatePending, status_);
@@ -196,6 +220,9 @@ TEST_F(UpdateStatusManagerTest,
 
 TEST_F(UpdateStatusManagerTest, ScheduleUpdate_ExpectStatusUpdateNeeded) {
   // Arrange
+  manager_->ScheduleUpdate();
+  status_ = manager_->GetLastUpdateStatus();
+  EXPECT_EQ(StatusUpdateRequired, status_);
   manager_->OnUpdateSentOut(k_timeout_);
   status_ = manager_->GetLastUpdateStatus();
   EXPECT_EQ(StatusUpdatePending, status_);
@@ -210,29 +237,6 @@ TEST_F(UpdateStatusManagerTest, ScheduleUpdate_ExpectStatusUpdateNeeded) {
   EXPECT_EQ(StatusUpdateRequired, status_);
   EXPECT_FALSE(manager_->IsUpdatePending());
   EXPECT_TRUE(manager_->IsUpdateRequired());
-}
-
-TEST_F(UpdateStatusManagerTest,
-       ResetUpdateSchedule_SetUpdateScheduleThenReset_ExpectStatusUpToDate) {
-  // Arrange
-  status_ = manager_->GetLastUpdateStatus();
-  EXPECT_EQ(StatusUpToDate, status_);
-  EXPECT_FALSE(manager_->IsUpdatePending());
-  EXPECT_FALSE(manager_->IsUpdateRequired());
-  manager_->ScheduleUpdate();
-  // Check
-  EXPECT_TRUE(manager_->IsUpdateRequired());
-  // Act
-  manager_->OnPolicyInit(false);
-  // Check
-  EXPECT_TRUE(manager_->IsUpdateRequired());
-  // Act
-  manager_->ResetUpdateSchedule();
-  // Check
-  EXPECT_FALSE(manager_->IsUpdateRequired());
-  status_ = manager_->GetLastUpdateStatus();
-  // Check
-  EXPECT_EQ(StatusUpToDate, status_);
 }
 
 TEST_F(UpdateStatusManagerTest,

--- a/src/components/policy/policy_regular/CMakeLists.txt
+++ b/src/components/policy/policy_regular/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SOURCES
   ${POLICY_PATH}/src/sql_pt_queries.cc
   ${POLICY_PATH}/src/sql_pt_representation.cc
   ${POLICY_PATH}/src/update_status_manager.cc
+  ${POLICY_PATH}/src/status.cc
   ${POLICY_PATH}/src/cache_manager.cc
   ${COMPONENTS_DIR}/rpc_base/src/rpc_base/rpc_base.cc
 )

--- a/src/components/policy/policy_regular/include/policy/status.h
+++ b/src/components/policy/policy_regular/include/policy/status.h
@@ -1,0 +1,204 @@
+/*
+ Copyright (c) 2016, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_POLICY_POLICY_EXTERNAL_INCLUDE_POLICY_STATUS_H_
+#define SRC_COMPONENTS_POLICY_POLICY_EXTERNAL_INCLUDE_POLICY_STATUS_H_
+
+#include <string>
+#include "policy/policy_types.h"
+#include "utils/macro.h"
+
+namespace policy {
+
+/**
+ * @brief The UpdateEvent enum defines system events which can change update
+ * status
+ */
+enum UpdateEvent {
+  kOnNewAppRegistered,
+  kOnValidUpdateReceived,
+  kOnWrongUpdateReceived,
+  kOnUpdateSentOut,
+  kOnUpdateTimeout,
+  kOnResetPolicyTableRequireUpdate,
+  kOnResetPolicyTableNoUpdate,
+  kScheduleUpdate,
+  kOnResetRetrySequence
+};
+
+class UpdateStatusManagerInterface;
+
+/**
+ * @brief The Status class defines base implementation of update status
+ */
+class Status {
+ public:
+  /**
+ * @brief Destructor
+ */
+  virtual ~Status();
+
+  /**
+ * @brief Process event by setting next status in case event can affect
+ * current status or ignores the event
+ * @param mng Status manager pointer
+ * @param event Event which needs to be processed
+ */
+  virtual void ProcessEvent(UpdateStatusManagerInterface* mng,
+                            UpdateEvent event) = 0;
+
+  /**
+ * @brief Return current status as string value
+ * @return Status as string
+ */
+  virtual const std::string get_status_string() const = 0;
+
+  /**
+ * @brief Return status as enum value
+ * @return Status as enum value
+ */
+  virtual PolicyTableStatus get_status() const = 0;
+
+  /**
+ * @brief Check whether update is required in terms of status
+ * @return True if update is required, otherwise - false
+ */
+  virtual bool IsUpdateRequired() const;
+
+  /**
+ * @brief Check whether update is pending in terms of status
+ * @return True if update is pending, otherwise - false
+ */
+  virtual bool IsUpdatePending() const;
+};
+
+/**
+ * @brief The UpToDateStatus class represents 'up-to-date' status
+ */
+class UpToDateStatus : public Status {
+ public:
+  /**
+ * @brief Process event by setting next status in case event can affect
+ * current status or ignores the event
+ * @param mng Status manager pointer
+ * @param event Event which needs to be processed
+ */
+  void ProcessEvent(UpdateStatusManagerInterface* mng,
+                    UpdateEvent event) OVERRIDE;
+
+  /**
+ * @brief Return current status as string value
+ * @return Status as string
+ */
+  const std::string get_status_string() const OVERRIDE;
+
+  /**
+ * @brief Return status as enum value
+ * @return Status as enum value
+ */
+  PolicyTableStatus get_status() const OVERRIDE;
+};
+
+/**
+ * @brief The UpdateNeededStatus class represents 'update needed' status
+ */
+class UpdateNeededStatus : public Status {
+ public:
+  /**
+ * @brief Process event by setting next status in case event can affect
+ * current status or ignores the event
+ * @param mng Status manager pointer
+ * @param event Event which needs to be processed
+ */
+  void ProcessEvent(UpdateStatusManagerInterface* mng,
+                    UpdateEvent event) OVERRIDE;
+
+  /**
+ * @brief Return current status as string value
+ * @return Status as string
+ */
+  const std::string get_status_string() const OVERRIDE;
+
+  /**
+ * @brief Return status as enum value
+ * @return Status as enum value
+ */
+  PolicyTableStatus get_status() const OVERRIDE;
+
+  /**
+ * @brief Check whether update is required in terms of status
+ * @return True if update is required, otherwise - false
+ */
+  bool IsUpdateRequired() const OVERRIDE;
+};
+
+/**
+ * @brief The UpdatingStatus class represents 'updating' status
+ */
+class UpdatingStatus : public Status {
+ public:
+  /**
+ * @brief Process event by setting next status in case event can affect
+ * current status or ignores the event
+ * @param mng Status manager pointer
+ * @param event Event which needs to be processed
+ */
+  void ProcessEvent(UpdateStatusManagerInterface* mng,
+                    UpdateEvent event) OVERRIDE;
+
+  /**
+ * @brief Return current status as string value
+ * @return Status as string
+ */
+  const std::string get_status_string() const OVERRIDE;
+
+  /**
+ * @brief Return status as enum value
+ * @return Status as enum value
+ */
+  PolicyTableStatus get_status() const OVERRIDE;
+
+  /**
+ * @brief Check whether update is required in terms of status
+ * @return True if update is required, otherwise - false
+ */
+  bool IsUpdateRequired() const OVERRIDE;
+
+  /**
+ * @brief Check whether update is pending in terms of status
+ * @return True if update is pending, otherwise - false
+ */
+  bool IsUpdatePending() const OVERRIDE;
+};
+}
+
+#endif  // SRC_COMPONENTS_POLICY_POLICY_EXTERNAL_INCLUDE_POLICY_STATUS_H_

--- a/src/components/policy/policy_regular/include/policy/status.h
+++ b/src/components/policy/policy_regular/include/policy/status.h
@@ -63,6 +63,12 @@ class UpdateStatusManagerInterface;
 class Status {
  public:
   /**
+   * @brief Constructor
+   */
+  Status(const std::string& string_status,
+         const policy::PolicyTableStatus enum_status);
+
+  /**
  * @brief Destructor
  */
   virtual ~Status();
@@ -70,23 +76,23 @@ class Status {
   /**
  * @brief Process event by setting next status in case event can affect
  * current status or ignores the event
- * @param mng Status manager pointer
+ * @param manager Status manager pointer
  * @param event Event which needs to be processed
  */
-  virtual void ProcessEvent(UpdateStatusManagerInterface* mng,
+  virtual void ProcessEvent(UpdateStatusManagerInterface* manager,
                             UpdateEvent event) = 0;
 
   /**
  * @brief Return current status as string value
  * @return Status as string
  */
-  virtual const std::string get_status_string() const = 0;
+  virtual const std::string get_status_string() const;
 
   /**
  * @brief Return status as enum value
  * @return Status as enum value
  */
-  virtual PolicyTableStatus get_status() const = 0;
+  virtual PolicyTableStatus get_status() const;
 
   /**
  * @brief Check whether update is required in terms of status
@@ -99,6 +105,10 @@ class Status {
  * @return True if update is pending, otherwise - false
  */
   virtual bool IsUpdatePending() const;
+
+ private:
+  const std::string string_status_;
+  const PolicyTableStatus enum_status_;
 };
 
 /**
@@ -107,25 +117,18 @@ class Status {
 class UpToDateStatus : public Status {
  public:
   /**
+   * @brief Constructor
+   */
+  UpToDateStatus();
+
+  /**
  * @brief Process event by setting next status in case event can affect
  * current status or ignores the event
- * @param mng Status manager pointer
+ * @param manager Status manager pointer
  * @param event Event which needs to be processed
  */
-  void ProcessEvent(UpdateStatusManagerInterface* mng,
-                    UpdateEvent event) OVERRIDE;
-
-  /**
- * @brief Return current status as string value
- * @return Status as string
- */
-  const std::string get_status_string() const OVERRIDE;
-
-  /**
- * @brief Return status as enum value
- * @return Status as enum value
- */
-  PolicyTableStatus get_status() const OVERRIDE;
+  void ProcessEvent(UpdateStatusManagerInterface* manager,
+                    UpdateEvent event) FINAL;
 };
 
 /**
@@ -134,31 +137,24 @@ class UpToDateStatus : public Status {
 class UpdateNeededStatus : public Status {
  public:
   /**
+   * @brief Constructor
+   */
+  UpdateNeededStatus();
+
+  /**
  * @brief Process event by setting next status in case event can affect
  * current status or ignores the event
- * @param mng Status manager pointer
+ * @param manager Status manager pointer
  * @param event Event which needs to be processed
  */
-  void ProcessEvent(UpdateStatusManagerInterface* mng,
-                    UpdateEvent event) OVERRIDE;
-
-  /**
- * @brief Return current status as string value
- * @return Status as string
- */
-  const std::string get_status_string() const OVERRIDE;
-
-  /**
- * @brief Return status as enum value
- * @return Status as enum value
- */
-  PolicyTableStatus get_status() const OVERRIDE;
+  void ProcessEvent(UpdateStatusManagerInterface* manager,
+                    UpdateEvent event) FINAL;
 
   /**
  * @brief Check whether update is required in terms of status
  * @return True if update is required, otherwise - false
  */
-  bool IsUpdateRequired() const OVERRIDE;
+  bool IsUpdateRequired() const FINAL;
 };
 
 /**
@@ -167,37 +163,30 @@ class UpdateNeededStatus : public Status {
 class UpdatingStatus : public Status {
  public:
   /**
+   * @brief Constructor
+   */
+  UpdatingStatus();
+
+  /**
  * @brief Process event by setting next status in case event can affect
  * current status or ignores the event
- * @param mng Status manager pointer
+ * @param manager Status manager pointer
  * @param event Event which needs to be processed
  */
-  void ProcessEvent(UpdateStatusManagerInterface* mng,
-                    UpdateEvent event) OVERRIDE;
-
-  /**
- * @brief Return current status as string value
- * @return Status as string
- */
-  const std::string get_status_string() const OVERRIDE;
-
-  /**
- * @brief Return status as enum value
- * @return Status as enum value
- */
-  PolicyTableStatus get_status() const OVERRIDE;
+  void ProcessEvent(UpdateStatusManagerInterface* manager,
+                    UpdateEvent event) FINAL;
 
   /**
  * @brief Check whether update is required in terms of status
  * @return True if update is required, otherwise - false
  */
-  bool IsUpdateRequired() const OVERRIDE;
+  bool IsUpdateRequired() const FINAL;
 
   /**
  * @brief Check whether update is pending in terms of status
  * @return True if update is pending, otherwise - false
  */
-  bool IsUpdatePending() const OVERRIDE;
+  bool IsUpdatePending() const FINAL;
 };
 }
 

--- a/src/components/policy/policy_regular/include/policy/update_status_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/update_status_manager_interface.h
@@ -35,6 +35,7 @@
 
 #include "utils/shared_ptr.h"
 #include "policy/policy_types.h"
+#include "policy/status.h"
 
 namespace policy {
 
@@ -43,6 +44,25 @@ class PolicyListener;
 class UpdateStatusManagerInterface {
  public:
   virtual ~UpdateStatusManagerInterface() {}
+
+  /**
+   * @brief Process event by current status implementations
+   * @param event Event
+   */
+  virtual void ProcessEvent(UpdateEvent event) = 0;
+
+  /**
+   * @brief Set next status during event processing
+   * @param status Status shared pointer
+   */
+  virtual void SetNextStatus(utils::SharedPtr<Status> status) = 0;
+
+  /**
+   * @brief Set postponed status (will be set after next status) during event
+   * processing
+   * @param status Status shared pointer
+   */
+  virtual void SetPostponedStatus(utils::SharedPtr<Status> status) = 0;
   /**
    * @brief Sets listener pointer
    * @param listener Pointer to policy listener implementation
@@ -84,19 +104,13 @@ class UpdateStatusManagerInterface {
   /**
    * @brief Update status handler on new application registering
    */
-  virtual void OnNewApplicationAdded() = 0;
+  virtual void OnNewApplicationAdded(DeviceConsent device_consent) = 0;
 
   /**
    * @brief Update status handler for policy initialization
    * @param is_update_required Update necessity flag
    */
   virtual void OnPolicyInit(bool is_update_required) = 0;
-
-  /**
-   * @brief Returns current policy update status
-   * @return
-   */
-  virtual PolicyTableStatus GetUpdateStatus() = 0;
 };
 
 typedef utils::SharedPtr<UpdateStatusManagerInterface>

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -274,11 +274,6 @@ bool PolicyManagerImpl::RequestPTUpdate() {
   BinaryMessage update(message_string.begin(), message_string.end());
 
   listener_->OnSnapshotCreated(update);
-
-  // Need to reset update schedule since all currenly registered applications
-  // were already added to the snapshot so no update for them required.
-  update_status_manager_.ResetUpdateSchedule();
-
   return true;
 }
 
@@ -907,7 +902,7 @@ void PolicyManagerImpl::AddApplication(const std::string& application_id) {
 
   if (IsNewApplication(application_id)) {
     AddNewApplication(application_id, device_consent);
-    update_status_manager_.OnNewApplicationAdded();
+    update_status_manager_.OnNewApplicationAdded(device_consent);
   } else {
     PromoteExistedApplication(application_id, device_consent);
   }

--- a/src/components/policy/policy_regular/src/status.cc
+++ b/src/components/policy/policy_regular/src/status.cc
@@ -34,91 +34,77 @@
 #include "policy/update_status_manager_interface.h"
 #include "utils/make_shared.h"
 
-void policy::UpToDateStatus::ProcessEvent(UpdateStatusManagerInterface* mng,
+policy::UpToDateStatus::UpToDateStatus()
+    : Status("UP_TO_DATE", policy::PolicyTableStatus::StatusUpToDate) {}
+
+void policy::UpToDateStatus::ProcessEvent(UpdateStatusManagerInterface* manager,
                                           policy::UpdateEvent event) {
   switch (event) {
     case kOnNewAppRegistered:
     case kOnResetPolicyTableRequireUpdate:
     case kScheduleUpdate:
     case kOnResetRetrySequence:
-      mng->SetNextStatus(new UpdateNeededStatus());
+      manager->SetNextStatus(utils::MakeShared<UpdateNeededStatus>());
       break;
     default:
       break;
   }
 }
 
-const std::string policy::UpToDateStatus::get_status_string() const {
-  return "UP_TO_DATE";
-}
-
-policy::PolicyTableStatus policy::UpToDateStatus::get_status() const {
-  return PolicyTableStatus::StatusUpToDate;
+policy::UpdateNeededStatus::UpdateNeededStatus()
+    : Status("UPDATE_NEEDED", policy::PolicyTableStatus::StatusUpdateRequired) {
 }
 
 void policy::UpdateNeededStatus::ProcessEvent(
-    policy::UpdateStatusManagerInterface* mng, policy::UpdateEvent event) {
+    policy::UpdateStatusManagerInterface* manager, policy::UpdateEvent event) {
   switch (event) {
     case kOnUpdateSentOut:
-      mng->SetNextStatus(utils::MakeShared<UpdatingStatus>());
+      manager->SetNextStatus(utils::MakeShared<UpdatingStatus>());
       break;
     case kOnResetPolicyTableRequireUpdate:
-      mng->SetNextStatus(utils::MakeShared<UpToDateStatus>());
-      mng->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
+      manager->SetNextStatus(utils::MakeShared<UpToDateStatus>());
+      manager->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
       break;
     case kOnResetPolicyTableNoUpdate:
-      mng->SetNextStatus(utils::MakeShared<UpToDateStatus>());
+      manager->SetNextStatus(utils::MakeShared<UpToDateStatus>());
       break;
     default:
       break;
   }
-}
-
-const std::string policy::UpdateNeededStatus::get_status_string() const {
-  return "UPDATE_NEEDED";
-}
-
-policy::PolicyTableStatus policy::UpdateNeededStatus::get_status() const {
-  return PolicyTableStatus::StatusUpdateRequired;
 }
 
 bool policy::UpdateNeededStatus::IsUpdateRequired() const {
   return true;
 }
 
+policy::UpdatingStatus::UpdatingStatus()
+    : Status("UPDATING", policy::PolicyTableStatus::StatusUpdatePending) {}
+
 void policy::UpdatingStatus::ProcessEvent(
-    policy::UpdateStatusManagerInterface* mng, policy::UpdateEvent event) {
+    policy::UpdateStatusManagerInterface* manager, policy::UpdateEvent event) {
   switch (event) {
     case kOnValidUpdateReceived:
     case kOnResetPolicyTableNoUpdate:
-      mng->SetNextStatus(utils::MakeShared<UpToDateStatus>());
+      manager->SetNextStatus(utils::MakeShared<UpToDateStatus>());
       break;
     case kOnNewAppRegistered:
-      mng->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
+      manager->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
       break;
     case kOnWrongUpdateReceived:
     case kOnUpdateTimeout:
-      mng->SetNextStatus(utils::MakeShared<UpdateNeededStatus>());
+      manager->SetNextStatus(utils::MakeShared<UpdateNeededStatus>());
       break;
     case kOnResetPolicyTableRequireUpdate:
-      mng->SetNextStatus(utils::MakeShared<UpToDateStatus>());
-      mng->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
+      manager->SetNextStatus(utils::MakeShared<UpToDateStatus>());
+      manager->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
       break;
     case kScheduleUpdate:
     case kOnResetRetrySequence:
-      mng->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
+      manager->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
       break;
     default:
       break;
   }
-}
-
-const std::string policy::UpdatingStatus::get_status_string() const {
-  return "UPDATING";
-}
-
-policy::PolicyTableStatus policy::UpdatingStatus::get_status() const {
-  return PolicyTableStatus::StatusUpdatePending;
 }
 
 bool policy::UpdatingStatus::IsUpdatePending() const {
@@ -129,7 +115,19 @@ bool policy::UpdatingStatus::IsUpdateRequired() const {
   return true;
 }
 
+policy::Status::Status(const std::string& string_status,
+                       const policy::PolicyTableStatus enum_status)
+    : string_status_(string_status), enum_status_(enum_status) {}
+
 policy::Status::~Status() {}
+
+const std::string policy::Status::get_status_string() const {
+  return string_status_;
+}
+
+policy::PolicyTableStatus policy::Status::get_status() const {
+  return enum_status_;
+}
 
 bool policy::Status::IsUpdateRequired() const {
   return false;

--- a/src/components/policy/policy_regular/src/status.cc
+++ b/src/components/policy/policy_regular/src/status.cc
@@ -1,0 +1,140 @@
+/*
+ Copyright (c) 2016, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "policy/status.h"
+#include "policy/update_status_manager_interface.h"
+#include "utils/make_shared.h"
+
+void policy::UpToDateStatus::ProcessEvent(UpdateStatusManagerInterface* mng,
+                                          policy::UpdateEvent event) {
+  switch (event) {
+    case kOnNewAppRegistered:
+    case kOnResetPolicyTableRequireUpdate:
+    case kScheduleUpdate:
+    case kOnResetRetrySequence:
+      mng->SetNextStatus(new UpdateNeededStatus());
+      break;
+    default:
+      break;
+  }
+}
+
+const std::string policy::UpToDateStatus::get_status_string() const {
+  return "UP_TO_DATE";
+}
+
+policy::PolicyTableStatus policy::UpToDateStatus::get_status() const {
+  return PolicyTableStatus::StatusUpToDate;
+}
+
+void policy::UpdateNeededStatus::ProcessEvent(
+    policy::UpdateStatusManagerInterface* mng, policy::UpdateEvent event) {
+  switch (event) {
+    case kOnUpdateSentOut:
+      mng->SetNextStatus(utils::MakeShared<UpdatingStatus>());
+      break;
+    case kOnResetPolicyTableRequireUpdate:
+      mng->SetNextStatus(utils::MakeShared<UpToDateStatus>());
+      mng->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
+      break;
+    case kOnResetPolicyTableNoUpdate:
+      mng->SetNextStatus(utils::MakeShared<UpToDateStatus>());
+      break;
+    default:
+      break;
+  }
+}
+
+const std::string policy::UpdateNeededStatus::get_status_string() const {
+  return "UPDATE_NEEDED";
+}
+
+policy::PolicyTableStatus policy::UpdateNeededStatus::get_status() const {
+  return PolicyTableStatus::StatusUpdateRequired;
+}
+
+bool policy::UpdateNeededStatus::IsUpdateRequired() const {
+  return true;
+}
+
+void policy::UpdatingStatus::ProcessEvent(
+    policy::UpdateStatusManagerInterface* mng, policy::UpdateEvent event) {
+  switch (event) {
+    case kOnValidUpdateReceived:
+    case kOnResetPolicyTableNoUpdate:
+      mng->SetNextStatus(utils::MakeShared<UpToDateStatus>());
+      break;
+    case kOnNewAppRegistered:
+      mng->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
+      break;
+    case kOnWrongUpdateReceived:
+    case kOnUpdateTimeout:
+      mng->SetNextStatus(utils::MakeShared<UpdateNeededStatus>());
+      break;
+    case kOnResetPolicyTableRequireUpdate:
+      mng->SetNextStatus(utils::MakeShared<UpToDateStatus>());
+      mng->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
+      break;
+    case kScheduleUpdate:
+    case kOnResetRetrySequence:
+      mng->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
+      break;
+    default:
+      break;
+  }
+}
+
+const std::string policy::UpdatingStatus::get_status_string() const {
+  return "UPDATING";
+}
+
+policy::PolicyTableStatus policy::UpdatingStatus::get_status() const {
+  return PolicyTableStatus::StatusUpdatePending;
+}
+
+bool policy::UpdatingStatus::IsUpdatePending() const {
+  return true;
+}
+
+bool policy::UpdatingStatus::IsUpdateRequired() const {
+  return true;
+}
+
+policy::Status::~Status() {}
+
+bool policy::Status::IsUpdateRequired() const {
+  return false;
+}
+
+bool policy::Status::IsUpdatePending() const {
+  return false;
+}

--- a/src/components/policy/policy_regular/src/update_status_manager.cc
+++ b/src/components/policy/policy_regular/src/update_status_manager.cc
@@ -33,6 +33,7 @@
 #include "policy/update_status_manager.h"
 #include "policy/policy_listener.h"
 #include "utils/logger.h"
+#include "utils/make_shared.h"
 
 namespace policy {
 
@@ -40,7 +41,7 @@ CREATE_LOGGERPTR_GLOBAL(logger_, "Policy")
 
 UpdateStatusManager::UpdateStatusManager()
     : listener_(NULL)
-    , current_status_(new UpToDateStatus())
+    , current_status_(utils::MakeShared<UpToDateStatus>())
     , apps_search_in_progress_(false)
     , app_registered_from_non_consented_device_(true) {
   update_status_thread_delegate_ = new UpdateThreadDelegate(this);

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -461,6 +461,8 @@ TEST_F(PolicyManagerImplTest, GetNotificationsNumber) {
 TEST_F(PolicyManagerImplTest2, GetNotificationsNumberAfterPTUpdate) {
   // Arrange
   Json::Value table = CreatePTforLoad();
+  manager->ForcePTExchange();
+  manager->OnUpdateStarted();
   policy_table::Table update(&table);
   update.SetPolicyTableType(rpc::policy_table_interface_base::PT_UPDATE);
   // Act
@@ -692,6 +694,8 @@ TEST_F(PolicyManagerImplTest, ResetPT) {
 
 TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
   // Arrange
+  manager->ForcePTExchange();
+  manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
   policy_table::Table update(&table);
   update.SetPolicyTableType(rpc::policy_table_interface_base::PT_UPDATE);
@@ -723,6 +727,8 @@ TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
 TEST_F(PolicyManagerImplTest, LoadPT_SetInvalidUpdatePT_PTIsNotLoaded) {
   // Arrange
   Json::Value table(Json::objectValue);
+  manager->ForcePTExchange();
+  manager->OnUpdateStarted();
 
   policy_table::Table update(&table);
   update.SetPolicyTableType(rpc::policy_table_interface_base::PT_UPDATE);
@@ -991,6 +997,7 @@ TEST_F(PolicyManagerImplTest2,
        OnExceededTimeout_GetPolicyTableStatus_ExpectUpdateNeeded) {
   // Arrange
   CreateLocalPT("sdl_preloaded_pt.json");
+  manager->ForcePTExchange();
   manager->OnExceededTimeout();
   // Check
   EXPECT_EQ("UPDATE_NEEDED", manager->GetPolicyTableStatus());

--- a/src/components/policy/policy_regular/test/update_status_manager_test.cc
+++ b/src/components/policy/policy_regular/test/update_status_manager_test.cc
@@ -34,6 +34,7 @@
 #include "policy/mock_policy_listener.h"
 #include "policy/policy_manager_impl.h"
 #include "policy/update_status_manager.h"
+#include "utils/make_shared.h"
 
 using ::policy::MockPolicyListener;
 
@@ -42,23 +43,27 @@ namespace components {
 namespace policy {
 
 using namespace ::policy;
+using ::testing::_;
+using ::testing::Return;
 
 class UpdateStatusManagerTest : public ::testing::Test {
  protected:
-  UpdateStatusManager* manager_;
-  PolicyTableStatus status_;
+  utils::SharedPtr<UpdateStatusManager> manager_;
   const uint32_t k_timeout_;
+  utils::SharedPtr<MockPolicyListener> listener_;
 
  public:
-  UpdateStatusManagerTest() : k_timeout_(1) {}
+  UpdateStatusManagerTest()
+      : manager_(utils::MakeShared<UpdateStatusManager>())
+      , k_timeout_(1)
+      , listener_(utils::MakeShared<MockPolicyListener>()) {}
 
-  void SetUp() {
-    manager_ = new UpdateStatusManager();
+  void SetUp() OVERRIDE {
+    manager_->set_listener(listener_.get());
+    ON_CALL(*listener_, OnUpdateStatusChanged(_)).WillByDefault(Return());
   }
 
-  void TearDown() OVERRIDE {
-    delete manager_;
-  }
+  void TearDown() OVERRIDE {}
 };
 
 TEST_F(UpdateStatusManagerTest,


### PR DESCRIPTION
Current implementation is complicated and it is not clear what and when triggers status changing, so implementation has been re-worked in order to resolve current defects for that and minimize risk of new defects.
New implementation still uses mostly old interface in order to not break lot of unit tests, so there will another ticket to completely switch to new interface usage and change unit tests.

Relates-to: APPLINK-30705, 30880, 30884 