### PR TITLE
SDL sends twice UPDATE_NEEDED for invalid PTU

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -900,7 +900,7 @@ bool PolicyHandler::ReceiveMessageFromSDK(const std::string& file,
         correlation_id, vehicle_data_args, application_manager_);
   } else {
     LOG4CXX_WARN(logger_, "Exchange wasn't successful, trying another one.");
-    OnPTExchangeNeeded();
+    policy_manager_->ForcePTExchange();
   }
   return ret;
 }


### PR DESCRIPTION
In case when invalid PTU happened SDL notifies system two times with the same status.
It happens because  because wrong method is using to trigger the new update.
`OnPTExchangeNeeded()` method has to be called only during `OnPolicyUpdate` notification
as it immediately notifies the system about current status.
In case of regular update `UpdateStatusManager` is care about system notifying so `PolicyHandler`
has to call ForcePTExchange directly  to start retry

Relates: [APPLINK-30864](https://adc.luxoft.com/jira/browse/APPLINK-30864)