### PR TITLE
Fix sending same URL in OnSystemRequest retry

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1287,6 +1287,7 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
   static size_t current_app = 0;
   static size_t current_url = 0;
   if (current_url >= urls.at(current_app).url.size()) {
+    bool is_default, is_registered, has_urls;
     ApplicationSharedPtr app;
     current_url = 0;
     do {
@@ -1295,8 +1296,11 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
       }
       app =
           application_manager_.application_by_policy_id(urls.at(current_app).app_id);
-    } while (!((urls.at(current_app).app_id == policy::kDefaultId) ||
-        (app && app->IsRegistered() && !urls.at(current_app).url.empty())));
+
+      is_default = urls.at(current_app).app_id == policy::kDefaultId;
+      is_registered = app && app->IsRegistered();
+      has_urls = !urls.at(current_app).url.empty();
+    } while (!(is_default || (is_registered && has_urls)));
   }
 
   SendMessageToSDK(pt_string, urls.at(current_app).url.at(current_url));

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1283,7 +1283,24 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
     LOG4CXX_ERROR(logger_, "Service URLs are empty! NOT sending PT to mobile!");
     return;
   }
-  SendMessageToSDK(pt_string, urls.front().url.front());
+
+  static size_t current_app = 0;
+  static size_t current_url = 0;
+  if (current_url >= urls.at(current_app).url.size()) {
+    ApplicationSharedPtr app;
+    current_url = 0;
+    do {
+      if (++current_app >= urls.size()) {
+        current_app = 0;
+      }
+      app =
+          application_manager_.application_by_policy_id(urls.at(current_app).app_id);
+    } while (!((urls.at(current_app).app_id == policy::kDefaultId) ||
+        (app && app->IsRegistered() && !urls.at(current_app).url.empty())));
+  }
+
+  SendMessageToSDK(pt_string, urls.at(current_app).url.at(current_url));
+  current_url++;
 #endif  // PROPRIETARY_MODE
   // reset update required false
   OnUpdateRequestSentToMobile();

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1287,9 +1287,12 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
   static size_t current_app = 0;
   static size_t current_url = 0;
   if (current_url >= urls.at(current_app).url.size()) {
-    bool is_default, is_registered, has_urls;
     ApplicationSharedPtr app;
     current_url = 0;
+
+    bool is_default = false;
+    bool is_registered = false;
+    bool has_urls = false;
     do {
       if (++current_app >= urls.size()) {
         current_app = 0;
@@ -1297,8 +1300,8 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
       app =
           application_manager_.application_by_policy_id(urls.at(current_app).app_id);
 
-      is_default = urls.at(current_app).app_id == policy::kDefaultId;
-      is_registered = app && app->IsRegistered();
+      is_default = (urls.at(current_app).app_id == policy::kDefaultId);
+      is_registered = (app && app->IsRegistered());
       has_urls = !urls.at(current_app).url.empty();
     } while (!(is_default || (is_registered && has_urls)));
   }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1293,17 +1293,20 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
     bool is_default = false;
     bool is_registered = false;
     bool has_urls = false;
+    bool valid_app_found = false;
     do {
       if (++current_app >= urls.size()) {
         current_app = 0;
       }
+      const std::string& app_id = urls.at(current_app).app_id;
       app =
-          application_manager_.application_by_policy_id(urls.at(current_app).app_id);
+          application_manager_.application_by_policy_id(app_id);
 
-      is_default = (urls.at(current_app).app_id == policy::kDefaultId);
+      is_default = (app_id == policy::kDefaultId);
       is_registered = (app && app->IsRegistered());
       has_urls = !urls.at(current_app).url.empty();
-    } while (!(is_default || (is_registered && has_urls)));
+      valid_app_found = (is_default || (is_registered && has_urls));
+    } while (!valid_app_found);
   }
 
   SendMessageToSDK(pt_string, urls.at(current_app).url.at(current_url));


### PR DESCRIPTION
    Fix sending same URL in OnSystemRequest retry
    
    SDL sends same URL in every OnSystemRequest retry, because
    for every message is used first url of the first application.
    
    As a fix, for each message is used the next URL from the current
    application URLs vector, starting from first valid application.
    It there is no more URLs for this application, the function looks
    for the next registered application (or default) and begin cycling
    through its URLs.
    
    Related-issues: [APPLINK-30859](https://adc.luxoft.com/jira/browse/APPLINK-30859)