### PR TITLE
Fix triger ptu process after x kilometers

### DIFF
--- a/src/components/application_manager/src/commands/hmi/on_vi_vehicle_data_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_vi_vehicle_data_notification.cc
@@ -50,6 +50,13 @@ void OnVIVehicleDataNotification::Run() {
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::eType::OnVehicleDataID);
 
+  const smart_objects::SmartObject& msg_params =
+      (*message_)[strings::msg_params];
+  if (msg_params.keyExists(strings::odometer)) {
+    application_manager_.IviInfoUpdated(ODOMETER,
+                                        msg_params[strings::odometer].asInt());
+  }
+
   SendNotificationToMobile(message_);
 }
 

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1016,6 +1016,7 @@ void PolicyManagerImpl::KmsChanged(int kilometers) {
     LOG4CXX_INFO(logger_, "Enough kilometers passed to send for PT update.");
     update_status_manager_.ScheduleUpdate();
     StartPTExchange();
+    PTUpdatedAt(KILOMETERS, kilometers);
   }
 }
 


### PR DESCRIPTION
Without updating value of odometer in PTS, PTU trigger works incorrectly.

Related req. : [APPLINK-17965](https://adc.luxoft.com/jira/browse/APPLINK-17965)
Fixed defect : [APPLINK-30879](https://adc.luxoft.com/jira/browse/APPLINK-30879)