### PR TITLE
Fix sending Custom_button when app in background

### DIFF
--- a/src/components/application_manager/src/commands/mobile/on_button_event_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_button_event_notification.cc
@@ -94,6 +94,14 @@ void OnButtonEventNotification::Run() {
       return;
     }
 
+    if ((mobile_api::HMILevel::HMI_FULL != app->hmi_level()) &&
+        (mobile_api::HMILevel::HMI_LIMITED != app->hmi_level())) {
+      LOG4CXX_WARN(logger_,
+                   "CUSTOM_BUTTON OnButtonEvent notification is allowed only "
+                       << "in FULL or LIMITED hmi level");
+      return;
+    }
+
     SendButtonEvent(app);
     return;
   }

--- a/src/components/application_manager/test/commands/mobile/on_button_notification_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_button_notification_commands_test.cc
@@ -227,8 +227,9 @@ TYPED_TEST(OnButtonNotificationCommandsTest, Run_CustomButton_SUCCESS) {
       this->template CreateCommand<Notification>(notification_msg));
 
   typename TestFixture::MockAppPtr mock_app = this->CreateMockApp();
+  ON_CALL(*mock_app, hmi_level())
+      .WillByDefault(Return(mobile_apis::HMILevel::HMI_FULL));
   EXPECT_CALL(this->app_mngr_, application(kAppId)).WillOnce(Return(mock_app));
-
   EXPECT_CALL(*mock_app, IsSubscribedToSoftButton(kCustomButtonId))
       .WillOnce(Return(true));
 

--- a/src/components/hmi_message_handler/test/hmi_message_handler_impl_test.cc
+++ b/src/components/hmi_message_handler/test/hmi_message_handler_impl_test.cc
@@ -181,6 +181,7 @@ TEST_F(HMIMessageHandlerImplTest, SendMessageToHMI_Success) {
 
   // Wait for the message to be processed
   hmi_handler_->messages_to_hmi()->WaitDumpQueue();
+  testing::Mock::AsyncVerifyAndClearExpectations(100);
 }
 
 }  // namespace hmi_message_handler_test


### PR DESCRIPTION
If app is not in FULL or Limited then onButtonEvent should not be sent

Related to [APPLINK-21977](https://adc.luxoft.com/jira/browse/APPLINK-21977)