### PR TITLE
[WiP] Fix sending OnButtonPress for Custom_button when app in background

### DIFF
--- a/src/components/application_manager/src/commands/mobile/on_button_press_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_button_press_notification.cc
@@ -94,6 +94,15 @@ void OnButtonPressNotification::Run() {
       return;
     }
 
+    // Send ButtonPress notification only in HMI_FULL or HMI_LIMITED mode
+    if ((mobile_api::HMILevel::HMI_FULL != app->hmi_level()) &&
+        (mobile_api::HMILevel::HMI_LIMITED != app->hmi_level())) {
+      LOG4CXX_WARN(logger_,
+                   "CUSTOM_BUTTON OnButtonPress notification is allowed only "
+                       << "in FULL or LIMITED hmi level");
+      return;
+    }
+
     SendButtonPress(app);
     return;
   }


### PR DESCRIPTION
If app is not in FULL or Limited then OnButtonPress should not be sent

Related to [APPLINK-21979](https://adc.luxoft.com/jira/browse/APPLINK-21979)