### PR TITLE
Fixes choosing of application to request backend for policy update

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -41,6 +41,7 @@
 #include <stdint.h>
 
 #include "policy/policy_manager.h"
+#include "application_manager/application.h"
 #include "application_manager/policies/policy_handler_interface.h"
 #include "application_manager/policies/policy_event_observer.h"
 #include "application_manager/policies/delegates/statistics_delegate.h"
@@ -294,8 +295,9 @@ class PolicyHandler : public PolicyHandlerInterface,
   void OnSystemError(int code) OVERRIDE;
 
   /**
-   * @brief Choose application id to be used for snapshot sending
-   * @return Application id or 0, if there are no applications registered
+   * @brief Chooses random application id to be used for snapshot sending
+   * considering HMI level
+   * @return Application id or 0, if there are no suitable applications
    */
   uint32_t GetAppIdForSending() const OVERRIDE;
 
@@ -475,6 +477,17 @@ class PolicyHandler : public PolicyHandlerInterface,
    * @brief Link all currently registered applications
    */
   void LinkAppsToDevice();
+
+  typedef std::vector<application_manager::ApplicationSharedPtr> Applications;
+
+  /**
+   * @brief Chooses application suitable for forwarding request for policy
+   * update to backend by checking its registration status and device consent
+   * @param app_list List of applications to choose from, list can be modified
+   * in the process of lookup
+   * @return Application id or 0 if no suitable application was found
+   */
+  uint32_t GetApplicationIdForPolicyUpdate(Applications app_list) const;
 
  private:
   class StatisticManagerImpl : public usage_statistics::StatisticsManager {

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -481,13 +481,20 @@ class PolicyHandler : public PolicyHandlerInterface,
   typedef std::vector<application_manager::ApplicationSharedPtr> Applications;
 
   /**
-   * @brief Chooses application suitable for forwarding request for policy
-   * update to backend by checking its registration status and device consent
-   * @param app_list List of applications to choose from, list can be modified
-   * in the process of lookup
-   * @return Application id or 0 if no suitable application was found
+   * @brief Checks application registration status (SDL4.0) and device consent
+   * to find out whether application is suitable
+   * @param value Item from applications collection
+   * @return true if application is suitable, otherwise - false
    */
-  uint32_t GetApplicationIdForPolicyUpdate(Applications app_list) const;
+  bool IsAppSuitableForPolicyUpdate(const Applications::value_type value) const;
+
+  /**
+   * @brief Chooses random application from list using
+   * IsAppSuitableForPolicyUpdate
+   * @param app_list Application collection
+   * @return Application id if suitable is found, otherwise - zero
+   */
+  uint32_t ChooseRandomAppForPolicyUpdate(Applications& app_list) const;
 
  private:
   class StatisticManagerImpl : public usage_statistics::StatisticsManager {

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -34,6 +34,7 @@
 #include <dlfcn.h>
 #include <algorithm>
 #include <vector>
+#include <functional>
 #include "application_manager/smart_object_keys.h"
 
 #include "application_manager/policies/delegates/app_permission_delegate.h"
@@ -115,7 +116,8 @@ const policy::DeviceParams GetDeviceParams(
 
 struct HMILevelPredicate
     : public std::unary_function<ApplicationSharedPtr, bool> {
-  HMILevelPredicate(const mobile_api::HMILevel::eType level) : level_(level) {}
+  explicit HMILevelPredicate(const mobile_api::HMILevel::eType level)
+      : level_(level) {}
 
   bool operator()(const ApplicationSharedPtr app) const {
     return level_ == app->hmi_level() ? true : false;
@@ -380,11 +382,10 @@ uint32_t PolicyHandler::GetAppIdForSending() const {
 
   HMILevelPredicate has_none_level(mobile_api::HMILevel::HMI_NONE);
   Applications apps_without_none_level;
-  std::copy_if(
-      accessor.begin(),
-      accessor.end(),
-      std::inserter(apps_without_none_level, apps_without_none_level.begin()),
-      std::not1(has_none_level));
+  std::copy_if(accessor.begin(),
+               accessor.end(),
+               std::back_inserter(apps_without_none_level),
+               std::not1(has_none_level));
 
   LOG4CXX_DEBUG(logger_,
                 "Number of apps with different from NONE level: "
@@ -401,11 +402,10 @@ uint32_t PolicyHandler::GetAppIdForSending() const {
   }
 
   Applications apps_with_none_level;
-  std::copy_if(
-      accessor.begin(),
-      accessor.end(),
-      std::inserter(apps_with_none_level, apps_with_none_level.begin()),
-      has_none_level);
+  std::copy_if(accessor.begin(),
+               accessor.end(),
+               std::back_inserter(apps_with_none_level),
+               has_none_level);
 
   LOG4CXX_DEBUG(
       logger_,

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -112,7 +112,20 @@ const policy::DeviceParams GetDeviceParams(
   device_params.device_handle = device_handle;
   return device_params;
 }
-}
+
+struct HMILevelPredicate
+    : public std::unary_function<ApplicationSharedPtr, bool> {
+  HMILevelPredicate(const mobile_api::HMILevel::eType level) : level_(level) {}
+
+  bool operator()(const ApplicationSharedPtr app) const {
+    return level_ == app->hmi_level() ? true : false;
+  }
+
+ private:
+  mobile_api::HMILevel::eType level_;
+};
+
+}  // namespace
 
 #define POLICY_LIB_CHECK(return_value)                                      \
   {                                                                         \
@@ -133,25 +146,6 @@ const policy::DeviceParams GetDeviceParams(
   }
 
 static const std::string kCerficateFileName = "certificate";
-
-struct ApplicationListHmiLevelSorter {
-  bool operator()(const application_manager::ApplicationSharedPtr& lhs,
-                  const application_manager::ApplicationSharedPtr& rhs) {
-    if (lhs && rhs) {
-      mobile_apis::HMILevel::eType lhs_hmi_level = lhs->hmi_level();
-      mobile_apis::HMILevel::eType rhs_hmi_level = rhs->hmi_level();
-
-      if (lhs_hmi_level == rhs_hmi_level) {
-        return lhs->app_id() < rhs->app_id();
-      }
-      return lhs_hmi_level < rhs_hmi_level;
-    }
-    return false;
-  }
-};
-
-typedef std::set<application_manager::ApplicationSharedPtr,
-                 ApplicationListHmiLevelSorter> HmiLevelOrderedApplicationList;
 
 struct DeactivateApplication {
   explicit DeactivateApplication(
@@ -379,40 +373,47 @@ bool PolicyHandler::ClearUserConsent() {
 }
 
 uint32_t PolicyHandler::GetAppIdForSending() const {
+  LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK(0);
   const ApplicationSet& accessor =
       application_manager_.applications().GetData();
-  HmiLevelOrderedApplicationList app_list(accessor.begin(), accessor.end());
 
-  LOG4CXX_INFO(logger_, "Apps size: " << app_list.size());
+  HMILevelPredicate has_none_level(mobile_api::HMILevel::HMI_NONE);
+  Applications apps_without_none_level;
+  std::copy_if(
+      accessor.begin(),
+      accessor.end(),
+      std::inserter(apps_without_none_level, apps_without_none_level.begin()),
+      std::not1(has_none_level));
 
-  for (HmiLevelOrderedApplicationList::const_iterator first = app_list.begin();
-       first != app_list.end();
-       ++first) {
-    if ((*first)->IsRegistered()) {
-      const uint32_t app_id = (*first)->app_id();
-      DeviceParams device_params = GetDeviceParams(
-          (*first)->device(),
-          application_manager_.connection_handler().get_session_observer());
+  LOG4CXX_DEBUG(logger_,
+                "Number of apps with different from NONE level: "
+                    << apps_without_none_level.size());
 
-      const bool is_device_allowed = (kDeviceAllowed ==
-                                      policy_manager_->GetUserConsentForDevice(
-                                          device_params.device_mac_address));
-      const bool is_single_app = (1 == app_list.size());
+  std::random_shuffle(apps_without_none_level.begin(),
+                      apps_without_none_level.end());
 
-      if (is_device_allowed && is_single_app) {
-        return app_id;
-      }
+  const uint32_t app_id =
+      GetApplicationIdForPolicyUpdate(apps_without_none_level);
 
-      const bool is_app_in_none =
-          ((*first)->hmi_level() == mobile_apis::HMILevel::HMI_NONE);
-
-      if (is_device_allowed && !is_app_in_none) {
-        return app_id;
-      }
-    }
+  if (app_id) {
+    return app_id;
   }
-  return 0;
+
+  Applications apps_with_none_level;
+  std::copy_if(
+      accessor.begin(),
+      accessor.end(),
+      std::inserter(apps_with_none_level, apps_with_none_level.begin()),
+      has_none_level);
+
+  LOG4CXX_DEBUG(
+      logger_,
+      "Number of apps with NONE level: " << apps_with_none_level.size());
+
+  std::random_shuffle(apps_with_none_level.begin(), apps_with_none_level.end());
+
+  return GetApplicationIdForPolicyUpdate(apps_with_none_level);
 }
 
 void PolicyHandler::OnAppPermissionConsent(
@@ -683,6 +684,49 @@ void PolicyHandler::LinkAppsToDevice() {
       std::for_each(accessor.begin(), accessor.end(), linker);
     }
   }
+}
+
+uint32_t PolicyHandler::GetApplicationIdForPolicyUpdate(
+    Applications app_list) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (app_list.empty()) {
+    return 0;
+  }
+
+  Applications::const_iterator it_app = app_list.begin();
+
+  const ApplicationSharedPtr application_ptr = *it_app;
+  const uint32_t app_id = application_ptr->app_id();
+
+  if (!application_ptr->IsRegistered()) {
+    LOG4CXX_DEBUG(logger_,
+                  "Application " << app_id << " is not marked as registered.");
+    app_list.erase(it_app);
+    return GetApplicationIdForPolicyUpdate(app_list);
+  }
+
+  LOG4CXX_DEBUG(logger_,
+                "Application " << app_id << " marked as registered."
+                                            "Checking its parameters.");
+
+  DeviceParams device_params = GetDeviceParams(
+      application_ptr->device(),
+      application_manager_.connection_handler().get_session_observer());
+
+  const bool is_device_allowed = (kDeviceAllowed ==
+                                  policy_manager_->GetUserConsentForDevice(
+                                      device_params.device_mac_address));
+
+  LOG4CXX_DEBUG(logger_,
+                "Is device " << device_params.device_mac_address << " allowed "
+                             << std::boolalpha << is_device_allowed);
+
+  if (!is_device_allowed) {
+    app_list.erase(it_app);
+    return GetApplicationIdForPolicyUpdate(app_list);
+  }
+
+  return app_id;
 }
 
 void PolicyHandler::OnGetStatusUpdate(const uint32_t correlation_id) {

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -1512,7 +1512,7 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_GetDefaultMacAddress) {
   // Check expectations
   test_app.insert(mock_app_);
   EXPECT_CALL(*mock_app_, IsRegistered()).WillOnce(Return(true));
-  EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppId_));
+  EXPECT_CALL(*mock_app_, app_id()).WillRepeatedly(Return(kAppId_));
   EXPECT_CALL(*mock_app_, hmi_level())
       .WillOnce(Return(mobile_api::HMILevel::HMI_FULL));
   EXPECT_CALL(app_manager_, connection_handler())
@@ -1534,7 +1534,7 @@ void PolicyHandlerTest::GetAppIDForSending() {
   test_app.insert(mock_app_);
 
   // Check expectations
-  EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppId_));
+  EXPECT_CALL(*mock_app_, app_id()).WillRepeatedly(Return(kAppId_));
   EXPECT_CALL(*mock_app_, IsRegistered()).WillOnce(Return(true));
   EXPECT_CALL(*mock_app_, hmi_level())
       .WillRepeatedly(Return(mobile_api::HMILevel::HMI_FULL));

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -1513,6 +1513,8 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_GetDefaultMacAddress) {
   test_app.insert(mock_app_);
   EXPECT_CALL(*mock_app_, IsRegistered()).WillOnce(Return(true));
   EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppId_));
+  EXPECT_CALL(*mock_app_, hmi_level())
+      .WillOnce(Return(mobile_api::HMILevel::HMI_FULL));
   EXPECT_CALL(app_manager_, connection_handler())
       .WillOnce(ReturnRef(conn_handler));
 
@@ -1534,6 +1536,8 @@ void PolicyHandlerTest::GetAppIDForSending() {
   // Check expectations
   EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppId_));
   EXPECT_CALL(*mock_app_, IsRegistered()).WillOnce(Return(true));
+  EXPECT_CALL(*mock_app_, hmi_level())
+      .WillRepeatedly(Return(mobile_api::HMILevel::HMI_FULL));
   EXPECT_CALL(mock_session_observer, GetDataOnDeviceID(_, _, _, _, _))
       .WillOnce(DoAll(SetArgPointee<3>(kMacAddr_), Return(0)));
 
@@ -1546,6 +1550,111 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_SetMacAddress) {
   GetAppIDForSending();
   // Act
   EXPECT_EQ(kAppId_, policy_handler_.GetAppIdForSending());
+}
+
+TEST_F(PolicyHandlerTest, GetAppIdForSending_ExpectReturnAnyIdButNone) {
+  // Arrange
+  EnablePolicyAndPolicyManagerMock();
+
+  utils::SharedPtr<application_manager_test::MockApplication> mock_app_in_full =
+      utils::MakeShared<application_manager_test::MockApplication>();
+  const uint32_t app_in_full_id = 1;
+  EXPECT_CALL(*mock_app_in_full, app_id())
+      .WillRepeatedly(Return(app_in_full_id));
+  EXPECT_CALL(*mock_app_in_full, hmi_level())
+      .WillRepeatedly(Return(mobile_api::HMILevel::HMI_FULL));
+  ON_CALL(*mock_app_in_full, IsRegistered()).WillByDefault(Return(true));
+
+  test_app.insert(mock_app_in_full);
+
+  utils::SharedPtr<application_manager_test::MockApplication>
+      mock_app_in_limited =
+          utils::MakeShared<application_manager_test::MockApplication>();
+  const uint32_t app_in_limited_id = 2;
+  EXPECT_CALL(*mock_app_in_limited, app_id())
+      .WillRepeatedly(Return(app_in_limited_id));
+  EXPECT_CALL(*mock_app_in_limited, hmi_level())
+      .WillRepeatedly(Return(mobile_api::HMILevel::HMI_LIMITED));
+  ON_CALL(*mock_app_in_limited, IsRegistered()).WillByDefault(Return(true));
+
+  test_app.insert(mock_app_in_limited);
+
+  utils::SharedPtr<application_manager_test::MockApplication>
+      mock_app_in_background =
+          utils::MakeShared<application_manager_test::MockApplication>();
+  const uint32_t app_in_background_id = 3;
+  EXPECT_CALL(*mock_app_in_background, app_id())
+      .WillRepeatedly(Return(app_in_background_id));
+  EXPECT_CALL(*mock_app_in_background, hmi_level())
+      .WillRepeatedly(Return(mobile_api::HMILevel::HMI_BACKGROUND));
+  ON_CALL(*mock_app_in_background, IsRegistered()).WillByDefault(Return(true));
+
+  test_app.insert(mock_app_in_background);
+
+  utils::SharedPtr<application_manager_test::MockApplication> mock_app_in_none =
+      utils::MakeShared<application_manager_test::MockApplication>();
+  const uint32_t app_in_none_id = 4;
+  EXPECT_CALL(*mock_app_in_none, app_id())
+      .WillRepeatedly(Return(app_in_none_id));
+  EXPECT_CALL(*mock_app_in_none, hmi_level())
+      .WillRepeatedly(Return(mobile_api::HMILevel::HMI_NONE));
+  EXPECT_CALL(*mock_app_in_none, IsRegistered()).Times(0);
+
+  test_app.insert(mock_app_in_none);
+
+  // Check expectations
+
+  EXPECT_CALL(mock_session_observer, GetDataOnDeviceID(_, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<3>(kMacAddr_), Return(0)));
+
+  EXPECT_CALL(*mock_policy_manager_, GetUserConsentForDevice(kMacAddr_))
+      .WillRepeatedly(Return(kDeviceAllowed));
+
+  // Act
+  EXPECT_NE(app_in_none_id, policy_handler_.GetAppIdForSending());
+}
+
+TEST_F(PolicyHandlerTest, GetAppIdForSending_ExpectReturnAnyAppInNone) {
+  // Arrange
+  EnablePolicyAndPolicyManagerMock();
+
+  utils::SharedPtr<application_manager_test::MockApplication>
+      mock_app_in_none_1 =
+          utils::MakeShared<application_manager_test::MockApplication>();
+  const uint32_t app_in_none_id_1 = 1;
+  EXPECT_CALL(*mock_app_in_none_1, app_id())
+      .WillRepeatedly(Return(app_in_none_id_1));
+  EXPECT_CALL(*mock_app_in_none_1, hmi_level())
+      .WillRepeatedly(Return(mobile_api::HMILevel::HMI_FULL));
+  ON_CALL(*mock_app_in_none_1, IsRegistered()).WillByDefault(Return(true));
+
+  test_app.insert(mock_app_in_none_1);
+
+  utils::SharedPtr<application_manager_test::MockApplication>
+      mock_app_in_none_2 =
+          utils::MakeShared<application_manager_test::MockApplication>();
+  const uint32_t app_in_none_id_2 = 2;
+  EXPECT_CALL(*mock_app_in_none_2, app_id())
+      .WillRepeatedly(Return(app_in_none_id_2));
+  EXPECT_CALL(*mock_app_in_none_2, hmi_level())
+      .WillRepeatedly(Return(mobile_api::HMILevel::HMI_NONE));
+  ON_CALL(*mock_app_in_none_2, IsRegistered()).WillByDefault(Return(true));
+
+  test_app.insert(mock_app_in_none_2);
+
+  // Check expectations
+
+  EXPECT_CALL(mock_session_observer, GetDataOnDeviceID(_, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<3>(kMacAddr_), Return(0)));
+
+  EXPECT_CALL(*mock_policy_manager_, GetUserConsentForDevice(kMacAddr_))
+      .WillRepeatedly(Return(kDeviceAllowed));
+
+  // Act
+
+  const uint32_t app_id = policy_handler_.GetAppIdForSending();
+
+  EXPECT_EQ(app_in_none_id_1 || app_in_none_id_2, app_id);
 }
 
 TEST_F(PolicyHandlerTest, SendMessageToSDK) {


### PR DESCRIPTION
SDL must choose application randomly from application having different
from NONE HMI level. In case no such apps - random from having NONE will
be choosen.

Closes-bug: APPLINK-31036, APPLINK-31037