### PR TITLE
Correct response params in UnSubscribeVehicleData

### DIFF
--- a/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -1,6 +1,6 @@
 /*
 
- Copyright (c) 2013, Ford Motor Company
+ Copyright (c) 2017, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -201,16 +201,14 @@ void UnsubscribeVehicleDataRequest::Run() {
   }
 
   if (is_everything_already_unsubscribed) {
-    mobile_apis::Result::eType result_code =
-        vi_already_unsubscribed_by_this_app_.size()
-            ? mobile_apis::Result::IGNORED
-            : mobile_apis::Result::SUCCESS;
-
-    const char* info = vi_already_unsubscribed_by_this_app_.size()
-                           ? "Already subscribed on some provided VehicleData."
-                           : NULL;
-
-    SendResponse(true, result_code, info, &response_params);
+    if (!vi_already_unsubscribed_by_this_app_.empty()) {
+      SendResponse(false,
+                   mobile_apis::Result::IGNORED,
+                   "Some provided VehicleData was not subscribed.",
+                   &response_params);
+    } else {
+      SendResponse(true, mobile_apis::Result::SUCCESS, NULL, &response_params);
+    }
     return;
   }
 


### PR DESCRIPTION
Corrected response parameters, generated in case when vi interface is not available.

Related to: [APPLINK-28727](https://adc.luxoft.com/jira/browse/APPLINK-28727)