### PR TITLE
Use miliseconds as parameter of OnUpdateSentOut function

### DIFF
--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -42,6 +42,7 @@
 #include "json/features.h"
 #include "json/writer.h"
 #include "utils/logger.h"
+#include "utils/date_time.h"
 #include "utils/gen_hash.h"
 #include "utils/threads/thread.h"
 #include "utils/threads/thread_delegate.h"
@@ -1067,7 +1068,8 @@ void CacheManager::ResetIgnitionCycles() {
 
 int CacheManager::TimeoutResponse() {
   CACHE_MANAGER_CHECK(0);
-  return pt_->policy_table.module_config.timeout_after_x_seconds;
+  return pt_->policy_table.module_config.timeout_after_x_seconds *
+         date_time::DateTime::MILLISECONDS_IN_SECOND;
 }
 
 bool CacheManager::SecondsBetweenRetries(std::vector<int>& seconds) {

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1075,7 +1075,7 @@ void PolicyManagerImpl::OnExceededTimeout() {
 void PolicyManagerImpl::OnUpdateStarted() {
   int update_timeout = TimeoutExchange();
   LOG4CXX_DEBUG(logger_,
-                "Update timeout will be set to (sec): " << update_timeout);
+                "Update timeout will be set to (milisec): " << update_timeout);
   update_status_manager_.OnUpdateSentOut(update_timeout);
   cache_->SaveUpdateRequired(true);
 }

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -37,6 +37,7 @@
 #include <unistd.h>
 
 #include "utils/logger.h"
+#include "utils/date_time.h"
 #include "utils/sqlite_wrapper/sql_database.h"
 #include "utils/file_system.h"
 #include "utils/gen_hash.h"
@@ -228,10 +229,10 @@ int SQLPTRepresentation::TimeoutResponse() {
   utils::dbms::SQLQuery query(db());
   if (!query.Prepare(sql_pt::kSelectTimeoutResponse) || !query.Exec()) {
     LOG4CXX_INFO(logger_, "Can not select timeout response for retry sequence");
-    const int kDefault = 30;
-    return kDefault;
+    const int defaultTimeout = 30 * date_time::DateTime::MILLISECONDS_IN_SECOND;
+    return defaultTimeout;
   }
-  return query.GetInteger(0);
+  return query.GetInteger(0) * date_time::DateTime::MILLISECONDS_IN_SECOND;
 }
 
 bool SQLPTRepresentation::SecondsBetweenRetries(std::vector<int>* seconds) {

--- a/src/components/policy/policy_external/src/update_status_manager.cc
+++ b/src/components/policy/policy_external/src/update_status_manager.cc
@@ -80,9 +80,7 @@ void UpdateStatusManager::set_listener(PolicyListener* listener) {
 void UpdateStatusManager::OnUpdateSentOut(uint32_t update_timeout) {
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK(update_status_thread_delegate_);
-  const unsigned milliseconds_in_second = 1000;
-  update_status_thread_delegate_->updateTimeOut(update_timeout *
-                                                milliseconds_in_second);
+  update_status_thread_delegate_->updateTimeOut(update_timeout);
   ProcessEvent(kOnUpdateSentOut);
 }
 

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -223,7 +223,7 @@ TEST_F(PolicyManagerImplTest2, TimeOutExchange) {
   // Arrange
   CreateLocalPT(preloadet_pt_filename_);
   // Check value taken from PT
-  EXPECT_EQ(70, manager_->TimeoutExchange());
+  EXPECT_EQ(70000, manager_->TimeoutExchange());
 }
 
 TEST_F(PolicyManagerImplTest,

--- a/src/components/policy/policy_external/test/sql_pt_representation_test.cc
+++ b/src/components/policy/policy_external/test/sql_pt_representation_test.cc
@@ -881,7 +881,7 @@ TEST_F(SQLPTRepresentationTest, TimeoutResponse_Set60Seconds_GetEqualTimeout) {
   // Assert
   ASSERT_TRUE(query_wrapper_->Exec(query));
   // Check
-  EXPECT_EQ(60, reps->TimeoutResponse());
+  EXPECT_EQ(60000, reps->TimeoutResponse());
 }
 
 TEST_F(SQLPTRepresentationTest,

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -42,6 +42,7 @@
 #include "json/features.h"
 #include "json/writer.h"
 #include "utils/logger.h"
+#include "utils/date_time.h"
 #include "utils/gen_hash.h"
 #include "utils/macro.h"
 #include "utils/threads/thread.h"
@@ -571,7 +572,8 @@ void CacheManager::ResetIgnitionCycles() {
 
 int CacheManager::TimeoutResponse() {
   CACHE_MANAGER_CHECK(0);
-  return pt_->policy_table.module_config.timeout_after_x_seconds;
+  return pt_->policy_table.module_config.timeout_after_x_seconds *
+         date_time::DateTime::MILLISECONDS_IN_SECOND;
 }
 
 bool CacheManager::SecondsBetweenRetries(std::vector<int>& seconds) {

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -812,7 +812,7 @@ void PolicyManagerImpl::OnExceededTimeout() {
 void PolicyManagerImpl::OnUpdateStarted() {
   int update_timeout = TimeoutExchange();
   LOG4CXX_DEBUG(logger_,
-                "Update timeout will be set to (sec): " << update_timeout);
+                "Update timeout will be set to (milisec): " << update_timeout);
   update_status_manager_.OnUpdateSentOut(update_timeout);
   cache_->SaveUpdateRequired(true);
 }

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -37,6 +37,7 @@
 #include <unistd.h>
 
 #include "utils/logger.h"
+#include "utils/date_time.h"
 #include "utils/file_system.h"
 #include "utils/gen_hash.h"
 #include "policy/sql_pt_representation.h"
@@ -186,10 +187,10 @@ int SQLPTRepresentation::TimeoutResponse() {
   utils::dbms::SQLQuery query(db());
   if (!query.Prepare(sql_pt::kSelectTimeoutResponse) || !query.Exec()) {
     LOG4CXX_INFO(logger_, "Can not select timeout response for retry sequence");
-    const int kDefault = 30;
-    return kDefault;
+    const int defaultTimeout = 30 * date_time::DateTime::MILLISECONDS_IN_SECOND;
+    return defaultTimeout;
   }
-  return query.GetInteger(0);
+  return query.GetInteger(0) * date_time::DateTime::MILLISECONDS_IN_SECOND;
 }
 
 bool SQLPTRepresentation::SecondsBetweenRetries(std::vector<int>* seconds) {

--- a/src/components/policy/policy_regular/src/update_status_manager.cc
+++ b/src/components/policy/policy_regular/src/update_status_manager.cc
@@ -80,9 +80,7 @@ void UpdateStatusManager::set_listener(PolicyListener* listener) {
 void UpdateStatusManager::OnUpdateSentOut(uint32_t update_timeout) {
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK(update_status_thread_delegate_);
-  const unsigned milliseconds_in_second = 1000;
-  update_status_thread_delegate_->updateTimeOut(update_timeout *
-                                                milliseconds_in_second);
+  update_status_thread_delegate_->updateTimeOut(update_timeout);
   ProcessEvent(kOnUpdateSentOut);
 }
 

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -894,7 +894,7 @@ TEST_F(PolicyManagerImplTest2, TimeOutExchange) {
   // Arrange
   CreateLocalPT("sdl_preloaded_pt.json");
   // Check value taken from PT
-  EXPECT_EQ(70, manager->TimeoutExchange());
+  EXPECT_EQ(70000, manager->TimeoutExchange());
 }
 
 TEST_F(PolicyManagerImplTest2, UpdatedPreloadedPT_ExpectLPT_IsUpdated) {

--- a/src/components/policy/policy_regular/test/sql_pt_representation_test.cc
+++ b/src/components/policy/policy_regular/test/sql_pt_representation_test.cc
@@ -857,7 +857,7 @@ TEST_F(SQLPTRepresentationTest, TimeoutResponse_Set60Seconds_GetEqualTimeout) {
   // Assert
   ASSERT_TRUE(dbms->Exec(query));
   // Check
-  EXPECT_EQ(60, reps->TimeoutResponse());
+  EXPECT_EQ(60000, reps->TimeoutResponse());
 }
 
 TEST_F(SQLPTRepresentationTest,

--- a/src/components/policy/policy_regular/test/update_status_manager_test.cc
+++ b/src/components/policy/policy_regular/test/update_status_manager_test.cc
@@ -55,7 +55,7 @@ class UpdateStatusManagerTest : public ::testing::Test {
  public:
   UpdateStatusManagerTest()
       : manager_(utils::MakeShared<UpdateStatusManager>())
-      , k_timeout_(1)
+      , k_timeout_(1000)
       , listener_(utils::MakeShared<MockPolicyListener>()) {}
 
   void SetUp() OVERRIDE {


### PR DESCRIPTION
Change returned value which is read from database in TimeoutResponse function to miliseconds, fix usages in code and unit tests.
Avoid using sleep in OnUpdateSentOut_WaitForTimeoutExpired_ExpectStatusUpdateNeeded unit test, use WaitAsync class that can wait for checking functionality of OnUpdateSentOut function.
Related task: [APPLINK-31222](https://adc.luxoft.com/jira/browse/APPLINK-31222)
