### PR TITLE
Update update_require in time

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -745,6 +745,8 @@ void PolicyHandler::OnGetStatusUpdate(const uint32_t correlation_id) {
 
 void PolicyHandler::OnUpdateStatusChanged(const std::string& status) {
   LOG4CXX_AUTO_TRACE(logger_);
+  POLICY_LIB_CHECK_VOID();
+  policy_manager_->SaveUpdateStatusRequired(policy::kUpToDate != status);
   MessageHelper::SendOnStatusUpdate(status, application_manager_);
 }
 

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -927,6 +927,7 @@ TEST_F(PolicyHandlerTest, OnGetStatusUpdate) {
 }
 
 TEST_F(PolicyHandlerTest, OnUpdateStatusChanged) {
+  ChangePolicyManagerToMock();
   // Check expectations
   const std::string& status("new status");
   EXPECT_CALL(mock_message_helper_, SendOnStatusUpdate(status, _));

--- a/src/components/policy/policy_external/include/policy/status.h
+++ b/src/components/policy/policy_external/include/policy/status.h
@@ -55,6 +55,10 @@ enum UpdateEvent {
   kOnResetRetrySequence
 };
 
+const std::string kUpToDate = "UP_TO_DATE";
+const std::string kUpdateNeeded = "UPDATE_NEEDED";
+const std::string kUpdating = "UPDATING";
+
 class UpdateStatusManager;
 
 /**

--- a/src/components/policy/policy_external/src/status.cc
+++ b/src/components/policy/policy_external/src/status.cc
@@ -35,7 +35,7 @@
 #include "utils/make_shared.h"
 
 policy::UpToDateStatus::UpToDateStatus()
-    : Status("UP_TO_DATE", policy::PolicyTableStatus::StatusUpToDate) {}
+    : Status(kUpToDate, policy::PolicyTableStatus::StatusUpToDate) {}
 
 void policy::UpToDateStatus::ProcessEvent(UpdateStatusManager* manager,
                                           policy::UpdateEvent event) {
@@ -52,8 +52,7 @@ void policy::UpToDateStatus::ProcessEvent(UpdateStatusManager* manager,
 }
 
 policy::UpdateNeededStatus::UpdateNeededStatus()
-    : Status("UPDATE_NEEDED", policy::PolicyTableStatus::StatusUpdateRequired) {
-}
+    : Status(kUpdateNeeded, policy::PolicyTableStatus::StatusUpdateRequired) {}
 
 void policy::UpdateNeededStatus::ProcessEvent(
     policy::UpdateStatusManager* manager, policy::UpdateEvent event) {
@@ -78,7 +77,7 @@ bool policy::UpdateNeededStatus::IsUpdateRequired() const {
 }
 
 policy::UpdatingStatus::UpdatingStatus()
-    : Status("UPDATING", policy::PolicyTableStatus::StatusUpdatePending) {}
+    : Status(kUpdating, policy::PolicyTableStatus::StatusUpdatePending) {}
 
 void policy::UpdatingStatus::ProcessEvent(policy::UpdateStatusManager* manager,
                                           policy::UpdateEvent event) {

--- a/src/components/policy/policy_regular/include/policy/status.h
+++ b/src/components/policy/policy_regular/include/policy/status.h
@@ -55,6 +55,11 @@ enum UpdateEvent {
   kOnResetRetrySequence
 };
 
+
+const std::string kUpToDate = "UP_TO_DATE";
+const std::string kUpdateNeeded = "UPDATE_NEEDED";
+const std::string kUpdating = "UPDATING";
+
 class UpdateStatusManagerInterface;
 
 /**


### PR DESCRIPTION
update_require should be store to cache manager in the same time as UPDATE_NEEDED sent to HMI

Related issue : APPLINK-30381