### PR TITLE
BlueZ 5.0+ modifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,15 @@ endif()
 if (BUILD_BT_SUPPORT)
   add_definitions(-DBLUETOOTH_SUPPORT)
   message(STATUS "Bluetooth support is enabled")
+  # Don't check for BlueZ version if we are cross-compiling, let that be specified in the toolchain
+  if (NOT CROSS_HOST)
+    exec_program("which bluetoothctl"
+                 OUTPUT_VARIABLE BLUETOOTHCTL_DIR)
+    if (BLUETOOTHCTL_DIR)
+      add_definitions(-DBLUEZ5)
+      message(STATUS "BlueZ 5 detected")
+    endif ()
+  endif ()
 endif()
 
 if (BUILD_BACKTRACE_SUPPORT)


### PR DESCRIPTION
The AGL platform does not have bluez-utils available, meaning that it cannot use the bt-device command to find paired devices. This PR adds an alternative way of finding paired devices using the bluetoothctl shell which was introduced with BlueZ 5.

Required for AGL Port.