### PR TITLE
Fix activation after DEACTIVATE_HMI 

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/hmi/request_from_hmi.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/request_from_hmi.h
@@ -63,9 +63,28 @@ class RequestFromHMI : public CommandImpl, public event_engine::EventObserver {
                     const hmi_apis::FunctionID::eType function_id,
                     const hmi_apis::Common_Result::eType result_code);
 
-  void FillCommonParametersOfSO(smart_objects::SmartObject* message,
-                                uint32_t correlation_id,
-                                hmi_apis::FunctionID::eType function_id);
+  /**
+   * @brief SendResponse allows to send error response to hmi
+   * @param correlation_id the correlation id for the response.
+   * @param function_id the function id for which response will be sent
+   * @param result_code the result code.
+   */
+  void SendErrorResponse(const uint32_t correlation_id,
+                         const hmi_apis::FunctionID::eType function_id,
+                         const hmi_apis::Common_Result::eType result_code,
+                         std::string error_message);
+
+ private:
+  /**
+   * @brief Fills common parameters for SO
+   * @param Contains SO for filling
+   * @param correlation_id the correlation id for the response.
+   * @param function_id the function id for which response will be sent
+   */
+  void FillCommonParametersOfSO(
+      NsSmartDeviceLink::NsSmartObjects::SmartObjectSPtr& message,
+      uint32_t correlation_id,
+      hmi_apis::FunctionID::eType function_id);
 
  private:
   DISALLOW_COPY_AND_ASSIGN(RequestFromHMI);

--- a/src/components/application_manager/include/application_manager/commands/hmi/request_from_hmi.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/request_from_hmi.h
@@ -68,6 +68,7 @@ class RequestFromHMI : public CommandImpl, public event_engine::EventObserver {
    * @param correlation_id the correlation id for the response.
    * @param function_id the function id for which response will be sent
    * @param result_code the result code.
+   * @param error_message info message for error.
    */
   void SendErrorResponse(const uint32_t correlation_id,
                          const hmi_apis::FunctionID::eType function_id,
@@ -77,14 +78,13 @@ class RequestFromHMI : public CommandImpl, public event_engine::EventObserver {
  private:
   /**
    * @brief Fills common parameters for SO
-   * @param Contains SO for filling
+   * @param message Contains SO for filling
    * @param correlation_id the correlation id for the response.
    * @param function_id the function id for which response will be sent
    */
-  void FillCommonParametersOfSO(
-      NsSmartDeviceLink::NsSmartObjects::SmartObjectSPtr& message,
-      uint32_t correlation_id,
-      hmi_apis::FunctionID::eType function_id);
+  void FillCommonParametersOfSO(smart_objects::SmartObjectSPtr& message,
+                                uint32_t correlation_id,
+                                hmi_apis::FunctionID::eType function_id);
 
  private:
   DISALLOW_COPY_AND_ASSIGN(RequestFromHMI);

--- a/src/components/application_manager/include/application_manager/commands/hmi/request_from_hmi.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/request_from_hmi.h
@@ -73,7 +73,7 @@ class RequestFromHMI : public CommandImpl, public event_engine::EventObserver {
   void SendErrorResponse(const uint32_t correlation_id,
                          const hmi_apis::FunctionID::eType function_id,
                          const hmi_apis::Common_Result::eType result_code,
-                         std::string error_message);
+                         const std::string error_message);
 
  private:
   /**
@@ -84,8 +84,8 @@ class RequestFromHMI : public CommandImpl, public event_engine::EventObserver {
    */
   void FillCommonParametersOfSO(
       NsSmartDeviceLink::NsSmartObjects::SmartObject& message,
-      uint32_t correlation_id,
-      hmi_apis::FunctionID::eType function_id);
+      const uint32_t correlation_id,
+      const hmi_apis::FunctionID::eType function_id);
 
  private:
   DISALLOW_COPY_AND_ASSIGN(RequestFromHMI);

--- a/src/components/application_manager/include/application_manager/commands/hmi/request_from_hmi.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/request_from_hmi.h
@@ -82,9 +82,10 @@ class RequestFromHMI : public CommandImpl, public event_engine::EventObserver {
    * @param correlation_id the correlation id for the response.
    * @param function_id the function id for which response will be sent
    */
-  void FillCommonParametersOfSO(smart_objects::SmartObjectSPtr& message,
-                                uint32_t correlation_id,
-                                hmi_apis::FunctionID::eType function_id);
+  void FillCommonParametersOfSO(
+      NsSmartDeviceLink::NsSmartObjects::SmartObject& message,
+      uint32_t correlation_id,
+      hmi_apis::FunctionID::eType function_id);
 
  private:
   DISALLOW_COPY_AND_ASSIGN(RequestFromHMI);

--- a/src/components/application_manager/src/commands/hmi/request_from_hmi.cc
+++ b/src/components/application_manager/src/commands/hmi/request_from_hmi.cc
@@ -60,13 +60,13 @@ void RequestFromHMI::Run() {}
 
 void RequestFromHMI::on_event(const event_engine::Event& event) {}
 
-void RequestFromHMI::SendResponse(
-    const bool success,
-    const uint32_t correlation_id,
-    const hmi_apis::FunctionID::eType function_id,
-    const hmi_apis::Common_Result::eType result_code) {
-  smart_objects::SmartObject* message =
-      new smart_objects::SmartObject(smart_objects::SmartType_Map);
+void RequestFromHMI::SendResponse(bool success,
+                                  uint32_t correlation_id,
+                                  hmi_apis::FunctionID::eType function_id,
+                                  hmi_apis::Common_Result::eType result_code) {
+  smart_objects::SmartObjectSPtr message =
+      ::utils::MakeShared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
   FillCommonParametersOfSO(message, correlation_id, function_id);
   (*message)[strings::params][strings::message_type] = MessageType::kResponse;
   (*message)[strings::params][hmi_response::code] = 0;
@@ -76,24 +76,26 @@ void RequestFromHMI::SendResponse(
   application_manager_.ManageHMICommand(message);
 }
 
-// void RequestFromHMI::SendErrorResponse(uint32_t correlation_id,
-//                                       hmi_apis::FunctionID::eType
-//                                       function_id,
-//                                       hmi_apis::Common_Result::eType
-//                                       result_code) {
-//  smart_objects::SmartObject* message = new smart_objects::SmartObject(
-//      smart_objects::SmartType_Map);
-//  FillCommonParametersOfSO(message, correlation_id, function_id);
-//  (*message)[strings::params][strings::message_type] =
-//  MessageType::kErrorResponse;
-//  (*message)[strings::params][hmi_response::code] = result_code;
-//  (*message)[strings::params][strings::error_msg] = "HMIDeactivate is active";
+void RequestFromHMI::SendErrorResponse(
+    uint32_t correlation_id,
+    hmi_apis::FunctionID::eType function_id,
+    hmi_apis::Common_Result::eType result_code,
+    std::string error_message) {
+  smart_objects::SmartObjectSPtr message =
+      ::utils::MakeShared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  FillCommonParametersOfSO(message, correlation_id, function_id);
+  (*message)[strings::params][strings::message_type] =
+      MessageType::kErrorResponse;
+  (*message)[strings::params][hmi_response::code] = result_code;
 
-//  application_manager_.ManageHMICommand(message);
-//}
+  (*message)[strings::params][strings::error_msg] = error_message;
+
+  application_manager_.ManageHMICommand(message);
+}
 
 void RequestFromHMI::FillCommonParametersOfSO(
-    smart_objects::SmartObject* message,
+    smart_objects::SmartObjectSPtr& message,
     uint32_t correlation_id,
     hmi_apis::FunctionID::eType function_id) {
   (*message)[strings::params][strings::function_id] = function_id;

--- a/src/components/application_manager/src/commands/hmi/request_from_hmi.cc
+++ b/src/components/application_manager/src/commands/hmi/request_from_hmi.cc
@@ -78,10 +78,10 @@ void RequestFromHMI::SendResponse(
 }
 
 void RequestFromHMI::SendErrorResponse(
-    uint32_t correlation_id,
-    hmi_apis::FunctionID::eType function_id,
-    hmi_apis::Common_Result::eType result_code,
-    std::string error_message) {
+    const uint32_t correlation_id,
+    const hmi_apis::FunctionID::eType function_id,
+    const hmi_apis::Common_Result::eType result_code,
+    const std::string error_message) {
   smart_objects::SmartObjectSPtr message =
       ::utils::MakeShared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
@@ -97,8 +97,8 @@ void RequestFromHMI::SendErrorResponse(
 
 void RequestFromHMI::FillCommonParametersOfSO(
     smart_objects::SmartObject& message,
-    uint32_t correlation_id,
-    hmi_apis::FunctionID::eType function_id) {
+    const uint32_t correlation_id,
+    const hmi_apis::FunctionID::eType function_id) {
   (message)[strings::params][strings::function_id] = function_id;
   (message)[strings::params][strings::protocol_type] = hmi_protocol_type_;
   (message)[strings::params][strings::protocol_version] = protocol_version_;

--- a/src/components/application_manager/src/commands/hmi/request_from_hmi.cc
+++ b/src/components/application_manager/src/commands/hmi/request_from_hmi.cc
@@ -60,14 +60,15 @@ void RequestFromHMI::Run() {}
 
 void RequestFromHMI::on_event(const event_engine::Event& event) {}
 
-void RequestFromHMI::SendResponse(bool success,
-                                  uint32_t correlation_id,
-                                  hmi_apis::FunctionID::eType function_id,
-                                  hmi_apis::Common_Result::eType result_code) {
+void RequestFromHMI::SendResponse(
+    const bool success,
+    const uint32_t correlation_id,
+    const hmi_apis::FunctionID::eType function_id,
+    const hmi_apis::Common_Result::eType result_code) {
   smart_objects::SmartObjectSPtr message =
       ::utils::MakeShared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  FillCommonParametersOfSO(message, correlation_id, function_id);
+  FillCommonParametersOfSO(*message, correlation_id, function_id);
   (*message)[strings::params][strings::message_type] = MessageType::kResponse;
   (*message)[strings::params][hmi_response::code] = 0;
   (*message)[strings::msg_params][strings::success] = success;
@@ -84,7 +85,7 @@ void RequestFromHMI::SendErrorResponse(
   smart_objects::SmartObjectSPtr message =
       ::utils::MakeShared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  FillCommonParametersOfSO(message, correlation_id, function_id);
+  FillCommonParametersOfSO(*message, correlation_id, function_id);
   (*message)[strings::params][strings::message_type] =
       MessageType::kErrorResponse;
   (*message)[strings::params][hmi_response::code] = result_code;
@@ -95,13 +96,13 @@ void RequestFromHMI::SendErrorResponse(
 }
 
 void RequestFromHMI::FillCommonParametersOfSO(
-    smart_objects::SmartObjectSPtr& message,
+    smart_objects::SmartObject& message,
     uint32_t correlation_id,
     hmi_apis::FunctionID::eType function_id) {
-  (*message)[strings::params][strings::function_id] = function_id;
-  (*message)[strings::params][strings::protocol_type] = hmi_protocol_type_;
-  (*message)[strings::params][strings::protocol_version] = protocol_version_;
-  (*message)[strings::params][strings::correlation_id] = correlation_id;
+  (message)[strings::params][strings::function_id] = function_id;
+  (message)[strings::params][strings::protocol_type] = hmi_protocol_type_;
+  (message)[strings::params][strings::protocol_version] = protocol_version_;
+  (message)[strings::params][strings::correlation_id] = correlation_id;
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/hmi_interfaces_impl.cc
+++ b/src/components/application_manager/src/hmi_interfaces_impl.cc
@@ -48,10 +48,6 @@ generate_function_to_interface_convert_map() {
       HmiInterfaces::HMI_INTERFACE_BasicCommunication;
   convert_map[BasicCommunication_OnUpdateDeviceList] =
       HmiInterfaces::HMI_INTERFACE_BasicCommunication;
-  convert_map[BasicCommunication_OnPhoneCall] =
-      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
-  convert_map[BasicCommunication_OnEmergencyEvent] =
-      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
   convert_map[BasicCommunication_OnResumeAudioSource] =
       HmiInterfaces::HMI_INTERFACE_BasicCommunication;
   convert_map[BasicCommunication_OnSDLPersistenceComplete] =
@@ -103,8 +99,6 @@ generate_function_to_interface_convert_map() {
   convert_map[BasicCommunication_OnSystemInfoChanged] =
       HmiInterfaces::HMI_INTERFACE_BasicCommunication;
   convert_map[BasicCommunication_OnIgnitionCycleOver] =
-      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
-  convert_map[BasicCommunication_OnDeactivateHMI] =
       HmiInterfaces::HMI_INTERFACE_BasicCommunication;
   convert_map[BasicCommunication_OnEventChanged] =
       HmiInterfaces::HMI_INTERFACE_BasicCommunication;

--- a/src/components/hmi_message_handler/src/dbus_message_adapter.cc
+++ b/src/components/hmi_message_handler/src/dbus_message_adapter.cc
@@ -126,8 +126,6 @@ void DBusMessageAdapter::SubscribeTo() {
   DBusMessageController::SubscribeTo("BasicCommunication", "OnSystemRequest");
   DBusMessageController::SubscribeTo("BasicCommunication",
                                      "OnSystemInfoChanged");
-  DBusMessageController::SubscribeTo("BasicCommunication", "OnPhoneCall");
-  DBusMessageController::SubscribeTo("BasicCommunication", "OnEmergencyEvent");
   DBusMessageController::SubscribeTo("TTS", "Started");
   DBusMessageController::SubscribeTo("TTS", "Stopped");
   DBusMessageController::SubscribeTo("TTS", "OnLanguageChange");

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -2140,21 +2140,6 @@
     <function name="OnUpdateDeviceList" messagetype="notification">
       <description>Notification from HMI to SDL sent when HMI requires update of device list (i.e. when user clicks 'Change Device' button)</description>
     </function>
-    <function name="OnPhoneCall" messagetype="notification">
-        <description>Sender: HMI->SDL. When: upon phone-call event started or ended</description>
-        <param name="isActive" type="Boolean" mandatory="true">
-            <description>Must be 'true' - when the phone call is started on HMI. Must be 'false' when the phone call is ended on HMI</description>
-        </param>
-    </function>
-    <function name="OnEmergencyEvent" messagetype="notification">
-        <description>
-            "Sender: HMI->SDL. Conditions: when HMI enters the mode of "911 Assist", or other rear view camera,
-            or something else in the future. Purpose: for SDL to change the audioStreamingState of the related apps to
-            NOT_AUDIBLE when "enabled:true" and back to AUDIBLE when "enabled:false""
-        </description>
-        <param name="enabled" type="Boolean" mandatory="true">
-        </param>
-    </function>
     <function name="OnResumeAudioSource" messagetype="notification">
       <description>This method must be invoked by SDL to update audio state.</description>
       <param name="appID" type="Integer" mandatory="true">
@@ -2456,16 +2441,6 @@
     <description>Notification from system to SDL to let it know that ignition cycle is over.</description>
   </function>
   <!-- End of Policies -->
-   <function name="OnDeactivateHMI" messagetype="notification">
-        <description>
-          Sender: HMI->SDL. When: in case GAL/DIO is active or disabling
-        </description>
-     <param name="isDeactivated" type="Boolean" mandatory="true">
-        <description>
-          Must be 'true' - GAL/DIO is active. Must be 'false' when GAL/DIO is disabling
-        </description>
-     </param>
-   </function>
    <function name="OnEventChanged" messagetype="notification">
      <description>Sender: HMI->SDL. When event is become active</description>
      <param name="eventName" type="Common.EventTypes" mandatory="true">
@@ -3415,9 +3390,9 @@
     <param name="wayPointType" type="Common.WayPointType" defvalue="ALL" mandatory="false">
       <description>To request for either the destination only or for all waypoints including destination</description>
     </param>
-    <param name="appID" type="Integer" mandatory="true"> 
-      <description>ID of the application.</description> 
-    </param> 
+    <param name="appID" type="Integer" mandatory="true">
+      <description>ID of the application.</description>
+    </param>
   </function>
   <function name="GetWayPoints" functionID="GetWayPointsID" messagetype="response">
     <param name="appID" type="Integer" mandatory="true">


### PR DESCRIPTION
According [APPLINK-16172](https://adc.luxoft.com/jira/browse/APPLINK-16172) SDL.ActivateApp should be rejected after DEACTIVATE_HMI
Added error response for HMI

Related to [APPLINK-21868](https://adc.luxoft.com/jira/browse/APPLINK-21868)