### PR TITLE
[WiP] Fix AppHMIType in Policy

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -440,6 +440,9 @@ class PolicyHandler : public PolicyHandlerInterface,
   virtual void OnUpdateHMILevel(const std::string& device_id,
                                 const std::string& policy_app_id,
                                 const std::string& hmi_level) OVERRIDE;
+
+  void AddApplication(const std::string& application_id,
+                      const smart_objects::SmartObject* app_types) OVERRIDE;
 #endif
 
   virtual void OnCertificateUpdated(

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -657,8 +657,17 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
   applications_.insert(application);
   applications_list_lock_.Release();
 
+#ifdef SDL_REMOTE_CONTROL
+  if (message[strings::msg_params].keyExists(strings::app_hmi_type)) {
+    GetPolicyHandler().AddApplication(
+        application->policy_app_id(),
+        &message[strings::msg_params][strings::app_hmi_type]);
+  } else {
+    GetPolicyHandler().AddApplication(application->policy_app_id());
+  }
+#else   // SDL_REMOTE_CONTROL
   GetPolicyHandler().AddApplication(application->policy_app_id());
-
+#endif  // SDL_REMOTE_CONTROL
   return application;
 }
 

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -85,17 +85,21 @@ mobile_apis::AppHMIType::eType StringToAppHMIType(const std::string& str) {
 }
 
 std::string AppHMITypeToString(mobile_apis::AppHMIType::eType type) {
-  const std::map<mobile_apis::AppHMIType::eType, std::string> app_hmi_type_map =
-      {{mobile_apis::AppHMIType::DEFAULT, "DEFAULT"},
-       {mobile_apis::AppHMIType::COMMUNICATION, "COMMUNICATION"},
-       {mobile_apis::AppHMIType::MEDIA, "MEDIA"},
-       {mobile_apis::AppHMIType::MESSAGING, "MESSAGING"},
-       {mobile_apis::AppHMIType::NAVIGATION, "NAVIGATION"},
-       {mobile_apis::AppHMIType::INFORMATION, "INFORMATION"},
-       {mobile_apis::AppHMIType::SOCIAL, "SOCIAL"},
-       {mobile_apis::AppHMIType::BACKGROUND_PROCESS, "BACKGROUND_PROCESS"},
-       {mobile_apis::AppHMIType::TESTING, "TESTING"},
-       {mobile_apis::AppHMIType::SYSTEM, "SYSTEM"}};
+  static const std::map<mobile_apis::AppHMIType::eType, std::string>
+      app_hmi_type_map = {
+          {mobile_apis::AppHMIType::DEFAULT, "DEFAULT"},
+#ifdef SDL_REMOTE_CONTROL
+          {mobile_apis::AppHMIType::REMOTE_CONTROL, "REMOTE_CONTROL"},
+#endif  // SDL_REMOTE_CONTROL
+          {mobile_apis::AppHMIType::COMMUNICATION, "COMMUNICATION"},
+          {mobile_apis::AppHMIType::MEDIA, "MEDIA"},
+          {mobile_apis::AppHMIType::MESSAGING, "MESSAGING"},
+          {mobile_apis::AppHMIType::NAVIGATION, "NAVIGATION"},
+          {mobile_apis::AppHMIType::INFORMATION, "INFORMATION"},
+          {mobile_apis::AppHMIType::SOCIAL, "SOCIAL"},
+          {mobile_apis::AppHMIType::BACKGROUND_PROCESS, "BACKGROUND_PROCESS"},
+          {mobile_apis::AppHMIType::TESTING, "TESTING"},
+          {mobile_apis::AppHMIType::SYSTEM, "SYSTEM"}};
 
   std::map<mobile_apis::AppHMIType::eType, std::string>::const_iterator iter =
       app_hmi_type_map.find(type);

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -493,6 +493,21 @@ void PolicyHandler::AddApplication(const std::string& application_id) {
 }
 
 #ifdef SDL_REMOTE_CONTROL
+void PolicyHandler::AddApplication(
+    const std::string& application_id,
+    const smart_objects::SmartObject* app_types) {
+  POLICY_LIB_CHECK_VOID();
+  std::vector<int> hmi_types;
+  if (app_types && app_types->asArray()) {
+    smart_objects::SmartArray* hmi_list = app_types->asArray();
+    std::transform(hmi_list->begin(),
+                   hmi_list->end(),
+                   std::back_inserter(hmi_types),
+                   SmartObjectToInt());
+  }
+  policy_manager_->AddApplication(application_id, hmi_types);
+}
+
 bool PolicyHandler::CheckHMIType(const std::string& application_id,
                                  mobile_apis::AppHMIType::eType hmi,
                                  const smart_objects::SmartObject* app_types) {

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -129,6 +129,8 @@ class PolicyHandlerInterface {
   virtual bool CheckHMIType(const std::string& application_id,
                             mobile_apis::AppHMIType::eType hmi,
                             const smart_objects::SmartObject* app_types) = 0;
+  virtual void AddApplication(const std::string& application_id,
+                              const smart_objects::SmartObject* app_types) = 0;
 #endif
   /**
    * Lets client to notify PolicyHandler that more kilometers expired

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -268,6 +268,10 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_CONST_METHOD2(GetModuleTypes,
                      bool(const std::string& policy_app_id,
                           std::vector<std::string>* modules));
+
+  MOCK_METHOD2(AddApplication,
+               void(const std::string& application_id,
+                    const smart_objects::SmartObject* app_types));
 #endif
 
  private:

--- a/src/components/policy/src/sql_pt_queries.cc
+++ b/src/components/policy/src/sql_pt_queries.cc
@@ -385,6 +385,19 @@ const std::string kCreateSchema =
     "CREATE INDEX `access_module.fk_module_1_idx` ON "
     "`access_module`(`zone_id`); "
 
+    /* remote_rpc */
+    "CREATE TABLE `remote_rpc`( "
+    "  `id` INTEGER PRIMARY KEY NOT NULL, "
+    "  `name` VARCHAR(255) NOT NULL, "
+    "  `parameter` VARCHAR(45), "
+    "  `module_id` INTEGER NOT NULL, "
+    "CONSTRAINT `fk_remote_rpc_1` "
+    "  FOREIGN KEY(`module_id`) "
+    "  REFERENCES `access_module`(`id`) "
+    "); "
+    "CREATE INDEX `remote_rpc.fk_remote_rpc_1_idx` ON "
+    "`remote_rpc`(`module_id`); "
+
     /* module type */
     "CREATE TABLE IF NOT EXISTS `module_type`( "
     "  `name` VARCHAR(50) NOT NULL, "
@@ -590,6 +603,8 @@ const std::string kDropSchema =
     "DROP TABLE IF EXISTS `priority`; "
     "DROP TABLE IF EXISTS `functional_group`; "
     "DROP TABLE IF EXISTS `module_config`; "
+    "DROP TABLE IF EXISTS `remote_rpc`; "
+    "DROP INDEX IF EXISTS `remote_rpc.fk_remote_rpc_1_idx`; "
     "DROP TABLE IF EXISTS `module_meta`; "
     "DROP TABLE IF EXISTS `usage_and_error_count`; "
     "DROP TABLE IF EXISTS `device`; "
@@ -625,6 +640,7 @@ const std::string kDeleteData =
     "DELETE FROM `functional_group`; "
     "DELETE FROM `module_config`; "
     "DELETE FROM `module_meta`; "
+    "DELETE FROM `remote_rpc`; "
     "DELETE FROM `usage_and_error_count`; "
     "DELETE FROM `device`; "
     "COMMIT; "

--- a/src/components/policy/test/sql_pt_representation_test.cc
+++ b/src/components/policy/test/sql_pt_representation_test.cc
@@ -426,7 +426,7 @@ TEST_F(SQLPTRepresentationTest,
   ASSERT_EQ(0, dbms->FetchOneInt(query_select));
   ASSERT_TRUE(reps->RefreshDB());
   // Check PT structure destroyed and tables number is 0
-  ASSERT_EQ(30, dbms->FetchOneInt(query_select));
+  ASSERT_EQ(31, dbms->FetchOneInt(query_select));
   const char* query_select_count_of_iap_buffer_full =
       "SELECT `count_of_iap_buffer_full` FROM `usage_and_error_count`";
   const char* query_select_count_sync_out_of_memory =


### PR DESCRIPTION
Fixed error with missing `AppHMITypes` in `AccessRemote` component
Also fixed issue with `SQL PT`

Fix: [SDLOPEN-498](https://adc.luxoft.com/jira/browse/SDLOPEN-498)
##
@LuxoftAKutsan, please review