### PR TITLE
Use secconds against ms in RPCs

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -341,11 +341,11 @@ class MessageHelper {
     * @brief Send request to SyncP process to read file and send
     * Policy Table Snapshot using Retry Strategy
     * @param file_path Path to file with PTS
-    * @param timeout Timeout to wait for PTU
+    * @param timeout Timeout to wait for PTU in seconds
     * @param retries Seconds between retries
     */
   static void SendPolicyUpdate(const std::string& file_path,
-                               int timeout,
+                               const uint32_t timeout,
                                const std::vector<int>& retries,
                                ApplicationManager& app_mngr);
 

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -96,7 +96,7 @@ class PolicyHandler : public PolicyHandlerInterface,
 #ifdef EXTERNAL_PROPRIETARY_MODE
   void OnSnapshotCreated(const BinaryMessage& pt_string,
                          const std::vector<int>& retry_delay_seconds,
-                         int timeout_exchange) OVERRIDE;
+                         uint32_t timeout_exchange) OVERRIDE;
 #else   // EXTERNAL_PROPRIETARY_MODE
   void OnSnapshotCreated(const BinaryMessage& pt_string) OVERRIDE;
 #endif  // EXTERNAL_PROPRIETARY_MODE
@@ -123,7 +123,8 @@ class PolicyHandler : public PolicyHandlerInterface,
   virtual std::string GetLockScreenIconUrl() const OVERRIDE;
   void ResetRetrySequence() OVERRIDE;
   uint32_t NextRetryTimeout() OVERRIDE;
-  int TimeoutExchange() OVERRIDE;
+  uint32_t TimeoutExchangeSec() OVERRIDE;
+  uint32_t TimeoutExchangeMSec() OVERRIDE;
   void OnExceededTimeout() OVERRIDE;
   void OnSystemReady() OVERRIDE;
   void PTUpdatedAt(Counters counter, int value) OVERRIDE;

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -380,8 +380,8 @@ class ResumeCtrlImpl : public ResumeCtrl,
 
   /**
    * @brief CheckDelayAfterIgnOn should check if SDL was started less
-   * then N secconds ago. N will be readed from profile.
-   * @return true if SDL started N secconds ago, otherwise return false
+   * then N seconds ago. N will be readed from profile.
+   * @return true if SDL started N seconds ago, otherwise return false
    */
   bool CheckDelayAfterIgnOn();
 

--- a/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
@@ -104,7 +104,8 @@ void OnSystemRequestNotification::Run() {
 #ifdef PROPRIETARY_MODE
 void OnSystemRequestNotification::AddHeader(BinaryMessage& message) const {
   LOG4CXX_AUTO_TRACE(logger_);
-  const int timeout = application_manager_.GetPolicyHandler().TimeoutExchange();
+  const uint32_t timeout =
+      application_manager_.GetPolicyHandler().TimeoutExchangeSec();
 
   size_t content_length;
   char size_str[24];

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1498,7 +1498,7 @@ void MessageHelper::SendOnSDLConsentNeeded(
 }
 
 void MessageHelper::SendPolicyUpdate(const std::string& file_path,
-                                     const int timeout,
+                                     const uint32_t timeout,
                                      const std::vector<int>& retries,
                                      ApplicationManager& app_mngr) {
   smart_objects::SmartObjectSPtr message =
@@ -1891,15 +1891,13 @@ void MessageHelper::SendQueryApps(const uint32_t connection_key,
 
   policy::PolicyHandlerInterface& policy_handler = app_mngr.GetPolicyHandler();
 
+  const uint32_t timeout = policy_handler.TimeoutExchangeSec();
   smart_objects::SmartObject content(smart_objects::SmartType_Map);
   content[strings::msg_params][strings::request_type] = RequestType::QUERY_APPS;
   content[strings::msg_params][strings::url] = policy_handler.RemoteAppsUrl();
-  content[strings::msg_params][strings::timeout] =
-      policy_handler.TimeoutExchange();
+  content[strings::msg_params][strings::timeout] = timeout;
 
   Json::Value http_header;
-
-  const int timeout = policy_handler.TimeoutExchange();
 
   http_header[http_request::content_type] = "application/json";
   http_header[http_request::connect_timeout] = timeout;

--- a/src/components/application_manager/src/policies/policy_retry_sequence.cc
+++ b/src/components/application_manager/src/policies/policy_retry_sequence.cc
@@ -57,7 +57,7 @@ void RetrySequence::StartNextRetry() {
   if (pt_snapshot) {
     policy_handler_->SendMessageToSDK(*pt_snapshot);
 
-    const int timeout = policy_handler_->TimeoutExchange();
+    const uint32_t timeout = policy_handler_->TimeoutExchangeSec();
     const int seconds = policy_handler_->NextRetryTimeout();
     LOG4CXX_DEBUG(logger_,
                   "Timeout response: " << timeout << " Next try: " << seconds);

--- a/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
@@ -100,11 +100,11 @@ TEST_F(OnSystemRequestNotificationTest, Run_ProprietaryType_SUCCESS) {
   EXPECT_CALL(mock_policy_handler, IsRequestTypeAllowed(_, _))
       .WillOnce(Return(true));
 
-#if defined(PROPRIETARY_MODE)
+#ifdef PROPRIETARY_MODE
   EXPECT_CALL(app_mngr_, GetPolicyHandler())
       .Times(2)
       .WillRepeatedly(ReturnRef(mock_policy_handler));
-  EXPECT_CALL(mock_policy_handler, TimeoutExchange()).WillOnce(Return(5u));
+  EXPECT_CALL(mock_policy_handler, TimeoutExchangeSec()).WillOnce(Return(5u));
 #endif  // PROPRIETARY_MODE
 
   EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -110,7 +110,7 @@ class MockMessageHelper {
 
   MOCK_METHOD4(SendPolicyUpdate,
                void(const std::string& file_path,
-                    int timeout,
+                    const uint32_t timeout,
                     const std::vector<int>& retries,
                     ApplicationManager& app_mngr));
   MOCK_METHOD2(SendDecryptCertificateToHMI,

--- a/src/components/application_manager/test/include/application_manager/policy_handler_interface_mock.h
+++ b/src/components/application_manager/test/include/application_manager/policy_handler_interface_mock.h
@@ -95,7 +95,8 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                void(int service_type, policy::EndpointUrls& end_points));
   MOCK_METHOD0(ResetRetrySequence, void());
   MOCK_METHOD0(NextRetryTimeout, uint32_t());
-  MOCK_METHOD0(TimeoutExchange, int());
+  MOCK_METHOD0(TimeoutExchangeSec, uint32_t());
+  MOCK_METHOD0(TimeoutExchangeMSec, uint32_t());
   MOCK_METHOD0(OnExceededTimeout, void());
   MOCK_METHOD0(OnSystemReady, void());
   MOCK_METHOD2(PTUpdatedAt, void(policy::Counters counter, int value));

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -202,7 +202,7 @@ void MessageHelper::SendSDLActivateAppResponse(
 }
 
 void MessageHelper::SendPolicyUpdate(const std::string& file_path,
-                                     int timeout,
+                                     const uint32_t timeout,
                                      const std::vector<int>& retries,
                                      ApplicationManager& app_mngr) {
   MockMessageHelper::message_helper_mock()->SendPolicyUpdate(

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -194,7 +194,8 @@ class PolicyHandlerTest : public ::testing::Test {
     EXPECT_CALL(policy_settings_, system_files_path())
         .WillOnce(ReturnRef(kSnapshotStorage_));
 #ifdef PROPRIETARY_MODE
-    EXPECT_CALL(*mock_policy_manager_, TimeoutExchange()).WillOnce(Return(1));
+    EXPECT_CALL(*mock_policy_manager_, TimeoutExchangeMSec())
+        .WillOnce(Return(1));
     EXPECT_CALL(*mock_policy_manager_, RetrySequenceDelaysSeconds())
         .WillOnce(Return(retry_sequence_delay_seconds));
 #endif  // PROPRIETARY_MODE
@@ -515,13 +516,24 @@ TEST_F(PolicyHandlerTest, NextRetryTimeout) {
   policy_handler_.NextRetryTimeout();
 }
 
-TEST_F(PolicyHandlerTest, TimeoutExchange) {
+TEST_F(PolicyHandlerTest, TimeoutExchangeSec) {
   // Arrange
   EnablePolicyAndPolicyManagerMock();
   // Check expectations
-  EXPECT_CALL(*mock_policy_manager_, TimeoutExchange());
+  EXPECT_CALL(*mock_policy_manager_, TimeoutExchangeMSec())
+      .WillOnce(Return(1000));
   // Act
-  policy_handler_.TimeoutExchange();
+  EXPECT_EQ(1u, policy_handler_.TimeoutExchangeSec());
+}
+
+TEST_F(PolicyHandlerTest, TimeoutExchangeMsec) {
+  // Arrange
+  EnablePolicyAndPolicyManagerMock();
+  // Check expectations
+  EXPECT_CALL(*mock_policy_manager_, TimeoutExchangeMSec())
+      .WillOnce(Return(1000));
+  // Act
+  EXPECT_EQ(1000u, policy_handler_.TimeoutExchangeMSec());
 }
 
 TEST_F(PolicyHandlerTest, OnExceededTimeout) {
@@ -1283,7 +1295,7 @@ TEST_F(PolicyHandlerTest, OnSnapshotCreated_UrlNotAdded) {
 #endif  // PROPRIETARY_MODE || EXTERNAL_PROPRIETARY_MODE
 #ifdef EXTERNAL_PROPRIETARY_MODE
   std::vector<int> retry_delay_seconds;
-  const int timeout_exchange = 10;
+  const uint32_t timeout_exchange = 10;
   // TODO(AKutsan): Policy move issues
   EXPECT_CALL(*mock_policy_manager_, GetUpdateUrls("0x07", _))
       .WillRepeatedly(SetArgReferee<1>(test_data));
@@ -1321,7 +1333,7 @@ TEST_F(PolicyHandlerTest, OnSnapshotCreated_UrlAdded) {
   EndpointUrls test_data;
   EndpointData data("some_data");
   std::vector<int> retry_delay_seconds;
-  const int timeout_exchange = 10;
+  const uint32_t timeout_exchange = 10;
   test_data.push_back(data);
 
   ExtendedPolicyExpectations();

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -71,7 +71,7 @@ class PolicyHandlerInterface {
 #ifdef EXTERNAL_PROPRIETARY_MODE
   virtual void OnSnapshotCreated(const BinaryMessage& pt_string,
                                  const std::vector<int>& retry_delay_seconds,
-                                 int timeout_exchange) = 0;
+                                 uint32_t timeout_exchange) = 0;
 #else   // EXTERNAL_PROPRIETARY_MODE
   virtual void OnSnapshotCreated(const BinaryMessage& pt_string) = 0;
 #endif  // EXTERNAL_PROPRIETARY_MODE
@@ -99,7 +99,8 @@ class PolicyHandlerInterface {
   virtual std::string GetLockScreenIconUrl() const = 0;
   virtual void ResetRetrySequence() = 0;
   virtual uint32_t NextRetryTimeout() = 0;
-  virtual int TimeoutExchange() = 0;
+  virtual uint32_t TimeoutExchangeSec() = 0;
+  virtual uint32_t TimeoutExchangeMSec() = 0;
   virtual void OnExceededTimeout() = 0;
   virtual void OnSystemReady() = 0;
   virtual void PTUpdatedAt(Counters counter, int value) = 0;

--- a/src/components/include/policy/policy_external/policy/policy_listener.h
+++ b/src/components/include/policy/policy_external/policy/policy_listener.h
@@ -81,7 +81,7 @@ class PolicyListener {
    */
   virtual void OnSnapshotCreated(const BinaryMessage& pt_string,
                                  const std::vector<int>& retry_seconds,
-                                 int timeout_exceed) = 0;
+                                 uint32_t timeout_exceed) = 0;
 
   /**
    * @brief Make appropriate changes for related applications permissions and

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -159,7 +159,7 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * Gets timeout to wait until receive response
    * @return timeout in seconds
    */
-  virtual int TimeoutExchange() = 0;
+  virtual uint32_t TimeoutExchangeMSec() = 0;
 
   /**
    * @brief List of timeouts in seconds between retries

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -68,7 +68,7 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD3(OnSnapshotCreated,
                void(const policy::BinaryMessage& pt_string,
                     const std::vector<int>& retry_delay_seconds,
-                    int timeout_exchange));
+                    uint32_t timeout_exchange));
 #else   // EXTERNAL_PROPRIETARY_MODE
   MOCK_METHOD1(OnSnapshotCreated, void(const policy::BinaryMessage& pt_string));
 #endif  // EXTERNAL_PROPRIETARY_MODE
@@ -104,7 +104,8 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
   MOCK_METHOD0(ResetRetrySequence, void());
   MOCK_METHOD0(NextRetryTimeout, uint32_t());
-  MOCK_METHOD0(TimeoutExchange, int());
+  MOCK_METHOD0(TimeoutExchangeSec, uint32_t());
+  MOCK_METHOD0(TimeoutExchangeMSec, uint32_t());
   MOCK_METHOD0(OnExceededTimeout, void());
   MOCK_METHOD0(OnSystemReady, void());
   MOCK_METHOD2(PTUpdatedAt, void(policy::Counters counter, int value));

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_listener.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_listener.h
@@ -78,7 +78,7 @@ class MockPolicyListener : public ::policy::PolicyListener {
   MOCK_METHOD3(OnSnapshotCreated,
                void(const policy::BinaryMessage& pt_string,
                     const std::vector<int>& retry_seconds,
-                    int timeout_exceed));
+                    uint32_t timeout_exceed));
   MOCK_METHOD0(CanUpdate, bool());
   MOCK_METHOD1(OnCertificateUpdated, void(const std::string&));
   MOCK_CONST_METHOD2(SendOnAppPermissionsChanged,

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -80,7 +80,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(ForcePTExchange, std::string());
   MOCK_METHOD0(ResetRetrySequence, void());
   MOCK_METHOD0(NextRetryTimeout, int());
-  MOCK_METHOD0(TimeoutExchange, int());
+  MOCK_METHOD0(TimeoutExchangeMSec, uint32_t());
   MOCK_METHOD0(RetrySequenceDelaysSeconds, const std::vector<int>());
   MOCK_METHOD0(OnExceededTimeout, void());
   MOCK_METHOD0(OnUpdateStarted, void());

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -80,7 +80,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(ForcePTExchange, std::string());
   MOCK_METHOD0(ResetRetrySequence, void());
   MOCK_METHOD0(NextRetryTimeout, uint32_t());
-  MOCK_METHOD0(TimeoutExchange, int());
+  MOCK_METHOD0(TimeoutExchangeMSec, uint32_t());
   MOCK_METHOD0(RetrySequenceDelaysSeconds, const std::vector<int>());
   MOCK_METHOD0(OnExceededTimeout, void());
   MOCK_METHOD0(OnUpdateStarted, void());

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -77,7 +77,7 @@ class PolicyManagerImpl : public PolicyManager {
   virtual std::string GetPolicyTableStatus() const;
   virtual void ResetRetrySequence();
   virtual int NextRetryTimeout();
-  virtual int TimeoutExchange();
+  virtual uint32_t TimeoutExchangeMSec();
   virtual const std::vector<int> RetrySequenceDelaysSeconds();
   virtual void OnExceededTimeout();
   virtual std::string GetLockScreenIconUrl() const OVERRIDE;

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -236,7 +236,7 @@ void PolicyManagerImpl::RequestPTUpdate() {
     BinaryMessage update(message_string.begin(), message_string.end());
 
     listener_->OnSnapshotCreated(
-        update, RetrySequenceDelaysSeconds(), TimeoutExchange());
+        update, RetrySequenceDelaysSeconds(), TimeoutExchangeMSec());
   } else {
     LOG4CXX_ERROR(logger_, "Invalid Policy table snapshot - PTUpdate failed");
   }
@@ -1059,7 +1059,7 @@ void PolicyManagerImpl::ResetRetrySequence() {
   update_status_manager_.OnResetRetrySequence();
 }
 
-int PolicyManagerImpl::TimeoutExchange() {
+uint32_t PolicyManagerImpl::TimeoutExchangeMSec() {
   return retry_sequence_timeout_;
 }
 
@@ -1073,7 +1073,7 @@ void PolicyManagerImpl::OnExceededTimeout() {
 }
 
 void PolicyManagerImpl::OnUpdateStarted() {
-  int update_timeout = TimeoutExchange();
+  uint32_t update_timeout = TimeoutExchangeMSec();
   LOG4CXX_DEBUG(logger_,
                 "Update timeout will be set to (milisec): " << update_timeout);
   update_status_manager_.OnUpdateSentOut(update_timeout);

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -223,7 +223,7 @@ TEST_F(PolicyManagerImplTest2, TimeOutExchange) {
   // Arrange
   CreateLocalPT(preloadet_pt_filename_);
   // Check value taken from PT
-  EXPECT_EQ(70000, manager_->TimeoutExchange());
+  EXPECT_EQ(70000u, manager_->TimeoutExchangeMSec());
 }
 
 TEST_F(PolicyManagerImplTest,

--- a/src/components/policy/policy_external/test/update_status_manager_test.cc
+++ b/src/components/policy/policy_external/test/update_status_manager_test.cc
@@ -148,6 +148,7 @@ TEST_F(UpdateStatusManagerTest,
   // Arrange
   EXPECT_CALL(listener_, OnUpdateStatusChanged(update_needed_status_));
   manager_->ScheduleUpdate();
+  status_ = manager_->GetLastUpdateStatus();
   EXPECT_EQ(StatusUpdateRequired, status_);
   EXPECT_CALL(listener_, OnUpdateStatusChanged(updating_status_));
   manager_->OnUpdateSentOut(k_timeout_);

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -114,7 +114,7 @@ class CacheManager : public CacheManagerInterface {
 
   /**
    * @brief Returns timeout to wait for a response of PT update
-   * @return value in seconds
+   * @return value in msec
    */
   virtual int TimeoutResponse();
 

--- a/src/components/policy/policy_regular/include/policy/policy_manager.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager.h
@@ -159,7 +159,7 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * Gets timeout to wait until receive response
    * @return timeout in seconds
    */
-  virtual int TimeoutExchange() = 0;
+  virtual uint32_t TimeoutExchangeMSec() = 0;
 
   /**
    * @brief List of timeouts in seconds between retries

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -84,7 +84,7 @@ class PolicyManagerImpl : public PolicyManager {
   virtual std::string GetPolicyTableStatus() const;
   virtual void ResetRetrySequence();
   virtual uint32_t NextRetryTimeout();
-  virtual int TimeoutExchange();
+  virtual uint32_t TimeoutExchangeMSec();
   virtual const std::vector<int> RetrySequenceDelaysSeconds();
   virtual void OnExceededTimeout();
   virtual void OnUpdateStarted();
@@ -313,7 +313,7 @@ class PolicyManagerImpl : public PolicyManager {
   std::map<std::string, AppPermissions> app_permissions_diff_;
 
   /**
-   * Timeout to wait response with UpdatePT
+   * Timeout to wait response with UpdatePT (msec)
    */
   uint32_t retry_sequence_timeout_;
 

--- a/src/components/policy/policy_regular/include/policy/status.h
+++ b/src/components/policy/policy_regular/include/policy/status.h
@@ -55,7 +55,6 @@ enum UpdateEvent {
   kOnResetRetrySequence
 };
 
-
 const std::string kUpToDate = "UP_TO_DATE";
 const std::string kUpdateNeeded = "UPDATE_NEEDED";
 const std::string kUpdating = "UPDATING";

--- a/src/components/policy/policy_regular/include/policy/update_status_manager.h
+++ b/src/components/policy/policy_regular/include/policy/update_status_manager.h
@@ -83,7 +83,7 @@ class UpdateStatusManager : public UpdateStatusManagerInterface {
 
   /**
    * @brief Update status hanlder for PTS sending out
-   * @param update_timeout Timeout for waiting of incoming PTU
+   * @param update_timeout Timeout for waiting of incoming PTU (msec)
    */
   void OnUpdateSentOut(uint32_t update_timeout);
 

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -58,7 +58,7 @@ void DeleteManager(policy::PolicyManager* pm) {
 }
 
 namespace {
-const uint32_t kDefaultRetryTimeoutInSec = 60u;
+const uint32_t kDefaultRetryTimeoutInMSec = 60u * date_time::DateTime::MILLISECONDS_IN_SECOND;
 }  // namespace
 
 namespace policy {
@@ -69,7 +69,7 @@ PolicyManagerImpl::PolicyManagerImpl()
     : PolicyManager()
     , listener_(NULL)
     , cache_(new CacheManager)
-    , retry_sequence_timeout_(kDefaultRetryTimeoutInSec)
+    , retry_sequence_timeout_(kDefaultRetryTimeoutInMSec)
     , retry_sequence_index_(0)
     , timer_retry_sequence_("Retry sequence timer",
                             new timer::TimerTaskImpl<PolicyManagerImpl>(
@@ -796,7 +796,7 @@ void PolicyManagerImpl::ResetRetrySequence() {
   update_status_manager_.OnResetRetrySequence();
 }
 
-int PolicyManagerImpl::TimeoutExchange() {
+uint32_t PolicyManagerImpl::TimeoutExchangeMSec() {
   return retry_sequence_timeout_;
 }
 
@@ -810,7 +810,7 @@ void PolicyManagerImpl::OnExceededTimeout() {
 }
 
 void PolicyManagerImpl::OnUpdateStarted() {
-  int update_timeout = TimeoutExchange();
+  uint32_t update_timeout = TimeoutExchangeMSec();
   LOG4CXX_DEBUG(logger_,
                 "Update timeout will be set to (milisec): " << update_timeout);
   update_status_manager_.OnUpdateSentOut(update_timeout);

--- a/src/components/policy/policy_regular/test/include/policy/mock_policy_manager.h
+++ b/src/components/policy/policy_regular/test/include/policy/mock_policy_manager.h
@@ -78,7 +78,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(ForcePTExchange, std::string());
   MOCK_METHOD0(ResetRetrySequence, void());
   MOCK_METHOD0(NextRetryTimeout, int());
-  MOCK_METHOD0(TimeoutExchange, int());
+  MOCK_METHOD0(TimeoutExchangeMSec, uint32_t());
   MOCK_METHOD0(RetrySequenceDelaysSeconds, const std::vector<int>());
   MOCK_METHOD0(OnExceededTimeout, void());
   MOCK_METHOD0(OnUpdateStarted, void());

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -881,7 +881,7 @@ TEST_F(PolicyManagerImplTest2, NextRetryTimeout_ExpectTimeoutsFromPT) {
 
     for (uint32_t retry_number = 0u; retry_number < size; ++retry_number) {
       waiting_timeout += seconds_between_retries[retry_number].asInt();
-      waiting_timeout += manager->TimeoutExchange();
+      waiting_timeout += manager->TimeoutExchangeMSec();
 
       // it's in miliseconds
       EXPECT_EQ(waiting_timeout * date_time::DateTime::MILLISECONDS_IN_SECOND,
@@ -894,7 +894,7 @@ TEST_F(PolicyManagerImplTest2, TimeOutExchange) {
   // Arrange
   CreateLocalPT("sdl_preloaded_pt.json");
   // Check value taken from PT
-  EXPECT_EQ(70000, manager->TimeoutExchange());
+  EXPECT_EQ(70000u, manager->TimeoutExchangeMSec());
 }
 
 TEST_F(PolicyManagerImplTest2, UpdatedPreloadedPT_ExpectLPT_IsUpdated) {


### PR DESCRIPTION
Send to external communication time in seconds according API, 
But handle storing milliseconds for internal needs 
Related issue : APPLINK-31433