### PR TITLE
Fix SDL omits URL during retry sequence

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1388,8 +1388,8 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
   }
 
   SendMessageToSDK(pt_string, urls.at(current_app).url.at(current_url));
-  if(!(urls.at(current_app).app_id == policy::kDefaultId))
-  current_url++;
+  if (!(urls.at(current_app).app_id == policy::kDefaultId))
+    current_url++;
 #endif  // PROPRIETARY_MODE
   // reset update required false
   OnUpdateRequestSentToMobile();

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1388,6 +1388,7 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
   }
 
   SendMessageToSDK(pt_string, urls.at(current_app).url.at(current_url));
+  if(!(urls.at(current_app).app_id == policy::kDefaultId))
   current_url++;
 #endif  // PROPRIETARY_MODE
   // reset update required false


### PR DESCRIPTION
Fix SDL omits one of the URLs while cyclically changing during retry sequence

Related defect APPLINK-31325