### PR TITLE
Fix transferring OnKeyboardInput notification

### DIFF
--- a/src/components/application_manager/src/commands/mobile/on_keyboard_input_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_keyboard_input_notification.cc
@@ -58,7 +58,9 @@ void OnKeyBoardInputNotification::Run() {
   for (; accessor.GetData().end() != it; ++it) {
     // if there is app with active perform interaction use it for notification
     ApplicationSharedPtr app = *it;
-    if (app->is_perform_interaction_active()) {
+    if (app->is_perform_interaction_active() &&
+        (*it)->perform_interaction_layout() ==
+            mobile_apis::LayoutMode::KEYBOARD) {
       LOG4CXX_INFO(logger_,
                    "There is application with active PerformInteraction");
       app_to_notify = app;

--- a/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
@@ -205,6 +205,7 @@ void PerformInteractionRequest::Run() {
 
   app->set_perform_interaction_mode(static_cast<int32_t>(interaction_mode_));
   app->set_perform_interaction_active(true);
+  app->set_perform_interaction_layout(interaction_layout);
   // increment amount of active requests
   ++pi_requests_count_;
   SendVRPerformInteractionRequest(app);

--- a/src/components/application_manager/test/commands/mobile/on_keyboard_input_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_keyboard_input_notification_test.cc
@@ -108,6 +108,8 @@ TEST_F(OnKeyBoardInputNotificationTest, Run_ActionActive_SUCCESS) {
 
   MockAppPtr mock_app(InitAppSetDataAccessor(app_set_));
   EXPECT_CALL(*mock_app, is_perform_interaction_active()).WillOnce(Return(1));
+  EXPECT_CALL(*mock_app, perform_interaction_layout())
+      .WillOnce(Return(mobile_apis::LayoutMode::KEYBOARD));
   EXPECT_CALL(*mock_app, hmi_level()).Times(0);
 
   EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kConnectionKey));


### PR DESCRIPTION
OnKeyboardInput should be sent for any app in FULL when no active PerformInteraction(KEYBOARD)

Close-bug [APPLINK-22167](https://adc.luxoft.com/jira/browse/APPLINK-22167)