### PR TITLE
Fix issue in UT for mobile commands

### DIFF
--- a/src/components/application_manager/test/commands/mobile/get_dtcs_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/get_dtcs_request_test.cc
@@ -38,14 +38,16 @@
 #include "utils/shared_ptr.h"
 #include "smart_objects/smart_object.h"
 #include "application_manager/smart_object_keys.h"
-#include "application_manager/test/include/application_manager/commands/commands_test.h"
-#include "application_manager/test/include/application_manager/commands/command_request_test.h"
+#include "commands/commands_test.h"
+#include "commands/command_request_test.h"
 #include "application_manager/application.h"
 #include "application_manager/mock_application_manager.h"
 #include "application_manager/mock_application.h"
+#include "application_manager/mock_message_helper.h"
 #include "application_manager/event_engine/event.h"
-#include "application_manager/commands/mobile/get_dtcs_request.h"
+#include "mobile/get_dtcs_request.h"
 #include "interfaces/MOBILE_API.h"
+#include "interfaces/HMI_API.h"
 
 namespace test {
 namespace components {
@@ -54,17 +56,33 @@ namespace mobile_commands_test {
 namespace get_dtcs_request {
 
 using ::testing::_;
+using ::testing::Mock;
 using ::testing::Return;
 namespace am = ::application_manager;
 using am::commands::MessageSharedPtr;
 using am::commands::GetDTCsRequest;
 using am::event_engine::Event;
+using am::MockMessageHelper;
 namespace mobile_result = mobile_apis::Result;
 
 typedef SharedPtr<GetDTCsRequest> GetDTCsRequestPtr;
 
 class GetDTCsRequestTest
-    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  GetDTCsRequestTest()
+      : mock_message_helper_(*MockMessageHelper::message_helper_mock()) {}
+
+  void SetUp() OVERRIDE {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+  void TearDown() OVERRIDE {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+
+ protected:
+  MockMessageHelper& mock_message_helper_;
+};
 
 TEST_F(GetDTCsRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
   GetDTCsRequestPtr command(CreateCommand<GetDTCsRequest>());
@@ -115,11 +133,14 @@ TEST_F(GetDTCsRequestTest, OnEvent_SUCCESS) {
   MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
   (*event_msg)[am::strings::msg_params] = 0;
   (*event_msg)[am::strings::params][am::hmi_response::code] =
-      mobile_apis::Result::SUCCESS;
+      hmi_apis::Common_Result::SUCCESS;
 
   Event event(hmi_apis::FunctionID::VehicleInfo_GetDTCs);
   event.set_smart_object(*event_msg);
 
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
   EXPECT_CALL(
       app_mngr_,
       ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));

--- a/src/components/application_manager/test/commands/mobile/subscribe_way_points_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/subscribe_way_points_request_test.cc
@@ -33,14 +33,17 @@
 #include "gtest/gtest.h"
 #include "utils/shared_ptr.h"
 #include "smart_objects/smart_object.h"
-#include "application_manager/test/include/application_manager/commands/commands_test.h"
-#include "application_manager/test/include/application_manager/commands/command_request_test.h"
+#include "commands/commands_test.h"
+#include "commands/command_request_test.h"
 #include "application_manager/application.h"
 #include "application_manager/mock_application_manager.h"
 #include "application_manager/mock_application.h"
 #include "application_manager/mock_hmi_capabilities.h"
-#include "application_manager/include/application_manager/commands/mobile/subscribe_way_points_request.h"
+#include "application_manager/mock_message_helper.h"
+#include "mobile/subscribe_way_points_request.h"
 #include "interfaces/MOBILE_API.h"
+#include "interfaces/HMI_API.h"
+
 #include "application_manager/smart_object_keys.h"
 
 namespace test {
@@ -50,6 +53,7 @@ namespace mobile_commands_test {
 namespace subscribe_way_points_request {
 
 using ::testing::_;
+using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::DoAll;
@@ -58,11 +62,26 @@ using ::testing::InSequence;
 namespace am = ::application_manager;
 using am::commands::SubscribeWayPointsRequest;
 using am::commands::MessageSharedPtr;
+using am::MockMessageHelper;
 
 typedef SharedPtr<SubscribeWayPointsRequest> CommandPtr;
 
 class SubscribeWayPointsRequestTest
-    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  SubscribeWayPointsRequestTest()
+      : mock_message_helper_(*MockMessageHelper::message_helper_mock()) {}
+
+  void SetUp() OVERRIDE {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+  void TearDown() OVERRIDE {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+
+ protected:
+  MockMessageHelper& mock_message_helper_;
+};
 
 TEST_F(SubscribeWayPointsRequestTest, Run_SUCCESS) {
   CommandPtr command(CreateCommand<SubscribeWayPointsRequest>());
@@ -96,7 +115,7 @@ TEST_F(SubscribeWayPointsRequestTest, OnEvent_SUCCESS) {
 
   MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
   (*event_msg)[am::strings::params][am::hmi_response::code] =
-      mobile_apis::Result::SUCCESS;
+      hmi_apis::Common_Result::SUCCESS;
   (*event_msg)[am::strings::msg_params] = 0;
 
   event.set_smart_object(*event_msg);
@@ -106,6 +125,9 @@ TEST_F(SubscribeWayPointsRequestTest, OnEvent_SUCCESS) {
   {
     InSequence dummy;
     EXPECT_CALL(app_mngr_, SubscribeAppForWayPoints(_));
+    EXPECT_CALL(mock_message_helper_,
+                HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
+        .WillOnce(Return(mobile_apis::Result::SUCCESS));
     EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
     EXPECT_CALL(*app, UpdateHash());
   }


### PR DESCRIPTION
  - fixed issue with mock_message_helper in UTs
    for GetDTCsRequest and SubscribeWayPointsRequest

Related to [SDLOPEN-556](https://adc.luxoft.com/jira/browse/SDLOPEN-556)