### PR TITLE
Add support for audioPassThruIcon parameter

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -259,6 +259,20 @@ class CommandRequestImpl : public CommandImpl,
   mobile_apis::Result::eType PrepareResultCodeForResponse(
       const ResponseInfo& first, const ResponseInfo& second);
 
+  /**
+   * @brief Resolves if the return code must be
+   * UNSUPPORTED_RESOURCE
+   * @param first contains result_code from HMI response and
+   * interface that returns response
+   * @param second contains result_code from HMI response and
+   * interface that returns response.
+   * @return if the communication return code must be
+   * UNSUPPORTED_RESOURCE, function returns true, else
+   * false
+   */
+  bool IsResultCodeUnsupported(const ResponseInfo& first,
+                               const ResponseInfo& second) const;
+
  protected:
   /**
    * @brief Returns policy parameters permissions

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -272,6 +272,16 @@ class CommandRequestImpl : public CommandImpl,
    */
   bool IsResultCodeUnsupported(const ResponseInfo& first,
                                const ResponseInfo& second) const;
+  /**
+   * @brief Checks result code from HMI for split RPC
+   * and set flags to the info structures.
+   * @param first contains result_code from HMI response and
+   * interface that returns response
+   * @param second contains result_code from HMI response and
+   * interface that returns response
+   */
+  void SetResultCodeFlagsForHMIResponses(ResponseInfo& out_first,
+                                         ResponseInfo& out_second) const;
 
  protected:
   /**

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -136,7 +136,7 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
   /**
    * @brief Validates audioPassThruIcon parameter and
    * removes it if is not valid
-   * @param Pointer to the application whose storage directory
+   * @param app Pointer to the application whose storage directory
    * must be accessed
    */
   void ProcessAudioPassThruIcon(ApplicationSharedPtr app);
@@ -154,7 +154,7 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
   /**
    * @brief Maintains the full path filename for the
    * audioPassThruIcon file
-   * @param Pointer to the application whose storage directory
+   * @param app Pointer to the application whose storage directory
    * must be accessed
    */
   std::string GetAudioPassThruIconFilename(ApplicationSharedPtr app);
@@ -174,8 +174,8 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
   /**
    * @brief Checks if any of audioPassThru communication components
    * returned ABORTED code
-   * @param ui_response contains result_code from UI
-   * @param tts_response contains result_code from TTS
+   * @param ui contains result_code from UI
+   * @param tts contains result_code from TTS
    * @return if TTS or UI responded with ABORTED function returns TRUE,
    * else is returns FALSE
    */

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -133,10 +133,64 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
    */
   bool IsWaitingHMIResponse();
 
+  /**
+   * @brief Validates audioPassThruIcon parameter and
+   * removes it if is not valid
+   * @param Pointer to the application whose storage directory
+   * must be accessed
+   */
+  void ProcessAudioPassThruIcon(ApplicationSharedPtr app);
+
+  /**
+   * @brief Checks if the audioPassThruIcon parameter value
+   * contains special characters (\n,\t) or
+   * contains only white spaces
+   * @return If the audioPassthruIcon parameter value contains
+   * above mentioned symbols, the function returns FALSE, else
+   * the parameter value is valid and it returns TRUE
+   */
+  bool IsAudioPassThruIconParamValid();
+
+  /**
+   * @brief Maintains the full path filename for the
+   * audioPassThruIcon file
+   * @param Pointer to the application whose storage directory
+   * must be accessed
+   */
+  std::string GetAudioPassThruIconFilename(ApplicationSharedPtr app);
+
+  /**
+   * @brief Checks result code from HMI for splitted RPC
+   * and returns parameter for sending to mobile app in
+   * audioPassThru communication.
+   * @param ui_response contains result_code from UI
+   * @param tts_response contains result_code from TTS
+   * @return result code - 1) UI error code has precedence than TTS's
+   * 2) error_code from TTS is turned to WARNINGS
+   */
+  mobile_apis::Result::eType PrepareAudioPassThruResultCodeForResponse(
+      const ResponseInfo& ui_response, const ResponseInfo& tts_response);
+
+  /**
+   * @brief Checks if any of audioPassThru communication components
+   * returned ABORTED code
+   * @param ui_response contains result_code from UI
+   * @param tts_response contains result_code from TTS
+   * @return if TTS or UI responded with ABORTED function returns TRUE,
+   * else is returns FALSE
+   */
+  bool IsAnyHMIComponentAborted(const ResponseInfo& ui,
+                                const ResponseInfo& tts);
+
   /* flag display state of speak and ui perform audio
   during perform audio pass thru*/
   bool awaiting_tts_speak_response_;
   bool awaiting_ui_response_;
+
+  /* flag shows if last received audioPassThruIcon exists
+   * in the file system
+   */
+  bool audio_pass_thru_icon_exists_;
 
   hmi_apis::Common_Result::eType result_tts_speak_;
   hmi_apis::Common_Result::eType result_ui_;

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -152,14 +152,6 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
   bool IsAudioPassThruIconParamValid();
 
   /**
-   * @brief Maintains the full path filename for the
-   * audioPassThruIcon file
-   * @param app Pointer to the application whose storage directory
-   * must be accessed
-   */
-  std::string GetAudioPassThruIconFilename(ApplicationSharedPtr app);
-
-  /**
    * @brief Checks result code from HMI for splitted RPC
    * and returns parameter for sending to mobile app in
    * audioPassThru communication.

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -164,6 +164,7 @@ extern const char* speech_capabilities;
 extern const char* vr_capabilities;
 extern const char* audio_pass_thru_capabilities;
 extern const char* pcm_stream_capabilities;
+extern const char* audio_pass_thru_icon;
 
 // PutFile
 extern const char* sync_file_name;

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -681,6 +681,18 @@ bool CommandRequestImpl::PrepareResultForMobileResponse(
 
 bool CommandRequestImpl::PrepareResultForMobileResponse(
     ResponseInfo& out_first, ResponseInfo& out_second) const {
+  SetResultCodeFlagsForHMIResponses(out_first, out_second);
+
+  bool result = (out_first.is_ok && out_second.is_ok) ||
+                (out_second.is_invalid_enum && out_first.is_ok) ||
+                (out_first.is_invalid_enum && out_second.is_ok);
+  result = result || CheckResultCode(out_first, out_second);
+  result = result || CheckResultCode(out_second, out_first);
+  return result;
+}
+
+void CommandRequestImpl::SetResultCodeFlagsForHMIResponses(
+    ResponseInfo& out_first, ResponseInfo& out_second) const {
   using namespace helpers;
 
   out_first.is_ok = Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
@@ -717,13 +729,6 @@ bool CommandRequestImpl::PrepareResultForMobileResponse(
   out_second.interface_state =
       application_manager_.hmi_interfaces().GetInterfaceState(
           out_second.interface);
-
-  bool result = (out_first.is_ok && out_second.is_ok) ||
-                (out_second.is_invalid_enum && out_first.is_ok) ||
-                (out_first.is_invalid_enum && out_second.is_ok);
-  result = result || CheckResultCode(out_first, out_second);
-  result = result || CheckResultCode(out_second, out_first);
-  return result;
 }
 
 void CommandRequestImpl::GetInfo(

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -109,15 +109,6 @@ bool CheckResultCode(const ResponseInfo& first, const ResponseInfo& second) {
   return false;
 }
 
-bool IsResultCodeUnsupported(const ResponseInfo& first,
-                             const ResponseInfo& second) {
-  return ((first.is_ok || first.is_invalid_enum) &&
-          second.is_unsupported_resource) ||
-         ((second.is_ok || second.is_invalid_enum) &&
-          first.is_unsupported_resource) ||
-         (first.is_unsupported_resource && second.is_unsupported_resource);
-}
-
 struct DisallowedParamsInserter {
   DisallowedParamsInserter(smart_objects::SmartObject& response,
                            mobile_apis::VehicleDataResultCode::eType code)
@@ -773,6 +764,15 @@ mobile_apis::Result::eType CommandRequestImpl::PrepareResultCodeForResponse(
 const CommandParametersPermissions& CommandRequestImpl::parameters_permissions()
     const {
   return parameters_permissions_;
+}
+
+bool CommandRequestImpl::IsResultCodeUnsupported(
+    const ResponseInfo& first, const ResponseInfo& second) const {
+  return ((first.is_ok || first.is_invalid_enum) &&
+          second.is_unsupported_resource) ||
+         ((second.is_ok || second.is_invalid_enum) &&
+          first.is_unsupported_resource) ||
+         (first.is_unsupported_resource && second.is_unsupported_resource);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -394,9 +394,10 @@ void PerformAudioPassThruRequest::ProcessAudioPassThruIcon(
   if ((*message_)[strings::msg_params].keyExists(
           strings::audio_pass_thru_icon)) {
     if (IsAudioPassThruIconParamValid()) {
-      const std::string& icon_storage_file = GetAudioPassThruIconFilename(app);
-
-      if (!file_system::FileExists(icon_storage_file)) {
+      smart_objects::SmartObject icon =
+          (*message_)[strings::msg_params][strings::audio_pass_thru_icon];
+      if (MessageHelper::VerifyImage(icon, app, application_manager_) !=
+          mobile_apis::Result::SUCCESS) {
         LOG4CXX_WARN(
             logger_,
             "Invalid audio_pass_thru_icon doesn't exist in the file system");
@@ -423,8 +424,6 @@ PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
   if ((ui_result == hmi_apis::Common_Result::SUCCESS) &&
       (tts_result != hmi_apis::Common_Result::SUCCESS)) {
     common_result = hmi_apis::Common_Result::WARNINGS;
-  } else if (tts_result == hmi_apis::Common_Result::ABORTED) {
-    common_result = hmi_apis::Common_Result::ABORTED;
   } else if (ui_result == hmi_apis::Common_Result::INVALID_ENUM) {
     common_result = tts_result;
   } else {
@@ -449,21 +448,6 @@ bool PerformAudioPassThruRequest::IsAudioPassThruIconParamValid() {
   }
 
   return true;
-}
-
-std::string PerformAudioPassThruRequest::GetAudioPassThruIconFilename(
-    ApplicationSharedPtr app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  const std::string& str =
-      (*message_)[strings::msg_params][strings::audio_pass_thru_icon]
-                 [strings::value].asString();
-  const std::string storage_directory(
-      application_manager_.get_settings().app_storage_folder() + "/");
-  const std::string icon_storage_file(storage_directory + app->folder_name() +
-                                      "/" + str);
-
-  return icon_storage_file;
 }
 
 bool PerformAudioPassThruRequest::IsAnyHMIComponentAborted(

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -201,10 +201,7 @@ bool PerformAudioPassThruRequest::PrepareResponseParameters(
   ResponseInfo tts_perform_info(result_tts_speak_,
                                 HmiInterfaces::HMI_INTERFACE_TTS);
 
-  bool result_unused =
-      PrepareResultForMobileResponse(ui_perform_info, tts_perform_info);
-  UNUSED(result_unused);
-
+  SetResultCodeFlagsForHMIResponses(ui_perform_info, tts_perform_info);
   if (ui_perform_info.is_ok && tts_perform_info.is_unsupported_resource &&
       HmiInterfaces::STATE_AVAILABLE == tts_perform_info.interface_state) {
     result_code = mobile_apis::Result::WARNINGS;

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -37,6 +37,7 @@
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
 #include "utils/helpers.h"
+#include "utils/file_system.h"
 
 namespace application_manager {
 
@@ -49,6 +50,7 @@ PerformAudioPassThruRequest::PerformAudioPassThruRequest(
     : CommandRequestImpl(message, application_manager)
     , awaiting_tts_speak_response_(false)
     , awaiting_ui_response_(false)
+    , audio_pass_thru_icon_exists_(true)
     , result_tts_speak_(hmi_apis::Common_Result::INVALID_ENUM)
     , result_ui_(hmi_apis::Common_Result::INVALID_ENUM) {
   subscribe_on_event(hmi_apis::FunctionID::TTS_OnResetTimeout);
@@ -97,6 +99,7 @@ void PerformAudioPassThruRequest::Run() {
   // According with new implementation processing of UNSUPPORTE_RESOURCE
   // need set flag before sending to hmi
 
+  ProcessAudioPassThruIcon(app);
   awaiting_ui_response_ = true;
   if ((*message_)[str::msg_params].keyExists(str::initial_prompt) &&
       (0 < (*message_)[str::msg_params][str::initial_prompt].length())) {
@@ -193,21 +196,35 @@ bool PerformAudioPassThruRequest::PrepareResponseParameters(
     mobile_apis::Result::eType& result_code, std::string& info) {
   LOG4CXX_AUTO_TRACE(logger_);
 
+  bool result = true;
   ResponseInfo ui_perform_info(result_ui_, HmiInterfaces::HMI_INTERFACE_UI);
   ResponseInfo tts_perform_info(result_tts_speak_,
                                 HmiInterfaces::HMI_INTERFACE_TTS);
-  const bool result =
-      PrepareResultForMobileResponse(ui_perform_info, tts_perform_info);
+
+  PrepareResultForMobileResponse(ui_perform_info, tts_perform_info);
 
   if (ui_perform_info.is_ok && tts_perform_info.is_unsupported_resource &&
       HmiInterfaces::STATE_AVAILABLE == tts_perform_info.interface_state) {
     result_code = mobile_apis::Result::WARNINGS;
     tts_info_ = "Unsupported phoneme type sent in a prompt";
-    info = MergeInfos(ui_perform_info, ui_info_, tts_perform_info, tts_info_);
-    return result;
+  } else if (IsResultCodeUnsupported(ui_perform_info, tts_perform_info)) {
+    result_code = mobile_apis::Result::UNSUPPORTED_RESOURCE;
+  } else if (IsAnyHMIComponentAborted(ui_perform_info, tts_perform_info)) {
+    result_code = mobile_apis::Result::ABORTED;
+    result = false;
+  } else {
+    result_code = PrepareAudioPassThruResultCodeForResponse(ui_perform_info,
+                                                            tts_perform_info);
+    if (!ui_perform_info.is_ok) {
+      result = false;
+    }
   }
-  result_code = PrepareResultCodeForResponse(ui_perform_info, tts_perform_info);
+
   info = MergeInfos(ui_perform_info, ui_info_, tts_perform_info, tts_info_);
+  if (audio_pass_thru_icon_exists_ == false) {
+    info = MergeInfos("Reference image(s) not found", info);
+  }
+
   return result;
 }
 
@@ -271,6 +288,11 @@ void PerformAudioPassThruRequest::SendPerformAudioPassThruRequest() {
   } else {
     // If omitted, the value is set to true
     msg_params[str::mute_audio] = true;
+  }
+
+  if ((*message_)[str::msg_params].keyExists(str::audio_pass_thru_icon)) {
+    msg_params[str::audio_pass_thru_icon] =
+        (*message_)[str::msg_params][str::audio_pass_thru_icon];
   }
 
   SendHMIRequest(
@@ -363,6 +385,93 @@ void PerformAudioPassThruRequest::FinishTTSSpeak() {
 bool PerformAudioPassThruRequest::IsWaitingHMIResponse() {
   LOG4CXX_AUTO_TRACE(logger_);
   return awaiting_tts_speak_response_ || awaiting_ui_response_;
+}
+
+void PerformAudioPassThruRequest::ProcessAudioPassThruIcon(
+    ApplicationSharedPtr app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  audio_pass_thru_icon_exists_ = true;
+  if ((*message_)[strings::msg_params].keyExists(
+          strings::audio_pass_thru_icon)) {
+    if (IsAudioPassThruIconParamValid()) {
+      const std::string& icon_storage_file = GetAudioPassThruIconFilename(app);
+
+      if (!file_system::FileExists(icon_storage_file)) {
+        LOG4CXX_WARN(
+            logger_,
+            "Invalid audio_pass_thru_icon doesn't exist in the file system");
+        audio_pass_thru_icon_exists_ = false;
+      }
+    } else {
+      LOG4CXX_WARN(logger_,
+                   "Invalid audio_pass_thru_icon validation check failed");
+      (*message_)[strings::msg_params].erase(strings::audio_pass_thru_icon);
+    }
+  }
+}
+
+mobile_apis::Result::eType
+PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
+    const ResponseInfo& ui_response, const ResponseInfo& tts_response) {
+  mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
+
+  hmi_apis::Common_Result::eType common_result =
+      hmi_apis::Common_Result::INVALID_ENUM;
+  const hmi_apis::Common_Result::eType ui_result = ui_response.result_code;
+  const hmi_apis::Common_Result::eType tts_result = tts_response.result_code;
+
+  if ((ui_result == hmi_apis::Common_Result::SUCCESS) &&
+      (tts_result != hmi_apis::Common_Result::SUCCESS)) {
+    common_result = hmi_apis::Common_Result::WARNINGS;
+  } else if (tts_result == hmi_apis::Common_Result::ABORTED) {
+    common_result = hmi_apis::Common_Result::ABORTED;
+  } else if (ui_result == hmi_apis::Common_Result::INVALID_ENUM) {
+    common_result = tts_result;
+  } else {
+    common_result = ui_result;
+  }
+
+  result_code = MessageHelper::HMIToMobileResult(common_result);
+  return result_code;
+}
+
+bool PerformAudioPassThruRequest::IsAudioPassThruIconParamValid() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const std::string& value =
+      (*message_)[strings::msg_params][strings::audio_pass_thru_icon]
+                 [strings::value].asString();
+
+  if (!CheckSyntax(value, false)) {
+    LOG4CXX_WARN(logger_,
+                 "Invalid audio_pass_thru_icon value syntax check failed");
+    return false;
+  }
+
+  return true;
+}
+
+std::string PerformAudioPassThruRequest::GetAudioPassThruIconFilename(
+    ApplicationSharedPtr app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const std::string& str =
+      (*message_)[strings::msg_params][strings::audio_pass_thru_icon]
+                 [strings::value].asString();
+  const std::string storage_directory(
+      application_manager_.get_settings().app_storage_folder() + "/");
+  const std::string icon_storage_file(storage_directory + app->folder_name() +
+                                      "/" + str);
+
+  return icon_storage_file;
+}
+
+bool PerformAudioPassThruRequest::IsAnyHMIComponentAborted(
+    const ResponseInfo& ui, const ResponseInfo& tts) {
+  using namespace helpers;
+
+  return ((ui.result_code == hmi_apis::Common_Result::ABORTED) ||
+          (tts.result_code == hmi_apis::Common_Result::ABORTED));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -131,6 +131,7 @@ const char* speech_capabilities = "speechCapabilities";
 const char* vr_capabilities = "vrCapabilities";
 const char* audio_pass_thru_capabilities = "audioPassThruCapabilities";
 const char* pcm_stream_capabilities = "pcmStreamCapabilities";
+const char* audio_pass_thru_icon = "audioPassThruIcon";
 // PutFile
 const char* sync_file_name = "syncFileName";
 const char* file_name = "fileName";
@@ -348,6 +349,7 @@ const char* auto_complete_text = "autoCompleteText";
 const char* file = "file";
 const char* retry = "retry";
 const char* service = "service";
+const char* audio_pass_thru_icon = "audioPassThruIcon";
 }  // namespace hmi_request
 
 namespace hmi_response {

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -497,6 +497,9 @@
   <element name="phoneNumber">
     <description> Optional hone number of intended location / establishment (if applicable) for SendLocation.</description>
   </element>
+  <element name="audioPassThruIcon">
+	<description>The optional image field for AudioPassThru</description>
+  </element>
   <element name="timeToDestination"/>
     <!-- TO DO to be removed -->
     <element name="turnText"/>
@@ -538,6 +541,9 @@
   </element>
   <element name="locationImage">
     <description>The optional image of a destination / location</description>
+  </element>
+  <element name="audiPassThruIcon">
+    <description>The optional image for AudioPassThru</description>
   </element>
 </enum>
 
@@ -3203,6 +3209,12 @@
         If omitted, the value is set to true.
       </description>
     </param>
+    <param name="audioPassThruIcon" type="Common.Image" mandatory="false">
+	  <description>
+	    Image struct determinig wheter static or dynamic icon.
+		If omitted on supported displays, no (or the default if applicable) icon shall be displayed.
+	  </description>
+	</param>
   </function>
   <function name="PerformAudioPassThru" messagetype="response">
   </function>

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -34,7 +34,7 @@
 
 <interfaces name="SmartDeviceLink HMI API">
 
-<interface name="Common" version="1.4" date="2016-05-11">
+<interface name="Common" version="1.5" date="2017-01-16">
 
 <enum name="Result">
     <element name="SUCCESS" value="0"/>
@@ -498,7 +498,7 @@
     <description> Optional hone number of intended location / establishment (if applicable) for SendLocation.</description>
   </element>
   <element name="audioPassThruIcon">
-	<description>The optional image field for AudioPassThru</description>
+    <description>The optional image field for AudioPassThru</description>
   </element>
   <element name="timeToDestination"/>
     <!-- TO DO to be removed -->
@@ -2758,7 +2758,7 @@
   </function>
 </interface>
 
-<interface name="UI" version="1.0" date="2013-04-16">
+<interface name="UI" version="1.1" date="2017-01-16">
   <function name="Alert" messagetype="request">
     <description>Request from SDL to show an alert message on the display.</description>
     <param name="alertStrings" type="Common.TextFieldStruct" mandatory="true" array="true" minsize="0" maxsize="3">
@@ -3210,11 +3210,11 @@
       </description>
     </param>
     <param name="audioPassThruIcon" type="Common.Image" mandatory="false">
-	  <description>
-	    Image struct determinig wheter static or dynamic icon.
-		If omitted on supported displays, no (or the default if applicable) icon shall be displayed.
-	  </description>
-	</param>
+      <description>
+        Image struct determinig wheter static or dynamic icon.
+        If omitted on supported displays, no (or the default if applicable) icon shall be displayed.
+      </description>
+    </param>
   </function>
   <function name="PerformAudioPassThru" messagetype="response">
   </function>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -747,6 +747,10 @@
       <description>The optional image of a destination / location</description>
     </element>
 
+    <element name="audioPassThruIcon">
+      <description>The optional image field for AudioPassThru</description>
+    </element>
+
   </enum>
 
   <enum name="CharacterSet">
@@ -3393,6 +3397,10 @@
 		Defines if the current audio source should be muted during the APT session.  If not, the audio source will play without interruption.
       	If omitted, the value is set to true.
       </description>
+    </param>
+    <param name="audioPassThruIcon" type="Image" mandatory="false">
+      <description>Image struct determinig wheter static or dynamic icon.
+        If omitted on supported displays, no (or the default if applicable) icon shall be displayed.</description>
     </param>
   </function>
 


### PR DESCRIPTION
New Image type parameter is added to MOBILE_API and HMI_API.
It is processed on audioPassThru request from the mobile side
and if it is valid, it is transmited to the HMI side.
Resolution of UI and TTS result codes received from the HMI
and their transfer to the mobile side is changed due to the
new CRQ.

Related-issues: [APPLINK-23360](https://adc.luxoft.com/jira/browse/APPLINK-23360)
Implements: [APPLINK-23358](https://adc.luxoft.com/jira/browse/APPLINK-23358)