### PR TITLE
Move hmi_capabilities  tests

### DIFF
--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -63,6 +63,13 @@ class HMICapabilitiesImpl : public HMICapabilities {
    */
   virtual ~HMICapabilitiesImpl();
 
+  /**
+   * @brief Checks if all HMI capabilities received
+   *
+   * @return TRUE if all information received, otherwise FALSE
+   */
+  bool is_hmi_capabilities_initialized() const OVERRIDE;
+
   /*
    * @brief Checks is image type(Static/Dynamic) requested by
    * Mobile Device is supported on current HMI.
@@ -462,6 +469,13 @@ class HMICapabilitiesImpl : public HMICapabilities {
   bool is_ui_cooperating_;
   bool is_navi_cooperating_;
   bool is_ivi_cooperating_;
+
+  // to check if IsReady response for corresponding interface received
+  bool is_vr_ready_response_recieved_;
+  bool is_tts_ready_response_recieved_;
+  bool is_ui_ready_response_recieved_;
+  bool is_navi_ready_response_recieved_;
+  bool is_ivi_ready_response_recieved_;
 
   bool attenuated_supported_;
   hmi_apis::Common_Language::eType ui_language_;

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -324,6 +324,11 @@ HMICapabilitiesImpl::HMICapabilitiesImpl(ApplicationManager& app_mngr)
     , is_ui_cooperating_(false)
     , is_navi_cooperating_(false)
     , is_ivi_cooperating_(false)
+    , is_vr_ready_response_recieved_(false)
+    , is_tts_ready_response_recieved_(false)
+    , is_ui_ready_response_recieved_(false)
+    , is_navi_ready_response_recieved_(false)
+    , is_ivi_ready_response_recieved_(false)
     , attenuated_supported_(false)
     , ui_language_(hmi_apis::Common_Language::INVALID_ENUM)
     , vr_language_(hmi_apis::Common_Language::INVALID_ENUM)
@@ -348,6 +353,12 @@ HMICapabilitiesImpl::HMICapabilitiesImpl(ApplicationManager& app_mngr)
     , hmi_language_handler_(app_mngr) {
   InitCapabilities();
   if (false == app_mngr_.get_settings().launch_hmi()) {
+    is_vr_ready_response_recieved_ = true;
+    is_tts_ready_response_recieved_ = true;
+    is_ui_ready_response_recieved_ = true;
+    is_navi_ready_response_recieved_ = true;
+    is_ivi_ready_response_recieved_ = true;
+
     is_vr_cooperating_ = true;
     is_tts_cooperating_ = true;
     is_ui_cooperating_ = true;
@@ -371,6 +382,45 @@ HMICapabilitiesImpl::~HMICapabilitiesImpl() {
   delete audio_pass_thru_capabilities_;
   delete pcm_stream_capabilities_;
   delete prerecorded_speech_;
+}
+
+bool HMICapabilitiesImpl::is_hmi_capabilities_initialized() const {
+  bool result = true;
+
+  if (is_vr_ready_response_recieved_ && is_tts_ready_response_recieved_ &&
+      is_ui_ready_response_recieved_ && is_navi_ready_response_recieved_ &&
+      is_ivi_ready_response_recieved_) {
+    if (is_vr_cooperating_) {
+      if ((!vr_supported_languages_) ||
+          (hmi_apis::Common_Language::INVALID_ENUM == vr_language_)) {
+        result = false;
+      }
+    }
+
+    if (is_tts_cooperating_) {
+      if ((!tts_supported_languages_) ||
+          (hmi_apis::Common_Language::INVALID_ENUM == tts_language_)) {
+        result = false;
+      }
+    }
+
+    if (is_ui_cooperating_) {
+      if ((!ui_supported_languages_) ||
+          (hmi_apis::Common_Language::INVALID_ENUM == ui_language_)) {
+        result = false;
+      }
+    }
+
+    if (is_ivi_cooperating_) {
+      if (!vehicle_type_) {
+        result = false;
+      }
+    }
+  } else {
+    result = false;
+  }
+
+  return result;
 }
 
 bool HMICapabilitiesImpl::VerifyImageType(const int32_t image_type) const {

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -352,6 +352,52 @@ TEST_F(HMICapabilitiesTest, LoadCapabilitiesFromFile) {
   EXPECT_EQ("SE", vehicle_type_so["trim"].asString());
 }
 
+TEST_F(HMICapabilitiesTest,
+       HmiCapabilitiesInitialized_UiVrTtsIviNotCooperating) {
+  // Precondition
+  hmi_capabilities_test->set_is_vr_cooperating(false);
+  hmi_capabilities_test->set_is_tts_cooperating(false);
+
+  hmi_capabilities_test->set_is_ui_cooperating(false);
+  hmi_capabilities_test->set_is_navi_cooperating(false);
+  hmi_capabilities_test->set_is_ivi_cooperating(false);
+  EXPECT_TRUE(hmi_capabilities_test->is_hmi_capabilities_initialized());
+}
+
+TEST_F(HMICapabilitiesTest, HmiCapabilitiesInitialized) {
+  // Precondition
+  SetCooperating();
+  smart_objects::SmartObjectSPtr language(
+      new smart_objects::SmartObject(smart_objects::SmartType_Map));
+
+  EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
+              CreateModuleInfoSO(_, _)).WillRepeatedly(Return(language));
+
+  hmi_capabilities_test->set_is_vr_cooperating(true);
+  smart_objects::SmartObject supported_languages;
+  supported_languages[0] = "EN_US";
+  hmi_capabilities_test->set_vr_supported_languages(supported_languages);
+  hmi_capabilities_test->set_tts_supported_languages(supported_languages);
+  hmi_capabilities_test->set_ui_supported_languages(supported_languages);
+  hmi_capabilities_test->set_vehicle_type(supported_languages);
+
+  hmi_capabilities_test->set_is_tts_cooperating(true);
+  hmi_capabilities_test->set_is_ui_cooperating(true);
+  hmi_capabilities_test->set_is_navi_cooperating(true);
+  hmi_capabilities_test->set_is_ivi_cooperating(true);
+
+  hmi_capabilities_test->set_active_vr_language(
+      hmi_apis::Common_Language::EN_US);
+  SetCooperating();
+  hmi_capabilities_test->set_active_tts_language(
+      hmi_apis::Common_Language::EN_US);
+  SetCooperating();
+  hmi_capabilities_test->set_active_ui_language(
+      hmi_apis::Common_Language::EN_US);
+
+  EXPECT_TRUE(hmi_capabilities_test->is_hmi_capabilities_initialized());
+}
+
 TEST_F(HMICapabilitiesTest, VerifyImageType) {
   const int32_t image_type = 1;
   smart_objects::SmartObject sm_obj;

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -44,6 +44,7 @@ namespace application_manager_test {
 
 class MockHMICapabilities : public ::application_manager::HMICapabilities {
  public:
+  MOCK_CONST_METHOD0(is_hmi_capabilities_initialized, bool());
   MOCK_CONST_METHOD1(VerifyImageType, bool(const int32_t image_type));
 
   MOCK_CONST_METHOD0(is_vr_cooperating, bool());

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -56,6 +56,13 @@ class HMICapabilities {
   virtual ~HMICapabilities() {}
 
   /**
+   * @brief Checks if all HMI capabilities received
+   *
+   * @return TRUE if all information received, otherwise FALSE
+   */
+  virtual bool is_hmi_capabilities_initialized() const = 0;
+
+  /**
      * @brief return component which follows for correctness of
      * languages
      * @return HMI language handler


### PR DESCRIPTION
Move HmiCapabilitiesInitialized and HmiCapabilitiesInitialized_UiVrTtsIviNotCooperating tests from pre_5_0 branch to develop and fix usages in code.
Move is_hmi_capabilities_initialized() function that checks if all HMI capabilities received, return TRUE if all information received, otherwise FALSE.
Related task: [SDLOPEN-559](https://adc.luxoft.com/jira/browse/SDLOPEN-559)