### PR TITLE
Add new parameter enableSeek and OnSeekMediaClockTimer notification

### DIFF
--- a/src/components/application_manager/CMakeLists.txt
+++ b/src/components/application_manager/CMakeLists.txt
@@ -265,6 +265,7 @@ file (GLOB MOBILE_COMMANDS_SOURCES
   ${COMMANDS_SOURCE_DIR}/hmi/on_app_permission_changed_notification.cc
   ${COMMANDS_SOURCE_DIR}/hmi/on_app_unregistered_notification.cc
   ${COMMANDS_SOURCE_DIR}/hmi/on_driver_distraction_notification.cc
+  ${COMMANDS_SOURCE_DIR}/hmi/on_seek_media_clock_timer_notification.cc
   ${COMMANDS_SOURCE_DIR}/hmi/on_ignition_cycle_over_notification.cc
   ${COMMANDS_SOURCE_DIR}/hmi/on_system_info_changed_notification.cc
   ${COMMANDS_SOURCE_DIR}/hmi/on_file_removed_notification.cc

--- a/src/components/application_manager/include/application_manager/commands/hmi/on_seek_media_clock_timer_notification.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/on_seek_media_clock_timer_notification.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_ON_SEEK_MEDIA_CLOCK_TIMER_NOTIFICATION_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_ON_SEEK_MEDIA_CLOCK_TIMER_NOTIFICATION_H_
+
+#include "application_manager/commands/hmi/notification_from_hmi.h"
+
+namespace application_manager {
+
+class Application;
+
+namespace commands {
+
+namespace hmi {
+
+/**
+ * @brief OnSeekMediaClockTimerNotificationl command class
+ **/
+class OnSeekMediaClockTimerNotification : public NotificationFromHMI {
+ public:
+  /**
+   * @brief OnSeekMediaClockTimerNotification class constructor
+   *
+   * @param message Incoming SmartObject message
+   **/
+  OnSeekMediaClockTimerNotification(const MessageSharedPtr& message,
+                                    ApplicationManager& application_manager);
+
+  /**
+   * @brief OnSeekMediaClockTimerNotification class destructor
+   **/
+  virtual ~OnSeekMediaClockTimerNotification();
+
+  /**
+   * @brief Execute command
+   **/
+  virtual void Run();
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(OnSeekMediaClockTimerNotification);
+};
+
+}  // namespace hmi
+
+}  // namespace commands
+
+}  // namespace application_manager
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_ON_SEEK_MEDIA_CLOCK_TIMER_NOTIFICATION_H_

--- a/src/components/application_manager/include/application_manager/commands/mobile/on_seek_media_clock_timer_notification.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/on_seek_media_clock_timer_notification.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_ON_SEEK_MEDIA_CLOCK_TIMER_NOTIFICATION_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_ON_SEEK_MEDIA_CLOCK_TIMER_NOTIFICATION_H_
+
+#include "application_manager/commands/command_notification_impl.h"
+#include "utils/macro.h"
+
+namespace application_manager {
+
+namespace commands {
+
+namespace mobile {
+
+/**
+ * @brief OnSeekMediaClockTimerNotification class
+ **/
+class OnSeekMediaClockTimerNotification : public CommandNotificationImpl {
+ public:
+  /**
+   * @brief OnSeekMediaClockTimerNotification class constructor
+   *
+   * @param message Incoming SmartObject message
+   **/
+  OnSeekMediaClockTimerNotification(const MessageSharedPtr& message,
+                                    ApplicationManager& application_manager);
+
+  /**
+   * @brief OnSeekMediaClockTimerNotification class destructor
+   **/
+  virtual ~OnSeekMediaClockTimerNotification();
+
+  /**
+   * @brief Execute command
+   **/
+  virtual void Run() OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(OnSeekMediaClockTimerNotification);
+};
+
+}  // namespace mobile
+
+}  // namespace commands
+}  // namespace application_manager
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_ON_SEEK_MEDIA_CLOCK_TIMER_NOTIFICATION_H_

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -155,6 +155,7 @@ extern const char* hours;
 extern const char* minutes;
 extern const char* seconds;
 extern const char* update_mode;
+extern const char* enable_seek;
 extern const char* trigger_source;
 extern const char* hmi_level;
 extern const char* activate_app_hmi_level;
@@ -438,7 +439,6 @@ extern const char* policyfile;
 extern const char* is_active;
 extern const char* is_deactivated;
 extern const char* event_name;
-
 }  // namespace hmi_notification
 
 }  // namespace application_manager

--- a/src/components/application_manager/src/commands/hmi/on_seek_media_clock_timer_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_seek_media_clock_timer_notification.cc
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/commands/hmi/on_seek_media_clock_timer_notification.h"
+
+#include "application_manager/application_impl.h"
+#include "utils/logger.h"
+
+namespace application_manager {
+
+namespace commands {
+
+namespace hmi {
+
+OnSeekMediaClockTimerNotification::OnSeekMediaClockTimerNotification(
+    const MessageSharedPtr& message, ApplicationManager& application_manager)
+    : NotificationFromHMI(message, application_manager) {}
+
+OnSeekMediaClockTimerNotification::~OnSeekMediaClockTimerNotification() {}
+
+void OnSeekMediaClockTimerNotification::Run() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  (*message_)[strings::params][strings::function_id] =
+      static_cast<int32_t>(mobile_apis::FunctionID::OnSeekMediaClockTimerID);
+
+  SendNotificationToMobile(message_);
+}
+
+}  // namespace hmi
+
+}  // namespace commands
+
+}  // namespace application_manager

--- a/src/components/application_manager/src/commands/mobile/on_seek_media_clock_timer_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_seek_media_clock_timer_notification.cc
@@ -1,0 +1,59 @@
+/*
+
+ Copyright (c) 2017, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/commands/mobile/on_seek_media_clock_timer_notification.h"
+#include "application_manager/application_manager.h"
+
+namespace application_manager {
+
+namespace commands {
+
+namespace mobile {
+
+OnSeekMediaClockTimerNotification::OnSeekMediaClockTimerNotification(
+    const MessageSharedPtr& message, ApplicationManager& application_manager)
+    : CommandNotificationImpl(message, application_manager) {}
+
+OnSeekMediaClockTimerNotification::~OnSeekMediaClockTimerNotification() {}
+
+void OnSeekMediaClockTimerNotification::Run() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  SendNotification();
+}
+
+}  // namespace mobile
+
+}  // namespace commands
+
+}  // namespace application_manager

--- a/src/components/application_manager/src/hmi_command_factory.cc
+++ b/src/components/application_manager/src/hmi_command_factory.cc
@@ -246,6 +246,7 @@
 #include "application_manager/commands/hmi/on_ui_keyboard_input_notification.h"
 #include "application_manager/commands/hmi/on_ui_touch_event_notification.h"
 #include "application_manager/commands/hmi/on_ui_reset_timeout_notification.h"
+#include "application_manager/commands/hmi/on_seek_media_clock_timer_notification.h"
 #include "application_manager/commands/hmi/navi_start_stream_request.h"
 #include "application_manager/commands/hmi/navi_start_stream_response.h"
 #include "application_manager/commands/hmi/navi_stop_stream_request.h"
@@ -1279,6 +1280,11 @@ CommandSharedPtr HMICommandFactory::CreateCommand(
     }
     case hmi_apis::FunctionID::UI_OnDriverDistraction: {
       command.reset(new commands::hmi::OnDriverDistractionNotification(
+          message, application_manager));
+      break;
+    }
+    case hmi_apis::FunctionID::UI_OnSeekMediaClockTimer: {
+      command.reset(new commands::hmi::OnSeekMediaClockTimerNotification(
           message, application_manager));
       break;
     }

--- a/src/components/application_manager/src/mobile_command_factory.cc
+++ b/src/components/application_manager/src/mobile_command_factory.cc
@@ -127,6 +127,7 @@
 #include "application_manager/commands/mobile/on_keyboard_input_notification.h"
 #include "application_manager/commands/mobile/on_touch_event_notification.h"
 #include "application_manager/commands/mobile/on_system_request_notification.h"
+#include "application_manager/commands/mobile/on_seek_media_clock_timer_notification.h"
 #include "application_manager/commands/mobile/diagnostic_message_request.h"
 #include "application_manager/commands/mobile/diagnostic_message_response.h"
 #include "application_manager/commands/mobile/send_location_request.h"
@@ -687,6 +688,11 @@ CommandSharedPtr MobileCommandFactory::CreateCommand(
     case mobile_apis::FunctionID::OnWayPointChangeID: {
       command = utils::MakeShared<commands::OnWayPointChangeNotification>(
           message, application_manager);
+      break;
+    }
+    case mobile_apis::FunctionID::OnSeekMediaClockTimerID: {
+      command.reset(new commands::mobile::OnSeekMediaClockTimerNotification(
+          message, application_manager));
       break;
     }
     default: {

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -122,6 +122,7 @@ const char* hours = "hours";
 const char* minutes = "minutes";
 const char* seconds = "seconds";
 const char* update_mode = "updateMode";
+const char* enable_seek = "enableSeek";
 const char* trigger_source = "triggerSource";
 const char* hmi_level = "hmiLevel";
 const char* activate_app_hmi_level = "level";
@@ -404,6 +405,7 @@ const char* policyfile = "policyfile";
 const char* is_active = "isActive";
 const char* is_deactivated = "isDeactivated";
 const char* event_name = "eventName";
+const char* enable_seek = "enable_seek";
 
 }  // namespace hmi_notification
 

--- a/src/components/application_manager/test/commands/hmi/on_seek_media_clock_timer_notification_test.cc
+++ b/src/components/application_manager/test/commands/hmi/on_seek_media_clock_timer_notification_test.cc
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/commands/hmi/on_seek_media_clock_timer_notification.h"
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/hmi_interfaces.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+namespace on_seek_media_clock_timer_notification {
+
+using ::testing::Mock;
+using ::utils::SharedPtr;
+using ::application_manager::commands::MessageSharedPtr;
+using am::commands::MessageSharedPtr;
+
+class OnSeekMediaClockTimerNotificationTest
+    : public components::commands_test::CommandsTest<
+          CommandsTestMocks::kIsNice> {};
+
+TEST_F(OnSeekMediaClockTimerNotificationTest,
+       OnSeekMediaClockTimer_SendNotificationToMobile_SUCCESS) {
+  MessageSharedPtr message = CreateMessage();
+  utils::SharedPtr<Command> command =
+      CreateCommand<am::commands::hmi::OnSeekMediaClockTimerNotification>(
+          message);
+
+  EXPECT_CALL(app_mngr_,
+              ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
+  command->Run();
+  EXPECT_EQ(
+      static_cast<int32_t>(mobile_apis::FunctionID::OnSeekMediaClockTimerID),
+      (*message)[am::strings::params][am::strings::function_id].asInt());
+  EXPECT_EQ(static_cast<int32_t>(am::MessageType::kNotification),
+            (*message)[am::strings::params][am::strings::message_type].asInt());
+}
+
+}  // namespace on_seek_media_clock_timer_notification
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/mobile/simple_notification_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/simple_notification_commands_test.cc
@@ -44,6 +44,7 @@
 #include "application_manager/commands/mobile/on_driver_distraction_notification.h"
 #include "application_manager/commands/mobile/on_language_change_notification.h"
 #include "application_manager/commands/mobile/on_permissions_change_notification.h"
+#include "application_manager/commands/mobile/on_seek_media_clock_timer_notification.h"
 
 namespace test {
 namespace components {
@@ -68,6 +69,7 @@ typedef Types<commands::OnAppInterfaceUnregisteredNotification,
               commands::OnAudioPassThruNotification,
               commands::OnLanguageChangeNotification,
               commands::OnPermissionsChangeNotification,
+              commands::mobile::OnSeekMediaClockTimerNotification,
               commands::mobile::OnDriverDistractionNotification>
     NotificationCommandsList;
 

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -2762,6 +2762,15 @@
 </interface>
 
 <interface name="UI" version="1.0" date="2013-04-16">
+  <function name="OnSeekMediaClockTimer" functionID="OnSeekMediaClockTimerID" messagetype="notification">
+   <description>Callback for the seek media clock timer notification. Notification is triggered when the user selects a position and releases the mediaclock timer or when the user selects a position and holds for a full 2 second period. System will automatically the media clock timer position based on the seek notification location.</description> 
+   <param name="seekTime" type="Common.TimeFormat" mandatory="true">
+    <description>See StartTime.</description>
+   </param>
+   <param name="appID" type="Integer" mandatory="true">
+    <description>The ID of application that relates to this mediaclock position change.</description>
+   </param>
+  </function>
   <function name="Alert" messagetype="request">
     <description>Request from SDL to show an alert message on the display.</description>
     <param name="alertStrings" type="Common.TextFieldStruct" mandatory="true" array="true" minsize="0" maxsize="3">
@@ -2937,6 +2946,12 @@
     <param name="appID" type="Integer" mandatory="true">
       <description>ID of application that requested this RPC.</description>
     </param>
+    <param name="enableSeek" type="Boolean" mandatory="false">
+     <description>
+       Defines if seek media clock timer functionality will be available (when DD is off) allowing for touch input on the media clock timer from the user.
+       If omitted, the value is set to false.
+     </description>
+   </param>
   </function>
   <function name="SetMediaClockTimer" messagetype="response">
   </function>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -2248,7 +2248,7 @@
     <element name="OnSystemRequestID" value="32781" hexvalue="800D" />
     <element name="OnHashChangeID" value="32782" hexvalue="800E" />
     <element name="OnWayPointChangeID" value="32783" hexvalue="800F" />
-
+    <element name="OnSeekMediaClockTimerID" value="32785" hexvalue="8011" />
 <!--
 	Ford Specific Request / Response RPCs
 	Range = 0x 0001 0000 - 0x 0001 7FFF
@@ -3335,6 +3335,13 @@
       	Enumeration to control the media clock.
       	In case of pause, resume, or clear, the start time value is ignored and shall be left out.  For resume, the time continues with the same value as it was when paused.
       </description>
+    </param>
+
+    <param name="enableSeek" type="Boolean" mandatory="false">
+     <description>
+       Defines if seek media clock timer functionality will be available (when DD is off) allowing for touch input on the media clock timer from the user.
+       If omitted, the value is set to false.
+     </description>
     </param>
   </function>
 
@@ -5331,6 +5338,12 @@
     </param>
   </function>
 
+  <function name="OnSeekMediaClockTimer" functionID="OnSeekMediaClockTimerID" messagetype="notification">
+     <description>Callback for the seek media clock timer notification. Notification is triggered when the user selects a position and releases the mediaclock timer or when the user selects a position and holds for a full 2 second period. System will automatically the media clock timer position based on the seek notification location.</description> 
+     <param name="seekTime" type="StartTime" mandatory="true">
+      <description>See StartTime.</description>
+     </param>
+  </function>
 
 <!-- Deprecating - covered by OnSystemRequest
   <function name="OnSyncPData" functionID="OnSyncPDataID" messagetype="notification" >


### PR DESCRIPTION
 SetMediaClockTimer: SDL must support new parameter "enableSeek" and transfer OnSeekMediaClockTimer notification from HMI to mobile app.

 Related task APPLINK-23391