### PR TITLE
Fix TTS capabilities to array

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -343,7 +343,7 @@
 },
     "TTS":
 	{
-		"capabilities":"TEXT",
+		"capabilities":["TEXT"],
 		"language":"EN-US",
 	    "languages":
 	    [


### PR DESCRIPTION
According HMI_API.xml TTS capabilities should be array

Related to [APPLINK-31660](https://adc.luxoft.com/jira/browse/APPLINK-31660)