### PR TITLE
Fix invalid audioPassThruIcon handling

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -142,16 +142,6 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
   void ProcessAudioPassThruIcon(ApplicationSharedPtr app);
 
   /**
-   * @brief Checks if the audioPassThruIcon parameter value
-   * contains special characters (\n,\t) or
-   * contains only white spaces
-   * @return If the audioPassthruIcon parameter value contains
-   * above mentioned symbols, the function returns FALSE, else
-   * the parameter value is valid and it returns TRUE
-   */
-  bool IsAudioPassThruIconParamValid();
-
-  /**
    * @brief Checks result code from HMI for splitted RPC
    * and returns parameter for sending to mobile app in
    * audioPassThru communication.

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -368,6 +368,17 @@ bool PerformAudioPassThruRequest::IsWhiteSpaceExist() {
       return true;
     }
   }
+
+  if ((*message_)[strings::msg_params].keyExists(
+          strings::audio_pass_thru_icon)) {
+    str = (*message_)[strings::msg_params][strings::audio_pass_thru_icon]
+                     [strings::value].asCharArray();
+    if (!CheckSyntax(str)) {
+      LOG4CXX_ERROR(logger_,
+                    "Invalid audio_pass_thru_icon value syntax check failed");
+      return true;
+    }
+  }
   return false;
 }
 
@@ -396,20 +407,13 @@ void PerformAudioPassThruRequest::ProcessAudioPassThruIcon(
 
   audio_pass_thru_icon_exists_ = true;
   if (msg_params.keyExists(strings::audio_pass_thru_icon)) {
-    if (IsAudioPassThruIconParamValid()) {
-      smart_objects::SmartObject icon =
-          msg_params[strings::audio_pass_thru_icon];
-      if (MessageHelper::VerifyImage(icon, app, application_manager_) !=
-          mobile_apis::Result::SUCCESS) {
-        LOG4CXX_WARN(
-            logger_,
-            "Invalid audio_pass_thru_icon doesn't exist in the file system");
-        audio_pass_thru_icon_exists_ = false;
-      }
-    } else {
-      LOG4CXX_WARN(logger_,
-                   "Invalid audio_pass_thru_icon validation check failed");
-      msg_params.erase(strings::audio_pass_thru_icon);
+    smart_objects::SmartObject icon = msg_params[strings::audio_pass_thru_icon];
+    if (MessageHelper::VerifyImage(icon, app, application_manager_) !=
+        mobile_apis::Result::SUCCESS) {
+      LOG4CXX_WARN(
+          logger_,
+          "Invalid audio_pass_thru_icon doesn't exist in the file system");
+      audio_pass_thru_icon_exists_ = false;
     }
   }
 }
@@ -435,22 +439,6 @@ PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
 
   result_code = MessageHelper::HMIToMobileResult(common_result);
   return result_code;
-}
-
-bool PerformAudioPassThruRequest::IsAudioPassThruIconParamValid() {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  const std::string& value =
-      (*message_)[strings::msg_params][strings::audio_pass_thru_icon]
-                 [strings::value].asString();
-
-  if (!CheckSyntax(value, false)) {
-    LOG4CXX_WARN(logger_,
-                 "Invalid audio_pass_thru_icon value syntax check failed");
-    return false;
-  }
-
-  return true;
 }
 
 bool PerformAudioPassThruRequest::IsAnyHMIComponentAborted(


### PR DESCRIPTION
Due to CRQ [APPLINK-23358](https://adc.luxoft.com/jira/browse/APPLINK-23358) changes according to validation
of audioPassThruIcon parameter, handling of its value had
to be changed. If the value contains special characters as
'\t', '\n', only white spaces or it is an empty string, SDL
must respond with INVALID_DATA, success:false.

Related-issues: [APPLINK-23360](https://adc.luxoft.com/jira/browse/APPLINK-23360), [APPLINK-23363](https://adc.luxoft.com/jira/browse/APPLINK-23363)
Implements: [APPLINK-23358](https://adc.luxoft.com/jira/browse/APPLINK-23358)