### PR TITLE
Fix SegFault of hmi_message_handler_test UT

### DIFF
--- a/src/components/hmi_message_handler/test/hmi_message_handler_impl_test.cc
+++ b/src/components/hmi_message_handler/test/hmi_message_handler_impl_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2017, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,7 +36,7 @@
 #include "hmi_message_handler/messagebroker_adapter.h"
 #include "hmi_message_handler/mock_hmi_message_observer.h"
 #include "hmi_message_handler/mock_hmi_message_handler_settings.h"
-#include "hmi_message_handler/mock_hmi_message_adapter_impl.h"
+#include "hmi_message_handler/mock_hmi_message_adapter.h"
 
 namespace test {
 namespace components {
@@ -56,6 +56,7 @@ class HMIMessageHandlerImplTest : public ::testing::Test {
   hmi_message_handler::MessageBrokerAdapter* mb_adapter_;
   hmi_message_handler::HMIMessageHandlerImpl* hmi_handler_;
   hmi_message_handler::MockHMIMessageObserver* mock_hmi_message_observer_;
+  MockHMIMessageAdapter message_adapter_;
   testing::NiceMock<MockHMIMessageHandlerSettings>
       mock_hmi_message_handler_settings;
   const uint64_t stack_size = 1000u;
@@ -151,8 +152,7 @@ TEST_F(HMIMessageHandlerImplTest, RemoveHMIMessageAdapter_ExpectRemoved) {
 }
 
 // TODO(atimchenko) SDLOPEN-44 Wrong message to observer
-TEST_F(HMIMessageHandlerImplTest,
-       DISABLED_OnMessageReceived_ValidObserver_Success) {
+TEST_F(HMIMessageHandlerImplTest, OnMessageReceived_ValidObserver_Success) {
   hmi_message_handler::MessageSharedPointer message = CreateMessage();
   EXPECT_CALL(*mock_hmi_message_observer_, OnMessageReceived(message));
 
@@ -173,10 +173,9 @@ TEST_F(HMIMessageHandlerImplTest, OnMessageReceived_InvalidObserver_Cancelled) {
 TEST_F(HMIMessageHandlerImplTest, SendMessageToHMI_Success) {
   hmi_message_handler::MessageSharedPointer message = CreateMessage();
 
-  MockHMIMessageAdapterImpl message_adapter(hmi_handler_);
-  EXPECT_CALL(message_adapter, SendMessageToHMI(message));
+  EXPECT_CALL(message_adapter_, SendMessageToHMI(message));
 
-  hmi_handler_->AddHMIMessageAdapter(&message_adapter);
+  hmi_handler_->AddHMIMessageAdapter(&message_adapter_);
   hmi_handler_->SendMessageToHMI(message);
 
   // Wait for the message to be processed

--- a/src/components/hmi_message_handler/test/include/hmi_message_handler/mock_hmi_message_adapter.h
+++ b/src/components/hmi_message_handler/test/include/hmi_message_handler/mock_hmi_message_adapter.h
@@ -1,0 +1,62 @@
+/*
+* Copyright (c) 2017, Ford Motor Company
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following
+* disclaimer in the documentation and/or other materials provided with the
+* distribution.
+*
+* Neither the name of the Ford Motor Company nor the names of its contributors
+* may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef SRC_COMPONENTS_HMI_MESSAGE_HANDLER_TEST_INCLUDE_HMI_MESSAGE_HANDLER_MOCK_HMI_MESSAGE_ADAPTER_H_
+#define SRC_COMPONENTS_HMI_MESSAGE_HANDLER_TEST_INCLUDE_HMI_MESSAGE_HANDLER_MOCK_HMI_MESSAGE_ADAPTER_H_
+
+#include "gmock/gmock.h"
+#include "hmi_message_handler/hmi_message_adapter.h"
+#include "hmi_message_handler/hmi_message_handler.h"
+
+namespace test {
+namespace components {
+namespace hmi_message_handler_test {
+
+using hmi_message_handler::HMIMessageAdapterImpl;
+using hmi_message_handler::HMIMessageHandler;
+using hmi_message_handler::MessageSharedPointer;
+
+class MockHMIMessageAdapter : public hmi_message_handler::HMIMessageAdapter {
+ public:
+  MOCK_METHOD0(SubscribeTo, void());
+  MOCK_METHOD1(SendMessageToHMI, void(MessageSharedPointer SPtr));
+#ifdef SDL_REMOTE_CONTROL
+  MOCK_METHOD1(SubscribeToHMINotification,
+               void(const std::string& hmi_notification));
+#endif  // SDL_REMOTE_CONTROL
+};
+
+}  // namespace hmi_message_handler_test
+}  // namespace components
+}  // namespace test
+
+#endif  // SRC_COMPONENTS_HMI_MESSAGE_HANDLER_TEST_INCLUDE_HMI_MESSAGE_HANDLER_MOCK_HMI_MESSAGE_ADAPTER_H_


### PR DESCRIPTION
Next test cases has been fixed:
- `SendMessageToHMI_Success`
- `OnMessageReceived_ValidObserver_Success`

Related to: [APPLINK-31734](https://adc.luxoft.com/jira/browse/APPLINK-31734)
##
@LuxoftAKutsan, @okozlovlux, please, review.