### PR TITLE
Fix incorrect protocol version in can_module

### DIFF
--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -231,8 +231,6 @@ functional_modules::ProcessResult CANModule::HandleMessage(
     return ProcessResult::FAILED;
   }
 
-  msg->set_protocol_version(application_manager::ProtocolVersion::kV3);
-
   switch (msg->type()) {
     case application_manager::MessageType::kResponse:
     case application_manager::MessageType::kErrorResponse: {


### PR DESCRIPTION
 SDL respond result code: APPLICATION_NOT_REGISTERED when HMI send notification OnAppDeactivated

