### PR TITLE
Feature/audio pass thru icon param

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -259,6 +259,30 @@ class CommandRequestImpl : public CommandImpl,
   mobile_apis::Result::eType PrepareResultCodeForResponse(
       const ResponseInfo& first, const ResponseInfo& second);
 
+  /**
+   * @brief Resolves if the return code must be
+   * UNSUPPORTED_RESOURCE
+   * @param first contains result_code from HMI response and
+   * interface that returns response
+   * @param second contains result_code from HMI response and
+   * interface that returns response.
+   * @return if the communication return code must be
+   * UNSUPPORTED_RESOURCE, function returns true, else
+   * false
+   */
+  bool IsResultCodeUnsupported(const ResponseInfo& first,
+                               const ResponseInfo& second) const;
+  /**
+   * @brief Checks result code from HMI for split RPC
+   * and set flags to the info structures.
+   * @param first contains result_code from HMI response and
+   * interface that returns response
+   * @param second contains result_code from HMI response and
+   * interface that returns response
+   */
+  void SetResultCodeFlagsForHMIResponses(ResponseInfo& out_first,
+                                         ResponseInfo& out_second) const;
+
  protected:
   /**
    * @brief Returns policy parameters permissions

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -266,9 +266,8 @@ class CommandRequestImpl : public CommandImpl,
    * interface that returns response
    * @param second contains result_code from HMI response and
    * interface that returns response.
-   * @return if the communication return code must be
-   * UNSUPPORTED_RESOURCE, function returns true, else
-   * false
+   * @return True, if the communication return code must be
+   * UNSUPPORTED_RESOURCE, otherwise false.
    */
   bool IsResultCodeUnsupported(const ResponseInfo& first,
                                const ResponseInfo& second) const;

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -133,10 +133,46 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
    */
   bool IsWaitingHMIResponse();
 
+  /**
+   * @brief Validates audioPassThruIcon parameter and
+   * removes it if is not valid
+   * @param app Pointer to the application whose storage directory
+   * must be accessed
+   */
+  void ProcessAudioPassThruIcon(ApplicationSharedPtr app);
+
+  /**
+   * @brief Checks result code from HMI for splitted RPC
+   * and returns parameter for sending to mobile app in
+   * audioPassThru communication.
+   * @param ui_response contains result_code from UI
+   * @param tts_response contains result_code from TTS
+   * @return result code - 1) UI error code has precedence than TTS's
+   * 2) error_code from TTS is turned to WARNINGS
+   */
+  mobile_apis::Result::eType PrepareAudioPassThruResultCodeForResponse(
+      const ResponseInfo& ui_response, const ResponseInfo& tts_response);
+
+  /**
+   * @brief Checks if any of audioPassThru communication components
+   * returned ABORTED code
+   * @param ui contains result_code from UI
+   * @param tts contains result_code from TTS
+   * @return if TTS or UI responded with ABORTED function returns TRUE,
+   * else is returns FALSE
+   */
+  bool IsAnyHMIComponentAborted(const ResponseInfo& ui,
+                                const ResponseInfo& tts);
+
   /* flag display state of speak and ui perform audio
   during perform audio pass thru*/
   bool awaiting_tts_speak_response_;
   bool awaiting_ui_response_;
+
+  /* flag shows if last received audioPassThruIcon exists
+   * in the file system
+   */
+  bool audio_pass_thru_icon_exists_;
 
   hmi_apis::Common_Result::eType result_tts_speak_;
   hmi_apis::Common_Result::eType result_ui_;

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2016, Ford Motor Company
+ Copyright (c) 2017, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2013, Ford Motor Company
+ Copyright (c) 2016, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -165,6 +165,8 @@ extern const char* speech_capabilities;
 extern const char* vr_capabilities;
 extern const char* audio_pass_thru_capabilities;
 extern const char* pcm_stream_capabilities;
+extern const char* device_rank;
+extern const char* audio_pass_thru_icon;
 
 // PutFile
 extern const char* sync_file_name;
@@ -440,6 +442,7 @@ extern const char* policyfile;
 extern const char* is_active;
 extern const char* is_deactivated;
 extern const char* event_name;
+
 }  // namespace hmi_notification
 
 }  // namespace application_manager

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -109,15 +109,6 @@ bool CheckResultCode(const ResponseInfo& first, const ResponseInfo& second) {
   return false;
 }
 
-bool IsResultCodeUnsupported(const ResponseInfo& first,
-                             const ResponseInfo& second) {
-  return ((first.is_ok || first.is_invalid_enum) &&
-          second.is_unsupported_resource) ||
-         ((second.is_ok || second.is_invalid_enum) &&
-          first.is_unsupported_resource) ||
-         (first.is_unsupported_resource && second.is_unsupported_resource);
-}
-
 struct DisallowedParamsInserter {
   DisallowedParamsInserter(smart_objects::SmartObject& response,
                            mobile_apis::VehicleDataResultCode::eType code)
@@ -690,6 +681,18 @@ bool CommandRequestImpl::PrepareResultForMobileResponse(
 
 bool CommandRequestImpl::PrepareResultForMobileResponse(
     ResponseInfo& out_first, ResponseInfo& out_second) const {
+  SetResultCodeFlagsForHMIResponses(out_first, out_second);
+
+  bool result = (out_first.is_ok && out_second.is_ok) ||
+                (out_second.is_invalid_enum && out_first.is_ok) ||
+                (out_first.is_invalid_enum && out_second.is_ok);
+  result = result || CheckResultCode(out_first, out_second);
+  result = result || CheckResultCode(out_second, out_first);
+  return result;
+}
+
+void CommandRequestImpl::SetResultCodeFlagsForHMIResponses(
+    ResponseInfo& out_first, ResponseInfo& out_second) const {
   using namespace helpers;
 
   out_first.is_ok = Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
@@ -726,13 +729,6 @@ bool CommandRequestImpl::PrepareResultForMobileResponse(
   out_second.interface_state =
       application_manager_.hmi_interfaces().GetInterfaceState(
           out_second.interface);
-
-  bool result = (out_first.is_ok && out_second.is_ok) ||
-                (out_second.is_invalid_enum && out_first.is_ok) ||
-                (out_first.is_invalid_enum && out_second.is_ok);
-  result = result || CheckResultCode(out_first, out_second);
-  result = result || CheckResultCode(out_second, out_first);
-  return result;
 }
 
 void CommandRequestImpl::GetInfo(
@@ -773,6 +769,15 @@ mobile_apis::Result::eType CommandRequestImpl::PrepareResultCodeForResponse(
 const CommandParametersPermissions& CommandRequestImpl::parameters_permissions()
     const {
   return parameters_permissions_;
+}
+
+bool CommandRequestImpl::IsResultCodeUnsupported(
+    const ResponseInfo& first, const ResponseInfo& second) const {
+  return ((first.is_ok || first.is_invalid_enum) &&
+          second.is_unsupported_resource) ||
+         ((second.is_ok || second.is_invalid_enum) &&
+          first.is_unsupported_resource) ||
+         (first.is_unsupported_resource && second.is_unsupported_resource);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -132,6 +132,8 @@ const char* speech_capabilities = "speechCapabilities";
 const char* vr_capabilities = "vrCapabilities";
 const char* audio_pass_thru_capabilities = "audioPassThruCapabilities";
 const char* pcm_stream_capabilities = "pcmStreamCapabilities";
+const char* device_rank = "deviceRank";
+const char* audio_pass_thru_icon = "audioPassThruIcon";
 // PutFile
 const char* sync_file_name = "syncFileName";
 const char* file_name = "fileName";
@@ -351,6 +353,7 @@ const char* file = "file";
 const char* file_name = "fileName";
 const char* retry = "retry";
 const char* service = "service";
+const char* audio_pass_thru_icon = "audioPassThruIcon";
 }  // namespace hmi_request
 
 namespace hmi_response {

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -34,7 +34,7 @@
 
 <interfaces name="SmartDeviceLink HMI API">
 
-<interface name="Common" version="1.5" date="2017-01-17">
+<interface name="Common" version="1.6" date="2017-01-24">
 
 <enum name="Result">
     <element name="SUCCESS" value="0"/>
@@ -63,6 +63,7 @@
     <element name="USER_DISALLOWED" value="23"/>
     <element name="TRUNCATED_DATA" value="24"/>
     <element name="SAVED" value="25"/>
+    <element name="READ_ONLY " value="26"/>
 </enum>
 
 <enum name="TransportType">
@@ -92,6 +93,27 @@
     <element name="PRESET_9"/>
     <element name="CUSTOM_BUTTON"/>
     <element name="SEARCH"/>
+      <!-- Climate Buttons -->
+    <element name="AC_MAX" />
+    <element name="AC" />
+    <element name="RECIRCULATE" />
+    <element name="FAN_UP" />
+    <element name="FAN_DOWN" />
+    <element name="TEMP_UP" />
+    <element name="TEMP_DOWN" />
+    <element name="DEFROST_MAX" />
+    <element name="DEFROST" />
+    <element name="DEFROST_REAR" />
+    <element name="UPPER_VENT" />
+    <element name="LOWER_VENT" />
+
+    <!-- Radio Buttons -->
+    <element name="VOLUME_UP" />
+    <element name="VOLUME_DOWN" />
+    <element name="EJECT" />
+    <element name="SOURCE" />
+    <element name="SHUFFLE" />
+    <element name="REPEAT" />
 </enum>
 
 <enum name="ButtonEventMode">
@@ -234,6 +256,7 @@
   <element name="BACKGROUND_PROCESS" />
   <element name="TESTING" />
   <element name="SYSTEM" />
+  <element name="REMOTE_CONTROL" />
 </enum>
 
   <enum name="WayPointType">
@@ -263,6 +286,28 @@
     <description>This mode causes the interaction to display the previous set of choices as a list along with a search field in the HMI.</description>
   <element name="KEYBOARD" />
     <description>This mode causes the interaction to immediately display a keyboard entry through the HMI.</description>
+</enum>
+
+<enum name="DeactivateReason">
+  <description>Specifies the functionality the User has switched to.</description>
+  <element name="AUDIO">
+      <description>Navigated to audio(radio, etc)</description>
+  </element>
+  <element name="PHONECALL">
+      <description>Navigated to make a call.</description>
+  </element>
+  <element name="NAVIGATIONMAP">
+      <description>Navigated to navigation screen.</description>
+  </element>
+  <element name="PHONEMENU">
+      <description>Navigated to phone menu.</description>
+  </element>
+  <element name="SYNCSETTINGS">
+      <description>Navigated to settings menu.</description>
+  </element>
+  <element name="GENERAL">
+      <description>Other screens navigation apart from other mobile app.</description>
+  </element>
 </enum>
 
 <enum name="ClockUpdateMode">
@@ -497,6 +542,9 @@
   <element name="phoneNumber">
     <description> Optional hone number of intended location / establishment (if applicable) for SendLocation.</description>
   </element>
+  <element name="audioPassThruIcon">
+    <description>The optional image field for AudioPassThru</description>
+  </element>
   <element name="timeToDestination"/>
     <!-- TO DO to be removed -->
     <element name="turnText"/>
@@ -538,6 +586,9 @@
   </element>
   <element name="locationImage">
     <description>The optional image of a destination / location</description>
+  </element>
+  <element name="audiPassThruIcon">
+    <description>The optional image for AudioPassThru</description>
   </element>
 </enum>
 
@@ -1263,6 +1314,159 @@
   </struct>
 <!-- End of Policies -->
 
+<!-- Remote Control -->
+<struct name="InteriorZone">
+  <description>Describes the origin and span of a zone in the vehicle. Vehicle zones can be overlapping</description>
+  <param name="col" type="Integer" minvalue="0" maxvalue="100">
+  </param>
+  <param name="row" type="Integer" minvalue="0" maxvalue="100">
+  </param>
+  <param name="level" type="Integer" minvalue="0" maxvalue="100">
+  </param>
+  <param name="colspan" type="Integer" minvalue="0" maxvalue="100">
+  </param>
+  <param name="rowspan" type="Integer" minvalue="0" maxvalue="100">
+  </param>
+  <param name="levelspan" type="Integer" minvalue="0" maxvalue="100">
+  </param>
+</struct>
+
+<enum name="ModuleType">
+  <element name="CLIMATE"/>
+  <element name="RADIO"/>
+</enum>
+
+<struct name="ModuleDescription">
+  <param name="moduleZone" type="Common.InteriorZone">
+  </param>
+  <param name="moduleType" type="Common.ModuleType">
+  </param>
+</struct>
+
+<enum name="RadioBand">
+  <element name="AM"/>
+  <element name="FM"/>
+  <element name="XM"/>
+</enum>
+
+<enum name="TemperatureUnit">
+  <element name="KELVIN"/>
+  <element name="FAHRENHEIT"/>
+  <element name="CELSIUS"/>
+</enum>
+
+<enum name="DeviceRank">
+  <element name="DRIVER">
+    <description>The device is ranked as driver's</description>
+  </element>
+  <element name="PASSENGER">
+    <description>The device is ranked as passenger's</description>
+  </element>
+</enum>
+
+<struct name="RdsData">
+  <param name="PS" type="String" minlength="0" maxlength="8">
+    <description>Program Service Name</description>
+  </param>
+  <param name="RT" type="String" minlength="0" maxlength="64">
+    <description>Radio Text</description>
+  </param>
+  <param name="CT" type="String" minlength="24" maxlength="24">
+    <description>The clock text in UTC format as YYYY-MM-DDThh:mm:ss.sTZD</description>
+  </param>
+  <param name="PI" type="String" minlength="0" maxlength="6">
+    <description>Program Identification - the call sign for the radio station</description>
+  </param>
+  <param name="PTY" type="Integer" minvalue="0" maxvalue="31">
+    <description>The program type - The region should be used to differentiate between EU and North America program types</description>
+  </param>
+  <param name="TP" type="Boolean">
+    <description>Traffic Program Identification - Identifies a station that offers traffic</description>
+  </param>
+  <param name="TA" type="Boolean">
+    <description>Traffic Announcement Identification - Indicates an ongoing traffic announcement</description>
+  </param>
+  <param name="REG" type="String">
+    <description>Region</description>
+  </param>
+</struct>
+
+<enum name="RadioState">
+  <element name="ACQUIRING"/>
+  <element name="ACQUIRED"/>
+  <element name="MULTICAST"/>
+  <element name="NOT_FOUND"/>
+</enum>
+
+<struct name="RadioControlData">
+  <param name="frequencyInteger" type="Integer" minvalue="0" maxvalue="1710" mandatory="false">
+    <description>The integer part of the frequency ie for 101.7 this value should be 101</description>
+  </param>
+  <param name="frequencyFraction" type="Integer" minvalue="0" maxvalue="9" mandatory="false">
+    <description>The fractional part of the frequency for 101.7 is 7</description>
+  </param>
+  <param name="band" type="Common.RadioBand" mandatory="false">
+  </param>
+  <param name="rdsData" type="Common.RdsData" mandatory="false">
+  </param>
+  <param name="availableHDs" type="Integer" minvalue="1" maxvalue="3" mandatory="false">
+    <description>number of HD sub-channels if available</description>
+  </param>
+  <param name="hdChannel" type="Integer" minvalue="1" maxvalue="3" mandatory="false">
+    <description>Current HD sub-channel if available</description>
+  </param>
+  <param name="signalStrength" type="Integer" minvalue="0" maxvalue="100" mandatory="false">
+  </param>
+  <param name="signalChangeThreshold" type="Integer" minvalue="0" maxvalue="100" mandatory="false">
+    <description>If the signal strength falls below the set value for this parameter, the radio will tune to an alternative frequency</description>
+  </param>
+  <param name="radioEnable" type="Boolean" mandatory="false">
+    <description> True if the radio is on, false is the radio is off</description>
+  </param>
+  <param name="state" type="Common.RadioState" mandatory="false">
+  </param>
+</struct>
+
+<enum name="DefrostZone">
+  <element name="FRONT"/>
+  <element name="REAR"/>
+  <element name="ALL"/>
+</enum>
+
+<struct name="ClimateControlData">
+  <param name="fanSpeed" type="Integer" minvalue="0" maxvalue="100" mandatory="false">
+  </param>
+  <param name="currentTemp" type="Integer" minvalue="0" maxvalue="100" mandatory="false">
+  </param>
+  <param name="desiredTemp" type="Integer" minvalue="0" maxvalue="100" mandatory="false">
+  </param>
+  <param name="temperatureUnit" type="Common.TemperatureUnit" mandatory="false">
+  </param>
+  <param name="acEnable" type="Boolean" mandatory="false">
+  </param>
+  <param name="circulateAirEnable" type="Boolean" mandatory="false">
+  </param>
+  <param name="autoModeEnable" type="Boolean" mandatory="false">
+  </param>
+  <param name="defrostZone" type="Common.DefrostZone" mandatory="false">
+  </param>
+  <param name="dualModeEnable" type="Boolean" mandatory="false">
+  </param>
+</struct>
+
+<struct name="ModuleData">
+  <description>The moduleType indicates which type of data should be changed and identifies which data object exists in this struct. For example, if the moduleType is CLIMATE then a "climateControlData" should exist</description>
+  <param name="moduleType" type="Common.ModuleType">
+  </param>
+  <param name="moduleZone" type="Common.InteriorZone">
+  </param>
+  <param name="radioControlData" type="Common.RadioControlData" mandatory="false">
+  </param>
+  <param name="climateControlData" type="Common.ClimateControlData" mandatory="false">
+  </param>
+</struct>
+
+<!-- End Remote Control -->
 <struct name="TextField">
   <param name="name" type="Common.TextFieldName">
     <description>The name that identifies the field. See TextFieldName.</description>
@@ -2073,6 +2277,105 @@
 
 </interface>
 
+<interface name="RC" version="1.0" date="2015-10-13">
+  <function name="GetInteriorVehicleDataCapabilities" messagetype="request">
+    <description>Called to retrieve the available zones and supported control types</description>
+    <param name="zone" type="Common.InteriorZone" mandatory="false">
+      <description>If included, only the corresponding modules able to be controlled by that zone will be sent back. If not included, all modules will be returned regardless of their ability to be controlled by specifc zones.</description>
+    </param>
+    <param name="moduleTypes" type="Common.ModuleType" array="true" mandatory="false" minsize="1" maxsize="1000">
+      <description>If included, only the corresponding type of modules a will be sent back. If not included, all module types will be returned.</description>
+    </param>
+    <param name="appID" type="Integer" mandatory="true">
+      <description>Internal SDL-assigned ID of the related application</description>
+    </param>
+  </function>
+  <function name="GetInteriorVehicleDataCapabilities" messagetype="response">
+    <param name="interiorVehicleDataCapabilities" type="Common.ModuleDescription" array="true" minsize="1" maxsize="1000">
+  </param>
+  </function>
+  <function name="SetInteriorVehicleData" functionID="SetInteriorVehicleDataID" messagetype="request">
+    <param name="moduleData" type="Common.ModuleData">
+      <description>The zone, module, and data to set for the (zone, module) pair</description>
+    </param>
+    <param name="appID" type="Integer" mandatory="true">
+      <description>Internal SDL-assigned ID of the related application</description>
+    </param>
+  </function>
+  <function name="SetInteriorVehicleData" functionID="SetInteriorVehicleDataID" messagetype="response">
+    <description>Used to set the values of one zone and one data type within that zone</description>
+    <param name="moduleData" type="Common.ModuleData">
+    </param>
+  </function>
+  <function name="GetInteriorVehicleData" functionID="GetInteriorVehicleDataID" messagetype="request">
+    <param name="moduleDescription" type="Common.ModuleDescription">
+      <description>The zone and module data to retrieve from the vehicle for that zone</description>
+    </param>
+    <param name="subscribe" type="Boolean" mandatory="false" defvalue="false">
+      <description>If subscribe is true, the head unit will send onInteriorVehicleData notifications for the moduleDescription</description>
+    </param>
+    <param name="appID" type="Integer" mandatory="true">
+      <description>Internal SDL-assigned ID of the related application</description>
+    </param>
+  </function>
+  <function name="GetInteriorVehicleData" functionID="GetInteriorVehicleDataID" messagetype="response">
+    <param name="moduleData" type="Common.ModuleData">
+    </param>
+    <param name="isSubscribed" type="Boolean" mandatory="false" >
+      <description>Is a conditional-mandatory parameter: must be returned in case "subscribe" parameter was present in the related request.
+      if "true" - the "moduleDescription" from request is successfully subscribed and  the head unit will send onInteriorVehicleData notifications for the moduleDescription.
+      if "false" - the "moduleDescription" from request is either unsubscribed or failed to subscribe.</description>
+    </param>
+  </function>
+  <function name="GetInteriorVehicleDataConsent" messagetype="request">
+    <description>Sender: SDL->HMI. </description>
+    <description>HMI is expected to display a permission prompt to the driver showing the module, zone, and app details (for example, app's name). The driver is expected to have an ability to grant or deny the permission.</description>
+    <param name="moduleType" type="Common.ModuleType" mandatory="true">
+      <description>The module that the app requests to control.</description>
+    </param>
+    <param name="zone" type="Common.InteriorZone" mandatory="true">
+      <description>A zone from which the app requests to control the named module.</description>
+    </param>
+    <param name="appID" type="Integer" mandatory="true">
+      <description>ID of the application that triggers the permission prompt.</description>
+    </param>
+  </function>
+  <function name="GetInteriorVehicleDataConsent" messagetype="response">
+    <param name="allowed" type="Boolean" mandatory="true">
+      <description>"true" - if the driver grants the permission for controlling to the named app; "false" - in case the driver denies the permission for controlling to the named app.</description>
+    </param>
+  </function>
+
+  <function name="OnInteriorVehicleData" functionID="OnInteriorVehicleDataID" messagetype="notification">
+    <param name="moduleData" type="Common.ModuleData">
+    </param>
+  </function>
+  <function name="OnReverseAppsAllowing" messagetype="notification">
+    <description>Sender: vehicle -> RSDL. Notification about remote-control for passenger`s applications must be either turned off or turned on. Sent after User`s choice through HMI.</description>
+    <param name="allowed" type="Boolean" mandatory="true" >
+      <description>If "true" - RC for passengers is allowed; if "false" - disallowed.</description>
+    </param>
+  </function>
+  <function name="OnDeviceRankChanged" messagetype="notification">
+    <description>Sender: vehicle->RSDL. Purpose: inform about the device is set either as driver`s or as passenger`s  device by the HMI settings or by the HMI User through the appropriate menu.</description>
+    <param name="deviceRank" type="Common.DeviceRank" mandatory="true">
+      <description>If "DRIVER" - the named by "DeviceInfo" device is set as driver`s. If "PASSENGER" -  the named by "DeviceInfo" device is set as passenger`s. </description>
+    </param>
+    <param name="device" type="Common.DeviceInfo" mandatory="true">
+      <description>The device info: name and ID. Initially is sent by SDL via UpdateDeviceList to the vehicle.</description>
+    </param>
+  </function>
+  <function name="OnDeviceLocationChanged" messagetype="notification">
+    <description>Sender: vehicle->RSDL. Purpose: inform about the device location in the vehicle interior.</description>
+    <param name="deviceLocation" type="Common.InteriorZone" mandatory="true">
+      <description>Defines the vehicle zone where the named device is located. </description>
+    </param>
+    <param name="device" type="Common.DeviceInfo" mandatory="true">
+      <description>The device info: name and ID. Initially is sent by SDL via UpdateDeviceList to HMI.</description>
+    </param>
+  </function>
+</interface>
+
 <interface name="Buttons" version="1.1" date="2016-08-18">
     <function name="GetCapabilities" messagetype="request">
       <description>Method is invoked at system start-up. SDL requests the information about all supported hardware buttons and their capabilities</description>
@@ -2085,6 +2388,26 @@
         <description>Must be returned if the platform supports custom on-screen Presets</description>
       </param>
     </function>
+
+    <function name="ButtonPress" messagetype="request">
+      <description>Method is invoked when the application tries to press a button</description>
+      <param name="zone" type="Common.InteriorZone">
+        <description>The zone where the button press should occur.</description>
+      </param>
+      <param name="moduleType" type="Common.ModuleType">
+        <description>The module where the button should be pressed</description>
+      </param>
+      <param name="buttonName" type="Common.ButtonName"/>
+      <param name="buttonPressMode" type="Common.ButtonPressMode">
+        <description>Indicates whether this is a LONG or SHORT button press event.</description>
+      </param>
+      <param name="appID" type="Integer" mandatory="true">
+        <description>ID of the application that triggers the permission prompt.</description>
+      </param>
+    </function>
+    <function name="ButtonPress" messagetype="response">
+    </function>
+
     <function name="OnButtonEvent" messagetype="notification">
       <description>HU system must notify about every UP/DOWN event for buttons</description>
       <param name="name" type="Common.ButtonName" mandatory="true"/>
@@ -2243,6 +2566,9 @@
       <param name="appID" type="Integer" mandatory="true">
         <description>ID of deactivated application.</description>
       </param>
+      <param name="reason" type="Common.DeactivateReason" mandatory="true">
+        <description>Specifies the functionality the user has switched to.</description>
+      </param>
     </function>
     <function name="OnAppRegistered" messagetype="notification">
       <description>Issued by SDL to notify HMI about new application registered.</description>
@@ -2313,6 +2639,15 @@
       <description>If no response received SDL supposes that mixing audio is not supported</description>
       <param name="attenuatedSupported" type="Boolean" mandatory="true">
         <description>Must be true if supported</description>
+      </param>
+    </function>
+    <function name="PlayTone" messagetype="notification">
+      <description>Sent by SDL to HMI to notify that the tone should be played.</description>
+      <param name="appID" type="Integer" mandatory="true">
+         <description>ID of the application that invoked this notification</description>
+      </param>
+      <param name="methodName" type="Common.MethodName" mandatory="true">
+         <description>Defines the name of app's request that initiates playing a tone</description>
       </param>
     </function>
     <function name="DialNumber" messagetype="request">
@@ -2771,7 +3106,7 @@
   </function>
 </interface>
 
-<interface name="UI" version="1.0" date="2013-04-16">
+<interface name="UI" version="1.1" date="2017-01-24">
   <function name="OnSeekMediaClockTimer" functionID="OnSeekMediaClockTimerID" messagetype="notification">
    <description>Callback for the seek media clock timer notification. Notification is triggered when the user selects a position and releases the mediaclock timer or when the user selects a position and holds for a full 2 second period. System will automatically the media clock timer position based on the seek notification location.</description> 
    <param name="seekTime" type="Common.TimeFormat" mandatory="true">
@@ -3237,6 +3572,12 @@
         If omitted, the value is set to true.
       </description>
     </param>
+    <param name="audioPassThruIcon" type="Common.Image" mandatory="false">
+      <description>
+        Image struct determinig wheter static or dynamic icon.
+        If omitted on supported displays, no (or the default if applicable) icon shall be displayed.
+      </description>
+    </param>
   </function>
   <function name="PerformAudioPassThru" messagetype="response">
   </function>
@@ -3449,9 +3790,9 @@
     <param name="wayPointType" type="Common.WayPointType" defvalue="ALL" mandatory="false">
       <description>To request for either the destination only or for all waypoints including destination</description>
     </param>
-    <param name="appID" type="Integer" mandatory="true"> 
-      <description>ID of the application.</description> 
-    </param> 
+    <param name="appID" type="Integer" mandatory="true">
+      <description>ID of the application.</description>
+    </param>
   </function>
   <function name="GetWayPoints" functionID="GetWayPointsID" messagetype="response">
     <param name="appID" type="Integer" mandatory="true">
@@ -3571,6 +3912,9 @@
         The application will be notified by the onVehicleData notification whenever new data is available.
         To unsubscribe the notifications, use unsubscribe with the same subscriptionType.
     </description>
+    <param name="appID" type="Integer" mandatory="true">
+      <description>ID of application that requested this RPC.</description>
+    </param>
     <param name="gps" type="Boolean" mandatory="false">
       <description>See GPSData</description>
     </param>
@@ -3956,6 +4300,9 @@
     </param>
     <param name="myKey" type="Boolean" mandatory="false">
       <description>Information related to the MyKey feature</description>
+    </param>
+    <param name="appID" type="Integer" mandatory="true">
+      <description>ID of application requested this RPC.</description>
     </param>
   </function>
   <function name="GetVehicleData" messagetype="response">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -747,6 +747,10 @@
       <description>The optional image of a destination / location</description>
     </element>
 
+    <element name="audioPassThruIcon">
+      <description>The optional image field for AudioPassThru</description>
+    </element>
+
   </enum>
 
   <enum name="CharacterSet">
@@ -3410,6 +3414,10 @@
 		Defines if the current audio source should be muted during the APT session.  If not, the audio source will play without interruption.
       	If omitted, the value is set to true.
       </description>
+    </param>
+    <param name="audioPassThruIcon" type="Image" mandatory="false">
+      <description>Image struct determinig wheter static or dynamic icon.
+        If omitted on supported displays, no (or the default if applicable) icon shall be displayed.</description>
     </param>
   </function>
 


### PR DESCRIPTION
New Image type parameter is added to MOBILE_API and HMI_API.
It is processed on audioPassThru request from the mobile side
and if it is valid, it is transmited to the HMI side.
Resolution of UI and TTS result codes received from the HMI
and their transfer to the mobile side is changed due to the
new CRQ.

Related-issues: APPLINK-23360
Implements: APPLINK-23358

This PR is a combination of:
https://github.com/smartdevicelink/sdl_core/pull/1182
and 
https://github.com/smartdevicelink/sdl_core/pull/1200
which were created against develop branch.