### PR TITLE
Implements audioPassThruIcon unit tests

### DIFF
--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -133,7 +133,7 @@ class PerformAudioPassThruRequestTest
     EXPECT_EQ((*msg)[am::strings::msg_params][am::strings::success].asBool(),
               success);
     EXPECT_EQ((*msg)[am::strings::msg_params][am::strings::result_code].asInt(),
-              (code));
+              code);
     EXPECT_EQ((*msg)[am::strings::msg_params][am::strings::info].asString(),
               info);
   }
@@ -148,21 +148,15 @@ class PerformAudioPassThruRequestTest
     (*msg)[am::strings::msg_params][am::strings::audio_pass_thru_icon] = icon;
   }
 
-  void DefineUIsAvailable() {
-    ON_CALL(hmi_interfaces_,
-            GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
-        .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
-  }
-
-  void DefineTTSsAvailable() {
-    ON_CALL(hmi_interfaces_,
-            GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
-        .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
-  }
-
   void DefineHMIAvailable() {
-    DefineUIsAvailable();
-    DefineTTSsAvailable();
+    DefineInterfaceAvailable(am::HmiInterfaces::HMI_INTERFACE_UI);
+    DefineInterfaceAvailable(am::HmiInterfaces::HMI_INTERFACE_TTS);
+  }
+
+  void DefineInterfaceAvailable(
+      const am::HmiInterfaces::InterfaceID interface) {
+    ON_CALL(hmi_interfaces_, GetInterfaceState(interface))
+        .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   }
 
   void DefineHMILevelUIAvailable() {
@@ -170,7 +164,7 @@ class PerformAudioPassThruRequestTest
         .WillByDefault(Return(mobile_apis::HMILevel::HMI_FULL));
     ON_CALL(hmi_interfaces_, GetInterfaceFromFunction(_))
         .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
-    DefineUIsAvailable();
+    DefineInterfaceAvailable(am::HmiInterfaces::HMI_INTERFACE_UI);
   }
 
   sync_primitives::Lock lock_;
@@ -216,7 +210,7 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   MessageSharedPtr msg_tts =
       CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCmdId);
-  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  Event event_tts(hmi_apis::FunctionID::TTS_Speak);
   event_tts.set_smart_object(*msg_tts);
 
   DefineHMIAvailable();
@@ -257,7 +251,7 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   MessageSharedPtr msg_tts =
       CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCmdId);
-  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  Event event_tts(hmi_apis::FunctionID::TTS_Speak);
   event_tts.set_smart_object(*msg_tts);
 
   DefineHMIAvailable();
@@ -299,7 +293,7 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   MessageSharedPtr msg_tts =
       CreateHMIMessageSO(hmi_apis::Common_Result::TRUNCATED_DATA, kCmdId);
-  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  Event event_tts(hmi_apis::FunctionID::TTS_Speak);
   event_tts.set_smart_object(*msg_tts);
 
   DefineHMIAvailable();
@@ -339,7 +333,7 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   MessageSharedPtr msg_tts =
       CreateHMIMessageSO(hmi_apis::Common_Result::TRUNCATED_DATA, kCmdId);
-  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  Event event_tts(hmi_apis::FunctionID::TTS_Speak);
   event_tts.set_smart_object(*msg_tts);
 
   DefineHMIAvailable();
@@ -386,7 +380,7 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   MessageSharedPtr msg_tts =
       CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCmdId);
-  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  Event event_tts(hmi_apis::FunctionID::TTS_Speak);
   event_tts.set_smart_object(*msg_tts);
 
   DefineHMIAvailable();
@@ -434,7 +428,7 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   MessageSharedPtr msg_tts =
       CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCmdId);
-  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  Event event_tts(hmi_apis::FunctionID::TTS_Speak);
   event_tts.set_smart_object(*msg_tts);
 
   DefineHMIAvailable();
@@ -482,7 +476,7 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   MessageSharedPtr msg_tts =
       CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCmdId);
-  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  Event event_tts(hmi_apis::FunctionID::TTS_Speak);
   event_tts.set_smart_object(*msg_tts);
 
   DefineHMIAvailable();
@@ -532,7 +526,7 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   MessageSharedPtr msg_tts =
       CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCmdId);
-  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  Event event_tts(hmi_apis::FunctionID::TTS_Speak);
   event_tts.set_smart_object(*msg_tts);
 
   DefineHMIAvailable();

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -67,6 +67,10 @@ const int32_t kCommandId = 1;
 const uint32_t kAppId = 1u;
 const uint32_t kCmdId = 1u;
 const uint32_t kConnectionKey = 2u;
+const std::string kIconName = "icon.png";
+const std::string kTypeStatic = "STATIC";
+const std::string kTypeDynamic = "DYNAMIC";
+const std::string kIconNameInvalid = "icon\t.png";
 }  // namespace
 
 class PerformAudioPassThruRequestTest
@@ -76,7 +80,7 @@ class PerformAudioPassThruRequestTest
       : mock_message_helper_(*MockMessageHelper::message_helper_mock())
       , mock_app_(CreateMockApp()) {}
 
-  MessageSharedPtr CreateFullParamsUISO() {
+  MessageSharedPtr CreateMobileMessageSO() {
     MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
     (*msg)[am::strings::params][am::strings::connection_key] = kConnectionKey;
     smart_objects::SmartObject menu_params =
@@ -96,6 +100,19 @@ class PerformAudioPassThruRequestTest
     return msg;
   }
 
+  MessageSharedPtr CreateHMIMessageSO(int32_t code, uint32_t cmd) {
+    MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
+    (*msg)[am::strings::params][am::hmi_response::code] = code;
+    (*msg)[am::strings::msg_params][am::strings::cmd_id] = cmd;
+
+    return msg;
+  }
+
+  void CreateImageFile(std::string name) {
+    const std::string kFullFilePath = file_system::CurrentWorkingDirectory();
+    file_system::CreateFile(kFullFilePath + "/" + name);
+  }
+
   void SetUp() OVERRIDE {
     ON_CALL(app_mngr_, application(kConnectionKey))
         .WillByDefault(Return(mock_app_));
@@ -108,15 +125,35 @@ class PerformAudioPassThruRequestTest
     Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }
 
-  void ResultCommandExpectations(MessageSharedPtr msg,
-                                 const std::string& info) {
+  void ResultCommandInfoExpectations(MessageSharedPtr msg,
+                                     const std::string& info,
+                                     int32_t code,
+                                     bool success) {
     EXPECT_EQ((*msg)[am::strings::msg_params][am::strings::success].asBool(),
-              true);
-    EXPECT_EQ(
-        (*msg)[am::strings::msg_params][am::strings::result_code].asInt(),
-        static_cast<int32_t>(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE));
+              success);
+    EXPECT_EQ((*msg)[am::strings::msg_params][am::strings::result_code].asInt(),
+              static_cast<int32_t>(code));
     EXPECT_EQ((*msg)[am::strings::msg_params][am::strings::info].asString(),
               info);
+  }
+
+  void ResultCommandCodeExpectations(MessageSharedPtr msg,
+                                     int32_t code,
+                                     bool success) {
+    EXPECT_EQ((*msg)[am::strings::msg_params][am::strings::success].asBool(),
+              success);
+    EXPECT_EQ((*msg)[am::strings::msg_params][am::strings::result_code].asInt(),
+              static_cast<int32_t>(code));
+  }
+
+  void SetupIconParameter(MessageSharedPtr msg,
+                          std::string type,
+                          std::string value) {
+    smart_objects::SmartObject icon =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    icon[am::strings::type] = type;
+    icon[am::strings::value] = value;
+    (*msg)[am::strings::msg_params][am::strings::audio_pass_thru_icon] = icon;
   }
 
   sync_primitives::Lock lock_;
@@ -126,86 +163,465 @@ class PerformAudioPassThruRequestTest
 };
 
 TEST_F(PerformAudioPassThruRequestTest, OnTimeout_GENERIC_ERROR) {
-  MessageSharedPtr msg_ui = CreateMessage(smart_objects::SmartType_Map);
-  (*msg_ui)[am::strings::msg_params][am::strings::result_code] =
+  MessageSharedPtr msg_mobile_response =
+      CreateMessage(smart_objects::SmartType_Map);
+  (*msg_mobile_response)[am::strings::msg_params][am::strings::result_code] =
       am::mobile_api::Result::GENERIC_ERROR;
-  (*msg_ui)[am::strings::msg_params][am::strings::success] = false;
+  (*msg_mobile_response)[am::strings::msg_params][am::strings::success] = false;
 
   utils::SharedPtr<PerformAudioPassThruRequest> command =
       CreateCommand<PerformAudioPassThruRequest>();
 
   EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(true));
   EXPECT_CALL(app_mngr_, StopAudioPassThru(_));
-
   EXPECT_CALL(
       mock_message_helper_,
       CreateNegativeResponse(_, _, _, am::mobile_api::Result::GENERIC_ERROR))
-      .WillOnce(Return(msg_ui));
-
-  MessageSharedPtr vr_command_result;
+      .WillOnce(Return(msg_mobile_response));
   EXPECT_CALL(
       app_mngr_,
       ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
-      .WillOnce(DoAll(SaveArg<0>(&vr_command_result), Return(true)));
+      .WillOnce(DoAll(SaveArg<0>(&msg_mobile_response), Return(true)));
 
   command->onTimeOut();
-  EXPECT_EQ((*vr_command_result)[am::strings::msg_params][am::strings::success]
-                .asBool(),
-            false);
-  EXPECT_EQ(
-      (*vr_command_result)[am::strings::msg_params][am::strings::result_code]
-          .asInt(),
-      static_cast<int32_t>(am::mobile_api::Result::GENERIC_ERROR));
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
+
+  ResultCommandCodeExpectations(
+      msg_mobile_response, am::mobile_api::Result::GENERIC_ERROR, false);
 }
 
 TEST_F(PerformAudioPassThruRequestTest,
        OnEvent_UIHmiSendUnsupportedResource_UNSUPPORTED_RESOURCE) {
-  MessageSharedPtr msg_ui = CreateFullParamsUISO();
-  (*msg_ui)[am::strings::params][am::strings::connection_key] = kConnectionKey;
-
+  MessageSharedPtr msg_mobile = CreateMobileMessageSO();
   utils::SharedPtr<PerformAudioPassThruRequest> command =
-      CreateCommand<PerformAudioPassThruRequest>(msg_ui);
+      CreateCommand<PerformAudioPassThruRequest>(msg_mobile);
 
-  MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
-  (*msg)[am::strings::params][am::hmi_response::code] =
-      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE;
-  (*msg)[am::strings::msg_params][am::strings::cmd_id] = kCommandId;
-  (*msg)[am::strings::msg_params][am::strings::info] =
-      "UI is not supported by system";
+  MessageSharedPtr msg_tts =
+      CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCmdId);
+  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  event_tts.set_smart_object(*msg_tts);
 
-  Event event(hmi_apis::FunctionID::UI_PerformAudioPassThru);
-  event.set_smart_object(*msg);
-
-  ON_CALL(hmi_interfaces_,
-          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
   ON_CALL(hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
 
-  MessageSharedPtr response_msg_tts =
-      CreateMessage(smart_objects::SmartType_Map);
-  (*response_msg_tts)[am::strings::params][am::hmi_response::code] =
-      hmi_apis::Common_Result::SUCCESS;
-  (*response_msg_tts)[am::strings::msg_params][am::strings::cmd_id] = kCmdId;
-  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
-  event_tts.set_smart_object(*response_msg_tts);
-  ON_CALL(mock_message_helper_,
-          HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
-      .WillByDefault(Return(mobile_apis::Result::SUCCESS));
   command->on_event(event_tts);
 
-  MessageSharedPtr ui_command_result;
+  MessageSharedPtr msg_ui = CreateHMIMessageSO(
+      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE, kCommandId);
+  (*msg_ui)[am::strings::msg_params][am::strings::info] =
+      "UI is not supported by system";
+  Event event_ui(hmi_apis::FunctionID::UI_PerformAudioPassThru);
+  event_ui.set_smart_object(*msg_ui);
+
   EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(false));
+
+  MessageSharedPtr msg_mobile_response;
   EXPECT_CALL(
       app_mngr_,
       ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
-      .WillOnce(DoAll(SaveArg<0>(&ui_command_result), Return(true)));
+      .WillOnce(DoAll(SaveArg<0>(&msg_mobile_response), Return(true)));
 
-  command->on_event(event);
+  command->on_event(event_ui);
 
-  ResultCommandExpectations(ui_command_result, "UI is not supported by system");
+  ResultCommandInfoExpectations(msg_mobile_response,
+                                "UI is not supported by system",
+                                am::mobile_api::Result::UNSUPPORTED_RESOURCE,
+                                true);
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       OnEvent_UIHmiSendTruncatedData_TRUNCATED_DATA) {
+  MessageSharedPtr msg_mobile = CreateMobileMessageSO();
+  utils::SharedPtr<PerformAudioPassThruRequest> command =
+      CreateCommand<PerformAudioPassThruRequest>(msg_mobile);
+
+  MessageSharedPtr msg_tts =
+      CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCmdId);
+  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  event_tts.set_smart_object(*msg_tts);
+
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
+  command->on_event(event_tts);
+
+  MessageSharedPtr msg_ui =
+      CreateHMIMessageSO(hmi_apis::Common_Result::TRUNCATED_DATA, kCommandId);
+  Event event_ui(hmi_apis::FunctionID::UI_PerformAudioPassThru);
+  event_ui.set_smart_object(*msg_ui);
+
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::TRUNCATED_DATA))
+      .WillOnce(Return(mobile_apis::Result::TRUNCATED_DATA));
+  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(false));
+
+  MessageSharedPtr msg_mobile_response;
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&msg_mobile_response), Return(true)));
+
+  command->on_event(event_ui);
+
+  ResultCommandCodeExpectations(
+      msg_mobile_response, am::mobile_api::Result::TRUNCATED_DATA, false);
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       OnEvent_TTSHmiSendTruncatedData_TRUNCATED_DATA) {
+  MessageSharedPtr msg_mobile = CreateMobileMessageSO();
+  utils::SharedPtr<PerformAudioPassThruRequest> command =
+      CreateCommand<PerformAudioPassThruRequest>(msg_mobile);
+
+  MessageSharedPtr msg_tts =
+      CreateHMIMessageSO(hmi_apis::Common_Result::TRUNCATED_DATA, kCmdId);
+  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  event_tts.set_smart_object(*msg_tts);
+
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::TRUNCATED_DATA))
+      .WillOnce(Return(mobile_apis::Result::TRUNCATED_DATA));
+
+  command->on_event(event_tts);
+
+  MessageSharedPtr msg_ui =
+      CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCommandId);
+  Event event_ui(hmi_apis::FunctionID::UI_PerformAudioPassThru);
+  event_ui.set_smart_object(*msg_ui);
+
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::WARNINGS))
+      .WillOnce(Return(mobile_apis::Result::WARNINGS));
+  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(false));
+
+  MessageSharedPtr msg_mobile_response;
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&msg_mobile_response), Return(true)));
+
+  command->on_event(event_ui);
+
+  ResultCommandCodeExpectations(
+      msg_mobile_response, am::mobile_api::Result::WARNINGS, true);
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       OnEvent_UISendInvalidIdTTSSendTruncatedData_INVALID_ID) {
+  MessageSharedPtr msg_mobile = CreateMobileMessageSO();
+  utils::SharedPtr<PerformAudioPassThruRequest> command =
+      CreateCommand<PerformAudioPassThruRequest>(msg_mobile);
+
+  MessageSharedPtr msg_tts =
+      CreateHMIMessageSO(hmi_apis::Common_Result::TRUNCATED_DATA, kCmdId);
+  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  event_tts.set_smart_object(*msg_tts);
+
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::TRUNCATED_DATA))
+      .WillOnce(Return(mobile_apis::Result::TRUNCATED_DATA));
+
+  command->on_event(event_tts);
+
+  MessageSharedPtr msg_ui =
+      CreateHMIMessageSO(hmi_apis::Common_Result::INVALID_ID, kCommandId);
+  Event event_ui(hmi_apis::FunctionID::UI_PerformAudioPassThru);
+  event_ui.set_smart_object(*msg_ui);
+
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::INVALID_ID))
+      .WillOnce(Return(mobile_apis::Result::INVALID_ID));
+  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(false));
+
+  MessageSharedPtr msg_mobile_response;
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&msg_mobile_response), Return(true)));
+
+  command->on_event(event_ui);
+
+  ResultCommandCodeExpectations(
+      msg_mobile_response, am::mobile_api::Result::INVALID_ID, false);
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       Run_MobileSendAudioPassThruIconMissing_WARNINGS) {
+  MessageSharedPtr msg_mobile = CreateMobileMessageSO();
+  utils::SharedPtr<PerformAudioPassThruRequest> command =
+      CreateCommand<PerformAudioPassThruRequest>(msg_mobile);
+
+  ON_CALL(*mock_app_, hmi_level())
+      .WillByDefault(Return(mobile_apis::HMILevel::HMI_FULL));
+  ON_CALL(hmi_interfaces_, GetInterfaceFromFunction(_))
+      .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
+  ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _)).Times(0);
+
+  command->Run();
+
+  MessageSharedPtr msg_tts =
+      CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCmdId);
+  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  event_tts.set_smart_object(*msg_tts);
+
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  command->on_event(event_tts);
+
+  MessageSharedPtr msg_ui =
+      CreateHMIMessageSO(hmi_apis::Common_Result::WARNINGS, kCommandId);
+  Event event_ui(hmi_apis::FunctionID::UI_PerformAudioPassThru);
+  event_ui.set_smart_object(*msg_ui);
+
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::WARNINGS))
+      .WillOnce(Return(mobile_apis::Result::WARNINGS));
+  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(false));
+
+  MessageSharedPtr msg_mobile_response;
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&msg_mobile_response), Return(true)));
+
+  command->on_event(event_ui);
+
+  ResultCommandCodeExpectations(
+      msg_mobile_response, am::mobile_api::Result::WARNINGS, true);
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       Run_MobileSendAudioPassThruIconStatic_SUCCESS) {
+  MessageSharedPtr msg_mobile = CreateMobileMessageSO();
+  SetupIconParameter(msg_mobile, kTypeStatic, kIconName);
+  utils::SharedPtr<PerformAudioPassThruRequest> command =
+      CreateCommand<PerformAudioPassThruRequest>(msg_mobile);
+
+  ON_CALL(*mock_app_, hmi_level())
+      .WillByDefault(Return(mobile_apis::HMILevel::HMI_FULL));
+  ON_CALL(hmi_interfaces_, GetInterfaceFromFunction(_))
+      .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
+  ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  ON_CALL(app_mngr_, ManageHMICommand(_)).WillByDefault(Return(true));
+  EXPECT_CALL(mock_message_helper_,
+              VerifyImage((*msg_mobile)[am::strings::msg_params]
+                                       [am::strings::audio_pass_thru_icon],
+                          _,
+                          _)).WillOnce(Return(mobile_apis::Result::SUCCESS));
+
+  command->Run();
+
+  MessageSharedPtr msg_tts =
+      CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCmdId);
+  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  event_tts.set_smart_object(*msg_tts);
+
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  command->on_event(event_tts);
+
+  MessageSharedPtr msg_ui =
+      CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCommandId);
+  Event event_ui(hmi_apis::FunctionID::UI_PerformAudioPassThru);
+  event_ui.set_smart_object(*msg_ui);
+
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(false));
+
+  MessageSharedPtr msg_mobile_response;
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&msg_mobile_response), Return(true)));
+
+  command->on_event(event_ui);
+
+  ResultCommandCodeExpectations(
+      msg_mobile_response, am::mobile_api::Result::SUCCESS, true);
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       Run_MobileSendAudioPassThruIconDynamic_WARNINGS) {
+  MessageSharedPtr msg_mobile = CreateMobileMessageSO();
+  SetupIconParameter(msg_mobile, kTypeDynamic, kIconName);
+  utils::SharedPtr<PerformAudioPassThruRequest> command =
+      CreateCommand<PerformAudioPassThruRequest>(msg_mobile);
+
+  ON_CALL(*mock_app_, hmi_level())
+      .WillByDefault(Return(mobile_apis::HMILevel::HMI_FULL));
+  ON_CALL(hmi_interfaces_, GetInterfaceFromFunction(_))
+      .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
+  ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(mock_message_helper_,
+              VerifyImage((*msg_mobile)[am::strings::msg_params]
+                                       [am::strings::audio_pass_thru_icon],
+                          _,
+                          _))
+      .WillOnce(Return(mobile_apis::Result::INVALID_DATA));
+
+  command->Run();
+
+  MessageSharedPtr msg_tts =
+      CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCmdId);
+  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  event_tts.set_smart_object(*msg_tts);
+
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  command->on_event(event_tts);
+
+  MessageSharedPtr msg_ui =
+      CreateHMIMessageSO(hmi_apis::Common_Result::WARNINGS, kCommandId);
+  Event event_ui(hmi_apis::FunctionID::UI_PerformAudioPassThru);
+  event_ui.set_smart_object(*msg_ui);
+
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::WARNINGS))
+      .WillOnce(Return(mobile_apis::Result::WARNINGS));
+  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(false));
+
+  MessageSharedPtr msg_mobile_response;
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&msg_mobile_response), Return(true)));
+
+  command->on_event(event_ui);
+
+  ResultCommandInfoExpectations(msg_mobile_response,
+                                "Reference image(s) not found",
+                                am::mobile_api::Result::WARNINGS,
+                                true);
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       Run_MobileSendAudioPassThruIconDynamic_SUCCESS) {
+  MessageSharedPtr msg_mobile = CreateMobileMessageSO();
+  CreateImageFile(kIconName);
+  SetupIconParameter(msg_mobile, kTypeDynamic, kIconName);
+  utils::SharedPtr<PerformAudioPassThruRequest> command =
+      CreateCommand<PerformAudioPassThruRequest>(msg_mobile);
+
+  ON_CALL(*mock_app_, hmi_level())
+      .WillByDefault(Return(mobile_apis::HMILevel::HMI_FULL));
+  ON_CALL(hmi_interfaces_, GetInterfaceFromFunction(_))
+      .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
+  ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(mock_message_helper_,
+              VerifyImage((*msg_mobile)[am::strings::msg_params]
+                                       [am::strings::audio_pass_thru_icon],
+                          _,
+                          _)).WillOnce(Return(mobile_apis::Result::SUCCESS));
+
+  command->Run();
+
+  MessageSharedPtr msg_tts =
+      CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCmdId);
+  am::event_engine::Event event_tts(hmi_apis::FunctionID::TTS_Speak);
+  event_tts.set_smart_object(*msg_tts);
+
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  ON_CALL(hmi_interfaces_,
+          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  command->on_event(event_tts);
+
+  MessageSharedPtr msg_ui =
+      CreateHMIMessageSO(hmi_apis::Common_Result::SUCCESS, kCommandId);
+  Event event_ui(hmi_apis::FunctionID::UI_PerformAudioPassThru);
+  event_ui.set_smart_object(*msg_ui);
+
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(false));
+
+  MessageSharedPtr msg_mobile_response;
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&msg_mobile_response), Return(true)));
+
+  command->on_event(event_ui);
+
+  ResultCommandCodeExpectations(
+      msg_mobile_response, am::mobile_api::Result::SUCCESS, true);
+}
+
+TEST_F(PerformAudioPassThruRequestTest,
+       Run_MobileSendAudioPassThruIconInvalid_INVALID_DATA) {
+  MessageSharedPtr msg_mobile = CreateMobileMessageSO();
+  SetupIconParameter(msg_mobile, kTypeStatic, kIconNameInvalid);
+  utils::SharedPtr<PerformAudioPassThruRequest> command =
+      CreateCommand<PerformAudioPassThruRequest>(msg_mobile);
+
+  ON_CALL(*mock_app_, hmi_level())
+      .WillByDefault(Return(mobile_apis::HMILevel::HMI_FULL));
+  ON_CALL(hmi_interfaces_, GetInterfaceFromFunction(_))
+      .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
+  ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _)).Times(0);
+
+  MessageSharedPtr msg_mobile_response;
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&msg_mobile_response), Return(true)));
+  command->Run();
+
+  ResultCommandCodeExpectations(
+      msg_mobile_response, am::mobile_api::Result::INVALID_DATA, false);
 }
 
 }  // namespace perform_audio_pass_thru_request


### PR DESCRIPTION
Unit tests coverage for the changes introduced in CRQ [APPLINK-23358](https://adc.luxoft.com/jira/browse/APPLINK-23358).
Implementation of test cases for:
 - UI and TTS result code resolution (3 test cases)
 - Validation of audioPassThruIcon parameter (4 test cases)
 - Transition of audioPassThruIcon parameter (1 test case)

Related-issues: [APPLINK-23363](https://adc.luxoft.com/jira/browse/APPLINK-23363)