### PR TITLE
Moved application manager implementation tests

### DIFF
--- a/src/components/application_manager/test/CMakeLists.txt
+++ b/src/components/application_manager/test/CMakeLists.txt
@@ -62,6 +62,7 @@ set(testSources
   ${AM_TEST_DIR}/usage_statistics_test.cc
   ${AM_TEST_DIR}/policy_handler_test.cc
   ${AM_TEST_DIR}/mock_message_helper.cc
+  ${AM_TEST_DIR}/application_manager_impl_test.cc
 )
 
 set(request_controller_SOURCES

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <stdint.h>
+#include <memory>
+#include <set>
+
+#include "gtest/gtest.h"
+#include "application_manager/application.h"
+#include "application_manager/application_impl.h"
+#include "application_manager/application_manager_impl.h"
+#include "application_manager/mock_application_manager_settings.h"
+#include "application_manager/mock_resumption_data.h"
+#include "application_manager/resumption/resume_ctrl_impl.h"
+#include "application_manager/test/include/application_manager/mock_message_helper.h"
+#include "connection_handler/mock_connection_handler.h"
+#include "hmi_message_handler/mock_hmi_message_handler.h"
+#include "policy/mock_policy_settings.h"
+#include "policy/usage_statistics/mock_statistics_manager.h"
+#include "protocol_handler/mock_session_observer.h"
+#include "utils/custom_string.h"
+#include "utils/file_system.h"
+#include "utils/lock.h"
+#include "utils/make_shared.h"
+#include "utils/push_log.h"
+
+namespace test {
+namespace components {
+namespace application_manager_test {
+
+namespace am = application_manager;
+namespace policy_test = test::components::policy_handler_test;
+namespace con_test = connection_handler_test;
+
+using testing::_;
+using ::testing::Mock;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using ::testing::NiceMock;
+using ::testing::SetArgPointee;
+
+using namespace application_manager;
+
+namespace {
+const std::string kDirectoryName = "./test_storage";
+const uint32_t kTimeout = 10000u;
+sync_primitives::Lock state_lock_;
+sync_primitives::ConditionalVariable state_condition_;
+}  // namespace
+
+class ApplicationManagerImplTest : public ::testing::Test {
+ public:
+  ApplicationManagerImplTest()
+      : mock_storage_(
+            ::utils::MakeShared<NiceMock<resumption_test::MockResumptionData> >(
+                app_mngr_))
+      , mock_message_helper_(
+            application_manager::MockMessageHelper::message_helper_mock())
+      , app_id_(0u) {
+    logger::create_log_message_loop_thread();
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+  ~ApplicationManagerImplTest() {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+
+ protected:
+  void SetUp() OVERRIDE {
+    CreateAppManager();
+
+    ON_CALL(mock_connection_handler_, GetDataOnSessionKey(_, _, _, _))
+        .WillByDefault(DoAll(SetArgPointee<3u>(app_id_), Return(0)));
+    ON_CALL(mock_connection_handler_, get_session_observer())
+        .WillByDefault(ReturnRef(mock_session_observer_));
+
+    app_manager_impl_->resume_controller().set_resumption_storage(
+        mock_storage_);
+    app_manager_impl_->set_connection_handler(&mock_connection_handler_);
+  }
+
+  void CreateAppManager() {
+    const uint8_t expected_tread_pool_size = 2u;
+    const uint8_t stop_streaming_timeout = 1u;
+
+    ON_CALL(mock_application_manager_settings_, thread_pool_size())
+        .WillByDefault(Return(expected_tread_pool_size));
+    ON_CALL(mock_application_manager_settings_, app_icons_folder())
+        .WillByDefault(ReturnRef(kDirectoryName));
+    ON_CALL(mock_application_manager_settings_, app_storage_folder())
+        .WillByDefault(ReturnRef(kDirectoryName));
+    ON_CALL(mock_application_manager_settings_, launch_hmi())
+        .WillByDefault(Return(true));
+    ON_CALL(mock_application_manager_settings_, stop_streaming_timeout())
+        .WillByDefault(Return(stop_streaming_timeout));
+    ON_CALL(mock_application_manager_settings_, default_timeout())
+        .WillByDefault(ReturnRef(kTimeout));
+    app_manager_impl_.reset(new am::ApplicationManagerImpl(
+        mock_application_manager_settings_, mock_policy_settings_));
+
+    ASSERT_TRUE(app_manager_impl_.get());
+  }
+
+  NiceMock<policy_test::MockPolicySettings> mock_policy_settings_;
+  utils::SharedPtr<NiceMock<resumption_test::MockResumptionData> >
+      mock_storage_;
+  NiceMock<con_test::MockConnectionHandler> mock_connection_handler_;
+  NiceMock<protocol_handler_test::MockSessionObserver> mock_session_observer_;
+  NiceMock<MockApplicationManagerSettings> mock_application_manager_settings_;
+  application_manager_test::MockApplicationManager app_mngr_;
+  std::auto_ptr<am::ApplicationManagerImpl> app_manager_impl_;
+  application_manager::MockMessageHelper* mock_message_helper_;
+  uint32_t app_id_;
+  application_manager::MessageHelper* message_helper_;
+};
+
+TEST_F(ApplicationManagerImplTest, ProcessQueryApp_ExpectSuccess) {
+  using namespace NsSmartDeviceLink::NsSmartObjects;
+  SmartObject app_data;
+  const uint32_t connection_key = 65537u;
+
+  app_data[am::json::name] = "application_manager_test";
+  app_data[am::json::appId] = app_id_;
+  app_data[am::json::android] = "bucket";
+  app_data[am::json::android][am::json::packageName] = "com.android.test";
+  smart_objects::SmartObject sm_object(SmartType_Map);
+  sm_object[am::json::response][0] = app_data;
+  SmartObjectSPtr sptr = MakeShared<SmartObject>(sm_object);
+
+  ON_CALL(*mock_message_helper_, CreateModuleInfoSO(_, _))
+      .WillByDefault(Return(sptr));
+  ON_CALL(*mock_message_helper_, CreateNegativeResponse(_, _, _, _))
+      .WillByDefault(Return(sptr));
+  app_manager_impl_->ProcessQueryApp(sm_object, connection_key);
+}
+
+TEST_F(ApplicationManagerImplTest,
+       SubscribeAppForWayPoints_ExpectSubscriptionApp) {
+  app_manager_impl_->SubscribeAppForWayPoints(app_id_);
+  EXPECT_TRUE(app_manager_impl_->IsAppSubscribedForWayPoints(app_id_));
+}
+
+TEST_F(ApplicationManagerImplTest,
+       UnsubscribeAppForWayPoints_ExpectUnsubscriptionApp) {
+  app_manager_impl_->SubscribeAppForWayPoints(app_id_);
+  EXPECT_TRUE(app_manager_impl_->IsAppSubscribedForWayPoints(app_id_));
+  app_manager_impl_->UnsubscribeAppFromWayPoints(app_id_);
+  EXPECT_FALSE(app_manager_impl_->IsAppSubscribedForWayPoints(app_id_));
+  const std::set<int32_t> result =
+      app_manager_impl_->GetAppsSubscribedForWayPoints();
+  EXPECT_TRUE(result.empty());
+}
+
+TEST_F(
+    ApplicationManagerImplTest,
+    IsAnyAppSubscribedForWayPoints_SubcribeAppForWayPoints_ExpectCorrectResult) {
+  EXPECT_FALSE(app_manager_impl_->IsAnyAppSubscribedForWayPoints());
+  app_manager_impl_->SubscribeAppForWayPoints(app_id_);
+  EXPECT_TRUE(app_manager_impl_->IsAnyAppSubscribedForWayPoints());
+}
+
+TEST_F(
+    ApplicationManagerImplTest,
+    GetAppsSubscribedForWayPoints_SubcribeAppForWayPoints_ExpectCorrectResult) {
+  app_manager_impl_->SubscribeAppForWayPoints(app_id_);
+  std::set<int32_t> result = app_manager_impl_->GetAppsSubscribedForWayPoints();
+  EXPECT_EQ(1u, result.size());
+  EXPECT_TRUE(result.find(app_id_) != result.end());
+}
+
+}  // application_manager_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -65,9 +65,11 @@ class MockMessageHelper {
                    const mobile_api::Result::eType mobile_result));
   MOCK_METHOD1(StringToHMILevel,
                mobile_api::HMILevel::eType(const std::string& hmi_level));
-  MOCK_METHOD1(CreateDeviceListSO,
+  MOCK_METHOD3(CreateDeviceListSO,
                smart_objects::SmartObjectSPtr(
-                   const connection_handler::DeviceMap& devices));
+                   const connection_handler::DeviceMap& devices,
+                   const policy::PolicyHandlerInterface& policy_handler,
+                   ApplicationManager& app_mngr));
   MOCK_METHOD2(SendNaviStartStream,
                void(int32_t connection_key, ApplicationManager& app_mngr));
   MOCK_METHOD2(SendNaviStopStream,

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -115,9 +115,12 @@ mobile_api::HMILevel::eType MessageHelper::StringToHMILevel(
   return MockMessageHelper::message_helper_mock()->StringToHMILevel(hmi_level);
 }
 
-smart_objects::SmartObjectSPtr CreateDeviceListSO(
-    const connection_handler::DeviceMap& devices) {
-  return MockMessageHelper::message_helper_mock()->CreateDeviceListSO(devices);
+smart_objects::SmartObjectSPtr MessageHelper::CreateDeviceListSO(
+    const connection_handler::DeviceMap& devices,
+    const policy::PolicyHandlerInterface& policy_handler,
+    ApplicationManager& app_mngr) {
+  return MockMessageHelper::message_helper_mock()->CreateDeviceListSO(
+      devices, policy_handler, app_mngr);
 }
 
 void MessageHelper::SendOnAppPermissionsChangedNotification(

--- a/src/components/hmi_message_handler/mock_hmi_message_handler.h
+++ b/src/components/hmi_message_handler/mock_hmi_message_handler.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_INCLUDE_TEST_HMI_MESSAGE_HANDLER_MOCK_HMI_MESSAGE_HANDLER_H_
+#define SRC_COMPONENTS_INCLUDE_TEST_HMI_MESSAGE_HANDLER_MOCK_HMI_MESSAGE_HANDLER_H_
+
+#include "gmock/gmock.h"
+#include "hmi_message_handler/hmi_message_handler.h"
+
+namespace test {
+namespace components {
+namespace hmi_message_handler_test {
+
+using hmi_message_handler::HMIMessageAdapter;
+using hmi_message_handler::HMIMessageHandlerSettings;
+using hmi_message_handler::MessageSharedPointer;
+
+class MockHMIMessageHandler : public ::hmi_message_handler::HMIMessageHandler {
+ public:
+  MOCK_METHOD1(AddHMIMessageAdapter, void(HMIMessageAdapter* adapter));
+  MOCK_METHOD1(RemoveHMIMessageAdapter, void(HMIMessageAdapter* adapter));
+  MOCK_CONST_METHOD0(get_settings, const HMIMessageHandlerSettings&());
+  MOCK_METHOD1(OnMessageReceived,
+               void(utils::SharedPtr<application_manager::Message> message));
+  MOCK_METHOD1(OnErrorSending,
+               void(utils::SharedPtr<application_manager::Message> message));
+  MOCK_METHOD1(SendMessageToHMI, void(MessageSharedPointer message));
+};
+}  // namespace hmi_message_handler_test
+}  // namespace components
+}  // namespace test
+#endif  // SRC_COMPONENTS_INCLUDE_TEST_HMI_MESSAGE_HANDLER_MOCK_HMI_MESSAGE_HANDLER_H_


### PR DESCRIPTION
Moved application manager implementation tests from pre_5_0_0 branch to develop

List of changes :
- added new unit test class ApplicationManagerImplTest which contains 5 working unit test cases for ApplicationManagerImpl:
  1. ProcessQueryApp_ExpectSuccess
  2. SubscribeAppForWayPoints_ExpectSubscriptionApp
  3. UnsubscribeAppForWayPoints_ExpectUnsubscriptionApp
  4. IsAnyAppSubscribedForWayPoints_SubcribeAppForWayPoints_ExpectCorrectResult
  5. GetAppsSubscribedForWayPoints_SubcribeAppForWayPoints_ExpectCorrectResult

- added new mock method CreateDeviceListSO into MockMessageHelper;
- added new mock class MockHmiMessageHandler for HMIMessageHandler.

