### PR TITLE
Increase frequency of OnAudioPassThru notifications

### DIFF
--- a/src/components/media_manager/src/audio/audio_stream_sender_thread.cc
+++ b/src/components/media_manager/src/audio/audio_stream_sender_thread.cc
@@ -52,7 +52,11 @@
 namespace media_manager {
 using sync_primitives::AutoLock;
 
-const int32_t AudioStreamSenderThread::kAudioPassThruTimeout = 1;
+#ifdef EXTENDED_MEDIA_MODE
+const int32_t AudioStreamSenderThread::kAudioPassThruTimeout = 50;
+#else
+const int32_t AudioStreamSenderThread::kAudioPassThruTimeout = 1000;
+#endif
 const uint32_t kMqueueMessageSize = 4095;
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "MediaManager")
@@ -79,7 +83,7 @@ void AudioStreamSenderThread::threadMain() {
 
   while (false == getShouldBeStopped()) {
     AutoLock auto_lock(shouldBeStoped_lock_);
-    shouldBeStoped_cv_.WaitFor(auto_lock, kAudioPassThruTimeout * 1000);
+    shouldBeStoped_cv_.WaitFor(auto_lock, kAudioPassThruTimeout);
     sendAudioChunkToMobile();
   }
 }


### PR DESCRIPTION
It was requested that during AudioPassThru, notifications should be sent on a more frequent basis to allow for better real-time processing of the data. This delay value is not changed from 1 second when EXTENDED_MEDIA_MODE is disabled, as the AudioPassThru data is faked in this case.

Fixes #835