### PR TITLE
Move request_controller tests from pre_5_0 branch to develop

### DIFF
--- a/src/components/application_manager/test/CMakeLists.txt
+++ b/src/components/application_manager/test/CMakeLists.txt
@@ -65,6 +65,10 @@ set(SOURCES
   ${AM_TEST_DIR}/application_manager_impl_test.cc
 )
 
+set (RequestController_SOURCES
+  ${AM_TEST_DIR}/request_controller/request_controller_test.cc
+)
+
 set(LIBRARIES
   Utils
   ApplicationManager
@@ -111,6 +115,7 @@ set(CMAKE_EXE_LINKER_FLAGS
   "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath=${CMAKE_CURRENT_BINARY_DIR}"
 )
 create_test("application_manager_test" "${SOURCES}" "${LIBRARIES}")
+create_test("request_controller_test" "${RequestController_SOURCES}" "${LIBRARIES}")
 
 # TODO [AKozoriz] : Fix not buildable tests
 set(ResumptionData_SOURCES

--- a/src/components/application_manager/test/include/application_manager/mock_request.h
+++ b/src/components/application_manager/test/include/application_manager/mock_request.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_REQUEST_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_REQUEST_H_
+
+#include "gmock/gmock.h"
+#include "application_manager/commands/command.h"
+
+namespace test {
+namespace components {
+namespace application_manager_test {
+
+using ::testing::Return;
+
+class MockRequest : public application_manager::commands::Command {
+ public:
+  MockRequest(uint32_t connection_key, uint32_t correlation_id) {
+    ON_CALL(*this, correlation_id()).WillByDefault(Return(correlation_id));
+    ON_CALL(*this, connection_key()).WillByDefault(Return(connection_key));
+  }
+
+  MOCK_METHOD0(CheckPermissions, bool());
+  MOCK_METHOD0(Init, bool());
+  MOCK_METHOD0(Run, void());
+  MOCK_METHOD0(CleanUp, bool());
+  MOCK_CONST_METHOD0(default_timeout, uint32_t());
+  MOCK_CONST_METHOD0(function_id, int32_t());
+  MOCK_METHOD0(onTimeOut, void());
+  MOCK_METHOD0(AllowedToTerminate, bool());
+  MOCK_METHOD1(SetAllowedToTerminate, void(bool is_allowed));
+
+  MOCK_CONST_METHOD0(connection_key, uint32_t());
+  MOCK_CONST_METHOD0(correlation_id, uint32_t());
+};
+
+}  // namespace application_manager_test
+}  // namespace components
+}  // namespace test
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_REQUEST_H_

--- a/src/components/application_manager/test/request_controller/request_controller_test.cc
+++ b/src/components/application_manager/test/request_controller/request_controller_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2017, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,8 +30,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdint.h>
+
 #include "gtest/gtest.h"
 #include "application_manager/request_controller.h"
+#include "application_manager/request_info.h"
 #include "application_manager/mock_request.h"
 #include "utils/shared_ptr.h"
 #include "smart_objects/smart_object.h"
@@ -52,91 +55,147 @@ namespace test {
 namespace components {
 namespace request_controller_test {
 
-using application_manager::request_controller::RequestController;
-using application_manager::request_controller::RequestInfo;
+using ::application_manager::request_controller::RequestController;
+using ::application_manager::request_controller::RequestInfo;
 
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::NiceMock;
 
-typedef utils::SharedPtr<application_manager_test::MockRequest> RequestPtr;
+typedef NiceMock<application_manager_test::MockRequest> MRequest;
+typedef utils::SharedPtr<MRequest> RequestPtr;
 typedef utils::SharedPtr<RequestController> RequestControllerSPtr;
+
+namespace {
+const size_t kNumberOfRequests = 10u;
+const uint32_t kTimeScale = 5000u;  // 5 seconds
+const uint32_t kMaxRequestAmount = 2u;
+const uint32_t kDefaultCorrelationID = 1u;
+const uint32_t kDefaultConnectionKey = 0u;
+const uint32_t kDefaultTimeout = 100u;
+const uint32_t kThreadPoolSize = 1u;
+}  // namespace
 
 class RequestControllerTestClass : public ::testing::Test {
  public:
-  RequestControllerTestClass()
-      : request_ctrl_(utils::MakeShared<RequestController>(
-            mock_request_controller_settings_)) {
-    register_request_ = GetMockRequest();
+  struct TestSettings {
+    uint32_t app_hmi_level_none_requests_time_scale_;
+    uint32_t app_hmi_level_none_time_scale_max_requests_;
+    uint32_t app_time_scale_max_requests_;
+    uint32_t app_requests_time_scale_;
+    uint32_t pending_requests_amount_;
+
+    TestSettings(const uint32_t app_hmi_level_none_requests_time_scale = 0u,
+                 const uint32_t app_hmi_level_none_time_scale_max_requests = 0u,
+                 const uint32_t app_time_scale_max_requests = 0u,
+                 const uint32_t app_requests_time_scale = 0u,
+                 const uint32_t pending_requests_amount = 0u)
+        : app_hmi_level_none_requests_time_scale_(
+              app_hmi_level_none_requests_time_scale)
+        , app_hmi_level_none_time_scale_max_requests_(
+              app_hmi_level_none_time_scale_max_requests)
+        , app_time_scale_max_requests_(app_time_scale_max_requests)
+        , app_requests_time_scale_(app_requests_time_scale)
+        , pending_requests_amount_(pending_requests_amount) {}
+  };
+
+  RequestControllerTestClass() {
+    ON_CALL(mock_request_controller_settings_, thread_pool_size())
+        .WillByDefault(Return(kThreadPoolSize));
+    request_ctrl_ =
+        utils::MakeShared<RequestController>(mock_request_controller_settings_);
+  }
+
+  RequestPtr GetMockRequest(
+      const uint32_t correlation_id = kDefaultCorrelationID,
+      const uint32_t connection_key = kDefaultConnectionKey,
+      const uint32_t default_timeout = kDefaultTimeout) {
+    RequestPtr output =
+        utils::MakeShared<MRequest>(connection_key, correlation_id);
+    ON_CALL(*output, default_timeout()).WillByDefault(Return(default_timeout));
+    return output;
   }
 
   RequestController::TResult AddRequest(
-      const RequestInfo::RequestType request_type,
-      const bool RegisterRequest = false,
+      const TestSettings& settings,
+      RequestPtr request,
+      const RequestInfo::RequestType request_type =
+          RequestInfo::RequestType::HMIRequest,
       const mobile_apis::HMILevel::eType& hmi_level =
           mobile_apis::HMILevel::INVALID_ENUM) {
-    RequestPtr request;
-    if (RegisterRequest) {
-      request = register_request_;
-      EXPECT_CALL(*register_request_, default_timeout()).WillOnce(Return(0));
-    } else {
-      request = empty_register_request_;
-    }
     if (RequestInfo::RequestType::HMIRequest == request_type) {
       return request_ctrl_->addHMIRequest(request);
     }
+    CallSettings(settings);
     return request_ctrl_->addMobileRequest(request, hmi_level);
   }
 
-  RequestPtr GetMockRequest(const uint32_t id = 1,
-                            const uint32_t connection_key = 0) {
-    return utils::MakeShared<application_manager_test::MockRequest>(
-        connection_key, id);
-  }
-  void CallSettings() {
-    EXPECT_CALL(mock_request_controller_settings_,
-                app_hmi_level_none_time_scale())
-        .WillOnce(ReturnRef(kDefaultAppHmiLevelNoneRequestsTimeScale));
-    EXPECT_CALL(mock_request_controller_settings_,
-                app_hmi_level_none_time_scale_max_requests())
-        .WillOnce(ReturnRef(kDefaultAppHmiLevelNoneTimeScaleMaxRequests));
+  void CallSettings(const TestSettings& settings) const {
+    ON_CALL(mock_request_controller_settings_, app_hmi_level_none_time_scale())
+        .WillByDefault(
+            ReturnRef(settings.app_hmi_level_none_requests_time_scale_));
 
-    EXPECT_CALL(mock_request_controller_settings_, app_time_scale())
-        .WillOnce(ReturnRef(kDefaultAppRequestsTimeScale));
-    EXPECT_CALL(mock_request_controller_settings_,
-                app_time_scale_max_requests())
-        .WillOnce(ReturnRef(kDefaultAppTimeScaleMaxRequests));
+    ON_CALL(mock_request_controller_settings_,
+            app_hmi_level_none_time_scale_max_requests())
+        .WillByDefault(
+            ReturnRef(settings.app_hmi_level_none_time_scale_max_requests_));
 
-    EXPECT_CALL(mock_request_controller_settings_, pending_requests_amount())
-        .WillOnce(ReturnRef(kDefaultPendingRequestsAmount));
+    ON_CALL(mock_request_controller_settings_, app_time_scale())
+        .WillByDefault(ReturnRef(settings.app_requests_time_scale_));
+
+    ON_CALL(mock_request_controller_settings_, app_time_scale_max_requests())
+        .WillByDefault(ReturnRef(settings.app_time_scale_max_requests_));
+
+    ON_CALL(mock_request_controller_settings_, pending_requests_amount())
+        .WillByDefault(ReturnRef(settings.pending_requests_amount_));
   }
 
-  application_manager_test::MockRequestControlerSettings
+  NiceMock<application_manager_test::MockRequestControlerSettings>
       mock_request_controller_settings_;
-  RequestPtr register_request_;
-  RequestPtr empty_register_request_;
   RequestControllerSPtr request_ctrl_;
-
-  const uint32_t kDefaultAppHmiLevelNoneRequestsTimeScale = 10;
-  const uint32_t kDefaultAppHmiLevelNoneTimeScaleMaxRequests = 100u;
-  const uint32_t kDefaultAppTimeScaleMaxRequests = 0;
-  const uint32_t kDefaultAppRequestsTimeScale = 0;
-  const uint32_t kDefaultPendingRequestsAmount = 0;
+  RequestPtr empty_mock_request_;
+  const TestSettings default_settings_;
 };
 
-TEST_F(RequestControllerTestClass, CheckPosibilitytoAdd_HMI_FULL_SUCCESS) {
-  CallSettings();
-  EXPECT_EQ(RequestController::TResult::SUCCESS,
-            AddRequest(RequestInfo::RequestType::MobileRequest,
-                       true,
-                       mobile_apis::HMILevel::HMI_FULL));
+TEST_F(RequestControllerTestClass,
+       CheckPosibilitytoAdd_ZeroValueLimiters_SUCCESS) {
+  // Test case than pending_requests_amount,
+  // app_time_scale_max_requests_ and
+  // app_hmi_level_none_time_scale_max_requests_ equals 0
+  // (in the default settings they setted to 0)
+  for (size_t i = 0; i < kMaxRequestAmount; ++i) {
+    EXPECT_EQ(RequestController::SUCCESS,
+              AddRequest(default_settings_,
+                         GetMockRequest(i),
+                         RequestInfo::RequestType::MobileRequest,
+                         mobile_apis::HMILevel::HMI_FULL));
+  }
 }
 
-TEST_F(RequestControllerTestClass, CheckPosibilitytoAdd_HMI_NONE_SUCCESS) {
-  CallSettings();
-  EXPECT_EQ(RequestController::TResult::SUCCESS,
-            AddRequest(RequestInfo::RequestType::MobileRequest,
-                       true,
-                       mobile_apis::HMILevel::HMI_NONE));
+TEST_F(
+    RequestControllerTestClass,
+    CheckPosibilitytoAdd_ExcessPendingRequestsAmount_TooManyPendingRequests) {
+  TestSettings settings;
+  settings.pending_requests_amount_ = kNumberOfRequests;
+
+  request_ctrl_->DestroyThreadpool();
+
+  // Adding requests to fit in pending_requests_amount_
+  for (size_t i = 0; i < kNumberOfRequests; ++i) {
+    EXPECT_EQ(RequestController::TResult::SUCCESS,
+              AddRequest(settings,
+                         GetMockRequest(),
+                         RequestInfo::RequestType::MobileRequest,
+                         mobile_apis::HMILevel::HMI_FULL));
+  }
+
+  // Trying to add one more extra request
+  // Expect overflow and TOO_MANY_PENDING_REQUESTS result
+  EXPECT_EQ(RequestController::TResult::TOO_MANY_PENDING_REQUESTS,
+            AddRequest(settings,
+                       GetMockRequest(),
+                       RequestInfo::RequestType::MobileRequest,
+                       mobile_apis::HMILevel::HMI_FULL));
 }
 
 TEST_F(RequestControllerTestClass, IsLowVoltage_SetOnLowVoltage_TRUE) {
@@ -151,34 +210,51 @@ TEST_F(RequestControllerTestClass, IsLowVoltage_SetOnWakeUp_FALSE) {
   EXPECT_EQ(result, request_ctrl_->IsLowVoltage());
 }
 
+TEST_F(RequestControllerTestClass, AddMobileRequest_SetValidData_SUCCESS) {
+  EXPECT_EQ(RequestController::SUCCESS,
+            AddRequest(default_settings_,
+                       GetMockRequest(),
+                       RequestInfo::RequestType::MobileRequest,
+                       mobile_apis::HMILevel::HMI_FULL));
+}
+
 TEST_F(RequestControllerTestClass,
        AddMobileRequest_SetInvalidData_INVALID_DATA) {
   EXPECT_EQ(RequestController::INVALID_DATA,
-            AddRequest(RequestInfo::RequestType::MobileRequest,
-                       false,
+            AddRequest(default_settings_,
+                       empty_mock_request_,
+                       RequestInfo::RequestType::MobileRequest,
                        mobile_apis::HMILevel::HMI_NONE));
 }
 
-TEST_F(RequestControllerTestClass, addHMIRequest_AddRequest_SUCCESS) {
+TEST_F(RequestControllerTestClass, AddHMIRequest_AddRequest_SUCCESS) {
   EXPECT_EQ(RequestController::SUCCESS,
-            AddRequest(RequestInfo::RequestType::HMIRequest, true));
+            AddRequest(default_settings_,
+                       GetMockRequest(),
+                       RequestInfo::RequestType::HMIRequest));
 }
 
-TEST_F(RequestControllerTestClass, addHMIRequest_AddInvalidData_INVALID_DATA) {
+TEST_F(RequestControllerTestClass, AddHMIRequest_AddInvalidData_INVALID_DATA) {
   EXPECT_EQ(RequestController::INVALID_DATA,
-            AddRequest(RequestInfo::RequestType::HMIRequest));
+            AddRequest(default_settings_,
+                       empty_mock_request_,
+                       RequestInfo::RequestType::HMIRequest));
 }
 
-TEST_F(RequestControllerTestClass, ZeroValuePendingRequestsAmount) {
-  // Bigger than pending_requests_amount count
-  const uint32_t big_count_of_requests_for_test_ = 10;
-  for (uint32_t i = 0; i < big_count_of_requests_for_test_; ++i) {
-    CallSettings();
-    EXPECT_EQ(RequestController::SUCCESS,
-              AddRequest(RequestInfo::RequestType::MobileRequest,
-                         true,
-                         mobile_apis::HMILevel::HMI_FULL));
-  }
+TEST_F(RequestControllerTestClass, OnTimer_SUCCESS) {
+  const uint32_t request_timeout = 1u;
+  RequestPtr mock_request = GetMockRequest(
+      kDefaultCorrelationID, kDefaultConnectionKey, request_timeout);
+
+  EXPECT_EQ(RequestController::SUCCESS,
+            AddRequest(default_settings_,
+                       mock_request,
+                       RequestInfo::RequestType::MobileRequest));
+
+  EXPECT_CALL(*mock_request, onTimeOut());
+
+  // Waiting for call of `onTimeOut` for `kTimeScale` seconds
+  testing::Mock::AsyncVerifyAndClearExpectations(kTimeScale);
 }
 
 }  // namespace request_controller_test

--- a/src/components/application_manager/test/request_info_test.cc
+++ b/src/components/application_manager/test/request_info_test.cc
@@ -31,6 +31,7 @@
  */
 
 #include "application_manager/request_info.h"
+#include "application_manager/mock_request.h"
 #include <iostream>
 #include <vector>
 #include <limits>
@@ -43,30 +44,6 @@ namespace request_info = application_manager::request_controller;
 namespace test {
 namespace components {
 namespace application_manager_test {
-
-class MockRequest : public application_manager::commands::Command {
- public:
-  MockRequest(uint32_t connection_key, uint32_t correlation_id)
-      : connection_key_(connection_key), correlation_id_(correlation_id) {}
-  MOCK_METHOD0(CheckPermissions, bool());
-  MOCK_METHOD0(Init, bool());
-  MOCK_METHOD0(Run, void());
-  MOCK_METHOD0(CleanUp, bool());
-  MOCK_CONST_METHOD0(default_timeout, uint32_t());
-  MOCK_CONST_METHOD0(function_id, int32_t());
-  MOCK_METHOD0(onTimeOut, void());
-  MOCK_METHOD0(AllowedToTerminate, bool());
-  MOCK_METHOD1(SetAllowedToTerminate, void(bool));
-
-  uint32_t connection_key_;
-  uint32_t correlation_id_;
-  virtual uint32_t connection_key() const {
-    return connection_key_;
-  }
-  virtual uint32_t correlation_id() const {
-    return correlation_id_;
-  }
-};
 
 class TestRequestInfo : public request_info::RequestInfo {
  public:


### PR DESCRIPTION
Make request_controller_test executable, move actual tests from pre_5_0 branch, move MockRequest in a separate file, raise cover functions up to 75%.
Related task: [SDLOPEN-583](https://adc.luxoft.com/jira/browse/SDLOPEN-583)