### PR TITLE
Fix HMI Message Handler UTs

### DIFF
--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -211,7 +211,7 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   /**
    * @brief Returns desirable thread stack size
    */
-  const uint64_t& thread_min_stack_size() const;
+  const uint64_t thread_min_stack_size() const;
 
   /**
     * @brief Returns true if audio mixing is supported

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -509,7 +509,7 @@ const uint16_t& Profile::time_testing_port() const {
   return time_testing_port_;
 }
 
-const uint64_t& Profile::thread_min_stack_size() const {
+const uint64_t Profile::thread_min_stack_size() const {
   return min_tread_stack_size_;
 }
 

--- a/src/components/hmi_message_handler/include/hmi_message_handler/hmi_message_handler_impl.h
+++ b/src/components/hmi_message_handler/include/hmi_message_handler/hmi_message_handler_impl.h
@@ -136,8 +136,9 @@ class HMIMessageHandlerImpl : public HMIMessageHandler,
  private:
   const HMIMessageHandlerSettings& settings_;
   HMIMessageObserver* observer_;
-  mutable sync_primitives::Lock observer_locker_;
   std::set<HMIMessageAdapter*> message_adapters_;
+  mutable sync_primitives::Lock observer_locker_;
+  mutable sync_primitives::Lock message_adapters_locker_;
 
   // Construct message threads when everything is already created
 

--- a/src/components/hmi_message_handler/src/hmi_message_handler_impl.cc
+++ b/src/components/hmi_message_handler/src/hmi_message_handler_impl.cc
@@ -54,6 +54,7 @@ HMIMessageHandlerImpl::~HMIMessageHandlerImpl() {
   LOG4CXX_AUTO_TRACE(logger_);
   messages_to_hmi_.Shutdown();
   messages_from_hmi_.Shutdown();
+  message_adapters_.clear();
   set_message_observer(NULL);
 }
 
@@ -94,6 +95,7 @@ void HMIMessageHandlerImpl::AddHMIMessageAdapter(HMIMessageAdapter* adapter) {
     LOG4CXX_WARN(logger_, "HMIMessageAdapter is not valid!");
     return;
   }
+  sync_primitives::AutoLock lock(message_adapters_locker_);
   message_adapters_.insert(adapter);
 }
 
@@ -104,6 +106,7 @@ void HMIMessageHandlerImpl::RemoveHMIMessageAdapter(
     LOG4CXX_WARN(logger_, "HMIMessageAdapter is not valid!");
     return;
   }
+  sync_primitives::AutoLock lock(message_adapters_locker_);
   message_adapters_.erase(adapter);
 }
 
@@ -123,6 +126,7 @@ void HMIMessageHandlerImpl::Handle(const impl::MessageFromHmi message) {
   LOG4CXX_INFO(logger_, "Message from hmi given away.");
 }
 void HMIMessageHandlerImpl::Handle(const impl::MessageToHmi message) {
+  sync_primitives::AutoLock lock(message_adapters_locker_);
   for (std::set<HMIMessageAdapter*>::iterator it = message_adapters_.begin();
        it != message_adapters_.end();
        ++it) {
@@ -133,6 +137,7 @@ void HMIMessageHandlerImpl::Handle(const impl::MessageToHmi message) {
 #ifdef SDL_REMOTE_CONTROL
 void HMIMessageHandlerImpl::SubscribeToHMINotification(
     const std::string& hmi_notification) {
+  sync_primitives::AutoLock lock(message_adapters_locker_);
   for (std::set<HMIMessageAdapter*>::iterator it = message_adapters_.begin();
        it != message_adapters_.end();
        ++it) {

--- a/src/components/hmi_message_handler/test/hmi_message_adapter_test.cc
+++ b/src/components/hmi_message_handler/test/hmi_message_adapter_test.cc
@@ -42,7 +42,7 @@ namespace test {
 namespace components {
 namespace hmi_message_handler_test {
 
-using ::testing::ReturnRef;
+using ::testing::Return;
 using hmi_message_handler::HMIMessageHandlerImpl;
 
 typedef utils::SharedPtr<MockHMIMessageAdapterImpl>
@@ -53,7 +53,7 @@ TEST(HMIMessageAdapterImplTest, Handler_CorrectPointer_CorrectReturnedPointer) {
       mock_hmi_message_handler_settings;
   const uint64_t stack_size = 1000u;
   ON_CALL(mock_hmi_message_handler_settings, thread_min_stack_size())
-      .WillByDefault(ReturnRef(stack_size));
+      .WillByDefault(Return(stack_size));
   HMIMessageHandler* message_handler =
       new hmi_message_handler::HMIMessageHandlerImpl(
           mock_hmi_message_handler_settings);

--- a/src/components/hmi_message_handler/test/include/hmi_message_handler/mock_hmi_message_observer.h
+++ b/src/components/hmi_message_handler/test/include/hmi_message_handler/mock_hmi_message_observer.h
@@ -43,8 +43,7 @@ namespace hmi_message_handler {
 
 using ::hmi_message_handler::HMIMessageObserver;
 
-class MockHMIMessageObserver : public HMIMessageObserver,
-                               public utils::Singleton<MockHMIMessageObserver> {
+class MockHMIMessageObserver : public HMIMessageObserver {
  public:
   MOCK_METHOD1(OnMessageReceived,
                void(utils::SharedPtr<application_manager::Message> message));

--- a/src/components/include/hmi_message_handler/hmi_message_handler_settings.h
+++ b/src/components/include/hmi_message_handler/hmi_message_handler_settings.h
@@ -44,7 +44,7 @@ class HMIMessageHandlerSettings {
  public:
   virtual ~HMIMessageHandlerSettings() {}
 
-  virtual const uint64_t& thread_min_stack_size() const = 0;
+  virtual const uint64_t thread_min_stack_size() const = 0;
 };
 }  // namespace  hmi_message_handler
 #endif  // SRC_COMPONENTS_INCLUDE_HMI_MESSAGE_HANDLER_HMI_MESSAGE_HANDLER_SETTINGS_H_

--- a/src/components/include/test/hmi_message_handler/mock_hmi_message_handler_settings.h
+++ b/src/components/include/test/hmi_message_handler/mock_hmi_message_handler_settings.h
@@ -44,7 +44,7 @@ namespace hmi_message_handler_test {
 class MockHMIMessageHandlerSettings
     : public ::hmi_message_handler::HMIMessageHandlerSettings {
  public:
-  MOCK_CONST_METHOD0(thread_min_stack_size, const uint64_t&());
+  MOCK_CONST_METHOD0(thread_min_stack_size, const uint64_t());
 };
 }  // namespace hmi_message_handler_test
 }  // namespace components


### PR DESCRIPTION
### Updated interfaces
- Removed unnecessary refarences to `POD`
- `MockHMIMessageObserver` not a `Singletone` anymore
##
### Added lock for message adapters set
##
### Fixed `SegFault`of `HMIMessageHandler` Uts
##
Related to: [SDLOPEN-44](https://adc.luxoft.com/jira/browse/SDLOPEN-44)

@okozlovlux, @LuxoftAKutsan, @indlu, please, review.