### PR TITLE
Fix missing OnInteriorVehicleData msg to mobile

### DIFF
--- a/src/components/application_manager/src/core_service.cc
+++ b/src/components/application_manager/src/core_service.cc
@@ -223,7 +223,7 @@ uint32_t CoreService::GetNextCorrelationID() {
 
 std::vector<ApplicationSharedPtr> CoreService::GetApplications(
     AppExtensionUID uid) {
-  ApplicationSet accessor;
+  ApplicationSet accessor = application_manager_.applications().GetData();
   AppExtensionPredicate predicate;
   predicate.uid = uid;
 


### PR DESCRIPTION
The reason SDL was not sending OnInteriorVehicleData message to the
mobile application is that the vector with applications it must notify
is empty (with matching UID). It is empty because the data accessor to
all applications set is not initialized. Initializing the accessor
variable fixed the problem.

Related-issues: [SDLOPEN-600](https://adc.luxoft.com/jira/browse/SDLOPEN-600)