### PR TITLE
Fix incorrect behavior when hmi send GetInteriorVehicleData

### DIFF
--- a/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
@@ -77,16 +77,6 @@ void RegisterAppInterfaceResponse::Run() {
   }
 
   SetHeartBeatTimeout(connection_key(), application->policy_app_id());
-
-  // Default HMI level should be set before any permissions validation, since
-  // it
-  // relies on HMI level.
-  application_manager_.OnApplicationRegistered(application);
-
-  // Sends OnPermissionChange notification to mobile right after RAI response
-  // and HMI level set-up
-  application_manager_.GetPolicyHandler().OnAppRegisteredOnMobile(
-      application->policy_app_id());
 }
 
 void RegisterAppInterfaceResponse::SetHeartBeatTimeout(

--- a/src/components/can_cooperation/reverse_sdl_pt.json
+++ b/src/components/can_cooperation/reverse_sdl_pt.json
@@ -2388,17 +2388,6 @@
                 "groups_primaryRC": ["Base-4", "RemoteControl"],
                 "groups_nonPrimaryRC": ["Notifications-RC", "RemoteControl"]
             },
-            "8675311": {
-                "keep_context": false,
-                "steal_focus": false,
-                "priority": "NONE",
-                "default_hmi": "NONE",
-                "moduleType": ["RADIO"],
-                "groups": ["Base-4"],
-                "groups_primaryRC": ["Base-4", "RemoteControl"],
-                "groups_nonPrimaryRC": ["Notifications-RC", "RemoteControl"],
-                "AppHMIType": ["REMOTE_CONTROL"]
-            },
             "pre_consent_passengersRC": {
                 "keep_context": false,
                 "steal_focus": false,


### PR DESCRIPTION
Removed OnApplicationRegistered notification from RegisterAppInterfaceResponse method Run().


Related to [SDLOPEN-698](https://adc.luxoft.com/jira/browse/SDLOPEN-698)