### PR TITLE
Fix SDL OnSeekMediaClockTimer notification from HMI

### DIFF
--- a/src/components/application_manager/src/commands/hmi/on_seek_media_clock_timer_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_seek_media_clock_timer_notification.cc
@@ -53,7 +53,15 @@ void OnSeekMediaClockTimerNotification::Run() {
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnSeekMediaClockTimerID);
 
-  SendNotificationToMobile(message_);
+  const ApplicationSet& accessor =
+      application_manager_.applications().GetData();
+
+  ApplicationSetIt it = accessor.begin();
+  for (; accessor.end() != it; ++it) {
+    const ApplicationSharedPtr app = *it;
+    (*message_)[strings::params][strings::connection_key] = app->app_id();
+    SendNotificationToMobile(message_);
+  }
 }
 
 }  // namespace hmi

--- a/src/components/application_manager/test/commands/hmi/on_seek_media_clock_timer_notification_test.cc
+++ b/src/components/application_manager/test/commands/hmi/on_seek_media_clock_timer_notification_test.cc
@@ -39,6 +39,7 @@
 #include "application_manager/commands/command_request_test.h"
 #include "application_manager/mock_application_manager.h"
 #include "application_manager/hmi_interfaces.h"
+#include "application_manager/mock_message_helper.h"
 
 namespace test {
 namespace components {
@@ -51,9 +52,41 @@ using ::utils::SharedPtr;
 using ::application_manager::commands::MessageSharedPtr;
 using am::commands::MessageSharedPtr;
 
+#define NOT_VC false
+#define NOT_MEDIA false
+#define NOT_NAVI false
+
+namespace {
+const uint32_t kAppId = 2014u;
+}  // namespace
+
 class OnSeekMediaClockTimerNotificationTest
     : public components::commands_test::CommandsTest<
-          CommandsTestMocks::kIsNice> {};
+          CommandsTestMocks::kIsNice> {
+ public:
+  OnSeekMediaClockTimerNotificationTest()
+      : applications_(application_set_, applications_lock_) {}
+
+ protected:
+  am::ApplicationSet application_set_;
+  sync_primitives::Lock applications_lock_;
+  DataAccessor<am::ApplicationSet> applications_;
+  static MockAppPtr ConfigureApp(uint32_t app_id,
+                                 bool media,
+                                 bool navi,
+                                 bool vc) {
+    MockAppPtr mock_app_ptr = new NiceMock<MockApplication>;
+
+    ON_CALL(*mock_app_ptr, app_id()).WillByDefault(Return(app_id));
+    ON_CALL(*mock_app_ptr, is_media_application()).WillByDefault(Return(media));
+    ON_CALL(*mock_app_ptr, is_navi()).WillByDefault(Return(navi));
+    ON_CALL(*mock_app_ptr, is_voice_communication_supported())
+        .WillByDefault(Return(vc));
+    ON_CALL(*mock_app_ptr, IsAudioApplication())
+        .WillByDefault(Return(media || navi || vc));
+    return mock_app_ptr;
+  }
+};
 
 TEST_F(OnSeekMediaClockTimerNotificationTest,
        OnSeekMediaClockTimer_SendNotificationToMobile_SUCCESS) {
@@ -61,10 +94,17 @@ TEST_F(OnSeekMediaClockTimerNotificationTest,
   utils::SharedPtr<Command> command =
       CreateCommand<am::commands::hmi::OnSeekMediaClockTimerNotification>(
           message);
+  MockAppPtr mock_app_ptr = ConfigureApp(kAppId, NOT_MEDIA, NOT_NAVI, NOT_VC);
+  application_set_.insert(mock_app_ptr);
+  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
 
   EXPECT_CALL(app_mngr_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   command->Run();
+
+  EXPECT_EQ(
+      static_cast<int32_t>(kAppId),
+      (*message)[am::strings::params][am::strings::connection_key].asInt());
   EXPECT_EQ(
       static_cast<int32_t>(mobile_apis::FunctionID::OnSeekMediaClockTimerID),
       (*message)[am::strings::params][am::strings::function_id].asInt());

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -43,6 +43,7 @@
 #include "application_manager/mock_message_helper.h"
 #include "application_manager/event_engine/event.h"
 #include "application_manager/mock_hmi_interface.h"
+#include "utils/file_system.h"
 
 namespace test {
 namespace components {

--- a/src/components/hmi_message_handler/src/messagebroker_adapter.cc
+++ b/src/components/hmi_message_handler/src/messagebroker_adapter.cc
@@ -96,6 +96,7 @@ void MessageBrokerAdapter::SubscribeTo() {
   MessageBrokerController::subscribeTo(
       "BasicCommunication.OnExitAllApplications");
   MessageBrokerController::subscribeTo("UI.OnDriverDistraction");
+  MessageBrokerController::subscribeTo("UI.OnSeekMediaClockTimer");
   MessageBrokerController::subscribeTo("UI.OnSystemContext");
   MessageBrokerController::subscribeTo("UI.OnAppActivated");
   MessageBrokerController::subscribeTo("UI.OnKeyboardInput");


### PR DESCRIPTION
 Fixed OnSeekMediaClockTimer notification from HMI
 Added to MessageBroker subscription on missing notification UI.OnSeekMediaClockTimer

 
 