### PR TITLE
[WIP] Fix/cycling urls refactoring

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -756,11 +756,13 @@ class PolicyHandler : public PolicyHandlerInterface,
   /**
    * @brief Checks if the application with the given policy
    * application id is registered or it is default id
-   * @param policy_app_id Application policy id
-   * @return TRUE if the application with given id is registered or
-   * it is default id, otherwise FALSE
+   * @param app_idx Application idx from EndpointUrls vector
+   * @param urls EndpointUrls vector
+   * @return TRUE if the vector with URLs with given idx is not empty
+   * and is related to a registered application or these are default URLs,
+   * otherwise FALSE
    */
-  bool IsUrlAppIdValid(const std::string& policy_app_id) const;
+  bool IsUrlAppIdValid(const int app_idx, const EndpointUrls& urls) const;
 
   DISALLOW_COPY_AND_ASSIGN(PolicyHandler);
 };

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -753,6 +753,15 @@ class PolicyHandler : public PolicyHandlerInterface,
   application_manager::ApplicationManager& application_manager_;
   friend class AppPermissionDelegate;
 
+  /**
+   * @brief Checks if the application with the given policy
+   * application id is registered or it is default id
+   * @param policy_app_id Application policy id
+   * @return TRUE if the application with given id is registered or
+   * it is default id, otherwise FALSE
+   */
+  bool IsUrlAppIdValid(const std::string& policy_app_id) const;
+
   DISALLOW_COPY_AND_ASSIGN(PolicyHandler);
 };
 

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -762,7 +762,7 @@ class PolicyHandler : public PolicyHandlerInterface,
    * and is related to a registered application or these are default URLs,
    * otherwise FALSE
    */
-  bool IsUrlAppIdValid(const int app_idx, const EndpointUrls& urls) const;
+  bool IsUrlAppIdValid(const uint32_t app_idx, const EndpointUrls& urls) const;
 
   DISALLOW_COPY_AND_ASSIGN(PolicyHandler);
 };

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -392,7 +392,7 @@ uint32_t PolicyHandler::GetAppIdForSending() const {
                 "Number of apps with different from NONE level: "
                     << apps_without_none_level.size());
 
-  const uint32_t choosen_app_id =
+  uint32_t choosen_app_id =
       ChooseRandomAppForPolicyUpdate(apps_without_none_level);
 
   if (choosen_app_id) {
@@ -485,11 +485,6 @@ void PolicyHandler::GetAvailableApps(std::queue<std::string>& apps) {
   }
 }
 
-struct SmartObjectToInt {
-  int operator()(const smart_objects::SmartObject& item) const {
-    return item.asInt();
-  }
-};
 StatusNotifier PolicyHandler::AddApplication(
     const std::string& application_id) {
   POLICY_LIB_CHECK(utils::MakeShared<utils::CallNothing>());
@@ -1419,32 +1414,12 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
     return;
   }
 
-  static size_t current_app = 0;
-  static size_t current_url = 0;
-  if (current_url >= urls.at(current_app).url.size()) {
-    ApplicationSharedPtr app;
-    current_url = 0;
-
-    bool is_default = false;
-    bool is_registered = false;
-    bool has_urls = false;
-    bool valid_app_found = false;
-    do {
-      if (++current_app >= urls.size()) {
-        current_app = 0;
-      }
-      const std::string& app_id = urls.at(current_app).app_id;
-      app = application_manager_.application_by_policy_id(app_id);
-
-      is_default = (app_id == policy::kDefaultId);
-      is_registered = (app && app->IsRegistered());
-      has_urls = !urls.at(current_app).url.empty();
-      valid_app_found = (is_default || (is_registered && has_urls));
-    } while (!valid_app_found);
+  AppIdURL app_url;
+  app_url = policy_manager_->GetNextUpdateUrl(urls);
+  while (!IsUrlAppIdValid(app_url.first)) {
+    app_url = policy_manager_->GetNextUpdateUrl(urls);
   }
-
-  SendMessageToSDK(pt_string, urls.at(current_app).url.at(current_url));
-  current_url++;
+  SendMessageToSDK(pt_string, app_url.second);
 #endif  // PROPRIETARY_MODE
   // reset update required false
   OnUpdateRequestSentToMobile();
@@ -1880,6 +1855,18 @@ void PolicyHandler::Add(const std::string& app_id,
   policy_manager_->Add(app_id, type, timespan_seconds);
 }
 
+bool PolicyHandler::IsUrlAppIdValid(const std::string& policy_app_id) const {
+  bool is_registered = false;
+  bool is_default = false;
+
+  ApplicationSharedPtr app =
+      application_manager_.application_by_policy_id(policy_app_id);
+
+  is_registered = (app && (app->IsRegistered()));
+  is_default = (policy_app_id == policy::kDefaultId);
+
+  return (is_registered || is_default);
+}
 #ifdef SDL_REMOTE_CONTROL
 void PolicyHandler::UpdateHMILevel(ApplicationSharedPtr app,
                                    mobile_apis::HMILevel::eType level) {

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1415,10 +1415,11 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
   }
 
   AppIdURL app_url = policy_manager_->GetNextUpdateUrl(urls);
-  while (!IsUrlAppIdValid(app_url.first)) {
+  while (!IsUrlAppIdValid(app_url.first, urls)) {
     app_url = policy_manager_->GetNextUpdateUrl(urls);
   }
-  SendMessageToSDK(pt_string, app_url.second);
+  const std::string& url = urls[app_url.first].url[app_url.second];
+  SendMessageToSDK(pt_string, url);
 #endif  // PROPRIETARY_MODE
   // reset update required false
   OnUpdateRequestSentToMobile();
@@ -1854,14 +1855,18 @@ void PolicyHandler::Add(const std::string& app_id,
   policy_manager_->Add(app_id, type, timespan_seconds);
 }
 
-bool PolicyHandler::IsUrlAppIdValid(const std::string& policy_app_id) const {
-  ApplicationSharedPtr app =
-      application_manager_.application_by_policy_id(policy_app_id);
+bool PolicyHandler::IsUrlAppIdValid(const int app_idx,
+                                    const EndpointUrls& urls) const {
+  const EndpointData& app_data = urls[app_idx];
+  const std::vector<std::string> app_urls = app_data.url;
+  const ApplicationSharedPtr app =
+      application_manager_.application_by_policy_id(app_data.app_id);
 
   const bool is_registered = (app && (app->IsRegistered()));
-  const bool is_default = (policy_app_id == policy::kDefaultId);
+  const bool is_default = (app_data.app_id == policy::kDefaultId);
+  const bool is_empty_urls = app_urls.empty();
 
-  return (is_registered || is_default);
+  return ((is_registered && !is_empty_urls) || is_default);
 }
 #ifdef SDL_REMOTE_CONTROL
 void PolicyHandler::UpdateHMILevel(ApplicationSharedPtr app,

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1855,7 +1855,7 @@ void PolicyHandler::Add(const std::string& app_id,
   policy_manager_->Add(app_id, type, timespan_seconds);
 }
 
-bool PolicyHandler::IsUrlAppIdValid(const int app_idx,
+bool PolicyHandler::IsUrlAppIdValid(const uint32_t app_idx,
                                     const EndpointUrls& urls) const {
   const EndpointData& app_data = urls[app_idx];
   const std::vector<std::string> app_urls = app_data.url;

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -485,6 +485,12 @@ void PolicyHandler::GetAvailableApps(std::queue<std::string>& apps) {
   }
 }
 
+struct SmartObjectToInt {
+  int operator()(const smart_objects::SmartObject& item) const {
+    return item.asInt();
+  }
+};
+
 StatusNotifier PolicyHandler::AddApplication(
     const std::string& application_id) {
   POLICY_LIB_CHECK(utils::MakeShared<utils::CallNothing>());

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1414,8 +1414,7 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
     return;
   }
 
-  AppIdURL app_url;
-  app_url = policy_manager_->GetNextUpdateUrl(urls);
+  AppIdURL app_url = policy_manager_->GetNextUpdateUrl(urls);
   while (!IsUrlAppIdValid(app_url.first)) {
     app_url = policy_manager_->GetNextUpdateUrl(urls);
   }
@@ -1856,14 +1855,11 @@ void PolicyHandler::Add(const std::string& app_id,
 }
 
 bool PolicyHandler::IsUrlAppIdValid(const std::string& policy_app_id) const {
-  bool is_registered = false;
-  bool is_default = false;
-
   ApplicationSharedPtr app =
       application_manager_.application_by_policy_id(policy_app_id);
 
-  is_registered = (app && (app->IsRegistered()));
-  is_default = (policy_app_id == policy::kDefaultId);
+  const bool is_registered = (app && (app->IsRegistered()));
+  const bool is_default = (policy_app_id == policy::kDefaultId);
 
   return (is_registered || is_default);
 }

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -88,6 +88,8 @@ using ::testing::DoAll;
 using ::testing::SetArgReferee;
 using ::testing::Mock;
 
+const std::string kDummyData = "some_data";
+
 class PolicyHandlerTest : public ::testing::Test {
  public:
   PolicyHandlerTest()
@@ -1662,9 +1664,9 @@ TEST_F(PolicyHandlerTest, DISABLED_OnSnapshotCreated_UrlAdded) {
   EnablePolicyAndPolicyManagerMock();
   BinaryMessage msg;
   EndpointUrls test_data;
-  EndpointData data("some_data");
+  EndpointData data(kDummyData);
   test_data.push_back(data);
-  AppIdURL next_app_url = std::make_pair("default", "some data");
+  AppIdURL next_app_url = std::make_pair(kDefaultId, kDummyData);
   ApplicationSharedPtr mock_app;
 
 #ifdef PROPRIETARY_MODE

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -1664,12 +1664,18 @@ TEST_F(PolicyHandlerTest, DISABLED_OnSnapshotCreated_UrlAdded) {
   EndpointUrls test_data;
   EndpointData data("some_data");
   test_data.push_back(data);
+  AppIdURL next_app_url = std::make_pair("default", "some data");
+  ApplicationSharedPtr mock_app;
 
 #ifdef PROPRIETARY_MODE
   ExtendedPolicyExpectations();
 #else
   EXPECT_CALL(*mock_policy_manager_, GetUpdateUrls("0x07", _))
       .WillRepeatedly(SetArgReferee<1>(test_data));
+  EXPECT_CALL(*mock_policy_manager_, GetNextUpdateUrl(_))
+      .WillOnce(Return(next_app_url));
+  EXPECT_CALL(app_manager_, application_by_policy_id(_))
+      .WillOnce(Return(mock_app));
   EXPECT_CALL(app_manager_, connection_handler())
       .WillOnce(ReturnRef(conn_handler));
   EXPECT_CALL(conn_handler, get_session_observer())
@@ -1685,6 +1691,7 @@ TEST_F(PolicyHandlerTest, DISABLED_OnSnapshotCreated_UrlAdded) {
   EXPECT_CALL(*mock_app_, policy_app_id()).WillOnce(Return(kPolicyAppId_));
 #endif  // PROPRIETARY_MODE
 
+  EXPECT_CALL(*mock_policy_manager_, OnUpdateStarted());
   policy_handler_.OnSnapshotCreated(msg);
 }
 #endif  // EXTERNAL_PROPRIETARY_MODE

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -1666,7 +1666,7 @@ TEST_F(PolicyHandlerTest, DISABLED_OnSnapshotCreated_UrlAdded) {
   EndpointUrls test_data;
   EndpointData data(kDummyData);
   test_data.push_back(data);
-  AppIdURL next_app_url = std::make_pair(kDefaultId, kDummyData);
+  AppIdURL next_app_url = std::make_pair(0, 0);
   ApplicationSharedPtr mock_app;
 
 #ifdef PROPRIETARY_MODE

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -1666,12 +1666,12 @@ TEST_F(PolicyHandlerTest, DISABLED_OnSnapshotCreated_UrlAdded) {
   EndpointUrls test_data;
   EndpointData data(kDummyData);
   test_data.push_back(data);
-  AppIdURL next_app_url = std::make_pair(0, 0);
   ApplicationSharedPtr mock_app;
 
 #ifdef PROPRIETARY_MODE
   ExtendedPolicyExpectations();
 #else
+  AppIdURL next_app_url = std::make_pair(0, 0);
   EXPECT_CALL(*mock_policy_manager_, GetUpdateUrls("0x07", _))
       .WillRepeatedly(SetArgReferee<1>(test_data));
   EXPECT_CALL(*mock_policy_manager_, GetNextUpdateUrl(_))

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -487,7 +487,8 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   /**
    * @brief Finds the next URL that must be sent on OnSystemRequest retry
    * @param urls vector of vectors that contain urls for each application
-   * @return Pair of policy application id and application url id
+   * @return Pair of policy application id and application url id from the
+   * urls vector
    */
   virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) = 0;
 #ifdef SDL_REMOTE_CONTROL
@@ -646,6 +647,18 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void set_access_remote(
       utils::SharedPtr<AccessRemote> access_remote) = 0;
 #endif  // SDL_REMOTE_CONTROL
+
+  /**
+   * @brief Checks if there is existing URL in the EndpointUrls vector with
+   * index saved in the policy manager and if not, it moves to the next
+   * application index
+   * @param rs contains the application index and url index from the
+   * urls vector that are to be sent on the next OnSystemRequest
+   * @param urls vector of vectors that contain urls for each application
+   * @return Pair of application index and url index
+   */
+  virtual AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
+                                    const EndpointUrls& urls) const = 0;
 
   /**
    * @brief Saves customer connectivity settings status

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -484,10 +484,15 @@ class PolicyManager : public usage_statistics::StatisticsManager {
 
   virtual const PolicySettings& get_settings() const = 0;
 
+  /**
+   * @brief Finds the next URL that must be sent on OnSystemRequest retry
+   * @param urls vector of vectors that contain urls for each application
+   * @return Pair of policy application id and application url
+   */
+  virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) = 0;
 #ifdef SDL_REMOTE_CONTROL
   virtual void SetDefaultHmiTypes(const std::string& application_id,
                                   const std::vector<int>& hmi_types) = 0;
-
   /**
    * Gets HMI types
    * @param application_id ID application

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -487,7 +487,7 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   /**
    * @brief Finds the next URL that must be sent on OnSystemRequest retry
    * @param urls vector of vectors that contain urls for each application
-   * @return Pair of policy application id and application url
+   * @return Pair of policy application id and application url id
    */
   virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) = 0;
 #ifdef SDL_REMOTE_CONTROL

--- a/src/components/include/policy/policy_external/policy/policy_types.h
+++ b/src/components/include/policy/policy_external/policy/policy_types.h
@@ -366,17 +366,20 @@ struct MetaInfo {
 };
 
 /**
- * @brief The index of the application and the index of its URL
- * from the Endpoints vector that will be sent on the next
- * OnSystemRequest retry sequence
+ * @brief The index of the application, the index of its URL
+ * and the policy application id from the Endpoints vector
+ * that will be sent on the next OnSystemRequest retry sequence
  */
 struct RetrySequenceURL {
   int app_idx_;
   int url_idx_;
-  RetrySequenceURL(int app, int url) : app_idx_(app), url_idx_(url) {}
+  std::string policy_app_id_;
+  RetrySequenceURL(int app, int url, const std::string& app_id)
+      : app_idx_(app), url_idx_(url), policy_app_id_(app_id) {}
   RetrySequenceURL() {
     app_idx_ = 0;
     url_idx_ = 0;
+    policy_app_id_ = "";
   }
 }
 

--- a/src/components/include/policy/policy_external/policy/policy_types.h
+++ b/src/components/include/policy/policy_external/policy/policy_types.h
@@ -365,6 +365,11 @@ struct MetaInfo {
   std::string language;
 };
 
+/**
+ * @brief The index of the application and the index of its URL
+ * from the Endpoints vector that will be sent on the next
+ * OnSystemRequest retry sequence
+ */
 struct RetrySequenceURL {
   int app_idx_;
   int url_idx_;
@@ -375,7 +380,7 @@ struct RetrySequenceURL {
   }
 }
 
-typedef std::pair<std::string, std::string> AppIdURL;
+typedef std::pair<int, int> AppIdURL;
 
 /**
  * @brief The ExternalConsentStatusItem struct represents external user consent

--- a/src/components/include/policy/policy_external/policy/policy_types.h
+++ b/src/components/include/policy/policy_external/policy/policy_types.h
@@ -365,6 +365,19 @@ struct MetaInfo {
   std::string language;
 };
 
+struct RetrySequenceURL {
+  int app;
+  int url;
+  RetrySequenceURL(int app_idx, int url_idx) {
+    app = app_idx;
+    url = url_idx;
+  }
+}
+
+typedef struct RetrySequenceURL RetrySequenceURL;
+
+typedef std::pair<std::string, std::string> AppIdURL;
+
 /**
  * @brief The ExternalConsentStatusItem struct represents external user consent
  * settings item

--- a/src/components/include/policy/policy_external/policy/policy_types.h
+++ b/src/components/include/policy/policy_external/policy/policy_types.h
@@ -366,15 +366,14 @@ struct MetaInfo {
 };
 
 struct RetrySequenceURL {
-  int app;
-  int url;
-  RetrySequenceURL(int app_idx, int url_idx) {
-    app = app_idx;
-    url = url_idx;
+  int app_idx_;
+  int url_idx_;
+  RetrySequenceURL(int app, int url) : app_idx_(app), url_idx_(url) {}
+  RetrySequenceURL() {
+    app_idx_ = 0;
+    url_idx_ = 0;
   }
 }
-
-typedef struct RetrySequenceURL RetrySequenceURL;
 
 typedef std::pair<std::string, std::string> AppIdURL;
 

--- a/src/components/include/policy/policy_external/policy/policy_types.h
+++ b/src/components/include/policy/policy_external/policy/policy_types.h
@@ -371,19 +371,19 @@ struct MetaInfo {
  * that will be sent on the next OnSystemRequest retry sequence
  */
 struct RetrySequenceURL {
-  int app_idx_;
-  int url_idx_;
+  uint32_t app_idx_;
+  uint32_t url_idx_;
   std::string policy_app_id_;
-  RetrySequenceURL(int app, int url, const std::string& app_id)
+  RetrySequenceURL(uint32_t app, uint32_t url, const std::string& app_id)
       : app_idx_(app), url_idx_(url), policy_app_id_(app_id) {}
-  RetrySequenceURL() {
-    app_idx_ = 0;
-    url_idx_ = 0;
-    policy_app_id_ = "";
-  }
-}
+  RetrySequenceURL() : app_idx_(0), url_idx_(0) {}
+};
 
-typedef std::pair<int, int> AppIdURL;
+/**
+ * @brief Index of the application, index of its URL
+ * from the Endpoints vector
+ */
+typedef std::pair<uint32_t, uint32_t> AppIdURL;
 
 /**
  * @brief The ExternalConsentStatusItem struct represents external user consent

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -473,6 +473,13 @@ class PolicyManager : public usage_statistics::StatisticsManager {
 
   virtual const PolicySettings& get_settings() const = 0;
 
+  /**
+   * @brief Finds the next URL that must be sent on OnSystemRequest retry
+   * @param urls vector of vectors that contain urls for each application
+   * @return Pair of policy application id and application url id from the
+   * urls vector
+   */
+  virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) = 0;
 #ifdef SDL_REMOTE_CONTROL
   virtual void SetDefaultHmiTypes(const std::string& application_id,
                                   const std::vector<int>& hmi_types) = 0;
@@ -630,6 +637,18 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void set_access_remote(
       utils::SharedPtr<AccessRemote> access_remote) = 0;
 #endif  // SDL_REMOTE_CONTROL
+
+  /**
+   * @brief Checks if there is existing URL in the EndpointUrls vector with
+   * index saved in the policy manager and if not, it moves to the next
+   * application index
+   * @param rs contains the application index and url index from the
+   * urls vector that are to be sent on the next OnSystemRequest
+   * @param urls vector of vectors that contain urls for each application
+   * @return Pair of application index and url index
+   */
+  virtual AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
+                                    const EndpointUrls& urls) const = 0;
 
  protected:
   /**

--- a/src/components/include/policy/policy_regular/policy/policy_types.h
+++ b/src/components/include/policy/policy_regular/policy/policy_types.h
@@ -316,17 +316,20 @@ struct MetaInfo {
 };
 
 /**
- * @brief The index of the application and the index of its URL
- * from the Endpoints vector that will be sent on the next
- * OnSystemRequest retry sequence
+ * @brief The index of the application, the index of its URL
+ * and the policy application id from the Endpoints vector
+ * that will be sent on the next OnSystemRequest retry sequence
  */
 struct RetrySequenceURL {
   int app_idx_;
   int url_idx_;
-  RetrySequenceURL(int app, int url) : app_idx_(app), url_idx_(url) {}
+  std::string policy_app_id_;
+  RetrySequenceURL(int app, int url, const std::string& app_id)
+      : app_idx_(app), url_idx_(url), policy_app_id_(app_id) {}
   RetrySequenceURL() {
     app_idx_ = 0;
     url_idx_ = 0;
+    policy_app_id_ = "";
   }
 };
 

--- a/src/components/include/policy/policy_regular/policy/policy_types.h
+++ b/src/components/include/policy/policy_regular/policy/policy_types.h
@@ -315,6 +315,11 @@ struct MetaInfo {
   std::string language;
 };
 
+/**
+ * @brief The index of the application and the index of its URL
+ * from the Endpoints vector that will be sent on the next
+ * OnSystemRequest retry sequence
+ */
 struct RetrySequenceURL {
   int app_idx_;
   int url_idx_;
@@ -325,7 +330,7 @@ struct RetrySequenceURL {
   }
 };
 
-typedef std::pair<std::string, std::string> AppIdURL;
+typedef std::pair<int, int> AppIdURL;
 
 }  //  namespace policy
 

--- a/src/components/include/policy/policy_regular/policy/policy_types.h
+++ b/src/components/include/policy/policy_regular/policy/policy_types.h
@@ -321,19 +321,19 @@ struct MetaInfo {
  * that will be sent on the next OnSystemRequest retry sequence
  */
 struct RetrySequenceURL {
-  int app_idx_;
-  int url_idx_;
+  uint32_t app_idx_;
+  uint32_t url_idx_;
   std::string policy_app_id_;
-  RetrySequenceURL(int app, int url, const std::string& app_id)
+  RetrySequenceURL(uint32_t app, uint32_t url, const std::string& app_id)
       : app_idx_(app), url_idx_(url), policy_app_id_(app_id) {}
-  RetrySequenceURL() {
-    app_idx_ = 0;
-    url_idx_ = 0;
-    policy_app_id_ = "";
-  }
+  RetrySequenceURL() : app_idx_(0), url_idx_(0) {}
 };
 
-typedef std::pair<int, int> AppIdURL;
+/**
+ * @brief Index of the application, index of its URL
+ * from the Endpoints vector
+ */
+typedef std::pair<uint32_t, uint32_t> AppIdURL;
 
 }  //  namespace policy
 

--- a/src/components/include/policy/policy_regular/policy/policy_types.h
+++ b/src/components/include/policy/policy_regular/policy/policy_types.h
@@ -315,6 +315,19 @@ struct MetaInfo {
   std::string language;
 };
 
+struct RetrySequenceURL {
+  int app;
+  int url;
+  RetrySequenceURL(int app_idx, int url_idx) {
+    app = app_idx;
+    url = url_idx;
+  }
+};
+
+typedef struct RetrySequenceURL RetrySequenceURL;
+
+typedef std::pair<std::string, std::string> AppIdURL;
+
 }  //  namespace policy
 
 #endif  // SRC_COMPONENTS_INCLUDE_POLICY_POLICY_TYPES_H_

--- a/src/components/include/policy/policy_regular/policy/policy_types.h
+++ b/src/components/include/policy/policy_regular/policy/policy_types.h
@@ -316,15 +316,14 @@ struct MetaInfo {
 };
 
 struct RetrySequenceURL {
-  int app;
-  int url;
-  RetrySequenceURL(int app_idx, int url_idx) {
-    app = app_idx;
-    url = url_idx;
+  int app_idx_;
+  int url_idx_;
+  RetrySequenceURL(int app, int url) : app_idx_(app), url_idx_(url) {}
+  RetrySequenceURL() {
+    app_idx_ = 0;
+    url_idx_ = 0;
   }
 };
-
-typedef struct RetrySequenceURL RetrySequenceURL;
 
 typedef std::pair<std::string, std::string> AppIdURL;
 

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -235,6 +235,7 @@ class MockPolicyManager : public PolicyManager {
                     int32_t timespan_seconds));
   MOCK_CONST_METHOD0(get_settings, const PolicySettings&());
   MOCK_METHOD1(set_settings, void(const PolicySettings* get_settings));
+  MOCK_METHOD1(GetNextUpdateUrl, AppIdURL(const EndpointUrls& urls));
   MOCK_METHOD1(SaveExternalConsentStatus, bool(const ExternalConsentStatus&));
   MOCK_METHOD0(GetExternalConsentStatus, ExternalConsentStatus());
 };

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -236,6 +236,9 @@ class MockPolicyManager : public PolicyManager {
   MOCK_CONST_METHOD0(get_settings, const PolicySettings&());
   MOCK_METHOD1(set_settings, void(const PolicySettings* get_settings));
   MOCK_METHOD1(GetNextUpdateUrl, AppIdURL(const EndpointUrls& urls));
+  MOCK_CONST_METHOD2(RetrySequenceUrl,
+                     AppIdURL(const struct RetrySequenceURL&,
+                              const EndpointUrls& urls));
   MOCK_METHOD1(SaveExternalConsentStatus, bool(const ExternalConsentStatus&));
   MOCK_METHOD0(GetExternalConsentStatus, ExternalConsentStatus());
 };

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -240,6 +240,9 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD1(set_settings, void(const PolicySettings* get_settings));
   MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
   MOCK_METHOD1(GetNextUpdateUrl, AppIdURL(const EndpointUrls& urls));
+  MOCK_CONST_METHOD2(RetrySequenceUrl,
+                     AppIdURL(const struct RetrySequenceURL&,
+                              const EndpointUrls& urls));
   MOCK_METHOD6(CheckPermissions,
                void(const PTString& device_id,
                     const PTString& app_id,

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -239,6 +239,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_CONST_METHOD0(get_settings, const PolicySettings&());
   MOCK_METHOD1(set_settings, void(const PolicySettings* get_settings));
   MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
+  MOCK_METHOD1(GetNextUpdateUrl, AppIdURL(const EndpointUrls& urls));
   MOCK_METHOD6(CheckPermissions,
                void(const PTString& device_id,
                     const PTString& app_id,

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -419,6 +419,12 @@ class PolicyManagerImpl : public PolicyManager {
 
   const PolicySettings* settings_;
   friend struct CheckAppPolicy;
+
+  /**
+   * @brief Pair of app index and url index from Endpoints vector
+   * that contains all application URLs
+   */
+  RetrySequenceURL retry_sequence_url_;
   friend struct ProccessAppGroups;
 };
 

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -247,6 +247,7 @@ class PolicyManagerImpl : public PolicyManager {
 
   const PolicySettings& get_settings() const OVERRIDE;
 
+  virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) OVERRIDE;
   bool SaveExternalConsentStatus(const ExternalConsentStatus& status) OVERRIDE;
   ExternalConsentStatus GetExternalConsentStatus() OVERRIDE;
 

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -247,6 +247,10 @@ class PolicyManagerImpl : public PolicyManager {
 
   const PolicySettings& get_settings() const OVERRIDE;
 
+  AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) OVERRIDE;
+
+  AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
+                            const EndpointUrls& urls) const OVERRIDE;
   virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) OVERRIDE;
   bool SaveExternalConsentStatus(const ExternalConsentStatus& status) OVERRIDE;
   ExternalConsentStatus GetExternalConsentStatus() OVERRIDE;

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -76,7 +76,7 @@ PolicyManagerImpl::PolicyManagerImpl()
     , retry_sequence_timeout_(60)
     , retry_sequence_index_(0)
     , ignition_check(true)
-    , retry_sequence_url_(0, 0) {
+    , retry_sequence_url_(0, 0, "") {
 }
 
 PolicyManagerImpl::PolicyManagerImpl(bool in_memory)
@@ -90,7 +90,7 @@ PolicyManagerImpl::PolicyManagerImpl(bool in_memory)
     , retry_sequence_timeout_(60)
     , retry_sequence_index_(0)
     , ignition_check(true)
-    , retry_sequence_url_(0, 0) {
+    , retry_sequence_url_(0, 0, "") {
 }
 
 void PolicyManagerImpl::set_listener(PolicyListener* listener) {

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1248,20 +1248,21 @@ void PolicyManagerImpl::SetDecryptedCertificate(
 AppIdURL PolicyManagerImpl::GetNextUpdateUrl(const EndpointUrls& urls) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  AppIdURL next_app_url;
-  uint32_t url = retry_sequence_url_.url;
-  uint32_t app = retry_sequence_url_.app;
+  uint32_t current_url_idx = retry_sequence_url_.url_idx_;
+  uint32_t current_app_idx = retry_sequence_url_.app_idx_;
 
-  if (url >= urls[app].url.size()) {
-    url = 0;
-    if (++app >= urls.size()) {
-      app = 0;
+  if (current_url_idx >= urls[current_app_idx].url.size()) {
+    current_url_idx = 0;
+    if (++current_app_idx >= urls.size()) {
+      current_app_idx = 0;
     }
   }
 
-  next_app_url = std::make_pair(urls[app].app_id, urls[app].url[url]);
-  retry_sequence_url_.url = url + 1;
-  retry_sequence_url_.app = app;
+  const std::string app = urls[current_app_idx].app_id;
+  const std::string url = urls[current_app_idx].url[current_url_idx];
+  const AppIdURL next_app_url = std::make_pair(app, url);
+  retry_sequence_url_.url_idx_ = current_url_idx + 1;
+  retry_sequence_url_.app_idx_ = current_app_idx;
 
   return next_app_url;
 }

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1261,14 +1261,20 @@ AppIdURL PolicyManagerImpl::RetrySequenceUrl(const struct RetrySequenceURL& rs,
                                              const EndpointUrls& urls) const {
   uint32_t url_idx = rs.url_idx_;
   uint32_t app_idx = rs.app_idx_;
-  const std::string app_id = rs.policy_app_id_;
+  const std::string& app_id = rs.policy_app_id_;
 
   if (urls.size() <= app_idx) {
+    // Index of current application doesn't exist any more due to app(s)
+    // unregistration
     url_idx = 0;
     app_idx = 0;
   } else if (urls[app_idx].app_id != app_id) {
+    // Index of current application points to another one due to app(s)
+    // registration/unregistration
     url_idx = 0;
   } else if (url_idx >= urls[app_idx].url.size()) {
+    // Index of current application is OK, but all of its URL are sent,
+    // move to the next application
     url_idx = 0;
     if (++app_idx >= urls.size()) {
       app_idx = 0;

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1252,6 +1252,7 @@ AppIdURL PolicyManagerImpl::GetNextUpdateUrl(const EndpointUrls& urls) {
 
   retry_sequence_url_.url_idx_ = next_app_url.second + 1;
   retry_sequence_url_.app_idx_ = next_app_url.first;
+  retry_sequence_url_.policy_app_id_ = urls[next_app_url.first].app_id;
 
   return next_app_url;
 }
@@ -1260,8 +1261,14 @@ AppIdURL PolicyManagerImpl::RetrySequenceUrl(const struct RetrySequenceURL& rs,
                                              const EndpointUrls& urls) const {
   uint32_t url_idx = rs.url_idx_;
   uint32_t app_idx = rs.app_idx_;
+  const std::string app_id = rs.policy_app_id_;
 
-  if (url_idx >= urls[app_idx].url.size()) {
+  if (urls.size() <= app_idx) {
+    url_idx = 0;
+    app_idx = 0;
+  } else if (urls[app_idx].app_id != app_id) {
+    url_idx = 0;
+  } else if (url_idx >= urls[app_idx].url.size()) {
     url_idx = 0;
     if (++app_idx >= urls.size()) {
       app_idx = 0;

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1248,21 +1248,26 @@ void PolicyManagerImpl::SetDecryptedCertificate(
 AppIdURL PolicyManagerImpl::GetNextUpdateUrl(const EndpointUrls& urls) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  uint32_t current_url_idx = retry_sequence_url_.url_idx_;
-  uint32_t current_app_idx = retry_sequence_url_.app_idx_;
+  const AppIdURL next_app_url = RetrySequenceUrl(retry_sequence_url_, urls);
 
-  if (current_url_idx >= urls[current_app_idx].url.size()) {
-    current_url_idx = 0;
-    if (++current_app_idx >= urls.size()) {
-      current_app_idx = 0;
+  retry_sequence_url_.url_idx_ = next_app_url.second + 1;
+  retry_sequence_url_.app_idx_ = next_app_url.first;
+
+  return next_app_url;
+}
+
+AppIdURL PolicyManagerImpl::RetrySequenceUrl(const struct RetrySequenceURL& rs,
+                                             const EndpointUrls& urls) const {
+  uint32_t url_idx = rs.url_idx_;
+  uint32_t app_idx = rs.app_idx_;
+
+  if (url_idx >= urls[app_idx].url.size()) {
+    url_idx = 0;
+    if (++app_idx >= urls.size()) {
+      app_idx = 0;
     }
   }
-
-  const std::string app = urls[current_app_idx].app_id;
-  const std::string url = urls[current_app_idx].url[current_url_idx];
-  const AppIdURL next_app_url = std::make_pair(app, url);
-  retry_sequence_url_.url_idx_ = current_url_idx + 1;
-  retry_sequence_url_.app_idx_ = current_app_idx;
+  const AppIdURL next_app_url = std::make_pair(app_idx, url_idx);
 
   return next_app_url;
 }

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -246,6 +246,11 @@ class PolicyManagerImpl : public PolicyManager {
 
   virtual bool HasCertificate() const OVERRIDE;
 
+  AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) OVERRIDE;
+
+  AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
+                            const EndpointUrls& urls) const OVERRIDE;
+
  protected:
 #ifdef USE_HMI_PTU_DECRYPTION
   virtual utils::SharedPtr<policy_table::Table> Parse(
@@ -256,11 +261,6 @@ class PolicyManagerImpl : public PolicyManager {
 #endif
 
   const PolicySettings& get_settings() const OVERRIDE;
-
-  AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) OVERRIDE;
-
-  AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
-                            const EndpointUrls& urls) const OVERRIDE;
 
  private:
   void CheckTriggers();

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -257,7 +257,7 @@ class PolicyManagerImpl : public PolicyManager {
 
   const PolicySettings& get_settings() const OVERRIDE;
 
-  virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls);
+  virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) OVERRIDE;
 
  private:
   void CheckTriggers();

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -257,7 +257,10 @@ class PolicyManagerImpl : public PolicyManager {
 
   const PolicySettings& get_settings() const OVERRIDE;
 
-  virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) OVERRIDE;
+  AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) OVERRIDE;
+
+  AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
+                            const EndpointUrls& urls) const OVERRIDE;
 
  private:
   void CheckTriggers();

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -257,6 +257,8 @@ class PolicyManagerImpl : public PolicyManager {
 
   const PolicySettings& get_settings() const OVERRIDE;
 
+  virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls);
+
  private:
   void CheckTriggers();
   /*
@@ -430,6 +432,12 @@ class PolicyManagerImpl : public PolicyManager {
   const PolicySettings* settings_;
   friend struct CheckAppPolicy;
   friend struct ProccessAppGroups;
+
+  /**
+   * @brief Pair of app index and url index from Endpoints vector
+   * that contains all application URLs
+   */
+  RetrySequenceURL retry_sequence_url_;
 };
 
 }  // namespace policy

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -973,22 +973,24 @@ std::string PolicyManagerImpl::RetrieveCertificate() const {
 AppIdURL PolicyManagerImpl::GetNextUpdateUrl(const EndpointUrls& urls) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  AppIdURL next_app_url;
-  uint32_t url = retry_sequence_url_.url;
-  uint32_t app = retry_sequence_url_.app;
+  uint32_t current_url_idx = retry_sequence_url_.url_idx_;
+  uint32_t current_app_idx = retry_sequence_url_.app_idx_;
 
-  if (url >= urls[app].url.size()) {
-    url = 0;
-    if (++app >= urls.size()) {
-      app = 0;
+  if (current_url_idx >= urls[current_app_idx].url.size()) {
+    current_url_idx = 0;
+    if (++current_app_idx >= urls.size()) {
+      current_app_idx = 0;
     }
   }
 
-  next_app_url = std::make_pair(urls[app].app_id, urls[app].url[url]);
-  retry_sequence_url_.url = url + 1;
-  retry_sequence_url_.app = app;
+  const std::string app = urls[current_app_idx].app_id;
+  const std::string url = urls[current_app_idx].url[current_url_idx];
+  const AppIdURL next_app_url = std::make_pair(app, url);
+  retry_sequence_url_.url_idx_ = current_url_idx + 1;
+  retry_sequence_url_.app_idx_ = current_app_idx;
 
   return next_app_url;
+}
 bool PolicyManagerImpl::HasCertificate() const {
   return !cache_->GetCertificate().empty();
 }

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -986,14 +986,20 @@ AppIdURL PolicyManagerImpl::RetrySequenceUrl(const struct RetrySequenceURL& rs,
                                              const EndpointUrls& urls) const {
   uint32_t url_idx = rs.url_idx_;
   uint32_t app_idx = rs.app_idx_;
-  const std::string app_id = rs.policy_app_id_;
+  const std::string& app_id = rs.policy_app_id_;
 
   if (urls.size() <= app_idx) {
+    // Index of current application doesn't exist any more due to app(s)
+    // unregistration
     url_idx = 0;
     app_idx = 0;
   } else if (urls[app_idx].app_id != app_id) {
+    // Index of current application points to another one due to app(s)
+    // registration/unregistration
     url_idx = 0;
   } else if (url_idx >= urls[app_idx].url.size()) {
+    // Index of current application is OK, but all of its URL are sent,
+    // move to the next application
     url_idx = 0;
     if (++app_idx >= urls.size()) {
       app_idx = 0;

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -977,6 +977,7 @@ AppIdURL PolicyManagerImpl::GetNextUpdateUrl(const EndpointUrls& urls) {
 
   retry_sequence_url_.url_idx_ = next_app_url.second + 1;
   retry_sequence_url_.app_idx_ = next_app_url.first;
+  retry_sequence_url_.policy_app_id_ = urls[next_app_url.first].app_id;
 
   return next_app_url;
 }
@@ -985,8 +986,14 @@ AppIdURL PolicyManagerImpl::RetrySequenceUrl(const struct RetrySequenceURL& rs,
                                              const EndpointUrls& urls) const {
   uint32_t url_idx = rs.url_idx_;
   uint32_t app_idx = rs.app_idx_;
+  const std::string app_id = rs.policy_app_id_;
 
-  if (url_idx >= urls[app_idx].url.size()) {
+  if (urls.size() <= app_idx) {
+    url_idx = 0;
+    app_idx = 0;
+  } else if (urls[app_idx].app_id != app_id) {
+    url_idx = 0;
+  } else if (url_idx >= urls[app_idx].url.size()) {
     url_idx = 0;
     if (++app_idx >= urls.size()) {
       app_idx = 0;

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -973,21 +973,26 @@ std::string PolicyManagerImpl::RetrieveCertificate() const {
 AppIdURL PolicyManagerImpl::GetNextUpdateUrl(const EndpointUrls& urls) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  uint32_t current_url_idx = retry_sequence_url_.url_idx_;
-  uint32_t current_app_idx = retry_sequence_url_.app_idx_;
+  const AppIdURL next_app_url = RetrySequenceUrl(retry_sequence_url_, urls);
 
-  if (current_url_idx >= urls[current_app_idx].url.size()) {
-    current_url_idx = 0;
-    if (++current_app_idx >= urls.size()) {
-      current_app_idx = 0;
+  retry_sequence_url_.url_idx_ = next_app_url.second + 1;
+  retry_sequence_url_.app_idx_ = next_app_url.first;
+
+  return next_app_url;
+}
+
+AppIdURL PolicyManagerImpl::RetrySequenceUrl(const struct RetrySequenceURL& rs,
+                                             const EndpointUrls& urls) const {
+  uint32_t url_idx = rs.url_idx_;
+  uint32_t app_idx = rs.app_idx_;
+
+  if (url_idx >= urls[app_idx].url.size()) {
+    url_idx = 0;
+    if (++app_idx >= urls.size()) {
+      app_idx = 0;
     }
   }
-
-  const std::string app = urls[current_app_idx].app_id;
-  const std::string url = urls[current_app_idx].url[current_url_idx];
-  const AppIdURL next_app_url = std::make_pair(app, url);
-  retry_sequence_url_.url_idx_ = current_url_idx + 1;
-  retry_sequence_url_.app_idx_ = current_app_idx;
+  const AppIdURL next_app_url = std::make_pair(app_idx, url_idx);
 
   return next_app_url;
 }

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -86,7 +86,7 @@ PolicyManagerImpl::PolicyManagerImpl()
                             new timer::TimerTaskImpl<PolicyManagerImpl>(
                                 this, &PolicyManagerImpl::RetrySequence))
     , ignition_check(true)
-    , retry_sequence_url_(0, 0) {
+    , retry_sequence_url_(0, 0, "") {
 }
 
 void PolicyManagerImpl::set_listener(PolicyListener* listener) {

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -85,7 +85,8 @@ PolicyManagerImpl::PolicyManagerImpl()
     , timer_retry_sequence_("Retry sequence timer",
                             new timer::TimerTaskImpl<PolicyManagerImpl>(
                                 this, &PolicyManagerImpl::RetrySequence))
-    , ignition_check(true) {
+    , ignition_check(true)
+    , retry_sequence_url_(0, 0) {
 }
 
 void PolicyManagerImpl::set_listener(PolicyListener* listener) {
@@ -969,6 +970,25 @@ std::string PolicyManagerImpl::RetrieveCertificate() const {
   return cache_->GetCertificate();
 }
 
+AppIdURL PolicyManagerImpl::GetNextUpdateUrl(const EndpointUrls& urls) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  AppIdURL next_app_url;
+  uint32_t url = retry_sequence_url_.url;
+  uint32_t app = retry_sequence_url_.app;
+
+  if (url >= urls[app].url.size()) {
+    url = 0;
+    if (++app >= urls.size()) {
+      app = 0;
+    }
+  }
+
+  next_app_url = std::make_pair(urls[app].app_id, urls[app].url[url]);
+  retry_sequence_url_.url = url + 1;
+  retry_sequence_url_.app = app;
+
+  return next_app_url;
 bool PolicyManagerImpl::HasCertificate() const {
   return !cache_->GetCertificate().empty();
 }


### PR DESCRIPTION
Fix OnSystemRequest cycling urls refactoring

Required refactoring of the functionality that is responsible
for sending different application URL on each OnSystemRequest.
The logic was placed in OnSnapshotCreated method. Now it is
separated on two methods - GetNextUpdateUrl - returns pair of
policy application id and url from the Endpoints vector that
potentially will be sent, IsUrlAppIdValid - checks if given 
policy application id is assigned to a registered application
or it is the default id.

Related-issues: [APPLINK-31359](https://adc.luxoft.com/jira/browse/APPLINK-31359) 