### PR TITLE
[WiP] Fix issue when SDL does not send BC.ActiveApp to HMI

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -254,8 +254,9 @@ class PolicyHandler : public PolicyHandlerInterface,
                                 const std::string& policy_app_id,
                                 const std::string& hmi_level) OVERRIDE;
 
-  void AddApplication(const std::string& application_id,
-                      const smart_objects::SmartObject* app_types) OVERRIDE;
+  StatusNotifier AddApplication(
+      const std::string& application_id,
+      const smart_objects::SmartObject* app_types) OVERRIDE;
 
   /**
      * Checks if application has HMI type

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2564,6 +2564,7 @@ void MessageHelper::SendActivateAppToHMI(
     ApplicationManager& application_manager,
     hmi_apis::Common_HMILevel::eType level,
     bool send_policy_priority) {
+  LOG4CXX_AUTO_TRACE(logger_);
   application_manager::ApplicationConstSharedPtr app =
       application_manager.application(app_id);
   if (!app) {

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -181,7 +181,7 @@ struct SDLAllowedNotification {
   void operator()(const ApplicationSharedPtr& app) {
     DCHECK_OR_RETURN_VOID(policy_manager_);
     if (device_id_ == app->device()) {
-      std::string hmi_level;
+      std::string hmi_level = "NONE";
       mobile_apis::HMILevel::eType default_mobile_hmi;
       policy_manager_->GetDefaultHmi(app->policy_app_id(), &hmi_level);
       if ("BACKGROUND" == hmi_level) {
@@ -2177,10 +2177,11 @@ bool PolicyHandler::GetModuleTypes(const std::string& policy_app_id,
   return policy_manager_->GetModuleTypes(policy_app_id, modules);
 }
 
-void PolicyHandler::AddApplication(
+StatusNotifier PolicyHandler::AddApplication(
     const std::string& application_id,
     const smart_objects::SmartObject* app_types) {
-  POLICY_LIB_CHECK_VOID();
+  LOG4CXX_AUTO_TRACE(logger_);
+  POLICY_LIB_CHECK(utils::MakeShared<utils::CallNothing>());
   std::vector<int> hmi_types;
   if (app_types && app_types->asArray()) {
     smart_objects::SmartArray* hmi_list = app_types->asArray();
@@ -2189,7 +2190,7 @@ void PolicyHandler::AddApplication(
                    std::back_inserter(hmi_types),
                    SmartObjectToInt());
   }
-  policy_manager_->AddApplication(application_id, hmi_types);
+  return policy_manager_->AddApplication(application_id, hmi_types);
 }
 
 bool PolicyHandler::CheckHMIType(const std::string& application_id,

--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -451,6 +451,7 @@ void CANModule::RemoveAppExtension(uint32_t app_id) {
 }
 
 bool CANModule::IsAppForPlugin(application_manager::ApplicationSharedPtr app) {
+  LOG4CXX_AUTO_TRACE(logger_);
   application_manager::AppExtensionPtr app_extension =
       app->QueryInterface(GetModuleID());
   if (app_extension) {

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -402,8 +402,9 @@ class PolicyHandlerInterface {
 #endif  // ENABLE_SECURITY
 
 #ifdef SDL_REMOTE_CONTROL
-  virtual void AddApplication(const std::string& application_id,
-                              const smart_objects::SmartObject* app_types) = 0;
+  virtual StatusNotifier AddApplication(
+      const std::string& application_id,
+      const smart_objects::SmartObject* app_types) = 0;
 
   /**
    * Checks if application has HMI type

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -466,8 +466,8 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual const PolicySettings& get_settings() const = 0;
 
 #ifdef SDL_REMOTE_CONTROL
-  virtual void AddApplication(const std::string& application_id,
-                              const std::vector<int>& hmi_types) = 0;
+  virtual StatusNotifier AddApplication(const std::string& application_id,
+                                        const std::vector<int>& hmi_types) = 0;
 
   /**
    * Gets HMI types

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -288,9 +288,10 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_CONST_METHOD2(GetModuleTypes,
                      bool(const std::string& policy_app_id,
                           std::vector<std::string>* modules));
-  MOCK_METHOD2(AddApplication,
-               void(const std::string& application_id,
-                    const smart_objects::SmartObject* app_types));
+  MOCK_METHOD2(
+      AddApplication,
+      policy::StatusNotifier(const std::string& application_id,
+                             const smart_objects::SmartObject* app_types));
 #endif  // SDL_REMOTE_CONTROL
 
  private:

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -146,8 +146,8 @@ class MockPolicyManager : public PolicyManager {
                StatusNotifier(const std::string& application_id));
 #ifdef SDL_REMOTE_CONTROL
   MOCK_METHOD2(AddApplication,
-               void(const std::string& application_id,
-                    const std::vector<int>& hmi_types));
+               StatusNotifier(const std::string& application_id,
+                              const std::vector<int>& hmi_types));
   MOCK_METHOD2(GetHMITypes,
                bool(const std::string& application_id,
                     std::vector<int>* app_types));

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1393,7 +1393,7 @@ std::ostream& operator<<(std::ostream& output,
   return output;
 }
 
-#if SDL_REMOTE_CONTROL
+#ifdef SDL_REMOTE_CONTROL
 void PolicyManagerImpl::AddApplication(const std::string& application_id,
                                        const std::vector<int>& hmi_types) {
   LOG4CXX_INFO(logger_, "AddApplication");

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -178,8 +178,8 @@ class PolicyManagerImpl : public PolicyManager {
 
   StatusNotifier AddApplication(const std::string& application_id);
 #ifdef SDL_REMOTE_CONTROL
-  void AddApplication(const std::string& application_id,
-                      const std::vector<int>& hmi_types);
+  StatusNotifier AddApplication(const std::string& application_id,
+                                const std::vector<int>& hmi_types);
 
   /**
        * Gets HMI types


### PR DESCRIPTION
 
 - moved implementation for application_manager_imp.cc fro RC SDL
  - change order of sending notification in register_app_interface_request
  - added default value for hmi_level in RC SDL