### PR TITLE
Fix sending incorrect path to dynamic image

### DIFF
--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -403,11 +403,12 @@ bool PerformAudioPassThruRequest::IsWaitingHMIResponse() {
 void PerformAudioPassThruRequest::ProcessAudioPassThruIcon(
     ApplicationSharedPtr app) {
   LOG4CXX_AUTO_TRACE(logger_);
-  smart_objects::SmartObject msg_params = (*message_)[strings::msg_params];
+  smart_objects::SmartObject& msg_params = (*message_)[strings::msg_params];
 
   audio_pass_thru_icon_exists_ = true;
   if (msg_params.keyExists(strings::audio_pass_thru_icon)) {
-    smart_objects::SmartObject icon = msg_params[strings::audio_pass_thru_icon];
+    smart_objects::SmartObject& icon =
+        msg_params[strings::audio_pass_thru_icon];
     if (MessageHelper::VerifyImage(icon, app, application_manager_) !=
         mobile_apis::Result::SUCCESS) {
       LOG4CXX_WARN(


### PR DESCRIPTION
SDL used to send only icon name in the value of dynamic image
parameter when it is transfered to the HMI in AudioPassThru.
Fix just allowes the image verification funcion to change the value
of the given name.