### PR TITLE
Fix registration of applications with same names and ids but from different rank devices

### DIFF
--- a/src/components/application_manager/include/application_manager/core_service.h
+++ b/src/components/application_manager/include/application_manager/core_service.h
@@ -122,6 +122,13 @@ class CoreService : public Service {
   virtual void ResetAccess(const SeatLocation& zone, const std::string& module);
 
   /**
+   * Gets device handler for device with certain ID
+   * @param device_id the ID of the connected device
+   * @return device handler if device with requested ID was found
+   */
+  virtual uint32_t GetDeviceHandlerById(const std::string& device_id) OVERRIDE;
+
+  /**
    * Sets device as primary device
    * @param dev_id ID device
    */

--- a/src/components/application_manager/include/application_manager/service.h
+++ b/src/components/application_manager/include/application_manager/service.h
@@ -123,6 +123,13 @@ class Service {
                            const std::string& module) = 0;
 
   /**
+   * Gets device handler for device with certain ID
+   * @param device_id the ID of the connected device
+   * @return device handler if device with requested ID was found
+   */
+  virtual uint32_t GetDeviceHandlerById(const std::string& device_id) = 0;
+
+  /**
    * Sets device as primary device
    * @param dev_id ID device
    */

--- a/src/components/application_manager/src/core_service.cc
+++ b/src/components/application_manager/src/core_service.cc
@@ -143,6 +143,13 @@ void CoreService::ResetAccess(const SeatLocation& zone,
 #endif  // SDL_REMOTE_CONTROL
 }
 
+uint32_t CoreService::GetDeviceHandlerById(const std::string& device_id) {
+  uint32_t device_handle = 0;
+  application_manager_.connection_handler().GetDeviceID(device_id,
+                                                        &device_handle);
+  return device_handle;
+}
+
 void CoreService::SetPrimaryDevice(const uint32_t dev_id) {
 #ifdef SDL_REMOTE_CONTROL
   std::string device_handle =

--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -275,11 +275,13 @@ functional_modules::ProcessResult CANModule::HandleMessage(
               params.isMember(message_params::kRank) &&
               params[message_params::kRank].isString();
           if (valid) {
-            uint32_t device_id =
-                params[message_params::kDevice][json_keys::kId].asUInt();
+            const std::string device_id =
+                params[message_params::kDevice][json_keys::kId].asString();
+            const uint32_t device_handle =
+                service()->GetDeviceHandlerById(device_id);
             std::string rank = params[message_params::kRank].asString();
-            PolicyHelper::ChangeDeviceRank(device_id, rank, *this);
-            ModuleHelper::ProccessDeviceRankChanged(device_id, rank, *this);
+            PolicyHelper::ChangeDeviceRank(device_handle, rank, *this);
+            ModuleHelper::ProccessDeviceRankChanged(device_handle, rank, *this);
           } else {
             LOG4CXX_ERROR(logger_,
                           "Invalid RC.OnDeviceRankChanged notification");
@@ -300,16 +302,18 @@ functional_modules::ProcessResult CANModule::HandleMessage(
                   params.get(message_params::kDeviceLocation,
                              Json::Value(Json::nullValue)));
           if (valid) {
-            uint32_t device_id =
-                params[message_params::kDevice][json_keys::kId].asUInt();
+            const std::string device_id =
+                params[message_params::kDevice][json_keys::kId].asString();
+            const uint32_t device_handle =
+                service()->GetDeviceHandlerById(device_id);
             SeatLocation zone =
                 GetInteriorZone(params[message_params::kDeviceLocation]);
 
-            if (DoNeedUnsubscribe(device_id, zone)) {
-              UnsubscribeAppsFromAllInteriorZones(device_id);
+            if (DoNeedUnsubscribe(device_handle, zone)) {
+              UnsubscribeAppsFromAllInteriorZones(device_handle);
             }
 
-            service()->SetDeviceZone(device_id, zone);
+            service()->SetDeviceZone(device_handle, zone);
 
           } else {
             LOG4CXX_ERROR(logger_,

--- a/src/components/can_cooperation/src/message_helper.cc
+++ b/src/components/can_cooperation/src/message_helper.cc
@@ -120,7 +120,6 @@ bool IsMember(const Json::Value& value, const std::string& key) {
 // this validate methods may move to commands
 bool MessageHelper::ValidateDeviceInfo(const Json::Value& value) {
   return value.isObject() && value.isMember(json_keys::kId) &&
-         value[json_keys::kId].isIntegral() &&
          value.isMember(message_params::kName) &&
          value[message_params::kName].isString();
 }

--- a/src/components/can_cooperation/test/include/mock_service.h
+++ b/src/components/can_cooperation/test/include/mock_service.h
@@ -71,6 +71,7 @@ class MockService : public Service {
   MOCK_METHOD1(ResetAccess, void(const ApplicationId& app_id));
   MOCK_METHOD2(ResetAccess,
                void(const SeatLocation& zone, const std::string& module));
+  MOCK_METHOD1(GetDeviceHandlerById, uint32_t(const std::string& device_id));
   MOCK_METHOD1(SetPrimaryDevice, void(const uint32_t dev_id));
   MOCK_METHOD0(ResetPrimaryDevice, void());
   MOCK_CONST_METHOD0(PrimaryDevice, uint32_t());

--- a/src/components/can_cooperation/test/src/can_module_test.cc
+++ b/src/components/can_cooperation/test/src/can_module_test.cc
@@ -64,6 +64,12 @@ using ::application_manager::MessageType;
 using ::application_manager::ApplicationSharedPtr;
 using ::protocol_handler::MessagePriority;
 
+namespace {
+const bool kDeviceHandle = 1u;
+const std::string kDeviceId = "1";
+const std::string kDeviceName = "1";
+}
+
 namespace can_cooperation {
 
 class CanModuleTest : public ::testing::Test {
@@ -303,9 +309,10 @@ TEST_F(CanModuleTest, ChangeDriverDevice) {
   value[json_keys::kParams] = Json::Value(Json::ValueType::objectValue);
   value[json_keys::kParams][message_params::kDevice] =
       Json::Value(Json::ValueType::objectValue);
-  value[json_keys::kParams][message_params::kDevice][json_keys::kId] = 1;
+  value[json_keys::kParams][message_params::kDevice][json_keys::kId] =
+      kDeviceId;
   value[json_keys::kParams][message_params::kDevice][message_params::kName] =
-      "1";
+      kDeviceName;
   value[json_keys::kParams][message_params::kRank] = "DRIVER";
   Json::FastWriter writer;
   std::string json_str = writer.write(value);
@@ -323,7 +330,9 @@ TEST_F(CanModuleTest, ChangeDriverDevice) {
       .WillRepeatedly(Return(can_app_extention_));
   EXPECT_CALL(*mock_service_, GetApplications(module_.GetModuleID()))
       .WillOnce(Return(apps_));
-  EXPECT_CALL(*mock_service_, SetPrimaryDevice(1)).Times(1);
+  EXPECT_CALL(*mock_service_, GetDeviceHandlerById(kDeviceId))
+      .WillRepeatedly(Return(kDeviceHandle));
+  EXPECT_CALL(*mock_service_, SetPrimaryDevice(kDeviceHandle)).Times(1);
   EXPECT_CALL(*mock_service_, ResetPrimaryDevice()).Times(0);
 
   CanModuleTest::HandleMessage();
@@ -337,9 +346,10 @@ TEST_F(CanModuleTest, ChangeDriverDeviceOnOther) {
   value[json_keys::kParams] = Json::Value(Json::ValueType::objectValue);
   value[json_keys::kParams][message_params::kDevice] =
       Json::Value(Json::ValueType::objectValue);
-  value[json_keys::kParams][message_params::kDevice][json_keys::kId] = 1;
+  value[json_keys::kParams][message_params::kDevice][json_keys::kId] =
+      kDeviceId;
   value[json_keys::kParams][message_params::kDevice][message_params::kName] =
-      "1";
+      kDeviceName;
   value[json_keys::kParams][message_params::kRank] = "DRIVER";
   Json::FastWriter writer;
   std::string json_str = writer.write(value);
@@ -364,7 +374,9 @@ TEST_F(CanModuleTest, ChangeDriverDeviceOnOther) {
       .WillOnce(Return(can_app_extention_));
   EXPECT_CALL(*mock_service_, GetApplications(module_.GetModuleID()))
       .WillRepeatedly(Return(apps_));
-  EXPECT_CALL(*mock_service_, SetPrimaryDevice(1)).Times(1);
+  EXPECT_CALL(*mock_service_, GetDeviceHandlerById(kDeviceId))
+      .WillRepeatedly(Return(kDeviceHandle));
+  EXPECT_CALL(*mock_service_, SetPrimaryDevice(kDeviceHandle)).Times(1);
   EXPECT_CALL(*mock_service_, ResetPrimaryDevice()).Times(0);
 
   CanModuleTest::HandleMessage();
@@ -379,9 +391,10 @@ TEST_F(CanModuleTest, ChangeDriverDeviceToPassenger) {
   value[json_keys::kParams] = Json::Value(Json::ValueType::objectValue);
   value[json_keys::kParams][message_params::kDevice] =
       Json::Value(Json::ValueType::objectValue);
-  value[json_keys::kParams][message_params::kDevice][json_keys::kId] = 1;
+  value[json_keys::kParams][message_params::kDevice][json_keys::kId] =
+      kDeviceId;
   value[json_keys::kParams][message_params::kDevice][message_params::kName] =
-      "1";
+      kDeviceName;
   value[json_keys::kParams][message_params::kRank] = "PASSENGER";
   Json::FastWriter writer;
   std::string json_str = writer.write(value);
@@ -402,6 +415,8 @@ TEST_F(CanModuleTest, ChangeDriverDeviceToPassenger) {
       .WillRepeatedly(Return(can_app_extention_));
   EXPECT_CALL(*mock_service_, GetApplications(module_.GetModuleID()))
       .WillRepeatedly(Return(apps_));
+  EXPECT_CALL(*mock_service_, GetDeviceHandlerById(kDeviceId))
+      .WillRepeatedly(Return(kDeviceHandle));
   EXPECT_CALL(*mock_service_, PrimaryDevice()).Times(1).WillOnce(Return(1));
   EXPECT_CALL(*mock_service_, ResetPrimaryDevice()).Times(1);
 
@@ -416,9 +431,10 @@ TEST_F(CanModuleTest, ChangePassengerDeviceToPassenger) {
   value[json_keys::kParams] = Json::Value(Json::ValueType::objectValue);
   value[json_keys::kParams][message_params::kDevice] =
       Json::Value(Json::ValueType::objectValue);
-  value[json_keys::kParams][message_params::kDevice][json_keys::kId] = 1;
+  value[json_keys::kParams][message_params::kDevice][json_keys::kId] =
+      kDeviceId;
   value[json_keys::kParams][message_params::kDevice][message_params::kName] =
-      "1";
+      kDeviceName;
   value[json_keys::kParams][message_params::kRank] = "PASSENGER";
   Json::FastWriter writer;
   std::string json_str = writer.write(value);

--- a/src/components/functional_module/test/include/mock_service.h
+++ b/src/components/functional_module/test/include/mock_service.h
@@ -71,6 +71,7 @@ class MockService : public Service {
   MOCK_METHOD1(ResetAccess, void(const ApplicationId& app_id));
   MOCK_METHOD2(ResetAccess,
                void(const SeatLocation& zone, const std::string& module));
+  MOCK_METHOD1(GetDeviceHandlerById, uint32_t(const std::string& device_id));
   MOCK_METHOD1(SetPrimaryDevice, void(const uint32_t dev_id));
   MOCK_METHOD0(ResetPrimaryDevice, void());
   MOCK_CONST_METHOD0(PrimaryDevice, uint32_t());


### PR DESCRIPTION
Added new method GetDeviceHandlerById into Service to get device handler by device identifier;
Fixed registration of applications with the same names and app ids but from different rank devices;
Removed incorrect check from ValidateDeviceInfo checking method.