### PR TITLE
Fix wrong info parameter AudioPassThru

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -172,11 +172,6 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
   bool awaiting_tts_speak_response_;
   bool awaiting_ui_response_;
 
-  /* flag shows if last received audioPassThruIcon exists
-   * in the file system
-   */
-  bool audio_pass_thru_icon_exists_;
-
   hmi_apis::Common_Result::eType result_tts_speak_;
   hmi_apis::Common_Result::eType result_ui_;
   std::string ui_info_;

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -51,7 +51,6 @@ PerformAudioPassThruRequest::PerformAudioPassThruRequest(
     : CommandRequestImpl(message, application_manager)
     , awaiting_tts_speak_response_(false)
     , awaiting_ui_response_(false)
-    , audio_pass_thru_icon_exists_(true)
     , result_tts_speak_(hmi_apis::Common_Result::INVALID_ENUM)
     , result_ui_(hmi_apis::Common_Result::INVALID_ENUM) {
   subscribe_on_event(hmi_apis::FunctionID::TTS_OnResetTimeout);
@@ -223,11 +222,8 @@ bool PerformAudioPassThruRequest::PrepareResponseParameters(
     result_code = PrepareAudioPassThruResultCodeForResponse(
         ui_perform_info, tts_perform_info, result);
   }
-
   info = MergeInfos(ui_perform_info, ui_info_, tts_perform_info, tts_info_);
-  if (!audio_pass_thru_icon_exists_) {
-    info = MergeInfos("Reference image(s) not found", info);
-  }
+
   return result;
 }
 
@@ -409,7 +405,6 @@ void PerformAudioPassThruRequest::ProcessAudioPassThruIcon(
   LOG4CXX_AUTO_TRACE(logger_);
   smart_objects::SmartObject msg_params = (*message_)[strings::msg_params];
 
-  audio_pass_thru_icon_exists_ = true;
   if (msg_params.keyExists(strings::audio_pass_thru_icon)) {
     smart_objects::SmartObject icon = msg_params[strings::audio_pass_thru_icon];
     if (MessageHelper::VerifyImage(icon, app, application_manager_) !=
@@ -417,7 +412,6 @@ void PerformAudioPassThruRequest::ProcessAudioPassThruIcon(
       LOG4CXX_WARN(
           logger_,
           "Invalid audio_pass_thru_icon doesn't exist in the file system");
-      audio_pass_thru_icon_exists_ = false;
     }
   }
 }

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -521,6 +521,7 @@ TEST_F(PerformAudioPassThruRequestTest,
 
 TEST_F(PerformAudioPassThruRequestTest,
        Run_MobileSendAudioPassThruIconDynamic_WARNINGS) {
+  const char *hmi_info = "Reference image(s) not found";
   MessageSharedPtr msg_mobile = CreateMobileMessageSO();
   SetupIconParameter(msg_mobile, kTypeDynamic, kIconName);
   utils::SharedPtr<PerformAudioPassThruRequest> command =
@@ -547,6 +548,7 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   MessageSharedPtr msg_ui =
       PrepareResponseFromHMI(hmi_apis::Common_Result::WARNINGS, NULL);
+  (*msg_ui)[am::strings::msg_params][am::strings::info] = hmi_info;
   Event event_ui(hmi_apis::FunctionID::UI_PerformAudioPassThru);
   event_ui.set_smart_object(*msg_ui);
 
@@ -564,7 +566,7 @@ TEST_F(PerformAudioPassThruRequestTest,
   command->on_event(event_ui);
 
   ResultCommandExpectations(msg_mobile_response,
-                            "Reference image(s) not found",
+                            hmi_info,
                             am::mobile_api::Result::WARNINGS,
                             true);
 }


### PR DESCRIPTION
    Fix wrong info parameter AudioPassThru
    
    In case received from mobile side audioPassThruIcon does not exist in
    the application storage folder SDL used to add string "Reference image(s)
    not found" to the info parameter in the response. After clarification it
    turned out that this info must be generated from the HMI, so that the 
    member variable that was used for storing the state of the icon is removed.
