### PR TITLE
Fix incorrect result code to mobile

### DIFF
--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -435,7 +435,8 @@ PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
   const hmi_apis::Common_Result::eType tts_result = tts_response.result_code;
 
   if ((ui_result == hmi_apis::Common_Result::SUCCESS) &&
-      (tts_result != hmi_apis::Common_Result::SUCCESS)) {
+      ((tts_result != hmi_apis::Common_Result::SUCCESS) &&
+       (tts_result != hmi_apis::Common_Result::INVALID_ENUM))) {
     common_result = hmi_apis::Common_Result::WARNINGS;
     out_result = true;
   } else if (ui_result == hmi_apis::Common_Result::INVALID_ENUM) {

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -435,8 +435,8 @@ PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
   const hmi_apis::Common_Result::eType tts_result = tts_response.result_code;
 
   if ((ui_result == hmi_apis::Common_Result::SUCCESS) &&
-      ((tts_result != hmi_apis::Common_Result::SUCCESS) &&
-       (tts_result != hmi_apis::Common_Result::INVALID_ENUM))) {
+      (tts_result != hmi_apis::Common_Result::SUCCESS) &&
+      (tts_result != hmi_apis::Common_Result::INVALID_ENUM)) {
     common_result = hmi_apis::Common_Result::WARNINGS;
     out_result = true;
   } else if (ui_result == hmi_apis::Common_Result::INVALID_ENUM) {


### PR DESCRIPTION
SDL used to return wrong result code if only mandatory parameters
are sent from HMI.