### PR TITLE
Fix/tts aborted processing

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -156,17 +156,6 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
       const ResponseInfo& tts_response,
       bool& out_result);
 
-  /**
-   * @brief Checks if any of audioPassThru communication components
-   * returned ABORTED code
-   * @param ui contains result_code from UI
-   * @param tts contains result_code from TTS
-   * @return if TTS or UI responded with ABORTED function returns TRUE,
-   * else is returns FALSE
-   */
-  bool IsAnyHMIComponentAborted(const ResponseInfo& ui,
-                                const ResponseInfo& tts);
-
   /* flag display state of speak and ui perform audio
   during perform audio pass thru*/
   bool awaiting_tts_speak_response_;

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -216,8 +216,6 @@ bool PerformAudioPassThruRequest::PrepareResponseParameters(
 
   if (IsResultCodeUnsupported(ui_perform_info, tts_perform_info)) {
     result_code = mobile_apis::Result::UNSUPPORTED_RESOURCE;
-  } else if (IsAnyHMIComponentAborted(ui_perform_info, tts_perform_info)) {
-    result_code = mobile_apis::Result::ABORTED;
   } else {
     result_code = PrepareAudioPassThruResultCodeForResponse(
         ui_perform_info, tts_perform_info, result);
@@ -441,14 +439,6 @@ PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
   }
   result_code = MessageHelper::HMIToMobileResult(common_result);
   return result_code;
-}
-
-bool PerformAudioPassThruRequest::IsAnyHMIComponentAborted(
-    const ResponseInfo& ui, const ResponseInfo& tts) {
-  using namespace helpers;
-
-  return ((ui.result_code == hmi_apis::Common_Result::ABORTED) ||
-          (tts.result_code == hmi_apis::Common_Result::ABORTED));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
@@ -494,7 +494,8 @@ bool SetGlobalPropertiesRequest::IsWhiteSpaceExist() {
       }
 
       if ((*it_vh).keyExists(strings::image)) {
-        const char* sub_str = (*it_vh)[strings::image][strings::value].asCharArray();
+        const char* sub_str =
+            (*it_vh)[strings::image][strings::value].asCharArray();
         if (!CheckSyntax(sub_str)) {
           LOG4CXX_ERROR(logger_,
                         "Invalid vr_help image value syntax check failed");

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -521,7 +521,7 @@ TEST_F(PerformAudioPassThruRequestTest,
 
 TEST_F(PerformAudioPassThruRequestTest,
        Run_MobileSendAudioPassThruIconDynamic_WARNINGS) {
-  const char *hmi_info = "Reference image(s) not found";
+  const char* hmi_info = "Reference image(s) not found";
   MessageSharedPtr msg_mobile = CreateMobileMessageSO();
   SetupIconParameter(msg_mobile, kTypeDynamic, kIconName);
   utils::SharedPtr<PerformAudioPassThruRequest> command =
@@ -565,10 +565,8 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   command->on_event(event_ui);
 
-  ResultCommandExpectations(msg_mobile_response,
-                            hmi_info,
-                            am::mobile_api::Result::WARNINGS,
-                            true);
+  ResultCommandExpectations(
+      msg_mobile_response, hmi_info, am::mobile_api::Result::WARNINGS, true);
 }
 
 TEST_F(PerformAudioPassThruRequestTest,


### PR DESCRIPTION
Fix incorrect ABORTED code processing

ABORTED code received from TTS HMI part used to be processed
as exception of other result codes - SDL was transfering it to
the mobile application. After clarification it turned out that
it must be processed as all other error codes - resolved to
WARNINGS
