### PR TITLE
Disable protocol handler tests

### DIFF
--- a/src/components/protocol_handler/test/CMakeLists.txt
+++ b/src/components/protocol_handler/test/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories (
   ${GMOCK_INCLUDE_DIRECTORY}
 )
 
-collect_sources(SOURCES ${CMAKE_CURRENT_SOURCE_DIR})
+collect_sources(SOURCES ${CMAKE_CURRENT_SOURCE_DIR} protocol_handler_tm_test.cc)
 
 set(LIBRARIES
   gmock


### PR DESCRIPTION
Protocol handler tests are Async and sometimes fail. It should be fixed before enabling