### PR TITLE
Fix SDL does not return DISALLOWED for revoked app

### DIFF
--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -357,6 +357,16 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
                                        << " for " << hmi_level << " level.");
 
   cache_->CheckPermissions(app_id, hmi_level, rpc, result);
+  if (cache_->IsApplicationRevoked(app_id)) {
+    // SDL must be able to notify mobile side with its status after app has
+    // been revoked by backend
+    if ("OnHMIStatus" == rpc && "NONE" == hmi_level) {
+      result.hmi_level_permitted = kRpcAllowed;
+    } else {
+      result.hmi_level_permitted = kRpcDisallowed;
+    }
+    return;
+  }
 }
 
 bool PolicyManagerImpl::ResetUserConsent() {

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -365,7 +365,6 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
     } else {
       result.hmi_level_permitted = kRpcDisallowed;
     }
-    return;
   }
 }
 

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -563,7 +563,7 @@ TEST_F(PolicyManagerImplTest2,
   manager->CheckPermissions(
       app_id1, std::string("FULL"), "Alert", input_params, output);
   // Check RPC is disallowed
-  EXPECT_EQ(::policy::kRpcAllowed, output.hmi_level_permitted);
+  EXPECT_EQ(::policy::kRpcDisallowed, output.hmi_level_permitted);
   ASSERT_TRUE(output.list_of_allowed_params.empty());
 }
 


### PR DESCRIPTION
 SDL doesn't return DISALLOWED for revoked application

 Added appropriate functionality in policy_regular