### PR TITLE
Fix missing GENERIC_ERROR message

### DIFF
--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -66,8 +66,6 @@ void PerformAudioPassThruRequest::onTimeOut() {
 }
 
 bool PerformAudioPassThruRequest::Init() {
-  default_timeout_ +=
-      (((*message_)[str::msg_params][str::max_duration].asUInt()));
   return true;
 }
 
@@ -159,10 +157,6 @@ void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
       if (is_tts_speak_success_unsuported) {
         SendRecordStartNotification();
         StartMicrophoneRecording();
-
-        // update request timeout to get time for perform audio recording
-        application_manager_.updateRequestTimeout(
-            connection_key(), correlation_id(), default_timeout());
       }
       break;
     }


### PR DESCRIPTION
SDL sends GENERIC_ERROR when the watchdog timeout expires in
PerformAudioPassThru RPC. First problem was that the value of the
timeout is a sum of default timeout value and the value send in
maxDuration parameter. After clarification it turned out that the
maxDuration parameter doesn't have to be added, so the sum statement
is removed. The other problem was that on every TTS.Speak_response
from the HMI the timeout was reset. The clarified behavior defines
that SDL must expect onResetTimeout notification from the HMI and it
doesn't have to reset the timeout when receives TTS.Speak_response.