### PR TITLE
Add rejection of PT if it does not support default language

### DIFF
--- a/src/components/policy/policy_external/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/types.h
@@ -331,7 +331,7 @@ struct MessageLanguages : CompositeType {
 
  private:
   bool Validate() const;
-  static const std::string kMandatoryLanguage_;
+  static const std::string default_language_;
 };
 
 struct ConsumerFriendlyMessages : CompositeType {

--- a/src/components/policy/policy_external/src/policy_table/types.cc
+++ b/src/components/policy/policy_external/src/policy_table/types.cc
@@ -859,7 +859,7 @@ void MessageString::SetPolicyTableType(PolicyTableType pt_type) {
 }
 
 // MessageLanguages methods
-const std::string MessageLanguages::kMandatoryLanguage_("en-us");
+const std::string MessageLanguages::default_language_("en-us");
 
 MessageLanguages::MessageLanguages() : CompositeType(kUninitialized) {}
 
@@ -883,7 +883,7 @@ bool MessageLanguages::is_valid() const {
     return false;
   }
   // Each RPC must have message in english
-  if (languages.end() == languages.find(kMandatoryLanguage_)) {
+  if (languages.end() == languages.find(default_language_)) {
     return false;
   }
   return Validate();
@@ -916,9 +916,10 @@ void MessageLanguages::ReportErrors(rpc::ValidationReport* report__) const {
   if (!languages.is_valid()) {
     languages.ReportErrors(&report__->ReportSubobject("languages"));
   }
-  if (languages.end() == languages.find(kMandatoryLanguage_)) {
-    report__->set_validation_info("no mandatory language '" +
-                                  kMandatoryLanguage_ + "' is present");
+  if (languages.end() == languages.find(default_language_)) {
+    report__->set_validation_info(
+        "this message does not support the default language '" +
+        default_language_ + "'");
   }
 }
 

--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -263,6 +263,7 @@ struct MessageLanguages : CompositeType {
 
  private:
   bool Validate() const;
+  static const std::string default_language_;
 };
 
 struct ConsumerFriendlyMessages : CompositeType {

--- a/src/components/policy/policy_regular/src/policy_table/types.cc
+++ b/src/components/policy/policy_regular/src/policy_table/types.cc
@@ -737,6 +737,8 @@ void MessageString::SetPolicyTableType(PolicyTableType pt_type) {
 }
 
 // MessageLanguages methods
+const std::string MessageLanguages::default_language_("en-us");
+
 MessageLanguages::MessageLanguages() : CompositeType(kUninitialized) {}
 MessageLanguages::MessageLanguages(const Languages& languages)
     : CompositeType(kUninitialized), languages(languages) {}
@@ -751,6 +753,10 @@ Json::Value MessageLanguages::ToJsonValue() const {
 }
 bool MessageLanguages::is_valid() const {
   if (!languages.is_valid()) {
+    return false;
+  }
+  // Each RPC must have message in english
+  if (languages.end() == languages.find(default_language_)) {
     return false;
   }
   return Validate();
@@ -780,6 +786,11 @@ void MessageLanguages::ReportErrors(rpc::ValidationReport* report__) const {
   }
   if (!languages.is_valid()) {
     languages.ReportErrors(&report__->ReportSubobject("languages"));
+  }
+  if (languages.end() == languages.find(default_language_)) {
+    report__->set_validation_info(
+        "this message does not support the default language '" +
+        default_language_ + "'");
   }
 }
 


### PR DESCRIPTION
Added check if PT section consumer_friendly_messages supports default language for all of it's messages,
if this check is failed the PT will be rejected.