### PR TITLE
Fix defect param seconds_between_retries

### DIFF
--- a/src/components/policy/policy_external/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/types.h
@@ -80,7 +80,7 @@ typedef uint8_t NumberOfNotificationsType;
 typedef Map<Integer<NumberOfNotificationsType, 0, 255>, 0, 6>
     NumberOfNotificationsPerMinute;
 
-typedef Array<Integer<uint16_t, 1, 1000>, 0, 10> SecondsBetweenRetries;
+typedef Array<Integer<uint16_t, 1, 1000>, 0, 5> SecondsBetweenRetries;
 
 typedef Map<MessageString, 0, 600> Languages;
 

--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -46,7 +46,7 @@ typedef uint8_t NumberOfNotificationsType;
 typedef Map<Integer<NumberOfNotificationsType, 0, 255>, 0, 6>
     NumberOfNotificationsPerMinute;
 
-typedef Array<Integer<uint16_t, 1, 1000>, 0, 10> SecondsBetweenRetries;
+typedef Array<Integer<uint16_t, 1, 1000>, 0, 5> SecondsBetweenRetries;
 
 typedef Map<MessageString, 0, 500> Languages;
 


### PR DESCRIPTION
PM should verify that "seconds_between_retries" array has maxlength 5

Changed:
* src/components/policy/policy_external/include/policy/policy_table/types.h
* src/components/policy/policy_regular/include/policy/policy_table/types.h
  Now SDL terminates execution if seconds_between_retries array in json contain more then 5 elements