### PR TITLE
Fix responding Warnings for PerformAudioPassThru

### DIFF
--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -414,7 +414,6 @@ PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
     const ResponseInfo& ui_response,
     const ResponseInfo& tts_response,
     bool& out_result) {
-  using namespace helpers;
   mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
 
   hmi_apis::Common_Result::eType common_result =
@@ -428,13 +427,11 @@ PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
     common_result = hmi_apis::Common_Result::WARNINGS;
     out_result = true;
   }
-
   else if (ui_response.is_ok &&
            tts_result == hmi_apis::Common_Result::WARNINGS) {
     common_result = hmi_apis::Common_Result::WARNINGS;
     out_result = true;
   }
-
   else if (ui_result == hmi_apis::Common_Result::INVALID_ENUM) {
     common_result = tts_result;
   } else {

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -429,20 +429,8 @@ PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
     out_result = true;
   }
 
-  else if ((ui_result == hmi_apis::Common_Result::WARNINGS ||
-            tts_result == hmi_apis::Common_Result::WARNINGS) &&
-           Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
-               ui_result, hmi_apis::Common_Result::SUCCESS,
-               hmi_apis::Common_Result::WARNINGS,
-               hmi_apis::Common_Result::WRONG_LANGUAGE,
-               hmi_apis::Common_Result::RETRY,
-               hmi_apis::Common_Result::SAVED) &&
-           Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
-               tts_result, hmi_apis::Common_Result::SUCCESS,
-               hmi_apis::Common_Result::WARNINGS,
-               hmi_apis::Common_Result::WRONG_LANGUAGE,
-               hmi_apis::Common_Result::RETRY,
-               hmi_apis::Common_Result::SAVED)) {
+  else if (ui_response.is_ok &&
+           tts_result == hmi_apis::Common_Result::WARNINGS) {
     common_result = hmi_apis::Common_Result::WARNINGS;
     out_result = true;
   }

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -414,6 +414,7 @@ PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
     const ResponseInfo& ui_response,
     const ResponseInfo& tts_response,
     bool& out_result) {
+  using namespace helpers;
   mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
 
   hmi_apis::Common_Result::eType common_result =
@@ -426,7 +427,27 @@ PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
       (tts_result != hmi_apis::Common_Result::INVALID_ENUM)) {
     common_result = hmi_apis::Common_Result::WARNINGS;
     out_result = true;
-  } else if (ui_result == hmi_apis::Common_Result::INVALID_ENUM) {
+  }
+
+  else if ((ui_result == hmi_apis::Common_Result::WARNINGS ||
+            tts_result == hmi_apis::Common_Result::WARNINGS) &&
+           Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+               ui_result, hmi_apis::Common_Result::SUCCESS,
+               hmi_apis::Common_Result::WARNINGS,
+               hmi_apis::Common_Result::WRONG_LANGUAGE,
+               hmi_apis::Common_Result::RETRY,
+               hmi_apis::Common_Result::SAVED) &&
+           Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+               tts_result, hmi_apis::Common_Result::SUCCESS,
+               hmi_apis::Common_Result::WARNINGS,
+               hmi_apis::Common_Result::WRONG_LANGUAGE,
+               hmi_apis::Common_Result::RETRY,
+               hmi_apis::Common_Result::SAVED)) {
+    common_result = hmi_apis::Common_Result::WARNINGS;
+    out_result = true;
+  }
+
+  else if (ui_result == hmi_apis::Common_Result::INVALID_ENUM) {
     common_result = tts_result;
   } else {
     common_result = ui_result;

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -473,6 +473,74 @@ TEST_F(
                     success);
 }
 
+
+TEST_F(
+    PerformAudioPassThruRequestTest,
+    OnEvent_BothInterfaceIsAvailable_TTSResultWARNINGS_UIResultSUCCESS_WARNINGS) {
+  const hmi_apis::Common_Result::eType ui_hmi_response =
+      hmi_apis::Common_Result::SUCCESS;
+  const hmi_apis::Common_Result::eType tts_hmi_response =
+      hmi_apis::Common_Result::WARNINGS;
+  const char* ui_info = NULL;
+  const char* tts_info = NULL;
+  const mobile_apis::Result::eType mobile_response =
+      mobile_apis::Result::WARNINGS;
+  const char* mobile_info = NULL;
+  const am::HmiInterfaces::InterfaceState ui_state =
+      am::HmiInterfaces::STATE_AVAILABLE;
+  const am::HmiInterfaces::InterfaceState tts_state =
+      am::HmiInterfaces::STATE_AVAILABLE;
+  const bool success = true;
+
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::WARNINGS))
+      .WillOnce(Return(mobile_response));
+
+  CheckExpectations(ui_hmi_response,
+                    tts_hmi_response,
+                    ui_info,
+                    tts_info,
+                    mobile_response,
+                    mobile_info,
+                    ui_state,
+                    tts_state,
+                    success);
+}
+
+
+TEST_F(
+    PerformAudioPassThruRequestTest,
+    OnEvent_BothInterfaceIsAvailable_TTSResultSUCCESS_UIResultWARNINGS_WARNINGS) {
+  const hmi_apis::Common_Result::eType ui_hmi_response =
+      hmi_apis::Common_Result::WARNINGS;
+  const hmi_apis::Common_Result::eType tts_hmi_response =
+      hmi_apis::Common_Result::SUCCESS;
+  const char* ui_info = NULL;
+  const char* tts_info = NULL;
+  const mobile_apis::Result::eType mobile_response =
+      mobile_apis::Result::WARNINGS;
+  const char* mobile_info = NULL;
+  const am::HmiInterfaces::InterfaceState ui_state =
+      am::HmiInterfaces::STATE_AVAILABLE;
+  const am::HmiInterfaces::InterfaceState tts_state =
+      am::HmiInterfaces::STATE_AVAILABLE;
+  const bool success = true;
+
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::WARNINGS))
+      .WillOnce(Return(mobile_response));
+
+  CheckExpectations(ui_hmi_response,
+                    tts_hmi_response,
+                    ui_info,
+                    tts_info,
+                    mobile_response,
+                    mobile_info,
+                    ui_state,
+                    tts_state,
+                    success);
+}
+
 TEST_F(PerformAudioPassThruRequestTest,
        Run_MobileSendAudioPassThruIconStatic_SUCCESS) {
   MessageSharedPtr msg_mobile = CreateMobileMessageSO();
@@ -637,6 +705,7 @@ TEST_F(PerformAudioPassThruRequestTest,
   ResultCommandExpectations(
       msg_mobile_response, NULL, am::mobile_api::Result::INVALID_DATA, false);
 }
+
 
 }  // namespace perform_audio_pass_thru_request
 }  // namespace mobile_commands_test


### PR DESCRIPTION
In case the response for UI.Alert or TTS.Speak is Warnings and other response is successful
then Warnings should be sent on mobile.