### PR TITLE
Fixed defect SDL doesn't send APPid on Speak

### DIFF
--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -120,6 +120,7 @@ void AlertManeuverRequest::Run() {
         (*message_)[strings::msg_params][strings::tts_chunks];
     msg_params[hmi_request::speak_type] =
         hmi_apis::Common_MethodName::ALERT_MANEUVER;
+    msg_params[strings::app_id] = app->app_id();
 
     SendHMIRequest(hmi_apis::FunctionID::TTS_Speak, &msg_params, true);
   }


### PR DESCRIPTION
SDL does not send mandatory parameter appID with request TTS.Speak

Changed:
* src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
  Added appId to msg_params

@LuxoftAKutsan Please review
@dcherniev Please review
@istoilovgithub Please review
@okozlovlux Please review
