### PR TITLE
Fix TTS capabilities

### DIFF
--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -49,6 +49,8 @@ namespace Formatters = NsSmartDeviceLink::NsJSONHandler::Formatters;
 namespace {
 std::map<std::string, hmi_apis::Common_VrCapabilities::eType>
     vr_enum_capabilities;
+std::map<std::string, hmi_apis::Common_SpeechCapabilities::eType>
+    tts_enum_capabilities;
 std::map<std::string, hmi_apis::Common_ButtonName::eType> button_enum_name;
 std::map<std::string, hmi_apis::Common_TextFieldName::eType>
     text_fields_enum_name;
@@ -70,6 +72,19 @@ std::map<std::string, hmi_apis::Common_CharacterSet::eType> character_set_enum;
 void InitCapabilities() {
   vr_enum_capabilities.insert(std::make_pair(
       std::string("TEXT"), hmi_apis::Common_VrCapabilities::VR_TEXT));
+
+  tts_enum_capabilities.insert(std::make_pair(
+      std::string("TEXT"), hmi_apis::Common_SpeechCapabilities::SC_TEXT));
+  tts_enum_capabilities.insert(std::make_pair(
+      std::string("SAPI_PHONEMES"), hmi_apis::Common_SpeechCapabilities::SAPI_PHONEMES));
+  tts_enum_capabilities.insert(std::make_pair(
+      std::string("LHPLUS_PHONEMES"), hmi_apis::Common_SpeechCapabilities::LHPLUS_PHONEMES));
+  tts_enum_capabilities.insert(std::make_pair(
+      std::string("SAPI_PHONEMES"), hmi_apis::Common_SpeechCapabilities::SAPI_PHONEMES));
+  tts_enum_capabilities.insert(std::make_pair(
+      std::string("PRE_RECORDED"), hmi_apis::Common_SpeechCapabilities::PRE_RECORDED));
+  tts_enum_capabilities.insert(std::make_pair(
+      std::string("SILENCE"), hmi_apis::Common_SpeechCapabilities::SILENCE));
 
   button_enum_name.insert(
       std::make_pair(std::string("OK"), hmi_apis::Common_ButtonName::OK));
@@ -995,8 +1010,14 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
       }
 
       if (check_existing_json_member(tts, "capabilities")) {
-        set_speech_capabilities(
-            smart_objects::SmartObject(tts.get("capabilities", "").asString()));
+        Json::Value capabilities = tts.get("capabilities", "");
+        smart_objects::SmartObject tts_capabilities_so =
+            smart_objects::SmartObject(smart_objects::SmartType_Array);
+        for (uint32_t i = 0; i < capabilities.size(); ++i) {
+          tts_capabilities_so[i] =
+              tts_enum_capabilities.find(capabilities[i].asString())->second;
+        }
+        set_speech_capabilities(tts_capabilities_so);
       }
     }  // TTS end
 

--- a/src/components/application_manager/test/hmi_capabilities.json
+++ b/src/components/application_manager/test/hmi_capabilities.json
@@ -2,7 +2,7 @@
     "UI":
     {
         "language":"EN_US",
-        "languages":[ 
+        "languages":[
           "EN_US","ES_MX","FR_CA","DE_DE","ES_ES","EN_GB","RU_RU","TR_TR","PL_PL","FR_FR","IT_IT","SV_SE","PT_PT","NL_NL","ZH_TW",
 "JA_JP","AR_SA","KO_KR","PT_BR","CS_CZ","DA_DK","NO_NO"
         ],
@@ -250,7 +250,7 @@
                                         "name":"graphic",
                                         "imageTypeSupported":
                                          [
-                        
+
                                          ],
                                         "imageResolution":
                                          {
@@ -270,7 +270,7 @@
                                                 "resolutionHeight":35
                                          }
                             }
-                            
+
                         ],
             "mediaClockFormats":
             [
@@ -279,7 +279,7 @@
             "graphicSupported":true,
                         "templatesAvailable":
                         [
-                          
+
                             "DEFAULT","MEDIA","NON-MEDIA","ONSCREEN_PRESETS","NAV_FULLSCREEN_MAP","NAV_KEYBOARD",
                             "GRAPHIC_WITH_TEXT","TEXT_WITH_GRAPHIC","TILES_ONLY","TEXTBUTTONS_ONLY",
                                 "GRAPHIC_WITH_TILES","TILES_WITH_GRAPHIC","GRAPHIC_WITH_TEXT_AND_SOFTBUTTONS",
@@ -335,15 +335,15 @@
     {
         "capabilities":["TEXT"],
         "language":"ES_MX",
-        "languages":    
-            [ 
+        "languages":
+            [
          "AR_SA", "EN_US","ES_MX","FR_CA","DE_DE","ES_ES","EN_GB","RU_RU","TR_TR","PL_PL","FR_FR","IT_IT","SV_SE","PT_PT","NL_NL","ZH_TW",
 "JA_JP","KO_KR","PT_BR","CS_CZ","DA_DK","NO_NO"
-            ]       
+            ]
 },
     "TTS":
     {
-        "capabilities":"TEXT",
+        "capabilities":["TEXT"],
         "language":"DE_DE",
         "languages":
         [

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -229,6 +229,13 @@ TEST_F(HMICapabilitiesTest, LoadCapabilitiesFromFile) {
             static_cast<hmi_apis::Common_Language::eType>(
                 tts_supported_languages[2].asInt()));
 
+  // Check TTS capabilities
+  const smart_objects::SmartObject tts_capabilities =
+      *(hmi_capabilities_test->speech_capabilities());
+  EXPECT_EQ(hmi_apis::Common_SpeechCapabilities::SC_TEXT,
+            static_cast<hmi_apis::Common_SpeechCapabilities::eType>(
+                tts_capabilities[0].asInt()));
+
   // Check button capabilities
   const smart_objects::SmartObject buttons_capabilities_so =
       *(hmi_capabilities_test->button_capabilities());


### PR DESCRIPTION
The same in #1320 
According HMI_API TTS capabilities should be array.
Added check for TTS capabilities in unit test.

Closing bug-fix [#1321](https://github.com/smartdevicelink/sdl_core/issues/1321)