### PR TITLE
Fix AddSubMenu, SDL responds with resultCode INVALID_DATA

### DIFF
--- a/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
@@ -113,9 +113,6 @@ void AddSubMenuRequest::Run() {
     msg_params[strings::sub_menu_icon] =
         (*message_)[strings::msg_params][strings::sub_menu_icon];
   }
-  if(!is_key_icon_exist) {
-     msg_params.erase(strings::sub_menu_icon);
-  }
   SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);
 }
 std::string AddSubMenuRequest::ImageFullPath(const std::string& file_name,

--- a/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
@@ -104,19 +104,19 @@ void AddSubMenuRequest::Run() {
   const mobile_apis::ImageType::eType type =
       static_cast<mobile_apis::ImageType::eType>(image_type);
   const bool is_dynamic_image = mobile_apis::ImageType::DYNAMIC == type;
-  if (!is_key_icon_exist) {
-    SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);
-  } else if (is_key_icon_exist && is_icon_path_valid && is_dynamic_image) {
+
+  if (is_key_icon_exist && is_icon_path_valid && is_dynamic_image) {
     (*message_)[strings::msg_params][strings::sub_menu_icon][strings::value] =
         ImageFullPath((*message_)[strings::msg_params][strings::sub_menu_icon]
                                  [strings::value].asString(),
                       app,
                       application_manager_);
-
     msg_params[strings::sub_menu_icon] =
         (*message_)[strings::msg_params][strings::sub_menu_icon];
-    SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);
-  } 
+  } else {
+     msg_params.erase(strings::sub_menu_icon);
+  }
+  SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);
 }
 std::string AddSubMenuRequest::ImageFullPath(const std::string& file_name,
                                              ApplicationConstSharedPtr app,

--- a/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
@@ -102,19 +102,28 @@ void AddSubMenuRequest::Run() {
                  [strings::image_type].asUInt();
   const mobile_apis::ImageType::eType type =
       static_cast<mobile_apis::ImageType::eType>(image_type);
-  const bool is_dynamic_image = mobile_apis::ImageType::DYNAMIC == type;
 
-  if (is_key_icon_exist && is_icon_path_valid && is_dynamic_image) {
-    (*message_)[strings::msg_params][strings::sub_menu_icon][strings::value] =
-        ImageFullPath((*message_)[strings::msg_params][strings::sub_menu_icon]
-                                 [strings::value].asString(),
-                      app,
-                      application_manager_);
+  if (is_key_icon_exist && is_icon_path_valid) {
     msg_params[strings::sub_menu_icon] =
         (*message_)[strings::msg_params][strings::sub_menu_icon];
+    const bool is_dynamic_image = mobile_apis::ImageType::DYNAMIC == type;
+    if (is_dynamic_image) {
+      msg_params[strings::sub_menu_icon][strings::value] =
+          ImageFullPath((*message_)[strings::msg_params][strings::sub_menu_icon]
+                                   [strings::value].asString(),
+                        app,
+                        application_manager_);
+    }
   }
-  SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);
+
+  if (is_key_icon_exist && !is_icon_path_valid) {
+    LOG4CXX_ERROR(logger_, "Sub-menu icon is not valid.");
+    SendResponse(false, mobile_apis::Result::INVALID_DATA);
+  } else {  // no matter, exists key_icon or not
+    SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);
+  }
 }
+
 std::string AddSubMenuRequest::ImageFullPath(const std::string& file_name,
                                              ApplicationConstSharedPtr app,
                                              ApplicationManager& app_mngr) {

--- a/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
@@ -94,7 +94,6 @@ void AddSubMenuRequest::Run() {
   msg_params[strings::menu_params][strings::menu_name] =
       (*message_)[strings::msg_params][strings::menu_name];
   msg_params[strings::app_id] = app->app_id();
-  
   const bool is_key_icon_exist =
       ((*message_)[strings::msg_params].keyExists(strings::sub_menu_icon));
   const bool is_icon_path_valid = CheckSubMenuIcon();

--- a/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
@@ -104,8 +104,9 @@ void AddSubMenuRequest::Run() {
   const mobile_apis::ImageType::eType type =
       static_cast<mobile_apis::ImageType::eType>(image_type);
   const bool is_dynamic_image = mobile_apis::ImageType::DYNAMIC == type;
-
-  if (is_key_icon_exist && is_icon_path_valid && is_dynamic_image) {
+  if (!is_key_icon_exist) {
+    SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);
+  } else if (is_key_icon_exist && is_icon_path_valid && is_dynamic_image) {
     (*message_)[strings::msg_params][strings::sub_menu_icon][strings::value] =
         ImageFullPath((*message_)[strings::msg_params][strings::sub_menu_icon]
                                  [strings::value].asString(),
@@ -115,9 +116,7 @@ void AddSubMenuRequest::Run() {
     msg_params[strings::sub_menu_icon] =
         (*message_)[strings::msg_params][strings::sub_menu_icon];
     SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);
-  } else {
-    SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);
-  }
+  } 
 }
 std::string AddSubMenuRequest::ImageFullPath(const std::string& file_name,
                                              ApplicationConstSharedPtr app,

--- a/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
@@ -94,6 +94,7 @@ void AddSubMenuRequest::Run() {
   msg_params[strings::menu_params][strings::menu_name] =
       (*message_)[strings::msg_params][strings::menu_name];
   msg_params[strings::app_id] = app->app_id();
+  
   const bool is_key_icon_exist =
       ((*message_)[strings::msg_params].keyExists(strings::sub_menu_icon));
   const bool is_icon_path_valid = CheckSubMenuIcon();
@@ -115,8 +116,7 @@ void AddSubMenuRequest::Run() {
         (*message_)[strings::msg_params][strings::sub_menu_icon];
     SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);
   } else {
-    LOG4CXX_ERROR(logger_, "Sub-menu icon is not valid.");
-    SendResponse(false, mobile_apis::Result::INVALID_DATA);
+    SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);
   }
 }
 std::string AddSubMenuRequest::ImageFullPath(const std::string& file_name,

--- a/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
@@ -113,7 +113,8 @@ void AddSubMenuRequest::Run() {
                       application_manager_);
     msg_params[strings::sub_menu_icon] =
         (*message_)[strings::msg_params][strings::sub_menu_icon];
-  } else {
+  }
+  if(!is_key_icon_exist) {
      msg_params.erase(strings::sub_menu_icon);
   }
   SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);


### PR DESCRIPTION
Fix AddSubMenu, SDL responds with resultCode INVALID_DATA 
in case not mandatory parameter subMenuIcon omitted in request from Mobile app

Changed:
* add_sub_menu_request.cc 
changed logic to send request if no image is specified

Review:
@LuxoftAKutsan please review
@okozlovlux please review
@tkireva please review