### PR TITLE
Fix wrong dynamic image parameter

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -529,6 +529,21 @@ class MessageHelper {
       int32_t function_id,
       const uint32_t correlation_id,
       int32_t result_code);
+  /*
+     * @brief Verify image and add image file full path
+     * and add path, although the image doesn't exist
+     *
+     * @param SmartObject with image
+     *
+     * @param app current application
+     *
+     * @return verification result
+     *
+     */
+  static mobile_apis::Result::eType VerifyImageApplyPath(
+      smart_objects::SmartObject& image,
+      ApplicationConstSharedPtr app,
+      ApplicationManager& app_mngr);
 
   /*
    * @brief Verify image and add image file full path

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -400,7 +400,7 @@ void PerformAudioPassThruRequest::ProcessAudioPassThruIcon(
   if (msg_params.keyExists(strings::audio_pass_thru_icon)) {
     smart_objects::SmartObject& icon =
         msg_params[strings::audio_pass_thru_icon];
-    if (MessageHelper::VerifyImage(icon, app, application_manager_) !=
+    if (MessageHelper::VerifyImageApplyPath(icon, app, application_manager_) !=
         mobile_apis::Result::SUCCESS) {
       LOG4CXX_WARN(
           logger_,
@@ -426,13 +426,11 @@ PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
       (tts_result != hmi_apis::Common_Result::INVALID_ENUM)) {
     common_result = hmi_apis::Common_Result::WARNINGS;
     out_result = true;
-  }
-  else if (ui_response.is_ok &&
-           tts_result == hmi_apis::Common_Result::WARNINGS) {
+  } else if (ui_response.is_ok &&
+             tts_result == hmi_apis::Common_Result::WARNINGS) {
     common_result = hmi_apis::Common_Result::WARNINGS;
     out_result = true;
-  }
-  else if (ui_result == hmi_apis::Common_Result::INVALID_ENUM) {
+  } else if (ui_result == hmi_apis::Common_Result::INVALID_ENUM) {
     common_result = tts_result;
   } else {
     common_result = ui_result;

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2307,16 +2307,16 @@ mobile_apis::Result::eType MessageHelper::VerifyImage(
     smart_objects::SmartObject& image,
     ApplicationConstSharedPtr app,
     ApplicationManager& app_mngr) {
-  smart_objects::SmartObject img = image;
+  smart_objects::SmartObject temp_image = image;
   const uint32_t image_type = image[strings::image_type].asUInt();
-  mobile_apis::ImageType::eType type =
+  const mobile_apis::ImageType::eType type =
       static_cast<mobile_apis::ImageType::eType>(image_type);
-  mobile_apis::Result::eType result;
 
-  result = VerifyImageApplyPath(img, app, app_mngr);
+  const mobile_apis::Result::eType result =
+      VerifyImageApplyPath(temp_image, app, app_mngr);
   if ((mobile_apis::Result::SUCCESS == result) &&
       (mobile_apis::ImageType::DYNAMIC == type)) {
-    image[strings::value] = img[strings::value];
+    image[strings::value] = temp_image[strings::value];
   }
 
   return result;

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2251,7 +2251,7 @@ mobile_apis::Result::eType MessageHelper::VerifyImageFiles(
   return mobile_apis::Result::SUCCESS;
 }
 
-mobile_apis::Result::eType MessageHelper::VerifyImage(
+mobile_apis::Result::eType MessageHelper::VerifyImageApplyPath(
     smart_objects::SmartObject& image,
     ApplicationConstSharedPtr app,
     ApplicationManager& app_mngr) {
@@ -2295,13 +2295,31 @@ mobile_apis::Result::eType MessageHelper::VerifyImage(
     full_file_path += file_name;
   }
 
+  image[strings::value] = full_file_path;
   if (!file_system::FileExists(full_file_path)) {
     return mobile_apis::Result::INVALID_DATA;
   }
 
-  image[strings::value] = full_file_path;
-
   return mobile_apis::Result::SUCCESS;
+}
+
+mobile_apis::Result::eType MessageHelper::VerifyImage(
+    smart_objects::SmartObject& image,
+    ApplicationConstSharedPtr app,
+    ApplicationManager& app_mngr) {
+  smart_objects::SmartObject img = image;
+  const uint32_t image_type = image[strings::image_type].asUInt();
+  mobile_apis::ImageType::eType type =
+      static_cast<mobile_apis::ImageType::eType>(image_type);
+  mobile_apis::Result::eType result;
+
+  result = VerifyImageApplyPath(img, app, app_mngr);
+  if ((mobile_apis::Result::SUCCESS == result) &&
+      (mobile_apis::ImageType::DYNAMIC == type)) {
+    image[strings::value] = img[strings::value];
+  }
+
+  return result;
 }
 
 mobile_apis::Result::eType MessageHelper::VerifyImageVrHelpItems(

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -473,7 +473,6 @@ TEST_F(
                     success);
 }
 
-
 TEST_F(
     PerformAudioPassThruRequestTest,
     OnEvent_BothInterfaceIsAvailable_TTSResultWARNINGS_UIResultSUCCESS_WARNINGS) {
@@ -506,7 +505,6 @@ TEST_F(
                     tts_state,
                     success);
 }
-
 
 TEST_F(
     PerformAudioPassThruRequestTest,
@@ -550,11 +548,12 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   DefineHMILevelUIAvailable();
   ON_CALL(app_mngr_, ManageHMICommand(_)).WillByDefault(Return(true));
-  EXPECT_CALL(mock_message_helper_,
-              VerifyImage((*msg_mobile)[am::strings::msg_params]
-                                       [am::strings::audio_pass_thru_icon],
-                          _,
-                          _)).WillOnce(Return(mobile_apis::Result::SUCCESS));
+  EXPECT_CALL(
+      mock_message_helper_,
+      VerifyImageApplyPath((*msg_mobile)[am::strings::msg_params]
+                                        [am::strings::audio_pass_thru_icon],
+                           _,
+                           _)).WillOnce(Return(mobile_apis::Result::SUCCESS));
 
   command->Run();
 
@@ -597,11 +596,11 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   DefineHMILevelUIAvailable();
   EXPECT_CALL(mock_message_helper_,
-              VerifyImage((*msg_mobile)[am::strings::msg_params]
-                                       [am::strings::audio_pass_thru_icon],
-                          _,
-                          _))
-      .WillOnce(Return(mobile_apis::Result::INVALID_DATA));
+              VerifyImageApplyPath(
+                  (*msg_mobile)[am::strings::msg_params]
+                               [am::strings::audio_pass_thru_icon],
+                  _,
+                  _)).WillOnce(Return(mobile_apis::Result::INVALID_DATA));
 
   command->Run();
 
@@ -646,11 +645,12 @@ TEST_F(PerformAudioPassThruRequestTest,
       CreateCommand<PerformAudioPassThruRequest>(msg_mobile);
 
   DefineHMILevelUIAvailable();
-  EXPECT_CALL(mock_message_helper_,
-              VerifyImage((*msg_mobile)[am::strings::msg_params]
-                                       [am::strings::audio_pass_thru_icon],
-                          _,
-                          _)).WillOnce(Return(mobile_apis::Result::SUCCESS));
+  EXPECT_CALL(
+      mock_message_helper_,
+      VerifyImageApplyPath((*msg_mobile)[am::strings::msg_params]
+                                        [am::strings::audio_pass_thru_icon],
+                           _,
+                           _)).WillOnce(Return(mobile_apis::Result::SUCCESS));
 
   command->Run();
 
@@ -693,7 +693,7 @@ TEST_F(PerformAudioPassThruRequestTest,
       CreateCommand<PerformAudioPassThruRequest>(msg_mobile);
 
   DefineHMILevelUIAvailable();
-  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _)).Times(0);
+  EXPECT_CALL(mock_message_helper_, VerifyImageApplyPath(_, _, _)).Times(0);
 
   MessageSharedPtr msg_mobile_response;
   EXPECT_CALL(
@@ -705,7 +705,6 @@ TEST_F(PerformAudioPassThruRequestTest,
   ResultCommandExpectations(
       msg_mobile_response, NULL, am::mobile_api::Result::INVALID_DATA, false);
 }
-
 
 }  // namespace perform_audio_pass_thru_request
 }  // namespace mobile_commands_test

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -163,6 +163,10 @@ class MockMessageHelper {
                mobile_apis::Result::eType(smart_objects::SmartObject& message,
                                           ApplicationConstSharedPtr app,
                                           ApplicationManager& app_mngr));
+  MOCK_METHOD3(VerifyImageApplyPath,
+               mobile_apis::Result::eType(smart_objects::SmartObject& message,
+                                          ApplicationConstSharedPtr app,
+                                          ApplicationManager& app_mngr));
 
   MOCK_METHOD6(GetBCActivateAppRequestToHMI,
                smart_objects::SmartObjectSPtr(

--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -779,6 +779,36 @@ TEST_F(MessageHelperTest, VerifyImage_ImageValueNotValid_InvalidData) {
   EXPECT_EQ(mobile_apis::Result::INVALID_DATA, result);
 }
 
+TEST_F(MessageHelperTest, VerifyImageApplyPath_ImageTypeIsStatic_Success) {
+  // Creating sharedPtr to MockApplication
+  MockApplicationSharedPtr appSharedMock = utils::MakeShared<MockApplication>();
+  // Creating input data for method
+  smart_objects::SmartObject image;
+  image[strings::image_type] = mobile_apis::ImageType::STATIC;
+  image[strings::value] = "icon.png";
+  // Method call
+  mobile_apis::Result::eType result = MessageHelper::VerifyImageApplyPath(
+      image, appSharedMock, mock_application_manager);
+  // EXPECT
+  EXPECT_EQ(mobile_apis::Result::SUCCESS, result);
+  EXPECT_EQ("icon.png", image[strings::value]);
+}
+
+TEST_F(MessageHelperTest, VerifyImageApplyPath_ImageValueNotValid_InvalidData) {
+  // Creating sharedPtr to MockApplication
+  MockApplicationSharedPtr appSharedMock = utils::MakeShared<MockApplication>();
+  // Creating input data for method
+  smart_objects::SmartObject image;
+  image[strings::image_type] = mobile_apis::ImageType::DYNAMIC;
+  // Invalid value
+  image[strings::value] = "   ";
+  // Method call
+  mobile_apis::Result::eType result = MessageHelper::VerifyImageApplyPath(
+      image, appSharedMock, mock_application_manager);
+  // EXPECT
+  EXPECT_EQ(mobile_apis::Result::INVALID_DATA, result);
+}
+
 TEST_F(MessageHelperTest, VerifyImageFiles_SmartObjectWithValidData_Success) {
   // Creating sharedPtr to MockApplication
   MockApplicationSharedPtr appSharedMock = utils::MakeShared<MockApplication>();

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -286,6 +286,14 @@ mobile_apis::Result::eType MessageHelper::VerifyImage(
       message, app, app_mngr);
 }
 
+mobile_apis::Result::eType MessageHelper::VerifyImageApplyPath(
+    smart_objects::SmartObject& message,
+    ApplicationConstSharedPtr app,
+    ApplicationManager& app_mngr) {
+  return MockMessageHelper::message_helper_mock()->VerifyImageApplyPath(
+      message, app, app_mngr);
+}
+
 mobile_apis::Result::eType MessageHelper::VerifyImageFiles(
     smart_objects::SmartObject& message,
     ApplicationConstSharedPtr app,


### PR DESCRIPTION
SDL didn't apply the full image path if it doesn't
exist in the file system. VerifyImage wrapper function
is created that overwrite the image name with path + name
if the image is dynamic regardless of its existence.