### PR TITLE
Fix SDL not resend parameter info

### DIFF
--- a/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
@@ -398,14 +398,14 @@ void PerformInteractionRequest::ProcessUIResponse(
   if (result) {
     if (is_pi_warning) {
       ui_result_code_ = hmi_apis::Common_Result::WARNINGS;
-      ui_info_ = "Unsupported phoneme type was sent in an item";
+      ui_info_ = message[strings::msg_params][strings::info].asString();
       if (message.keyExists(strings::params) &&
           message[strings::params].keyExists(strings::data)) {
         msg_params = message[strings::params][strings::data];
       }
     } else if (is_pi_unsupported) {
       ui_result_code_ = hmi_apis::Common_Result::UNSUPPORTED_RESOURCE;
-      ui_info_ = "Unsupported phoneme type was sent in an item";
+      ui_info_ = message[strings::msg_params][strings::info].asString();
     } else if (message.keyExists(strings::msg_params)) {
       msg_params = message[strings::msg_params];
     }


### PR DESCRIPTION
 Fixed SDL does not resend parameters info with PerformInteraction response
 with UNSUPPORTED_RESOURCE resultcode to MobileApp