### PR TITLE
Fixed SDL behavior  after FACTORY_DEFAULTS

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1040,6 +1040,12 @@ class ApplicationManagerImpl
     return is_stopping_;
   }
 
+  /**
+   * @brief Clear all applications' persistent data in app_storage and
+   * AppIconsFolder
+   */
+  void ClearUserStorage();
+
   StateController& state_controller() OVERRIDE;
   const ApplicationManagerSettings& get_settings() const OVERRIDE;
   virtual event_engine::EventDispatcher& event_dispatcher() OVERRIDE;

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2394,22 +2394,38 @@ void ApplicationManagerImpl::HeadUnitReset(
       GetPolicyHandler().UnloadPolicyLibrary();
 
       resume_controller().StopSavePersistentDataTimer();
-      file_system::remove_directory_content(
-          get_settings().app_storage_folder());
+      ClearUserStorage();
       break;
     }
     case mobile_api::AppInterfaceUnregisteredReason::FACTORY_DEFAULTS: {
       GetPolicyHandler().ClearUserConsent();
 
       resume_controller().StopSavePersistentDataTimer();
-      file_system::remove_directory_content(
-          get_settings().app_storage_folder());
+
+      ClearUserStorage();
       break;
     }
     default: {
       LOG4CXX_ERROR(logger_, "Bad AppInterfaceUnregisteredReason");
       return;
     }
+  }
+}
+
+void ApplicationManagerImpl::ClearUserStorage() {
+  const ApplicationSet& accessor = applications().GetData();
+
+  ApplicationSetConstIt it_app_list = accessor.begin();
+  ApplicationSetConstIt it_app_list_end = accessor.end();
+  const std::string storage_folder = get_settings().app_storage_folder() + "/";
+  const std::string icon_folder = get_settings().app_icons_folder() + "/";
+  for (; it_app_list != it_app_list_end; ++it_app_list) {
+    const std::string directory_path =
+        storage_folder + (*it_app_list).get()->folder_name();
+    file_system::RemoveDirectory(directory_path);
+    const std::string icon_path =
+        icon_folder + (*it_app_list).get()->policy_app_id();
+    file_system::DeleteFile(icon_path);
   }
 }
 

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -213,6 +213,7 @@ bool CacheManager::ResetUserConsent() {
   for (; iter != iter_end; ++iter) {
     iter->second.user_consent_records->clear();
   }
+  Backup();
   return true;
 }
 


### PR DESCRIPTION
1. Backup LPT after reset of UserConsent
2.  After SDL receives BC.OnExitAllApplications(MASTER_RESET) or BC.OnExitAllApplications(FACTORY_DEFAULTS) SDL should clear stored persistent data of all registered applications.