### PR TITLE
Fix broken build for ext_prop flag

### DIFF
--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -251,7 +251,7 @@ class PolicyManagerImpl : public PolicyManager {
 
   AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
                             const EndpointUrls& urls) const OVERRIDE;
-  virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) OVERRIDE;
+
   bool SaveExternalConsentStatus(const ExternalConsentStatus& status) OVERRIDE;
   ExternalConsentStatus GetExternalConsentStatus() OVERRIDE;
 

--- a/src/components/utils/include/utils/optional.h
+++ b/src/components/utils/include/utils/optional.h
@@ -66,6 +66,7 @@ class Optional {
   bool is_initialized() const {
     return value_state_;
   }
+
  private:
   Type value_;
   bool value_state_;


### PR DESCRIPTION
Redundant function prototype was removed.
Probably it had appeared after merging changes.
In optional.h file check_style script fixed issue.