### PR TITLE
Add missing OnHashChange notification

### DIFF
--- a/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -208,6 +208,7 @@ void UnsubscribeVehicleDataRequest::Run() {
                    &response_params);
     } else {
       SendResponse(true, mobile_apis::Result::SUCCESS, NULL, &response_params);
+      UpdateHash();
     }
     return;
   }


### PR DESCRIPTION
Added OnHashChange notification which should be sent when during UnsubscribeVehicleData 2 applications are registered;
Added expectation of new notification to update UnsubscribeVehicleRequestTest unit tests.