### PR TITLE
Fix defect Json validation is failed

### DIFF
--- a/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
@@ -114,6 +114,9 @@ void AddSubMenuRequest::Run() {
     msg_params[strings::sub_menu_icon] =
         (*message_)[strings::msg_params][strings::sub_menu_icon];
     SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);
+  } else {
+    LOG4CXX_ERROR(logger_, "Sub-menu icon is not valid.");
+    SendResponse(false, mobile_apis::Result::INVALID_DATA);
   }
 }
 std::string AddSubMenuRequest::ImageFullPath(const std::string& file_name,

--- a/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
@@ -114,9 +114,6 @@ void AddSubMenuRequest::Run() {
     msg_params[strings::sub_menu_icon] =
         (*message_)[strings::msg_params][strings::sub_menu_icon];
     SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);
-  } else {
-    LOG4CXX_ERROR(logger_, "Sub-menu icon is not valid.");
-    SendResponse(false, mobile_apis::Result::INVALID_DATA);
   }
 }
 std::string AddSubMenuRequest::ImageFullPath(const std::string& file_name,

--- a/src/components/application_manager/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/src/commands/mobile/system_request.cc
@@ -102,12 +102,17 @@ class QueryAppsDataValidator {
     return true;
   }
 
+  /**
+   * \brief Function checks, if language json array has 'ttsName' parameter omitted.
+   * \param languages SmartObject containing languages json array
+   * \return true of parameter was omitted, false otherwise
+  */
   bool CheckIfHasOmittedParam(const smart_objects::SmartObject& languages) {
     const size_t languages_array_size = languages.length();
     for (size_t idx = 0; idx < languages_array_size; ++idx) {
       const smart_objects::SmartObject& language = languages.getElement(idx);
       if (smart_objects::SmartType_Map != language.getType()) {
-        LOG4CXX_WARN(logger_,
+        LOG4CXX_DEBUG(logger_,
                      kQueryAppsValidationFailedPrefix
                          << "language is not a map.");
         return false;
@@ -115,7 +120,7 @@ class QueryAppsDataValidator {
       const std::string language_name = (*language.map_begin()).first;
       if (!language[language_name].keyExists(json::ttsName) ||
           language[language_name][json::ttsName].empty()) {
-        LOG4CXX_WARN(logger_,
+        LOG4CXX_DEBUG(logger_,
                      kQueryAppsValidationFailedPrefix
                          << "'languages.ttsName' doesn't exist");
         return true;
@@ -124,6 +129,12 @@ class QueryAppsDataValidator {
     return false;
   }
 
+  /**
+   * \brief Function writes 'app_id' value to ttsName parameter.
+   * \param languages SmartObject containing languages json array
+   * \param app_id string containt application id
+   * \return true of parameter was omitted, false otherwise
+  */
   void WriteAppIdToOmittedParam(smart_objects::SmartObject& languages,
                                 const std::string& app_id) {
     const size_t languages_array_size = languages.length();
@@ -134,7 +145,7 @@ class QueryAppsDataValidator {
       if (!language[language_name].keyExists(json::ttsName)) {
         language[language_name][json::ttsName] = app_id;
         language.asString();
-        LOG4CXX_INFO(logger_, "app_id written instead of ttsName");
+        LOG4CXX_DEBUG(logger_, "app_id written instead of ttsName");
       }
     }
   }

--- a/src/components/application_manager/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/src/commands/mobile/system_request.cc
@@ -105,7 +105,7 @@ class QueryAppsDataValidator {
   /**
    * \brief Function checks, if language json array has 'ttsName' parameter omitted.
    * \param languages SmartObject containing languages json array
-   * \return true of parameter was omitted, false otherwise
+   * \return true if parameter was omitted, false otherwise
   */
   bool CheckIfHasOmittedParam(const smart_objects::SmartObject& languages) {
     const size_t languages_array_size = languages.length();
@@ -132,8 +132,7 @@ class QueryAppsDataValidator {
   /**
    * \brief Function writes 'app_id' value to ttsName parameter.
    * \param languages SmartObject containing languages json array
-   * \param app_id string containt application id
-   * \return true of parameter was omitted, false otherwise
+   * \param app_id string containing application id
   */
   void WriteAppIdToOmittedParam(smart_objects::SmartObject& languages,
                                 const std::string& app_id) {
@@ -144,7 +143,6 @@ class QueryAppsDataValidator {
       const std::string language_name = (*language.map_begin()).first;
       if (!language[language_name].keyExists(json::ttsName)) {
         language[language_name][json::ttsName] = app_id;
-        language.asString();
         LOG4CXX_DEBUG(logger_, "app_id written instead of ttsName");
       }
     }


### PR DESCRIPTION
 Json validation is failed  in case language parameter does not contain
 vrSynonyms or ttsName

Modified:
* src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
* src/components/application_manager/src/commands/mobile/system_request.cc

Code now sets ttsName field in json to appID, as requested by requirements

Please review:
@LuxoftAKutsan 
@tkireva 
@dcherniev 
