### PR TITLE
Fix missing OnHMIStatus full

### DIFF
--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -549,9 +549,6 @@ void PolicyManagerImpl::SendNotificationOnPermissionsUpdated(
   }
 #endif  // SDL_REMOTE_CONTROL
   GetDefaultHmi(application_id, &default_hmi);
-#ifdef SDL_REMOTE_CONTROL
-  listener()->OnUpdateHMILevel(device_id, application_id, default_hmi);
-#endif  // SDL_REMOTE_CONTROL
   listener()->OnPermissionsUpdated(
       application_id, notification_data, default_hmi);
 }


### PR DESCRIPTION
Redundant OnHMIStatus with wrong data was sent before
the real one. This fix will be applied for other policy
flags in different commit as a part of investigation of
another problem.