### PR TITLE
Fix component info send along with GENERIC_ERROR

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -296,10 +296,10 @@ class CommandRequestImpl : public CommandImpl,
       const hmi_apis::FunctionID::eType& function_id);
 
   /**
-   * @brief Add information for the component of response
+   * @brief Add information for the component of response in case of timeout
    * @param response Response message, which info should be extended
    */
-  void AddComponentInfoToMessage(
+  void AddTimeOutComponentInfoToMessage(
       smart_objects::SmartObjectSPtr& response) const;
 
   /**

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -294,6 +294,21 @@ class CommandRequestImpl : public CommandImpl,
   bool ProcessHMIInterfacesAvailability(
       const uint32_t hmi_correlation_id,
       const hmi_apis::FunctionID::eType& function_id);
+
+  /**
+   * @brief Add information for the component of response
+   * @param response Response message, which info should be extended
+   */
+  void AddComponentInfoToMessage(
+      smart_objects::SmartObjectSPtr& response) const;
+
+  /**
+   * @brief Method transforms AppHMIType to string
+   * @param enum AppHMIType app_hmi_type contains enum value
+   * @return string of AppHMIType
+   */
+  std::string AppHMITypeToString(
+      const mobile_apis::AppHMIType::eType app_hmi_type) const;
 };
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -225,6 +225,8 @@ void CommandRequestImpl::onTimeOut() {
                                             correlation_id(),
                                             mobile_api::Result::GENERIC_ERROR);
 
+  AddComponentInfoToMessage(response);
+
   application_manager_.ManageMobileCommand(response, ORIGIN_SDL);
 }
 
@@ -786,6 +788,78 @@ bool CommandRequestImpl::IsResultCodeUnsupported(
          ((second.is_ok || second.is_invalid_enum) &&
           first.is_unsupported_resource) ||
          (first.is_unsupported_resource && second.is_unsupported_resource);
+}
+
+void CommandRequestImpl::AddComponentInfoToMessage(
+    smart_objects::SmartObjectSPtr& response) const {
+  using NsSmartDeviceLink::NsSmartObjects::SmartObject;
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (!response) {
+    LOG4CXX_WARN(logger_, "Invalid message object");
+    return;
+  }
+
+  const uint32_t app_connection_key = connection_key();
+  const ApplicationSharedPtr app =
+      application_manager_.application(app_connection_key);
+  if (!app) {
+    LOG4CXX_WARN(logger_, "Invalid connection_key: " << app_connection_key);
+    return;
+  }
+
+  const SmartObject* app_type = app->app_types();
+  if (!app_type) {
+    LOG4CXX_WARN(logger_, "Empty application types array!");
+    return;
+  }
+
+  if (NsSmartDeviceLink::NsSmartObjects::SmartType_Array !=
+      app_type->getType()) {
+    LOG4CXX_WARN(logger_, "Application types are not an array!");
+    return;
+  }
+
+  const SmartObject& app_type_so = app_type->getElement(0);
+  if (NsSmartDeviceLink::NsSmartObjects::invalid_object_value == app_type_so) {
+    LOG4CXX_WARN(logger_, "Invalid object for component type!");
+    return;
+  }
+
+  const int64_t app_hmi_type = app_type_so.asInt();
+  const std::string& component_name = AppHMITypeToString(
+      static_cast<mobile_apis::AppHMIType::eType>(app_hmi_type));
+  const std::string component_info =
+      component_name + " component does not respond";
+  (*response)[strings::msg_params][strings::info] = component_info;
+}
+
+std::string CommandRequestImpl::AppHMITypeToString(
+    const mobile_apis::AppHMIType::eType app_hmi_type) const {
+  switch (app_hmi_type) {
+    case mobile_apis::AppHMIType::DEFAULT:
+      return "Default";
+    case mobile_apis::AppHMIType::COMMUNICATION:
+      return "Communication";
+    case mobile_apis::AppHMIType::MEDIA:
+      return "Media";
+    case mobile_apis::AppHMIType::MESSAGING:
+      return "Messaging";
+    case mobile_apis::AppHMIType::NAVIGATION:
+      return "Navigation";
+    case mobile_apis::AppHMIType::INFORMATION:
+      return "Information";
+    case mobile_apis::AppHMIType::SOCIAL:
+      return "Social";
+    case mobile_apis::AppHMIType::BACKGROUND_PROCESS:
+      return "Background Process";
+    case mobile_apis::AppHMIType::TESTING:
+      return "Testing";
+    case mobile_apis::AppHMIType::SYSTEM:
+      return "System";
+    default:
+      return "Invalid Component Type";
+  }
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -225,7 +225,7 @@ void CommandRequestImpl::onTimeOut() {
                                             correlation_id(),
                                             mobile_api::Result::GENERIC_ERROR);
 
-  AddComponentInfoToMessage(response);
+  AddTimeOutComponentInfoToMessage(response);
 
   application_manager_.ManageMobileCommand(response, ORIGIN_SDL);
 }
@@ -790,7 +790,7 @@ bool CommandRequestImpl::IsResultCodeUnsupported(
          (first.is_unsupported_resource && second.is_unsupported_resource);
 }
 
-void CommandRequestImpl::AddComponentInfoToMessage(
+void CommandRequestImpl::AddTimeOutComponentInfoToMessage(
     smart_objects::SmartObjectSPtr& response) const {
   using NsSmartDeviceLink::NsSmartObjects::SmartObject;
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/application_manager/test/commands/CMakeLists.txt
+++ b/src/components/application_manager/test/commands/CMakeLists.txt
@@ -49,6 +49,7 @@ file(GLOB SOURCES
   ${COMMANDS_TEST_DIR}/hmi/*
   ${COMMANDS_TEST_DIR}/hmi/hmi_notifications/*
   ${COMMANDS_TEST_DIR}/mobile/*
+  ${COMMANDS_TEST_DIR}/*
 )
 
 set(LIBRARIES

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -179,6 +179,9 @@ TEST_F(CommandRequestImplTest, OnTimeOut_StateAwaitingHMIResponse_SUCCESS) {
       app_mngr_,
       ManageMobileCommand(dummy_msg, Command::CommandOrigin::ORIGIN_SDL));
 
+  MockAppPtr app = CreateMockApp();
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app));
+
   command->onTimeOut();
 
   // If `command` not done till now, then state should change to `kTimedOut`

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -172,15 +172,16 @@ TEST_F(CommandRequestImplTest, OnTimeOut_StateAwaitingHMIResponse_SUCCESS) {
 
   CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
 
+  MockAppPtr app = CreateMockApp();
+  ON_CALL(app_mngr_, application(command->connection_key()))
+      .WillByDefault(Return(app));
+
   MessageSharedPtr dummy_msg(CreateMessage());
   EXPECT_CALL(*mock_message_helper_, CreateNegativeResponse(_, _, _, _))
       .WillOnce(Return(dummy_msg));
   EXPECT_CALL(
       app_mngr_,
       ManageMobileCommand(dummy_msg, Command::CommandOrigin::ORIGIN_SDL));
-
-  MockAppPtr app = CreateMockApp();
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app));
 
   command->onTimeOut();
 

--- a/src/components/application_manager/test/commands/mobile/alert_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/alert_request_test.cc
@@ -224,6 +224,8 @@ TEST_F(AlertRequestTest, OnTimeout_GENERIC_ERROR) {
       ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
       .WillOnce(DoAll(SaveArg<0>(&ui_command_result), Return(true)));
 
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
+
   command->onTimeOut();
   EXPECT_EQ((*ui_command_result)[am::strings::msg_params][am::strings::success]
                 .asBool(),
@@ -318,6 +320,8 @@ TEST_F(AlertRequestTest, OnTimeOut_SUCCESS) {
       mock_message_helper_,
       CreateNegativeResponse(_, _, _, mobile_apis::Result::GENERIC_ERROR))
       .WillOnce(Return(result_msg));
+
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
   CommandPtr command(CreateCommand<AlertRequest>());
   MessageSharedPtr received_result_msg(

--- a/src/components/application_manager/test/commands/mobile/alert_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/alert_request_test.cc
@@ -213,6 +213,9 @@ TEST_F(AlertRequestTest, OnTimeout_GENERIC_ERROR) {
 
   utils::SharedPtr<AlertRequest> command = CreateCommand<AlertRequest>();
 
+  ON_CALL(app_mngr_, application(command->connection_key()))
+      .WillByDefault(Return(mock_app_));
+
   EXPECT_CALL(
       mock_message_helper_,
       CreateNegativeResponse(_, _, _, am::mobile_api::Result::GENERIC_ERROR))
@@ -223,8 +226,6 @@ TEST_F(AlertRequestTest, OnTimeout_GENERIC_ERROR) {
       app_mngr_,
       ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
       .WillOnce(DoAll(SaveArg<0>(&ui_command_result), Return(true)));
-
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
   command->onTimeOut();
   EXPECT_EQ((*ui_command_result)[am::strings::msg_params][am::strings::success]
@@ -321,11 +322,14 @@ TEST_F(AlertRequestTest, OnTimeOut_SUCCESS) {
       CreateNegativeResponse(_, _, _, mobile_apis::Result::GENERIC_ERROR))
       .WillOnce(Return(result_msg));
 
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
-
   CommandPtr command(CreateCommand<AlertRequest>());
+
+  ON_CALL(app_mngr_, application(command->connection_key()))
+      .WillByDefault(Return(mock_app_));
+
   MessageSharedPtr received_result_msg(
       CatchMobileCommandResult(CallOnTimeOut(*command)));
+
   EXPECT_EQ(result_msg, received_result_msg);
 }
 

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -340,6 +340,8 @@ TEST_F(PerformAudioPassThruRequestTest, OnTimeout_GENERIC_ERROR) {
       ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
       .WillOnce(DoAll(SaveArg<0>(&msg_mobile_response), Return(true)));
 
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
+
   command->onTimeOut();
 
   ResultCommandExpectations(

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -329,6 +329,9 @@ TEST_F(PerformAudioPassThruRequestTest, OnTimeout_GENERIC_ERROR) {
   utils::SharedPtr<PerformAudioPassThruRequest> command =
       CreateCommand<PerformAudioPassThruRequest>();
 
+  ON_CALL(app_mngr_, application(command->connection_key()))
+      .WillByDefault(Return(mock_app_));
+
   EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(true));
   EXPECT_CALL(app_mngr_, StopAudioPassThru(_));
   EXPECT_CALL(
@@ -339,8 +342,6 @@ TEST_F(PerformAudioPassThruRequestTest, OnTimeout_GENERIC_ERROR) {
       app_mngr_,
       ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
       .WillOnce(DoAll(SaveArg<0>(&msg_mobile_response), Return(true)));
-
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
   command->onTimeOut();
 

--- a/src/components/application_manager/test/commands/mobile/set_audio_streaming_indicator_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_audio_streaming_indicator_test.cc
@@ -493,8 +493,9 @@ TEST_F(SetAudioStreamingIndicatorRequestTest,
   const bool is_success = kIsNotSuccess;
 
   ApplicationSharedPtr mock_app_empty;
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app_empty));
+  EXPECT_CALL(app_mngr_, application(_))
+      .Times(2)
+      .WillRepeatedly(Return(mock_app_empty));
 
   EXPECT_CALL(*mock_app_, RemoveIndicatorWaitForResponse(_)).Times(0);
   EXPECT_CALL(


### PR DESCRIPTION
In the case of command request timeout SDL responds properly, but without
component information. After the fix component information is added in the
form "'%component-name%' component does not respond"