### PR TITLE
Fix incorrect validation of entityId and entityType parameters in Preloaded PT

### DIFF
--- a/src/components/policy/policy_external/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/types.h
@@ -311,7 +311,7 @@ struct RpcParameters : CompositeType {
 
 struct ExternalConsentEntity : CompositeType {
  public:
-  typedef Integer<int32_t, INT32_MIN, INT32_MAX> EntityInt;
+  typedef Integer<int32_t, 0, 128> EntityInt;
   EntityInt entity_type;
   EntityInt entity_id;
 


### PR DESCRIPTION
After the fix SDL considers numeric values in range 0..128 as valid