### PR TITLE
Fix running SDL after invalid preloaded_pt

### DIFF
--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -719,8 +719,9 @@ class CacheManager : public CacheManagerInterface {
    * JSON date is different than current database.
    *
    * @param file_name the preloaded policy table JSON file.
+   * @return false in case of invalid preloaded_pt
    */
-  void MergePreloadPT(const std::string& file_name);
+  bool MergePreloadPT(const std::string& file_name);
 
   bool GetPermissionsList(StringArray& perm_list) const;
 

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -2005,7 +2005,9 @@ bool CacheManager::Init(const std::string& file_name,
           backup_->UpdateDBVersion();
           Backup();
         }
-        MergePreloadPT(file_name);
+        if (!MergePreloadPT(file_name)) {
+          result = false;
+        }
       }
     } break;
     case InitResult::SUCCESS: {
@@ -2184,12 +2186,12 @@ ExternalConsentStatus CacheManager::GetExternalConsentStatus() {
   return ex_backup_->GetExternalConsentStatus();
 }
 
-void CacheManager::MergePreloadPT(const std::string& file_name) {
+bool CacheManager::MergePreloadPT(const std::string& file_name) {
   LOG4CXX_AUTO_TRACE(logger_);
   policy_table::Table table;
   if (!LoadFromFile(file_name, table)) {
     LOG4CXX_DEBUG(logger_, "Unable to load preloaded PT.");
-    return;
+    return false;
   }
 
   sync_primitives::AutoLock lock(cache_lock_);
@@ -2204,6 +2206,7 @@ void CacheManager::MergePreloadPT(const std::string& file_name) {
     MergeCFM(new_table, current);
     Backup();
   }
+  return true;
 }
 
 void CacheManager::MergeMC(const policy_table::PolicyTable& new_pt,

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -610,12 +610,13 @@ class CacheManager : public CacheManagerInterface {
   /**
    * @brief MergePreloadPT allows to load policy table from certain JSON file,
    * and then decide if merge is needed. The merge is needed in case when
-   *preload
+   * preload
    * JSON date is different than current database.
    *
    * @param file_name the preloaded policy table JSON file.
+   * @return false in case of invalid preloaded_pt
    */
-  void MergePreloadPT(const std::string& file_name);
+  bool MergePreloadPT(const std::string& file_name);
 
   /**
    * @brief MergeMC allows to merge ModuleConfig section by definite rules.

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -1352,7 +1352,9 @@ bool CacheManager::Init(const std::string& file_name,
           backup_->UpdateDBVersion();
           Backup();
         }
-        MergePreloadPT(file_name);
+        if (!MergePreloadPT(file_name)) {
+          result = false;
+        }
       }
     } break;
     case InitResult::SUCCESS: {
@@ -1494,12 +1496,12 @@ std::string CacheManager::GetCertificate() const {
   return std::string("");
 }
 
-void CacheManager::MergePreloadPT(const std::string& file_name) {
+bool CacheManager::MergePreloadPT(const std::string& file_name) {
   LOG4CXX_AUTO_TRACE(logger_);
   policy_table::Table table;
   if (!LoadFromFile(file_name, table)) {
     LOG4CXX_DEBUG(logger_, "Unable to load preloaded PT.");
-    return;
+    return false;
   }
 
   sync_primitives::AutoLock lock(cache_lock_);
@@ -1514,6 +1516,7 @@ void CacheManager::MergePreloadPT(const std::string& file_name) {
     MergeCFM(new_table, current);
     Backup();
   }
+  return true;
 }
 
 void CacheManager::MergeMC(const policy_table::PolicyTable& new_pt,


### PR DESCRIPTION
SDL skip merging in case of invalid preloaded_pt file loaded.
Method MergePreloadPT is changed to return boolean result that
indicates state of merging.