### PR TITLE
Fix IGNORED instead of UNSUPPORTED_RESOURCE for UnsubscribeButton

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/unsubscribe_button_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/unsubscribe_button_request.h
@@ -71,6 +71,8 @@ class UnsubscribeButtonRequest : public CommandRequestImpl {
    */
   void SendUnsubscribeButtonNotification();
 
+  bool CheckHMICapabilities(mobile_apis::ButtonName::eType button) const;
+
   DISALLOW_COPY_AND_ASSIGN(UnsubscribeButtonRequest);
 };
 

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_button_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_button_request.cc
@@ -33,6 +33,8 @@
 
 #include "application_manager/commands/mobile/unsubscribe_button_request.h"
 
+#include <algorithm>
+
 #include "application_manager/application_impl.h"
 
 namespace application_manager {
@@ -41,6 +43,22 @@ namespace commands {
 
 namespace str = strings;
 
+namespace {
+struct FindButtonName {
+  FindButtonName(const mobile_apis::ButtonName::eType target_name)
+      : target_name_(target_name) {}
+
+  const mobile_apis::ButtonName::eType target_name_;
+
+  bool operator()(const smart_objects::SmartObject& buttonSO) const {
+    using namespace mobile_apis;
+    const ButtonName::eType name = static_cast<ButtonName::eType>(
+        buttonSO.getElement(hmi_response::button_name).asInt());
+    return name == target_name_;
+  }
+};
+}  // namespace
+
 UnsubscribeButtonRequest::UnsubscribeButtonRequest(
     const MessageSharedPtr& message, ApplicationManager& application_manager)
     : CommandRequestImpl(message, application_manager) {}
@@ -48,6 +66,7 @@ UnsubscribeButtonRequest::UnsubscribeButtonRequest(
 UnsubscribeButtonRequest::~UnsubscribeButtonRequest() {}
 
 void UnsubscribeButtonRequest::Run() {
+  using namespace mobile_apis;
   LOG4CXX_AUTO_TRACE(logger_);
 
   ApplicationSharedPtr app = application_manager_.application(connection_key());
@@ -58,8 +77,15 @@ void UnsubscribeButtonRequest::Run() {
     return;
   }
 
-  const uint32_t btn_id =
-      (*message_)[str::msg_params][str::button_name].asUInt();
+  const ButtonName::eType btn_id = static_cast<ButtonName::eType>(
+      (*message_)[str::msg_params][str::button_name].asInt());
+
+  if (!CheckHMICapabilities(btn_id)) {
+    LOG4CXX_ERROR(logger_,
+                  "Button " << btn_id << " isn't allowed by HMI capabilities");
+    SendResponse(false, mobile_apis::Result::UNSUPPORTED_RESOURCE);
+    return;
+  }
 
   if (!app->UnsubscribeFromButton(
           static_cast<mobile_apis::ButtonName::eType>(btn_id))) {
@@ -73,6 +99,28 @@ void UnsubscribeButtonRequest::Run() {
   app->UpdateHash();
 }
 
+bool UnsubscribeButtonRequest::CheckHMICapabilities(
+    mobile_apis::ButtonName::eType button) const {
+  using namespace smart_objects;
+  using namespace mobile_apis;
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const HMICapabilities& hmi_caps = application_manager_.hmi_capabilities();
+  if (!hmi_caps.is_ui_cooperating()) {
+    LOG4CXX_ERROR(logger_, "UI is not supported by HMI.");
+    return false;
+  }
+
+  const SmartObject* button_caps_ptr = hmi_caps.button_capabilities();
+  if (button_caps_ptr && button_caps_ptr->asArray()) {
+    const SmartArray& button_caps = *button_caps_ptr->asArray();
+    const SmartArray::const_iterator result = std::find_if(
+        button_caps.begin(), button_caps.end(), FindButtonName(button));
+    return result != button_caps.end();
+  }
+  return false;
+}
+
 void UnsubscribeButtonRequest::SendUnsubscribeButtonNotification() {
   using namespace smart_objects;
   using namespace hmi_apis;
@@ -81,7 +129,7 @@ void UnsubscribeButtonRequest::SendUnsubscribeButtonNotification() {
   SmartObject msg_params = SmartObject(SmartType_Map);
   msg_params[strings::app_id] = connection_key();
   msg_params[strings::name] = static_cast<Common_ButtonName::eType>(
-      (*message_)[strings::msg_params][strings::button_name].asUInt());
+      (*message_)[strings::msg_params][strings::button_name].asInt());
   msg_params[strings::is_suscribed] = false;
   CreateHMINotification(FunctionID::Buttons_OnButtonSubscription, msg_params);
 }

--- a/src/components/application_manager/test/commands/mobile/unsubscribe_button_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unsubscribe_button_request_test.cc
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include <stdint.h>
 #include <string>
 
@@ -6,6 +38,7 @@
 #include "application_manager/commands/command_request_test.h"
 #include "application_manager/mock_application_manager.h"
 #include "application_manager/mock_message_helper.h"
+#include "application_manager/mock_hmi_capabilities.h"
 #include "application_manager/commands/mobile/unsubscribe_button_request.h"
 
 namespace test {
@@ -21,6 +54,7 @@ using ::testing::_;
 
 using am::commands::UnsubscribeButtonRequest;
 using am::commands::MessageSharedPtr;
+using application_manager_test::MockHMICapabilities;
 
 typedef ::utils::SharedPtr<UnsubscribeButtonRequest> CommandPtr;
 
@@ -30,7 +64,14 @@ const mobile_apis::ButtonName::eType kButtonId = mobile_apis::ButtonName::OK;
 }  // namespace
 
 class UnsubscribeButtonRequestTest
-    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  MOCK(MockHMICapabilities) mock_hmi_capabilities_;
+  UnsubscribeButtonRequestTest() {
+    ON_CALL(app_mngr_, hmi_capabilities())
+        .WillByDefault(ReturnRef(mock_hmi_capabilities_));
+  }
+};
 
 TEST_F(UnsubscribeButtonRequestTest, Run_AppNotRegistered_UNSUCCESS) {
   CommandPtr command(CreateCommand<UnsubscribeButtonRequest>());
@@ -47,7 +88,7 @@ TEST_F(UnsubscribeButtonRequestTest, Run_AppNotRegistered_UNSUCCESS) {
 }
 
 TEST_F(UnsubscribeButtonRequestTest,
-       Run_UnsubscribeNotSubscribedButton_UNSUCCESS) {
+       Run_UnsubscribeNotSubscribedButton_UNSUPPORTED_RESOURCE) {
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
   (*command_msg)[am::strings::params][am::strings::connection_key] =
       kConnectionKey;
@@ -59,12 +100,9 @@ TEST_F(UnsubscribeButtonRequestTest,
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
-  EXPECT_CALL(*mock_app, UnsubscribeFromButton(kButtonId))
-      .WillOnce(Return(false));
-
-  EXPECT_CALL(
-      app_mngr_,
-      ManageMobileCommand(MobileResultCodeIs(mobile_result::IGNORED), _));
+  EXPECT_CALL(app_mngr_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_result::UNSUPPORTED_RESOURCE), _));
 
   command->Run();
 }
@@ -82,6 +120,13 @@ TEST_F(UnsubscribeButtonRequestTest, Run_SUCCESS) {
   MockAppPtr mock_app(CreateMockApp());
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
+
+  EXPECT_CALL(mock_hmi_capabilities_, is_ui_cooperating())
+      .WillOnce(Return(true));
+  MessageSharedPtr button_cap(CreateMessage(smart_objects::SmartType_Array));
+  (*button_cap)[0][am::hmi_response::button_name] = kButtonId;
+  EXPECT_CALL(mock_hmi_capabilities_, button_capabilities())
+      .WillOnce(Return(button_cap.get()));
 
   EXPECT_CALL(*mock_app, UnsubscribeFromButton(kButtonId))
       .WillOnce(Return(true));


### PR DESCRIPTION
According to requirements for `UnsubscribeButton`,
`SDL` must send `UNSUPPORTED_RESOURCE`,
if button is not supported.
##
@pold500, @indlu, @tkireva, please, review.