### PR TITLE
Fix redundant PTU for existing app

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -356,7 +356,10 @@ bool PolicyHandler::InitPolicyTable() {
       hmi_apis::FunctionID::BasicCommunication_OnReady);
   std::string preloaded_file = get_settings().preloaded_pt_file();
   if (file_system::FileExists(preloaded_file)) {
-    return policy_manager_->InitPT(preloaded_file, &get_settings());
+    const bool result =
+        policy_manager_->InitPT(preloaded_file, &get_settings());
+    SetDaysAfterEpoch();
+    return result;
   }
   LOG4CXX_FATAL(logger_, "The file which contains preloaded PT is not exist");
   return false;


### PR DESCRIPTION
The trigger of PTU was exceeded days because of
wrong value of pt_exchanged_x_days_after_epoch.