### PR TITLE
Fix issue with incorrect behaviour in AlertManeuver

### DIFF
--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -238,6 +238,22 @@ bool AlertManeuverRequest::IsWhiteSpaceExist() {
       }
     }
   }
+  if ((*message_)[strings::msg_params].keyExists(strings::soft_buttons)) {
+    const smart_objects::SmartArray* sb_array =
+        (*message_)[strings::msg_params][strings::soft_buttons].asArray();
+
+    smart_objects::SmartArray::const_iterator it_sb = sb_array->begin();
+    smart_objects::SmartArray::const_iterator it_sb_end = sb_array->end();
+
+    for (; it_sb != it_sb_end; ++it_sb) {
+      str = (*it_sb)[strings::text].asCharArray();
+      if (!CheckSyntax(str, false)) {
+        LOG4CXX_ERROR(logger_, "Invalid soft_buttons syntax check failed");
+        return true;
+      }
+    }
+  }
+
   return false;
 }
 

--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -221,7 +221,6 @@ bool AlertManeuverRequest::PrepareResponseParameters(
 
 bool AlertManeuverRequest::IsWhiteSpaceExist() {
   LOG4CXX_AUTO_TRACE(logger_);
-  const char* str = NULL;
 
   if ((*message_)[strings::msg_params].keyExists(strings::tts_chunks)) {
     const smart_objects::SmartArray* tc_array =
@@ -231,7 +230,7 @@ bool AlertManeuverRequest::IsWhiteSpaceExist() {
     smart_objects::SmartArray::const_iterator it_tc_end = tc_array->end();
 
     for (; it_tc != it_tc_end; ++it_tc) {
-      str = (*it_tc)[strings::text].asCharArray();
+      const char* str = (*it_tc)[strings::text].asCharArray();
       if (strlen(str) && !CheckSyntax(str)) {
         LOG4CXX_ERROR(logger_, "Invalid tts_chunks syntax check failed");
         return true;
@@ -239,6 +238,10 @@ bool AlertManeuverRequest::IsWhiteSpaceExist() {
     }
   }
   if ((*message_)[strings::msg_params].keyExists(strings::soft_buttons)) {
+    DCHECK_OR_RETURN(
+        (*message_)[strings::msg_params][strings::soft_buttons].getType() ==
+            smart_objects::SmartType_Array,
+        true);
     const smart_objects::SmartArray* sb_array =
         (*message_)[strings::msg_params][strings::soft_buttons].asArray();
 
@@ -246,11 +249,8 @@ bool AlertManeuverRequest::IsWhiteSpaceExist() {
     smart_objects::SmartArray::const_iterator it_sb_end = sb_array->end();
 
     for (; it_sb != it_sb_end; ++it_sb) {
-      str = (*it_sb)[strings::text].asCharArray();
-      if (strlen(str) && !CheckSyntax(str)) {
-        LOG4CXX_ERROR(logger_, "Invalid soft_buttons syntax check failed");
-        return true;
-      } else if (!CheckSyntax(str, false)) {
+      const char* str = (*it_sb)[strings::text].asCharArray();
+      if (!CheckSyntax(str)) {
         LOG4CXX_ERROR(logger_, "Invalid soft_buttons syntax check failed");
         return true;
       }

--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -247,7 +247,10 @@ bool AlertManeuverRequest::IsWhiteSpaceExist() {
 
     for (; it_sb != it_sb_end; ++it_sb) {
       str = (*it_sb)[strings::text].asCharArray();
-      if (!CheckSyntax(str, false)) {
+      if (strlen(str) && !CheckSyntax(str)) {
+        LOG4CXX_ERROR(logger_, "Invalid soft_buttons syntax check failed");
+        return true;
+      } else if (!CheckSyntax(str, false)) {
         LOG4CXX_ERROR(logger_, "Invalid soft_buttons syntax check failed");
         return true;
       }

--- a/src/components/application_manager/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/src/commands/mobile/system_request.cc
@@ -103,7 +103,8 @@ class QueryAppsDataValidator {
   }
 
   /**
-   * \brief Function checks, if language json array has 'ttsName' parameter omitted.
+   * \brief Function checks, if language json array has 'ttsName' parameter
+   * omitted.
    * \param languages SmartObject containing languages json array
    * \return true if parameter was omitted, false otherwise
   */
@@ -113,16 +114,16 @@ class QueryAppsDataValidator {
       const smart_objects::SmartObject& language = languages.getElement(idx);
       if (smart_objects::SmartType_Map != language.getType()) {
         LOG4CXX_DEBUG(logger_,
-                     kQueryAppsValidationFailedPrefix
-                         << "language is not a map.");
+                      kQueryAppsValidationFailedPrefix
+                          << "language is not a map.");
         return false;
       }
       const std::string language_name = (*language.map_begin()).first;
       if (!language[language_name].keyExists(json::ttsName) ||
           language[language_name][json::ttsName].empty()) {
         LOG4CXX_DEBUG(logger_,
-                     kQueryAppsValidationFailedPrefix
-                         << "'languages.ttsName' doesn't exist");
+                      kQueryAppsValidationFailedPrefix
+                          << "'languages.ttsName' doesn't exist");
         return true;
       }
     }
@@ -228,10 +229,8 @@ class QueryAppsDataValidator {
 
       auto& app_data_non_const = *(objects_array->begin());
       if (CheckIfHasOmittedParam(app_data[os_type][json::languages])) {
-        WriteAppIdToOmittedParam(
-            app_data_non_const[os_type][json::languages],
-            app_data[json::appId]
-                .asString());
+        WriteAppIdToOmittedParam(app_data_non_const[os_type][json::languages],
+                                 app_data[json::appId].asString());
       }
 
       if (!ValidateLanguages(app_data[os_type][json::languages],

--- a/src/components/application_manager/test/commands/mobile/alert_maneuver_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/alert_maneuver_request_test.cc
@@ -245,7 +245,8 @@ TEST_F(AlertManeuverRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
 
 TEST_F(AlertManeuverRequestTest, Run_ProcessingResult_UNSUCCESS) {
   MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
-  (*msg)[am::strings::msg_params][am::strings::soft_buttons] = 0;
+  (*msg)[am::strings::msg_params][am::strings::soft_buttons][0]
+        [am::strings::text] = "text";
 
   CommandPtr command(CreateCommand<AlertManeuverRequest>(msg));
 
@@ -292,7 +293,8 @@ TEST_F(AlertManeuverRequestTest, Run_IsWhiteSpaceExist_UNSUCCESS) {
 
 TEST_F(AlertManeuverRequestTest, Run_ProcessingResult_SUCCESS) {
   MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
-  (*msg)[am::strings::msg_params][am::strings::soft_buttons] = 0;
+  (*msg)[am::strings::msg_params][am::strings::soft_buttons][0]
+        [am::strings::text] = "text";
 
   CommandPtr command(CreateCommand<AlertManeuverRequest>(msg));
 


### PR DESCRIPTION
  - fixed issue when in AlertManeuver SDL responds GENERIC_ERROR instead of
    INVALID_DATA when soft button has Type is Image or Both and Text is
    whitespace or \t or \n or empty
  - fixed failed UTs

Related to [Issue-980](https://github.com/smartdevicelink/sdl_core/issues/980)