### PR TITLE
Fix INVALID_DATA returned by SDL on request SetGlobalProperties with valid parameters

### DIFF
--- a/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
@@ -135,7 +135,7 @@ void SetGlobalPropertiesRequest::Run() {
   }
 
   if (is_vr_help_title_present && is_vr_help_present) {
-    LOG4CXX_DEBUG(logger_, "VRHelp params presents");
+    LOG4CXX_DEBUG(logger_, "VRHelp params are present");
 
     if (!CheckVrHelpItemsOrder(msg_params[strings::vr_help])) {
       LOG4CXX_ERROR(logger_,
@@ -154,7 +154,7 @@ void SetGlobalPropertiesRequest::Run() {
     params[strings::app_id] = app->app_id();
     SendUIRequest(params, true);
   } else {
-    LOG4CXX_DEBUG(logger_, "VRHelp params does not present");
+    LOG4CXX_DEBUG(logger_, "VRHelp params are not present");
     DCHECK_OR_RETURN_VOID(!is_vr_help_title_present && !is_vr_help_present);
 
     smart_objects::SmartObject params =
@@ -163,7 +163,7 @@ void SetGlobalPropertiesRequest::Run() {
     if (ValidateVRHelpTitle(app->vr_help_title())) {
       LOG4CXX_DEBUG(logger_, "App already contains VRHelp data");
     } else if (!PrepareUIRequestDefaultVRHelpData(app, params)) {
-      LOG4CXX_ERROR(logger_, "default VRHElp data could not be generated");
+      LOG4CXX_ERROR(logger_, "Default VRHelp data could not be generated");
       SendResponse(false, mobile_apis::Result::INVALID_DATA);
       return;
     }

--- a/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
@@ -162,13 +162,12 @@ void SetGlobalPropertiesRequest::Run() {
 
     if (ValidateVRHelpTitle(app->vr_help_title())) {
       LOG4CXX_DEBUG(logger_, "App already contains VRHelp data");
-    } else {
-      if (!PrepareUIRequestDefaultVRHelpData(app, params)) {
-        LOG4CXX_ERROR(logger_, "default VRHElp data could not be generated");
-        SendResponse(false, mobile_apis::Result::INVALID_DATA);
-        return;
-      }
+    } else if (!PrepareUIRequestDefaultVRHelpData(app, params)) {
+      LOG4CXX_ERROR(logger_, "default VRHElp data could not be generated");
+      SendResponse(false, mobile_apis::Result::INVALID_DATA);
+      return;
     }
+
     PrepareUIRequestMenuAndKeyboardData(app, msg_params, params);
 
     // Preparing data
@@ -358,21 +357,29 @@ bool SetGlobalPropertiesRequest::PrepareUIRequestDefaultVRHelpData(
         (*command_it->second)[strings::vr_commands][0];
   }
 
-  if (!vr_help_items.empty()) {
-    app->set_vr_help(vr_help_items);
-  } else {
-    // No one AddCommand happened before, so get vrHelp from first vrSynonym
-    // that was taken at registration
-    LOG4CXX_DEBUG(logger_, "Create vrHelp from vrSynonyms");
+  // No one AddCommand happened before, so try to fill out help items using
+  // vrSynonyms or app name
+  if (vr_help_items.empty()) {
+    smart_objects::SmartObject vr_help_item =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
     if (app->vr_synonyms() && !app->vr_synonyms()->empty()) {
-      app->set_vr_help(app->vr_synonyms()->getElement(0));
+      // try first to get vrHelp from first vrSynonym that was taken at
+      // registration
+      LOG4CXX_DEBUG(logger_, "Create vrHelp from vrSynonyms");
+      vr_help_item[strings::text] = app->vr_synonyms()->getElement(0);
     } else {
-      LOG4CXX_ERROR(logger_, "Can't create default vrHelp");
-      return false;
+      // finally fail back to app name
+      LOG4CXX_ERROR(logger_, "Create vrHelp from app name");
+      vr_help_item[strings::text] = app->name();
     }
+    vr_help_item[strings::position] = 1;
+
+    vr_help_items[0] = vr_help_item;
   }
 
+  app->set_vr_help(vr_help_items);
   app->set_vr_help_title(smart_objects::SmartObject(app->name()));
+
   out_params[strings::vr_help_title] = (*app->vr_help_title());
   out_params[strings::vr_help] = (*app->vr_help());
 


### PR DESCRIPTION
The issue is caused by the inability to be prepare default help data, after
the fix SDL hail backs to use application name as the last possible option.
