### PR TITLE
Fix external_consent param out of limit

### DIFF
--- a/src/components/policy/policy_external/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/types.h
@@ -327,7 +327,7 @@ struct ExternalConsentEntity : CompositeType {
   void SetPolicyTableType(PolicyTableType pt_type) OVERRIDE;
 };
 
-typedef Array<ExternalConsentEntity, 0, 255>
+typedef Array<ExternalConsentEntity, 0, 100>
     DisallowedByExternalConsentEntities;
 
 struct Rpcs : CompositeType {


### PR DESCRIPTION
disallowed_by_external_consent_entities_on / _off parameter
array was defined with size 255. It is changed to 100.