### PR TITLE
Fix PT array size validation of "default" section in "endpoints"

### DIFF
--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -72,7 +72,7 @@ typedef Array<Enum<Parameter>, 0, 24> Parameters;
 
 typedef Map<RpcParameters, 0, 65535> Rpc;
 
-typedef Array<String<10, 255>, 1, 255> URL;
+typedef Array<String<10, 255>, 1, 3> URL;
 
 typedef Map<URL, 1, 255> URLList;
 


### PR DESCRIPTION
After the fix PM allows 1 to 3 array elements in "endpoints"
for PROPRIETARY and HTTP flows