### PR TITLE
Fix SDL does not send StopAudioStream to exit app if Video and Audio services are starting

### DIFF
--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -485,7 +485,16 @@ void ApplicationImpl::StopStreaming(
 
   SuspendStreaming(service_type);
 
-  if (service_type == ServiceType::kMobileNav && video_streaming_approved()) {
+  if (service_type == ServiceType::kMobileNav && video_streaming_approved() &&
+      audio_streaming_approved()) {
+    StopNaviStreaming();
+    StopAudioStreaming();
+  } else if (service_type == ServiceType::kMobileNav &&
+             video_streaming_approved()) {
+    StopNaviStreaming();
+  } else if (service_type == ServiceType::kAudio &&
+             audio_streaming_approved() && video_streaming_approved()) {
+    StopAudioStreaming();
     StopNaviStreaming();
   } else if (service_type == ServiceType::kAudio &&
              audio_streaming_approved()) {


### PR DESCRIPTION
 Fixed SDL does not send StopAudioStream to exit app if Video and Audio services are starting

 Related to [Issue-1002](https://github.com/smartdevicelink/sdl_core/issues/1002)