### PR TITLE
Fix incorrect behavior of SDL when OnPermissionsChange is sent

### DIFF
--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1114,7 +1114,7 @@ void PolicyManagerImpl::GetPermissionsForApp(
 #ifdef SDL_REMOTE_CONTROL
   allowed_by_default = false;
   bool ret = access_remote_->GetPermissionsForApp(
-      device_id, policy_app_id, group_types);
+      device_id, app_id_to_check, group_types);
 #else
   bool ret =
       cache_->GetPermissionsForApp(device_id, app_id_to_check, group_types);


### PR DESCRIPTION
Fix when OnPermissionsChange is sent with incorrect data  in case of SDL functionality is disallowed