### PR TITLE
[WIP] Fix case sensitive app name and id

### DIFF
--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -247,7 +247,7 @@ struct IsSameAppName : public IsSameApp {
       return false;
     }
 
-    bool same = (name_ == other->name().AsMBString());
+    const bool same = (name_ == other->name().AsMBString());
     if (same) {
       LOG4CXX_AUTO_TRACE(logger_);
       LOG4CXX_ERROR(logger_, "Application name is known already.");
@@ -299,7 +299,7 @@ struct IsSameAppName {
                 const smart_objects::SmartArray* vr_synonyms)
       : name_(name), matcher_(name_), vr_synonyms_(vr_synonyms) {}
   bool operator()(ApplicationSharedPtr other) const {
-    bool same = (name_ == other->name().AsMBString());
+    const bool same = (name_ == other->name().AsMBString());
     if (same) {
       LOG4CXX_AUTO_TRACE(logger_);
       LOG4CXX_ERROR(logger_, "Application name is known already.");
@@ -1031,7 +1031,7 @@ mobile_apis::Result::eType RegisterAppInterfaceRequest::CheckCoincidence() {
   for (; accessor.end() != it; ++it) {
     // name check
     const custom_str::CustomString& cur_name = (*it)->name();
-    if (app_name == cur_name.AsMBString()) {
+    if (app_name.Compare(cur_name.AsMBString())) {
       LOG4CXX_ERROR(logger_, "Application name is known already.");
       return mobile_apis::Result::DUPLICATE_NAME;
     }
@@ -1203,7 +1203,7 @@ bool RegisterAppInterfaceRequest::IsApplicationWithSameAppIdRegistered() {
   ApplicationSetConstIt it = applications.begin();
   ApplicationSetConstIt it_end = applications.end();
   for (; it != it_end; ++it) {
-    if (mobile_app_id == (*it)->policy_app_id()) {
+    if (mobile_app_id.Compare(policy_app_id().c_str())) {
       return true;
     }
   }

--- a/src/components/include/utils/custom_string.h
+++ b/src/components/include/utils/custom_string.h
@@ -180,6 +180,20 @@ class CustomString {
   bool CompareIgnoreCase(const char* str) const;
 
   /**
+   * @brief Compares the value of the string (case sensitive).
+   * @param Contains string for comparing
+   * @return Returns TRUE if strings is equal otherwise returns FALSE.
+   */
+  bool Compare(const CustomString& str) const;
+
+  /**
+   * @brief Compares the value of the string (case sensitive).
+   * @param Contains string for comparing
+   * @return Returns TRUE if strings is equal otherwise returns FALSE.
+   */
+  bool Compare(const char* str) const;
+
+  /**
    * @brief Returns a pointer to string from CustomString.
    */
   const char* c_str() const;

--- a/src/components/utils/src/custom_string.cc
+++ b/src/components/utils/src/custom_string.cc
@@ -172,6 +172,14 @@ bool CustomString::CompareIgnoreCase(const char* str) const {
   return CompareIgnoreCase(CustomString(str));
 }
 
+bool CustomString::Compare(const CustomString& str) const {
+  return mb_string_ == str.mb_string_;
+}
+
+bool CustomString::Compare(const char* str) const {
+  return Compare(CustomString(str));
+}
+
 const char* CustomString::c_str() const {
   return mb_string_.c_str();
 }


### PR DESCRIPTION
SDL was not case sensitive according to application name and id.
Fix for matchers that compare names and ids and changing of usage
of strcasecmp to strncmp.