### PR TITLE
Fixed defect "no external_consent_status_groups section"

### DIFF
--- a/src/components/application_manager/src/commands/hmi/on_app_permission_consent_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_app_permission_consent_notification.cc
@@ -157,7 +157,7 @@ void OnAppPermissionConsentNotification::Run() {
 #ifdef EXTERNAL_PROPRIETARY_MODE
   policy::ExternalConsentStatus external_consent_status;
   if (msg_params.keyExists(strings::external_consent_status)) {
-    const utils::SharedPtr<smart_objects::SmartArray>
+    const smart_objects::SmartArray*
         system_external_consent_status =
             msg_params[strings::external_consent_status].asArray();
     ExternalConsentStatusAppender status_appender(external_consent_status);

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -292,7 +292,7 @@ const char* const auto_complete_text_supported = "autoCompleteTextSupported";
 const char* const entity_type = "entityType";
 const char* const entity_id = "entityID";
 const char* const status = "status";
-const char* const external_consent_status = "ExternalConsentStatus";
+const char* const external_consent_status = "externalConsentStatus";
 const char* const consented_functions = "consentedFunctions";
 const char* const source = "source";
 }  // namespace strings


### PR DESCRIPTION
This pull request fixes a defect about that there's no external_consent_status_groups section 
in policy table in case SDL gets SDL.OnAppPermissionConsent from HMI with externalConsentStatus change from "ON" to "OFF".

Changed files:
* src/components/application_manager/src/smart_object_keys.cc
   fixed name of the key 'ExtendedConsentStatus' to start from the lowercase letter
* src/components/application_manager/src/commands/hmi/on_app_permission_consent_notification.cc
   removed smart pointer from where it should not belong (which caused crash of the application)