### PR TITLE
Fix not triggered PTU for NAVI app

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -505,7 +505,9 @@ class PolicyHandler : public PolicyHandlerInterface,
    * @param app_types list of hmi types
    * @return function that will notify update manager about new application
    */
-  StatusNotifier AddApplication(const std::string& application_id) OVERRIDE;
+  StatusNotifier AddApplication(
+      const std::string& application_id,
+      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) OVERRIDE;
 
   /**
    * Checks whether application is revoked

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -816,6 +816,7 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
   if ((*message_)[strings::msg_params].keyExists(strings::app_hmi_type)) {
     smart_objects::SmartArray* hmi_types_ptr =
         (*message_)[strings::msg_params][strings::app_hmi_type].asArray();
+    DCHECK_OR_RETURN_VOID(hmi_types_ptr);
     SmartArrayValueExtractor extractor;
     if (hmi_types_ptr && 0 < hmi_types_ptr->size()) {
       std::transform(hmi_types_ptr->begin(),

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -151,6 +151,13 @@ struct CheckMissedTypes {
   std::string& log_;
 };
 
+class SmartArrayValueExtractor {
+ public:
+  AppHmiType operator()(const smart_objects::SmartObject& so) const {
+    return static_cast<AppHmiType>(so.asInt());
+  }
+};
+
 struct IsSameNickname {
   IsSameNickname(const custom_str::CustomString& app_id) : app_id_(app_id) {}
   bool operator()(const policy::StringArray::value_type& nickname) const {
@@ -805,9 +812,21 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
     resumption = resumer.IsApplicationSaved(application->policy_app_id(),
                                             application->mac_address());
   }
+  AppHmiTypes hmi_types;
+  if ((*message_)[strings::msg_params].keyExists(strings::app_hmi_type)) {
+    smart_objects::SmartArray* hmi_types_ptr =
+        (*message_)[strings::msg_params][strings::app_hmi_type].asArray();
+    SmartArrayValueExtractor extractor;
+    if (hmi_types_ptr && 0 < hmi_types_ptr->size()) {
+      std::transform(hmi_types_ptr->begin(),
+                     hmi_types_ptr->end(),
+                     std::back_inserter(hmi_types),
+                     extractor);
+    }
+  }
 
-  policy::StatusNotifier notify_upd_manager =
-      GetPolicyHandler().AddApplication(application->policy_app_id());
+  policy::StatusNotifier notify_upd_manager = GetPolicyHandler().AddApplication(
+      application->policy_app_id(), hmi_types);
   SendOnAppRegisteredNotificationToHMI(
       *(application.get()), resumption, need_restore_vr);
 #ifdef SDL_REMOTE_CONTROL

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -513,9 +513,10 @@ struct SmartObjectToInt {
 };
 
 StatusNotifier PolicyHandler::AddApplication(
-    const std::string& application_id) {
+    const std::string& application_id,
+    const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) {
   POLICY_LIB_CHECK(utils::MakeShared<utils::CallNothing>());
-  return policy_manager_->AddApplication(application_id);
+  return policy_manager_->AddApplication(application_id, hmi_types);
 }
 
 void PolicyHandler::AddDevice(const std::string& device_id,

--- a/src/components/application_manager/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/register_app_interface_request_test.cc
@@ -410,7 +410,7 @@ TEST_F(RegisterAppInterfaceRequestTest,
                   HMIResultCodeIs(hmi_apis::FunctionID::UI_ChangeRegistration)))
       .WillOnce(Return(true));
   policy::StatusNotifier notifier = utils::MakeShared<utils::CallNothing>();
-  EXPECT_CALL(mock_policy_handler_, AddApplication(_))
+  EXPECT_CALL(mock_policy_handler_, AddApplication(_, _))
       .WillOnce(Return(notifier));
   {
     InSequence s;

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -265,6 +265,12 @@ class PolicyHandlerTest : public ::testing::Test {
       const int levelspan = 1) {
     return {col, row, level, colspan, rowspan, levelspan};
   }
+
+  policy_table::AppHmiTypes HmiTypes(const policy_table::AppHMIType hmi_type) {
+    policy_table::AppHmiTypes hmi_types;
+    hmi_types.push_back(hmi_type);
+    return hmi_types;
+  }
 };
 
 namespace {
@@ -1323,10 +1329,13 @@ TEST_F(PolicyHandlerTest, AddApplication) {
   // Arrange
   EnablePolicyAndPolicyManagerMock();
   // Check expectations
-  EXPECT_CALL(*mock_policy_manager_, AddApplication(kPolicyAppId_))
+  EXPECT_CALL(
+      *mock_policy_manager_,
+      AddApplication(kPolicyAppId_, HmiTypes(policy_table::AHT_DEFAULT)))
       .WillOnce(Return(utils::MakeShared<utils::CallNothing>()));
   // Act
-  policy_handler_.AddApplication(kPolicyAppId_);
+  policy_handler_.AddApplication(kPolicyAppId_,
+                                 HmiTypes(policy_table::AHT_DEFAULT));
 }
 
 TEST_F(PolicyHandlerTest, HeartBeatTimeout) {

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -47,7 +47,9 @@
 #include "policy/policy_settings.h"
 #include "smart_objects/smart_object.h"
 #include "policy/policy_types.h"
+#include "policy/policy_table/types.h"
 
+using namespace ::rpc::policy_table_interface_base;
 namespace policy {
 typedef utils::SharedPtr<utils::Callable> StatusNotifier;
 
@@ -321,7 +323,9 @@ class PolicyHandlerInterface {
    * @param application_id The policy aplication id.
    * @return function that will notify update manager about new application
    */
-  virtual StatusNotifier AddApplication(const std::string& application_id) = 0;
+  virtual StatusNotifier AddApplication(
+      const std::string& application_id,
+      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) = 0;
 
   /**
    * Checks whether application is revoked

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -364,7 +364,9 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * @param Application id assigned by Ford to the application
    * @return function that will notify update manager about new application
    */
-  virtual StatusNotifier AddApplication(const std::string& application_id) = 0;
+  virtual StatusNotifier AddApplication(
+      const std::string& application_id,
+      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) = 0;
 
   /**
    * @brief Removes unpaired device records and related records from DB

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -364,7 +364,9 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * @param Application id assigned by Ford to the application
    * @return function that will notify update manager about new application
    */
-  virtual StatusNotifier AddApplication(const std::string& application_id) = 0;
+  virtual StatusNotifier AddApplication(
+      const std::string& application_id,
+      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) = 0;
 
   /**
    * @brief Removes unpaired device records and related records from DB

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -181,8 +181,11 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                           const std::string& policy_app_id));
   MOCK_METHOD0(OnPTExchangeNeeded, void());
   MOCK_METHOD1(GetAvailableApps, void(std::queue<std::string>& apps));
-  MOCK_METHOD1(AddApplication,
-               policy::StatusNotifier(const std::string& application_id));
+  MOCK_METHOD2(
+      AddApplication,
+      policy::StatusNotifier(
+          const std::string& application_id,
+          const rpc::policy_table_interface_base::AppHmiTypes& hmi_types));
   MOCK_METHOD1(IsApplicationRevoked, bool(const std::string& app_id));
   MOCK_METHOD0(OnUpdateRequestSentToMobile, void());
   MOCK_CONST_METHOD1(HeartBeatTimeout, uint32_t(const std::string& app_id));

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -141,8 +141,11 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD1(SendNotificationOnPermissionsUpdated,
                void(const std::string& application_id));
   MOCK_METHOD1(MarkUnpairedDevice, void(const std::string& device_id));
-  MOCK_METHOD1(AddApplication,
-               StatusNotifier(const std::string& application_id));
+  MOCK_METHOD2(
+      AddApplication,
+      StatusNotifier(
+          const std::string& application_id,
+          const rpc::policy_table_interface_base::AppHmiTypes& hmi_types));
 #ifdef SDL_REMOTE_CONTROL
   MOCK_METHOD2(SetDefaultHmiTypes,
                void(const std::string& application_id,

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -142,8 +142,11 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD1(SendNotificationOnPermissionsUpdated,
                void(const std::string& application_id));
   MOCK_METHOD1(MarkUnpairedDevice, void(const std::string& device_id));
-  MOCK_METHOD1(AddApplication,
-               StatusNotifier(const std::string& application_id));
+  MOCK_METHOD2(
+      AddApplication,
+      StatusNotifier(
+          const std::string& application_id,
+          const rpc::policy_table_interface_base::AppHmiTypes& hmi_types));
 #ifdef SDL_REMOTE_CONTROL
   MOCK_METHOD2(SetDefaultHmiTypes,
                void(const std::string& application_id,

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -172,7 +172,9 @@ class PolicyManagerImpl : public PolicyManager {
   bool CanAppStealFocus(const std::string& app_id) const;
   void MarkUnpairedDevice(const std::string& device_id);
 
-  StatusNotifier AddApplication(const std::string& application_id);
+  StatusNotifier AddApplication(
+      const std::string& application_id,
+      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types);
 #ifdef SDL_REMOTE_CONTROL
   void SetDefaultHmiTypes(const std::string& application_id,
                           const std::vector<int>& hmi_types);

--- a/src/components/policy/policy_external/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/types.h
@@ -112,6 +112,9 @@ typedef Map<RemoteRpcs, 0, 255> AccessModules;
 typedef Array<Enum<ModuleType>, 0, 255> ModuleTypes;
 #endif  // SDL_REMOTE_CONTROL
 
+typedef AppHMIType AppHmiType;
+typedef std::vector<AppHMIType> AppHmiTypes;
+
 struct RequestTypes : public RequestsTypeArray {
   RequestTypes();
   explicit RequestTypes(Json::Value* value);

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1644,7 +1644,8 @@ class CallStatusChange : public utils::Callable {
 };
 
 StatusNotifier PolicyManagerImpl::AddApplication(
-    const std::string& application_id) {
+    const std::string& application_id,
+    const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) {
   LOG4CXX_AUTO_TRACE(logger_);
   const std::string device_id = GetCurrentDeviceId(application_id);
   DeviceConsent device_consent = GetUserConsentForDevice(device_id);
@@ -1655,6 +1656,11 @@ StatusNotifier PolicyManagerImpl::AddApplication(
                                                device_consent);
   } else {
     PromoteExistedApplication(application_id, device_consent);
+    if (helpers::in_range(hmi_types, policy_table::AHT_NAVIGATION) &&
+        !HasCertificate()) {
+      LOG4CXX_DEBUG(logger_, "Certificate does not exist, scheduling update.");
+      update_status_manager_.ScheduleUpdate();
+    }
     return utils::MakeShared<utils::CallNothing>();
   }
 }

--- a/src/components/policy/policy_external/test/include/policy/policy_manager_impl_test_base.h
+++ b/src/components/policy/policy_external/test/include/policy/policy_manager_impl_test_base.h
@@ -86,6 +86,7 @@ void CheckIsParamInList(const ::policy::RPCParams& list,
                         const std::string& parameter);
 Json::Value createPTforLoad();
 void InsertRpcParametersInList(::policy::RPCParams& input_params);
+policy_table::AppHmiTypes HmiTypes(const policy_table::AppHMIType hmi_type);
 
 template <typename T>
 void SortAndCheckEquality(std::vector<T> first, std::vector<T> second) {

--- a/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
@@ -92,7 +92,7 @@ TEST_F(PolicyManagerImplTest,
   EXPECT_CALL(*cache_manager_, IsApplicationRepresented(_))
       .WillOnce(Return(true));
   EXPECT_EQ(manager_->GetPolicyTableStatus(), "UP_TO_DATE");
-  manager_->AddApplication(kDefaultId);
+  manager_->AddApplication(kDefaultId, HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_EQ(manager_->GetPolicyTableStatus(), "UP_TO_DATE");
 }
 
@@ -141,7 +141,8 @@ TEST_F(PolicyManagerImplTest2, IsAppRevoked_SetRevokedAppID_ExpectAppRevoked) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
 
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   std::ifstream ifile(kValidSdlPtUpdateJson);
   Json::Reader reader;
@@ -172,7 +173,8 @@ TEST_F(PolicyManagerImplTest2, AppRevokedOne_AppRegistered) {
   EXPECT_FALSE(policy_manager_->GetCache()->IsPTPreloaded());
   ASSERT_TRUE(
       (policy_manager_->GetCache())->AddDevice(device_id_2_, "Bluetooth"));
-  policy_manager_->AddApplication(application_id_);
+  policy_manager_->AddApplication(application_id_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   // Registration is allowed
   CheckRpcPermissions("RegisterAppInterface", ::policy::kRpcAllowed);
 }
@@ -184,7 +186,8 @@ TEST_F(PolicyManagerImplTest2, AppRevokedOne_AppRegistered_HMIDefault) {
   EmulatePTAppRevoked(kPtu2Json);
 
   EXPECT_FALSE(policy_manager_->GetCache()->IsPTPreloaded());
-  policy_manager_->AddApplication(application_id_);
+  policy_manager_->AddApplication(application_id_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   std::string default_hmi;
   // Default HMI level is NONE
@@ -210,7 +213,8 @@ TEST_F(PolicyManagerImplTest2,
       .WillRepeatedly(Return(device_id_1_));
   policy_manager_->SetUserConsentForDevice(device_id_1_, true);
   // Add app from consented device. App will be assigned with default policies
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   // Check before action
   policy_table::RpcParameters rpc_parameters;
   rpc_parameters.hmi_levels.push_back(policy_table::HL_FULL);
@@ -268,7 +272,8 @@ TEST_F(PolicyManagerImplTest2,
       .WillRepeatedly(Return(device_id_1_));
   policy_manager_->SetUserConsentForDevice(device_id_1_, true);
   // Add app from consented device. App will be assigned with default policies
-  policy_manager_->AddApplication(application_id_);
+  policy_manager_->AddApplication(application_id_,
+                                  HmiTypes(policy_table::AHT_MEDIA));
   // Emulate PTU with new policies for app added above
   std::ifstream ifile(kValidSdlPtUpdateJson);
   Json::Reader reader;
@@ -582,7 +587,8 @@ TEST_F(PolicyManagerImplTest2, GetCorrectStatus_PTUSuccessful) {
   EXPECT_EQ("UP_TO_DATE", policy_manager_->GetPolicyTableStatus());
 
   // Adding changes PT status
-  policy_manager_->AddApplication(application_id_);
+  policy_manager_->AddApplication(application_id_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_EQ("UP_TO_DATE", policy_manager_->GetPolicyTableStatus());
   // Before load PT we should send notification about start updating
   policy_manager_->OnUpdateStarted();
@@ -721,7 +727,8 @@ TEST_F(PolicyManagerImplTest2,
                                    "Bluetooth"));
 
   // Add app from consented device. App will be assigned with default policies
-  policy_manager_->AddApplication(application_id_);
+  policy_manager_->AddApplication(application_id_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   std::ifstream ifile("json/sdl_update_pt_2_groups_no_params_in1.json");
   Json::Reader reader;
@@ -807,7 +814,8 @@ TEST_F(PolicyManagerImplTest2,
                                    "Bluetooth"));
 
   // Add app from consented device. App will be assigned with default policies
-  policy_manager_->AddApplication(application_id_);
+  policy_manager_->AddApplication(application_id_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   std::ifstream ifile(
       "json/sdl_update_pt_2_groups_no_params_in1_omitted_in2.json");
@@ -909,7 +917,8 @@ TEST_F(
   GetPTU(kValidSdlPtUpdateJson);
   EXPECT_EQ("UP_TO_DATE", policy_manager_->GetPolicyTableStatus());
   // Try to add existing app
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   // Check no update required
   EXPECT_EQ("UP_TO_DATE", policy_manager_->GetPolicyTableStatus());
 }
@@ -930,7 +939,8 @@ TEST_F(PolicyManagerImplTest2,
   GetPTU(kValidSdlPtUpdateJson);
   EXPECT_EQ("UP_TO_DATE", policy_manager_->GetPolicyTableStatus());
 
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_EQ("UP_TO_DATE", policy_manager_->GetPolicyTableStatus());
   ::policy::Counters counter = ::policy::Counters::DAYS_AFTER_EPOCH;
   // Set PT was updated 10 days ago (limit is 30 days for now)
@@ -949,7 +959,8 @@ TEST_F(PolicyManagerImplTest2,
   GetPTU(kValidSdlPtUpdateJson);
   EXPECT_EQ("UP_TO_DATE", policy_manager_->GetPolicyTableStatus());
 
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_EQ("UP_TO_DATE", policy_manager_->GetPolicyTableStatus());
   ::policy::Counters counter = ::policy::Counters::DAYS_AFTER_EPOCH;
   // Set PT was updated 50 days ago (limit is 30 days for now)
@@ -968,7 +979,8 @@ TEST_F(
   GetPTU(kValidSdlPtUpdateJson);
   EXPECT_EQ("UP_TO_DATE", policy_manager_->GetPolicyTableStatus());
   // Try to add existing app
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_EQ("UP_TO_DATE", policy_manager_->GetPolicyTableStatus());
   ::policy::Counters counter = ::policy::Counters::DAYS_AFTER_EPOCH;
   // Set PT was updated 10 days ago (limit is 30 days for now)
@@ -1012,7 +1024,8 @@ TEST_F(PolicyManagerImplTest2,
   policy_manager_->SetUserConsentForDevice(device_id_2_, true);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   GetPTU(kValidSdlPtUpdateJson);
 
   ::policy::PermissionConsent perm_consent;
@@ -1055,7 +1068,8 @@ TEST_F(PolicyManagerImplTest2,
        CanAppKeepContext_SetPoliciesForAppUpdated_ExpectAppCanKeepContext) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   GetPTU(kValidSdlPtUpdateJson);
   // Check keep context in updated policies for app
   EXPECT_TRUE(policy_manager_->CanAppKeepContext(app_id_2_));
@@ -1065,7 +1079,8 @@ TEST_F(PolicyManagerImplTest2,
        CanAppStealFocus_SetPoliciesForAppUpdated_ExpectAppCanStealFocus) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   GetPTU(kValidSdlPtUpdateJson);
   // Check keep context in updated policies for app
   EXPECT_TRUE(policy_manager_->CanAppKeepContext(app_id_2_));
@@ -1116,7 +1131,8 @@ TEST_F(
   policy_manager_->SetUserConsentForDevice(device_id_2_, true);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   GetPTU(kValidSdlPtUpdateJson);
   ::policy::PermissionConsent perm_consent;
@@ -1161,7 +1177,8 @@ TEST_F(
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
 
-  policy_manager_->AddApplication(app_id_3_);
+  policy_manager_->AddApplication(app_id_3_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   ::policy::StringArray app_requests =
       policy_manager_->GetAppRequestTypes(app_id_3_);
   EXPECT_EQ(1u, app_requests.size());
@@ -1195,7 +1212,8 @@ TEST_F(
     pt->ReportErrors(&report);
   }
   // Add new app
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   uint32_t result = policy_manager_->HeartBeatTimeout(app_id_2_);
   // By default hertbeat timeout is 0
   EXPECT_EQ(0u, result);
@@ -1243,7 +1261,8 @@ TEST_F(PolicyManagerImplTest2,
   policy_manager_->SetUserConsentForDevice(device_id_2_, true);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   GetPTU(kValidSdlPtUpdateJson);
 
   ::policy::PermissionConsent perm_consent;
@@ -1319,7 +1338,8 @@ TEST_F(PolicyManagerImplTest2,
   policy_manager_->SetUserConsentForDevice(device_id_1_, true);
 
   // Add app
-  policy_manager_->AddApplication(section_name);
+  policy_manager_->AddApplication(section_name,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_CALL(listener_, OnPendingPermissionChange(section_name)).Times(2);
 
   // PTU has single invalid RequestTypes, which must be dropped and replaced

--- a/src/components/policy/policy_external/test/policy_manager_impl_snapshot_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_snapshot_test.cc
@@ -264,7 +264,7 @@ TEST_F(
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
   // Add app
-  policy_manager_->AddApplication(app_id);
+  policy_manager_->AddApplication(app_id, HmiTypes(policy_table::AHT_DEFAULT));
   // Check app gets RequestTypes from pre_DataConsent of app_policies
   // section
   pt_request_types_ = policy_manager_->GetAppRequestTypes(app_id);

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -500,7 +500,8 @@ TEST_F(
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
       .WillRepeatedly(Return(device_id_1_));
 
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   // Check ExternalConsent consents for application
   updated_device_data = pt->policy_table.device_data->find(device_id_1_);
@@ -567,7 +568,8 @@ TEST_F(
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
       .WillRepeatedly(Return(device_id_1_));
 
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   // Checking ExternalConsent consents after setting new ExternalConsent status
   ApplicationPolicies::const_iterator app_parameters =
@@ -624,7 +626,8 @@ TEST_F(
       .WillRepeatedly(Return(device_id_1_));  // again registered
 
   // First register w/o app having groups to consent
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   // Act
   utils::SharedPtr<policy_table::Table> pt =
@@ -655,7 +658,8 @@ TEST_F(
   EXPECT_TRUE(policy_manager_->GetCache()->ApplyUpdate(t));
 
   // Second time register w/ app having groups to consent
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   // Checking ExternalConsent consents after setting new ExternalConsent status
   ApplicationPolicies::const_iterator app_parameters =
@@ -712,7 +716,8 @@ TEST_F(
       .WillRepeatedly(Return(device_id_1_));  // registered again
 
   // First register w/o app having groups to consent
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   // Act
   utils::SharedPtr<policy_table::Table> pt =
@@ -743,7 +748,8 @@ TEST_F(
   EXPECT_TRUE(policy_manager_->GetCache()->ApplyUpdate(t));
 
   // Second time register w/ app having groups to consent
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   // Check ExternalConsent consents for application
   updated_device_data = pt->policy_table.device_data->find(device_id_1_);
@@ -805,7 +811,8 @@ TEST_F(PolicyManagerImplTest_ExternalConsent,
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
       .WillRepeatedly(Return(device_id_1_));
 
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   utils::SharedPtr<policy_table::Table> pt =
       policy_manager_->GetCache()->GetPT();
@@ -929,7 +936,8 @@ TEST_F(PolicyManagerImplTest_ExternalConsent,
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
       .WillRepeatedly(Return(device_id_1_));
 
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   utils::SharedPtr<policy_table::Table> pt =
       policy_manager_->GetCache()->GetPT();

--- a/src/components/policy/policy_external/test/policy_manager_impl_test_base.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test_base.cc
@@ -192,6 +192,13 @@ void InsertRpcParametersInList(::policy::RPCParams& input_params) {
   input_params.insert("timeStamp");
   input_params.insert("address");
 }
+
+policy_table::AppHmiTypes HmiTypes(const policy_table::AppHMIType hmi_type) {
+  policy_table::AppHmiTypes hmi_types;
+  hmi_types.push_back(hmi_type);
+  return hmi_types;
+}
+
 // PolicyManagerImplTest class methods
 PolicyManagerImplTest::PolicyManagerImplTest()
     : unpaired_device_id_("08-00-27-CE-76-FE")
@@ -323,7 +330,8 @@ void PolicyManagerImplTest2::AddRTtoAppSectionPT(
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
   // Add app
-  policy_manager_->AddApplication(section_name);
+  policy_manager_->AddApplication(section_name,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   // Check app gets RequestTypes from pre_DataConsent of app_policies
   // section
   pt_request_types_ = policy_manager_->GetAppRequestTypes(section_name);
@@ -442,7 +450,8 @@ void PolicyManagerImplTest2::
                                    "Bluetooth"));
 
   // Add app from consented device. App will be assigned with default policies
-  policy_manager_->AddApplication(application_id_);
+  policy_manager_->AddApplication(application_id_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   // Expect all parameters are allowed
   std::ifstream ifile(update_file);
@@ -567,7 +576,8 @@ void PolicyManagerImplTest2::AddSetDeviceData() {
                                   "Bluetooth"));
 
   // Add app from consented device. App will be assigned with default policies
-  policy_manager_->AddApplication(application_id_);
+  policy_manager_->AddApplication(application_id_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   (policy_manager_->GetCache())->AddDevice(device_id_1_, "Bluetooth");
 }
 

--- a/src/components/policy/policy_external/test/policy_manager_impl_user_consent_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_user_consent_test.cc
@@ -54,7 +54,8 @@ TEST_F(
 
   policy_manager_->SetUserConsentForDevice(device_id_1_, true);
 
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   EXPECT_EQ("UPDATE_NEEDED", policy_manager_->GetPolicyTableStatus());
 }
@@ -80,7 +81,8 @@ TEST_F(
 
   policy_manager_->SetUserConsentForDevice(device_id_1_, false);
 
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   EXPECT_EQ("UP_TO_DATE", policy_manager_->GetPolicyTableStatus());
 }
@@ -90,7 +92,8 @@ TEST_F(
     ReactOnUserDevConsentForApp_AddNewApplicationFromDeviceWithoutConsent_ExpectPreDataConsent) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   ASSERT_TRUE(policy_manager_->IsPredataPolicy(app_id_1_));
   policy_manager_->ReactOnUserDevConsentForApp(app_id_1_, false);
   EXPECT_TRUE(policy_manager_->IsPredataPolicy(app_id_1_));
@@ -103,7 +106,8 @@ TEST_F(PolicyManagerImplTest2,
   CreateLocalPT(kSdlPreloadedPtJson2);
   ASSERT_TRUE(
       (policy_manager_->GetCache())->AddDevice(device_id_2_, "Bluetooth"));
-  policy_manager_->AddApplication(application_id_);
+  policy_manager_->AddApplication(application_id_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
 
   // Expect RPCs from pre_dataConsent group are allowed
   // Next checks are equal to BaseBeforeDataConsent_APIs.xml checks from task
@@ -151,7 +155,8 @@ TEST_F(PolicyManagerImplTest2,
 TEST_F(PolicyManagerImplTest2, CheckPreDataConsent_GetDefaultHmiLevel_NONE) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   std::string default_hmi;
   // Default HMI level is NONE
   policy_manager_->GetDefaultHmi(app_id_2_, &default_hmi);
@@ -168,7 +173,8 @@ TEST_F(PolicyManagerImplTest2,
        CheckPreDataConsent_GetDefaultHmiLevel_BACKGROUNG) {
   // Arrange
   CreateLocalPT(kSdlPreloadedPtJson2);
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   std::string default_hmi;
   // Default HMI level is BACKGROUND
   policy_manager_->GetDefaultHmi(app_id_2_, &default_hmi);
@@ -185,7 +191,8 @@ TEST_F(
   // Arrange
   // RequestTypes for default & preDataConsent are different
   CreateLocalPT("json/ptu_requestType.json");
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   ASSERT_TRUE(policy_manager_->IsPredataPolicy(app_id_1_));
   policy_manager_->ReactOnUserDevConsentForApp(app_id_1_, true);
   EXPECT_FALSE(policy_manager_->IsPredataPolicy(app_id_1_));
@@ -199,7 +206,8 @@ TEST_F(
   // Arrange
   // RequestTypes for default & preDataConsent are the same
   CreateLocalPT(kPtu2RequestTypeJson);
-  policy_manager_->AddApplication(app_id_1_);
+  policy_manager_->AddApplication(app_id_1_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   ASSERT_TRUE(policy_manager_->IsPredataPolicy(app_id_1_));
   EXPECT_CALL(listener_, OnPendingPermissionChange(app_id_1_)).Times(0);
   policy_manager_->ReactOnUserDevConsentForApp(app_id_1_, true);
@@ -291,7 +299,8 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(::policy::DeviceConsent::kDeviceDisallowed, consent);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   std::string default_hmi;
   policy_manager_->GetDefaultHmi(app_id_2_, &default_hmi);
   EXPECT_EQ("NONE", default_hmi);
@@ -301,7 +310,8 @@ TEST_F(PolicyManagerImplTest2,
        GetDefaultHmi_SetDeviceAllowed_ExpectReceivedHmiCorrect) {
   // Arrange
   CreateLocalPT(kPtu2RequestTypeJson);
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_TRUE(policy_manager_->IsPredataPolicy(app_id_2_));
   std::string default_hmi1;
@@ -325,7 +335,8 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_TRUE((policy_manager_->GetCache())->IsDefaultPolicy(app_id_2_));
   std::string default_hmi2;
   policy_manager_->GetDefaultHmi(app_id_2_, &default_hmi2);
@@ -336,7 +347,8 @@ TEST_F(PolicyManagerImplTest2,
        GetDefaultPriority_SetDeviceAllowed_ExpectReceivedPriorityCorrect) {
   // Arrange
   CreateLocalPT(kPtu2RequestTypeJson);
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_TRUE(policy_manager_->IsPredataPolicy(app_id_2_));
   std::string priority1;
@@ -360,7 +372,8 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_TRUE((policy_manager_->GetCache())->IsDefaultPolicy(app_id_2_));
   std::string priority2;
   EXPECT_TRUE(policy_manager_->GetPriority(app_id_2_, &priority2));
@@ -477,7 +490,8 @@ TEST_F(PolicyManagerImplTest2, SetDeviceInfo_ExpectDevInfoAddedToPT) {
 TEST_F(PolicyManagerImplTest2, GetInitialAppData_ExpectReceivedConsentCorrect) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   ::policy::StringArray app_nicknames;
   ::policy::StringArray app_hmi_types;
   policy_manager_->GetInitialAppData(app_id_2_, &app_nicknames, &app_hmi_types);
@@ -520,7 +534,8 @@ TEST_F(
     CanAppKeepContext_AddAppFromUnconsentedDevice_ExpectAppCannotKeepContext) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_TRUE(policy_manager_->IsPredataPolicy(app_id_2_));
   // Check keep context in preData policy
@@ -533,7 +548,8 @@ TEST_F(PolicyManagerImplTest2,
   CreateLocalPT(preloaded_pt_filename_);
   ASSERT_TRUE(
       (policy_manager_->GetCache())->AddDevice(device_id_2_, "Bluetooth"));
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   ASSERT_TRUE((policy_manager_->GetCache())
                   ->SetDeviceData(device_id_2_,
                                   "hardware IPX",
@@ -549,7 +565,8 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_TRUE((policy_manager_->GetCache())->IsDefaultPolicy(app_id_2_));
   // Check keep context in default policy
   EXPECT_FALSE(policy_manager_->CanAppKeepContext(app_id_2_));
@@ -559,7 +576,8 @@ TEST_F(PolicyManagerImplTest2,
        CanAppStealFocus_AddAppFromUnconsentedDevice_ExpectAppCannotStealFocus) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_TRUE(policy_manager_->IsPredataPolicy(app_id_2_));
   // Check keep context in preData policy
@@ -572,7 +590,8 @@ TEST_F(PolicyManagerImplTest2,
   CreateLocalPT(preloaded_pt_filename_);
   ASSERT_TRUE(
       (policy_manager_->GetCache())->AddDevice(device_id_2_, "Bluetooth"));
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   ASSERT_TRUE((policy_manager_->GetCache())
                   ->SetDeviceData(device_id_2_,
                                   "hardware IPX",
@@ -588,7 +607,8 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_TRUE((policy_manager_->GetCache())->IsDefaultPolicy(app_id_2_));
   // Check keep context in default policy
   EXPECT_FALSE(policy_manager_->CanAppStealFocus(app_id_2_));
@@ -598,7 +618,8 @@ TEST_F(PolicyManagerImplTest2,
        IsPredataPolicy_SetAppWIthPredataPolicy_ExpectPredataPolicy) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_TRUE(policy_manager_->IsPredataPolicy(app_id_2_));
 }
@@ -608,7 +629,8 @@ TEST_F(
     SendNotificationOnPermissionsUpdated_SetDeviceAllowed_ExpectNotificationSent) {
   // Arrange
   CreateLocalPT(kPtu2RequestTypeJson);
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_TRUE(policy_manager_->IsPredataPolicy(app_id_2_));
   std::string default_hmi1;
@@ -638,7 +660,8 @@ TEST_F(
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_);
+  policy_manager_->AddApplication(app_id_2_,
+                                  HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_TRUE((policy_manager_->GetCache())->IsDefaultPolicy(app_id_2_));
   std::string default_hmi2;
   policy_manager_->GetDefaultHmi(app_id_2_, &default_hmi2);

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -176,7 +176,9 @@ class PolicyManagerImpl : public PolicyManager {
   bool CanAppStealFocus(const std::string& app_id) const;
   void MarkUnpairedDevice(const std::string& device_id);
 
-  StatusNotifier AddApplication(const std::string& application_id);
+  StatusNotifier AddApplication(
+      const std::string& application_id,
+      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types);
 #ifdef SDL_REMOTE_CONTROL
   void SetDefaultHmiTypes(const std::string& application_id,
                           const std::vector<int>& hmi_types);

--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -106,6 +106,9 @@ typedef Map<RemoteRpcs, 0, 255> AccessModules;
 typedef Array<Enum<ModuleType>, 0, 255> ModuleTypes;
 #endif  // SDL_REMOTE_CONTROL
 
+typedef AppHMIType AppHmiType;
+typedef std::vector<AppHMIType> AppHmiTypes;
+
 struct PolicyBase : CompositeType {
  public:
   Enum<Priority> priority;

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -138,6 +138,12 @@ struct StringsForUpdate CreateNewRandomData(StringsForUpdate& str) {
   return str;
 }
 
+policy_table::AppHmiTypes HmiTypes(const policy_table::AppHMIType hmi_type) {
+  policy_table::AppHmiTypes hmi_types;
+  hmi_types.push_back(hmi_type);
+  return hmi_types;
+}
+
 class PolicyManagerImplTest : public ::testing::Test {
  public:
   PolicyManagerImplTest() : device_id("08-00-27-CE-76-FE") {}
@@ -291,7 +297,7 @@ class PolicyManagerImplTest2 : public ::testing::Test {
     // Arrange
     CreateLocalPT("sdl_preloaded_pt.json");
     // Add app
-    manager->AddApplication(section_name);
+    manager->AddApplication(section_name, HmiTypes(policy_table::AHT_DEFAULT));
     // Check app gets RequestTypes from pre_DataConsent of app_policies
     // section
     PT_request_types = manager->GetAppRequestTypes(section_name);
@@ -558,7 +564,7 @@ TEST_F(PolicyManagerImplTest2,
       .WillRepeatedly(Return(dev_id1));
   manager->SetUserConsentForDevice(dev_id1, true);
   // Add app from consented device. App will be assigned with default policies
-  manager->AddApplication(app_id1);
+  manager->AddApplication(app_id1, HmiTypes(policy_table::AHT_DEFAULT));
   // Check before action
   policy_table::RpcParameters rpc_parameters;
   rpc_parameters.hmi_levels.push_back(policy_table::HL_FULL);
@@ -615,7 +621,7 @@ TEST_F(PolicyManagerImplTest2,
       .WillRepeatedly(Return(dev_id1));
   manager->SetUserConsentForDevice(dev_id1, true);
   // Add app from consented device. App will be assigned with default policies
-  manager->AddApplication("1234");
+  manager->AddApplication("1234", HmiTypes(policy_table::AHT_MEDIA));
   // Emulate PTU with new policies for app added above
   std::ifstream ifile("sdl_preloaded_pt.json");
   Json::Reader reader;
@@ -717,11 +723,14 @@ TEST_F(
   EXPECT_CALL(*cache_manager, IsPredataPolicy(_)).WillOnce(Return(false));
   EXPECT_CALL(*cache_manager, IsApplicationRepresented(_))
       .WillOnce(Return(true));
-  EXPECT_CALL(*cache_manager, GetCertificate()).WillOnce(Return(""));
+  EXPECT_CALL(*cache_manager, GetCertificate())
+      .Times(2)
+      .WillRepeatedly(Return(""));
   EXPECT_CALL(*cache_manager, AppHasHMIType(_, policy_table::AHT_NAVIGATION))
       .WillOnce(Return(true));
   EXPECT_EQ("UP_TO_DATE", manager->GetPolicyTableStatus());
-  manager->AddApplication(policy::kDefaultId);
+  manager->AddApplication(policy::kDefaultId,
+                          HmiTypes(policy_table::AHT_NAVIGATION));
   EXPECT_EQ("UPDATE_NEEDED", manager->GetPolicyTableStatus());
 }
 
@@ -817,7 +826,8 @@ TEST_F(
     AddApplication_AddNewApplicationFromDeviceWithoutConsent_ExpectUpdateRequired) {
   // Arrange
   CreateLocalPT("sdl_preloaded_pt.json");
-  ::policy::StatusNotifier notifyer = manager->AddApplication(app_id1);
+  ::policy::StatusNotifier notifyer =
+      manager->AddApplication(app_id1, HmiTypes(policy_table::AHT_DEFAULT));
   DCHECK(notifyer);
   (*notifyer)();
   EXPECT_EQ("UPDATE_NEEDED", manager->GetPolicyTableStatus());
@@ -829,7 +839,7 @@ TEST_F(
   // Arrange
   // RequestTypes for default & preDataConsent are different
   CreateLocalPT("ptu_requestType.json");
-  manager->AddApplication(app_id1);
+  manager->AddApplication(app_id1, HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_FALSE(manager->IsPredataPolicy(app_id1));
   manager->ReactOnUserDevConsentForApp(app_id1, true);
   EXPECT_FALSE(manager->IsPredataPolicy(app_id1));
@@ -842,7 +852,7 @@ TEST_F(
   // Arrange
   // RequestTypes for default & preDataConsent are the same
   CreateLocalPT("ptu2_requestType.json");
-  manager->AddApplication(app_id1);
+  manager->AddApplication(app_id1, HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_FALSE(manager->IsPredataPolicy(app_id1));
   EXPECT_CALL(listener, OnPendingPermissionChange(app_id1)).Times(0);
   manager->ReactOnUserDevConsentForApp(app_id1, true);
@@ -859,7 +869,7 @@ TEST_F(
   GetPTU("valid_sdl_pt_update.json");
   EXPECT_EQ("UP_TO_DATE", manager->GetPolicyTableStatus());
   // Try to add existing app
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   // Check no update required
   EXPECT_EQ("UP_TO_DATE", manager->GetPolicyTableStatus());
 }
@@ -876,7 +886,7 @@ TEST_F(PolicyManagerImplTest2,
   GetPTU("valid_sdl_pt_update.json");
   EXPECT_EQ("UP_TO_DATE", manager->GetPolicyTableStatus());
 
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_EQ("UP_TO_DATE", manager->GetPolicyTableStatus());
   ::policy::Counters counter = ::policy::Counters::DAYS_AFTER_EPOCH;
   // Set PT was updated 10 days ago (limit is 30 days for now)
@@ -1076,7 +1086,7 @@ TEST_F(PolicyManagerImplTest2,
        DISABLED_GetDefaultHmi_SetDeviceAllowed_ExpectReceivedHmiCorrect) {
   // Arrange
   CreateLocalPT("ptu2_requestType.json");
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_FALSE(manager->IsPredataPolicy(app_id2));
   std::string default_hmi1;
@@ -1098,7 +1108,7 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
   EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(app_id2))
       .WillRepeatedly(Return(dev_id2));
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_TRUE((manager->GetCache())->IsDefaultPolicy(app_id2));
   std::string default_hmi2;
   manager->GetDefaultHmi(app_id2, &default_hmi2);
@@ -1109,7 +1119,7 @@ TEST_F(PolicyManagerImplTest2,
        GetDefaultPriority_SetDeviceAllowed_ExpectReceivedPriorityCorrect) {
   // Arrange
   CreateLocalPT("ptu2_requestType.json");
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_FALSE(manager->IsPredataPolicy(app_id2));
   std::string priority1;
@@ -1131,7 +1141,7 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
   EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(app_id2))
       .WillRepeatedly(Return(dev_id2));
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_TRUE((manager->GetCache())->IsDefaultPolicy(app_id2));
   std::string priority2;
   EXPECT_TRUE(manager->GetPriority(app_id2, &priority2));
@@ -1141,7 +1151,7 @@ TEST_F(PolicyManagerImplTest2,
 TEST_F(PolicyManagerImplTest2, GetInitialAppData_ExpectReceivedConsentCorrect) {
   // Arrange
   CreateLocalPT("sdl_preloaded_pt.json");
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   ::policy::StringArray app_nicknames;
   ::policy::StringArray app_hmi_types;
   manager->GetInitialAppData(app_id2, &app_nicknames, &app_hmi_types);
@@ -1183,7 +1193,7 @@ TEST_F(
     CanAppKeepContext_AddAppFromUnconsentedDevice_ExpectAppCannotKeepContext) {
   // Arrange
   CreateLocalPT("sdl_preloaded_pt.json");
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_FALSE(manager->IsPredataPolicy(app_id2));
   // Check keep context in preData policy
@@ -1195,7 +1205,8 @@ TEST_F(PolicyManagerImplTest2,
   // Arrange
   CreateLocalPT("sdl_preloaded_pt.json");
   ASSERT_TRUE((manager->GetCache())->AddDevice(dev_id2, "Bluetooth"));
-  manager->AddApplication(app_id2);
+
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   ASSERT_TRUE((manager->GetCache())
                   ->SetDeviceData(dev_id2,
                                   "hardware IPX",
@@ -1210,7 +1221,7 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
   EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(app_id2))
       .WillRepeatedly(Return(dev_id2));
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_TRUE((manager->GetCache())->IsDefaultPolicy(app_id2));
   // Check keep context in default policy
   EXPECT_TRUE(manager->CanAppKeepContext(app_id2));
@@ -1220,7 +1231,7 @@ TEST_F(PolicyManagerImplTest2,
        CanAppKeepContext_SetPoliciesForAppUpdated_ExpectAppCanKeepContext) {
   // Arrange
   CreateLocalPT("sdl_preloaded_pt.json");
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   GetPTU("valid_sdl_pt_update.json");
   // Check keep context in updated policies for app
   EXPECT_TRUE(manager->CanAppKeepContext(app_id2));
@@ -1231,7 +1242,7 @@ TEST_F(PolicyManagerImplTest2,
   // Arrange
   CreateLocalPT("sdl_preloaded_pt.json");
   ASSERT_TRUE((manager->GetCache())->AddDevice(dev_id2, "Bluetooth"));
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   ASSERT_TRUE((manager->GetCache())
                   ->SetDeviceData(dev_id2,
                                   "hardware IPX",
@@ -1246,7 +1257,7 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
   EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(app_id2))
       .WillRepeatedly(Return(dev_id2));
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_TRUE((manager->GetCache())->IsDefaultPolicy(app_id2));
   // Check keep context in default policy
   EXPECT_TRUE(manager->CanAppStealFocus(app_id2));
@@ -1256,7 +1267,7 @@ TEST_F(PolicyManagerImplTest2,
        CanAppStealFocus_SetPoliciesForAppUpdated_ExpectAppCanStealFocus) {
   // Arrange
   CreateLocalPT("sdl_preloaded_pt.json");
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   GetPTU("valid_sdl_pt_update.json");
   // Check keep context in updated policies for app
   EXPECT_TRUE(manager->CanAppKeepContext(app_id2));
@@ -1312,7 +1323,7 @@ TEST_F(
   manager->SetUserConsentForDevice(dev_id2, true);
   EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(app_id2))
       .WillRepeatedly(Return(dev_id2));
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
 
   GetPTU("valid_sdl_pt_update.json");
   ::policy::PermissionConsent perm_consent;
@@ -1366,7 +1377,7 @@ TEST_F(
     pt->ReportErrors(&report);
   }
   // Add new app
-  manager->AddApplication(app_id2);
+  manager->AddApplication(app_id2, HmiTypes(policy_table::AHT_DEFAULT));
   uint32_t result = manager->HeartBeatTimeout(app_id2);
   // By default hertbeat timeout is 0
   EXPECT_EQ(0u, result);


### PR DESCRIPTION
When a NAVI application that already persists in the PT
and is registered again, no PTU was trigered. The reason
was in missing check for HMI_TYPE in the right moment.
When this feature is moved from FS, this piece of code is
skipped.