### PR TITLE
Fix incorrect behavior of SDL during response ACK 

### DIFF
--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -176,13 +176,16 @@ void set_hash_id(uint32_t hash_id, protocol_handler::ProtocolPacket& packet) {
 
 void ProtocolHandlerImpl::SendStartSessionAck(ConnectionID connection_id,
                                               uint8_t session_id,
-                                              uint8_t,
+                                              uint8_t protocol_version,
                                               uint32_t hash_id,
                                               uint8_t service_type,
                                               bool protection) {
   LOG4CXX_AUTO_TRACE(logger_);
-
   uint8_t protocolVersion = SupportedSDLProtocolVersion();
+
+  if (kRpc != service_type) {
+    protocolVersion = protocol_version;
+  }
 
   ProtocolFramePtr ptr(
       new protocol_handler::ProtocolPacket(connection_id,


### PR DESCRIPTION
Fix incorrect behavior of SDL during response ACK when video and audio services start

  - added condition in SendStartSessionAck to avoid sending max supported protocol version
    when video or audio services start.
    SDL must send negotiated protocol_version from message from mobile app

Related to [Issue-1365](https://github.com/smartdevicelink/sdl_core/issues/1365)