### PR TITLE
Fix defect consumer_friendly_messages are deleted from PT

### DIFF
--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -1338,11 +1338,12 @@ bool SQLPTRepresentation::SaveConsumerFriendlyMessages(
   // the policy table. So it won't be changed/updated
   if (messages.messages.is_initialized()) {
     utils::dbms::SQLQuery query(db());
-    if (!query.Exec(sql_pt::kDeleteMessageString)) {
-      LOG4CXX_WARN(logger_, "Incorrect delete from message.");
-      return false;
+    if (!messages.messages->empty()) {
+      if (!query.Exec(sql_pt::kDeleteMessageString)) {
+        LOG4CXX_WARN(logger_, "Incorrect delete from message.");
+        return false;
+      }
     }
-
     if (query.Prepare(sql_pt::kUpdateVersion)) {
       query.Bind(0, messages.version);
       if (!query.Exec()) {


### PR DESCRIPTION
* Changed files
 src/components/policy/policy_external/src/sql_pt_representation.cc
 Removed deletion of the table if param consumer_friendly_messages is omitted