### PR TITLE
Fix missing PTU for encrypted service

### DIFF
--- a/src/components/security_manager/include/security_manager/crypto_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/crypto_manager_impl.h
@@ -127,6 +127,7 @@ class CryptoManagerImpl : public CryptoManager {
 
   int pull_number_from_buf(char* buf, int* idx);
   void asn1_time_to_tm(ASN1_TIME* time);
+  void InitCertExpTime();
 
   const utils::SharedPtr<const CryptoManagerSettings> settings_;
   SSL_CTX* context_;

--- a/src/components/security_manager/src/crypto_manager_impl.cc
+++ b/src/components/security_manager/src/crypto_manager_impl.cc
@@ -93,6 +93,7 @@ CryptoManagerImpl::CryptoManagerImpl(
     OpenSSL_add_all_algorithms();
     SSL_library_init();
   }
+  InitCertExpTime();
 }
 
 CryptoManagerImpl::~CryptoManagerImpl() {
@@ -395,6 +396,10 @@ void CryptoManagerImpl::asn1_time_to_tm(ASN1_TIME* time) {
     const int sec = pull_number_from_buf(buf, &index);
     expiration_time_.tm_sec = sec;
   }
+}
+
+void CryptoManagerImpl::InitCertExpTime() {
+  strptime("1 Jan 1970 00:00:00", "%d %b %Y %H:%M:%S", &expiration_time_);
 }
 
 }  // namespace security_manager


### PR DESCRIPTION
SDL didn't trigger PTU when a secured service is started and the
certificate is missing because the member variable that contains
the certificate expiration time was not inited and when it checked
it the time was in the future. As fix this variable is inited in
the constructor.