### PR TITLE
Fix sending StartServiceACK when try to start session with encryption ON

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -730,6 +730,10 @@ class ApplicationManagerImpl
 
   security_manager::SSLContext::HandshakeContext GetHandshakeContext(
       uint32_t key) const OVERRIDE;
+
+  bool CanStartProtectedService(
+      const int32_t& session_key,
+      const protocol_handler::ServiceType& type) const OVERRIDE;
 #endif  // ENABLE_SECURITY
 
   /**

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1283,6 +1283,23 @@ ApplicationManagerImpl::GetHandshakeContext(uint32_t key) const {
   }
   return SSLContext::HandshakeContext();
 }
+
+bool ApplicationManagerImpl::CanStartProtectedService(
+    const int32_t& session_key,
+    const protocol_handler::ServiceType& type) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(logger_,
+                "Request for service protection, type: "
+                    << type << ", session: " << std::hex << session_key);
+
+  ApplicationSharedPtr app = application(session_key);
+  LOG4CXX_INFO(logger_,
+               "Service " << (app ? "can" : "cannot")
+                          << " be started protected");
+
+  return app;
+}
+
 #endif  // ENABLE_SECURITY
 
 void ApplicationManagerImpl::set_hmi_message_handler(

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -179,7 +179,7 @@ class ConnectionHandlerImpl
    * \param session_id Identifier of the session to be started
    * \param service_type Type of service
    * \param is_protected request service protection
-   * \param hash_id pointer for session hash identifier
+   * \param out_hash_id pointer for session hash identifier
    * \param out_start_protected whether service protection is requested
    * \return uint32_t Id (number) of new session if successful, otherwise 0.
    */
@@ -188,7 +188,7 @@ class ConnectionHandlerImpl
       const uint8_t session_id,
       const protocol_handler::ServiceType& service_type,
       const bool is_protected,
-      uint32_t* hash_id,
+      uint32_t* out_hash_id,
       bool* out_start_protected) OVERRIDE;
 
   /**

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -178,16 +178,18 @@ class ConnectionHandlerImpl
    * be started.
    * \param session_id Identifier of the session to be started
    * \param service_type Type of service
-   * \param is_protected would be service protected
+   * \param is_protected request service protection
    * \param hash_id pointer for session hash identifier
+   * \param out_start_protected whether service protection is requested
    * \return uint32_t Id (number) of new session if successful, otherwise 0.
    */
-  virtual uint32_t OnSessionStartedCallback(
+  uint32_t OnSessionStartedCallback(
       const transport_manager::ConnectionUID connection_handle,
       const uint8_t session_id,
       const protocol_handler::ServiceType& service_type,
       const bool is_protected,
-      uint32_t* hash_id);
+      uint32_t* hash_id,
+      bool* out_start_protected) OVERRIDE;
 
   /**
    * \brief Callback function used by ProtocolHandler
@@ -445,6 +447,12 @@ class ConnectionHandlerImpl
   void RemoveConnection(const ConnectionHandle connection_handle);
 
   void OnConnectionEnded(const transport_manager::ConnectionUID connection_id);
+
+#ifdef ENABLE_SECURITY
+  bool CanStartProtectedService(
+      const int32_t& session_key,
+      const protocol_handler::ServiceType& type) const;
+#endif  // ENABLE_SECURITY
 
   const ConnectionHandlerSettings& settings_;
   /**

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -285,17 +285,27 @@ uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
     const uint8_t session_id,
     const protocol_handler::ServiceType& service_type,
     const bool is_protected,
-    uint32_t* hash_id) {
+    uint32_t* hash_id,
+    bool* out_start_protected) {
   LOG4CXX_AUTO_TRACE(logger_);
 
   if (hash_id) {
     *hash_id = protocol_handler::HASH_ID_WRONG;
   }
+
 #ifdef ENABLE_SECURITY
   if (!AllowProtection(get_settings(), service_type, is_protected)) {
     return 0;
   }
+  bool can_start_protected =
+      is_protected && CanStartProtectedService(session_id, service_type);
+#else
+  bool can_start_protected = false;
 #endif  // ENABLE_SECURITY
+  if (out_start_protected) {
+    *out_start_protected = can_start_protected;
+  }
+
   sync_primitives::AutoReadLock lock(connection_list_lock_);
   ConnectionList::iterator it = connection_list_.find(connection_handle);
   if (connection_list_.end() == it) {
@@ -315,11 +325,12 @@ uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
       *hash_id = KeyFromPair(connection_handle, new_session_id);
     }
   } else {  // Could be create new service or protected exists one
-    if (!connection->AddNewService(session_id, service_type, is_protected)) {
+    if (!connection->AddNewService(
+            session_id, service_type, can_start_protected)) {
       LOG4CXX_ERROR(logger_,
                     "Couldn't establish "
 #ifdef ENABLE_SECURITY
-                        << (is_protected ? "protected" : "non-protected")
+                        << (can_start_protected ? "protected" : "non-protected")
 #endif  // ENABLE_SECURITY
                         << " service " << static_cast<int>(service_type)
                         << " for session " << static_cast<int>(session_id));
@@ -670,6 +681,7 @@ security_manager::SSLContext::HandshakeContext
 ConnectionHandlerImpl::GetHandshakeContext(uint32_t key) const {
   return connection_handler_observer_->GetHandshakeContext(key);
 }
+
 #endif  // ENABLE_SECURITY
 
 void ConnectionHandlerImpl::StartDevicesDiscovery() {
@@ -1014,6 +1026,21 @@ bool ConnectionHandlerImpl::ProtocolVersionUsed(
   LOG4CXX_WARN(logger_, "Connection not found !");
   return false;
 }
+
+#ifdef ENABLE_SECURITY
+
+bool ConnectionHandlerImpl::CanStartProtectedService(
+    const int32_t& session_key,
+    const protocol_handler::ServiceType& type) const {
+  sync_primitives::AutoReadLock read_lock(connection_handler_observer_lock_);
+  if (connection_handler_observer_) {
+    return connection_handler_observer_->CanStartProtectedService(session_key,
+                                                                  type);
+  }
+  return true;
+}
+
+#endif  // ENABLE_SECURITY
 
 #ifdef BUILD_TESTS
 ConnectionList& ConnectionHandlerImpl::getConnectionList() {

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -285,12 +285,12 @@ uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
     const uint8_t session_id,
     const protocol_handler::ServiceType& service_type,
     const bool is_protected,
-    uint32_t* hash_id,
+    uint32_t* out_hash_id,
     bool* out_start_protected) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  if (hash_id) {
-    *hash_id = protocol_handler::HASH_ID_WRONG;
+  if (out_hash_id) {
+    *out_hash_id = protocol_handler::HASH_ID_WRONG;
   }
 
 #ifdef ENABLE_SECURITY
@@ -321,8 +321,8 @@ uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
       LOG4CXX_ERROR(logger_, "Couldn't start new session!");
       return 0;
     }
-    if (hash_id) {
-      *hash_id = KeyFromPair(connection_handle, new_session_id);
+    if (out_hash_id) {
+      *out_hash_id = KeyFromPair(connection_handle, new_session_id);
     }
   } else {  // Could be create new service or protected exists one
     if (!connection->AddNewService(
@@ -337,8 +337,8 @@ uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
       return 0;
     }
     new_session_id = session_id;
-    if (hash_id) {
-      *hash_id = protocol_handler::HASH_ID_NOT_SUPPORTED;
+    if (out_hash_id) {
+      *out_hash_id = protocol_handler::HASH_ID_NOT_SUPPORTED;
     }
   }
   sync_primitives::AutoReadLock read_lock(connection_handler_observer_lock_);

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -109,7 +109,7 @@ class ConnectionHandlerTest : public ::testing::Test {
   }
   void AddTestSession() {
     start_session_id_ = connection_handler_->OnSessionStartedCallback(
-        uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_);
+        uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_, NULL);
     EXPECT_NE(0u, start_session_id_);
     EXPECT_EQ(SessionHash(uid_, start_session_id_), out_hash_id_);
     connection_key_ = connection_handler_->KeyFromPair(uid_, start_session_id_);
@@ -124,7 +124,7 @@ class ConnectionHandlerTest : public ::testing::Test {
     connection_key_ = connection_handler_->KeyFromPair(uid_, start_session_id_);
     CheckSessionExists(uid_, start_session_id_);
     uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, service_type, PROTECTION_OFF, 0);
+        uid_, start_session_id_, service_type, PROTECTION_OFF, NULL, NULL);
     EXPECT_EQ(session_id, start_session_id_);
   }
 
@@ -268,7 +268,7 @@ TEST_F(ConnectionHandlerTest, StartSession_NoConnection) {
   const uint8_t sessionID = 0;
   // Start new session with RPC service
   const uint32_t result_fail = connection_handler_->OnSessionStartedCallback(
-      uid_, sessionID, kRpc, PROTECTION_ON, &out_hash_id_);
+      uid_, sessionID, kRpc, PROTECTION_ON, &out_hash_id_, NULL);
   // Unknown connection error is '0'
   EXPECT_EQ(0u, result_fail);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
@@ -1015,14 +1015,14 @@ TEST_F(ConnectionHandlerTest, StartService_withServices) {
 
   // Start Audio service
   const uint32_t start_audio = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_, NULL);
   EXPECT_EQ(start_session_id_, start_audio);
   CheckServiceExists(uid_, start_session_id_, kAudio, true);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
 
   // Start Audio service
   const uint32_t start_video = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kMobileNav, PROTECTION_OFF, &out_hash_id_);
+      uid_, start_session_id_, kMobileNav, PROTECTION_OFF, &out_hash_id_, NULL);
   EXPECT_EQ(start_session_id_, start_video);
   CheckServiceExists(uid_, start_session_id_, kMobileNav, true);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
@@ -1054,7 +1054,7 @@ TEST_F(ConnectionHandlerTest, ServiceStop) {
   for (uint32_t some_hash_id = 0; some_hash_id < 0xFF; ++some_hash_id) {
     // Start audio service
     const uint32_t start_audio = connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
+        uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_, NULL);
     EXPECT_EQ(start_session_id_, start_audio);
     EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
 
@@ -1124,7 +1124,7 @@ TEST_F(ConnectionHandlerTest, SessionStarted_WithRpc) {
 
   // Start new session with RPC service
   uint32_t new_session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_);
+      uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_, NULL);
 
   EXPECT_NE(0u, new_session_id);
 }
@@ -1141,7 +1141,7 @@ TEST_F(ConnectionHandlerTest,
   // Start new session with RPC service
   const uint32_t session_id_fail =
       connection_handler_->OnSessionStartedCallback(
-          uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_);
+          uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_fail);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
@@ -1156,7 +1156,7 @@ TEST_F(ConnectionHandlerTest,
   SetSpecificServices();
   // Start new session with RPC service
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_);
+      uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_, NULL);
   EXPECT_NE(0u, session_id);
   CheckService(uid_, session_id, kRpc, NULL, PROTECTION_OFF);
   EXPECT_EQ(SessionHash(uid_, session_id), out_hash_id_);
@@ -1175,7 +1175,7 @@ TEST_F(ConnectionHandlerTest,
   // Start new session with RPC service
   const uint32_t session_id_fail =
       connection_handler_->OnSessionStartedCallback(
-          uid_, 0, kRpc, PROTECTION_ON, NULL);
+          uid_, 0, kRpc, PROTECTION_ON, NULL, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_fail);
 #else
@@ -1188,7 +1188,7 @@ TEST_F(ConnectionHandlerTest,
   SetSpecificServices();
   // Start new session with RPC service
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_ON, &out_hash_id_);
+      uid_, 0, kRpc, PROTECTION_ON, &out_hash_id_, NULL);
   EXPECT_NE(0u, session_id);
   EXPECT_EQ(SessionHash(uid_, session_id), out_hash_id_);
 
@@ -1209,7 +1209,7 @@ TEST_F(ConnectionHandlerTest,
   SetSpecificServices();
   // Start new session with Audio service
   const uint32_t session_id2 = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL);
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id2);
 #else
@@ -1223,7 +1223,7 @@ TEST_F(ConnectionHandlerTest,
   protected_services_.push_back(kControl);
   SetSpecificServices();
   const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_, NULL);
 // Returned original session id
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
@@ -1249,7 +1249,7 @@ TEST_F(ConnectionHandlerTest,
   // Start new session with Audio service
   const uint32_t session_id_reject =
       connection_handler_->OnSessionStartedCallback(
-          uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
+          uid_, start_session_id_, kAudio, PROTECTION_ON, NULL, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_reject);
 #else
@@ -1259,7 +1259,7 @@ TEST_F(ConnectionHandlerTest,
   unprotected_services_.clear();
   SetSpecificServices();
   const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_ON, &out_hash_id_);
+      uid_, start_session_id_, kAudio, PROTECTION_ON, &out_hash_id_, NULL);
 // Returned original session id
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
@@ -1278,7 +1278,7 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtect) {
 
   // Start RPC protection
   const uint32_t session_id_new = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kRpc, PROTECTION_ON, &out_hash_id_);
+      uid_, start_session_id_, kRpc, PROTECTION_ON, &out_hash_id_, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id_new);
   // Post protection nedd no hash
@@ -1293,14 +1293,14 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtect) {
 
   // Start Audio session without protection
   const uint32_t session_id2 = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_, NULL);
   EXPECT_EQ(start_session_id_, session_id2);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
   CheckService(uid_, start_session_id_, kAudio, NULL, PROTECTION_OFF);
 
   // Start Audio protection
   const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_ON, &out_hash_id_);
+      uid_, start_session_id_, kAudio, PROTECTION_ON, &out_hash_id_, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
@@ -1317,7 +1317,7 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtectBulk) {
   AddTestSession();
 
   const uint32_t session_id_new = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kBulk, PROTECTION_ON, NULL);
+      uid_, start_session_id_, kBulk, PROTECTION_ON, NULL, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id_new);
   CheckService(uid_, start_session_id_, kRpc, NULL, PROTECTION_ON);
@@ -1414,7 +1414,7 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByProtectedService) {
             reinterpret_cast<security_manager::SSLContext*>(NULL));
   // Open kAudio service
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
+      uid_, start_session_id_, kAudio, PROTECTION_ON, NULL, NULL);
   EXPECT_EQ(session_id, start_session_id_);
   CheckService(uid_, session_id, kAudio, &mock_ssl_context, PROTECTION_ON);
 
@@ -1439,7 +1439,7 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedRPC) {
 
   // Protect kRpc (Bulk will be protect also)
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kRpc, PROTECTION_ON, NULL);
+      uid_, start_session_id_, kRpc, PROTECTION_ON, NULL, NULL);
   EXPECT_EQ(start_session_id_, session_id);
   CheckService(uid_, session_id, kRpc, &mock_ssl_context, PROTECTION_ON);
 
@@ -1467,7 +1467,7 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedBulk) {
 
   // Protect Bulk (kRpc will be protected also)
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kBulk, PROTECTION_ON, NULL);
+      uid_, start_session_id_, kBulk, PROTECTION_ON, NULL, NULL);
   EXPECT_EQ(start_session_id_, session_id);
   CheckService(uid_, session_id, kRpc, &mock_ssl_context, PROTECTION_ON);
 

--- a/src/components/include/connection_handler/connection_handler_observer.h
+++ b/src/components/include/connection_handler/connection_handler_observer.h
@@ -108,6 +108,10 @@ class ConnectionHandlerObserver {
 #ifdef ENABLE_SECURITY
   virtual security_manager::SSLContext::HandshakeContext GetHandshakeContext(
       uint32_t key) const = 0;
+
+  virtual bool CanStartProtectedService(
+      const int32_t& session_key,
+      const protocol_handler::ServiceType& type) const = 0;
 #endif  // ENABLE_SECURITY
  protected:
   /**

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -70,7 +70,7 @@ class SessionObserver {
    * \param service_type Type of service
    * \param protocol_version Version of protocol
    * \param is_protected request service protection
-   * \param hash_id pointer for session hash identifier, uint32_t* hash_id
+   * \param out_hash_id pointer for session hash identifier, uint32_t* hash_id
    * \param out_start_protected whether service protection is used
    * \return uint32_t Id (number) of new session if successful, otherwise 0.
    */
@@ -79,7 +79,7 @@ class SessionObserver {
       const uint8_t sessionId,
       const protocol_handler::ServiceType& service_type,
       const bool is_protected,
-      uint32_t* hash_id,
+      uint32_t* out_hash_id,
       bool* out_start_protected) = 0;
 
   /**

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -69,8 +69,9 @@ class SessionObserver {
    * \param sessionId Identifier of the session to be start
    * \param service_type Type of service
    * \param protocol_version Version of protocol
-   * \param is_protected would be service protected
+   * \param is_protected request service protection
    * \param hash_id pointer for session hash identifier, uint32_t* hash_id
+   * \param out_start_protected whether service protection is used
    * \return uint32_t Id (number) of new session if successful, otherwise 0.
    */
   virtual uint32_t OnSessionStartedCallback(
@@ -78,7 +79,8 @@ class SessionObserver {
       const uint8_t sessionId,
       const protocol_handler::ServiceType& service_type,
       const bool is_protected,
-      uint32_t* hash_id) = 0;
+      uint32_t* hash_id,
+      bool* out_start_protected) = 0;
 
   /**
    * \brief Callback function used by ProtocolHandler

--- a/src/components/include/test/connection_handler/mock_connection_handler_observer.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler_observer.h
@@ -57,9 +57,14 @@ class MockConnectionHandlerObserver
       void(const int32_t& session_key,
            const protocol_handler::ServiceType& type,
            const connection_handler::CloseSessionReason& close_reason));
+#ifdef ENABLE_SECURITY
   MOCK_CONST_METHOD1(
       GetHandshakeContext,
       security_manager::SSLContext::HandshakeContext(uint32_t key));
+  MOCK_CONST_METHOD2(CanStartProtectedService,
+                     bool(const int32_t& session_key,
+                          const protocol_handler::ServiceType& type));
+#endif  // ENABLE_SECURITY
 };
 
 }  // namespace connection_handler_test

--- a/src/components/include/test/protocol_handler/mock_session_observer.h
+++ b/src/components/include/test/protocol_handler/mock_session_observer.h
@@ -46,13 +46,14 @@ namespace protocol_handler_test {
  */
 class MockSessionObserver : public ::protocol_handler::SessionObserver {
  public:
-  MOCK_METHOD5(
+  MOCK_METHOD6(
       OnSessionStartedCallback,
       uint32_t(const transport_manager::ConnectionUID connection_handle,
                const uint8_t sessionId,
                const protocol_handler::ServiceType& service_type,
                const bool is_protected,
-               uint32_t* hash_id));
+               uint32_t* hash_id,
+               bool* out_start_protected));
   MOCK_METHOD4(
       OnSessionEndedCallback,
       uint32_t(const transport_manager::ConnectionUID connection_handle,

--- a/src/components/include/test/protocol_handler/mock_session_observer.h
+++ b/src/components/include/test/protocol_handler/mock_session_observer.h
@@ -52,7 +52,7 @@ class MockSessionObserver : public ::protocol_handler::SessionObserver {
                const uint8_t sessionId,
                const protocol_handler::ServiceType& service_type,
                const bool is_protected,
-               uint32_t* hash_id,
+               uint32_t* out_hash_id,
                bool* out_start_protected));
   MOCK_METHOD4(
       OnSessionEndedCallback,

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1085,9 +1085,15 @@ RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(
 #endif  // ENABLE_SECURITY
 
   uint32_t hash_id;
+  bool protection_requested = false;
   const ConnectionID connection_id = packet.connection_id();
-  const uint32_t session_id = session_observer_.OnSessionStartedCallback(
-      connection_id, packet.session_id(), service_type, protection, &hash_id);
+  const uint32_t session_id =
+      session_observer_.OnSessionStartedCallback(connection_id,
+                                                 packet.session_id(),
+                                                 service_type,
+                                                 protection,
+                                                 &hash_id,
+                                                 &protection_requested);
 
   if (0 == session_id) {
     LOG4CXX_WARN(logger_,
@@ -1102,7 +1108,7 @@ RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(
 
 #ifdef ENABLE_SECURITY
   // for packet is encrypted and security plugin is enable
-  if (protection && security_manager_) {
+  if (protection_requested && security_manager_) {
     const uint32_t connection_key =
         session_observer_.KeyFromPair(connection_id, session_id);
 


### PR DESCRIPTION
Fix enables requested service protection only if
there is an registered application in the current session.