### PR TITLE
Fix missing PTU by exchg_after_x_days trigger

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -356,10 +356,7 @@ bool PolicyHandler::InitPolicyTable() {
       hmi_apis::FunctionID::BasicCommunication_OnReady);
   std::string preloaded_file = get_settings().preloaded_pt_file();
   if (file_system::FileExists(preloaded_file)) {
-    const bool result =
-        policy_manager_->InitPT(preloaded_file, &get_settings());
-    SetDaysAfterEpoch();
-    return result;
+    return policy_manager_->InitPT(preloaded_file, &get_settings());
   }
   LOG4CXX_FATAL(logger_, "The file which contains preloaded PT is not exist");
   return false;

--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -102,7 +102,7 @@ class CacheManager : public CacheManagerInterface {
    * @param current value in days after epoch
    * @return value in days
    */
-  virtual int DaysBeforeExchange(uint16_t current);
+  virtual ReturnValue DaysBeforeExchange(uint16_t current);
 
   /**
    * @brief Increments number of ignition cycles since last exchange by 1

--- a/src/components/policy/policy_external/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager_interface.h
@@ -98,7 +98,7 @@ class CacheManagerInterface {
    * @param current value in days after epoch
    * @return value in days
    */
-  virtual int DaysBeforeExchange(uint16_t current) = 0;
+  virtual ReturnValue DaysBeforeExchange(uint16_t current) = 0;
 
   /**
    * @brief Increment number of ignition cycles since last exchange by 1

--- a/src/components/policy/policy_external/include/policy/policy_types.h
+++ b/src/components/policy/policy_external/include/policy/policy_types.h
@@ -389,6 +389,8 @@ typedef std::pair<uint32_t, uint32_t> AppIdURL;
 
 enum EntityStatus { kStatusOn, kStatusOff };
 
+enum ReturnValue { kZero, kNonZero };
+
 /**
  * @brief The ExternalConsentStatusItem struct represents customer connectivity
  * settings

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1218,7 +1218,7 @@ bool CacheManager::SetCountersPassedForSuccessfulUpdate(
   return true;
 }
 
-int CacheManager::DaysBeforeExchange(uint16_t current) {
+ReturnValue CacheManager::DaysBeforeExchange(uint16_t current) {
   LOG4CXX_AUTO_TRACE(logger_);
   CACHE_MANAGER_CHECK(0);
 
@@ -1239,7 +1239,7 @@ int CacheManager::DaysBeforeExchange(uint16_t current) {
       std::max(static_cast<uint16_t>(current - *days_after_epoch), uint16_t(0));
   LOG4CXX_DEBUG(logger_, "The days since last update: " << actual);
 
-  return std::max(limit - actual, 0);
+  return (std::max(limit - actual, 0) ? kNonZero : kZero);
 }
 
 void CacheManager::IncrementIgnitionCycles() {

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1221,16 +1221,22 @@ bool CacheManager::SetCountersPassedForSuccessfulUpdate(
 int CacheManager::DaysBeforeExchange(uint16_t current) {
   LOG4CXX_AUTO_TRACE(logger_);
   CACHE_MANAGER_CHECK(0);
+
+  const rpc::Optional<rpc::Integer<uint16_t, 0, 65535> > days_after_epoch =
+      (pt_->policy_table.module_meta->pt_exchanged_x_days_after_epoch);
+
+  if (!days_after_epoch->is_initialized()) {
+    return kNonZero;
+  }
+
   const uint8_t limit = pt_->policy_table.module_config.exchange_after_x_days;
   LOG4CXX_DEBUG(logger_,
                 "Exchange after: " << static_cast<int>(limit) << " days");
 
-  const uint16_t days_after_epoch =
-      (*pt_->policy_table.module_meta->pt_exchanged_x_days_after_epoch);
-  LOG4CXX_DEBUG(logger_, "Epoch since last update: " << days_after_epoch);
+  LOG4CXX_DEBUG(logger_, "Epoch since last update: " << *days_after_epoch);
 
   const uint16_t actual =
-      std::max(static_cast<uint16_t>(current - days_after_epoch), uint16_t(0));
+      std::max(static_cast<uint16_t>(current - *days_after_epoch), uint16_t(0));
   LOG4CXX_DEBUG(logger_, "The days since last update: " << actual);
 
   return std::max(limit - actual, 0);

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1220,7 +1220,7 @@ bool CacheManager::SetCountersPassedForSuccessfulUpdate(
 
 ReturnValue CacheManager::DaysBeforeExchange(uint16_t current) {
   LOG4CXX_AUTO_TRACE(logger_);
-  CACHE_MANAGER_CHECK(0);
+  CACHE_MANAGER_CHECK(kZero);
 
   const rpc::Optional<rpc::Integer<uint16_t, 0, 65535> > days_after_epoch =
       (pt_->policy_table.module_meta->pt_exchanged_x_days_after_epoch);

--- a/src/components/policy/policy_external/test/include/policy/mock_cache_manager.h
+++ b/src/components/policy/policy_external/test/include/policy/mock_cache_manager.h
@@ -60,7 +60,7 @@ class MockCacheManagerInterface : public ::policy::CacheManagerInterface {
   MOCK_CONST_METHOD1(GetPermissionsList, bool(StringArray& perm_list));
   MOCK_METHOD2(SetCountersPassedForSuccessfulUpdate,
                bool(Counters counter, int value));
-  MOCK_METHOD1(DaysBeforeExchange, int(uint16_t current));
+  MOCK_METHOD1(DaysBeforeExchange, ReturnValue(uint16_t current));
   MOCK_METHOD0(IncrementIgnitionCycles, void());
 
   MOCK_METHOD2(SaveDeviceConsentToCache,

--- a/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
@@ -873,6 +873,8 @@ TEST_F(PolicyManagerImplTest2,
 
 TEST_F(PolicyManagerImplTest, LoadPT_SetInvalidUpdatePT_PTIsNotLoaded) {
   // Arrange
+  EXPECT_CALL(*cache_manager_, DaysBeforeExchange(_))
+      .WillOnce(Return(kNonZero));
   manager_->ForcePTExchange();
   manager_->OnUpdateStarted();
   Json::Value table(Json::objectValue);

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -129,6 +129,8 @@ TEST_F(PolicyManagerImplTest, ResetPT) {
 
 TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
   // Arrange
+  EXPECT_CALL(*cache_manager_, DaysBeforeExchange(_))
+      .WillOnce(Return(kNonZero));
   manager_->ForcePTExchange();
   manager_->OnUpdateStarted();
   Json::Value table = createPTforLoad();
@@ -285,6 +287,8 @@ TEST_F(PolicyManagerImplTest2, GetPolicyTableStatus_ExpectUpToDate) {
 TEST_F(PolicyManagerImplTest,
        SetUpdateStarted_GetPolicyTableStatus_Expect_Updating) {
   // Arrange
+  EXPECT_CALL(*cache_manager_, DaysBeforeExchange(_))
+      .WillOnce(Return(kNonZero));
   manager_->ForcePTExchange();
   EXPECT_CALL(*cache_manager_, SaveUpdateRequired(true));
   manager_->OnUpdateStarted();
@@ -332,7 +336,8 @@ TEST_F(PolicyManagerImplTest, MarkUnpairedDevice) {
               HasDeviceSpecifiedConsent(unpaired_device_id_, false))
       .WillRepeatedly(Return(true));
   EXPECT_CALL(*cache_manager_, IgnitionCyclesBeforeExchange());
-  EXPECT_CALL(*cache_manager_, DaysBeforeExchange(_));
+  EXPECT_CALL(*cache_manager_, DaysBeforeExchange(_))
+      .WillOnce(Return(kNonZero));
   // Act
   manager_->MarkUnpairedDevice(unpaired_device_id_);
 }

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -101,7 +101,7 @@ class CacheManager : public CacheManagerInterface {
    * @param current value in days after epoch
    * @return value in days
    */
-  virtual int DaysBeforeExchange(int current);
+  virtual ReturnValue DaysBeforeExchange(int current);
 
   /**
    * @brief Increment number of ignition cycles since last exchange by 1

--- a/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
@@ -99,7 +99,7 @@ class CacheManagerInterface {
    * @param current value in days after epoch
    * @return value in days
    */
-  virtual int DaysBeforeExchange(int current) = 0;
+  virtual ReturnValue DaysBeforeExchange(int current) = 0;
 
   /**
    * @brief Increment number of ignition cycles since last exchange by 1

--- a/src/components/policy/policy_regular/include/policy/policy_types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_types.h
@@ -482,6 +482,8 @@ struct RetrySequenceURL {
  */
 typedef std::pair<uint32_t, uint32_t> AppIdURL;
 
+enum ReturnValue { kZero, kNonZero };
+
 }  //  namespace policy
 
 #endif  // SRC_COMPONENTS_POLICY_POLICY_EXTERNAL_INCLUDE_POLICY_POLICY_TYPES_H_

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -561,9 +561,9 @@ bool CacheManager::SetCountersPassedForSuccessfulUpdate(
   return true;
 }
 
-int CacheManager::DaysBeforeExchange(int current) {
+ReturnValue CacheManager::DaysBeforeExchange(int current) {
   LOG4CXX_AUTO_TRACE(logger_);
-  CACHE_MANAGER_CHECK(0);
+  CACHE_MANAGER_CHECK(kZero);
 
   const rpc::Optional<rpc::Integer<uint16_t, 0, 65535> > days_after_epoch =
       (pt_->policy_table.module_meta->pt_exchanged_x_days_after_epoch);
@@ -582,7 +582,7 @@ int CacheManager::DaysBeforeExchange(int current) {
       std::max(static_cast<uint16_t>(current - *days_after_epoch), uint16_t(0));
   LOG4CXX_DEBUG(logger_, "The days since last update: " << actual);
 
-  return std::max(limit - actual, 0);
+  return (std::max(limit - actual, 0) ? kNonZero : kZero);
 }
 
 void CacheManager::IncrementIgnitionCycles() {

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -564,16 +564,22 @@ bool CacheManager::SetCountersPassedForSuccessfulUpdate(
 int CacheManager::DaysBeforeExchange(int current) {
   LOG4CXX_AUTO_TRACE(logger_);
   CACHE_MANAGER_CHECK(0);
+
+  const rpc::Optional<rpc::Integer<uint16_t, 0, 65535> > days_after_epoch =
+      (pt_->policy_table.module_meta->pt_exchanged_x_days_after_epoch);
+
+  if (!days_after_epoch->is_initialized()) {
+    return kNonZero;
+  }
+
   const uint8_t limit = pt_->policy_table.module_config.exchange_after_x_days;
   LOG4CXX_DEBUG(logger_,
                 "Exchange after: " << static_cast<int>(limit) << " days");
 
-  const uint16_t days_after_epoch =
-      (*pt_->policy_table.module_meta->pt_exchanged_x_days_after_epoch);
-  LOG4CXX_DEBUG(logger_, "Epoch since last update: " << days_after_epoch);
+  LOG4CXX_DEBUG(logger_, "Epoch since last update: " << *days_after_epoch);
 
   const uint16_t actual =
-      std::max(static_cast<uint16_t>(current - days_after_epoch), uint16_t(0));
+      std::max(static_cast<uint16_t>(current - *days_after_epoch), uint16_t(0));
   LOG4CXX_DEBUG(logger_, "The days since last update: " << actual);
 
   return std::max(limit - actual, 0);

--- a/src/components/policy/policy_regular/test/include/policy/mock_cache_manager.h
+++ b/src/components/policy/policy_regular/test/include/policy/mock_cache_manager.h
@@ -57,7 +57,7 @@ class MockCacheManagerInterface : public CacheManagerInterface {
   MOCK_METHOD1(KilometersBeforeExchange, int(int current));
   MOCK_METHOD2(SetCountersPassedForSuccessfulUpdate,
                bool(Counters counter, int value));
-  MOCK_METHOD1(DaysBeforeExchange, int(int current));
+  MOCK_METHOD1(DaysBeforeExchange, ReturnValue(int current));
   MOCK_METHOD0(IncrementIgnitionCycles, void());
   MOCK_METHOD0(ResetIgnitionCycles, void());
   MOCK_METHOD0(TimeoutResponse, int());


### PR DESCRIPTION
Wrong fix to old defect related to redundant PTU is removed.
As a fix first pt_exchanged_x_days_after_epoch is checked if
it is initialized.