### PR TITLE
Update API versions

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -34,7 +34,7 @@
 
 <interfaces name="SmartDeviceLink HMI API">
 
-<interface name="Common" version="1.4" date="2016-05-11">
+<interface name="Common" version="1.5" date="2017-03-27">
 
 <enum name="Result">
     <element name="SUCCESS" value="0"/>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <?xml-stylesheet type="text/xml" href="protocol2html.xsl"?>
 
-<interface name="Ford Sync RAPI" version="4.2" date="2016-11-16">
+<interface name="Ford Sync RAPI" version="4.3" date="2017-03-27">
 
   <enum name="Result" internal_scope="base">
     <element name="SUCCESS">


### PR DESCRIPTION
Due to changes in #1316, the version of the Mobile API needs to be increased as well as the `Common` interface of the HMI API.