### PR TITLE
SDL sends BC.UpdateDeviceList with out of upper bound size of deviceList

### DIFF
--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -1051,7 +1051,7 @@ mobile_apis::Result::eType RegisterAppInterfaceRequest::CheckCoincidence() {
   for (; accessor.end() != it; ++it) {
     // name check
     const custom_str::CustomString& cur_name = (*it)->name();
-    if (app_name.Compare(cur_name.AsMBString())) {
+    if (app_name.Compare(cur_name)) {
       LOG4CXX_ERROR(logger_, "Application name is known already.");
       return mobile_apis::Result::DUPLICATE_NAME;
     }
@@ -1223,7 +1223,7 @@ bool RegisterAppInterfaceRequest::IsApplicationWithSameAppIdRegistered() {
   ApplicationSetConstIt it = applications.begin();
   ApplicationSetConstIt it_end = applications.end();
   for (; it != it_end; ++it) {
-    if (mobile_app_id.Compare(policy_app_id().c_str())) {
+    if (mobile_app_id.Compare((*it)->policy_app_id().c_str())) {
       return true;
     }
   }

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -651,8 +651,11 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateDeviceListSO(
   smart_objects::SmartObject& list_so = (*device_list_so)[strings::device_list];
 
   int32_t index = 0;
+  // According to requirements, SDL should send info about 100 devices at
+  // maximum, even if SDL has more devices connected.
+  const int32_t max_device_count = 100;
   for (connection_handler::DeviceMap::const_iterator it = devices.begin();
-       devices.end() != it;
+       devices.end() != it && index < max_device_count;
        ++it) {
     const connection_handler::Device& d =
         static_cast<connection_handler::Device>(it->second);

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -38,6 +38,7 @@
 
 #include "utils/callable.h"
 #include "policy/policy_types.h"
+#include "policy/policy_table/types.h"
 #include "policy/policy_listener.h"
 #include "policy/usage_statistics/statistics_manager.h"
 #ifdef SDL_REMOTE_CONTROL


### PR DESCRIPTION
According to requirements, `SDL` should send
info about 100 devices at maximum, even if
`SDL` has more devices connected.
##
@pold500, @indlu, @tkireva, please, review.