### PR TITLE
Fix sending info message for ResetGlobalProperties after timeout

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/reset_global_properties_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/reset_global_properties_request.h
@@ -126,12 +126,6 @@ class ResetGlobalPropertiesRequest : public CommandRequestImpl {
 
   DISALLOW_COPY_AND_ASSIGN(ResetGlobalPropertiesRequest);
 
-  bool is_ui_send_;
-  bool is_tts_send_;
-
-  bool is_ui_received_;
-  bool is_tts_received_;
-
   hmi_apis::Common_Result::eType ui_result_;
   hmi_apis::Common_Result::eType tts_result_;
   std::string ui_response_info_;

--- a/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
@@ -46,10 +46,6 @@ namespace commands {
 ResetGlobalPropertiesRequest::ResetGlobalPropertiesRequest(
     const MessageSharedPtr& message, ApplicationManager& application_manager)
     : CommandRequestImpl(message, application_manager)
-    , is_ui_send_(false)
-    , is_tts_send_(false)
-    , is_ui_received_(false)
-    , is_tts_received_(false)
     , ui_result_(hmi_apis::Common_Result::INVALID_ENUM)
     , tts_result_(hmi_apis::Common_Result::INVALID_ENUM) {}
 
@@ -111,11 +107,11 @@ void ResetGlobalPropertiesRequest::Run() {
 
   if (vr_help_title_items || menu_name || menu_icon ||
       is_key_board_properties) {
-    is_ui_send_ = true;
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   }
 
   if (timeout_prompt || helpt_promt) {
-    is_tts_send_ = true;
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
   }
 
   app->set_reset_global_properties_active(true);
@@ -248,7 +244,7 @@ void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_SetGlobalProperties: {
       LOG4CXX_INFO(logger_, "Received UI_SetGlobalProperties event");
-      is_ui_received_ = true;
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       ui_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
       GetInfo(message, ui_response_info_);
@@ -256,7 +252,7 @@ void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
     }
     case hmi_apis::FunctionID::TTS_SetGlobalProperties: {
       LOG4CXX_INFO(logger_, "Received TTS_SetGlobalProperties event");
-      is_tts_received_ = true;
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
       tts_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
       GetInfo(message, tts_response_info_);
@@ -330,7 +326,8 @@ bool ResetGlobalPropertiesRequest::PrepareResponseParameters(
 }
 
 bool ResetGlobalPropertiesRequest::IsPendingResponseExist() {
-  return is_ui_send_ != is_ui_received_ || is_tts_send_ != is_tts_received_;
+  return GetInterfaceAwaitState(HmiInterfaces::HMI_INTERFACE_TTS) ||
+         GetInterfaceAwaitState(HmiInterfaces::HMI_INTERFACE_UI);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/test/commands/mobile/reset_global_properties_test.cc
+++ b/src/components/application_manager/test/commands/mobile/reset_global_properties_test.cc
@@ -364,11 +364,9 @@ TEST_F(ResetGlobalPropertiesRequestTest,
 
   Event ui_event(hmi_apis::FunctionID::UI_SetGlobalProperties);
   ui_event.set_smart_object(*ui_msg);
-
   command_->on_event(ui_event);
 
   // TTS doesn't respond, so timeout should send generic error
-
   smart_objects::SmartObjectSPtr response =
       utils::MakeShared<smart_objects::SmartObject>();
   (*response)[am::strings::msg_params][am::strings::result_code] =
@@ -428,9 +426,9 @@ TEST_F(ResetGlobalPropertiesRequestTest,
 
   Event tts_event(hmi_apis::FunctionID::TTS_SetGlobalProperties);
   tts_event.set_smart_object(*tts_msg);
-
   command_->on_event(tts_event);
 
+  // UI doesn't respond, so timeout should send generic error
   smart_objects::SmartObjectSPtr response =
       utils::MakeShared<smart_objects::SmartObject>();
   (*response)[am::strings::msg_params][am::strings::result_code] =
@@ -448,7 +446,7 @@ TEST_F(ResetGlobalPropertiesRequestTest,
 }
 
 TEST_F(ResetGlobalPropertiesRequestTest,
-       Run_WaitUIAndTTS_Timeout_GENERIC_ERROR_TTSUINotRespond) {
+       Run_WaitUIAndTTS_Timeout_GENERIC_ERROR_TTSAndUINotRespond) {
   Event event(hmi_apis::FunctionID::TTS_SetGlobalProperties);
   (*msg_)[am::strings::params][am::hmi_response::code] =
       hmi_apis::Common_Result::eType::UNSUPPORTED_RESOURCE;
@@ -483,7 +481,7 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       .WillOnce(Return(true));
 
   command_->Run();
-
+  // TTS and UI don't respond, so timeout should send generic error
   std::string info = "TTS, UI component does not respond";
   smart_objects::SmartObjectSPtr response =
       utils::MakeShared<smart_objects::SmartObject>();

--- a/src/components/application_manager/test/commands/mobile/reset_global_properties_test.cc
+++ b/src/components/application_manager/test/commands/mobile/reset_global_properties_test.cc
@@ -311,16 +311,6 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   command_->on_event(event);
 }
 
-TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_PendingRequest_UNSUCCESS) {
-  Event event(hmi_apis::FunctionID::UI_SetGlobalProperties);
-  event.set_smart_object(*msg_);
-
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
-  EXPECT_CALL(*mock_app_, UpdateHash()).Times(0);
-
-  command_->on_event(event);
-}
-
 TEST_F(ResetGlobalPropertiesResponseTest, Run_Sendmsg_SUCCESS) {
   MessageSharedPtr message(CreateMessage());
   ResetGlobalPropertiesResponsePtr command(
@@ -328,6 +318,185 @@ TEST_F(ResetGlobalPropertiesResponseTest, Run_Sendmsg_SUCCESS) {
 
   EXPECT_CALL(app_mngr_, SendMessageToMobile(message, _));
   command->Run();
+}
+
+TEST_F(ResetGlobalPropertiesRequestTest,
+       Run_WaitTTS_Timeout_GENERIC_ERROR_TTSNotRespond) {
+  (*msg_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::UNSUPPORTED_RESOURCE;
+
+  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
+      mobile_apis::GlobalProperty::TIMEOUTPROMPT;
+  (*msg_)[am::strings::msg_params][am::strings::properties][1] =
+      mobile_apis::GlobalProperty::MENUICON;
+
+  std::vector<std::string> time_out_prompt;
+  time_out_prompt.push_back("time_out");
+  EXPECT_CALL(app_mngr_settings_, time_out_promt())
+      .WillOnce(ReturnRef(time_out_prompt));
+
+  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
+
+  smart_objects::SmartObjectSPtr prompt =
+      utils::MakeShared<smart_objects::SmartObject>();
+  *prompt = "prompt";
+
+  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+
+  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::UI_SetGlobalProperties)))
+      .WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::TTS_SetGlobalProperties)))
+      .WillOnce(Return(true));
+
+  command_->Run();
+
+  // Received response only from UI
+  MessageSharedPtr ui_msg = CreateMessage();
+  (*ui_msg)[am::strings::params][am::strings::correlation_id] = kCorrelationId;
+  (*ui_msg)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::SUCCESS;
+
+  Event ui_event(hmi_apis::FunctionID::UI_SetGlobalProperties);
+  ui_event.set_smart_object(*ui_msg);
+
+  command_->on_event(ui_event);
+
+  // TTS doesn't respond, so timeout should send generic error
+
+  smart_objects::SmartObjectSPtr response =
+      utils::MakeShared<smart_objects::SmartObject>();
+  (*response)[am::strings::msg_params][am::strings::result_code] =
+      mobile_apis::Result::GENERIC_ERROR;
+  EXPECT_CALL(*mock_message_helper_, CreateNegativeResponse(_, _, _, _))
+      .WillOnce(Return(response));
+  std::string info = "TTS component does not respond";
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(
+          MobileResponseIs(mobile_apis::Result::GENERIC_ERROR, info, false),
+          am::commands::Command::ORIGIN_SDL));
+  command_->onTimeOut();
+}
+
+TEST_F(ResetGlobalPropertiesRequestTest,
+       Run_WaitUI_Timeout_GENERIC_ERROR_UINotRespond) {
+  (*msg_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::UNSUPPORTED_RESOURCE;
+
+  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
+      mobile_apis::GlobalProperty::TIMEOUTPROMPT;
+  (*msg_)[am::strings::msg_params][am::strings::properties][1] =
+      mobile_apis::GlobalProperty::MENUICON;
+
+  std::vector<std::string> time_out_prompt;
+  time_out_prompt.push_back("time_out");
+  EXPECT_CALL(app_mngr_settings_, time_out_promt())
+      .WillOnce(ReturnRef(time_out_prompt));
+
+  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
+
+  smart_objects::SmartObjectSPtr prompt =
+      utils::MakeShared<smart_objects::SmartObject>();
+  *prompt = "prompt";
+
+  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+
+  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::UI_SetGlobalProperties)))
+      .WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::TTS_SetGlobalProperties)))
+      .WillOnce(Return(true));
+
+  command_->Run();
+
+  // Received response only from TTS
+  MessageSharedPtr tts_msg = CreateMessage();
+  (*tts_msg)[am::strings::params][am::strings::correlation_id] = kCorrelationId;
+  (*tts_msg)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::SUCCESS;
+
+  Event tts_event(hmi_apis::FunctionID::TTS_SetGlobalProperties);
+  tts_event.set_smart_object(*tts_msg);
+
+  command_->on_event(tts_event);
+
+  smart_objects::SmartObjectSPtr response =
+      utils::MakeShared<smart_objects::SmartObject>();
+  (*response)[am::strings::msg_params][am::strings::result_code] =
+      mobile_apis::Result::GENERIC_ERROR;
+  EXPECT_CALL(*mock_message_helper_, CreateNegativeResponse(_, _, _, _))
+      .WillOnce(Return(response));
+
+  std::string info = "UI component does not respond";
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(
+          MobileResponseIs(mobile_apis::Result::GENERIC_ERROR, info, false),
+          am::commands::Command::ORIGIN_SDL));
+  command_->onTimeOut();
+}
+
+TEST_F(ResetGlobalPropertiesRequestTest,
+       Run_WaitUIAndTTS_Timeout_GENERIC_ERROR_TTSUINotRespond) {
+  Event event(hmi_apis::FunctionID::TTS_SetGlobalProperties);
+  (*msg_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::eType::UNSUPPORTED_RESOURCE;
+
+  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
+      mobile_apis::GlobalProperty::TIMEOUTPROMPT;
+  (*msg_)[am::strings::msg_params][am::strings::properties][1] =
+      mobile_apis::GlobalProperty::MENUICON;
+
+  std::vector<std::string> time_out_prompt;
+  time_out_prompt.push_back("time_out");
+  EXPECT_CALL(app_mngr_settings_, time_out_promt())
+      .WillOnce(ReturnRef(time_out_prompt));
+
+  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
+
+  smart_objects::SmartObjectSPtr prompt =
+      utils::MakeShared<smart_objects::SmartObject>();
+  *prompt = "prompt";
+
+  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+
+  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::UI_SetGlobalProperties)))
+      .WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::TTS_SetGlobalProperties)))
+      .WillOnce(Return(true));
+
+  command_->Run();
+
+  std::string info = "TTS, UI component does not respond";
+  smart_objects::SmartObjectSPtr response =
+      utils::MakeShared<smart_objects::SmartObject>();
+  (*response)[am::strings::msg_params][am::strings::result_code] =
+      mobile_apis::Result::GENERIC_ERROR;
+  EXPECT_CALL(*mock_message_helper_, CreateNegativeResponse(_, _, _, _))
+      .WillOnce(Return(response));
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(
+          MobileResponseIs(mobile_apis::Result::GENERIC_ERROR, info, false),
+          am::commands::Command::ORIGIN_SDL));
+  command_->onTimeOut();
 }
 
 }  // namespace reset_global_properties


### PR DESCRIPTION
Fixed sending HMI response of UI.SetGlobalProperties, TTS.SetGlobalProperties or both.

Add unit tests for check timeout for ResetGlobalProperties