### PR TITLE
Fixed copying of icon to icon folder

### DIFF
--- a/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
@@ -83,10 +83,6 @@ void SetAppIconRequest::Run() {
     return;
   }
 
-  if (is_icons_saving_enabled_) {
-    CopyToIconStorage(full_file_path);
-  }
-
   smart_objects::SmartObject msg_params =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
 
@@ -253,6 +249,10 @@ void SetAppIconRequest::on_event(const event_engine::Event& event) {
         const std::string& path =
             (*message_)[strings::msg_params][strings::sync_file_name]
                        [strings::value].asString();
+        if (is_icons_saving_enabled_) {
+          CopyToIconStorage(path);
+        }
+
         app->set_app_icon_path(path);
 
         LOG4CXX_INFO(logger_,

--- a/src/components/application_manager/test/commands/mobile/set_app_icon_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_app_icon_test.cc
@@ -44,6 +44,9 @@
 #include "application_manager/event_engine/event.h"
 #include "application_manager/mock_hmi_interface.h"
 
+#include "include/test/protocol_handler/mock_protocol_handler.h"
+#include "include/test/protocol_handler/mock_protocol_handler_settings.h"
+
 namespace test {
 namespace components {
 namespace commands_test {
@@ -113,6 +116,13 @@ TEST_F(SetAppIconRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
   MockAppPtr mock_app = CreateMockApp();
   ON_CALL(app_mngr_, application(kConnectionKey))
       .WillByDefault(Return(mock_app));
+
+  protocol_handler_test::MockProtocolHandler mock_protocol;
+  protocol_handler_test::MockProtocolHandlerSettings mock_protocol_settings;
+  ON_CALL(app_mngr_, protocol_handler())
+      .WillByDefault(ReturnRef(mock_protocol));
+  ON_CALL(mock_protocol, get_settings())
+      .WillByDefault(ReturnRef(mock_protocol_settings));
 
   ON_CALL(*mock_app, app_id()).WillByDefault(Return(kConnectionKey));
   ON_CALL(*mock_app, set_app_icon_path(_)).WillByDefault(Return(true));


### PR DESCRIPTION
SDL must copy icon from AppStorageFolder to AppIconsFolder ONLY in case of successfull response from HMI