### PR TITLE
Fix issue when SDL sends NACK instead of PTU trigger

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -486,9 +486,9 @@ void PolicyHandler::SendOnAppPermissionsChanged(
 }
 
 void PolicyHandler::OnPTExchangeNeeded() {
+  LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK_VOID();
-  MessageHelper::SendOnStatusUpdate(policy_manager_->ForcePTExchange(),
-                                    application_manager_);
+  policy_manager_->ForcePTExchange();
 }
 
 void PolicyHandler::GetAvailableApps(std::queue<std::string>& apps) {

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -1084,7 +1084,7 @@ TEST_F(PolicyHandlerTest, PTExchangeAtUserRequest) {
   ChangePolicyManagerToMock();
   // Check expectations
   EXPECT_CALL(*mock_policy_manager_, ForcePTExchange());
-  EXPECT_CALL(mock_message_helper_, SendUpdateSDLResponse(_, _, _));
+  EXPECT_CALL(mock_message_helper_, SendUpdateSDLResponse(_, _, _)).Times(0);
   // Act
   const uint32_t correlation_id = 2;
   policy_handler_.PTExchangeAtUserRequest(correlation_id);


### PR DESCRIPTION
  - removed redundant notification about PTU
  - fixed issue when SDL sends NACK instead of PTU trigger