### PR TITLE
Correct deletion of oldest app icon

### DIFF
--- a/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
@@ -190,7 +190,8 @@ void SetAppIconRequest::CopyToIconStorage(
 void SetAppIconRequest::RemoveOldestIcons(const std::string& storage,
                                           const uint32_t icons_amount) const {
   const std::vector<std::string> icons_list = file_system::ListFiles(storage);
-  std::map<uint64_t, std::string> icon_modification_time;
+  std::set<file_system::FileDescriptor, file_system::FileDescriptor>
+      info_about_icons;
   std::vector<std::string>::const_iterator it = icons_list.begin();
   for (; it != icons_list.end(); ++it) {
     const std::string file_name = *it;
@@ -198,23 +199,28 @@ void SetAppIconRequest::RemoveOldestIcons(const std::string& storage,
     if (!file_system::FileExists(file_path)) {
       continue;
     }
-    const uint64_t time = file_system::GetFileModificationTime(file_path);
-    icon_modification_time[time] = file_name;
+    struct timespec modification_time =
+        file_system::GetFileModificationTime(file_path);
+    file_system::FileDescriptor icon_descriptor;
+    icon_descriptor.file_name = file_name;
+    icon_descriptor.modification_time = modification_time;
+    info_about_icons.insert(icon_descriptor);
   }
 
   for (size_t counter = 0; counter < icons_amount; ++counter) {
-    if (!icon_modification_time.size()) {
+    if (!info_about_icons.size()) {
       LOG4CXX_ERROR(logger_, "No more icons left for deletion.");
       return;
     }
-    const std::string file_name = icon_modification_time.begin()->second;
+    const std::string file_name = (*info_about_icons.begin()).file_name;
     const std::string file_path = storage + "/" + file_name;
-    if (!file_system::DeleteFile(file_path)) {
-      LOG4CXX_DEBUG(logger_, "Error while deleting icon " << file_path);
+    if (file_system::DeleteFile(file_path)) {
+      LOG4CXX_DEBUG(logger_,
+                    "Old icon " << file_path << " was deleted successfully.");
+    } else {
+      LOG4CXX_WARN(logger_, "Error while deleting icon " << file_path);
     }
-    icon_modification_time.erase(icon_modification_time.begin());
-    LOG4CXX_DEBUG(logger_,
-                  "Old icon " << file_path << " was deleted successfully.");
+    info_about_icons.erase(info_about_icons.begin());
   }
 }
 

--- a/src/components/utils/include/utils/file_system.h
+++ b/src/components/utils/include/utils/file_system.h
@@ -42,6 +42,33 @@
 namespace file_system {
 
 /**
+ * @brief This struct allow to bind file name with time stamp representing it's
+ * last modification time
+ */
+struct FileDescriptor {
+  std::string file_name;
+  timespec modification_time;
+
+  /**
+   * @brief Compare time stamps for file A and file B
+   * @param file_a contains file descriptor for file A
+   * @param file_b contains file descriptor for file B
+   * @return true if file A is older than file B, false otherwise
+   */
+  bool operator()(FileDescriptor file_a, FileDescriptor file_b) const {
+    if (file_a.modification_time.tv_sec < file_b.modification_time.tv_sec) {
+      return true;
+    } else if (file_a.modification_time.tv_sec ==
+               file_b.modification_time.tv_sec) {
+      if (file_a.modification_time.tv_nsec < file_b.modification_time.tv_nsec) {
+        return true;
+      }
+    }
+    return false;
+  }
+};
+
+/**
  * @brief Get available disc space.
  *
  * @param path to directory
@@ -241,11 +268,12 @@ const std::string ConvertPathForURL(const std::string& path);
 bool CreateFile(const std::string& path);
 
 /**
- * @brief Get modification time of file
- * @param path Path to file
- * @return Modification time in nanoseconds
+ * @brief Get information of file's last modification time
+ * @param path contains full path to file (including file name and extension)
+ * @return time stamp with file modification time information, which represents
+ * modification time in seconds and nanoseconds
  */
-uint64_t GetFileModificationTime(const std::string& path);
+struct timespec GetFileModificationTime(const std::string& path);
 
 /**
   * @brief Copy file from source to destination

--- a/src/components/utils/src/file_system.cc
+++ b/src/components/utils/src/file_system.cc
@@ -388,14 +388,18 @@ bool file_system::CreateFile(const std::string& path) {
   }
 }
 
-uint64_t file_system::GetFileModificationTime(const std::string& path) {
+struct timespec file_system::GetFileModificationTime(const std::string& path) {
   struct stat info;
   stat(path.c_str(), &info);
+  struct timespec modification_time = {0, 0};
 #ifndef __QNXNTO__
-  return static_cast<uint64_t>(info.st_mtim.tv_nsec);
+  modification_time.tv_sec = info.st_mtim.tv_sec;
+  modification_time.tv_nsec = info.st_mtim.tv_nsec;
 #else
-  return static_cast<uint64_t>(info.st_mtime);
+  modification_time.tv_sec = info.st_mtime;
+  modification_time.tv_nsec = info.st_mtimensec;
 #endif
+  return modification_time;
 }
 
 bool file_system::CopyFile(const std::string& src, const std::string& dst) {

--- a/src/components/utils/test/file_system_test.cc
+++ b/src/components/utils/test/file_system_test.cc
@@ -1022,14 +1022,21 @@ TEST(FileSystemTest, GetFileModificationTime) {
 
   EXPECT_TRUE(CreateFile("./test file"));
 
-  uint64_t modif_time = GetFileModificationTime("./test file");
-  EXPECT_LE(0ul, modif_time);
+  // file time info before modification
+  struct timespec modif_time_before = GetFileModificationTime("./test file");
+  uint64_t modif_time_before_sec =
+      static_cast<uint64_t>(modif_time_before.tv_sec);
+  EXPECT_LE(0ul, modif_time_before_sec);
 
   std::vector<uint8_t> data(1, 1);
   EXPECT_TRUE(WriteBinaryFile("./test file", data));
 
-  EXPECT_LE(0ul, GetFileModificationTime("./test file"));
-  EXPECT_LE(modif_time, GetFileModificationTime("./test file"));
+  // file time info after modification
+  struct timespec modif_time_after = GetFileModificationTime("./test file");
+  uint64_t modif_time_after_sec =
+      static_cast<uint64_t>(modif_time_after.tv_sec);
+  EXPECT_LE(0ul, modif_time_after_sec);
+  EXPECT_LE(modif_time_before_sec, modif_time_after_sec);
 
   EXPECT_TRUE(DeleteFile("./test file"));
   EXPECT_FALSE(FileExists("./test file"));


### PR DESCRIPTION
Corrected value of file modification time that was recieved from file system.
Previously file system sent only "nanoseconds in one second" value which was an incorrect behaviour.
Provided new way to compare more precisely the file modification time for two files, which includes both values to compare time:
nanoseconds in one second and seconds that represent time since start of epoch.
Updated the UT GetFileModificationTime for file system class.