### PR TITLE
Stop removing icon in case previous deleting was unsuccessful

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/set_app_icon_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/set_app_icon_request.h
@@ -87,10 +87,11 @@ class SetAppIconRequest : public CommandRequestImpl {
    * @brief Remove oldest icons
    * @param storage Path to icons storage
    * @param icons_amount Amount of icons to be deleted
+   * @param is_correct_removed_out Checks, if removing of icons was correct
    */
   void RemoveOldestIcons(const std::string& storage,
                          const uint32_t icons_amount,
-                         bool& is_correct_removed) const;
+                         bool& is_correct_removed_out) const;
 
   /**
    * @brief Checks, if there enough space in storage for icon copy

--- a/src/components/application_manager/include/application_manager/commands/mobile/set_app_icon_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/set_app_icon_request.h
@@ -81,17 +81,15 @@ class SetAppIconRequest : public CommandRequestImpl {
    * @brief Copies file to icon storage
    * @param path_to_file Path to icon
    */
-  void CopyToIconStorage(const std::string& path_to_file) const;
+  void CopyToIconStorage(const std::string& path_to_file);
 
   /**
    * @brief Remove oldest icons
    * @param storage Path to icons storage
    * @param icons_amount Amount of icons to be deleted
-   * @param is_correct_removed_out Checks, if removing of icons was correct
    */
   void RemoveOldestIcons(const std::string& storage,
-                         const uint32_t icons_amount,
-                         bool& is_correct_removed_out) const;
+                         const uint32_t icons_amount);
 
   /**
    * @brief Checks, if there enough space in storage for icon copy
@@ -101,7 +99,6 @@ class SetAppIconRequest : public CommandRequestImpl {
   bool IsEnoughSpaceForIcon(const uint64_t icon_size) const;
   DISALLOW_COPY_AND_ASSIGN(SetAppIconRequest);
 
- private:
   /**
    * @brief Checks, if icons saving to configured folder is enabled
    */

--- a/src/components/application_manager/include/application_manager/commands/mobile/set_app_icon_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/set_app_icon_request.h
@@ -89,7 +89,8 @@ class SetAppIconRequest : public CommandRequestImpl {
    * @param icons_amount Amount of icons to be deleted
    */
   void RemoveOldestIcons(const std::string& storage,
-                         const uint32_t icons_amount) const;
+                         const uint32_t icons_amount,
+                         bool& is_correct_removed) const;
 
   /**
    * @brief Checks, if there enough space in storage for icon copy

--- a/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
@@ -151,11 +151,11 @@ void SetAppIconRequest::CopyToIconStorage(
       return;
     }
 
-    bool is_correct_removed = true;
-    while (!IsEnoughSpaceForIcon(file_size) && is_correct_removed) {
-      RemoveOldestIcons(icon_storage, icons_amount, is_correct_removed);
+    bool is_correct_removed_out = true;
+    while (!IsEnoughSpaceForIcon(file_size) && is_correct_removed_out) {
+      RemoveOldestIcons(icon_storage, icons_amount, is_correct_removed_out);
     }
-    if (!is_correct_removed &&
+    if (!is_correct_removed_out &&
         (storage_max_size < (file_size + storage_size))) {
       LOG4CXX_WARN(logger_,
                    "Enable to got enough space for storing icon. "
@@ -193,7 +193,7 @@ void SetAppIconRequest::CopyToIconStorage(
 
 void SetAppIconRequest::RemoveOldestIcons(const std::string& storage,
                                           const uint32_t icons_amount,
-                                          bool& is_correct_removed) const {
+                                          bool& is_correct_removed_out) const {
   const std::vector<std::string> icons_list = file_system::ListFiles(storage);
   std::set<file_system::FileDescriptor, file_system::FileDescriptor>
       info_about_icons;
@@ -215,6 +215,7 @@ void SetAppIconRequest::RemoveOldestIcons(const std::string& storage,
   for (size_t counter = 0; counter < icons_amount; ++counter) {
     if (!info_about_icons.size()) {
       LOG4CXX_ERROR(logger_, "No more icons left for deletion.");
+      is_correct_removed_out = false;
       return;
     }
     const std::string file_name = (*info_about_icons.begin()).file_name;
@@ -224,7 +225,7 @@ void SetAppIconRequest::RemoveOldestIcons(const std::string& storage,
                     "Old icon " << file_path << " was deleted successfully.");
     } else {
       LOG4CXX_WARN(logger_, "Error while deleting icon " << file_path);
-      is_correct_removed = false;
+      is_correct_removed_out = false;
     }
     info_about_icons.erase(info_about_icons.begin());
   }

--- a/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
@@ -107,8 +107,7 @@ void SetAppIconRequest::Run() {
   SendHMIRequest(hmi_apis::FunctionID::UI_SetAppIcon, &msg_params, true);
 }
 
-void SetAppIconRequest::CopyToIconStorage(
-    const std::string& path_to_file) const {
+void SetAppIconRequest::CopyToIconStorage(const std::string& path_to_file) {
   if (!application_manager_.protocol_handler()
            .get_settings()
            .enable_protocol_4()) {
@@ -151,14 +150,13 @@ void SetAppIconRequest::CopyToIconStorage(
       return;
     }
 
-    bool is_correct_removed_out = true;
-    while (!IsEnoughSpaceForIcon(file_size) && is_correct_removed_out) {
-      RemoveOldestIcons(icon_storage, icons_amount, is_correct_removed_out);
+    while (!IsEnoughSpaceForIcon(file_size) && is_icons_saving_enabled_) {
+      RemoveOldestIcons(icon_storage, icons_amount);
     }
-    if (!is_correct_removed_out &&
+    if (!is_icons_saving_enabled_ &&
         (storage_max_size < (file_size + storage_size))) {
       LOG4CXX_WARN(logger_,
-                   "Enable to got enough space for storing icon. "
+                   "Unable to get enough space for storing icon. "
                    "Icon saving skipped.");
       return;
     }
@@ -192,8 +190,7 @@ void SetAppIconRequest::CopyToIconStorage(
 }
 
 void SetAppIconRequest::RemoveOldestIcons(const std::string& storage,
-                                          const uint32_t icons_amount,
-                                          bool& is_correct_removed_out) const {
+                                          const uint32_t icons_amount) {
   const std::vector<std::string> icons_list = file_system::ListFiles(storage);
   std::set<file_system::FileDescriptor, file_system::FileDescriptor>
       info_about_icons;
@@ -215,7 +212,7 @@ void SetAppIconRequest::RemoveOldestIcons(const std::string& storage,
   for (size_t counter = 0; counter < icons_amount; ++counter) {
     if (!info_about_icons.size()) {
       LOG4CXX_ERROR(logger_, "No more icons left for deletion.");
-      is_correct_removed_out = false;
+      is_icons_saving_enabled_ = false;
       return;
     }
     const std::string file_name = (*info_about_icons.begin()).file_name;
@@ -225,7 +222,7 @@ void SetAppIconRequest::RemoveOldestIcons(const std::string& storage,
                     "Old icon " << file_path << " was deleted successfully.");
     } else {
       LOG4CXX_WARN(logger_, "Error while deleting icon " << file_path);
-      is_correct_removed_out = false;
+      is_icons_saving_enabled_ = false;
     }
     info_about_icons.erase(info_about_icons.begin());
   }


### PR DESCRIPTION
In case icon removing is impossible and free space is not enough for saving icon then the saving should be skipped