### PR TITLE
Fix SDL.OnAppPermissionConsent with 'externalConsentStatus' parameter

### DIFF
--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -450,9 +450,12 @@ class CacheManager : public CacheManagerInterface {
   /**
    * @brief Set user consent on functional groups
    * @param permissions User consent on functional group
+   * @param out_app_permissions_changed Indicates whether the permissions were
+   * changed
    * @return true, if operation succedeed, otherwise - false
    */
-  bool SetUserPermissionsForApp(const PermissionConsent& permissions);
+  bool SetUserPermissionsForApp(const PermissionConsent& permissions,
+                                bool* out_app_permissions_changed);
 
   /**
    * @brief Records information about head unit system to PT

--- a/src/components/policy/policy_external/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager_interface.h
@@ -456,10 +456,12 @@ class CacheManagerInterface {
   /**
    * @brief Set user consent on functional groups
    * @param permissions User consent on functional group
+   * @param out_app_permissions_changed Indicates whether the permissions were
+   * changed
    * @return true, if operation succedeed, otherwise - false
    */
-  virtual bool SetUserPermissionsForApp(
-      const PermissionConsent& permissions) = 0;
+  virtual bool SetUserPermissionsForApp(const PermissionConsent& permissions,
+                                        bool* out_app_permissions_changed) = 0;
 
   /**
    * @brief Records information about head unit system to PT

--- a/src/components/policy/policy_external/test/include/policy/mock_cache_manager.h
+++ b/src/components/policy/policy_external/test/include/policy/mock_cache_manager.h
@@ -156,8 +156,9 @@ class MockCacheManagerInterface : public ::policy::CacheManagerInterface {
                     const StringArray& disallowed_groups));
   MOCK_METHOD2(ReactOnUserDevConsentForApp,
                bool(const std::string& app_id, bool is_device_allowed));
-  MOCK_METHOD1(SetUserPermissionsForApp,
-               bool(const PermissionConsent& permissions));
+  MOCK_METHOD2(SetUserPermissionsForApp,
+               bool(const PermissionConsent& permissions,
+                    bool* out_app_permissions_changed));
   MOCK_METHOD3(SetMetaInfo,
                bool(const std::string& ccpu_version,
                     const std::string& wers_country_code,

--- a/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
@@ -74,18 +74,6 @@ TEST_F(PolicyManagerImplTest,
               GetGroupsWithSameEntities(external_consent_status))
       .WillOnce(Return(group));
 
-  EXPECT_CALL(*cache_manager_, ResetCalculatedPermissions());
-
-  EXPECT_CALL(*cache_manager_, GetPermissionsForApp(_, _, _))
-      .WillOnce(Return(true))
-      .WillOnce(Return(true));
-  EXPECT_CALL(*cache_manager_, GetFunctionalGroupNames(_))
-      .WillOnce(Return(true))
-      .WillOnce(Return(true));
-
-  EXPECT_CALL(*cache_manager_, SetUserPermissionsForApp(_, _))
-      .WillOnce(Return(false));
-
   EXPECT_CALL(*cache_manager_, SetExternalConsentForApp(_));
 
   EXPECT_CALL(*cache_manager_, IsPredataPolicy(_)).WillOnce(Return(false));

--- a/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
@@ -83,7 +83,7 @@ TEST_F(PolicyManagerImplTest,
       .WillOnce(Return(true))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*cache_manager_, SetUserPermissionsForApp(_))
+  EXPECT_CALL(*cache_manager_, SetUserPermissionsForApp(_, _))
       .WillOnce(Return(false));
 
   EXPECT_CALL(*cache_manager_, SetExternalConsentForApp(_));

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -624,7 +624,7 @@ TEST_F(
 
   EXPECT_TRUE(policy_manager_->GetCache()->ApplyUpdate(t));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _)).Times(AtLeast(2));
+  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _)).Times(1);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
       .WillOnce(Return(device_id_1_))         // registered
       .WillOnce(Return(""))                   // not registered
@@ -714,7 +714,7 @@ TEST_F(
 
   EXPECT_TRUE(policy_manager_->GetCache()->ApplyUpdate(t));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _)).Times(AtLeast(2));
+  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _)).Times(1);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
       .WillOnce(Return(device_id_1_))         // registered
       .WillOnce(Return(""))                   // not registered
@@ -812,7 +812,7 @@ TEST_F(PolicyManagerImplTest_ExternalConsent,
 
   EXPECT_TRUE(policy_manager_->SetExternalConsentStatus(status));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _)).Times(AtLeast(1));
+  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _)).Times(0);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
       .WillRepeatedly(Return(device_id_1_));
 
@@ -937,7 +937,7 @@ TEST_F(PolicyManagerImplTest_ExternalConsent,
 
   EXPECT_TRUE(policy_manager_->SetExternalConsentStatus(status));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _)).Times(AtLeast(1));
+  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _)).Times(0);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
       .WillRepeatedly(Return(device_id_1_));
 
@@ -1107,7 +1107,7 @@ TEST_F(
   status_off.insert(ExternalConsentStatusItem(type_2_, id_2_, kStatusOff));
   status_off.insert(ExternalConsentStatusItem(type_3_, id_3_, kStatusOff));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _));
+  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _)).Times(0);
 
   EXPECT_TRUE(policy_manager_->SetExternalConsentStatus(status_on));
 

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -344,7 +344,7 @@ TEST_F(PolicyManagerImplTest, MarkUnpairedDevice) {
 
 TEST_F(PolicyManagerImplTest2, GetCurrentDeviceId) {
   // Arrange
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_)).Times(1);
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_));
   EXPECT_EQ("", policy_manager_->GetCurrentDeviceId(app_id_2_));
 }
 
@@ -624,7 +624,7 @@ TEST_F(
 
   EXPECT_TRUE(policy_manager_->GetCache()->ApplyUpdate(t));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _)).Times(1);
+  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _));
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
       .WillOnce(Return(device_id_1_))         // registered
       .WillOnce(Return(""))                   // not registered
@@ -714,7 +714,7 @@ TEST_F(
 
   EXPECT_TRUE(policy_manager_->GetCache()->ApplyUpdate(t));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _)).Times(1);
+  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _));
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
       .WillOnce(Return(device_id_1_))         // registered
       .WillOnce(Return(""))                   // not registered


### PR DESCRIPTION
The fix changes the permission change notifications to be send according
to the previous consent status state of the group which will be consented