### PR TITLE
Fix sending ACK/NACK before PTU finished

### DIFF
--- a/src/appMain/life_cycle.cc
+++ b/src/appMain/life_cycle.cc
@@ -176,6 +176,7 @@ bool LifeCycle::StartComponents() {
   security_manager_->AddListener(app_manager_);
 
   app_manager_->AddPolicyObserver(crypto_manager_);
+  app_manager_->AddPolicyObserver(protocol_handler_);
   if (!crypto_manager_->Init()) {
     LOG4CXX_ERROR(logger_, "CryptoManager initialization fail.");
     return false;

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -734,6 +734,7 @@ class ApplicationManagerImpl
   bool CanStartProtectedService(
       const int32_t& session_key,
       const protocol_handler::ServiceType& type) const OVERRIDE;
+  bool IsNaviApp(const int32_t& session_key) const OVERRIDE;
 #endif  // ENABLE_SECURITY
 
   /**

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -734,7 +734,7 @@ class ApplicationManagerImpl
   bool CanStartProtectedService(
       const int32_t& session_key,
       const protocol_handler::ServiceType& type) const OVERRIDE;
-  bool IsNaviApp(const int32_t& session_key) const OVERRIDE;
+  bool HasNaviApp(const int32_t& session_key) const OVERRIDE;
 #endif  // ENABLE_SECURITY
 
   /**

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -476,11 +476,6 @@ class PolicyHandler : public PolicyHandlerInterface,
   custom_str::CustomString GetAppName(
       const std::string& policy_app_id) OVERRIDE;
 
-  virtual void OnUpdateHMIAppType(
-      std::map<std::string, StringArray> app_hmi_types) OVERRIDE;
-
-  virtual void OnCertificateUpdated(
-      const std::string& certificate_data) OVERRIDE;
 #ifdef EXTERNAL_PROPRIETARY_MODE
   void OnCertificateDecrypted(bool is_succeeded) OVERRIDE;
 #endif  // EXTERNAL_PROPRIETARY_MODE
@@ -612,6 +607,14 @@ class PolicyHandler : public PolicyHandlerInterface,
 #endif  // ENABLE_SECURITY
 
   const PolicySettings& get_settings() const OVERRIDE;
+
+  virtual void OnUpdateHMIAppType(
+      std::map<std::string, StringArray> app_hmi_types) OVERRIDE;
+
+  virtual void OnCertificateUpdated(
+      const std::string& certificate_data) OVERRIDE;
+
+  virtual void OnPTUFinished(const bool ptu_result) OVERRIDE;
 
  protected:
   /**

--- a/src/components/application_manager/include/application_manager/policies/regular/policy_handler_observer.h
+++ b/src/components/application_manager/include/application_manager/policies/regular/policy_handler_observer.h
@@ -43,9 +43,13 @@ class PolicyHandlerObserver {
  public:
   virtual void OnUpdateHMIAppType(
       std::map<std::string, std::vector<std::string> > app_hmi_types) {}
+
   virtual bool OnCertificateUpdated(const std::string& certificate_data) {
     return false;
   }
+
+  virtual void OnPTUFinished(const bool ptu_result) {}
+
   virtual ~PolicyHandlerObserver() {}
 };
 }  //  namespace policy

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1284,6 +1284,15 @@ ApplicationManagerImpl::GetHandshakeContext(uint32_t key) const {
   return SSLContext::HandshakeContext();
 }
 
+bool ApplicationManagerImpl::IsNaviApp(const int32_t& session_key) const {
+  ApplicationSharedPtr app = application(session_key);
+  if (app) {
+    return app->is_navi();
+  }
+
+  return false;
+}
+
 bool ApplicationManagerImpl::CanStartProtectedService(
     const int32_t& session_key,
     const protocol_handler::ServiceType& type) const {
@@ -1296,7 +1305,6 @@ bool ApplicationManagerImpl::CanStartProtectedService(
   LOG4CXX_INFO(logger_,
                "Service " << (app ? "can" : "cannot")
                           << " be started protected");
-
   return app;
 }
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1284,7 +1284,7 @@ ApplicationManagerImpl::GetHandshakeContext(uint32_t key) const {
   return SSLContext::HandshakeContext();
 }
 
-bool ApplicationManagerImpl::IsNaviApp(const int32_t& session_key) const {
+bool ApplicationManagerImpl::HasNaviApp(const int32_t& session_key) const {
   ApplicationSharedPtr app = application(session_key);
   if (app) {
     return app->is_navi();

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1088,6 +1088,7 @@ bool PolicyHandler::ReceiveMessageFromSDK(const std::string& file,
     LOG4CXX_WARN(logger_, "Exchange wasn't successful, trying another one.");
     policy_manager_->ForcePTExchange();
   }
+  OnPTUFinished(ret);
   return ret;
 }
 
@@ -1759,6 +1760,16 @@ void PolicyHandler::OnCertificateUpdated(const std::string& certificate_data) {
   }
 }
 #endif  // EXTERNAL_PROPRIETARY_MODE
+
+void PolicyHandler::OnPTUFinished(const bool ptu_result) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock lock(listeners_lock_);
+  HandlersCollection::const_iterator it = listeners_.begin();
+  for (; it != listeners_.end(); ++it) {
+    PolicyHandlerObserver* observer = *it;
+    observer->OnPTUFinished(ptu_result);
+  }
+}
 
 bool PolicyHandler::CanUpdate() {
   return 0 != GetAppIdForSending();

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1765,10 +1765,11 @@ void PolicyHandler::OnPTUFinished(const bool ptu_result) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(listeners_lock_);
   HandlersCollection::const_iterator it = listeners_.begin();
-  for (; it != listeners_.end(); ++it) {
-    PolicyHandlerObserver* observer = *it;
-    observer->OnPTUFinished(ptu_result);
-  }
+  std::for_each(
+      listeners_.begin(),
+      listeners_.end(),
+      std::bind2nd(std::mem_fun(&PolicyHandlerObserver::OnPTUFinished),
+                   ptu_result));
 }
 
 bool PolicyHandler::CanUpdate() {

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -188,7 +188,7 @@ class ConnectionHandlerImpl
       const uint8_t session_id,
       const protocol_handler::ServiceType& service_type,
       const bool is_protected,
-      struct ExistingSessionInfo* out_si) OVERRIDE;
+      struct ExistingSessionInfo* out_session_info) OVERRIDE;
 
   /**
    * \brief Callback function used by ProtocolHandler
@@ -451,7 +451,7 @@ class ConnectionHandlerImpl
   bool CanStartProtectedService(
       const int32_t& session_key,
       const protocol_handler::ServiceType& type) const;
-  bool IsNaviApp(const int32_t& session_key) const;
+  bool HasNaviApp(const int32_t& session_key) const;
   uint32_t FindAppIdBySession(
       const transport_manager::ConnectionUID connection_handle,
       const uint8_t& session_id) const;

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -188,9 +188,7 @@ class ConnectionHandlerImpl
       const uint8_t session_id,
       const protocol_handler::ServiceType& service_type,
       const bool is_protected,
-      uint32_t* out_hash_id,
-      bool* out_start_protected,
-      bool* out_service_exists) OVERRIDE;
+      struct ExistingSessionInfo* out_si) OVERRIDE;
 
   /**
    * \brief Callback function used by ProtocolHandler
@@ -453,6 +451,7 @@ class ConnectionHandlerImpl
   bool CanStartProtectedService(
       const int32_t& session_key,
       const protocol_handler::ServiceType& type) const;
+  bool IsNaviApp(const int32_t& session_key) const;
   uint32_t FindAppIdBySession(
       const transport_manager::ConnectionUID connection_handle,
       const uint8_t& session_id) const;

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -285,13 +285,11 @@ uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
     const uint8_t session_id,
     const protocol_handler::ServiceType& service_type,
     const bool is_protected,
-    uint32_t* out_hash_id,
-    bool* out_start_protected,
-    bool* out_service_exists) {
+    struct ExistingSessionInfo* out_si) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  if (out_hash_id) {
-    *out_hash_id = protocol_handler::HASH_ID_WRONG;
+  if (out_si) {
+    out_si->hash_id_ = protocol_handler::HASH_ID_WRONG;
   }
 
 #ifdef ENABLE_SECURITY
@@ -299,13 +297,16 @@ uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
     return 0;
   }
   const uint32_t app_id = FindAppIdBySession(connection_handle, session_id);
+  if (out_si) {
+    out_si->is_navi_ = IsNaviApp(app_id);
+  }
   bool can_start_protected =
       is_protected && CanStartProtectedService(app_id, service_type);
 #else
   bool can_start_protected = false;
 #endif  // ENABLE_SECURITY
-  if (out_start_protected) {
-    *out_start_protected = can_start_protected;
+  if (out_si) {
+    out_si->start_protected_ = can_start_protected;
   }
 
   sync_primitives::AutoReadLock lock(connection_list_lock_);
@@ -323,14 +324,13 @@ uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
       LOG4CXX_ERROR(logger_, "Couldn't start new session!");
       return 0;
     }
-    if (out_hash_id) {
-      *out_hash_id = KeyFromPair(connection_handle, new_session_id);
+    if (out_si) {
+      out_si->hash_id_ = KeyFromPair(connection_handle, new_session_id);
     }
   } else {  // Could be create new service or protected exists one
-    if (!connection->AddNewService(session_id,
-                                   service_type,
-                                   can_start_protected,
-                                   out_service_exists)) {
+    bool service_exists = false;
+    if (!connection->AddNewService(
+            session_id, service_type, can_start_protected, &service_exists)) {
       LOG4CXX_ERROR(logger_,
                     "Couldn't establish "
 #ifdef ENABLE_SECURITY
@@ -341,8 +341,9 @@ uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
       return 0;
     }
     new_session_id = session_id;
-    if (out_hash_id) {
-      *out_hash_id = protocol_handler::HASH_ID_NOT_SUPPORTED;
+    if (out_si) {
+      out_si->hash_id_ = protocol_handler::HASH_ID_NOT_SUPPORTED;
+      out_si->service_exists_ = service_exists;
     }
   }
   sync_primitives::AutoReadLock read_lock(connection_handler_observer_lock_);
@@ -1042,6 +1043,14 @@ bool ConnectionHandlerImpl::CanStartProtectedService(
                                                                   type);
   }
   return true;
+}
+
+bool ConnectionHandlerImpl::IsNaviApp(const int32_t& session_key) const {
+  sync_primitives::AutoReadLock read_lock(connection_handler_observer_lock_);
+  if (connection_handler_observer_) {
+    return connection_handler_observer_->IsNaviApp(session_key);
+  }
+  return false;
 }
 
 uint32_t ConnectionHandlerImpl::FindAppIdBySession(

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -108,8 +108,10 @@ class ConnectionHandlerTest : public ::testing::Test {
     // Remove all specific services
   }
   void AddTestSession() {
+    struct ExistingSessionInfo si;
     start_session_id_ = connection_handler_->OnSessionStartedCallback(
-        uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_, NULL, NULL);
+        uid_, 0, kRpc, PROTECTION_OFF, &si);
+    out_hash_id_ = si.hash_id_;
     EXPECT_NE(0u, start_session_id_);
     EXPECT_EQ(SessionHash(uid_, start_session_id_), out_hash_id_);
     connection_key_ = connection_handler_->KeyFromPair(uid_, start_session_id_);
@@ -123,14 +125,8 @@ class ConnectionHandlerTest : public ::testing::Test {
     EXPECT_EQ(SessionHash(uid_, start_session_id_), out_hash_id_);
     connection_key_ = connection_handler_->KeyFromPair(uid_, start_session_id_);
     CheckSessionExists(uid_, start_session_id_);
-    uint32_t session_id =
-        connection_handler_->OnSessionStartedCallback(uid_,
-                                                      start_session_id_,
-                                                      service_type,
-                                                      PROTECTION_OFF,
-                                                      NULL,
-                                                      NULL,
-                                                      NULL);
+    uint32_t session_id = connection_handler_->OnSessionStartedCallback(
+        uid_, start_session_id_, service_type, PROTECTION_OFF, NULL);
     EXPECT_EQ(session_id, start_session_id_);
   }
 
@@ -273,8 +269,10 @@ TEST_F(ConnectionHandlerTest, StartSession_NoConnection) {
   // Null sessionId for start new session
   const uint8_t sessionID = 0;
   // Start new session with RPC service
+  struct ExistingSessionInfo si;
   const uint32_t result_fail = connection_handler_->OnSessionStartedCallback(
-      uid_, sessionID, kRpc, PROTECTION_ON, &out_hash_id_, NULL, NULL);
+      uid_, sessionID, kRpc, PROTECTION_ON, &si);
+  out_hash_id_ = si.hash_id_;
   // Unknown connection error is '0'
   EXPECT_EQ(0u, result_fail);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
@@ -1019,27 +1017,18 @@ TEST_F(ConnectionHandlerTest, StartService_withServices) {
   AddTestDeviceConnection();
   AddTestSession();
   // Start Audio service
-  const uint32_t start_audio =
-      connection_handler_->OnSessionStartedCallback(uid_,
-                                                    start_session_id_,
-                                                    kAudio,
-                                                    PROTECTION_OFF,
-                                                    &out_hash_id_,
-                                                    NULL,
-                                                    NULL);
+  struct ExistingSessionInfo si;
+  const uint32_t start_audio = connection_handler_->OnSessionStartedCallback(
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, &si);
+  out_hash_id_ = si.hash_id_;
   EXPECT_EQ(start_session_id_, start_audio);
   CheckServiceExists(uid_, start_session_id_, kAudio, true);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
 
   // Start Audio service
-  const uint32_t start_video =
-      connection_handler_->OnSessionStartedCallback(uid_,
-                                                    start_session_id_,
-                                                    kMobileNav,
-                                                    PROTECTION_OFF,
-                                                    &out_hash_id_,
-                                                    NULL,
-                                                    NULL);
+  const uint32_t start_video = connection_handler_->OnSessionStartedCallback(
+      uid_, start_session_id_, kMobileNav, PROTECTION_OFF, &si);
+  out_hash_id_ = si.hash_id_;
   EXPECT_EQ(start_session_id_, start_video);
   CheckServiceExists(uid_, start_session_id_, kMobileNav, true);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
@@ -1068,16 +1057,12 @@ TEST_F(ConnectionHandlerTest, ServiceStop) {
   AddTestDeviceConnection();
   AddTestSession();
   // Check ignoring hash_id on stop non-rpc service
+  struct ExistingSessionInfo si;
   for (uint32_t some_hash_id = 0; some_hash_id < 0xFF; ++some_hash_id) {
     // Start audio service
-    const uint32_t start_audio =
-        connection_handler_->OnSessionStartedCallback(uid_,
-                                                      start_session_id_,
-                                                      kAudio,
-                                                      PROTECTION_OFF,
-                                                      &out_hash_id_,
-                                                      NULL,
-                                                      NULL);
+    const uint32_t start_audio = connection_handler_->OnSessionStartedCallback(
+        uid_, start_session_id_, kAudio, PROTECTION_OFF, &si);
+    out_hash_id_ = si.hash_id_;
     EXPECT_EQ(start_session_id_, start_audio);
     EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
 
@@ -1145,8 +1130,10 @@ TEST_F(ConnectionHandlerTest, SessionStarted_WithRpc) {
               OnServiceStartedCallback(device_handle_, session_key, kRpc))
       .WillOnce(Return(true));
   // Start new session with RPC service
+  struct ExistingSessionInfo si;
   uint32_t new_session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_, NULL, NULL);
+      uid_, 0, kRpc, PROTECTION_OFF, &si);
+  out_hash_id_ = si.hash_id_;
 
   EXPECT_NE(0u, new_session_id);
 }
@@ -1161,9 +1148,11 @@ TEST_F(ConnectionHandlerTest,
   protected_services_.push_back(kRpc);
   SetSpecificServices();
   // Start new session with RPC service
+  struct ExistingSessionInfo si;
   const uint32_t session_id_fail =
       connection_handler_->OnSessionStartedCallback(
-          uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_, NULL, NULL);
+          uid_, 0, kRpc, PROTECTION_OFF, &si);
+  out_hash_id_ = si.hash_id_;
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_fail);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
@@ -1178,7 +1167,8 @@ TEST_F(ConnectionHandlerTest,
   SetSpecificServices();
   // Start new session with RPC service
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_, NULL, NULL);
+      uid_, 0, kRpc, PROTECTION_OFF, &si);
+  out_hash_id_ = si.hash_id_;
   EXPECT_NE(0u, session_id);
   CheckService(uid_, session_id, kRpc, NULL, PROTECTION_OFF);
   EXPECT_EQ(SessionHash(uid_, session_id), out_hash_id_);
@@ -1197,7 +1187,7 @@ TEST_F(ConnectionHandlerTest,
   // Start new session with RPC service
   const uint32_t session_id_fail =
       connection_handler_->OnSessionStartedCallback(
-          uid_, 0, kRpc, PROTECTION_ON, NULL, NULL, NULL);
+          uid_, 0, kRpc, PROTECTION_ON, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_fail);
 #else
@@ -1209,8 +1199,10 @@ TEST_F(ConnectionHandlerTest,
   unprotected_services_.push_back(kControl);
   SetSpecificServices();
   // Start new session with RPC service
+  struct ExistingSessionInfo si;
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_ON, &out_hash_id_, NULL, NULL);
+      uid_, 0, kRpc, PROTECTION_ON, &si);
+  out_hash_id_ = si.hash_id_;
   EXPECT_NE(0u, session_id);
   EXPECT_EQ(SessionHash(uid_, session_id), out_hash_id_);
 
@@ -1231,7 +1223,7 @@ TEST_F(ConnectionHandlerTest,
   SetSpecificServices();
   // Start new session with Audio service
   const uint32_t session_id2 = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL, NULL, NULL);
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id2);
 #else
@@ -1244,14 +1236,10 @@ TEST_F(ConnectionHandlerTest,
   protected_services_.push_back(UnnamedService::kServedService2);
   protected_services_.push_back(kControl);
   SetSpecificServices();
-  const uint32_t session_id3 =
-      connection_handler_->OnSessionStartedCallback(uid_,
-                                                    start_session_id_,
-                                                    kAudio,
-                                                    PROTECTION_OFF,
-                                                    &out_hash_id_,
-                                                    NULL,
-                                                    NULL);
+  struct ExistingSessionInfo si;
+  const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, &si);
+  out_hash_id_ = si.hash_id_;
 // Returned original session id
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
@@ -1277,7 +1265,7 @@ TEST_F(ConnectionHandlerTest,
   // Start new session with Audio service
   const uint32_t session_id_reject =
       connection_handler_->OnSessionStartedCallback(
-          uid_, start_session_id_, kAudio, PROTECTION_ON, NULL, NULL, NULL);
+          uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_reject);
 #else
@@ -1286,14 +1274,10 @@ TEST_F(ConnectionHandlerTest,
   // Allow start kAudio with encryption
   unprotected_services_.clear();
   SetSpecificServices();
-  const uint32_t session_id3 =
-      connection_handler_->OnSessionStartedCallback(uid_,
-                                                    start_session_id_,
-                                                    kAudio,
-                                                    PROTECTION_ON,
-                                                    &out_hash_id_,
-                                                    NULL,
-                                                    NULL);
+  struct ExistingSessionInfo si;
+  const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
+      uid_, start_session_id_, kAudio, PROTECTION_ON, &si);
+  out_hash_id_ = si.hash_id_;
 // Returned original session id
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
@@ -1310,8 +1294,10 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtect) {
   AddTestDeviceConnection();
   AddTestSession();
   // Start RPC protection
+  struct ExistingSessionInfo si;
   const uint32_t session_id_new = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kRpc, PROTECTION_ON, &out_hash_id_, NULL, NULL);
+      uid_, start_session_id_, kRpc, PROTECTION_ON, &si);
+  out_hash_id_ = si.hash_id_;
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id_new);
   // Post protection nedd no hash
@@ -1324,26 +1310,16 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtect) {
   CheckService(uid_, start_session_id_, kRpc, NULL, PROTECTION_OFF);
 #endif  // ENABLE_SECURITY
   // Start Audio session without protection
-  const uint32_t session_id2 =
-      connection_handler_->OnSessionStartedCallback(uid_,
-                                                    start_session_id_,
-                                                    kAudio,
-                                                    PROTECTION_OFF,
-                                                    &out_hash_id_,
-                                                    NULL,
-                                                    NULL);
+  const uint32_t session_id2 = connection_handler_->OnSessionStartedCallback(
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, &si);
+  out_hash_id_ = si.hash_id_;
   EXPECT_EQ(start_session_id_, session_id2);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
   CheckService(uid_, start_session_id_, kAudio, NULL, PROTECTION_OFF);
   // Start Audio protection
-  const uint32_t session_id3 =
-      connection_handler_->OnSessionStartedCallback(uid_,
-                                                    start_session_id_,
-                                                    kAudio,
-                                                    PROTECTION_ON,
-                                                    &out_hash_id_,
-                                                    NULL,
-                                                    NULL);
+  const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
+      uid_, start_session_id_, kAudio, PROTECTION_ON, &si);
+  out_hash_id_ = si.hash_id_;
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
@@ -1359,7 +1335,7 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtectBulk) {
   AddTestDeviceConnection();
   AddTestSession();
   const uint32_t session_id_new = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kBulk, PROTECTION_ON, NULL, NULL, NULL);
+      uid_, start_session_id_, kBulk, PROTECTION_ON, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id_new);
   CheckService(uid_, start_session_id_, kRpc, NULL, PROTECTION_ON);
@@ -1456,7 +1432,7 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByProtectedService) {
             reinterpret_cast<security_manager::SSLContext*>(NULL));
   // Open kAudio service
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_ON, NULL, NULL, NULL);
+      uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
   EXPECT_EQ(session_id, start_session_id_);
   CheckService(uid_, session_id, kAudio, &mock_ssl_context, PROTECTION_ON);
 
@@ -1481,7 +1457,7 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedRPC) {
 
   // Protect kRpc (Bulk will be protect also)
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kRpc, PROTECTION_ON, NULL, NULL, NULL);
+      uid_, start_session_id_, kRpc, PROTECTION_ON, NULL);
   EXPECT_EQ(start_session_id_, session_id);
   CheckService(uid_, session_id, kRpc, &mock_ssl_context, PROTECTION_ON);
 
@@ -1509,7 +1485,7 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedBulk) {
 
   // Protect Bulk (kRpc will be protected also)
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kBulk, PROTECTION_ON, NULL, NULL, NULL);
+      uid_, start_session_id_, kBulk, PROTECTION_ON, NULL);
   EXPECT_EQ(start_session_id_, session_id);
   CheckService(uid_, session_id, kRpc, &mock_ssl_context, PROTECTION_ON);
 

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -108,10 +108,10 @@ class ConnectionHandlerTest : public ::testing::Test {
     // Remove all specific services
   }
   void AddTestSession() {
-    struct ExistingSessionInfo si;
+    struct SessionObserver::ExistingSessionInfo session_info;
     start_session_id_ = connection_handler_->OnSessionStartedCallback(
-        uid_, 0, kRpc, PROTECTION_OFF, &si);
-    out_hash_id_ = si.hash_id_;
+        uid_, 0, kRpc, PROTECTION_OFF, &session_info);
+    out_hash_id_ = session_info.hash_id_;
     EXPECT_NE(0u, start_session_id_);
     EXPECT_EQ(SessionHash(uid_, start_session_id_), out_hash_id_);
     connection_key_ = connection_handler_->KeyFromPair(uid_, start_session_id_);
@@ -269,10 +269,10 @@ TEST_F(ConnectionHandlerTest, StartSession_NoConnection) {
   // Null sessionId for start new session
   const uint8_t sessionID = 0;
   // Start new session with RPC service
-  struct ExistingSessionInfo si;
+  struct SessionObserver::ExistingSessionInfo session_info;
   const uint32_t result_fail = connection_handler_->OnSessionStartedCallback(
-      uid_, sessionID, kRpc, PROTECTION_ON, &si);
-  out_hash_id_ = si.hash_id_;
+      uid_, sessionID, kRpc, PROTECTION_ON, &session_info);
+  out_hash_id_ = session_info.hash_id_;
   // Unknown connection error is '0'
   EXPECT_EQ(0u, result_fail);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
@@ -1017,18 +1017,18 @@ TEST_F(ConnectionHandlerTest, StartService_withServices) {
   AddTestDeviceConnection();
   AddTestSession();
   // Start Audio service
-  struct ExistingSessionInfo si;
+  struct SessionObserver::ExistingSessionInfo session_info;
   const uint32_t start_audio = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, &si);
-  out_hash_id_ = si.hash_id_;
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, &session_info);
+  out_hash_id_ = session_info.hash_id_;
   EXPECT_EQ(start_session_id_, start_audio);
   CheckServiceExists(uid_, start_session_id_, kAudio, true);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
 
   // Start Audio service
   const uint32_t start_video = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kMobileNav, PROTECTION_OFF, &si);
-  out_hash_id_ = si.hash_id_;
+      uid_, start_session_id_, kMobileNav, PROTECTION_OFF, &session_info);
+  out_hash_id_ = session_info.hash_id_;
   EXPECT_EQ(start_session_id_, start_video);
   CheckServiceExists(uid_, start_session_id_, kMobileNav, true);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
@@ -1057,12 +1057,12 @@ TEST_F(ConnectionHandlerTest, ServiceStop) {
   AddTestDeviceConnection();
   AddTestSession();
   // Check ignoring hash_id on stop non-rpc service
-  struct ExistingSessionInfo si;
+  struct SessionObserver::ExistingSessionInfo session_info;
   for (uint32_t some_hash_id = 0; some_hash_id < 0xFF; ++some_hash_id) {
     // Start audio service
     const uint32_t start_audio = connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, kAudio, PROTECTION_OFF, &si);
-    out_hash_id_ = si.hash_id_;
+        uid_, start_session_id_, kAudio, PROTECTION_OFF, &session_info);
+    out_hash_id_ = session_info.hash_id_;
     EXPECT_EQ(start_session_id_, start_audio);
     EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
 
@@ -1130,10 +1130,10 @@ TEST_F(ConnectionHandlerTest, SessionStarted_WithRpc) {
               OnServiceStartedCallback(device_handle_, session_key, kRpc))
       .WillOnce(Return(true));
   // Start new session with RPC service
-  struct ExistingSessionInfo si;
+  struct SessionObserver::ExistingSessionInfo session_info;
   uint32_t new_session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_OFF, &si);
-  out_hash_id_ = si.hash_id_;
+      uid_, 0, kRpc, PROTECTION_OFF, &session_info);
+  out_hash_id_ = session_info.hash_id_;
 
   EXPECT_NE(0u, new_session_id);
 }
@@ -1148,11 +1148,11 @@ TEST_F(ConnectionHandlerTest,
   protected_services_.push_back(kRpc);
   SetSpecificServices();
   // Start new session with RPC service
-  struct ExistingSessionInfo si;
+  struct SessionObserver::ExistingSessionInfo session_info;
   const uint32_t session_id_fail =
       connection_handler_->OnSessionStartedCallback(
-          uid_, 0, kRpc, PROTECTION_OFF, &si);
-  out_hash_id_ = si.hash_id_;
+          uid_, 0, kRpc, PROTECTION_OFF, &session_info);
+  out_hash_id_ = session_info.hash_id_;
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_fail);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
@@ -1167,8 +1167,8 @@ TEST_F(ConnectionHandlerTest,
   SetSpecificServices();
   // Start new session with RPC service
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_OFF, &si);
-  out_hash_id_ = si.hash_id_;
+      uid_, 0, kRpc, PROTECTION_OFF, &session_info);
+  out_hash_id_ = session_info.hash_id_;
   EXPECT_NE(0u, session_id);
   CheckService(uid_, session_id, kRpc, NULL, PROTECTION_OFF);
   EXPECT_EQ(SessionHash(uid_, session_id), out_hash_id_);
@@ -1199,10 +1199,10 @@ TEST_F(ConnectionHandlerTest,
   unprotected_services_.push_back(kControl);
   SetSpecificServices();
   // Start new session with RPC service
-  struct ExistingSessionInfo si;
+  struct SessionObserver::ExistingSessionInfo session_info;
   const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_ON, &si);
-  out_hash_id_ = si.hash_id_;
+      uid_, 0, kRpc, PROTECTION_ON, &session_info);
+  out_hash_id_ = session_info.hash_id_;
   EXPECT_NE(0u, session_id);
   EXPECT_EQ(SessionHash(uid_, session_id), out_hash_id_);
 
@@ -1236,10 +1236,10 @@ TEST_F(ConnectionHandlerTest,
   protected_services_.push_back(UnnamedService::kServedService2);
   protected_services_.push_back(kControl);
   SetSpecificServices();
-  struct ExistingSessionInfo si;
+  struct SessionObserver::ExistingSessionInfo session_info;
   const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, &si);
-  out_hash_id_ = si.hash_id_;
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, &session_info);
+  out_hash_id_ = session_info.hash_id_;
 // Returned original session id
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
@@ -1274,10 +1274,10 @@ TEST_F(ConnectionHandlerTest,
   // Allow start kAudio with encryption
   unprotected_services_.clear();
   SetSpecificServices();
-  struct ExistingSessionInfo si;
+  struct SessionObserver::ExistingSessionInfo session_info;
   const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_ON, &si);
-  out_hash_id_ = si.hash_id_;
+      uid_, start_session_id_, kAudio, PROTECTION_ON, &session_info);
+  out_hash_id_ = session_info.hash_id_;
 // Returned original session id
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
@@ -1294,10 +1294,10 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtect) {
   AddTestDeviceConnection();
   AddTestSession();
   // Start RPC protection
-  struct ExistingSessionInfo si;
+  struct SessionObserver::ExistingSessionInfo session_info;
   const uint32_t session_id_new = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kRpc, PROTECTION_ON, &si);
-  out_hash_id_ = si.hash_id_;
+      uid_, start_session_id_, kRpc, PROTECTION_ON, &session_info);
+  out_hash_id_ = session_info.hash_id_;
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id_new);
   // Post protection nedd no hash
@@ -1311,15 +1311,15 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtect) {
 #endif  // ENABLE_SECURITY
   // Start Audio session without protection
   const uint32_t session_id2 = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, &si);
-  out_hash_id_ = si.hash_id_;
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, &session_info);
+  out_hash_id_ = session_info.hash_id_;
   EXPECT_EQ(start_session_id_, session_id2);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
   CheckService(uid_, start_session_id_, kAudio, NULL, PROTECTION_OFF);
   // Start Audio protection
   const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_ON, &si);
-  out_hash_id_ = si.hash_id_;
+      uid_, start_session_id_, kAudio, PROTECTION_ON, &session_info);
+  out_hash_id_ = session_info.hash_id_;
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -305,6 +305,9 @@ class PolicyHandlerInterface {
       std::map<std::string, StringArray> app_hmi_types) = 0;
 
   virtual void OnCertificateUpdated(const std::string& certificate_data) = 0;
+
+  virtual void OnPTUFinished(const bool ptu_result) = 0;
+
 #ifdef EXTERNAL_PROPRIETARY_MODE
   virtual void OnCertificateDecrypted(bool is_succeeded) = 0;
 #endif  // EXTERNAL_PROPRIETARY_MODE

--- a/src/components/include/application_manager/policies/policy_handler_observer.h
+++ b/src/components/include/application_manager/policies/policy_handler_observer.h
@@ -43,9 +43,13 @@ class PolicyHandlerObserver {
  public:
   virtual void OnUpdateHMIAppType(
       std::map<std::string, std::vector<std::string> > app_hmi_types) {}
+
   virtual bool OnCertificateUpdated(const std::string& certificate_data) {
     return false;
   }
+
+  virtual void OnPTUFinished(const bool ptu_result) {}
+
   virtual ~PolicyHandlerObserver() {}
 };
 }  //  namespace policy

--- a/src/components/include/connection_handler/connection_handler_observer.h
+++ b/src/components/include/connection_handler/connection_handler_observer.h
@@ -113,7 +113,7 @@ class ConnectionHandlerObserver {
       const int32_t& session_key,
       const protocol_handler::ServiceType& type) const = 0;
 
-  virtual bool IsNaviApp(const int32_t& session_key) const = 0;
+  virtual bool HasNaviApp(const int32_t& session_key) const = 0;
 #endif  // ENABLE_SECURITY
  protected:
   /**

--- a/src/components/include/connection_handler/connection_handler_observer.h
+++ b/src/components/include/connection_handler/connection_handler_observer.h
@@ -112,6 +112,8 @@ class ConnectionHandlerObserver {
   virtual bool CanStartProtectedService(
       const int32_t& session_key,
       const protocol_handler::ServiceType& type) const = 0;
+
+  virtual bool IsNaviApp(const int32_t& session_key) const = 0;
 #endif  // ENABLE_SECURITY
  protected:
   /**

--- a/src/components/include/policy/policy_external/policy/policy_listener.h
+++ b/src/components/include/policy/policy_external/policy/policy_listener.h
@@ -120,6 +120,14 @@ class PolicyListener {
    */
   virtual void OnCertificateUpdated(const std::string& certificate_data) = 0;
 
+  /**
+   * @brief OnPTUFinishedd the callback which signals PTU has finished
+   *
+   * @param ptu_result the result from the PTU - true if successful,
+   * otherwise false.
+   */
+  virtual void OnPTUFinished(const bool ptu_result) = 0;
+
 #ifdef SDL_REMOTE_CONTROL
   /**
    * Gets devices ids by policy application id

--- a/src/components/include/policy/policy_regular/policy/policy_listener.h
+++ b/src/components/include/policy/policy_regular/policy/policy_listener.h
@@ -112,6 +112,14 @@ class PolicyListener {
    */
   virtual void OnCertificateUpdated(const std::string& certificate_data) = 0;
 
+  /**
+   * @brief OnPTUFinishedd the callback which signals PTU has finished
+   *
+   * @param ptu_result the result from the PTU - true if successful,
+   * otherwise false.
+   */
+  virtual void OnPTUFinished(const bool ptu_result) = 0;
+
 #ifdef SDL_REMOTE_CONTROL
   /**
    * Gets devices ids by policy application id

--- a/src/components/include/protocol_handler/protocol_handler.h
+++ b/src/components/include/protocol_handler/protocol_handler.h
@@ -34,6 +34,7 @@
 
 #include "protocol/common.h"
 #include "protocol_handler/protocol_handler_settings.h"
+#include "application_manager/policies/policy_handler_observer.h"
 
 /**
  *\namespace protocol_handlerHandler
@@ -48,7 +49,7 @@ class SessionObserver;
  * \brief Interface for component parsing protocol header
  * on the messages between SDL and mobile application.
  */
-class ProtocolHandler {
+class ProtocolHandler : public policy::PolicyHandlerObserver {
  public:
   /**
    * \brief Adds pointer to higher layer handler for message exchange
@@ -107,6 +108,25 @@ class ProtocolHandler {
    */
   virtual const ProtocolHandlerSettings& get_settings() const = 0;
   virtual SessionObserver& get_session_observer() = 0;
+
+  virtual void OnUpdateHMIAppType(
+      std::map<std::string, std::vector<std::string> > app_hmi_types) = 0;
+
+  /**
+   * @brief OnCertificateUpdated the callback which signals if certificate field
+   * has been updated during PTU
+   *
+   * @param certificate_data the value of the updated field.
+   */
+  virtual bool OnCertificateUpdated(const std::string& certificate_data) = 0;
+
+  /**
+   * @brief OnPTUFinishedd the callback which signals PTU has finished
+   *
+   * @param ptu_result the result from the PTU - true if successful,
+   * otherwise false.
+   */
+  virtual void OnPTUFinished(const bool ptu_status) = 0;
 
  protected:
   /**

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -43,12 +43,7 @@
          *\namespace protocol_handlerHandler
          *\brief Namespace for SmartDeviceLink ProtocolHandler related functionality.
          */
-struct ExistingSessionInfo {
-  uint32_t hash_id_;
-  bool start_protected_;
-  bool service_exists_;
-  bool is_navi_;
-};
+
 namespace protocol_handler {
 /**
  * \brief HASH_ID constants.
@@ -67,6 +62,12 @@ enum { HASH_ID_NOT_SUPPORTED = 0, HASH_ID_WRONG = 0xFFFF0000 };
 // TODO(EZamakhov): Reconsider rename KeyFromPair and PairFromKey
 class SessionObserver {
  public:
+  struct ExistingSessionInfo {
+    uint32_t hash_id_;
+    bool start_protected_;
+    bool service_exists_;
+    bool is_navi_;
+  };
   /**
    * \brief Callback function used by ProtocolHandler
    * when Mobile Application initiates start of new session.
@@ -85,7 +86,7 @@ class SessionObserver {
       const uint8_t sessionId,
       const protocol_handler::ServiceType& service_type,
       const bool is_protected,
-      struct ExistingSessionInfo* si) = 0;
+      struct ExistingSessionInfo* out_session_info) = 0;
 
   /**
    * \brief Callback function used by ProtocolHandler

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -43,6 +43,12 @@
          *\namespace protocol_handlerHandler
          *\brief Namespace for SmartDeviceLink ProtocolHandler related functionality.
          */
+struct ExistingSessionInfo {
+  uint32_t hash_id_;
+  bool start_protected_;
+  bool service_exists_;
+  bool is_navi_;
+};
 namespace protocol_handler {
 /**
  * \brief HASH_ID constants.
@@ -79,9 +85,7 @@ class SessionObserver {
       const uint8_t sessionId,
       const protocol_handler::ServiceType& service_type,
       const bool is_protected,
-      uint32_t* out_hash_id,
-      bool* out_start_protected,
-      bool* out_service_exists) = 0;
+      struct ExistingSessionInfo* si) = 0;
 
   /**
    * \brief Callback function used by ProtocolHandler

--- a/src/components/include/security_manager/crypto_manager.h
+++ b/src/components/include/security_manager/crypto_manager.h
@@ -62,7 +62,6 @@ class CryptoManager : public policy::PolicyHandlerObserver {
    */
   virtual bool Init() = 0;
   virtual SSLContext* CreateSSLContext() = 0;
-  virtual bool OnCertificateUpdated(const std::string& data) = 0;
   virtual void ReleaseSSLContext(SSLContext* context) = 0;
   virtual std::string LastError() const = 0;
 
@@ -73,6 +72,8 @@ class CryptoManager : public policy::PolicyHandlerObserver {
   */
   virtual const CryptoManagerSettings& get_settings() const = 0;
   virtual void SetCertExpTime(const std::string& time) = 0;
+  virtual bool OnCertificateUpdated(const std::string& data) = 0;
+  virtual void OnPTUFinished(const bool ptu_result) = 0;
   virtual ~CryptoManager() {}
 };
 

--- a/src/components/include/security_manager/security_manager.h
+++ b/src/components/include/security_manager/security_manager.h
@@ -132,6 +132,14 @@ class SecurityManager : public protocol_handler::ProtocolObserver {
    */
   virtual void AddListener(SecurityManagerListener* const listener) = 0;
   virtual void RemoveListener(SecurityManagerListener* const listener) = 0;
+  virtual void NotifyOnCertififcateUpdateRequired() = 0;
+
+  /**
+   * \brief Checks if the SSL certificate is not expired
+   * @return true if the certificate is expired or not set,
+   * otherwise false
+   */
+  virtual bool IsCertificateUpdateRequired() const = 0;
 };
 }  // namespace security_manager
 #endif  // SRC_COMPONENTS_INCLUDE_SECURITY_MANAGER_SECURITY_MANAGER_H_

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -172,6 +172,7 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD1(OnUpdateHMIAppType,
                void(std::map<std::string, policy::StringArray> app_hmi_types));
   MOCK_METHOD1(OnCertificateUpdated, void(const std::string& certificate_data));
+  MOCK_METHOD1(OnPTUFinished, void(const bool ptu_result));
   MOCK_METHOD1(OnCertificateDecrypted, void(bool is_succeeded));
   MOCK_METHOD0(CanUpdate, bool());
   MOCK_METHOD2(OnDeviceConsentChanged,

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_observer.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_observer.h
@@ -49,6 +49,7 @@ class MockPolicyHandlerObserver : public ::policy::PolicyHandlerObserver {
   MOCK_METHOD1(OnUpdateHMIAppType,
                void(std::map<std::string, std::vector<std::string> >));
   MOCK_METHOD1(OnCertificateUpdated, bool(const std::string&));
+  MOCK_METHOD1(OnPTUFinished, void(const bool ptu_result));
 };
 }  //  namespace application_manager_test
 }  //  namespace components

--- a/src/components/include/test/connection_handler/mock_connection_handler_observer.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler_observer.h
@@ -66,7 +66,7 @@ class MockConnectionHandlerObserver
                           const protocol_handler::ServiceType& type));
   MOCK_CONST_METHOD1(CanStartProtectedService,
                      bool(const int32_t& session_key));
-  MOCK_CONST_METHOD1(IsNaviApp, bool(const int32_t& session_key));
+  MOCK_CONST_METHOD1(HasNaviApp, bool(const int32_t& session_key));
 #endif  // ENABLE_SECURITY
 };
 

--- a/src/components/include/test/connection_handler/mock_connection_handler_observer.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler_observer.h
@@ -64,6 +64,9 @@ class MockConnectionHandlerObserver
   MOCK_CONST_METHOD2(CanStartProtectedService,
                      bool(const int32_t& session_key,
                           const protocol_handler::ServiceType& type));
+  MOCK_CONST_METHOD1(CanStartProtectedService,
+                     bool(const int32_t& session_key));
+  MOCK_CONST_METHOD1(IsNaviApp, bool(const int32_t& session_key));
 #endif  // ENABLE_SECURITY
 };
 

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_listener.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_listener.h
@@ -81,6 +81,7 @@ class MockPolicyListener : public ::policy::PolicyListener {
                     uint32_t timeout_exceed));
   MOCK_METHOD0(CanUpdate, bool());
   MOCK_METHOD1(OnCertificateUpdated, void(const std::string&));
+  MOCK_METHOD1(OnPTUFinished, void(const bool ptu_result));
   MOCK_CONST_METHOD2(SendOnAppPermissionsChanged,
                      void(const policy::AppPermissions&, const std::string&));
   MOCK_METHOD1(GetDevicesIds,

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_listener.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_listener.h
@@ -75,6 +75,7 @@ class MockPolicyListener : public ::policy::PolicyListener {
   MOCK_METHOD1(OnSnapshotCreated, void(const policy::BinaryMessage& pt_string));
   MOCK_METHOD0(CanUpdate, bool());
   MOCK_METHOD1(OnCertificateUpdated, void(const std::string&));
+  MOCK_METHOD1(OnPTUFinished, void(const bool ptu_result));
   MOCK_CONST_METHOD2(SendOnAppPermissionsChanged,
                      void(const policy::AppPermissions&, const std::string&));
   MOCK_METHOD1(GetDevicesIds,

--- a/src/components/include/test/protocol_handler/mock_protocol_handler.h
+++ b/src/components/include/test/protocol_handler/mock_protocol_handler.h
@@ -62,6 +62,10 @@ class MockProtocolHandler : public ::protocol_handler::ProtocolHandler {
   MOCK_CONST_METHOD0(get_settings,
                      const ::protocol_handler::ProtocolHandlerSettings&());
   MOCK_METHOD0(get_session_observer, protocol_handler::SessionObserver&());
+  MOCK_METHOD1(OnPTUFinished, void(const bool ptu_result));
+  MOCK_METHOD1(OnUpdateHMIAppType,
+               void(std::map<std::string, std::vector<std::string> >));
+  MOCK_METHOD1(OnCertificateUpdated, bool(const std::string&));
 };
 }  // namespace protocol_handler_test
 }  // namespace components

--- a/src/components/include/test/protocol_handler/mock_session_observer.h
+++ b/src/components/include/test/protocol_handler/mock_session_observer.h
@@ -52,7 +52,7 @@ class MockSessionObserver : public ::protocol_handler::SessionObserver {
                const uint8_t sessionId,
                const protocol_handler::ServiceType& service_type,
                const bool is_protected,
-               struct ExistingSessionInfo* out_si));
+               struct ExistingSessionInfo* out_session_info));
   MOCK_METHOD4(
       OnSessionEndedCallback,
       uint32_t(const transport_manager::ConnectionUID connection_handle,

--- a/src/components/include/test/protocol_handler/mock_session_observer.h
+++ b/src/components/include/test/protocol_handler/mock_session_observer.h
@@ -46,15 +46,13 @@ namespace protocol_handler_test {
  */
 class MockSessionObserver : public ::protocol_handler::SessionObserver {
  public:
-  MOCK_METHOD7(
+  MOCK_METHOD5(
       OnSessionStartedCallback,
       uint32_t(const transport_manager::ConnectionUID connection_handle,
                const uint8_t sessionId,
                const protocol_handler::ServiceType& service_type,
                const bool is_protected,
-               uint32_t* out_hash_id,
-               bool* out_start_protected,
-               bool* service_exists));
+               struct ExistingSessionInfo* out_si));
   MOCK_METHOD4(
       OnSessionEndedCallback,
       uint32_t(const transport_manager::ConnectionUID connection_handle,

--- a/src/components/include/test/security_manager/mock_crypto_manager.h
+++ b/src/components/include/test/security_manager/mock_crypto_manager.h
@@ -54,6 +54,7 @@ class MockCryptoManager : public ::security_manager::CryptoManager {
   MOCK_CONST_METHOD0(LastError, std::string());
   MOCK_CONST_METHOD0(IsCertificateUpdateRequired, bool());
   MOCK_METHOD1(SetCertExpTime, void(const std::string& time));
+  MOCK_METHOD1(OnPTUFinished, void(const bool ptu_result));
 };
 }  // namespace security_manager_test
 }  // namespace components

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -622,6 +622,7 @@ class ProtocolHandlerImpl
 #endif  // TELEMETRY_MONITOR
   PTUState ptu_state_;
   struct SessionInfo pending_session_;
+  mutable sync_primitives::Lock ptu_state_lock_;
 };
 }  // namespace protocol_handler
 #endif  // SRC_COMPONENTS_PROTOCOL_HANDLER_INCLUDE_PROTOCOL_HANDLER_PROTOCOL_HANDLER_IMPL_H_

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -87,6 +87,36 @@ typedef std::multimap<int32_t, RawMessagePtr> MessagesOverNaviMap;
 typedef std::set<ProtocolObserver*> ProtocolObservers;
 typedef transport_manager::ConnectionUID ConnectionID;
 
+enum PTUState { kNotTriggered = 0, kTriggered, kFinSuccess, kFinNotSuccess };
+
+struct SessionInfo {
+  ConnectionID connection_id_;
+  uint8_t session_id_;
+  uint8_t protocol_version_;
+  uint8_t service_type_;
+  uint32_t hash_id_;
+  bool service_exists_;
+  SessionInfo(ConnectionID connection_id,
+              uint8_t session_id,
+              uint8_t protocol_version,
+              uint8_t service_type,
+              uint32_t hash_id,
+              bool service_exists)
+      : connection_id_(connection_id)
+      , session_id_(session_id)
+      , protocol_version_(protocol_version)
+      , service_type_(service_type)
+      , hash_id_(hash_id)
+      , service_exists_(service_exists) {}
+  SessionInfo()
+      : connection_id_(0)
+      , session_id_(0)
+      , protocol_version_(0)
+      , service_type_(0)
+      , hash_id_(0)
+      , service_exists_(0) {}
+};
+
 namespace impl {
 /*
  * These dummy classes are here to locally impose strong typing on different
@@ -307,6 +337,25 @@ class ProtocolHandlerImpl
   }
 #endif
 
+  /**
+   * @brief OnPTUFinishedd the callback which signals PTU has finished
+   *
+   * @param ptu_result the result from the PTU - true if successful,
+   * otherwise false.
+   */
+  void OnPTUFinished(const bool ptu_result) OVERRIDE;
+
+  /**
+   * @brief OnCertificateUpdated the callback which signals if certificate field
+   * has been updated during PTU
+   *
+   * @param certificate_data the value of the updated field.
+   */
+  bool OnCertificateUpdated(const std::string& certificate_data) OVERRIDE;
+
+  void OnUpdateHMIAppType(
+      std::map<std::string, std::vector<std::string> > app_hmi_types) OVERRIDE;
+
  private:
   void SendEndServicePrivate(int32_t connection_id,
                              uint8_t session_id,
@@ -483,6 +532,8 @@ class ProtocolHandlerImpl
    */
   uint8_t SupportedSDLProtocolVersion() const;
 
+  void StartEncryptedService(const SessionInfo& si);
+
   const ProtocolHandlerSettings& settings_;
 
   /**
@@ -569,6 +620,8 @@ class ProtocolHandlerImpl
 #ifdef TELEMETRY_MONITOR
   PHTelemetryObserver* metric_observer_;
 #endif  // TELEMETRY_MONITOR
+  PTUState ptu_state_;
+  struct SessionInfo pending_session_;
 };
 }  // namespace protocol_handler
 #endif  // SRC_COMPONENTS_PROTOCOL_HANDLER_INCLUDE_PROTOCOL_HANDLER_PROTOCOL_HANDLER_IMPL_H_

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -79,9 +79,9 @@ ProtocolHandlerImpl::ProtocolHandlerImpl(
           "PH ToMobile", this, threads::ThreadOptions(kStackSize))
 #ifdef TELEMETRY_MONITOR
     , metric_observer_(NULL)
+    ,
 #endif  // TELEMETRY_MONITOR
-
-{
+    ptu_state_(kNotTriggered) {
   LOG4CXX_AUTO_TRACE(logger_);
   protocol_header_validator_.set_max_payload_size(
       get_settings().maximum_payload_size());
@@ -1077,25 +1077,17 @@ RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(
 
 #ifdef ENABLE_SECURITY
   const bool protection =
-      // Protocolo version 1 is not support protection
+      // Protocol version 1 is not support protection
       (protocol_version > PROTOCOL_VERSION_1) ? packet.protection_flag()
                                               : false;
 #else
   const bool protection = false;
 #endif  // ENABLE_SECURITY
 
-  uint32_t hash_id;
-  bool protection_requested = false;
-  bool service_exists = false;
+  struct ExistingSessionInfo si;
   const ConnectionID connection_id = packet.connection_id();
-  const uint32_t session_id =
-      session_observer_.OnSessionStartedCallback(connection_id,
-                                                 packet.session_id(),
-                                                 service_type,
-                                                 protection,
-                                                 &hash_id,
-                                                 &protection_requested,
-                                                 &service_exists);
+  const uint32_t session_id = session_observer_.OnSessionStartedCallback(
+      connection_id, packet.session_id(), service_type, protection, &si);
 
   if (0 == session_id) {
     LOG4CXX_WARN(logger_,
@@ -1109,65 +1101,59 @@ RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(
   }
 
 #ifdef ENABLE_SECURITY
-  // for packet is encrypted and security plugin is enable
-  if (protection_requested && security_manager_) {
+  // for packet is encrypted and security plug-in is enable
+  if (si.start_protected_ && security_manager_) {
     const uint32_t connection_key =
         session_observer_.KeyFromPair(connection_id, session_id);
-
     security_manager::SSLContext* ssl_context =
         security_manager_->CreateSSLContext(connection_key);
-    if (!ssl_context) {
+    if (!ssl_context || security_manager_->IsCertificateUpdateRequired()) {
       const std::string error("CreateSSLContext failed");
       LOG4CXX_ERROR(logger_, error);
       security_manager_->SendInternalError(
           connection_key,
           security_manager::SecurityManager::ERROR_INTERNAL,
           error);
-      // Start service without protection
-      if (service_exists) {
+      if (si.is_navi_) {
+        if (si.service_exists_) {
+          SendStartSessionNAck(connection_id,
+                               packet.session_id(),
+                               protocol_version,
+                               packet.service_type());
+        } else {
+          SendStartSessionAck(connection_id,
+                              session_id,
+                              packet.protocol_version(),
+                              si.hash_id_,
+                              packet.service_type(),
+                              PROTECTION_OFF);
+        }
+        return RESULT_OK;
+      }
+      if (ptu_state_ == kNotTriggered) {
+        ptu_state_ = kTriggered;
+        pending_session_ = SessionInfo(connection_id,
+                                       packet.session_id(),
+                                       protocol_version,
+                                       packet.service_type(),
+                                       si.hash_id_,
+                                       si.service_exists_);
+        security_manager_->NotifyOnCertififcateUpdateRequired();
+      } else if (ptu_state_ != kTriggered) {
         SendStartSessionNAck(connection_id,
                              packet.session_id(),
                              protocol_version,
                              packet.service_type());
-      } else {
-        SendStartSessionAck(connection_id,
-                            session_id,
-                            packet.protocol_version(),
-                            hash_id,
-                            packet.service_type(),
-                            PROTECTION_OFF);
       }
       return RESULT_OK;
     }
-    if (ssl_context->IsInitCompleted()) {
-      // mark service as protected
-      session_observer_.SetProtectionFlag(connection_key, service_type);
-      // Start service as protected with current SSLContext
-      SendStartSessionAck(connection_id,
-                          session_id,
-                          packet.protocol_version(),
-                          hash_id,
-                          packet.service_type(),
-                          PROTECTION_ON);
-    } else {
-      security_manager_->AddListener(
-          new StartSessionHandler(connection_key,
-                                  this,
-                                  session_observer_,
-                                  connection_id,
-                                  session_id,
-                                  packet.protocol_version(),
-                                  hash_id,
-                                  service_type,
-                                  get_settings().force_protected_service()));
-      if (!ssl_context->IsHandshakePending()) {
-        // Start handshake process
-        security_manager_->StartHandshake(connection_key);
-      }
-    }
-    LOG4CXX_DEBUG(logger_,
-                  "Protection establishing for connection "
-                      << connection_key << " is in progress");
+    struct SessionInfo si = SessionInfo(connection_id,
+                                        packet.session_id(),
+                                        protocol_version,
+                                        packet.service_type(),
+                                        si.hash_id_,
+                                        si.service_exists_);
+    StartEncryptedService(si);
     return RESULT_OK;
   }
 #endif  // ENABLE_SECURITY
@@ -1175,7 +1161,7 @@ RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(
   SendStartSessionAck(connection_id,
                       session_id,
                       packet.protocol_version(),
-                      hash_id,
+                      si.hash_id_,
                       packet.service_type(),
                       PROTECTION_OFF);
   return RESULT_OK;
@@ -1535,4 +1521,79 @@ uint8_t ProtocolHandlerImpl::SupportedSDLProtocolVersion() const {
   }
   return PROTOCOL_VERSION_2;
 }
+
+void ProtocolHandlerImpl::OnPTUFinished(const bool ptu_result) {
+  LOG4CXX_AUTO_TRACE(logger_);
+#ifdef ENABLE_SECURITY
+  if (ptu_state_ != kTriggered) {
+    return;
+  }
+  if (ptu_result) {
+    ptu_state_ = kFinSuccess;
+    StartEncryptedService(pending_session_);
+    return;
+  }
+  ptu_state_ = kFinNotSuccess;
+  SendStartSessionNAck(pending_session_.connection_id_,
+                       pending_session_.session_id_,
+                       pending_session_.protocol_version_,
+                       pending_session_.service_type_);
+#endif
+}
+
+bool ProtocolHandlerImpl::OnCertificateUpdated(
+    const std::string& certificate_data) {
+  LOG4CXX_AUTO_TRACE(logger_);
+#ifdef ENABLE_SECURITY
+  if (ptu_state_ != kTriggered) {
+    ptu_state_ = kNotTriggered;
+  }
+  return false;
+#else
+  return false;
+#endif
+}
+
+void ProtocolHandlerImpl::OnUpdateHMIAppType(
+    std::map<std::string, std::vector<std::string> > app_hmi_types) {}
+
+#ifdef ENABLE_SECURITY
+void ProtocolHandlerImpl::StartEncryptedService(const SessionInfo& si) {
+  // mark service as protected
+  const uint32_t connection_key =
+      session_observer_.KeyFromPair(si.connection_id_, si.session_id_);
+  session_observer_.SetProtectionFlag(connection_key,
+                                      ServiceTypeFromByte(si.service_type_));
+  security_manager::SSLContext* ssl_context = session_observer_.GetSSLContext(
+      connection_key, protocol_handler::kControl);
+  // Start service as protected with current SSLContext
+  if (ssl_context && ssl_context->IsInitCompleted()) {
+    SendStartSessionAck(si.connection_id_,
+                        si.session_id_,
+                        si.protocol_version_,
+                        si.hash_id_,
+                        si.service_type_,
+                        PROTECTION_ON);
+  } else {
+    security_manager_->AddListener(
+        new StartSessionHandler(connection_key,
+                                this,
+                                session_observer_,
+                                si.connection_id_,
+                                si.session_id_,
+                                si.protocol_version_,
+                                si.hash_id_,
+                                ServiceTypeFromByte(si.service_type_),
+                                get_settings().force_protected_service()));
+    if (!ssl_context->IsHandshakePending()) {
+      // Start handshake process
+      security_manager_->StartHandshake(connection_key);
+    }
+  }
+  LOG4CXX_DEBUG(logger_,
+                "Protection establishing for connection " << connection_key
+                                                          << " is in progress");
+}
+#endif
+
 }  // namespace protocol_handler

--- a/src/components/security_manager/include/security_manager/crypto_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/crypto_manager_impl.h
@@ -122,6 +122,7 @@ class CryptoManagerImpl : public CryptoManager {
   virtual bool IsCertificateUpdateRequired() const OVERRIDE;
   virtual const CryptoManagerSettings& get_settings() const OVERRIDE;
   virtual void SetCertExpTime(const std::string& time) OVERRIDE;
+  void OnPTUFinished(const bool ptu_result) OVERRIDE;
 
  private:
   bool set_certificate(const std::string& cert_data);

--- a/src/components/security_manager/include/security_manager/security_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/security_manager_impl.h
@@ -165,6 +165,7 @@ class SecurityManagerImpl : public SecurityManager,
    * @return Session name in config file
    */
   static const char* ConfigSection();
+  bool IsCertificateUpdateRequired() const;
 
  private:
   /**

--- a/src/components/security_manager/src/crypto_manager_impl.cc
+++ b/src/components/security_manager/src/crypto_manager_impl.cc
@@ -406,4 +406,6 @@ void CryptoManagerImpl::SetCertExpTime(const std::string& time) {
   strptime(time.c_str(), "%d %b %Y %H:%M:%S", &expiration_time_);
 }
 
+void CryptoManagerImpl::OnPTUFinished(const bool ptu_result) {}
+
 }  // namespace security_manager

--- a/src/components/security_manager/src/security_manager_impl.cc
+++ b/src/components/security_manager/src/security_manager_impl.cc
@@ -188,10 +188,6 @@ void SecurityManagerImpl::StartHandshake(uint32_t connection_key) {
     return;
   }
 
-  if (crypto_manager_->IsCertificateUpdateRequired()) {
-    NotifyOnCertififcateUpdateRequired();
-  }
-
   if (ssl_context->IsInitCompleted()) {
     NotifyListenersOnHandshakeDone(connection_key,
                                    SSLContext::Handshake_Result_Success);
@@ -413,4 +409,8 @@ const char* SecurityManagerImpl::ConfigSection() {
   return "Security Manager";
 }
 
+bool SecurityManagerImpl::IsCertificateUpdateRequired() const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return crypto_manager_->IsCertificateUpdateRequired();
+}
 }  // namespace security_manager

--- a/src/components/security_manager/test/security_manager_test.cc
+++ b/src/components/security_manager/test/security_manager_test.cc
@@ -607,8 +607,6 @@ TEST_F(SecurityManagerTest, StartHandshake_SSLInitIsComplete) {
       .WillOnce(Return(&mock_ssl_context_exists));
   EXPECT_CALL(mock_ssl_context_exists, IsInitCompleted())
       .WillOnce(Return(true));
-  EXPECT_CALL(mock_crypto_manager, IsCertificateUpdateRequired())
-      .WillOnce(Return(false));
 
   security_manager_->StartHandshake(key);
 }


### PR DESCRIPTION
These changes solve the problem that is observed in most of the test cases, related to CRQ:
PolicyTableUpdate must be triggered in case no "certificate" exist at "module_config" section of PolicyTable:
SDL shoul wait PTU to be finished before answering with startServiceACK/startServiceNack to the start service request
According to the implementation - it is not the correct solution of the problem, because:
1) protocol handler mustn't be policy_handler observer - this relation must be removed
2) maybe session observer must handle these PTU events
3) No UT covarage is implemented to these changes, because this functionality must be refactored