### PR TITLE
Fix sending UPDATE_NEEDED after failed ptu retry sequence

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1524,6 +1524,7 @@ void PolicyHandler::ResetRetrySequence() {
 
 uint32_t PolicyHandler::NextRetryTimeout() {
   POLICY_LIB_CHECK(0);
+  LOG4CXX_AUTO_TRACE(logger_);
   return policy_manager_->NextRetryTimeout();
 }
 

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1490,6 +1490,7 @@ std::string PolicyManagerImpl::GetPolicyTableStatus() const {
 }
 
 int PolicyManagerImpl::NextRetryTimeout() {
+  LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock auto_lock(retry_sequence_lock_);
   LOG4CXX_DEBUG(logger_, "Index: " << retry_sequence_index_);
   int next = 0;

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -851,6 +851,9 @@ uint32_t PolicyManagerImpl::NextRetryTimeout() {
     // According to requirement APPLINK-18244
     next += retry_sequence_timeout_;
   }
+  if (retry_sequence_index_ == retry_sequence_seconds_.size()) {
+    retry_sequence_timeout_ = 1;
+  }
 
   // Return miliseconds
   return next;
@@ -1158,9 +1161,11 @@ void PolicyManagerImpl::RetrySequence() {
   RequestPTUpdate();
 
   uint32_t timeout = NextRetryTimeout();
-
+  LOG4CXX_INFO(logger_, "new timeout is" << timeout);
   if (!timeout && timer_retry_sequence_.is_running()) {
+    LOG4CXX_INFO(logger_, "Stop retry PTU");
     timer_retry_sequence_.Stop();
+
     listener()->OnPTUFinished(false);
     return;
   }

--- a/src/components/policy/policy_regular/src/update_status_manager.cc
+++ b/src/components/policy/policy_regular/src/update_status_manager.cc
@@ -227,6 +227,7 @@ void UpdateStatusManager::UpdateThreadDelegate::threadMain() {
     } else {
       // Time is not active, wait until timeout will be set,
       // or UpdateStatusManager will be deleted
+      LOG4CXX_DEBUG(logger_, "Timeout is equal to 0");
       termination_condition_.Wait(auto_lock);
     }
   }


### PR DESCRIPTION
In case it is last PTU sending of notification should be starting right after updating