### PR TITLE
Fix UPDATE_NEEDED is sent in case of unconsented device

### DIFF
--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1035,16 +1035,22 @@ bool CacheManager::SetCountersPassedForSuccessfulUpdate(
 int CacheManager::DaysBeforeExchange(uint16_t current) {
   LOG4CXX_AUTO_TRACE(logger_);
   CACHE_MANAGER_CHECK(0);
+
+  const rpc::Optional<rpc::Integer<uint16_t, 0, 65535> >& days_after_epoch =
+      (pt_->policy_table.module_meta->pt_exchanged_x_days_after_epoch);
+
+  if (!days_after_epoch->is_initialized()) {
+    return -1;
+  }
+
   const uint8_t limit = pt_->policy_table.module_config.exchange_after_x_days;
   LOG4CXX_DEBUG(logger_,
                 "Exchange after: " << static_cast<int>(limit) << " days");
 
-  const uint16_t days_after_epoch =
-      (*pt_->policy_table.module_meta->pt_exchanged_x_days_after_epoch);
-  LOG4CXX_DEBUG(logger_, "Epoch since last update: " << days_after_epoch);
+  LOG4CXX_DEBUG(logger_, "Epoch since last update: " << *days_after_epoch);
 
   const uint16_t actual =
-      std::max(static_cast<uint16_t>(current - days_after_epoch), uint16_t(0));
+      std::max(static_cast<uint16_t>(current - *days_after_epoch), uint16_t(0));
   LOG4CXX_DEBUG(logger_, "The days since last update: " << actual);
 
   return std::max(limit - actual, 0);

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -539,16 +539,22 @@ bool CacheManager::SetCountersPassedForSuccessfulUpdate(
 int CacheManager::DaysBeforeExchange(int current) {
   LOG4CXX_AUTO_TRACE(logger_);
   CACHE_MANAGER_CHECK(0);
+
+  const rpc::Optional<rpc::Integer<uint16_t, 0, 65535> >& days_after_epoch =
+      (pt_->policy_table.module_meta->pt_exchanged_x_days_after_epoch);
+
+  if (!days_after_epoch->is_initialized()) {
+    return -1;
+  }
+
   const uint8_t limit = pt_->policy_table.module_config.exchange_after_x_days;
   LOG4CXX_DEBUG(logger_,
                 "Exchange after: " << static_cast<int>(limit) << " days");
 
-  const uint16_t days_after_epoch =
-      (*pt_->policy_table.module_meta->pt_exchanged_x_days_after_epoch);
-  LOG4CXX_DEBUG(logger_, "Epoch since last update: " << days_after_epoch);
+  LOG4CXX_DEBUG(logger_, "Epoch since last update: " << *days_after_epoch);
 
   const uint16_t actual =
-      std::max(static_cast<uint16_t>(current - days_after_epoch), uint16_t(0));
+      std::max(static_cast<uint16_t>(current - *days_after_epoch), uint16_t(0));
   LOG4CXX_DEBUG(logger_, "The days since last update: " << actual);
 
   return std::max(limit - actual, 0);


### PR DESCRIPTION
Add check that pt_exchanged_x_days_after_epoch is initialized,

https://github.com/smartdevicelink/sdl_core/issues/1215