### PR TITLE
Fixed bug OnPermissionChange sent twice

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -598,11 +598,11 @@ void PolicyHandler::OnAppPermissionConsentInternal(
       out_permissions.device_id = it->first;
 #ifdef EXTERNAL_PROPRIETARY_MODE
       if (!k_isNeedToUpdateExternalConsent) {
-#endif
         policy_manager_->SetUserConsentForApp(out_permissions);
-#ifdef EXTERNAL_PROPRIETARY_MODE
       }
-#endif
+#else
+      policy_manager_->SetUserConsentForApp(out_permissions);
+#endif  // EXTERNAL_PROPRIETARY_MODE
     }
   } else {
     LOG4CXX_WARN(logger_,

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1380,26 +1380,17 @@ bool ConsentStatusComparatorFunc(const ExternalConsentStatusItem& i1,
 bool PolicyManagerImpl::IsNeedToUpdateExternalConsentStatus(
     const ExternalConsentStatus& new_status) const {
   LOG4CXX_AUTO_TRACE(logger_);
-  typedef std::vector<ExternalConsentStatusItem> ItemV;
   const ExternalConsentStatus existing_status =
       cache_->GetExternalConsentEntities();
 
-  ItemV new_status_v(new_status.begin(), new_status.end());
-  ItemV existing_status_v(existing_status.begin(), existing_status.end());
-
-  ItemV difference_v;
-  difference_v.resize(new_status_v.size() + existing_status_v.size());
-
-  ItemV::iterator ci = difference_v.begin();
-  ci = std::set_difference(new_status_v.begin(),
-                           new_status_v.end(),
-                           existing_status_v.begin(),
-                           existing_status_v.end(),
-                           difference_v.begin(),
-                           ConsentStatusComparatorFunc);
-  difference_v.resize(ci - difference_v.begin());
-
-  return !difference_v.empty();
+  ExternalConsentStatus difference;
+  std::set_difference(new_status.begin(),
+                      new_status.end(),
+                      existing_status.begin(),
+                      existing_status.end(),
+                      std::inserter(difference, difference.begin()),
+                      ConsentStatusComparatorFunc);
+  return !difference.empty();
 }
 
 bool PolicyManagerImpl::SetExternalConsentStatus(


### PR DESCRIPTION
Fixed bug that OnPermissionChange sent twice when needs to change only one time.
Added checks that if we had and NEED an update in externalConsent properties
then we ignore system permission consent requests.

That fix should finally fix the failed CRQ.