### PR TITLE
Temporary solution for finish work of retry timeout after finishing updating

### DIFF
--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -841,6 +841,8 @@ uint32_t PolicyManagerImpl::NextRetryTimeout() {
   uint32_t next = 0u;
   if (retry_sequence_seconds_.empty() ||
       retry_sequence_index_ >= (retry_sequence_seconds_.size())) {
+    sync_primitives::ConditionalVariable termination_condition_;
+    termination_condition_.WaitFor(auto_lock, retry_sequence_timeout_ * 60);
     return next;
   }
 


### PR DESCRIPTION
PTU should finish retry cycle only after all update notifications are finished.

According requirements, PTU should be finished and startservice which trigger PTU should be sent only after finish PTU sequence.