### PR TITLE
Fix SDL doesn't send SDL.OnStatusUpdate(UPDATE_NEEDED) in case of failed retry strategy during previous IGN_ON

### DIFF
--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -927,7 +927,8 @@ StatusNotifier PolicyManagerImpl::AddApplication(
                                                device_consent);
   } else {
     PromoteExistedApplication(application_id, device_consent);
-    return utils::MakeShared<utils::CallNothing>();
+    return utils::MakeShared<CallStatusChange>(update_status_manager_,
+                                               device_consent);
   }
 }
 

--- a/src/components/policy/policy_regular/src/status.cc
+++ b/src/components/policy/policy_regular/src/status.cc
@@ -68,6 +68,9 @@ void policy::UpdateNeededStatus::ProcessEvent(
     case kOnResetPolicyTableNoUpdate:
       manager->SetNextStatus(utils::MakeShared<UpToDateStatus>());
       break;
+    case kOnNewAppRegistered:
+      manager->SetNextStatus(utils::MakeShared<UpdateNeededStatus>());
+      break;
     default:
       break;
   }


### PR DESCRIPTION
Add missed notification SDL.OnStatusUpdate(UPDATE_NEEDED) in case of failed retry strategy during previous IGN_ON