### PR TITLE
Fix UPDATE_NEEDED is sent if user requested PTU from HMI

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -121,7 +121,6 @@ class PolicyHandler : public PolicyHandlerInterface,
   void GetUpdateUrls(const uint32_t service_type,
                      EndpointUrls& out_end_points) OVERRIDE;
   virtual std::string GetLockScreenIconUrl() const OVERRIDE;
-  void ResetRetrySequence() OVERRIDE;
   uint32_t NextRetryTimeout() OVERRIDE;
   uint32_t TimeoutExchangeSec() OVERRIDE;
   uint32_t TimeoutExchangeMSec() OVERRIDE;

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1442,11 +1442,6 @@ std::string PolicyHandler::GetLockScreenIconUrl() const {
   return policy_manager_->GetLockScreenIconUrl();
 }
 
-void PolicyHandler::ResetRetrySequence() {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->ResetRetrySequence();
-}
-
 uint32_t PolicyHandler::NextRetryTimeout() {
   POLICY_LIB_CHECK(0);
   return policy_manager_->NextRetryTimeout();

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1232,7 +1232,7 @@ void PolicyHandler::KmsChanged(int kilometers) {
 void PolicyHandler::PTExchangeAtUserRequest(uint32_t correlation_id) {
   LOG4CXX_TRACE(logger_, "PT exchange at user request");
   POLICY_LIB_CHECK_VOID();
-  std::string update_status = policy_manager_->ForcePTExchange();
+  std::string update_status = policy_manager_->ForcePTExchangeAtUserRequest();
   MessageHelper::SendUpdateSDLResponse(
       update_status, correlation_id, application_manager_);
 }

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -867,7 +867,7 @@ TEST_F(PolicyHandlerTest, PTExchangeAtUserRequest) {
   // Arrange
   ChangePolicyManagerToMock();
   // Check expectations
-  EXPECT_CALL(*mock_policy_manager_, ForcePTExchange());
+  EXPECT_CALL(*mock_policy_manager_, ForcePTExchangeAtUserRequest());
   EXPECT_CALL(mock_message_helper_, SendUpdateSDLResponse(_, _, _));
   // Act
   const uint32_t correlation_id = 2;

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -500,15 +500,6 @@ TEST_F(PolicyHandlerTest, GetUpdateUrls) {
   policy_handler_.GetUpdateUrls(service_type, endpoints);
 }
 
-TEST_F(PolicyHandlerTest, ResetRetrySequence) {
-  // Arrange
-  EnablePolicyAndPolicyManagerMock();
-  // Check expectations
-  EXPECT_CALL(*mock_policy_manager_, ResetRetrySequence());
-  // Act
-  policy_handler_.ResetRetrySequence();
-}
-
 TEST_F(PolicyHandlerTest, NextRetryTimeout) {
   // Arrange
   EnablePolicyAndPolicyManagerMock();

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -100,7 +100,6 @@ class PolicyHandlerInterface {
   virtual void GetUpdateUrls(const uint32_t service_type,
                              EndpointUrls& out_end_points) = 0;
   virtual std::string GetLockScreenIconUrl() const = 0;
-  virtual void ResetRetrySequence() = 0;
   virtual uint32_t NextRetryTimeout() = 0;
   virtual uint32_t TimeoutExchangeSec() = 0;
   virtual uint32_t TimeoutExchangeMSec() = 0;

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -142,9 +142,14 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void IncrementIgnitionCycles() = 0;
 
   /**
-   * @brief ExchangeByUserRequest
+   * @brief Exchange by hmi or mobile request
    */
   virtual std::string ForcePTExchange() = 0;
+
+  /**
+   * @brief ExchangeByUserRequest
+   */
+  virtual std::string ForcePTExchangeAtUserRequest() = 0;
 
   /**
    * Resets retry sequence

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -141,15 +141,19 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void IncrementIgnitionCycles() = 0;
 
   /**
-   * @brief ExchangeByUserRequest
+   * @brief Exchange by hmi or mobile request
    */
   virtual std::string ForcePTExchange() = 0;
+
+  /**
+   * @brief ExchangeByUserRequest
+   */
+  virtual std::string ForcePTExchangeAtUserRequest() = 0;
 
   /**
    * Resets retry sequence
    */
   virtual void ResetRetrySequence() = 0;
-
   /**
    * Gets timeout to wait before next retry updating PT
    * If timeout is equal to zero then the retry sequence is not need.

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -151,10 +151,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual std::string ForcePTExchangeAtUserRequest() = 0;
 
   /**
-   * Resets retry sequence
-   */
-  virtual void ResetRetrySequence() = 0;
-  /**
    * Gets timeout to wait before next retry updating PT
    * If timeout is equal to zero then the retry sequence is not need.
    * @return timeout in seconds

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -78,6 +78,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD1(KmsChanged, void(int kilometers));
   MOCK_METHOD0(IncrementIgnitionCycles, void());
   MOCK_METHOD0(ForcePTExchange, std::string());
+  MOCK_METHOD0(ForcePTExchangeAtUserRequest, std::string());
   MOCK_METHOD0(ResetRetrySequence, void());
   MOCK_METHOD0(NextRetryTimeout, int());
   MOCK_METHOD0(TimeoutExchangeMSec, uint32_t());

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -80,6 +80,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD1(KmsChanged, void(int kilometers));
   MOCK_METHOD0(IncrementIgnitionCycles, void());
   MOCK_METHOD0(ForcePTExchange, std::string());
+  MOCK_METHOD0(ForcePTExchangeAtUserRequest, std::string());
   MOCK_METHOD0(ResetRetrySequence, void());
   MOCK_METHOD0(NextRetryTimeout, uint32_t());
   MOCK_METHOD0(TimeoutExchangeMSec, uint32_t());

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -74,6 +74,7 @@ class PolicyManagerImpl : public PolicyManager {
   virtual void KmsChanged(int kilometers);
   virtual void IncrementIgnitionCycles();
   virtual std::string ForcePTExchange();
+  virtual std::string ForcePTExchangeAtUserRequest();
   virtual std::string GetPolicyTableStatus() const;
   virtual void ResetRetrySequence();
   virtual int NextRetryTimeout();

--- a/src/components/policy/policy_external/include/policy/status.h
+++ b/src/components/policy/policy_external/include/policy/status.h
@@ -52,6 +52,7 @@ enum UpdateEvent {
   kOnResetPolicyTableRequireUpdate,
   kOnResetPolicyTableNoUpdate,
   kScheduleUpdate,
+  kScheduleManualUpdate,
   kOnResetRetrySequence
 };
 

--- a/src/components/policy/policy_external/include/policy/update_status_manager.h
+++ b/src/components/policy/policy_external/include/policy/update_status_manager.h
@@ -151,6 +151,13 @@ class UpdateStatusManager {
   void ScheduleUpdate();
 
   /**
+   * @brief ScheduleUpdate allows to schedule next update.
+   * It will change state to Update_Needed, that's is
+   * and will not send any notifications about updating to HMI
+   */
+  void ScheduleManualUpdate();
+
+  /**
    * @brief StringifiedUpdateStatus allows to obtain update status as a string.
    *
    * @return stringified update status.
@@ -205,6 +212,7 @@ class UpdateStatusManager {
   utils::SharedPtr<Status> postponed_status_;
   sync_primitives::Lock status_lock_;
 
+  UpdateEvent last_processed_event_;
   bool apps_search_in_progress_;
   bool app_registered_from_non_consented_device_;
   sync_primitives::Lock apps_search_in_progress_lock_;

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1033,6 +1033,13 @@ std::string PolicyManagerImpl::ForcePTExchange() {
   return update_status_manager_.StringifiedUpdateStatus();
 }
 
+std::string PolicyManagerImpl::ForcePTExchangeAtUserRequest() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  update_status_manager_.ScheduleManualUpdate();
+  StartPTExchange();
+  return update_status_manager_.StringifiedUpdateStatus();
+}
+
 std::string PolicyManagerImpl::GetPolicyTableStatus() const {
   return update_status_manager_.StringifiedUpdateStatus();
 }

--- a/src/components/policy/policy_external/src/status.cc
+++ b/src/components/policy/policy_external/src/status.cc
@@ -43,6 +43,7 @@ void policy::UpToDateStatus::ProcessEvent(UpdateStatusManager* manager,
     case kOnNewAppRegistered:
     case kOnResetPolicyTableRequireUpdate:
     case kScheduleUpdate:
+    case kScheduleManualUpdate:
     case kOnResetRetrySequence:
       manager->SetNextStatus(utils::MakeShared<UpdateNeededStatus>());
       break;
@@ -98,6 +99,7 @@ void policy::UpdatingStatus::ProcessEvent(policy::UpdateStatusManager* manager,
       manager->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
       break;
     case kScheduleUpdate:
+    case kScheduleManualUpdate:
     case kOnResetRetrySequence:
       manager->SetPostponedStatus(utils::MakeShared<UpdateNeededStatus>());
       break;

--- a/src/components/policy/policy_external/src/update_status_manager.cc
+++ b/src/components/policy/policy_external/src/update_status_manager.cc
@@ -62,6 +62,7 @@ UpdateStatusManager::~UpdateStatusManager() {
 void UpdateStatusManager::ProcessEvent(UpdateEvent event) {
   sync_primitives::AutoLock lock(status_lock_);
   current_status_->ProcessEvent(this, event);
+  last_processed_event_ = event;
   DoTransition();
 }
 
@@ -154,6 +155,10 @@ void UpdateStatusManager::ScheduleUpdate() {
   ProcessEvent(kScheduleUpdate);
 }
 
+void UpdateStatusManager::ScheduleManualUpdate() {
+  ProcessEvent(kScheduleManualUpdate);
+}
+
 std::string UpdateStatusManager::StringifiedUpdateStatus() const {
   return current_status_->get_status_string();
 }
@@ -184,14 +189,19 @@ void UpdateStatusManager::DoTransition() {
 
   current_status_ = next_status_;
   next_status_.reset();
-  listener_->OnUpdateStatusChanged(current_status_->get_status_string());
+
+  if (last_processed_event_ != kScheduleManualUpdate) {
+    listener_->OnUpdateStatusChanged(current_status_->get_status_string());
+  }
 
   if (!postponed_status_) {
     return;
   }
 
   current_status_ = postponed_status_;
-  listener_->OnUpdateStatusChanged(current_status_->get_status_string());
+  if (last_processed_event_ != kScheduleManualUpdate) {
+    listener_->OnUpdateStatusChanged(current_status_->get_status_string());
+  }
   postponed_status_.reset();
 }
 

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -81,6 +81,7 @@ class PolicyManagerImpl : public PolicyManager {
   virtual void KmsChanged(int kilometers);
   virtual void IncrementIgnitionCycles();
   virtual std::string ForcePTExchange();
+  virtual std::string ForcePTExchangeAtUserRequest();
   virtual std::string GetPolicyTableStatus() const;
   virtual void ResetRetrySequence();
   virtual uint32_t NextRetryTimeout();

--- a/src/components/policy/policy_regular/include/policy/status.h
+++ b/src/components/policy/policy_regular/include/policy/status.h
@@ -52,6 +52,7 @@ enum UpdateEvent {
   kOnResetPolicyTableRequireUpdate,
   kOnResetPolicyTableNoUpdate,
   kScheduleUpdate,
+  kScheduleManualUpdate,
   kOnResetRetrySequence
 };
 

--- a/src/components/policy/policy_regular/include/policy/update_status_manager.h
+++ b/src/components/policy/policy_regular/include/policy/update_status_manager.h
@@ -151,6 +151,13 @@ class UpdateStatusManager : public UpdateStatusManagerInterface {
   void ScheduleUpdate();
 
   /**
+   * @brief ScheduleUpdate allows to schedule next update.
+   * It will change state to Update_Needed, that's is
+   * and will not send any notifications about updating to HMI
+   */
+  void ScheduleManualUpdate();
+
+  /**
    * @brief StringifiedUpdateStatus allows to obtain update status as a string.
    *
    * @return stringified update status.
@@ -205,6 +212,7 @@ class UpdateStatusManager : public UpdateStatusManagerInterface {
   utils::SharedPtr<Status> postponed_status_;
   sync_primitives::Lock status_lock_;
 
+  UpdateEvent last_processed_event_;
   bool apps_search_in_progress_;
   bool app_registered_from_non_consented_device_;
   sync_primitives::Lock apps_search_in_progress_lock_;

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -764,6 +764,12 @@ std::string PolicyManagerImpl::ForcePTExchange() {
   return update_status_manager_.StringifiedUpdateStatus();
 }
 
+std::string PolicyManagerImpl::ForcePTExchangeAtUserRequest() {
+  update_status_manager_.ScheduleManualUpdate();
+  StartPTExchange();
+  return update_status_manager_.StringifiedUpdateStatus();
+}
+
 std::string PolicyManagerImpl::GetPolicyTableStatus() const {
   return update_status_manager_.StringifiedUpdateStatus();
 }


### PR DESCRIPTION
Add is_notification_needed flag as a parameter to ForcePTExchange function, 
because according to EXTERNAL_PROPRIETARY exception: No notification should be sent on user requested PTU from HMI (via SDL.UpdateSDL request). 