### PR TITLE
Add CORS header on video stream response

### DIFF
--- a/src/components/media_manager/src/video/socket_video_streamer_adapter.cc
+++ b/src/components/media_manager/src/video/socket_video_streamer_adapter.cc
@@ -38,6 +38,7 @@ const std::string kHeader =
     "Connection: Keep-Alive\r\n"
     "Keep-Alive: timeout=15, max=300\r\n"
     "Server: SDL\r\n"
+    "Access-Control-Allow-Origin: *\r\n"
     "Content-Type: video/mp4\r\n\r\n";
 }
 


### PR DESCRIPTION
I need the CORS header on Video Streaming response, because of used by HTML5 HMI.