### PR TITLE
Fix SDL ignores externalConsentStatus

### DIFF
--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -2167,10 +2167,13 @@ TEST_F(PolicyHandlerTest,
   sync_primitives::Lock wait_hmi_lock_first;
   sync_primitives::AutoLock auto_lock_first(wait_hmi_lock_first);
   WaitAsync waiter_first(kCallsCount_, kTimeout_);
-
+#ifdef EXTERNAL_PROPRIETARY_MODE
+  EXPECT_CALL(*mock_policy_manager_, SetUserConsentForApp(_, _))
+      .WillOnce(NotifyAsync(&waiter_first));
+#else
   EXPECT_CALL(*mock_policy_manager_, SetUserConsentForApp(_))
       .WillOnce(NotifyAsync(&waiter_first));
-
+#endif
   ExternalConsentStatusItem item(1u, 1u, kStatusOn);
   ExternalConsentStatus external_consent_status;
   external_consent_status.insert(item);

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -2187,7 +2187,9 @@ TEST_F(PolicyHandlerTest,
       .WillByDefault(Return(false));
 
   EXPECT_CALL(*mock_policy_manager_,
-              SetExternalConsentStatus(external_consent_status)).Times(0);
+              SetExternalConsentStatus(external_consent_status))
+      .WillOnce(Return(true));
+  ;
   policy_handler_.OnAppPermissionConsent(
       kConnectionKey_, permissions, external_consent_status);
 #else
@@ -2271,7 +2273,8 @@ TEST_F(PolicyHandlerTest,
   ON_CALL(*mock_policy_manager_, IsNeedToUpdateExternalConsentStatus(_))
       .WillByDefault(Return(false));
   EXPECT_CALL(*mock_policy_manager_,
-              SetExternalConsentStatus(external_consent_status)).Times(0);
+              SetExternalConsentStatus(external_consent_status))
+      .WillOnce(Return(true));
   policy_handler_.OnAppPermissionConsent(
       invalid_connection_key, permissions, external_consent_status);
 #else
@@ -2397,7 +2400,8 @@ TEST_F(PolicyHandlerTest,
   ON_CALL(*mock_policy_manager_, IsNeedToUpdateExternalConsentStatus(_))
       .WillByDefault(Return(false));
   EXPECT_CALL(*mock_policy_manager_,
-              SetExternalConsentStatus(external_consent_status)).Times(0);
+              SetExternalConsentStatus(external_consent_status))
+      .WillOnce(Return(true));
   policy_handler_.OnAppPermissionConsent(
       invalid_connection_key, permissions, external_consent_status);
 #else

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -51,6 +51,11 @@ typedef utils::SharedPtr<utils::Callable> StatusNotifier;
 
 class PolicyManager : public usage_statistics::StatisticsManager {
  public:
+  /**
+   * @brief The NotificationMode enum defines whether application will be
+   * notified about changes done (e.g. after consents were changed) or not
+   */
+  enum NotificationMode { kSilentMode, kNotifyApplicationMode };
   virtual ~PolicyManager() {}
 
   virtual void set_listener(PolicyListener* listener) = 0;
@@ -261,7 +266,8 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * valid data as well as invalid. So we will remove all invalid data
    * from this structure.
    */
-  virtual void SetUserConsentForApp(const PermissionConsent& permissions) = 0;
+  virtual void SetUserConsentForApp(const PermissionConsent& permissions,
+                                    const NotificationMode mode) = 0;
 
   /**
    * @brief Get default HMI level for application

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -109,8 +109,9 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD2(SetDeviceInfo,
                void(const std::string& device_id,
                     const policy::DeviceInfo& device_info));
-  MOCK_METHOD1(SetUserConsentForApp,
-               void(const policy::PermissionConsent& permissions));
+  MOCK_METHOD2(SetUserConsentForApp,
+               void(const policy::PermissionConsent& permissions,
+                    const NotificationMode mode));
   MOCK_CONST_METHOD2(GetDefaultHmi,
                      bool(const std::string& policy_app_id,
                           std::string* default_hmi));

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -114,7 +114,8 @@ class PolicyManagerImpl : public PolicyManager {
   virtual void SetDeviceInfo(const std::string& device_id,
                              const DeviceInfo& device_info);
 
-  virtual void SetUserConsentForApp(const PermissionConsent& permissions);
+  void SetUserConsentForApp(const PermissionConsent& permissions,
+                            const NotificationMode mode) OVERRIDE;
 
   virtual bool GetDefaultHmi(const std::string& policy_app_id,
                              std::string* default_hmi) const;

--- a/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
@@ -1033,7 +1033,8 @@ TEST_F(PolicyManagerImplTest2,
   groups_permissions.push_back(group1_perm);
   perm_consent.group_permissions = groups_permissions;
 
-  policy_manager_->SetUserConsentForApp(perm_consent);
+  policy_manager_->SetUserConsentForApp(perm_consent,
+                                        policy::PolicyManager::kSilentMode);
   policy_manager_->SendNotificationOnPermissionsUpdated(app_id_2_);
   std::vector< ::policy::FunctionalGroupPermission> actual_groups_permissions;
   std::vector< ::policy::FunctionalGroupPermission>::iterator it;
@@ -1140,7 +1141,8 @@ TEST_F(
   groups_permissions.push_back(group1_perm);
   perm_consent.group_permissions = groups_permissions;
 
-  policy_manager_->SetUserConsentForApp(perm_consent);
+  policy_manager_->SetUserConsentForApp(perm_consent,
+                                        policy::PolicyManager::kSilentMode);
   policy_manager_->SendNotificationOnPermissionsUpdated(app_id_2_);
   std::vector< ::policy::FunctionalGroupPermission> actual_groups_permissions;
   std::vector< ::policy::FunctionalGroupPermission>::iterator it;
@@ -1270,7 +1272,8 @@ TEST_F(PolicyManagerImplTest2,
   groups_permissions.push_back(group1_perm);
   perm_consent.group_permissions = groups_permissions;
 
-  policy_manager_->SetUserConsentForApp(perm_consent);
+  policy_manager_->SetUserConsentForApp(perm_consent,
+                                        policy::PolicyManager::kSilentMode);
   policy_manager_->SendNotificationOnPermissionsUpdated(app_id_2_);
   std::vector< ::policy::FunctionalGroupPermission> actual_groups_permissions;
   std::vector< ::policy::FunctionalGroupPermission>::iterator it;

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -812,7 +812,7 @@ TEST_F(PolicyManagerImplTest_ExternalConsent,
 
   EXPECT_TRUE(policy_manager_->SetExternalConsentStatus(status));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _)).Times(0);
+  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _));
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
       .WillRepeatedly(Return(device_id_1_));
 
@@ -937,7 +937,7 @@ TEST_F(PolicyManagerImplTest_ExternalConsent,
 
   EXPECT_TRUE(policy_manager_->SetExternalConsentStatus(status));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _)).Times(0);
+  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _));
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
       .WillRepeatedly(Return(device_id_1_));
 

--- a/src/components/policy/policy_external/test/policy_manager_impl_test_base.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test_base.cc
@@ -794,7 +794,8 @@ void PolicyManagerImplTest_ExternalConsent::
   permissions.group_permissions.push_back(group_permissions_1);
   permissions.group_permissions.push_back(group_permissions_2);
 
-  policy_manager_->SetUserConsentForApp(permissions);
+  policy_manager_->SetUserConsentForApp(permissions,
+                                        policy::PolicyManager::kSilentMode);
 }
 
 void PolicyManagerImplTest_ExternalConsent::


### PR DESCRIPTION
 Fixed SDL ignores externalConsentStatus when is sent together with consentedFunction in OnAppPermissionConsent notification.