### PR TITLE
Add new parameter SteeringWheelLocation

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -6,7 +6,13 @@
           "EN-US","ES-MX","FR-CA","DE-DE","ES-ES","EN-GB","RU-RU","TR-TR","PL-PL","FR-FR","IT-IT","SV-SE","PT-PT","NL-NL","ZH-TW",
 "JA-JP","AR-SA","KO-KR","PT-BR","CS-CZ","DA-DK","NO-NO"
 	    ],
-	    "displayCapabilities":
+        "hmiCapabilities":
+        {
+          "navigation" : false,
+          "phoneCall" : true,
+          "steeringWheelLocation": "LEFT"
+        },
+        "displayCapabilities":
 		{
 			"displayType":"GEN2_8_DMA",
 			"textFields": [{

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -378,34 +378,20 @@ class HMICapabilitiesImpl : public HMICapabilities {
       const smart_objects::SmartObject& prerecorded_speech) OVERRIDE;
 
   /*
-   * @brief Interface used to store information if navigation
+   * @brief Interface used to store information about ui hmi capabilities
    * supported by the system
-   *
-   * @param supported Indicates if navigation supported by the system
-   */
-  void set_navigation_supported(const bool supported) OVERRIDE;
-
-  /*
-   * @brief Retrieves information if navi supported by the system
-   *
-   * @return TRUE if it supported, otherwise FALSE
-   */
-  bool navigation_supported() const OVERRIDE;
-
-  /*
-   * @brief Interface used to store information if phone call
+   * @param ui_hmi_capabilities contains ui hmi capabilities
    * supported by the system
-   *
-   * @param supported Indicates if navigation supported by the sustem
    */
-  void set_phone_call_supported(const bool supported) OVERRIDE;
+  void set_ui_hmi_capabilities(
+      const smart_objects::SmartObject& ui_hmi_capabilities) OVERRIDE;
 
   /*
-   * @brief Retrieves information if phone call supported by the system
-   *
-   * @return TRUE if it supported, otherwise FALSE
+   * @brief Retrieves ui hmi capabilities that is supported
+   * by system
+   * @return ui hmi capabilities
    */
-  bool phone_call_supported() const OVERRIDE;
+  const smart_objects::SmartObject& ui_hmi_capabilities() const OVERRIDE;
 
   void Init(resumption::LastState* last_state) OVERRIDE;
 
@@ -481,8 +467,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
   smart_objects::SmartObject* audio_pass_thru_capabilities_;
   smart_objects::SmartObject* pcm_stream_capabilities_;
   smart_objects::SmartObject* prerecorded_speech_;
-  bool is_navigation_supported_;
-  bool is_phone_call_supported_;
+  smart_objects::SmartObject ui_hmi_capabilities_;
   std::string ccpu_version_;
 
   ApplicationManager& app_mngr_;

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -261,6 +261,7 @@ extern const char* phone_call;
 extern const char* sdl_version;
 extern const char* system_software_version;
 extern const char* priority;
+extern const char* steering_wheel_location;
 
 // resuming
 extern const char* application_commands;

--- a/src/components/application_manager/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/src/commands/hmi/ui_get_capabilities_response.cc
@@ -68,16 +68,9 @@ void UIGetCapabilitiesResponse::Run() {
     hmi_capabilities.set_audio_pass_thru_capabilities(
         msg_params[strings::audio_pass_thru_capabilities]);
   }
-
   if (msg_params.keyExists(strings::hmi_capabilities)) {
-    if (msg_params[strings::hmi_capabilities].keyExists(strings::navigation)) {
-      hmi_capabilities.set_navigation_supported(
-          msg_params[strings::hmi_capabilities][strings::navigation].asBool());
-    }
-    if (msg_params[strings::hmi_capabilities].keyExists(strings::phone_call)) {
-      hmi_capabilities.set_phone_call_supported(
-          msg_params[strings::hmi_capabilities][strings::phone_call].asBool());
-    }
+    hmi_capabilities.set_ui_hmi_capabilities(
+        msg_params[strings::hmi_capabilities]);
   }
 }
 

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -463,11 +463,7 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
     }
   }
   response_params[strings::hmi_capabilities] =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  response_params[strings::hmi_capabilities][strings::navigation] =
-      hmi_capabilities.navigation_supported();
-  response_params[strings::hmi_capabilities][strings::phone_call] =
-      hmi_capabilities.phone_call_supported();
+      hmi_capabilities.ui_hmi_capabilities();
 }
 
 void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
@@ -563,12 +559,6 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
       response_params[hmi_response::hmi_zone_capabilities][0] =
           *hmi_capabilities.hmi_zone_capabilities();
     }
-  }
-
-  if (HmiInterfaces::STATE_NOT_AVAILABLE !=
-      application_manager_.hmi_interfaces().GetInterfaceState(
-          HmiInterfaces::HMI_INTERFACE_TTS)) {
-    FillTTSRelatedFields(response_params, hmi_capabilities);
   }
 
   if (hmi_capabilities.pcm_stream_capabilities()) {

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -228,6 +228,7 @@ const char* phone_call = "phoneCall";
 const char* sdl_version = "sdlVersion";
 const char* system_software_version = "systemSoftwareVersion";
 const char* priority = "priority";
+const char* steering_wheel_location = "steeringWheelLocation";
 
 // resuming
 const char* application_commands = "applicationCommands";

--- a/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Ford Motor Company
+ * Copyright (c) 2017, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -51,6 +51,7 @@ namespace ui_get_capabilities_response {
 
 using ::utils::SharedPtr;
 using ::testing::NiceMock;
+using ::testing::Return;
 namespace am = ::application_manager;
 namespace strings = am::strings;
 namespace hmi_response = am::hmi_response;
@@ -71,7 +72,7 @@ class UIGetCapabilitiesResponseTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
   MessageSharedPtr CreateCommandMsg() {
-    MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+    MessageSharedPtr command_msg(CreateMessage(::smart_objects::SmartType_Map));
     (*command_msg)[strings::msg_params][strings::number] = "123";
     (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
     (*command_msg)[strings::params][hmi_response::code] =
@@ -83,13 +84,13 @@ class UIGetCapabilitiesResponseTest
   }
 
   MockHMICapabilities mock_hmi_capabilities_;
-  SmartObject capabilities_;
+  ::smart_objects::SmartObject capabilities_;
 };
 
-TEST_F(UIGetCapabilitiesResponseTest, RUN_SetDisplay_SUCCESSS) {
+TEST_F(UIGetCapabilitiesResponseTest, Run_SetDisplay_SUCCESSS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
   (*command_msg)[strings::msg_params][hmi_response::display_capabilities] =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
+      ::smart_objects::SmartObject(::smart_objects::SmartType_Map);
   (*command_msg)[strings::msg_params][hmi_response::display_capabilities]
                 [hmi_response::display_type] = "GEN2_8_DMA";
 
@@ -99,8 +100,14 @@ TEST_F(UIGetCapabilitiesResponseTest, RUN_SetDisplay_SUCCESSS) {
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
-  smart_objects::SmartObject display_capabilities_so =
+  ::smart_objects::SmartObject display_capabilities_so =
       (*command_msg)[strings::msg_params][hmi_response::display_capabilities];
+
+  MessageSharedPtr display_caps_old =
+      CreateMessage(smart_objects::SmartType_Map);
+
+  ON_CALL(mock_hmi_capabilities_, display_capabilities())
+      .WillByDefault(Return(display_caps_old.get()));
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_display_capabilities(display_capabilities_so));
@@ -108,10 +115,10 @@ TEST_F(UIGetCapabilitiesResponseTest, RUN_SetDisplay_SUCCESSS) {
   command->Run();
 }
 
-TEST_F(UIGetCapabilitiesResponseTest, SetSoftButton_SUCCESS) {
+TEST_F(UIGetCapabilitiesResponseTest, Run_SetSoftButton_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
   (*command_msg)[strings::msg_params][hmi_response::soft_button_capabilities] =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
+      ::smart_objects::SmartObject(::smart_objects::SmartType_Array);
   (*command_msg)[strings::msg_params][hmi_response::soft_button_capabilities]
                 [hmi_response::image_supported] = true;
 
@@ -121,7 +128,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetSoftButton_SUCCESS) {
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
-  smart_objects::SmartObject soft_button_capabilities_so = (*command_msg)
+  ::smart_objects::SmartObject soft_button_capabilities_so = (*command_msg)
       [strings::msg_params][hmi_response::soft_button_capabilities];
 
   EXPECT_CALL(mock_hmi_capabilities_,
@@ -130,10 +137,10 @@ TEST_F(UIGetCapabilitiesResponseTest, SetSoftButton_SUCCESS) {
   command->Run();
 }
 
-TEST_F(UIGetCapabilitiesResponseTest, SetHmiZone_SUCCESS) {
+TEST_F(UIGetCapabilitiesResponseTest, Run_SetHmiZone_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
   (*command_msg)[strings::msg_params][hmi_response::hmi_zone_capabilities] =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
+      ::smart_objects::SmartObject(::smart_objects::SmartType_Array);
   (*command_msg)[strings::msg_params][hmi_response::hmi_zone_capabilities][0] =
       "FRONT";
 
@@ -143,7 +150,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetHmiZone_SUCCESS) {
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
-  smart_objects::SmartObject hmi_zone_capabilities_so =
+  ::smart_objects::SmartObject hmi_zone_capabilities_so =
       (*command_msg)[strings::msg_params][hmi_response::hmi_zone_capabilities];
 
   EXPECT_CALL(mock_hmi_capabilities_,
@@ -152,10 +159,10 @@ TEST_F(UIGetCapabilitiesResponseTest, SetHmiZone_SUCCESS) {
   command->Run();
 }
 
-TEST_F(UIGetCapabilitiesResponseTest, SetAudioPassThru_SUCCESS) {
+TEST_F(UIGetCapabilitiesResponseTest, Run_SetAudioPassThru_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
   (*command_msg)[strings::msg_params][strings::audio_pass_thru_capabilities] =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
+      ::smart_objects::SmartObject(::smart_objects::SmartType_Array);
 
   ResponseFromHMIPtr command(
       CreateCommand<UIGetCapabilitiesResponse>(command_msg));
@@ -163,7 +170,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetAudioPassThru_SUCCESS) {
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
-  smart_objects::SmartObject audio_pass_thru_capabilities_so = (*command_msg)
+  ::smart_objects::SmartObject audio_pass_thru_capabilities_so = (*command_msg)
       [strings::msg_params][strings::audio_pass_thru_capabilities];
   EXPECT_CALL(
       mock_hmi_capabilities_,
@@ -172,10 +179,10 @@ TEST_F(UIGetCapabilitiesResponseTest, SetAudioPassThru_SUCCESS) {
   command->Run();
 }
 
-TEST_F(UIGetCapabilitiesResponseTest, SetNavigation_SUCCESS) {
+TEST_F(UIGetCapabilitiesResponseTest, Run_SetUICapabilities_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
   (*command_msg)[strings::msg_params][strings::hmi_capabilities] =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
+      ::smart_objects::SmartObject(::smart_objects::SmartType_Map);
   (*command_msg)[strings::msg_params][strings::hmi_capabilities]
                 [strings::navigation] = true;
 
@@ -185,33 +192,10 @@ TEST_F(UIGetCapabilitiesResponseTest, SetNavigation_SUCCESS) {
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
-  smart_objects::SmartObject hmi_capabilities_so =
+  ::smart_objects::SmartObject hmi_capabilities_so =
       (*command_msg)[strings::msg_params][strings::hmi_capabilities];
   EXPECT_CALL(mock_hmi_capabilities_,
-              set_navigation_supported(
-                  hmi_capabilities_so[strings::navigation].asBool()));
-
-  command->Run();
-}
-
-TEST_F(UIGetCapabilitiesResponseTest, SetPhoneCall_SUCCESS) {
-  MessageSharedPtr command_msg = CreateCommandMsg();
-  (*command_msg)[strings::msg_params][strings::hmi_capabilities] =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  (*command_msg)[strings::msg_params][strings::hmi_capabilities]
-                [strings::phone_call] = true;
-
-  ResponseFromHMIPtr command(
-      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
-
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
-      .WillOnce(ReturnRef(mock_hmi_capabilities_));
-
-  smart_objects::SmartObject hmi_capabilities_so =
-      (*command_msg)[strings::msg_params][strings::hmi_capabilities];
-  EXPECT_CALL(mock_hmi_capabilities_,
-              set_phone_call_supported(
-                  hmi_capabilities_so[strings::phone_call].asBool()));
+              set_ui_hmi_capabilities(hmi_capabilities_so));
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/register_app_interface_request_test.cc
@@ -65,6 +65,7 @@ using ::testing::_;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::DoAll;
+using ::testing::InSequence;
 
 namespace am = ::application_manager;
 
@@ -317,6 +318,18 @@ TEST_F(RegisterAppInterfaceRequestTest,
       .WillByDefault(
           Return(&(*expected_message)[am::hmi_response::display_capabilities]));
 
+  SmartObject& audio_pass_thru_capabilities =
+      (*expected_message)[am::strings::audio_pass_thru_capabilities][0];
+  audio_pass_thru_capabilities = "audio_pass_thru_capabilities";
+  ON_CALL(mock_hmi_capabilities_, audio_pass_thru_capabilities())
+      .WillByDefault(Return(&audio_pass_thru_capabilities));
+
+  SmartObject& ui_hmi_capabilities =
+      (*expected_message)[am::strings::hmi_capabilities];
+  ui_hmi_capabilities = "ui_hmi_capabilities";
+  ON_CALL(mock_hmi_capabilities_, ui_hmi_capabilities())
+      .WillByDefault(ReturnRef(ui_hmi_capabilities));
+
   ON_CALL(app_mngr_, applications())
       .WillByDefault(Return(DataAccessor<am::ApplicationSet>(app_set_, lock_)));
   ON_CALL(mock_policy_handler_, PolicyEnabled()).WillByDefault(Return(true));
@@ -356,6 +369,92 @@ TEST_F(RegisterAppInterfaceRequestTest,
               ManageMobileCommand(_, am::commands::Command::ORIGIN_SDL))
       .Times(2);
 
+  command_->Run();
+}
+
+MATCHER_P(CheckMobileResponseParameters, ui_hmi_capabilities, "") {
+  const bool is_result_id_correct =
+      mobile_apis::Result::SUCCESS ==
+      static_cast<mobile_apis::Result::eType>(
+          (*arg)[am::strings::msg_params][am::strings::result_code].asInt());
+  const bool is_navigation_value_valid =
+      (*arg)[am::strings::msg_params][am::strings::hmi_capabilities]
+            [am::strings::navigation].asBool() ==
+      (*ui_hmi_capabilities)[am::strings::navigation].asBool();
+  const bool is_phone_call_value_valid =
+      (*arg)[am::strings::msg_params][am::strings::hmi_capabilities]
+            [am::strings::phone_call].asBool() ==
+      (*ui_hmi_capabilities)[am::strings::phone_call].asBool();
+  const bool is_steering_wheel_location_value_valid =
+      (*arg)[am::strings::msg_params][am::strings::hmi_capabilities]
+            [am::strings::steering_wheel_location].asInt() ==
+      (*ui_hmi_capabilities)[am::strings::steering_wheel_location].asInt();
+  return is_result_id_correct && is_navigation_value_valid &&
+         is_phone_call_value_valid && is_steering_wheel_location_value_valid;
+}
+
+TEST_F(RegisterAppInterfaceRequestTest,
+       Check_Sending_UI_HMI_Capabilities_SUCCESS) {
+  InitBasicMessage();
+
+  MockAppPtr mock_app = CreateBasicMockedApp();
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(ApplicationSharedPtr()))
+      .WillRepeatedly(Return(mock_app));
+
+  MessageSharedPtr ui_hmi_capabilities =
+      CreateMessage(smart_objects::SmartType_Map);
+  (*ui_hmi_capabilities)[am::strings::navigation] = true;
+  (*ui_hmi_capabilities)[am::strings::phone_call] = false;
+  (*ui_hmi_capabilities)[am::strings::steering_wheel_location] =
+      static_cast<int64_t>(mobile_apis::SteeringWheelLocation::RIGHT);
+
+  ON_CALL(mock_hmi_capabilities_, ui_hmi_capabilities())
+      .WillByDefault(ReturnRef((*ui_hmi_capabilities)));
+
+  ON_CALL(app_mngr_, applications())
+      .WillByDefault(Return(DataAccessor<am::ApplicationSet>(app_set_, lock_)));
+  ON_CALL(mock_policy_handler_, PolicyEnabled()).WillByDefault(Return(true));
+  ON_CALL(mock_policy_handler_, GetInitialAppData(kAppId, _, _))
+      .WillByDefault(Return(true));
+
+  policy::StatusNotifier notify_upd_manager =
+      utils::MakeShared<utils::CallNothing>();
+  ON_CALL(mock_policy_handler_, AddApplication(_))
+      .WillByDefault(Return(notify_upd_manager));
+
+  EXPECT_CALL(app_mngr_, RegisterApplication(msg_)).WillOnce(Return(mock_app));
+
+  EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
+      .WillRepeatedly(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::BasicCommunication_OnAppRegistered)))
+      .WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::Buttons_OnButtonSubscription)))
+      .WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(
+                  HMIResultCodeIs(hmi_apis::FunctionID::VR_ChangeRegistration)))
+      .WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::TTS_ChangeRegistration)))
+      .WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_,
+              ManageHMICommand(
+                  HMIResultCodeIs(hmi_apis::FunctionID::UI_ChangeRegistration)))
+      .WillOnce(Return(true));
+  {
+    InSequence s;
+    EXPECT_CALL(app_mngr_,
+                ManageMobileCommand(
+                    CheckMobileResponseParameters(ui_hmi_capabilities), _));
+    EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  }
   command_->Run();
 }
 

--- a/src/components/application_manager/test/hmi_capabilities.json
+++ b/src/components/application_manager/test/hmi_capabilities.json
@@ -6,6 +6,12 @@
           "EN_US","ES_MX","FR_CA","DE_DE","ES_ES","EN_GB","RU_RU","TR_TR","PL_PL","FR_FR","IT_IT","SV_SE","PT_PT","NL_NL","ZH_TW",
 "JA_JP","AR_SA","KO_KR","PT_BR","CS_CZ","DA_DK","NO_NO"
         ],
+        "hmiCapabilities":
+        {
+            "navigation" : false,
+            "phoneCall" : true,
+            "steeringWheelLocation": "LEFT"
+        },
         "displayCapabilities":
         {
             "displayType":"GEN2_8_DMA",

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -179,6 +179,14 @@ TEST_F(HMICapabilitiesTest, LoadCapabilitiesFromFile) {
   }
   EXPECT_TRUE(hmi_capabilities_test->LoadCapabilitiesFromFile());
 
+  // Check ui hmiCapabilities
+  const smart_objects::SmartObject ui_hmi_capabilities =
+      hmi_capabilities_test->ui_hmi_capabilities();
+  EXPECT_FALSE(ui_hmi_capabilities[strings::navigation].asBool());
+  EXPECT_TRUE(ui_hmi_capabilities[strings::phone_call].asBool());
+  EXPECT_EQ(static_cast<int64_t>(hmi_apis::Common_SteeringWheelLocation::LEFT),
+            ui_hmi_capabilities[strings::steering_wheel_location].asInt());
+
   // Check active languages
   EXPECT_EQ(hmi_apis::Common_Language::EN_US,
             hmi_capabilities_test->active_ui_language());

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -148,11 +148,10 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
   MOCK_METHOD1(set_prerecorded_speech,
                void(const smart_objects::SmartObject& prerecorded_speech));
 
-  MOCK_CONST_METHOD0(navigation_supported, bool());
-  MOCK_METHOD1(set_navigation_supported, void(const bool supported));
+  MOCK_CONST_METHOD0(ui_hmi_capabilities, const smart_objects::SmartObject&());
 
-  MOCK_CONST_METHOD0(phone_call_supported, bool());
-  MOCK_METHOD1(set_phone_call_supported, void(const bool supported));
+  MOCK_METHOD1(set_ui_hmi_capabilities,
+               void(const smart_objects::SmartObject& ui_hmi_capabilities));
 
   MOCK_METHOD1(Init, void(resumption::LastState* last_state));
 

--- a/src/components/application_manager/test/request_tracker_test.cc
+++ b/src/components/application_manager/test/request_tracker_test.cc
@@ -72,7 +72,7 @@ class RequestTrackerTestClass : public ::testing::Test {
 
   application_manager::request_controller::RequestTracker tracker_;
 
-  const uint32_t kDefaultAppHmiLevelNoneRequestsTimeScale = 10u;
+  const uint32_t kDefaultAppHmiLevelNoneRequestsTimeScale = 100u;
   const uint32_t kDefaultAppHmiLevelNoneTimeScaleMaxRequests = 100u;
   const uint32_t kDefaultAppTimeScaleMaxRequests = 5u;
   const uint32_t kDefaultAppRequestsTimeScale = 200u;
@@ -82,14 +82,11 @@ TEST_F(RequestTrackerTestClass, TrackAppRequestInNone_ExpectSuccessTillLimit) {
   const uint32_t app_id = 1u;
   const mobile_apis::HMILevel::eType none_level =
       mobile_apis::HMILevel::HMI_NONE;
-
   SetDefaultConstraints();
-
   for (uint32_t i = 0; i < kDefaultAppHmiLevelNoneTimeScaleMaxRequests; ++i) {
     EXPECT_EQ(application_manager::request_controller::TrackResult::kSuccess,
               tracker_.Track(app_id, none_level));
   }
-
   EXPECT_EQ(application_manager::request_controller::TrackResult::
                 kNoneLevelMaxRequestsExceeded,
             tracker_.Track(app_id, none_level));
@@ -210,8 +207,8 @@ TEST_F(RequestTrackerTestClass,
 
 TEST_F(RequestTrackerTestClass,
        TrackAppRequestInNone_DoPause_TrackAgain_ExpectSuccessTillLimit) {
-  const uint32_t max_requests = 5;
-  const uint32_t time_scale_ms = 1;
+  const uint32_t max_requests = 5u;
+  const uint32_t time_scale_ms = 10u;
 
   sync_primitives::ConditionalVariable awaiter;
   sync_primitives::Lock lock;

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -380,34 +380,20 @@ class HMICapabilities {
       const smart_objects::SmartObject& prerecorded_speech) = 0;
 
   /*
-   * @brief Interface used to store information if navigation
+   * @brief Interface used to store ui hmi capabilities that is
    * supported by the system
-   *
-   * @param supported Indicates if navigation supported by the system
-   */
-  virtual void set_navigation_supported(const bool supported) = 0;
-
-  /*
-   * @brief Retrieves information if navi supported by the system
-   *
-   * @return TRUE if it supported, otherwise FALSE
-   */
-  virtual bool navigation_supported() const = 0;
-
-  /*
-   * @brief Interface used to store information if phone call
+   * @param ui_hmi_capabilities contains ui hmi capabilities
    * supported by the system
-   *
-   * @param supported Indicates if navigation supported by the sustem
    */
-  virtual void set_phone_call_supported(const bool supported) = 0;
+  virtual void set_ui_hmi_capabilities(
+      const smart_objects::SmartObject& ui_hmi_capabilities) = 0;
 
   /*
-   * @brief Retrieves information if phone call supported by the system
-   *
-   * @return TRUE if it supported, otherwise FALSE
+   * @brief Retrieves ui hmi capabilities that is supported
+   * by system
+   * @return ui hmi capabilities
    */
-  virtual bool phone_call_supported() const = 0;
+  virtual const smart_objects::SmartObject& ui_hmi_capabilities() const = 0;
 
   virtual void Init(resumption::LastState* last_state) = 0;
 

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1199,6 +1199,13 @@
   </element>
 </enum>
 
+<enum name="SteeringWheelLocation">
+  <description>Describes the location of the Steering Wheel.</description>
+  <element name="LEFT" />
+  <element name="RIGHT" />
+  <element name="CENTER" />
+</enum>
+
 <enum name="DeliveryMode">
   <description>The mode in which the SendLocation request is sent</description>
   <element name="PROMPT" />
@@ -1604,6 +1611,9 @@
   </param>
   <param name="phoneCall" type="Boolean" mandatory="false">
     <description>Availability of build in phone. True: Available, False: Not Available</description>
+  </param>
+  <param name="steeringWheelLocation" type="Common.SteeringWheelLocation" mandatory="false">
+    <description>See SteeringWheelLocation</description>
   </param>
 </struct>
 

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -805,6 +805,13 @@
     <element name="QUEUE" />
   </enum>
 
+  <enum name="SteeringWheelLocation"> 
+    <description>Describes the location of the Steering Wheel.</description>
+    <element name="LEFT" />
+    <element name="RIGHT" />
+    <element name="CENTER" />
+  </enum>
+
   <struct name="Image">
     <param name="value" minlength="0" maxlength="65535" type="String"> 
       <description>Either the static hex icon value or the binary image file name identifier (sent by PutFile).</description>
@@ -1869,6 +1876,9 @@
     </param>
     <param name="phoneCall" type="Boolean" mandatory="false">
       <description>Availability of build in phone. True: Available, False: Not Available </description>
+    </param>
+    <param name="steeringWheelLocation" type="SteeringWheelLocation" mandatory="false">
+      <description>See SteeringWheelLocation</description>
     </param>
   </struct>
 


### PR DESCRIPTION
Add new parameter SteeringWheelLocation to hmiCapabilities struct in RegisterAppInterface response
Create UT for coverage CRQ functionality, remove redundant code from register_app_interface.cc
Fix RequestTrackerClass's UT: Increase time scale in UT because EXPECT_CALL has delay and tests were faled

[PR 1181](https://github.com/smartdevicelink/sdl_core/pull/1181)

[Issues-1064](https://github.com/smartdevicelink/sdl_core/issues/1064)
