### PR TITLE
Allow OnHMIStatus notification for revoked application

### DIFF
--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -359,6 +359,17 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
                       << " returns true");
   }
 
+  if (cache_->IsApplicationRevoked(app_id)) {
+    // SDL must be able to notify mobile side with its status after app has
+    // been revoked by backend
+    if ("OnHMIStatus" == rpc && "NONE" == hmi_level) {
+      result.hmi_level_permitted = kRpcAllowed;
+    } else {
+      result.hmi_level_permitted = kRpcDisallowed;
+    }
+    return;
+  }
+
   const bool known_rpc = rpc_permissions.end() != rpc_permissions.find(rpc);
   LOG4CXX_INFO(logger_, "Is known rpc " << known_rpc);
   if (!known_rpc) {
@@ -459,17 +470,6 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
   } else if (!result.IsAnyAllowed(rpc_params)) {
     LOG4CXX_DEBUG(logger_, "There are no parameters allowed.");
     result.hmi_level_permitted = kRpcDisallowed;
-  }
-
-  if (cache_->IsApplicationRevoked(app_id)) {
-    // SDL must be able to notify mobile side with its status after app has
-    // been revoked by backend
-    if ("OnHMIStatus" == rpc && "NONE" == hmi_level) {
-      result.hmi_level_permitted = kRpcAllowed;
-    } else {
-      result.hmi_level_permitted = kRpcDisallowed;
-    }
-    return;
   }
 }
 


### PR DESCRIPTION
Fixed sending of OnHMIStatus after re-registration of revoked application, by moving check IsApplicationRevoked before the RPC permission check.
Added unit test related to revoked application into PolicyManagerImpl.