### PR TITLE
Fix SDL does not send OnPermissionsChange after PTU

### DIFF
--- a/src/components/policy/policy_external/src/policy_helper.cc
+++ b/src/components/policy/policy_external/src/policy_helper.cc
@@ -339,7 +339,7 @@ bool CheckAppPolicy::operator()(const AppPoliciesValueType& app_policy) {
                "Permissions for application:" << app_id
                                               << " have been changed.");
 
-  if (!IsPredefinedApp(app_policy) && RESULT_CONSENT_NOT_REQIURED != result) {
+  if (!IsPredefinedApp(app_policy)) {
     SetPendingPermissions(app_policy, result);
     AddResult(app_id, result);
   }


### PR DESCRIPTION
Send OnPermissionsChange after app groups updated
Enable sending notifications for apps that have groups without user_consent