### PR TITLE
Fix issue when  SDL uses url in GetURLs for not registered application

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/hmi/get_urls.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/get_urls.h
@@ -63,13 +63,13 @@ class GetUrls : public RequestFromHMI {
   void Run() OVERRIDE;
 
  private:
-#if defined(PROPRIETARY_MODE) || defined(EXTERNAL_PROPRIETARY_MODE)
+#ifdef PROPRIETARY_MODE
   /**
    * @brief Processes URLs collecting for policy service
    * @param endpoints Endpoints section of policy table
    */
   void ProcessPolicyServiceURLs(const policy::EndpointUrls& endpoints);
-#endif  // PROPRIETARY_MODE || EXTERNAL_PROPRIETARY_MODE
+#endif  // PROPRIETARY_MODE
 
   /**
    * @brief Process URLs collecting for service

--- a/src/components/application_manager/test/commands/hmi/get_urls_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_urls_test.cc
@@ -312,6 +312,9 @@ TEST_F(GetUrlsTest, ProcessServiceURLs_PolicyDefaultId_SUCCESS) {
   endpoints_.push_back(data);
   EXPECT_CALL(mock_policy_handler_, GetUpdateUrls(kServiceType, _))
       .WillOnce(SetArgReferee<1>(endpoints_));
+  MockAppPtr mock_app = CreateMockApp();
+  EXPECT_CALL(app_mngr_, application_by_policy_id(_))
+      .WillOnce(Return(mock_app));
   request_command_->Run();
 
   EXPECT_FALSE((*command_msg_)[am::strings::msg_params].keyExists(


### PR DESCRIPTION
  - SmartObject for each application URL was created,
    although it could never be used.
    GetUrls::ProcessServiceURLs is reimplemented.

Related to [Issues-1226](https://github.com/smartdevicelink/sdl_core/issues/1226)

Moved from [PR-1475](https://github.com/smartdevicelink/sdl_core/pull/1475)