### PR TITLE
Fix retry sequence timeout

### DIFF
--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -857,7 +857,8 @@ uint32_t PolicyManagerImpl::NextRetryTimeout() {
   ++retry_sequence_index_;
 
   for (uint32_t i = 0u; i < retry_sequence_index_; ++i) {
-    next += retry_sequence_seconds_[i];
+    next += retry_sequence_seconds_[i] *
+            date_time::DateTime::MILLISECONDS_IN_SECOND;
     // According to requirement APPLINK-18244
     next += retry_sequence_timeout_;
   }

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -854,14 +854,18 @@ uint32_t PolicyManagerImpl::NextRetryTimeout() {
     return next;
   }
 
-  ++retry_sequence_index_;
+  if (0 == retry_sequence_index_) {
+    ++retry_sequence_index_;
+    // Return miliseconds
+    return retry_sequence_timeout_;
+  }
 
   for (uint32_t i = 0u; i < retry_sequence_index_; ++i) {
     next += retry_sequence_seconds_[i] *
             date_time::DateTime::MILLISECONDS_IN_SECOND;
-    // According to requirement APPLINK-18244
     next += retry_sequence_timeout_;
   }
+  ++retry_sequence_index_;
   if (retry_sequence_index_ == retry_sequence_seconds_.size()) {
     retry_sequence_timeout_ = 1;
   }

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -934,19 +934,30 @@ TEST_F(PolicyManagerImplTest2, NextRetryTimeout_ExpectTimeoutsFromPT) {
     Json::Value seconds_between_retries = Json::Value(Json::arrayValue);
     seconds_between_retries =
         root["policy_table"]["module_config"]["seconds_between_retries"];
-    uint32_t size = seconds_between_retries.size();
     CreateLocalPT("sdl_preloaded_pt.json");
-
-    uint32_t waiting_timeout = 0u;
-
-    for (uint32_t retry_number = 0u; retry_number < size; ++retry_number) {
-      waiting_timeout += seconds_between_retries[retry_number].asInt() *
-                         date_time::DateTime::MILLISECONDS_IN_SECOND;
-      waiting_timeout += manager->TimeoutExchangeMSec();
-
-      // it's in miliseconds
-      EXPECT_EQ(waiting_timeout, manager->NextRetryTimeout());
-    }
+    // Check data
+    uint32_t timeout_after_x_seconds =
+        root["policy_table"]["module_config"]["timeout_after_x_seconds"]
+            .asInt() *
+        date_time::DateTime::MILLISECONDS_IN_SECOND;
+    const uint32_t first_retry = timeout_after_x_seconds;
+    EXPECT_EQ(first_retry, manager->NextRetryTimeout());
+    uint32_t next_retry = first_retry +
+                          seconds_between_retries[0].asInt() *
+                              date_time::DateTime::MILLISECONDS_IN_SECOND;
+    EXPECT_EQ(next_retry, manager->NextRetryTimeout());
+    next_retry = first_retry + next_retry +
+                 seconds_between_retries[1].asInt() *
+                     date_time::DateTime::MILLISECONDS_IN_SECOND;
+    EXPECT_EQ(next_retry, manager->NextRetryTimeout());
+    next_retry = first_retry + next_retry +
+                 seconds_between_retries[2].asInt() *
+                     date_time::DateTime::MILLISECONDS_IN_SECOND;
+    EXPECT_EQ(next_retry, manager->NextRetryTimeout());
+    next_retry = first_retry + next_retry +
+                 seconds_between_retries[3].asInt() *
+                     date_time::DateTime::MILLISECONDS_IN_SECOND;
+    EXPECT_EQ(next_retry, manager->NextRetryTimeout());
   }
 }
 

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -940,7 +940,8 @@ TEST_F(PolicyManagerImplTest2, NextRetryTimeout_ExpectTimeoutsFromPT) {
     uint32_t waiting_timeout = 0u;
 
     for (uint32_t retry_number = 0u; retry_number < size; ++retry_number) {
-      waiting_timeout += seconds_between_retries[retry_number].asInt();
+      waiting_timeout += seconds_between_retries[retry_number].asInt() *
+                         date_time::DateTime::MILLISECONDS_IN_SECOND;
       waiting_timeout += manager->TimeoutExchangeMSec();
 
       // it's in miliseconds


### PR DESCRIPTION
Convert seconds to miliseconds before adding them to retry timeout.

PR- #1483 