### PR TITLE
Disabling test HandshakeData_ServiceNotProtect

### DIFF
--- a/src/components/security_manager/test/security_manager_test.cc
+++ b/src/components/security_manager/test/security_manager_test.cc
@@ -643,7 +643,8 @@ TEST_F(SecurityManagerTest, ProccessHandshakeData_WrongDataSize) {
  * getting SEND_HANDSHAKE_DATA from mobile side
  * for service which is not protected
  */
-TEST_F(SecurityManagerTest, ProccessHandshakeData_ServiceNotProtected) {
+TEST_F(SecurityManagerTest,
+       DISABLED_ProccessHandshakeData_ServiceNotProtected) {
   SetMockCryptoManager();
   // Expect InternalError with ERROR_ID
   uint32_t connection_id = 0;


### PR DESCRIPTION
 Disabled ProcessHandshakeData_ServiceNotProtected test in security_manager_test