### PR TITLE
Complement checks that consider HMI response to be invalid

### DIFF
--- a/src/components/application_manager/test/commands/mobile/alert_maneuver_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/alert_maneuver_request_test.cc
@@ -238,7 +238,7 @@ TEST_F(AlertManeuverRequestTest, OnEvent_ReceivedUnknownEvent_UNSUCCESS) {
 
   MessageSharedPtr result_msg(
       CatchMobileCommandResult(CallOnEvent(*command, event)));
-  EXPECT_EQ(mobile_apis::Result::INVALID_ENUM,
+  EXPECT_EQ(mobile_apis::Result::GENERIC_ERROR,
             static_cast<mobile_apis::Result::eType>(
                 (*result_msg)[am::strings::msg_params][am::strings::result_code]
                     .asInt()));

--- a/src/components/application_manager/test/commands/mobile/alert_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/alert_request_test.cc
@@ -355,7 +355,7 @@ TEST_F(AlertRequestTest, Run_AlertFrequencyIsTooHigh_UNSUCCESS) {
 TEST_F(AlertRequestTest, Run_FailToProcessSoftButtons_UNSUCCESS) {
   Expectations();
   const mobile_apis::Result::eType result_code =
-      mobile_apis::Result::INVALID_ENUM;
+      mobile_apis::Result::GENERIC_ERROR;
 
   EXPECT_CALL(mock_message_helper_,
               ProcessSoftButtons((*msg_)[am::strings::msg_params], _, _, _))

--- a/src/components/application_manager/test/commands/mobile/update_turn_list_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/update_turn_list_request_test.cc
@@ -156,7 +156,7 @@ TEST_F(UpdateTurnListRequestTest,
   EXPECT_CALL(app_mngr_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler_));
 
-  const mobile_result::eType kExpectedResult = mobile_result::INVALID_ENUM;
+  const mobile_result::eType kExpectedResult = mobile_result::GENERIC_ERROR;
   EXPECT_CALL(mock_message_helper_,
               ProcessSoftButtons((*command_msg_)[am::strings::msg_params],
                                  Eq(mock_app),


### PR DESCRIPTION
Added additional check for one of the cases which should consider received HMI response as invalid response.