### PR TITLE
Fix SDL doesnt send timeout param OnSystemRequest

### DIFF
--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1857,6 +1857,10 @@ void MessageHelper::SendSystemRequestNotification(
 
   content[strings::params][strings::connection_key] = connection_key;
 
+  policy::PolicyHandlerInterface& policy_handler = app_mngr.GetPolicyHandler();
+  content[strings::msg_params][strings::timeout] =
+      policy_handler.TimeoutExchangeSec();
+
 #ifdef DEBUG
   PrintSmartObject(content);
 #endif


### PR DESCRIPTION
 Fixed SDL doesn't send timeout parameter by OnSystemRequest