### PR TITLE
Fix SDL doesn't send SDL.OnStatusUpdate(UPDATE_NEEDED)

### DIFF
--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1270,6 +1270,9 @@ StatusNotifier PolicyManagerImpl::AddApplication(
                                                device_consent);
   } else {
     PromoteExistedApplication(application_id, device_consent);
+    if (update_status_manager_.IsUpdateRequired()) {
+      update_status_manager_.OnNewApplicationAdded(device_consent);
+    }
     return utils::MakeShared<utils::CallNothing>();
   }
 }

--- a/src/components/policy/policy_external/src/status.cc
+++ b/src/components/policy/policy_external/src/status.cc
@@ -68,6 +68,9 @@ void policy::UpdateNeededStatus::ProcessEvent(
     case kOnResetPolicyTableNoUpdate:
       manager->SetNextStatus(utils::MakeShared<UpToDateStatus>());
       break;
+    case kOnNewAppRegistered:
+      manager->SetNextStatus(utils::MakeShared<UpdateNeededStatus>());
+      break;
     default:
       break;
   }

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -979,8 +979,10 @@ StatusNotifier PolicyManagerImpl::AddApplication(
                                                device_consent);
   } else {
     PromoteExistedApplication(application_id, device_consent);
-    return utils::MakeShared<CallStatusChange>(update_status_manager_,
-                                               device_consent);
+    if (update_status_manager_.IsUpdateRequired()) {
+      update_status_manager_.OnNewApplicationAdded(device_consent);
+    }
+    return utils::MakeShared<utils::CallNothing>();
   }
 }
 


### PR DESCRIPTION
Fix SDL doesn't send SDL.OnStatusUpdate(UPDATE_NEEDED) in case of failed retry strategy during previous IGN_ON.
PoliciesManager must check the stored status of PTUpdate upon every Ign_On and
in case it is UPDATE_NEEDED, PoliciesManager must initiate the PTUpdate sequence
right after the first application has registered on SDL.
Should be merged after [#1535](https://github.com/smartdevicelink/sdl_core/pull/1535)