### PR TITLE
Fix SDL doesn't return info param for generic error in case of at least one hmi components doesn't respond

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -247,6 +247,18 @@ class CommandRequestImpl : public CommandImpl,
    */
   void GetInfo(const smart_objects::SmartObject& response_from_hmi,
                std::string& out_info);
+  /**
+     * @brief Resolves if the return code must be
+     * UNSUPPORTED_RESOURCE
+     * @param first contains result_code from HMI response and
+     * interface that returns response
+     * @param second contains result_code from HMI response and
+     * interface that returns response.
+     * @return True, if the communication return code must be
+     * UNSUPPORTED_RESOURCE, otherwise false.
+     */
+  bool IsResultCodeUnsupported(const ResponseInfo& first,
+                               const ResponseInfo& second) const;
 
   /**
    * @brief Prepare result code for sending to mobile application
@@ -267,10 +279,9 @@ class CommandRequestImpl : public CommandImpl,
   const CommandParametersPermissions& parameters_permissions() const;
 
   /**
-   * @brief Adds interface to be awaited for by sdl request command
-     @param interface_id interface which SDL expects to response in given time
+   * @brief Start waiting for response from 'inderface_id' interface
   */
-  void StartAwaitForInterface(const HmiInterfaces::InterfaceID& interface_id);
+  void StartAwaitForInterface(const HmiInterfaces::InterfaceID interface_id);
 
   /**
    * @brief Gets interface await state.
@@ -278,7 +289,7 @@ class CommandRequestImpl : public CommandImpl,
      @return true if SDL awaits for response from given interface in
    interface_id
   */
-  bool GetInterfaceAwaitState(const HmiInterfaces::InterfaceID& interface_id);
+  bool IsInterfaceAwaitState(const HmiInterfaces::InterfaceID& interface_id);
 
   /**
    * @brief Sets given HMI interface await status to false

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -266,6 +266,33 @@ class CommandRequestImpl : public CommandImpl,
    */
   const CommandParametersPermissions& parameters_permissions() const;
 
+  /**
+   * @brief Adds interface to be awaited for by sdl request command
+     @param interface_id interface which SDL expects to response in given time
+  */
+  void StartAwaitForInterface(const HmiInterfaces::InterfaceID& interface_id);
+
+  /**
+   * @brief Gets interface await state.
+     @param interface_id interface which SDL awaits for response in given time
+     @return true if SDL awaits for response from given interface in
+   interface_id
+  */
+  bool GetInterfaceAwaitState(const HmiInterfaces::InterfaceID& interface_id);
+
+  /**
+   * @brief Sets given HMI interface await status to false
+     @param interface_id interface which SDL no longer awaits for response in
+   given time
+  */
+  void EndAwaitForInterface(const HmiInterfaces::InterfaceID& interface_id);
+
+  /**
+   * @brief This set stores all the interfaces which are awaited by SDL to
+            return a response on some request
+  */
+  std::set<HmiInterfaces::InterfaceID> awaiting_response_interfaces_;
+
   RequestState current_state_;
   sync_primitives::Lock state_lock_;
   CommandParametersPermissions parameters_permissions_;
@@ -292,6 +319,23 @@ class CommandRequestImpl : public CommandImpl,
   bool ProcessHMIInterfacesAvailability(
       const uint32_t hmi_correlation_id,
       const hmi_apis::FunctionID::eType& function_id);
+
+  /**
+   * @brief Method transforms AppHMIType to string
+   * @param enum AppHMIType app_hmi_type contains enum value
+   * @return string of AppHMIType
+   */
+  std::string AppHMITypeToString(
+      const mobile_apis::AppHMIType::eType app_hmi_type) const;
+
+  /**
+   * @brief Adds information to result message "info" param in case of
+   GENERIC_ERROR
+            about component which not responded in time
+   * @param response Response message, which info should be extended
+   */
+  void AddTimeOutComponentInfoToMessage(
+      smart_objects::SmartObject& response) const;
 };
 
 }  // namespace commands

--- a/src/components/application_manager/include/application_manager/commands/mobile/alert_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/alert_request.h
@@ -72,13 +72,6 @@ class AlertRequest : public CommandRequestImpl {
    **/
   virtual void Run();
 
-  /*
-   * @brief Will caled by request controller, when default will be expired.
-   * If Alert request has soft buttons, timeout response should not be sent to
-   * mobile
-   */
-  virtual void onTimeOut();
-
   /**
    * @brief Interface method that is called whenever new event received
    *

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -86,13 +86,28 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
 
  private:
   /**
+   * @brief Response params
+   * result for sending to mobile application
+   * result code for sending to mobile application
+   * info for sending to mobile application
+   */
+  struct ResponseParams {
+    bool result;
+    mobile_apis::Result::eType result_code;
+    std::string info;
+    ResponseParams()
+        : result(false)
+        , result_code(mobile_apis::Result::INVALID_ENUM)
+        , info("") {}
+  };
+  ResponseParams response_params_;
+  /**
    * @brief Prepare result code, result and info for sending to mobile
    * application
    * @param result_code contains result code for sending to mobile application
    * @return result for sending to mobile application.
    */
-  bool PrepareResponseParameters(mobile_apis::Result::eType& result_code,
-                                 std::string& info);
+  const ResponseParams& PrepareResponseParameters();
   /**
    * @brief Sends TTS Speak request
    */
@@ -142,19 +157,22 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
   void ProcessAudioPassThruIcon(ApplicationSharedPtr app);
 
   /**
+   * @brief Pair of result code and result for mobile app
+   */
+  typedef std::pair<mobile_apis::Result::eType, bool> AudioPassThruResults;
+
+  /**
    * @brief Checks result code from HMI for splitted RPC
    * and returns parameter for sending to mobile app in
    * audioPassThru communication.
    * @param ui_response contains result_code from UI
    * @param tts_response contains result_code from TTS
-   * @param out_result contains result for mobile app
-   * @return result code - 1) UI error code has precedence than TTS's
-   * 2) error_code from TTS is turned to WARNINGS
+   * @return pair of result code (UI error code has precedence than TTS's,
+   * error_code from TTS is turned to WARNINGS) and
+   * result for mobile app
    */
-  mobile_apis::Result::eType PrepareAudioPassThruResultCodeForResponse(
-      const ResponseInfo& ui_response,
-      const ResponseInfo& tts_response,
-      bool& out_result);
+  AudioPassThruResults PrepareAudioPassThruResultCodeForResponse(
+      const ResponseInfo& ui_response, const ResponseInfo& tts_response);
 
   hmi_apis::Common_Result::eType result_tts_speak_;
   hmi_apis::Common_Result::eType result_ui_;

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -133,10 +133,28 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
    */
   bool IsWaitingHMIResponse();
 
-  /* flag display state of speak and ui perform audio
-  during perform audio pass thru*/
-  bool awaiting_tts_speak_response_;
-  bool awaiting_ui_response_;
+  /**
+   * @brief Validates audioPassThruIcon parameter and
+   * removes it if is not valid
+   * @param app Pointer to the application whose storage directory
+   * must be accessed
+   */
+  void ProcessAudioPassThruIcon(ApplicationSharedPtr app);
+
+  /**
+   * @brief Checks result code from HMI for splitted RPC
+   * and returns parameter for sending to mobile app in
+   * audioPassThru communication.
+   * @param ui_response contains result_code from UI
+   * @param tts_response contains result_code from TTS
+   * @param out_result contains result for mobile app
+   * @return result code - 1) UI error code has precedence than TTS's
+   * 2) error_code from TTS is turned to WARNINGS
+   */
+  mobile_apis::Result::eType PrepareAudioPassThruResultCodeForResponse(
+      const ResponseInfo& ui_response,
+      const ResponseInfo& tts_response,
+      bool& out_result);
 
   hmi_apis::Common_Result::eType result_tts_speak_;
   hmi_apis::Common_Result::eType result_ui_;

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -520,6 +520,22 @@ class MessageHelper {
       int32_t result_code);
 
   /*
+     * @brief Verify image and add image file full path
+     * and add path, although the image doesn't exist
+     *
+     * @param SmartObject with image
+     *
+     * @param app current application
+     *
+     * @return verification result
+     *
+     */
+  static mobile_apis::Result::eType VerifyImageApplyPath(
+      smart_objects::SmartObject& image,
+      ApplicationConstSharedPtr app,
+      ApplicationManager& app_mngr);
+
+  /*
    * @brief Verify image and add image file full path
    *
    * @param SmartObject with image

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -802,15 +802,6 @@ void CommandRequestImpl::EndAwaitForInterface(
   }
 }
 
-bool CommandRequestImpl::IsResultCodeUnsupported(
-    const ResponseInfo& first, const ResponseInfo& second) const {
-  return ((first.is_ok || first.is_invalid_enum) &&
-          second.is_unsupported_resource) ||
-         ((second.is_ok || second.is_invalid_enum) &&
-          first.is_unsupported_resource) ||
-         (first.is_unsupported_resource && second.is_unsupported_resource);
-}
-
 std::string GetComponentNameFromInterface(
     const HmiInterfaces::InterfaceID& interface) {
   switch (interface) {

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -110,8 +110,8 @@ bool CheckResultCode(const ResponseInfo& first, const ResponseInfo& second) {
   return false;
 }
 
-bool IsResultCodeUnsupported(const ResponseInfo& first,
-                             const ResponseInfo& second) {
+bool CommandRequestImpl::IsResultCodeUnsupported(
+    const ResponseInfo& first, const ResponseInfo& second) const {
   return ((first.is_ok || first.is_invalid_enum) &&
           second.is_unsupported_resource) ||
          ((second.is_ok || second.is_invalid_enum) &&
@@ -777,15 +777,15 @@ const CommandParametersPermissions& CommandRequestImpl::parameters_permissions()
 }
 
 void CommandRequestImpl::StartAwaitForInterface(
-    const HmiInterfaces::InterfaceID& interface_id) {
+    const HmiInterfaces::InterfaceID interface_id) {
   awaiting_response_interfaces_.insert(interface_id);
 }
 
-bool CommandRequestImpl::GetInterfaceAwaitState(
+bool CommandRequestImpl::IsInterfaceAwaitState(
     const HmiInterfaces::InterfaceID& interface_id) {
   std::set<HmiInterfaces::InterfaceID>::const_iterator it =
       awaiting_response_interfaces_.find(interface_id);
-  return (it != awaiting_response_interfaces_.end());
+  return it != awaiting_response_interfaces_.end();
 }
 
 void CommandRequestImpl::EndAwaitForInterface(
@@ -839,7 +839,7 @@ void CommandRequestImpl::AddTimeOutComponentInfoToMessage(
   LOG4CXX_AUTO_TRACE(logger_);
 
   if (awaiting_response_interfaces_.empty()) {
-    LOG4CXX_ERROR(logger_, "No interfaces awaiting, info param is empty");
+    LOG4CXX_WARN(logger_, "No interfaces awaiting, info param is empty");
     return;
   }
 

--- a/src/components/application_manager/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_command_request.cc
@@ -187,10 +187,12 @@ void AddCommandRequest::Run() {
   }
 
   if (send_ui_) {
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
     SendHMIRequest(hmi_apis::FunctionID::UI_AddCommand, &ui_msg_params, true);
   }
 
   if (send_vr_) {
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
     SendHMIRequest(hmi_apis::FunctionID::VR_AddCommand, &vr_msg_params, true);
   }
 }
@@ -312,6 +314,7 @@ void AddCommandRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_AddCommand: {
       LOG4CXX_INFO(logger_, "Received UI_AddCommand event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       is_ui_received_ = true;
       ui_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
@@ -323,6 +326,7 @@ void AddCommandRequest::on_event(const event_engine::Event& event) {
     }
     case hmi_apis::FunctionID::VR_AddCommand: {
       LOG4CXX_INFO(logger_, "Received VR_AddCommand event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
       is_vr_received_ = true;
       vr_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
@@ -94,6 +94,7 @@ void AddSubMenuRequest::Run() {
       (*message_)[strings::msg_params][strings::menu_name];
   msg_params[strings::app_id] = app->app_id();
 
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);
 }
 
@@ -103,6 +104,7 @@ void AddSubMenuRequest::on_event(const event_engine::Event& event) {
 
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_AddSubMenu: {
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -111,6 +111,7 @@ void AlertManeuverRequest::Run() {
   }
 
   pending_requests_.Add(hmi_apis::FunctionID::Navigation_AlertManeuver);
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
   SendHMIRequest(
       hmi_apis::FunctionID::Navigation_AlertManeuver, &msg_params, true);
 
@@ -123,6 +124,7 @@ void AlertManeuverRequest::Run() {
     msg_params[hmi_request::speak_type] =
         hmi_apis::Common_MethodName::ALERT_MANEUVER;
 
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
     SendHMIRequest(hmi_apis::FunctionID::TTS_Speak, &msg_params, true);
   }
 }
@@ -134,6 +136,7 @@ void AlertManeuverRequest::on_event(const event_engine::Event& event) {
   switch (event_id) {
     case hmi_apis::FunctionID::Navigation_AlertManeuver: {
       LOG4CXX_INFO(logger_, "Received Navigation_AlertManeuver event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
       pending_requests_.Remove(event_id);
       navi_alert_maneuver_result_code_ =
           static_cast<hmi_apis::Common_Result::eType>(
@@ -143,6 +146,7 @@ void AlertManeuverRequest::on_event(const event_engine::Event& event) {
     }
     case hmi_apis::FunctionID::TTS_Speak: {
       LOG4CXX_INFO(logger_, "Received TTS_Speak event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
       pending_requests_.Remove(event_id);
       tts_speak_result_code_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/alert_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_request.cc
@@ -146,6 +146,7 @@ void AlertRequest::on_event(const event_engine::Event& event) {
       if (awaiting_tts_speak_response_ &&
           HmiInterfaces::STATE_NOT_AVAILABLE != ui_interface_state) {
         awaiting_tts_stop_speaking_response_ = true;
+        StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
         SendHMIRequest(hmi_apis::FunctionID::TTS_StopSpeaking, NULL, true);
       }
       alert_result_ = static_cast<hmi_apis::Common_Result::eType>(
@@ -169,6 +170,7 @@ void AlertRequest::on_event(const event_engine::Event& event) {
     }
     case hmi_apis::FunctionID::TTS_StopSpeaking: {
       LOG4CXX_INFO(logger_, "Received TTS_StopSpeaking event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
       // Unsubscribe from event to avoid unwanted messages
       unsubscribe_from_event(hmi_apis::FunctionID::TTS_StopSpeaking);
       awaiting_tts_stop_speaking_response_ = false;

--- a/src/components/application_manager/src/commands/mobile/alert_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_request.cc
@@ -116,18 +116,6 @@ void AlertRequest::Run() {
   }
 }
 
-void AlertRequest::onTimeOut() {
-  LOG4CXX_AUTO_TRACE(logger_);
-  if (false ==
-      (*message_)[strings::msg_params].keyExists(strings::soft_buttons)) {
-    CommandRequestImpl::onTimeOut();
-    return;
-  }
-  LOG4CXX_INFO(logger_,
-               "Default timeout ignored. "
-               "AlertRequest with soft buttons wait timeout on HMI side");
-}
-
 void AlertRequest::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
   const smart_objects::SmartObject& message = event.smart_object();
@@ -148,6 +136,7 @@ void AlertRequest::on_event(const event_engine::Event& event) {
     case hmi_apis::FunctionID::UI_Alert: {
       LOG4CXX_INFO(logger_, "Received UI_Alert event");
       // Unsubscribe from event to avoid unwanted messages
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       unsubscribe_from_event(hmi_apis::FunctionID::UI_Alert);
       awaiting_ui_alert_response_ = false;
       HmiInterfaces::InterfaceState ui_interface_state =
@@ -170,6 +159,7 @@ void AlertRequest::on_event(const event_engine::Event& event) {
     case hmi_apis::FunctionID::TTS_Speak: {
       LOG4CXX_INFO(logger_, "Received TTS_Speak event");
       // Unsubscribe from event to avoid unwanted messages
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
       unsubscribe_from_event(hmi_apis::FunctionID::TTS_Speak);
       awaiting_tts_speak_response_ = false;
       tts_speak_result_ = static_cast<hmi_apis::Common_Result::eType>(
@@ -346,6 +336,7 @@ void AlertRequest::SendAlertRequest(int32_t app_id) {
       msg_params.keyExists(hmi_request::soft_buttons)) {
     awaiting_ui_alert_response_ = true;
     is_ui_alert_sent_ = true;
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
     SendHMIRequest(hmi_apis::FunctionID::UI_Alert, &msg_params, true);
   }
 }
@@ -370,6 +361,7 @@ void AlertRequest::SendSpeakRequest(int32_t app_id,
   }
   msg_params[strings::app_id] = app_id;
   msg_params[hmi_request::speak_type] = Common_MethodName::ALERT;
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
   SendHMIRequest(FunctionID::TTS_Speak, &msg_params, true);
 }
 

--- a/src/components/application_manager/src/commands/mobile/change_registration_request.cc
+++ b/src/components/application_manager/src/commands/mobile/change_registration_request.cc
@@ -131,6 +131,7 @@ void ChangeRegistrationRequest::Run() {
         msg_params[strings::ngn_media_screen_app_name]);
   }
 
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   SendHMIRequest(hmi_apis::FunctionID::UI_ChangeRegistration, &ui_params, true);
 
   // VR processing
@@ -143,6 +144,7 @@ void ChangeRegistrationRequest::Run() {
     vr_params[strings::vr_synonyms] = msg_params[strings::vr_synonyms];
     app->set_vr_synonyms(msg_params[strings::vr_synonyms]);
   }
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
   SendHMIRequest(hmi_apis::FunctionID::VR_ChangeRegistration, &vr_params, true);
 
   // TTS processing
@@ -155,7 +157,7 @@ void ChangeRegistrationRequest::Run() {
     tts_params[strings::tts_name] = msg_params[strings::tts_name];
     app->set_tts_name(msg_params[strings::tts_name]);
   }
-
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
   SendHMIRequest(
       hmi_apis::FunctionID::TTS_ChangeRegistration, &tts_params, true);
 }
@@ -169,6 +171,7 @@ void ChangeRegistrationRequest::on_event(const event_engine::Event& event) {
   switch (event_id) {
     case hmi_apis::FunctionID::UI_ChangeRegistration: {
       LOG4CXX_INFO(logger_, "Received UI_ChangeRegistration event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       pending_requests_.Remove(event_id);
       ui_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
@@ -177,6 +180,7 @@ void ChangeRegistrationRequest::on_event(const event_engine::Event& event) {
     }
     case hmi_apis::FunctionID::VR_ChangeRegistration: {
       LOG4CXX_INFO(logger_, "Received VR_ChangeRegistration event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
       pending_requests_.Remove(event_id);
       vr_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
@@ -185,6 +189,7 @@ void ChangeRegistrationRequest::on_event(const event_engine::Event& event) {
     }
     case hmi_apis::FunctionID::TTS_ChangeRegistration: {
       LOG4CXX_INFO(logger_, "Received TTS_ChangeRegistration event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
       pending_requests_.Remove(event_id);
       tts_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -285,6 +285,7 @@ void CreateInteractionChoiceSetRequest::SendVRAddCommandRequests(
 
     sync_primitives::AutoLock commands_lock(vr_commands_lock_);
     const uint32_t vr_cmd_id = msg_params[strings::cmd_id].asUInt();
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
     const uint32_t vr_corr_id =
         SendHMIRequest(hmi_apis::FunctionID::VR_AddCommand, &msg_params, true);
 
@@ -354,6 +355,7 @@ void CreateInteractionChoiceSetRequest::on_event(
   uint32_t corr_id = static_cast<uint32_t>(
       message[strings::params][strings::correlation_id].asUInt());
   if (event.id() == hmi_apis::FunctionID::VR_AddCommand) {
+    EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
     {
       sync_primitives::AutoLock commands_lock(vr_commands_lock_);
       if (is_no_error) {
@@ -374,6 +376,7 @@ void CreateInteractionChoiceSetRequest::onTimeOut() {
   if (!error_from_hmi_) {
     SendResponse(false, mobile_apis::Result::GENERIC_ERROR);
   }
+  CommandRequestImpl::onTimeOut();
   DeleteChoices();
 
   // We have to keep request alive until receive all responses from HMI

--- a/src/components/application_manager/src/commands/mobile/delete_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/delete_command_request.cc
@@ -156,7 +156,7 @@ void DeleteCommandRequest::on_event(const event_engine::Event& event) {
       break;
     }
     case hmi_apis::FunctionID::VR_DeleteCommand: {
-      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
       is_vr_received_ = true;
       vr_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/delete_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/delete_command_request.cc
@@ -104,12 +104,14 @@ void DeleteCommandRequest::Run() {
     is_vr_send_ = true;
   }
   if (is_ui_send_) {
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
     SendHMIRequest(hmi_apis::FunctionID::UI_DeleteCommand, &msg_params, true);
   }
   if (is_vr_send_) {
     // VR params
     msg_params[strings::grammar_id] = application->get_grammar_id();
     msg_params[strings::type] = hmi_apis::Common_VRCommandType::Command;
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
     SendHMIRequest(hmi_apis::FunctionID::VR_DeleteCommand, &msg_params, true);
   }
 }
@@ -143,6 +145,7 @@ void DeleteCommandRequest::on_event(const event_engine::Event& event) {
   const smart_objects::SmartObject& message = event.smart_object();
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_DeleteCommand: {
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       is_ui_received_ = true;
       ui_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
@@ -153,6 +156,7 @@ void DeleteCommandRequest::on_event(const event_engine::Event& event) {
       break;
     }
     case hmi_apis::FunctionID::VR_DeleteCommand: {
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       is_vr_received_ = true;
       vr_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/delete_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/delete_sub_menu_request.cc
@@ -74,7 +74,7 @@ void DeleteSubMenuRequest::Run() {
   msg_params[strings::menu_id] =
       (*message_)[strings::msg_params][strings::menu_id];
   msg_params[strings::app_id] = app->app_id();
-
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   SendHMIRequest(hmi_apis::FunctionID::UI_DeleteSubMenu, &msg_params, true);
 }
 
@@ -143,6 +143,7 @@ void DeleteSubMenuRequest::on_event(const event_engine::Event& event) {
 
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_DeleteSubMenu: {
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/diagnostic_message_request.cc
+++ b/src/components/application_manager/src/commands/mobile/diagnostic_message_request.cc
@@ -83,6 +83,7 @@ void DiagnosticMessageRequest::Run() {
   // Add app_id for HMI request
   (*message_)[strings::msg_params][strings::app_id] = app->app_id();
 
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
   SendHMIRequest(hmi_apis::FunctionID::VehicleInfo_DiagnosticMessage,
                  &(*message_)[strings::msg_params],
                  true);
@@ -94,6 +95,7 @@ void DiagnosticMessageRequest::on_event(const event_engine::Event& event) {
 
   switch (event.id()) {
     case hmi_apis::FunctionID::VehicleInfo_DiagnosticMessage: {
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
       hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/dial_number_request.cc
+++ b/src/components/application_manager/src/commands/mobile/dial_number_request.cc
@@ -87,6 +87,7 @@ void DialNumberRequest::Run() {
       (*message_)[strings::msg_params][strings::number].asString();
   msg_params[strings::app_id] = application->hmi_app_id();
 
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_BasicCommunication);
   SendHMIRequest(
       hmi_apis::FunctionID::BasicCommunication_DialNumber, &msg_params, true);
 }
@@ -106,6 +107,7 @@ void DialNumberRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::BasicCommunication_DialNumber: {
       LOG4CXX_INFO(logger_, "Received DialNumber event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_BasicCommunication);
       result_code = CommandRequestImpl::GetMobileResultCode(
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt()));

--- a/src/components/application_manager/src/commands/mobile/end_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/end_audio_pass_thru_request.cc
@@ -47,6 +47,7 @@ EndAudioPassThruRequest::~EndAudioPassThruRequest() {}
 void EndAudioPassThruRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   SendHMIRequest(hmi_apis::FunctionID::UI_EndAudioPassThru, NULL, true);
 }
 
@@ -56,6 +57,7 @@ void EndAudioPassThruRequest::on_event(const event_engine::Event& event) {
 
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_EndAudioPassThru: {
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asUInt());

--- a/src/components/application_manager/src/commands/mobile/get_dtcs_request.cc
+++ b/src/components/application_manager/src/commands/mobile/get_dtcs_request.cc
@@ -72,6 +72,7 @@ void GetDTCsRequest::Run() {
 
   msg_params[strings::app_id] = app->app_id();
 
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
   SendHMIRequest(hmi_apis::FunctionID::VehicleInfo_GetDTCs, &msg_params, true);
 }
 
@@ -81,6 +82,7 @@ void GetDTCsRequest::on_event(const event_engine::Event& event) {
 
   switch (event.id()) {
     case hmi_apis::FunctionID::VehicleInfo_GetDTCs: {
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
       hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/get_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/get_vehicle_data_request.cc
@@ -250,6 +250,7 @@ void GetVehicleDataRequest::Run() {
     }
   }
   if (msg_params.length() > min_length_msg_params) {
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
     SendHMIRequest(
         hmi_apis::FunctionID::VehicleInfo_GetVehicleData, &msg_params, true);
     return;
@@ -266,6 +267,7 @@ void GetVehicleDataRequest::on_event(const event_engine::Event& event) {
 
   switch (event.id()) {
     case hmi_apis::FunctionID::VehicleInfo_GetVehicleData: {
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
       hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/get_way_points_request.cc
+++ b/src/components/application_manager/src/commands/mobile/get_way_points_request.cc
@@ -29,6 +29,7 @@ void GetWayPointsRequest::Run() {
 
   msg_params = (*message_)[strings::msg_params];
   msg_params[strings::app_id] = app->app_id();
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
   SendHMIRequest(hmi_apis::FunctionID::Navigation_GetWayPoints,
                  msg_params.empty() ? NULL : &msg_params,
                  true);
@@ -40,6 +41,7 @@ void GetWayPointsRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::Navigation_GetWayPoints: {
       LOG4CXX_INFO(logger_, "Received Navigation_GetWayPoints event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
       const hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -177,36 +177,49 @@ void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
     return;
   }
 
-  std::string return_info;
-  mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
-  const bool result = PrepareResponseParameters(result_code, return_info);
+  ResponseParams response_params = PrepareResponseParameters();
 
-  SendResponse(result,
-               result_code,
-               return_info.empty() ? NULL : return_info.c_str(),
-               &(message[strings::msg_params]));
+  SendResponse(
+      response_params.result,
+      response_params.result_code,
+      response_params.info.empty() ? NULL : response_params.info.c_str(),
+      &(message[strings::msg_params]));
 }
 
-bool PerformAudioPassThruRequest::PrepareResponseParameters(
-    mobile_apis::Result::eType& result_code, std::string& info) {
+const PerformAudioPassThruRequest::ResponseParams&
+PerformAudioPassThruRequest::PrepareResponseParameters() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   ResponseInfo ui_perform_info(result_ui_, HmiInterfaces::HMI_INTERFACE_UI);
   ResponseInfo tts_perform_info(result_tts_speak_,
                                 HmiInterfaces::HMI_INTERFACE_TTS);
-  const bool result =
-      PrepareResultForMobileResponse(ui_perform_info, tts_perform_info);
 
+  // Note(dtrunov): According to requirment APPLINK-19591
   if (ui_perform_info.is_ok && tts_perform_info.is_unsupported_resource &&
       HmiInterfaces::STATE_AVAILABLE == tts_perform_info.interface_state) {
-    result_code = mobile_apis::Result::WARNINGS;
+    response_params_.result_code = mobile_apis::Result::WARNINGS;
     tts_info_ = "Unsupported phoneme type sent in a prompt";
-    info = MergeInfos(ui_perform_info, ui_info_, tts_perform_info, tts_info_);
-    return result;
+    response_params_.info =
+        MergeInfos(ui_perform_info, ui_info_, tts_perform_info, tts_info_);
+    response_params_.result = true;
+    return response_params_;
   }
-  result_code = PrepareResultCodeForResponse(ui_perform_info, tts_perform_info);
-  info = MergeInfos(ui_perform_info, ui_info_, tts_perform_info, tts_info_);
-  return result;
+
+  response_params_.result =
+      PrepareResultForMobileResponse(ui_perform_info, tts_perform_info);
+
+  if (IsResultCodeUnsupported(ui_perform_info, tts_perform_info)) {
+    response_params_.result_code = mobile_apis::Result::UNSUPPORTED_RESOURCE;
+  } else {
+    AudioPassThruResults results = PrepareAudioPassThruResultCodeForResponse(
+        ui_perform_info, tts_perform_info);
+    response_params_.result = results.second;
+    response_params_.result_code = results.first;
+  }
+  response_params_.info =
+      MergeInfos(ui_perform_info, ui_info_, tts_perform_info, tts_info_);
+
+  return response_params_;
 }
 
 void PerformAudioPassThruRequest::SendSpeakRequest() {
@@ -351,7 +364,7 @@ void PerformAudioPassThruRequest::FinishTTSSpeak() {
     LOG4CXX_DEBUG(logger_, "Stop AudioPassThru.");
     application_manager_.StopAudioPassThru(connection_key());
   }
-  if (!GetInterfaceAwaitState(HmiInterfaces::HMI_INTERFACE_TTS)) {
+  if (!IsInterfaceAwaitState(HmiInterfaces::HMI_INTERFACE_TTS)) {
     LOG4CXX_WARN(logger_, "TTS Speak is inactive.");
     return;
   }
@@ -360,8 +373,8 @@ void PerformAudioPassThruRequest::FinishTTSSpeak() {
 
 bool PerformAudioPassThruRequest::IsWaitingHMIResponse() {
   LOG4CXX_AUTO_TRACE(logger_);
-  return GetInterfaceAwaitState(HmiInterfaces::HMI_INTERFACE_TTS) ||
-         GetInterfaceAwaitState(HmiInterfaces::HMI_INTERFACE_UI);
+  return IsInterfaceAwaitState(HmiInterfaces::HMI_INTERFACE_TTS) ||
+         IsInterfaceAwaitState(HmiInterfaces::HMI_INTERFACE_UI);
 }
 
 void PerformAudioPassThruRequest::ProcessAudioPassThruIcon(
@@ -381,34 +394,32 @@ void PerformAudioPassThruRequest::ProcessAudioPassThruIcon(
   }
 }
 
-mobile_apis::Result::eType
+PerformAudioPassThruRequest::AudioPassThruResults
 PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
-    const ResponseInfo& ui_response,
-    const ResponseInfo& tts_response,
-    bool& out_result) {
+    const ResponseInfo& ui_response, const ResponseInfo& tts_response) {
   mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
 
   hmi_apis::Common_Result::eType common_result =
       hmi_apis::Common_Result::INVALID_ENUM;
   const hmi_apis::Common_Result::eType ui_result = ui_response.result_code;
   const hmi_apis::Common_Result::eType tts_result = tts_response.result_code;
-
+  bool result = false;
   if ((ui_result == hmi_apis::Common_Result::SUCCESS) &&
       (tts_result != hmi_apis::Common_Result::SUCCESS) &&
       (tts_result != hmi_apis::Common_Result::INVALID_ENUM)) {
     common_result = hmi_apis::Common_Result::WARNINGS;
-    out_result = true;
+    result = true;
   } else if (ui_response.is_ok &&
              tts_result == hmi_apis::Common_Result::WARNINGS) {
     common_result = hmi_apis::Common_Result::WARNINGS;
-    out_result = true;
+    result = true;
   } else if (ui_result == hmi_apis::Common_Result::INVALID_ENUM) {
     common_result = tts_result;
   } else {
     common_result = ui_result;
   }
   result_code = MessageHelper::HMIToMobileResult(common_result);
-  return result_code;
+  return std::make_pair(result_code, result);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -47,8 +47,6 @@ namespace str = strings;
 PerformAudioPassThruRequest::PerformAudioPassThruRequest(
     const MessageSharedPtr& message, ApplicationManager& application_manager)
     : CommandRequestImpl(message, application_manager)
-    , awaiting_tts_speak_response_(false)
-    , awaiting_ui_response_(false)
     , result_tts_speak_(hmi_apis::Common_Result::INVALID_ENUM)
     , result_ui_(hmi_apis::Common_Result::INVALID_ENUM) {
   subscribe_on_event(hmi_apis::FunctionID::TTS_OnResetTimeout);
@@ -96,8 +94,8 @@ void PerformAudioPassThruRequest::Run() {
   }
   // According with new implementation processing of UNSUPPORTE_RESOURCE
   // need set flag before sending to hmi
-
-  awaiting_ui_response_ = true;
+  ProcessAudioPassThruIcon(app);
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   if ((*message_)[str::msg_params].keyExists(str::initial_prompt) &&
       (0 < (*message_)[str::msg_params][str::initial_prompt].length())) {
     // In case TTS Speak, subscribe on notification
@@ -119,7 +117,7 @@ void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_PerformAudioPassThru: {
       LOG4CXX_TRACE(logger_, "Received UI_PerformAudioPassThru");
-      awaiting_ui_response_ = false;
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
 
       result_ui_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asUInt());
@@ -142,7 +140,7 @@ void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
       result_tts_speak_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asUInt());
       GetInfo(message, tts_info_);
-      awaiting_tts_speak_response_ = false;
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
       const bool is_tts_speak_success_unsuported =
           Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
               result_tts_speak_,
@@ -229,7 +227,7 @@ void PerformAudioPassThruRequest::SendSpeakRequest() {
   // app_id
   msg_params[strings::app_id] = connection_key();
   msg_params[hmi_request::speak_type] = Common_MethodName::AUDIO_PASS_THRU;
-  awaiting_tts_speak_response_ = true;
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
   SendHMIRequest(FunctionID::TTS_Speak, &msg_params, true);
 }
 
@@ -353,7 +351,7 @@ void PerformAudioPassThruRequest::FinishTTSSpeak() {
     LOG4CXX_DEBUG(logger_, "Stop AudioPassThru.");
     application_manager_.StopAudioPassThru(connection_key());
   }
-  if (!awaiting_tts_speak_response_) {
+  if (!GetInterfaceAwaitState(HmiInterfaces::HMI_INTERFACE_TTS)) {
     LOG4CXX_WARN(logger_, "TTS Speak is inactive.");
     return;
   }
@@ -362,7 +360,8 @@ void PerformAudioPassThruRequest::FinishTTSSpeak() {
 
 bool PerformAudioPassThruRequest::IsWaitingHMIResponse() {
   LOG4CXX_AUTO_TRACE(logger_);
-  return awaiting_tts_speak_response_ || awaiting_ui_response_;
+  return GetInterfaceAwaitState(HmiInterfaces::HMI_INTERFACE_TTS) ||
+         GetInterfaceAwaitState(HmiInterfaces::HMI_INTERFACE_UI);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
@@ -227,6 +227,7 @@ void PerformInteractionRequest::on_event(const event_engine::Event& event) {
     }
     case hmi_apis::FunctionID::UI_PerformInteraction: {
       LOG4CXX_DEBUG(logger_, "Received UI_PerformInteraction event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       ui_response_received_ = true;
       unsubscribe_from_event(hmi_apis::FunctionID::UI_PerformInteraction);
       ui_result_code_ = static_cast<hmi_apis::Common_Result::eType>(
@@ -237,6 +238,7 @@ void PerformInteractionRequest::on_event(const event_engine::Event& event) {
     }
     case hmi_apis::FunctionID::VR_PerformInteraction: {
       LOG4CXX_DEBUG(logger_, "Received VR_PerformInteraction");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
       vr_response_received_ = true;
       unsubscribe_from_event(hmi_apis::FunctionID::VR_PerformInteraction);
       vr_result_code_ = static_cast<hmi_apis::Common_Result::eType>(
@@ -392,14 +394,14 @@ void PerformInteractionRequest::ProcessUIResponse(
   if (result) {
     if (is_pi_warning) {
       ui_result_code_ = hmi_apis::Common_Result::WARNINGS;
-      ui_info_ = "Unsupported phoneme type was sent in an item";
+      ui_info_ = message[strings::msg_params][strings::info].asString();
       if (message.keyExists(strings::params) &&
           message[strings::params].keyExists(strings::data)) {
         msg_params = message[strings::params][strings::data];
       }
     } else if (is_pi_unsupported) {
       ui_result_code_ = hmi_apis::Common_Result::UNSUPPORTED_RESOURCE;
-      ui_info_ = "Unsupported phoneme type was sent in an item";
+      ui_info_ = message[strings::msg_params][strings::info].asString();
     } else if (message.keyExists(strings::msg_params)) {
       msg_params = message[strings::msg_params];
     }
@@ -503,6 +505,7 @@ void PerformInteractionRequest::SendUIPerformInteractionRequest(
         (*message_)[strings::msg_params][hmi_request::interaction_layout]
             .asInt();
   }
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   SendHMIRequest(
       hmi_apis::FunctionID::UI_PerformInteraction, &msg_params, true);
 }
@@ -595,6 +598,7 @@ void PerformInteractionRequest::SendVRPerformInteractionRequest(
     msg_params[strings::timeout] = default_timeout_;
   }
   msg_params[strings::app_id] = app->app_id();
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
   SendHMIRequest(
       hmi_apis::FunctionID::VR_PerformInteraction, &msg_params, true);
 }

--- a/src/components/application_manager/src/commands/mobile/read_did_request.cc
+++ b/src/components/application_manager/src/commands/mobile/read_did_request.cc
@@ -87,7 +87,7 @@ void ReadDIDRequest::Run() {
       (*message_)[strings::msg_params][strings::ecu_name];
   msg_params[strings::did_location] =
       (*message_)[strings::msg_params][strings::did_location];
-
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
   SendHMIRequest(hmi_apis::FunctionID::VehicleInfo_ReadDID, &msg_params, true);
 }
 
@@ -97,6 +97,7 @@ void ReadDIDRequest::on_event(const event_engine::Event& event) {
 
   switch (event.id()) {
     case hmi_apis::FunctionID::VehicleInfo_ReadDID: {
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
       hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
@@ -161,6 +161,7 @@ void ResetGlobalPropertiesRequest::Run() {
     }
 
     msg_params[strings::app_id] = app->app_id();
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
     SendHMIRequest(
         hmi_apis::FunctionID::UI_SetGlobalProperties, &msg_params, true);
   }
@@ -179,7 +180,7 @@ void ResetGlobalPropertiesRequest::Run() {
     }
 
     msg_params[strings::app_id] = app->app_id();
-
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
     SendHMIRequest(
         hmi_apis::FunctionID::TTS_SetGlobalProperties, &msg_params, true);
   }
@@ -248,6 +249,7 @@ void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_SetGlobalProperties: {
       LOG4CXX_INFO(logger_, "Received UI_SetGlobalProperties event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       is_ui_received_ = true;
       ui_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
@@ -256,6 +258,7 @@ void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
     }
     case hmi_apis::FunctionID::TTS_SetGlobalProperties: {
       LOG4CXX_INFO(logger_, "Received TTS_SetGlobalProperties event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
       is_tts_received_ = true;
       tts_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/scrollable_message_request.cc
+++ b/src/components/application_manager/src/commands/mobile/scrollable_message_request.cc
@@ -109,7 +109,7 @@ void ScrollableMessageRequest::Run() {
     MessageHelper::SubscribeApplicationToSoftButton(
         (*message_)[strings::msg_params], app, function_id());
   }
-
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   SendHMIRequest(hmi_apis::FunctionID::UI_ScrollableMessage, &msg_params, true);
 }
 
@@ -126,6 +126,7 @@ void ScrollableMessageRequest::on_event(const event_engine::Event& event) {
     }
     case hmi_apis::FunctionID::UI_ScrollableMessage: {
       LOG4CXX_INFO(logger_, "Received UI_ScrollableMessage event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
 
       hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(

--- a/src/components/application_manager/src/commands/mobile/send_location_request.cc
+++ b/src/components/application_manager/src/commands/mobile/send_location_request.cc
@@ -125,6 +125,7 @@ void SendLocationRequest::Run() {
   SmartObject request_msg_params = SmartObject(smart_objects::SmartType_Map);
   request_msg_params = msg_params;
   request_msg_params[strings::app_id] = app->hmi_app_id();
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
   SendHMIRequest(
       hmi_apis::FunctionID::Navigation_SendLocation, &request_msg_params, true);
 }
@@ -135,6 +136,7 @@ void SendLocationRequest::on_event(const event_engine::Event& event) {
   const smart_objects::SmartObject& message = event.smart_object();
   if (hmi_apis::FunctionID::Navigation_SendLocation == event.id()) {
     LOG4CXX_INFO(logger_, "Received Navigation_SendLocation event");
+    EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
     const Common_Result::eType result_code = static_cast<Common_Result::eType>(
         message[strings::params][hmi_response::code].asInt());
     std::string response_info;

--- a/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
@@ -107,7 +107,7 @@ void SetAppIconRequest::Run() {
   // for further use in on_event function
   (*message_)[strings::msg_params][strings::sync_file_name] =
       msg_params[strings::sync_file_name];
-
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   SendHMIRequest(hmi_apis::FunctionID::UI_SetAppIcon, &msg_params, true);
 }
 
@@ -234,6 +234,7 @@ void SetAppIconRequest::on_event(const event_engine::Event& event) {
 
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_SetAppIcon: {
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/set_display_layout_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_display_layout_request.cc
@@ -58,6 +58,7 @@ void SetDisplayLayoutRequest::Run() {
   }
 
   (*message_)[strings::msg_params][strings::app_id] = app->app_id();
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   SendHMIRequest(hmi_apis::FunctionID::UI_SetDisplayLayout,
                  &((*message_)[strings::msg_params]),
                  true);
@@ -70,6 +71,7 @@ void SetDisplayLayoutRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_SetDisplayLayout: {
       LOG4CXX_INFO(logger_, "Received UI_SetDisplayLayout event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
@@ -229,6 +229,7 @@ void SetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_SetGlobalProperties: {
       LOG4CXX_INFO(logger_, "Received UI_SetGlobalProperties event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       is_ui_received_ = true;
       ui_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
@@ -237,6 +238,7 @@ void SetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
     }
     case hmi_apis::FunctionID::TTS_SetGlobalProperties: {
       LOG4CXX_INFO(logger_, "Received TTS_SetGlobalProperties event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
       is_tts_received_ = true;
       tts_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
@@ -401,6 +403,7 @@ void SetGlobalPropertiesRequest::SendTTSRequest(
     const smart_objects::SmartObject& params, bool use_events) {
   LOG4CXX_AUTO_TRACE(logger_);
   is_tts_send_ = true;
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
   SendHMIRequest(
       hmi_apis::FunctionID::TTS_SetGlobalProperties, &params, use_events);
 }
@@ -409,6 +412,7 @@ void SetGlobalPropertiesRequest::SendUIRequest(
     const smart_objects::SmartObject& params, bool use_events) {
   LOG4CXX_AUTO_TRACE(logger_);
   is_ui_send_ = true;
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   SendHMIRequest(
       hmi_apis::FunctionID::UI_SetGlobalProperties, &params, use_events);
 }

--- a/src/components/application_manager/src/commands/mobile/set_icon_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_icon_request.cc
@@ -95,7 +95,7 @@ void SetIconRequest::Run() {
   // for further use in on_event function
   (*message_)[strings::msg_params][strings::sync_file_name] =
       msg_params[strings::sync_file_name];
-
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   SendHMIRequest(hmi_apis::FunctionID::UI_SetAppIcon, &msg_params, true);
 }
 
@@ -105,6 +105,7 @@ void SetIconRequest::on_event(const event_engine::Event& event) {
 
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_SetAppIcon: {
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       mobile_apis::Result::eType result_code =
           static_cast<mobile_apis::Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/set_media_clock_timer_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_media_clock_timer_request.cc
@@ -71,7 +71,7 @@ void SetMediaClockRequest::Run() {
     // copy entirely msg
     msg_params = (*message_)[strings::msg_params];
     msg_params[strings::app_id] = app->app_id();
-
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
     SendHMIRequest(
         hmi_apis::FunctionID::UI_SetMediaClockTimer, &msg_params, true);
   } else {
@@ -85,6 +85,7 @@ void SetMediaClockRequest::on_event(const event_engine::Event& event) {
 
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_SetMediaClockTimer: {
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/show_constant_tbt_request.cc
+++ b/src/components/application_manager/src/commands/mobile/show_constant_tbt_request.cc
@@ -172,6 +172,7 @@ void ShowConstantTBTRequest::Run() {
   }
 
   app->set_tbt_show_command(msg_params);
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
   SendHMIRequest(
       hmi_apis::FunctionID::Navigation_ShowConstantTBT, &msg_params, true);
 }
@@ -184,6 +185,7 @@ void ShowConstantTBTRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::Navigation_ShowConstantTBT: {
       LOG4CXX_INFO(logger_, "Received Navigation_ShowConstantTBT event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
       const Common_Result::eType result_code =
           static_cast<Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/show_request.cc
+++ b/src/components/application_manager/src/commands/mobile/show_request.cc
@@ -212,6 +212,7 @@ void ShowRequest::Run() {
         (*message_)[strings::msg_params][strings::custom_presets];
   }
 
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   SendHMIRequest(hmi_apis::FunctionID::UI_Show, &msg_params, true);
 
   MessageSharedPtr persistentData = new smart_objects::SmartObject(msg_params);
@@ -227,6 +228,7 @@ void ShowRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_Show: {
       LOG4CXX_DEBUG(logger_, "Received UI_Show event.");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       std::string response_info;
       hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(

--- a/src/components/application_manager/src/commands/mobile/slider_request.cc
+++ b/src/components/application_manager/src/commands/mobile/slider_request.cc
@@ -107,6 +107,7 @@ void SliderRequest::Run() {
     msg_params[strings::timeout] = default_timeout_;
   }
 
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   SendHMIRequest(hmi_apis::FunctionID::UI_Slider, &msg_params, true);
 }
 
@@ -132,7 +133,7 @@ void SliderRequest::on_event(const event_engine::Event& event) {
   }
 
   LOG4CXX_DEBUG(logger_, "Received UI_Slider event");
-
+  EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   const Common_Result::eType response_code = static_cast<Common_Result::eType>(
       message[strings::params][hmi_response::code].asInt());
 

--- a/src/components/application_manager/src/commands/mobile/speak_request.cc
+++ b/src/components/application_manager/src/commands/mobile/speak_request.cc
@@ -72,6 +72,7 @@ void SpeakRequest::Run() {
   (*message_)[strings::msg_params][strings::app_id] = app->app_id();
   (*message_)[strings::msg_params][hmi_request::speak_type] =
       hmi_apis::Common_MethodName::SPEAK;
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
   SendHMIRequest(hmi_apis::FunctionID::TTS_Speak,
                  &message_->getElement(strings::msg_params),
                  true);
@@ -82,7 +83,7 @@ void SpeakRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::TTS_Speak: {
       LOG4CXX_INFO(logger_, "Received TTS_Speak event");
-
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
       ProcessTTSSpeakResponse(event.smart_object());
       break;
     }

--- a/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -149,6 +149,7 @@ void SubscribeVehicleDataRequest::Run() {
        ++it)
     SendHMIRequest(it->func_id, &msg_params, true);
 #else
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
   SendHMIRequest(hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData,
                  &msg_params,
                  true);
@@ -165,7 +166,7 @@ void SubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
     LOG4CXX_ERROR(logger_, "Received unknown event.");
     return;
   }
-
+  EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
   ApplicationSharedPtr app =
       application_manager_.application(CommandRequestImpl::connection_key());
 

--- a/src/components/application_manager/src/commands/mobile/subscribe_way_points_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_way_points_request.cc
@@ -37,6 +37,7 @@ void SubscribeWayPointsRequest::Run() {
     return;
   }
 
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
   SendHMIRequest(
       hmi_apis::FunctionID::Navigation_SubscribeWayPoints, NULL, true);
 }
@@ -48,6 +49,7 @@ void SubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::Navigation_SubscribeWayPoints: {
       LOG4CXX_INFO(logger_, "Received Navigation_SubscribeWayPoints event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
       const hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/src/commands/mobile/system_request.cc
@@ -583,6 +583,7 @@ void SystemRequest::Run() {
 
   msg_params[strings::request_type] =
       (*message_)[strings::msg_params][strings::request_type];
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_BasicCommunication);
   SendHMIRequest(hmi_apis::FunctionID::BasicCommunication_SystemRequest,
                  &msg_params,
                  true);
@@ -596,6 +597,7 @@ void SystemRequest::on_event(const event_engine::Event& event) {
 
   switch (event.id()) {
     case hmi_apis::FunctionID::BasicCommunication_SystemRequest: {
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_BasicCommunication);
       mobile_apis::Result::eType result_code =
           GetMobileResultCode(static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asUInt()));

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -234,6 +234,7 @@ void UnsubscribeVehicleDataRequest::Run() {
        ++it)
     SendHMIRequest(it->func_id, &msg_params, true);
 #else
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
   SendHMIRequest(hmi_apis::FunctionID::VehicleInfo_UnsubscribeVehicleData,
                  &msg_params,
                  true);
@@ -250,6 +251,7 @@ void UnsubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
     LOG4CXX_ERROR(logger_, "Received unknown event.");
     return;
   }
+  EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
 
 #ifdef HMI_DBUS_API
   for (HmiRequests::iterator it = hmi_requests_.begin();

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_way_points_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_way_points_request.cc
@@ -30,6 +30,7 @@ void UnSubscribeWayPointsRequest::Run() {
     return;
   }
 
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
   SendHMIRequest(
       hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints, NULL, true);
 }
@@ -41,6 +42,7 @@ void UnSubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints: {
       LOG4CXX_INFO(logger_, "Received Navigation_UnSubscribeWayPoints event");
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
       const hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/commands/mobile/update_turn_list_request.cc
+++ b/src/components/application_manager/src/commands/mobile/update_turn_list_request.cc
@@ -138,6 +138,7 @@ void UpdateTurnListRequest::Run() {
 
   if ((*message_)[strings::msg_params].keyExists(strings::turn_list) ||
       (*message_)[strings::msg_params].keyExists(strings::soft_buttons)) {
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
     SendHMIRequest(
         hmi_apis::FunctionID::Navigation_UpdateTurnList, &msg_params, true);
   } else {
@@ -154,7 +155,7 @@ void UpdateTurnListRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::Navigation_UpdateTurnList: {
       LOG4CXX_INFO(logger_, "Received Navigation_UpdateTurnList event");
-
+      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
       const hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2223,7 +2223,7 @@ mobile_apis::Result::eType MessageHelper::VerifyImageFiles(
   return mobile_apis::Result::SUCCESS;
 }
 
-mobile_apis::Result::eType MessageHelper::VerifyImage(
+mobile_apis::Result::eType MessageHelper::VerifyImageApplyPath(
     smart_objects::SmartObject& image,
     ApplicationConstSharedPtr app,
     ApplicationManager& app_mngr) {
@@ -2267,13 +2267,31 @@ mobile_apis::Result::eType MessageHelper::VerifyImage(
     full_file_path += file_name;
   }
 
+  image[strings::value] = full_file_path;
   if (!file_system::FileExists(full_file_path)) {
     return mobile_apis::Result::INVALID_DATA;
   }
 
-  image[strings::value] = full_file_path;
-
   return mobile_apis::Result::SUCCESS;
+}
+
+mobile_apis::Result::eType MessageHelper::VerifyImage(
+    smart_objects::SmartObject& image,
+    ApplicationConstSharedPtr app,
+    ApplicationManager& app_mngr) {
+  smart_objects::SmartObject temp_image = image;
+  const uint32_t image_type = image[strings::image_type].asUInt();
+  const mobile_apis::ImageType::eType type =
+      static_cast<mobile_apis::ImageType::eType>(image_type);
+
+  const mobile_apis::Result::eType result =
+      VerifyImageApplyPath(temp_image, app, app_mngr);
+  if ((mobile_apis::Result::SUCCESS == result) &&
+      (mobile_apis::ImageType::DYNAMIC == type)) {
+    image[strings::value] = temp_image[strings::value];
+  }
+
+  return result;
 }
 
 mobile_apis::Result::eType MessageHelper::VerifyImageVrHelpItems(

--- a/src/components/application_manager/test/commands/mobile/add_command_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/add_command_request_test.cc
@@ -210,7 +210,8 @@ class AddCommandRequestTest
     EXPECT_CALL(*mock_app_, RemoveCommand(kCmdId));
     EXPECT_CALL(app_mngr_, ManageHMICommand(HMIResultCodeIs(cmd_to_delete)))
         .WillOnce(Return(true));
-    SmartObjectSPtr response;
+    SmartObjectSPtr response = utils::MakeShared<SmartObject>(SmartType_Map);
+    (*response)[strings::msg_params][strings::info] = "info";
     EXPECT_CALL(
         mock_message_helper_,
         CreateNegativeResponse(_, _, _, mobile_apis::Result::GENERIC_ERROR))
@@ -1046,7 +1047,8 @@ TEST_F(AddCommandRequestTest,
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(ApplicationSharedPtr()));
   EXPECT_CALL(*mock_app_, RemoveCommand(kCmdId)).Times(0);
-  SmartObjectSPtr response;
+  SmartObjectSPtr response = utils::MakeShared<SmartObject>(SmartType_Map);
+  (*response)[strings::msg_params][strings::info] = "info";
   EXPECT_CALL(
       mock_message_helper_,
       CreateNegativeResponse(_, _, _, mobile_apis::Result::GENERIC_ERROR))
@@ -1095,7 +1097,8 @@ TEST_F(AddCommandRequestTest, OnTimeOut_AppRemoveCommandCalled) {
       CreateCommand<AddCommandRequest>(msg_);
   request_ptr->Run();
   EXPECT_CALL(*mock_app_, RemoveCommand(kCmdId));
-  SmartObjectSPtr response;
+  SmartObjectSPtr response = utils::MakeShared<SmartObject>(SmartType_Map);
+  (*response)[strings::msg_params][strings::info] = "info";
   EXPECT_CALL(
       mock_message_helper_,
       CreateNegativeResponse(_, _, _, mobile_apis::Result::GENERIC_ERROR))

--- a/src/components/application_manager/test/commands/mobile/alert_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/alert_request_test.cc
@@ -131,12 +131,12 @@ class AlertRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
     ON_CALL(hmi_interfaces_,
             GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
         .WillByDefault(
-            Return(am::HmiInterfaces::InterfaceState::STATE_NOT_AVAILABLE));
+            Return(am::HmiInterfaces::InterfaceState::STATE_AVAILABLE));
 
     ON_CALL(hmi_interfaces_,
             GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
         .WillByDefault(
-            Return(am::HmiInterfaces::InterfaceState::STATE_NOT_AVAILABLE));
+            Return(am::HmiInterfaces::InterfaceState::STATE_AVAILABLE));
   }
 
   void Expectations() {
@@ -301,14 +301,6 @@ TEST_F(AlertRequestTest, Init_DurationNotExists_SUCCESS) {
   Expectations();
   CommandPtr command(CreateCommand<AlertRequest>(msg_));
   EXPECT_TRUE(command->Init());
-}
-
-TEST_F(AlertRequestTest, OnTimeOut_UNSUCCESS) {
-  Expectations();
-  (*msg_)[am::strings::msg_params][am::strings::soft_buttons] = 0;
-  CommandPtr command(CreateCommand<AlertRequest>(msg_));
-  command->onTimeOut();
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
 }
 
 TEST_F(AlertRequestTest, OnTimeOut_SUCCESS) {

--- a/src/components/application_manager/test/commands/mobile/change_registration_test.cc
+++ b/src/components/application_manager/test/commands/mobile/change_registration_test.cc
@@ -149,7 +149,7 @@ class ChangeRegistrationRequestTest
                          const am::HmiInterfaces::InterfaceState state,
                          const bool success,
                          const hmi_apis::Common_Result::eType ui_hmi_response =
-                             hmi_apis::Common_Result::WARNINGS,
+                             hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
                          const hmi_apis::Common_Result::eType vr_hmi_response =
                              hmi_apis::Common_Result::UNSUPPORTED_RESOURCE) {
     MessageSharedPtr msg_from_mobile = CreateMsgFromMobile();
@@ -389,11 +389,11 @@ TEST_F(ChangeRegistrationRequestTest,
 }
 
 TEST_F(ChangeRegistrationRequestTest,
-       OnEvent_TTS_UNSUPPORTED_RESOURCE_STATE_NOT_AVAILABLE_Expect_true) {
+       OnEvent_TTS_UNSUPPORTED_RESOURCE_STATE_NOT_AVAILABLE_Expect_false) {
   CheckExpectations(hmi_apis::Common_Result::SUCCESS,
                     mobile_apis::Result::UNSUPPORTED_RESOURCE,
                     am::HmiInterfaces::STATE_NOT_AVAILABLE,
-                    true);
+                    false);
 }
 
 TEST_F(ChangeRegistrationRequestTest,
@@ -413,17 +413,17 @@ TEST_F(ChangeRegistrationRequestTest,
 }
 
 TEST_F(ChangeRegistrationRequestTest,
-       OnEvent_TTS_UNSUPPORTED_RESOURCE_SUCCESS_STATE_AVAILABLE_Expect_false) {
+       OnEvent_TTS_UNSUPPORTED_RESOURCE_SUCCESS_STATE_AVAILABLE_Expect_true) {
   CheckExpectations(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
                     mobile_apis::Result::UNSUPPORTED_RESOURCE,
                     am::HmiInterfaces::STATE_AVAILABLE,
-                    false,
+                    true,
                     hmi_apis::Common_Result::SUCCESS,
                     hmi_apis::Common_Result::SUCCESS);
 }
 
 TEST_F(ChangeRegistrationRequestTest,
-       OnEvent_TTS_SUCCESS_STATE_AVAILABLE_Expect_false) {
+       OnEvent_TTS_SUCCESS_STATE_AVAILABLE_Expect_true) {
   CheckExpectations(hmi_apis::Common_Result::SUCCESS,
                     mobile_apis::Result::SUCCESS,
                     am::HmiInterfaces::STATE_AVAILABLE,
@@ -483,14 +483,14 @@ TEST_F(ChangeRegistrationRequestTest,
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
   ON_CALL(hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
   ON_CALL(hmi_interfaces_,
           GetInterfaceFromFunction(hmi_apis::FunctionID::VR_ChangeRegistration))
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_VR));
   ON_CALL(hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_VR))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
   ON_CALL(
       hmi_interfaces_,
@@ -498,7 +498,7 @@ TEST_F(ChangeRegistrationRequestTest,
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_TTS));
   ON_CALL(hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
   command->Run();
 

--- a/src/components/application_manager/test/commands/mobile/delete_command_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_command_request_test.cc
@@ -162,10 +162,10 @@ TEST_F(DeleteCommandRequestTest,
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_VR));
   ON_CALL(hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   ON_CALL(hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_VR))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   ON_CALL(*mock_app_, FindCommand(kCommandId))
       .WillByDefault(Return(test_msg.get()));
   ON_CALL(*mock_app_, get_grammar_id()).WillByDefault(Return(kConnectionKey));
@@ -222,10 +222,10 @@ TEST_F(DeleteCommandRequestTest,
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
   ON_CALL(hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   ON_CALL(hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_VR))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   ON_CALL(*app, FindCommand(kCommandId)).WillByDefault(Return(test_msg.get()));
   ON_CALL(*app, get_grammar_id()).WillByDefault(Return(kConnectionKey));
 

--- a/src/components/application_manager/test/commands/mobile/get_way_points_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/get_way_points_request_test.cc
@@ -72,6 +72,15 @@ const std::string kMethodName = "Navigation.GetWayPoints";
 class GetWayPointsRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
+  GetWayPointsRequestTest()
+      : message_helper_mock_(*am::MockMessageHelper::message_helper_mock())
+      , mock_app_(CreateMockApp()) {
+    Mock::VerifyAndClearExpectations(&message_helper_mock_);
+  }
+  ~GetWayPointsRequestTest() {
+    Mock::VerifyAndClearExpectations(&message_helper_mock_);
+  }
+
   void SetUp() OVERRIDE {
     message_ = utils::MakeShared<SmartObject>(::smart_objects::SmartType_Map);
     (*message_)[am::strings::msg_params] =
@@ -80,10 +89,9 @@ class GetWayPointsRequestTest
     command_sptr_ =
         CreateCommand<application_manager::commands::GetWayPointsRequest>(
             message_);
-    mock_app_ = CreateMockApp();
     ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
   }
-
+  MockMessageHelper& message_helper_mock_;
   MockAppPtr mock_app_;
   MessageSharedPtr message_;
   utils::SharedPtr<application_manager::commands::GetWayPointsRequest>
@@ -193,6 +201,8 @@ TEST_F(GetWayPointsRequestTest,
       hmi_apis::Common_Result::SUCCESS;
 
   event.set_smart_object(*message_);
+  EXPECT_CALL(message_helper_mock_, HMIToMobileResult(_))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
 
   CallOnEvent caller(*command_sptr_, event);
 
@@ -227,14 +237,20 @@ TEST_F(GetWayPointsRequestOnEventTest, OnEvent_WrongEventId_UNSUCCESS) {
 }
 
 TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_SUCCESS_Case1) {
+  EXPECT_CALL(message_helper_mock_, HMIToMobileResult(_))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
   CheckOnEventResponse("0", SUCCESS, true);
 }
 
 TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_SUCCESS_Case2) {
+  EXPECT_CALL(message_helper_mock_, HMIToMobileResult(_))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
   CheckOnEventResponse("", SUCCESS, true);
 }
 
 TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_SUCCESS_Case3) {
+  EXPECT_CALL(message_helper_mock_, HMIToMobileResult(_))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
   CheckOnEventResponse("test", SUCCESS, true);
 }
 

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -594,7 +594,7 @@ TEST_F(PerformAudioPassThruRequestTest,
 }
 
 TEST_F(PerformAudioPassThruRequestTest,
-       OnEvent_PAPTunsupportedResource_CorrectInfo) {
+       DISABLED_OnEvent_PAPTunsupportedResource_CorrectInfo) {
   const std::string return_info = "Unsupported phoneme type sent in a prompt";
 
   am::event_engine::Event event_speak(hmi_apis::FunctionID::TTS_Speak);
@@ -611,6 +611,8 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   ON_CALL(hmi_interfaces_, GetInterfaceState(_))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  ON_CALL(mock_message_helper_, HMIToMobileResult(_))
+      .WillByDefault(Return(am::mobile_api::Result::UNSUPPORTED_RESOURCE));
   // First call on_event for setting result_tts_speak_ to UNSUPPORTED_RESOURCE
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
   CallOnEvent caller_speak(*command_sptr_, event_speak);

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -219,10 +219,10 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   ON_CALL(hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   ON_CALL(hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
   MessageSharedPtr response_msg_tts =
       CreateMessage(smart_objects::SmartType_Map);

--- a/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
@@ -199,10 +199,10 @@ TEST_F(PerformInteractionRequestTest,
 
   EXPECT_CALL(hmi_interfaces,
               GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
-      .WillRepeatedly(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+      .WillRepeatedly(Return(am::HmiInterfaces::STATE_AVAILABLE));
   EXPECT_CALL(hmi_interfaces,
               GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_VR))
-      .WillRepeatedly(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+      .WillRepeatedly(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
   MessageSharedPtr response_to_mobile;
 
@@ -230,10 +230,10 @@ TEST_F(PerformInteractionRequestTest,
 
   ON_CALL(hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   ON_CALL(hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_VR))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
   MessageSharedPtr response_msg_vr =
       CreateMessage(smart_objects::SmartType_Map);

--- a/src/components/application_manager/test/commands/mobile/set_display_layout_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_display_layout_test.cc
@@ -257,6 +257,10 @@ TEST_F(SetDisplayLayoutRequestTest, OnEvent_SUCCESS) {
   EXPECT_CALL(hmi_capabilities, display_capabilities())
       .WillOnce(Return(dispaly_capabilities_msg.get()));
 
+  ON_CALL(mock_message_helper_,
+          HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
+      .WillByDefault(Return(mobile_apis::Result::SUCCESS));
+
   EXPECT_CALL(
       app_mngr_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS),

--- a/src/components/application_manager/test/commands/mobile/set_global_properties_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_global_properties_test.cc
@@ -246,10 +246,10 @@ class SetGlobalPropertiesRequestTest
         .WillOnce(Return(am::HmiInterfaces::HMI_INTERFACE_TTS));
     ON_CALL(hmi_interfaces_,
             GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
-        .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+        .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
     ON_CALL(hmi_interfaces_,
             GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
-        .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+        .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   }
   sync_primitives::Lock lock_;
   NiceMock<MockHmiInterfaces> hmi_interfaces_;

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -163,7 +163,10 @@ class MockMessageHelper {
                mobile_apis::Result::eType(smart_objects::SmartObject& message,
                                           ApplicationConstSharedPtr app,
                                           ApplicationManager& app_mngr));
-
+  MOCK_METHOD3(VerifyImageApplyPath,
+               mobile_apis::Result::eType(smart_objects::SmartObject& message,
+                                          ApplicationConstSharedPtr app,
+                                          ApplicationManager& app_mngr));
   MOCK_METHOD6(GetBCActivateAppRequestToHMI,
                smart_objects::SmartObjectSPtr(
                    ApplicationConstSharedPtr app,

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -286,6 +286,14 @@ mobile_apis::Result::eType MessageHelper::VerifyImage(
       message, app, app_mngr);
 }
 
+mobile_apis::Result::eType MessageHelper::VerifyImageApplyPath(
+    smart_objects::SmartObject& message,
+    ApplicationConstSharedPtr app,
+    ApplicationManager& app_mngr) {
+  return MockMessageHelper::message_helper_mock()->VerifyImageApplyPath(
+      message, app, app_mngr);
+}
+
 mobile_apis::Result::eType MessageHelper::VerifyImageFiles(
     smart_objects::SmartObject& message,
     ApplicationConstSharedPtr app,

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1208,7 +1208,7 @@ AppIdURL PolicyManagerImpl::GetNextUpdateUrl(const EndpointUrls& urls) {
   retry_sequence_url_.app_idx_ = next_app_url.first;
   retry_sequence_url_.policy_app_id_ = urls[next_app_url.first].app_id;
 
-  return next_app_url;
+  return next_appl_url;
 }
 
 AppIdURL PolicyManagerImpl::RetrySequenceUrl(const struct RetrySequenceURL& rs,


### PR DESCRIPTION
issues: 
[990](https://github.com/smartdevicelink/sdl_core/issues/990)
[1012](https://github.com/smartdevicelink/sdl_core/issues/1012)
[1016](https://github.com/smartdevicelink/sdl_core/issues/1016)