### PR TITLE
Fix ResetGlobalProperties help prompt parameter

### DIFF
--- a/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
@@ -194,6 +194,22 @@ bool ResetGlobalPropertiesRequest::ResetHelpPromt(
   }
   smart_objects::SmartObject so_help_prompt =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  const std::vector<std::string>& help_prompt_default =
+      application_manager_.get_settings().help_prompt();
+
+  for (std::vector<std::string>::const_iterator it =
+           help_prompt_default.begin();
+       help_prompt_default.end() != it;
+       ++it) {
+    smart_objects::SmartObject so_help_prompt_item =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    so_help_prompt_item[strings::text] = *it;
+    so_help_prompt_item[strings::type] =
+        hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+    so_help_prompt[so_help_prompt.length()] = so_help_prompt_item;
+  }
+
   app->set_help_prompt(so_help_prompt);
   return true;
 }

--- a/src/components/include/application_manager/application_manager_settings.h
+++ b/src/components/include/application_manager/application_manager_settings.h
@@ -67,6 +67,7 @@ class ApplicationManagerSettings : public RequestControlerSettings,
   virtual const std::string& tts_delimiter() const = 0;
   virtual const uint32_t& put_file_in_none() const = 0;
   virtual const std::string& sdl_version() const = 0;
+  virtual const std::vector<std::string>& help_prompt() const = 0;
   virtual const std::vector<std::string>& time_out_promt() const = 0;
   virtual const std::string& hmi_capabilities_file_name() const = 0;
   virtual const std::string& video_server_type() const = 0;

--- a/src/components/include/test/application_manager/mock_application_manager_settings.h
+++ b/src/components/include/test/application_manager/mock_application_manager_settings.h
@@ -75,6 +75,7 @@ class MockApplicationManagerSettings
   MOCK_CONST_METHOD0(tts_delimiter, const std::string&());
   MOCK_CONST_METHOD0(put_file_in_none, const uint32_t&());
   MOCK_CONST_METHOD0(sdl_version, const std::string&());
+  MOCK_CONST_METHOD0(help_prompt, const std::vector<std::string>&());
   MOCK_CONST_METHOD0(time_out_promt, const std::vector<std::string>&());
   MOCK_CONST_METHOD0(hmi_capabilities_file_name, const std::string&());
   MOCK_CONST_METHOD0(video_server_type, const std::string&());


### PR DESCRIPTION
Fixed `ResetGlobalProperties` help prompt request parameter reset to default value. 
The root cause of this defect is that SDL does not get default help prompt value from Application Manager settings and does not assign it to app's help prompt. It just assigns an empty map.

In this pull request:
- Added missed `help_prompt()` function to `ApplicationManagerSettings` interface
- Added related mock method to `MockApplicationManagerSettings` class
- Updated `ResetGlobalPropertiesRequest::ResetHelpPromt()` function logic to work as expected
- Updated related unit tests