### PR TITLE
Fix SDL sends redundant UPDATING after failed ptu

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -974,8 +974,7 @@ bool PolicyHandler::ReceiveMessageFromSDK(const std::string& file,
     MessageHelper::CreateGetVehicleDataRequest(
         correlation_id, vehicle_data_args, application_manager_);
   } else {
-    LOG4CXX_WARN(logger_, "Exchange wasn't successful, trying another one.");
-    policy_manager_->ForcePTExchange();
+    LOG4CXX_WARN(logger_, "Exchange wasn't successful.");
   }
   return ret;
 }

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -314,7 +314,6 @@ TEST_F(PolicyHandlerTest, ReceiveMessageFromSDK_PTNotLoaded) {
   // Checks
 
   EXPECT_CALL(*mock_policy_manager_, LoadPT("", msg)).WillOnce(Return(false));
-  EXPECT_CALL(*mock_policy_manager_, ForcePTExchange()).WillOnce(Return(""));
   EXPECT_CALL(app_manager_, GetNextHMICorrelationID()).Times(0);
   EXPECT_CALL(mock_message_helper_, CreateGetVehicleDataRequest(_, _, _))
       .Times(0);


### PR DESCRIPTION
 Deleted ForcePTExchange from PolicyHandler_ReceiveMessageFromSDK