### PR TITLE
Fix GetVehicleData request sending by SDL without mobile request

### DIFF
--- a/src/components/application_manager/src/commands/hmi/vi_is_ready_request.cc
+++ b/src/components/application_manager/src/commands/hmi/vi_is_ready_request.cc
@@ -66,7 +66,6 @@ void VIIsReadyRequest::on_event(const event_engine::Event& event) {
       HMICapabilities& hmi_capabilities =
           application_manager_.hmi_capabilities();
       hmi_capabilities.set_is_ivi_cooperating(is_available);
-      application_manager_.GetPolicyHandler().OnVIIsReady();
       if (!CheckAvailabilityHMIInterfaces(
               application_manager_, HmiInterfaces::HMI_INTERFACE_VehicleInfo)) {
         LOG4CXX_INFO(

--- a/src/components/application_manager/test/commands/hmi/vi_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vi_is_ready_request_test.cc
@@ -87,9 +87,6 @@ class VIIsReadyRequestTest
           .WillOnce(ReturnRef(mock_hmi_interfaces_));
       EXPECT_CALL(mock_hmi_interfaces_, SetInterfaceState(_, _)).Times(0);
     }
-    EXPECT_CALL(app_mngr_, GetPolicyHandler())
-        .WillOnce(ReturnRef(mock_policy_handler_interface_));
-    EXPECT_CALL(mock_policy_handler_interface_, OnVIIsReady());
 
     EXPECT_CALL(mock_hmi_interfaces_,
                 GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_VehicleInfo))


### PR DESCRIPTION
- Removed redundant sending of GetVehicleData request as
  it should be sent only in case of appropriate mobile request
- Fixed appropriate unit tests
