### PR TITLE
Fix IsReady acceptance after error response

### DIFF
--- a/src/components/application_manager/test/commands/hmi/navi_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_is_ready_request_test.cc
@@ -85,6 +85,8 @@ TEST_F(NaviIsReadyRequestTest,
   MessageSharedPtr event_msg = CreateMessage();
   (*event_msg)[am::strings::msg_params][am::strings::available] =
       is_hmi_interface_available;
+  (*event_msg)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
 
   Event event(kEventID);
   event.set_smart_object(*event_msg);
@@ -92,6 +94,29 @@ TEST_F(NaviIsReadyRequestTest,
   EXPECT_CALL(mock_hmi_interfaces_,
               SetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_Navigation,
                                 am::HmiInterfaces::STATE_AVAILABLE));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_is_navi_cooperating(is_hmi_interface_available));
+
+  command_->on_event(event);
+}
+
+TEST_F(NaviIsReadyRequestTest,
+       OnEvent_HmiInterfaceIsAvailableWithErrorCode_NaviIsNotAvailable) {
+  const bool is_hmi_interface_available = true;
+
+  MessageSharedPtr event_msg = CreateMessage();
+  (*event_msg)[am::strings::msg_params][am::strings::available] =
+      is_hmi_interface_available;
+  (*event_msg)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::GENERIC_ERROR;
+
+  Event event(kEventID);
+  event.set_smart_object(*event_msg);
+
+  EXPECT_CALL(mock_hmi_interfaces_,
+              SetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_Navigation,
+                                am::HmiInterfaces::STATE_NOT_AVAILABLE));
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_is_navi_cooperating(is_hmi_interface_available));

--- a/src/components/application_manager/test/commands/hmi/ui_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_is_ready_request_test.cc
@@ -143,6 +143,23 @@ class UIIsReadyRequestTest
                     Event& event,
                     bool is_ui_cooperating_available = false) {
     MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
+
+    (*msg)[am::strings::params][am::hmi_response::code] =
+        hmi_apis::Common_Result::SUCCESS;
+    if (is_message_contain_param) {
+      (*msg)[am::strings::msg_params][am::strings::available] =
+          is_ui_cooperating_available;
+    }
+    event.set_smart_object(*msg);
+  }
+
+  void PrepareErrorEvent(bool is_message_contain_param,
+                         Event& event,
+                         bool is_ui_cooperating_available = false) {
+    MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
+
+    (*msg)[am::strings::params][am::hmi_response::code] =
+        hmi_apis::Common_Result::GENERIC_ERROR;
     if (is_message_contain_param) {
       (*msg)[am::strings::msg_params][am::strings::available] =
           is_ui_cooperating_available;
@@ -196,6 +213,21 @@ TEST_F(UIIsReadyRequestTest, OnEvent_KeyAvailableEqualToTrue_StateAvailable) {
                     is_send_message_to_hmi,
                     is_message_contain_param,
                     am::HmiInterfaces::STATE_AVAILABLE);
+  command_->on_event(event);
+}
+
+TEST_F(UIIsReadyRequestTest,
+       OnEvent_KeyAvailableEqualToTrue_ResultCodeError_StateNotAvailable) {
+  const bool is_ui_cooperating_available = true;
+  const bool is_send_message_to_hmi = false;
+  const bool is_message_contain_param = true;
+  Event event(hmi_apis::FunctionID::UI_IsReady);
+  PrepareErrorEvent(
+      is_message_contain_param, event, is_ui_cooperating_available);
+  SetUpExpectations(is_ui_cooperating_available,
+                    is_send_message_to_hmi,
+                    is_message_contain_param,
+                    am::HmiInterfaces::STATE_NOT_AVAILABLE);
   command_->on_event(event);
 }
 

--- a/src/components/application_manager/test/commands/hmi/vi_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vi_is_ready_request_test.cc
@@ -113,9 +113,25 @@ class VIIsReadyRequestTest
                     Event& event,
                     bool is_vi_cooperating_available = false) {
     MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
+    (*msg)[am::strings::params][am::hmi_response::code] =
+        hmi_apis::Common_Result::SUCCESS;
     if (is_message_contain_param) {
       (*msg)[am::strings::msg_params][am::strings::available] =
           is_vi_cooperating_available;
+    }
+    event.set_smart_object(*msg);
+  }
+
+  void PrepareErrorEvent(bool is_message_contain_param,
+                         Event& event,
+                         bool is_ui_cooperating_available = false) {
+    MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
+
+    (*msg)[am::strings::params][am::hmi_response::code] =
+        hmi_apis::Common_Result::GENERIC_ERROR;
+    if (is_message_contain_param) {
+      (*msg)[am::strings::msg_params][am::strings::available] =
+          is_ui_cooperating_available;
     }
     event.set_smart_object(*msg);
   }
@@ -162,6 +178,21 @@ TEST_F(VIIsReadyRequestTest, Run_KeyAvailableEqualToTrue_StateAvailable) {
                     is_send_message_to_hmi,
                     is_message_contain_param,
                     am::HmiInterfaces::STATE_AVAILABLE);
+  command_->on_event(event);
+}
+
+TEST_F(VIIsReadyRequestTest,
+       OnEvent_KeyAvailableEqualToTrue_ResultCodeError_StateNotAvailable) {
+  const bool is_vi_cooperating_available = true;
+  const bool is_send_message_to_hmi = false;
+  const bool is_message_contain_param = true;
+  Event event(hmi_apis::FunctionID::VehicleInfo_IsReady);
+  PrepareErrorEvent(
+      is_message_contain_param, event, is_vi_cooperating_available);
+  SetUpExpectations(is_vi_cooperating_available,
+                    is_send_message_to_hmi,
+                    is_message_contain_param,
+                    am::HmiInterfaces::STATE_NOT_AVAILABLE);
   command_->on_event(event);
 }
 

--- a/src/components/application_manager/test/commands/hmi/vr_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_is_ready_request_test.cc
@@ -131,9 +131,24 @@ class VRIsReadyRequestTest
                     Event& event,
                     bool is_vr_cooperating_available = false) {
     MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
+    (*msg)[am::strings::params][am::hmi_response::code] =
+        hmi_apis::Common_Result::SUCCESS;
     if (is_message_contain_param) {
       (*msg)[am::strings::msg_params][am::strings::available] =
           is_vr_cooperating_available;
+    }
+    event.set_smart_object(*msg);
+  }
+
+  void PrepareErrorEvent(bool is_message_contain_param,
+                         Event& event,
+                         bool is_ui_cooperating_available = false) {
+    MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
+    (*msg)[am::strings::params][am::hmi_response::code] =
+        hmi_apis::Common_Result::GENERIC_ERROR;
+    if (is_message_contain_param) {
+      (*msg)[am::strings::msg_params][am::strings::available] =
+          is_ui_cooperating_available;
     }
     event.set_smart_object(*msg);
   }
@@ -179,6 +194,21 @@ TEST_F(VRIsReadyRequestTest, Run_KeyAvailableEqualToTrue_StateAvailable) {
                     is_send_message_to_hmi,
                     is_message_contain_param,
                     am::HmiInterfaces::STATE_AVAILABLE);
+  command_->on_event(event);
+}
+
+TEST_F(VRIsReadyRequestTest,
+       OnEvent_KeyAvailableEqualToTrue_ResultCodeError_StateNotAvailable) {
+  const bool is_vr_cooperating_available = true;
+  const bool is_send_message_to_hmi = false;
+  const bool is_message_contain_param = true;
+  Event event(hmi_apis::FunctionID::VR_IsReady);
+  PrepareErrorEvent(
+      is_message_contain_param, event, is_vr_cooperating_available);
+  SetUpExpectations(is_vr_cooperating_available,
+                    is_send_message_to_hmi,
+                    is_message_contain_param,
+                    am::HmiInterfaces::STATE_NOT_AVAILABLE);
   command_->on_event(event);
 }
 


### PR DESCRIPTION
If result code from HMI on .IsReady is errorCode then SDL ) SDL should consider that works incorrectly and not available.