### PR TITLE
Fixes processing ABORTED code for VR in PerformInteraction

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -233,8 +233,8 @@ class CommandRequestImpl : public CommandImpl,
    * @return true if result code complies successful result code
    * otherwise returns false
    */
-  bool PrepareResultForMobileResponse(ResponseInfo& out_first,
-                                      ResponseInfo& out_second) const;
+  virtual bool PrepareResultForMobileResponse(ResponseInfo& out_first,
+                                              ResponseInfo& out_second) const;
 
   /**
    * @brief If message from HMI contains returns this info
@@ -256,7 +256,7 @@ class CommandRequestImpl : public CommandImpl,
    * interface that returns response.
    * @return resulting code for sending to mobile application.
    */
-  mobile_apis::Result::eType PrepareResultCodeForResponse(
+  virtual mobile_apis::Result::eType PrepareResultCodeForResponse(
       const ResponseInfo& first, const ResponseInfo& second);
 
  protected:

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_interaction_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_interaction_request.h
@@ -90,6 +90,30 @@ class PerformInteractionRequest : public CommandRequestImpl {
 
  private:
   /**
+   * @brief Checks result code from HMI for splitted RPC
+   * and returns parameter for sending to mobile app.
+   * @param first contains result_code from HMI response and
+   * interface that returns response
+   * @param second contains result_code from HMI response and
+   * interface that returns response
+   * @return true if result code complies successful result code
+   * otherwise returns false
+   */
+  bool PrepareResultForMobileResponse(ResponseInfo& out_first,
+                                      ResponseInfo& out_second) const OVERRIDE;
+
+  /**
+   * @brief Prepare result code for sending to mobile application
+   * @param first contains result_code from HMI response and
+   * interface that returns response
+   * @param second contains result_code from HMI response and
+   * interface that returns response.
+   * @return resulting code for sending to mobile application.
+   */
+  mobile_apis::Result::eType PrepareResultCodeForResponse(
+      const ResponseInfo& first, const ResponseInfo& second) OVERRIDE;
+
+  /**
    * @brief Function will be called when VR_OnCommand event
    * comes
    * @param message which should send to mobile side

--- a/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
@@ -296,6 +296,46 @@ void PerformInteractionRequest::onTimeOut() {
   };
 }
 
+bool PerformInteractionRequest::PrepareResultForMobileResponse(
+    ResponseInfo& out_first, ResponseInfo& out_second) const {
+  const bool is_ui_or_both_mode =
+      helpers::Compare<mobile_apis::InteractionMode::eType,
+                       helpers::EQ,
+                       helpers::ONE>(interaction_mode_,
+                                     mobile_apis::InteractionMode::BOTH,
+                                     mobile_apis::InteractionMode::MANUAL_ONLY);
+
+  if (is_ui_or_both_mode) {
+    if (vr_result_code_ == hmi_apis::Common_Result::ABORTED &&
+        ui_result_code_ == hmi_apis::Common_Result::UNSUPPORTED_RESOURCE) {
+      return true;
+    }
+  }
+
+  return CommandRequestImpl::PrepareResultForMobileResponse(out_first,
+                                                            out_second);
+}
+
+mobile_apis::Result::eType
+PerformInteractionRequest::PrepareResultCodeForResponse(
+    const ResponseInfo& first, const ResponseInfo& second) {
+  const bool is_ui_or_both_mode =
+      helpers::Compare<mobile_apis::InteractionMode::eType,
+                       helpers::EQ,
+                       helpers::ONE>(interaction_mode_,
+                                     mobile_apis::InteractionMode::BOTH,
+                                     mobile_apis::InteractionMode::MANUAL_ONLY);
+
+  if (is_ui_or_both_mode) {
+    if (vr_result_code_ == hmi_apis::Common_Result::ABORTED &&
+        ui_result_code_ == hmi_apis::Common_Result::UNSUPPORTED_RESOURCE) {
+      return mobile_apis::Result::UNSUPPORTED_RESOURCE;
+    }
+  }
+
+  return CommandRequestImpl::PrepareResultCodeForResponse(first, second);
+}
+
 bool PerformInteractionRequest::ProcessVRResponse(
     const smart_objects::SmartObject& message,
     smart_objects::SmartObject& msg_params) {


### PR DESCRIPTION
Usually ABORTED code has higher priority over other resuls, but for
PerformInteraction there is an exception. So in case VR returns ABORTED
and interation mode is BOTH or MANUAL_ONLY SDL has to wait for UI response and
consider only UI response.
Common interfaces have been override to cover that exception.