### PR TITLE
Fix SubscribeVehicleData general result in case of IGNORED resultCode

### DIFF
--- a/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -474,22 +474,26 @@ void SubscribeVehicleDataRequest::CheckVISubscriptions(
       out_info = "No data in the request";
     }
     out_result = false;
+    return;
   }
 
   if (0 == subscribed_items && !is_interface_not_available) {
     out_result_code = mobile_apis::Result::IGNORED;
     out_info = "Already subscribed on provided VehicleData.";
     out_result = false;
+    return;
   }
 
   if (is_everything_already_subscribed) {
-    out_result_code = vi_already_subscribed_by_this_app_.size()
-                          ? mobile_apis::Result::IGNORED
-                          : mobile_apis::Result::SUCCESS;
-    if (!(vi_already_subscribed_by_this_app_.empty())) {
+    if (vi_already_subscribed_by_this_app_.empty()) {
+      out_result_code = mobile_apis::Result::SUCCESS;
+      out_result = true;
+    } else {
+      out_result_code = mobile_apis::Result::IGNORED;
       out_info = "Already subscribed on some provided VehicleData.";
+      out_result = false;
     }
-    out_result = true;
+    return;
   }
 }
 


### PR DESCRIPTION
Fixes #1581

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests
ATF tests

### Summary
Fixed `SubscribeVehicleData` general result in case of IGNORED resultCode.
The problem was that result code for case when everyting is already subscribed not set to false in case of IGNORED result.

### Changelog
- Updated output result for `is_everything_already_subscribed` case
- Added `return` to avoid redundant checks when output result already set

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
