### PR TITLE
Replaces assert macro with logic in case of failed handshake

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1267,7 +1267,9 @@ bool ApplicationManagerImpl::OnHandshakeDone(
   using namespace helpers;
 
   ApplicationSharedPtr app = application(connection_key);
-  DCHECK_OR_RETURN(app, false);
+  if (!app) {
+    return false;
+  }
   if (Compare<SSLContext::HandshakeResult, EQ, ONE>(
           result,
           SSLContext::Handshake_Result_CertExpired,


### PR DESCRIPTION
Establishing of secure connection requires checking of application name and
application id which can be assigned only to already registered application.
Due to wrong mobile behavior (it starts handshake before RAI response received)
SDL triggers assertion on missing application. So it is replaced with logic
and in case application is not registered yet handshake will fail and no
secure connection will be established. Mobile can try to establish that
connection after application is registered.