### PR TITLE
Fix UnregisterAppInterface for not found app

### DIFF
--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -487,9 +487,11 @@ mobile_apis::Result::eType CommandRequestImpl::GetMobileResultCode(
 bool CommandRequestImpl::CheckAllowedParameters() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  // RegisterAppInterface should always be allowed
-  if (mobile_apis::FunctionID::RegisterAppInterfaceID ==
-      static_cast<mobile_apis::FunctionID::eType>(function_id())) {
+  // RegisterAppInterface and UnregisterAppInterface should always be allowed
+  const mobile_apis::FunctionID::eType func_id =
+      static_cast<mobile_apis::FunctionID::eType>(function_id());
+  if (mobile_apis::FunctionID::RegisterAppInterfaceID == func_id ||
+      mobile_apis::FunctionID::UnregisterAppInterfaceID == func_id) {
     return true;
   }
 


### PR DESCRIPTION
If an app is not found in SDL but the mobile side
sends UnregisterAppInterface, SDL creates the mobile
request but never runs it because the app is not found.
Then the request times out and the response to the
mobile side is `GENERIC_ERROR`. Now command will be
ran and the proper response of `APPLICATION_NOT_REGISTERED`
will be sent.