### PR TITLE
Fix RPC's success code in case of UNSUPPORTED_RESOURCE

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -107,6 +107,33 @@ std::string MergeInfos(const std::string& first,
                        const std::string& second,
                        const std::string& third);
 
+/**
+ * @brief IsResultCodeUnsupported check if overall result code of provided infos
+ * is UNSUPPORTED_RESOURCE
+ * @param first_iface_response - contains result_code from first HMI response
+ * and interface that returns response
+ * @param second_iface_response - contains result_code from second HMI response
+ * and interface that returns response
+ * @return true if overall result code is UNSUPPORTED_RESOURCE otherwise false
+ */
+bool IsResultCodeUnsupported(const ResponseInfo& first_iface_response,
+                             const ResponseInfo& second_iface_response);
+
+/**
+ * @brief IsResultCodeUnsupported check if overall result code of provided infos
+ * is UNSUPPORTED_RESOURCE
+ * @param first_iface_response - contains result_code from first HMI response
+ * and interface that returns response
+ * @param second_iface_response - contains result_code from second HMI response
+ * and interface that returns response
+ * @param third_iface_response - contains result_code from third HMI response
+ * and interface that returns response
+ * @return true if overall result code is UNSUPPORTED_RESOURCE otherwise false
+ */
+bool IsResultCodeUnsupported(const ResponseInfo& first_iface_response,
+                             const ResponseInfo& second_iface_response,
+                             const ResponseInfo& third_iface_response);
+
 class CommandRequestImpl : public CommandImpl,
                            public event_engine::EventObserver {
  public:
@@ -226,15 +253,16 @@ class CommandRequestImpl : public CommandImpl,
   /**
    * @brief Checks result code from HMI for splitted RPC
    * and returns parameter for sending to mobile app.
-   * @param first contains result_code from HMI response and
-   * interface that returns response
-   * @param second contains result_code from HMI response and
-   * interface that returns response
+   * @param out_first_iface_response contains result_code from first HMI
+   * response and interface that returns response
+   * @param out_second_iface_response contains result_code from second HMI
+   * response and interface that returns response
    * @return true if result code complies successful result code
    * otherwise returns false
    */
-  bool PrepareResultForMobileResponse(ResponseInfo& out_first,
-                                      ResponseInfo& out_second) const;
+  virtual bool PrepareResultForMobileResponse(
+      ResponseInfo& out_first_iface_response,
+      ResponseInfo& out_second_iface_response) const;
 
   /**
    * @brief If message from HMI contains returns this info
@@ -250,14 +278,15 @@ class CommandRequestImpl : public CommandImpl,
 
   /**
    * @brief Prepare result code for sending to mobile application
-   * @param first contains result_code from HMI response and
-   * interface that returns response
-   * @param second contains result_code from HMI response and
-   * interface that returns response.
+   * @param first_iface_response contains result_code from first HMI response
+   * and interface that returns response
+   * @param second_iface_response contains result_code from second HMI response
+   * and interface that returns response.
    * @return resulting code for sending to mobile application.
    */
-  mobile_apis::Result::eType PrepareResultCodeForResponse(
-      const ResponseInfo& first, const ResponseInfo& second);
+  virtual mobile_apis::Result::eType PrepareResultCodeForResponse(
+      const ResponseInfo& first_iface_response,
+      const ResponseInfo& second_iface_response);
 
  protected:
   /**

--- a/src/components/application_manager/include/application_manager/commands/mobile/alert_maneuver_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/alert_maneuver_request.h
@@ -83,6 +83,32 @@ class AlertManeuverRequest : public CommandRequestImpl {
    */
   bool PrepareResponseParameters(mobile_apis::Result::eType& result_code,
                                  std::string& return_info);
+
+  /**
+   * @brief Checks result code from HMI for splitted RPC
+   * and returns parameter for sending to mobile app.
+   * @param navigation_alert_info contains result_code from HMI response and
+   * interface that returns navi response
+   * @param tts_alert_info contains result_code from HMI response and
+   * interface that returns tts response
+   * @return true if result code complies successful result code
+   * otherwise returns false
+   */
+  bool PrepareResultForMobileResponse(ResponseInfo& navigation_alert_info,
+                                      ResponseInfo& tts_alert_info) const FINAL;
+
+  /**
+   * @brief Prepare result code for sending to mobile application
+   * @param navigation_alert_info contains result_code from HMI response and
+   * interface that returns navi response
+   * @param tts_alert_info contains result_code from HMI response and
+   * interface that returns tts response.
+   * @return resulting code for sending to mobile application.
+   */
+  mobile_apis::Result::eType PrepareResultCodeForResponse(
+      const ResponseInfo& navigation_alert_info,
+      const ResponseInfo& tts_alert_info) FINAL;
+
   /**
    * @brief Checks alert maneuver params(ttsChunks, ...).
    * When type is String there is a check on the contents \t\n \\t \\n

--- a/src/components/application_manager/include/application_manager/commands/mobile/alert_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/alert_request.h
@@ -137,6 +137,31 @@ class AlertRequest : public CommandRequestImpl {
   bool PrepareResponseParameters(mobile_apis::Result::eType& result_code,
                                  std::string& info);
 
+  /**
+   * @brief Checks result code from HMI for splitted RPC
+   * and returns parameter for sending to mobile app.
+   * @param ui_alert_info contains result_code from HMI response and
+   * interface that returns ui response
+   * @param tts_alert_info contains result_code from HMI response and
+   * interface that returns tts response
+   * @return true if result code complies successful result code
+   * otherwise returns false
+   */
+  bool PrepareResultForMobileResponse(ResponseInfo& ui_alert_info,
+                                      ResponseInfo& tts_alert_info) const FINAL;
+
+  /**
+   * @brief Prepare result code for sending to mobile application
+   * @param ui_alert_info contains result_code from HMI response and
+   * interface that returns ui response
+   * @param tts_alert_info contains result_code from HMI response and
+   * interface that returns tts response.
+   * @return resulting code for sending to mobile application.
+   */
+  mobile_apis::Result::eType PrepareResultCodeForResponse(
+      const ResponseInfo& ui_alert_info,
+      const ResponseInfo& tts_alert_info) FINAL;
+
   bool awaiting_ui_alert_response_;
   bool awaiting_tts_speak_response_;
   bool awaiting_tts_stop_speaking_response_;

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -93,6 +93,33 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
    */
   bool PrepareResponseParameters(mobile_apis::Result::eType& result_code,
                                  std::string& info);
+
+  /**
+   * @brief Checks result code from HMI for splitted RPC
+   * and returns parameter for sending to mobile app.
+   * @param ui_perform_info contains result_code from HMI response and
+   * interface that returns ui response
+   * @param tts_perform_info contains result_code from HMI response and
+   * interface that returns tts response
+   * @return true if result code complies successful result code
+   * otherwise returns false
+   */
+  bool PrepareResultForMobileResponse(
+      ResponseInfo& ui_perform_info,
+      ResponseInfo& tts_perform_info) const FINAL;
+
+  /**
+   * @brief Prepare result code for sending to mobile application
+   * @param ui_perform_info contains result_code from HMI response and
+   * interface that returns ui response
+   * @param tts_perform_info contains result_code from HMI response and
+   * interface that returns tts response.
+   * @return resulting code for sending to mobile application.
+   */
+  mobile_apis::Result::eType PrepareResultCodeForResponse(
+      const ResponseInfo& ui_perform_info,
+      const ResponseInfo& tts_perform_info) FINAL;
+
   /**
    * @brief Sends TTS Speak request
    */

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -109,13 +109,26 @@ bool CheckResultCode(const ResponseInfo& first, const ResponseInfo& second) {
   return false;
 }
 
-bool IsResultCodeUnsupported(const ResponseInfo& first,
-                             const ResponseInfo& second) {
-  return ((first.is_ok || first.is_invalid_enum) &&
-          second.is_unsupported_resource) ||
-         ((second.is_ok || second.is_invalid_enum) &&
-          first.is_unsupported_resource) ||
-         (first.is_unsupported_resource && second.is_unsupported_resource);
+bool IsResultCodeUnsupported(const ResponseInfo& first_iface_response,
+                             const ResponseInfo& second_iface_response) {
+  const bool is_first_unsupported =
+      (second_iface_response.is_ok || second_iface_response.is_invalid_enum) &&
+      first_iface_response.is_unsupported_resource;
+  const bool is_second_unsupported =
+      (first_iface_response.is_ok || first_iface_response.is_invalid_enum) &&
+      second_iface_response.is_unsupported_resource;
+  const bool is_both_unsupported =
+      first_iface_response.is_unsupported_resource &&
+      second_iface_response.is_unsupported_resource;
+
+  return is_first_unsupported || is_second_unsupported || is_both_unsupported;
+}
+
+bool IsResultCodeUnsupported(const ResponseInfo& first_iface_response,
+                             const ResponseInfo& second_iface_response,
+                             const ResponseInfo& third_iface_response) {
+  return IsResultCodeUnsupported(first_iface_response, second_iface_response) ||
+         IsResultCodeUnsupported(second_iface_response, third_iface_response);
 }
 
 struct DisallowedParamsInserter {
@@ -689,49 +702,61 @@ bool CommandRequestImpl::PrepareResultForMobileResponse(
 }
 
 bool CommandRequestImpl::PrepareResultForMobileResponse(
-    ResponseInfo& out_first, ResponseInfo& out_second) const {
+    ResponseInfo& out_first_iface_response,
+    ResponseInfo& out_second_iface_response) const {
   using namespace helpers;
 
-  out_first.is_ok = Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
-      out_first.result_code,
+  out_first_iface_response.is_ok =
+      Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+          out_first_iface_response.result_code,
+          hmi_apis::Common_Result::SUCCESS,
+          hmi_apis::Common_Result::WARNINGS,
+          hmi_apis::Common_Result::WRONG_LANGUAGE,
+          hmi_apis::Common_Result::RETRY,
+          hmi_apis::Common_Result::SAVED);
+
+  out_second_iface_response.is_ok =
+      Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+          out_second_iface_response.result_code,
       hmi_apis::Common_Result::SUCCESS,
       hmi_apis::Common_Result::WARNINGS,
       hmi_apis::Common_Result::WRONG_LANGUAGE,
       hmi_apis::Common_Result::RETRY,
       hmi_apis::Common_Result::SAVED);
 
-  out_second.is_ok = Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
-      out_second.result_code,
-      hmi_apis::Common_Result::SUCCESS,
-      hmi_apis::Common_Result::WARNINGS,
-      hmi_apis::Common_Result::WRONG_LANGUAGE,
-      hmi_apis::Common_Result::RETRY,
-      hmi_apis::Common_Result::SAVED);
+  out_first_iface_response.is_invalid_enum =
+      hmi_apis::Common_Result::INVALID_ENUM ==
+      out_first_iface_response.result_code;
 
-  out_first.is_invalid_enum =
-      hmi_apis::Common_Result::INVALID_ENUM == out_first.result_code;
+  out_second_iface_response.is_invalid_enum =
+      hmi_apis::Common_Result::INVALID_ENUM ==
+      out_second_iface_response.result_code;
 
-  out_second.is_invalid_enum =
-      hmi_apis::Common_Result::INVALID_ENUM == out_second.result_code;
+  out_first_iface_response.is_unsupported_resource =
+      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE ==
+      out_first_iface_response.result_code;
 
-  out_first.is_unsupported_resource =
-      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == out_first.result_code;
+  out_second_iface_response.is_unsupported_resource =
+      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE ==
+      out_second_iface_response.result_code;
 
-  out_second.is_unsupported_resource =
-      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == out_second.result_code;
-
-  out_first.interface_state =
+  out_first_iface_response.interface_state =
       application_manager_.hmi_interfaces().GetInterfaceState(
-          out_first.interface);
-  out_second.interface_state =
+          out_first_iface_response.interface);
+  out_second_iface_response.interface_state =
       application_manager_.hmi_interfaces().GetInterfaceState(
-          out_second.interface);
+          out_second_iface_response.interface);
 
-  bool result = (out_first.is_ok && out_second.is_ok) ||
-                (out_second.is_invalid_enum && out_first.is_ok) ||
-                (out_first.is_invalid_enum && out_second.is_ok);
-  result = result || CheckResultCode(out_first, out_second);
-  result = result || CheckResultCode(out_second, out_first);
+  bool result =
+      (out_first_iface_response.is_ok && out_second_iface_response.is_ok) ||
+      (out_second_iface_response.is_invalid_enum &&
+       out_first_iface_response.is_ok) ||
+      (out_first_iface_response.is_invalid_enum &&
+       out_second_iface_response.is_ok);
+  result = result ||
+           CheckResultCode(out_first_iface_response, out_second_iface_response);
+  result = result ||
+           CheckResultCode(out_second_iface_response, out_first_iface_response);
   return result;
 }
 
@@ -747,9 +772,10 @@ void CommandRequestImpl::GetInfo(
 }
 
 mobile_apis::Result::eType CommandRequestImpl::PrepareResultCodeForResponse(
-    const ResponseInfo& first, const ResponseInfo& second) {
+    const ResponseInfo& first_iface_response,
+    const ResponseInfo& second_iface_response) {
   mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
-  if (IsResultCodeUnsupported(first, second)) {
+  if (IsResultCodeUnsupported(first_iface_response, second_iface_response)) {
     result_code = mobile_apis::Result::UNSUPPORTED_RESOURCE;
   } else {
     // If response contains erroneous result code SDL need return erroneus
@@ -758,11 +784,11 @@ mobile_apis::Result::eType CommandRequestImpl::PrepareResultCodeForResponse(
         hmi_apis::Common_Result::INVALID_ENUM;
     hmi_apis::Common_Result::eType second_result =
         hmi_apis::Common_Result::INVALID_ENUM;
-    if (!first.is_unsupported_resource) {
-      first_result = first.result_code;
+    if (!first_iface_response.is_unsupported_resource) {
+      first_result = first_iface_response.result_code;
     }
-    if (!second.is_unsupported_resource) {
-      second_result = second.result_code;
+    if (!second_iface_response.is_unsupported_resource) {
+      second_result = second_iface_response.result_code;
     }
     result_code =
         MessageHelper::HMIToMobileResult(std::max(first_result, second_result));

--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -223,8 +223,9 @@ mobile_apis::Result::eType AlertManeuverRequest::PrepareResultCodeForResponse(
     const ResponseInfo& tts_alert_info) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  if (tts_alert_info.is_unsupported_resource &&
-      (navigation_alert_info.is_ok || navigation_alert_info.is_invalid_enum)) {
+  if ((navigation_alert_info.is_ok || navigation_alert_info.is_invalid_enum) &&
+      tts_alert_info.is_unsupported_resource &&
+      HmiInterfaces::STATE_AVAILABLE == tts_alert_info.interface_state) {
     return mobile_apis::Result::WARNINGS;
   }
 

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -602,12 +602,13 @@ TEST_F(PerformAudioPassThruRequestTest,
       hmi_apis::FunctionID::UI_PerformAudioPassThru);
 
   (*message_)[am::strings::params][am::hmi_response::code] =
-      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE;
-  event_speak.set_smart_object(*message_);
-
-  (*message_)[am::strings::params][am::hmi_response::code] =
       hmi_apis::Common_Result::SUCCESS;
   event_perform.set_smart_object(*message_);
+
+  (*message_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE;
+  (*message_)[am::strings::msg_params][am::strings::info] = return_info;
+  event_speak.set_smart_object(*message_);
 
   ON_CALL(hmi_interfaces_, GetInterfaceState(_))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));


### PR DESCRIPTION
Fixed Alert, AlertManeuver, PerformAudioPassThru success code in case of `UNSUPPORTED_RESOURCE`. The root cause of problem here is that SDL does not check specific case for this result code for RPC with two or more interfaces and just return wrong success result code.

In this pull request:
- Added overriden functions `PrepareResultForMobileResponse/PrepareResultCodeForResponse`
to cover specific cases for listed RPCs
- Updated unit test expectations for `PerformAudioPassThruRequestTest`

**Note**
Some changes are from PR #1567 and will disappear after rebase.