### PR TITLE
Change navigationText field name in UpdateTurnList request

### DIFF
--- a/src/components/application_manager/src/commands/mobile/update_turn_list_request.cc
+++ b/src/components/application_manager/src/commands/mobile/update_turn_list_request.cc
@@ -122,7 +122,7 @@ void UpdateTurnListRequest::Run() {
         msg_params[strings::turn_list][i].erase(hmi_request::navi_text);
         msg_params[strings::turn_list][i][hmi_request::navi_text]
                   [hmi_request::field_name] = static_cast<int>(
-                      hmi_apis::Common_TextFieldName::turnText);
+                      hmi_apis::Common_TextFieldName::navigationText);
         msg_params[strings::turn_list][i][hmi_request::navi_text]
                   [hmi_request::field_text] = navigation_text;
       }


### PR DESCRIPTION
`turnText` field name is legacy and should be replaced with `navigationText`