### PR TITLE
Fix CMessageBroker invalid JSON object processing

### DIFF
--- a/src/3rd_party-static/message_broker/src/client/mb_controller.cpp
+++ b/src/3rd_party-static/message_broker/src/client/mb_controller.cpp
@@ -6,7 +6,7 @@
 
 #include "mb_controller.hpp"
 
-#include "MBDebugHelper.h" 
+#include "MBDebugHelper.h"
 #include "CMessageBroker.hpp"
 
 namespace NsMessageBroker
@@ -45,7 +45,7 @@ namespace NsMessageBroker
             return recv;
          }
          std::string wmes = m_receiverWriter.write(root);
-         DBG_MSG(("Parsed JSON string:%s; length: %d\n", wmes.c_str(), wmes.length()));
+         DBG_MSG(("Parsed JSON string:%s; length: %zu\n", wmes.c_str(), wmes.length()));
          DBG_MSG(("Buffer is:%s\n", m_receivingBuffer.c_str()));
          ssize_t beginpos = m_receivingBuffer.find(wmes);
          if (-1 != beginpos)
@@ -125,7 +125,7 @@ namespace NsMessageBroker
       }
       int bytesSent = Send(mes);
       bytesSent = bytesSent; // to prevent compiler warnings in case DBG_MSG off
-      DBG_MSG(("Length:%d, Sent: %d bytes\n", mes.length(), bytesSent));
+      DBG_MSG(("Length: %zu, Sent: %d bytes\n", mes.length(), bytesSent));
    }
 
    std::string CMessageBrokerController::findMethodById(std::string id)
@@ -153,7 +153,7 @@ namespace NsMessageBroker
          return mControllersIdCurrent = mControllersIdStart;
       }
    }
-   
+
    void CMessageBrokerController::prepareMessage(Json::Value& root)
    {
       root["jsonrpc"] = "2.0";
@@ -286,11 +286,11 @@ namespace NsMessageBroker
    {
       DBG_MSG(("CMessageBrokerController::checkMessage()\n"));
       Json::Value err;
-   
+
       try
       {
          /* check the JSON-RPC version => 2.0 */
-         if (!root.isObject() || !root.isMember("jsonrpc") || root["jsonrpc"] != "2.0") 
+         if (!root.isObject() || !root.isMember("jsonrpc") || root["jsonrpc"] != "2.0")
          {
             error["id"] = Json::Value::null;
             error["jsonrpc"] = "2.0";

--- a/src/3rd_party-static/message_broker/src/lib_messagebroker/CMessageBroker.cpp
+++ b/src/3rd_party-static/message_broker/src/lib_messagebroker/CMessageBroker.cpp
@@ -458,12 +458,22 @@ void CMessageBroker::onMessageReceived(int fd, std::string& aJSONData, bool tryH
          * It can be a coincidence of course, but we have to give it a try. */
         return;
       } else if ('{' == aJSONData[0]) {
-        DBG_MSG_ERROR((" Incomplete JSON object probably.\n"));
+        const bool is_object = true;
+        const size_t next_object_pos =
+            p->jumpOverJSONObjectOrArray(is_object, aJSONData);
+
+        if (next_object_pos != std::string::npos) {
+          DBG_MSG_ERROR(("Invalid JSON object probably. Skipping.\n"));
+          aJSONData.erase(0, next_object_pos);
+          DBG_MSG(("Buffer after cut is: '%s'\n", aJSONData.c_str()));
+          continue;
+        }
+        DBG_MSG_ERROR(("Incomplete JSON object probably.\n"));
         return;
       } else {
-        DBG_MSG_ERROR((" Step in the buffer and try again...\n"));
+        DBG_MSG_ERROR(("Step in the buffer and try again...\n"));
         aJSONData.erase(0, 1);
-        DBG_MSG_ERROR(("Buffer after cut is: '%s'\n", aJSONData.c_str()));
+        DBG_MSG(("Buffer after cut is: '%s'\n", aJSONData.c_str()));
         continue;
       }
 

--- a/src/3rd_party-static/message_broker/src/lib_messagebroker/CMessageBroker.cpp
+++ b/src/3rd_party-static/message_broker/src/lib_messagebroker/CMessageBroker.cpp
@@ -444,13 +444,13 @@ void CMessageBroker::onMessageReceived(int fd, std::string& aJSONData, bool tryH
   while (! aJSONData.empty()) {
     Json::Value root;
     if ((! p->m_reader.parse(aJSONData, root)) || root.isNull()) {
-      DBG_MSG_ERROR(("Unable to parse JSON!"));
+      DBG_MSG_ERROR(("Unable to parse JSON!\n"));
       if (! tryHard) {
         return;
       }
       uint8_t first_byte = static_cast<uint8_t>(aJSONData[0]);
       if ((first_byte <= 0x08) || ((first_byte >= 0x80) && (first_byte <= 0x88))) {
-        DBG_MSG((" There is an unparsed websocket header probably.\n"));
+        DBG_MSG(("There is an unparsed websocket header probably.\n"));
         /* Websocket headers can have FIN flag set in the first byte (0x80).
          * Then there are 3 zero bits and 4 bits for opcode (from 0x00 to 0x0A).
          * But actually we don't use opcodes above 0x08.
@@ -505,7 +505,7 @@ void CMessageBroker::Test() {
       return;
     }
     std::string wmes = p->m_recieverWriter.write(root);
-    DBG_MSG(("Parsed JSON string:%s; length: %d\n", wmes.c_str(), wmes.length()));
+    DBG_MSG(("Parsed JSON string:%s; length: %zu\n", wmes.c_str(), wmes.length()));
     DBG_MSG(("Buffer is:%s\n", ReceivingBuffer.c_str()));
     ssize_t beginpos = ReceivingBuffer.find(wmes);
     ReceivingBuffer.erase(0, beginpos + wmes.length());
@@ -853,7 +853,7 @@ void CMessageBroker_Private::sendJsonMessage(int fd, Json::Value message) {
       DBG_MSG_ERROR(("Message hasn't been sent!\n"));
       return;
     }
-    DBG_MSG(("Length:%d, Sent: %d bytes\n", mes.length(), retVal));
+    DBG_MSG(("Length: %zu, Sent: %d bytes\n", mes.length(), retVal));
   } else {
     DBG_MSG_ERROR(("mpSender NULL pointer\n"));
   }

--- a/src/3rd_party-static/message_broker/src/lib_messagebroker/CMessageBrokerRegistry.cpp
+++ b/src/3rd_party-static/message_broker/src/lib_messagebroker/CMessageBrokerRegistry.cpp
@@ -10,7 +10,7 @@
 #include <vector>
 #include <string>
 
-namespace NsMessageBroker 
+namespace NsMessageBroker
 {
    CMessageBrokerRegistry::CMessageBrokerRegistry()
    {
@@ -43,7 +43,7 @@ namespace NsMessageBroker
          DBG_MSG(("Controller already exists!\n"));
       }
 
-      DBG_MSG(("Count of controllers: %d\n", mControllersList.size()));
+      DBG_MSG(("Count of controllers: %zu\n", mControllersList.size()));
       return result;
    }
 
@@ -64,7 +64,7 @@ namespace NsMessageBroker
             DBG_MSG(("No such controller in the list!\n"));
             return;
          }
-         DBG_MSG(("Count of controllers: %d\n", mControllersList.size()));
+         DBG_MSG(("Count of controllers: %zu\n", mControllersList.size()));
       }
       removeSubscribersByDescriptor(fd);
    }
@@ -124,7 +124,7 @@ namespace NsMessageBroker
          mSubscribersList.insert(std::map <std::string, int>::value_type(name, fd));
       }
 
-      DBG_MSG(("Count of subscribers: %d\n", mSubscribersList.size()));
+      DBG_MSG(("Count of subscribers: %zu\n", mSubscribersList.size()));
       return result;
    }
 
@@ -146,7 +146,7 @@ namespace NsMessageBroker
            }
        }
 
-       DBG_MSG(("Count of subscribers: %d\n", mSubscribersList.size()));
+       DBG_MSG(("Count of subscribers: %zu\n", mSubscribersList.size()));
    }
 
    int CMessageBrokerRegistry::getDestinationFd(std::string name)

--- a/src/3rd_party-static/message_broker/src/lib_messagebroker/websocket_handler.cpp
+++ b/src/3rd_party-static/message_broker/src/lib_messagebroker/websocket_handler.cpp
@@ -19,7 +19,7 @@
 #include "libMBDebugHelper.h"
 #include "md5.h"
 
-namespace NsMessageBroker 
+namespace NsMessageBroker
 {
 
    unsigned int CWebSocketHandler::parseWebSocketDataLength(
@@ -576,43 +576,43 @@ namespace NsMessageBroker
 
       return 0;
    }
-   
+
    rawBytes CWebSocketHandler::handshake_hybi00(const std::string &key1, const std::string &key2, const rawBytes &key3)
    {
       if (key3.size() < 8)
       {
-         DBG_MSG_ERROR(("key3's size is %d, less than 8 bytes\n", key3.size()));
+         DBG_MSG_ERROR(("key3's size is %zu, less than 8 bytes\n", key3.size()));
          return rawBytes();
       }
-      
+
       unsigned long number1 = extractNumber(key1);
       unsigned long number2 = extractNumber(key2);
       DBG_MSG(("number1 is %ld, number2 is %ld\n", number1, number2));
-      
+
       if ((number1 == 0) || (number2 == 0))
       {
          return rawBytes();
       }
-      
+
       // represent the numbers in big-endian format (network-byte order)
       unsigned long bigEndianNumber1 = htonl(number1);
       unsigned long bigEndianNumber2 = htonl(number2);
-      
+
       // the temporary key consists of bytes of the first and second numbers
       // and the key3
       rawBytes key(8);
       memcpy(&key[0], &bigEndianNumber1, 4);
       memcpy(&key[4], &bigEndianNumber2, 4);
       key.insert(key.end(), key3.begin(), key3.begin() + 8);
-      
+
       MD5 md5(std::string(key.begin(), key.end()));
       char digest[16];
       md5.getdigest(digest);
       rawBytes resultBytes(&digest[0], &digest[16]);
-      
+
       return resultBytes;
    }
-   
+
    unsigned long CWebSocketHandler::extractNumber(const std::string &key) const
    {
       // leave digits only
@@ -631,9 +631,9 @@ namespace NsMessageBroker
             keyDigits += keyChar;
          }
       }
-      
+
       unsigned long result = 0;
-      
+
       // convert string to number
       long long numberKey;
       if (std::stringstream(keyDigits) >> numberKey)
@@ -659,9 +659,9 @@ namespace NsMessageBroker
       {
          // couldn't convert
       }
-      
+
       return result;
    }
-   
+
 } /* namespace NsMessageBroker */
 

--- a/src/3rd_party-static/message_broker/src/server/mb_tcpserver.cpp
+++ b/src/3rd_party-static/message_broker/src/server/mb_tcpserver.cpp
@@ -64,7 +64,7 @@ bool TcpServer::Recv(int fd) {
 
   std::vector<char> buf;
   buf.reserve(RECV_BUFFER_LENGTH + pReceivingBuffer->size());
-  DBG_MSG(("Left in  pReceivingBuffer: %d \n",
+  DBG_MSG(("Left in  pReceivingBuffer: %zu\n",
            pReceivingBuffer->size()));
   buf.assign(pReceivingBuffer->c_str(),
              pReceivingBuffer->c_str() + pReceivingBuffer->size());
@@ -102,7 +102,7 @@ bool TcpServer::Recv(int fd) {
     }
 
     *pReceivingBuffer = std::string(&buf[0], nb);
-    DBG_MSG(("pReceivingBuffer before onMessageReceived:%d : %s\n",
+    DBG_MSG(("pReceivingBuffer before onMessageReceived: %zu: %s\n",
              pReceivingBuffer->size(), pReceivingBuffer->c_str()));
 
     // we need to check for websocket handshake


### PR DESCRIPTION
Fixed CMessageBroker invalid JSON object processing. The root cause of the problem is that CMessageBroker drops whole message buffer when it receives some invalid json objects. It seems to be not correct because message buffer could contain also some valid json objects.

For example CMessageBroker receives buffer where:
`{valid_response_1}{invalid_response_2}{valid_response_3}...`
Then it parse JSON objects one by one until buffer become empty. `{valid_response_1}` will be parsed OK and SDL will receive parsed message, but `{invalid_response_2}` will not be parsed OK and CMessageBroker will not continue parsing objects after that. Then if CMessageBroker receives some `{new_valid_response}` and parse it OK, it will drop the whole buffer with `{invalid_response_2}{valid_response_3}...` so SDL will not receive parsed messages of `{valid_response_3}` and all others in buffer and this is a reason why SDL will not react on them.

In this commit:
- In case of invalid JSON object received CMessageBroker tries to find next JSON object after current invalid and if it was found, current invalid JSON object will be dropped and parsing will be continued
- Fixed string formatting in MB debug messages to avoid compile errors when MB logs are enabled