### PR TITLE
Fixes hash update logic on unavailable UI interface

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -112,13 +112,36 @@ class CommandRequestImpl : public CommandImpl,
  public:
   enum RequestState { kAwaitingHMIResponse = 0, kTimedOut, kCompleted };
 
+  /**
+   * @brief The HashUpdateMode enum defines whether request has to update
+   * hash after its execution is finished
+   */
+  enum HashUpdateMode { kSkipHashUpdate, kDoHashUpdate };
+
   CommandRequestImpl(const MessageSharedPtr& message,
                      ApplicationManager& application_manager);
-  virtual ~CommandRequestImpl();
-  virtual bool CheckPermissions();
-  virtual bool Init();
-  virtual bool CleanUp();
-  virtual void Run();
+
+  ~CommandRequestImpl();
+
+  /**
+   * @brief Checks command permissions according to policy table
+   */
+  bool CheckPermissions() OVERRIDE;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() OVERRIDE;
+
+  /**
+   * @brief Cleanup all resources used by command
+   **/
+  bool CleanUp() OVERRIDE;
+
+  /**
+   * @brief Execute corresponding command by calling the action on reciever
+   **/
+  void Run() OVERRIDE;
 
   /*
    * @brief Function is called by RequestController when request execution time
@@ -271,6 +294,12 @@ class CommandRequestImpl : public CommandImpl,
   CommandParametersPermissions parameters_permissions_;
   CommandParametersPermissions removed_parameters_permissions_;
 
+  /**
+   * @brief hash_update_mode_ Defines whether request must update hash value of
+   * application or not
+   */
+  HashUpdateMode hash_update_mode_;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(CommandRequestImpl);
 
@@ -292,6 +321,19 @@ class CommandRequestImpl : public CommandImpl,
   bool ProcessHMIInterfacesAvailability(
       const uint32_t hmi_correlation_id,
       const hmi_apis::FunctionID::eType& function_id);
+
+  /**
+   * @brief UpdateHash updates hash field for application and sends
+   * OnHashChanged notification to mobile side in case of approriate hash mode
+   * is set
+   */
+  void UpdateHash();
+
+  /**
+   * @brief is_success_result_ Defines whether request succeded, at the moment
+   * it is value of 'success' field of appropriate response sent to mobile
+   */
+  bool is_success_result_;
 };
 
 }  // namespace commands

--- a/src/components/application_manager/include/application_manager/commands/mobile/add_command_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/add_command_request.h
@@ -60,25 +60,30 @@ class AddCommandRequest : public CommandRequestImpl {
   /**
    * @brief AddCommandRequest class destructor
    **/
-  virtual ~AddCommandRequest();
+  ~AddCommandRequest();
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
 
   /**
    * @brief Interface method that is called whenever new event received
    *
    * @param event The received event
    */
-  void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) FINAL;
 
   /**
    * @brief Function is called by RequestController when request execution time
    * has exceed it's limit
    */
-  virtual void onTimeOut();
+  void onTimeOut() FINAL;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
 
  private:
   /*

--- a/src/components/application_manager/include/application_manager/commands/mobile/add_sub_menu_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/add_sub_menu_request.h
@@ -57,19 +57,24 @@ class AddSubMenuRequest : public CommandRequestImpl {
   /**
    * @brief AddSubMenuRequest class destructor
    **/
-  virtual ~AddSubMenuRequest();
+  ~AddSubMenuRequest();
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
 
   /**
    * @brief Interface method that is called whenever new event received
    *
    * @param event The received event
    */
-  void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) FINAL;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
 
  private:
   /*

--- a/src/components/application_manager/include/application_manager/commands/mobile/create_interaction_choice_set_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/create_interaction_choice_set_request.h
@@ -64,31 +64,36 @@ class CreateInteractionChoiceSetRequest : public CommandRequestImpl {
   /**
    * @brief CreateInteractionChoiceSetRequest class destructor
    **/
-  virtual ~CreateInteractionChoiceSetRequest();
+  ~CreateInteractionChoiceSetRequest();
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
 
   /**
    * @brief Interface method that is called whenever new event received
    *
    * @param event The received event
    */
-  virtual void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) FINAL;
 
   /**
    * @brief Function is called by RequestController when request execution time
    * has exceed it's limit
    */
-  virtual void onTimeOut();
+  void onTimeOut() FINAL;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
+
+ private:
   /**
    * @brief DeleteChoices allows to walk through the sent commands collection
    * in order to sent appropriate DeleteCommand request.
    */
-
- private:
   void DeleteChoices();
 
   /**

--- a/src/components/application_manager/include/application_manager/commands/mobile/delete_command_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/delete_command_request.h
@@ -59,19 +59,24 @@ class DeleteCommandRequest : public CommandRequestImpl {
   /**
    * @brief DeleteCommandRequest class destructor
    **/
-  virtual ~DeleteCommandRequest();
+  ~DeleteCommandRequest();
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
 
   /**
    * @brief Interface method that is called whenever new event received
    *
    * @param event The received event
    */
-  void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) FINAL;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(DeleteCommandRequest);

--- a/src/components/application_manager/include/application_manager/commands/mobile/delete_interaction_choice_set_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/delete_interaction_choice_set_request.h
@@ -58,12 +58,17 @@ class DeleteInteractionChoiceSetRequest : public CommandRequestImpl {
   /**
    * @brief DeleteInteractionChoiceSetRequest class destructor
    **/
-  virtual ~DeleteInteractionChoiceSetRequest();
+  ~DeleteInteractionChoiceSetRequest();
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
 
  private:
   /*

--- a/src/components/application_manager/include/application_manager/commands/mobile/delete_sub_menu_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/delete_sub_menu_request.h
@@ -58,19 +58,24 @@ class DeleteSubMenuRequest : public CommandRequestImpl {
   /**
    * @brief DeleteSubMenuRequest class destructor
    **/
-  virtual ~DeleteSubMenuRequest();
+  ~DeleteSubMenuRequest();
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
 
   /**
    * @brief Interface method that is called whenever new event received
    *
    * @param event The received event
    */
-  void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) FINAL;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
 
  private:
   /*

--- a/src/components/application_manager/include/application_manager/commands/mobile/reset_global_properties_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/reset_global_properties_request.h
@@ -58,19 +58,24 @@ class ResetGlobalPropertiesRequest : public CommandRequestImpl {
   /**
    * @brief ResetGlobalPropertiesRequest class destructor
    **/
-  virtual ~ResetGlobalPropertiesRequest();
+  ~ResetGlobalPropertiesRequest();
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
 
   /**
    * @brief Interface method that is called whenever new event received
    *
    * @param event The received event
    */
-  void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) FINAL;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
 
  private:
   /*

--- a/src/components/application_manager/include/application_manager/commands/mobile/set_global_properties_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/set_global_properties_request.h
@@ -57,19 +57,24 @@ class SetGlobalPropertiesRequest : public CommandRequestImpl {
   /**
    * @brief SetGlobalPropertiesRequest class destructor
    **/
-  virtual ~SetGlobalPropertiesRequest();
+  ~SetGlobalPropertiesRequest();
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
 
   /**
    * @brief Interface method that is called whenever new event received
    *
    * @param event The received event
    */
-  void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) FINAL;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
 
  private:
   // Verify correctness VrHelptitle value

--- a/src/components/application_manager/include/application_manager/commands/mobile/subscribe_button_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/subscribe_button_request.h
@@ -58,12 +58,17 @@ class SubscribeButtonRequest : public CommandRequestImpl {
   /**
    * @brief SubscribeButtonRequest class destructor
    **/
-  virtual ~SubscribeButtonRequest();
+  ~SubscribeButtonRequest();
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
 
  private:
   /**

--- a/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
@@ -58,19 +58,24 @@ class SubscribeVehicleDataRequest : public CommandRequestImpl {
   /**
    * @brief SubscribeButtonCommandRequest class destructor
    **/
-  virtual ~SubscribeVehicleDataRequest();
+  ~SubscribeVehicleDataRequest();
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
 
   /**
    * @brief Interface method that is called whenever new event received
    *
    * @param event The received event
    */
-  virtual void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) FINAL;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
 
 #ifdef HMI_DBUS_API
  private:

--- a/src/components/application_manager/include/application_manager/commands/mobile/subscribe_way_points_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/subscribe_way_points_request.h
@@ -53,18 +53,23 @@ class SubscribeWayPointsRequest : public CommandRequestImpl {
   /**
    * \brief SubscribeWayPointsRequest class destructor
    **/
-  virtual ~SubscribeWayPointsRequest();
+  ~SubscribeWayPointsRequest();
 
   /**
    * @brief Execute command
    **/
-  virtual void Run() OVERRIDE;
+  void Run() FINAL;
   /**
    * @brief Interface method that is called whenever new event received
    *
    * @param event The received event
    */
-  virtual void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) FINAL;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(SubscribeWayPointsRequest);

--- a/src/components/application_manager/include/application_manager/commands/mobile/unsubscribe_button_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/unsubscribe_button_request.h
@@ -57,12 +57,17 @@ class UnsubscribeButtonRequest : public CommandRequestImpl {
   /**
    * @brief UnsubscribeButtonRequest class destructor
    **/
-  virtual ~UnsubscribeButtonRequest();
+  ~UnsubscribeButtonRequest() FINAL;
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
 
  private:
   /**

--- a/src/components/application_manager/include/application_manager/commands/mobile/unsubscribe_vehicle_data_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/unsubscribe_vehicle_data_request.h
@@ -58,19 +58,24 @@ class UnsubscribeVehicleDataRequest : public CommandRequestImpl {
   /**
    * @brief UnsubscribeVehicleDataRequest class destructor
    **/
-  virtual ~UnsubscribeVehicleDataRequest();
+  ~UnsubscribeVehicleDataRequest();
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
 
   /**
    * @brief Interface method that is called whenever new event received
    *
    * @param event The received event
    */
-  virtual void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) FINAL;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
 
 #ifdef HMI_DBUS_API
  private:
@@ -101,11 +106,6 @@ class UnsubscribeVehicleDataRequest : public CommandRequestImpl {
    * @param msg_params 'message_params' response section reference
    */
   void AddAlreadyUnsubscribedVI(smart_objects::SmartObject& response) const;
-
-  /**
-   * @brief Allows to update hash after sending response to mobile.
-   */
-  void UpdateHash() const;
 
   /**
    * @brief VI parameters which still being subscribed by another apps after

--- a/src/components/application_manager/include/application_manager/commands/mobile/unsubscribe_way_points_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/unsubscribe_way_points_request.h
@@ -50,18 +50,24 @@ class UnSubscribeWayPointsRequest : public CommandRequestImpl {
   /**
    * \brief UnSubscribeWayPointsRequest class destructor
    **/
-  virtual ~UnSubscribeWayPointsRequest();
+  ~UnSubscribeWayPointsRequest();
 
   /**
    * @brief Execute command
    **/
-  virtual void Run() OVERRIDE;
+  void Run() FINAL;
+
   /**
    * @brief Interface method that is called whenever new event received
    *
    * @param event The received event
    */
-  virtual void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) FINAL;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UnSubscribeWayPointsRequest);

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -147,11 +147,15 @@ CommandRequestImpl::CommandRequestImpl(const MessageSharedPtr& message,
                                        ApplicationManager& application_manager)
     : CommandImpl(message, application_manager)
     , EventObserver(application_manager.event_dispatcher())
-    , current_state_(kAwaitingHMIResponse) {}
+    , current_state_(kAwaitingHMIResponse)
+    , is_success_result_(false) {}
 
-CommandRequestImpl::~CommandRequestImpl() {}
+CommandRequestImpl::~CommandRequestImpl() {
+  UpdateHash();
+}
 
 bool CommandRequestImpl::Init() {
+  hash_update_mode_ = kSkipHashUpdate;
   return true;
 }
 
@@ -249,6 +253,8 @@ void CommandRequestImpl::SendResponse(
   response[strings::msg_params][strings::success] = success;
   response[strings::msg_params][strings::result_code] = result_code;
 
+  is_success_result_ = success;
+
   application_manager_.ManageMobileCommand(result, ORIGIN_SDL);
 }
 
@@ -306,6 +312,46 @@ bool CommandRequestImpl::ProcessHMIInterfacesAvailability(
     return false;
   }
   return true;
+}
+
+void CommandRequestImpl::UpdateHash() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (hash_update_mode_ == kSkipHashUpdate) {
+    LOG4CXX_DEBUG(logger_, "Hash update is disabled for " << function_id());
+    return;
+  }
+
+  if (HmiInterfaces::InterfaceState::STATE_NOT_RESPONSE ==
+      application_manager_.hmi_interfaces().GetInterfaceState(
+          HmiInterfaces::InterfaceID::HMI_INTERFACE_UI)) {
+    LOG4CXX_ERROR(logger_,
+                  "UI interface has not responded. Hash won't be updated.");
+    return;
+  }
+
+  if (!is_success_result_) {
+    LOG4CXX_WARN(logger_, "Command is not succeeded. Hash won't be updated.");
+    return;
+  }
+
+  ApplicationSharedPtr application =
+      application_manager_.application(connection_key());
+  if (!application) {
+    LOG4CXX_ERROR(logger_,
+                  "Application with connection key "
+                      << connection_key()
+                      << " not found. Not able to update hash.");
+    return;
+  }
+
+  LOG4CXX_DEBUG(
+      logger_,
+      "Updating hash for application with connection key "
+          << connection_key() << " while processing function id "
+          << MessageHelper::StringifiedFunctionID(
+                 static_cast<mobile_api::FunctionID::eType>(function_id())));
+
+  application->UpdateHash();
 }
 
 uint32_t CommandRequestImpl::SendHMIRequest(

--- a/src/components/application_manager/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_command_request.cc
@@ -64,6 +64,11 @@ void AddCommandRequest::onTimeOut() {
   CommandRequestImpl::onTimeOut();
 }
 
+bool AddCommandRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
+}
+
 void AddCommandRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
@@ -492,10 +497,6 @@ void AddCommandRequest::on_event(const event_engine::Event& event) {
                result_code,
                info.empty() ? NULL : info.c_str(),
                &(message[strings::msg_params]));
-
-  if (result) {
-    application->UpdateHash();
-  }
 }
 
 bool AddCommandRequest::IsPendingResponseExist() {

--- a/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/add_sub_menu_request.cc
@@ -128,9 +128,6 @@ void AddSubMenuRequest::on_event(const event_engine::Event& event) {
                    MessageHelper::HMIToMobileResult(result_code),
                    response_info.empty() ? NULL : response_info.c_str(),
                    &(message[strings::msg_params]));
-      if (result) {
-        application->UpdateHash();
-      }
       break;
     }
     default: {
@@ -138,6 +135,11 @@ void AddSubMenuRequest::on_event(const event_engine::Event& event) {
       return;
     }
   }
+}
+
+bool AddSubMenuRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
 }
 
 bool AddSubMenuRequest::CheckSubMenuName() {

--- a/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -384,6 +384,11 @@ void CreateInteractionChoiceSetRequest::onTimeOut() {
       connection_key(), correlation_id(), function_id());
 }
 
+bool CreateInteractionChoiceSetRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
+}
+
 void CreateInteractionChoiceSetRequest::DeleteChoices() {
   LOG4CXX_AUTO_TRACE(logger_);
 
@@ -419,14 +424,6 @@ void CreateInteractionChoiceSetRequest::OnAllHMIResponsesReceived() {
 
   if (!error_from_hmi_) {
     SendResponse(true, mobile_apis::Result::SUCCESS);
-
-    ApplicationSharedPtr application =
-        application_manager_.application(connection_key());
-    if (!application) {
-      LOG4CXX_ERROR(logger_, "NULL pointer");
-      return;
-    }
-    application->UpdateHash();
   } else {
     DeleteChoices();
   }

--- a/src/components/application_manager/src/commands/mobile/delete_command_request.cc
+++ b/src/components/application_manager/src/commands/mobile/delete_command_request.cc
@@ -201,9 +201,11 @@ void DeleteCommandRequest::on_event(const event_engine::Event& event) {
   }
   SendResponse(
       result, result_code, info.empty() ? NULL : info.c_str(), &msg_params);
-  if (result) {
-    application->UpdateHash();
-  }
+}
+
+bool DeleteCommandRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
 }
 
 bool DeleteCommandRequest::IsPendingResponseExist() {

--- a/src/components/application_manager/src/commands/mobile/delete_interaction_choice_set_request.cc
+++ b/src/components/application_manager/src/commands/mobile/delete_interaction_choice_set_request.cc
@@ -90,9 +90,11 @@ void DeleteInteractionChoiceSetRequest::Run() {
   // Checking of HMI responses will be implemented with APPLINK-14600
   const bool result = true;
   SendResponse(result, mobile_apis::Result::SUCCESS);
-  if (result) {
-    app->UpdateHash();
-  }
+}
+
+bool DeleteInteractionChoiceSetRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
 }
 
 bool DeleteInteractionChoiceSetRequest::ChoiceSetInUse(

--- a/src/components/application_manager/src/commands/mobile/delete_sub_menu_request.cc
+++ b/src/components/application_manager/src/commands/mobile/delete_sub_menu_request.cc
@@ -171,9 +171,6 @@ void DeleteSubMenuRequest::on_event(const event_engine::Event& event) {
                    MessageHelper::HMIToMobileResult(result_code),
                    response_info.empty() ? NULL : response_info.c_str(),
                    &(message[strings::msg_params]));
-      if (result) {
-        application->UpdateHash();
-      }
       break;
     }
     default: {
@@ -181,6 +178,11 @@ void DeleteSubMenuRequest::on_event(const event_engine::Event& event) {
       return;
     }
   }
+}
+
+bool DeleteSubMenuRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/reset_global_properties_request.cc
@@ -242,9 +242,6 @@ void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
   const smart_objects::SmartObject& message = event.smart_object();
 
-  ApplicationSharedPtr application =
-      application_manager_.application(connection_key());
-
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_SetGlobalProperties: {
       LOG4CXX_INFO(logger_, "Received UI_SetGlobalProperties event");
@@ -281,15 +278,11 @@ void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
                static_cast<mobile_apis::Result::eType>(result_code),
                response_info.empty() ? NULL : response_info.c_str(),
                &(message[strings::msg_params]));
+}
 
-  if (!application) {
-    LOG4CXX_ERROR(logger_, "NULL pointer");
-    return;
-  }
-
-  if (result) {
-    application->UpdateHash();
-  }
+bool ResetGlobalPropertiesRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
 }
 
 bool ResetGlobalPropertiesRequest::PrepareResponseParameters(

--- a/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_global_properties_request.cc
@@ -265,15 +265,11 @@ void SetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
                result_code,
                response_info.empty() ? NULL : response_info.c_str(),
                &(message[strings::msg_params]));
+}
 
-  if (!application) {
-    LOG4CXX_DEBUG(logger_, "NULL pointer.");
-    return;
-  }
-
-  if (result) {
-    application->UpdateHash();
-  }
+bool SetGlobalPropertiesRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
 }
 
 bool SetGlobalPropertiesRequest::PrepareResponseParameters(

--- a/src/components/application_manager/src/commands/mobile/subscribe_button_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_button_request.cc
@@ -86,10 +86,11 @@ void SubscribeButtonRequest::Run() {
 
   const bool is_succedeed = true;
   SendResponse(is_succedeed, mobile_apis::Result::SUCCESS);
+}
 
-  if (is_succedeed) {
-    app->UpdateHash();
-  }
+bool SubscribeButtonRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
 }
 
 bool SubscribeButtonRequest::IsSubscriptionAllowed(

--- a/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -264,11 +264,12 @@ void SubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
                result_code,
                response_info.empty() ? NULL : response_info.c_str(),
                &(message[strings::msg_params]));
-
-  if (is_succeeded) {
-    app->UpdateHash();
-  }
 #endif  // #ifdef HMI_DBUS_API
+}
+
+bool SubscribeVehicleDataRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
 }
 
 void SubscribeVehicleDataRequest::AddAlreadySubscribedVI(

--- a/src/components/application_manager/src/commands/mobile/subscribe_way_points_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_way_points_request.cc
@@ -33,7 +33,6 @@ void SubscribeWayPointsRequest::Run() {
   if (application_manager_.IsAnyAppSubscribedForWayPoints()) {
     application_manager_.SubscribeAppForWayPoints(app->app_id());
     SendResponse(true, mobile_apis::Result::SUCCESS);
-    app->UpdateHash();
     return;
   }
 
@@ -62,9 +61,6 @@ void SubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
                    MessageHelper::HMIToMobileResult(result_code),
                    response_info.empty() ? NULL : response_info.c_str(),
                    &(message[strings::msg_params]));
-      if (result) {
-        app->UpdateHash();
-      }
       break;
     }
     default: {
@@ -72,6 +68,11 @@ void SubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
       break;
     }
   }
+}
+
+bool SubscribeWayPointsRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_button_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_button_request.cc
@@ -70,7 +70,11 @@ void UnsubscribeButtonRequest::Run() {
 
   SendUnsubscribeButtonNotification();
   SendResponse(true, mobile_apis::Result::SUCCESS);
-  app->UpdateHash();
+}
+
+bool UnsubscribeButtonRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
 }
 
 void UnsubscribeButtonRequest::SendUnsubscribeButtonNotification() {

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -342,9 +342,15 @@ void UnsubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
                response_info.empty() ? NULL : response_info.c_str(),
                &(message[strings::msg_params]));
   if (result) {
-    UpdateHash();
+    application_manager_.TerminateRequest(
+        connection_key(), correlation_id(), function_id());
   }
 #endif  // #ifdef HMI_DBUS_API
+}
+
+bool UnsubscribeVehicleDataRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
 }
 
 struct SubscribedToIVIPredicate {
@@ -385,21 +391,6 @@ void UnsubscribeVehicleDataRequest::AddAlreadyUnsubscribedVI(
     response[*it_another_app][strings::result_code] =
         VehicleDataResultCode::VDRC_SUCCESS;
   }
-}
-
-void UnsubscribeVehicleDataRequest::UpdateHash() const {
-  LOG4CXX_AUTO_TRACE(logger_);
-  ApplicationSharedPtr application =
-      application_manager_.application(connection_key());
-  if (application) {
-    application->UpdateHash();
-  } else {
-    LOG4CXX_ERROR(logger_,
-                  "Application with connection_key = " << connection_key()
-                                                       << " doesn't exist.");
-  }
-  application_manager_.TerminateRequest(
-      connection_key(), correlation_id(), function_id());
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_way_points_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_way_points_request.cc
@@ -55,9 +55,6 @@ void UnSubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
                    MessageHelper::HMIToMobileResult(result_code),
                    response_info.empty() ? NULL : response_info.c_str(),
                    &(message[strings::msg_params]));
-      if (result) {
-        app->UpdateHash();
-      }
       break;
     }
     default: {
@@ -65,6 +62,11 @@ void UnSubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
       break;
     }
   }
+}
+
+bool UnSubscribeWayPointsRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
 }
 
 }  // namespace commands

--- a/src/components/application_manager/test/commands/CMakeLists.txt
+++ b/src/components/application_manager/test/commands/CMakeLists.txt
@@ -44,6 +44,7 @@ include_directories(
 set(COMMANDS_TEST_DIR ${AM_TEST_DIR}/commands)
 
 file(GLOB SOURCES
+  ${COMMANDS_TEST_DIR}/*
   ${COMPONENTS_DIR}/application_manager/test/mock_message_helper.cc
   ${COMPONENTS_DIR}/application_manager/src/smart_object_keys.cc
   ${COMMANDS_TEST_DIR}/hmi/*

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -64,6 +64,7 @@ using ::testing::_;
 using ::testing::Return;
 using ::testing::SaveArg;
 using ::testing::DoAll;
+using ::testing::Mock;
 
 using ::utils::SharedPtr;
 using am::commands::MessageSharedPtr;
@@ -121,13 +122,18 @@ class CommandRequestImplTest
     CommandParametersPermissions& removed_parameters_permissions() {
       return removed_parameters_permissions_;
     }
+
+    void SetHashUpdateMode(HashUpdateMode mode) {
+      hash_update_mode_ = mode;
+    }
   };
 
-  CommandRequestImplTest() {
-    mock_message_helper_ = am::MockMessageHelper::message_helper_mock();
+  CommandRequestImplTest()
+      : mock_message_helper_(*am::MockMessageHelper::message_helper_mock()) {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }
   ~CommandRequestImplTest() {
-    mock_message_helper_ = NULL;
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }
 
   MockAppPtr InitAppSetDataAccessor(SharedPtr<ApplicationSet>& app_set) {
@@ -141,7 +147,7 @@ class CommandRequestImplTest
   }
 
   sync_primitives::Lock app_set_lock_;
-  am::MockMessageHelper* mock_message_helper_;
+  am::MockMessageHelper& mock_message_helper_;
 };
 
 typedef CommandRequestImplTest::UnwrappedCommandRequestImpl UCommandRequestImpl;
@@ -173,7 +179,7 @@ TEST_F(CommandRequestImplTest, OnTimeOut_StateAwaitingHMIResponse_SUCCESS) {
   CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
 
   MessageSharedPtr dummy_msg(CreateMessage());
-  EXPECT_CALL(*mock_message_helper_, CreateNegativeResponse(_, _, _, _))
+  EXPECT_CALL(mock_message_helper_, CreateNegativeResponse(_, _, _, _))
       .WillOnce(Return(dummy_msg));
   EXPECT_CALL(
       app_mngr_,
@@ -269,12 +275,11 @@ TEST_F(CommandRequestImplTest, SendHMIRequest_NoUseEvent_SUCCESS) {
 
   EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillOnce(Return(kCorrelationId));
-  MockHmiInterfaces hmi_interfaces;
-  EXPECT_CALL(app_mngr_, hmi_interfaces()).WillOnce(ReturnRef(hmi_interfaces));
-  EXPECT_CALL(hmi_interfaces, GetInterfaceFromFunction(_))
-      .WillOnce(Return(am::HmiInterfaces::HMI_INTERFACE_BasicCommunication));
-  EXPECT_CALL(hmi_interfaces, GetInterfaceState(_))
-      .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceFromFunction(_))
+      .WillRepeatedly(
+          Return(am::HmiInterfaces::HMI_INTERFACE_BasicCommunication));
+  EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
+      .WillRepeatedly(Return(am::HmiInterfaces::STATE_AVAILABLE));
   // Return `true` prevents call of `SendResponse` method;
   EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
 
@@ -287,12 +292,11 @@ TEST_F(CommandRequestImplTest, SendHMIRequest_UseEvent_SUCCESS) {
 
   EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillOnce(Return(kCorrelationId));
-  MockHmiInterfaces hmi_interfaces;
-  EXPECT_CALL(app_mngr_, hmi_interfaces()).WillOnce(ReturnRef(hmi_interfaces));
-  EXPECT_CALL(hmi_interfaces, GetInterfaceFromFunction(_))
-      .WillOnce(Return(am::HmiInterfaces::HMI_INTERFACE_BasicCommunication));
-  EXPECT_CALL(hmi_interfaces, GetInterfaceState(_))
-      .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceFromFunction(_))
+      .WillRepeatedly(
+          Return(am::HmiInterfaces::HMI_INTERFACE_BasicCommunication));
+  EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
+      .WillRepeatedly(Return(am::HmiInterfaces::STATE_AVAILABLE));
   // Return `true` prevents call of `SendResponse` method;
   EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
 
@@ -307,7 +311,7 @@ TEST_F(CommandRequestImplTest, RemoveDisallowedParameters_SUCCESS) {
   vehicle_data.insert(
       am::VehicleData::value_type(kMissedParam, am::VehicleDataType::MYKEY));
 
-  EXPECT_CALL(*mock_message_helper_, vehicle_data())
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
       .WillOnce(ReturnRef(vehicle_data));
 
   MessageSharedPtr msg = CreateMessage();
@@ -348,33 +352,24 @@ TEST_F(CommandRequestImplTest,
 }
 
 TEST_F(CommandRequestImplTest,
-       CheckAllowedParameters_NoAppWithSameConnectionKey_SUCCESS) {
-  MessageSharedPtr msg = CreateMessage();
-  (*msg)[strings::params][strings::connection_key] = kConnectionKey;
-
-  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
-
-  SharedPtr<ApplicationSet> app_set;
-  MockAppPtr app(InitAppSetDataAccessor(app_set));
-  EXPECT_CALL(*app, app_id()).WillOnce(Return(6u));
-  EXPECT_TRUE(command->CheckPermissions());
+       CheckAllowedParameters_NoAppWithSameConnectionKey_UNSUCCESS) {
+  MessageSharedPtr message = CreateMessage();
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(message);
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(MockAppPtr()));
+  EXPECT_FALSE(command->CheckPermissions());
 }
 
 TEST_F(CommandRequestImplTest, CheckAllowedParameters_NoMsgParamsMap_SUCCESS) {
-  MessageSharedPtr msg = CreateMessage();
-  (*msg)[strings::params][strings::connection_key] = kConnectionKey;
-  (*msg)[strings::msg_params] = 0u;
+  MockAppPtr mock_app = CreateMockApp();
+  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app));
 
-  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+  MessageSharedPtr message = CreateMessage();
+  (*message)[strings::msg_params] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
 
-  SharedPtr<ApplicationSet> app_set;
-  MockAppPtr app(InitAppSetDataAccessor(app_set));
-  EXPECT_CALL(*app, app_id()).WillOnce(Return(kConnectionKey));
-  EXPECT_CALL(*app, policy_app_id()).WillOnce(Return(kPolicyAppId));
-  EXPECT_CALL(*app, hmi_level())
-      .WillOnce(Return(mobile_apis::HMILevel::HMI_NONE));
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(message);
 
-  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _, _))
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
       .WillOnce(Return(kMobResultSuccess));
 
   EXPECT_TRUE(command->CheckPermissions());
@@ -382,32 +377,31 @@ TEST_F(CommandRequestImplTest, CheckAllowedParameters_NoMsgParamsMap_SUCCESS) {
 
 TEST_F(CommandRequestImplTest,
        CheckAllowedParameters_WrongPolicyPermissions_UNSUCCESS) {
-  MessageSharedPtr msg = CreateMessage();
-  (*msg)[strings::params][strings::connection_key] = kConnectionKey;
-  (*msg)[strings::msg_params] = 0u;
+  MockAppPtr mock_app = CreateMockApp();
+  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app));
 
-  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+  MessageSharedPtr message = CreateMessage();
+  (*message)[strings::msg_params] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
 
-  SharedPtr<ApplicationSet> app_set;
-  MockAppPtr app(InitAppSetDataAccessor(app_set));
-  EXPECT_CALL(*app, app_id()).Times(2).WillRepeatedly(Return(kConnectionKey));
-  EXPECT_CALL(*app, policy_app_id()).WillOnce(Return(kPolicyAppId));
-  EXPECT_CALL(*app, hmi_level())
-      .WillOnce(Return(mobile_apis::HMILevel::HMI_NONE));
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(message);
 
-  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _, _))
+  EXPECT_CALL(*mock_app, app_id())
+      .Times(1)
+      .WillRepeatedly(Return(kConnectionKey));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
       .WillOnce(Return(mobile_apis::Result::INVALID_ENUM));
 
-  MessageSharedPtr dummy_msg;
-  EXPECT_CALL(*mock_message_helper_,
-              CreateBlockedByPoliciesResponse(_, _, _, _))
-      .WillOnce(Return(dummy_msg));
+  EXPECT_CALL(mock_message_helper_, CreateBlockedByPoliciesResponse(_, _, _, _))
+      .WillOnce(Return(smart_objects::SmartObjectSPtr()));
+
   EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _));
   EXPECT_FALSE(command->CheckPermissions());
 }
 
 ACTION_P(GetArg3, output) {
-  *output = arg3;
+  *output = arg2;
 }
 
 TEST_F(CommandRequestImplTest, CheckAllowedParameters_MsgParamsMap_SUCCESS) {
@@ -417,15 +411,11 @@ TEST_F(CommandRequestImplTest, CheckAllowedParameters_MsgParamsMap_SUCCESS) {
 
   CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
 
-  SharedPtr<ApplicationSet> app_set;
-  MockAppPtr app(InitAppSetDataAccessor(app_set));
-  EXPECT_CALL(*app, app_id()).WillOnce(Return(kConnectionKey));
-  EXPECT_CALL(*app, policy_app_id()).WillOnce(Return(kPolicyAppId));
-  EXPECT_CALL(*app, hmi_level())
-      .WillOnce(Return(mobile_apis::HMILevel::HMI_NONE));
+  MockAppPtr app = CreateMockApp();
+  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
 
   RPCParams params;
-  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _, _))
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
       .WillOnce(DoAll(GetArg3(&params), Return(kMobResultSuccess)));
 
   EXPECT_TRUE(command->CheckPermissions());
@@ -438,7 +428,7 @@ TEST_F(CommandRequestImplTest, AddDisallowedParameters_SUCCESS) {
   vehicle_data.insert(am::VehicleData::value_type(kDisallowedParam1,
                                                   am::VehicleDataType::MYKEY));
 
-  EXPECT_CALL(*mock_message_helper_, vehicle_data())
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
       .WillOnce(ReturnRef(vehicle_data));
 
   MessageSharedPtr msg;
@@ -476,6 +466,9 @@ TEST_F(CommandRequestImplTest, SendResponse_SUCCESS) {
   EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _))
       .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
 
+  MockAppPtr mock_app;
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app));
+
   // Args do not affect on anything in this case;
   command->SendResponse(true, kMobResultSuccess, NULL, NULL);
 
@@ -490,7 +483,7 @@ TEST_F(CommandRequestImplTest,
   vehicle_data.insert(am::VehicleData::value_type(kDisallowedParam1,
                                                   am::VehicleDataType::MYKEY));
 
-  EXPECT_CALL(*mock_message_helper_, vehicle_data())
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
       .WillOnce(ReturnRef(vehicle_data));
 
   MessageSharedPtr msg = CreateMessage();
@@ -506,6 +499,9 @@ TEST_F(CommandRequestImplTest,
   EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _))
       .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
 
+  MockAppPtr mock_app;
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app));
+
   command->SendResponse(true, kMobResultSuccess, NULL, NULL);
 
   EXPECT_EQ(RequestState::kCompleted, command->current_state());
@@ -513,6 +509,81 @@ TEST_F(CommandRequestImplTest,
   EXPECT_TRUE((*result)[strings::msg_params].keyExists(strings::info));
   EXPECT_FALSE(
       (*result)[strings::msg_params][strings::info].asString().empty());
+}
+
+TEST_F(CommandRequestImplTest, HashUpdateAllowed_UpdateExpected) {
+  MessageSharedPtr msg;
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+  command->SetHashUpdateMode(CommandRequestImpl::HashUpdateMode::kDoHashUpdate);
+
+  MessageSharedPtr result;
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+
+  const bool is_succedeed = true;
+  command->SendResponse(is_succedeed, kMobResultSuccess, NULL, NULL);
+
+  MockAppPtr mock_app = CreateMockApp();
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app));
+  EXPECT_CALL(*mock_app, UpdateHash());
+
+  command.reset();
+}
+
+TEST_F(CommandRequestImplTest, HashUpdateDisallowed_HashUpdateNotExpected) {
+  MessageSharedPtr msg;
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+  command->SetHashUpdateMode(
+      CommandRequestImpl::HashUpdateMode::kSkipHashUpdate);
+
+  MessageSharedPtr result;
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+
+  const bool is_succedeed = true;
+  command->SendResponse(is_succedeed, kMobResultSuccess, NULL, NULL);
+
+  MockAppPtr mock_app = CreateMockApp();
+  EXPECT_CALL(*mock_app, UpdateHash()).Times(0);
+
+  command.reset();
+}
+
+TEST_F(CommandRequestImplTest, RequestFailed_HashUpdateNotExpected) {
+  MessageSharedPtr msg;
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+  command->SetHashUpdateMode(CommandRequestImpl::HashUpdateMode::kDoHashUpdate);
+
+  MessageSharedPtr result;
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+
+  const bool is_succedeed = false;
+  command->SendResponse(is_succedeed, kMobResultSuccess, NULL, NULL);
+
+  MockAppPtr mock_app = CreateMockApp();
+  EXPECT_CALL(*mock_app, UpdateHash()).Times(0);
+
+  command.reset();
+}
+
+TEST_F(CommandRequestImplTest, AppNotFound_HashUpdateNotExpected) {
+  MessageSharedPtr msg;
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+  command->SetHashUpdateMode(CommandRequestImpl::HashUpdateMode::kDoHashUpdate);
+
+  MessageSharedPtr result;
+  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+
+  const bool is_succedeed = true;
+  command->SendResponse(is_succedeed, kMobResultSuccess, NULL, NULL);
+
+  MockAppPtr mock_app = CreateMockApp();
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(MockAppPtr()));
+  EXPECT_CALL(*mock_app, UpdateHash()).Times(0);
+
+  command.reset();
 }
 
 }  // namespace command_request_impl

--- a/src/components/application_manager/test/commands/hmi/navi_audio_start_stream_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_audio_start_stream_request_test.cc
@@ -67,8 +67,6 @@ class AudioStartStreamRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
   AudioStartStreamRequestTest() {
-    ON_CALL(app_mngr_, hmi_interfaces())
-        .WillByDefault(ReturnRef(mock_hmi_interfaces_));
     ON_CALL(app_mngr_settings_, start_stream_retry_amount())
         .WillByDefault(ReturnRef(start_stream_retry_amount_));
     msg_ = CreateMessage();
@@ -78,7 +76,6 @@ class AudioStartStreamRequestTest
   std::pair<uint32_t, int32_t> start_stream_retry_amount_;
   MessageSharedPtr msg_;
   SharedPtr<AudioStartStreamRequest> command_;
-  MOCK(am::MockHmiInterfaces) mock_hmi_interfaces_;
 };
 
 TEST_F(AudioStartStreamRequestTest, Run_HmiInterfaceNotAvailable_NoRequest) {

--- a/src/components/application_manager/test/commands/hmi/navi_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_is_ready_request_test.cc
@@ -69,12 +69,9 @@ class NaviIsReadyRequestTest
   NaviIsReadyRequestTest() : command_(CreateCommand<NaviIsReadyRequest>()) {
     ON_CALL(app_mngr_, hmi_capabilities())
         .WillByDefault(ReturnRef(mock_hmi_capabilities_));
-    ON_CALL(app_mngr_, hmi_interfaces())
-        .WillByDefault(ReturnRef(mock_hmi_interfaces_));
   }
 
   NaviIsReadyRequestPtr command_;
-  MOCK(am::MockHmiInterfaces) mock_hmi_interfaces_;
   MOCK(application_manager_test::MockHMICapabilities) mock_hmi_capabilities_;
 };
 

--- a/src/components/application_manager/test/commands/hmi/navi_start_stream_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_start_stream_request_test.cc
@@ -67,8 +67,6 @@ class NaviStartStreamRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
   NaviStartStreamRequestTest() {
-    ON_CALL(app_mngr_, hmi_interfaces())
-        .WillByDefault(ReturnRef(mock_hmi_interfaces_));
     ON_CALL(app_mngr_settings_, start_stream_retry_amount())
         .WillByDefault(ReturnRef(start_stream_retry_amount_));
     msg_ = CreateMessage();
@@ -78,7 +76,6 @@ class NaviStartStreamRequestTest
   std::pair<uint32_t, int32_t> start_stream_retry_amount_;
   MessageSharedPtr msg_;
   SharedPtr<NaviStartStreamRequest> command_;
-  MOCK(am::MockHmiInterfaces) mock_hmi_interfaces_;
 };
 
 TEST_F(NaviStartStreamRequestTest, Run_HmiInterfaceNotAvailable_NoRequest) {

--- a/src/components/application_manager/test/commands/hmi/navi_stop_stream_requests_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_stop_stream_requests_test.cc
@@ -73,7 +73,6 @@ class NaviStopStreamRequestsTest
 
   MessageSharedPtr msg_;
   SharedPtr<Command> command_;
-  MOCK(am::MockHmiInterfaces) mock_hmi_interfaces_;
 };
 
 typedef testing::Types<commands::AudioStopStreamRequest,

--- a/src/components/application_manager/test/commands/hmi/ui_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_is_ready_request_test.cc
@@ -151,7 +151,6 @@ class UIIsReadyRequestTest
   }
 
   UIIsReadyRequestPtr command_;
-  am::MockHmiInterfaces mock_hmi_interfaces_;
   MockMessageHelper& mock_message_helper_;
   application_manager_test::MockHMICapabilities mock_hmi_capabilities_;
   policy_test::MockPolicyHandlerInterface mock_policy_handler_interface_;

--- a/src/components/application_manager/test/commands/hmi/vi_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vi_is_ready_request_test.cc
@@ -121,7 +121,6 @@ class VIIsReadyRequestTest
   }
 
   VIIsReadyRequestPtr command_;
-  am::MockHmiInterfaces mock_hmi_interfaces_;
   application_manager_test::MockHMICapabilities mock_hmi_capabilities_;
   policy_test::MockPolicyHandlerInterface mock_policy_handler_interface_;
 };

--- a/src/components/application_manager/test/commands/hmi/vr_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_is_ready_request_test.cc
@@ -139,7 +139,6 @@ class VRIsReadyRequestTest
   }
 
   VRIsReadyRequestPtr command_;
-  am::MockHmiInterfaces mock_hmi_interfaces_;
   application_manager_test::MockHMICapabilities mock_hmi_capabilities_;
 };
 

--- a/src/components/application_manager/test/commands/mobile/add_command_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/add_command_request_test.cc
@@ -62,7 +62,6 @@ using am::ApplicationManager;
 using am::commands::MessageSharedPtr;
 using am::ApplicationSharedPtr;
 using am::MockMessageHelper;
-using am::MockHmiInterfaces;
 using ::testing::_;
 using ::utils::SharedPtr;
 using ::testing::Return;
@@ -520,7 +519,6 @@ TEST_F(AddCommandRequestTest, OnEvent_UI_SUCCESS) {
   EXPECT_CALL(mock_message_helper_,
               HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
       .WillOnce(Return(mobile_apis::Result::SUCCESS));
-  EXPECT_CALL(*mock_app_, UpdateHash());
   request_ptr->on_event(event);
 }
 
@@ -541,7 +539,6 @@ TEST_F(AddCommandRequestTest, OnEvent_VR_SUCCESS) {
   EXPECT_CALL(*mock_app_, commands_map())
       .WillRepeatedly(
           Return(DataAccessor<am::CommandsMap>(commands_map, lock_)));
-  EXPECT_CALL(*mock_app_, UpdateHash());
   EXPECT_CALL(
       app_mngr_,
       ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::VR_AddCommand)))
@@ -668,7 +665,6 @@ TEST_F(AddCommandRequestTest,
   event_ui.set_smart_object(*msg_);
   Event event_vr(hmi_apis::FunctionID::VR_AddCommand);
   event_vr.set_smart_object(*msg_);
-  EXPECT_CALL(*mock_app_, UpdateHash());
   request_ptr->on_event(event_ui);
   request_ptr->on_event(event_vr);
 }

--- a/src/components/application_manager/test/commands/mobile/add_sub_menu_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/add_sub_menu_request_test.cc
@@ -54,7 +54,6 @@ namespace am = ::application_manager;
 using am::commands::AddSubMenuRequest;
 using am::commands::MessageSharedPtr;
 using am::event_engine::Event;
-using am::MockHmiInterfaces;
 using am::MockMessageHelper;
 using ::testing::_;
 using ::testing::Mock;
@@ -97,12 +96,6 @@ TEST_F(AddSubMenuRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
 
   Event event(hmi_apis::FunctionID::UI_AddSubMenu);
   event.set_smart_object(*ev_msg);
-
-  MockHmiInterfaces hmi_interfaces;
-  ON_CALL(app_mngr_, hmi_interfaces()).WillByDefault(ReturnRef(hmi_interfaces));
-  EXPECT_CALL(hmi_interfaces,
-              GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
-      .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
   EXPECT_CALL(mock_message_helper_,
               HMIToMobileResult(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE))

--- a/src/components/application_manager/test/commands/mobile/alert_maneuver_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/alert_maneuver_request_test.cc
@@ -63,7 +63,6 @@ namespace am = ::application_manager;
 using am::commands::AlertManeuverRequest;
 using am::commands::MessageSharedPtr;
 using am::event_engine::Event;
-using am::MockHmiInterfaces;
 using am::MockMessageHelper;
 
 typedef SharedPtr<AlertManeuverRequest> CommandPtr;
@@ -93,10 +92,7 @@ class AlertManeuverRequestTest
     EXPECT_CALL(*mock_message_helper, HMIToMobileResult(_))
         .WillOnce(Return(mobile_apis::Result::UNSUPPORTED_RESOURCE));
 
-    MockHmiInterfaces hmi_interfaces;
-    EXPECT_CALL(app_mngr_, hmi_interfaces())
-        .WillRepeatedly(ReturnRef(hmi_interfaces));
-    EXPECT_CALL(hmi_interfaces, GetInterfaceState(_))
+    EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
         .WillRepeatedly(Return(state));
 
     MessageSharedPtr response_to_mobile;
@@ -213,13 +209,10 @@ TEST_F(AlertManeuverRequestTest, Run_ProcessingResult_SUCCESS) {
               ProcessSoftButtons(_, _, _, _))
       .WillOnce(Return(mobile_apis::Result::SUCCESS));
 
-  MockHmiInterfaces hmi_interfaces;
-  EXPECT_CALL(app_mngr_, hmi_interfaces())
-      .WillRepeatedly(ReturnRef(hmi_interfaces));
-  EXPECT_CALL(hmi_interfaces, GetInterfaceFromFunction(_))
+  EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceFromFunction(_))
       .WillRepeatedly(
           Return(am::HmiInterfaces::InterfaceID::HMI_INTERFACE_TTS));
-  EXPECT_CALL(hmi_interfaces, GetInterfaceState(_))
+  EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
       .WillRepeatedly(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
   EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()),

--- a/src/components/application_manager/test/commands/mobile/alert_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/alert_request_test.cc
@@ -56,7 +56,6 @@ using am::commands::AlertRequest;
 using am::commands::CommandImpl;
 using am::commands::MessageSharedPtr;
 using am::MockMessageHelper;
-using am::MockHmiInterfaces;
 using ::utils::SharedPtr;
 using am::event_engine::Event;
 using policy_test::MockPolicyHandlerInterface;
@@ -125,15 +124,13 @@ class AlertRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
     ON_CALL(app_mngr_, application(kConnectionKey))
         .WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
-    ON_CALL(app_mngr_, hmi_interfaces())
-        .WillByDefault(ReturnRef(hmi_interfaces_));
 
-    ON_CALL(hmi_interfaces_,
+    ON_CALL(mock_hmi_interfaces_,
             GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
         .WillByDefault(
             Return(am::HmiInterfaces::InterfaceState::STATE_NOT_AVAILABLE));
 
-    ON_CALL(hmi_interfaces_,
+    ON_CALL(mock_hmi_interfaces_,
             GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
         .WillByDefault(
             Return(am::HmiInterfaces::InterfaceState::STATE_NOT_AVAILABLE));
@@ -199,7 +196,6 @@ class AlertRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
   MockAppPtr mock_app_;
   MessageSharedPtr msg_;
   MockPolicyHandlerInterface mock_policy_handler_;
-  NiceMock<MockHmiInterfaces> hmi_interfaces_;
 };
 
 TEST_F(AlertRequestTest, OnTimeout_GENERIC_ERROR) {

--- a/src/components/application_manager/test/commands/mobile/change_registration_test.cc
+++ b/src/components/application_manager/test/commands/mobile/change_registration_test.cc
@@ -65,7 +65,6 @@ using am::ApplicationManager;
 using am::commands::MessageSharedPtr;
 using am::ApplicationSharedPtr;
 using am::MockMessageHelper;
-using am::MockHmiInterfaces;
 using ::testing::_;
 using ::testing::Mock;
 using ::utils::SharedPtr;
@@ -118,28 +117,28 @@ class ChangeRegistrationRequestTest
         .WillOnce(Return(supported_languages_.get()));
 
     EXPECT_CALL(app_mngr_, hmi_interfaces())
-        .WillRepeatedly(ReturnRef(hmi_interfaces_));
+        .WillRepeatedly(ReturnRef(mock_hmi_interfaces_));
     EXPECT_CALL(
-        hmi_interfaces_,
+        mock_hmi_interfaces_,
         GetInterfaceFromFunction(hmi_apis::FunctionID::UI_ChangeRegistration))
         .WillOnce(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
-    EXPECT_CALL(hmi_interfaces_,
+    EXPECT_CALL(mock_hmi_interfaces_,
                 GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
         .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
     EXPECT_CALL(
-        hmi_interfaces_,
+        mock_hmi_interfaces_,
         GetInterfaceFromFunction(hmi_apis::FunctionID::VR_ChangeRegistration))
         .WillOnce(Return(am::HmiInterfaces::HMI_INTERFACE_VR));
-    EXPECT_CALL(hmi_interfaces_,
+    EXPECT_CALL(mock_hmi_interfaces_,
                 GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_VR))
         .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
     EXPECT_CALL(
-        hmi_interfaces_,
+        mock_hmi_interfaces_,
         GetInterfaceFromFunction(hmi_apis::FunctionID::TTS_ChangeRegistration))
         .WillOnce(Return(am::HmiInterfaces::HMI_INTERFACE_TTS));
-    EXPECT_CALL(hmi_interfaces_,
+    EXPECT_CALL(mock_hmi_interfaces_,
                 GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
         .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
   }
@@ -185,10 +184,7 @@ class ChangeRegistrationRequestTest
     (*tts_response)[strings::params][hmi_response::code] = hmi_response;
     (*tts_response)[strings::msg_params] = 0;
 
-    MockHmiInterfaces hmi_interfaces;
-    EXPECT_CALL(app_mngr_, hmi_interfaces())
-        .WillRepeatedly(ReturnRef(hmi_interfaces));
-    EXPECT_CALL(hmi_interfaces, GetInterfaceState(_))
+    EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
         .WillRepeatedly(Return(state));
 
     am::event_engine::Event event_ui(
@@ -251,8 +247,6 @@ class ChangeRegistrationRequestTest
     ON_CALL(app_mngr_, application(kConnectionKey))
         .WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
-    ON_CALL(app_mngr_, hmi_interfaces())
-        .WillByDefault(ReturnRef(hmi_interfaces_));
     ON_CALL(app_mngr_, hmi_capabilities())
         .WillByDefault(ReturnRef(hmi_capabilities_));
   }
@@ -288,7 +282,6 @@ class ChangeRegistrationRequestTest
       MockHMICapabilities;
   sync_primitives::Lock app_set_lock_;
   MockHMICapabilities hmi_capabilities_;
-  NiceMock<MockHmiInterfaces> hmi_interfaces_;
   MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
   MessageSharedPtr supported_languages_;
@@ -322,25 +315,25 @@ TEST_F(ChangeRegistrationRequestTest,
 
   ExpectationsHmiCapabilities(supported_languages);
 
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceFromFunction(hmi_apis::FunctionID::UI_ChangeRegistration))
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceFromFunction(hmi_apis::FunctionID::VR_ChangeRegistration))
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_VR));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_VR))
       .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_RESPONSE));
 
   ON_CALL(
-      hmi_interfaces_,
+      mock_hmi_interfaces_,
       GetInterfaceFromFunction(hmi_apis::FunctionID::TTS_ChangeRegistration))
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_TTS));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   command->Run();
@@ -367,10 +360,7 @@ TEST_F(ChangeRegistrationRequestTest,
       hmi_apis::FunctionID::TTS_ChangeRegistration);
   event_tts.set_smart_object(*tts_response);
 
-  MockHmiInterfaces hmi_interfaces;
-  EXPECT_CALL(app_mngr_, hmi_interfaces())
-      .WillRepeatedly(ReturnRef(hmi_interfaces));
-  EXPECT_CALL(hmi_interfaces, GetInterfaceState(_))
+  EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
       .WillRepeatedly(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
 
   MessageSharedPtr response_to_mobile;
@@ -478,25 +468,25 @@ TEST_F(ChangeRegistrationRequestTest,
 
   ExpectationsHmiCapabilities(supported_languages);
 
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceFromFunction(hmi_apis::FunctionID::UI_ChangeRegistration))
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
       .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
 
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceFromFunction(hmi_apis::FunctionID::VR_ChangeRegistration))
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_VR));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_VR))
       .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
 
   ON_CALL(
-      hmi_interfaces_,
+      mock_hmi_interfaces_,
       GetInterfaceFromFunction(hmi_apis::FunctionID::TTS_ChangeRegistration))
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_TTS));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
       .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
 

--- a/src/components/application_manager/test/commands/mobile/create_interaction_choice_set_test.cc
+++ b/src/components/application_manager/test/commands/mobile/create_interaction_choice_set_test.cc
@@ -115,7 +115,7 @@ class CreateInteractionChoiceSetRequestTest
       : message_helper_mock_(*am::MockMessageHelper::message_helper_mock())
       , message_(CreateMessage())
       , command_(CreateCommand<CreateInteractionChoiceSetRequest>(message_))
-      , app_(CreateMockApp()) {
+      , mock_app_(CreateMockApp()) {
     Mock::VerifyAndClearExpectations(&message_helper_mock_);
   }
   ~CreateInteractionChoiceSetRequestTest() {
@@ -165,7 +165,7 @@ class CreateInteractionChoiceSetRequestTest
   MockMessageHelper& message_helper_mock_;
   MessageSharedPtr message_;
   CreateInteractionChoiceSetRequestPtr command_;
-  MockAppPtr app_;
+  MockAppPtr mock_app_;
   sync_primitives::Lock lock_;
 };
 
@@ -212,10 +212,10 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnEvent_VR_UNSUPPORTED_RESOURCE) {
   utils::SharedPtr<CreateInteractionChoiceSetRequest> req_vr =
       CreateCommand<CreateInteractionChoiceSetRequest>(msg_vr);
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
 
   smart_objects::SmartObject* null_obj = NULL;
-  ON_CALL(*app_, FindChoiceSet(_)).WillByDefault(Return(null_obj));
+  ON_CALL(*mock_app_, FindChoiceSet(_)).WillByDefault(Return(null_obj));
 
   MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
   (*msg)[strings::params][hmi_response::code] =
@@ -227,14 +227,14 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnEvent_VR_UNSUPPORTED_RESOURCE) {
   event.set_smart_object(*msg);
 
   smart_objects::SmartObject* ptr = NULL;
-  ON_CALL(*app_, FindCommand(kCmdId)).WillByDefault(Return(ptr));
+  ON_CALL(*mock_app_, FindCommand(kCmdId)).WillByDefault(Return(ptr));
   EXPECT_EQ(NULL, ptr);
 
   ON_CALL(message_helper_mock_, HMIToMobileResult(_))
       .WillByDefault(Return(mobile_apis::Result::SUCCESS));
 
   am::CommandsMap commands_map;
-  ON_CALL(*app_, commands_map())
+  ON_CALL(*mock_app_, commands_map())
       .WillByDefault(
           Return(DataAccessor<am::CommandsMap>(commands_map, lock_)));
 
@@ -281,7 +281,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest, Run_VerifyImageFail_UNSUCCESS) {
   (*message_)[am::strings::msg_params][am::strings::choice_set][0]
              [am::strings::secondary_image] = kSecondImage;
 
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
   EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::INVALID_DATA));
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
@@ -297,14 +297,14 @@ TEST_F(CreateInteractionChoiceSetRequestTest, Run_FindChoiceSetFail_UNSUCCESS) {
   (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
       kChoiceSetId;
 
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
   EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* invalid_choice_set_id =
       &((*message_)[am::strings::msg_params]
                    [am::strings::interaction_choice_set_id]);
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(invalid_choice_set_id));
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
   command_->Run();
@@ -331,13 +331,13 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   (*message_)[am::strings::msg_params][am::strings::choice_set][1]
              [am::strings::vr_commands][0] = kVrCommands1;
 
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
   EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(choice_set_id));
 
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
@@ -366,9 +366,9 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
       kChoiceSetId;
 
   smart_objects::SmartObject* choice_set_id = NULL;
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
       .WillRepeatedly(Return(choice_set_id));
-  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(app_));
+  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(mock_app_));
 
   EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
@@ -437,17 +437,17 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
        Run_ValidAmountVrCommands_SUCCESS) {
   FillMessageFieldsItem1(message_);
   FillMessageFieldsItem2(message_);
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
   EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(choice_set_id));
 
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).WillOnce(Return(kGrammarId));
-  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
   EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())
       .Times(AtLeast(2))
       .WillOnce(Return(kConnectionKey))
@@ -476,16 +476,16 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   (*message_)[am::strings::msg_params][am::strings::choice_set][1]
              [am::strings::vr_commands][0] = kVrCommands2;
 
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
   EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(choice_set_id));
 
-  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
   command_->Run();
 }
 
@@ -522,17 +522,17 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnEvent_ValidVrNoError_SUCCESS) {
   FillMessageFieldsItem1(message_);
   FillMessageFieldsItem2(message_);
 
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
   EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(choice_set_id));
 
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).WillOnce(Return(kGrammarId));
-  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
   command_->Run();
@@ -555,17 +555,17 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
 
   FillMessageFieldsItem1(message_);
   FillMessageFieldsItem2(message_);
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
   EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(choice_set_id));
 
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).WillOnce(Return(kGrammarId));
-  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
   command_->Run();
@@ -589,17 +589,17 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
 
   (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
       kChoiceSetId;
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
 
   EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(choice_set_id));
 
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).WillOnce(Return(kGrammarId));
-  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
   command_->Run();
@@ -614,7 +614,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
 
 TEST_F(CreateInteractionChoiceSetRequestTest,
        OnTimeOut_InvalidErrorFromHMI_UNSUCCESS) {
-  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app_));
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
   EXPECT_CALL(app_mngr_,
               ManageMobileCommand(
@@ -636,17 +636,17 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
       kChoiceSetId;
 
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
 
   EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(choice_set_id));
 
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).WillOnce(Return(kGrammarId));
-  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
   command_->Run();
@@ -658,7 +658,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   event.set_smart_object(*message_);
   command_->on_event(event);
 
-  EXPECT_CALL(*app_, RemoveChoiceSet(kChoiceSetId));
+  EXPECT_CALL(*mock_app_, RemoveChoiceSet(kChoiceSetId));
   EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
   EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
   command_->onTimeOut();
@@ -676,17 +676,17 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeOut_InvalidApp_UNSUCCESS) {
   (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
       kChoiceSetId;
 
-  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(app_));
+  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(mock_app_));
 
   EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(choice_set_id));
 
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).WillOnce(Return(kGrammarId));
-  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
   command_->Run();
@@ -701,7 +701,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeOut_InvalidApp_UNSUCCESS) {
   MockAppPtr invalid_app;
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(invalid_app));
-  EXPECT_CALL(*app_, RemoveChoiceSet(_)).Times(0);
+  EXPECT_CALL(*mock_app_, RemoveChoiceSet(_)).Times(0);
   command_->onTimeOut();
 }
 
@@ -723,14 +723,15 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
 
   smart_objects::SmartObject* choice_set_id = NULL;
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app_));
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(mock_app_));
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).WillOnce(Return(kGrammarId));
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
 
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(choice_set_id));
-  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _));
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
 
   command_->Run();
 
@@ -745,8 +746,9 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   command_->on_event(event);
 
   EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app_));
-  EXPECT_CALL(*app_, RemoveChoiceSet(_));
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(mock_app_));
+  EXPECT_CALL(*mock_app_, RemoveChoiceSet(_));
 
   command_->onTimeOut();
 }
@@ -787,18 +789,18 @@ TEST_F(CreateInteractionChoiceSetRequestTest, Run_ErrorFromHmiFalse_UNSUCCESS) {
 
   (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
       kChoiceSetId;
-  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app_));
+  ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
 
   EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::GENERIC_ERROR));
 
   smart_objects::SmartObject* choice_set_id = NULL;
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+  EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
       .WillRepeatedly(Return(choice_set_id));
 
   EXPECT_CALL(app_mngr_, GenerateGrammarID())
       .WillRepeatedly(Return(kGrammarId));
-  EXPECT_CALL(*app_, AddChoiceSet(kChoiceSetId, _)).Times(2);
+  EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _)).Times(2);
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
   command_->Run();

--- a/src/components/application_manager/test/commands/mobile/delete_command_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_command_request_test.cc
@@ -61,7 +61,6 @@ using am::commands::DeleteCommandRequest;
 using am::commands::MessageSharedPtr;
 using am::event_engine::Event;
 using am::MockMessageHelper;
-using am::MockHmiInterfaces;
 
 typedef SharedPtr<DeleteCommandRequest> DeleteCommandPtr;
 
@@ -130,15 +129,12 @@ class DeleteCommandRequestTest
     ON_CALL(app_mngr_, application(kConnectionKey))
         .WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
-    ON_CALL(app_mngr_, hmi_interfaces())
-        .WillByDefault(ReturnRef(hmi_interfaces_));
   }
 
   void TearDown() OVERRIDE {
     Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }
 
-  NiceMock<MockHmiInterfaces> hmi_interfaces_;
   MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
 };
@@ -158,12 +154,12 @@ TEST_F(DeleteCommandRequestTest,
   (*test_msg)[am::strings::vr_commands] = 0;
   (*test_msg)[am::strings::menu_params] = 0;
 
-  ON_CALL(hmi_interfaces_, GetInterfaceFromFunction(_))
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceFromFunction(_))
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_VR));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
       .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_VR))
       .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
   ON_CALL(*mock_app_, FindCommand(kCommandId))
@@ -188,8 +184,6 @@ TEST_F(DeleteCommandRequestTest,
   event_vr.set_smart_object(*event_msg);
 
   EXPECT_CALL(*mock_app_, RemoveCommand(kCommandId));
-
-  EXPECT_CALL(*mock_app_, UpdateHash());
 
   MessageSharedPtr vr_command_result;
   EXPECT_CALL(
@@ -218,12 +212,12 @@ TEST_F(DeleteCommandRequestTest,
   (*test_msg)[am::strings::vr_commands] = 0;
   (*test_msg)[am::strings::menu_params] = 0;
 
-  ON_CALL(hmi_interfaces_, GetInterfaceFromFunction(_))
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceFromFunction(_))
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
       .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_VR))
       .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
   ON_CALL(*app, FindCommand(kCommandId)).WillByDefault(Return(test_msg.get()));
@@ -247,8 +241,6 @@ TEST_F(DeleteCommandRequestTest,
   event_ui.set_smart_object(*event_msg);
 
   EXPECT_CALL(*app, RemoveCommand(kCommandId));
-
-  EXPECT_CALL(*app, UpdateHash());
 
   MessageSharedPtr result_msg(
       CatchMobileCommandResult(CallOnEvent(*command, event_ui)));

--- a/src/components/application_manager/test/commands/mobile/delete_file_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_file_test.cc
@@ -159,7 +159,7 @@ TEST_F(DeleteFileRequestTest, Run_ValidFileName_SUCCESS) {
       kConnectionKey;
 
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app_));
+      .WillRepeatedly(Return(mock_app_));
   EXPECT_CALL(*mock_app_, hmi_level())
       .WillOnce(Return(am::mobile_api::HMILevel::HMI_FULL));
 

--- a/src/components/application_manager/test/commands/mobile/delete_interaction_choice_set_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_interaction_choice_set_test.cc
@@ -191,8 +191,10 @@ TEST_F(DeleteInteractionChoiceSetRequestTest,
                    [am::strings::interaction_choice_set_id]);
   smart_objects::SmartObject* invalid_choice_set_id = NULL;
 
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillRepeatedly(Return(app_));
+
   InSequence seq;
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app_));
 
   EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(choice_set_id));
@@ -206,8 +208,10 @@ TEST_F(DeleteInteractionChoiceSetRequestTest,
   EXPECT_CALL(*app_, RemoveChoiceSet(kChoiceSetId));
   EXPECT_CALL(*app_, UpdateHash());
 
-  command_->Run();
-  EXPECT_TRUE(Mock::VerifyAndClearExpectations(app_.get()));
+  DeleteInteractionChoiceSetRequestPtr command =
+      CreateCommand<DeleteInteractionChoiceSetRequest>(message_);
+
+  command->Run();
 }
 
 TEST_F(DeleteInteractionChoiceSetRequestTest, Run_SendVrDeleteCommand_SUCCESS) {
@@ -221,8 +225,10 @@ TEST_F(DeleteInteractionChoiceSetRequestTest, Run_SendVrDeleteCommand_SUCCESS) {
   smart_objects::SmartObject* choice_set_id =
       &((*message_)[am::strings::msg_params]);
 
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillRepeatedly(Return(app_));
+
   InSequence seq;
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app_));
 
   EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(choice_set_id));
@@ -238,8 +244,10 @@ TEST_F(DeleteInteractionChoiceSetRequestTest, Run_SendVrDeleteCommand_SUCCESS) {
   EXPECT_CALL(*app_, RemoveChoiceSet(kChoiceSetId));
   EXPECT_CALL(*app_, UpdateHash());
 
-  command_->Run();
-  EXPECT_TRUE(Mock::VerifyAndClearExpectations(app_.get()));
+  DeleteInteractionChoiceSetRequestPtr command =
+      CreateCommand<DeleteInteractionChoiceSetRequest>(message_);
+
+  command->Run();
 }
 
 TEST_F(DeleteInteractionChoiceSetResponseTest, Run_SuccessFalse_UNSUCCESS) {

--- a/src/components/application_manager/test/commands/mobile/diagnostic_message_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/diagnostic_message_request_test.cc
@@ -189,6 +189,9 @@ TEST_F(DiagnosticMessageRequestTest, OnEvent_SUCCESS) {
       app_mngr_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
 
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app));
+
   command->on_event(event);
 }
 

--- a/src/components/application_manager/test/commands/mobile/dial_number_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/dial_number_request_test.cc
@@ -156,15 +156,6 @@ TEST_F(DialNumberRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
 }
 
 TEST_F(DialNumberRequestTest, OnEvent_SUCCESS) {
-  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
-  (*command_msg)[am::strings::params][am::strings::connection_key] =
-      kConnectionKey;
-
-  DialNumberRequestPtr command(CreateCommand<DialNumberRequest>(command_msg));
-
-  MockAppPtr app(CreateMockApp());
-  EXPECT_CALL(app_mngr_, application(kConnectionKey)).WillOnce(Return(app));
-
   MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
   (*event_msg)[am::strings::params][am::hmi_response::code] =
       mobile_apis::Result::SUCCESS;
@@ -173,10 +164,19 @@ TEST_F(DialNumberRequestTest, OnEvent_SUCCESS) {
   Event event(hmi_apis::FunctionID::BasicCommunication_DialNumber);
   event.set_smart_object(*event_msg);
 
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillRepeatedly(Return(app));
+
   EXPECT_CALL(
       app_mngr_,
       ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
 
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  DialNumberRequestPtr command(CreateCommand<DialNumberRequest>(command_msg));
   command->on_event(event);
 }
 

--- a/src/components/application_manager/test/commands/mobile/end_audio_pass_thru_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/end_audio_pass_thru_request_test.cc
@@ -59,7 +59,6 @@ using ::testing::ReturnRef;
 using am::commands::MessageSharedPtr;
 using am::commands::EndAudioPassThruRequest;
 using am::event_engine::Event;
-using am::MockHmiInterfaces;
 using am::MockMessageHelper;
 
 typedef SharedPtr<EndAudioPassThruRequest> EndAudioPassThruRequestPtr;
@@ -90,12 +89,6 @@ TEST_F(EndAudioPassThruRequestTest, OnEvent_UI_UNSUPPORTED_RESOUCRE) {
   Event event(hmi_apis::FunctionID::UI_EndAudioPassThru);
   event.set_smart_object(*event_msg);
 
-  MockHmiInterfaces hmi_interfaces;
-  ON_CALL(app_mngr_, hmi_interfaces()).WillByDefault(ReturnRef(hmi_interfaces));
-  ON_CALL(hmi_interfaces,
-          GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
-
   EXPECT_CALL(mock_message_helper_,
               HMIToMobileResult(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE))
       .WillOnce(Return(mobile_apis::Result::UNSUPPORTED_RESOURCE));
@@ -107,6 +100,9 @@ TEST_F(EndAudioPassThruRequestTest, OnEvent_UI_UNSUPPORTED_RESOUCRE) {
       app_mngr_,
       ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
       .WillOnce(DoAll(SaveArg<0>(&ui_command_result), Return(true)));
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(app));
 
   command->on_event(event);
 

--- a/src/components/application_manager/test/commands/mobile/get_dtcs_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/get_dtcs_request_test.cc
@@ -112,8 +112,6 @@ TEST_F(GetDTCsRequestTest, OnEvent_UnknownEvent_UNSUCCESS) {
 }
 
 TEST_F(GetDTCsRequestTest, OnEvent_SUCCESS) {
-  GetDTCsRequestPtr command(CreateCommand<GetDTCsRequest>());
-
   MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
   (*event_msg)[am::strings::msg_params] = 0;
   (*event_msg)[am::strings::params][am::hmi_response::code] =
@@ -130,6 +128,10 @@ TEST_F(GetDTCsRequestTest, OnEvent_SUCCESS) {
       app_mngr_,
       ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
 
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(app));
+
+  GetDTCsRequestPtr command(CreateCommand<GetDTCsRequest>());
   command->on_event(event);
 }
 

--- a/src/components/application_manager/test/commands/mobile/get_way_points_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/get_way_points_request_test.cc
@@ -57,7 +57,6 @@ using ::testing::Mock;
 using ::testing::_;
 using application_manager::commands::GetWayPointsRequest;
 using application_manager::MockMessageHelper;
-using application_manager::MockHmiInterfaces;
 
 typedef SharedPtr<GetWayPointsRequest> CommandPtr;
 typedef mobile_apis::Result::eType MobileResult;
@@ -76,6 +75,7 @@ class GetWayPointsRequestTest
       : message_helper_mock_(*am::MockMessageHelper::message_helper_mock()) {
     Mock::VerifyAndClearExpectations(&message_helper_mock_);
   }
+
   ~GetWayPointsRequestTest() {
     Mock::VerifyAndClearExpectations(&message_helper_mock_);
   }
@@ -90,6 +90,9 @@ class GetWayPointsRequestTest
             message_);
     mock_app_ = CreateMockApp();
     ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
+
+    ON_CALL(message_helper_mock_, HMIToMobileResult(_))
+        .WillByDefault(Return(mobile_apis::Result::SUCCESS));
   }
 
   MockMessageHelper& message_helper_mock_;
@@ -127,6 +130,12 @@ class GetWayPointsRequestOnEventTest
 
     event.set_smart_object(*event_msg);
 
+    EXPECT_CALL(message_helper_mock_, HMIToMobileResult(_))
+        .WillOnce(Return(ResultCode));
+
+    MockAppPtr app(CreateMockApp());
+    EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(app));
+
     MessageSharedPtr result_msg(
         CatchMobileCommandResult(CallOnEvent(*command, event)));
     EXPECT_EQ(
@@ -142,7 +151,6 @@ class GetWayPointsRequestOnEventTest
  protected:
   MockMessageHelper& message_helper_mock_;
   MockAppPtr app_;
-  MockHmiInterfaces hmi_interfaces_;
 };
 
 TEST_F(GetWayPointsRequestTest,
@@ -195,7 +203,7 @@ TEST_F(GetWayPointsRequestTest, Run_ApplicationRegistered_Success) {
 }
 
 TEST_F(GetWayPointsRequestTest,
-       OnEvent_NavigationGetWayPointsEvent_SendResponce) {
+       OnEvent_NavigationGetWayPointsEvent_SendResponse) {
   am::event_engine::Event event(hmi_apis::FunctionID::Navigation_GetWayPoints);
 
   (*message_)[am::strings::params][am::hmi_response::code] =
@@ -248,42 +256,46 @@ TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_SUCCESS_Case3) {
 }
 
 TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_GENERIC_ERROR_Case1) {
-  EXPECT_CALL(app_mngr_, hmi_interfaces()).WillOnce(ReturnRef(hmi_interfaces_));
-  EXPECT_CALL(hmi_interfaces_,
+  EXPECT_CALL(mock_hmi_interfaces_,
+              GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
+      .WillRepeatedly(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(mock_hmi_interfaces_,
               GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_Navigation))
-      .WillOnce(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
-  EXPECT_CALL(message_helper_mock_, HMIToMobileResult(_))
-      .WillOnce(Return(mobile_apis::Result::GENERIC_ERROR));
+      .WillRepeatedly(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+
   CheckOnEventResponse("    ", GENERIC_ERROR, false);
 }
 
 TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_GENERIC_ERROR_Case2) {
-  EXPECT_CALL(app_mngr_, hmi_interfaces()).WillOnce(ReturnRef(hmi_interfaces_));
-  EXPECT_CALL(hmi_interfaces_,
+  EXPECT_CALL(mock_hmi_interfaces_,
+              GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
+      .WillRepeatedly(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(mock_hmi_interfaces_,
               GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_Navigation))
-      .WillOnce(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
-  EXPECT_CALL(message_helper_mock_, HMIToMobileResult(_))
-      .WillOnce(Return(mobile_apis::Result::GENERIC_ERROR));
+      .WillRepeatedly(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+
   CheckOnEventResponse("test\t", GENERIC_ERROR, false);
 }
 
 TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_GENERIC_ERROR_Case3) {
-  EXPECT_CALL(app_mngr_, hmi_interfaces()).WillOnce(ReturnRef(hmi_interfaces_));
-  EXPECT_CALL(hmi_interfaces_,
+  EXPECT_CALL(mock_hmi_interfaces_,
+              GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
+      .WillRepeatedly(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(mock_hmi_interfaces_,
               GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_Navigation))
-      .WillOnce(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
-  EXPECT_CALL(message_helper_mock_, HMIToMobileResult(_))
-      .WillOnce(Return(mobile_apis::Result::GENERIC_ERROR));
+      .WillRepeatedly(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+
   CheckOnEventResponse("test\n", GENERIC_ERROR, false);
 }
 
 TEST_F(GetWayPointsRequestOnEventTest, OnEvent_Expect_GENERIC_ERROR_Case4) {
-  EXPECT_CALL(app_mngr_, hmi_interfaces()).WillOnce(ReturnRef(hmi_interfaces_));
-  EXPECT_CALL(hmi_interfaces_,
+  EXPECT_CALL(mock_hmi_interfaces_,
+              GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
+      .WillRepeatedly(Return(am::HmiInterfaces::STATE_AVAILABLE));
+  EXPECT_CALL(mock_hmi_interfaces_,
               GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_Navigation))
-      .WillOnce(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
-  EXPECT_CALL(message_helper_mock_, HMIToMobileResult(_))
-      .WillOnce(Return(mobile_apis::Result::GENERIC_ERROR));
+      .WillRepeatedly(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
+
   CheckOnEventResponse("test\t\n", GENERIC_ERROR, false);
 }
 

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -55,7 +55,6 @@ using am::commands::PerformAudioPassThruRequest;
 using am::commands::CommandImpl;
 using am::commands::MessageSharedPtr;
 using am::MockMessageHelper;
-using am::MockHmiInterfaces;
 using ::utils::SharedPtr;
 using ::testing::_;
 using ::testing::Mock;
@@ -131,8 +130,6 @@ class PerformAudioPassThruRequestTest
     ON_CALL(app_mngr_, application(kConnectionKey))
         .WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
-    ON_CALL(app_mngr_, hmi_interfaces())
-        .WillByDefault(ReturnRef(hmi_interfaces_));
     command_sptr_ =
         CreateCommand<am::commands::PerformAudioPassThruRequest>(message_);
 
@@ -156,7 +153,6 @@ class PerformAudioPassThruRequestTest
   }
 
   sync_primitives::Lock lock_;
-  NiceMock<MockHmiInterfaces> hmi_interfaces_;
   MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
   MessageSharedPtr message_;
@@ -217,10 +213,10 @@ TEST_F(PerformAudioPassThruRequestTest,
   am::event_engine::Event event(hmi_apis::FunctionID::UI_PerformAudioPassThru);
   event.set_smart_object(*msg);
 
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
       .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
       .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
 
@@ -312,10 +308,10 @@ TEST_F(PerformAudioPassThruRequestTest,
     // Send speak request sending
     ON_CALL(app_mngr_, GetNextHMICorrelationID())
         .WillByDefault(Return(kCorrelationId));
-    ON_CALL(hmi_interfaces_,
+    ON_CALL(mock_hmi_interfaces_,
             GetInterfaceFromFunction(hmi_apis::FunctionID::TTS_Speak))
         .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_TTS));
-    ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+    ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
         .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
     EXPECT_CALL(app_mngr_, ManageHMICommand(_))
         .WillOnce(DoAll(SaveArg<0>(&speak_reqeust_result_msg), Return(true)));
@@ -324,10 +320,10 @@ TEST_F(PerformAudioPassThruRequestTest,
     ON_CALL(app_mngr_, GetNextHMICorrelationID())
         .WillByDefault(Return(kCorrelationId));
     ON_CALL(
-        hmi_interfaces_,
+        mock_hmi_interfaces_,
         GetInterfaceFromFunction(hmi_apis::FunctionID::UI_PerformAudioPassThru))
         .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
-    ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+    ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
         .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
     EXPECT_CALL(app_mngr_, ManageHMICommand(_))
         .WillOnce(DoAll(SaveArg<0>(&perform_result_msg), Return(true)));
@@ -359,10 +355,10 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceFromFunction(hmi_apis::FunctionID::TTS_StopSpeaking))
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_TTS));
-  ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
   EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
@@ -395,10 +391,10 @@ TEST_F(PerformAudioPassThruRequestTest,
     InSequence dummy;
     ON_CALL(app_mngr_, GetNextHMICorrelationID())
         .WillByDefault(Return(kCorrelationId));
-    ON_CALL(hmi_interfaces_,
+    ON_CALL(mock_hmi_interfaces_,
             GetInterfaceFromFunction(hmi_apis::FunctionID::TTS_Speak))
         .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_TTS));
-    ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+    ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
         .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
     EXPECT_CALL(app_mngr_, ManageHMICommand(_))
         .WillOnce(DoAll(SaveArg<0>(&speak_reqeust_result_msg), Return(true)));
@@ -407,10 +403,10 @@ TEST_F(PerformAudioPassThruRequestTest,
     ON_CALL(app_mngr_, GetNextHMICorrelationID())
         .WillByDefault(Return(kCorrelationId));
     ON_CALL(
-        hmi_interfaces_,
+        mock_hmi_interfaces_,
         GetInterfaceFromFunction(hmi_apis::FunctionID::UI_PerformAudioPassThru))
         .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
-    ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+    ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
         .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
     EXPECT_CALL(app_mngr_, ManageHMICommand(_))
         .WillOnce(DoAll(SaveArg<0>(&perform_result_msg), Return(true)));
@@ -463,10 +459,10 @@ TEST_F(PerformAudioPassThruRequestTest,
     InSequence dummy;
     ON_CALL(app_mngr_, GetNextHMICorrelationID())
         .WillByDefault(Return(kCorrelationId));
-    ON_CALL(hmi_interfaces_,
+    ON_CALL(mock_hmi_interfaces_,
             GetInterfaceFromFunction(hmi_apis::FunctionID::TTS_Speak))
         .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_TTS));
-    ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+    ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
         .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
     EXPECT_CALL(app_mngr_, ManageHMICommand(_))
         .WillOnce(DoAll(SaveArg<0>(&speak_reqeust_result_msg), Return(true)));
@@ -475,10 +471,10 @@ TEST_F(PerformAudioPassThruRequestTest,
     ON_CALL(app_mngr_, GetNextHMICorrelationID())
         .WillByDefault(Return(kCorrelationId));
     ON_CALL(
-        hmi_interfaces_,
+        mock_hmi_interfaces_,
         GetInterfaceFromFunction(hmi_apis::FunctionID::UI_PerformAudioPassThru))
         .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
-    ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+    ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
         .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
     EXPECT_CALL(app_mngr_, ManageHMICommand(_))
         .WillOnce(DoAll(SaveArg<0>(&perform_result_msg), Return(true)));
@@ -506,10 +502,10 @@ TEST_F(
     ON_CALL(app_mngr_, GetNextHMICorrelationID())
         .WillByDefault(Return(kCorrelationId));
     ON_CALL(
-        hmi_interfaces_,
+        mock_hmi_interfaces_,
         GetInterfaceFromFunction(hmi_apis::FunctionID::UI_PerformAudioPassThru))
         .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_TTS));
-    ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+    ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
         .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
     // Perform audio path thru request sending
     EXPECT_CALL(app_mngr_, ManageHMICommand(_))
@@ -518,10 +514,10 @@ TEST_F(
     // Perform audio path thru request sending
     ON_CALL(app_mngr_, GetNextHMICorrelationID())
         .WillByDefault(Return(kCorrelationId));
-    ON_CALL(hmi_interfaces_,
+    ON_CALL(mock_hmi_interfaces_,
             GetInterfaceFromFunction(hmi_apis::FunctionID::UI_OnRecordStart))
         .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
-    ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+    ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
         .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
     // Start recording notification sending
     EXPECT_CALL(app_mngr_, ManageHMICommand(_))
@@ -583,7 +579,7 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
 
-  ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
   EXPECT_CALL(mock_message_helper_, HMIToMobileResult(_))
@@ -609,7 +605,7 @@ TEST_F(PerformAudioPassThruRequestTest,
       hmi_apis::Common_Result::SUCCESS;
   event_perform.set_smart_object(*message_);
 
-  ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   // First call on_event for setting result_tts_speak_ to UNSUPPORTED_RESOURCE
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
@@ -619,7 +615,7 @@ TEST_F(PerformAudioPassThruRequestTest,
   // Second call for test correct behavior of UI_PerformAudioPassThru event
   EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(false));
   EXPECT_CALL(app_mngr_, StopAudioPassThru(_)).Times(0);
-  ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   CallOnEvent caller_perform(*command_sptr_, event_perform);
 
@@ -648,7 +644,7 @@ TEST_F(PerformAudioPassThruRequestTest,
       StartAudioPassThruThread(kConnectionKey, kCorrelationId, _, _, _, _));
 
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
-  ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   ON_CALL(mock_message_helper_, HMIToMobileResult(_))
       .WillByDefault(Return(am::mobile_api::Result::SUCCESS));
@@ -673,7 +669,7 @@ TEST_F(PerformAudioPassThruRequestTest,
       app_mngr_,
       StartAudioPassThruThread(kConnectionKey, kCorrelationId, _, _, _, _));
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
-  ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   CallOnEvent caller(*command_sptr_, event);
   caller();
@@ -732,10 +728,10 @@ TEST_F(PerformAudioPassThruRequestTest,
   MessageSharedPtr perform_result_msg;
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceFromFunction(hmi_apis::FunctionID::TTS_Speak))
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_TTS));
-  ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   EXPECT_CALL(app_mngr_, ManageHMICommand(_))
       .WillOnce(DoAll(SaveArg<0>(&speak_reqeust_result_msg), Return(true)));
@@ -744,10 +740,10 @@ TEST_F(PerformAudioPassThruRequestTest,
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
   ON_CALL(
-      hmi_interfaces_,
+      mock_hmi_interfaces_,
       GetInterfaceFromFunction(hmi_apis::FunctionID::UI_PerformAudioPassThru))
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
-  ON_CALL(hmi_interfaces_, GetInterfaceState(_))
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   EXPECT_CALL(app_mngr_, ManageHMICommand(_))
       .WillOnce(DoAll(SaveArg<0>(&perform_result_msg), Return(true)));

--- a/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
@@ -62,7 +62,6 @@ using am::ApplicationManager;
 using am::commands::MessageSharedPtr;
 using am::ApplicationSharedPtr;
 using am::MockMessageHelper;
-using am::MockHmiInterfaces;
 using ::testing::_;
 using ::testing::Mock;
 using ::utils::SharedPtr;
@@ -91,8 +90,6 @@ class PerformInteractionRequestTest
     ON_CALL(app_mngr_, application(kConnectionKey))
         .WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
-    ON_CALL(app_mngr_, hmi_interfaces())
-        .WillByDefault(ReturnRef(hmi_interfaces_));
   }
 
   void TearDown() OVERRIDE {
@@ -111,7 +108,6 @@ class PerformInteractionRequestTest
   }
 
   sync_primitives::Lock lock_;
-  NiceMock<MockHmiInterfaces> hmi_interfaces_;
   MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
 };
@@ -174,10 +170,6 @@ TEST_F(PerformInteractionRequestTest,
   MockAppPtr mock_app;
   EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(mock_app));
 
-  MockHmiInterfaces hmi_interfaces;
-  EXPECT_CALL(app_mngr_, hmi_interfaces())
-      .WillRepeatedly(ReturnRef(hmi_interfaces));
-
   MessageSharedPtr response_msg_vr =
       CreateMessage(smart_objects::SmartType_Map);
   (*response_msg_vr)[strings::params][hmi_response::code] =
@@ -197,10 +189,10 @@ TEST_F(PerformInteractionRequestTest,
   am::event_engine::Event event_ui(hmi_apis::FunctionID::UI_PerformInteraction);
   event_ui.set_smart_object(*response_msg_ui);
 
-  EXPECT_CALL(hmi_interfaces,
+  EXPECT_CALL(mock_hmi_interfaces_,
               GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
       .WillRepeatedly(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
-  EXPECT_CALL(hmi_interfaces,
+  EXPECT_CALL(mock_hmi_interfaces_,
               GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_VR))
       .WillRepeatedly(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
 
@@ -228,10 +220,10 @@ TEST_F(PerformInteractionRequestTest,
   utils::SharedPtr<PerformInteractionRequest> command =
       CreateCommand<PerformInteractionRequest>(msg_from_mobile);
 
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
       .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_VR))
       .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
 

--- a/src/components/application_manager/test/commands/mobile/read_did_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/read_did_request_test.cc
@@ -98,6 +98,9 @@ TEST_F(ReadDIDRequestTest, OnEvent_SUCCESS) {
   EXPECT_CALL(app_mngr_,
               ManageMobileCommand(MobileResultCodeIs(mobile_response_code), _));
 
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(app));
+
   command->on_event(event);
 
   testing::Mock::VerifyAndClearExpectations(&mock_message_helper);

--- a/src/components/application_manager/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/register_app_interface_request_test.cc
@@ -151,8 +151,6 @@ class RegisterAppInterfaceRequestTest
         .WillByDefault(Return(policy::DeviceConsent::kDeviceAllowed));
     ON_CALL(app_mngr_, GetDeviceTransportType(_))
         .WillByDefault(Return(hmi_apis::Common_TransportType::WIFI));
-    ON_CALL(app_mngr_, hmi_interfaces())
-        .WillByDefault(ReturnRef(mock_hmi_interfaces_));
     ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
         .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
     ON_CALL(
@@ -191,15 +189,11 @@ class RegisterAppInterfaceRequestTest
   typedef IsNiceMock<application_manager_test::MockHMICapabilities,
                      kMocksAreNice>::Result MockHMICapabilities;
 
-  typedef IsNiceMock<am::MockHmiInterfaces, kMocksAreNice>::Result
-      MockHmiInterfaces;
-
   MockPolicyHandlerInterface mock_policy_handler_;
   MockResumeCtrl mock_resume_crt_;
   MockConnectionHandler mock_connection_handler_;
   MockSessionObserver mock_session_observer_;
   MockHMICapabilities mock_hmi_capabilities_;
-  MockHmiInterfaces mock_hmi_interfaces_;
 };
 
 TEST_F(RegisterAppInterfaceRequestTest, Init_SUCCESS) {

--- a/src/components/application_manager/test/commands/mobile/scrollable_message_test.cc
+++ b/src/components/application_manager/test/commands/mobile/scrollable_message_test.cc
@@ -61,7 +61,6 @@ using am::commands::ScrollableMessageRequest;
 using am::commands::CommandImpl;
 using am::commands::MessageSharedPtr;
 using am::MockMessageHelper;
-using am::MockHmiInterfaces;
 using ::utils::SharedPtr;
 using ::testing::_;
 using ::testing::Eq;
@@ -146,11 +145,6 @@ TEST_F(ScrollableMessageRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
       .WillByDefault(Return(mock_app));
 
   ON_CALL(*mock_app, app_id()).WillByDefault(Return(kConnectionKey));
-  MockHmiInterfaces hmi_interfaces;
-  ON_CALL(app_mngr_, hmi_interfaces()).WillByDefault(ReturnRef(hmi_interfaces));
-  EXPECT_CALL(hmi_interfaces,
-              GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
-      .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
   MockHMICapabilities hmi_capabilities;
   ON_CALL(app_mngr_, hmi_capabilities())
@@ -297,11 +291,6 @@ TEST_F(ScrollableMessageRequestTest,
 
   EXPECT_CALL(mock_message_helper_, HMIToMobileResult(_))
       .WillOnce(Return(mobile_apis::Result::UNSUPPORTED_RESOURCE));
-
-  MockHmiInterfaces hmi_interfaces;
-  ON_CALL(app_mngr_, hmi_interfaces()).WillByDefault(ReturnRef(hmi_interfaces));
-  EXPECT_CALL(hmi_interfaces, GetInterfaceState(_))
-      .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
   EXPECT_CALL(
       app_mngr_,

--- a/src/components/application_manager/test/commands/mobile/send_location_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/send_location_request_test.cc
@@ -351,11 +351,19 @@ TEST_F(SendLocationRequestTest, Run_HMIUINotCoop_Cancelled) {
 TEST_F(SendLocationRequestTest, OnEvent_Success) {
   mobile_apis::Result::eType response_code = mobile_apis::Result::SUCCESS;
   (*message_)[strings::params][hmi_response::code] = response_code;
+  (*message_)[strings::params][strings::connection_key] = kConnectionKey;
+
   Event event(hmi_apis::FunctionID::Navigation_SendLocation);
   event.set_smart_object(*message_);
+
   EXPECT_CALL(mock_message_helper_,
               HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
       .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillRepeatedly(Return(app));
+
   command_->on_event(event);
 }
 

--- a/src/components/application_manager/test/commands/mobile/set_app_icon_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_app_icon_test.cc
@@ -55,7 +55,6 @@ using am::commands::SetAppIconRequest;
 using am::commands::CommandImpl;
 using am::commands::MessageSharedPtr;
 using am::MockMessageHelper;
-using am::MockHmiInterfaces;
 using ::utils::SharedPtr;
 using ::testing::_;
 using ::testing::Mock;
@@ -73,6 +72,15 @@ class SetAppIconRequestTest
  public:
   SetAppIconRequestTest()
       : mock_message_helper_(*MockMessageHelper::message_helper_mock()) {}
+
+  void SetUp() OVERRIDE {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+
+  void TearDown() OVERRIDE {
+    Mock::VerifyAndClearExpectations(&mock_message_helper_);
+  }
+
   MockMessageHelper& mock_message_helper_;
 
   MessageSharedPtr CreateFullParamsUISO() {
@@ -118,12 +126,6 @@ TEST_F(SetAppIconRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
   ON_CALL(*mock_app, set_app_icon_path(_)).WillByDefault(Return(true));
   ON_CALL(*mock_app, app_icon_path()).WillByDefault(ReturnRef(file_path));
 
-  MockHmiInterfaces hmi_interfaces;
-  ON_CALL(app_mngr_, hmi_interfaces()).WillByDefault(ReturnRef(hmi_interfaces));
-  EXPECT_CALL(hmi_interfaces,
-              GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
-      .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
-
   MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
   (*msg)[am::strings::params][am::hmi_response::code] =
       hmi_apis::Common_Result::UNSUPPORTED_RESOURCE;
@@ -158,7 +160,6 @@ TEST_F(SetAppIconRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
             .asString()
             .empty());
   }
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 }  // namespace set_app_icon_request

--- a/src/components/application_manager/test/commands/mobile/set_display_layout_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_display_layout_test.cc
@@ -57,7 +57,6 @@ using am::commands::SetDisplayLayoutRequest;
 using am::commands::CommandImpl;
 using am::commands::MessageSharedPtr;
 using am::MockMessageHelper;
-using am::MockHmiInterfaces;
 using ::utils::SharedPtr;
 using ::testing::_;
 using ::testing::Mock;
@@ -89,8 +88,6 @@ class SetDisplayLayoutRequestTest
     ON_CALL(app_mngr_, application(kConnectionKey))
         .WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
-    ON_CALL(app_mngr_, hmi_interfaces())
-        .WillByDefault(ReturnRef(hmi_interfaces_));
   }
 
   ~SetDisplayLayoutRequestTest() {
@@ -133,7 +130,6 @@ class SetDisplayLayoutRequestTest
   }
 
   sync_primitives::Lock lock_;
-  NiceMock<MockHmiInterfaces> hmi_interfaces_;
   MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
 };
@@ -164,7 +160,7 @@ TEST_F(SetDisplayLayoutRequestTest,
   Event event(hmi_apis::FunctionID::UI_SetDisplayLayout);
   event.set_smart_object(*msg);
 
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
       .WillByDefault(Return(am::HmiInterfaces::STATE_NOT_AVAILABLE));
 
@@ -186,6 +182,7 @@ TEST_F(SetDisplayLayoutRequestTest, Run_InvalidApp_UNSUCCESS) {
   MessageSharedPtr msg(CreateMessage(smart_objects::SmartType_Map));
   (*msg)[am::strings::params][am::strings::connection_key] = kConnectionKey;
   CommandPtr command(CreateCommand<SetDisplayLayoutRequest>(msg));
+
   MockAppPtr invalid_mock_app;
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(invalid_mock_app));
@@ -209,8 +206,6 @@ TEST_F(SetDisplayLayoutRequestTest, Run_SUCCESS) {
 
   EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillOnce(Return(kCorrelationKey));
-  EXPECT_CALL(app_mngr_, hmi_interfaces())
-      .WillOnce(ReturnRef(mock_hmi_interfaces_));
   EXPECT_CALL(
       mock_hmi_interfaces_,
       GetInterfaceFromFunction(hmi_apis::FunctionID::UI_SetDisplayLayout))
@@ -236,20 +231,22 @@ TEST_F(SetDisplayLayoutRequestTest, OnEvent_InvalidEventId_UNSUCCESS) {
 }
 
 TEST_F(SetDisplayLayoutRequestTest, OnEvent_SUCCESS) {
-  CommandPtr command(CreateCommand<SetDisplayLayoutRequest>());
-
   am::event_engine::Event event(hmi_apis::FunctionID::UI_SetDisplayLayout);
   MessageSharedPtr msg = CreateMessage();
 
   (*msg)[am::strings::params][am::hmi_response::code] =
       hmi_apis::Common_Result::SUCCESS;
   (*msg)[am::strings::msg_params][am::hmi_response::display_capabilities] = 0;
+  (*msg)[am::strings::params][am::strings::connection_key] = kConnectionKey;
   event.set_smart_object(*msg);
 
   MockHMICapabilities hmi_capabilities;
   MessageSharedPtr dispaly_capabilities_msg = CreateMessage();
   (*dispaly_capabilities_msg)[am::hmi_response::templates_available] =
       "templates_available";
+
+  EXPECT_CALL(mock_message_helper_, HMIToMobileResult(_))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
 
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(hmi_capabilities));
@@ -262,6 +259,7 @@ TEST_F(SetDisplayLayoutRequestTest, OnEvent_SUCCESS) {
       ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS),
                           am::commands::Command::CommandOrigin::ORIGIN_SDL));
 
+  CommandPtr command(CreateCommand<SetDisplayLayoutRequest>(msg));
   command->on_event(event);
 }
 

--- a/src/components/application_manager/test/commands/mobile/set_media_clock_timer_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_media_clock_timer_test.cc
@@ -53,7 +53,6 @@ namespace am = ::application_manager;
 using am::commands::SetMediaClockRequest;
 using am::commands::MessageSharedPtr;
 using am::event_engine::Event;
-using am::MockHmiInterfaces;
 using am::MockMessageHelper;
 using ::testing::_;
 using ::testing::Mock;
@@ -84,8 +83,6 @@ class SetMediaClockRequestTest
     ON_CALL(app_mngr_, application(kConnectionKey))
         .WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
-    ON_CALL(app_mngr_, hmi_interfaces())
-        .WillByDefault(ReturnRef(hmi_interfaces_));
   }
 
   void TearDown() OVERRIDE {
@@ -117,7 +114,6 @@ class SetMediaClockRequestTest
     EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
   }
 
-  NiceMock<MockHmiInterfaces> hmi_interfaces_;
   MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
 };
@@ -140,7 +136,7 @@ TEST_F(SetMediaClockRequestTest,
   Event event(hmi_apis::FunctionID::UI_SetMediaClockTimer);
   event.set_smart_object(*ev_msg);
 
-  EXPECT_CALL(hmi_interfaces_,
+  EXPECT_CALL(mock_hmi_interfaces_,
               GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
       .WillRepeatedly(Return(am::HmiInterfaces::STATE_NOT_RESPONSE));
 
@@ -183,10 +179,10 @@ TEST_F(SetMediaClockRequestTest, Run_UpdateCountUp_SUCCESS) {
   EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppID));
   EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillOnce(Return(kCorrelationId));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceFromFunction(hmi_apis::FunctionID::UI_SetMediaClockTimer))
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
@@ -218,10 +214,10 @@ TEST_F(SetMediaClockRequestTest, Run_UpdateCountDown_SUCCESS) {
   EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppID));
   EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillOnce(Return(kCorrelationId));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceFromFunction(hmi_apis::FunctionID::UI_SetMediaClockTimer))
       .WillByDefault(Return(am::HmiInterfaces::HMI_INTERFACE_UI));
-  ON_CALL(hmi_interfaces_,
+  ON_CALL(mock_hmi_interfaces_,
           GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
@@ -339,6 +335,9 @@ TEST_F(SetMediaClockRequestTest, OnEvent_Success) {
       CreateCommand<SetMediaClockRequest>(msg));
 
   EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+
+  MockAppPtr app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(app));
 
   Event event(hmi_apis::FunctionID::UI_SetMediaClockTimer);
   event.set_smart_object(*msg);

--- a/src/components/application_manager/test/commands/mobile/show_test.cc
+++ b/src/components/application_manager/test/commands/mobile/show_test.cc
@@ -56,7 +56,6 @@ using am::commands::ShowRequest;
 using am::commands::CommandImpl;
 using am::commands::MessageSharedPtr;
 using am::MockMessageHelper;
-using am::MockHmiInterfaces;
 using test::components::policy_test::MockPolicyHandlerInterface;
 using ::utils::SharedPtr;
 using ::testing::_;
@@ -177,13 +176,6 @@ TEST_F(ShowRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
   ON_CALL(app_mngr_, application(kConnectionKey))
       .WillByDefault(Return(mock_app));
   ON_CALL(*mock_app, app_id()).WillByDefault(Return(kConnectionKey));
-  MockHmiInterfaces hmi_interfaces;
-  ON_CALL(app_mngr_, hmi_interfaces()).WillByDefault(ReturnRef(hmi_interfaces));
-  ON_CALL(hmi_interfaces, GetInterfaceFromFunction(_))
-      .WillByDefault(
-          Return(am::HmiInterfaces::HMI_INTERFACE_BasicCommunication));
-  ON_CALL(hmi_interfaces, GetInterfaceState(_))
-      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
   MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
   (*msg)[am::strings::params][am::hmi_response::code] =
@@ -770,6 +762,8 @@ TEST_F(ShowRequestTest, OnEvent_SuccessResultCode_SUCCESS) {
   Event event(hmi_apis::FunctionID::UI_Show);
   event.set_smart_object(*msg);
 
+  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(mock_app_));
+
   command->on_event(event);
 }
 
@@ -786,6 +780,8 @@ TEST_F(ShowRequestTest, OnEvent_WarningsResultCode_SUCCESS) {
 
   Event event(hmi_apis::FunctionID::UI_Show);
   event.set_smart_object(*msg);
+
+  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(mock_app_));
 
   command->on_event(event);
 }

--- a/src/components/application_manager/test/commands/mobile/slider_test.cc
+++ b/src/components/application_manager/test/commands/mobile/slider_test.cc
@@ -56,7 +56,6 @@ using am::commands::SliderRequest;
 using am::commands::CommandImpl;
 using am::commands::MessageSharedPtr;
 using am::MockMessageHelper;
-using am::MockHmiInterfaces;
 using policy_test::MockPolicyHandlerInterface;
 using ::utils::SharedPtr;
 using ::testing::_;
@@ -159,11 +158,6 @@ TEST_F(SliderRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
       .WillByDefault(Return(mock_app));
 
   ON_CALL(*mock_app, app_id()).WillByDefault(Return(kConnectionKey));
-  MockHmiInterfaces hmi_interfaces;
-  ON_CALL(app_mngr_, hmi_interfaces()).WillByDefault(ReturnRef(hmi_interfaces));
-  EXPECT_CALL(hmi_interfaces,
-              GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_UI))
-      .WillOnce(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
   MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
   (*msg)[am::strings::params][am::hmi_response::code] =

--- a/src/components/application_manager/test/commands/mobile/speak_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/speak_request_test.cc
@@ -67,7 +67,6 @@ using am::ApplicationManager;
 using am::commands::MessageSharedPtr;
 using am::ApplicationSharedPtr;
 using am::MockMessageHelper;
-using am::MockHmiInterfaces;
 using ::testing::_;
 using ::utils::SharedPtr;
 using ::testing::Return;
@@ -113,10 +112,8 @@ class SpeakRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
     ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app));
 
     MessageSharedPtr response_to_mobile;
-    MockHmiInterfaces hmi_interfaces;
-    EXPECT_CALL(app_mngr_, hmi_interfaces())
-        .WillOnce(ReturnRef(hmi_interfaces));
-    EXPECT_CALL(hmi_interfaces, GetInterfaceState(_)).WillOnce(Return(state));
+    EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
+        .WillRepeatedly(Return(state));
     MockMessageHelper* mock_message_helper =
         MockMessageHelper::message_helper_mock();
     EXPECT_CALL(*mock_message_helper, HMIToMobileResult(_))

--- a/src/components/application_manager/test/commands/mobile/unregister_app_interface_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unregister_app_interface_request_test.cc
@@ -84,7 +84,7 @@ TEST_F(UnregisterAppInterfaceRequestTest, Run_SUCCESS) {
 
   MockAppPtr mock_app(CreateMockApp());
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .WillRepeatedly(Return(mock_app));
 
   const mobile_apis::AppInterfaceUnregisteredReason::eType kUnregisterReason =
       mobile_apis::AppInterfaceUnregisteredReason::INVALID_ENUM;

--- a/src/components/application_manager/test/commands/mobile/unsubscribe_button_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unsubscribe_button_request_test.cc
@@ -81,7 +81,7 @@ TEST_F(UnsubscribeButtonRequestTest, Run_SUCCESS) {
 
   MockAppPtr mock_app(CreateMockApp());
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .WillRepeatedly(Return(mock_app));
 
   EXPECT_CALL(*mock_app, UnsubscribeFromButton(kButtonId))
       .WillOnce(Return(true));

--- a/src/components/application_manager/test/commands/mobile/unsubscribe_vehicle_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unsubscribe_vehicle_request_test.cc
@@ -181,22 +181,26 @@ void UnsubscribeVehicleRequestTest::UnsubscribeSuccessfully() {
   (*command_msg)[am::strings::params][am::strings::connection_key] =
       kConnectionKey;
   (*command_msg)[am::strings::msg_params][kMsgParamKey] = true;
+
   am::VehicleData vehicle_data;
   vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
+
   EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()), vehicle_data())
       .WillOnce(ReturnRef(vehicle_data));
-  CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
   am::ApplicationSet application_set_;
   MockAppPtr mock_app(CreateMockApp());
   application_set_.insert(mock_app);
   DataAccessor<am::ApplicationSet> accessor(application_set_, app_set_lock_);
+
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+      .WillRepeatedly(Return(mock_app));
+
+  EXPECT_CALL(app_mngr_, applications()).WillRepeatedly(Return(accessor));
 
   EXPECT_CALL(*mock_app, IsSubscribedToIVI(kVehicleType))
       .WillRepeatedly(Return(true));
+
   EXPECT_CALL(*mock_app, UnsubscribeFromIVI(kVehicleType))
       .WillRepeatedly(Return(true));
 
@@ -204,6 +208,7 @@ void UnsubscribeVehicleRequestTest::UnsubscribeSuccessfully() {
       app_mngr_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
 
+  CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
   command->Run();
 }
 
@@ -280,8 +285,6 @@ TEST_F(UnsubscribeVehicleRequestTest, OnEvent_DataUnsubscribed_SUCCESS) {
   EXPECT_CALL(
       app_mngr_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS), _));
-
-  EXPECT_CALL(*mock_app, UpdateHash());
 
   command->on_event(test_event);
 }

--- a/src/components/application_manager/test/commands/mobile/unsubscribe_way_points_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unsubscribe_way_points_request_test.cc
@@ -152,7 +152,7 @@ TEST_F(UnSubscribeWayPointsRequestTest,
        OnEvent_ReceivedNavigationUnSubscribeWayPointsEvent_SUCCESS) {
   MockAppPtr mock_app(CreateMockApp());
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .WillRepeatedly(Return(mock_app));
 
   MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
   (*event_msg)[am::strings::msg_params] = 0;

--- a/src/components/application_manager/test/commands/mobile/update_turn_list_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/update_turn_list_request_test.cc
@@ -281,6 +281,9 @@ TEST_F(UpdateTurnListRequestTest, OnEvent_UnsupportedResource_SUCCESS) {
   EXPECT_CALL(app_mngr_,
               ManageMobileCommand(MobileResultCodeIs(mobile_response_code), _));
 
+  MockAppPtr mock_app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app));
+
   command_->on_event(event);
 }
 
@@ -302,6 +305,9 @@ TEST_F(UpdateTurnListRequestTest,
 
   EXPECT_CALL(app_mngr_,
               ManageMobileCommand(MobileResultCodeIs(mobile_response_code), _));
+
+  MockAppPtr mock_app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app));
 
   command_->on_event(event);
 }


### PR DESCRIPTION
In case RPC is expected to update application hash but UI component is not available, i.e. UI.IsReady returned 'false', hash update must be skipped.

Changes move logic of hash updating into base class instead of duplicating it inside every related command class. UI interface state now is checked  before hash update. 

Also unit tests for **commands** had been fixed: 
- enabled missed unit tests for CommandRequestImpl class
- added new unit test for changes hash update logic
- removed duplicated local test mock instances,
- added missing expectations, updated some existing expectations.

Fixes https://github.com/smartdevicelink/sdl_core/issues/993