### PR TITLE
Fixes sending OnSystemRequest with HTTP mode

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -445,10 +445,6 @@ class PolicyHandler : public PolicyHandlerInterface,
   void SetPolicyManager(utils::SharedPtr<PolicyManager> pm) {
     policy_manager_ = pm;
   }
-
-  AppIds& last_used_app_ids() {
-    return last_used_app_ids_;
-  }
 #endif  // BUILD_TESTS
 
 #ifdef ENABLE_SECURITY
@@ -609,7 +605,6 @@ class PolicyHandler : public PolicyHandlerInterface,
   mutable sync_primitives::RWLock policy_manager_lock_;
   utils::SharedPtr<PolicyManager> policy_manager_;
   void* dl_handle_;
-  AppIds last_used_app_ids_;
   utils::SharedPtr<PolicyEventObserver> event_observer_;
   uint32_t last_activated_app_id_;
 

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1021,16 +1021,9 @@ bool PolicyHandler::SendMessageToSDK(const BinaryMessage& pt_string,
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK(false);
 
-  ApplicationSharedPtr app;
-  uint32_t app_id = 0;
-  if (last_used_app_ids_.empty()) {
-    LOG4CXX_WARN(logger_, "last_used_app_ids_ is empty");
-    return false;
-  } else {
-    app_id = last_used_app_ids_.back();
+  uint32_t app_id = GetAppIdForSending();
 
-    app = application_manager_.application(app_id);
-  }
+  ApplicationSharedPtr app = application_manager_.application(app_id);
 
   if (!app) {
     LOG4CXX_WARN(logger_,

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -1997,34 +1997,59 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_ExpectReturnAnyAppInNone) {
   EXPECT_EQ(app_in_none_id_1 || app_in_none_id_2, app_id);
 }
 
-TEST_F(PolicyHandlerTest, SendMessageToSDK) {
-  // Precondition
+TEST_F(PolicyHandlerTest,
+       SendMessageToSDK_SuitableAppPresent_ExpectedNotificationSending) {
   BinaryMessage msg;
   const std::string url = "test_url";
   EnablePolicyAndPolicyManagerMock();
   test_app.insert(mock_app_);
-  // Expectations
+
   EXPECT_CALL(app_manager_, application(kAppId1_))
       .WillRepeatedly(Return(mock_app_));
-  EXPECT_CALL(*mock_app_, policy_app_id()).WillOnce(Return(kPolicyAppId_));
+  EXPECT_CALL(*mock_app_, app_id()).WillRepeatedly(Return(kAppId1_));
+  EXPECT_CALL(*mock_app_, policy_app_id())
+      .WillRepeatedly(Return(kPolicyAppId_));
+  EXPECT_CALL(*mock_app_, hmi_level())
+      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
+  EXPECT_CALL(*mock_app_, IsRegistered()).WillRepeatedly(Return(true));
+
+  const connection_handler::DeviceHandle test_device_id = 1u;
+  EXPECT_CALL(*mock_app_, device()).WillRepeatedly(Return(test_device_id));
+  EXPECT_CALL(*mock_policy_manager_, GetUserConsentForDevice(_))
+      .WillOnce(Return(kDeviceAllowed));
 
   // Act
-  policy_handler_.last_used_app_ids().push_back(kAppId1_);
   EXPECT_CALL(mock_message_helper_,
               SendPolicySnapshotNotification(kAppId1_, msg, url, _));
   EXPECT_TRUE(policy_handler_.SendMessageToSDK(msg, url));
 }
 
-TEST_F(PolicyHandlerTest, SendMessageToSDK_InavalidApp_UNSUCCESS) {
+TEST_F(PolicyHandlerTest,
+       SendMessageToSDK_NoSuitableApp_ExpectedNotificationNotSent) {
   BinaryMessage msg;
   const std::string url = "test_url";
   EnablePolicyAndPolicyManagerMock();
-  utils::SharedPtr<application_manager_test::MockApplication> invalid_app;
-  policy_handler_.last_used_app_ids().push_back(kAppId1_);
+  test_app.insert(mock_app_);
 
   EXPECT_CALL(app_manager_, application(kAppId1_))
-      .WillOnce(Return(invalid_app));
-  EXPECT_CALL(*mock_app_, policy_app_id()).Times(0);
+      .WillRepeatedly(Return(mock_app_));
+  EXPECT_CALL(*mock_app_, app_id()).WillRepeatedly(Return(kAppId1_));
+  EXPECT_CALL(*mock_app_, policy_app_id())
+      .WillRepeatedly(Return(kPolicyAppId_));
+  EXPECT_CALL(*mock_app_, hmi_level())
+      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_NONE));
+  EXPECT_CALL(*mock_app_, IsRegistered()).WillRepeatedly(Return(true));
+
+  const connection_handler::DeviceHandle test_device_id = 1u;
+  EXPECT_CALL(*mock_app_, device()).WillRepeatedly(Return(test_device_id));
+  EXPECT_CALL(*mock_policy_manager_, GetUserConsentForDevice(_))
+      .WillOnce(Return(kDeviceDisallowed));
+
+  // Expected to get 0 as application id so SDL does not have valid application
+  // with such id
+  EXPECT_CALL(app_manager_, application(0))
+      .WillOnce(Return(
+          utils::SharedPtr<application_manager_test::MockApplication>()));
 
   EXPECT_FALSE(policy_handler_.SendMessageToSDK(msg, url));
 }


### PR DESCRIPTION
PolicyHandler::SendMessageToSDK was using obsolete logic of choosing appropriate application to send OnSystemRequest. Changes replace it with call to GetAppIdForSending() which considers application HMI level, registration status, device consent etc. 
Primary source of changes is https://github.com/ATymchenko/sdl_core/commit/2c8677595c0e85c36871774bb1993a783f0f511f

Also appropriate unit test have been modified.

**Note:** there is a **dependency** on https://github.com/smartdevicelink/sdl_core/pull/1548 so these PRs both have to be merges in order to pass ATF tests for HTTP mode.