### PR TITLE
Fix SUSPEND -> OnSDLAwake -> SUSPEND -> IGN_OFF sequence for resumption data saving 

### DIFF
--- a/src/components/application_manager/CMakeLists.txt
+++ b/src/components/application_manager/CMakeLists.txt
@@ -324,6 +324,7 @@ set (HMI_COMMANDS_SOURCES
   ${COMMANDS_SOURCE_DIR}/hmi/on_system_error_notification.cc
   ${COMMANDS_SOURCE_DIR}/hmi/basic_communication_system_request.cc
   ${COMMANDS_SOURCE_DIR}/hmi/basic_communication_system_response.cc
+  ${COMMANDS_SOURCE_DIR}/hmi/basic_communication_on_awake_sdl.cc
   ${COMMANDS_SOURCE_DIR}/hmi/sdl_policy_update.cc
   ${COMMANDS_SOURCE_DIR}/hmi/sdl_policy_update_response.cc
   ${COMMANDS_SOURCE_DIR}/hmi/on_received_policy_update.cc

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -413,15 +413,14 @@ class Application : public virtual InitialApplicationData,
    * @return Returns TRUE if hashID was changed during suspended state
    * otherwise returns FALSE.
    */
-  virtual bool IsHashChangedAfterAwake() const = 0;
+  virtual bool IsHashChangedDuringSuspend() const = 0;
 
   /**
-   * @brief notifies is hashID was changed during suspended state
-   * Method is used when core receives OnAwakeSDL notification
-   * in order to change value of flag_sending_hash_change_after_awake_
-   * @param state new state value
+   * @brief changes state of the flag which tracks is hashID was changed during
+   * suspended state or not
+   * @param state new state of the flag
    */
-  virtual void SetHashChangedAfterAwake(const bool state) = 0;
+  virtual void SetHashChangedDuringSuspend(const bool state) = 0;
 
   /**
    * @brief method is called when SDL is saving application data for resumption

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -409,18 +409,19 @@ class Application : public virtual InitialApplicationData,
   virtual void UpdateHash() = 0;
 
   /**
-   * @brief Retrieves flag_sending_hash_change_after_awake_
+   * @brief checks is hashID was changed during suspended state
    * @return Returns TRUE if hashID was changed during suspended state
    * otherwise returns FALSE.
    */
-  virtual bool flag_sending_hash_change_after_awake() const = 0;
+  virtual bool IsHashChangedAfterAwake() const = 0;
 
   /**
-   * @brief Method is used when core receives OnAwakeSDL notification
+   * @brief notifies is hashID was changed during suspended state
+   * Method is used when core receives OnAwakeSDL notification
    * in order to change value of flag_sending_hash_change_after_awake_
-   * @param Contains FALSE
+   * @param state new state value
    */
-  virtual void set_flag_sending_hash_change_after_awake(bool flag) = 0;
+  virtual void SetHashChangedAfterAwake(const bool state) = 0;
 
   /**
    * @brief method is called when SDL is saving application data for resumption

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -409,6 +409,20 @@ class Application : public virtual InitialApplicationData,
   virtual void UpdateHash() = 0;
 
   /**
+   * @brief Retrieves flag_sending_hash_change_after_awake_
+   * @return Returns TRUE if hashID was changed during suspended state
+   * otherwise returns FALSE.
+   */
+  virtual bool flag_sending_hash_change_after_awake() const = 0;
+
+  /**
+   * @brief Method is used when core receives OnAwakeSDL notification
+   * in order to change value of flag_sending_hash_change_after_awake_
+   * @param Contains FALSE
+   */
+  virtual void set_flag_sending_hash_change_after_awake(bool flag) = 0;
+
+  /**
    * @brief method is called when SDL is saving application data for resumption
    * @return TRUE if data of application need to save for resumption, otherwise
    * return FALSE

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -198,15 +198,26 @@ class ApplicationImpl : public virtual Application,
   virtual DataAccessor<ButtonSubscriptions> SubscribedButtons() const OVERRIDE;
 
   virtual const std::string& curHash() const;
-#ifdef CUSTOMER_PASA
-  virtual bool flag_sending_hash_change_after_awake() const;
-  virtual void set_flag_sending_hash_change_after_awake(bool flag);
-#endif  // CUSTOMER_PASA
-        /**
-         * @brief Change Hash for current application
-         * and send notification to mobile
-         * @return updated_hash
-         */
+
+  /**
+   * @brief Retrieves flag_sending_hash_change_after_awake_
+   * @return Returns TRUE if hashID was changed during suspended state
+   * otherwise returns FALSE.
+   */
+  bool flag_sending_hash_change_after_awake() const OVERRIDE;
+
+  /**
+   * @brief Method is used when core receives OnAwakeSDL notification
+   * in order to change value of flag_sending_hash_change_after_awake_
+   * @param Contains FALSE
+   */
+  void set_flag_sending_hash_change_after_awake(bool flag) OVERRIDE;
+
+  /**
+   * @brief Change Hash for current application
+   * and send notification to mobile
+   * @return updated_hash
+   */
   virtual void UpdateHash();
 
   UsageStatistics& usage_report();
@@ -432,6 +443,7 @@ class ApplicationImpl : public virtual Application,
   protocol_handler::MajorProtocolVersion protocol_version_;
   bool is_voice_communication_application_;
   sync_primitives::atomic_bool is_resuming_;
+  bool flag_sending_hash_change_after_awake_;
 
   uint32_t video_stream_retry_number_;
   uint32_t audio_stream_retry_number_;

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -199,20 +199,12 @@ class ApplicationImpl : public virtual Application,
 
   virtual const std::string& curHash() const;
 
-  /**
-   * @brief checks is hashID was changed during suspended state
-   * @return Returns TRUE if hashID was changed during suspended state
-   * otherwise returns FALSE.
-   */
-  bool IsHashChangedAfterAwake() const OVERRIDE;
-
-  /**
-   * @brief notifies is hashID was changed during suspended state
-   * Method is used when core receives OnAwakeSDL notification
-   * in order to change value of flag_sending_hash_change_after_awake_
-   * @param state new state value
-   */
-  void SetHashChangedAfterAwake(const bool state) OVERRIDE;
+#ifdef CUSTOMER_PASA
+  // DEPRECATED
+  virtual bool flag_sending_hash_change_after_awake() const;
+  // DEPRECATED
+  virtual void set_flag_sending_hash_change_after_awake(bool flag);
+#endif  // CUSTOMER_PASA
 
   /**
    * @brief Change Hash for current application
@@ -220,6 +212,20 @@ class ApplicationImpl : public virtual Application,
    * @return updated_hash
    */
   virtual void UpdateHash();
+
+  /**
+   * @brief checks is hashID was changed during suspended state
+   * @return Returns TRUE if hashID was changed during suspended state
+   * otherwise returns FALSE.
+   */
+  bool IsHashChangedDuringSuspend() const OVERRIDE;
+
+  /**
+   * @brief changes state of the flag which tracks is hashID was changed during
+   * suspended state or not
+   * @param state new state of the flag
+   */
+  void SetHashChangedDuringSuspend(const bool state) OVERRIDE;
 
   UsageStatistics& usage_report();
 

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -200,18 +200,19 @@ class ApplicationImpl : public virtual Application,
   virtual const std::string& curHash() const;
 
   /**
-   * @brief Retrieves flag_sending_hash_change_after_awake_
+   * @brief checks is hashID was changed during suspended state
    * @return Returns TRUE if hashID was changed during suspended state
    * otherwise returns FALSE.
    */
-  bool flag_sending_hash_change_after_awake() const OVERRIDE;
+  bool IsHashChangedAfterAwake() const OVERRIDE;
 
   /**
-   * @brief Method is used when core receives OnAwakeSDL notification
+   * @brief notifies is hashID was changed during suspended state
+   * Method is used when core receives OnAwakeSDL notification
    * in order to change value of flag_sending_hash_change_after_awake_
-   * @param Contains FALSE
+   * @param state new state value
    */
-  void set_flag_sending_hash_change_after_awake(bool flag) OVERRIDE;
+  void SetHashChangedAfterAwake(const bool state) OVERRIDE;
 
   /**
    * @brief Change Hash for current application
@@ -443,7 +444,7 @@ class ApplicationImpl : public virtual Application,
   protocol_handler::MajorProtocolVersion protocol_version_;
   bool is_voice_communication_application_;
   sync_primitives::atomic_bool is_resuming_;
-  bool flag_sending_hash_change_after_awake_;
+  bool is_hash_changed_during_suspend_;
 
   uint32_t video_stream_retry_number_;
   uint32_t audio_stream_retry_number_;

--- a/src/components/application_manager/include/application_manager/commands/hmi/basic_communication_on_awake_sdl.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/basic_communication_on_awake_sdl.h
@@ -60,7 +60,7 @@ class OnAwakeSDLNotification : public NotificationFromHMI {
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(OnAwakeSDLNotification);

--- a/src/components/application_manager/include/application_manager/commands/hmi/basic_communication_on_awake_sdl.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/basic_communication_on_awake_sdl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Ford Motor Company
+ * Copyright (c) 2017, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,3 +29,45 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_BASIC_COMMUNICATION_ON_AWAKE_SDL_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_BASIC_COMMUNICATION_ON_AWAKE_SDL_H_
+
+#include "application_manager/commands/hmi/notification_from_hmi.h"
+
+namespace application_manager {
+
+namespace commands {
+
+/**
+ * @brief OnAwakeSDLNotification command class
+ **/
+class OnAwakeSDLNotification : public NotificationFromHMI {
+ public:
+  /**
+   * @brief OnAwakeSDLNotification class constructor
+   * @param message Incoming SmartObject message
+   * @param application_manager reference to ApplicationManager instance
+   **/
+  OnAwakeSDLNotification(const MessageSharedPtr& message,
+                         ApplicationManager& application_manager);
+
+  /**
+   * @brief OnAwakeSDLNotification class destructor
+   **/
+  virtual ~OnAwakeSDLNotification();
+
+  /**
+   * @brief Execute command
+   **/
+  virtual void Run();
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(OnAwakeSDLNotification);
+};
+
+}  // namespace commands
+
+}  // namespace application_manager
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_BASIC_COMMUNICATION_ON_AWAKE_SDL_H_

--- a/src/components/application_manager/include/application_manager/commands/hmi/on_exit_all_applications_notification.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/on_exit_all_applications_notification.h
@@ -60,7 +60,7 @@ class OnExitAllApplicationsNotification : public NotificationFromHMI {
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
 
  private:
   /**

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -125,22 +125,13 @@ class ResumeCtrl {
   virtual void OnAwake() = 0;
 
   /**
-   * @brief Retrieves value of is_suspended_
+   * @brief Checks if SDL has already received OnExitAllApplication notification
+   * with "SUSPEND" reason
    *
    * @return Returns TRUE if SDL has received OnExitAllApplication notification
    * with reason "SUSPEND" otherwise returns FALSE
    */
   virtual bool is_suspended() const = 0;
-
-  /**
-   * @brief Sets value of is_suspended_
-   *
-   * @param contains TRUE if method is called when SDL has received
-   * OnExitAllApplication notification with reason "SUSPEND"
-   * contains FALSE if method is called when SDL has received
-   * OnAwakeSDL notification.
-   */
-  virtual void set_is_suspended(const bool suspended_flag) = 0;
 
   /**
    * @brief Method stops timer "RsmCtrlPercist" when SDL

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -115,9 +115,32 @@ class ResumeCtrl {
   virtual void OnSuspend() = 0;
 
   /**
+   * @brief Processes resumption data after receiving signal "Ignition Off"
+   */
+  virtual void OnIgnitionOff() = 0;
+
+  /**
    * @brief Processes resumption data after receiving signal "Awake"
    */
   virtual void OnAwake() = 0;
+
+  /**
+   * @brief Retrieves value of is_suspended_
+   *
+   * @return Returns TRUE if SDL has received OnExitAllApplication notification
+   * with reason "SUSPEND" otherwise returns FALSE
+   */
+  virtual bool is_suspended() const = 0;
+
+  /**
+   * @brief Sets value of is_suspended_
+   *
+   * @param contains TRUE if method is called when SDL has received
+   * OnExitAllApplication notification with reason "SUSPEND"
+   * contains FALSE if method is called when SDL has received
+   * OnAwakeSDL notification.
+   */
+  virtual void set_is_suspended(const bool suspended_flag) = 0;
 
   /**
    * @brief Method stops timer "RsmCtrlPercist" when SDL

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -129,9 +129,32 @@ class ResumeCtrlImpl : public ResumeCtrl,
   void OnSuspend() OVERRIDE;
 
   /**
+   * @brief Processes resumption data after receiving signal "Ignition Off"
+   */
+  void OnIgnitionOff() OVERRIDE;
+
+  /**
    * @brief Processes resumption data after receiving signal "Awake"
    */
   void OnAwake() OVERRIDE;
+
+  /**
+   * @brief Retrieves value of is_suspended_
+   *
+   * @return Returns TRUE if SDL has received OnExitAllApplication notification
+   * with reason "SUSPEND" otherwise returns FALSE
+   */
+  bool is_suspended() const OVERRIDE;
+
+  /**
+   * @brief Sets value of is_suspended_
+   *
+   * @param contains TRUE if method is called when SDL has received
+   * OnExitAllApplication notification with reason "SUSPEND"
+   * contains FALSE if method is called when SDL has received
+   * OnAwakeSDL notification.
+   */
+  void set_is_suspended(const bool suspended_flag) OVERRIDE;
 
   /**
    * @brief Method stops timer "RsmCtrlPercist" when SDL
@@ -491,6 +514,7 @@ class ResumeCtrlImpl : public ResumeCtrl,
   WaitingForTimerList waiting_for_timer_;
   bool is_resumption_active_;
   bool is_data_saved_;
+  bool is_suspended_;
   time_t launch_time_;
   utils::SharedPtr<ResumptionData> resumption_storage_;
   application_manager::ApplicationManager& application_manager_;

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -139,22 +139,13 @@ class ResumeCtrlImpl : public ResumeCtrl,
   void OnAwake() OVERRIDE;
 
   /**
-   * @brief Retrieves value of is_suspended_
+   * @brief Checks if SDL has already received OnExitAllApplication notification
+   * with "SUSPEND" reason
    *
    * @return Returns TRUE if SDL has received OnExitAllApplication notification
    * with reason "SUSPEND" otherwise returns FALSE
    */
   bool is_suspended() const OVERRIDE;
-
-  /**
-   * @brief Sets value of is_suspended_
-   *
-   * @param contains TRUE if method is called when SDL has received
-   * OnExitAllApplication notification with reason "SUSPEND"
-   * contains FALSE if method is called when SDL has received
-   * OnAwakeSDL notification.
-   */
-  void set_is_suspended(const bool suspended_flag) OVERRIDE;
 
   /**
    * @brief Method stops timer "RsmCtrlPercist" when SDL
@@ -322,6 +313,12 @@ class ResumeCtrlImpl : public ResumeCtrl,
    *  N gets from property
    */
   void SaveDataOnTimer();
+
+  /**
+   * @brief FinalPersistData persists ResumptionData last time and stops
+   * persistent data timer to avoid further persisting
+   */
+  void FinalPersistData();
 
   /**
    * @brief AddFiles allows to add files for the application

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data.h
@@ -91,7 +91,12 @@ class ResumptionData {
    * @brief Increments ignition counter for all registered applications
    * and remember ign_off time stamp
    */
-  virtual void OnSuspend() = 0;
+  virtual void IncrementIgnOffCount() = 0;
+
+  /**
+   * @brief Decrements ignition counter for all registered applications
+   */
+  virtual void DecrementIgnOffCount() = 0;
 
   /**
    * @brief Retrieves hash ID for the given mobile app ID
@@ -106,12 +111,6 @@ class ResumptionData {
   virtual bool GetHashId(const std::string& policy_app_id,
                          const std::string& device_id,
                          std::string& hash_id) const = 0;
-
-  /**
-   * @brief Increments ignition counter for all registered applications
-   * and remember ign_off time stamp
-   */
-  virtual void OnAwake() = 0;
 
   /**
    * @brief Retrieves data of saved application for the given mobile app ID

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data.h
@@ -94,9 +94,22 @@ class ResumptionData {
   virtual void IncrementIgnOffCount() = 0;
 
   /**
+   * @brief Increments ignition counter for all registered applications
+   * and remember ign_off time stamp
+   */
+  // DEPRECATED
+  virtual void OnSuspend() = 0;
+
+  /**
    * @brief Decrements ignition counter for all registered applications
    */
   virtual void DecrementIgnOffCount() = 0;
+
+  /**
+   * @brief Decrements ignition counter for all registered applications
+   */
+  // DEPRECATED
+  virtual void OnAwake() = 0;
 
   /**
    * @brief Retrieves hash ID for the given mobile app ID

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
@@ -113,11 +113,23 @@ class ResumptionDataDB : public ResumptionData {
    * @brief Increments ignition counter for all registered applications
    * and remember ign_off time stamp
    */
+  // DEPRECATED
+  void OnSuspend() FINAL;
+
+  /**
+   * @brief Decrements ignition counter for all registered applications
+   */
+  // DEPRECATED
+  void OnAwake() FINAL;
+
+  /**
+   * @brief Increments ignition counter for all registered applications
+   * and remember ign_off time stamp
+   */
   void IncrementIgnOffCount() FINAL;
 
   /**
    * @brief Decrements ignition counter for all registered applications
-   * and remember ign_off time stamp
    */
   void DecrementIgnOffCount() FINAL;
 

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
@@ -113,7 +113,13 @@ class ResumptionDataDB : public ResumptionData {
    * @brief Increments ignition counter for all registered applications
    * and remember ign_off time stamp
    */
-  virtual void OnSuspend();
+  void IncrementIgnOffCount() FINAL;
+
+  /**
+   * @brief Decrements ignition counter for all registered applications
+   * and remember ign_off time stamp
+   */
+  void DecrementIgnOffCount() FINAL;
 
   /**
    * @brief Retrieves hash ID for the given mobile app ID
@@ -128,12 +134,6 @@ class ResumptionDataDB : public ResumptionData {
   virtual bool GetHashId(const std::string& policy_app_id,
                          const std::string& device_id,
                          std::string& hash_id) const;
-
-  /**
-   * @brief Decrements ignition counter for all registered applications
-   * and remember ign_off time stamp
-   */
-  virtual void OnAwake();
 
   /**
    * @brief Retrieves data of saved application for the given mobile app ID

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_json.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_json.h
@@ -85,11 +85,23 @@ class ResumptionDataJson : public ResumptionData {
    * @brief Increments ignition counter for all registered applications
    * and remember ign_off time stamp
    */
-  void IncrementIgnOffCount() FINAL;
+  // DEPRECATED
+  void OnSuspend() FINAL;
+
+  /**
+   * @brief Decrements ignition counter for all registered applications
+   */
+  // DEPRECATED
+  void OnAwake() FINAL;
 
   /**
    * @brief Increments ignition counter for all registered applications
    * and remember ign_off time stamp
+   */
+  void IncrementIgnOffCount() FINAL;
+
+  /**
+   * @brief Decrements ignition counter for all registered applications
    */
   void DecrementIgnOffCount() FINAL;
 

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_json.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_json.h
@@ -85,13 +85,13 @@ class ResumptionDataJson : public ResumptionData {
    * @brief Increments ignition counter for all registered applications
    * and remember ign_off time stamp
    */
-  virtual void OnSuspend();
+  void IncrementIgnOffCount() FINAL;
 
   /**
    * @brief Increments ignition counter for all registered applications
    * and remember ign_off time stamp
    */
-  virtual void OnAwake();
+  void DecrementIgnOffCount() FINAL;
 
   /**
    * @brief Retrieves hash ID for the given mobile app ID

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -881,11 +881,11 @@ void ApplicationImpl::UpdateHash() {
   }
 }
 
-bool ApplicationImpl::IsHashChangedAfterAwake() const {
+bool ApplicationImpl::IsHashChangedDuringSuspend() const {
   return is_hash_changed_during_suspend_;
 }
 
-void ApplicationImpl::SetHashChangedAfterAwake(const bool state) {
+void ApplicationImpl::SetHashChangedDuringSuspend(const bool state) {
   is_hash_changed_during_suspend_ = state;
 }
 

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -44,6 +44,7 @@
 #include "utils/make_shared.h"
 #include "utils/timer_task_impl.h"
 #include "application_manager/policies/policy_handler_interface.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace {
 
@@ -111,6 +112,7 @@ ApplicationImpl::ApplicationImpl(
           protocol_handler::MajorProtocolVersion::PROTOCOL_VERSION_3)
     , is_voice_communication_application_(false)
     , is_resuming_(false)
+    , flag_sending_hash_change_after_awake_(false)
     , video_stream_retry_number_(0)
     , audio_stream_retry_number_(0)
     , video_stream_suspend_timer_(
@@ -872,7 +874,19 @@ void ApplicationImpl::UpdateHash() {
       utils::gen_hash(application_manager_.get_settings().hash_string_size());
   set_is_application_data_changed(true);
 
-  MessageHelper::SendHashUpdateNotification(app_id(), application_manager_);
+  if (!application_manager_.resume_controller().is_suspended()) {
+    MessageHelper::SendHashUpdateNotification(app_id(), application_manager_);
+  } else {
+    flag_sending_hash_change_after_awake_ = true;
+  }
+}
+
+bool ApplicationImpl::flag_sending_hash_change_after_awake() const {
+  return flag_sending_hash_change_after_awake_;
+}
+
+void ApplicationImpl::set_flag_sending_hash_change_after_awake(bool flag) {
+  flag_sending_hash_change_after_awake_ = flag;
 }
 
 void ApplicationImpl::CleanupFiles() {

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -112,7 +112,7 @@ ApplicationImpl::ApplicationImpl(
           protocol_handler::MajorProtocolVersion::PROTOCOL_VERSION_3)
     , is_voice_communication_application_(false)
     , is_resuming_(false)
-    , flag_sending_hash_change_after_awake_(false)
+    , is_hash_changed_during_suspend_(false)
     , video_stream_retry_number_(0)
     , audio_stream_retry_number_(0)
     , video_stream_suspend_timer_(
@@ -877,16 +877,16 @@ void ApplicationImpl::UpdateHash() {
   if (!application_manager_.resume_controller().is_suspended()) {
     MessageHelper::SendHashUpdateNotification(app_id(), application_manager_);
   } else {
-    flag_sending_hash_change_after_awake_ = true;
+    is_hash_changed_during_suspend_ = true;
   }
 }
 
-bool ApplicationImpl::flag_sending_hash_change_after_awake() const {
-  return flag_sending_hash_change_after_awake_;
+bool ApplicationImpl::IsHashChangedAfterAwake() const {
+  return is_hash_changed_during_suspend_;
 }
 
-void ApplicationImpl::set_flag_sending_hash_change_after_awake(bool flag) {
-  flag_sending_hash_change_after_awake_ = flag;
+void ApplicationImpl::SetHashChangedAfterAwake(const bool state) {
+  is_hash_changed_during_suspend_ = state;
 }
 
 void ApplicationImpl::CleanupFiles() {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2883,7 +2883,7 @@ void ApplicationManagerImpl::UnregisterAllApplications() {
     }
   }
   if (is_ignition_off) {
-    resume_controller().OnSuspend();
+    resume_controller().OnIgnitionOff();
   }
   request_ctrl_.terminateAllHMIRequests();
 }

--- a/src/components/application_manager/src/commands/hmi/basic_communication_on_awake_sdl.cc
+++ b/src/components/application_manager/src/commands/hmi/basic_communication_on_awake_sdl.cc
@@ -57,10 +57,10 @@ void OnAwakeSDLNotification::Run() {
     ApplicationSetIt itEnd = accessor.GetData().end();
     for (; itBegin != itEnd; ++itBegin) {
       const ApplicationSharedPtr app = *itBegin;
-      if (app && app->IsHashChangedAfterAwake()) {
+      if (app && app->IsHashChangedDuringSuspend()) {
         MessageHelper::SendHashUpdateNotification(app->app_id(),
                                                   application_manager_);
-        app->SetHashChangedAfterAwake(false);
+        app->SetHashChangedDuringSuspend(false);
       }
     }
   }

--- a/src/components/application_manager/src/commands/hmi/basic_communication_on_awake_sdl.cc
+++ b/src/components/application_manager/src/commands/hmi/basic_communication_on_awake_sdl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Ford Motor Company
+ * Copyright (c) 2017, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,3 +29,45 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "application_manager/commands/hmi/basic_communication_on_awake_sdl.h"
+#include "application_manager/message_helper.h"
+#include "application_manager/resumption/resume_ctrl.h"
+
+namespace application_manager {
+
+namespace commands {
+
+OnAwakeSDLNotification::OnAwakeSDLNotification(
+    const MessageSharedPtr& message, ApplicationManager& application_manager)
+    : NotificationFromHMI(message, application_manager) {}
+
+OnAwakeSDLNotification::~OnAwakeSDLNotification() {}
+
+void OnAwakeSDLNotification::Run() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (application_manager_.resume_controller().is_suspended()) {
+    {
+      application_manager_.resume_controller().set_is_suspended(false);
+      DataAccessor<ApplicationSet> accessor =
+          application_manager_.applications();
+      ApplicationSetIt it = accessor.GetData().begin();
+      ApplicationSetIt itEnd = accessor.GetData().end();
+      for (; it != itEnd; ++it) {
+        if ((*it).get()) {
+          if ((*it)->flag_sending_hash_change_after_awake()) {
+            MessageHelper::SendHashUpdateNotification((*it)->app_id(),
+                                                      application_manager_);
+            (*it)->set_flag_sending_hash_change_after_awake(false);
+          }
+        }
+      }
+    }
+    application_manager_.resume_controller().OnAwake();
+  }
+}
+
+}  // namespace commands
+
+}  // namespace application_manager

--- a/src/components/application_manager/src/commands/hmi/on_exit_all_applications_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_exit_all_applications_notification.cc
@@ -75,7 +75,6 @@ void OnExitAllApplicationsNotification::Run() {
       break;
     }
     case hmi_apis::Common_ApplicationsCloseReason::SUSPEND: {
-      application_manager_.resume_controller().set_is_suspended(true);
       application_manager_.resume_controller().OnSuspend();
       SendOnSDLPersistenceComplete();
       return;

--- a/src/components/application_manager/src/commands/hmi/on_exit_all_applications_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_exit_all_applications_notification.cc
@@ -75,6 +75,8 @@ void OnExitAllApplicationsNotification::Run() {
       break;
     }
     case hmi_apis::Common_ApplicationsCloseReason::SUSPEND: {
+      application_manager_.resume_controller().set_is_suspended(true);
+      application_manager_.resume_controller().OnSuspend();
       SendOnSDLPersistenceComplete();
       return;
     }

--- a/src/components/application_manager/src/hmi_command_factory.cc
+++ b/src/components/application_manager/src/hmi_command_factory.cc
@@ -269,6 +269,7 @@
 #include "application_manager/commands/hmi/on_system_error_notification.h"
 #include "application_manager/commands/hmi/basic_communication_system_request.h"
 #include "application_manager/commands/hmi/basic_communication_system_response.h"
+#include "application_manager/commands/hmi/basic_communication_on_awake_sdl.h"
 #include "application_manager/commands/hmi/sdl_policy_update.h"
 #include "application_manager/commands/hmi/sdl_policy_update_response.h"
 #include "application_manager/commands/hmi/on_received_policy_update.h"
@@ -779,6 +780,11 @@ CommandSharedPtr HMICommandFactory::CreateCommand(
     case hmi_apis::FunctionID::BasicCommunication_OnAppActivated: {
       command.reset(new commands::OnAppActivatedNotification(
           message, application_manager));
+      break;
+    }
+    case hmi_apis::FunctionID::BasicCommunication_OnAwakeSDL: {
+      command.reset(
+          new commands::OnAwakeSDLNotification(message, application_manager));
       break;
     }
     case hmi_apis::FunctionID::BasicCommunication_OnExitApplication: {

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -264,29 +264,25 @@ bool ResumeCtrlImpl::RemoveApplicationFromSaved(
 
 void ResumeCtrlImpl::OnSuspend() {
   LOG4CXX_AUTO_TRACE(logger_);
-  StopSavePersistentDataTimer();
-  SaveAllApplications();
-  resumption_storage_->Persist();
+  is_suspended_ = true;
+  FinalPersistData();
 }
 
 void ResumeCtrlImpl::OnIgnitionOff() {
   LOG4CXX_AUTO_TRACE(logger_);
   resumption_storage_->IncrementIgnOffCount();
-  OnSuspend();
+  FinalPersistData();
 }
 
 void ResumeCtrlImpl::OnAwake() {
   LOG4CXX_AUTO_TRACE(logger_);
+  is_suspended_ = false;
   ResetLaunchTime();
   StartSavePersistentDataTimer();
 }
 
 bool ResumeCtrlImpl::is_suspended() const {
   return is_suspended_;
-}
-
-void ResumeCtrlImpl::set_is_suspended(const bool suspended_flag) {
-  is_suspended_ = suspended_flag;
 }
 
 void ResumeCtrlImpl::StartSavePersistentDataTimer() {
@@ -445,6 +441,13 @@ void ResumeCtrlImpl::SaveDataOnTimer() {
       resumption_storage_->Persist();
     }
   }
+}
+
+void ResumeCtrlImpl::FinalPersistData() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  StopSavePersistentDataTimer();
+  SaveAllApplications();
+  resumption_storage_->Persist();
 }
 
 bool ResumeCtrlImpl::IsDeviceMacAddressEqual(

--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -212,6 +212,9 @@ uint32_t ResumptionDataDB::GetHMIApplicationID(
   return hmi_app_id;
 }
 
+// DEPRECATED
+void ResumptionDataDB::OnSuspend() {}
+
 void ResumptionDataDB::IncrementIgnOffCount() {
   LOG4CXX_AUTO_TRACE(logger_);
 
@@ -290,6 +293,9 @@ bool ResumptionDataDB::GetHashId(const std::string& policy_app_id,
 
   return SelectHashId(policy_app_id, device_id, hash_id);
 }
+
+// DEPRECATED
+void ResumptionDataDB::OnAwake() {}
 
 void ResumptionDataDB::DecrementIgnOffCount() {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -212,7 +212,7 @@ uint32_t ResumptionDataDB::GetHMIApplicationID(
   return hmi_app_id;
 }
 
-void ResumptionDataDB::OnSuspend() {
+void ResumptionDataDB::IncrementIgnOffCount() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   utils::dbms::SQLQuery query_update_suspend_data(db());
@@ -291,7 +291,7 @@ bool ResumptionDataDB::GetHashId(const std::string& policy_app_id,
   return SelectHashId(policy_app_id, device_id, hash_id);
 }
 
-void ResumptionDataDB::OnAwake() {
+void ResumptionDataDB::DecrementIgnOffCount() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   UpdateDataOnAwake();

--- a/src/components/application_manager/src/resumption/resumption_data_json.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_json.cc
@@ -143,6 +143,9 @@ uint32_t ResumptionDataJson::GetHMIApplicationID(
   return hmi_app_id;
 }
 
+// DEPRECATED
+void ResumptionDataJson::OnSuspend() {}
+
 void ResumptionDataJson::IncrementIgnOffCount() {
   using namespace app_mngr;
   LOG4CXX_AUTO_TRACE(logger_);
@@ -166,6 +169,9 @@ void ResumptionDataJson::IncrementIgnOffCount() {
   SetLastIgnOffTime(time(NULL));
   LOG4CXX_DEBUG(logger_, GetResumptionData().toStyledString());
 }
+
+// DEPRECATED
+void ResumptionDataJson::OnAwake() {}
 
 void ResumptionDataJson::DecrementIgnOffCount() {
   using namespace app_mngr;

--- a/src/components/application_manager/src/resumption/resumption_data_json.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_json.cc
@@ -143,11 +143,11 @@ uint32_t ResumptionDataJson::GetHMIApplicationID(
   return hmi_app_id;
 }
 
-void ResumptionDataJson::OnSuspend() {
+void ResumptionDataJson::IncrementIgnOffCount() {
   using namespace app_mngr;
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock autolock(resumption_lock_);
-  Json::Value to_save;
+  Json::Value to_save = Json::arrayValue;
   for (Json::Value::iterator it = GetSavedApplications().begin();
        it != GetSavedApplications().end();
        ++it) {
@@ -167,7 +167,7 @@ void ResumptionDataJson::OnSuspend() {
   LOG4CXX_DEBUG(logger_, GetResumptionData().toStyledString());
 }
 
-void ResumptionDataJson::OnAwake() {
+void ResumptionDataJson::DecrementIgnOffCount() {
   using namespace app_mngr;
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock autolock(resumption_lock_);

--- a/src/components/application_manager/test/application_impl_test.cc
+++ b/src/components/application_manager/test/application_impl_test.cc
@@ -50,6 +50,7 @@
 #include "resumption/last_state.h"
 #include "application_manager/resumption/resume_ctrl.h"
 #include "application_manager/policies/mock_policy_handler_interface.h"
+#include "application_manager/mock_resume_ctrl.h"
 #include "policy/usage_statistics/mock_statistics_manager.h"
 #include "smart_objects/smart_object.h"
 
@@ -652,6 +653,22 @@ TEST_F(ApplicationImplTest,
 TEST_F(ApplicationImplTest, UpdateHash_AppMngrNotSuspended) {
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendHashUpdateNotification(app_id, _)).Times(1);
+  resumprion_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(mock_application_manager_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, is_suspended()).WillOnce(Return(false));
+  app_impl->UpdateHash();
+
+  EXPECT_TRUE(app_impl->is_application_data_changed());
+}
+
+TEST_F(ApplicationImplTest, UpdateHash_AppMngrSuspended) {
+  EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
+              SendHashUpdateNotification(app_id, _)).Times(0);
+  resumprion_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(mock_application_manager_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, is_suspended()).WillOnce(Return(true));
   app_impl->UpdateHash();
 
   EXPECT_TRUE(app_impl->is_application_data_changed());

--- a/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
+++ b/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
@@ -1035,7 +1035,6 @@ TEST_F(HMICommandsNotificationsTest,
   EXPECT_CALL(app_mngr_, resume_controller())
       .Times(2)
       .WillRepeatedly(ReturnRef(mock_resume_ctrl));
-  EXPECT_CALL(mock_resume_ctrl, set_is_suspended(true));
   EXPECT_CALL(mock_resume_ctrl, OnSuspend());
 
   EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())

--- a/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
+++ b/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
@@ -130,6 +130,8 @@
 #include "application_manager/policies/mock_policy_handler_interface.h"
 #include "application_manager/mock_message_helper.h"
 #include "protocol_handler/mock_session_observer.h"
+#include "application_manager/mock_resume_ctrl.h"
+
 #ifdef SDL_REMOTE_CONTROL
 #include "functional_module/plugin_manager.h"
 #endif  // SDL_REMOTE_CONTROL
@@ -1029,10 +1031,18 @@ TEST_F(HMICommandsNotificationsTest,
       kCorrelationId_;
   MessageSharedPtr temp_message = CreateMessage();
 
+  resumprion_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .Times(2)
+      .WillRepeatedly(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, set_is_suspended(true));
+  EXPECT_CALL(mock_resume_ctrl, OnSuspend());
+
   EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillOnce(Return(kCorrelationId_));
   EXPECT_CALL(app_mngr_, ManageHMICommand(_))
       .WillOnce(GetMessage(temp_message));
+
   command->Run();
   EXPECT_EQ(
       static_cast<uint32_t>(

--- a/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
+++ b/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
@@ -1033,8 +1033,7 @@ TEST_F(HMICommandsNotificationsTest,
 
   resumprion_test::MockResumeCtrl mock_resume_ctrl;
   EXPECT_CALL(app_mngr_, resume_controller())
-      .Times(2)
-      .WillRepeatedly(ReturnRef(mock_resume_ctrl));
+      .WillOnce(ReturnRef(mock_resume_ctrl));
   EXPECT_CALL(mock_resume_ctrl, OnSuspend());
 
   EXPECT_CALL(app_mngr_, GetNextHMICorrelationID())

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -50,8 +50,8 @@ class MockApplication : public ::application_manager::Application {
   MOCK_CONST_METHOD0(active_message, const smart_objects::SmartObject*());
   MOCK_CONST_METHOD0(curHash, const std::string&());
   MOCK_METHOD0(UpdateHash, void());
-  MOCK_CONST_METHOD0(flag_sending_hash_change_after_awake, bool());
-  MOCK_METHOD1(set_flag_sending_hash_change_after_awake, void(bool flag));
+  MOCK_CONST_METHOD0(IsHashChangedAfterAwake, bool());
+  MOCK_METHOD1(SetHashChangedAfterAwake, void(const bool flag));
   MOCK_CONST_METHOD0(is_application_data_changed, bool());
   MOCK_METHOD1(set_is_application_data_changed,
                void(bool state_application_data));

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -50,8 +50,12 @@ class MockApplication : public ::application_manager::Application {
   MOCK_CONST_METHOD0(active_message, const smart_objects::SmartObject*());
   MOCK_CONST_METHOD0(curHash, const std::string&());
   MOCK_METHOD0(UpdateHash, void());
-  MOCK_CONST_METHOD0(IsHashChangedAfterAwake, bool());
-  MOCK_METHOD1(SetHashChangedAfterAwake, void(const bool flag));
+  // DEPRECATED
+  MOCK_CONST_METHOD0(flag_sending_hash_change_after_awake, bool());
+  // DEPRECATED
+  MOCK_METHOD1(set_flag_sending_hash_change_after_awake, void(bool flag));
+  MOCK_CONST_METHOD0(IsHashChangedDuringSuspend, bool());
+  MOCK_METHOD1(SetHashChangedDuringSuspend, void(const bool flag));
   MOCK_CONST_METHOD0(is_application_data_changed, bool());
   MOCK_METHOD1(set_is_application_data_changed,
                void(bool state_application_data));

--- a/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
@@ -48,7 +48,10 @@ class MockResumeCtrl : public resumption::ResumeCtrl {
   MOCK_METHOD1(RemoveApplicationFromSaved,
                bool(app_mngr::ApplicationConstSharedPtr application));
   MOCK_METHOD0(OnSuspend, void());
+  MOCK_METHOD0(OnIgnitionOff, void());
   MOCK_METHOD0(OnAwake, void());
+  MOCK_CONST_METHOD0(is_suspended, bool());
+  MOCK_METHOD1(set_is_suspended, void(const bool));
   MOCK_METHOD0(StopSavePersistentDataTimer, void());
   MOCK_METHOD2(StartResumption,
                bool(app_mngr::ApplicationSharedPtr application,

--- a/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
@@ -51,7 +51,6 @@ class MockResumeCtrl : public resumption::ResumeCtrl {
   MOCK_METHOD0(OnIgnitionOff, void());
   MOCK_METHOD0(OnAwake, void());
   MOCK_CONST_METHOD0(is_suspended, bool());
-  MOCK_METHOD1(set_is_suspended, void(const bool));
   MOCK_METHOD0(StopSavePersistentDataTimer, void());
   MOCK_METHOD2(StartResumption,
                bool(app_mngr::ApplicationSharedPtr application,

--- a/src/components/application_manager/test/include/application_manager/mock_resumption_data.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resumption_data.h
@@ -59,12 +59,12 @@ class MockResumptionData : public ::resumption::ResumptionData {
   MOCK_CONST_METHOD2(GetHMIApplicationID,
                      uint32_t(const std::string& policy_app_id,
                               const std::string& device_id));
-  MOCK_METHOD0(OnSuspend, void());
+  MOCK_METHOD0(IncrementIgnOffCount, void());
   MOCK_CONST_METHOD3(GetHashId,
                      bool(const std::string& policy_app_id,
                           const std::string& device_id,
                           std::string& hash_id));
-  MOCK_METHOD0(OnAwake, void());
+  MOCK_METHOD0(DecrementIgnOffCount, void());
   MOCK_CONST_METHOD3(GetSavedApplication,
                      bool(const std::string& policy_app_id,
                           const std::string& device_id,

--- a/src/components/application_manager/test/include/application_manager/mock_resumption_data.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resumption_data.h
@@ -59,11 +59,13 @@ class MockResumptionData : public ::resumption::ResumptionData {
   MOCK_CONST_METHOD2(GetHMIApplicationID,
                      uint32_t(const std::string& policy_app_id,
                               const std::string& device_id));
+  MOCK_METHOD0(OnSuspend, void());
   MOCK_METHOD0(IncrementIgnOffCount, void());
   MOCK_CONST_METHOD3(GetHashId,
                      bool(const std::string& policy_app_id,
                           const std::string& device_id,
                           std::string& hash_id));
+  MOCK_METHOD0(OnAwake, void());
   MOCK_METHOD0(DecrementIgnOffCount, void());
   MOCK_CONST_METHOD3(GetSavedApplication,
                      bool(const std::string& policy_app_id,

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -880,7 +880,7 @@ TEST_F(ResumeCtrlTest, CheckPersistenceFilesForResumption_WithChoiceSet) {
 
 // TODO (VVeremjova) APPLINK-16718
 TEST_F(ResumeCtrlTest, DISABLED_OnSuspend) {
-  EXPECT_CALL(*mock_storage_, OnSuspend());
+  EXPECT_CALL(*mock_storage_, IncrementIgnOffCount());
   res_ctrl_->OnSuspend();
 }
 
@@ -896,7 +896,7 @@ TEST_F(ResumeCtrlTest, OnSuspend_EmptyApplicationlist) {
   ON_CALL(app_mngr_, applications()).WillByDefault(Return(accessor));
   EXPECT_CALL(*mock_storage_, SaveApplication(mock_app)).Times(0);
 
-  EXPECT_CALL(*mock_storage_, OnSuspend());
+  EXPECT_CALL(*mock_storage_, IncrementIgnOffCount()).Times(0);
   EXPECT_CALL(*mock_storage_, Persist());
   res_ctrl_->OnSuspend();
 }
@@ -906,7 +906,7 @@ TEST_F(ResumeCtrlTest, OnAwake) {
   EXPECT_CALL(mock_application_manager_settings_,
               app_resumption_save_persistent_data_timeout())
       .WillOnce(ReturnRef(timeout));
-  EXPECT_CALL(*mock_storage_, OnAwake());
+  EXPECT_CALL(*mock_storage_, DecrementIgnOffCount()).Times(0);
   res_ctrl_->OnAwake();
 }
 

--- a/src/components/application_manager/test/resumption/resumption_data_db_test.cc
+++ b/src/components/application_manager/test/resumption/resumption_data_db_test.cc
@@ -728,7 +728,7 @@ TEST_F(ResumptionDataDBTest, OnSuspend) {
   res_db()->SaveApplication(app_mock);
   CheckSavedDB();
 
-  res_db()->OnSuspend();
+  res_db()->IncrementIgnOffCount();
   ign_off_count_++;
   CheckSavedDB();
 }
@@ -740,18 +740,18 @@ TEST_F(ResumptionDataDBTest, OnSuspendFourTimes) {
   res_db()->SaveApplication(app_mock);
   CheckSavedDB();
 
-  res_db()->OnSuspend();
+  res_db()->IncrementIgnOffCount();
   ign_off_count_++;
   CheckSavedDB();
 
-  res_db()->OnSuspend();
+  res_db()->IncrementIgnOffCount();
   ign_off_count_++;
   CheckSavedDB();
-  res_db()->OnSuspend();
+  res_db()->IncrementIgnOffCount();
   ign_off_count_++;
   CheckSavedDB();
 
-  res_db()->OnSuspend();
+  res_db()->IncrementIgnOffCount();
 
   ssize_t result = res_db()->IsApplicationSaved(policy_app_id_, kMacAddress_);
   EXPECT_EQ(-1, result);
@@ -765,11 +765,11 @@ TEST_F(ResumptionDataDBTest, OnSuspendOnAwake) {
   res_db()->SaveApplication(app_mock);
   CheckSavedDB();
 
-  res_db()->OnSuspend();
+  res_db()->IncrementIgnOffCount();
 
   ign_off_count_++;
   CheckSavedDB();
-  res_db()->OnAwake();
+  res_db()->DecrementIgnOffCount();
   ign_off_count_ = 0;
   CheckSavedDB();
 }
@@ -782,7 +782,7 @@ TEST_F(ResumptionDataDBTest, Awake_AppNotSuspended) {
   res_db()->SaveApplication(app_mock);
   CheckSavedDB();
 
-  res_db()->OnAwake();
+  res_db()->DecrementIgnOffCount();
   ign_off_count_ = 0;
   CheckSavedDB();
 }
@@ -795,12 +795,12 @@ TEST_F(ResumptionDataDBTest, TwiceAwake_AppNotSuspended) {
   res_db()->SaveApplication(app_mock);
   CheckSavedDB();
 
-  res_db()->OnSuspend();
-  res_db()->OnAwake();
+  res_db()->IncrementIgnOffCount();
+  res_db()->DecrementIgnOffCount();
   ign_off_count_ = 0;
   CheckSavedDB();
 
-  res_db()->OnAwake();
+  res_db()->DecrementIgnOffCount();
   CheckSavedDB();
 }
 
@@ -826,14 +826,14 @@ TEST_F(ResumptionDataDBTest, GetIgnOffTime_AfterSuspendAndAwake) {
   last_ign_off_time = res_db()->GetIgnOffTime();
   EXPECT_EQ(0u, last_ign_off_time);
 
-  res_db()->OnSuspend();
+  res_db()->IncrementIgnOffCount();
 
   uint32_t after_suspend;
   after_suspend = res_db()->GetIgnOffTime();
   EXPECT_LE(last_ign_off_time, after_suspend);
 
   uint32_t after_awake;
-  res_db()->OnAwake();
+  res_db()->DecrementIgnOffCount();
 
   after_awake = res_db()->GetIgnOffTime();
   EXPECT_LE(after_suspend, after_awake);

--- a/src/components/application_manager/test/resumption/resumption_data_json_test.cc
+++ b/src/components/application_manager/test/resumption/resumption_data_json_test.cc
@@ -257,7 +257,7 @@ TEST_F(ResumptionDataJsonTest, OnSuspend) {
   res_json.SaveApplication(app_mock);
   CheckSavedJson();
 
-  res_json.OnSuspend();
+  res_json.IncrementIgnOffCount();
   ign_off_count_++;
   CheckSavedJson();
 }
@@ -268,13 +268,13 @@ TEST_F(ResumptionDataJsonTest, OnSuspendFourTimes) {
   res_json.SaveApplication(app_mock);
   CheckSavedJson();
 
-  res_json.OnSuspend();
+  res_json.IncrementIgnOffCount();
   ign_off_count_++;
   CheckSavedJson();
 
-  res_json.OnSuspend();
-  res_json.OnSuspend();
-  res_json.OnSuspend();
+  res_json.IncrementIgnOffCount();
+  res_json.IncrementIgnOffCount();
+  res_json.IncrementIgnOffCount();
 
   EXPECT_TRUE(-1 != res_json.IsApplicationSaved(policy_app_id_, kMacAddress_));
 }
@@ -285,11 +285,11 @@ TEST_F(ResumptionDataJsonTest, OnSuspendOnAwake) {
   res_json.SaveApplication(app_mock);
   CheckSavedJson();
 
-  res_json.OnSuspend();
+  res_json.IncrementIgnOffCount();
   ign_off_count_++;
   CheckSavedJson();
 
-  res_json.OnAwake();
+  res_json.DecrementIgnOffCount();
   ign_off_count_ = 0;
   CheckSavedJson();
 }
@@ -300,7 +300,7 @@ TEST_F(ResumptionDataJsonTest, Awake_AppNotSuspended) {
   res_json.SaveApplication(app_mock);
   CheckSavedJson();
 
-  res_json.OnAwake();
+  res_json.DecrementIgnOffCount();
   ign_off_count_ = 0;
   CheckSavedJson();
 }
@@ -311,12 +311,12 @@ TEST_F(ResumptionDataJsonTest, TwiceAwake_AppNotSuspended) {
   res_json.SaveApplication(app_mock);
   CheckSavedJson();
 
-  res_json.OnSuspend();
-  res_json.OnAwake();
+  res_json.IncrementIgnOffCount();
+  res_json.DecrementIgnOffCount();
   ign_off_count_ = 0;
   CheckSavedJson();
 
-  res_json.OnAwake();
+  res_json.DecrementIgnOffCount();
   CheckSavedJson();
 }
 
@@ -339,14 +339,14 @@ TEST_F(ResumptionDataJsonTest, GetIgnOffTime_AfterSuspendAndAwake) {
   last_ign_off_time = res_json.GetIgnOffTime();
   EXPECT_EQ(0u, last_ign_off_time);
 
-  res_json.OnSuspend();
+  res_json.IncrementIgnOffCount();
 
   uint32_t after_suspend;
   after_suspend = res_json.GetIgnOffTime();
   EXPECT_LE(last_ign_off_time, after_suspend);
 
   uint32_t after_awake;
-  res_json.OnAwake();
+  res_json.DecrementIgnOffCount();
 
   after_awake = res_json.GetIgnOffTime();
   EXPECT_LE(after_suspend, after_awake);

--- a/src/components/hmi_message_handler/src/messagebroker_adapter.cc
+++ b/src/components/hmi_message_handler/src/messagebroker_adapter.cc
@@ -108,6 +108,7 @@ void MessageBrokerAdapter::SubscribeTo() {
   MessageBrokerController::subscribeTo("BasicCommunication.OnUpdateDeviceList");
   MessageBrokerController::subscribeTo("BasicCommunication.OnFindApplications");
   MessageBrokerController::subscribeTo("BasicCommunication.OnAppActivated");
+  MessageBrokerController::subscribeTo("BasicCommunication.OnAwakeSDL");
   MessageBrokerController::subscribeTo("BasicCommunication.OnExitApplication");
   MessageBrokerController::subscribeTo(
       "BasicCommunication.OnExitAllApplications");

--- a/src/components/remote_control/test/include/mock_application.h
+++ b/src/components/remote_control/test/include/mock_application.h
@@ -59,10 +59,12 @@ class MockApplication : public ::application_manager::Application {
   MOCK_CONST_METHOD0(active_message, const smart_objects::SmartObject*());
   MOCK_CONST_METHOD0(curHash, const std::string&());
   MOCK_METHOD0(UpdateHash, void());
-  MOCK_CONST_METHOD0(IsHashChangedAfterAwake, bool());
-  MOCK_METHOD1(SetHashChangedAfterAwake, void(const bool state));
+  // DEPRECATED
   MOCK_CONST_METHOD0(flag_sending_hash_change_after_awake, bool());
+  // DEPRECATED
   MOCK_METHOD1(set_flag_sending_hash_change_after_awake, void(bool flag));
+  MOCK_CONST_METHOD0(IsHashChangedDuringSuspend, bool());
+  MOCK_METHOD1(SetHashChangedDuringSuspend, void(const bool state));
   MOCK_CONST_METHOD0(is_application_data_changed, bool());
   MOCK_METHOD1(set_is_application_data_changed,
                void(bool state_application_data));

--- a/src/components/remote_control/test/include/mock_application.h
+++ b/src/components/remote_control/test/include/mock_application.h
@@ -59,6 +59,8 @@ class MockApplication : public ::application_manager::Application {
   MOCK_CONST_METHOD0(active_message, const smart_objects::SmartObject*());
   MOCK_CONST_METHOD0(curHash, const std::string&());
   MOCK_METHOD0(UpdateHash, void());
+  MOCK_CONST_METHOD0(IsHashChangedAfterAwake, bool());
+  MOCK_METHOD1(SetHashChangedAfterAwake, void(const bool state));
   MOCK_CONST_METHOD0(flag_sending_hash_change_after_awake, bool());
   MOCK_METHOD1(set_flag_sending_hash_change_after_awake, void(bool flag));
   MOCK_CONST_METHOD0(is_application_data_changed, bool());


### PR DESCRIPTION
Fixed SUSPEND -> OnSDLAwake -> SUSPEND -> IGN_OFF sequence for resumption data saving.

The problems was found in this sequence:
- SDL does not store all applications resumption-related data on the file system on suspend received
- SDL incorrectly increments `ign_off_count` parameter
- SDL sends `OnHashChanged` notification in suspended state and does not send it after `OnSDLAwake`
- SDL incorrectly removes application resumption-related data from file system after 3rd ignition cycle

To fix this problems, in this pull request was provided following changes:
- Renamed `OnSuspend->IncrementIgnOffCount` and `OnAwake->DecrementIgnOffCount`. This functions of `ResumptionData` class was renamed according to their exact logic. Also renamed in mock class and in unit tests
- Added `OnIgnitionOff()` to `ResumeCtrl` class. SDL should distinct ignition off and suspend notifications. SDL should not increment ignition off count in case of suspended notification, only in case of ignition off. This logic was separated by appending new function `OnIgnitionOff()` which will be called from application manager on ignition off instead of `OnSuspend()`
- `IncrementIgnOffCount` will be called only on ignition off event
- Fixed application resumption-related data removing after 3rd ignition cycle
- Added `is_suspended` flag and related getter/setter. This flag is used in: 
  1. `ApplicationImpl` to check should SDL send `OnHashChange` or not
  2. In `OnAwakeSDLNotification` to check should SDL do `OnAwake` actions or not
  3. `OnExitAllApplicationsNotification` and `OnAwakeSDLNotification` switches this flag
- Fixed some related UT expectations and mocks
- Added new bool flag to `ApplicationImpl` class. This flag is needed for checking, should SDL send `OnHashChange` notification after `OnAwake` notification. During suspend state SDL must not send `OnHashChange` according to requirements. If some of RPC's triggers `OnHashChange` notification
sending during suspend, this flag will be set to true and after `OnAwake` notification if this flag was set, SDL will send `OnHashChange` notification
- Added missed implementation of `OnAwakeSDLNotification`. This notification works in pair with `OnExitAllApplications(SUSPEND)` notification. However first one is present in code but second one was omitted. There was just empty file
- Message broker was subscribed to `OnAwake` notification from HMI.
- Added `OnAwakeSDLNotification` creation in HMI Command Factory class

#1395 