### PR TITLE
Fix OnSystemRequest timeout sequence

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -123,8 +123,8 @@ class PolicyHandler : public PolicyHandlerInterface,
                      EndpointUrls& out_end_points) OVERRIDE;
   virtual std::string GetLockScreenIconUrl() const OVERRIDE;
   uint32_t NextRetryTimeout() OVERRIDE;
-  uint32_t TimeoutExchangeSec() OVERRIDE;
-  uint32_t TimeoutExchangeMSec() OVERRIDE;
+  uint32_t TimeoutExchangeSec() const OVERRIDE;
+  uint32_t TimeoutExchangeMSec() const OVERRIDE;
   void OnExceededTimeout() OVERRIDE;
   void OnSystemReady() OVERRIDE;
   void PTUpdatedAt(Counters counter, int value) OVERRIDE;

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -445,10 +445,6 @@ class PolicyHandler : public PolicyHandlerInterface,
   void SetPolicyManager(utils::SharedPtr<PolicyManager> pm) {
     policy_manager_ = pm;
   }
-
-  AppIds& last_used_app_ids() {
-    return last_used_app_ids_;
-  }
 #endif  // BUILD_TESTS
 
 #ifdef ENABLE_SECURITY
@@ -609,7 +605,6 @@ class PolicyHandler : public PolicyHandlerInterface,
   mutable sync_primitives::RWLock policy_manager_lock_;
   utils::SharedPtr<PolicyManager> policy_manager_;
   void* dl_handle_;
-  AppIds last_used_app_ids_;
   utils::SharedPtr<PolicyEventObserver> event_observer_;
   uint32_t last_activated_app_id_;
 

--- a/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_system_request_notification.cc
@@ -99,6 +99,10 @@ void OnSystemRequestNotification::Run() {
     (*message_)[strings::msg_params][strings::file_type] = FileType::JSON;
   } else if (RequestType::HTTP == request_type) {
     (*message_)[strings::msg_params][strings::file_type] = FileType::BINARY;
+    if ((*message_)[strings::msg_params].keyExists(strings::url)) {
+      (*message_)[strings::msg_params][strings::timeout] =
+          policy_handler.TimeoutExchangeSec();
+    }
   }
 
   SendNotification();

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1021,16 +1021,8 @@ bool PolicyHandler::SendMessageToSDK(const BinaryMessage& pt_string,
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK(false);
 
-  ApplicationSharedPtr app;
-  uint32_t app_id = 0;
-  if (last_used_app_ids_.empty()) {
-    LOG4CXX_WARN(logger_, "last_used_app_ids_ is empty");
-    return false;
-  } else {
-    app_id = last_used_app_ids_.back();
-
-    app = application_manager_.application(app_id);
-  }
+  const uint32_t app_id = GetAppIdForSending();
+  ApplicationSharedPtr app = application_manager_.application(app_id);
 
   if (!app) {
     LOG4CXX_WARN(logger_,

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1565,11 +1565,11 @@ uint32_t PolicyHandler::NextRetryTimeout() {
   return policy_manager_->NextRetryTimeout();
 }
 
-uint32_t PolicyHandler::TimeoutExchangeSec() {
+uint32_t PolicyHandler::TimeoutExchangeSec() const {
   return TimeoutExchangeMSec() / date_time::DateTime::MILLISECONDS_IN_SECOND;
 }
 
-uint32_t PolicyHandler::TimeoutExchangeMSec() {
+uint32_t PolicyHandler::TimeoutExchangeMSec() const {
   POLICY_LIB_CHECK(0);
   return policy_manager_->TimeoutExchangeMSec();
 }

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -1997,34 +1997,59 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_ExpectReturnAnyAppInNone) {
   EXPECT_EQ(app_in_none_id_1 || app_in_none_id_2, app_id);
 }
 
-TEST_F(PolicyHandlerTest, SendMessageToSDK) {
-  // Precondition
+TEST_F(PolicyHandlerTest,
+       SendMessageToSDK_SuitableAppPresent_ExpectedNotificationSending) {
   BinaryMessage msg;
   const std::string url = "test_url";
   EnablePolicyAndPolicyManagerMock();
   test_app.insert(mock_app_);
-  // Expectations
+
   EXPECT_CALL(app_manager_, application(kAppId1_))
       .WillRepeatedly(Return(mock_app_));
-  EXPECT_CALL(*mock_app_, policy_app_id()).WillOnce(Return(kPolicyAppId_));
+  EXPECT_CALL(*mock_app_, app_id()).WillRepeatedly(Return(kAppId1_));
+  EXPECT_CALL(*mock_app_, policy_app_id())
+      .WillRepeatedly(Return(kPolicyAppId_));
+  EXPECT_CALL(*mock_app_, hmi_level())
+      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
+  EXPECT_CALL(*mock_app_, IsRegistered()).WillRepeatedly(Return(true));
+
+  const connection_handler::DeviceHandle test_device_id = 1u;
+  EXPECT_CALL(*mock_app_, device()).WillRepeatedly(Return(test_device_id));
+  EXPECT_CALL(*mock_policy_manager_, GetUserConsentForDevice(_))
+      .WillOnce(Return(kDeviceAllowed));
 
   // Act
-  policy_handler_.last_used_app_ids().push_back(kAppId1_);
   EXPECT_CALL(mock_message_helper_,
               SendPolicySnapshotNotification(kAppId1_, msg, url, _));
   EXPECT_TRUE(policy_handler_.SendMessageToSDK(msg, url));
 }
 
-TEST_F(PolicyHandlerTest, SendMessageToSDK_InavalidApp_UNSUCCESS) {
+TEST_F(PolicyHandlerTest,
+       SendMessageToSDK_NoSuitableApp_ExpectedNotificationNotSent) {
   BinaryMessage msg;
   const std::string url = "test_url";
   EnablePolicyAndPolicyManagerMock();
-  utils::SharedPtr<application_manager_test::MockApplication> invalid_app;
-  policy_handler_.last_used_app_ids().push_back(kAppId1_);
+  test_app.insert(mock_app_);
 
   EXPECT_CALL(app_manager_, application(kAppId1_))
-      .WillOnce(Return(invalid_app));
-  EXPECT_CALL(*mock_app_, policy_app_id()).Times(0);
+      .WillRepeatedly(Return(mock_app_));
+  EXPECT_CALL(*mock_app_, app_id()).WillRepeatedly(Return(kAppId1_));
+  EXPECT_CALL(*mock_app_, policy_app_id())
+      .WillRepeatedly(Return(kPolicyAppId_));
+  EXPECT_CALL(*mock_app_, hmi_level())
+      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_NONE));
+  EXPECT_CALL(*mock_app_, IsRegistered()).WillRepeatedly(Return(true));
+
+  const connection_handler::DeviceHandle test_device_id = 1u;
+  EXPECT_CALL(*mock_app_, device()).WillRepeatedly(Return(test_device_id));
+  EXPECT_CALL(*mock_policy_manager_, GetUserConsentForDevice(_))
+      .WillOnce(Return(kDeviceDisallowed));
+
+  // Expected to get 0 as application id so SDL does not have valid application
+  // with such id
+  EXPECT_CALL(app_manager_, application(0))
+      .WillOnce(Return(
+          utils::SharedPtr<application_manager_test::MockApplication>()));
 
   EXPECT_FALSE(policy_handler_.SendMessageToSDK(msg, url));
 }

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -105,8 +105,8 @@ class PolicyHandlerInterface {
                              EndpointUrls& out_end_points) = 0;
   virtual std::string GetLockScreenIconUrl() const = 0;
   virtual uint32_t NextRetryTimeout() = 0;
-  virtual uint32_t TimeoutExchangeSec() = 0;
-  virtual uint32_t TimeoutExchangeMSec() = 0;
+  virtual uint32_t TimeoutExchangeSec() const = 0;
+  virtual uint32_t TimeoutExchangeMSec() const = 0;
   virtual void OnExceededTimeout() = 0;
   virtual void OnSystemReady() = 0;
   virtual void PTUpdatedAt(Counters counter, int value) = 0;

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -104,8 +104,8 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
   MOCK_METHOD0(ResetRetrySequence, void());
   MOCK_METHOD0(NextRetryTimeout, uint32_t());
-  MOCK_METHOD0(TimeoutExchangeSec, uint32_t());
-  MOCK_METHOD0(TimeoutExchangeMSec, uint32_t());
+  MOCK_CONST_METHOD0(TimeoutExchangeSec, uint32_t());
+  MOCK_CONST_METHOD0(TimeoutExchangeMSec, uint32_t());
   MOCK_METHOD0(OnExceededTimeout, void());
   MOCK_METHOD0(OnSystemReady, void());
   MOCK_METHOD2(PTUpdatedAt, void(policy::Counters counter, int value));

--- a/src/components/policy/policy_regular/include/policy/update_status_manager.h
+++ b/src/components/policy/policy_regular/include/policy/update_status_manager.h
@@ -83,9 +83,8 @@ class UpdateStatusManager : public UpdateStatusManagerInterface {
 
   /**
    * @brief Update status hanlder for PTS sending out
-   * @param update_timeout Timeout for waiting of incoming PTU (msec)
    */
-  void OnUpdateSentOut(uint32_t update_timeout);
+  void OnUpdateSentOut();
 
   /**
    * @brief Update status handler for PTU waiting timeout
@@ -216,24 +215,6 @@ class UpdateStatusManager : public UpdateStatusManagerInterface {
   bool apps_search_in_progress_;
   bool app_registered_from_non_consented_device_;
   sync_primitives::Lock apps_search_in_progress_lock_;
-
-  class UpdateThreadDelegate : public threads::ThreadDelegate {
-   public:
-    UpdateThreadDelegate(UpdateStatusManager* update_status_manager);
-    ~UpdateThreadDelegate();
-    virtual void threadMain();
-    virtual void exitThreadMain();
-    void updateTimeOut(const uint32_t timeout_ms);
-
-    volatile uint32_t timeout_;
-    volatile bool stop_flag_;
-    sync_primitives::Lock state_lock_;
-    sync_primitives::ConditionalVariable termination_condition_;
-    UpdateStatusManager* update_status_manager_;
-  };
-
-  UpdateThreadDelegate* update_status_thread_delegate_;
-  threads::Thread* thread_;
 };
 }
 

--- a/src/components/policy/policy_regular/include/policy/update_status_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/update_status_manager_interface.h
@@ -71,9 +71,8 @@ class UpdateStatusManagerInterface {
 
   /**
    * @brief Update status hanlder for PTS sending out
-   * @param update_timeout Timeout for waiting of incoming PTU
    */
-  virtual void OnUpdateSentOut(uint32_t update_timeout) = 0;
+  virtual void OnUpdateSentOut() = 0;
 
   /**
    * @brief Update status handler for PTU waiting timeout

--- a/src/components/policy/policy_regular/src/update_status_manager.cc
+++ b/src/components/policy/policy_regular/src/update_status_manager.cc
@@ -43,21 +43,9 @@ UpdateStatusManager::UpdateStatusManager()
     : listener_(NULL)
     , current_status_(utils::MakeShared<UpToDateStatus>())
     , apps_search_in_progress_(false)
-    , app_registered_from_non_consented_device_(true) {
-  update_status_thread_delegate_ = new UpdateThreadDelegate(this);
-  thread_ = threads::CreateThread("UpdateStatusThread",
-                                  update_status_thread_delegate_);
-  thread_->start();
-}
+    , app_registered_from_non_consented_device_(true) {}
 
-UpdateStatusManager::~UpdateStatusManager() {
-  LOG4CXX_AUTO_TRACE(logger_);
-  DCHECK(update_status_thread_delegate_);
-  DCHECK(thread_);
-  thread_->join();
-  delete update_status_thread_delegate_;
-  threads::DeleteThread(thread_);
-}
+UpdateStatusManager::~UpdateStatusManager() {}
 
 void UpdateStatusManager::ProcessEvent(UpdateEvent event) {
   sync_primitives::AutoLock lock(status_lock_);
@@ -78,29 +66,23 @@ void UpdateStatusManager::set_listener(PolicyListener* listener) {
   listener_ = listener;
 }
 
-void UpdateStatusManager::OnUpdateSentOut(uint32_t update_timeout) {
+void UpdateStatusManager::OnUpdateSentOut() {
   LOG4CXX_AUTO_TRACE(logger_);
-  DCHECK(update_status_thread_delegate_);
-  update_status_thread_delegate_->updateTimeOut(update_timeout);
   ProcessEvent(kOnUpdateSentOut);
 }
 
 void UpdateStatusManager::OnUpdateTimeoutOccurs() {
   LOG4CXX_AUTO_TRACE(logger_);
   ProcessEvent(kOnUpdateTimeout);
-  DCHECK(update_status_thread_delegate_);
-  update_status_thread_delegate_->updateTimeOut(0);  // Stop Timer
 }
 
 void UpdateStatusManager::OnValidUpdateReceived() {
   LOG4CXX_AUTO_TRACE(logger_);
-  update_status_thread_delegate_->updateTimeOut(0);  // Stop Timer
   ProcessEvent(kOnValidUpdateReceived);
 }
 
 void UpdateStatusManager::OnWrongUpdateReceived() {
   LOG4CXX_AUTO_TRACE(logger_);
-  update_status_thread_delegate_->updateTimeOut(0);  // Stop Timer
   ProcessEvent(kOnWrongUpdateReceived);
 }
 
@@ -202,59 +184,6 @@ void UpdateStatusManager::DoTransition() {
     listener_->OnUpdateStatusChanged(current_status_->get_status_string());
   }
   postponed_status_.reset();
-}
-
-UpdateStatusManager::UpdateThreadDelegate::UpdateThreadDelegate(
-    UpdateStatusManager* update_status_manager)
-    : timeout_(0)
-    , stop_flag_(false)
-    , state_lock_(true)
-    , update_status_manager_(update_status_manager) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  LOG4CXX_DEBUG(logger_, "Create UpdateThreadDelegate");
-}
-
-UpdateStatusManager::UpdateThreadDelegate::~UpdateThreadDelegate() {
-  LOG4CXX_AUTO_TRACE(logger_);
-  LOG4CXX_DEBUG(logger_, "Delete UpdateThreadDelegate");
-}
-
-void UpdateStatusManager::UpdateThreadDelegate::threadMain() {
-  LOG4CXX_AUTO_TRACE(logger_);
-  LOG4CXX_DEBUG(logger_, "UpdateStatusManager thread started (started normal)");
-  sync_primitives::AutoLock auto_lock(state_lock_);
-  while (false == stop_flag_) {
-    if (timeout_ > 0) {
-      LOG4CXX_DEBUG(logger_, "Timeout is greater then 0");
-      sync_primitives::ConditionalVariable::WaitStatus wait_status =
-          termination_condition_.WaitFor(auto_lock, timeout_);
-      if (sync_primitives::ConditionalVariable::kTimeout == wait_status) {
-        if (update_status_manager_) {
-          update_status_manager_->OnUpdateTimeoutOccurs();
-        }
-      }
-    } else {
-      // Time is not active, wait until timeout will be set,
-      // or UpdateStatusManager will be deleted
-      termination_condition_.Wait(auto_lock);
-    }
-  }
-}
-
-void UpdateStatusManager::UpdateThreadDelegate::exitThreadMain() {
-  LOG4CXX_AUTO_TRACE(logger_);
-  sync_primitives::AutoLock auto_lock(state_lock_);
-  stop_flag_ = true;
-  LOG4CXX_DEBUG(logger_, "before notify");
-  termination_condition_.NotifyOne();
-}
-
-void UpdateStatusManager::UpdateThreadDelegate::updateTimeOut(
-    const uint32_t timeout_ms) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  sync_primitives::AutoLock auto_lock(state_lock_);
-  timeout_ = timeout_ms;
-  termination_condition_.NotifyOne();
 }
 
 }  // namespace policy

--- a/src/components/policy/policy_regular/test/include/policy/mock_update_status_manager.h
+++ b/src/components/policy/policy_regular/test/include/policy/mock_update_status_manager.h
@@ -41,7 +41,7 @@ namespace policy {
 class MockUpdateStatusManager : public UpdateStatusManager {
  public:
   MOCK_METHOD1(set_listener, void(PolicyListener* listener));
-  MOCK_METHOD1(OnUpdateSentOut, void(uint32_t update_timeout));
+  MOCK_METHOD0(OnUpdateSentOut, void());
   MOCK_METHOD0(OnUpdateTimeoutOccurs, void());
   MOCK_METHOD0(OnValidUpdateReceived, void());
   MOCK_METHOD0(OnWrongUpdateReceived, void());

--- a/src/components/policy/policy_regular/test/update_status_manager_test.cc
+++ b/src/components/policy/policy_regular/test/update_status_manager_test.cc
@@ -47,13 +47,11 @@ using ::testing::Return;
 class UpdateStatusManagerTest : public ::testing::Test {
  protected:
   utils::SharedPtr<UpdateStatusManager> manager_;
-  const uint32_t k_timeout_;
   utils::SharedPtr<MockPolicyListener> listener_;
 
  public:
   UpdateStatusManagerTest()
       : manager_(utils::MakeShared<UpdateStatusManager>())
-      , k_timeout_(1000)
       , listener_(utils::MakeShared<MockPolicyListener>()) {}
 
   void SetUp() OVERRIDE {
@@ -73,7 +71,7 @@ TEST_F(UpdateStatusManagerTest,
   manager_->OnPolicyInit(true);
   // Check
   EXPECT_EQ("UPDATE_NEEDED", manager_->StringifiedUpdateStatus());
-  manager_->OnUpdateSentOut(k_timeout_);
+  manager_->OnUpdateSentOut();
   // Check
   EXPECT_EQ("UPDATING", manager_->StringifiedUpdateStatus());
 }


### PR DESCRIPTION
Fixed `OnSystemRequest` timeout sequence.

In this pull request:
- Updated `NextRetryTimeout()` logic to calculate last timeout correctly 
- Fixed `SDL.OnStatusUpdate(UPDATE_NEEDED)` sending timeout (changes from related PR #1542)
- Fixed timeout param sending via `OnSystemRequest` (changes from related PR #1496)
- Fixed sending `OnSystemRequest` with HTTP mode (changes from related PR #1602)

