### PR TITLE
Fix policy table loading with functional_group RPCs greater than 50

### DIFF
--- a/src/components/policy/policy_external/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/types.h
@@ -69,7 +69,7 @@ typedef Array<Enum<HmiLevel>, 0, 4> HmiLevels;
 
 typedef Array<Enum<Parameter>, 0, 100> Parameters;
 
-typedef Map<RpcParameters, 0, 65535> Rpc;
+typedef Map<RpcParameters, 0, UINT_MAX> Rpc;
 
 typedef Array<String<10, 65535>, 1, 3> URL;
 

--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -67,7 +67,7 @@ typedef Array<Enum<HmiLevel>, 0, 4> HmiLevels;
 
 typedef Array<Enum<Parameter>, 0, 24> Parameters;
 
-typedef Map<RpcParameters, 0, 50> Rpc;
+typedef Map<RpcParameters, 0, UINT_MAX> Rpc;
 
 typedef Array<String<10, 255>, 1, 255> URL;
 


### PR DESCRIPTION
SDL rejects to load policy table when sdl_preloaded_pt.json contains at least one functional group with more than 50 RPCs. The fix changes number of allowed RPC's to unlimited (65535).

Changes was taken from related PR #1328 from another branch
Fixes #968 