### PR TITLE
Fix SubscribeVehicleData request subscriptions

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
@@ -143,6 +143,11 @@ class SubscribeVehicleDataRequest : public CommandRequestImpl {
    */
   VehicleInfoSubscriptions vi_already_subscribed_by_this_app_;
 
+  /**
+   * @brief VI parameters which wait for subscribe after HMI respond
+   */
+  VehicleInfoSubscriptions vi_waiting_for_subscribe_;
+
   DISALLOW_COPY_AND_ASSIGN(SubscribeVehicleDataRequest);
 };
 

--- a/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -250,6 +250,15 @@ void SubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
       result_code = mobile_apis::Result::IGNORED;
       response_info = "Already subscribed on some provided VehicleData.";
     }
+
+    if (!vi_waiting_for_subscribe_.empty()) {
+      LOG4CXX_DEBUG(logger_, "Subscribing to all pending VehicleData");
+      VehicleInfoSubscriptions::const_iterator key =
+          vi_waiting_for_subscribe_.begin();
+      for (; key != vi_waiting_for_subscribe_.end(); ++key) {
+        app->SubscribeToIVI(*key);
+      }
+    }
   }
 
   UnsubscribeFailedSubscriptions(app, message[strings::msg_params]);
@@ -406,12 +415,13 @@ void SubscribeVehicleDataRequest::CheckVISubscribtions(
 
         out_request_params[key_name] = is_key_enabled;
 
-        if (app->SubscribeToIVI(static_cast<uint32_t>(key_type))) {
+        if (is_key_enabled) {
+          vi_waiting_for_subscribe_.insert(key_type);
           LOG4CXX_DEBUG(
               logger_,
               "App with connection key "
                   << connection_key()
-                  << " have been subscribed for VehicleDataType: " << key_type);
+                  << " will be subscribed for VehicleDataType: " << key_type);
           ++subscribed_items;
         }
       }


### PR DESCRIPTION
The main idea here is to perform subscriptions only after SDL receives successful result from HMI. Currently SDL subscribes on requested vehicle data right after `SubscribeVehicleData` request received, event if HMI returns erroneous result. This is a reason why `UnsubscribedVehicleData` returns wrong result code on its call.

In case of erroneous result code SDL should not subscribe to requested VehicleData. 

Changes of this pull request was based on PR #1410 
Fixes #996 