### PR TITLE
Fix RPC response in case filename contains forbidden symbols

### DIFF
--- a/src/components/application_manager/src/commands/mobile/delete_file_request.cc
+++ b/src/components/application_manager/src/commands/mobile/delete_file_request.cc
@@ -73,6 +73,13 @@ void DeleteFileRequest::Run() {
   const std::string& sync_file_name =
       (*message_)[strings::msg_params][strings::sync_file_name].asString();
 
+  if (!file_system::IsFileNameValid(sync_file_name)) {
+    const std::string err_msg = "Sync file name contains forbidden symbols.";
+    LOG4CXX_ERROR(logger_, err_msg);
+    SendResponse(false, mobile_apis::Result::INVALID_DATA, err_msg.c_str());
+    return;
+  }
+
   std::string full_file_path =
       application_manager_.get_settings().app_storage_folder() + "/";
   full_file_path += application->folder_name();

--- a/src/components/application_manager/src/commands/mobile/put_file_request.cc
+++ b/src/components/application_manager/src/commands/mobile/put_file_request.cc
@@ -110,6 +110,17 @@ void PutFileRequest::Run() {
   }
   sync_file_name_ =
       (*message_)[strings::msg_params][strings::sync_file_name].asString();
+
+  if (!file_system::IsFileNameValid(sync_file_name_)) {
+    const std::string err_msg = "Sync file name contains forbidden symbols.";
+    LOG4CXX_ERROR(logger_, err_msg);
+    SendResponse(false,
+                 mobile_apis::Result::INVALID_DATA,
+                 err_msg.c_str(),
+                 &response_params);
+    return;
+  }
+
   file_type_ = static_cast<mobile_apis::FileType::eType>(
       (*message_)[strings::msg_params][strings::file_type].asInt());
   const std::vector<uint8_t> binary_data =

--- a/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
@@ -71,6 +71,13 @@ void SetAppIconRequest::Run() {
   const std::string& sync_file_name =
       (*message_)[strings::msg_params][strings::sync_file_name].asString();
 
+  if (!file_system::IsFileNameValid(sync_file_name)) {
+    const std::string err_msg = "Sync file name contains forbidden symbols.";
+    LOG4CXX_ERROR(logger_, err_msg);
+    SendResponse(false, mobile_apis::Result::INVALID_DATA, err_msg.c_str());
+    return;
+  }
+
   std::string full_file_path =
       application_manager_.get_settings().app_storage_folder() + "/";
   full_file_path += app->folder_name();

--- a/src/components/application_manager/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/src/commands/mobile/system_request.cc
@@ -466,6 +466,20 @@ void SystemRequest::Run() {
     file_name = kSYNC;
   }
 
+  if (!CheckSyntax(file_name)) {
+    LOG4CXX_ERROR(logger_,
+                  "Incoming request contains \t\n \\t \\n or whitespace");
+    SendResponse(false, mobile_apis::Result::INVALID_DATA);
+    return;
+  }
+
+  if (!file_system::IsFileNameValid(file_name)) {
+    const std::string err_msg = "Sync file name contains forbidden symbols.";
+    LOG4CXX_ERROR(logger_, err_msg);
+    SendResponse(false, mobile_apis::Result::INVALID_DATA, err_msg.c_str());
+    return;
+  }
+
   bool is_system_file = std::string::npos != file_name.find(kSYNC) ||
                         std::string::npos != file_name.find(kIVSU);
 

--- a/src/components/utils/include/utils/file_system.h
+++ b/src/components/utils/include/utils/file_system.h
@@ -153,6 +153,14 @@ std::string CurrentWorkingDirectory();
 std::string GetAbsolutePath(const std::string& path);
 
 /**
+ * @brief Checks if file name contains invalid symbols e.g. '/'
+ * @param file_name file name to check
+ * @return true if file name does not contain any invalid symbol otherwise
+ * returns false
+ */
+bool IsFileNameValid(const std::string& file_name);
+
+/**
   * @brief Removes file
   *
   * @param name path to file

--- a/src/components/utils/src/file_system.cc
+++ b/src/components/utils/src/file_system.cc
@@ -222,6 +222,10 @@ std::string file_system::GetAbsolutePath(const std::string& path) {
   return std::string(abs_path);
 }
 
+bool file_system::IsFileNameValid(const std::string& file_name) {
+  return file_name.end() == std::find(file_name.begin(), file_name.end(), '/');
+}
+
 bool file_system::DeleteFile(const std::string& name) {
   if (FileExists(name) && IsAccessible(name, W_OK)) {
     return !remove(name.c_str());


### PR DESCRIPTION
According to requirements SDL must respond with `INVALID_DATA` to RPC request, which contains some filename param, which contains '/' symbol. The main idea here is to prevent access to files outside SDL working directory using such RPCs.

In this pull request:
- Added `IsFileNameValid` function to check filename symbols
- Added checking filename param for: `DeleteFile`, `PutFile`, `SetAppIcon`, `SystemRequest`

Related PR from another branch: #1373 
Fixes #975 