### PR TITLE
Fix Consumer Friendly Messages removing from PT

### DIFF
--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -1265,7 +1265,7 @@ bool SQLPTRepresentation::SaveConsumerFriendlyMessages(
   // the current local consumer_friendly_messages section shall be maintained in
   // the policy table. So it won't be changed/updated
   if (!messages.messages.is_initialized()) {
-    LOG4CXX_INFO(logger_, "Messages list is empty");
+    LOG4CXX_INFO(logger_, "ConsumerFriendlyMessages messages list is empty");
     return true;
   }
 
@@ -1276,18 +1276,18 @@ bool SQLPTRepresentation::SaveConsumerFriendlyMessages(
   }
 
   if (!delete_query_exec_result) {
-    LOG4CXX_WARN(logger_, "Incorrect delete from message.");
+    LOG4CXX_WARN(logger_, "Failed to delete messages from DB.");
     return false;
   }
 
   if (!query.Prepare(sql_pt::kUpdateVersion)) {
-    LOG4CXX_WARN(logger_, "Incorrect update statement for version.");
+    LOG4CXX_WARN(logger_, "Invalid update messages version statement.");
     return false;
   }
 
   query.Bind(0, messages.version);
   if (!query.Exec()) {
-    LOG4CXX_WARN(logger_, "Incorrect update into version.");
+    LOG4CXX_WARN(logger_, "Failed to update messages version number in DB.");
     return false;
   }
 

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -1264,46 +1264,48 @@ bool SQLPTRepresentation::SaveConsumerFriendlyMessages(
   // According CRS-2419  If there is no “consumer_friendly_messages” key,
   // the current local consumer_friendly_messages section shall be maintained in
   // the policy table. So it won't be changed/updated
-  if (messages.messages.is_initialized()) {
-    utils::dbms::SQLQuery query(db());
-    if (!messages.messages->empty()) {
-      if (!query.Exec(sql_pt::kDeleteMessageString)) {
-        LOG4CXX_WARN(logger_, "Incorrect delete from message.");
-        return false;
-      }
-    }
+  if (!messages.messages.is_initialized()) {
+    LOG4CXX_INFO(logger_, "Messages list is empty");
+    return true;
+  }
 
-    if (query.Prepare(sql_pt::kUpdateVersion)) {
-      query.Bind(0, messages.version);
-      if (!query.Exec()) {
-        LOG4CXX_WARN(logger_, "Incorrect update into version.");
-        return false;
-      }
-    } else {
-      LOG4CXX_WARN(logger_, "Incorrect update statement for version.");
+  utils::dbms::SQLQuery query(db());
+  bool delete_query_exec_result = true;
+  if (!messages.messages->empty()) {
+    delete_query_exec_result = query.Exec(sql_pt::kDeleteMessageString);
+  }
+
+  if (!delete_query_exec_result) {
+    LOG4CXX_WARN(logger_, "Incorrect delete from message.");
+    return false;
+  }
+
+  if (!query.Prepare(sql_pt::kUpdateVersion)) {
+    LOG4CXX_WARN(logger_, "Incorrect update statement for version.");
+    return false;
+  }
+
+  query.Bind(0, messages.version);
+  if (!query.Exec()) {
+    LOG4CXX_WARN(logger_, "Incorrect update into version.");
+    return false;
+  }
+
+  policy_table::Messages::const_iterator it;
+  for (it = messages.messages->begin(); it != messages.messages->end(); ++it) {
+    if (!SaveMessageType(it->first)) {
       return false;
     }
-
-    policy_table::Messages::const_iterator it;
-    // TODO(IKozyrenko): Check logic if optional container is missing
-    for (it = messages.messages->begin(); it != messages.messages->end();
-         ++it) {
-      if (!SaveMessageType(it->first)) {
+    const policy_table::Languages& langs = it->second.languages;
+    policy_table::Languages::const_iterator lang_it;
+    for (lang_it = langs.begin(); lang_it != langs.end(); ++lang_it) {
+      if (!SaveLanguage(lang_it->first)) {
         return false;
       }
-      const policy_table::Languages& langs = it->second.languages;
-      policy_table::Languages::const_iterator lang_it;
-      for (lang_it = langs.begin(); lang_it != langs.end(); ++lang_it) {
-        if (!SaveLanguage(lang_it->first)) {
-          return false;
-        }
-        if (!SaveMessageString(it->first, lang_it->first, lang_it->second)) {
-          return false;
-        }
+      if (!SaveMessageString(it->first, lang_it->first, lang_it->second)) {
+        return false;
       }
     }
-  } else {
-    LOG4CXX_INFO(logger_, "Messages list is empty");
   }
 
   return true;

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -1177,9 +1177,11 @@ bool SQLPTRepresentation::SaveConsumerFriendlyMessages(
   // the policy table. So it won't be changed/updated
   if (messages.messages.is_initialized()) {
     utils::dbms::SQLQuery query(db());
-    if (!query.Exec(sql_pt::kDeleteMessageString)) {
-      LOG4CXX_WARN(logger_, "Incorrect delete from message.");
-      return false;
+    if (!messages.messages->empty()) {
+      if (!query.Exec(sql_pt::kDeleteMessageString)) {
+        LOG4CXX_WARN(logger_, "Incorrect delete from message.");
+        return false;
+      }
     }
 
     if (query.Prepare(sql_pt::kUpdateVersion)) {

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -1176,7 +1176,7 @@ bool SQLPTRepresentation::SaveConsumerFriendlyMessages(
   // the current local consumer_friendly_messages section shall be maintained in
   // the policy table. So it won't be changed/updated
   if (!messages.messages.is_initialized()) {
-    LOG4CXX_INFO(logger_, "Messages list is empty");
+    LOG4CXX_INFO(logger_, "ConsumerFriendlyMessages messages list is empty");
     return true;
   }
 
@@ -1187,18 +1187,18 @@ bool SQLPTRepresentation::SaveConsumerFriendlyMessages(
   }
 
   if (!delete_query_exec_result) {
-    LOG4CXX_WARN(logger_, "Incorrect delete from message.");
+    LOG4CXX_WARN(logger_, "Failed to delete messages from DB.");
     return false;
   }
 
   if (!query.Prepare(sql_pt::kUpdateVersion)) {
-    LOG4CXX_WARN(logger_, "Incorrect update statement for version.");
+    LOG4CXX_WARN(logger_, "Invalid update messages version statement.");
     return false;
   }
 
   query.Bind(0, messages.version);
   if (!query.Exec()) {
-    LOG4CXX_WARN(logger_, "Incorrect update into version.");
+    LOG4CXX_WARN(logger_, "Failed to update messages version number in DB.");
     return false;
   }
 

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -1175,45 +1175,48 @@ bool SQLPTRepresentation::SaveConsumerFriendlyMessages(
   // According CRS-2419  If there is no “consumer_friendly_messages” key,
   // the current local consumer_friendly_messages section shall be maintained in
   // the policy table. So it won't be changed/updated
-  if (messages.messages.is_initialized()) {
-    utils::dbms::SQLQuery query(db());
-    if (!messages.messages->empty()) {
-      if (!query.Exec(sql_pt::kDeleteMessageString)) {
-        LOG4CXX_WARN(logger_, "Incorrect delete from message.");
-        return false;
-      }
-    }
+  if (!messages.messages.is_initialized()) {
+    LOG4CXX_INFO(logger_, "Messages list is empty");
+    return true;
+  }
 
-    if (query.Prepare(sql_pt::kUpdateVersion)) {
-      query.Bind(0, messages.version);
-      if (!query.Exec()) {
-        LOG4CXX_WARN(logger_, "Incorrect update into version.");
-        return false;
-      }
-    } else {
-      LOG4CXX_WARN(logger_, "Incorrect update statement for version.");
+  utils::dbms::SQLQuery query(db());
+  bool delete_query_exec_result = true;
+  if (!messages.messages->empty()) {
+    delete_query_exec_result = query.Exec(sql_pt::kDeleteMessageString);
+  }
+
+  if (!delete_query_exec_result) {
+    LOG4CXX_WARN(logger_, "Incorrect delete from message.");
+    return false;
+  }
+
+  if (!query.Prepare(sql_pt::kUpdateVersion)) {
+    LOG4CXX_WARN(logger_, "Incorrect update statement for version.");
+    return false;
+  }
+
+  query.Bind(0, messages.version);
+  if (!query.Exec()) {
+    LOG4CXX_WARN(logger_, "Incorrect update into version.");
+    return false;
+  }
+
+  policy_table::Messages::const_iterator it;
+  for (it = messages.messages->begin(); it != messages.messages->end(); ++it) {
+    if (!SaveMessageType(it->first)) {
       return false;
     }
-
-    policy_table::Messages::const_iterator it;
-    for (it = messages.messages->begin(); it != messages.messages->end();
-         ++it) {
-      if (!SaveMessageType(it->first)) {
+    const policy_table::Languages& langs = it->second.languages;
+    policy_table::Languages::const_iterator lang_it;
+    for (lang_it = langs.begin(); lang_it != langs.end(); ++lang_it) {
+      if (!SaveLanguage(lang_it->first)) {
         return false;
       }
-      const policy_table::Languages& langs = it->second.languages;
-      policy_table::Languages::const_iterator lang_it;
-      for (lang_it = langs.begin(); lang_it != langs.end(); ++lang_it) {
-        if (!SaveLanguage(lang_it->first)) {
-          return false;
-        }
-        if (!SaveMessageString(it->first, lang_it->first, lang_it->second)) {
-          return false;
-        }
+      if (!SaveMessageString(it->first, lang_it->first, lang_it->second)) {
+        return false;
       }
     }
-  } else {
-    LOG4CXX_INFO(logger_, "Messages list is empty");
   }
 
   return true;


### PR DESCRIPTION
In case PTU comes with omitted `consumer_friendly_messages` param, SDL should maintain current `consumer_friendly_messages` section in Local PT. 
Currently SDL removes all `consumer_friendly_messages` from PT even if this param was omitted in PTU.

Related PR in another branch: #1415 
Fixes #1027 