### PR TITLE
Add missed setup of last_processed_event_

### DIFF
--- a/src/components/policy/policy_external/src/update_status_manager.cc
+++ b/src/components/policy/policy_external/src/update_status_manager.cc
@@ -62,6 +62,7 @@ UpdateStatusManager::~UpdateStatusManager() {
 void UpdateStatusManager::ProcessEvent(UpdateEvent event) {
   sync_primitives::AutoLock lock(status_lock_);
   current_status_->ProcessEvent(this, event);
+  last_processed_event_ = event;
   DoTransition();
 }
 


### PR DESCRIPTION
Add missed last_processed_event_ key setup from changes related to "Fix UPDATE_NEEDED is sent if user requested PTU from HMI". #1491