### PR TITLE
Clear persistent data of all registered applications after FACTORY_DEFAULTS and MASTER_RESET

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1145,6 +1145,11 @@ class ApplicationManagerImpl
     return is_stopping_;
   }
 
+  /**
+   * @brief Clears all applications' persistent data
+   */
+  void ClearAppsPersistentData();
+
   StateController& state_controller() OVERRIDE;
   const ApplicationManagerSettings& get_settings() const OVERRIDE;
   virtual event_engine::EventDispatcher& event_dispatcher() OVERRIDE;

--- a/src/components/application_manager/src/commands/hmi/on_exit_all_applications_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_exit_all_applications_notification.cc
@@ -110,5 +110,4 @@ void OnExitAllApplicationsNotification::SendOnSDLPersistenceComplete() {
 }
 
 }  // namespace commands
-
 }  // namespace application_manager

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -323,7 +323,7 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   /*
    * @brief Returns file name for storing applications data
    */
-  const std::string& app_info_storage() const;
+  const std::string& app_info_storage() const OVERRIDE;
 
   /*
    * @brief Path to preloaded policy file

--- a/src/components/include/application_manager/application_manager_settings.h
+++ b/src/components/include/application_manager/application_manager_settings.h
@@ -63,6 +63,7 @@ class ApplicationManagerSettings : public RequestControlerSettings,
   virtual bool launch_hmi() const = 0;
   virtual const uint32_t& delete_file_in_none() const = 0;
   virtual const std::vector<uint32_t>& supported_diag_modes() const = 0;
+  virtual const std::string& app_info_storage() const = 0;
   virtual const uint32_t& list_files_in_none() const = 0;
   virtual const std::string& tts_delimiter() const = 0;
   virtual const uint32_t& put_file_in_none() const = 0;

--- a/src/components/include/test/application_manager/mock_application_manager_settings.h
+++ b/src/components/include/test/application_manager/mock_application_manager_settings.h
@@ -57,6 +57,7 @@ class MockApplicationManagerSettings
                      const std::pair<uint32_t, int32_t>&());
   MOCK_CONST_METHOD0(hash_string_size, uint32_t());
   MOCK_CONST_METHOD0(app_storage_folder, const std::string&());
+  MOCK_CONST_METHOD0(app_info_storage, const std::string&());
   MOCK_CONST_METHOD0(app_dir_quota, const uint32_t&());
   MOCK_CONST_METHOD0(stop_streaming_timeout, uint32_t());
   MOCK_CONST_METHOD0(application_list_update_timeout, uint32_t());

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -713,10 +713,7 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
 }
 
 bool PolicyManagerImpl::ResetUserConsent() {
-  bool result = true;
-  result = cache_->ResetUserConsent();
-
-  return result;
+  return cache_->ResetUserConsent();
 }
 
 policy_table::Strings PolicyManagerImpl::GetGroupsNames(

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -392,9 +392,7 @@ void PolicyManagerImpl::CheckPermissions(const PTString& device_id,
 }
 
 bool PolicyManagerImpl::ResetUserConsent() {
-  bool result = true;
-
-  return result;
+  return cache_->ResetUserConsent();
 }
 
 void PolicyManagerImpl::SendNotificationOnPermissionsUpdated(


### PR DESCRIPTION
After SDL receives 
- BC.OnExitAllApplications(MASTER_RESET) :
SDL should clear stored persistent data of all applications and revert local PT to preloaded state.
- BC.OnExitAllApplications(FACTORY_DEFAULTS): 
SDL should clear stored persistent data of all applications and remove all user consent records from local PT.

Related PR in another branch: #1338 
Fixes issue: #1024 