### PR TITLE
Fix UnsubscribeButton wrong result code in case of UNSUPPORTED_RESOURCE

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -193,6 +193,14 @@ class CommandRequestImpl : public CommandImpl,
   bool CheckAllowedParameters();
 
   /**
+   * @brief Checks HMI capabilities for specified button support
+   * @param button Button to check
+   * @return true if button is present in HMI capabilities
+   * otherwise returns false
+   */
+  bool CheckHMICapabilities(const mobile_apis::ButtonName::eType button) const;
+
+  /**
    * @brief Remove from current message parameters disallowed by policy table
    */
   void RemoveDisallowedParameters();

--- a/src/components/application_manager/include/application_manager/commands/mobile/subscribe_button_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/subscribe_button_request.h
@@ -85,12 +85,6 @@ class SubscribeButtonRequest : public CommandRequestImpl {
    */
   void SendSubscribeButtonNotification();
 
-  /**
-   * @brief Checks HMI capabilities for specified button support
-   * @param button Button to check
-   */
-  bool CheckHMICapabilities(mobile_apis::ButtonName::eType button);
-
   DISALLOW_COPY_AND_ASSIGN(SubscribeButtonRequest);
 };
 

--- a/src/components/application_manager/src/commands/mobile/subscribe_button_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_button_request.cc
@@ -104,34 +104,6 @@ bool SubscribeButtonRequest::IsSubscriptionAllowed(
   return true;
 }
 
-bool SubscribeButtonRequest::CheckHMICapabilities(
-    mobile_apis::ButtonName::eType button) {
-  using namespace smart_objects;
-  using namespace mobile_apis;
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  const HMICapabilities& hmi_caps = application_manager_.hmi_capabilities();
-  if (!hmi_caps.is_ui_cooperating()) {
-    LOG4CXX_ERROR(logger_, "UI is not supported by HMI.");
-    return false;
-  }
-
-  const SmartObject* button_caps_ptr = hmi_caps.button_capabilities();
-  if (button_caps_ptr) {
-    const SmartObject& button_caps = *button_caps_ptr;
-    const size_t length = button_caps.length();
-    for (size_t i = 0; i < length; ++i) {
-      const SmartObject& caps = button_caps[i];
-      const ButtonName::eType name = static_cast<ButtonName::eType>(
-          caps.getElement(hmi_response::button_name).asInt());
-      if (name == button) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 void SubscribeButtonRequest::SendSubscribeButtonNotification() {
   using namespace smart_objects;
   using namespace hmi_apis;

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_button_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_button_request.cc
@@ -58,8 +58,16 @@ void UnsubscribeButtonRequest::Run() {
     return;
   }
 
-  const uint32_t btn_id =
-      (*message_)[str::msg_params][str::button_name].asUInt();
+  const mobile_apis::ButtonName::eType btn_id =
+      static_cast<mobile_apis::ButtonName::eType>(
+          (*message_)[str::msg_params][str::button_name].asInt());
+
+  if (!CheckHMICapabilities(btn_id)) {
+    LOG4CXX_ERROR(logger_,
+                  "Button " << btn_id << " isn't allowed by HMI capabilities");
+    SendResponse(false, mobile_apis::Result::UNSUPPORTED_RESOURCE);
+    return;
+  }
 
   if (!app->UnsubscribeFromButton(
           static_cast<mobile_apis::ButtonName::eType>(btn_id))) {
@@ -81,7 +89,7 @@ void UnsubscribeButtonRequest::SendUnsubscribeButtonNotification() {
   SmartObject msg_params = SmartObject(SmartType_Map);
   msg_params[strings::app_id] = connection_key();
   msg_params[strings::name] = static_cast<Common_ButtonName::eType>(
-      (*message_)[strings::msg_params][strings::button_name].asUInt());
+      (*message_)[strings::msg_params][strings::button_name].asInt());
   msg_params[strings::is_suscribed] = false;
   CreateHMINotification(FunctionID::Buttons_OnButtonSubscription, msg_params);
 }

--- a/src/components/application_manager/test/commands/mobile/unsubscribe_button_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unsubscribe_button_request_test.cc
@@ -6,6 +6,7 @@
 #include "application_manager/commands/command_request_test.h"
 #include "application_manager/mock_application_manager.h"
 #include "application_manager/mock_message_helper.h"
+#include "application_manager/mock_hmi_capabilities.h"
 #include "application_manager/commands/mobile/unsubscribe_button_request.h"
 
 namespace test {
@@ -30,7 +31,13 @@ const mobile_apis::ButtonName::eType kButtonId = mobile_apis::ButtonName::OK;
 }  // namespace
 
 class UnsubscribeButtonRequestTest
-    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  typedef TypeIf<kMocksAreNice,
+                 NiceMock<application_manager_test::MockHMICapabilities>,
+                 application_manager_test::MockHMICapabilities>::Result
+      MockHMICapabilities;
+};
 
 TEST_F(UnsubscribeButtonRequestTest, Run_AppNotRegistered_UNSUCCESS) {
   CommandPtr command(CreateCommand<UnsubscribeButtonRequest>());
@@ -55,13 +62,21 @@ TEST_F(UnsubscribeButtonRequestTest,
 
   CommandPtr command(CreateCommand<UnsubscribeButtonRequest>(command_msg));
 
+  UnsubscribeButtonRequestTest::MockHMICapabilities hmi_capabilities;
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(hmi_capabilities));
+  EXPECT_CALL(hmi_capabilities, is_ui_cooperating()).WillOnce(Return(true));
+
+  MessageSharedPtr button_caps_ptr(CreateMessage(smart_objects::SmartType_Map));
+  (*button_caps_ptr)[0][am::hmi_response::button_name] = kButtonId;
+  EXPECT_CALL(hmi_capabilities, button_capabilities())
+      .WillOnce(Return(button_caps_ptr.get()));
+
   MockAppPtr mock_app(CreateMockApp());
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
-
   EXPECT_CALL(*mock_app, UnsubscribeFromButton(kButtonId))
       .WillOnce(Return(false));
-
   EXPECT_CALL(
       app_mngr_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::IGNORED), _));
@@ -69,15 +84,51 @@ TEST_F(UnsubscribeButtonRequestTest,
   command->Run();
 }
 
-TEST_F(UnsubscribeButtonRequestTest, Run_SUCCESS) {
-  const mobile_apis::ButtonName::eType kButtonId = mobile_apis::ButtonName::OK;
+TEST_F(UnsubscribeButtonRequestTest,
+       Run_UnsubscribeNotAllowedByHmiCapabilities_UNSUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+  (*command_msg)[am::strings::msg_params][am::strings::button_name] = kButtonId;
+  CommandPtr command(CreateCommand<UnsubscribeButtonRequest>(command_msg));
 
+  MockAppPtr mock_app(CreateMockApp());
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
+
+  UnsubscribeButtonRequestTest::MockHMICapabilities hmi_capabilities;
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(hmi_capabilities));
+  EXPECT_CALL(hmi_capabilities, is_ui_cooperating()).WillOnce(Return(true));
+
+  MessageSharedPtr button_caps_ptr(CreateMessage(smart_objects::SmartType_Map));
+  EXPECT_CALL(hmi_capabilities, button_capabilities())
+      .WillOnce(Return(button_caps_ptr.get()));
+
+  EXPECT_CALL(app_mngr_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_result::UNSUPPORTED_RESOURCE), _));
+
+  command->Run();
+}
+
+TEST_F(UnsubscribeButtonRequestTest, Run_SUCCESS) {
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
   (*command_msg)[am::strings::params][am::strings::connection_key] =
       kConnectionKey;
   (*command_msg)[am::strings::msg_params][am::strings::button_name] = kButtonId;
 
   CommandPtr command(CreateCommand<UnsubscribeButtonRequest>(command_msg));
+
+  UnsubscribeButtonRequestTest::MockHMICapabilities hmi_capabilities;
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(hmi_capabilities));
+  EXPECT_CALL(hmi_capabilities, is_ui_cooperating()).WillOnce(Return(true));
+
+  MessageSharedPtr button_caps_ptr(CreateMessage(smart_objects::SmartType_Map));
+  (*button_caps_ptr)[0][am::hmi_response::button_name] = kButtonId;
+  EXPECT_CALL(hmi_capabilities, button_capabilities())
+      .WillOnce(Return(button_caps_ptr.get()));
 
   MockAppPtr mock_app(CreateMockApp());
   EXPECT_CALL(app_mngr_, application(kConnectionKey))


### PR DESCRIPTION
Fixed `UnsubscribeButton` wrong result code in case of `UNSUPPORTED_RESOURCE`.
This checking was already implemented for `SubscribeButton` rpc, but was not implemented for `UnsubscribeButton`.

In this pull request:
- Function `CheckHMICapabilities()`, which responsible for HMI capabilities permissions checking, was moved to `CommandRequestImpl` class to use from both `SubscribeButton/UnsubscribeButton`.
- Added logs and minor changes in `CheckHMICapabilities()` function
- Added checking HMI capabilities for `UnsubscribeButton`
- Added new UT for covering new test case and fixes expectations in existing UT's

Related PR: #1358 
Fixes #998