### PR TITLE
Fix Policy Table validation in case group subsection is empty/invalid

### DIFF
--- a/src/components/policy/policy_regular/src/policy_table/validation.cc
+++ b/src/components/policy/policy_regular/src/policy_table/validation.cc
@@ -115,8 +115,13 @@ bool ApplicationPoliciesSection::Validate() const {
 }
 
 bool ApplicationParams::Validate() const {
+  // Check for empty "groups" sub-sections
+  if (groups.empty()) {
+    return false;
+  }
   return true;
 }
+
 bool RpcParameters::Validate() const {
   return true;
 }
@@ -178,20 +183,40 @@ bool UsageAndErrorCounts::Validate() const {
   }
   return true;
 }
+
 bool DeviceParams::Validate() const {
   return true;
 }
+
 bool PolicyTable::Validate() const {
-  if (PT_PRELOADED == GetPolicyTableType() ||
-      PT_UPDATE == GetPolicyTableType()) {
+  const PolicyTableType policy_table_type = GetPolicyTableType();
+
+  if (PT_PRELOADED == policy_table_type || PT_UPDATE == policy_table_type) {
     if (device_data.is_initialized()) {
       return false;
     }
   }
+
+  if (PT_PRELOADED == policy_table_type || PT_SNAPSHOT == policy_table_type) {
+    // Check upper bound of each "groups" sub section in the app policies
+    const FunctionalGroupings::size_type functional_groupings_count =
+        functional_groupings.size();
+    for (ApplicationPolicies::const_iterator app_policiies_it =
+             app_policies_section.apps.begin();
+         app_policies_section.apps.end() != app_policiies_it;
+         ++app_policiies_it) {
+      if (app_policiies_it->second.groups.size() > functional_groupings_count) {
+        return false;
+      }
+    }
+  }
+
   return true;
 }
+
 bool Table::Validate() const {
   return true;
 }
+
 }  // namespace policy_table_interface_base
 }  // namespace rpc


### PR DESCRIPTION
This issue was already fixed for external policy, but still was not fixed for regular policy.
In this PR was added validation checks for empty and upper bound of group subsection of each section which were missed in regular policies.

Related PR with fixes #1422 
Fixes #973