### PR TITLE
Fixed Regular Policy endpoints validation

### DIFF
--- a/src/components/policy/policy_external/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/types.h
@@ -71,7 +71,7 @@ typedef Array<Enum<Parameter>, 0, 100> Parameters;
 
 typedef Map<RpcParameters, 0, 65535> Rpc;
 
-typedef Array<String<10, 65535>, 1, 3> URL;
+typedef Array<String<10, 255>, 1, 3> URL;
 
 typedef Map<URL, 1, 255> URLList;
 

--- a/src/components/policy/policy_external/src/policy_table/validation.cc
+++ b/src/components/policy/policy_external/src/policy_table/validation.cc
@@ -177,6 +177,19 @@ bool ModuleConfig::Validate() const {
     default:
       break;
   }
+
+  for (ServiceEndpoints::const_iterator it_endpoints = endpoints.begin();
+       it_endpoints != endpoints.end();
+       ++it_endpoints) {
+    const URLList& endpoint_list = it_endpoints->second;
+    if (endpoint_list.end() == endpoint_list.find(kDefaultApp)) {
+      LOG4CXX_ERROR(logger_,
+                    "Endpoint " << it_endpoints->first
+                                << "does not contain default group");
+      return false;
+    }
+  }
+
   return true;
 }
 

--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -69,7 +69,7 @@ typedef Array<Enum<Parameter>, 0, 24> Parameters;
 
 typedef Map<RpcParameters, 0, 50> Rpc;
 
-typedef Array<String<10, 255>, 1, 255> URL;
+typedef Array<String<10, 255>, 1, 3> URL;
 
 typedef Map<URL, 1, 255> URLList;
 

--- a/src/components/policy/policy_regular/src/policy_table/validation.cc
+++ b/src/components/policy/policy_regular/src/policy_table/validation.cc
@@ -136,6 +136,19 @@ bool ModuleConfig::Validate() const {
       return false;
     }
   }
+
+  for (ServiceEndpoints::const_iterator it_endpoints = endpoints.begin();
+       it_endpoints != endpoints.end();
+       ++it_endpoints) {
+    const URLList& endpoint_list = it_endpoints->second;
+    if (endpoint_list.end() == endpoint_list.find(kDefaultApp)) {
+      LOG4CXX_ERROR(logger_,
+                    "Endpoint " << it_endpoints->first
+                                << "does not contain default group");
+      return false;
+    }
+  }
+
   return true;
 }
 


### PR DESCRIPTION
For regular policies there was a wrong upper bound for endpoints which allows for each endpoint to have a list with more than 3 items. This issue was fixed for external policies earlier.

The second part of issue is that PM does not check endpoints for containing "default" group. This check was added for all policies flows.

Related PR #1380 
Fixes #978 