### PR TITLE
Fixes minor memory leaks

### DIFF
--- a/src/components/application_manager/include/application_manager/message.h
+++ b/src/components/application_manager/include/application_manager/message.h
@@ -93,7 +93,7 @@ class Message {
   void set_correlation_id(int32_t id);
   void set_connection_key(int32_t key);
   void set_message_type(MessageType type);
-  void set_binary_data(BinaryData* data);
+  void set_binary_data(const BinaryData* data);
   void set_json_message(const std::string& json_message);
   void set_protocol_version(protocol_handler::MajorProtocolVersion version);
   void set_smart_object(const smart_objects::SmartObject& object);

--- a/src/components/application_manager/include/application_manager/message.h
+++ b/src/components/application_manager/include/application_manager/message.h
@@ -93,6 +93,8 @@ class Message {
   void set_correlation_id(int32_t id);
   void set_connection_key(int32_t key);
   void set_message_type(MessageType type);
+  // DEPRECATED
+  void set_binary_data(BinaryData* data);
   void set_binary_data(const BinaryData* data);
   void set_json_message(const std::string& json_message);
   void set_protocol_version(protocol_handler::MajorProtocolVersion version);

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <string>
 #include "utils/macro.h"
+#include "utils/make_shared.h"
 #include "application_manager/commands/command_request_impl.h"
 #include "application_manager/application_manager.h"
 #include "application_manager/message_helper.h"
@@ -214,11 +215,9 @@ void CommandRequestImpl::SendResponse(
     current_state_ = kCompleted;
   }
 
-  smart_objects::SmartObjectSPtr result = new smart_objects::SmartObject;
-  if (!result) {
-    LOG4CXX_ERROR(logger_, "Memory allocation failed.");
-    return;
-  }
+  smart_objects::SmartObjectSPtr result =
+      utils::MakeShared<smart_objects::SmartObject>();
+
   smart_objects::SmartObject& response = *result;
 
   response[strings::params][strings::message_type] = MessageType::kResponse;

--- a/src/components/application_manager/src/message.cc
+++ b/src/components/application_manager/src/message.cc
@@ -194,6 +194,20 @@ void Message::set_message_type(MessageType type) {
   type_ = type;
 }
 
+// DEPRECATED
+void Message::set_binary_data(BinaryData* data) {
+  if (NULL == data) {
+    NOTREACHED();
+    return;
+  }
+
+  if (binary_data_) {
+    delete binary_data_;
+  }
+
+  binary_data_ = new BinaryData(*data);
+}
+
 void Message::set_binary_data(const BinaryData* data) {
   if (NULL == data) {
     NOTREACHED();

--- a/src/components/application_manager/src/message.cc
+++ b/src/components/application_manager/src/message.cc
@@ -194,7 +194,7 @@ void Message::set_message_type(MessageType type) {
   type_ = type;
 }
 
-void Message::set_binary_data(BinaryData* data) {
+void Message::set_binary_data(const BinaryData* data) {
   if (NULL == data) {
     NOTREACHED();
     return;

--- a/src/components/application_manager/src/mobile_message_handler.cc
+++ b/src/components/application_manager/src/mobile_message_handler.cc
@@ -196,8 +196,7 @@ MobileMessageHandler::HandleIncomingMessageProtocolV2(
   outgoing_message->set_payload_size(message->payload_size());
 
   if (!payload.data.empty()) {
-    outgoing_message->set_binary_data(
-        new application_manager::BinaryData(payload.data));
+    outgoing_message->set_binary_data(&payload.data);
   }
   return outgoing_message.release();
 }

--- a/src/components/telemetry_monitor/include/telemetry_monitor/telemetry_monitor.h
+++ b/src/components/telemetry_monitor/include/telemetry_monitor/telemetry_monitor.h
@@ -35,7 +35,6 @@
 
 #include <string>
 
-#include "utils/shared_ptr.h"
 #include "utils/message_queue.h"
 #include "utils/threads/thread.h"
 #include "utils/threads/thread_delegate.h"
@@ -46,6 +45,11 @@
 #include "transport_manager/transport_manager_impl.h"
 #include "protocol_handler_observer.h"
 #include "protocol_handler/protocol_handler_impl.h"
+
+namespace utils {
+template <typename T>
+class SharedPtr;
+}
 
 namespace telemetry_monitor {
 
@@ -88,7 +92,9 @@ class TelemetryMonitor {
   virtual void Stop();
   virtual void Start();
   virtual void SendMetric(utils::SharedPtr<MetricWrapper> metric);
+  // DEPRECATED
   void set_streamer(Streamer* streamer);
+  void set_streamer(utils::SharedPtr<Streamer> streamer);
   const std::string& ip() const;
   int16_t port() const;
 
@@ -96,7 +102,7 @@ class TelemetryMonitor {
   std::string server_address_;
   int16_t port_;
   threads::Thread* thread_;
-  Streamer* streamer_;
+  utils::SharedPtr<Streamer> streamer_;
   ApplicationManagerObserver app_observer;
   TransportManagerObserver tm_observer;
   ProtocolHandlerObserver ph_observer;

--- a/src/components/telemetry_monitor/src/telemetry_monitor.cc
+++ b/src/components/telemetry_monitor/src/telemetry_monitor.cc
@@ -42,6 +42,8 @@
 
 #include "transport_manager/transport_manager_default.h"
 #include "utils/resource_usage.h"
+#include "utils/make_shared.h"
+#include "utils/shared_ptr.h"
 #include "telemetry_monitor/telemetry_observable.h"
 
 namespace telemetry_monitor {
@@ -53,24 +55,23 @@ TelemetryMonitor::TelemetryMonitor(const std::string& server_address,
     : server_address_(server_address)
     , port_(port)
     , thread_(NULL)
-    , streamer_(NULL)
     , app_observer(this)
     , tm_observer(this)
     , ph_observer(this) {}
 
 void TelemetryMonitor::Start() {
-  streamer_ = streamer_ ? streamer_ : new Streamer(this);
-  thread_ = threads::CreateThread("TelemetryMonitor", streamer_);
+  streamer_ = streamer_ ? streamer_ : utils::MakeShared<Streamer>(this);
+  thread_ = threads::CreateThread("TelemetryMonitor", streamer_.get());
 }
 
-void TelemetryMonitor::set_streamer(Streamer* streamer) {
+// DEPRECATED
+void TelemetryMonitor::set_streamer(Streamer* streamer) {}
+
+void TelemetryMonitor::set_streamer(utils::SharedPtr<Streamer> streamer) {
   LOG4CXX_AUTO_TRACE(logger_);
   if (thread_ && !thread_->is_running()) {
-    thread_->set_delegate(streamer);
-    if (streamer_) {
-      delete streamer_;
-    }
     streamer_ = streamer;
+    thread_->set_delegate(streamer_.get());
   } else {
     LOG4CXX_ERROR(logger_, "Unable to replace streamer if it is active");
   }
@@ -86,7 +87,6 @@ int16_t TelemetryMonitor::port() const {
 
 TelemetryMonitor::~TelemetryMonitor() {
   Stop();
-  delete streamer_;
 }
 
 void TelemetryMonitor::Init(
@@ -117,7 +117,7 @@ void TelemetryMonitor::Stop() {
 }
 
 void TelemetryMonitor::SendMetric(utils::SharedPtr<MetricWrapper> metric) {
-  if ((NULL != streamer_) && streamer_->is_client_connected_) {
+  if (streamer_ && streamer_->is_client_connected_) {
     streamer_->PushMessage(metric);
   }
 }

--- a/src/components/telemetry_monitor/test/telemetry_monitor_test.cc
+++ b/src/components/telemetry_monitor/test/telemetry_monitor_test.cc
@@ -40,6 +40,8 @@
 #include "connection_handler/mock_connection_handler.h"
 #include "transport_manager/mock_transport_manager.h"
 #include "telemetry_monitor/mock_telemetry_observable.h"
+#include "utils/shared_ptr.h"
+#include "utils/make_shared.h"
 
 using testing::Return;
 using testing::_;
@@ -90,7 +92,8 @@ TEST(TelemetryMonitorTest, MessageProcess) {
   EXPECT_CALL(am_observeble, SetTelemetryObserver(_));
   EXPECT_CALL(transport_manager_mock, SetTelemetryObserver(_));
   telemetry_monitor::TelemetryMonitor telemetry_monitor(server_address, port);
-  StreamerMock* streamer_mock = new StreamerMock(&telemetry_monitor);
+  utils::SharedPtr<StreamerMock> streamer_mock =
+      utils::MakeShared<StreamerMock>(&telemetry_monitor);
   // streamer_mock will be freed by telemetry_monitor on destruction
   telemetry_monitor.Start();
   telemetry_monitor.set_streamer(streamer_mock);


### PR DESCRIPTION
It is wrong expectation to have all memory requested by process to be freed immediately after certain function within process completes its execution since that behavior is out of process capabilities but is related to OS memory management.
However there were several other memory leaks which had been fixed.

Original PR: #1397 
Relates to: #1029