### PR TITLE
Fix issue with incorrect behaviour in AlertManeuver

### DIFF
--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -216,17 +216,17 @@ bool AlertManeuverRequest::PrepareResponseParameters(
 
 bool AlertManeuverRequest::IsWhiteSpaceExist() {
   LOG4CXX_AUTO_TRACE(logger_);
+  using smart_objects::SmartArray;
 
   if ((*message_)[strings::msg_params].keyExists(strings::tts_chunks)) {
-    const smart_objects::SmartArray* tc_array =
+    const SmartArray* tts_chuncks_arr =
         (*message_)[strings::msg_params][strings::tts_chunks].asArray();
 
-    smart_objects::SmartArray::const_iterator it_tc = tc_array->begin();
-    smart_objects::SmartArray::const_iterator it_tc_end = tc_array->end();
+    SmartArray::const_iterator it_tts_chunk = tts_chuncks_arr->begin();
 
-    for (; it_tc != it_tc_end; ++it_tc) {
-      const char* str = (*it_tc)[strings::text].asCharArray();
-      if (strlen(str) && !CheckSyntax(str)) {
+    for (; it_tts_chunk != tts_chuncks_arr->end(); ++it_tts_chunk) {
+      const char* tts_chunk_text = (*it_tts_chunk)[strings::text].asCharArray();
+      if (strlen(tts_chunk_text) && !CheckSyntax(tts_chunk_text)) {
         LOG4CXX_ERROR(logger_, "Invalid tts_chunks syntax check failed");
         return true;
       }
@@ -237,15 +237,14 @@ bool AlertManeuverRequest::IsWhiteSpaceExist() {
         (*message_)[strings::msg_params][strings::soft_buttons].getType() ==
             smart_objects::SmartType_Array,
         true);
-    const smart_objects::SmartArray* sb_array =
+    const smart_objects::SmartArray* soft_button_array =
         (*message_)[strings::msg_params][strings::soft_buttons].asArray();
 
-    smart_objects::SmartArray::const_iterator it_sb = sb_array->begin();
-    smart_objects::SmartArray::const_iterator it_sb_end = sb_array->end();
+    SmartArray::const_iterator it_soft_button = soft_button_array->begin();
 
-    for (; it_sb != it_sb_end; ++it_sb) {
-      const char* str = (*it_sb)[strings::text].asCharArray();
-      if (!CheckSyntax(str)) {
+    for (; it_soft_button != soft_button_array->end(); ++it_soft_button) {
+      const char* soft_button_text = (*it_soft_button)[strings::text].asCharArray();
+      if (!CheckSyntax(soft_button_text)) {
         LOG4CXX_ERROR(logger_, "Invalid soft_buttons syntax check failed");
         return true;
       }

--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -219,12 +219,12 @@ bool AlertManeuverRequest::IsWhiteSpaceExist() {
   using smart_objects::SmartArray;
 
   if ((*message_)[strings::msg_params].keyExists(strings::tts_chunks)) {
-    const SmartArray* tts_chuncks_arr =
+    const SmartArray* tts_chunks_arr =
         (*message_)[strings::msg_params][strings::tts_chunks].asArray();
 
-    SmartArray::const_iterator it_tts_chunk = tts_chuncks_arr->begin();
+    SmartArray::const_iterator it_tts_chunk = tts_chunks_arr->begin();
 
-    for (; it_tts_chunk != tts_chuncks_arr->end(); ++it_tts_chunk) {
+    for (; it_tts_chunk != tts_chunks_arr->end(); ++it_tts_chunk) {
       const char* tts_chunk_text = (*it_tts_chunk)[strings::text].asCharArray();
       if (strlen(tts_chunk_text) && !CheckSyntax(tts_chunk_text)) {
         LOG4CXX_ERROR(logger_, "Invalid tts_chunks syntax check failed");

--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -216,7 +216,6 @@ bool AlertManeuverRequest::PrepareResponseParameters(
 
 bool AlertManeuverRequest::IsWhiteSpaceExist() {
   LOG4CXX_AUTO_TRACE(logger_);
-  const char* str = NULL;
 
   if ((*message_)[strings::msg_params].keyExists(strings::tts_chunks)) {
     const smart_objects::SmartArray* tc_array =
@@ -226,13 +225,33 @@ bool AlertManeuverRequest::IsWhiteSpaceExist() {
     smart_objects::SmartArray::const_iterator it_tc_end = tc_array->end();
 
     for (; it_tc != it_tc_end; ++it_tc) {
-      str = (*it_tc)[strings::text].asCharArray();
+      const char* str = (*it_tc)[strings::text].asCharArray();
       if (strlen(str) && !CheckSyntax(str)) {
         LOG4CXX_ERROR(logger_, "Invalid tts_chunks syntax check failed");
         return true;
       }
     }
   }
+  if ((*message_)[strings::msg_params].keyExists(strings::soft_buttons)) {
+    DCHECK_OR_RETURN(
+        (*message_)[strings::msg_params][strings::soft_buttons].getType() ==
+            smart_objects::SmartType_Array,
+        true);
+    const smart_objects::SmartArray* sb_array =
+        (*message_)[strings::msg_params][strings::soft_buttons].asArray();
+
+    smart_objects::SmartArray::const_iterator it_sb = sb_array->begin();
+    smart_objects::SmartArray::const_iterator it_sb_end = sb_array->end();
+
+    for (; it_sb != it_sb_end; ++it_sb) {
+      const char* str = (*it_sb)[strings::text].asCharArray();
+      if (!CheckSyntax(str)) {
+        LOG4CXX_ERROR(logger_, "Invalid soft_buttons syntax check failed");
+        return true;
+      }
+    }
+  }
+
   return false;
 }
 

--- a/src/components/application_manager/test/commands/mobile/alert_maneuver_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/alert_maneuver_request_test.cc
@@ -149,7 +149,8 @@ TEST_F(AlertManeuverRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
 
 TEST_F(AlertManeuverRequestTest, Run_ProcessingResult_UNSUCCESS) {
   MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
-  (*msg)[am::strings::msg_params][am::strings::soft_buttons] = 0;
+  (*msg)[am::strings::msg_params][am::strings::soft_buttons][0]
+        [am::strings::text] = "text";
 
   CommandPtr command(CreateCommand<AlertManeuverRequest>(msg));
 
@@ -199,7 +200,8 @@ TEST_F(AlertManeuverRequestTest, Run_IsWhiteSpaceExist_UNSUCCESS) {
 
 TEST_F(AlertManeuverRequestTest, Run_ProcessingResult_SUCCESS) {
   MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
-  (*msg)[am::strings::msg_params][am::strings::soft_buttons] = 0;
+  (*msg)[am::strings::msg_params][am::strings::soft_buttons][0]
+        [am::strings::text] = "text";
 
   CommandPtr command(CreateCommand<AlertManeuverRequest>(msg));
 


### PR DESCRIPTION
Resend PR #1374 to develop branch
 
Fixed issue when in AlertManeuver SDL responds GENERIC_ERROR instead of
INVALID_DATA when soft button has Type is Image or Both and Text is 
whitespace or \t or \n or empty

Related to #980 