### PR TITLE
Fix unstable unit test 

### DIFF
--- a/src/components/application_manager/test/commands/mobile/show_test.cc
+++ b/src/components/application_manager/test/commands/mobile/show_test.cc
@@ -776,12 +776,15 @@ TEST_F(ShowRequestTest, OnEvent_SuccessResultCode_SUCCESS) {
 TEST_F(ShowRequestTest, OnEvent_WarningsResultCode_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
   (*msg)[am::strings::params][am::hmi_response::code] =
-      mobile_apis::Result::WARNINGS;
+      hmi_apis::Common_Result::WARNINGS;
   (*msg)[am::strings::params][am::hmi_response::message] = "Response Info";
   (*msg)[am::strings::msg_params] = SmartObject(smart_objects::SmartType_Map);
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
 
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::WARNINGS))
+      .WillOnce(Return(mobile_apis::Result::WARNINGS));
   EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
 
   Event event(hmi_apis::FunctionID::UI_Show);


### PR DESCRIPTION
Unit test OnEvent_WarningsResultCode_SUCCESS was unstable due to missed HMIToMobileResult expectation. 
Due to HMIToMobileResult returns simple type (enum) gmock generates it on some systems, but sometimes it cause gmock exception due to missed specification of return value. 
This PR adds expectation of calling HMIToMobileResult and specify return value for it. 
