### PR TITLE
Fix seconds_between_retries upper bound for regular policy

### DIFF
--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -79,7 +79,7 @@ typedef uint8_t NumberOfNotificationsType;
 typedef Map<Integer<NumberOfNotificationsType, 0, 255>, 0, 6>
     NumberOfNotificationsPerMinute;
 
-typedef Array<Integer<uint16_t, 1, 1000>, 0, 10> SecondsBetweenRetries;
+typedef Array<Integer<uint16_t, 1, 1000>, 0, 5> SecondsBetweenRetries;
 
 typedef Map<MessageString, 0, 500> Languages;
 


### PR DESCRIPTION
Fixed `seconds_between_retries` upper bound parameter for regular policy.
According to requirements maximum size for this param is 5.

In this pull request:
- Fixed `SecondsBetweenRetries` template parameter for regular policy as it's done for external policy

Related PR #1315 
Fixes #962 