### PR TITLE
Fix incorrect behaviour of SDL during respose ACK when not rpc service started

### DIFF
--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -245,7 +245,7 @@ class ProtocolHandlerImpl
    */
   void SendStartSessionAck(ConnectionID connection_id,
                            uint8_t session_id,
-                           uint8_t protocol_version,
+                           uint8_t input_protocol_version,
                            uint32_t hash_code,
                            uint8_t service_type,
                            bool protection);

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -176,13 +176,16 @@ void set_hash_id(uint32_t hash_id, protocol_handler::ProtocolPacket& packet) {
 
 void ProtocolHandlerImpl::SendStartSessionAck(ConnectionID connection_id,
                                               uint8_t session_id,
-                                              uint8_t,
+                                              uint8_t protocol_version,
                                               uint32_t hash_id,
                                               uint8_t service_type,
                                               bool protection) {
   LOG4CXX_AUTO_TRACE(logger_);
-
   uint8_t protocolVersion = SupportedSDLProtocolVersion();
+
+  if (kRpc != service_type) {
+    protocolVersion = protocol_version;
+  }
 
   ProtocolFramePtr ptr(
       new protocol_handler::ProtocolPacket(connection_id,

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -176,20 +176,23 @@ void set_hash_id(uint32_t hash_id, protocol_handler::ProtocolPacket& packet) {
 
 void ProtocolHandlerImpl::SendStartSessionAck(ConnectionID connection_id,
                                               uint8_t session_id,
-                                              uint8_t protocol_version,
+                                              uint8_t input_protocol_version,
                                               uint32_t hash_id,
                                               uint8_t service_type,
                                               bool protection) {
   LOG4CXX_AUTO_TRACE(logger_);
-  uint8_t protocolVersion = SupportedSDLProtocolVersion();
+  uint8_t ack_protocol_version = SupportedSDLProtocolVersion();
 
   if (kRpc != service_type) {
-    protocolVersion = protocol_version;
+    // In case if input protocol version os bigger then supported, SDL should respond with maximum supported protocol version
+    ack_protocol_version = input_protocol_version < ack_protocol_version
+                               ? input_protocol_version
+                               : ack_protocol_version;
   }
 
   ProtocolFramePtr ptr(
       new protocol_handler::ProtocolPacket(connection_id,
-                                           protocolVersion,
+                                           ack_protocol_version,
                                            protection,
                                            FRAME_TYPE_CONTROL,
                                            service_type,


### PR DESCRIPTION
Resend #1413 to develop branch

In the case of start not rpc service by low protocol, SDL was answered ACK with highest supported protocol version. It is fairly for RPC service but nit correct for Audio and VIdeo. 

This PR adds check of type service before sending Ack. In case if this is RPC service SDL should respond with maximum supported version. In the case of not RPC service sdl should respond with the same version of protocol as StartService received. 

Fixes : #1365
 