### PR TITLE
Fix SDL does not set timeout for OnSystemRequest with URL

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -190,7 +190,17 @@ class PolicyHandler : public PolicyHandlerInterface,
                      EndpointUrls& out_end_points) OVERRIDE;
   virtual std::string GetLockScreenIconUrl() const OVERRIDE;
   uint32_t NextRetryTimeout() OVERRIDE;
+
+  /**
+   * Gets timeout to wait until receive response
+   * @return timeout in seconds
+   */
   uint32_t TimeoutExchangeSec() const OVERRIDE;
+
+  /**
+   * Gets timeout to wait until receive response
+   * @return timeout in miliseconds
+   */
   uint32_t TimeoutExchangeMSec() const OVERRIDE;
   void OnExceededTimeout() OVERRIDE;
   void OnSystemReady() OVERRIDE;

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -106,7 +106,17 @@ class PolicyHandlerInterface {
                              EndpointUrls& out_end_points) = 0;
   virtual std::string GetLockScreenIconUrl() const = 0;
   virtual uint32_t NextRetryTimeout() = 0;
+
+  /**
+   * Gets timeout to wait until receive response
+   * @return timeout in seconds
+   */
   virtual uint32_t TimeoutExchangeSec() const = 0;
+
+  /**
+   * Gets timeout to wait until receive response
+   * @return timeout in miliseconds
+   */
   virtual uint32_t TimeoutExchangeMSec() const = 0;
   virtual void OnExceededTimeout() = 0;
   virtual void OnSystemReady() = 0;


### PR DESCRIPTION
SDL send OnSystemRequest to mobile with URL but without timeout parameter,
but parameter timeout is **required if a URL is provided**.
Add parameter timeout to sending OnSystemRequest notification if URL is provided.
Also add const to TimeoutExchangeSec() and TimeoutExchangeMSec() because policy_handler is const.
Original PR: #1411
Relates to: #1021