### PR TITLE
Fix GetWayPoints request OnResetTimeout processing

### DIFF
--- a/src/components/application_manager/src/commands/mobile/get_way_points_request.cc
+++ b/src/components/application_manager/src/commands/mobile/get_way_points_request.cc
@@ -8,7 +8,9 @@ namespace commands {
 
 GetWayPointsRequest::GetWayPointsRequest(
     const MessageSharedPtr& message, ApplicationManager& application_manager)
-    : CommandRequestImpl(message, application_manager) {}
+    : CommandRequestImpl(message, application_manager) {
+  subscribe_on_event(hmi_apis::FunctionID::UI_OnResetTimeout);
+}
 
 GetWayPointsRequest::~GetWayPointsRequest() {}
 
@@ -38,6 +40,12 @@ void GetWayPointsRequest::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
   const smart_objects::SmartObject& message = event.smart_object();
   switch (event.id()) {
+    case hmi_apis::FunctionID::UI_OnResetTimeout: {
+      LOG4CXX_INFO(logger_, "Received UI_OnResetTimeout event");
+      application_manager_.updateRequestTimeout(
+          connection_key(), correlation_id(), default_timeout());
+      break;
+    }
     case hmi_apis::FunctionID::Navigation_GetWayPoints: {
       LOG4CXX_INFO(logger_, "Received Navigation_GetWayPoints event");
       const hmi_apis::Common_Result::eType result_code =


### PR DESCRIPTION
The root cause of this problem is that `GetWayPoints` was not subscribed on `OnResetTimeout` notifications from HMI and does not react on this notifications. This is a reason why this RPC does not reset own timeout.

In this pull request:
- Added subscription to `UI_OnResetTimeout` event for `GetWayPoints`
- Implemented logic for processing this event in `on_event()`

There are no related pull requests with fixes
Fixes #991 