### PR TITLE
Fix SDL not send Stop A/V Stream by unregistering

### DIFF
--- a/src/components/application_manager/src/commands/mobile/unregister_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unregister_app_interface_request.cc
@@ -53,6 +53,7 @@ void UnregisterAppInterfaceRequest::Run() {
           connection_key(),
           mobile_api::AppInterfaceUnregisteredReason::INVALID_ENUM),
       commands::Command::ORIGIN_SDL);
+  application_manager_.EndNaviServices(connection_key());
   application_manager_.UnregisterApplication(connection_key(),
                                              mobile_apis::Result::SUCCESS);
   SendResponse(true, mobile_apis::Result::SUCCESS);


### PR DESCRIPTION
Fixed problem that SDL does not send StopStream/StopAudioStream to HMI if app unregistered during  streaming. 
Added EndNaviServices call to UnregisterAppInterface request.

Related PR in other branch: [1407](https://github.com/smartdevicelink/sdl_core/pull/1407)
Related to [Issue-1010](https://github.com/smartdevicelink/sdl_core/issues/1010)