### PR TITLE
Fix message param value replacing in HMI response

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/hmi/response_from_hmi.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/response_from_hmi.h
@@ -43,7 +43,7 @@ namespace commands {
 
 class ResponseFromHMI : public CommandImpl {
  public:
-  ResponseFromHMI(const MessageSharedPtr& message,
+  ResponseFromHMI(const MessageSharedPtr& response_message,
                   ApplicationManager& application_manager);
   virtual ~ResponseFromHMI();
   virtual bool Init();
@@ -52,7 +52,7 @@ class ResponseFromHMI : public CommandImpl {
   void SendResponseToMobile(const MessageSharedPtr& message,
                             ApplicationManager& application_manager);
 
-  /*
+  /**
    * @brief Creates HMI request
    *
    * @param function_id HMI request ID
@@ -60,6 +60,15 @@ class ResponseFromHMI : public CommandImpl {
    */
   void CreateHMIRequest(const hmi_apis::FunctionID::eType& function_id,
                         const smart_objects::SmartObject& msg_params) const;
+
+  /**
+   * @brief Extracts "message" param value from HMI response
+   *
+   * @param message HMI response message to process
+   * @return value of message param if exists otherwise returns empty string
+   */
+  const std::string GetMessageParamValue(
+      const MessageSharedPtr& response_message) const;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(ResponseFromHMI);


### PR DESCRIPTION
The root cause of this defect is that there was a wrong logic in `ResponseFromHMI` for replacing "info" param with value of "message" param. This param could be in `msg_params` section of `SmartObject` in case of normal response and in `params` section in case of erroneous response.

In this pull request:
- Added `GetMessageParamValue()` function with correct logic for reading "message" param from provided `SmartObject`
- Existing logic in ctor was replaced with new function call

There is no related pull requests
Fixes #997 