### PR TITLE
Fix resource leak (CID 148704)

### DIFF
--- a/src/components/utils/src/timer.cc
+++ b/src/components/utils/src/timer.cc
@@ -64,7 +64,7 @@ timer::Timer::~Timer() {
   StopDelegate();
   single_shot_ = true;
 
-  delegate_.release();
+  delegate_.reset();
   DeleteThread(thread_);
   DCHECK(task_);
   delete task_;


### PR DESCRIPTION
The `release` function for `auto_ptr` does not free the allocated memory, `reset` does.