### PR TITLE
Update SDL to support PEM serts and generate_test_certificates.py script

### DIFF
--- a/src/components/security_manager/test/crypto_manager_impl_test.cc
+++ b/src/components/security_manager/test/crypto_manager_impl_test.cc
@@ -39,6 +39,7 @@
 #include <fstream>
 #include <sstream>
 
+#include "utils/make_shared.h"
 #include "gtest/gtest.h"
 #include "security_manager/crypto_manager_impl.h"
 #include "security_manager/mock_security_manager_settings.h"
@@ -64,10 +65,14 @@ namespace test {
 namespace components {
 namespace crypto_manager_test {
 
+using security_manager::CryptoManagerImpl;
+
 class CryptoManagerTest : public testing::Test {
  protected:
+  typedef NiceMock<security_manager_test::MockCryptoManagerSettings>
+      MockCryptoManagerSettings;
   static void SetUpTestCase() {
-    std::ifstream certificate_file("server/spt_credential.p12.enc");
+    std::ifstream certificate_file("server/spt_credential.pem");
     ASSERT_TRUE(certificate_file.is_open())
         << "Could not open certificate data file";
 
@@ -81,16 +86,9 @@ class CryptoManagerTest : public testing::Test {
   void SetUp() OVERRIDE {
     ASSERT_FALSE(certificate_data_base64_.empty());
     mock_security_manager_settings_ =
-        new NiceMock<security_manager_test::MockCryptoManagerSettings>();
-    utils::SharedPtr<security_manager::CryptoManagerSettings> scrypto =
-        utils::SharedPtr<security_manager::CryptoManagerSettings>::
-            static_pointer_cast<security_manager::CryptoManagerSettings>(
-                mock_security_manager_settings_);
-    crypto_manager_ = new security_manager::CryptoManagerImpl(scrypto);
-  }
-
-  void TearDown() OVERRIDE {
-    delete mock_security_manager_settings_;
+        utils::MakeShared<MockCryptoManagerSettings>();
+    crypto_manager_ =
+        utils::MakeShared<CryptoManagerImpl>(mock_security_manager_settings_);
   }
 
   void InitSecurityManager() {
@@ -117,11 +115,9 @@ class CryptoManagerTest : public testing::Test {
         .WillByDefault(Return(false));
   }
 
-  security_manager::CryptoManager* crypto_manager_;
+  utils::SharedPtr<CryptoManagerImpl> crypto_manager_;
+  utils::SharedPtr<MockCryptoManagerSettings> mock_security_manager_settings_;
   static std::string certificate_data_base64_;
-
-  NiceMock<security_manager_test::MockCryptoManagerSettings>*
-      mock_security_manager_settings_;
 };
 std::string CryptoManagerTest::certificate_data_base64_;
 

--- a/src/components/security_manager/test/ssl_certificate_handshake_test.cc
+++ b/src/components/security_manager/test/ssl_certificate_handshake_test.cc
@@ -56,12 +56,12 @@ namespace custom_str = utils::custom_string;
 namespace {
 const std::string server_ca_cert_filename = "server";
 const std::string client_ca_cert_filename = "client";
-const std::string client_certificate = "client/client_credential.p12.enc";
-const std::string server_certificate = "server/spt_credential.p12.enc";
+const std::string client_certificate = "client/client_credential.pem";
+const std::string server_certificate = "server/spt_credential.pem";
 const std::string server_unsigned_cert_file =
-    "server/spt_credential_unsigned.p12.enc";
+    "server/spt_credential_unsigned.pem";
 const std::string server_expired_cert_file =
-    "server/spt_credential_expired.p12.enc";
+    "server/spt_credential_expired.pem";
 
 const bool verify_peer = true;
 const bool skip_peer_verification = false;

--- a/src/components/security_manager/test/ssl_context_test.cc
+++ b/src/components/security_manager/test/ssl_context_test.cc
@@ -88,9 +88,9 @@ struct ProtocolAndCipher {
 class SSLTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
-    SetCertificate("server/spt_credential_unsigned.p12.enc",
+    SetCertificate("server/spt_credential_unsigned.pem",
                    server_certificate_data_base64_);
-    SetCertificate("client/client_credential_unsigned.p12.enc",
+    SetCertificate("client/client_credential_unsigned.pem",
                    client_certificate_data_base64_);
   }
 

--- a/tools/Utils/generate_test_certificates.py
+++ b/tools/Utils/generate_test_certificates.py
@@ -118,12 +118,13 @@ def gen_pkcs12(out, key_file, cert_file, verification_certificate) :
        "-name 'SPT key and certificates'", "-CAfile ", verification_certificate, \
        " -passout pass:")
 
-    """
-    Encode certificate $out to base 64
-    """
-    with open(out, "rb") as cert:
-        with open(out + ".enc", "wb") as enc_cert:
-            enc_cert.write(cert.read().encode("base64"))
+def gen_pem_file(out, key_file, cert_file, verification_certificate) :
+    """Join $key_file, $cert_file, $verification_certificate in pem file named $out"""
+    files = [key_file, cert_file, verification_certificate]
+    with open(out, "wb") as cert:
+        for fl in files:
+            with open(fl) as infile:
+                cert.write(infile.read())
 
 def answers(name, app_id, country, state, locality, organization, unit, email) :
     """Answer string generator
@@ -228,47 +229,53 @@ def main():
     server_key_file = os.path.join(server_dir, "server.key")
     server_cert_file = os.path.join(server_dir, "server.crt")
     server_pkcs12_file = os.path.join(server_dir, "spt_credential.p12")
+    server_pem_file = os.path.join(server_dir, "spt_credential.pem")
     gen_rsa_key(server_key_file, 2048)
     gen_cert(server_cert_file, server_key_file, ford_server_cert_file, ford_server_key_file, days, server_answer)
     gen_pkcs12(server_pkcs12_file, server_key_file, server_cert_file, client_verification_ca_cert_file)
+    gen_pem_file(server_pem_file, server_key_file, server_cert_file, client_verification_ca_cert_file)
 
     print
     print " --== Server unsigned certificate generating ==-- "
     server_unsigned_cert_file = os.path.join(server_dir, "server_unsigned.crt")
     server_pkcs12_unsigned_file = os.path.join(server_dir, "spt_credential_unsigned.p12")
+    server_pem_unsigned_file = os.path.join(server_dir, "spt_credential_unsigned.pem")
     gen_root_cert(server_unsigned_cert_file, server_key_file, days, server_unsigned_answer)
     gen_pkcs12(server_pkcs12_unsigned_file, server_key_file, server_unsigned_cert_file, client_verification_ca_cert_file)
+    gen_pem_file(server_pem_unsigned_file, server_key_file, server_unsigned_cert_file, client_verification_ca_cert_file)
 
     print
     print " --== Server expired certificate generating ==-- "
     server_expired_cert_file = os.path.join(server_dir, "server_expired.crt")
     server_pkcs12_expired_file = os.path.join(server_dir, "spt_credential_expired.p12")
+    server_pem_expired_file = os.path.join(server_dir, "spt_credential_expired.pem")
     gen_expire_cert(server_expired_cert_file, server_key_file, ford_server_cert_file, ford_server_key_file, days, server_expired_answer)
     gen_pkcs12(server_pkcs12_expired_file, server_key_file, server_expired_cert_file, client_verification_ca_cert_file)
+    gen_pem_file(server_pem_expired_file, server_key_file, server_expired_cert_file, client_verification_ca_cert_file)
 
 
     print
     print " --== Client pkcs12 certificate generating ==-- "
     client_key_file = os.path.join(client_dir, "client.key")
     client_cert_file = os.path.join(client_dir, "client.crt")
-    client_pkcs12_file = os.path.join(client_dir, "client_credential.p12")
+    client_pkcs12_file = os.path.join(client_dir, "client_credential.pem")
     gen_rsa_key(client_key_file, 2048)
     gen_cert(client_cert_file, client_key_file, ford_client_cert_file, ford_client_key_file, days, client_answer)
-    gen_pkcs12(client_pkcs12_file, client_key_file, client_cert_file, server_verification_ca_cert_file)
+    gen_pem_file(client_pkcs12_file, client_key_file, client_cert_file, server_verification_ca_cert_file)
 
     print
     print " --== Client pkcs12 unsigned certificate generating ==-- "
     client_unsigned_cert_file = os.path.join(client_dir, "client_unsigned.crt")
-    client_pkcs12_unsigned_file = os.path.join(client_dir, "client_credential_unsigned.p12")
+    client_pkcs12_unsigned_file = os.path.join(client_dir, "client_credential_unsigned.pem")
     gen_root_cert(client_unsigned_cert_file, client_key_file, days, client_unsigned_answer)
-    gen_pkcs12(client_pkcs12_unsigned_file, client_key_file, client_unsigned_cert_file, server_verification_ca_cert_file)
+    gen_pem_file(client_pkcs12_unsigned_file, client_key_file, client_unsigned_cert_file, server_verification_ca_cert_file)
 
     print
     print " --== Client pkcs12 expired certificate generating ==-- "
     client_expired_cert_file = os.path.join(client_dir, "client_expired.crt")
-    client_pkcs12_expired_file = os.path.join(client_dir, "client_credential_expired.p12")
+    client_pkcs12_expired_file = os.path.join(client_dir, "client_credential_expired.pem")
     gen_expire_cert(client_expired_cert_file, client_key_file, ford_client_cert_file, ford_client_key_file, days, client_expired_answer)
-    gen_pkcs12(client_pkcs12_expired_file, client_key_file, client_expired_cert_file, server_verification_ca_cert_file)
+    gen_pem_file(client_pkcs12_expired_file, client_key_file, client_expired_cert_file, server_verification_ca_cert_file)
 
     subprocess.call(["c_rehash", server_dir])
     subprocess.call(["c_rehash", client_dir])


### PR DESCRIPTION
Previously SDL was implemented in the way to support certificate in PKCS12
Now it has been changed to simple PEM format according to the new requirements.

- generate_test_certificates.py updated
- unit tests updated

Related PR in other branch: [#1402](https://github.com/smartdevicelink/sdl_core/pull/1402)