### PR TITLE
Fix/unused but set variable

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1756,7 +1756,6 @@ void PolicyHandler::OnCertificateUpdated(const std::string& certificate_data) {
 void PolicyHandler::OnPTUFinished(const bool ptu_result) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(listeners_lock_);
-  HandlersCollection::const_iterator it = listeners_.begin();
   std::for_each(
       listeners_.begin(),
       listeners_.end(),


### PR DESCRIPTION
Hello,
On Debian 9.0 GCC is build to use -Werror=unused-but-set-variable.
This patch removes the only unused variable into SDL_core.
Best regards.