### PR TITLE
Fix/issue 1663

### DIFF
--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -944,7 +944,6 @@ void ConnectionHandlerImpl::OnConnectionEnded(
   connection_list_lock_.AcquireForWriting();
   ConnectionList::iterator itr = connection_list_.find(connection_id);
   if (connection_list_.end() == itr) {
-    connection_list_lock_.Release();
     LOG4CXX_ERROR(logger_, "Connection not found!");
     return;
   }

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -944,6 +944,7 @@ void ConnectionHandlerImpl::OnConnectionEnded(
   connection_list_lock_.AcquireForWriting();
   ConnectionList::iterator itr = connection_list_.find(connection_id);
   if (connection_list_.end() == itr) {
+    connection_list_lock_.Release();
     LOG4CXX_ERROR(logger_, "Connection not found!");
     return;
   }

--- a/src/components/transport_manager/src/transport_manager_impl.cc
+++ b/src/components/transport_manager/src/transport_manager_impl.cc
@@ -919,7 +919,6 @@ void TransportManagerImpl::Handle(TransportAdapterEvent event) {
                    id,
                    *static_cast<CommunicationError*>(event.event_error.get()));
         RemoveConnection(id, connection->transport_adapter);
-        std::cout << "ON_UNEXPECTED_DISCONNECT conn_id = " << id << " app_id = " << event.application_id << "\n";
       } else {
         connections_lock_.Release();
         LOG4CXX_ERROR(logger_,


### PR DESCRIPTION
This PR fixes https://github.com/smartdevicelink/sdl_core/issues/1663. It also includes a fix for a bug in connection_handler_impl.cc where the lock is not released in the case where the end of the collection is reached in the iterator loop.