### PR TITLE
fix: invalid memory access in websocket_handler

### DIFF
--- a/src/3rd_party-static/message_broker/src/lib_messagebroker/websocket_handler.cpp
+++ b/src/3rd_party-static/message_broker/src/lib_messagebroker/websocket_handler.cpp
@@ -160,8 +160,9 @@ namespace NsMessageBroker
        DBG_MSG(("CWebSocketHandler::parseWebSocketData()length:%d; size:%d;"
                 " position:%d\n", (int)length, size, position));
 
-       memmove(&Buffer[parsedBufferPosition], &recBuffer[position], length);
-
+       for (unsigned long i = 0; (i < size); i++) {
+         Buffer[parsedBufferPosition + i] = recBuffer[i+position];
+       }
        b_size -= position;
        parsedBufferPosition += length;
        recBuffer += length;

--- a/src/3rd_party-static/message_broker/src/lib_messagebroker/websocket_handler.cpp
+++ b/src/3rd_party-static/message_broker/src/lib_messagebroker/websocket_handler.cpp
@@ -160,9 +160,9 @@ namespace NsMessageBroker
        DBG_MSG(("CWebSocketHandler::parseWebSocketData()length:%d; size:%d;"
                 " position:%d\n", (int)length, size, position));
 
-       for (unsigned long i = 0; (i < size); i++) {
-         Buffer[parsedBufferPosition + i] = recBuffer[i+position];
-       }
+       memmove(&Buffer[parsedBufferPosition], &recBuffer[position],
+               size - position);
+
        b_size -= position;
        parsedBufferPosition += length;
        recBuffer += length;

--- a/src/3rd_party-static/message_broker/src/lib_messagebroker/websocket_handler.cpp
+++ b/src/3rd_party-static/message_broker/src/lib_messagebroker/websocket_handler.cpp
@@ -160,9 +160,8 @@ namespace NsMessageBroker
        DBG_MSG(("CWebSocketHandler::parseWebSocketData()length:%d; size:%d;"
                 " position:%d\n", (int)length, size, position));
 
-       for (unsigned long i = 0; (i < size); i++) {
-         Buffer[parsedBufferPosition + i] = recBuffer[i+position];
-       }
+       memmove(&Buffer[parsedBufferPosition], &recBuffer[position], length);
+
        b_size -= position;
        parsedBufferPosition += length;
        recBuffer += length;


### PR DESCRIPTION
This is to fix https://github.com/smartdevicelink/sdl_core/issues/1686. Using the value of 'size' seems wrong, it should be 'length'.
Note: an unit test for this fix is not available since invalid memory access cannot be detected with an unit test.