### PR TITLE
Feature/video streaming capabilities

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -302,6 +302,11 @@
                 "dialNumberEnabled": true
             },
             "videoStreamingCapability": {
+                "preferredResolution": {
+                    "resolutionWidth": 800,
+                    "resolutionHeight": 350
+                },
+                "maxBitrate": 10000,
                 "supportedFormats": [{
                     "protocol": "RAW",
                     "codec": "H264"

--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -300,6 +300,12 @@
             },
             "phoneCapability": {
                 "dialNumberEnabled": true
+            },
+            "videoStreamingCapability": {
+                "supportedFormats": [{
+                    "protocol": "RAW",
+                    "codec": "H264"
+                }]
             }
         }
     },

--- a/src/components/application_manager/CMakeLists.txt
+++ b/src/components/application_manager/CMakeLists.txt
@@ -306,6 +306,8 @@ set (HMI_COMMANDS_SOURCES
   ${COMMANDS_SOURCE_DIR}/hmi/navi_audio_stop_stream_response.cc
   ${COMMANDS_SOURCE_DIR}/hmi/navi_get_way_points_request.cc
   ${COMMANDS_SOURCE_DIR}/hmi/navi_get_way_points_response.cc
+  ${COMMANDS_SOURCE_DIR}/hmi/navi_set_video_config_request.cc
+  ${COMMANDS_SOURCE_DIR}/hmi/navi_set_video_config_response.cc
   ${COMMANDS_SOURCE_DIR}/hmi/on_system_request_notification.cc
   ${COMMANDS_SOURCE_DIR}/hmi/on_put_file_notification.cc
   ${COMMANDS_SOURCE_DIR}/hmi/on_resume_audio_source_notification.cc

--- a/src/components/application_manager/CMakeLists.txt
+++ b/src/components/application_manager/CMakeLists.txt
@@ -57,6 +57,7 @@ include_directories (
   ${ENCRYPTION_INCLUDE_DIRECTORY}
   ${MESSAGE_BROKER_INCLUDE_DIRECTORY}
   ${LOG4CXX_INCLUDE_DIRECTORY}
+  ${BSON_INCLUDE_DIRECTORY}
 )
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
@@ -399,6 +400,8 @@ set(LIBRARIES
   formatters
   dbms
   Utils
+  bson -L${BSON_LIBS_DIRECTORY}
+  emhashmap -L${EMHASHMAP_LIBS_DIRECTORY}
 )
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -437,6 +440,7 @@ if(ENABLE_LOG)
   list(APPEND LIBRARIES log4cxx -L${LOG4CXX_LIBS_DIRECTORY})
 endif()
 
+add_dependencies("ApplicationManager" libbson)
 target_link_libraries("ApplicationManager" ${LIBRARIES})
 
 if(BUILD_TESTS)

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -37,6 +37,7 @@
 #include <map>
 #include <set>
 #include <list>
+#include <vector>
 #include "utils/shared_ptr.h"
 #include "utils/data_accessor.h"
 #include "interfaces/MOBILE_API.h"
@@ -439,6 +440,25 @@ class Application : public virtual InitialApplicationData,
   virtual void set_video_streaming_allowed(bool state) = 0;
   virtual bool audio_streaming_allowed() const = 0;
   virtual void set_audio_streaming_allowed(bool state) = 0;
+
+  /**
+   * @brief Sends SetVideoConfig request to HMI to configure streaming
+   * @param service_type Type of streaming service, should be kMobileNav
+   * @param params parameters of video streaming in key-value format
+   * @return true if SetVideoConfig is sent, false otherwise
+   */
+  virtual bool SetVideoConfig(protocol_handler::ServiceType service_type,
+                              const smart_objects::SmartObject& params) = 0;
+
+  /**
+   * @brief Callback when SetVideoConfig response is received
+   * @param result true if HMI accepts video streaming parameters,
+   *        false otherwise
+   * @param rejected_params list of rejected parameters' names. Only
+   *        valid when result is false
+   */
+  virtual void OnNaviSetVideoConfigDone(
+      bool result, std::vector<std::string>& rejected_params) = 0;
 
   /**
    * @brief Starts streaming service for application

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -451,16 +451,6 @@ class Application : public virtual InitialApplicationData,
                               const smart_objects::SmartObject& params) = 0;
 
   /**
-   * @brief Callback when SetVideoConfig response is received
-   * @param result true if HMI accepts video streaming parameters,
-   *        false otherwise
-   * @param rejected_params list of rejected parameters' names. Only
-   *        valid when result is false
-   */
-  virtual void OnNaviSetVideoConfigDone(
-      bool result, std::vector<std::string>& rejected_params) = 0;
-
-  /**
    * @brief Starts streaming service for application
    * @param service_type Type of streaming service
    */

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -110,6 +110,10 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
   bool audio_streaming_allowed() const;
   void set_audio_streaming_allowed(bool state);
 
+  bool SetVideoConfig(protocol_handler::ServiceType service_type,
+                      const smart_objects::SmartObject& params);
+  void OnNaviSetVideoConfigDone(bool result,
+                                std::vector<std::string>& rejected_params);
   void StartStreaming(protocol_handler::ServiceType service_type);
   void StopStreamingForce(protocol_handler::ServiceType service_type);
   void StopStreaming(protocol_handler::ServiceType service_type);

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -112,8 +112,6 @@ class ApplicationImpl : public virtual InitialApplicationDataImpl,
 
   bool SetVideoConfig(protocol_handler::ServiceType service_type,
                       const smart_objects::SmartObject& params);
-  void OnNaviSetVideoConfigDone(bool result,
-                                std::vector<std::string>& rejected_params);
   void StartStreaming(protocol_handler::ServiceType service_type);
   void StopStreamingForce(protocol_handler::ServiceType service_type);
   void StopStreaming(protocol_handler::ServiceType service_type);

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1559,8 +1559,12 @@ class ApplicationManagerImpl
   volatile bool is_stopping_;
 
 #ifdef BUILD_TESTS
-  // Methods for test usage
  public:
+  /**
+   * @brief register a mock application without going through the formal
+   * registration process. Only for unit testing.
+   * @param mock_app the mock app to be registered
+   */
   void AddMockApplication(ApplicationSharedPtr mock_app);
 #endif
 

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1542,6 +1542,12 @@ class ApplicationManagerImpl
 
   volatile bool is_stopping_;
 
+#ifdef BUILD_TESTS
+  // Methods for test usage
+ public:
+  void AddMockApplication(ApplicationSharedPtr mock_app);
+#endif
+
   DISALLOW_COPY_AND_ASSIGN(ApplicationManagerImpl);
 };
 

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1566,6 +1566,8 @@ class ApplicationManagerImpl
    * @param mock_app the mock app to be registered
    */
   void AddMockApplication(ApplicationSharedPtr mock_app);
+
+ private:
 #endif
 
   DISALLOW_COPY_AND_ASSIGN(ApplicationManagerImpl);

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1516,6 +1516,7 @@ class ApplicationManagerImpl
   HmiInterfacesImpl hmi_interfaces_;
 
   NaviServiceStatusMap navi_service_status_;
+  sync_primitives::Lock navi_service_status_lock_;
   std::deque<uint32_t> navi_app_to_stop_;
   std::deque<uint32_t> navi_app_to_end_stream_;
   uint32_t navi_close_app_timeout_;

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -794,6 +794,11 @@ class ApplicationManagerImpl
   void OnFindNewApplicationsRequest() OVERRIDE;
   void RemoveDevice(
       const connection_handler::DeviceHandle& device_handle) OVERRIDE;
+  // DEPRECATED
+  bool OnServiceStartedCallback(
+      const connection_handler::DeviceHandle& device_handle,
+      const int32_t& session_key,
+      const protocol_handler::ServiceType& type) OVERRIDE;
   void OnServiceStartedCallback(
       const connection_handler::DeviceHandle& device_handle,
       const int32_t& session_key,

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -901,10 +901,11 @@ class ApplicationManagerImpl
    * @param rejected_params list of rejected parameters' name. Valid
    *                        only when result is false.
    */
-  void OnStreamingConfigured(uint32_t app_id,
-                             protocol_handler::ServiceType service_type,
-                             bool result,
-                             std::vector<std::string>& rejected_params);
+  void OnStreamingConfigured(
+      uint32_t app_id,
+      protocol_handler::ServiceType service_type,
+      bool result,
+      std::vector<std::string>& rejected_params) OVERRIDE;
 
   /**
    * @brief Callback calls when application starts/stops data streaming

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1346,6 +1346,16 @@ class ApplicationManagerImpl
    * @brief Starts specified navi service for application
    * @param app_id Application to proceed
    * @param service_type Type of service to start
+   * @return True on success, false on fail
+   */
+  // DEPRECATED
+  bool StartNaviService(uint32_t app_id,
+                        protocol_handler::ServiceType service_type);
+
+  /**
+   * @brief Starts specified navi service for application
+   * @param app_id Application to proceed
+   * @param service_type Type of service to start
    * @param params configuration parameters specified by mobile
    * @return True if service is immediately started or configuration
    * parameters are sent to HMI, false on other cases

--- a/src/components/application_manager/include/application_manager/commands/hmi/navi_set_video_config_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/navi_set_video_config_request.h
@@ -62,17 +62,17 @@ class NaviSetVideoConfigRequest : public RequestToHMI,
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() OVERRIDE;
 
   /**
    * @brief On event callback
    **/
-  virtual void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) OVERRIDE;
 
   /**
    * @brief onTimeOut callback
    */
-  virtual void onTimeOut();
+  void onTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(NaviSetVideoConfigRequest);

--- a/src/components/application_manager/include/application_manager/commands/hmi/navi_set_video_config_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/navi_set_video_config_request.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017 Xevo Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_NAVI_SET_VIDEO_CONFIG_REQUEST_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_NAVI_SET_VIDEO_CONFIG_REQUEST_H_
+
+#include "application_manager/commands/hmi/request_to_hmi.h"
+
+namespace application_manager {
+
+namespace commands {
+
+/**
+ * @brief NaviSetVideoConfigRequest command class
+ **/
+class NaviSetVideoConfigRequest : public RequestToHMI,
+                                  public event_engine::EventObserver {
+ public:
+  /**
+   * @brief NaviSetVideoConfigRequest class constructor
+   *
+   * @param message Incoming SmartObject message
+   * @param application_manager Reference of application manager
+   **/
+  NaviSetVideoConfigRequest(const MessageSharedPtr& message,
+                            ApplicationManager& application_manager);
+
+  /**
+   * @brief NaviSetVideoConfigRequest class destructor
+   **/
+  virtual ~NaviSetVideoConfigRequest();
+
+  /**
+   * @brief Execute command
+   **/
+  virtual void Run();
+
+  /**
+   * @brief On event callback
+   **/
+  virtual void on_event(const event_engine::Event& event);
+
+  /**
+   * @brief onTimeOut callback
+   */
+  virtual void onTimeOut();
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(NaviSetVideoConfigRequest);
+};
+
+}  // namespace commands
+
+}  // namespace application_manager
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_NAVI_SET_VIDEO_CONFIG_REQUEST_H_

--- a/src/components/application_manager/include/application_manager/commands/hmi/navi_set_video_config_request.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/navi_set_video_config_request.h
@@ -13,7 +13,7 @@
  * disclaimer in the documentation and/or other materials provided with the
  * distribution.
  *
- * Neither the name of the Ford Motor Company nor the names of its contributors
+ * Neither the names of the copyright holders nor the names of its contributors
  * may be used to endorse or promote products derived from this software
  * without specific prior written permission.
  *

--- a/src/components/application_manager/include/application_manager/commands/hmi/navi_set_video_config_response.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/navi_set_video_config_response.h
@@ -13,7 +13,7 @@
  * disclaimer in the documentation and/or other materials provided with the
  * distribution.
  *
- * Neither the name of the Ford Motor Company nor the names of its contributors
+ * Neither the names of the copyright holders nor the names of its contributors
  * may be used to endorse or promote products derived from this software
  * without specific prior written permission.
  *

--- a/src/components/application_manager/include/application_manager/commands/hmi/navi_set_video_config_response.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/navi_set_video_config_response.h
@@ -61,7 +61,7 @@ class NaviSetVideoConfigResponse : public ResponseFromHMI {
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(NaviSetVideoConfigResponse);

--- a/src/components/application_manager/include/application_manager/commands/hmi/navi_set_video_config_response.h
+++ b/src/components/application_manager/include/application_manager/commands/hmi/navi_set_video_config_response.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2017 Xevo Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_NAVI_SET_VIDEO_CONFIG_RESPONSE_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_NAVI_SET_VIDEO_CONFIG_RESPONSE_H_
+
+#include "application_manager/commands/hmi/response_from_hmi.h"
+
+namespace application_manager {
+
+namespace commands {
+
+/**
+ * @brief NaviSetVideoConfigResponse command class
+ **/
+class NaviSetVideoConfigResponse : public ResponseFromHMI {
+ public:
+  /**
+   * @brief NaviSetVideoConfigResponse class constructor
+   *
+   * @param message Incoming SmartObject message
+   * @param application_manager Reference of application manager
+   **/
+  NaviSetVideoConfigResponse(const MessageSharedPtr& message,
+                             ApplicationManager& application_manager);
+
+  /**
+   * @brief NaviSetVideoConfigResponse class destructor
+   **/
+  virtual ~NaviSetVideoConfigResponse();
+
+  /**
+   * @brief Execute command
+   **/
+  virtual void Run();
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(NaviSetVideoConfigResponse);
+};
+
+}  // namespace commands
+
+}  // namespace application_manager
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_HMI_NAVI_SET_VIDEO_CONFIG_RESPONSE_H_

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -408,6 +408,20 @@ class HMICapabilitiesImpl : public HMICapabilities {
   bool phone_call_supported() const OVERRIDE;
 
   /*
+   * @brief Interface to store whether HMI supports video streaming
+   *
+   * @param supported Indicates whether video streaming is supported by HMI
+   */
+  void set_video_streaming_supported(const bool supported) OVERRIDE;
+
+  /*
+   * @brief Retrieves whether HMI supports video streaming
+   *
+   * @return TRUE if it supported, otherwise FALSE
+   */
+  bool video_streaming_supported() const OVERRIDE;
+
+  /*
    * @brief Interface used to store information regarding
    * the navigation "System Capability"
    *
@@ -441,6 +455,21 @@ class HMICapabilitiesImpl : public HMICapabilities {
    */
 
   const smart_objects::SmartObject* phone_capability() const OVERRIDE;
+
+  /*
+   * @brief Sets HMI's video streaming related capability information
+   *
+   * @param video_streaming_capability the video streaming related capabilities
+   */
+  void set_video_streaming_capability(
+      const smart_objects::SmartObject& video_streaming_capability) OVERRIDE;
+
+  /*
+   * @brief Retrieves HMI's video streaming related capabilities
+   *
+   * @return HMI's video streaming related capability information
+   */
+  const smart_objects::SmartObject* video_streaming_capability() const OVERRIDE;
 
   void Init(resumption::LastState* last_state) OVERRIDE;
 
@@ -518,9 +547,11 @@ class HMICapabilitiesImpl : public HMICapabilities {
   smart_objects::SmartObject* prerecorded_speech_;
   bool is_navigation_supported_;
   bool is_phone_call_supported_;
+  bool is_video_streaming_supported_;
   std::string ccpu_version_;
   smart_objects::SmartObject* navigation_capability_;
   smart_objects::SmartObject* phone_capability_;
+  smart_objects::SmartObject* video_streaming_capability_;
 
   ApplicationManager& app_mngr_;
   HMILanguageHandler hmi_language_handler_;

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -381,6 +381,18 @@ class MessageHelper {
 #endif  // EXTERNAL_PROPRIETARY_MODE
 
   /*
+   * @brief Sends SetVideoConfig request to HMI to negotiate video parameters
+   *
+   * @param app_id       the application which will start video streaming
+   * @param app_mngr     reference of application manager
+   * @param video_params parameters of video streaming, notified by mobile
+   */
+  static void SendNaviSetVideoConfig(
+      int32_t app_id,
+      ApplicationManager& app_mngr,
+      const smart_objects::SmartObject& video_params);
+
+  /*
    * @brief Sends notification to HMI to start video streaming
    *
    * @param connection_key  Application connection key

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -172,6 +172,7 @@ extern const char* system_capability_type;
 extern const char* system_capabilities;
 extern const char* navigation_capability;
 extern const char* phone_capability;
+extern const char* video_streaming_capability;
 
 // PutFile
 extern const char* sync_file_name;
@@ -263,6 +264,7 @@ extern const char* supported_diag_modes;
 extern const char* hmi_capabilities;
 extern const char* navigation;
 extern const char* phone_call;
+extern const char* video_streaming;
 extern const char* sdl_version;
 extern const char* system_software_version;
 extern const char* priority;

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -345,6 +345,11 @@ extern const char* const codec;
 extern const char* const width;
 extern const char* const height;
 extern const char* const rejected_params;
+extern const char* const preferred_resolution;
+extern const char* const resolution_width;
+extern const char* const resolution_height;
+extern const char* const max_bitrate;
+extern const char* const supported_formats;
 }  // namespace strings
 
 namespace json {

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -339,6 +339,11 @@ extern const char* const status;
 extern const char* const external_consent_status;
 extern const char* const consented_functions;
 extern const char* const source;
+extern const char* const config;
+extern const char* const protocol;
+extern const char* const codec;
+extern const char* const width;
+extern const char* const height;
 }  // namespace strings
 
 namespace json {

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -344,6 +344,7 @@ extern const char* const protocol;
 extern const char* const codec;
 extern const char* const width;
 extern const char* const height;
+extern const char* const rejected_params;
 }  // namespace strings
 
 namespace json {

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -416,6 +416,33 @@ bool ApplicationImpl::audio_streaming_allowed() const {
   return audio_streaming_allowed_;
 }
 
+bool ApplicationImpl::SetVideoConfig(protocol_handler::ServiceType service_type,
+                                     const smart_objects::SmartObject& params) {
+  using namespace protocol_handler;
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (ServiceType::kMobileNav == service_type) {
+    // See StartStreaming(). We issue SetVideoConfig and StartStream
+    // only when streaming is not approved yet
+    if (!video_streaming_approved()) {
+      LOG4CXX_TRACE(logger_, "Video streaming not approved");
+      MessageHelper::SendNaviSetVideoConfig(
+          app_id(), application_manager_, params);
+      return true;
+    }
+  }
+  return false;
+}
+
+void ApplicationImpl::OnNaviSetVideoConfigDone(
+    bool result, std::vector<std::string>& rejected_params) {
+  using namespace protocol_handler;
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  application_manager_.OnStreamingConfigured(
+      app_id(), ServiceType::kMobileNav, result, rejected_params);
+}
+
 void ApplicationImpl::StartStreaming(
     protocol_handler::ServiceType service_type) {
   using namespace protocol_handler;

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -434,15 +434,6 @@ bool ApplicationImpl::SetVideoConfig(protocol_handler::ServiceType service_type,
   return false;
 }
 
-void ApplicationImpl::OnNaviSetVideoConfigDone(
-    bool result, std::vector<std::string>& rejected_params) {
-  using namespace protocol_handler;
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  application_manager_.OnStreamingConfigured(
-      app_id(), ServiceType::kMobileNav, result, rejected_params);
-}
-
 void ApplicationImpl::StartStreaming(
     protocol_handler::ServiceType service_type) {
   using namespace protocol_handler;

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3864,14 +3864,16 @@ void ApplicationManagerImpl::ConvertVideoParamsToSO(
 std::vector<std::string> ApplicationManagerImpl::ConvertRejectedParamList(
     const std::vector<std::string>& input) {
   std::vector<std::string> output;
-  for (unsigned int i = 0; i < input.size(); i++) {
-    if (input[i] == strings::protocol) {
+  for (std::vector<std::string>::const_iterator it = input.begin();
+       it != input.end();
+       ++it) {
+    if (*it == strings::protocol) {
       output.push_back(protocol_handler::strings::video_protocol);
-    } else if (input[i] == strings::codec) {
+    } else if (*it == strings::codec) {
       output.push_back(protocol_handler::strings::video_codec);
-    } else if (input[i] == strings::height) {
+    } else if (*it == strings::height) {
       output.push_back(protocol_handler::strings::height);
-    } else if (input[i] == strings::width) {
+    } else if (*it == strings::width) {
       output.push_back(protocol_handler::strings::width);
     }
     // ignore unknown parameters

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1275,7 +1275,8 @@ void ApplicationManagerImpl::StopNaviService(
 
     NaviServiceStatusMap::iterator it = navi_service_status_.find(app_id);
     if (navi_service_status_.end() == it) {
-      LOG4CXX_WARN(logger_, "No Information about navi service " << service_type);
+      LOG4CXX_WARN(logger_,
+                   "No Information about navi service " << service_type);
     } else {
       // Fill NaviServices map. Set false to first value of pair if
       // we've stopped video service or to second value if we've

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3844,13 +3844,13 @@ void ApplicationManagerImpl::ConvertVideoParamsToSO(
       output[strings::codec] = codec_enum;
     }
   }
-  BsonElement* element = bson_object_get(obj, "desiredHeight");
+  BsonElement* element = bson_object_get(obj, "height");
   if (element != NULL && element->type == TYPE_INT32) {
-    output[strings::height] = bson_object_get_int32(obj, "desiredHeight");
+    output[strings::height] = bson_object_get_int32(obj, "height");
   }
-  element = bson_object_get(obj, "desiredWidth");
+  element = bson_object_get(obj, "width");
   if (element != NULL && element->type == TYPE_INT32) {
-    output[strings::width] = bson_object_get_int32(obj, "desiredWidth");
+    output[strings::width] = bson_object_get_int32(obj, "width");
   }
 }
 
@@ -3864,9 +3864,9 @@ std::vector<std::string> ApplicationManagerImpl::ConvertRejectedParamList(
     } else if (input[i] == strings::codec) {
       output.push_back("videoCodec");
     } else if (input[i] == strings::height) {
-      output.push_back("desiredHeight");
+      output.push_back("height");
     } else if (input[i] == strings::width) {
-      output.push_back("desiredWidth");
+      output.push_back("width");
     }
     // ignore unknown parameters
   }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1244,7 +1244,7 @@ void ApplicationManagerImpl::OnStreamingConfigured(
       NaviServiceStatusMap::iterator it = navi_service_status_.find(app_id);
       if (navi_service_status_.end() == it) {
         LOG4CXX_WARN(logger_, "Application not found in navi status map");
-        connection_handler().NotifyServiceStartedResult(false, empty);
+        connection_handler().NotifyServiceStartedResult(app_id, false, empty);
         return;
       }
 
@@ -1256,11 +1256,12 @@ void ApplicationManagerImpl::OnStreamingConfigured(
     }
 
     application(app_id)->StartStreaming(service_type);
-    connection_handler().NotifyServiceStartedResult(true, empty);
+    connection_handler().NotifyServiceStartedResult(app_id, true, empty);
   } else {
     std::vector<std::string> converted_params =
         ConvertRejectedParamList(rejected_params);
-    connection_handler().NotifyServiceStartedResult(false, converted_params);
+    connection_handler().NotifyServiceStartedResult(
+        app_id, false, converted_params);
   }
 }
 
@@ -1345,7 +1346,7 @@ void ApplicationManagerImpl::OnServiceStartedCallback(
 
   if (type == kRpc) {
     LOG4CXX_DEBUG(logger_, "RPC service is about to be started.");
-    connection_handler().NotifyServiceStartedResult(true, empty);
+    connection_handler().NotifyServiceStartedResult(session_key, true, empty);
     return;
   }
   ApplicationSharedPtr app = application(session_key);
@@ -1353,7 +1354,7 @@ void ApplicationManagerImpl::OnServiceStartedCallback(
     LOG4CXX_WARN(logger_,
                  "The application with id:" << session_key
                                             << " doesn't exists.");
-    connection_handler().NotifyServiceStartedResult(false, empty);
+    connection_handler().NotifyServiceStartedResult(session_key, false, empty);
     return;
   }
 
@@ -1361,7 +1362,8 @@ void ApplicationManagerImpl::OnServiceStartedCallback(
           type, ServiceType::kMobileNav, ServiceType::kAudio)) {
     if (app->is_navi() || app->mobile_projection_enabled()) {
       if (!StartNaviService(session_key, type, params)) {
-        connection_handler().NotifyServiceStartedResult(false, empty);
+        connection_handler().NotifyServiceStartedResult(
+            session_key, false, empty);
       }
       return;
     } else {
@@ -1370,7 +1372,7 @@ void ApplicationManagerImpl::OnServiceStartedCallback(
   } else {
     LOG4CXX_WARN(logger_, "Refuse unknown service");
   }
-  connection_handler().NotifyServiceStartedResult(false, empty);
+  connection_handler().NotifyServiceStartedResult(session_key, false, empty);
 }
 
 void ApplicationManagerImpl::OnServiceEndedCallback(

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1232,13 +1232,12 @@ void ApplicationManagerImpl::OnStreamingConfigured(
   using namespace protocol_handler;
   LOG4CXX_AUTO_TRACE(logger_);
 
-  std::vector<std::string> empty;
-
   LOG4CXX_INFO(logger_,
                "OnStreamingConfigured called for service "
                    << service_type << ", result=" << result);
 
   if (result) {
+    std::vector<std::string> empty;
     {
       sync_primitives::AutoLock lock(navi_service_status_lock_);
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1260,6 +1260,43 @@ void ApplicationManagerImpl::StopNaviService(
   app->StopStreaming(service_type);
 }
 
+// DEPRECATED
+bool ApplicationManagerImpl::OnServiceStartedCallback(
+    const connection_handler::DeviceHandle& device_handle,
+    const int32_t& session_key,
+    const protocol_handler::ServiceType& type) {
+  using namespace helpers;
+  using namespace protocol_handler;
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(logger_,
+                "ServiceType = " << type << ". Session = " << std::hex
+                                 << session_key);
+
+  if (type == kRpc) {
+    LOG4CXX_DEBUG(logger_, "RPC service is about to be started.");
+    return true;
+  }
+  ApplicationSharedPtr app = application(session_key);
+  if (!app) {
+    LOG4CXX_WARN(logger_,
+                 "The application with id:" << session_key
+                                            << " doesn't exists.");
+    return false;
+  }
+
+  if (Compare<ServiceType, EQ, ONE>(
+          type, ServiceType::kMobileNav, ServiceType::kAudio)) {
+    if (app->is_navi()) {
+      return StartNaviService(session_key, type);
+    } else {
+      LOG4CXX_WARN(logger_, "Refuse not navi application");
+    }
+  } else {
+    LOG4CXX_WARN(logger_, "Refuse unknown service");
+  }
+  return false;
+}
+
 void ApplicationManagerImpl::OnServiceStartedCallback(
     const connection_handler::DeviceHandle& device_handle,
     const int32_t& session_key,

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -56,6 +56,7 @@
 #include "formatters/formatter_json_rpc.h"
 #include "formatters/CFormatterJsonSDLRPCv2.h"
 #include "formatters/CFormatterJsonSDLRPCv1.h"
+#include "protocol/bson_object_keys.h"
 
 #include "utils/threads/thread.h"
 #include "utils/file_system.h"
@@ -3828,7 +3829,8 @@ void ApplicationManagerImpl::ConvertVideoParamsToSO(
   }
   BsonObject* obj = const_cast<BsonObject*>(input);
 
-  const char* protocol = bson_object_get_string(obj, "videoProtocol");
+  const char* protocol =
+      bson_object_get_string(obj, protocol_handler::strings::video_protocol);
   if (protocol != NULL) {
     hmi_apis::Common_VideoStreamingProtocol::eType protocol_enum =
         ConvertVideoProtocol(protocol);
@@ -3837,7 +3839,8 @@ void ApplicationManagerImpl::ConvertVideoParamsToSO(
       output[strings::protocol] = protocol_enum;
     }
   }
-  const char* codec = bson_object_get_string(obj, "videoCodec");
+  const char* codec =
+      bson_object_get_string(obj, protocol_handler::strings::video_codec);
   if (codec != NULL) {
     hmi_apis::Common_VideoStreamingCodec::eType codec_enum =
         ConvertVideoCodec(codec);
@@ -3845,13 +3848,16 @@ void ApplicationManagerImpl::ConvertVideoParamsToSO(
       output[strings::codec] = codec_enum;
     }
   }
-  BsonElement* element = bson_object_get(obj, "height");
+  BsonElement* element =
+      bson_object_get(obj, protocol_handler::strings::height);
   if (element != NULL && element->type == TYPE_INT32) {
-    output[strings::height] = bson_object_get_int32(obj, "height");
+    output[strings::height] =
+        bson_object_get_int32(obj, protocol_handler::strings::height);
   }
-  element = bson_object_get(obj, "width");
+  element = bson_object_get(obj, protocol_handler::strings::width);
   if (element != NULL && element->type == TYPE_INT32) {
-    output[strings::width] = bson_object_get_int32(obj, "width");
+    output[strings::width] =
+        bson_object_get_int32(obj, protocol_handler::strings::width);
   }
 }
 
@@ -3861,13 +3867,13 @@ std::vector<std::string> ApplicationManagerImpl::ConvertRejectedParamList(
   std::vector<std::string> output;
   for (unsigned int i = 0; i < input.size(); i++) {
     if (input[i] == strings::protocol) {
-      output.push_back("videoProtocol");
+      output.push_back(protocol_handler::strings::video_protocol);
     } else if (input[i] == strings::codec) {
-      output.push_back("videoCodec");
+      output.push_back(protocol_handler::strings::video_codec);
     } else if (input[i] == strings::height) {
-      output.push_back("height");
+      output.push_back(protocol_handler::strings::height);
     } else if (input[i] == strings::width) {
-      output.push_back("width");
+      output.push_back(protocol_handler::strings::width);
     }
     // ignore unknown parameters
   }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3753,4 +3753,13 @@ std::vector<std::string> ApplicationManagerImpl::ConvertRejectedParamList(
   return output;
 }
 
+#ifdef BUILD_TESTS
+void ApplicationManagerImpl::AddMockApplication(ApplicationSharedPtr mock_app) {
+  applications_list_lock_.Acquire();
+  applications_.insert(mock_app);
+  apps_size_ = applications_.size();
+  applications_list_lock_.Release();
+}
+#endif  // BUILD_TESTS
+
 }  // namespace application_manager

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3831,7 +3831,7 @@ void ApplicationManagerImpl::ConvertVideoParamsToSO(
         ConvertVideoProtocol(protocol);
     if (protocol_enum !=
         hmi_apis::Common_VideoStreamingProtocol::INVALID_ENUM) {
-      output["protocol"] = protocol_enum;
+      output[strings::protocol] = protocol_enum;
     }
   }
   const char* codec = bson_object_get_string(obj, "videoCodec");
@@ -3839,16 +3839,16 @@ void ApplicationManagerImpl::ConvertVideoParamsToSO(
     hmi_apis::Common_VideoStreamingCodec::eType codec_enum =
         ConvertVideoCodec(codec);
     if (codec_enum != hmi_apis::Common_VideoStreamingCodec::INVALID_ENUM) {
-      output["codec"] = codec_enum;
+      output[strings::codec] = codec_enum;
     }
   }
   BsonElement* element = bson_object_get(obj, "desiredHeight");
   if (element != NULL && element->type == TYPE_INT32) {
-    output["height"] = bson_object_get_int32(obj, "desiredHeight");
+    output[strings::height] = bson_object_get_int32(obj, "desiredHeight");
   }
   element = bson_object_get(obj, "desiredWidth");
   if (element != NULL && element->type == TYPE_INT32) {
-    output["width"] = bson_object_get_int32(obj, "desiredWidth");
+    output[strings::width] = bson_object_get_int32(obj, "desiredWidth");
   }
 }
 
@@ -3857,13 +3857,13 @@ std::vector<std::string> ApplicationManagerImpl::ConvertRejectedParamList(
     const std::vector<std::string>& input) {
   std::vector<std::string> output;
   for (unsigned int i = 0; i < input.size(); i++) {
-    if (input[i] == "protocol") {
+    if (input[i] == strings::protocol) {
       output.push_back("videoProtocol");
-    } else if (input[i] == "codec") {
+    } else if (input[i] == strings::codec) {
       output.push_back("videoCodec");
-    } else if (input[i] == "height") {
+    } else if (input[i] == strings::height) {
       output.push_back("desiredHeight");
-    } else if (input[i] == "width") {
+    } else if (input[i] == strings::width) {
       output.push_back("desiredWidth");
     }
     // ignore unknown parameters

--- a/src/components/application_manager/src/commands/hmi/navi_set_video_config_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_set_video_config_request.cc
@@ -111,7 +111,11 @@ void NaviSetVideoConfigRequest::on_event(const event_engine::Event& event) {
           }
         }
       }
-      app->OnNaviSetVideoConfigDone(result, rejected_params);
+      application_manager_.OnStreamingConfigured(
+          application_id(),
+          protocol_handler::ServiceType::kMobileNav,
+          result,
+          rejected_params);
       break;
     }
     default:
@@ -131,7 +135,11 @@ void NaviSetVideoConfigRequest::onTimeOut() {
   }
 
   std::vector<std::string> empty;
-  app->OnNaviSetVideoConfigDone(false, empty);
+  application_manager_.OnStreamingConfigured(
+      application_id(),
+      protocol_handler::ServiceType::kMobileNav,
+      false,
+      empty);
 
   application_manager_.TerminateRequest(
       connection_key(), correlation_id(), function_id());

--- a/src/components/application_manager/src/commands/hmi/navi_set_video_config_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_set_video_config_request.cc
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2017 Xevo Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/commands/hmi/navi_set_video_config_request.h"
+#include <string>
+#include <vector>
+
+namespace application_manager {
+
+namespace commands {
+
+NaviSetVideoConfigRequest::NaviSetVideoConfigRequest(
+    const MessageSharedPtr& message, ApplicationManager& application_manager)
+    : RequestToHMI(message, application_manager)
+    , EventObserver(application_manager.event_dispatcher()) {}
+
+NaviSetVideoConfigRequest::~NaviSetVideoConfigRequest() {}
+
+void NaviSetVideoConfigRequest::Run() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!CheckAvailabilityHMIInterfaces(
+          application_manager_, HmiInterfaces::HMI_INTERFACE_Navigation)) {
+    LOG4CXX_WARN(logger_, "HMI interface Navigation is not supported");
+    return;
+  }
+
+  ApplicationSharedPtr app =
+      application_manager_.application_by_hmi_app(application_id());
+  if (!app) {
+    LOG4CXX_ERROR(logger_,
+                  "Application with hmi_app_id " << application_id()
+                                                 << "does not exist");
+    return;
+  }
+
+  subscribe_on_event(hmi_apis::FunctionID::Navigation_SetVideoConfig,
+                     correlation_id());
+  SendRequest();
+}
+
+void NaviSetVideoConfigRequest::on_event(const event_engine::Event& event) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  ApplicationSharedPtr app =
+      application_manager_.application_by_hmi_app(application_id());
+  if (!app) {
+    LOG4CXX_ERROR(logger_,
+                  "Application is not found, abort NaviSetVideoConfigRequest");
+    return;
+  }
+
+  const smart_objects::SmartObject& message = event.smart_object();
+  switch (event.id()) {
+    case hmi_apis::FunctionID::Navigation_SetVideoConfig: {
+      const hmi_apis::Common_Result::eType code =
+          static_cast<hmi_apis::Common_Result::eType>(
+              message[strings::params][hmi_response::code].asInt());
+      bool result = false;
+      std::vector<std::string> rejected_params;
+
+      if (code == hmi_apis::Common_Result::SUCCESS) {
+        LOG4CXX_DEBUG(logger_, "Received SetVideoConfig success response");
+        result = true;
+      } else {
+        LOG4CXX_DEBUG(logger_,
+                      "Received SetVideoConfig failure response (" << event.id()
+                                                                   << ")");
+        result = false;
+        if (message[strings::msg_params].keyExists("rejectedParams")) {
+          const smart_objects::SmartArray* list =
+              message[strings::msg_params]["rejectedParams"].asArray();
+          if (list != NULL) {
+            for (unsigned int i = 0; i < list->size(); i++) {
+              const std::string& param = (*list)[i].asString();
+              // Make sure that we actually sent the parameter in the request
+              if ((*message_)[strings::msg_params].keyExists("config") &&
+                  (*message_)[strings::msg_params]["config"].keyExists(param)) {
+                rejected_params.push_back(param);
+              }
+            }
+          }
+        }
+      }
+//      app->OnNaviSetVideoConfigDone(result, rejected_params);
+      break;
+    }
+    default:
+      LOG4CXX_ERROR(logger_, "Received unknown event" << event.id());
+      break;
+  }
+}
+
+void NaviSetVideoConfigRequest::onTimeOut() {
+  LOG4CXX_WARN(logger_, "Timed out while waiting for SetVideoConfig response");
+
+  ApplicationSharedPtr app =
+      application_manager_.application_by_hmi_app(application_id());
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "Application is not found");
+    return;
+  }
+
+//  std::vector<std::string> empty;
+//  app->OnNaviSetVideoConfigDone(false, empty);
+
+  application_manager_.TerminateRequest(
+      connection_key(), correlation_id(), function_id());
+}
+
+}  // namespace commands
+
+}  // namespace application_manager

--- a/src/components/application_manager/src/commands/hmi/navi_set_video_config_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_set_video_config_request.cc
@@ -95,9 +95,9 @@ void NaviSetVideoConfigRequest::on_event(const event_engine::Event& event) {
                       "Received SetVideoConfig failure response (" << event.id()
                                                                    << ")");
         result = false;
-        if (message[strings::msg_params].keyExists("rejectedParams")) {
+        if (message[strings::msg_params].keyExists(strings::rejected_params)) {
           const smart_objects::SmartArray* list =
-              message[strings::msg_params]["rejectedParams"].asArray();
+              message[strings::msg_params][strings::rejected_params].asArray();
           if (list != NULL) {
             for (unsigned int i = 0; i < list->size(); i++) {
               const std::string& param = (*list)[i].asString();

--- a/src/components/application_manager/src/commands/hmi/navi_set_video_config_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_set_video_config_request.cc
@@ -13,7 +13,7 @@
  * disclaimer in the documentation and/or other materials provided with the
  * distribution.
  *
- * Neither the name of the Ford Motor Company nor the names of its contributors
+ * Neither the names of the copyright holders nor the names of its contributors
  * may be used to endorse or promote products derived from this software
  * without specific prior written permission.
  *

--- a/src/components/application_manager/src/commands/hmi/navi_set_video_config_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_set_video_config_request.cc
@@ -102,8 +102,9 @@ void NaviSetVideoConfigRequest::on_event(const event_engine::Event& event) {
             for (unsigned int i = 0; i < list->size(); i++) {
               const std::string& param = (*list)[i].asString();
               // Make sure that we actually sent the parameter in the request
-              if ((*message_)[strings::msg_params].keyExists("config") &&
-                  (*message_)[strings::msg_params]["config"].keyExists(param)) {
+              if ((*message_)[strings::msg_params].keyExists(strings::config) &&
+                  (*message_)[strings::msg_params][strings::config].keyExists(
+                      param)) {
                 rejected_params.push_back(param);
               }
             }

--- a/src/components/application_manager/src/commands/hmi/navi_set_video_config_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_set_video_config_request.cc
@@ -110,7 +110,7 @@ void NaviSetVideoConfigRequest::on_event(const event_engine::Event& event) {
           }
         }
       }
-//      app->OnNaviSetVideoConfigDone(result, rejected_params);
+      app->OnNaviSetVideoConfigDone(result, rejected_params);
       break;
     }
     default:
@@ -129,8 +129,8 @@ void NaviSetVideoConfigRequest::onTimeOut() {
     return;
   }
 
-//  std::vector<std::string> empty;
-//  app->OnNaviSetVideoConfigDone(false, empty);
+  std::vector<std::string> empty;
+  app->OnNaviSetVideoConfigDone(false, empty);
 
   application_manager_.TerminateRequest(
       connection_key(), correlation_id(), function_id());

--- a/src/components/application_manager/src/commands/hmi/navi_set_video_config_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_set_video_config_request.cc
@@ -112,7 +112,7 @@ void NaviSetVideoConfigRequest::on_event(const event_engine::Event& event) {
         }
       }
       application_manager_.OnStreamingConfigured(
-          application_id(),
+          app->app_id(),
           protocol_handler::ServiceType::kMobileNav,
           result,
           rejected_params);
@@ -136,10 +136,7 @@ void NaviSetVideoConfigRequest::onTimeOut() {
 
   std::vector<std::string> empty;
   application_manager_.OnStreamingConfigured(
-      application_id(),
-      protocol_handler::ServiceType::kMobileNav,
-      false,
-      empty);
+      app->app_id(), protocol_handler::ServiceType::kMobileNav, false, empty);
 
   application_manager_.TerminateRequest(
       connection_key(), correlation_id(), function_id());

--- a/src/components/application_manager/src/commands/hmi/navi_set_video_config_response.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_set_video_config_response.cc
@@ -13,7 +13,7 @@
  * disclaimer in the documentation and/or other materials provided with the
  * distribution.
  *
- * Neither the name of the Ford Motor Company nor the names of its contributors
+ * Neither the names of the copyright holders nor the names of its contributors
  * may be used to endorse or promote products derived from this software
  * without specific prior written permission.
  *

--- a/src/components/application_manager/src/commands/hmi/navi_set_video_config_response.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_set_video_config_response.cc
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017 Xevo Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "application_manager/commands/hmi/navi_set_video_config_response.h"
+#include "application_manager/event_engine/event.h"
+
+namespace application_manager {
+
+namespace commands {
+
+NaviSetVideoConfigResponse::NaviSetVideoConfigResponse(
+    const MessageSharedPtr& message, ApplicationManager& application_manager)
+    : ResponseFromHMI(message, application_manager) {}
+
+NaviSetVideoConfigResponse::~NaviSetVideoConfigResponse() {}
+
+void NaviSetVideoConfigResponse::Run() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  event_engine::Event event(hmi_apis::FunctionID::Navigation_SetVideoConfig);
+  event.set_smart_object(*message_);
+  event.raise(application_manager_.event_dispatcher());
+}
+
+}  // namespace commands
+
+}  // namespace application_manager

--- a/src/components/application_manager/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/src/commands/hmi/ui_get_capabilities_response.cc
@@ -78,6 +78,12 @@ void UIGetCapabilitiesResponse::Run() {
       hmi_capabilities.set_phone_call_supported(
           msg_params[strings::hmi_capabilities][strings::phone_call].asBool());
     }
+    if (msg_params[strings::hmi_capabilities].keyExists(
+            strings::video_streaming)) {
+      hmi_capabilities.set_video_streaming_supported(
+          msg_params[strings::hmi_capabilities][strings::video_streaming]
+              .asBool());
+    }
   }
 
   if (msg_params.keyExists(strings::system_capabilities)) {
@@ -91,6 +97,12 @@ void UIGetCapabilitiesResponse::Run() {
             strings::phone_capability)) {
       hmi_capabilities.set_phone_capability(
           msg_params[strings::system_capabilities][strings::phone_capability]);
+    }
+    if (msg_params[strings::system_capabilities].keyExists(
+            strings::video_streaming_capability)) {
+      hmi_capabilities.set_video_streaming_capability(
+          msg_params[strings::system_capabilities]
+                    [strings::video_streaming_capability]);
     }
   }
 }

--- a/src/components/application_manager/src/commands/mobile/get_system_capability_request.cc
+++ b/src/components/application_manager/src/commands/mobile/get_system_capability_request.cc
@@ -60,8 +60,15 @@ void GetSystemCapabilityRequest::Run() {
       break;
     }
     case mobile_apis::SystemCapabilityType::VIDEO_STREAMING:
-      SendResponse(false, mobile_apis::Result::UNSUPPORTED_RESOURCE);
-      return;
+      if (hmi_capabilities.video_streaming_capability()) {
+        response_params[strings::system_capability]
+                       [strings::video_streaming_capability] =
+                           *hmi_capabilities.video_streaming_capability();
+      } else {
+        SendResponse(false, mobile_apis::Result::DATA_NOT_AVAILABLE);
+        return;
+      }
+      break;
     case mobile_apis::SystemCapabilityType::AUDIO_STREAMING:
       SendResponse(false, mobile_apis::Result::UNSUPPORTED_RESOURCE);
       return;

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -485,6 +485,8 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
       hmi_capabilities.navigation_supported();
   response_params[strings::hmi_capabilities][strings::phone_call] =
       hmi_capabilities.phone_call_supported();
+  response_params[strings::hmi_capabilities][strings::video_streaming] =
+      hmi_capabilities.video_streaming_supported();
 }
 
 void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {

--- a/src/components/application_manager/src/hmi_command_factory.cc
+++ b/src/components/application_manager/src/hmi_command_factory.cc
@@ -246,6 +246,8 @@
 #include "application_manager/commands/hmi/on_ui_keyboard_input_notification.h"
 #include "application_manager/commands/hmi/on_ui_touch_event_notification.h"
 #include "application_manager/commands/hmi/on_ui_reset_timeout_notification.h"
+#include "application_manager/commands/hmi/navi_set_video_config_request.h"
+#include "application_manager/commands/hmi/navi_set_video_config_response.h"
 #include "application_manager/commands/hmi/navi_start_stream_request.h"
 #include "application_manager/commands/hmi/navi_start_stream_response.h"
 #include "application_manager/commands/hmi/navi_stop_stream_request.h"
@@ -2076,6 +2078,16 @@ CommandSharedPtr HMICommandFactory::CreateCommand(
     case hmi_apis::FunctionID::UI_OnResetTimeout: {
       command.reset(new commands::hmi::OnUIResetTimeoutNotification(
           message, application_manager));
+      break;
+    }
+    case hmi_apis::FunctionID::Navigation_SetVideoConfig: {
+      if (is_response) {
+        command.reset(new commands::NaviSetVideoConfigResponse(
+            message, application_manager));
+      } else {
+        command.reset(new commands::NaviSetVideoConfigRequest(
+            message, application_manager));
+      }
       break;
     }
     case hmi_apis::FunctionID::Navigation_StartStream: {

--- a/src/components/application_manager/src/hmi_interfaces_impl.cc
+++ b/src/components/application_manager/src/hmi_interfaces_impl.cc
@@ -166,6 +166,7 @@ generate_function_to_interface_convert_map() {
       HmiInterfaces::HMI_INTERFACE_Navigation;
   convert_map[Navigation_OnTBTClientState] =
       HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_SetVideoConfig] = HmiInterfaces::HMI_INTERFACE_Navigation;
   convert_map[Navigation_StartStream] = HmiInterfaces::HMI_INTERFACE_Navigation;
   convert_map[Navigation_StopStream] = HmiInterfaces::HMI_INTERFACE_Navigation;
   convert_map[Navigation_StartAudioStream] =

--- a/src/components/application_manager/src/hmi_interfaces_impl.cc
+++ b/src/components/application_manager/src/hmi_interfaces_impl.cc
@@ -166,7 +166,8 @@ generate_function_to_interface_convert_map() {
       HmiInterfaces::HMI_INTERFACE_Navigation;
   convert_map[Navigation_OnTBTClientState] =
       HmiInterfaces::HMI_INTERFACE_Navigation;
-  convert_map[Navigation_SetVideoConfig] = HmiInterfaces::HMI_INTERFACE_Navigation;
+  convert_map[Navigation_SetVideoConfig] =
+      HmiInterfaces::HMI_INTERFACE_Navigation;
   convert_map[Navigation_StartStream] = HmiInterfaces::HMI_INTERFACE_Navigation;
   convert_map[Navigation_StopStream] = HmiInterfaces::HMI_INTERFACE_Navigation;
   convert_map[Navigation_StartAudioStream] =

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1745,6 +1745,26 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateNegativeResponse(
   return utils::MakeShared<smart_objects::SmartObject>(response_data);
 }
 
+void MessageHelper::SendNaviSetVideoConfig(
+    int32_t app_id,
+    ApplicationManager& app_mngr,
+    const smart_objects::SmartObject& video_params) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  smart_objects::SmartObjectSPtr request =
+      CreateRequestObject(app_mngr.GetNextHMICorrelationID());
+  if (!request) {
+    return;
+  }
+
+  (*request)[strings::params][strings::function_id] =
+      hmi_apis::FunctionID::Navigation_SetVideoConfig;
+
+  (*request)[strings::msg_params][strings::app_id] = app_id;
+  (*request)[strings::msg_params]["config"] = video_params;
+
+  app_mngr.ManageHMICommand(request);
+}
+
 void MessageHelper::SendNaviStartStream(const int32_t app_id,
                                         ApplicationManager& app_mngr) {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1760,7 +1760,7 @@ void MessageHelper::SendNaviSetVideoConfig(
       hmi_apis::FunctionID::Navigation_SetVideoConfig;
 
   (*request)[strings::msg_params][strings::app_id] = app_id;
-  (*request)[strings::msg_params]["config"] = video_params;
+  (*request)[strings::msg_params][strings::config] = video_params;
 
   app_mngr.ManageHMICommand(request);
 }

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -139,6 +139,7 @@ const char* system_capability_type = "systemCapabilityType";
 const char* system_capabilities = "systemCapabilities";
 const char* navigation_capability = "navigationCapability";
 const char* phone_capability = "phoneCapability";
+const char* video_streaming_capability = "videoStreamingCapability";
 
 // PutFile
 const char* sync_file_name = "syncFileName";
@@ -230,6 +231,7 @@ const char* supported_diag_modes = "supportedDiagModes";
 const char* hmi_capabilities = "hmiCapabilities";
 const char* navigation = "navigation";
 const char* phone_call = "phoneCall";
+const char* video_streaming = "videoStreaming";
 const char* sdl_version = "sdlVersion";
 const char* system_software_version = "systemSoftwareVersion";
 const char* priority = "priority";

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -300,6 +300,11 @@ const char* const status = "status";
 const char* const external_consent_status = "externalConsentStatus";
 const char* const consented_functions = "consentedFunctions";
 const char* const source = "source";
+const char* const config = "config";
+const char* const protocol = "protocol";
+const char* const codec = "codec";
+const char* const width = "width";
+const char* const height = "height";
 }  // namespace strings
 
 namespace json {

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -305,6 +305,7 @@ const char* const protocol = "protocol";
 const char* const codec = "codec";
 const char* const width = "width";
 const char* const height = "height";
+const char* const rejected_params = "rejectedParams";
 }  // namespace strings
 
 namespace json {

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -306,6 +306,11 @@ const char* const codec = "codec";
 const char* const width = "width";
 const char* const height = "height";
 const char* const rejected_params = "rejectedParams";
+const char* const preferred_resolution = "preferredResolution";
+const char* const resolution_width = "resolutionWidth";
+const char* const resolution_height = "resolutionHeight";
+const char* const max_bitrate = "maxBitrate";
+const char* const supported_formats = "supportedFormats";
 }  // namespace strings
 
 namespace json {

--- a/src/components/application_manager/test/CMakeLists.txt
+++ b/src/components/application_manager/test/CMakeLists.txt
@@ -51,6 +51,7 @@ include_directories(
   ${COMPONENTS_DIR}/security_manager/include/
   ${COMPONENTS_DIR}/policy/test/include/
   ${COMPONENTS_DIR}/application_manager/test/include/
+  ${BSON_INCLUDE_DIRECTORY}
 )
 
 set(testSources
@@ -68,7 +69,7 @@ set(testSources
   ${AM_TEST_DIR}/usage_statistics_test.cc
   ${AM_TEST_DIR}/policy_handler_test.cc
   ${AM_TEST_DIR}/mock_message_helper.cc
- #${AM_TEST_DIR}/application_manager_impl_test.cc
+  ${AM_TEST_DIR}/application_manager_impl_test.cc
 
 )
 
@@ -97,6 +98,8 @@ set(LIBRARIES
   Resumption
   ProtocolHandler
   SecurityManager
+  bson -L${BSON_LIBS_DIRECTORY}
+  emhashmap -L${EMHASHMAP_LIBS_DIRECTORY}
 )
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "QNX")
@@ -123,6 +126,7 @@ set(CMAKE_EXE_LINKER_FLAGS
   "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath=${CMAKE_CURRENT_BINARY_DIR}"
 )
 create_test("application_manager_test" "${testSources}" "${LIBRARIES}")
+add_dependencies("application_manager_test" libbson)
 create_test("request_controller_test" "${RequestController_SOURCES}" "${LIBRARIES}")
 
 # TODO [AKozoriz] : Fix not buildable tests

--- a/src/components/application_manager/test/application_impl_test.cc
+++ b/src/components/application_manager/test/application_impl_test.cc
@@ -657,6 +657,42 @@ TEST_F(ApplicationImplTest, UpdateHash_AppMngrNotSuspended) {
   EXPECT_TRUE(app_impl->is_application_data_changed());
 }
 
+TEST_F(ApplicationImplTest, SetVideoConfig_MobileNavi_StreamingNotApproved) {
+  EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
+              SendNaviSetVideoConfig(app_id, _, _));
+
+  smart_objects::SmartObject params;
+  app_impl->SetVideoConfig(protocol_handler::ServiceType::kMobileNav, params);
+}
+
+TEST_F(ApplicationImplTest, SetVideoConfig_MobileNavi_StreamingApproved) {
+  app_impl->set_video_streaming_approved(true);
+  EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
+              SendNaviSetVideoConfig(app_id, _, _)).Times(0);
+
+  smart_objects::SmartObject params;
+  app_impl->SetVideoConfig(protocol_handler::ServiceType::kMobileNav, params);
+}
+
+TEST_F(ApplicationImplTest, SetVideoConfig_NotMobileNavi) {
+  EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
+              SendNaviSetVideoConfig(app_id, _, _)).Times(0);
+
+  smart_objects::SmartObject params;
+  app_impl->SetVideoConfig(protocol_handler::ServiceType::kAudio, params);
+}
+
+TEST_F(ApplicationImplTest, OnNaviSetVideoConfigDone) {
+  bool result = true;
+  std::vector<std::string> empty;
+  EXPECT_CALL(
+      mock_application_manager_,
+      OnStreamingConfigured(
+          app_id, protocol_handler::ServiceType::kMobileNav, result, empty));
+
+  app_impl->OnNaviSetVideoConfigDone(result, empty);
+}
+
 TEST_F(ApplicationImplTest, StartStreaming_MobileNavi_StreamingNotApproved) {
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendNaviStartStream(app_id, _));

--- a/src/components/application_manager/test/application_impl_test.cc
+++ b/src/components/application_manager/test/application_impl_test.cc
@@ -682,17 +682,6 @@ TEST_F(ApplicationImplTest, SetVideoConfig_NotMobileNavi) {
   app_impl->SetVideoConfig(protocol_handler::ServiceType::kAudio, params);
 }
 
-TEST_F(ApplicationImplTest, OnNaviSetVideoConfigDone) {
-  bool result = true;
-  std::vector<std::string> empty;
-  EXPECT_CALL(
-      mock_application_manager_,
-      OnStreamingConfigured(
-          app_id, protocol_handler::ServiceType::kMobileNav, result, empty));
-
-  app_impl->OnNaviSetVideoConfigDone(result, empty);
-}
-
 TEST_F(ApplicationImplTest, StartStreaming_MobileNavi_StreamingNotApproved) {
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendNaviStartStream(app_id, _));

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -32,11 +32,13 @@
 #include <stdint.h>
 #include <memory>
 #include <set>
+#include <bson_object.h>
 
 #include "gtest/gtest.h"
 #include "application_manager/application.h"
 #include "application_manager/application_impl.h"
 #include "application_manager/application_manager_impl.h"
+#include "application_manager/mock_application.h"
 #include "application_manager/mock_application_manager_settings.h"
 #include "application_manager/mock_resumption_data.h"
 #include "application_manager/resumption/resume_ctrl_impl.h"
@@ -61,13 +63,21 @@ namespace policy_test = test::components::policy_handler_test;
 namespace con_test = connection_handler_test;
 
 using testing::_;
+using ::testing::ByRef;
+using ::testing::DoAll;
 using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::NiceMock;
+using ::testing::SaveArg;
 using ::testing::SetArgPointee;
 
 using namespace application_manager;
+
+// custom action to call a member function with 4 arguments
+ACTION_P6(InvokeMemberFuncWithArg4, ptr, memberFunc, a, b, c, d) {
+  (ptr->*memberFunc)(a, b, c, d);
+}
 
 namespace {
 const std::string kDirectoryName = "./test_storage";
@@ -124,8 +134,14 @@ class ApplicationManagerImplTest : public ::testing::Test {
         .WillByDefault(ReturnRef(kTimeout));
     app_manager_impl_.reset(new am::ApplicationManagerImpl(
         mock_application_manager_settings_, mock_policy_settings_));
+    mock_app_ptr_ = utils::SharedPtr<MockApplication>(new MockApplication());
 
     ASSERT_TRUE(app_manager_impl_.get());
+    ASSERT_TRUE(mock_app_ptr_.get());
+  }
+
+  void AddMockApplication() {
+    app_manager_impl_->AddMockApplication(mock_app_ptr_);
   }
 
   NiceMock<policy_test::MockPolicySettings> mock_policy_settings_;
@@ -139,6 +155,7 @@ class ApplicationManagerImplTest : public ::testing::Test {
   application_manager::MockMessageHelper* mock_message_helper_;
   uint32_t app_id_;
   application_manager::MessageHelper* message_helper_;
+  utils::SharedPtr<MockApplication> mock_app_ptr_;
 };
 
 TEST_F(ApplicationManagerImplTest, ProcessQueryApp_ExpectSuccess) {
@@ -193,6 +210,417 @@ TEST_F(
   std::set<int32_t> result = app_manager_impl_->GetAppsSubscribedForWayPoints();
   EXPECT_EQ(1u, result.size());
   EXPECT_TRUE(result.find(app_id_) != result.end());
+}
+
+TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_RpcService) {
+  AddMockApplication();
+
+  const connection_handler::DeviceHandle device_handle = 0;
+  const protocol_handler::ServiceType service_type =
+      protocol_handler::ServiceType::kRpc;
+  const int32_t session_key = 123;
+  EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
+
+  bool result = false;
+  std::vector<std::string> rejected_params;
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+
+  app_manager_impl_->OnServiceStartedCallback(
+      device_handle, session_key, service_type, NULL);
+
+  // check: return value is true and list is empty
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(rejected_params.empty());
+}
+
+TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_UnknownApp) {
+  AddMockApplication();
+
+  const connection_handler::DeviceHandle device_handle = 0;
+  const protocol_handler::ServiceType service_type =
+      protocol_handler::ServiceType::kInvalidServiceType;
+  const int32_t session_key = 123;
+  EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(456));
+
+  bool result = false;
+  std::vector<std::string> rejected_params;
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+
+  app_manager_impl_->OnServiceStartedCallback(
+      device_handle, session_key, service_type, NULL);
+
+  // check: return value is false and list is empty
+  EXPECT_FALSE(result);
+  EXPECT_TRUE(rejected_params.empty());
+}
+
+TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_UnknownService) {
+  AddMockApplication();
+
+  const connection_handler::DeviceHandle device_handle = 0;
+  const protocol_handler::ServiceType service_type =
+      protocol_handler::ServiceType::kInvalidServiceType;
+  const int32_t session_key = 123;
+  EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
+
+  bool result = false;
+  std::vector<std::string> rejected_params;
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+
+  app_manager_impl_->OnServiceStartedCallback(
+      device_handle, session_key, service_type, NULL);
+
+  // check: return value is false and list is empty
+  EXPECT_FALSE(result);
+  EXPECT_TRUE(rejected_params.empty());
+}
+
+TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_VideoServiceStart) {
+  AddMockApplication();
+
+  const connection_handler::DeviceHandle device_handle = 0;
+  const protocol_handler::ServiceType service_type =
+      protocol_handler::ServiceType::kMobileNav;
+  const int32_t session_key = 123;
+  EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
+  EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*mock_app_ptr_, hmi_level())
+      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
+
+  bool result = false;
+  std::vector<std::string> rejected_params;
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+
+  // check: SetVideoConfig() should not be called, StartStreaming() is called
+  EXPECT_CALL(*mock_app_ptr_, SetVideoConfig(_, _)).Times(0);
+  EXPECT_CALL(*mock_app_ptr_, StartStreaming(service_type)).WillOnce(Return());
+
+  app_manager_impl_->OnServiceStartedCallback(
+      device_handle, session_key, service_type, NULL);
+
+  // check: return value is true and list is empty
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(rejected_params.empty());
+}
+
+TEST_F(ApplicationManagerImplTest,
+       OnServiceStartedCallback_VideoServiceNotStart1) {
+  AddMockApplication();
+
+  const connection_handler::DeviceHandle device_handle = 0;
+  const protocol_handler::ServiceType service_type =
+      protocol_handler::ServiceType::kMobileNav;
+  const int32_t session_key = 123;
+  EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
+  // is_navi() is false
+  EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(false));
+  EXPECT_CALL(*mock_app_ptr_, hmi_level())
+      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
+
+  bool result = false;
+  std::vector<std::string> rejected_params;
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+
+  // check: SetVideoConfig() and StartStreaming() should not be called
+  EXPECT_CALL(*mock_app_ptr_, SetVideoConfig(_, _)).Times(0);
+  EXPECT_CALL(*mock_app_ptr_, StartStreaming(service_type)).Times(0);
+
+  app_manager_impl_->OnServiceStartedCallback(
+      device_handle, session_key, service_type, NULL);
+
+  // check: return value is false and list is empty
+  EXPECT_FALSE(result);
+  EXPECT_TRUE(rejected_params.empty());
+}
+
+TEST_F(ApplicationManagerImplTest,
+       OnServiceStartedCallback_VideoServiceNotStart2) {
+  AddMockApplication();
+
+  const connection_handler::DeviceHandle device_handle = 0;
+  const protocol_handler::ServiceType service_type =
+      protocol_handler::ServiceType::kMobileNav;
+  const int32_t session_key = 123;
+  EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
+  EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(true));
+  // HMI level is not FULL nor LIMITED
+  EXPECT_CALL(*mock_app_ptr_, hmi_level())
+      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_BACKGROUND));
+
+  bool result = false;
+  std::vector<std::string> rejected_params;
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+
+  // check: SetVideoConfig() and StartStreaming() should not be called
+  EXPECT_CALL(*mock_app_ptr_, SetVideoConfig(_, _)).Times(0);
+  EXPECT_CALL(*mock_app_ptr_, StartStreaming(service_type)).Times(0);
+
+  app_manager_impl_->OnServiceStartedCallback(
+      device_handle, session_key, service_type, NULL);
+
+  // check: return value is false and list is empty
+  EXPECT_FALSE(result);
+  EXPECT_TRUE(rejected_params.empty());
+}
+
+TEST_F(ApplicationManagerImplTest,
+       OnServiceStartedCallback_VideoSetConfig_SUCCESS) {
+  AddMockApplication();
+
+  const connection_handler::DeviceHandle device_handle = 0;
+  const protocol_handler::ServiceType service_type =
+      protocol_handler::ServiceType::kMobileNav;
+  const int32_t session_key = 123;
+  EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
+  EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*mock_app_ptr_, hmi_level())
+      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_LIMITED));
+
+  bool result = false;
+  std::vector<std::string> rejected_params;
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+
+  BsonObject input_params;
+  bson_object_initialize_default(&input_params);
+  char protocol_version[] = "1.0.0";
+  bson_object_put_string(&input_params, "protocolVersion", protocol_version);
+  bson_object_put_int64(&input_params, "mtu", 100);
+  char protocol_name[] = "RTP";
+  bson_object_put_string(&input_params, "videoProtocol", protocol_name);
+  char codec_name[] = "VP9";
+  bson_object_put_string(&input_params, "videoCodec", codec_name);
+  bson_object_put_int32(&input_params, "desiredHeight", 640);
+  bson_object_put_int32(&input_params, "desiredWidth", 480);
+
+  smart_objects::SmartObject converted_params(smart_objects::SmartType_Map);
+  converted_params["protocol"] = hmi_apis::Common_VideoStreamingProtocol::RTP;
+  converted_params["codec"] = hmi_apis::Common_VideoStreamingCodec::VP9;
+  converted_params["height"] = 640;
+  converted_params["width"] = 480;
+
+  std::vector<std::string> empty;
+
+  // check: SetVideoConfig() and StartStreaming() are called
+  EXPECT_CALL(*mock_app_ptr_, SetVideoConfig(service_type, converted_params))
+      .WillOnce(DoAll(InvokeMemberFuncWithArg4(
+                          app_manager_impl_.get(),
+                          &ApplicationManagerImpl::OnStreamingConfigured,
+                          session_key,
+                          service_type,
+                          true,
+                          ByRef(empty)),
+                      Return(true)));
+  EXPECT_CALL(*mock_app_ptr_, StartStreaming(service_type)).WillOnce(Return());
+
+  app_manager_impl_->OnServiceStartedCallback(
+      device_handle, session_key, service_type, &input_params);
+
+  // check: return value is true and list is empty
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(rejected_params.empty());
+}
+
+static bool ValidateList(std::vector<std::string>& expected,
+                         std::vector<std::string>& actual) {
+  if (expected.size() != actual.size()) {
+    return false;
+  }
+  for (unsigned int i = 0; i < expected.size(); i++) {
+    std::string& param = expected[i];
+    unsigned int j;
+    for (j = 0; j < actual.size(); j++) {
+      if (param == actual[j]) {
+        break;
+      }
+    }
+    if (j == actual.size()) {
+      // not found
+      return false;
+    }
+  }
+  return true;
+}
+
+TEST_F(ApplicationManagerImplTest,
+       OnServiceStartedCallback_VideoSetConfig_FAILURE) {
+  AddMockApplication();
+
+  const connection_handler::DeviceHandle device_handle = 0;
+  const protocol_handler::ServiceType service_type =
+      protocol_handler::ServiceType::kMobileNav;
+  const int32_t session_key = 123;
+  EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
+  EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*mock_app_ptr_, hmi_level())
+      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
+
+  bool result = false;
+  std::vector<std::string> rejected_params;
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+
+  BsonObject input_params;
+  bson_object_initialize_default(&input_params);
+  char protocol_version[] = "1.0.0";
+  bson_object_put_string(&input_params, "protocolVersion", protocol_version);
+  bson_object_put_int64(&input_params, "mtu", 100);
+  char protocol_name[] = "RTP";
+  bson_object_put_string(&input_params, "videoProtocol", protocol_name);
+  char codec_name[] = "VP9";
+  bson_object_put_string(&input_params, "videoCodec", codec_name);
+  bson_object_put_int32(&input_params, "desiredHeight", 640);
+  bson_object_put_int32(&input_params, "desiredWidth", 480);
+
+  smart_objects::SmartObject converted_params(smart_objects::SmartType_Map);
+  converted_params["protocol"] = hmi_apis::Common_VideoStreamingProtocol::RTP;
+  converted_params["codec"] = hmi_apis::Common_VideoStreamingCodec::VP9;
+  converted_params["height"] = 640;
+  converted_params["width"] = 480;
+
+  std::vector<std::string> rejected_list;
+  rejected_list.push_back(std::string("protocol"));
+  rejected_list.push_back(std::string("codec"));
+
+  // simulate HMI returning negative response
+  EXPECT_CALL(*mock_app_ptr_, SetVideoConfig(service_type, converted_params))
+      .WillOnce(DoAll(InvokeMemberFuncWithArg4(
+                          app_manager_impl_.get(),
+                          &ApplicationManagerImpl::OnStreamingConfigured,
+                          session_key,
+                          service_type,
+                          false,
+                          ByRef(rejected_list)),
+                      Return(true)));
+
+  // check: StartStreaming() should not be called
+  EXPECT_CALL(*mock_app_ptr_, StartStreaming(service_type)).Times(0);
+
+  app_manager_impl_->OnServiceStartedCallback(
+      device_handle, session_key, service_type, &input_params);
+
+  // check: return value is false
+  EXPECT_FALSE(result);
+
+  // check: rejected param list contains "videoProtocol" and "videoCodec"
+  ASSERT_EQ(2u, rejected_params.size());
+  std::vector<std::string> expected_list;
+  expected_list.push_back(std::string("videoProtocol"));
+  expected_list.push_back(std::string("videoCodec"));
+  ASSERT_TRUE(ValidateList(expected_list, rejected_params));
+}
+
+TEST_F(ApplicationManagerImplTest,
+       OnServiceStartedCallback_VideoServiceWithoutVideoParams) {
+  AddMockApplication();
+
+  const connection_handler::DeviceHandle device_handle = 0;
+  const protocol_handler::ServiceType service_type =
+      protocol_handler::ServiceType::kMobileNav;
+  const int32_t session_key = 123;
+  EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
+  EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*mock_app_ptr_, hmi_level())
+      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
+
+  bool result = false;
+  std::vector<std::string> rejected_params;
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+
+  BsonObject input_params;
+  bson_object_initialize_default(&input_params);
+  char protocol_version[] = "1.0.0";
+  bson_object_put_string(&input_params, "protocolVersion", protocol_version);
+  bson_object_put_int64(&input_params, "mtu", 100);
+
+  // check: SetVideoConfig() should not be called, StartStreaming() is called
+  EXPECT_CALL(*mock_app_ptr_, SetVideoConfig(_, _)).Times(0);
+  EXPECT_CALL(*mock_app_ptr_, StartStreaming(service_type)).WillOnce(Return());
+
+  app_manager_impl_->OnServiceStartedCallback(
+      device_handle, session_key, service_type, &input_params);
+
+  // check: return value is true and list is empty
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(rejected_params.empty());
+}
+
+TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_AudioServiceStart) {
+  AddMockApplication();
+
+  const connection_handler::DeviceHandle device_handle = 0;
+  const protocol_handler::ServiceType service_type =
+      protocol_handler::ServiceType::kAudio;
+  const int32_t session_key = 123;
+  EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
+  EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*mock_app_ptr_, hmi_level())
+      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
+
+  bool result = false;
+  std::vector<std::string> rejected_params;
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+
+  // check: SetVideoConfig() should not be called, StartStreaming() is called
+  EXPECT_CALL(*mock_app_ptr_, SetVideoConfig(_, _)).Times(0);
+  EXPECT_CALL(*mock_app_ptr_, StartStreaming(service_type)).WillOnce(Return());
+
+  app_manager_impl_->OnServiceStartedCallback(
+      device_handle, session_key, service_type, NULL);
+
+  // check: return value is true and list is empty
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(rejected_params.empty());
+}
+
+TEST_F(ApplicationManagerImplTest,
+       OnServiceStartedCallback_AudioServiceWithParams) {
+  AddMockApplication();
+
+  const connection_handler::DeviceHandle device_handle = 0;
+  const protocol_handler::ServiceType service_type =
+      protocol_handler::ServiceType::kAudio;
+  const int32_t session_key = 123;
+  EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
+  EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*mock_app_ptr_, hmi_level())
+      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
+
+  bool result = false;
+  std::vector<std::string> rejected_params;
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+
+  BsonObject input_params;
+  bson_object_initialize_default(&input_params);
+  char protocol_version[] = "1.0.0";
+  bson_object_put_string(&input_params, "protocolVersion", protocol_version);
+  bson_object_put_int64(&input_params, "mtu", 100);
+  char protocol_name[] = "RTP";
+  bson_object_put_string(&input_params, "videoProtocol", protocol_name);
+  char codec_name[] = "VP9";
+  bson_object_put_string(&input_params, "videoCodec", codec_name);
+  bson_object_put_int32(&input_params, "desiredHeight", 640);
+  bson_object_put_int32(&input_params, "desiredWidth", 480);
+
+  // check: SetVideoConfig() should not be called, StartStreaming() is called
+  EXPECT_CALL(*mock_app_ptr_, SetVideoConfig(_, _)).Times(0);
+  EXPECT_CALL(*mock_app_ptr_, StartStreaming(service_type)).WillOnce(Return());
+
+  app_manager_impl_->OnServiceStartedCallback(
+      device_handle, session_key, service_type, &input_params);
+
+  // check: return value is true and list is empty
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(rejected_params.empty());
 }
 
 }  // application_manager_test

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -396,8 +396,8 @@ TEST_F(ApplicationManagerImplTest,
   bson_object_put_string(&input_params, "videoProtocol", protocol_name);
   char codec_name[] = "VP9";
   bson_object_put_string(&input_params, "videoCodec", codec_name);
-  bson_object_put_int32(&input_params, "desiredHeight", 640);
-  bson_object_put_int32(&input_params, "desiredWidth", 480);
+  bson_object_put_int32(&input_params, "height", 640);
+  bson_object_put_int32(&input_params, "width", 480);
 
   smart_objects::SmartObject converted_params(smart_objects::SmartType_Map);
   converted_params[strings::protocol] =
@@ -476,8 +476,8 @@ TEST_F(ApplicationManagerImplTest,
   bson_object_put_string(&input_params, "videoProtocol", protocol_name);
   char codec_name[] = "VP9";
   bson_object_put_string(&input_params, "videoCodec", codec_name);
-  bson_object_put_int32(&input_params, "desiredHeight", 640);
-  bson_object_put_int32(&input_params, "desiredWidth", 480);
+  bson_object_put_int32(&input_params, "height", 640);
+  bson_object_put_int32(&input_params, "width", 480);
 
   smart_objects::SmartObject converted_params(smart_objects::SmartType_Map);
   converted_params[strings::protocol] =
@@ -610,8 +610,8 @@ TEST_F(ApplicationManagerImplTest,
   bson_object_put_string(&input_params, "videoProtocol", protocol_name);
   char codec_name[] = "VP9";
   bson_object_put_string(&input_params, "videoCodec", codec_name);
-  bson_object_put_int32(&input_params, "desiredHeight", 640);
-  bson_object_put_int32(&input_params, "desiredWidth", 480);
+  bson_object_put_int32(&input_params, "height", 640);
+  bson_object_put_int32(&input_params, "width", 480);
 
   // check: SetVideoConfig() should not be called, StartStreaming() is called
   EXPECT_CALL(*mock_app_ptr_, SetVideoConfig(_, _)).Times(0);

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -47,6 +47,7 @@
 #include "hmi_message_handler/mock_hmi_message_handler.h"
 #include "policy/mock_policy_settings.h"
 #include "policy/usage_statistics/mock_statistics_manager.h"
+#include "protocol/bson_object_keys.h"
 #include "protocol_handler/mock_session_observer.h"
 #include "utils/custom_string.h"
 #include "utils/file_system.h"
@@ -390,14 +391,18 @@ TEST_F(ApplicationManagerImplTest,
   BsonObject input_params;
   bson_object_initialize_default(&input_params);
   char protocol_version[] = "1.0.0";
-  bson_object_put_string(&input_params, "protocolVersion", protocol_version);
-  bson_object_put_int64(&input_params, "mtu", 100);
+  bson_object_put_string(&input_params,
+                         protocol_handler::strings::protocol_version,
+                         protocol_version);
+  bson_object_put_int64(&input_params, protocol_handler::strings::mtu, 100);
   char protocol_name[] = "RTP";
-  bson_object_put_string(&input_params, "videoProtocol", protocol_name);
+  bson_object_put_string(
+      &input_params, protocol_handler::strings::video_protocol, protocol_name);
   char codec_name[] = "VP9";
-  bson_object_put_string(&input_params, "videoCodec", codec_name);
-  bson_object_put_int32(&input_params, "height", 640);
-  bson_object_put_int32(&input_params, "width", 480);
+  bson_object_put_string(
+      &input_params, protocol_handler::strings::video_codec, codec_name);
+  bson_object_put_int32(&input_params, protocol_handler::strings::height, 640);
+  bson_object_put_int32(&input_params, protocol_handler::strings::width, 480);
 
   smart_objects::SmartObject converted_params(smart_objects::SmartType_Map);
   converted_params[strings::protocol] =
@@ -470,14 +475,18 @@ TEST_F(ApplicationManagerImplTest,
   BsonObject input_params;
   bson_object_initialize_default(&input_params);
   char protocol_version[] = "1.0.0";
-  bson_object_put_string(&input_params, "protocolVersion", protocol_version);
-  bson_object_put_int64(&input_params, "mtu", 100);
+  bson_object_put_string(&input_params,
+                         protocol_handler::strings::protocol_version,
+                         protocol_version);
+  bson_object_put_int64(&input_params, protocol_handler::strings::mtu, 100);
   char protocol_name[] = "RTP";
-  bson_object_put_string(&input_params, "videoProtocol", protocol_name);
+  bson_object_put_string(
+      &input_params, protocol_handler::strings::video_protocol, protocol_name);
   char codec_name[] = "VP9";
-  bson_object_put_string(&input_params, "videoCodec", codec_name);
-  bson_object_put_int32(&input_params, "height", 640);
-  bson_object_put_int32(&input_params, "width", 480);
+  bson_object_put_string(
+      &input_params, protocol_handler::strings::video_codec, codec_name);
+  bson_object_put_int32(&input_params, protocol_handler::strings::height, 640);
+  bson_object_put_int32(&input_params, protocol_handler::strings::width, 480);
 
   smart_objects::SmartObject converted_params(smart_objects::SmartType_Map);
   converted_params[strings::protocol] =
@@ -513,8 +522,9 @@ TEST_F(ApplicationManagerImplTest,
   // check: rejected param list contains "videoProtocol" and "videoCodec"
   ASSERT_EQ(2u, rejected_params.size());
   std::vector<std::string> expected_list;
-  expected_list.push_back(std::string("videoProtocol"));
-  expected_list.push_back(std::string("videoCodec"));
+  expected_list.push_back(
+      std::string(protocol_handler::strings::video_protocol));
+  expected_list.push_back(std::string(protocol_handler::strings::video_codec));
   ASSERT_TRUE(ValidateList(expected_list, rejected_params));
 }
 
@@ -604,14 +614,18 @@ TEST_F(ApplicationManagerImplTest,
   BsonObject input_params;
   bson_object_initialize_default(&input_params);
   char protocol_version[] = "1.0.0";
-  bson_object_put_string(&input_params, "protocolVersion", protocol_version);
-  bson_object_put_int64(&input_params, "mtu", 100);
+  bson_object_put_string(&input_params,
+                         protocol_handler::strings::protocol_version,
+                         protocol_version);
+  bson_object_put_int64(&input_params, protocol_handler::strings::mtu, 100);
   char protocol_name[] = "RTP";
-  bson_object_put_string(&input_params, "videoProtocol", protocol_name);
+  bson_object_put_string(
+      &input_params, protocol_handler::strings::video_protocol, protocol_name);
   char codec_name[] = "VP9";
-  bson_object_put_string(&input_params, "videoCodec", codec_name);
-  bson_object_put_int32(&input_params, "height", 640);
-  bson_object_put_int32(&input_params, "width", 480);
+  bson_object_put_string(
+      &input_params, protocol_handler::strings::video_codec, codec_name);
+  bson_object_put_int32(&input_params, protocol_handler::strings::height, 640);
+  bson_object_put_int32(&input_params, protocol_handler::strings::width, 480);
 
   // check: SetVideoConfig() should not be called, StartStreaming() is called
   EXPECT_CALL(*mock_app_ptr_, SetVideoConfig(_, _)).Times(0);

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -400,10 +400,11 @@ TEST_F(ApplicationManagerImplTest,
   bson_object_put_int32(&input_params, "desiredWidth", 480);
 
   smart_objects::SmartObject converted_params(smart_objects::SmartType_Map);
-  converted_params["protocol"] = hmi_apis::Common_VideoStreamingProtocol::RTP;
-  converted_params["codec"] = hmi_apis::Common_VideoStreamingCodec::VP9;
-  converted_params["height"] = 640;
-  converted_params["width"] = 480;
+  converted_params[strings::protocol] =
+      hmi_apis::Common_VideoStreamingProtocol::RTP;
+  converted_params[strings::codec] = hmi_apis::Common_VideoStreamingCodec::VP9;
+  converted_params[strings::height] = 640;
+  converted_params[strings::width] = 480;
 
   std::vector<std::string> empty;
 
@@ -479,10 +480,11 @@ TEST_F(ApplicationManagerImplTest,
   bson_object_put_int32(&input_params, "desiredWidth", 480);
 
   smart_objects::SmartObject converted_params(smart_objects::SmartType_Map);
-  converted_params["protocol"] = hmi_apis::Common_VideoStreamingProtocol::RTP;
-  converted_params["codec"] = hmi_apis::Common_VideoStreamingCodec::VP9;
-  converted_params["height"] = 640;
-  converted_params["width"] = 480;
+  converted_params[strings::protocol] =
+      hmi_apis::Common_VideoStreamingProtocol::RTP;
+  converted_params[strings::codec] = hmi_apis::Common_VideoStreamingCodec::VP9;
+  converted_params[strings::height] = 640;
+  converted_params[strings::width] = 480;
 
   std::vector<std::string> rejected_list;
   rejected_list.push_back(std::string("protocol"));

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -223,8 +223,8 @@ TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_RpcService) {
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
-      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+      .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   app_manager_impl_->OnServiceStartedCallback(
       device_handle, session_key, service_type, NULL);
@@ -245,8 +245,8 @@ TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_UnknownApp) {
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
-      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+      .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   app_manager_impl_->OnServiceStartedCallback(
       device_handle, session_key, service_type, NULL);
@@ -267,8 +267,8 @@ TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_UnknownService) {
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
-      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+      .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   app_manager_impl_->OnServiceStartedCallback(
       device_handle, session_key, service_type, NULL);
@@ -292,8 +292,8 @@ TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_VideoServiceStart) {
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
-      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+      .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   // check: SetVideoConfig() should not be called, StartStreaming() is called
   EXPECT_CALL(*mock_app_ptr_, SetVideoConfig(_, _)).Times(0);
@@ -323,8 +323,8 @@ TEST_F(ApplicationManagerImplTest,
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
-      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+      .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   // check: SetVideoConfig() and StartStreaming() should not be called
   EXPECT_CALL(*mock_app_ptr_, SetVideoConfig(_, _)).Times(0);
@@ -354,8 +354,8 @@ TEST_F(ApplicationManagerImplTest,
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
-      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+      .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   // check: SetVideoConfig() and StartStreaming() should not be called
   EXPECT_CALL(*mock_app_ptr_, SetVideoConfig(_, _)).Times(0);
@@ -384,8 +384,8 @@ TEST_F(ApplicationManagerImplTest,
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
-      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+      .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   BsonObject input_params;
   bson_object_initialize_default(&input_params);
@@ -464,8 +464,8 @@ TEST_F(ApplicationManagerImplTest,
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
-      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+      .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   BsonObject input_params;
   bson_object_initialize_default(&input_params);
@@ -533,8 +533,8 @@ TEST_F(ApplicationManagerImplTest,
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
-      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+      .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   BsonObject input_params;
   bson_object_initialize_default(&input_params);
@@ -568,8 +568,8 @@ TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_AudioServiceStart) {
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
-      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+      .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   // check: SetVideoConfig() should not be called, StartStreaming() is called
   EXPECT_CALL(*mock_app_ptr_, SetVideoConfig(_, _)).Times(0);
@@ -598,8 +598,8 @@ TEST_F(ApplicationManagerImplTest,
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _))
-      .WillOnce(DoAll(SaveArg<0>(&result), SaveArg<1>(&rejected_params)));
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+      .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   BsonObject input_params;
   bson_object_initialize_default(&input_params);

--- a/src/components/application_manager/test/commands/hmi/navi_set_video_config_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_set_video_config_request_test.cc
@@ -152,10 +152,12 @@ TEST_F(NaviSetVideoConfigRequestTest, OnEvent_FAILURE) {
   (*event_msg)[am::strings::params][am::hmi_response::code] =
       hmi_apis::Common_Result::REJECTED;
 
-  (*event_msg)[am::strings::msg_params]["rejectedParams"] =
+  (*event_msg)[am::strings::msg_params][am::strings::rejected_params] =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
-  (*event_msg)[am::strings::msg_params]["rejectedParams"][0] = "codec";
-  (*event_msg)[am::strings::msg_params]["rejectedParams"][1] = "protocol";
+  (*event_msg)[am::strings::msg_params][am::strings::rejected_params][0] =
+      "codec";
+  (*event_msg)[am::strings::msg_params][am::strings::rejected_params][1] =
+      "protocol";
   Event event(kEventID);
   event.set_smart_object(*event_msg);
 

--- a/src/components/application_manager/test/commands/hmi/navi_set_video_config_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_set_video_config_request_test.cc
@@ -87,7 +87,7 @@ class NaviSetVideoConfigRequestTest
   MockEventDispatcher mock_event_dispatcher_;
 };
 
-TEST_F(NaviSetVideoConfigRequestTest, OnEvent_SUCCESS) {
+TEST_F(NaviSetVideoConfigRequestTest, OnEventWithSuccessResponse) {
   MessageSharedPtr request_msg = CreateMessage();
   (*request_msg)[am::strings::msg_params][am::strings::app_id] = kAppId;
 
@@ -117,7 +117,7 @@ static bool ValidateList(std::vector<std::string>& expected,
   return std::equal(expected.begin(), expected.end(), actual.begin());
 }
 
-TEST_F(NaviSetVideoConfigRequestTest, OnEvent_FAILURE) {
+TEST_F(NaviSetVideoConfigRequestTest, OnEventWithRejectedResponse) {
   MessageSharedPtr request_msg = CreateMessage();
   (*request_msg)[am::strings::msg_params][am::strings::app_id] = kAppId;
   (*request_msg)[am::strings::msg_params][am::strings::config] =
@@ -165,7 +165,8 @@ TEST_F(NaviSetVideoConfigRequestTest, OnEvent_FAILURE) {
   ASSERT_TRUE(ValidateList(expected_list, rejected_params));
 }
 
-TEST_F(NaviSetVideoConfigRequestTest, OnEvent_FAILURE_WithoutParams) {
+TEST_F(NaviSetVideoConfigRequestTest,
+       OnEventWithRejectedResponseWithoutParams) {
   MessageSharedPtr request_msg = CreateMessage();
   (*request_msg)[am::strings::msg_params][am::strings::app_id] = kAppId;
 

--- a/src/components/application_manager/test/commands/hmi/navi_set_video_config_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_set_video_config_request_test.cc
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2017 Xevo Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/commands/hmi/navi_set_video_config_request.h"
+
+#include "gtest/gtest.h"
+#include "utils/shared_ptr.h"
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/hmi_interfaces.h"
+#include "application_manager/mock_hmi_interface.h"
+#include "application_manager/event_engine/event.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+namespace navi_set_video_config_request {
+
+using ::testing::_;
+using ::testing::ReturnRef;
+namespace am = ::application_manager;
+using am::commands::MessageSharedPtr;
+using am::commands::NaviSetVideoConfigRequest;
+using am::event_engine::Event;
+
+namespace {
+const hmi_apis::FunctionID::eType kEventID =
+    hmi_apis::FunctionID::Navigation_SetVideoConfig;
+}  // namespace
+
+typedef SharedPtr<NaviSetVideoConfigRequest> NaviSetVideoConfigRequestPtr;
+
+class NaviSetVideoConfigRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  NaviSetVideoConfigRequestTest() {
+    mock_app_ptr_ = CreateMockApp();
+    ON_CALL(app_mngr_, hmi_interfaces())
+        .WillByDefault(ReturnRef(mock_hmi_interfaces_));
+    ON_CALL(app_mngr_, application_by_hmi_app(_))
+        .WillByDefault(Return(mock_app_ptr_));
+  }
+
+  MOCK(am::MockHmiInterfaces) mock_hmi_interfaces_;
+  MockAppPtr mock_app_ptr_;
+};
+
+TEST_F(NaviSetVideoConfigRequestTest, OnEvent_SUCCESS) {
+  NaviSetVideoConfigRequestPtr command =
+      CreateCommand<NaviSetVideoConfigRequest>();
+
+  MessageSharedPtr event_msg = CreateMessage();
+  (*event_msg)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  Event event(kEventID);
+  event.set_smart_object(*event_msg);
+
+  std::vector<std::string> empty;
+  EXPECT_CALL(*mock_app_ptr_, OnNaviSetVideoConfigDone(true, empty)).Times(1);
+
+  command->on_event(event);
+}
+
+static bool ValidateList(std::vector<std::string>& expected,
+                         std::vector<std::string>& actual) {
+  if (expected.size() != actual.size()) {
+    return false;
+  }
+  for (unsigned int i = 0; i < expected.size(); i++) {
+    std::string& param = expected[i];
+    unsigned int j;
+    for (j = 0; j < actual.size(); j++) {
+      if (param == actual[j]) {
+        break;
+      }
+    }
+    if (j == actual.size()) {
+      // not found
+      return false;
+    }
+  }
+  return true;
+}
+
+TEST_F(NaviSetVideoConfigRequestTest, OnEvent_FAILURE) {
+  MessageSharedPtr request_msg = CreateMessage();
+  (*request_msg)[am::strings::msg_params]["config"] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  (*request_msg)[am::strings::msg_params]["config"]["protocol"] =
+      hmi_apis::Common_VideoStreamingProtocol::RTP;
+  (*request_msg)[am::strings::msg_params]["config"]["codec"] =
+      hmi_apis::Common_VideoStreamingCodec::H265;
+  (*request_msg)[am::strings::msg_params]["config"]["height"] = 640;
+  (*request_msg)[am::strings::msg_params]["config"]["width"] = 480;
+
+  NaviSetVideoConfigRequestPtr command =
+      CreateCommand<NaviSetVideoConfigRequest>(request_msg);
+
+  MessageSharedPtr event_msg = CreateMessage();
+  (*event_msg)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::REJECTED;
+
+  (*event_msg)[am::strings::msg_params]["rejectedParams"] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  (*event_msg)[am::strings::msg_params]["rejectedParams"][0] = "codec";
+  (*event_msg)[am::strings::msg_params]["rejectedParams"][1] = "protocol";
+  Event event(kEventID);
+  event.set_smart_object(*event_msg);
+
+  std::vector<std::string> rejected_params;
+  EXPECT_CALL(*mock_app_ptr_, OnNaviSetVideoConfigDone(false, _))
+      .WillOnce(SaveArg<1>(&rejected_params));
+
+  command->on_event(event);
+
+  ASSERT_EQ(2u, rejected_params.size());
+  std::vector<std::string> expected_list;
+  expected_list.push_back(std::string("protocol"));
+  expected_list.push_back(std::string("codec"));
+  ASSERT_TRUE(ValidateList(expected_list, rejected_params));
+}
+
+TEST_F(NaviSetVideoConfigRequestTest, OnEvent_FAILURE_WithoutParams) {
+  NaviSetVideoConfigRequestPtr command =
+      CreateCommand<NaviSetVideoConfigRequest>();
+
+  MessageSharedPtr event_msg = CreateMessage();
+  (*event_msg)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::REJECTED;
+
+  Event event(kEventID);
+  event.set_smart_object(*event_msg);
+
+  std::vector<std::string> empty;
+  EXPECT_CALL(*mock_app_ptr_, OnNaviSetVideoConfigDone(false, empty)).Times(1);
+
+  command->on_event(event);
+}
+
+TEST_F(NaviSetVideoConfigRequestTest, OnTimeout) {
+  NaviSetVideoConfigRequestPtr command =
+      CreateCommand<NaviSetVideoConfigRequest>();
+
+  std::vector<std::string> empty;
+  EXPECT_CALL(*mock_app_ptr_, OnNaviSetVideoConfigDone(false, empty)).Times(1);
+
+  EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _)).Times(1);
+
+  command->onTimeOut();
+}
+
+}  // namespace navi_set_video_config_request
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/navi_set_video_config_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_set_video_config_request_test.cc
@@ -116,14 +116,18 @@ static bool ValidateList(std::vector<std::string>& expected,
 
 TEST_F(NaviSetVideoConfigRequestTest, OnEvent_FAILURE) {
   MessageSharedPtr request_msg = CreateMessage();
-  (*request_msg)[am::strings::msg_params]["config"] =
+  (*request_msg)[am::strings::msg_params][am::strings::config] =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
-  (*request_msg)[am::strings::msg_params]["config"]["protocol"] =
-      hmi_apis::Common_VideoStreamingProtocol::RTP;
-  (*request_msg)[am::strings::msg_params]["config"]["codec"] =
-      hmi_apis::Common_VideoStreamingCodec::H265;
-  (*request_msg)[am::strings::msg_params]["config"]["height"] = 640;
-  (*request_msg)[am::strings::msg_params]["config"]["width"] = 480;
+  (*request_msg)[am::strings::msg_params][am::strings::config]
+                [am::strings::protocol] =
+                    hmi_apis::Common_VideoStreamingProtocol::RTP;
+  (*request_msg)[am::strings::msg_params][am::strings::config]
+                [am::strings::codec] =
+                    hmi_apis::Common_VideoStreamingCodec::H265;
+  (*request_msg)[am::strings::msg_params][am::strings::config]
+                [am::strings::height] = 640;
+  (*request_msg)[am::strings::msg_params][am::strings::config]
+                [am::strings::width] = 480;
 
   NaviSetVideoConfigRequestPtr command =
       CreateCommand<NaviSetVideoConfigRequest>(request_msg);

--- a/src/components/application_manager/test/commands/hmi/navi_set_video_config_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_set_video_config_request_test.cc
@@ -13,7 +13,7 @@
  * disclaimer in the documentation and/or other materials provided with the
  * distribution.
  *
- * Neither the name of the Ford Motor Company nor the names of its contributors
+ * Neither the names of the copyright holders nor the names of its contributors
  * may be used to endorse or promote products derived from this software
  * without specific prior written permission.
  *

--- a/src/components/application_manager/test/commands/hmi/navi_set_video_config_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_set_video_config_request_test.cc
@@ -79,6 +79,7 @@ class NaviSetVideoConfigRequestTest
         .WillByDefault(Return(mock_app_ptr_));
     ON_CALL(app_mngr_, event_dispatcher())
         .WillByDefault(ReturnRef(mock_event_dispatcher_));
+    ON_CALL(*mock_app_ptr_, app_id()).WillByDefault(Return(kAppId));
     ON_CALL(*mock_app_ptr_, hmi_app_id()).WillByDefault(Return(kHmiAppId));
   }
 
@@ -104,7 +105,7 @@ TEST_F(NaviSetVideoConfigRequestTest, OnEventWithSuccessResponse) {
   EXPECT_CALL(
       app_mngr_,
       OnStreamingConfigured(
-          kHmiAppId, protocol_handler::ServiceType::kMobileNav, true, empty))
+          kAppId, protocol_handler::ServiceType::kMobileNav, true, empty))
       .Times(1);
 
   command->on_event(event);
@@ -150,10 +151,9 @@ TEST_F(NaviSetVideoConfigRequestTest, OnEventWithRejectedResponse) {
   event.set_smart_object(*event_msg);
 
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(
-      app_mngr_,
-      OnStreamingConfigured(
-          kHmiAppId, protocol_handler::ServiceType::kMobileNav, false, _))
+  EXPECT_CALL(app_mngr_,
+              OnStreamingConfigured(
+                  kAppId, protocol_handler::ServiceType::kMobileNav, false, _))
       .WillOnce(SaveArg<3>(&rejected_params));
 
   command->on_event(event);
@@ -184,7 +184,7 @@ TEST_F(NaviSetVideoConfigRequestTest,
   EXPECT_CALL(
       app_mngr_,
       OnStreamingConfigured(
-          kHmiAppId, protocol_handler::ServiceType::kMobileNav, false, empty))
+          kAppId, protocol_handler::ServiceType::kMobileNav, false, empty))
       .WillOnce(Return());
 
   command->on_event(event);
@@ -201,7 +201,7 @@ TEST_F(NaviSetVideoConfigRequestTest, OnTimeout) {
   EXPECT_CALL(
       app_mngr_,
       OnStreamingConfigured(
-          kHmiAppId, protocol_handler::ServiceType::kMobileNav, false, empty))
+          kAppId, protocol_handler::ServiceType::kMobileNav, false, empty))
       .WillOnce(Return());
 
   EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _)).Times(1);

--- a/src/components/application_manager/test/commands/hmi/navi_set_video_config_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_set_video_config_request_test.cc
@@ -30,6 +30,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <algorithm>
+
 #include "application_manager/commands/hmi/navi_set_video_config_request.h"
 
 #include "gtest/gtest.h"
@@ -110,23 +112,9 @@ TEST_F(NaviSetVideoConfigRequestTest, OnEvent_SUCCESS) {
 
 static bool ValidateList(std::vector<std::string>& expected,
                          std::vector<std::string>& actual) {
-  if (expected.size() != actual.size()) {
-    return false;
-  }
-  for (unsigned int i = 0; i < expected.size(); i++) {
-    std::string& param = expected[i];
-    unsigned int j;
-    for (j = 0; j < actual.size(); j++) {
-      if (param == actual[j]) {
-        break;
-      }
-    }
-    if (j == actual.size()) {
-      // not found
-      return false;
-    }
-  }
-  return true;
+  std::sort(expected.begin(), expected.end());
+  std::sort(actual.begin(), actual.end());
+  return std::equal(expected.begin(), expected.end(), actual.begin());
 }
 
 TEST_F(NaviSetVideoConfigRequestTest, OnEvent_FAILURE) {

--- a/src/components/application_manager/test/commands/hmi/navi_set_video_config_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_set_video_config_response_test.cc
@@ -13,7 +13,7 @@
  * disclaimer in the documentation and/or other materials provided with the
  * distribution.
  *
- * Neither the name of the Ford Motor Company nor the names of its contributors
+ * Neither the names of the copyright holders nor the names of its contributors
  * may be used to endorse or promote products derived from this software
  * without specific prior written permission.
  *

--- a/src/components/application_manager/test/commands/hmi/navi_set_video_config_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/navi_set_video_config_response_test.cc
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2017 Xevo Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gtest/gtest.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/hmi/navi_set_video_config_response.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_event_dispatcher.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/smart_object_keys.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+namespace navi_set_video_config_response {
+
+using utils::SharedPtr;
+using application_manager::commands::NaviSetVideoConfigResponse;
+using test::components::event_engine_test::MockEventDispatcher;
+using testing::_;
+using testing::ReturnRef;
+using ::testing::NiceMock;
+
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+class NaviSetVideoConfigResponseTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(NaviSetVideoConfigResponseTest, RUN_SUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+
+  SharedPtr<NaviSetVideoConfigResponse> command(
+      CreateCommand<NaviSetVideoConfigResponse>(msg));
+
+  MockEventDispatcher mock_event_dispatcher;
+  EXPECT_CALL(app_mngr_, event_dispatcher())
+      .WillOnce(ReturnRef(mock_event_dispatcher));
+  EXPECT_CALL(mock_event_dispatcher, raise_event(_));
+
+  command->Run();
+}
+
+}  // namespace navi_set_video_config_response
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -297,45 +297,30 @@ TEST_F(UIGetCapabilitiesResponseTest, SetVideoStreamingCapability_SUCCESS) {
   (*command_msg)[strings::msg_params][strings::system_capabilities]
                 [strings::video_streaming_capability] =
                     smart_objects::SmartObject(smart_objects::SmartType_Map);
+  smart_objects::SmartObject& video_streaming_capability =
+      (*command_msg)[strings::msg_params][strings::system_capabilities]
+                    [strings::video_streaming_capability];
 
-  (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]
-                [strings::preferred_resolution] =
-                    smart_objects::SmartObject(smart_objects::SmartType_Map);
+  video_streaming_capability[strings::preferred_resolution] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  video_streaming_capability[strings::preferred_resolution]
+                            [strings::resolution_width] = 800;
+  video_streaming_capability[strings::preferred_resolution]
+                            [strings::resolution_height] = 350;
 
-  (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]
-                [strings::preferred_resolution][strings::resolution_width] =
-                    800;
+  video_streaming_capability[strings::max_bitrate] = 10000;
 
-  (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]
-                [strings::preferred_resolution][strings::resolution_height] =
-                    350;
+  video_streaming_capability[strings::supported_formats] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
 
-  (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability][strings::max_bitrate] =
-                    10000;
+  video_streaming_capability[strings::supported_formats][0] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
 
-  (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]
-                [strings::supported_formats] =
-                    smart_objects::SmartObject(smart_objects::SmartType_Array);
+  video_streaming_capability[strings::supported_formats][0][strings::protocol] =
+      hmi_apis::Common_VideoStreamingProtocol::RAW;
 
-  (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]
-                [strings::supported_formats][0] =
-                    smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-  (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]
-                [strings::supported_formats][0][strings::protocol] =
-                    hmi_apis::Common_VideoStreamingProtocol::RAW;
-
-  (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]
-                [strings::supported_formats][0][strings::codec] =
-                    hmi_apis::Common_VideoStreamingCodec::H264;
+  video_streaming_capability[strings::supported_formats][0][strings::codec] =
+      hmi_apis::Common_VideoStreamingCodec::H264;
 
   ResponseFromHMIPtr command(
       CreateCommand<UIGetCapabilitiesResponse>(command_msg));
@@ -343,12 +328,8 @@ TEST_F(UIGetCapabilitiesResponseTest, SetVideoStreamingCapability_SUCCESS) {
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
-  smart_objects::SmartObject vs_capability_so =
-      (*command_msg)[strings::msg_params][strings::system_capabilities]
-                    [strings::video_streaming_capability];
-
   EXPECT_CALL(mock_hmi_capabilities_,
-              set_video_streaming_capability(vs_capability_so));
+              set_video_streaming_capability(video_streaming_capability));
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -216,6 +216,28 @@ TEST_F(UIGetCapabilitiesResponseTest, SetPhoneCall_SUCCESS) {
   command->Run();
 }
 
+TEST_F(UIGetCapabilitiesResponseTest, SetVideoStreaming_SUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::msg_params][strings::hmi_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  (*command_msg)[strings::msg_params][strings::hmi_capabilities]
+                [strings::video_streaming] = true;
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  smart_objects::SmartObject hmi_capabilities_so =
+      (*command_msg)[strings::msg_params][strings::hmi_capabilities];
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_video_streaming_supported(
+                  hmi_capabilities_so[strings::video_streaming].asBool()));
+
+  command->Run();
+}
+
 TEST_F(UIGetCapabilitiesResponseTest, SetNavigationCapability_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
   (*command_msg)[strings::msg_params][strings::system_capabilities] =
@@ -263,6 +285,62 @@ TEST_F(UIGetCapabilitiesResponseTest, SetPhonenCapability_SUCCESS) {
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_phone_capability(phone_capability_so));
+
+  command->Run();
+}
+
+TEST_F(UIGetCapabilitiesResponseTest, SetVideoStreamingCapability_SUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::msg_params][strings::system_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  (*command_msg)[strings::msg_params][strings::system_capabilities]
+                [strings::video_streaming_capability] =
+                    smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  (*command_msg)[strings::msg_params][strings::system_capabilities]
+                [strings::video_streaming_capability]["preferredResolution"] =
+                    smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  (*command_msg)[strings::msg_params][strings::system_capabilities]
+                [strings::video_streaming_capability]["preferredResolution"]
+                ["resolutionWidth"] = 800;
+
+  (*command_msg)[strings::msg_params][strings::system_capabilities]
+                [strings::video_streaming_capability]["preferredResolution"]
+                ["resolutionWidth"] = 350;
+
+  (*command_msg)[strings::msg_params][strings::system_capabilities]
+                [strings::video_streaming_capability]["maxBitrate"] = 10000;
+
+  (*command_msg)[strings::msg_params][strings::system_capabilities]
+                [strings::video_streaming_capability]["supportedFormats"] =
+                    smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  (*command_msg)[strings::msg_params][strings::system_capabilities]
+                [strings::video_streaming_capability]["supportedFormats"][0] =
+                    smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  (*command_msg)[strings::msg_params][strings::system_capabilities]
+                [strings::video_streaming_capability]["supportedFormats"][0]
+                ["protocol"] = hmi_apis::Common_VideoStreamingProtocol::RAW;
+
+  (*command_msg)[strings::msg_params][strings::system_capabilities]
+                [strings::video_streaming_capability]["supportedFormats"][0]
+                ["codec"] = hmi_apis::Common_VideoStreamingCodec::H264;
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  smart_objects::SmartObject vs_capability_so =
+      (*command_msg)[strings::msg_params][strings::system_capabilities]
+                    [strings::video_streaming_capability];
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_video_streaming_capability(vs_capability_so));
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -299,35 +299,43 @@ TEST_F(UIGetCapabilitiesResponseTest, SetVideoStreamingCapability_SUCCESS) {
                     smart_objects::SmartObject(smart_objects::SmartType_Map);
 
   (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]["preferredResolution"] =
+                [strings::video_streaming_capability]
+                [strings::preferred_resolution] =
                     smart_objects::SmartObject(smart_objects::SmartType_Map);
 
   (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]["preferredResolution"]
-                ["resolutionWidth"] = 800;
+                [strings::video_streaming_capability]
+                [strings::preferred_resolution][strings::resolution_width] =
+                    800;
 
   (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]["preferredResolution"]
-                ["resolutionWidth"] = 350;
+                [strings::video_streaming_capability]
+                [strings::preferred_resolution][strings::resolution_width] =
+                    350;
 
   (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]["maxBitrate"] = 10000;
+                [strings::video_streaming_capability][strings::max_bitrate] =
+                    10000;
 
   (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]["supportedFormats"] =
+                [strings::video_streaming_capability]
+                [strings::supported_formats] =
                     smart_objects::SmartObject(smart_objects::SmartType_Array);
 
   (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]["supportedFormats"][0] =
+                [strings::video_streaming_capability]
+                [strings::supported_formats][0] =
                     smart_objects::SmartObject(smart_objects::SmartType_Map);
 
   (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]["supportedFormats"][0]
-                ["protocol"] = hmi_apis::Common_VideoStreamingProtocol::RAW;
+                [strings::video_streaming_capability]
+                [strings::supported_formats][0][strings::protocol] =
+                    hmi_apis::Common_VideoStreamingProtocol::RAW;
 
   (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::video_streaming_capability]["supportedFormats"][0]
-                ["codec"] = hmi_apis::Common_VideoStreamingCodec::H264;
+                [strings::video_streaming_capability]
+                [strings::supported_formats][0][strings::codec] =
+                    hmi_apis::Common_VideoStreamingCodec::H264;
 
   ResponseFromHMIPtr command(
       CreateCommand<UIGetCapabilitiesResponse>(command_msg));

--- a/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -310,7 +310,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetVideoStreamingCapability_SUCCESS) {
 
   (*command_msg)[strings::msg_params][strings::system_capabilities]
                 [strings::video_streaming_capability]
-                [strings::preferred_resolution][strings::resolution_width] =
+                [strings::preferred_resolution][strings::resolution_height] =
                     350;
 
   (*command_msg)[strings::msg_params][strings::system_capabilities]

--- a/src/components/application_manager/test/hmi_capabilities.json
+++ b/src/components/application_manager/test/hmi_capabilities.json
@@ -300,6 +300,21 @@
             },
             "phoneCapability": {
                 "dialNumberEnabled": true
+            },
+            "videoStreamingCapability": {
+                "preferredResolution": {
+                    "resolutionWidth": 800,
+                    "resolutionHeight": 350
+                },
+                "maxBitrate": 10000,
+                "supportedFormats": [{
+                    "protocol": "RAW",
+                    "codec": "H264"
+                },
+                {
+                    "protocol": "RTP",
+                    "codec": "Theora"
+                }]
             }
         }
     },

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -375,29 +375,44 @@ TEST_F(HMICapabilitiesTest, LoadCapabilitiesFromFile) {
   const smart_objects::SmartObject vs_capability_so =
       *(hmi_capabilities_test->video_streaming_capability());
 
-  EXPECT_TRUE(vs_capability_so.keyExists("preferredResolution"));
-  EXPECT_TRUE(
-      vs_capability_so["preferredResolution"].keyExists("resolutionWidth"));
-  EXPECT_TRUE(
-      vs_capability_so["preferredResolution"].keyExists("resolutionHeight"));
-  EXPECT_EQ(800,
-            vs_capability_so["preferredResolution"]["resolutionWidth"].asInt());
+  EXPECT_TRUE(vs_capability_so.keyExists(strings::preferred_resolution));
+  EXPECT_TRUE(vs_capability_so[strings::preferred_resolution].keyExists(
+      strings::resolution_width));
+  EXPECT_TRUE(vs_capability_so[strings::preferred_resolution].keyExists(
+      strings::resolution_height));
   EXPECT_EQ(
-      350, vs_capability_so["preferredResolution"]["resolutionHeight"].asInt());
-  EXPECT_TRUE(vs_capability_so.keyExists("maxBitrate"));
-  EXPECT_EQ(10000, vs_capability_so["maxBitrate"].asInt());
-  EXPECT_TRUE(vs_capability_so.keyExists("supportedFormats"));
+      800,
+      vs_capability_so[strings::preferred_resolution][strings::resolution_width]
+          .asInt());
+  EXPECT_EQ(350,
+            vs_capability_so[strings::preferred_resolution]
+                            [strings::resolution_height].asInt());
+  EXPECT_TRUE(vs_capability_so.keyExists(strings::max_bitrate));
+  EXPECT_EQ(10000, vs_capability_so[strings::max_bitrate].asInt());
+  EXPECT_TRUE(vs_capability_so.keyExists(strings::supported_formats));
   const uint32_t supported_formats_len =
-      vs_capability_so["supportedFormats"].length();
+      vs_capability_so[strings::supported_formats].length();
   EXPECT_EQ(2u, supported_formats_len);
-  EXPECT_TRUE(vs_capability_so["supportedFormats"][0].keyExists("protocol"));
-  EXPECT_TRUE(vs_capability_so["supportedFormats"][0].keyExists("codec"));
-  EXPECT_EQ(0, vs_capability_so["supportedFormats"][0]["protocol"].asInt());
-  EXPECT_EQ(0, vs_capability_so["supportedFormats"][0]["codec"].asInt());
-  EXPECT_TRUE(vs_capability_so["supportedFormats"][1].keyExists("protocol"));
-  EXPECT_TRUE(vs_capability_so["supportedFormats"][1].keyExists("codec"));
-  EXPECT_EQ(1, vs_capability_so["supportedFormats"][1]["protocol"].asInt());
-  EXPECT_EQ(2, vs_capability_so["supportedFormats"][1]["codec"].asInt());
+  EXPECT_TRUE(vs_capability_so[strings::supported_formats][0].keyExists(
+      strings::protocol));
+  EXPECT_TRUE(vs_capability_so[strings::supported_formats][0].keyExists(
+      strings::codec));
+  EXPECT_EQ(0,
+            vs_capability_so[strings::supported_formats][0][strings::protocol]
+                .asInt());
+  EXPECT_EQ(
+      0,
+      vs_capability_so[strings::supported_formats][0][strings::codec].asInt());
+  EXPECT_TRUE(vs_capability_so[strings::supported_formats][1].keyExists(
+      strings::protocol));
+  EXPECT_TRUE(vs_capability_so[strings::supported_formats][1].keyExists(
+      strings::codec));
+  EXPECT_EQ(1,
+            vs_capability_so[strings::supported_formats][1][strings::protocol]
+                .asInt());
+  EXPECT_EQ(
+      2,
+      vs_capability_so[strings::supported_formats][1][strings::codec].asInt());
 }
 
 TEST_F(HMICapabilitiesTest, VerifyImageType) {

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -371,6 +371,33 @@ TEST_F(HMICapabilitiesTest, LoadCapabilitiesFromFile) {
 
   EXPECT_TRUE(phone_capability_so.keyExists("dialNumberEnabled"));
   EXPECT_TRUE(phone_capability_so["dialNumberEnabled"].asBool());
+
+  const smart_objects::SmartObject vs_capability_so =
+      *(hmi_capabilities_test->video_streaming_capability());
+
+  EXPECT_TRUE(vs_capability_so.keyExists("preferredResolution"));
+  EXPECT_TRUE(
+      vs_capability_so["preferredResolution"].keyExists("resolutionWidth"));
+  EXPECT_TRUE(
+      vs_capability_so["preferredResolution"].keyExists("resolutionHeight"));
+  EXPECT_EQ(800,
+            vs_capability_so["preferredResolution"]["resolutionWidth"].asInt());
+  EXPECT_EQ(
+      350, vs_capability_so["preferredResolution"]["resolutionHeight"].asInt());
+  EXPECT_TRUE(vs_capability_so.keyExists("maxBitrate"));
+  EXPECT_EQ(10000, vs_capability_so["maxBitrate"].asInt());
+  EXPECT_TRUE(vs_capability_so.keyExists("supportedFormats"));
+  const uint32_t supported_formats_len =
+      vs_capability_so["supportedFormats"].length();
+  EXPECT_EQ(2u, supported_formats_len);
+  EXPECT_TRUE(vs_capability_so["supportedFormats"][0].keyExists("protocol"));
+  EXPECT_TRUE(vs_capability_so["supportedFormats"][0].keyExists("codec"));
+  EXPECT_EQ(0, vs_capability_so["supportedFormats"][0]["protocol"].asInt());
+  EXPECT_EQ(0, vs_capability_so["supportedFormats"][0]["codec"].asInt());
+  EXPECT_TRUE(vs_capability_so["supportedFormats"][1].keyExists("protocol"));
+  EXPECT_TRUE(vs_capability_so["supportedFormats"][1].keyExists("codec"));
+  EXPECT_EQ(1, vs_capability_so["supportedFormats"][1]["protocol"].asInt());
+  EXPECT_EQ(2, vs_capability_so["supportedFormats"][1]["codec"].asInt());
 }
 
 TEST_F(HMICapabilitiesTest, VerifyImageType) {

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -73,8 +73,6 @@ class MockApplication : public ::application_manager::Application {
   MOCK_METHOD2(SetVideoConfig,
                bool(protocol_handler::ServiceType service_type,
                     const smart_objects::SmartObject& params));
-  MOCK_METHOD2(OnNaviSetVideoConfigDone,
-               void(bool result, std::vector<std::string>& rejected_params));
   MOCK_METHOD1(StartStreaming,
                void(protocol_handler::ServiceType service_type));
   MOCK_METHOD1(StopStreaming, void(protocol_handler::ServiceType service_type));

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -70,6 +70,11 @@ class MockApplication : public ::application_manager::Application {
   MOCK_CONST_METHOD0(audio_streaming_allowed, bool());
   MOCK_METHOD1(set_audio_streaming_allowed, void(bool state));
   MOCK_CONST_METHOD0(is_audio, bool());
+  MOCK_METHOD2(SetVideoConfig,
+               bool(protocol_handler::ServiceType service_type,
+                    const smart_objects::SmartObject& params));
+  MOCK_METHOD2(OnNaviSetVideoConfigDone,
+               void(bool result, std::vector<std::string>& rejected_params));
   MOCK_METHOD1(StartStreaming,
                void(protocol_handler::ServiceType service_type));
   MOCK_METHOD1(StopStreaming, void(protocol_handler::ServiceType service_type));

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -154,6 +154,9 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
   MOCK_CONST_METHOD0(phone_call_supported, bool());
   MOCK_METHOD1(set_phone_call_supported, void(const bool supported));
 
+  MOCK_CONST_METHOD0(video_streaming_supported, bool());
+  MOCK_METHOD1(set_video_streaming_supported, void(const bool supported));
+
   MOCK_CONST_METHOD0(navigation_capability,
                      const smart_objects::SmartObject*());
   MOCK_METHOD1(set_navigation_capability,
@@ -162,6 +165,12 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
   MOCK_CONST_METHOD0(phone_capability, const smart_objects::SmartObject*());
   MOCK_METHOD1(set_phone_capability,
                void(const smart_objects::SmartObject& phone_capability));
+
+  MOCK_CONST_METHOD0(video_streaming_capability,
+                     const smart_objects::SmartObject*());
+  MOCK_METHOD1(
+      set_video_streaming_capability,
+      void(const smart_objects::SmartObject& video_streaming_capability));
 
   MOCK_METHOD1(Init, void(resumption::LastState* last_state));
 

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -70,6 +70,10 @@ class MockMessageHelper {
                    const connection_handler::DeviceMap& devices,
                    const policy::PolicyHandlerInterface& policy_handler,
                    ApplicationManager& app_mngr));
+  MOCK_METHOD3(SendNaviSetVideoConfig,
+               void(int32_t app_id,
+                    ApplicationManager& app_mngr,
+                    const smart_objects::SmartObject& video_params));
   MOCK_METHOD2(SendNaviStartStream,
                void(int32_t connection_key, ApplicationManager& app_mngr));
   MOCK_METHOD2(SendNaviStopStream,

--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -1034,10 +1034,11 @@ TEST_F(MessageHelperTest, SendNaviSetVideoConfigRequest) {
 
   int32_t app_id = 123;
   smart_objects::SmartObject video_params(smart_objects::SmartType_Map);
-  video_params["protocol"] = hmi_apis::Common_VideoStreamingProtocol::RTP;
-  video_params["codec"] = hmi_apis::Common_VideoStreamingCodec::H264;
-  video_params["width"] = 640;
-  video_params["height"] = 480;
+  video_params[strings::protocol] =
+      hmi_apis::Common_VideoStreamingProtocol::RTP;
+  video_params[strings::codec] = hmi_apis::Common_VideoStreamingCodec::H264;
+  video_params[strings::width] = 640;
+  video_params[strings::height] = 480;
 
   MessageHelper::SendNaviSetVideoConfig(
       app_id, mock_application_manager, video_params);
@@ -1046,16 +1047,16 @@ TEST_F(MessageHelperTest, SendNaviSetVideoConfigRequest) {
             (*result)[strings::params][strings::function_id].asInt());
 
   smart_objects::SmartObject& msg_params = (*result)[strings::msg_params];
-  EXPECT_TRUE(msg_params.keyExists("config"));
+  EXPECT_TRUE(msg_params.keyExists(strings::config));
 
-  EXPECT_TRUE(msg_params["config"].keyExists("protocol"));
-  EXPECT_EQ(1, msg_params["config"]["protocol"].asInt());
-  EXPECT_TRUE(msg_params["config"].keyExists("codec"));
-  EXPECT_EQ(0, msg_params["config"]["codec"].asInt());
-  EXPECT_TRUE(msg_params["config"].keyExists("width"));
-  EXPECT_EQ(640, msg_params["config"]["width"].asInt());
-  EXPECT_TRUE(msg_params["config"].keyExists("height"));
-  EXPECT_EQ(480, msg_params["config"]["height"].asInt());
+  EXPECT_TRUE(msg_params[strings::config].keyExists(strings::protocol));
+  EXPECT_EQ(1, msg_params[strings::config][strings::protocol].asInt());
+  EXPECT_TRUE(msg_params[strings::config].keyExists(strings::codec));
+  EXPECT_EQ(0, msg_params[strings::config][strings::codec].asInt());
+  EXPECT_TRUE(msg_params[strings::config].keyExists(strings::width));
+  EXPECT_EQ(640, msg_params[strings::config][strings::width].asInt());
+  EXPECT_TRUE(msg_params[strings::config].keyExists(strings::height));
+  EXPECT_EQ(480, msg_params[strings::config][strings::height].asInt());
 }
 
 }  // namespace application_manager_test

--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -1026,6 +1026,38 @@ TEST_F(MessageHelperTest,
               std::find(status_array->begin(), status_array->end(), item_2_so));
 }
 #endif
+
+TEST_F(MessageHelperTest, SendNaviSetVideoConfigRequest) {
+  smart_objects::SmartObjectSPtr result;
+  EXPECT_CALL(mock_application_manager, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
+
+  int32_t app_id = 123;
+  smart_objects::SmartObject video_params(smart_objects::SmartType_Map);
+  video_params["protocol"] = hmi_apis::Common_VideoStreamingProtocol::RTP;
+  video_params["codec"] = hmi_apis::Common_VideoStreamingCodec::H264;
+  video_params["width"] = 640;
+  video_params["height"] = 480;
+
+  MessageHelper::SendNaviSetVideoConfig(
+      app_id, mock_application_manager, video_params);
+
+  EXPECT_EQ(hmi_apis::FunctionID::Navigation_SetVideoConfig,
+            (*result)[strings::params][strings::function_id].asInt());
+
+  smart_objects::SmartObject& msg_params = (*result)[strings::msg_params];
+  EXPECT_TRUE(msg_params.keyExists("config"));
+
+  EXPECT_TRUE(msg_params["config"].keyExists("protocol"));
+  EXPECT_EQ(1, msg_params["config"]["protocol"].asInt());
+  EXPECT_TRUE(msg_params["config"].keyExists("codec"));
+  EXPECT_EQ(0, msg_params["config"]["codec"].asInt());
+  EXPECT_TRUE(msg_params["config"].keyExists("width"));
+  EXPECT_EQ(640, msg_params["config"]["width"].asInt());
+  EXPECT_TRUE(msg_params["config"].keyExists("height"));
+  EXPECT_EQ(480, msg_params["config"]["height"].asInt());
+}
+
 }  // namespace application_manager_test
 }  // namespace components
 }  // namespace test

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -41,6 +41,13 @@ void MessageHelper::SendHashUpdateNotification(uint32_t const app_id,
   MockMessageHelper::message_helper_mock()->SendHashUpdateNotification(
       app_id, app_mngr);
 }
+void MessageHelper::SendNaviSetVideoConfig(
+    int32_t app_id,
+    ApplicationManager& app_mngr,
+    const smart_objects::SmartObject& video_params) {
+  MockMessageHelper::message_helper_mock()->SendNaviSetVideoConfig(
+      app_id, app_mngr, video_params);
+}
 void MessageHelper::SendNaviStartStream(int32_t connection_key,
                                         ApplicationManager& app_mngr) {
   MockMessageHelper::message_helper_mock()->SendNaviStartStream(connection_key,

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -536,9 +536,15 @@ class ConnectionHandlerImpl
   /**
    * \brief Convenient method to call NotifySessionStartedResult() with
    * negative result.
+   * \param connection_handle Identifier of connection within which session
+   * exists
+   * \param session_id session ID passed to OnSessionStartedCallback()
    * \param is_protected whether the service would be protected
    **/
-  void NotifySessionStartedFailure(bool is_protected);
+  void NotifySessionStartedFailure(
+      const transport_manager::ConnectionUID connection_handle,
+      const uint8_t session_id,
+      bool is_protected);
 
   const ConnectionHandlerSettings& settings_;
   /**

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -175,6 +175,25 @@ class ConnectionHandlerImpl
   /**
    * \brief Callback function used by ProtocolHandler
    * when Mobile Application initiates start of new session.
+   * \param connection_handle Connection identifier within which session has to
+   * be started.
+   * \param session_id Identifier of the session to be started
+   * \param service_type Type of service
+   * \param is_protected would be service protected
+   * \param hash_id pointer for session hash identifier
+   * \return uint32_t Id (number) of new session if successful, otherwise 0.
+   */
+  // DEPRECATED
+  virtual uint32_t OnSessionStartedCallback(
+      const transport_manager::ConnectionUID connection_handle,
+      const uint8_t session_id,
+      const protocol_handler::ServiceType& service_type,
+      const bool is_protected,
+      uint32_t* hash_id);
+
+  /**
+   * \brief Callback function used by ProtocolHandler
+   * when Mobile Application initiates start of new session.
    * Result must be notified through NotifySessionStartedResult().
    * \param connection_handle Connection identifier within which session
    * has to be started.

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -464,6 +464,8 @@ class ConnectionHandlerImpl
 
   /**
    * \brief Invoked when observer's OnServiceStartedCallback is completed
+   * \param session_key the key of started session passed to
+   * OnServiceStartedCallback().
    * \param result true if observer accepts starting service, false otherwise
    * \param rejected_params list of rejected parameters' name. Only valid when
    * result is false. Note that even if result is false, this may be empty.
@@ -472,7 +474,9 @@ class ConnectionHandlerImpl
    * Also it can be invoked before OnServiceStartedCallback() returns.
    **/
   virtual void NotifyServiceStartedResult(
-      bool result, std::vector<std::string>& rejected_params);
+      uint32_t session_key,
+      bool result,
+      std::vector<std::string>& rejected_params);
 
  private:
   /**
@@ -580,8 +584,8 @@ class ConnectionHandlerImpl
    */
   utils::StlMapDeleter<ConnectionList> connection_list_deleter_;
 
-  // we need thread-safe queue
-  utils::MessageQueue<ServiceStartedContext> start_service_context_queue_;
+  sync_primitives::Lock start_service_context_map_lock_;
+  std::map<uint32_t, ServiceStartedContext> start_service_context_map_;
 
 #ifdef BUILD_TESTS
   // Methods for test usage

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -49,6 +49,7 @@
 
 #include "utils/logger.h"
 #include "utils/macro.h"
+#include "utils/message_queue.h"
 #include "utils/lock.h"
 #include "utils/stl_utils.h"
 #include "utils/rwlock.h"
@@ -174,20 +175,21 @@ class ConnectionHandlerImpl
   /**
    * \brief Callback function used by ProtocolHandler
    * when Mobile Application initiates start of new session.
-   * \param connection_handle Connection identifier within which session has to
-   * be started.
-   * \param session_id Identifier of the session to be started
+   * Result must be notified through NotifySessionStartedResult().
+   * \param connection_handle Connection identifier within which session
+   * has to be started.
+   * \param sessionId Identifier of the session to be start
    * \param service_type Type of service
+   * \param protocol_version Version of protocol
    * \param is_protected would be service protected
-   * \param hash_id pointer for session hash identifier
-   * \return uint32_t Id (number) of new session if successful, otherwise 0.
+   * \param params configuration parameters specified by mobile
    */
-  virtual uint32_t OnSessionStartedCallback(
+  virtual void OnSessionStartedCallback(
       const transport_manager::ConnectionUID connection_handle,
       const uint8_t session_id,
       const protocol_handler::ServiceType& service_type,
       const bool is_protected,
-      uint32_t* hash_id);
+      const BsonObject* params);
 
   // DEPRECATED
   uint32_t OnSessionEndedCallback(
@@ -441,7 +443,67 @@ class ConnectionHandlerImpl
   const protocol_handler::SessionObserver& get_session_observer();
   DevicesDiscoveryStarter& get_device_discovery_starter();
 
+  /**
+   * \brief Invoked when observer's OnServiceStartedCallback is completed
+   * \param result true if observer accepts starting service, false otherwise
+   * \param rejected_params list of rejected parameters' name. Only valid when
+   * result is false. Note that even if result is false, this may be empty.
+   *
+   * \note This is invoked only once but can be invoked by multiple threads.
+   * Also it can be invoked before OnServiceStartedCallback() returns.
+   **/
+  virtual void NotifyServiceStartedResult(
+      bool result, std::vector<std::string>& rejected_params);
+
  private:
+  /**
+   * \brief Struct to keep variables between OnSessionStartedCallback() and
+   * NotifyServiceStartedResult()
+   **/
+  struct ServiceStartedContext {
+    transport_manager::ConnectionUID connection_handle_;
+    uint8_t session_id_;
+    uint32_t new_session_id_;
+    protocol_handler::ServiceType service_type_;
+    uint32_t hash_id_;
+    bool is_protected_;
+
+    /**
+     * \brief Constructor
+     */
+    ServiceStartedContext()
+        : connection_handle_(0)
+        , session_id_(0)
+        , new_session_id_(0)
+        , service_type_(protocol_handler::kInvalidServiceType)
+        , hash_id_(0)
+        , is_protected_(0) {}
+
+    /**
+     * \brief Constructor
+     * \param connection_handle Connection identifier within which session is
+     * started.
+     * \param session_id Session ID specified to OnSessionStartedCallback()
+     * \param new_session_id Session ID generated
+     * \param service_type Type of service
+     * \param hash_id Hash ID generated from connection_handle and
+     * new_session_id
+     * \param is_protected Whether service will be protected
+     **/
+    ServiceStartedContext(transport_manager::ConnectionUID connection_handle,
+                          uint8_t session_id,
+                          uint32_t new_session_id,
+                          protocol_handler::ServiceType service_type,
+                          uint32_t hash_id,
+                          bool is_protected)
+        : connection_handle_(connection_handle)
+        , session_id_(session_id)
+        , new_session_id_(new_session_id)
+        , service_type_(service_type)
+        , hash_id_(hash_id)
+        , is_protected_(is_protected) {}
+  };
+
   /**
    * \brief Disconnect application.
    *
@@ -451,6 +513,13 @@ class ConnectionHandlerImpl
   void RemoveConnection(const ConnectionHandle connection_handle);
 
   void OnConnectionEnded(const transport_manager::ConnectionUID connection_id);
+
+  /**
+   * \brief Convenient method to call NotifySessionStartedResult() with
+   * negative result.
+   * \param is_protected whether the service would be protected
+   **/
+  void NotifySessionStartedFailure(bool is_protected);
 
   const ConnectionHandlerSettings& settings_;
   /**
@@ -485,6 +554,9 @@ class ConnectionHandlerImpl
    * \brief Cleans connection list on destruction
    */
   utils::StlMapDeleter<ConnectionList> connection_list_deleter_;
+
+  // we need thread-safe queue
+  utils::MessageQueue<ServiceStartedContext> start_service_context_queue_;
 
 #ifdef BUILD_TESTS
   // Methods for test usage

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -280,6 +280,76 @@ bool AllowProtection(const ConnectionHandlerSettings& settings,
 }
 #endif  // ENABLE_SECURITY
 
+// DEPRECATED
+uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
+    const transport_manager::ConnectionUID connection_handle,
+    const uint8_t session_id,
+    const protocol_handler::ServiceType& service_type,
+    const bool is_protected,
+    uint32_t* hash_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (hash_id) {
+    *hash_id = protocol_handler::HASH_ID_WRONG;
+  }
+#ifdef ENABLE_SECURITY
+  if (!AllowProtection(get_settings(), service_type, is_protected)) {
+    return 0;
+  }
+#endif  // ENABLE_SECURITY
+  sync_primitives::AutoReadLock lock(connection_list_lock_);
+  ConnectionList::iterator it = connection_list_.find(connection_handle);
+  if (connection_list_.end() == it) {
+    LOG4CXX_ERROR(logger_, "Unknown connection!");
+    return 0;
+  }
+  uint32_t new_session_id = 0;
+
+  Connection* connection = it->second;
+  if ((0 == session_id) && (protocol_handler::kRpc == service_type)) {
+    new_session_id = connection->AddNewSession();
+    if (0 == new_session_id) {
+      LOG4CXX_ERROR(logger_, "Couldn't start new session!");
+      return 0;
+    }
+    if (hash_id) {
+      *hash_id = KeyFromPair(connection_handle, new_session_id);
+    }
+  } else {  // Could be create new service or protected exists one
+    if (!connection->AddNewService(session_id, service_type, is_protected)) {
+      LOG4CXX_ERROR(logger_,
+                    "Couldn't establish "
+#ifdef ENABLE_SECURITY
+                        << (is_protected ? "protected" : "non-protected")
+#endif  // ENABLE_SECURITY
+                        << " service " << static_cast<int>(service_type)
+                        << " for session " << static_cast<int>(session_id));
+      return 0;
+    }
+    new_session_id = session_id;
+    if (hash_id) {
+      *hash_id = protocol_handler::HASH_ID_NOT_SUPPORTED;
+    }
+  }
+  sync_primitives::AutoReadLock read_lock(connection_handler_observer_lock_);
+  if (connection_handler_observer_) {
+    const uint32_t session_key = KeyFromPair(connection_handle, new_session_id);
+    const bool success = connection_handler_observer_->OnServiceStartedCallback(
+        connection->connection_device_handle(), session_key, service_type);
+    if (!success) {
+      LOG4CXX_WARN(logger_,
+                   "Service starting forbidden by connection_handler_observer");
+      if (protocol_handler::kRpc == service_type) {
+        connection->RemoveSession(new_session_id);
+      } else {
+        connection->RemoveService(session_id, service_type);
+      }
+      return 0;
+    }
+  }
+  return new_session_id;
+}
+
 void ConnectionHandlerImpl::OnSessionStartedCallback(
     const transport_manager::ConnectionUID connection_handle,
     const uint8_t session_id,

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -62,9 +62,9 @@ using ::testing::Return;
 using ::testing::ReturnRefOfCopy;
 using ::testing::SaveArg;
 
-// custom action to call a member function with 4 arguments
-ACTION_P4(InvokeMemberFuncWithArg2, ptr, memberFunc, a, b) {
-  (ptr->*memberFunc)(a, b);
+// custom action to call a member function with 3 arguments
+ACTION_P5(InvokeMemberFuncWithArg3, ptr, memberFunc, a, b, c) {
+  (ptr->*memberFunc)(a, b, c);
 }
 
 namespace {
@@ -1210,9 +1210,10 @@ TEST_F(ConnectionHandlerTest, SessionStarted_WithRpc) {
   std::vector<std::string> empty;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceStartedCallback(device_handle_, session_key, kRpc, NULL))
-      .WillOnce(InvokeMemberFuncWithArg2(
+      .WillOnce(InvokeMemberFuncWithArg3(
           connection_handler_,
           &ConnectionHandler::NotifyServiceStartedResult,
+          session_key,
           true,
           ByRef(empty)));
 
@@ -1246,9 +1247,10 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_SUCCESS) {
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceStartedCallback(
                   device_handle_, session_key, kMobileNav, dummy_params))
-      .WillOnce(InvokeMemberFuncWithArg2(
+      .WillOnce(InvokeMemberFuncWithArg3(
           connection_handler_,
           &ConnectionHandler::NotifyServiceStartedResult,
+          session_key,
           true,
           ByRef(empty)));
 
@@ -1282,9 +1284,10 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_FAILURE) {
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceStartedCallback(
                   device_handle_, session_key, kMobileNav, dummy_params))
-      .WillOnce(InvokeMemberFuncWithArg2(
+      .WillOnce(InvokeMemberFuncWithArg3(
           connection_handler_,
           &ConnectionHandler::NotifyServiceStartedResult,
+          session_key,
           false,
           ByRef(empty)));
 

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -118,9 +118,10 @@ class ConnectionHandlerTest : public ::testing::Test {
   void AddTestSession() {
     protocol_handler_test::MockProtocolHandler temp_protocol_handler;
     connection_handler_->set_protocol_handler(&temp_protocol_handler);
-    EXPECT_CALL(temp_protocol_handler, NotifySessionStartedResult(_, _, _, _))
+    EXPECT_CALL(temp_protocol_handler,
+                NotifySessionStartedResult(_, _, _, _, _, _))
         .WillOnce(
-            DoAll(SaveArg<0>(&start_session_id_), SaveArg<1>(&out_hash_id_)));
+            DoAll(SaveArg<2>(&start_session_id_), SaveArg<3>(&out_hash_id_)));
 
     connection_handler_->OnSessionStartedCallback(
         uid_, 0, kRpc, PROTECTION_OFF, static_cast<BsonObject*>(NULL));
@@ -142,8 +143,9 @@ class ConnectionHandlerTest : public ::testing::Test {
     uint32_t session_id = 0;
     protocol_handler_test::MockProtocolHandler temp_protocol_handler;
     connection_handler_->set_protocol_handler(&temp_protocol_handler);
-    EXPECT_CALL(temp_protocol_handler, NotifySessionStartedResult(_, _, _, _))
-        .WillOnce(SaveArg<0>(&session_id));
+    EXPECT_CALL(temp_protocol_handler,
+                NotifySessionStartedResult(_, _, _, _, _, _))
+        .WillOnce(SaveArg<2>(&session_id));
 
     connection_handler_->OnSessionStartedCallback(uid_,
                                                   start_session_id_,
@@ -295,8 +297,9 @@ TEST_F(ConnectionHandlerTest, StartSession_NoConnection) {
   // Start new session with RPC service
   uint32_t result_fail = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
-      .WillOnce(DoAll(SaveArg<0>(&result_fail), SaveArg<1>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_,
+              NotifySessionStartedResult(_, _, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<2>(&result_fail), SaveArg<3>(&out_hash_id_)));
 
   connection_handler_->OnSessionStartedCallback(
       uid_, sessionID, kRpc, PROTECTION_ON, static_cast<BsonObject*>(NULL));
@@ -1047,9 +1050,10 @@ TEST_F(ConnectionHandlerTest, StartService_withServices) {
   uint32_t start_audio = 0;
   uint32_t start_video = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
-      .WillOnce(DoAll(SaveArg<0>(&start_audio), SaveArg<1>(&out_hash_id_)))
-      .WillOnce(DoAll(SaveArg<0>(&start_video), SaveArg<1>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_,
+              NotifySessionStartedResult(_, _, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<2>(&start_audio), SaveArg<3>(&out_hash_id_)))
+      .WillOnce(DoAll(SaveArg<2>(&start_video), SaveArg<3>(&out_hash_id_)));
 
   // Start Audio service
   connection_handler_->OnSessionStartedCallback(uid_,
@@ -1085,8 +1089,8 @@ TEST_F(ConnectionHandlerTest, StartService_withServices_withParams) {
   BsonObject* dummy_param = reinterpret_cast<BsonObject*>(&dummy);
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
   EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, empty))
-      .WillOnce(DoAll(SaveArg<0>(&start_video), SaveArg<1>(&out_hash_id_)));
+              NotifySessionStartedResult(_, _, _, _, _, empty))
+      .WillOnce(DoAll(SaveArg<2>(&start_video), SaveArg<3>(&out_hash_id_)));
 
   connection_handler_->OnSessionStartedCallback(
       uid_, start_session_id_, kMobileNav, PROTECTION_OFF, dummy_param);
@@ -1124,9 +1128,10 @@ TEST_F(ConnectionHandlerTest, ServiceStop) {
 
   uint32_t start_audio = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
+  EXPECT_CALL(mock_protocol_handler_,
+              NotifySessionStartedResult(_, _, _, _, _, _))
       .WillRepeatedly(
-          DoAll(SaveArg<0>(&start_audio), SaveArg<1>(&out_hash_id_)));
+          DoAll(SaveArg<2>(&start_audio), SaveArg<3>(&out_hash_id_)));
 
   // Check ignoring hash_id on stop non-rpc service
   for (uint32_t some_hash_id = 0; some_hash_id < 0xFF; ++some_hash_id) {
@@ -1213,8 +1218,9 @@ TEST_F(ConnectionHandlerTest, SessionStarted_WithRpc) {
 
   uint32_t new_session_id = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
-      .WillOnce(DoAll(SaveArg<0>(&new_session_id), SaveArg<1>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_,
+              NotifySessionStartedResult(_, _, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<2>(&new_session_id), SaveArg<3>(&out_hash_id_)));
 
   // Start new session with RPC service
   connection_handler_->OnSessionStartedCallback(
@@ -1250,8 +1256,8 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_SUCCESS) {
   uint32_t new_session_id = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
   EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, false, empty))
-      .WillOnce(DoAll(SaveArg<0>(&new_session_id), SaveArg<1>(&out_hash_id_)));
+              NotifySessionStartedResult(_, _, _, _, false, empty))
+      .WillOnce(DoAll(SaveArg<2>(&new_session_id), SaveArg<3>(&out_hash_id_)));
 
   connection_handler_->OnSessionStartedCallback(
       uid_, start_session_id_, kMobileNav, PROTECTION_OFF, dummy_params);
@@ -1286,8 +1292,8 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_FAILURE) {
   uint32_t new_session_id = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
   EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, false, empty))
-      .WillOnce(DoAll(SaveArg<0>(&new_session_id), SaveArg<1>(&out_hash_id_)));
+              NotifySessionStartedResult(_, _, _, _, false, empty))
+      .WillOnce(DoAll(SaveArg<2>(&new_session_id), SaveArg<3>(&out_hash_id_)));
 
   connection_handler_->OnSessionStartedCallback(
       uid_, start_session_id_, kMobileNav, PROTECTION_OFF, dummy_params);
@@ -1308,9 +1314,10 @@ TEST_F(ConnectionHandlerTest,
   uint32_t session_id_fail = 0;
   uint32_t session_id = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
-      .WillOnce(DoAll(SaveArg<0>(&session_id_fail), SaveArg<1>(&out_hash_id_)))
-      .WillOnce(DoAll(SaveArg<0>(&session_id), SaveArg<1>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_,
+              NotifySessionStartedResult(_, _, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<2>(&session_id_fail), SaveArg<3>(&out_hash_id_)))
+      .WillOnce(DoAll(SaveArg<2>(&session_id), SaveArg<3>(&out_hash_id_)));
 
   // Start new session with RPC service
   connection_handler_->OnSessionStartedCallback(
@@ -1349,9 +1356,10 @@ TEST_F(ConnectionHandlerTest,
   uint32_t session_id_fail = 0;
   uint32_t session_id = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
-      .WillOnce(SaveArg<0>(&session_id_fail))
-      .WillOnce(DoAll(SaveArg<0>(&session_id), SaveArg<1>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_,
+              NotifySessionStartedResult(_, _, _, _, _, _))
+      .WillOnce(SaveArg<2>(&session_id_fail))
+      .WillOnce(DoAll(SaveArg<2>(&session_id), SaveArg<3>(&out_hash_id_)));
 
   // Start new session with RPC service
   connection_handler_->OnSessionStartedCallback(
@@ -1391,9 +1399,10 @@ TEST_F(ConnectionHandlerTest,
   uint32_t session_id2 = 0;
   uint32_t session_id3 = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
-      .WillOnce(SaveArg<0>(&session_id2))
-      .WillOnce(DoAll(SaveArg<0>(&session_id3), SaveArg<1>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_,
+              NotifySessionStartedResult(_, _, _, _, _, _))
+      .WillOnce(SaveArg<2>(&session_id2))
+      .WillOnce(DoAll(SaveArg<2>(&session_id3), SaveArg<3>(&out_hash_id_)));
 
   // Start new session with Audio service
   connection_handler_->OnSessionStartedCallback(uid_,
@@ -1444,9 +1453,10 @@ TEST_F(ConnectionHandlerTest,
   uint32_t session_id_reject = 0;
   uint32_t session_id3 = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
-      .WillOnce(SaveArg<0>(&session_id_reject))
-      .WillOnce(DoAll(SaveArg<0>(&session_id3), SaveArg<1>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_,
+              NotifySessionStartedResult(_, _, _, _, _, _))
+      .WillOnce(SaveArg<2>(&session_id_reject))
+      .WillOnce(DoAll(SaveArg<2>(&session_id3), SaveArg<3>(&out_hash_id_)));
 
   // Start new session with Audio service
   connection_handler_->OnSessionStartedCallback(uid_,
@@ -1487,10 +1497,11 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtect) {
   uint32_t session_id2 = 0;
   uint32_t session_id3 = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
-      .WillOnce(DoAll(SaveArg<0>(&session_id_new), SaveArg<1>(&out_hash_id_)))
-      .WillOnce(DoAll(SaveArg<0>(&session_id2), SaveArg<1>(&out_hash_id_)))
-      .WillOnce(DoAll(SaveArg<0>(&session_id3), SaveArg<1>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_,
+              NotifySessionStartedResult(_, _, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<2>(&session_id_new), SaveArg<3>(&out_hash_id_)))
+      .WillOnce(DoAll(SaveArg<2>(&session_id2), SaveArg<3>(&out_hash_id_)))
+      .WillOnce(DoAll(SaveArg<2>(&session_id3), SaveArg<3>(&out_hash_id_)));
 
   // Start RPC protection
   connection_handler_->OnSessionStartedCallback(uid_,
@@ -1543,8 +1554,9 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtectBulk) {
 
   uint32_t session_id_new = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
-      .WillOnce(SaveArg<0>(&session_id_new));
+  EXPECT_CALL(mock_protocol_handler_,
+              NotifySessionStartedResult(_, _, _, _, _, _))
+      .WillOnce(SaveArg<2>(&session_id_new));
   connection_handler_->OnSessionStartedCallback(uid_,
                                                 start_session_id_,
                                                 kBulk,
@@ -1647,8 +1659,9 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByProtectedService) {
 
   uint32_t session_id = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
-      .WillOnce(SaveArg<0>(&session_id));
+  EXPECT_CALL(mock_protocol_handler_,
+              NotifySessionStartedResult(_, _, _, _, _, _))
+      .WillOnce(SaveArg<2>(&session_id));
 
   // Open kAudio service
   connection_handler_->OnSessionStartedCallback(uid_,
@@ -1680,8 +1693,9 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedRPC) {
 
   uint32_t session_id = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
-      .WillOnce(SaveArg<0>(&session_id));
+  EXPECT_CALL(mock_protocol_handler_,
+              NotifySessionStartedResult(_, _, _, _, _, _))
+      .WillOnce(SaveArg<2>(&session_id));
 
   // Protect kRpc (Bulk will be protect also)
   connection_handler_->OnSessionStartedCallback(uid_,
@@ -1716,8 +1730,9 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedBulk) {
 
   uint32_t session_id = 0;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
-      .WillOnce(SaveArg<0>(&session_id));
+  EXPECT_CALL(mock_protocol_handler_,
+              NotifySessionStartedResult(_, _, _, _, _, _))
+      .WillOnce(SaveArg<2>(&session_id));
 
   // Protect Bulk (kRpc will be protected also)
   connection_handler_->OnSessionStartedCallback(uid_,

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -54,10 +54,18 @@ using namespace ::connection_handler;
 using ::protocol_handler::ServiceType;
 using namespace ::protocol_handler;
 using ::testing::_;
+using ::testing::ByRef;
+using ::testing::DoAll;
 using ::testing::InSequence;
 using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRefOfCopy;
+using ::testing::SaveArg;
+
+// custom action to call a member function with 4 arguments
+ACTION_P4(InvokeMemberFuncWithArg2, ptr, memberFunc, a, b) {
+  (ptr->*memberFunc)(a, b);
+}
 
 namespace {
 const uint32_t kAsyncExpectationsTimeout = 10000u;
@@ -108,8 +116,15 @@ class ConnectionHandlerTest : public ::testing::Test {
     // Remove all specific services
   }
   void AddTestSession() {
-    start_session_id_ = connection_handler_->OnSessionStartedCallback(
-        uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_);
+    protocol_handler_test::MockProtocolHandler temp_protocol_handler;
+    connection_handler_->set_protocol_handler(&temp_protocol_handler);
+    EXPECT_CALL(temp_protocol_handler, NotifySessionStartedResult(_, _, _, _))
+        .WillOnce(
+            DoAll(SaveArg<0>(&start_session_id_), SaveArg<1>(&out_hash_id_)));
+
+    connection_handler_->OnSessionStartedCallback(
+        uid_, 0, kRpc, PROTECTION_OFF, NULL);
+    connection_handler_->set_protocol_handler(NULL);
     EXPECT_NE(0u, start_session_id_);
     EXPECT_EQ(SessionHash(uid_, start_session_id_), out_hash_id_);
     connection_key_ = connection_handler_->KeyFromPair(uid_, start_session_id_);
@@ -123,8 +138,16 @@ class ConnectionHandlerTest : public ::testing::Test {
     EXPECT_EQ(SessionHash(uid_, start_session_id_), out_hash_id_);
     connection_key_ = connection_handler_->KeyFromPair(uid_, start_session_id_);
     CheckSessionExists(uid_, start_session_id_);
-    uint32_t session_id = connection_handler_->OnSessionStartedCallback(
+
+    uint32_t session_id = 0;
+    protocol_handler_test::MockProtocolHandler temp_protocol_handler;
+    connection_handler_->set_protocol_handler(&temp_protocol_handler);
+    EXPECT_CALL(temp_protocol_handler, NotifySessionStartedResult(_, _, _, _))
+        .WillOnce(SaveArg<0>(&session_id));
+
+    connection_handler_->OnSessionStartedCallback(
         uid_, start_session_id_, service_type, PROTECTION_OFF, 0);
+    connection_handler_->set_protocol_handler(NULL);
     EXPECT_EQ(session_id, start_session_id_);
   }
 
@@ -267,8 +290,13 @@ TEST_F(ConnectionHandlerTest, StartSession_NoConnection) {
   // Null sessionId for start new session
   const uint8_t sessionID = 0;
   // Start new session with RPC service
-  const uint32_t result_fail = connection_handler_->OnSessionStartedCallback(
-      uid_, sessionID, kRpc, PROTECTION_ON, &out_hash_id_);
+  uint32_t result_fail = 0;
+  connection_handler_->set_protocol_handler(&mock_protocol_handler_);
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
+      .WillOnce(DoAll(SaveArg<0>(&result_fail), SaveArg<1>(&out_hash_id_)));
+
+  connection_handler_->OnSessionStartedCallback(
+      uid_, sessionID, kRpc, PROTECTION_ON, NULL);
   // Unknown connection error is '0'
   EXPECT_EQ(0u, result_fail);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
@@ -1013,19 +1041,28 @@ TEST_F(ConnectionHandlerTest, StartService_withServices) {
   AddTestDeviceConnection();
   AddTestSession();
 
+  uint32_t start_audio = 0;
+  uint32_t start_video = 0;
+  connection_handler_->set_protocol_handler(&mock_protocol_handler_);
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
+      .WillOnce(DoAll(SaveArg<0>(&start_audio), SaveArg<1>(&out_hash_id_)))
+      .WillOnce(DoAll(SaveArg<0>(&start_video), SaveArg<1>(&out_hash_id_)));
+
   // Start Audio service
-  const uint32_t start_audio = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
+  connection_handler_->OnSessionStartedCallback(
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL);
   EXPECT_EQ(start_session_id_, start_audio);
   CheckServiceExists(uid_, start_session_id_, kAudio, true);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
 
   // Start Audio service
-  const uint32_t start_video = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kMobileNav, PROTECTION_OFF, &out_hash_id_);
+  connection_handler_->OnSessionStartedCallback(
+      uid_, start_session_id_, kMobileNav, PROTECTION_OFF, NULL);
   EXPECT_EQ(start_session_id_, start_video);
   CheckServiceExists(uid_, start_session_id_, kMobileNav, true);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
+
+  connection_handler_->set_protocol_handler(NULL);
 }
 
 TEST_F(ConnectionHandlerTest, ServiceStop_UnExistSession) {
@@ -1052,11 +1089,18 @@ TEST_F(ConnectionHandlerTest, ServiceStop_UnExistService) {
 TEST_F(ConnectionHandlerTest, ServiceStop) {
   AddTestDeviceConnection();
   AddTestSession();
+
+  uint32_t start_audio = 0;
+  connection_handler_->set_protocol_handler(&mock_protocol_handler_);
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
+      .WillRepeatedly(
+          DoAll(SaveArg<0>(&start_audio), SaveArg<1>(&out_hash_id_)));
+
   // Check ignoring hash_id on stop non-rpc service
   for (uint32_t some_hash_id = 0; some_hash_id < 0xFF; ++some_hash_id) {
     // Start audio service
-    const uint32_t start_audio = connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
+    connection_handler_->OnSessionStartedCallback(
+        uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL);
     EXPECT_EQ(start_session_id_, start_audio);
     EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
 
@@ -1122,13 +1166,23 @@ TEST_F(ConnectionHandlerTest, SessionStarted_WithRpc) {
       &mock_connection_handler_observer);
   uint32_t session_key =
       connection_handler_->KeyFromPair(uid_, start_session_id_);
+  std::vector<std::string> empty;
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceStartedCallback(device_handle_, session_key, kRpc))
-      .WillOnce(Return(true));
+              OnServiceStartedCallback(device_handle_, session_key, kRpc, NULL))
+      .WillOnce(InvokeMemberFuncWithArg2(
+          connection_handler_,
+          &ConnectionHandler::NotifyServiceStartedResult,
+          true,
+          ByRef(empty)));
+
+  uint32_t new_session_id = 0;
+  connection_handler_->set_protocol_handler(&mock_protocol_handler_);
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
+      .WillOnce(DoAll(SaveArg<0>(&new_session_id), SaveArg<1>(&out_hash_id_)));
 
   // Start new session with RPC service
-  uint32_t new_session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_);
+  connection_handler_->OnSessionStartedCallback(
+      uid_, 0, kRpc, PROTECTION_OFF, NULL);
 
   EXPECT_NE(0u, new_session_id);
 }
@@ -1142,10 +1196,17 @@ TEST_F(ConnectionHandlerTest,
   // Forbid start kRPC without encryption
   protected_services_.push_back(kRpc);
   SetSpecificServices();
+
+  uint32_t session_id_fail = 0;
+  uint32_t session_id = 0;
+  connection_handler_->set_protocol_handler(&mock_protocol_handler_);
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
+      .WillOnce(DoAll(SaveArg<0>(&session_id_fail), SaveArg<1>(&out_hash_id_)))
+      .WillOnce(DoAll(SaveArg<0>(&session_id), SaveArg<1>(&out_hash_id_)));
+
   // Start new session with RPC service
-  const uint32_t session_id_fail =
-      connection_handler_->OnSessionStartedCallback(
-          uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_);
+  connection_handler_->OnSessionStartedCallback(
+      uid_, 0, kRpc, PROTECTION_OFF, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_fail);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
@@ -1159,8 +1220,8 @@ TEST_F(ConnectionHandlerTest,
   protected_services_.push_back(kControl);
   SetSpecificServices();
   // Start new session with RPC service
-  const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_OFF, &out_hash_id_);
+  connection_handler_->OnSessionStartedCallback(
+      uid_, 0, kRpc, PROTECTION_OFF, NULL);
   EXPECT_NE(0u, session_id);
   CheckService(uid_, session_id, kRpc, NULL, PROTECTION_OFF);
   EXPECT_EQ(SessionHash(uid_, session_id), out_hash_id_);
@@ -1176,10 +1237,17 @@ TEST_F(ConnectionHandlerTest,
   unprotected_services_.push_back(UnnamedService::kServedService2);
   unprotected_services_.push_back(kControl);
   SetSpecificServices();
+
+  uint32_t session_id_fail = 0;
+  uint32_t session_id = 0;
+  connection_handler_->set_protocol_handler(&mock_protocol_handler_);
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
+      .WillOnce(SaveArg<0>(&session_id_fail))
+      .WillOnce(DoAll(SaveArg<0>(&session_id), SaveArg<1>(&out_hash_id_)));
+
   // Start new session with RPC service
-  const uint32_t session_id_fail =
-      connection_handler_->OnSessionStartedCallback(
-          uid_, 0, kRpc, PROTECTION_ON, NULL);
+  connection_handler_->OnSessionStartedCallback(
+      uid_, 0, kRpc, PROTECTION_ON, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_fail);
 #else
@@ -1191,8 +1259,8 @@ TEST_F(ConnectionHandlerTest,
   unprotected_services_.push_back(kControl);
   SetSpecificServices();
   // Start new session with RPC service
-  const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_ON, &out_hash_id_);
+  connection_handler_->OnSessionStartedCallback(
+      uid_, 0, kRpc, PROTECTION_ON, NULL);
   EXPECT_NE(0u, session_id);
   EXPECT_EQ(SessionHash(uid_, session_id), out_hash_id_);
 
@@ -1211,8 +1279,16 @@ TEST_F(ConnectionHandlerTest,
   protected_services_.push_back(UnnamedService::kServedService2);
   protected_services_.push_back(kControl);
   SetSpecificServices();
+
+  uint32_t session_id2 = 0;
+  uint32_t session_id3 = 0;
+  connection_handler_->set_protocol_handler(&mock_protocol_handler_);
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
+      .WillOnce(SaveArg<0>(&session_id2))
+      .WillOnce(DoAll(SaveArg<0>(&session_id3), SaveArg<1>(&out_hash_id_)));
+
   // Start new session with Audio service
-  const uint32_t session_id2 = connection_handler_->OnSessionStartedCallback(
+  connection_handler_->OnSessionStartedCallback(
       uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id2);
@@ -1226,8 +1302,8 @@ TEST_F(ConnectionHandlerTest,
   protected_services_.push_back(UnnamedService::kServedService2);
   protected_services_.push_back(kControl);
   SetSpecificServices();
-  const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
+  connection_handler_->OnSessionStartedCallback(
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL);
 // Returned original session id
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
@@ -1250,10 +1326,17 @@ TEST_F(ConnectionHandlerTest,
   unprotected_services_.push_back(UnnamedService::kServedService2);
   unprotected_services_.push_back(kControl);
   SetSpecificServices();
+
+  uint32_t session_id_reject = 0;
+  uint32_t session_id3 = 0;
+  connection_handler_->set_protocol_handler(&mock_protocol_handler_);
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
+      .WillOnce(SaveArg<0>(&session_id_reject))
+      .WillOnce(DoAll(SaveArg<0>(&session_id3), SaveArg<1>(&out_hash_id_)));
+
   // Start new session with Audio service
-  const uint32_t session_id_reject =
-      connection_handler_->OnSessionStartedCallback(
-          uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
+  connection_handler_->OnSessionStartedCallback(
+      uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_reject);
 #else
@@ -1262,8 +1345,8 @@ TEST_F(ConnectionHandlerTest,
   // Allow start kAudio with encryption
   unprotected_services_.clear();
   SetSpecificServices();
-  const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_ON, &out_hash_id_);
+  connection_handler_->OnSessionStartedCallback(
+      uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
 // Returned original session id
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
@@ -1280,9 +1363,18 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtect) {
   AddTestDeviceConnection();
   AddTestSession();
 
+  uint32_t session_id_new = 0;
+  uint32_t session_id2 = 0;
+  uint32_t session_id3 = 0;
+  connection_handler_->set_protocol_handler(&mock_protocol_handler_);
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
+      .WillOnce(DoAll(SaveArg<0>(&session_id_new), SaveArg<1>(&out_hash_id_)))
+      .WillOnce(DoAll(SaveArg<0>(&session_id2), SaveArg<1>(&out_hash_id_)))
+      .WillOnce(DoAll(SaveArg<0>(&session_id3), SaveArg<1>(&out_hash_id_)));
+
   // Start RPC protection
-  const uint32_t session_id_new = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kRpc, PROTECTION_ON, &out_hash_id_);
+  connection_handler_->OnSessionStartedCallback(
+      uid_, start_session_id_, kRpc, PROTECTION_ON, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id_new);
   // Post protection nedd no hash
@@ -1296,15 +1388,15 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtect) {
 #endif  // ENABLE_SECURITY
 
   // Start Audio session without protection
-  const uint32_t session_id2 = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, &out_hash_id_);
+  connection_handler_->OnSessionStartedCallback(
+      uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL);
   EXPECT_EQ(start_session_id_, session_id2);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
   CheckService(uid_, start_session_id_, kAudio, NULL, PROTECTION_OFF);
 
   // Start Audio protection
-  const uint32_t session_id3 = connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_ON, &out_hash_id_);
+  connection_handler_->OnSessionStartedCallback(
+      uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
@@ -1320,7 +1412,11 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtectBulk) {
   AddTestDeviceConnection();
   AddTestSession();
 
-  const uint32_t session_id_new = connection_handler_->OnSessionStartedCallback(
+  uint32_t session_id_new = 0;
+  connection_handler_->set_protocol_handler(&mock_protocol_handler_);
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
+      .WillOnce(SaveArg<0>(&session_id_new));
+  connection_handler_->OnSessionStartedCallback(
       uid_, start_session_id_, kBulk, PROTECTION_ON, NULL);
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id_new);
@@ -1416,8 +1512,14 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByProtectedService) {
   // kAudio is not exists yet
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kAudio),
             reinterpret_cast<security_manager::SSLContext*>(NULL));
+
+  uint32_t session_id = 0;
+  connection_handler_->set_protocol_handler(&mock_protocol_handler_);
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
+      .WillOnce(SaveArg<0>(&session_id));
+
   // Open kAudio service
-  const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
+  connection_handler_->OnSessionStartedCallback(
       uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
   EXPECT_EQ(session_id, start_session_id_);
   CheckService(uid_, session_id, kAudio, &mock_ssl_context, PROTECTION_ON);
@@ -1441,8 +1543,13 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedRPC) {
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kRpc),
             reinterpret_cast<security_manager::SSLContext*>(NULL));
 
+  uint32_t session_id = 0;
+  connection_handler_->set_protocol_handler(&mock_protocol_handler_);
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
+      .WillOnce(SaveArg<0>(&session_id));
+
   // Protect kRpc (Bulk will be protect also)
-  const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
+  connection_handler_->OnSessionStartedCallback(
       uid_, start_session_id_, kRpc, PROTECTION_ON, NULL);
   EXPECT_EQ(start_session_id_, session_id);
   CheckService(uid_, session_id, kRpc, &mock_ssl_context, PROTECTION_ON);
@@ -1469,8 +1576,13 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedBulk) {
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kRpc),
             reinterpret_cast<security_manager::SSLContext*>(NULL));
 
+  uint32_t session_id = 0;
+  connection_handler_->set_protocol_handler(&mock_protocol_handler_);
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
+      .WillOnce(SaveArg<0>(&session_id));
+
   // Protect Bulk (kRpc will be protected also)
-  const uint32_t session_id = connection_handler_->OnSessionStartedCallback(
+  connection_handler_->OnSessionStartedCallback(
       uid_, start_session_id_, kBulk, PROTECTION_ON, NULL);
   EXPECT_EQ(start_session_id_, session_id);
   CheckService(uid_, session_id, kRpc, &mock_ssl_context, PROTECTION_ON);

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -123,7 +123,7 @@ class ConnectionHandlerTest : public ::testing::Test {
             DoAll(SaveArg<0>(&start_session_id_), SaveArg<1>(&out_hash_id_)));
 
     connection_handler_->OnSessionStartedCallback(
-        uid_, 0, kRpc, PROTECTION_OFF, NULL);
+        uid_, 0, kRpc, PROTECTION_OFF, static_cast<BsonObject*>(NULL));
     connection_handler_->set_protocol_handler(NULL);
     EXPECT_NE(0u, start_session_id_);
     EXPECT_EQ(SessionHash(uid_, start_session_id_), out_hash_id_);
@@ -145,8 +145,11 @@ class ConnectionHandlerTest : public ::testing::Test {
     EXPECT_CALL(temp_protocol_handler, NotifySessionStartedResult(_, _, _, _))
         .WillOnce(SaveArg<0>(&session_id));
 
-    connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, service_type, PROTECTION_OFF, 0);
+    connection_handler_->OnSessionStartedCallback(uid_,
+                                                  start_session_id_,
+                                                  service_type,
+                                                  PROTECTION_OFF,
+                                                  static_cast<BsonObject*>(0));
     connection_handler_->set_protocol_handler(NULL);
     EXPECT_EQ(session_id, start_session_id_);
   }
@@ -296,7 +299,7 @@ TEST_F(ConnectionHandlerTest, StartSession_NoConnection) {
       .WillOnce(DoAll(SaveArg<0>(&result_fail), SaveArg<1>(&out_hash_id_)));
 
   connection_handler_->OnSessionStartedCallback(
-      uid_, sessionID, kRpc, PROTECTION_ON, NULL);
+      uid_, sessionID, kRpc, PROTECTION_ON, static_cast<BsonObject*>(NULL));
   // Unknown connection error is '0'
   EXPECT_EQ(0u, result_fail);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
@@ -1049,15 +1052,21 @@ TEST_F(ConnectionHandlerTest, StartService_withServices) {
       .WillOnce(DoAll(SaveArg<0>(&start_video), SaveArg<1>(&out_hash_id_)));
 
   // Start Audio service
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                start_session_id_,
+                                                kAudio,
+                                                PROTECTION_OFF,
+                                                static_cast<BsonObject*>(NULL));
   EXPECT_EQ(start_session_id_, start_audio);
   CheckServiceExists(uid_, start_session_id_, kAudio, true);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
 
   // Start Audio service
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kMobileNav, PROTECTION_OFF, NULL);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                start_session_id_,
+                                                kMobileNav,
+                                                PROTECTION_OFF,
+                                                static_cast<BsonObject*>(NULL));
   EXPECT_EQ(start_session_id_, start_video);
   CheckServiceExists(uid_, start_session_id_, kMobileNav, true);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
@@ -1123,7 +1132,11 @@ TEST_F(ConnectionHandlerTest, ServiceStop) {
   for (uint32_t some_hash_id = 0; some_hash_id < 0xFF; ++some_hash_id) {
     // Start audio service
     connection_handler_->OnSessionStartedCallback(
-        uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL);
+        uid_,
+        start_session_id_,
+        kAudio,
+        PROTECTION_OFF,
+        static_cast<BsonObject*>(NULL));
     EXPECT_EQ(start_session_id_, start_audio);
     EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
 
@@ -1205,7 +1218,7 @@ TEST_F(ConnectionHandlerTest, SessionStarted_WithRpc) {
 
   // Start new session with RPC service
   connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_OFF, NULL);
+      uid_, 0, kRpc, PROTECTION_OFF, static_cast<BsonObject*>(NULL));
 
   EXPECT_NE(0u, new_session_id);
 }
@@ -1301,7 +1314,7 @@ TEST_F(ConnectionHandlerTest,
 
   // Start new session with RPC service
   connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_OFF, NULL);
+      uid_, 0, kRpc, PROTECTION_OFF, static_cast<BsonObject*>(NULL));
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_fail);
   EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
@@ -1316,7 +1329,7 @@ TEST_F(ConnectionHandlerTest,
   SetSpecificServices();
   // Start new session with RPC service
   connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_OFF, NULL);
+      uid_, 0, kRpc, PROTECTION_OFF, static_cast<BsonObject*>(NULL));
   EXPECT_NE(0u, session_id);
   CheckService(uid_, session_id, kRpc, NULL, PROTECTION_OFF);
   EXPECT_EQ(SessionHash(uid_, session_id), out_hash_id_);
@@ -1342,7 +1355,7 @@ TEST_F(ConnectionHandlerTest,
 
   // Start new session with RPC service
   connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_ON, NULL);
+      uid_, 0, kRpc, PROTECTION_ON, static_cast<BsonObject*>(NULL));
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_fail);
 #else
@@ -1355,7 +1368,7 @@ TEST_F(ConnectionHandlerTest,
   SetSpecificServices();
   // Start new session with RPC service
   connection_handler_->OnSessionStartedCallback(
-      uid_, 0, kRpc, PROTECTION_ON, NULL);
+      uid_, 0, kRpc, PROTECTION_ON, static_cast<BsonObject*>(NULL));
   EXPECT_NE(0u, session_id);
   EXPECT_EQ(SessionHash(uid_, session_id), out_hash_id_);
 
@@ -1383,8 +1396,11 @@ TEST_F(ConnectionHandlerTest,
       .WillOnce(DoAll(SaveArg<0>(&session_id3), SaveArg<1>(&out_hash_id_)));
 
   // Start new session with Audio service
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                start_session_id_,
+                                                kAudio,
+                                                PROTECTION_OFF,
+                                                static_cast<BsonObject*>(NULL));
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id2);
 #else
@@ -1397,8 +1413,11 @@ TEST_F(ConnectionHandlerTest,
   protected_services_.push_back(UnnamedService::kServedService2);
   protected_services_.push_back(kControl);
   SetSpecificServices();
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                start_session_id_,
+                                                kAudio,
+                                                PROTECTION_OFF,
+                                                static_cast<BsonObject*>(NULL));
 // Returned original session id
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
@@ -1430,8 +1449,11 @@ TEST_F(ConnectionHandlerTest,
       .WillOnce(DoAll(SaveArg<0>(&session_id3), SaveArg<1>(&out_hash_id_)));
 
   // Start new session with Audio service
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                start_session_id_,
+                                                kAudio,
+                                                PROTECTION_ON,
+                                                static_cast<BsonObject*>(NULL));
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(0u, session_id_reject);
 #else
@@ -1440,8 +1462,11 @@ TEST_F(ConnectionHandlerTest,
   // Allow start kAudio with encryption
   unprotected_services_.clear();
   SetSpecificServices();
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                start_session_id_,
+                                                kAudio,
+                                                PROTECTION_ON,
+                                                static_cast<BsonObject*>(NULL));
 // Returned original session id
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
@@ -1468,8 +1493,11 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtect) {
       .WillOnce(DoAll(SaveArg<0>(&session_id3), SaveArg<1>(&out_hash_id_)));
 
   // Start RPC protection
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kRpc, PROTECTION_ON, NULL);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                start_session_id_,
+                                                kRpc,
+                                                PROTECTION_ON,
+                                                static_cast<BsonObject*>(NULL));
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id_new);
   // Post protection nedd no hash
@@ -1483,15 +1511,21 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtect) {
 #endif  // ENABLE_SECURITY
 
   // Start Audio session without protection
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_OFF, NULL);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                start_session_id_,
+                                                kAudio,
+                                                PROTECTION_OFF,
+                                                static_cast<BsonObject*>(NULL));
   EXPECT_EQ(start_session_id_, session_id2);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
   CheckService(uid_, start_session_id_, kAudio, NULL, PROTECTION_OFF);
 
   // Start Audio protection
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                start_session_id_,
+                                                kAudio,
+                                                PROTECTION_ON,
+                                                static_cast<BsonObject*>(NULL));
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id3);
   EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
@@ -1511,8 +1545,11 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtectBulk) {
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
   EXPECT_CALL(mock_protocol_handler_, NotifySessionStartedResult(_, _, _, _))
       .WillOnce(SaveArg<0>(&session_id_new));
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kBulk, PROTECTION_ON, NULL);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                start_session_id_,
+                                                kBulk,
+                                                PROTECTION_ON,
+                                                static_cast<BsonObject*>(NULL));
 #ifdef ENABLE_SECURITY
   EXPECT_EQ(start_session_id_, session_id_new);
   CheckService(uid_, start_session_id_, kRpc, NULL, PROTECTION_ON);
@@ -1614,8 +1651,11 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByProtectedService) {
       .WillOnce(SaveArg<0>(&session_id));
 
   // Open kAudio service
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kAudio, PROTECTION_ON, NULL);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                start_session_id_,
+                                                kAudio,
+                                                PROTECTION_ON,
+                                                static_cast<BsonObject*>(NULL));
   EXPECT_EQ(session_id, start_session_id_);
   CheckService(uid_, session_id, kAudio, &mock_ssl_context, PROTECTION_ON);
 
@@ -1644,8 +1684,11 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedRPC) {
       .WillOnce(SaveArg<0>(&session_id));
 
   // Protect kRpc (Bulk will be protect also)
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kRpc, PROTECTION_ON, NULL);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                start_session_id_,
+                                                kRpc,
+                                                PROTECTION_ON,
+                                                static_cast<BsonObject*>(NULL));
   EXPECT_EQ(start_session_id_, session_id);
   CheckService(uid_, session_id, kRpc, &mock_ssl_context, PROTECTION_ON);
 
@@ -1677,8 +1720,11 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedBulk) {
       .WillOnce(SaveArg<0>(&session_id));
 
   // Protect Bulk (kRpc will be protected also)
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kBulk, PROTECTION_ON, NULL);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                start_session_id_,
+                                                kBulk,
+                                                PROTECTION_ON,
+                                                static_cast<BsonObject*>(NULL));
   EXPECT_EQ(start_session_id_, session_id);
   CheckService(uid_, session_id, kRpc, &mock_ssl_context, PROTECTION_ON);
 

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -592,6 +592,20 @@ class ApplicationManager {
    */
   virtual void ForbidStreaming(uint32_t app_id) = 0;
 
+  /**
+   * @brief Called when application completes streaming configuration
+   * @param app_id Streaming application id
+   * @param service_type Streaming service type
+   * @param result true if configuration is successful, false otherwise
+   * @param rejected_params list of rejected parameters' name. Valid
+   *                        only when result is false.
+   */
+  virtual void OnStreamingConfigured(
+      uint32_t app_id,
+      protocol_handler::ServiceType service_type,
+      bool result,
+      std::vector<std::string>& rejected_params) = 0;
+
   virtual const ApplicationManagerSettings& get_settings() const = 0;
 
   virtual event_engine::EventDispatcher& event_dispatcher() = 0;

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -410,6 +410,20 @@ class HMICapabilities {
   virtual bool phone_call_supported() const = 0;
 
   /*
+   * @brief Interface to store whether HMI supports video streaming
+   *
+   * @param supported Indicates whether video streaming is supported by HMI
+   */
+  virtual void set_video_streaming_supported(const bool supported) = 0;
+
+  /*
+   * @brief Retrieves whether HMI supports video streaming
+   *
+   * @return TRUE if it supported, otherwise FALSE
+   */
+  virtual bool video_streaming_supported() const = 0;
+
+  /*
    * @brief Interface used to store information regarding
    * the navigation "System Capability"
    *
@@ -442,6 +456,22 @@ class HMICapabilities {
    * @return PHONE_CALL system capability
    */
   virtual const smart_objects::SmartObject* phone_capability() const = 0;
+
+  /*
+   * @brief Sets HMI's video streaming related capability information
+   *
+   * @param video_streaming_capability the video streaming related capabilities
+   */
+  virtual void set_video_streaming_capability(
+      const smart_objects::SmartObject& video_streaming_capability) = 0;
+
+  /*
+   * @brief Retrieves HMI's video streaming related capabilities
+   *
+   * @return HMI's video streaming related capability information
+   */
+  virtual const smart_objects::SmartObject* video_streaming_capability()
+      const = 0;
 
   virtual void Init(resumption::LastState* last_state) = 0;
 

--- a/src/components/include/connection_handler/connection_handler.h
+++ b/src/components/include/connection_handler/connection_handler.h
@@ -200,6 +200,8 @@ class ConnectionHandler {
 
   /**
    * \brief Invoked when observer's OnServiceStartedCallback is completed
+   * \param session_key the key of started session passed to
+   * OnServiceStartedCallback().
    * \param result true if observer accepts starting service, false otherwise
    * \param rejected_params list of rejected parameters' name. Only valid when
    * result is false. Note that even if result is false, this may be empty.
@@ -208,7 +210,9 @@ class ConnectionHandler {
    * Also it can be invoked before OnServiceStartedCallback() returns.
    **/
   virtual void NotifyServiceStartedResult(
-      bool result, std::vector<std::string>& rejected_params) = 0;
+      uint32_t session_key,
+      bool result,
+      std::vector<std::string>& rejected_params) = 0;
 
  protected:
   /**

--- a/src/components/include/connection_handler/connection_handler.h
+++ b/src/components/include/connection_handler/connection_handler.h
@@ -198,6 +198,18 @@ class ConnectionHandler {
 
   virtual DevicesDiscoveryStarter& get_device_discovery_starter() = 0;
 
+  /**
+   * \brief Invoked when observer's OnServiceStartedCallback is completed
+   * \param result true if observer accepts starting service, false otherwise
+   * \param rejected_params list of rejected parameters' name. Only valid when
+   * result is false. Note that even if result is false, this may be empty.
+   *
+   * \note This is invoked only once but can be invoked by multiple threads.
+   * Also it can be invoked before OnServiceStartedCallback() returns.
+   **/
+  virtual void NotifyServiceStartedResult(
+      bool result, std::vector<std::string>& rejected_params) = 0;
+
  protected:
   /**
    * \brief Destructor

--- a/src/components/include/connection_handler/connection_handler_observer.h
+++ b/src/components/include/connection_handler/connection_handler_observer.h
@@ -42,6 +42,8 @@
 #include "security_manager/ssl_context.h"
 #endif  // ENABLE_SECURITY
 
+struct BsonObject;
+
 /**
  * \namespace connection_handler
  * \brief SmartDeviceLink connection_handler namespace.
@@ -83,15 +85,18 @@ class ConnectionHandlerObserver {
   /**
    * \brief Callback function used by connection_handler
    * when Mobile Application initiates start of new service.
+   * Result must be notified through NotifyServiceStartedResult().
    * \param deviceHandle Device identifier within which session has to be
    * started.
    * \param sessionKey Key of started session.
    * \param type Established service type
+   * \param params Configuration parameters for this service
    */
-  virtual bool OnServiceStartedCallback(
+  virtual void OnServiceStartedCallback(
       const connection_handler::DeviceHandle& device_handle,
       const int32_t& session_key,
-      const protocol_handler::ServiceType& type) = 0;
+      const protocol_handler::ServiceType& type,
+      const BsonObject* params) = 0;
 
   /**
    * \brief Callback function used by connection_handler

--- a/src/components/include/connection_handler/connection_handler_observer.h
+++ b/src/components/include/connection_handler/connection_handler_observer.h
@@ -85,6 +85,19 @@ class ConnectionHandlerObserver {
   /**
    * \brief Callback function used by connection_handler
    * when Mobile Application initiates start of new service.
+   * \param deviceHandle Device identifier within which session has to be
+   * started.
+   * \param sessionKey Key of started session.
+   * \param type Established service type
+   */
+  virtual bool OnServiceStartedCallback(
+      const connection_handler::DeviceHandle& device_handle,
+      const int32_t& session_key,
+      const protocol_handler::ServiceType& type) = 0;
+
+  /**
+   * \brief Callback function used by connection_handler
+   * when Mobile Application initiates start of new service.
    * Result must be notified through NotifyServiceStartedResult().
    * \param deviceHandle Device identifier within which session has to be
    * started.

--- a/src/components/include/protocol/bson_object_keys.h
+++ b/src/components/include/protocol/bson_object_keys.h
@@ -38,6 +38,10 @@ extern const char* hash_id;
 extern const char* protocol_version;
 extern const char* mtu;
 extern const char* rejected_params;
+extern const char* height;
+extern const char* width;
+extern const char* video_protocol;
+extern const char* video_codec;
 
 }  // namespace strings
 

--- a/src/components/include/protocol_handler/protocol_handler.h
+++ b/src/components/include/protocol_handler/protocol_handler.h
@@ -108,6 +108,23 @@ class ProtocolHandler {
   virtual const ProtocolHandlerSettings& get_settings() const = 0;
   virtual SessionObserver& get_session_observer() = 0;
 
+  /**
+   * \brief Called by connection handler to notify the result of
+   * OnSessionStartedCallback().
+   * \param session_id Generated session ID, will be 0 if session is not
+   * started
+   * \param hash_id Generated Hash ID
+   * \param protection whether the service will be protected
+   * \param rejected_params list of parameters' name that are rejected.
+   * Only valid when session_id is 0. Note, even if session_id is 0, the
+   * list may be empty.
+   */
+  virtual void NotifySessionStartedResult(
+      uint8_t session_id,
+      uint32_t hash_id,
+      bool protection,
+      std::vector<std::string>& rejected_params) = 0;
+
  protected:
   /**
    * \brief Destructor

--- a/src/components/include/protocol_handler/protocol_handler.h
+++ b/src/components/include/protocol_handler/protocol_handler.h
@@ -111,16 +111,20 @@ class ProtocolHandler {
   /**
    * \brief Called by connection handler to notify the result of
    * OnSessionStartedCallback().
-   * \param session_id Generated session ID, will be 0 if session is not
-   * started
+   * \param connection_id Identifier of connection within which session exists
+   * \param session_id session ID passed to OnSessionStartedCallback()
+   * \param generated_session_id Generated session ID, will be 0 if session is
+   * not started
    * \param hash_id Generated Hash ID
    * \param protection whether the service will be protected
    * \param rejected_params list of parameters' name that are rejected.
-   * Only valid when session_id is 0. Note, even if session_id is 0, the
-   * list may be empty.
+   * Only valid when generated_session_id is 0. Note, even if
+   * generated_session_id is 0, the list may be empty.
    */
   virtual void NotifySessionStartedResult(
+      int32_t connection_id,
       uint8_t session_id,
+      uint8_t generated_session_id,
       uint32_t hash_id,
       bool protection,
       std::vector<std::string>& rejected_params) = 0;

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -42,10 +42,10 @@
 
 struct BsonObject;
 
-        /**
-         *\namespace protocol_handlerHandler
-         *\brief Namespace for SmartDeviceLink ProtocolHandler related functionality.
-         */
+/**
+ *\namespace protocol_handler
+ *\brief Namespace for SmartDeviceLink ProtocolHandler related functionality.
+ */
 namespace protocol_handler {
 /**
  * \brief HASH_ID constants.

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -39,6 +39,9 @@
 #ifdef ENABLE_SECURITY
 #include "security_manager/ssl_context.h"
 #endif  // ENABLE_SECURITY
+
+struct BsonObject;
+
         /**
          *\namespace protocol_handlerHandler
          *\brief Namespace for SmartDeviceLink ProtocolHandler related functionality.
@@ -64,21 +67,21 @@ class SessionObserver {
   /**
    * \brief Callback function used by ProtocolHandler
    * when Mobile Application initiates start of new session.
+   * Result must be notified through NotifySessionStartedResult().
    * \param connection_handle Connection identifier within which session
    * has to be started.
    * \param sessionId Identifier of the session to be start
    * \param service_type Type of service
    * \param protocol_version Version of protocol
    * \param is_protected would be service protected
-   * \param hash_id pointer for session hash identifier, uint32_t* hash_id
-   * \return uint32_t Id (number) of new session if successful, otherwise 0.
+   * \param params configuration parameters specified by mobile
    */
-  virtual uint32_t OnSessionStartedCallback(
+  virtual void OnSessionStartedCallback(
       const transport_manager::ConnectionUID connection_handle,
       const uint8_t sessionId,
       const protocol_handler::ServiceType& service_type,
       const bool is_protected,
-      uint32_t* hash_id) = 0;
+      const BsonObject *params) = 0;
 
   // DEPRECATED
   virtual uint32_t OnSessionEndedCallback(

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -101,7 +101,7 @@ class SessionObserver {
       const uint8_t sessionId,
       const protocol_handler::ServiceType& service_type,
       const bool is_protected,
-      const BsonObject *params) = 0;
+      const BsonObject* params) = 0;
 
   // DEPRECATED
   virtual uint32_t OnSessionEndedCallback(

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -67,6 +67,26 @@ class SessionObserver {
   /**
    * \brief Callback function used by ProtocolHandler
    * when Mobile Application initiates start of new session.
+   * \param connection_handle Connection identifier within which session
+   * has to be started.
+   * \param sessionId Identifier of the session to be start
+   * \param service_type Type of service
+   * \param protocol_version Version of protocol
+   * \param is_protected would be service protected
+   * \param hash_id pointer for session hash identifier, uint32_t* hash_id
+   * \return uint32_t Id (number) of new session if successful, otherwise 0.
+   */
+  // DEPRECATED
+  virtual uint32_t OnSessionStartedCallback(
+      const transport_manager::ConnectionUID connection_handle,
+      const uint8_t sessionId,
+      const protocol_handler::ServiceType& service_type,
+      const bool is_protected,
+      uint32_t* hash_id) = 0;
+
+  /**
+   * \brief Callback function used by ProtocolHandler
+   * when Mobile Application initiates start of new session.
    * Result must be notified through NotifySessionStartedResult().
    * \param connection_handle Connection identifier within which session
    * has to be started.

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -261,6 +261,11 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD0(OnTimerSendTTSGlobalProperties, void());
   MOCK_METHOD0(OnLowVoltage, void());
   MOCK_METHOD0(OnWakeUp, void());
+  MOCK_METHOD4(OnStreamingConfigured,
+               void(uint32_t app_id,
+                    protocol_handler::ServiceType service_type,
+                    bool result,
+                    std::vector<std::string>& rejected_params));
 };
 
 }  // namespace application_manager_test

--- a/src/components/include/test/connection_handler/mock_connection_handler.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler.h
@@ -96,6 +96,8 @@ class MockConnectionHandler : public connection_handler::ConnectionHandler {
   MOCK_METHOD0(get_device_discovery_starter, DevicesDiscoveryStarter&());
   MOCK_CONST_METHOD1(GetConnectedDevicesMAC,
                      void(std::vector<std::string>& macs));
+  MOCK_METHOD2(NotifyServiceStartedResult,
+               void(bool result, std::vector<std::string>& rejected_params));
 };
 
 }  // namespace connection_handler_test

--- a/src/components/include/test/connection_handler/mock_connection_handler.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler.h
@@ -96,8 +96,10 @@ class MockConnectionHandler : public connection_handler::ConnectionHandler {
   MOCK_METHOD0(get_device_discovery_starter, DevicesDiscoveryStarter&());
   MOCK_CONST_METHOD1(GetConnectedDevicesMAC,
                      void(std::vector<std::string>& macs));
-  MOCK_METHOD2(NotifyServiceStartedResult,
-               void(bool result, std::vector<std::string>& rejected_params));
+  MOCK_METHOD3(NotifyServiceStartedResult,
+               void(uint32_t session_key,
+                    bool result,
+                    std::vector<std::string>& rejected_params));
 };
 
 }  // namespace connection_handler_test

--- a/src/components/include/test/connection_handler/mock_connection_handler_observer.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler_observer.h
@@ -48,10 +48,11 @@ class MockConnectionHandlerObserver
   MOCK_METHOD0(OnFindNewApplicationsRequest, void());
   MOCK_METHOD1(RemoveDevice,
                void(const connection_handler::DeviceHandle& device_handle));
-  MOCK_METHOD3(OnServiceStartedCallback,
-               bool(const connection_handler::DeviceHandle& device_handle,
+  MOCK_METHOD4(OnServiceStartedCallback,
+               void(const connection_handler::DeviceHandle& device_handle,
                     const int32_t& session_key,
-                    const protocol_handler::ServiceType& type));
+                    const protocol_handler::ServiceType& type,
+                    const BsonObject* params));
   MOCK_METHOD3(
       OnServiceEndedCallback,
       void(const int32_t& session_key,

--- a/src/components/include/test/connection_handler/mock_connection_handler_observer.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler_observer.h
@@ -48,6 +48,11 @@ class MockConnectionHandlerObserver
   MOCK_METHOD0(OnFindNewApplicationsRequest, void());
   MOCK_METHOD1(RemoveDevice,
                void(const connection_handler::DeviceHandle& device_handle));
+  // DEPRECATED
+  MOCK_METHOD3(OnServiceStartedCallback,
+               bool(const connection_handler::DeviceHandle& device_handle,
+                    const int32_t& session_key,
+                    const protocol_handler::ServiceType& type));
   MOCK_METHOD4(OnServiceStartedCallback,
                void(const connection_handler::DeviceHandle& device_handle,
                     const int32_t& session_key,

--- a/src/components/include/test/protocol_handler/mock_protocol_handler.h
+++ b/src/components/include/test/protocol_handler/mock_protocol_handler.h
@@ -62,8 +62,10 @@ class MockProtocolHandler : public ::protocol_handler::ProtocolHandler {
   MOCK_CONST_METHOD0(get_settings,
                      const ::protocol_handler::ProtocolHandlerSettings&());
   MOCK_METHOD0(get_session_observer, protocol_handler::SessionObserver&());
-  MOCK_METHOD4(NotifySessionStartedResult,
-               void(uint8_t session_id,
+  MOCK_METHOD6(NotifySessionStartedResult,
+               void(int32_t connection_id,
+                    uint8_t session_id,
+                    uint8_t generated_session_id,
                     uint32_t hash_id,
                     bool protection,
                     std::vector<std::string>& rejected_params));

--- a/src/components/include/test/protocol_handler/mock_protocol_handler.h
+++ b/src/components/include/test/protocol_handler/mock_protocol_handler.h
@@ -62,6 +62,11 @@ class MockProtocolHandler : public ::protocol_handler::ProtocolHandler {
   MOCK_CONST_METHOD0(get_settings,
                      const ::protocol_handler::ProtocolHandlerSettings&());
   MOCK_METHOD0(get_session_observer, protocol_handler::SessionObserver&());
+  MOCK_METHOD4(NotifySessionStartedResult,
+               void(uint8_t session_id,
+                    uint32_t hash_id,
+                    bool protection,
+                    std::vector<std::string>& rejected_params));
 };
 }  // namespace protocol_handler_test
 }  // namespace components

--- a/src/components/include/test/protocol_handler/mock_session_observer.h
+++ b/src/components/include/test/protocol_handler/mock_session_observer.h
@@ -46,6 +46,14 @@ namespace protocol_handler_test {
  */
 class MockSessionObserver : public ::protocol_handler::SessionObserver {
  public:
+  // DEPRECATED
+  MOCK_METHOD5(
+      OnSessionStartedCallback,
+      uint32_t(const transport_manager::ConnectionUID connection_handle,
+               const uint8_t sessionId,
+               const protocol_handler::ServiceType& service_type,
+               const bool is_protected,
+               uint32_t* hash_id));
   MOCK_METHOD5(OnSessionStartedCallback,
                void(const transport_manager::ConnectionUID connection_handle,
                     const uint8_t sessionId,

--- a/src/components/include/test/protocol_handler/mock_session_observer.h
+++ b/src/components/include/test/protocol_handler/mock_session_observer.h
@@ -46,13 +46,12 @@ namespace protocol_handler_test {
  */
 class MockSessionObserver : public ::protocol_handler::SessionObserver {
  public:
-  MOCK_METHOD5(
-      OnSessionStartedCallback,
-      uint32_t(const transport_manager::ConnectionUID connection_handle,
-               const uint8_t sessionId,
-               const protocol_handler::ServiceType& service_type,
-               const bool is_protected,
-               uint32_t* hash_id));
+  MOCK_METHOD5(OnSessionStartedCallback,
+               void(const transport_manager::ConnectionUID connection_handle,
+                    const uint8_t sessionId,
+                    const protocol_handler::ServiceType& service_type,
+                    const bool is_protected,
+                    const BsonObject* params));
   MOCK_METHOD4(
       OnSessionEndedCallback,
       uint32_t(const transport_manager::ConnectionUID connection_handle,

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1661,6 +1661,22 @@
   </param>
 </struct>
 
+<struct name="VideoConfig">
+  <description>Configuration of a video stream.</description>
+  <param name="protocol" type="Common.VideoStreamingProtocol" mandatory="false">
+    <description>The video protocol configuration</description>
+  </param>
+  <param name="codec" type="Common.VideoStreamingCodec" mandatory="false">
+    <description>The video codec configuration</description>
+  </param>
+  <param name="width" type="Integer" mandatory="false">
+    <description>Width of the video stream, in pixels.</description>
+  </param>
+  <param name="height" type="Integer" mandatory="false">
+    <description>Height of the video stream, in pixels.</description>
+  </param>
+</struct>
+
 <struct name="DisplayCapabilities">
   <description>Contains information about the display capabilities.</description>
   <param name="displayType" type="Common.DisplayType" mandatory="true">
@@ -3505,6 +3521,27 @@
     <description>HMI must provide SDL with notifications specific to the current Turn-By-Turn client status on the module</description>
     <param name="state" type="Common.TBTState" mandatory="true">
       <description>Current State of TBT client</description>
+    </param>
+  </function>
+  <function name="SetVideoConfig" messagetype="request">
+    <description>Request from SDL to HMI to ask whether HMI accepts a video stream with given configuration.</description>
+    <param name="config" type="Common.VideoConfig" mandatory="true">
+      <description>Configuration of a video stream.</description>
+    </param>
+    <param name="appID" type="Integer" mandatory="true">
+      <description>ID of application related to this RPC.</description>
+    </param>
+  </function>
+  <function name="SetVideoConfig" messagetype="response">
+    <description>
+      Response from HMI to SDL whether the configuration is accepted.
+      In a negative response, a list of rejected parameters are supplied.
+    </description>
+    <param name="rejectedParams" type="String" array="true" minsize="1" maxsize="1000" mandatory="false">
+      <description>
+        List of params of VideoConfig struct which are not accepted by HMI, e.g. "protocol" and "codec".
+        This param exists only when the response is negative.
+      </description>
     </param>
   </function>
   <function name="StartStream" messagetype="request">

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1208,6 +1208,86 @@
   <element name="QUEUE" />
 </enum>
 
+<enum name="VideoStreamingProtocol">
+  <description>Enum for each type of video streaming protocol type.</description>
+  <element name="RAW">
+    <description>
+      Raw stream bytes that contains no timestamp data and is the lowest supported video streaming
+    </description>
+  </element>
+  <element name="RTP">
+    <description>
+      RTP facilitates the transfer of real-time data. Information provided by this protocol include
+      timestamps (for synchronization), sequence numbers (for packet loss and reordering detection)
+      and the payload format which indicates the encoded format of the data.
+    </description>
+  </element>
+  <element name="RTSP">
+    <description>
+      The transmission of streaming data itself is not a task of RTSP. Most RTSP servers use the
+      Real-time Transport Protocol (RTP) in conjunction with Real-time Control Protocol (RTCP)
+      for media stream delivery. However, some vendors implement proprietary transport protocols.
+    </description>
+  </element>
+  <element name="RTMP">
+    <description>
+      Real-Time Messaging Protocol (RTMP) was initially a proprietary protocol developed by
+      Macromedia for streaming audio, video and data over the Internet, between a Flash player
+      and a server. Macromedia is now owned by Adobe, which has released an incomplete version
+      of the specification of the protocol for public use.
+    </description>
+  </element>
+  <element name="WEBM">
+    <description>
+      The WebM container is based on a profile of Matroska. WebM initially supported VP8 video and
+      Vorbis audio streams. In 2013 it was updated to accommodate VP9 video and Opus audio.
+    </description>
+  </element>
+</enum>
+
+<enum name="VideoStreamingCodec">
+  <description>Enum for each type of video streaming codec.</description>
+  <element name="H264">
+    <description>
+      A block-oriented motion-compensation-based video compression standard.
+      As of 2014 it is one of the most commonly used formats for the recording, compression, and
+      distribution of video content.
+    </description>
+  </element>
+  <element name="H265">
+    <description>
+      High Efficiency Video Coding (HEVC), also known as H.265 and MPEG-H Part 2, is a video
+      compression standard, one of several potential successors to the widely used AVC (H.264 or
+      MPEG-4 Part 10). In comparison to AVC, HEVC offers about double the data compression ratio
+      at the same level of video quality, or substantially improved video quality at the same
+      bit rate. It supports resolutions up to 8192x4320, including 8K UHD.
+    </description>
+  </element>
+  <element name="Theora">
+    <description>
+      Theora is derived from the formerly proprietary VP3 codec, released into the public domain
+      by On2 Technologies. It is broadly comparable in design and bitrate efficiency to
+      MPEG-4 Part 2, early versions of Windows Media Video, and RealVideo while lacking some of
+      the features present in some of these other codecs. It is comparable in open standards
+      philosophy to the BBC's Dirac codec.
+    </description>
+  </element>
+  <element name="VP8">
+    <description>
+      VP8 can be multiplexed into the Matroska-based container format WebM along with Vorbis and
+      Opus audio. The image format WebP is based on VP8's intra-frame coding. VP8's direct
+      successor, VP9, and the emerging royalty-free internet video format AV1 from the Alliance for
+      Open Media (AOMedia) are based on VP8.
+    </description>
+  </element>
+  <element name="VP9">
+    <description>
+      Similar to VP8, but VP9 is customized for video resolutions beyond high-definition video (UHD)
+      and also enables lossless compression.
+    </description>
+  </element>
+</enum>
+
 <!-- Policies -->
   <enum name="UpdateResult">
     <element name="UP_TO_DATE"/>
@@ -1568,6 +1648,16 @@
   </param>
   <param name="imageResolution" type="Common.ImageResolution" mandatory="false">
     <description>The image resolution of this field.</description>
+  </param>
+</struct>
+
+<struct name="VideoStreamingFormat">
+  <description>Video streaming formats and their specifications.</description>
+  <param name="protocol" type="Common.VideoStreamingProtocol" mandatory="true">
+    <description>Protocol type, see VideoStreamingProtocol</description>
+  </param>
+  <param name="codec" type="Common.VideoStreamingCodec" mandatory="true">
+    <description>Codec type, see VideoStreamingCodec</description>
   </param>
 </struct>
 
@@ -2105,10 +2195,29 @@
     </param>
   </struct>
 
+  <struct name="VideoStreamingCapability">
+    <description>Contains information about this system's video streaming capabilities.</description>
+    <param name="preferredResolution" type="Common.ImageResolution" mandatory="false">
+      <description>The preferred resolution of a video stream for decoding and rendering on HMI.</description>
+    </param>
+    <param name="maxBitrate" type="Integer" minvalue="0" maxvalue="2147483647" mandatory="false">
+      <description>The maximum bitrate of video stream that is supported, in kbps.</description>
+    </param>
+    <param name="supportedFormats" type="Common.VideoStreamingFormat" array="true" mandatory="false">
+      <description>
+        Detailed information on each format supported by this system, in its preferred order
+        (i.e. the first element in the array is most preferable to the system).
+        Each object will contain a VideoStreamingFormat that describes what can be expected.
+      </description>
+    </param>
+  </struct>
+
   <struct name="SystemCapabilities">
       <param name="navigationCapability" type="NavigationCapability" mandatory="false">
       </param>
       <param name="phoneCapability" type="PhoneCapability" mandatory="false">
+      </param>
+      <param name="videoStreamingCapability" type="VideoStreamingCapability" mandatory="false">
       </param>
   </struct>
 

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -2527,6 +2527,8 @@
       </param>
       <param name="phoneCapability" type="PhoneCapability" mandatory="false">
       </param>
+      <param name="videoStreamingCapability" type="VideoStreamingCapability" mandatory="false">
+      </param>
   </struct>
 
   <!-- Requests/Responses -->

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -808,6 +808,86 @@
     <element name="QUEUE" />
   </enum>
 
+  <enum name="VideoStreamingProtocol">
+    <description>Enum for each type of video streaming protocol type.</description>
+    <element name="RAW">
+      <description>
+        Raw stream bytes that contains no timestamp data and is the lowest supported video streaming
+      </description>
+    </element>
+    <element name="RTP">
+      <description>
+        RTP facilitates the transfer of real-time data. Information provided by this protocol include
+        timestamps (for synchronization), sequence numbers (for packet loss and reordering detection)
+        and the payload format which indicates the encoded format of the data.
+      </description>
+    </element>
+    <element name="RTSP">
+      <description>
+        The transmission of streaming data itself is not a task of RTSP. Most RTSP servers use the
+        Real-time Transport Protocol (RTP) in conjunction with Real-time Control Protocol (RTCP)
+        for media stream delivery. However, some vendors implement proprietary transport protocols.
+      </description>
+    </element>
+    <element name="RTMP">
+      <description>
+        Real-Time Messaging Protocol (RTMP) was initially a proprietary protocol developed by
+        Macromedia for streaming audio, video and data over the Internet, between a Flash player
+        and a server. Macromedia is now owned by Adobe, which has released an incomplete version
+        of the specification of the protocol for public use.
+      </description>
+    </element>
+    <element name="WEBM">
+      <description>
+        The WebM container is based on a profile of Matroska. WebM initially supported VP8 video and
+        Vorbis audio streams. In 2013 it was updated to accommodate VP9 video and Opus audio.
+      </description>
+    </element>
+  </enum>
+
+  <enum name="VideoStreamingCodec">
+    <description>Enum for each type of video streaming codec.</description>
+    <element name="H264">
+      <description>
+        A block-oriented motion-compensation-based video compression standard.
+        As of 2014 it is one of the most commonly used formats for the recording, compression, and
+        distribution of video content.
+      </description>
+    </element>
+    <element name="H265">
+      <description>
+        High Efficiency Video Coding (HEVC), also known as H.265 and MPEG-H Part 2, is a video
+        compression standard, one of several potential successors to the widely used AVC (H.264 or
+        MPEG-4 Part 10). In comparison to AVC, HEVC offers about double the data compression ratio
+        at the same level of video quality, or substantially improved video quality at the same
+        bit rate. It supports resolutions up to 8192x4320, including 8K UHD.
+      </description>
+    </element>
+    <element name="Theora">
+      <description>
+        Theora is derived from the formerly proprietary VP3 codec, released into the public domain
+        by On2 Technologies. It is broadly comparable in design and bitrate efficiency to
+        MPEG-4 Part 2, early versions of Windows Media Video, and RealVideo while lacking some of
+        the features present in some of these other codecs. It is comparable in open standards
+        philosophy to the BBC's Dirac codec.
+      </description>
+    </element>
+    <element name="VP8">
+      <description>
+        VP8 can be multiplexed into the Matroska-based container format WebM along with Vorbis and
+        Opus audio. The image format WebP is based on VP8's intra-frame coding. VP8's direct
+        successor, VP9, and the emerging royalty-free internet video format AV1 from the Alliance for
+        Open Media (AOMedia) are based on VP8.
+      </description>
+    </element>
+    <element name="VP9">
+      <description>
+        Similar to VP8, but VP9 is customized for video resolutions beyond high-definition video (UHD)
+        and also enables lossless compression.
+      </description>
+    </element>
+  </enum>
+
   <struct name="Image">
     <param name="value" minlength="0" maxlength="65535" type="String" mandatory="true"> 
       <description>Either the static hex icon value or the binary image file name identifier (sent by PutFile).</description>
@@ -1778,6 +1858,16 @@
     <param name="parameterPermissions" type="ParameterPermissions"  mandatory="true"/>
  </struct>
 
+  <struct name="VideoStreamingFormat">
+    <description>Video streaming formats and their specifications.</description>
+    <param name="protocol" type="VideoStreamingProtocol" mandatory="true">
+      <description>Protocol type, see VideoStreamingProtocol</description>
+    </param>
+    <param name="codec" type="VideoStreamingCodec" mandatory="true">
+      <description>Codec type, see VideoStreamingCodec</description>
+    </param>
+  </struct>
+
   <struct name="DisplayCapabilities">
     <description>Contains information about the display capabilities.</description>
     <param name="displayType" type="DisplayType" mandatory="true">
@@ -1873,6 +1963,9 @@
     </param>
     <param name="phoneCall" type="Boolean" mandatory="false">
       <description>Availability of build in phone. True: Available, False: Not Available </description>
+    </param>
+    <param name="videoStreaming" type="Boolean" mandatory="false">
+      <description>Availability of video streaming. True: Available, False: Not Available</description>
     </param>
   </struct>
 
@@ -2406,6 +2499,23 @@
     <description>Extended capabilities of the module's phone feature</description>
     <param name="dialNumberEnabled" type="Boolean" mandatory="false">
       <description>If the module has the abiulity to perform dial number</description>
+    </param>
+  </struct>
+
+  <struct name="VideoStreamingCapability">
+    <description>Contains information about this system's video streaming capabilities.</description>
+    <param name="preferredResolution" type="ImageResolution" mandatory="false">
+      <description>The preferred resolution of a video stream for decoding and rendering on HMI.</description>
+    </param>
+    <param name="maxBitrate" type="Integer" minvalue="0" maxvalue="2147483647" mandatory="false">
+      <description>The maximum bitrate of video stream that is supported, in kbps.</description>
+    </param>
+    <param name="supportedFormats" type="VideoStreamingFormat" array="true" mandatory="false">
+      <description>
+        Detailed information on each format supported by this system, in its preferred order
+        (i.e. the first element in the array is most preferable to the system).
+        Each object will contain a VideoStreamingFormat that describes what can be expected.
+      </description>
     </param>
   </struct>
 

--- a/src/components/protocol/src/bson_object_keys.cc
+++ b/src/components/protocol/src/bson_object_keys.cc
@@ -8,6 +8,10 @@ const char* hash_id = "hashId";
 const char* protocol_version = "protocolVersion";
 const char* mtu = "mtu";
 const char* rejected_params = "rejectedParams";
+const char* height = "height";
+const char* width = "width";
+const char* video_protocol = "videoProtocol";
+const char* video_codec = "videoCodec";
 
 }  // namespace strings
 

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -522,6 +522,9 @@ class ProtocolHandlerImpl
 
   RESULT_CODE HandleControlMessageEndServiceACK(const ProtocolPacket& packet);
 
+  // DEPRECATED
+  RESULT_CODE HandleControlMessageStartSession(const ProtocolPacket& packet);
+
   RESULT_CODE HandleControlMessageStartSession(const ProtocolFramePtr packet);
 
   RESULT_CODE HandleControlMessageHeartBeat(const ProtocolPacket& packet);

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -349,6 +349,23 @@ class ProtocolHandlerImpl
 
   SessionObserver& get_session_observer() OVERRIDE;
 
+  /**
+   * \brief Called by connection handler to notify the result of
+   * OnSessionStartedCallback().
+   * \param session_id Generated session ID, will be 0 if session is not
+   * started
+   * \param hash_id Generated Hash ID
+   * \param protection whether the service will be protected
+   * \param rejected_params list of parameters' name that are rejected.
+   * Only valid when session_id is 0. Note, even if session_id is 0, the
+   * list may be empty.
+   */
+  void NotifySessionStartedResult(
+      uint8_t session_id,
+      uint32_t hash_id,
+      bool protection,
+      std::vector<std::string>& rejected_params) OVERRIDE;
+
 #ifdef BUILD_TESTS
   const impl::FromMobileQueue& get_from_mobile_queue() const {
     return raw_ford_messages_from_mobile_;
@@ -505,7 +522,7 @@ class ProtocolHandlerImpl
 
   RESULT_CODE HandleControlMessageEndServiceACK(const ProtocolPacket& packet);
 
-  RESULT_CODE HandleControlMessageStartSession(const ProtocolPacket& packet);
+  RESULT_CODE HandleControlMessageStartSession(const ProtocolFramePtr packet);
 
   RESULT_CODE HandleControlMessageHeartBeat(const ProtocolPacket& packet);
 
@@ -617,6 +634,9 @@ class ProtocolHandlerImpl
   impl::ToMobileQueue raw_ford_messages_to_mobile_;
 
   sync_primitives::Lock protocol_observers_lock_;
+
+  // we need thread-safe queue
+  utils::MessageQueue<ProtocolFramePtr> start_session_frame_queue_;
 
 #ifdef TELEMETRY_MONITOR
   PHTelemetryObserver* metric_observer_;

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -264,29 +264,6 @@ class ProtocolHandlerImpl
    * mobile app for using when ending session
    * \param service_type Type of session: RPC or BULK Data. RPC by default
    * \param protection Protection flag
-   * \param additional_params Additional parameters added in the payload. Can
-   *                          be NULL.
-   */
-  void SendStartSessionAck(ConnectionID connection_id,
-                           uint8_t session_id,
-                           uint8_t protocol_version,
-                           uint32_t hash_code,
-                           uint8_t service_type,
-                           bool protection,
-                           const BsonObject* additional_params);
-
-  /**
-   * \brief Sends acknowledgement of starting session to mobile application
-   * with session number and hash code for second version of protocol
-   * was started
-   * \param connection_id Identifier of connection within which session
-   * \param session_id ID of session to be sent to mobile application
-   * \param protocol_version Version of protocol used for communication
-   * \param hash_code For second version of protocol: identifier of session
-   * to be sent to
-   * mobile app for using when ending session
-   * \param service_type Type of session: RPC or BULK Data. RPC by default
-   * \param protection Protection flag
    * \param full_version full protocol version (major.minor.patch) used by the
    *                     mobile proxy
    */
@@ -312,8 +289,7 @@ class ProtocolHandlerImpl
    * \param protection Protection flag
    * \param full_version full protocol version (major.minor.patch) used by the
    *                     mobile proxy
-   * \param additional_params Additional parameters added in the payload. Can
-   *                          be NULL.
+   * \param params Parameters added in the payload
    */
   void SendStartSessionAck(ConnectionID connection_id,
                            uint8_t session_id,
@@ -322,7 +298,7 @@ class ProtocolHandlerImpl
                            uint8_t service_type,
                            bool protection,
                            ProtocolPacket::ProtocolVersion& full_version,
-                           const BsonObject* additional_params);
+                           BsonObject& params);
 
   const ProtocolHandlerSettings& get_settings() const OVERRIDE {
     return settings_;

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -264,6 +264,29 @@ class ProtocolHandlerImpl
    * mobile app for using when ending session
    * \param service_type Type of session: RPC or BULK Data. RPC by default
    * \param protection Protection flag
+   * \param additional_params Additional parameters added in the payload. Can
+   *                          be NULL.
+   */
+  void SendStartSessionAck(ConnectionID connection_id,
+                           uint8_t session_id,
+                           uint8_t protocol_version,
+                           uint32_t hash_code,
+                           uint8_t service_type,
+                           bool protection,
+                           const BsonObject* additional_params);
+
+  /**
+   * \brief Sends acknowledgement of starting session to mobile application
+   * with session number and hash code for second version of protocol
+   * was started
+   * \param connection_id Identifier of connection within which session
+   * \param session_id ID of session to be sent to mobile application
+   * \param protocol_version Version of protocol used for communication
+   * \param hash_code For second version of protocol: identifier of session
+   * to be sent to
+   * mobile app for using when ending session
+   * \param service_type Type of session: RPC or BULK Data. RPC by default
+   * \param protection Protection flag
    * \param full_version full protocol version (major.minor.patch) used by the
    *                     mobile proxy
    */
@@ -274,6 +297,32 @@ class ProtocolHandlerImpl
                            uint8_t service_type,
                            bool protection,
                            ProtocolPacket::ProtocolVersion& full_version);
+
+  /**
+   * \brief Sends acknowledgement of starting session to mobile application
+   * with session number and hash code for second version of protocol
+   * was started
+   * \param connection_id Identifier of connection within which session
+   * \param session_id ID of session to be sent to mobile application
+   * \param protocol_version Version of protocol used for communication
+   * \param hash_code For second version of protocol: identifier of session
+   * to be sent to
+   * mobile app for using when ending session
+   * \param service_type Type of session: RPC or BULK Data. RPC by default
+   * \param protection Protection flag
+   * \param full_version full protocol version (major.minor.patch) used by the
+   *                     mobile proxy
+   * \param additional_params Additional parameters added in the payload. Can
+   *                          be NULL.
+   */
+  void SendStartSessionAck(ConnectionID connection_id,
+                           uint8_t session_id,
+                           uint8_t protocol_version,
+                           uint32_t hash_code,
+                           uint8_t service_type,
+                           bool protection,
+                           ProtocolPacket::ProtocolVersion& full_version,
+                           const BsonObject* additional_params);
 
   const ProtocolHandlerSettings& get_settings() const OVERRIDE {
     return settings_;

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -304,23 +304,25 @@ void ProtocolHandlerImpl::SendStartSessionAck(
     } else if (serviceTypeValue == kMobileNav && additional_params != NULL) {
       BsonObject* input = const_cast<BsonObject*>(additional_params);
       BsonElement* element = NULL;
-      if ((element = bson_object_get(input, "height")) != NULL &&
+      if ((element = bson_object_get(input, strings::height)) != NULL &&
           element->type == TYPE_INT32) {
-        bson_object_put_int32(
-            &payloadObj, "height", bson_object_get_int32(input, "height"));
+        bson_object_put_int32(&payloadObj,
+                              strings::height,
+                              bson_object_get_int32(input, strings::height));
       }
-      if ((element = bson_object_get(input, "width")) != NULL &&
+      if ((element = bson_object_get(input, strings::width)) != NULL &&
           element->type == TYPE_INT32) {
-        bson_object_put_int32(
-            &payloadObj, "width", bson_object_get_int32(input, "width"));
+        bson_object_put_int32(&payloadObj,
+                              strings::width,
+                              bson_object_get_int32(input, strings::width));
       }
-      char* protocol = bson_object_get_string(input, "videoProtocol");
+      char* protocol = bson_object_get_string(input, strings::video_protocol);
       if (protocol != NULL) {
-        bson_object_put_string(&payloadObj, "videoProtocol", protocol);
+        bson_object_put_string(&payloadObj, strings::video_protocol, protocol);
       }
-      char* codec = bson_object_get_string(input, "videoCodec");
+      char* codec = bson_object_get_string(input, strings::video_codec);
       if (codec != NULL) {
-        bson_object_put_string(&payloadObj, "videoCodec", codec);
+        bson_object_put_string(&payloadObj, strings::video_codec, codec);
       }
     }
     uint8_t* payloadBytes = bson_object_to_bytes(&payloadObj);

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1545,6 +1545,7 @@ void ProtocolHandlerImpl::NotifySessionStartedResult(
     if (fullVersion->majorVersion < PROTOCOL_VERSION_5) {
       rejected_params.push_back(std::string(strings::protocol_version));
     }
+    bson_object_deinitialize(&request_params);
   } else {
     fullVersion = new ProtocolPacket::ProtocolVersion();
   }

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -57,7 +57,7 @@ CREATE_LOGGERPTR_GLOBAL(logger_, "ProtocolHandler")
 std::string ConvertPacketDataToString(const uint8_t* data,
                                       const size_t data_size);
 
-const size_t kStackSize = 32768;
+const size_t kStackSize = 65536;
 
 ProtocolPacket::ProtocolVersion defaultProtocolVersion(5, 0, 0);
 

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1537,6 +1537,7 @@ void ProtocolHandlerImpl::NotifySessionStartedResult(
       bson_object_put_string(
           &start_session_ack_params, strings::video_codec, codec);
     }
+    bson_object_deinitialize(&req_param);
   }
 
 #ifdef ENABLE_SECURITY

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1538,8 +1538,11 @@ void ProtocolHandlerImpl::NotifySessionStartedResult(
   // could still be a payload, in which case we can get the real protocol
   // version
   if (packet->service_type() == kRpc && packet->data() != NULL) {
-    fullVersion = new ProtocolPacket::ProtocolVersion(
-        std::string(bson_object_get_string(&start_session_ack_params, strings::protocol_version)));
+    BsonObject request_params = bson_object_from_bytes(packet->data());
+    char* version_param =
+        bson_object_get_string(&request_params, strings::protocol_version);
+    std::string version_string(version_param == NULL ? "" : version_param);
+    fullVersion = new ProtocolPacket::ProtocolVersion(version_string);
     // Constructed payloads added in Protocol v5
     if (fullVersion->majorVersion < PROTOCOL_VERSION_5) {
       rejected_params.push_back(std::string(strings::protocol_version));

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1261,7 +1261,12 @@ RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(
       "Protocol version:" << static_cast<int>(packet->protocol_version()));
   const ServiceType service_type = ServiceTypeFromByte(packet->service_type());
   const uint8_t protocol_version = packet->protocol_version();
-  BsonObject bson_obj = bson_object_from_bytes(packet->data());
+  BsonObject bson_obj;
+  if (packet->data() != NULL) {
+    bson_obj = bson_object_from_bytes(packet->data());
+  } else {
+    bson_object_initialize_default(&bson_obj);
+  }
 
 #ifdef ENABLE_SECURITY
   const bool protection =

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1250,8 +1250,7 @@ class StartSessionHandler : public security_manager::SecurityManagerListener {
       BsonObject params;
       if (payload_ != NULL) {
         params = bson_object_from_bytes(payload_);
-      }
-      else {
+      } else {
         bson_object_initialize_default(&params);
       }
       protocol_handler_->SendStartSessionAck(connection_id_,
@@ -1527,8 +1526,7 @@ void ProtocolHandlerImpl::NotifySessionStartedResult(
   // ("width", "height", "videoProtocol", "videoCodec") to the ACK packet
   if (packet->service_type() == kMobileNav && packet->data() != NULL) {
     start_session_ack_params = bson_object_from_bytes(packet->data());
-  }
-  else {
+  } else {
     bson_object_initialize_default(&start_session_ack_params);
   }
 
@@ -1599,20 +1597,20 @@ void ProtocolHandlerImpl::NotifySessionStartedResult(
                           *fullVersion,
                           start_session_ack_params);
     } else {
-      //Need a copy because fullVersion will be deleted
+      // Need a copy because fullVersion will be deleted
       ProtocolPacket::ProtocolVersion fullVersionCopy(*fullVersion);
-      security_manager_->AddListener(
-          new StartSessionHandler(connection_key,
-                                  this,
-                                  session_observer_,
-                                  connection_id,
-                                  generated_session_id,
-                                  packet->protocol_version(),
-                                  hash_id,
-                                  service_type,
-                                  get_settings().force_protected_service(),
-                                  fullVersionCopy,
-                                  bson_object_to_bytes(&start_session_ack_params)));
+      security_manager_->AddListener(new StartSessionHandler(
+          connection_key,
+          this,
+          session_observer_,
+          connection_id,
+          generated_session_id,
+          packet->protocol_version(),
+          hash_id,
+          service_type,
+          get_settings().force_protected_service(),
+          fullVersionCopy,
+          bson_object_to_bytes(&start_session_ack_params)));
       if (!ssl_context->IsHandshakePending()) {
         // Start handshake process
         security_manager_->StartHandshake(connection_key);

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1507,37 +1507,13 @@ void ProtocolHandlerImpl::NotifySessionStartedResult(
   }
 
   BsonObject start_session_ack_params;
-  bson_object_initialize_default(&start_session_ack_params);
   // when video service is successfully started, copy input parameters
   // ("width", "height", "videoProtocol", "videoCodec") to the ACK packet
   if (packet->service_type() == kMobileNav && packet->data() != NULL) {
-    BsonObject req_param = bson_object_from_bytes(packet->data());
-    BsonElement* element = NULL;
-
-    if ((element = bson_object_get(&req_param, strings::height)) != NULL &&
-        element->type == TYPE_INT32) {
-      bson_object_put_int32(&start_session_ack_params,
-                            strings::height,
-                            bson_object_get_int32(&req_param, strings::height));
-    }
-    if ((element = bson_object_get(&req_param, strings::width)) != NULL &&
-        element->type == TYPE_INT32) {
-      bson_object_put_int32(&start_session_ack_params,
-                            strings::width,
-                            bson_object_get_int32(&req_param, strings::width));
-    }
-    char* protocol =
-        bson_object_get_string(&req_param, strings::video_protocol);
-    if (protocol != NULL) {
-      bson_object_put_string(
-          &start_session_ack_params, strings::video_protocol, protocol);
-    }
-    char* codec = bson_object_get_string(&req_param, strings::video_codec);
-    if (codec != NULL) {
-      bson_object_put_string(
-          &start_session_ack_params, strings::video_codec, codec);
-    }
-    bson_object_deinitialize(&req_param);
+    start_session_ack_params = bson_object_from_bytes(packet->data());
+  }
+  else {
+    bson_object_initialize_default(&start_session_ack_params);
   }
 
 #ifdef ENABLE_SECURITY

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -33,6 +33,7 @@
 #include <string>
 #include "protocol_handler/protocol_handler.h"
 #include "protocol_handler/protocol_handler_impl.h"
+#include "protocol/bson_object_keys.h"
 #include "protocol/common.h"
 #include "protocol_handler/control_message_matcher.h"
 #include "protocol_handler/mock_protocol_handler.h"
@@ -597,10 +598,12 @@ TEST_F(ProtocolHandlerImplTest,
 
   BsonObject bson_params1;
   bson_object_initialize_default(&bson_params1);
-  bson_object_put_string(
-      &bson_params1, "videoProtocol", const_cast<char*>("RAW"));
-  bson_object_put_string(
-      &bson_params1, "videoCodec", const_cast<char*>("H264"));
+  bson_object_put_string(&bson_params1,
+                         protocol_handler::strings::video_protocol,
+                         const_cast<char*>("RAW"));
+  bson_object_put_string(&bson_params1,
+                         protocol_handler::strings::video_codec,
+                         const_cast<char*>("H264"));
   std::vector<uint8_t> params1 = CreateVectorFromBsonObject(&bson_params1);
 
   uint8_t generated_session_id1 = 100;
@@ -619,14 +622,16 @@ TEST_F(ProtocolHandlerImplTest,
 
   BsonObject bson_params2;
   bson_object_initialize_default(&bson_params2);
-  bson_object_put_string(
-      &bson_params2, "videoProtocol", const_cast<char*>("RTP"));
-  bson_object_put_string(
-      &bson_params2, "videoCodec", const_cast<char*>("H265"));
+  bson_object_put_string(&bson_params2,
+                         protocol_handler::strings::video_protocol,
+                         const_cast<char*>("RTP"));
+  bson_object_put_string(&bson_params2,
+                         protocol_handler::strings::video_codec,
+                         const_cast<char*>("H265"));
   std::vector<uint8_t> params2 = CreateVectorFromBsonObject(&bson_params2);
 
   std::vector<std::string> rejected_param_list;
-  rejected_param_list.push_back("videoCodec");
+  rejected_param_list.push_back(protocol_handler::strings::video_codec);
 
   EXPECT_CALL(session_observer_mock,
               OnSessionStartedCallback(connection_id2,
@@ -656,11 +661,14 @@ TEST_F(ProtocolHandlerImplTest,
 
   BsonObject bson_ack_params;
   bson_object_initialize_default(&bson_ack_params);
-  bson_object_put_int64(&bson_ack_params, "mtu", maximum_payload_size);
-  bson_object_put_string(
-      &bson_ack_params, "videoProtocol", const_cast<char*>("RAW"));
-  bson_object_put_string(
-      &bson_ack_params, "videoCodec", const_cast<char*>("H264"));
+  bson_object_put_int64(
+      &bson_ack_params, protocol_handler::strings::mtu, maximum_payload_size);
+  bson_object_put_string(&bson_ack_params,
+                         protocol_handler::strings::video_protocol,
+                         const_cast<char*>("RAW"));
+  bson_object_put_string(&bson_ack_params,
+                         protocol_handler::strings::video_codec,
+                         const_cast<char*>("H264"));
   std::vector<uint8_t> ack_params =
       CreateVectorFromBsonObject(&bson_ack_params);
   bson_object_deinitialize(&bson_ack_params);
@@ -681,7 +689,8 @@ TEST_F(ProtocolHandlerImplTest,
   }
   BsonObject bson_nack_params;
   bson_object_initialize_default(&bson_nack_params);
-  bson_object_put_array(&bson_nack_params, "rejectedParams", &bson_arr);
+  bson_object_put_array(
+      &bson_nack_params, protocol_handler::strings::rejected_params, &bson_arr);
   std::vector<uint8_t> nack_params =
       CreateVectorFromBsonObject(&bson_nack_params);
   bson_object_deinitialize(&bson_nack_params);

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -564,8 +564,8 @@ TEST_F(ProtocolHandlerImplTest,
        StartSession_Unprotected_Multiple_SessionObserverAcceptAndReject) {
   using namespace protocol_handler;
 
-  ON_CALL(protocol_handler_settings_mock, enable_protocol_5())
-      .WillByDefault(Return(true));
+  ON_CALL(protocol_handler_settings_mock, max_supported_protocol_version())
+      .WillByDefault(Return(PROTOCOL_VERSION_5));
 
   const size_t maximum_payload_size = 1000;
   InitProtocolHandlerImpl(0u, 0u, false, 0u, 0u, 0, maximum_payload_size);

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -107,9 +107,9 @@ using ::testing::SetArgPointee;
 
 typedef std::vector<uint8_t> UCharDataVector;
 
-// custom action to call a member function with 4 arguments
-ACTION_P6(InvokeMemberFuncWithArg4, ptr, memberFunc, a, b, c, d) {
-  (ptr->*memberFunc)(a, b, c, d);
+// custom action to call a member function with 6 arguments
+ACTION_P8(InvokeMemberFuncWithArg6, ptr, memberFunc, a, b, c, d, e, f) {
+  (ptr->*memberFunc)(a, b, c, d, e, f);
 }
 
 namespace {
@@ -211,9 +211,11 @@ class ProtocolHandlerImplTest : public ::testing::Test {
         .
         // Return sessions start success
         WillOnce(DoAll(NotifyTestAsyncWaiter(waiter),
-                       InvokeMemberFuncWithArg4(
+                       InvokeMemberFuncWithArg6(
                            protocol_handler_impl.get(),
                            &ProtocolHandler::NotifySessionStartedResult,
+                           connection_id,
+                           NEW_SESSION_ID,
                            session_id,
                            HASH_ID_WRONG,
                            callback_protection_flag,
@@ -377,8 +379,10 @@ TEST_F(ProtocolHandlerImplTest,
       // Return sessions start rejection
       WillRepeatedly(DoAll(
           NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg4(protocol_handler_impl.get(),
+          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
                                    &ProtocolHandler::NotifySessionStartedResult,
+                                   connection_id,
+                                   NEW_SESSION_ID,
                                    SESSION_START_REJECT,
                                    HASH_ID_WRONG,
                                    PROTECTION_OFF,
@@ -441,8 +445,10 @@ TEST_F(ProtocolHandlerImplTest, StartSession_Protected_SessionObserverReject) {
       // Return sessions start rejection
       WillRepeatedly(DoAll(
           NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg4(protocol_handler_impl.get(),
+          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
                                    &ProtocolHandler::NotifySessionStartedResult,
+                                   connection_id,
+                                   NEW_SESSION_ID,
                                    SESSION_START_REJECT,
                                    HASH_ID_WRONG,
                                    callback_protection_flag,
@@ -494,8 +500,10 @@ TEST_F(ProtocolHandlerImplTest,
       // Return sessions start success
       WillOnce(DoAll(
           NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg4(protocol_handler_impl.get(),
+          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
                                    &ProtocolHandler::NotifySessionStartedResult,
+                                   connection_id,
+                                   NEW_SESSION_ID,
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_OFF,
@@ -631,8 +639,10 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtocoloV1) {
       // Return sessions start success
       WillOnce(DoAll(
           NotifyTestAsyncWaiter(waiter),
-          InvokeMemberFuncWithArg4(protocol_handler_impl.get(),
+          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
                                    &ProtocolHandler::NotifySessionStartedResult,
+                                   connection_id,
+                                   NEW_SESSION_ID,
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_OFF,
@@ -685,8 +695,10 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionUnprotected) {
       // Return sessions start success
       WillOnce(DoAll(
           NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg4(protocol_handler_impl.get(),
+          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
                                    &ProtocolHandler::NotifySessionStartedResult,
+                                   connection_id,
+                                   NEW_SESSION_ID,
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_OFF,
@@ -729,8 +741,10 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtected_Fail) {
       // Return sessions start success
       WillOnce(DoAll(
           NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg4(protocol_handler_impl.get(),
+          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
                                    &ProtocolHandler::NotifySessionStartedResult,
+                                   connection_id,
+                                   NEW_SESSION_ID,
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_ON,
@@ -782,8 +796,10 @@ TEST_F(ProtocolHandlerImplTest,
       // Return sessions start success
       WillOnce(DoAll(
           NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg4(protocol_handler_impl.get(),
+          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
                                    &ProtocolHandler::NotifySessionStartedResult,
+                                   connection_id,
+                                   NEW_SESSION_ID,
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_ON,
@@ -848,8 +864,10 @@ TEST_F(ProtocolHandlerImplTest,
       // Return sessions start success
       WillOnce(DoAll(
           NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg4(protocol_handler_impl.get(),
+          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
                                    &ProtocolHandler::NotifySessionStartedResult,
+                                   connection_id,
+                                   NEW_SESSION_ID,
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_ON,
@@ -939,8 +957,10 @@ TEST_F(ProtocolHandlerImplTest,
       // Return sessions start success
       WillOnce(DoAll(
           NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg4(protocol_handler_impl.get(),
+          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
                                    &ProtocolHandler::NotifySessionStartedResult,
+                                   connection_id,
+                                   NEW_SESSION_ID,
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_ON,
@@ -1035,8 +1055,10 @@ TEST_F(
       // Return sessions start success
       WillOnce(DoAll(
           NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg4(protocol_handler_impl.get(),
+          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
                                    &ProtocolHandler::NotifySessionStartedResult,
+                                   connection_id,
+                                   NEW_SESSION_ID,
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_ON,
@@ -1129,8 +1151,10 @@ TEST_F(ProtocolHandlerImplTest,
       // Return sessions start success
       WillOnce(DoAll(
           NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg4(protocol_handler_impl.get(),
+          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
                                    &ProtocolHandler::NotifySessionStartedResult,
+                                   connection_id,
+                                   NEW_SESSION_ID,
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_ON,

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -207,7 +207,7 @@ class ProtocolHandlerImplTest : public ::testing::Test {
                                          NEW_SESSION_ID,
                                          start_service,
                                          callback_protection_flag,
-                                         _))
+                                         An<const BsonObject*>()))
         .
         // Return sessions start success
         WillOnce(DoAll(NotifyTestAsyncWaiter(waiter),
@@ -371,7 +371,7 @@ TEST_F(ProtocolHandlerImplTest,
                                NEW_SESSION_ID,
                                AnyOf(kControl, kRpc, kAudio, kMobileNav, kBulk),
                                PROTECTION_OFF,
-                               _))
+                               An<const BsonObject*>()))
       .Times(call_times)
       .
       // Return sessions start rejection
@@ -435,7 +435,7 @@ TEST_F(ProtocolHandlerImplTest, StartSession_Protected_SessionObserverReject) {
                                NEW_SESSION_ID,
                                AnyOf(kControl, kRpc, kAudio, kMobileNav, kBulk),
                                callback_protection_flag,
-                               _))
+                               An<const BsonObject*>()))
       .Times(call_times)
       .
       // Return sessions start rejection
@@ -484,10 +484,12 @@ TEST_F(ProtocolHandlerImplTest,
   uint32_t times = 0;
   std::vector<std::string> empty;
   // Expect ConnectionHandler check
-  EXPECT_CALL(
-      session_observer_mock,
-      OnSessionStartedCallback(
-          connection_id, NEW_SESSION_ID, start_service, PROTECTION_OFF, _))
+  EXPECT_CALL(session_observer_mock,
+              OnSessionStartedCallback(connection_id,
+                                       NEW_SESSION_ID,
+                                       start_service,
+                                       PROTECTION_OFF,
+                                       An<const BsonObject*>()))
       .
       // Return sessions start success
       WillOnce(DoAll(
@@ -619,10 +621,12 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtocoloV1) {
   const ServiceType start_service = kRpc;
   std::vector<std::string> empty;
   // Expect ConnectionHandler check
-  EXPECT_CALL(
-      session_observer_mock,
-      OnSessionStartedCallback(
-          connection_id, NEW_SESSION_ID, start_service, PROTECTION_OFF, _))
+  EXPECT_CALL(session_observer_mock,
+              OnSessionStartedCallback(connection_id,
+                                       NEW_SESSION_ID,
+                                       start_service,
+                                       PROTECTION_OFF,
+                                       An<const BsonObject*>()))
       .
       // Return sessions start success
       WillOnce(DoAll(
@@ -671,10 +675,12 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionUnprotected) {
   uint32_t times = 0;
   std::vector<std::string> empty;
   // Expect ConnectionHandler check
-  EXPECT_CALL(
-      session_observer_mock,
-      OnSessionStartedCallback(
-          connection_id, NEW_SESSION_ID, start_service, PROTECTION_OFF, _))
+  EXPECT_CALL(session_observer_mock,
+              OnSessionStartedCallback(connection_id,
+                                       NEW_SESSION_ID,
+                                       start_service,
+                                       PROTECTION_OFF,
+                                       An<const BsonObject*>()))
       .
       // Return sessions start success
       WillOnce(DoAll(
@@ -713,10 +719,12 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtected_Fail) {
   uint32_t times = 0;
   std::vector<std::string> empty;
   // Expect ConnectionHandler check
-  EXPECT_CALL(
-      session_observer_mock,
-      OnSessionStartedCallback(
-          connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _))
+  EXPECT_CALL(session_observer_mock,
+              OnSessionStartedCallback(connection_id,
+                                       NEW_SESSION_ID,
+                                       start_service,
+                                       PROTECTION_ON,
+                                       An<const BsonObject*>()))
       .
       // Return sessions start success
       WillOnce(DoAll(
@@ -764,10 +772,12 @@ TEST_F(ProtocolHandlerImplTest,
   uint32_t times = 0;
   std::vector<std::string> empty;
   // Expect ConnectionHandler check
-  EXPECT_CALL(
-      session_observer_mock,
-      OnSessionStartedCallback(
-          connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _))
+  EXPECT_CALL(session_observer_mock,
+              OnSessionStartedCallback(connection_id,
+                                       NEW_SESSION_ID,
+                                       start_service,
+                                       PROTECTION_ON,
+                                       An<const BsonObject*>()))
       .
       // Return sessions start success
       WillOnce(DoAll(
@@ -828,10 +838,12 @@ TEST_F(ProtocolHandlerImplTest,
   uint32_t times = 0;
   std::vector<std::string> empty;
   // Expect ConnectionHandler check
-  EXPECT_CALL(
-      session_observer_mock,
-      OnSessionStartedCallback(
-          connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _))
+  EXPECT_CALL(session_observer_mock,
+              OnSessionStartedCallback(connection_id,
+                                       NEW_SESSION_ID,
+                                       start_service,
+                                       PROTECTION_ON,
+                                       An<const BsonObject*>()))
       .
       // Return sessions start success
       WillOnce(DoAll(
@@ -917,10 +929,12 @@ TEST_F(ProtocolHandlerImplTest,
   uint32_t times = 0;
   std::vector<std::string> empty;
   // Expect ConnectionHandler check
-  EXPECT_CALL(
-      session_observer_mock,
-      OnSessionStartedCallback(
-          connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _))
+  EXPECT_CALL(session_observer_mock,
+              OnSessionStartedCallback(connection_id,
+                                       NEW_SESSION_ID,
+                                       start_service,
+                                       PROTECTION_ON,
+                                       An<const BsonObject*>()))
       .
       // Return sessions start success
       WillOnce(DoAll(
@@ -1011,10 +1025,12 @@ TEST_F(
   uint32_t times = 0;
   std::vector<std::string> empty;
   // Expect ConnectionHandler check
-  EXPECT_CALL(
-      session_observer_mock,
-      OnSessionStartedCallback(
-          connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _))
+  EXPECT_CALL(session_observer_mock,
+              OnSessionStartedCallback(connection_id,
+                                       NEW_SESSION_ID,
+                                       start_service,
+                                       PROTECTION_ON,
+                                       An<const BsonObject*>()))
       .
       // Return sessions start success
       WillOnce(DoAll(
@@ -1103,10 +1119,12 @@ TEST_F(ProtocolHandlerImplTest,
   uint32_t times = 0;
   std::vector<std::string> empty;
   // Expect ConnectionHandler check
-  EXPECT_CALL(
-      session_observer_mock,
-      OnSessionStartedCallback(
-          connection_id, NEW_SESSION_ID, start_service, PROTECTION_ON, _))
+  EXPECT_CALL(session_observer_mock,
+              OnSessionStartedCallback(connection_id,
+                                       NEW_SESSION_ID,
+                                       start_service,
+                                       PROTECTION_ON,
+                                       An<const BsonObject*>()))
       .
       // Return sessions start success
       WillOnce(DoAll(

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -202,7 +202,6 @@ class ProtocolHandlerImplTest : public ::testing::Test {
     // use protection OFF
     const bool callback_protection_flag = PROTECTION_OFF;
 #endif  // ENABLE_SECURITY
-    std::vector<std::string> empty;
 
     // Expect ConnectionHandler check
     EXPECT_CALL(session_observer_mock,
@@ -222,7 +221,7 @@ class ProtocolHandlerImplTest : public ::testing::Test {
                            session_id,
                            HASH_ID_WRONG,
                            callback_protection_flag,
-                           ByRef(empty))));
+                           ByRef(empty_rejected_param_))));
     times++;
 
     // Expect send Ack with PROTECTION_OFF (on no Security Manager)
@@ -315,6 +314,7 @@ class ProtocolHandlerImplTest : public ::testing::Test {
       security_manager_mock;
   testing::NiceMock<security_manager_test::MockSSLContext> ssl_context_mock;
 #endif  // ENABLE_SECURITY
+  std::vector<std::string> empty_rejected_param_;
 };
 
 #ifdef ENABLE_SECURITY
@@ -368,7 +368,6 @@ TEST_F(ProtocolHandlerImplTest,
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  std::vector<std::string> empty;
   // Expect ConnectionHandler check
   EXPECT_CALL(
       session_observer_mock,
@@ -389,7 +388,7 @@ TEST_F(ProtocolHandlerImplTest,
                                    SESSION_START_REJECT,
                                    HASH_ID_WRONG,
                                    PROTECTION_OFF,
-                                   ByRef(empty))));
+                                   ByRef(empty_rejected_param_))));
   times += call_times;
 
   // Expect send NAck
@@ -434,7 +433,6 @@ TEST_F(ProtocolHandlerImplTest, StartSession_Protected_SessionObserverReject) {
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  std::vector<std::string> empty;
   // Expect ConnectionHandler check
   EXPECT_CALL(
       session_observer_mock,
@@ -455,7 +453,7 @@ TEST_F(ProtocolHandlerImplTest, StartSession_Protected_SessionObserverReject) {
                                    SESSION_START_REJECT,
                                    HASH_ID_WRONG,
                                    callback_protection_flag,
-                                   ByRef(empty))));
+                                   ByRef(empty_rejected_param_))));
   times += call_times;
 
   // Expect send NAck with encryption OFF
@@ -491,7 +489,6 @@ TEST_F(ProtocolHandlerImplTest,
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  std::vector<std::string> empty;
   // Expect ConnectionHandler check
   EXPECT_CALL(session_observer_mock,
               OnSessionStartedCallback(connection_id,
@@ -510,7 +507,7 @@ TEST_F(ProtocolHandlerImplTest,
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_OFF,
-                                   ByRef(empty))));
+                                   ByRef(empty_rejected_param_))));
   times++;
 
   SetProtocolVersion2();
@@ -607,7 +604,6 @@ TEST_F(ProtocolHandlerImplTest,
   std::vector<uint8_t> params1 = CreateVectorFromBsonObject(&bson_params1);
 
   uint8_t generated_session_id1 = 100;
-  std::vector<std::string> empty;
 
   EXPECT_CALL(session_observer_mock,
               OnSessionStartedCallback(connection_id1,
@@ -656,7 +652,7 @@ TEST_F(ProtocolHandlerImplTest,
                                    generated_session_id1,
                                    HASH_ID_WRONG,
                                    PROTECTION_OFF,
-                                   ByRef(empty))));
+                                   ByRef(empty_rejected_param_))));
   times++;
 
   BsonObject bson_ack_params;
@@ -818,7 +814,6 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtocoloV1) {
   // Add security manager
   AddSecurityManager();
   const ServiceType start_service = kRpc;
-  std::vector<std::string> empty;
   // Expect ConnectionHandler check
   EXPECT_CALL(session_observer_mock,
               OnSessionStartedCallback(connection_id,
@@ -837,7 +832,7 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtocoloV1) {
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_OFF,
-                                   ByRef(empty))));
+                                   ByRef(empty_rejected_param_))));
   times++;
 
   SetProtocolVersion2();
@@ -874,7 +869,6 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionUnprotected) {
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  std::vector<std::string> empty;
   // Expect ConnectionHandler check
   EXPECT_CALL(session_observer_mock,
               OnSessionStartedCallback(connection_id,
@@ -893,7 +887,7 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionUnprotected) {
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_OFF,
-                                   ByRef(empty))));
+                                   ByRef(empty_rejected_param_))));
   times++;
 
   SetProtocolVersion2();
@@ -920,7 +914,6 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtected_Fail) {
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  std::vector<std::string> empty;
   // Expect ConnectionHandler check
   EXPECT_CALL(session_observer_mock,
               OnSessionStartedCallback(connection_id,
@@ -939,7 +932,7 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtected_Fail) {
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_ON,
-                                   ByRef(empty))));
+                                   ByRef(empty_rejected_param_))));
   times++;
 
   SetProtocolVersion2();
@@ -975,7 +968,6 @@ TEST_F(ProtocolHandlerImplTest,
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  std::vector<std::string> empty;
   // Expect ConnectionHandler check
   EXPECT_CALL(session_observer_mock,
               OnSessionStartedCallback(connection_id,
@@ -994,7 +986,7 @@ TEST_F(ProtocolHandlerImplTest,
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_ON,
-                                   ByRef(empty))));
+                                   ByRef(empty_rejected_param_))));
   times++;
 
   SetProtocolVersion2();
@@ -1043,7 +1035,6 @@ TEST_F(ProtocolHandlerImplTest,
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  std::vector<std::string> empty;
   // Expect ConnectionHandler check
   EXPECT_CALL(session_observer_mock,
               OnSessionStartedCallback(connection_id,
@@ -1062,7 +1053,7 @@ TEST_F(ProtocolHandlerImplTest,
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_ON,
-                                   ByRef(empty))));
+                                   ByRef(empty_rejected_param_))));
   times++;
 
   std::vector<int> services;
@@ -1136,7 +1127,6 @@ TEST_F(ProtocolHandlerImplTest,
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  std::vector<std::string> empty;
   // Expect ConnectionHandler check
   EXPECT_CALL(session_observer_mock,
               OnSessionStartedCallback(connection_id,
@@ -1155,7 +1145,7 @@ TEST_F(ProtocolHandlerImplTest,
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_ON,
-                                   ByRef(empty))));
+                                   ByRef(empty_rejected_param_))));
   times++;
 
   // call new SSLContext creation
@@ -1234,7 +1224,6 @@ TEST_F(
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  std::vector<std::string> empty;
   // Expect ConnectionHandler check
   EXPECT_CALL(session_observer_mock,
               OnSessionStartedCallback(connection_id,
@@ -1253,7 +1242,7 @@ TEST_F(
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_ON,
-                                   ByRef(empty))));
+                                   ByRef(empty_rejected_param_))));
   times++;
 
   // call new SSLContext creation
@@ -1330,7 +1319,6 @@ TEST_F(ProtocolHandlerImplTest,
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  std::vector<std::string> empty;
   // Expect ConnectionHandler check
   EXPECT_CALL(session_observer_mock,
               OnSessionStartedCallback(connection_id,
@@ -1349,7 +1337,7 @@ TEST_F(ProtocolHandlerImplTest,
                                    session_id,
                                    HASH_ID_WRONG,
                                    PROTECTION_ON,
-                                   ByRef(empty))));
+                                   ByRef(empty_rejected_param_))));
   times++;
 
   // call new SSLContext creation

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -654,12 +654,22 @@ TEST_F(ProtocolHandlerImplTest,
                                    ByRef(empty))));
   times++;
 
+  BsonObject bson_ack_params;
+  bson_object_initialize_default(&bson_ack_params);
+  bson_object_put_int64(&bson_ack_params, "mtu", maximum_payload_size);
+  bson_object_put_string(
+      &bson_ack_params, "videoProtocol", const_cast<char*>("RAW"));
+  bson_object_put_string(
+      &bson_ack_params, "videoCodec", const_cast<char*>("H264"));
+  std::vector<uint8_t> ack_params =
+      CreateVectorFromBsonObject(&bson_ack_params);
+  bson_object_deinitialize(&bson_ack_params);
+
   EXPECT_CALL(transport_manager_mock,
-              SendMessageToDevice(ControlMessage(
-                  FRAME_DATA_START_SERVICE_ACK,
-                  PROTECTION_OFF,
-                  connection_id1,
-                  _)))  // skip checking of non-video parameters like mtu
+              SendMessageToDevice(ControlMessage(FRAME_DATA_START_SERVICE_ACK,
+                                                 PROTECTION_OFF,
+                                                 connection_id1,
+                                                 Eq(ack_params))))
       .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter), Return(E_SUCCESS)));
   times++;
 

--- a/src/components/protocol_handler/test/protocol_header_validator_test.cc
+++ b/src/components/protocol_handler/test/protocol_header_validator_test.cc
@@ -68,7 +68,7 @@ TEST_F(ProtocolHeaderValidatorTest, MaxPayloadSizeSetGet) {
 }
 
 TEST_F(ProtocolHeaderValidatorTest, MaxControlPayloadSizeSetGet) {
-  EXPECT_EQ(0, header_validator.max_control_payload_size());
+  EXPECT_EQ(0u, header_validator.max_control_payload_size());
   for (size_t value = 0; value < MAXIMUM_FRAME_DATA_V3_SIZE * 2; ++value) {
     header_validator.set_max_control_payload_size(value);
     EXPECT_EQ(value, header_validator.max_control_payload_size());
@@ -76,7 +76,7 @@ TEST_F(ProtocolHeaderValidatorTest, MaxControlPayloadSizeSetGet) {
 }
 
 TEST_F(ProtocolHeaderValidatorTest, MaxRpcPayloadSizeSetGet) {
-  EXPECT_EQ(0, header_validator.max_rpc_payload_size());
+  EXPECT_EQ(0u, header_validator.max_rpc_payload_size());
   for (size_t value = 0; value < MAXIMUM_FRAME_DATA_V3_SIZE * 2; ++value) {
     header_validator.set_max_rpc_payload_size(value);
     EXPECT_EQ(value, header_validator.max_rpc_payload_size());
@@ -84,7 +84,7 @@ TEST_F(ProtocolHeaderValidatorTest, MaxRpcPayloadSizeSetGet) {
 }
 
 TEST_F(ProtocolHeaderValidatorTest, MaxAudioPayloadSizeSetGet) {
-  EXPECT_EQ(0, header_validator.max_audio_payload_size());
+  EXPECT_EQ(0u, header_validator.max_audio_payload_size());
   for (size_t value = 0; value < MAXIMUM_FRAME_DATA_V3_SIZE * 2; ++value) {
     header_validator.set_max_audio_payload_size(value);
     EXPECT_EQ(value, header_validator.max_audio_payload_size());
@@ -92,7 +92,7 @@ TEST_F(ProtocolHeaderValidatorTest, MaxAudioPayloadSizeSetGet) {
 }
 
 TEST_F(ProtocolHeaderValidatorTest, MaxVideoPayloadSizeSetGet) {
-  EXPECT_EQ(0, header_validator.max_video_payload_size());
+  EXPECT_EQ(0u, header_validator.max_video_payload_size());
   for (size_t value = 0; value < MAXIMUM_FRAME_DATA_V3_SIZE * 2; ++value) {
     header_validator.set_max_video_payload_size(value);
     EXPECT_EQ(value, header_validator.max_video_payload_size());


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/1591

This PR is **ready** for review.

### Summary of the changes
- Add video capability parameters in HMI capabilities, GetSystemCapability response and RegisterAppInterface response
- Add Navi.SetVideoConfig request and response between Core and HMI
- Change service start sequence from synchronous to asynchronous.
  This is because we need to wait for Navi.SetVideoConfig response before sending back StartService ACK/NACK to mobile.
  This change affects protocol handler, connection handler, application manager and application classes.
- Add unit tests for added/updated classes

### API changes
- This PR makes additions to both MOBILE_API.xml and HMI_API.xml

### Risk
- Normal sequence of starting video and audio streaming is affected.

### Testing Plan
- Adding unit tests

**Note:** I also looked into ATF but so far it doesn't support constructed payload as well as system capability yet. I plan to add tests to ATF when they are available.

### Tasks Remaining
- Verify behavior with proxy
