### PR TITLE
Use `MaxSupportedProtocolVersion` instead of `EnableProtocolX` to determine protocol version

### DIFF
--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -30,6 +30,8 @@ AudioStreamingPort = 5080
 ; SDL source version 
 ; represents as a git commit hash value
 SDLVersion = {GIT_COMMIT}
+; SDL supported protocol version
+MaxSupportedProtocolVersion = 5
 ; All logging event could be dropped by setting $LogsEnabled to false
 LogsEnabled = true
 ; Contains .json/.ini files
@@ -213,8 +215,7 @@ ThreadPoolSize = 1
 HashStringSize = 32
 
 [SDL4]
-; Enables SDL 4.0 support
-EnableProtocol4 = true
+; Section for features added in protocol version 4
 ; Path where apps icons must be stored
 AppIconsFolder = storage
 ; Max size of the folder in bytes
@@ -223,8 +224,7 @@ AppIconsFolderMaxSize = 104857600
 AppIconsAmountToRemove = 1
 
 [SDL5]
-; Enables SDL protocol 5.0 support
-EnableProtocol5 = true
+; Section for features added in protocol version 5
 ; Control service packet with payload bigger than this value will be marked as a malformed, 
 ; if not specified, this value will default to MaxPayloadSize
 ;MaximumControlPayloadSize = 131072

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3499,28 +3499,8 @@ void ApplicationManagerImpl::OnUpdateHMIAppType(
 
 ProtocolVersion ApplicationManagerImpl::SupportedSDLVersion() const {
   LOG4CXX_AUTO_TRACE(logger_);
-  bool heart_beat_support = get_settings().heart_beat_timeout();
-  bool sdl4_support = protocol_handler_->get_settings().enable_protocol_4();
-  bool sdl5_support = protocol_handler_->get_settings().enable_protocol_5();
-
-  if (sdl5_support) {
-    LOG4CXX_DEBUG(logger_,
-                  "SDL Supported protocol version " << ProtocolVersion::kV5);
-    return ProtocolVersion::kV5;
-  }
-  if (sdl4_support) {
-    LOG4CXX_DEBUG(logger_,
-                  "SDL Supported protocol version " << ProtocolVersion::kV4);
-    return ProtocolVersion::kV4;
-  }
-  if (heart_beat_support) {
-    LOG4CXX_DEBUG(logger_,
-                  "SDL Supported protocol version " << ProtocolVersion::kV3);
-    return ProtocolVersion::kV3;
-  }
-  LOG4CXX_DEBUG(logger_,
-                "SDL Supported protocol version " << ProtocolVersion::kV2);
-  return ProtocolVersion::kV2;
+  return static_cast<ProtocolVersion> get_settings()
+      .max_supported_protocol_version();
 }
 
 event_engine::EventDispatcher& ApplicationManagerImpl::event_dispatcher() {

--- a/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
@@ -115,7 +115,7 @@ void SetAppIconRequest::CopyToIconStorage(
     const std::string& path_to_file) const {
   if (!application_manager_.protocol_handler()
            .get_settings()
-           .enable_protocol_4()) {
+           .max_supported_protocol_version() >= ProtocolVersion::kV4) {
     LOG4CXX_WARN(logger_,
                  "Icon copying skipped, since protocol ver. 4 is not enabled.");
     return;

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -111,6 +111,7 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   /**
    * @brief Returns true, if SDL 4.0 is enabled
    */
+  // DEPRECATED, use max_supported_protocol_version instead
   bool enable_protocol_4() const OVERRIDE;
 
   /**
@@ -128,11 +129,6 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
    * if maximum size exceeded
    */
   const uint32_t& app_icons_amount_to_remove() const OVERRIDE;
-
-  /**
-   * @brief Returns true if SDL protocol v5 is enabled
-   */
-  bool enable_protocol_5() const OVERRIDE;
 
   /**
    * @brief Returns the maximum payload size for control services
@@ -784,11 +780,9 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   std::string app_config_folder_;
   std::string app_storage_folder_;
   std::string app_resource_folder_;
-  bool enable_protocol_4_;
   std::string app_icons_folder_;
   uint32_t app_icons_folder_max_size_;
   uint32_t app_icons_amount_to_remove_;
-  bool enable_protocol_5_;
   size_t maximum_control_payload_size_;
   size_t maximum_rpc_payload_size_;
   size_t maximum_audio_payload_size_;

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -101,11 +101,9 @@ const char* kAppStorageFolderKey = "AppStorageFolder";
 const char* kAppResourseFolderKey = "AppResourceFolder";
 const char* kLogsEnabledKey = "LogsEnabled";
 const char* kAppConfigFolderKey = "AppConfigFolder";
-const char* kEnableProtocol4Key = "EnableProtocol4";
 const char* kAppIconsFolderKey = "AppIconsFolder";
 const char* kAppIconsFolderMaxSizeKey = "AppIconsFolderMaxSize";
 const char* kAppIconsAmountToRemoveKey = "AppIconsAmountToRemove";
-const char* kEnableProtocol5Key = "EnableProtocol5";
 const char* kMaximumControlPayloadSizeKey = "MaximumControlPayloadSize";
 const char* kMaximumRpcPayloadSizeKey = "MaximumRpcPayloadSize";
 const char* kMaximumAudioPayloadSizeKey = "MaximumAudioPayloadSize";
@@ -244,7 +242,7 @@ const uint32_t kDefaultBeforeUpdateHours = 24;
 
 const uint32_t kDefaultHubProtocolIndex = 0;
 const uint32_t kDefaultHeartBeatTimeout = 0;
-const uint16_t kDefaultMaxSupportedProtocolVersion = 3;
+const uint16_t kDefaultMaxSupportedProtocolVersion = 5;
 const uint16_t kDefautTransportManagerTCPPort = 12345;
 const uint16_t kDefaultServerPort = 8087;
 const uint16_t kDefaultVideoStreamingPort = 5050;
@@ -323,11 +321,9 @@ Profile::Profile()
     app_config_folder_()
     , app_storage_folder_()
     , app_resource_folder_()
-    , enable_protocol_4_(false)
     , app_icons_folder_()
     , app_icons_folder_max_size_(kDefaultAppIconsFolderMaxSize)
     , app_icons_amount_to_remove_(kDefaultAppIconsAmountToRemove)
-    , enable_protocol_5_(false)
     , maximum_control_payload_size_(kDefaultMaximumControlPayloadSize)
     , maximum_rpc_payload_size_(kDefaultMaximumRpcPayloadSize)
     , maximum_audio_payload_size_(kDefaultMaximumAudioPayloadSize)
@@ -454,7 +450,7 @@ const std::string& Profile::app_resource_folder() const {
 }
 
 bool Profile::enable_protocol_4() const {
-  return enable_protocol_4_;
+  return max_supported_protocol_version_ >= 4;
 }
 
 const std::string& Profile::app_icons_folder() const {
@@ -467,10 +463,6 @@ const uint32_t& Profile::app_icons_folder_max_size() const {
 
 const uint32_t& Profile::app_icons_amount_to_remove() const {
   return app_icons_amount_to_remove_;
-}
-
-bool Profile::enable_protocol_5() const {
-  return enable_protocol_5_;
 }
 
 size_t Profile::maximum_control_payload_size() const {
@@ -1043,17 +1035,6 @@ void Profile::UpdateValues() {
 
   LOG_UPDATED_VALUE(app_resource_folder_, kAppResourseFolderKey, kMainSection);
 
-  // Enable protocol ver.4 parameter
-  std::string enable_protocol_4_value;
-  if (ReadValue(&enable_protocol_4_value, kSDL4Section, kEnableProtocol4Key) &&
-      0 == strcmp("true", enable_protocol_4_value.c_str())) {
-    enable_protocol_4_ = true;
-  } else {
-    enable_protocol_4_ = false;
-  }
-
-  LOG_UPDATED_BOOL_VALUE(enable_protocol_4_, kEnableProtocol4Key, kSDL4Section);
-
   // Application icon folder
   ReadStringValue(&app_icons_folder_,
                   file_system::CurrentWorkingDirectory().c_str(),
@@ -1087,17 +1068,6 @@ void Profile::UpdateValues() {
 
   LOG_UPDATED_VALUE(
       app_icons_amount_to_remove_, kAppIconsAmountToRemoveKey, kSDL4Section);
-
-  // Enable protocol ver.5 parameter
-  std::string enable_protocol_5_value;
-  if (ReadValue(&enable_protocol_5_value, kSDL5Section, kEnableProtocol5Key) &&
-      0 == strcmp("true", enable_protocol_5_value.c_str())) {
-    enable_protocol_5_ = true;
-  } else {
-    enable_protocol_5_ = false;
-  }
-
-  LOG_UPDATED_BOOL_VALUE(enable_protocol_5_, kEnableProtocol5Key, kSDL5Section);
 
   ReadUIntValue(&maximum_control_payload_size_,
                 kDefaultMaximumControlPayloadSize,
@@ -1712,10 +1682,11 @@ void Profile::UpdateValues() {
                 kProtocolHandlerSection,
                 kMaxSupportedProtocolVersionKey);
 
-  // if .ini file contains protocol version less than 2 or more than 3
-  // max_supported_protocol_version_ = 3
-  if (max_supported_protocol_version_ < 2) {
-    max_supported_protocol_version_ = 3;
+  if (max_supported_protocol_version_ < 1) {
+    max_supported_protocol_version_ = 1;
+  } else if (max_supported_protocol_version_ >
+             kDefaultMaxSupportedProtocolVersion) {
+    max_supported_protocol_version_ = kDefaultMaxSupportedProtocolVersion;
   }
 
   LOG_UPDATED_BOOL_VALUE(enable_policy_, kEnablePolicy, kPolicySection);

--- a/src/components/include/protocol_handler/protocol_handler_settings.h
+++ b/src/components/include/protocol_handler/protocol_handler_settings.h
@@ -29,12 +29,13 @@ class ProtocolHandlerSettings {
    */
   virtual uint32_t heart_beat_timeout() const = 0;
 
-  virtual uint16_t max_supported_protocol_version() const = 0;
   /*
    * @brief Protocol version, from .ini file.
    */
+  virtual uint16_t max_supported_protocol_version() const = 0;
+
+  // DEPRECATED
   virtual bool enable_protocol_4() const = 0;
-  virtual bool enable_protocol_5() const = 0;
 
   virtual uint32_t multiframe_waiting_timeout() const = 0;
 #ifdef ENABLE_SECURITY

--- a/src/components/include/test/protocol_handler/mock_protocol_handler_settings.h
+++ b/src/components/include/test/protocol_handler/mock_protocol_handler_settings.h
@@ -55,7 +55,6 @@ class MockProtocolHandlerSettings
   MOCK_CONST_METHOD0(heart_beat_timeout, uint32_t());
   MOCK_CONST_METHOD0(max_supported_protocol_version, uint16_t());
   MOCK_CONST_METHOD0(enable_protocol_4, bool());
-  MOCK_CONST_METHOD0(enable_protocol_5, bool());
   MOCK_CONST_METHOD0(multiframe_waiting_timeout, uint32_t());
 #ifdef ENABLE_SECURITY
   MOCK_CONST_METHOD0(force_protected_service, const std::vector<int>&());

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1742,21 +1742,6 @@ std::string ConvertPacketDataToString(const uint8_t* data,
 
 uint8_t ProtocolHandlerImpl::SupportedSDLProtocolVersion() const {
   LOG4CXX_AUTO_TRACE(logger_);
-
-  bool heart_beat_support = (0 != get_settings().heart_beat_timeout());
-
-  bool sdl4_support = get_settings().enable_protocol_4();
-  bool sdl5_support = get_settings().enable_protocol_5();
-
-  if (sdl5_support) {
-    return PROTOCOL_VERSION_5;
-  }
-  if (sdl4_support) {
-    return PROTOCOL_VERSION_4;
-  }
-  if (heart_beat_support) {
-    return PROTOCOL_VERSION_3;
-  }
-  return PROTOCOL_VERSION_2;
+  return get_settings().max_supported_protocol_version();
 }
 }  // namespace protocol_handler


### PR DESCRIPTION
An ini configuration was already implemented for `MaxSupportedProtocolVersion`.

This commit removes the `EnableProtocolX` options and instead uses the `MaxSupportedProtcolVersion` parameter to determine what features are supported.