### PR TITLE
Add constants for BSON object keys

### DIFF
--- a/src/components/include/protocol/bson_object_keys.h
+++ b/src/components/include/protocol/bson_object_keys.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace protocol_handler {
+
+namespace strings {
+
+extern const char* hash_id;
+extern const char* protocol_version;
+extern const char* mtu;
+extern const char* rejected_params;
+
+}  // namespace strings
+
+}  // namespace protocol_handler

--- a/src/components/protocol/src/bson_object_keys.cc
+++ b/src/components/protocol/src/bson_object_keys.cc
@@ -1,0 +1,14 @@
+#include <protocol/bson_object_keys.h>
+
+namespace protocol_handler {
+
+namespace strings {
+
+const char* hash_id = "hashId";
+const char* protocol_version = "protocolVersion";
+const char* mtu = "mtu";
+const char* rejected_params = "rejectedParams";
+
+}  // namespace strings
+
+}  // namespace protocol_handler


### PR DESCRIPTION
BSON object keys were hard-coded in the original Constructed Payloads implementation. This PR creates a collection of constants for these keys.