### PR TITLE
Fix instalation of bson to avoid root access

### DIFF
--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -283,22 +283,43 @@ if(HMI_DBUS_API)
   add_subdirectory(dbus-cmake)
 endif()
 
-set(BSON_LIBS_DIRECTORY ${3RD_PARTY_INSTALL_PREFIX_ARCH}/lib PARENT_SCOPE)
-set(BSON_INCLUDE_DIRECTORY ${3RD_PARTY_INSTALL_PREFIX}/include PARENT_SCOPE)
-set(EMHASHMAP_INCLUDE_DIRECTORY ${3RD_PARTY_INSTALL_PREFIX}/include PARENT_SCOPE)
-set(EMHASHMAP_LIBS_DIRECTORY ${3RD_PARTY_INSTALL_PREFIX_ARCH}/lib PARENT_SCOPE)
-set(BSON_LIB_SOURCE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bson_c_lib)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}")
+set(CMAKE_SOURCE_PREFIX ${CMAKE_SOURCE_PREFIX} "${3RD_PARTY_INSTALL_PREFIX}")
+find_package (BSON)
+message (STATUS "bson installed in " ${BSON_LIBS_DIRECTORY} " , " ${BSON_INCLUDE_DIRECTORY})
+message (STATUS "emhashmap installed in " ${EMHASHMAP_LIBS_DIRECTORY} " , " ${EMHASHMAP_INCLUDE_DIRECTORY})
 
-include(ExternalProject)
-ExternalProject_Add(libbson
-    GIT_REPOSITORY "http://github.com/smartdevicelink/bson_c_lib.git"
-    GIT_TAG "master"
-    BINARY_DIR ${BSON_LIB_SOURCE_DIRECTORY}
-    DOWNLOAD_DIR ${BSON_LIB_SOURCE_DIRECTORY}
-    SOURCE_DIR ${BSON_LIB_SOURCE_DIRECTORY}
-    CONFIGURE_COMMAND touch aclocal.m4 configure.ac Makefile.am Makefile.in configure && ./configure
-    BUILD_COMMAND make
-    INSTALL_COMMAND sudo make install)
+if (${BSON_LIB} MATCHES "BSON_LIB-NOTFOUND")
+  message (STATUS "Building bson required")
+  set(BSON_LIB_SOURCE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bson_c_lib CACHE INTERNAL "Sources of bson library" FORCE)
+  set(BSON_LIBS_DIRECTORY ${3RD_PARTY_INSTALL_PREFIX}/lib CACHE INTERNAL "Installation path of bson libraries" FORCE)
+  set(BSON_INCLUDE_DIRECTORY ${3RD_PARTY_INSTALL_PREFIX}/include CACHE INTERNAL "Installation path of bson headers" FORCE)
+  set(EMHASHMAP_LIBS_DIRECTORY ${3RD_PARTY_INSTALL_PREFIX}/lib CACHE INTERNAL "Installation path of emashmap libraries" FORCE)
+  set(EMHASHMAP_INCLUDE_DIRECTORY ${3RD_PARTY_INSTALL_PREFIX}/include CACHE INTERNAL "Installation path of emashmap headers" FORCE)
+
+  set(BSON_INSTALL_COMMAND make install)
+  if (${3RD_PARTY_INSTALL_PREFIX} MATCHES "/usr/local")
+    set(BSON_INSTALL_COMMAND sudo make install)
+  endif()
+  include(ExternalProject)
+  ExternalProject_Add(libbson
+      GIT_REPOSITORY "http://github.com/LuxoftAKutsan/bson_c_lib.git"
+# TODO Change GIT_REPOSITORY to http://github.com/smartdevicelink/bson_c_lib.git
+#      after merge of https://github.com/smartdevicelink/bson_c_lib/pull/2
+      GIT_TAG "master"
+      BINARY_DIR ${BSON_LIB_SOURCE_DIRECTORY}
+      INSTALL_DIR ${3RD_PARTY_INSTALL_PREFIX}
+      DOWNLOAD_DIR ${BSON_LIB_SOURCE_DIRECTORY}
+      SOURCE_DIR ${BSON_LIB_SOURCE_DIRECTORY}
+      CONFIGURE_COMMAND touch aclocal.m4 configure.ac Makefile.am Makefile.in configure && ./configure --prefix=${3RD_PARTY_INSTALL_PREFIX}
+      BUILD_COMMAND make
+      INSTALL_COMMAND ${BSON_INSTALL_COMMAND})
+else()
+  get_filename_component(BSON_LIBS_DIRECTORY ${BSON_LIB} DIRECTORY)
+  get_filename_component(EMHASHMAP_LIBS_DIRECTORY ${EMHASHMAP_LIB} DIRECTORY)
+  set(BSON_LIBS_DIRECTORY ${BSON_LIBS_DIRECTORY} CACHE INTERNAL "Installation path of bson libraries" FORCE)
+  set(EMHASHMAP_LIBS_DIRECTORY ${BSON_LIBS_DIRECTORY} CACHE INTERNAL "Installation path of emashmap libraries" FORCE)
+endif()
 
 add_custom_target(install-3rd_party
   DEPENDS ${install-3rd_party_logger_var}

--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -303,15 +303,13 @@ if (${BSON_LIB} MATCHES "BSON_LIB-NOTFOUND")
   endif()
   include(ExternalProject)
   ExternalProject_Add(libbson
-      GIT_REPOSITORY "http://github.com/LuxoftAKutsan/bson_c_lib.git"
-# TODO Change GIT_REPOSITORY to http://github.com/smartdevicelink/bson_c_lib.git
-#      after merge of https://github.com/smartdevicelink/bson_c_lib/pull/2
+      GIT_REPOSITORY "http://github.com/smartdevicelink/bson_c_lib.git"
       GIT_TAG "master"
       BINARY_DIR ${BSON_LIB_SOURCE_DIRECTORY}
       INSTALL_DIR ${3RD_PARTY_INSTALL_PREFIX}
       DOWNLOAD_DIR ${BSON_LIB_SOURCE_DIRECTORY}
       SOURCE_DIR ${BSON_LIB_SOURCE_DIRECTORY}
-      CONFIGURE_COMMAND touch aclocal.m4 configure.ac Makefile.am Makefile.in configure && ./configure --prefix=${3RD_PARTY_INSTALL_PREFIX}
+      CONFIGURE_COMMAND touch aclocal.m4 configure.ac Makefile.am Makefile.in configure config.h.in && ./configure --prefix=${3RD_PARTY_INSTALL_PREFIX}
       BUILD_COMMAND make
       INSTALL_COMMAND ${BSON_INSTALL_COMMAND})
 else()

--- a/src/3rd_party/FindBSON.cmake
+++ b/src/3rd_party/FindBSON.cmake
@@ -1,0 +1,26 @@
+set(INCLUDE_PATH "${CMAKE_SOURCE_PREFIX}/include")
+set(LIB_PATH "${CMAKE_SOURCE_PREFIX}/lib")
+
+find_path(BSON_INCLUDE_DIRECTORY bson_object.h bson_array.h bson_util.h
+          PATHS "${INCLUDE_PATH}")
+
+find_library(BSON_LIB
+             NAMES bson
+             PATHS ${LIB_PATH})
+
+find_path(EMHASHMAP_INCLUDE_DIRECTORY emhashmap.h
+          PATHS ${INCLUDE_PATH}
+          PATH_SUFFIXES emhashmap)
+
+find_library(EMHASHMAP_LIB
+             NAMES emhashmap
+             PATHS ${LIB_PATH})
+
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(BSON DEFAULT_MSG BSON_INCLUDE_DIRECTORY BSON_LIB
+						   EMHASHMAP_INCLUDE_DIRECTORY EMHASHMAP_LIB)
+
+mark_as_advanced(BSON_INCLUDE_DIRECTORY BSON_LIB)
+mark_as_advanced(EMHASHMAP_INCLUDE_DIRECTORY EMHASHMAP_LIB)


### PR DESCRIPTION
Fixes : #1722 #1721 

- Create cmake file for finding already installed bson to the system
- Add checking that bson is already installed to the system,  if bson installed - use it.
- Avoid root access if it is not required for installation bson
 

In this PR used custom fork of for bson_c_lib. After merging folowing PRs it shoudl be changes to origin one: 
https://github.com/smartdevicelink/bson_c_lib/pull/3
https://github.com/smartdevicelink/bson_c_lib/pull/2

:heavy_exclamation_mark: This pull request should not be merged only after merge Pull requests to smartdevicelink/bson_c_lib and changing link to bson_c_lib
