### PR TITLE
Replace Functional module library

### DIFF
--- a/src/components/application_manager/test/message_helper/CMakeLists.txt
+++ b/src/components/application_manager/test/message_helper/CMakeLists.txt
@@ -49,8 +49,8 @@ set(LIBRARIES
 
 if(REMOTE_CONTROL)
     SET (LIBRARIES
-      ${LIBRARIES}
       FunctionalModule
+      ${LIBRARIES}
     )
 endif(REMOTE_CONTROL)
 


### PR DESCRIPTION
Replace Adding functional module libraries before application manager library in message helper test
It fixes linkage issue.