### PR TITLE
Fix/core cannot find app via bt

### DIFF
--- a/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
+++ b/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
@@ -173,6 +173,7 @@ void ThreadedSocketConnection::threadMain() {
   if (!Establish(&connect_error)) {
     LOG4CXX_ERROR(logger_, "Connection Establish failed");
     delete connect_error;
+    Abort();
   }
   LOG4CXX_DEBUG(logger_, "Connection established");
   controller_->ConnectDone(device_handle(), application_handle());


### PR DESCRIPTION
This PR is to fix #1753.

We added ```Abort()``` function, it will help to over the ```Transmit()``` function, to directly call the ```Finalize()``` function to release the connection object. Thus avoiding program blocking in the Transmit function.

![image](https://user-images.githubusercontent.com/13449160/30312642-fc0bcc10-97cc-11e7-9f93-f63706c0e57d.png)
