### PR TITLE
Fix/unregister while audio pass thru

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -478,7 +478,7 @@ class ApplicationManagerImpl
   uint32_t GetNextHMICorrelationID() OVERRIDE;
 
   /* @brief Starts audio passthru process
-   * @deprecated Use BeginAudioPassThru(int32_t session_key) instead
+   * @deprecated Use BeginAudioPassThru(uint32_t app_id) instead
    *
    * @return true on success, false if passthru is already in process
    */
@@ -486,14 +486,14 @@ class ApplicationManagerImpl
 
   /**
    * @brief Starts AudioPassThru process by given application
-   * @param session_key Session key of connection for Mobile side
+   * @param app_id ID of the application which starts the process
    * @return true if AudioPassThru can be started, false otherwise
    */
-  bool BeginAudioPassThru(int32_t session_key) OVERRIDE;
+  bool BeginAudioPassThru(uint32_t app_id) OVERRIDE;
 
   /*
    * @brief Finishes already started audio passthru process
-   * @deprecated Use EndAudioPassThru(int32_t application_key) instead
+   * @deprecated Use EndAudioPassThru(uint32_t app_id) instead
    *
    * @return true on success, false if passthru is not active
    */
@@ -501,11 +501,11 @@ class ApplicationManagerImpl
 
   /**
    * @brief Finishes already started AudioPassThru process by given application
-   * @param application_key ID of the application which started the process
+   * @param app_id ID of the application which started the process
    * @return true if AudioPassThru process has been started with given
    * application and thus it can be stopped, false otherwise
    */
-  bool EndAudioPassThru(int32_t application_key) OVERRIDE;
+  bool EndAudioPassThru(uint32_t app_id) OVERRIDE;
 
   /*
    * @brief Retrieves driver distraction state
@@ -1719,7 +1719,7 @@ class ApplicationManagerImpl
   std::map<uint32_t, TimevalStruct> tts_global_properties_app_list_;
 
   bool audio_pass_thru_active_;
-  int32_t audio_pass_thru_app_key_;
+  uint32_t audio_pass_thru_app_id_;
   sync_primitives::Lock audio_pass_thru_lock_;
   sync_primitives::Lock tts_global_properties_app_list_lock_;
   hmi_apis::Common_DriverDistractionState::eType driver_distraction_state_;

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -481,7 +481,8 @@ class ApplicationManagerImpl
    *
    * @return true on success, false if passthru is already in process
    */
-  DEPRECATED bool BeginAudioPassThrough() OVERRIDE;
+  // DEPRECATED
+  bool BeginAudioPassThrough() OVERRIDE;
 
   /**
    * @brief Starts AudioPassThru process by given application
@@ -495,7 +496,8 @@ class ApplicationManagerImpl
    *
    * @return true on success, false if passthru is not active
    */
-  DEPRECATED bool EndAudioPassThrough() OVERRIDE;
+  // DEPRECATED
+  bool EndAudioPassThrough() OVERRIDE;
 
   /**
    * @brief Finishes already started AudioPassThru process by given application

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -481,8 +481,7 @@ class ApplicationManagerImpl
    *
    * @return true on success, false if passthru is already in process
    */
-  // DEPRECATED
-  bool BeginAudioPassThrough() OVERRIDE;
+  DEPRECATED bool BeginAudioPassThrough() OVERRIDE;
 
   /**
    * @brief Starts AudioPassThru process by given application
@@ -496,8 +495,7 @@ class ApplicationManagerImpl
    *
    * @return true on success, false if passthru is not active
    */
-  // DEPRECATED
-  bool EndAudioPassThrough() OVERRIDE;
+  DEPRECATED bool EndAudioPassThrough() OVERRIDE;
 
   /**
    * @brief Finishes already started AudioPassThru process by given application

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1820,6 +1820,13 @@ class ApplicationManagerImpl
    */
   void AddMockApplication(ApplicationSharedPtr mock_app);
 
+  /**
+   * @brief set a mock media manager without running Init(). Only for unit
+   * testing.
+   * @param mock_app the mock app to be registered
+   */
+  void SetMockMediaManager(media_manager::MediaManager* mock_media_manager);
+
  private:
 #endif
 

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -481,14 +481,31 @@ class ApplicationManagerImpl
    *
    * @return true on success, false if passthru is already in process
    */
+  // DEPRECATED
   bool BeginAudioPassThrough() OVERRIDE;
+
+  /**
+   * @brief Starts AudioPassThru process by given application
+   * @param session_key Session key of connection for Mobile side
+   * @return true if AudioPassThru can be started, false otherwise
+   */
+  bool BeginAudioPassThru(int32_t session_key) OVERRIDE;
 
   /*
    * @brief Finishes already started audio passthru process
    *
    * @return true on success, false if passthru is not active
    */
+  // DEPRECATED
   bool EndAudioPassThrough() OVERRIDE;
+
+  /**
+   * @brief Finishes already started AudioPassThru process by given application
+   * @param application_key ID of the application which started the process
+   * @return true if AudioPassThru process has been started with given
+   * application and thus it can be stopped, false otherwise
+   */
+  bool EndAudioPassThru(int32_t application_key) OVERRIDE;
 
   /*
    * @brief Retrieves driver distraction state
@@ -1702,6 +1719,7 @@ class ApplicationManagerImpl
   std::map<uint32_t, TimevalStruct> tts_global_properties_app_list_;
 
   bool audio_pass_thru_active_;
+  int32_t audio_pass_thru_app_key_;
   sync_primitives::Lock audio_pass_thru_lock_;
   sync_primitives::Lock tts_global_properties_app_list_lock_;
   hmi_apis::Common_DriverDistractionState::eType driver_distraction_state_;

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -478,10 +478,10 @@ class ApplicationManagerImpl
   uint32_t GetNextHMICorrelationID() OVERRIDE;
 
   /* @brief Starts audio passthru process
+   * @deprecated Use BeginAudioPassThru(int32_t session_key) instead
    *
    * @return true on success, false if passthru is already in process
    */
-  // DEPRECATED
   bool BeginAudioPassThrough() OVERRIDE;
 
   /**
@@ -493,10 +493,10 @@ class ApplicationManagerImpl
 
   /*
    * @brief Finishes already started audio passthru process
+   * @deprecated Use EndAudioPassThru(int32_t application_key) instead
    *
    * @return true on success, false if passthru is not active
    */
-  // DEPRECATED
   bool EndAudioPassThrough() OVERRIDE;
 
   /**

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -775,7 +775,7 @@ uint32_t ApplicationManagerImpl::GetNextHMICorrelationID() {
   return corelation_id_;
 }
 
-DEPRECATED bool ApplicationManagerImpl::BeginAudioPassThrough() {
+bool ApplicationManagerImpl::BeginAudioPassThrough() {
   sync_primitives::AutoLock lock(audio_pass_thru_lock_);
   if (audio_pass_thru_active_) {
     return false;
@@ -796,7 +796,7 @@ bool ApplicationManagerImpl::BeginAudioPassThru(int32_t session_key) {
   }
 }
 
-DEPRECATED bool ApplicationManagerImpl::EndAudioPassThrough() {
+bool ApplicationManagerImpl::EndAudioPassThrough() {
   sync_primitives::AutoLock lock(audio_pass_thru_lock_);
   if (audio_pass_thru_active_) {
     audio_pass_thru_active_ = false;

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -4441,6 +4441,11 @@ void ApplicationManagerImpl::AddMockApplication(ApplicationSharedPtr mock_app) {
   apps_size_ = applications_.size();
   applications_list_lock_.Release();
 }
+
+void ApplicationManagerImpl::SetMockMediaManager(
+    media_manager::MediaManager* mock_media_manager) {
+  media_manager_ = mock_media_manager;
+}
 #endif  // BUILD_TESTS
 #ifdef SDL_REMOTE_CONTROL
 struct MobileAppIdPredicate {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -143,7 +143,7 @@ ApplicationManagerImpl::ApplicationManagerImpl(
     : settings_(am_settings)
     , applications_list_lock_(true)
     , audio_pass_thru_active_(false)
-    , audio_pass_thru_app_key_(0)
+    , audio_pass_thru_app_id_(0)
     , driver_distraction_state_(
           hmi_apis::Common_DriverDistractionState::INVALID_ENUM)
     , is_vr_session_strated_(false)
@@ -785,13 +785,13 @@ bool ApplicationManagerImpl::BeginAudioPassThrough() {
   }
 }
 
-bool ApplicationManagerImpl::BeginAudioPassThru(int32_t session_key) {
+bool ApplicationManagerImpl::BeginAudioPassThru(uint32_t app_id) {
   sync_primitives::AutoLock lock(audio_pass_thru_lock_);
   if (audio_pass_thru_active_) {
     return false;
   } else {
     audio_pass_thru_active_ = true;
-    audio_pass_thru_app_key_ = session_key;
+    audio_pass_thru_app_id_ = app_id;
     return true;
   }
 }
@@ -806,11 +806,11 @@ bool ApplicationManagerImpl::EndAudioPassThrough() {
   }
 }
 
-bool ApplicationManagerImpl::EndAudioPassThru(int32_t application_key) {
+bool ApplicationManagerImpl::EndAudioPassThru(uint32_t app_id) {
   sync_primitives::AutoLock lock(audio_pass_thru_lock_);
-  if (audio_pass_thru_active_ && audio_pass_thru_app_key_ == application_key) {
+  if (audio_pass_thru_active_ && audio_pass_thru_app_id_ == app_id) {
     audio_pass_thru_active_ = false;
-    audio_pass_thru_app_key_ = 0;
+    audio_pass_thru_app_id_ = 0;
     return true;
   } else {
     return false;

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3245,9 +3245,8 @@ void ApplicationManagerImpl::UnregisterApplication(
 
   commands_holder_->Clear(app_to_remove);
 
-  if (audio_pass_thru_active_) {
+  if (EndAudioPassThru(app_id)) {
     // May be better to put this code in MessageHelper?
-    EndAudioPassThrough();
     StopAudioPassThru(app_id);
     MessageHelper::SendStopAudioPathThru(*this);
   }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -775,7 +775,7 @@ uint32_t ApplicationManagerImpl::GetNextHMICorrelationID() {
   return corelation_id_;
 }
 
-bool ApplicationManagerImpl::BeginAudioPassThrough() {
+DEPRECATED bool ApplicationManagerImpl::BeginAudioPassThrough() {
   sync_primitives::AutoLock lock(audio_pass_thru_lock_);
   if (audio_pass_thru_active_) {
     return false;
@@ -796,7 +796,7 @@ bool ApplicationManagerImpl::BeginAudioPassThru(int32_t session_key) {
   }
 }
 
-bool ApplicationManagerImpl::EndAudioPassThrough() {
+DEPRECATED bool ApplicationManagerImpl::EndAudioPassThrough() {
   sync_primitives::AutoLock lock(audio_pass_thru_lock_);
   if (audio_pass_thru_active_) {
     audio_pass_thru_active_ = false;

--- a/src/components/application_manager/src/commands/mobile/end_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/end_audio_pass_thru_request.cc
@@ -66,7 +66,8 @@ void EndAudioPassThruRequest::on_event(const event_engine::Event& event) {
       const bool result = PrepareResultForMobileResponse(
           result_code, HmiInterfaces::HMI_INTERFACE_UI);
       if (result) {
-        bool ended_successfully = application_manager_.EndAudioPassThrough();
+        bool ended_successfully =
+            application_manager_.EndAudioPassThru(connection_key());
         if (ended_successfully) {
           application_manager_.StopAudioPassThru(connection_key());
         }

--- a/src/components/application_manager/src/commands/mobile/end_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/end_audio_pass_thru_request.cc
@@ -66,10 +66,10 @@ void EndAudioPassThruRequest::on_event(const event_engine::Event& event) {
       const bool result = PrepareResultForMobileResponse(
           result_code, HmiInterfaces::HMI_INTERFACE_UI);
       if (result) {
-        bool ended_successfully =
-            application_manager_.EndAudioPassThru(connection_key());
+        uint32_t app_id = connection_key();
+        bool ended_successfully = application_manager_.EndAudioPassThru(app_id);
         if (ended_successfully) {
-          application_manager_.StopAudioPassThru(connection_key());
+          application_manager_.StopAudioPassThru(app_id);
         }
       }
 

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -311,7 +311,7 @@ void PerformAudioPassThruRequest::SendRecordStartNotification() {
 void PerformAudioPassThruRequest::StartMicrophoneRecording() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  application_manager_.BeginAudioPassThrough();
+  application_manager_.BeginAudioPassThru(connection_key());
 
   application_manager_.StartAudioPassThruThread(
       connection_key(),
@@ -370,7 +370,7 @@ bool PerformAudioPassThruRequest::IsWhiteSpaceExist() {
 
 void PerformAudioPassThruRequest::FinishTTSSpeak() {
   LOG4CXX_AUTO_TRACE(logger_);
-  if (application_manager_.EndAudioPassThrough()) {
+  if (application_manager_.EndAudioPassThru(connection_key())) {
     LOG4CXX_DEBUG(logger_, "Stop AudioPassThru.");
     application_manager_.StopAudioPassThru(connection_key());
   }

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -311,7 +311,8 @@ void PerformAudioPassThruRequest::SendRecordStartNotification() {
 void PerformAudioPassThruRequest::StartMicrophoneRecording() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  application_manager_.BeginAudioPassThru(connection_key());
+  uint32_t app_id = connection_key();
+  application_manager_.BeginAudioPassThru(app_id);
 
   application_manager_.StartAudioPassThruThread(
       connection_key(),
@@ -370,9 +371,10 @@ bool PerformAudioPassThruRequest::IsWhiteSpaceExist() {
 
 void PerformAudioPassThruRequest::FinishTTSSpeak() {
   LOG4CXX_AUTO_TRACE(logger_);
-  if (application_manager_.EndAudioPassThru(connection_key())) {
+  uint32_t app_id = connection_key();
+  if (application_manager_.EndAudioPassThru(app_id)) {
     LOG4CXX_DEBUG(logger_, "Stop AudioPassThru.");
-    application_manager_.StopAudioPassThru(connection_key());
+    application_manager_.StopAudioPassThru(app_id);
   }
   if (!IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_TTS)) {
     LOG4CXX_WARN(logger_, "TTS Speak is inactive.");

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -834,7 +834,7 @@ TEST_F(ApplicationManagerImplTest, StartStopAudioPassThru) {
       mock_media_manager;
   app_manager_impl_->SetMockMediaManager(&mock_media_manager);
 
-  const int32_t session_key = 65537;
+  const uint32_t app_id = 65537;
   const int32_t max_duration = 1000;
   // below are not used
   const int32_t correlation_id = 0;
@@ -843,15 +843,15 @@ TEST_F(ApplicationManagerImplTest, StartStopAudioPassThru) {
   const int32_t audio_type = 0;
 
   EXPECT_CALL(mock_media_manager,
-              StartMicrophoneRecording(session_key, _, max_duration))
+              StartMicrophoneRecording(app_id, _, max_duration))
       .WillOnce(Return());
-  EXPECT_CALL(mock_media_manager, StopMicrophoneRecording(session_key))
+  EXPECT_CALL(mock_media_manager, StopMicrophoneRecording(app_id))
       .WillOnce(Return());
 
-  bool result = app_manager_impl_->BeginAudioPassThru(session_key);
+  bool result = app_manager_impl_->BeginAudioPassThru(app_id);
   EXPECT_TRUE(result);
   if (result) {
-    app_manager_impl_->StartAudioPassThruThread(session_key,
+    app_manager_impl_->StartAudioPassThruThread(app_id,
                                                 correlation_id,
                                                 max_duration,
                                                 sampling_rate,
@@ -859,10 +859,10 @@ TEST_F(ApplicationManagerImplTest, StartStopAudioPassThru) {
                                                 audio_type);
   }
 
-  result = app_manager_impl_->EndAudioPassThru(session_key);
+  result = app_manager_impl_->EndAudioPassThru(app_id);
   EXPECT_TRUE(result);
   if (result) {
-    app_manager_impl_->StopAudioPassThru(session_key);
+    app_manager_impl_->StopAudioPassThru(app_id);
   }
 }
 
@@ -871,14 +871,13 @@ TEST_F(ApplicationManagerImplTest, UnregisterAnotherAppDuringAudioPassThru) {
   ON_CALL(mock_application_manager_settings_, recording_file_name())
       .WillByDefault(ReturnRef(dummy_file_name));
 
-  const int32_t session_key_of_app_1 = 65537;
-  const int32_t session_key_of_app_2 = 65538;
+  const uint32_t app_id_1 = 65537;
+  const uint32_t app_id_2 = 65538;
 
   std::string dummy_mac_address;
   utils::SharedPtr<MockApplication> mock_app_1 =
       utils::SharedPtr<MockApplication>(new MockApplication());
-  EXPECT_CALL(*mock_app_1, app_id())
-      .WillRepeatedly(Return(session_key_of_app_1));
+  EXPECT_CALL(*mock_app_1, app_id()).WillRepeatedly(Return(app_id_1));
   EXPECT_CALL(*mock_app_1, device()).WillRepeatedly(Return(0));
   EXPECT_CALL(*mock_app_1, mac_address())
       .WillRepeatedly(ReturnRef(dummy_mac_address));
@@ -889,8 +888,7 @@ TEST_F(ApplicationManagerImplTest, UnregisterAnotherAppDuringAudioPassThru) {
 
   utils::SharedPtr<MockApplication> mock_app_2 =
       utils::SharedPtr<MockApplication>(new MockApplication());
-  EXPECT_CALL(*mock_app_2, app_id())
-      .WillRepeatedly(Return(session_key_of_app_2));
+  EXPECT_CALL(*mock_app_2, app_id()).WillRepeatedly(Return(app_id_2));
   EXPECT_CALL(*mock_app_2, device()).WillRepeatedly(Return(0));
   EXPECT_CALL(*mock_app_2, mac_address())
       .WillRepeatedly(ReturnRef(dummy_mac_address));
@@ -914,16 +912,16 @@ TEST_F(ApplicationManagerImplTest, UnregisterAnotherAppDuringAudioPassThru) {
   const int32_t audio_type = 0;
 
   EXPECT_CALL(mock_media_manager,
-              StartMicrophoneRecording(session_key_of_app_2, _, max_duration))
+              StartMicrophoneRecording(app_id_2, _, max_duration))
       .WillOnce(Return());
-  EXPECT_CALL(mock_media_manager, StopMicrophoneRecording(session_key_of_app_2))
+  EXPECT_CALL(mock_media_manager, StopMicrophoneRecording(app_id_2))
       .WillOnce(Return());
 
   // app 2 starts Audio Pass Thru
-  bool result = app_manager_impl_->BeginAudioPassThru(session_key_of_app_2);
+  bool result = app_manager_impl_->BeginAudioPassThru(app_id_2);
   EXPECT_TRUE(result);
   if (result) {
-    app_manager_impl_->StartAudioPassThruThread(session_key_of_app_2,
+    app_manager_impl_->StartAudioPassThruThread(app_id_2,
                                                 correlation_id,
                                                 max_duration,
                                                 sampling_rate,
@@ -933,13 +931,13 @@ TEST_F(ApplicationManagerImplTest, UnregisterAnotherAppDuringAudioPassThru) {
 
   // while running APT, app 1 is unregistered
   app_manager_impl_->UnregisterApplication(
-      session_key_of_app_1, mobile_apis::Result::SUCCESS, false, true);
+      app_id_1, mobile_apis::Result::SUCCESS, false, true);
 
   // confirm that APT is still running
-  result = app_manager_impl_->EndAudioPassThru(session_key_of_app_2);
+  result = app_manager_impl_->EndAudioPassThru(app_id_2);
   EXPECT_TRUE(result);
   if (result) {
-    app_manager_impl_->StopAudioPassThru(session_key_of_app_2);
+    app_manager_impl_->StopAudioPassThru(app_id_2);
   }
 }
 

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -848,7 +848,7 @@ TEST_F(ApplicationManagerImplTest, StartStopAudioPassThru) {
   EXPECT_CALL(mock_media_manager, StopMicrophoneRecording(session_key))
       .WillOnce(Return());
 
-  bool result = app_manager_impl_->BeginAudioPassThrough();
+  bool result = app_manager_impl_->BeginAudioPassThru(session_key);
   EXPECT_TRUE(result);
   if (result) {
     app_manager_impl_->StartAudioPassThruThread(session_key,
@@ -859,7 +859,7 @@ TEST_F(ApplicationManagerImplTest, StartStopAudioPassThru) {
                                                 audio_type);
   }
 
-  result = app_manager_impl_->EndAudioPassThrough();
+  result = app_manager_impl_->EndAudioPassThru(session_key);
   EXPECT_TRUE(result);
   if (result) {
     app_manager_impl_->StopAudioPassThru(session_key);
@@ -920,7 +920,7 @@ TEST_F(ApplicationManagerImplTest, UnregisterAnotherAppDuringAudioPassThru) {
       .WillOnce(Return());
 
   // app 2 starts Audio Pass Thru
-  bool result = app_manager_impl_->BeginAudioPassThrough();
+  bool result = app_manager_impl_->BeginAudioPassThru(session_key_of_app_2);
   EXPECT_TRUE(result);
   if (result) {
     app_manager_impl_->StartAudioPassThruThread(session_key_of_app_2,
@@ -936,7 +936,7 @@ TEST_F(ApplicationManagerImplTest, UnregisterAnotherAppDuringAudioPassThru) {
       session_key_of_app_1, mobile_apis::Result::SUCCESS, false, true);
 
   // confirm that APT is still running
-  result = app_manager_impl_->EndAudioPassThrough();
+  result = app_manager_impl_->EndAudioPassThru(session_key_of_app_2);
   EXPECT_TRUE(result);
   if (result) {
     app_manager_impl_->StopAudioPassThru(session_key_of_app_2);

--- a/src/components/application_manager/test/commands/mobile/end_audio_pass_thru_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/end_audio_pass_thru_request_test.cc
@@ -67,6 +67,7 @@ class EndAudioPassThruRequestTest
 
 TEST_F(EndAudioPassThruRequestTest, OnEvent_UI_UNSUPPORTED_RESOUCRE) {
   const uint32_t kConnectionKey = 2u;
+  const uint32_t app_id = kConnectionKey;
 
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
   (*command_msg)[am::strings::params][am::strings::connection_key] =
@@ -83,8 +84,7 @@ TEST_F(EndAudioPassThruRequestTest, OnEvent_UI_UNSUPPORTED_RESOUCRE) {
   Event event(hmi_apis::FunctionID::UI_EndAudioPassThru);
   event.set_smart_object(*event_msg);
 
-  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey))
-      .WillOnce(Return(false));
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(app_id)).WillOnce(Return(false));
 
   MessageSharedPtr ui_command_result;
   EXPECT_CALL(

--- a/src/components/application_manager/test/commands/mobile/end_audio_pass_thru_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/end_audio_pass_thru_request_test.cc
@@ -83,7 +83,8 @@ TEST_F(EndAudioPassThruRequestTest, OnEvent_UI_UNSUPPORTED_RESOUCRE) {
   Event event(hmi_apis::FunctionID::UI_EndAudioPassThru);
   event.set_smart_object(*event_msg);
 
-  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(false));
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey))
+      .WillOnce(Return(false));
 
   MessageSharedPtr ui_command_result;
   EXPECT_CALL(

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -128,6 +128,8 @@ class PerformAudioPassThruRequestTest
     ON_CALL(app_mngr_, application(kConnectionKey))
         .WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
+    (*message_)[am::strings::params][am::strings::connection_key] =
+        kConnectionKey;
     command_sptr_ =
         CreateCommand<am::commands::PerformAudioPassThruRequest>(message_);
 
@@ -160,10 +162,15 @@ TEST_F(PerformAudioPassThruRequestTest, OnTimeout_GENERIC_ERROR) {
       am::mobile_api::Result::GENERIC_ERROR;
   (*msg_ui)[am::strings::msg_params][am::strings::success] = false;
 
-  utils::SharedPtr<PerformAudioPassThruRequest> command =
-      CreateCommand<PerformAudioPassThruRequest>();
+  MessageSharedPtr message =
+      utils::MakeShared<SmartObject>(::smart_objects::SmartType_Map);
+  (*message)[am::strings::params][am::strings::connection_key] = kConnectionKey;
 
-  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(true));
+  utils::SharedPtr<PerformAudioPassThruRequest> command =
+      CreateCommand<PerformAudioPassThruRequest>(message);
+
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey))
+      .WillOnce(Return(true));
   EXPECT_CALL(app_mngr_, StopAudioPassThru(_));
 
   EXPECT_CALL(
@@ -232,7 +239,8 @@ TEST_F(PerformAudioPassThruRequestTest,
   event_ui.set_smart_object(*response_ui);
 
   MessageSharedPtr response_to_mobile;
-  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(false));
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey))
+      .WillOnce(Return(false));
   EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillRepeatedly(Return(true));
   EXPECT_CALL(
       app_mngr_,
@@ -362,7 +370,8 @@ TEST_F(PerformAudioPassThruRequestTest,
       hmi_apis::Common_Result::GENERIC_ERROR;
   event.set_smart_object(*message_);
 
-  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(false));
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey))
+      .WillOnce(Return(false));
 
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
@@ -536,7 +545,7 @@ TEST_F(
   }
 
   // Start microphone recording cals
-  EXPECT_CALL(app_mngr_, BeginAudioPassThrough());
+  EXPECT_CALL(app_mngr_, BeginAudioPassThru(kConnectionKey));
   EXPECT_CALL(app_mngr_, StartAudioPassThruThread(_, _, _, _, _, _));
 
   CallRun caller(*command_sptr_);
@@ -581,7 +590,7 @@ TEST_F(PerformAudioPassThruRequestTest,
   EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
 
   // Start microphone recording cals
-  EXPECT_CALL(app_mngr_, BeginAudioPassThrough());
+  EXPECT_CALL(app_mngr_, BeginAudioPassThru(kConnectionKey));
   EXPECT_CALL(app_mngr_, StartAudioPassThruThread(_, _, _, _, _, _));
 
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
@@ -617,7 +626,8 @@ TEST_F(PerformAudioPassThruRequestTest,
   caller_speak();
 
   // Second call for test correct behavior of UI_PerformAudioPassThru event
-  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(false));
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey))
+      .WillOnce(Return(false));
   EXPECT_CALL(app_mngr_, StopAudioPassThru(_)).Times(0);
   ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
@@ -641,7 +651,8 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
 
-  EXPECT_CALL(app_mngr_, BeginAudioPassThrough()).WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_, BeginAudioPassThru(kConnectionKey))
+      .WillOnce(Return(true));
 
   EXPECT_CALL(
       app_mngr_,
@@ -665,7 +676,8 @@ TEST_F(PerformAudioPassThruRequestTest,
   msg_params_[am::strings::function_id] = kFunctionId;
 
   EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
-  EXPECT_CALL(app_mngr_, BeginAudioPassThrough()).WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_, BeginAudioPassThru(kConnectionKey))
+      .WillOnce(Return(true));
 
   EXPECT_CALL(
       app_mngr_,
@@ -684,7 +696,7 @@ TEST_F(PerformAudioPassThruRequestTest, OnEvent_DefaultCase) {
   am::event_engine::Event event(hmi_apis::FunctionID::INVALID_ENUM);
 
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).Times(0);
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey)).Times(0);
 
   CallOnEvent caller(*command_sptr_, event);
   caller();
@@ -703,7 +715,8 @@ TEST_F(PerformAudioPassThruRequestTest, Init_CorrectTimeout) {
 
 TEST_F(PerformAudioPassThruRequestTest,
        onTimeOut_ttsSpeakNotActive_DontSendHMIReqeust) {
-  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey))
+      .WillOnce(Return(true));
   EXPECT_CALL(app_mngr_, StopAudioPassThru(_));
 
   // For setting current_state_ -> kCompleted
@@ -717,7 +730,8 @@ TEST_F(PerformAudioPassThruRequestTest,
 
 TEST_F(PerformAudioPassThruRequestTest,
        DISABLED_onTimeOut_ttsSpeakActive_SendHMIReqeust) {
-  EXPECT_CALL(app_mngr_, EndAudioPassThrough()).WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey))
+      .WillOnce(Return(true));
   EXPECT_CALL(app_mngr_, StopAudioPassThru(_));
 
   EXPECT_CALL(*application_sptr_, hmi_level())

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -169,8 +169,8 @@ TEST_F(PerformAudioPassThruRequestTest, OnTimeout_GENERIC_ERROR) {
   utils::SharedPtr<PerformAudioPassThruRequest> command =
       CreateCommand<PerformAudioPassThruRequest>(message);
 
-  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey))
-      .WillOnce(Return(true));
+  uint32_t app_id = kConnectionKey;
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(app_id)).WillOnce(Return(true));
   EXPECT_CALL(app_mngr_, StopAudioPassThru(_));
 
   EXPECT_CALL(
@@ -239,8 +239,8 @@ TEST_F(PerformAudioPassThruRequestTest,
   event_ui.set_smart_object(*response_ui);
 
   MessageSharedPtr response_to_mobile;
-  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey))
-      .WillOnce(Return(false));
+  uint32_t app_id = kConnectionKey;
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(app_id)).WillOnce(Return(false));
   EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillRepeatedly(Return(true));
   EXPECT_CALL(
       app_mngr_,
@@ -370,8 +370,8 @@ TEST_F(PerformAudioPassThruRequestTest,
       hmi_apis::Common_Result::GENERIC_ERROR;
   event.set_smart_object(*message_);
 
-  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey))
-      .WillOnce(Return(false));
+  uint32_t app_id = kConnectionKey;
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(app_id)).WillOnce(Return(false));
 
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
@@ -545,7 +545,8 @@ TEST_F(
   }
 
   // Start microphone recording cals
-  EXPECT_CALL(app_mngr_, BeginAudioPassThru(kConnectionKey));
+  uint32_t app_id = kConnectionKey;
+  EXPECT_CALL(app_mngr_, BeginAudioPassThru(app_id));
   EXPECT_CALL(app_mngr_, StartAudioPassThruThread(_, _, _, _, _, _));
 
   CallRun caller(*command_sptr_);
@@ -590,7 +591,8 @@ TEST_F(PerformAudioPassThruRequestTest,
   EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
 
   // Start microphone recording cals
-  EXPECT_CALL(app_mngr_, BeginAudioPassThru(kConnectionKey));
+  uint32_t app_id = kConnectionKey;
+  EXPECT_CALL(app_mngr_, BeginAudioPassThru(app_id));
   EXPECT_CALL(app_mngr_, StartAudioPassThruThread(_, _, _, _, _, _));
 
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
@@ -626,8 +628,8 @@ TEST_F(PerformAudioPassThruRequestTest,
   caller_speak();
 
   // Second call for test correct behavior of UI_PerformAudioPassThru event
-  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey))
-      .WillOnce(Return(false));
+  uint32_t app_id = kConnectionKey;
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(app_id)).WillOnce(Return(false));
   EXPECT_CALL(app_mngr_, StopAudioPassThru(_)).Times(0);
   ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
       .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
@@ -651,8 +653,8 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
 
-  EXPECT_CALL(app_mngr_, BeginAudioPassThru(kConnectionKey))
-      .WillOnce(Return(true));
+  uint32_t app_id = kConnectionKey;
+  EXPECT_CALL(app_mngr_, BeginAudioPassThru(app_id)).WillOnce(Return(true));
 
   EXPECT_CALL(
       app_mngr_,
@@ -675,9 +677,9 @@ TEST_F(PerformAudioPassThruRequestTest,
   msg_params_[am::strings::connection_key] = kConnectionKey;
   msg_params_[am::strings::function_id] = kFunctionId;
 
+  uint32_t app_id = kConnectionKey;
   EXPECT_CALL(app_mngr_, ManageHMICommand(_)).WillOnce(Return(true));
-  EXPECT_CALL(app_mngr_, BeginAudioPassThru(kConnectionKey))
-      .WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_, BeginAudioPassThru(app_id)).WillOnce(Return(true));
 
   EXPECT_CALL(
       app_mngr_,
@@ -695,8 +697,9 @@ TEST_F(PerformAudioPassThruRequestTest,
 TEST_F(PerformAudioPassThruRequestTest, OnEvent_DefaultCase) {
   am::event_engine::Event event(hmi_apis::FunctionID::INVALID_ENUM);
 
+  uint32_t app_id = kConnectionKey;
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey)).Times(0);
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(app_id)).Times(0);
 
   CallOnEvent caller(*command_sptr_, event);
   caller();
@@ -715,8 +718,8 @@ TEST_F(PerformAudioPassThruRequestTest, Init_CorrectTimeout) {
 
 TEST_F(PerformAudioPassThruRequestTest,
        onTimeOut_ttsSpeakNotActive_DontSendHMIReqeust) {
-  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey))
-      .WillOnce(Return(true));
+  uint32_t app_id = kConnectionKey;
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(app_id)).WillOnce(Return(true));
   EXPECT_CALL(app_mngr_, StopAudioPassThru(_));
 
   // For setting current_state_ -> kCompleted
@@ -730,8 +733,8 @@ TEST_F(PerformAudioPassThruRequestTest,
 
 TEST_F(PerformAudioPassThruRequestTest,
        DISABLED_onTimeOut_ttsSpeakActive_SendHMIReqeust) {
-  EXPECT_CALL(app_mngr_, EndAudioPassThru(kConnectionKey))
-      .WillOnce(Return(true));
+  uint32_t app_id = kConnectionKey;
+  EXPECT_CALL(app_mngr_, EndAudioPassThru(app_id)).WillOnce(Return(true));
   EXPECT_CALL(app_mngr_, StopAudioPassThru(_));
 
   EXPECT_CALL(*application_sptr_, hmi_level())

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -393,8 +393,7 @@ class ApplicationManager {
    *
    * @return true on success, false if passthru is already in process
    */
-  // DEPRECATED
-  virtual bool BeginAudioPassThrough() = 0;
+  DEPRECATED virtual bool BeginAudioPassThrough() = 0;
 
   /**
    * @brief Starts AudioPassThru process by given application
@@ -408,8 +407,7 @@ class ApplicationManager {
    *
    * @return true on success, false if passthru is not active
    */
-  // DEPRECATED
-  virtual bool EndAudioPassThrough() = 0;
+  DEPRECATED virtual bool EndAudioPassThrough() = 0;
 
   /**
    * @brief Finishes already started AudioPassThru process by given application

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -390,6 +390,7 @@ class ApplicationManager {
   virtual void EndNaviServices(uint32_t app_id) = 0;
 
   /* @brief Starts audio passthru process
+   * @deprecated Use BeginAudioPassThru(int32_t session_key) instead
    *
    * @return true on success, false if passthru is already in process
    */
@@ -404,6 +405,7 @@ class ApplicationManager {
 
   /*
    * @brief Finishes already started audio passthru process
+   * @deprecated Use EndAudioPassThru(int32_t application_key) instead
    *
    * @return true on success, false if passthru is not active
    */

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -393,14 +393,31 @@ class ApplicationManager {
    *
    * @return true on success, false if passthru is already in process
    */
+  // DEPRECATED
   virtual bool BeginAudioPassThrough() = 0;
+
+  /**
+   * @brief Starts AudioPassThru process by given application
+   * @param session_key Session key of connection for Mobile side
+   * @return true if AudioPassThru can be started, false otherwise
+   */
+  virtual bool BeginAudioPassThru(int32_t session_key) = 0;
 
   /*
    * @brief Finishes already started audio passthru process
    *
    * @return true on success, false if passthru is not active
    */
+  // DEPRECATED
   virtual bool EndAudioPassThrough() = 0;
+
+  /**
+   * @brief Finishes already started AudioPassThru process by given application
+   * @param application_key ID of the application which started the process
+   * @return true if AudioPassThru process has been started with given
+   * application and thus it can be stopped, false otherwise
+   */
+  virtual bool EndAudioPassThru(int32_t application_key) = 0;
 
   virtual void ConnectToDevice(const std::string& device_mac) = 0;
 

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -390,7 +390,7 @@ class ApplicationManager {
   virtual void EndNaviServices(uint32_t app_id) = 0;
 
   /* @brief Starts audio passthru process
-   * @deprecated Use BeginAudioPassThru(int32_t session_key) instead
+   * @deprecated Use BeginAudioPassThru(uint32_t app_id) instead
    *
    * @return true on success, false if passthru is already in process
    */
@@ -398,14 +398,14 @@ class ApplicationManager {
 
   /**
    * @brief Starts AudioPassThru process by given application
-   * @param session_key Session key of connection for Mobile side
+   * @param app_id ID of the application which starts the process
    * @return true if AudioPassThru can be started, false otherwise
    */
-  virtual bool BeginAudioPassThru(int32_t session_key) = 0;
+  virtual bool BeginAudioPassThru(uint32_t app_id) = 0;
 
   /*
    * @brief Finishes already started audio passthru process
-   * @deprecated Use EndAudioPassThru(int32_t application_key) instead
+   * @deprecated Use EndAudioPassThru(uint32_t app_id) instead
    *
    * @return true on success, false if passthru is not active
    */
@@ -413,11 +413,11 @@ class ApplicationManager {
 
   /**
    * @brief Finishes already started AudioPassThru process by given application
-   * @param application_key ID of the application which started the process
+   * @param app_id ID of the application which started the process
    * @return true if AudioPassThru process has been started with given
    * application and thus it can be stopped, false otherwise
    */
-  virtual bool EndAudioPassThru(int32_t application_key) = 0;
+  virtual bool EndAudioPassThru(uint32_t app_id) = 0;
 
   virtual void ConnectToDevice(const std::string& device_mac) = 0;
 

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -162,9 +162,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD0(GenerateNewHMIAppID, uint32_t());
   MOCK_METHOD1(EndNaviServices, void(uint32_t app_id));
   DEPRECATED MOCK_METHOD0(BeginAudioPassThrough, bool());
-  MOCK_METHOD1(BeginAudioPassThru, bool(int32_t session_key));
+  MOCK_METHOD1(BeginAudioPassThru, bool(uint32_t app_id));
   DEPRECATED MOCK_METHOD0(EndAudioPassThrough, bool());
-  MOCK_METHOD1(EndAudioPassThru, bool(int32_t application_key));
+  MOCK_METHOD1(EndAudioPassThru, bool(uint32_t app_id));
   MOCK_METHOD1(ConnectToDevice, void(const std::string& device_mac));
   MOCK_METHOD0(OnHMIStartedCooperation, void());
   MOCK_CONST_METHOD0(IsHMICooperating, bool());

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -161,9 +161,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD0(GetNextHMICorrelationID, uint32_t());
   MOCK_METHOD0(GenerateNewHMIAppID, uint32_t());
   MOCK_METHOD1(EndNaviServices, void(uint32_t app_id));
-  MOCK_METHOD0(BeginAudioPassThrough, bool());
+  DEPRECATED MOCK_METHOD0(BeginAudioPassThrough, bool());
   MOCK_METHOD1(BeginAudioPassThru, bool(int32_t session_key));
-  MOCK_METHOD0(EndAudioPassThrough, bool());
+  DEPRECATED MOCK_METHOD0(EndAudioPassThrough, bool());
   MOCK_METHOD1(EndAudioPassThru, bool(int32_t application_key));
   MOCK_METHOD1(ConnectToDevice, void(const std::string& device_mac));
   MOCK_METHOD0(OnHMIStartedCooperation, void());

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -162,7 +162,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD0(GenerateNewHMIAppID, uint32_t());
   MOCK_METHOD1(EndNaviServices, void(uint32_t app_id));
   MOCK_METHOD0(BeginAudioPassThrough, bool());
+  MOCK_METHOD1(BeginAudioPassThru, bool(int32_t session_key));
   MOCK_METHOD0(EndAudioPassThrough, bool());
+  MOCK_METHOD1(EndAudioPassThru, bool(int32_t application_key));
   MOCK_METHOD1(ConnectToDevice, void(const std::string& device_mac));
   MOCK_METHOD0(OnHMIStartedCooperation, void());
   MOCK_CONST_METHOD0(IsHMICooperating, bool());

--- a/src/components/include/test/media_manager/mock_media_manager.h
+++ b/src/components/include/test/media_manager/mock_media_manager.h
@@ -56,7 +56,7 @@ class MockMediaManager : public media_manager::MediaManager {
                     protocol_handler::ServiceType service_type));
   MOCK_METHOD2(FramesProcessed,
                void(int32_t application_key, int32_t frame_number));
-  MOCK_CONST_METHOD0(settings, const MediaManagerSettings&());
+  MOCK_CONST_METHOD0(settings, const media_manager::MediaManagerSettings&());
 };
 
 }  // namespace media_manager_test


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/1756

This PR is **ready** for review.

### Summary of the changes
- In ApplicationManagerImpl::UnregisterApplication(), do not call StopAudioPassThru() if AudioPassThru is not started by the app.
  - ApplicationManager::BeginAudioPassThrough() and ApplicationManager::EndAudioPassThrough() are updated to receive app_id. EndAudioPassThrough() verifies app_id and returns true only when it is same as the ID provided to BeginAudioPassThrough().

### API changes
- This PR updates two public methods in ApplicationManager.
  - Old signatures are marked as "DUPLICATED".

### Risk
- Normal sequence of AudioPassThru operation is affected.

### Testing Plan
- Added an unit test that fails with existing Core and passes with this fix.
