### PR TITLE
Fix SDL crash on exit/unregistering of non-RC application

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3011,7 +3011,8 @@ void ApplicationManagerImpl::UnregisterApplication(
 
 #ifdef SDL_REMOTE_CONTROL
   plugin_manager_.OnApplicationEvent(
-      functional_modules::ApplicationEvent::kApplicationUnregistered, app_id);
+      functional_modules::ApplicationEvent::kApplicationUnregistered,
+      app_to_remove);
 #endif
 
   MessageHelper::SendOnAppUnregNotificationToHMI(

--- a/src/components/application_manager/src/commands/hmi/on_exit_application_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_exit_application_notification.cc
@@ -67,7 +67,7 @@ void OnExitApplicationNotification::Run() {
 
 #ifdef SDL_REMOTE_CONTROL
   application_manager_.GetPluginManager().OnApplicationEvent(
-      functional_modules::ApplicationEvent::kApplicationExit, app_id);
+      functional_modules::ApplicationEvent::kApplicationExit, app_impl);
 #endif  // SDL_REMOTE_CONTROL
 
   Common_ApplicationExitReason::eType reason;

--- a/src/components/functional_module/include/functional_module/generic_module.h
+++ b/src/components/functional_module/include/functional_module/generic_module.h
@@ -143,10 +143,11 @@ class GenericModule {
   /**
    * @brief OnApplicationEvent Processes application related events
    * @param event Event
-   * @param application_id Application id
+   * @param application Pointer to application struct
    */
-  virtual void OnApplicationEvent(ApplicationEvent event,
-                                  const uint32_t application_id) = 0;
+  virtual void OnApplicationEvent(
+      ApplicationEvent event,
+      application_manager::ApplicationSharedPtr application) = 0;
 
   /**
    * @brief OnPolicyEvent Processes policy related events

--- a/src/components/functional_module/include/functional_module/plugin_manager.h
+++ b/src/components/functional_module/include/functional_module/plugin_manager.h
@@ -130,10 +130,11 @@ class PluginManager : public ModuleObserver {
   /**
    * @brief OnApplicationEvent Notifies modules on certain application events
    * @param event Event
-   * @param application_id Application id of particular application
+   * @param application Pointer to application struct
    */
-  void OnApplicationEvent(functional_modules::ApplicationEvent event,
-                          const uint32_t application_id);
+  void OnApplicationEvent(
+      functional_modules::ApplicationEvent event,
+      application_manager::ApplicationSharedPtr application);
 
   /**
    * @brief OnPolicyEvent Notifies modules on certain events from policy

--- a/src/components/functional_module/src/plugin_manager.cc
+++ b/src/components/functional_module/src/plugin_manager.cc
@@ -351,14 +351,14 @@ typedef std::map<ModuleID, ModulePtr>::value_type PluginsValueType;
 struct HandleApplicationEvent {
  private:
   const functional_modules::ApplicationEvent event_;
-  const uint32_t app_id_;
+  application_manager::ApplicationSharedPtr application_;
 
  public:
   HandleApplicationEvent(functional_modules::ApplicationEvent e,
-                         const uint32_t app_id)
-      : event_(e), app_id_(app_id) {}
+                         application_manager::ApplicationSharedPtr application)
+      : event_(e), application_(application) {}
   void operator()(PluginsValueType& p) {
-    p.second->OnApplicationEvent(event_, app_id_);
+    p.second->OnApplicationEvent(event_, application_);
   }
 };
 
@@ -374,11 +374,14 @@ struct HandlePolicyEvent {
 };
 
 void PluginManager::OnApplicationEvent(
-    functional_modules::ApplicationEvent event, const uint32_t application_id) {
+    functional_modules::ApplicationEvent event,
+    application_manager::ApplicationSharedPtr application) {
   LOG4CXX_AUTO_TRACE(logger_);
-  std::for_each(plugins_.begin(),
-                plugins_.end(),
-                HandleApplicationEvent(event, application_id));
+  if (application) {
+    std::for_each(plugins_.begin(),
+                  plugins_.end(),
+                  HandleApplicationEvent(event, application));
+  }
 }
 
 void PluginManager::OnPolicyEvent(PolicyEvent event) {

--- a/src/components/functional_module/test/include/driver_generic_module_test.h
+++ b/src/components/functional_module/test/include/driver_generic_module_test.h
@@ -68,7 +68,7 @@ class DriverGenericModuleTest : public GenericModule {
   }
 
   void OnApplicationEvent(functional_modules::ApplicationEvent event,
-                          const uint32_t application_id) {}
+                          application_manager::ApplicationSharedPtr app) {}
 
   void OnPolicyEvent(functional_modules::PolicyEvent event) {}
 

--- a/src/components/functional_module/test/plugins/mock_generic_module.h
+++ b/src/components/functional_module/test/plugins/mock_generic_module.h
@@ -63,7 +63,7 @@ class MockGenericModule : public GenericModule {
   MOCK_METHOD1(OnUnregisterApplication, void(const uint32_t app_id));
   MOCK_METHOD2(OnApplicationEvent,
                void(functional_modules::ApplicationEvent event,
-                    const uint32_t application_id));
+                    application_manager::ApplicationSharedPtr application));
   MOCK_METHOD1(OnPolicyEvent, void(functional_modules::PolicyEvent event));
   MOCK_METHOD0(RemoveAppExtensions, void());
 };

--- a/src/components/functional_module/test/src/plugin_manager_test.cc
+++ b/src/components/functional_module/test/src/plugin_manager_test.cc
@@ -10,6 +10,7 @@
 using application_manager::Message;
 using protocol_handler::MajorProtocolVersion;
 using application_manager::MockService;
+using test::components::application_manager_test::MockApplication;
 using ::testing::NiceMock;
 using ::testing::Expectation;
 using ::testing::ReturnRef;
@@ -76,11 +77,12 @@ TEST_F(PluginManagerTest, SDL_events_triggers_module) {
   app_events.push_back(ApplicationEvent::kApplicationExit);
   app_events.push_back(ApplicationEvent::kApplicationUnregistered);
 
+  application_manager::ApplicationSharedPtr dummy_ptr =
+      utils::MakeShared<MockApplication>();
   std::vector<ApplicationEvent>::const_iterator ev = app_events.begin();
-  const uint32_t kDummyAppId = 1;
   for (; app_events.end() != ev; ++ev) {
-    EXPECT_CALL(*module, OnApplicationEvent(*ev, kDummyAppId));
-    manager->OnApplicationEvent(*ev, kDummyAppId);
+    EXPECT_CALL(*module, OnApplicationEvent(*ev, dummy_ptr));
+    manager->OnApplicationEvent(*ev, dummy_ptr);
   }
 
   std::vector<PolicyEvent> policy_events;

--- a/src/components/remote_control/include/remote_control/remote_control_plugin.h
+++ b/src/components/remote_control/include/remote_control/remote_control_plugin.h
@@ -116,13 +116,14 @@ class RemoteControlPlugin : public RemotePluginInterface {
    */
   void set_service(application_manager::ServicePtr service) OVERRIDE;
 
-  /*
+  /**
    * @brief OnApplicationEvent Processes application related events
    * @param event Event
-   * @param application_id Application id
+   * @param application Pointer to application struct
    */
-  void OnApplicationEvent(functional_modules::ApplicationEvent event,
-                          const uint32_t application_id) OVERRIDE;
+  void OnApplicationEvent(
+      functional_modules::ApplicationEvent event,
+      application_manager::ApplicationSharedPtr application) OVERRIDE;
 
   /**
    * @brief OnPolicyEvent Processes policy related events

--- a/src/components/remote_control/include/remote_control/resource_allocation_manager.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager.h
@@ -78,10 +78,11 @@ class ResourceAllocationManager {
   /**
    * @brief OnApplicationEvent Processes application related events
    * @param event Event
-   * @param application_id Application id
+   * @param application Pointer to application struct
    */
-  virtual void OnApplicationEvent(functional_modules::ApplicationEvent event,
-                                  const uint32_t application_id) = 0;
+  virtual void OnApplicationEvent(
+      functional_modules::ApplicationEvent event,
+      application_manager::ApplicationSharedPtr application) = 0;
 
   /**
    * @brief OnPolicyEvent Processes policy related events

--- a/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
@@ -37,12 +37,13 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
                           const uint32_t app_id) FINAL;
 
   /**
-   * @brief OnApplicationEvent Processes application related events
+   * @brief OnApplicationEvent Notifies modules on certain application events
    * @param event Event
-   * @param application_id Application id
+   * @param application Pointer to application struct
    */
-  void OnApplicationEvent(functional_modules::ApplicationEvent event,
-                          const uint32_t application_id) FINAL;
+  void OnApplicationEvent(
+      functional_modules::ApplicationEvent event,
+      application_manager::ApplicationSharedPtr application) FINAL;
 
   /**
    * @brief OnPolicyEvent Processes policy related events

--- a/src/components/remote_control/src/remote_control_plugin.cc
+++ b/src/components/remote_control/src/remote_control_plugin.cc
@@ -321,9 +321,17 @@ ResourceAllocationManager& RemoteControlPlugin::resource_allocation_manager() {
 }
 
 void RemoteControlPlugin::OnApplicationEvent(
-    functional_modules::ApplicationEvent event, const uint32_t application_id) {
+    functional_modules::ApplicationEvent event,
+    application_manager::ApplicationSharedPtr application) {
   LOG4CXX_AUTO_TRACE(logger_);
-  resource_allocation_manager_.OnApplicationEvent(event, application_id);
+    if (false == service()->IsRemoteControlApplication(application)) {
+      LOG4CXX_DEBUG(logger_,
+                    "Application " << application->app_id()
+                                   << " has no remote control functionality."
+                                   << " Event will be ignored for RC plugin");
+      return;
+    }
+  resource_allocation_manager_.OnApplicationEvent(event, application);
 }
 
 void RemoteControlPlugin::OnPolicyEvent(functional_modules::PolicyEvent event) {

--- a/src/components/remote_control/src/resource_allocation_manager_impl.cc
+++ b/src/components/remote_control/src/resource_allocation_manager_impl.cc
@@ -162,15 +162,16 @@ void ResourceAllocationManagerImpl::ProcessApplicationPolicyUpdate() {
 RCAppExtensionPtr ResourceAllocationManagerImpl::GetApplicationExtention(
     application_manager::ApplicationSharedPtr application) {
   LOG4CXX_AUTO_TRACE(logger_);
-  if (!application) {
-    return NULL;
-  }
 
   RCAppExtensionPtr rc_app_extension;
+  if (!application) {
+    return rc_app_extension;
+  }
+
   application_manager::AppExtensionPtr app_extension =
       application->QueryInterface(rc_plugin_.GetModuleID());
   if (!app_extension) {
-    return NULL;
+    return rc_app_extension;
   }
 
   rc_app_extension =
@@ -181,6 +182,7 @@ RCAppExtensionPtr ResourceAllocationManagerImpl::GetApplicationExtention(
 }
 
 void ResourceAllocationManagerImpl::RemoveAppsSubscriptions(const Apps& apps) {
+  LOG4CXX_AUTO_TRACE(logger_);
   Apps::const_iterator app = apps.begin();
   for (; apps.end() != app; ++app) {
     application_manager::ApplicationSharedPtr app_ptr = *app;

--- a/src/components/remote_control/src/resource_allocation_manager_impl.cc
+++ b/src/components/remote_control/src/resource_allocation_manager_impl.cc
@@ -317,20 +317,22 @@ void ResourceAllocationManagerImpl::OnDriverDisallowed(
 }
 
 void ResourceAllocationManagerImpl::OnApplicationEvent(
-    functional_modules::ApplicationEvent event, const uint32_t application_id) {
+    functional_modules::ApplicationEvent event,
+    application_manager::ApplicationSharedPtr application) {
   LOG4CXX_AUTO_TRACE(logger_);
-  LOG4CXX_DEBUG(logger_, "Event " << event << " came for " << application_id);
+  LOG4CXX_DEBUG(logger_,
+                "Event " << event << " came for " << application->app_id());
 
   if (functional_modules::ApplicationEvent::kApplicationExit == event ||
       functional_modules::ApplicationEvent::kApplicationUnregistered == event) {
-    Resources acquired_modules = GetAcquiredResources(application_id);
+    Resources acquired_modules = GetAcquiredResources(application->app_id());
     Resources::const_iterator module = acquired_modules.begin();
     for (; acquired_modules.end() != module; ++module) {
-      ReleaseResource(*module, application_id);
+      ReleaseResource(*module, application->app_id());
     }
 
     Apps app_list;
-    app_list.push_back(rc_plugin_.service()->GetApplication(application_id));
+    app_list.push_back(application);
     RemoveAppsSubscriptions(app_list);
   }
 }

--- a/src/components/remote_control/test/include/mock_remote_control_plugin.h
+++ b/src/components/remote_control/test/include/mock_remote_control_plugin.h
@@ -43,7 +43,7 @@ class MockRemotePluginInterface : public remote_control::RemotePluginInterface {
                remote_control::ResourceAllocationManager&());
   MOCK_METHOD2(OnApplicationEvent,
                void(functional_modules::ApplicationEvent event,
-                    const uint32_t application_id));
+                    application_manager::ApplicationSharedPtr application));
   MOCK_METHOD1(OnPolicyEvent, void(functional_modules::PolicyEvent event));
 };
 

--- a/src/components/remote_control/test/include/mock_resource_allocation_manager.h
+++ b/src/components/remote_control/test/include/mock_resource_allocation_manager.h
@@ -20,7 +20,7 @@ class MockResourceAllocationManager
                void(const std::string& module_type, const uint32_t app_id));
   MOCK_METHOD2(OnApplicationEvent,
                void(functional_modules::ApplicationEvent event,
-                    const uint32_t application_id));
+                    application_manager::ApplicationSharedPtr application));
   MOCK_METHOD1(OnPolicyEvent, void(functional_modules::PolicyEvent event));
   MOCK_METHOD1(SetAccessMode,
                void(const hmi_apis::Common_RCAccessMode::eType access_mode));

--- a/src/components/remote_control/test/src/resource_allocation_manager_impl_test.cc
+++ b/src/components/remote_control/test/src/resource_allocation_manager_impl_test.cc
@@ -258,8 +258,11 @@ TEST_F(RAManagerTest, AppExit_ReleaseResource) {
             ra_manager.AcquireResource(kModuleType1, kAppId1));
 
   // Act
+  application_manager::ApplicationSharedPtr app_ptr(mock_app_1_);
+  EXPECT_CALL(*mock_app_1_, app_id()).WillRepeatedly(Return(kAppId1));
+
   ra_manager.OnApplicationEvent(
-      functional_modules::ApplicationEvent::kApplicationExit, kAppId1);
+      functional_modules::ApplicationEvent::kApplicationExit, app_ptr);
 
   EXPECT_CALL(*mock_service_, GetApplication(kAppId2))
       .WillRepeatedly(Return(mock_app_2_));
@@ -289,8 +292,10 @@ TEST_F(RAManagerTest, AnotherAppExit_NoReleaseResource) {
       .WillOnce(Return(rc_extention_ptr));
 
   // Act
+  application_manager::ApplicationSharedPtr app_ptr(mock_app_2_);
+  EXPECT_CALL(*mock_app_2_, app_id()).WillRepeatedly(Return(kAppId2));
   ra_manager.OnApplicationEvent(
-      functional_modules::ApplicationEvent::kApplicationExit, kAppId2);
+      functional_modules::ApplicationEvent::kApplicationExit, app_ptr);
 
   EXPECT_CALL(*mock_service_, GetApplication(kAppId2))
       .WillOnce(Return(mock_app_2_));
@@ -318,8 +323,11 @@ TEST_F(RAManagerTest, AppUnregistered_ReleaseResource) {
             ra_manager.AcquireResource(kModuleType1, kAppId1));
 
   // Act
+  application_manager::ApplicationSharedPtr app_ptr(mock_app_1_);
+  EXPECT_CALL(*mock_app_1_, app_id()).WillRepeatedly(Return(kAppId1));
+
   ra_manager.OnApplicationEvent(
-      functional_modules::ApplicationEvent::kApplicationUnregistered, kAppId1);
+      functional_modules::ApplicationEvent::kApplicationUnregistered, app_ptr);
 
   EXPECT_CALL(*mock_service_, GetApplication(kAppId2))
       .WillOnce(Return(mock_app_2_));
@@ -348,8 +356,11 @@ TEST_F(RAManagerTest, AnotherAppUnregistered_NoReleaseResource) {
       .WillOnce(Return(rc_extention_ptr));
 
   // Act
+  application_manager::ApplicationSharedPtr app_ptr(mock_app_2_);
+  EXPECT_CALL(*mock_app_2_, app_id()).WillRepeatedly(Return(kAppId2));
+
   ra_manager.OnApplicationEvent(
-      functional_modules::ApplicationEvent::kApplicationUnregistered, kAppId2);
+      functional_modules::ApplicationEvent::kApplicationUnregistered, app_ptr);
 
   EXPECT_CALL(*mock_service_, GetApplication(kAppId2))
       .WillOnce(Return(mock_app_2_));


### PR DESCRIPTION
SDL plugin manager is receiving notifications from application manager when any application was deactivated or unregistered. This notification will be transfered from plugin manager to RC plugin. However RC plugin processes events from any application so when it try to process event from non-RC application, SDL crashes. RC plugin should process events only from applications with RC functionality.

Also there is another problem when application is unregistering its app_id() is removing from applications list in AM before OnApplicationEvent() call so when some of plugins will try to get shared_ptr using app_id, it will
receive null pointer, however in AM still exists shared_ptr to this app.
So it will be better to pass shared_ptr of application instead of accessing to it every time from plugins using app_id parameter. Moreover, some of plugins could require more information about application in future.

Following changes were done:
- Updated OnApplicationEvent() with application shared_ptr param for plugin manager and all related plugins
- RC plugin now triggers OnApplicationEvent only for events from RC applications
- Fixed possible NULL pointer assignment in Resource Allocation Manager
- Fixed affected mocks and unit tests logic

