### PR TITLE
Fix/enable system capabilities from file

### DIFF
--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -1068,6 +1068,7 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
       }
       if (check_existing_json_member(ui, "systemCapabilities")) {
         Json::Value system_capabilities = ui.get("systemCapabilities", "");
+        set_navigation_supported(false);
         if (check_existing_json_member(system_capabilities,
                                        "navigationCapability")) {
           Json::Value navigation_capability =
@@ -1076,7 +1077,11 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
           Formatters::CFormatterJsonBase::jsonValueToObj(
               navigation_capability, navigation_capability_so);
           set_navigation_capability(navigation_capability_so);
+          if (!navigation_capability_so.empty()) {
+            set_navigation_supported(true);
+          }
         }
+        set_phone_call_supported(false);
         if (check_existing_json_member(system_capabilities,
                                        "phoneCapability")) {
           Json::Value phone_capability =
@@ -1085,7 +1090,11 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
           Formatters::CFormatterJsonBase::jsonValueToObj(phone_capability,
                                                          phone_capability_so);
           set_phone_capability(phone_capability_so);
+          if (!phone_capability_so.empty()) {
+            set_phone_call_supported(true);
+          }
         }
+        set_video_streaming_supported(false);
         if (check_existing_json_member(system_capabilities,
                                        "videoStreamingCapability")) {
           Json::Value vs_capability =
@@ -1132,6 +1141,9 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
             vs_capability_so["supportedFormats"] = converted_array;
           }
           set_video_streaming_capability(vs_capability_so);
+          if (!vs_capability_so.empty()) {
+            set_video_streaming_supported(true);
+          }
         }
         if (check_existing_json_member(system_capabilities,
                                        "remoteControlCapability")) {

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -1068,7 +1068,6 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
       }
       if (check_existing_json_member(ui, "systemCapabilities")) {
         Json::Value system_capabilities = ui.get("systemCapabilities", "");
-        set_navigation_supported(false);
         if (check_existing_json_member(system_capabilities,
                                        "navigationCapability")) {
           Json::Value navigation_capability =
@@ -1081,7 +1080,6 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
             set_navigation_supported(true);
           }
         }
-        set_phone_call_supported(false);
         if (check_existing_json_member(system_capabilities,
                                        "phoneCapability")) {
           Json::Value phone_capability =
@@ -1094,7 +1092,6 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
             set_phone_call_supported(true);
           }
         }
-        set_video_streaming_supported(false);
         if (check_existing_json_member(system_capabilities,
                                        "videoStreamingCapability")) {
           Json::Value vs_capability =

--- a/src/components/application_manager/test/CMakeLists.txt
+++ b/src/components/application_manager/test/CMakeLists.txt
@@ -143,6 +143,8 @@ set(ResumptionData_SOURCES
 )
 
 file(COPY hmi_capabilities.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY hmi_capabilities_sc1.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY hmi_capabilities_sc2.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY smartDeviceLink_test.ini DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/resumption)

--- a/src/components/application_manager/test/hmi_capabilities_sc1.json
+++ b/src/components/application_manager/test/hmi_capabilities_sc1.json
@@ -1,0 +1,9 @@
+{
+  "UI": {
+    "systemCapabilities": {
+      "phoneCapability": {
+        "dialNumberEnabled": true
+      }
+    }
+  }
+}

--- a/src/components/application_manager/test/hmi_capabilities_sc2.json
+++ b/src/components/application_manager/test/hmi_capabilities_sc2.json
@@ -1,0 +1,14 @@
+{
+  "UI": {
+    "systemCapabilities": {
+      "navigationCapability": {
+        "sendLocationEnabled": true,
+        "getWayPointsEnabled": false
+      },
+      "phoneCapability": {
+      },
+      "videoStreamingCapability": {
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/1762

This PR is **ready** for review.

### Summary of the changes
- In HMICapabilitiesImpl::load_capabilities_from_file(), update `is_navigation_supported_`, `is_phone_call_supported_` and `is_video_streaming_supported_` flags according to the availability of capability information.

### Risk
- This PR only impacts the flags when HMI capabilities are read from a file.

### Testing Plan
- An unit test is updated to fail with existing implementation and pass with the fix.
- Extra unit tests are added.