### PR TITLE
Coverity fixes for 4.4.0

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2268,17 +2268,12 @@ bool ApplicationManagerImpl::ConvertSOtoMessage(
   }
 
   if (message.getElement(jhs::S_PARAMS).keyExists(strings::binary_data)) {
-    application_manager::BinaryData* binaryData =
-        new application_manager::BinaryData(
+    application_manager::BinaryData binaryData(
             message.getElement(jhs::S_PARAMS)
                 .getElement(strings::binary_data)
                 .asBinary());
 
-    if (NULL == binaryData) {
-      LOG4CXX_ERROR(logger_, "Null pointer");
-      return false;
-    }
-    output.set_binary_data(binaryData);
+    output.set_binary_data(&binaryData);
   }
 
   LOG4CXX_DEBUG(logger_, "Successfully parsed smart object into message");

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2269,9 +2269,9 @@ bool ApplicationManagerImpl::ConvertSOtoMessage(
 
   if (message.getElement(jhs::S_PARAMS).keyExists(strings::binary_data)) {
     application_manager::BinaryData binaryData(
-            message.getElement(jhs::S_PARAMS)
-                .getElement(strings::binary_data)
-                .asBinary());
+        message.getElement(jhs::S_PARAMS)
+            .getElement(strings::binary_data)
+            .asBinary());
 
     output.set_binary_data(&binaryData);
   }

--- a/src/components/application_manager/src/mobile_message_handler.cc
+++ b/src/components/application_manager/src/mobile_message_handler.cc
@@ -196,8 +196,8 @@ MobileMessageHandler::HandleIncomingMessageProtocolV2(
   outgoing_message->set_payload_size(message->payload_size());
 
   if (!payload.data.empty()) {
-    outgoing_message->set_binary_data(
-        new application_manager::BinaryData(payload.data));
+    BinaryData binary_payload_data(payload.data);
+    outgoing_message->set_binary_data(&binary_payload_data);
   }
   return outgoing_message.release();
 }

--- a/src/components/application_manager/test/commands/mobile/show_test.cc
+++ b/src/components/application_manager/test/commands/mobile/show_test.cc
@@ -746,8 +746,8 @@ TEST_F(ShowRequestTest, Run_MainField1_MetadataTagWithNoFieldData) {
   event.set_smart_object(*ev_msg);
 
   EXPECT_CALL(mock_message_helper_,
-            HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
-    .WillOnce(Return(mobile_apis::Result::SUCCESS));
+              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
 
   MessageSharedPtr ui_command_result;
   EXPECT_CALL(
@@ -764,7 +764,7 @@ TEST_F(ShowRequestTest, Run_MainField1_MetadataTagWithNoFieldData) {
       (*ui_command_result)[am::strings::msg_params][am::strings::result_code]
           .asInt(),
       static_cast<int32_t>(mobile_apis::Result::WARNINGS));
-  
+
   Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 

--- a/src/components/protocol_handler/include/protocol_handler/protocol_packet.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_packet.h
@@ -79,13 +79,13 @@ class ProtocolPacket {
     uint8_t majorVersion;
     uint8_t minorVersion;
     uint8_t patchVersion;
-    static inline uint8_t cmp(const ProtocolVersion& version1,
+    static inline int16_t cmp(const ProtocolVersion& version1,
                               const ProtocolVersion& version2) {
-      uint8_t diff = version1.majorVersion - version2.majorVersion;
+      int16_t diff = static_cast<int16_t>(version1.majorVersion - version2.majorVersion);
       if (diff == 0) {
-        diff = version1.minorVersion - version2.minorVersion;
+        diff = static_cast<int16_t>(version1.minorVersion - version2.minorVersion);
         if (diff == 0) {
-          diff = version1.minorVersion - version2.minorVersion;
+          diff = static_cast<int16_t>(version1.patchVersion - version2.patchVersion);
         }
       }
       return diff;

--- a/src/components/protocol_handler/include/protocol_handler/protocol_packet.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_packet.h
@@ -81,11 +81,14 @@ class ProtocolPacket {
     uint8_t patchVersion;
     static inline int16_t cmp(const ProtocolVersion& version1,
                               const ProtocolVersion& version2) {
-      int16_t diff = static_cast<int16_t>(version1.majorVersion - version2.majorVersion);
+      int16_t diff =
+          static_cast<int16_t>(version1.majorVersion - version2.majorVersion);
       if (diff == 0) {
-        diff = static_cast<int16_t>(version1.minorVersion - version2.minorVersion);
+        diff =
+            static_cast<int16_t>(version1.minorVersion - version2.minorVersion);
         if (diff == 0) {
-          diff = static_cast<int16_t>(version1.patchVersion - version2.patchVersion);
+          diff = static_cast<int16_t>(version1.patchVersion -
+                                      version2.patchVersion);
         }
       }
       return diff;

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -294,7 +294,7 @@ void ProtocolHandlerImpl::SendStartSessionAck(
               ? &defaultProtocolVersion
               : ProtocolPacket::ProtocolVersion::min(full_version,
                                                      defaultProtocolVersion);
-      char protocolVersionString[255];
+      char protocolVersionString[256];
       strncpy(protocolVersionString, (*minVersion).to_string().c_str(), 255);
       bson_object_put_string(
           &params, strings::protocol_version, protocolVersionString);
@@ -1214,7 +1214,8 @@ class StartSessionHandler : public security_manager::SecurityManagerListener {
       , hash_id_(hash_id)
       , service_type_(service_type)
       , force_protected_service_(force_protected_service)
-      , full_version_() {}
+      , full_version_()
+      , payload_(NULL) {}
   StartSessionHandler(uint32_t connection_key,
                       ProtocolHandlerImpl* protocol_handler,
                       SessionObserver& session_observer,

--- a/src/components/protocol_handler/src/protocol_packet.cc
+++ b/src/components/protocol_handler/src/protocol_packet.cc
@@ -84,7 +84,7 @@ ProtocolPacket::ProtocolVersion::ProtocolVersion(std::string versionString)
 }
 
 std::string ProtocolPacket::ProtocolVersion::to_string() {
-  char versionString[255];
+  char versionString[256];
   snprintf(versionString,
            255,
            "%u.%u.%u",


### PR DESCRIPTION
Fixes issues detected by Coverity

Fixes:
- Compare result for `ProtocolVersion` changed to signed
- Fixed potential issues causing non-null terminated string
- Fix uninitialized value in `StartSessionHandler` constructor
- Fixed resource leaks with `set_binary_data` function