### PR TITLE
Fix DISALLOWED response when app has specifically defined policies

### DIFF
--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -340,7 +340,10 @@ const policy_table::AppHMITypes* CacheManager::GetHMITypes(
       pt_->policy_table.app_policies_section.apps;
   policy_table::ApplicationPolicies::const_iterator i = apps.find(app_id);
   if (i != apps.end()) {
-    return &(*i->second.AppHMIType);
+    const policy_table::AppHMITypes& app_hmi_types = *i->second.AppHMIType;
+    if (app_hmi_types.is_initialized()) {
+      return &app_hmi_types;
+    }
   }
   return NULL;
 }

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -133,7 +133,10 @@ const policy_table::AppHMITypes* CacheManager::GetHMITypes(
       pt_->policy_table.app_policies_section.apps;
   policy_table::ApplicationPolicies::const_iterator i = apps.find(app_id);
   if (i != apps.end()) {
-    return &(*i->second.AppHMIType);
+    const policy_table::AppHMITypes& app_hmi_types = *i->second.AppHMIType;
+    if (app_hmi_types.is_initialized()) {
+      return &app_hmi_types;
+    }
   }
   return NULL;
 }


### PR DESCRIPTION
This problem mostly related to RC functionality. When SDL receives any RC request, it checks is sending app have `REMOTE_CONTROL` HMI type. If app does not have such HMI type, SDL disallows such RPC for it.

The problem was in `CacheManager::GetHMITypes()` function, which returns `appHMIType` array even if it was not initialized(param is not present in policy) so SDL tries to find HMI type in an empty array and that always evaluates to false so SDL decides that current app is not RC app. If `appHMITypes` is not specified in policies, SDL should search HMI type in array of HMI types, provided by application on its registration.
This check works correctly if application has default policies.

To fix that problem there was added check in `GetHMITypes()` to avoid returning of uninitialized array.

Fixes https://github.com/smartdevicelink/sdl_core/issues/1773