### PR TITLE
Fix PTU applying for "default" app policies

### DIFF
--- a/src/components/policy/policy_external/include/policy/policy_helper.h
+++ b/src/components/policy/policy_external/include/policy/policy_helper.h
@@ -199,6 +199,23 @@ struct CheckAppPolicy {
   CheckAppPolicyResults& out_results_;
 };
 
+/**
+ * @brief Helper struct for filling actions to be done for processed application
+ * using CheckAppPolicyResults data as a source
+ */
+struct FillActionsForAppPolicies {
+  FillActionsForAppPolicies(
+      ApplicationsPoliciesActions& actions,
+      const policy_table::ApplicationPolicies& app_policies)
+      : actions_(actions), app_policies_(app_policies) {}
+
+  void operator()(const policy::CheckAppPolicyResults::value_type& value);
+
+ private:
+  ApplicationsPoliciesActions& actions_;
+  const policy_table::ApplicationPolicies& app_policies_;
+};
+
 /*
  * @brief Fill permissions data with merged rpc permissions for hmi levels and
  * parameters

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -719,14 +719,28 @@ class PolicyManagerImpl : public PolicyManager {
 
   /**
    * @brief Processes results from policy table update analysis done by
-   * CheckPermissionsChanges() by sending OnPermissionChange and
-   * OnAppPermissionChanged notifications
+   * CheckPermissionsChanges() by filling ApplicationsPoliciesActions struct
+   * with actions which should be done for every application and passes them to
+   * ProcessActionsForAppPolicies()
    * @param results Collection of per-application results
    * @param app_policies Reference to updated application policies section as
    * a data source for generating notifications data
    */
   void ProcessAppPolicyCheckResults(
       const CheckAppPolicyResults& results,
+      const policy_table::ApplicationPolicies& app_policies);
+
+  /**
+   * @brief Processes actions filled in ProcessAppPolicyCheckResults() for every
+   * application by sending OnPermissionChange and OnAppPermissionChanged
+   * notifications and by checking consent where it needed
+   * @param actions Reference to map with actions to be done or not for every
+   * application
+   * @param app_policies Reference to updated application policies section as
+   * a data source for generating notifications data
+   */
+  void ProcessActionsForAppPolicies(
+      const ApplicationsPoliciesActions& actions,
       const policy_table::ApplicationPolicies& app_policies);
 
   /**

--- a/src/components/policy/policy_external/include/policy/policy_types.h
+++ b/src/components/policy/policy_external/include/policy/policy_types.h
@@ -432,6 +432,28 @@ struct ExternalConsentStatusItemSorter {
 };
 
 /**
+ * @brief The ApplicationPolicyActions struct contains actions which should be
+ * done for some application
+ */
+struct ApplicationPolicyActions {
+  ApplicationPolicyActions()
+      : is_notify_system(false)
+      , is_send_permissions_to_app(false)
+      , is_consent_needed(false) {}
+
+  bool is_notify_system;
+  bool is_send_permissions_to_app;
+  bool is_consent_needed;
+};
+
+/**
+ * @brief ApplicationsPoliciesActions map of actions to be done for every
+ * application
+ */
+typedef std::map<std::string, ApplicationPolicyActions>
+    ApplicationsPoliciesActions;
+
+/**
  * @brief Customer connectivity settings status
  */
 typedef std::set<ExternalConsentStatusItem, ExternalConsentStatusItemSorter>

--- a/src/components/policy/policy_external/src/policy_helper.cc
+++ b/src/components/policy/policy_external/src/policy_helper.cc
@@ -484,6 +484,41 @@ bool CheckAppPolicy::IsRequestTypeChanged(
   return diff.size();
 }
 
+void FillActionsForAppPolicies::operator()(
+    const policy::CheckAppPolicyResults::value_type& value) {
+  const std::string app_id = value.first;
+  const policy_table::ApplicationPolicies::const_iterator app_policy =
+      app_policies_.find(app_id);
+
+  if (app_policies_.end() == app_policy) {
+    return;
+  }
+
+  if (IsPredefinedApp(*app_policy)) {
+    return;
+  }
+
+  switch (value.second) {
+    case RESULT_APP_REVOKED:
+    case RESULT_NICKNAME_MISMATCH:
+      actions_[app_id].is_notify_system = true;
+      return;
+    case RESULT_CONSENT_NEEDED:
+    case RESULT_PERMISSIONS_REVOKED_AND_CONSENT_NEEDED:
+      actions_[app_id].is_consent_needed = true;
+      break;
+    case RESULT_CONSENT_NOT_REQIURED:
+    case RESULT_PERMISSIONS_REVOKED:
+    case RESULT_REQUEST_TYPE_CHANGED:
+      break;
+    case RESULT_NO_CHANGES:
+    default:
+      return;
+  }
+  actions_[app_id].is_notify_system = true;
+  actions_[app_id].is_send_permissions_to_app = true;
+}
+
 FillNotificationData::FillNotificationData(Permissions& data,
                                            GroupConsent group_state,
                                            GroupConsent undefined_group_consent,

--- a/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
@@ -1344,7 +1344,7 @@ TEST_F(PolicyManagerImplTest2,
   // Add app
   policy_manager_->AddApplication(section_name,
                                   HmiTypes(policy_table::AHT_DEFAULT));
-  EXPECT_CALL(listener_, OnPendingPermissionChange(section_name)).Times(2);
+  EXPECT_CALL(listener_, OnPendingPermissionChange(section_name));
 
   // PTU has single invalid RequestTypes, which must be dropped and replaced
   // with default RT

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -238,16 +238,6 @@ bool CacheManager::ApplyUpdate(const policy_table::Table& update_pt) {
       pt_->policy_table.app_policies_section.apps[iter->first].set_to_null();
       pt_->policy_table.app_policies_section.apps[iter->first].set_to_string(
           "");
-    } else if (policy::kDefaultId == (iter->second).get_string()) {
-      policy_table::ApplicationPolicies::const_iterator iter_default =
-          update_pt.policy_table.app_policies_section.apps.find(kDefaultId);
-      if (update_pt.policy_table.app_policies_section.apps.end() ==
-          iter_default) {
-        LOG4CXX_ERROR(logger_, "The default section was not found in PTU");
-        continue;
-      }
-      pt_->policy_table.app_policies_section.apps[iter->first] =
-          iter_default->second;
     } else {
       pt_->policy_table.app_policies_section.apps[iter->first] = iter->second;
     }


### PR DESCRIPTION
This issue is reproduced on EXTERNAL_PROPRIETARY flow only.

There was a problem that "default" policy section was not updated after PTU with changes in this section.
Also applications which have "default" policies in PTU was not updated too.

To fix this issue there was removed code in `CacheManager`, which incorrectly assigns default policies to apps with "default" policies.

Also there was a redundant code because "default" policies is unwrapped in PTU and replaced with actual default policies, so all specific application policies is already have actual new default policy permissions. In this case it is correct to assign to every app his own policies from PTU.

Also there was updated logic in `ProcessAppPolicyCheckResults()` to perform all needed actions once per app, because its possible that results could contain few results for one `app_id`.

Fixes https://github.com/SmartDeviceLink/sdl_core/issues/1772