### PR TITLE
Add `remoteControl` to HMICapability struct in Mobile API

### DIFF
--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -425,6 +425,20 @@ class HMICapabilitiesImpl : public HMICapabilities {
   bool video_streaming_supported() const OVERRIDE;
 
   /*
+   * @brief Interface to store whether HMI supports remote control
+   *
+   * @param supported Indicates whether video streaming is supported by HMI
+   */
+  void set_rc_supported(const bool supported) OVERRIDE;
+
+  /*
+   * @brief Retrieves whether HMI supports remote control
+   *
+   * @return TRUE if it supported, otherwise FALSE
+   */
+  bool rc_supported() const OVERRIDE;
+
+  /*
    * @brief Interface used to store information regarding
    * the navigation "System Capability"
    *
@@ -557,6 +571,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
   bool is_navigation_supported_;
   bool is_phone_call_supported_;
   bool is_video_streaming_supported_;
+  bool is_rc_supported_;
   std::string ccpu_version_;
   smart_objects::SmartObject* navigation_capability_;
   smart_objects::SmartObject* phone_capability_;

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -270,6 +270,7 @@ extern const char* hmi_capabilities;
 extern const char* navigation;
 extern const char* phone_call;
 extern const char* video_streaming;
+extern const char* remote_control;
 extern const char* sdl_version;
 extern const char* system_software_version;
 extern const char* priority;

--- a/src/components/application_manager/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/src/commands/hmi/ui_get_capabilities_response.cc
@@ -84,6 +84,12 @@ void UIGetCapabilitiesResponse::Run() {
           msg_params[strings::hmi_capabilities][strings::video_streaming]
               .asBool());
     }
+    if (msg_params[strings::hmi_capabilities].keyExists(
+            strings::remote_control)) {
+      hmi_capabilities.set_rc_supported(
+          msg_params[strings::hmi_capabilities][strings::remote_control]
+              .asBool());
+    }
   }
 
   if (msg_params.keyExists(strings::system_capabilities)) {
@@ -103,6 +109,11 @@ void UIGetCapabilitiesResponse::Run() {
       hmi_capabilities.set_video_streaming_capability(
           msg_params[strings::system_capabilities]
                     [strings::video_streaming_capability]);
+    }
+    if (msg_params[strings::system_capabilities].keyExists(
+            strings::rc_capability)) {
+      hmi_capabilities.set_rc_capability(
+          msg_params[strings::system_capabilities][strings::rc_capability]);
     }
   }
 }

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -494,6 +494,8 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
       hmi_capabilities.phone_call_supported();
   response_params[strings::hmi_capabilities][strings::video_streaming] =
       hmi_capabilities.video_streaming_supported();
+  response_params[strings::hmi_capabilities][strings::remote_control] =
+      hmi_capabilities.rc_supported();
 }
 
 void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -391,6 +391,7 @@ HMICapabilitiesImpl::HMICapabilitiesImpl(ApplicationManager& app_mngr)
     , is_navigation_supported_(false)
     , is_phone_call_supported_(false)
     , is_video_streaming_supported_(false)
+    , is_rc_supported_(false)
     , navigation_capability_(NULL)
     , phone_capability_(NULL)
     , video_streaming_capability_(NULL)
@@ -650,6 +651,10 @@ void HMICapabilitiesImpl::set_video_streaming_supported(const bool supported) {
   is_video_streaming_supported_ = supported;
 }
 
+void HMICapabilitiesImpl::set_rc_supported(const bool supported) {
+  is_rc_supported_ = supported;
+}
+
 void HMICapabilitiesImpl::set_navigation_capability(
     const smart_objects::SmartObject& navigation_capability) {
   if (navigation_capability_) {
@@ -801,6 +806,10 @@ bool HMICapabilitiesImpl::phone_call_supported() const {
 
 bool HMICapabilitiesImpl::video_streaming_supported() const {
   return is_video_streaming_supported_;
+}
+
+bool HMICapabilitiesImpl::rc_supported() const {
+  return is_rc_supported_;
 }
 
 const smart_objects::SmartObject* HMICapabilitiesImpl::navigation_capability()
@@ -1150,6 +1159,9 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
           Formatters::CFormatterJsonBase::jsonValueToObj(rc_capability,
                                                          rc_capability_so);
           set_rc_capability(rc_capability_so);
+          if (!rc_capability_so.empty()) {
+            set_rc_supported(true);
+          }
         }
       }
     }  // UI end

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -234,6 +234,7 @@ const char* hmi_capabilities = "hmiCapabilities";
 const char* navigation = "navigation";
 const char* phone_call = "phoneCall";
 const char* video_streaming = "videoStreaming";
+const char* remote_control = "remoteControl";
 const char* sdl_version = "sdlVersion";
 const char* system_software_version = "systemSoftwareVersion";
 const char* priority = "priority";

--- a/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -241,6 +241,28 @@ TEST_F(UIGetCapabilitiesResponseTest, SetVideoStreaming_SUCCESS) {
   command->Run();
 }
 
+TEST_F(UIGetCapabilitiesResponseTest, SetRemoteControl_SUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::msg_params][strings::hmi_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  (*command_msg)[strings::msg_params][strings::hmi_capabilities]
+                [strings::remote_control] = true;
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  smart_objects::SmartObject hmi_capabilities_so =
+      (*command_msg)[strings::msg_params][strings::hmi_capabilities];
+  EXPECT_CALL(
+      mock_hmi_capabilities_,
+      set_rc_supported(hmi_capabilities_so[strings::remote_control].asBool()));
+
+  command->Run();
+}
+
 TEST_F(UIGetCapabilitiesResponseTest, SetNavigationCapability_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
   (*command_msg)[strings::msg_params][strings::system_capabilities] =
@@ -335,6 +357,92 @@ TEST_F(UIGetCapabilitiesResponseTest, SetVideoStreamingCapability_SUCCESS) {
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_video_streaming_capability(video_streaming_capability));
+
+  command->Run();
+}
+
+TEST_F(UIGetCapabilitiesResponseTest, SetRemoteControlCapability_SUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::msg_params][strings::system_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  (*command_msg)[strings::msg_params][strings::system_capabilities]
+                [strings::rc_capability] =
+                    smart_objects::SmartObject(smart_objects::SmartType_Map);
+  smart_objects::SmartObject& remote_control_capability =
+      (*command_msg)[strings::msg_params][strings::system_capabilities]
+                    [strings::rc_capability];
+
+  remote_control_capability["climateControlCapabilities"] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  remote_control_capability["climateControlCapabilities"][0] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  smart_objects::SmartObject& climate_control_capability =
+      remote_control_capability["climateControlCapabilities"][0];
+
+  climate_control_capability["moduleName"] = "Climate";
+  climate_control_capability["fanSpeedAvailable"] = true;
+  climate_control_capability["desiredTemperatureAvailable"] = true;
+  climate_control_capability["acEnableAvailable"] = true;
+  climate_control_capability["acMaxEnableAvailable"] = true;
+  climate_control_capability["circulateAirEnableAvailable"] = true;
+  climate_control_capability["autoModeEnableAvailable"] = true;
+  climate_control_capability["dualModeEnableAvailable"] = true;
+
+  climate_control_capability["defrostZoneAvailable"] = true;
+  climate_control_capability["defrostZone"] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  climate_control_capability["defrostZone"][0] = "ALL";
+
+  climate_control_capability["ventilationModeAvailable"] = true;
+  climate_control_capability["ventilationMode"] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  climate_control_capability["ventilationMode"][0] = "BOTH";
+
+  remote_control_capability["radioControlCapabilities"] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  remote_control_capability["radioControlCapabilities"][0] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  smart_objects::SmartObject& radio_control_capability =
+      remote_control_capability["radioControlCapabilities"][0];
+
+  radio_control_capability["moduleName"] = "Radio";
+  radio_control_capability["radioEnableAvailable"] = true;
+  radio_control_capability["radioBandAvailable"] = true;
+  radio_control_capability["radioFrequencyAvailable"] = true;
+  radio_control_capability["hdChannelAvailable"] = true;
+  radio_control_capability["rdsDataAvailable"] = true;
+  radio_control_capability["availableHDsAvailable"] = true;
+  radio_control_capability["stateAvailable"] = true;
+  radio_control_capability["signalStrengthAvailable"] = true;
+  radio_control_capability["signalChangeThresholdAvailable"] = true;
+
+  remote_control_capability[hmi_response::button_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  remote_control_capability[hmi_response::button_capabilities][0] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  smart_objects::SmartObject& button_capability =
+      remote_control_capability[hmi_response::button_capabilities][0];
+
+  button_capability[strings::button_name] = "OK";
+  button_capability["shortPressAvailable"] = true;
+  button_capability["longPressAvailable"] = true;
+  button_capability["upDownAvailable"] = true;
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_rc_capability(remote_control_capability));
 
   command->Run();
 }

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -507,6 +507,7 @@ TEST_F(HMICapabilitiesTest,
   EXPECT_FALSE(hmi_capabilities->navigation_supported());
   EXPECT_TRUE(hmi_capabilities->phone_call_supported());
   EXPECT_FALSE(hmi_capabilities->video_streaming_supported());
+  EXPECT_FALSE(hmi_capabilities->rc_supported());
 
   // verify phone capability
   const smart_objects::SmartObject phone_capability_so =
@@ -547,6 +548,7 @@ TEST_F(HMICapabilitiesTest,
   EXPECT_TRUE(hmi_capabilities->navigation_supported());
   EXPECT_FALSE(hmi_capabilities->phone_call_supported());
   EXPECT_FALSE(hmi_capabilities->video_streaming_supported());
+  EXPECT_FALSE(hmi_capabilities->rc_supported());
 
   // verify navigation capabilities
   smart_objects::SmartObject navigation_capability_so =

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -160,6 +160,9 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
   MOCK_CONST_METHOD0(video_streaming_supported, bool());
   MOCK_METHOD1(set_video_streaming_supported, void(const bool supported));
 
+  MOCK_CONST_METHOD0(rc_supported, bool());
+  MOCK_METHOD1(set_rc_supported, void(const bool supported));
+
   MOCK_CONST_METHOD0(navigation_capability,
                      const smart_objects::SmartObject*());
   MOCK_METHOD1(set_navigation_capability,

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -427,6 +427,20 @@ class HMICapabilities {
   virtual bool video_streaming_supported() const = 0;
 
   /*
+   * @brief Interface to store whether HMI supports remote control
+   *
+   * @param supported Indicates whether remote control is supported by HMI
+   */
+  virtual void set_rc_supported(const bool supported) = 0;
+
+  /*
+   * @brief Retrieves whether HMI supports remote control
+   *
+   * @return TRUE if it supported, otherwise FALSE
+   */
+  virtual bool rc_supported() const = 0;
+
+  /*
    * @brief Interface used to store information regarding
    * the navigation "System Capability"
    *

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -1994,6 +1994,9 @@
         <param name="videoStreaming" type="Boolean" mandatory="false">
             <description>Availability of video streaming. </description>
         </param>
+        <param name="remoteControl" type="Boolean" mandatory="false">
+            <description>Availability of remote control feature. True: Available, False: Not Available</description>
+        </param>
     </struct>         
     <struct name="MenuParams">
         <param name="parentID" type="Integer" minvalue="0" maxvalue="2000000000" defvalue="0" mandatory="false">


### PR DESCRIPTION
This was missing from the original PR, Core must communicate in the RegisterAppInterface response whether or not it supports RC.