### PR TITLE
Fix SendLocation response for not applicable resultCodes from HMI

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1746,6 +1746,19 @@ bool ApplicationManagerImpl::ManageMobileCommand(
   }
 
   if (message_type == mobile_apis::messageType::response) {
+    if (!message->isValid()) {
+      LOG4CXX_ERROR(logger_, "Mobile message response is invalid");
+      smart_objects::SmartObjectSPtr response =
+          MessageHelper::CreateNegativeResponse(
+              connection_key,
+              static_cast<int32_t>(function_id),
+              correlation_id,
+              static_cast<int32_t>(mobile_apis::Result::GENERIC_ERROR));
+
+      SendMessageToMobile(response);
+      return false;
+    }
+
     if (command->Init()) {
       command->Run();
       command->CleanUp();

--- a/src/components/application_manager/src/commands/mobile/send_location_request.cc
+++ b/src/components/application_manager/src/commands/mobile/send_location_request.cc
@@ -146,7 +146,7 @@ void SendLocationRequest::on_event(const event_engine::Event& event) {
     const bool result = PrepareResultForMobileResponse(
         result_code, HmiInterfaces::HMI_INTERFACE_Navigation);
     SendResponse(result,
-                 MessageHelper::HMIToMobileResult(result_code),
+                 GetMobileResultCode(result_code),
                  response_info.empty() ? NULL : response_info.c_str(),
                  &(message[strings::params]));
     return;

--- a/src/components/application_manager/test/commands/mobile/send_location_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/send_location_request_test.cc
@@ -362,13 +362,13 @@ TEST_F(SendLocationRequestTest, OnEvent_Success) {
   Event event(hmi_apis::FunctionID::Navigation_SendLocation);
   event.set_smart_object(*message_);
 
-  EXPECT_CALL(mock_message_helper_,
-              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
-      .WillOnce(Return(mobile_apis::Result::SUCCESS));
-
   MockAppPtr app(CreateMockApp());
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillRepeatedly(Return(app));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
 
   command_->on_event(event);
 }


### PR DESCRIPTION
Currently SDL transfers from HMI to Mobile any result code which came in response. Some RPCs in MOBILE_API have own fixed list of valid result codes for this RPC. According to requirements if SDL receives some of result code which is not present in this fixed list, SDL should behave the same way as in case of "any unknown issue" and respond with `GENERIC_ERROR`.

In this fix was added response message validation check after applying schema and respond with `GENERIC_ERROR` if response message is invalid due to some reason. This fix affects all RPC responses.