### PR TITLE
Fix SDL behavior in case of param disallowed by policies and double subscription

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
@@ -130,7 +130,7 @@ class SubscribeVehicleDataRequest : public CommandRequestImpl {
    * HMI
    * @param result contains result that SDL sends to mobile app.
    */
-  void CheckVISubscribtions(ApplicationSharedPtr app,
+  void CheckVISubscriptions(ApplicationSharedPtr app,
                             std::string& out_info,
                             mobile_apis::Result::eType& out_result_code,
                             smart_objects::SmartObject& out_response_params,

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -748,6 +748,7 @@ void CommandRequestImpl::AddDisallowedParameters(
 }
 
 bool CommandRequestImpl::HasDisallowedParams() const {
+  LOG4CXX_AUTO_TRACE(logger_);
   return ((!removed_parameters_permissions_.disallowed_params.empty()) ||
           (!removed_parameters_permissions_.undefined_params.empty()));
 }


### PR DESCRIPTION

- Fixed response to mobile when app tries to subscribe to already
  subscribed param
- Fixed response to mobile when request contains parameter disallowed by
  policies
- Added some logging
- Fixed mistake in function name