### PR TITLE
fix: media_managet_test fails if EXTENDED_MEDIA_MODE is enabled

### DIFF
--- a/src/components/media_manager/test/media_manager_impl_test.cc
+++ b/src/components/media_manager/test/media_manager_impl_test.cc
@@ -123,10 +123,12 @@ class MediaManagerImplTest : public ::testing::Test {
         .WillOnce(Return(mock_app_));
     EXPECT_CALL(mock_media_manager_settings_, app_storage_folder())
         .WillOnce(ReturnRef(kStorageFolder));
+#ifndef EXTENDED_MEDIA_MODE
     EXPECT_CALL(mock_media_manager_settings_, app_resource_folder())
         .WillOnce(ReturnRef(kResourceFolder));
     EXPECT_CALL(mock_media_manager_settings_, recording_file_source())
         .WillOnce(ReturnRef(kRecordingFileSource));
+#endif
   }
 
   void InitMediaManagerPrecondition(const std::string& server_type) {


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/1802.