### PR TITLE
Fix transferring SendLocation request to HMI in case sendLocationEnabled:false

### DIFF
--- a/src/components/application_manager/src/commands/mobile/send_location_request.cc
+++ b/src/components/application_manager/src/commands/mobile/send_location_request.cc
@@ -35,6 +35,23 @@
 #include "application_manager/message_helper.h"
 #include "utils/custom_string.h"
 
+namespace {
+
+bool IsSendLocationEnabled(
+    const application_manager::HMICapabilities& hmi_capabilities) {
+  const smart_objects::SmartObject* navi_capabilities =
+      hmi_capabilities.navigation_capability();
+  if (navi_capabilities) {
+    if (navi_capabilities->keyExists("sendLocationEnabled")) {
+      return (*navi_capabilities)["sendLocationEnabled"].asBool();
+    }
+  }
+
+  return false;
+}
+
+}  // namespace
+
 namespace application_manager {
 
 namespace commands {
@@ -233,6 +250,11 @@ bool SendLocationRequest::CheckHMICapabilities(
   }
   if (!hmi_capabilities.is_navi_cooperating()) {
     LOG4CXX_ERROR(logger_, "NAVI is not supported.");
+    return false;
+  }
+  if (!IsSendLocationEnabled(hmi_capabilities)) {
+    LOG4CXX_ERROR(logger_,
+                  "SendLocation request is disallowed by hmi capabilities");
     return false;
   }
   if (!fields_names.empty()) {

--- a/src/components/application_manager/test/commands/mobile/send_location_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/send_location_request_test.cc
@@ -98,6 +98,7 @@ class SendLocationRequestTest
     disp_cap_ = utils::MakeShared<SmartObject>(smart_objects::SmartType_Map);
     message_ = CreateMessage();
     command_ = CreateCommand<UnwrappedSendLocationRequest>(message_);
+    navi_caps_so = SmartObject(smart_objects::SmartType_Map);
   }
 
   void TearDown() OVERRIDE {
@@ -123,6 +124,9 @@ class SendLocationRequestTest
         .WillOnce(Return(true));
     EXPECT_CALL(mock_hmi_capabilities_, is_navi_cooperating())
         .WillOnce(Return(true));
+    navi_caps_so["sendLocationEnabled"] = true;
+    EXPECT_CALL(mock_hmi_capabilities_, navigation_capability())
+        .WillOnce(Return(&navi_caps_so));
   }
 
   void HMICapabilitiesSetupWithArguments(
@@ -164,6 +168,7 @@ class SendLocationRequestTest
   SharedPtr<SmartObject> disp_cap_;
   MessageSharedPtr message_;
   CommandSPrt command_;
+  smart_objects::SmartObject navi_caps_so;
 };
 
 TEST_F(SendLocationRequestTest, Run_InvalidApp_Success) {


### PR DESCRIPTION
In case when HMI respond with sendLocationEnabled = false in UI.GetCapabilities,
SDL should  respond to App with UNSUPPORTED_RESOURCE, success: false.
So I added CheckHMINaviCapabilities() function that checks value of sendLocationEnabled param.
`"GitHub issue link" ~ "https://github.com/SmartDeviceLink/sdl_core/issues/1740"`