### PR TITLE
Fix sending binary data using OnSystemRequest for any requestType

### DIFF
--- a/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
@@ -61,6 +61,7 @@ using testing::_;
 
 namespace {
 const uint32_t kConnectionKey = 1u;
+const std::string kFileName = "some_file.txt";
 }  // namespace
 
 class OnSystemRequestNotificationTest
@@ -85,6 +86,7 @@ TEST_F(OnSystemRequestNotificationTest, Run_ProprietaryType_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
   (*msg)[strings::params][strings::connection_key] = kConnectionKey;
   (*msg)[strings::msg_params][strings::request_type] = kRequestType;
+  (*msg)[strings::msg_params][strings::file_name] = kFileName;
 
   SharedPtr<OnSystemRequestNotification> command =
       CreateCommand<OnSystemRequestNotification>(msg);
@@ -128,6 +130,7 @@ TEST_F(OnSystemRequestNotificationTest, Run_HTTPType_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
   (*msg)[strings::params][strings::connection_key] = kConnectionKey;
   (*msg)[strings::msg_params][strings::request_type] = kRequestType;
+  (*msg)[strings::msg_params][strings::file_name] = kFileName;
 
   SharedPtr<OnSystemRequestNotification> command =
       CreateCommand<OnSystemRequestNotification>(msg);


### PR DESCRIPTION
The SDL protocol supports binary data to be sent to the app from the module.
However, SDL Core only sends the binary data using the OnSystemRequest RPC for the PROPRIETARY requestType. SDL core should be capable of sending binary data for any requestType.

#1714 
`"GitHub issue link" ~ "https://github.com/SmartDeviceLink/sdl_core/issues/1714"`