### PR TITLE
Fix/wrong info message in case of specific parameter delivery mode

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -42,6 +42,8 @@
 namespace application_manager {
 namespace commands {
 
+typedef std::map<std::string, std::string> CustomInfo;
+
 struct ResponseInfo {
   ResponseInfo()
       : result_code(hmi_apis::Common_Result::INVALID_ENUM)
@@ -290,7 +292,6 @@ class CommandRequestImpl : public CommandImpl,
   mobile_apis::Result::eType PrepareResultCodeForResponse(
       const ResponseInfo& first, const ResponseInfo& second);
 
- protected:
   /**
    * @brief Returns policy parameters permissions
    * @return Parameters permissions struct reference
@@ -312,12 +313,12 @@ class CommandRequestImpl : public CommandImpl,
   DISALLOW_COPY_AND_ASSIGN(CommandRequestImpl);
 
   /**
-   * @brief Adds param to disallowed parameters enumeration
-   * @param info string with disallowed params enumeration
-   * @param param disallowed param
+   * @brief Returns map of parameters and their custom info strings
+   * specified especially for these parameters
+   * Can be overloaded in children classes
+   * @return empty map of parameters and their info strings
    */
-  void AddDissalowedParameterToInfoString(std::string& info,
-                                          const std::string& param) const;
+  virtual CustomInfo CustomInfoMap() const;
 
   /**
    * @brief Adds disallowed parameters to response info

--- a/src/components/application_manager/include/application_manager/commands/mobile/send_location_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/send_location_request.h
@@ -71,6 +71,13 @@ class SendLocationRequest : public CommandRequestImpl {
 
  private:
   /**
+   * @brief Returns map of parameters and their custom info strings
+   * specified especially for these parameters
+   * @return map of parameters and their info strings
+   */
+  CustomInfo CustomInfoMap() const OVERRIDE;
+
+  /**
  * @brief CheckFieldsCompatibility checks if fields are compatible with each
  * other.
  * @return true if compatible, otherwise return false

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -721,38 +721,69 @@ void CommandRequestImpl::RemoveDisallowedParameters() {
   }
 }
 
-void CommandRequestImpl::AddDissalowedParameterToInfoString(
-    std::string& info, const std::string& param) const {
-  // prepare disallowed params enumeration for response info string
-  if (info.empty()) {
-    info = "\'" + param + "\'";
+void AddDissalowedParameterToInfoString(const std::string& param,
+                                        std::string& info_out) {
+  // Prepare disallowed params enumeration for response info string
+  if (info_out.empty()) {
+    info_out = "\'" + param + "\'";
   } else {
-    info = info + "," + " " + "\'" + param + "\'";
+    info_out = info_out + "," + " " + "\'" + param + "\'";
   }
+}
+
+CustomInfo CommandRequestImpl::CustomInfoMap() const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return std::map<std::string, std::string>();
 }
 
 void CommandRequestImpl::AddDisallowedParametersToInfo(
     smart_objects::SmartObject& response) const {
-  std::string info;
+  LOG4CXX_AUTO_TRACE(logger_);
+  const CustomInfo& custom_info_map = CustomInfoMap();
 
-  RPCParams::const_iterator it =
-      removed_parameters_permissions_.disallowed_params.begin();
-  for (; it != removed_parameters_permissions_.disallowed_params.end(); ++it) {
-    AddDissalowedParameterToInfoString(info, (*it));
+  CustomInfo::const_iterator custom_param_it = custom_info_map.begin();
+  const RPCParams& disallowed_params =
+      removed_parameters_permissions_.disallowed_params;
+  const RPCParams& undefined_params =
+      removed_parameters_permissions_.undefined_params;
+
+  std::string info;
+  for (; custom_param_it != custom_info_map.end(); ++custom_param_it) {
+    const bool is_in_disallowed =
+        disallowed_params.find(custom_param_it->first) !=
+        disallowed_params.end();
+    const bool is_in_undefined =
+        undefined_params.find(custom_param_it->first) != undefined_params.end();
+    if (is_in_disallowed || is_in_undefined) {
+      info += custom_param_it->second;
+    }
   }
 
-  it = removed_parameters_permissions_.undefined_params.begin();
-  for (; it != removed_parameters_permissions_.undefined_params.end(); ++it) {
-    AddDissalowedParameterToInfoString(info, (*it));
+  uint32_t added_params_counter = 0;
+  RPCParams::const_iterator params_it = disallowed_params.begin();
+  for (; params_it != disallowed_params.end(); ++params_it) {
+    if (custom_info_map.find(*params_it) == custom_info_map.end()) {
+      LOG4CXX_INFO(logger_, "Adding param to info : " << *params_it);
+      AddDissalowedParameterToInfoString((*params_it), info);
+      ++added_params_counter;
+    }
+  }
+
+  params_it = undefined_params.begin();
+  for (; params_it != undefined_params.end(); ++params_it) {
+    if (custom_info_map.find(*params_it) == custom_info_map.end()) {
+      LOG4CXX_INFO(logger_, "Adding param to info : " << *params_it);
+      AddDissalowedParameterToInfoString((*params_it), info);
+      ++added_params_counter;
+    }
+  }
+
+  if (added_params_counter != 0) {
+    info += added_params_counter > 1 ? " parameters are " : " parameter is ";
+    info += "disallowed by Policies";
   }
 
   if (!info.empty()) {
-    const uint32_t params_count =
-        removed_parameters_permissions_.disallowed_params.size() +
-        removed_parameters_permissions_.undefined_params.size();
-    info += params_count > 1 ? " parameters are " : " parameter is ";
-    info += "disallowed by Policies";
-
     if (!response[strings::msg_params][strings::info].asString().empty()) {
       // If we already have info add info about disallowed params to it
       response[strings::msg_params][strings::info] =

--- a/src/components/application_manager/src/commands/mobile/send_location_request.cc
+++ b/src/components/application_manager/src/commands/mobile/send_location_request.cc
@@ -156,6 +156,7 @@ void SendLocationRequest::on_event(const event_engine::Event& event) {
         message[strings::params][hmi_response::code].asInt());
     std::string response_info;
     GetInfo(message, response_info);
+    LOG4CXX_INFO(logger_, "Response info : " << response_info);
     const bool result = PrepareResultForMobileResponse(
         result_code, HmiInterfaces::HMI_INTERFACE_Navigation);
     SendResponse(result,
@@ -174,6 +175,14 @@ void insert_if_contains(
   if (msg_params.keyExists(param_key)) {
     output_vector.push_back(msg_params[param_key].asCustomString());
   }
+}
+
+CustomInfo SendLocationRequest::CustomInfoMap() const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  std::map<std::string, std::string> custom_info_map;
+  custom_info_map[strings::delivery_mode] =
+      "default value of delivery mode will be used";
+  return custom_info_map;
 }
 
 bool SendLocationRequest::IsWhiteSpaceExist() {


### PR DESCRIPTION
Fixed info string generation in case of specific parameter `deliveryMode` present in request and it is disallowed by Policies.

Reqs: [SendLocation TRS](https://github.com/smartdevicelink/sdl_requirements/blob/master/detailed_docs/TRS/embedded_navi/SendLocation_TRS.md)

**Should be merged after** https://github.com/smartdevicelink/sdl_core/pull/1799

`"GitHub issue link" ~ "https://github.com/SmartDeviceLink/sdl_core/issues/1740"`