### PR TITLE
Reject invalid enum values in video params

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1227,8 +1227,22 @@ bool ApplicationManagerImpl::StartNaviService(
     if (service_type == ServiceType::kMobileNav) {
       smart_objects::SmartObject converted_params(smart_objects::SmartType_Map);
       ConvertVideoParamsToSO(converted_params, params);
+      std::vector<std::string> rejected_params;
+      if (converted_params.keyExists(strings::codec) &&
+          converted_params[strings::codec] ==
+              hmi_apis::Common_VideoStreamingCodec::INVALID_ENUM) {
+        rejected_params.push_back(strings::codec);
+      }
+      if (converted_params.keyExists(strings::protocol) &&
+          converted_params[strings::protocol] ==
+              hmi_apis::Common_VideoStreamingProtocol::INVALID_ENUM) {
+        rejected_params.push_back(strings::protocol);
+      }
 
-      if (!converted_params.empty()) {
+      if (!rejected_params.empty()) {
+        OnStreamingConfigured(app_id, service_type, false, rejected_params);
+        return false;
+      } else if (!converted_params.empty()) {
         LOG4CXX_INFO(logger_, "Sending video configuration params");
 #ifdef DEBUG
         MessageHelper::PrintSmartObject(converted_params);
@@ -1248,6 +1262,8 @@ bool ApplicationManagerImpl::StartNaviService(
   } else {
     LOG4CXX_WARN(logger_, "Refused navi service by HMI level");
   }
+  std::vector<std::string> empty;
+  OnStreamingConfigured(app_id, service_type, false, empty);
   return false;
 }
 
@@ -1390,8 +1406,7 @@ void ApplicationManagerImpl::OnServiceStartedCallback(
           type, ServiceType::kMobileNav, ServiceType::kAudio)) {
     if (app->is_navi() || app->mobile_projection_enabled()) {
       if (!StartNaviService(session_key, type, params)) {
-        connection_handler().NotifyServiceStartedResult(
-            session_key, false, empty);
+        LOG4CXX_WARN(logger_, "Starting Navigation service failed");
       }
       return;
     } else {
@@ -4020,21 +4035,12 @@ void ApplicationManagerImpl::ConvertVideoParamsToSO(
   const char* protocol =
       bson_object_get_string(obj, protocol_handler::strings::video_protocol);
   if (protocol != NULL) {
-    hmi_apis::Common_VideoStreamingProtocol::eType protocol_enum =
-        ConvertVideoProtocol(protocol);
-    if (protocol_enum !=
-        hmi_apis::Common_VideoStreamingProtocol::INVALID_ENUM) {
-      output[strings::protocol] = protocol_enum;
-    }
+    output[strings::protocol] = ConvertVideoProtocol(protocol);
   }
   const char* codec =
       bson_object_get_string(obj, protocol_handler::strings::video_codec);
   if (codec != NULL) {
-    hmi_apis::Common_VideoStreamingCodec::eType codec_enum =
-        ConvertVideoCodec(codec);
-    if (codec_enum != hmi_apis::Common_VideoStreamingCodec::INVALID_ENUM) {
-      output[strings::codec] = codec_enum;
-    }
+    output[strings::codec] = ConvertVideoCodec(codec);
   }
   BsonElement* element =
       bson_object_get(obj, protocol_handler::strings::height);


### PR DESCRIPTION
Fixes issue where invalid enum values are ignored but still reciprocated in the StartSessionACK.