### PR TITLE
Fix System Capabilities

### DIFF
--- a/src/components/application_manager/src/commands/hmi/rc_get_capabilities_response.cc
+++ b/src/components/application_manager/src/commands/hmi/rc_get_capabilities_response.cc
@@ -45,9 +45,14 @@ void RCGetCapabilitiesResponse::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   HMICapabilities& hmi_capabilities = application_manager_.hmi_capabilities();
+  bool capability_exists =
+      (*message_)[strings::msg_params].keyExists(strings::rc_capability);
 
-  hmi_capabilities.set_rc_capability(
-      (*message_)[strings::msg_params][strings::rc_capability]);
+  if (capability_exists) {
+    hmi_capabilities.set_rc_capability(
+        (*message_)[strings::msg_params][strings::rc_capability]);
+  }
+  hmi_capabilities.set_rc_supported(capability_exists);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/hmi/rc_is_ready_request.cc
+++ b/src/components/application_manager/src/commands/hmi/rc_is_ready_request.cc
@@ -62,10 +62,14 @@ void RCIsReadyRequest::on_event(const event_engine::Event& event) {
       HMICapabilities& hmi_capabilities =
           application_manager_.hmi_capabilities();
       hmi_capabilities.set_is_rc_cooperating(is_available);
+      if (!is_available) {
+        hmi_capabilities.set_rc_supported(false);
+      }
+
       if (!CheckAvailabilityHMIInterfaces(application_manager_,
                                           HmiInterfaces::HMI_INTERFACE_RC)) {
         LOG4CXX_INFO(logger_,
-                     "HmiInterfaces::HMI_INTERFACE_VR isn't available");
+                     "HmiInterfaces::HMI_INTERFACE_RC isn't available");
         return;
       }
       SendMessageToHMI();

--- a/src/components/application_manager/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/src/commands/hmi/ui_get_capabilities_response.cc
@@ -84,12 +84,6 @@ void UIGetCapabilitiesResponse::Run() {
           msg_params[strings::hmi_capabilities][strings::video_streaming]
               .asBool());
     }
-    if (msg_params[strings::hmi_capabilities].keyExists(
-            strings::remote_control)) {
-      hmi_capabilities.set_rc_supported(
-          msg_params[strings::hmi_capabilities][strings::remote_control]
-              .asBool());
-    }
   }
 
   if (msg_params.keyExists(strings::system_capabilities)) {
@@ -109,11 +103,6 @@ void UIGetCapabilitiesResponse::Run() {
       hmi_capabilities.set_video_streaming_capability(
           msg_params[strings::system_capabilities]
                     [strings::video_streaming_capability]);
-    }
-    if (msg_params[strings::system_capabilities].keyExists(
-            strings::rc_capability)) {
-      hmi_capabilities.set_rc_capability(
-          msg_params[strings::system_capabilities][strings::rc_capability]);
     }
   }
 }

--- a/src/components/application_manager/test/commands/hmi/rc_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/rc_get_capabilities_response_test.cc
@@ -87,6 +87,78 @@ class RCGetCapabilitiesResponseTest
 TEST_F(RCGetCapabilitiesResponseTest, RUN_SUCCESSS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
 
+  (*command_msg)[strings::msg_params][strings::system_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  (*command_msg)[strings::msg_params][strings::system_capabilities]
+                [strings::rc_capability] =
+                    smart_objects::SmartObject(smart_objects::SmartType_Map);
+  smart_objects::SmartObject& remote_control_capability =
+      (*command_msg)[strings::msg_params][strings::system_capabilities]
+                    [strings::rc_capability];
+
+  remote_control_capability["climateControlCapabilities"] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  remote_control_capability["climateControlCapabilities"][0] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  smart_objects::SmartObject& climate_control_capability =
+      remote_control_capability["climateControlCapabilities"][0];
+
+  climate_control_capability["moduleName"] = "Climate";
+  climate_control_capability["fanSpeedAvailable"] = true;
+  climate_control_capability["desiredTemperatureAvailable"] = true;
+  climate_control_capability["acEnableAvailable"] = true;
+  climate_control_capability["acMaxEnableAvailable"] = true;
+  climate_control_capability["circulateAirEnableAvailable"] = true;
+  climate_control_capability["autoModeEnableAvailable"] = true;
+  climate_control_capability["dualModeEnableAvailable"] = true;
+
+  climate_control_capability["defrostZoneAvailable"] = true;
+  climate_control_capability["defrostZone"] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  climate_control_capability["defrostZone"][0] = "ALL";
+
+  climate_control_capability["ventilationModeAvailable"] = true;
+  climate_control_capability["ventilationMode"] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  climate_control_capability["ventilationMode"][0] = "BOTH";
+
+  remote_control_capability["radioControlCapabilities"] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  remote_control_capability["radioControlCapabilities"][0] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  smart_objects::SmartObject& radio_control_capability =
+      remote_control_capability["radioControlCapabilities"][0];
+
+  radio_control_capability["moduleName"] = "Radio";
+  radio_control_capability["radioEnableAvailable"] = true;
+  radio_control_capability["radioBandAvailable"] = true;
+  radio_control_capability["radioFrequencyAvailable"] = true;
+  radio_control_capability["hdChannelAvailable"] = true;
+  radio_control_capability["rdsDataAvailable"] = true;
+  radio_control_capability["availableHDsAvailable"] = true;
+  radio_control_capability["stateAvailable"] = true;
+  radio_control_capability["signalStrengthAvailable"] = true;
+  radio_control_capability["signalChangeThresholdAvailable"] = true;
+
+  remote_control_capability[hmi_response::button_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  remote_control_capability[hmi_response::button_capabilities][0] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  smart_objects::SmartObject& button_capability =
+      remote_control_capability[hmi_response::button_capabilities][0];
+
+  button_capability[strings::button_name] = "OK";
+  button_capability["shortPressAvailable"] = true;
+  button_capability["longPressAvailable"] = true;
+  button_capability["upDownAvailable"] = true;
+
   RCGetCapabilitiesResponsePtr command(
       CreateCommand<RCGetCapabilitiesResponse>(command_msg));
 
@@ -97,6 +169,7 @@ TEST_F(RCGetCapabilitiesResponseTest, RUN_SUCCESSS) {
       (*command_msg)[strings::msg_params][strings::rc_capability];
 
   EXPECT_CALL(mock_hmi_capabilities_, set_rc_capability(rc_capability_so));
+  EXPECT_CALL(mock_hmi_capabilities_, set_rc_supported(true));
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/hmi/rc_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/rc_is_ready_request_test.cc
@@ -79,6 +79,9 @@ class RCIsReadyRequestTest
     }
     EXPECT_CALL(mock_hmi_capabilities_,
                 set_is_rc_cooperating(is_rc_cooperating_available));
+    if (!is_rc_cooperating_available) {
+      EXPECT_CALL(mock_hmi_capabilities_, set_rc_supported(false));
+    }
 
     if (is_message_contain_param) {
       EXPECT_CALL(app_mngr_, hmi_interfaces())

--- a/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -241,28 +241,6 @@ TEST_F(UIGetCapabilitiesResponseTest, SetVideoStreaming_SUCCESS) {
   command->Run();
 }
 
-TEST_F(UIGetCapabilitiesResponseTest, SetRemoteControl_SUCCESS) {
-  MessageSharedPtr command_msg = CreateCommandMsg();
-  (*command_msg)[strings::msg_params][strings::hmi_capabilities] =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  (*command_msg)[strings::msg_params][strings::hmi_capabilities]
-                [strings::remote_control] = true;
-
-  ResponseFromHMIPtr command(
-      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
-
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
-      .WillOnce(ReturnRef(mock_hmi_capabilities_));
-
-  smart_objects::SmartObject hmi_capabilities_so =
-      (*command_msg)[strings::msg_params][strings::hmi_capabilities];
-  EXPECT_CALL(
-      mock_hmi_capabilities_,
-      set_rc_supported(hmi_capabilities_so[strings::remote_control].asBool()));
-
-  command->Run();
-}
-
 TEST_F(UIGetCapabilitiesResponseTest, SetNavigationCapability_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
   (*command_msg)[strings::msg_params][strings::system_capabilities] =
@@ -357,92 +335,6 @@ TEST_F(UIGetCapabilitiesResponseTest, SetVideoStreamingCapability_SUCCESS) {
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_video_streaming_capability(video_streaming_capability));
-
-  command->Run();
-}
-
-TEST_F(UIGetCapabilitiesResponseTest, SetRemoteControlCapability_SUCCESS) {
-  MessageSharedPtr command_msg = CreateCommandMsg();
-  (*command_msg)[strings::msg_params][strings::system_capabilities] =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-  (*command_msg)[strings::msg_params][strings::system_capabilities]
-                [strings::rc_capability] =
-                    smart_objects::SmartObject(smart_objects::SmartType_Map);
-  smart_objects::SmartObject& remote_control_capability =
-      (*command_msg)[strings::msg_params][strings::system_capabilities]
-                    [strings::rc_capability];
-
-  remote_control_capability["climateControlCapabilities"] =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  remote_control_capability["climateControlCapabilities"][0] =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-  smart_objects::SmartObject& climate_control_capability =
-      remote_control_capability["climateControlCapabilities"][0];
-
-  climate_control_capability["moduleName"] = "Climate";
-  climate_control_capability["fanSpeedAvailable"] = true;
-  climate_control_capability["desiredTemperatureAvailable"] = true;
-  climate_control_capability["acEnableAvailable"] = true;
-  climate_control_capability["acMaxEnableAvailable"] = true;
-  climate_control_capability["circulateAirEnableAvailable"] = true;
-  climate_control_capability["autoModeEnableAvailable"] = true;
-  climate_control_capability["dualModeEnableAvailable"] = true;
-
-  climate_control_capability["defrostZoneAvailable"] = true;
-  climate_control_capability["defrostZone"] =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-  climate_control_capability["defrostZone"][0] = "ALL";
-
-  climate_control_capability["ventilationModeAvailable"] = true;
-  climate_control_capability["ventilationMode"] =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-  climate_control_capability["ventilationMode"][0] = "BOTH";
-
-  remote_control_capability["radioControlCapabilities"] =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  remote_control_capability["radioControlCapabilities"][0] =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-  smart_objects::SmartObject& radio_control_capability =
-      remote_control_capability["radioControlCapabilities"][0];
-
-  radio_control_capability["moduleName"] = "Radio";
-  radio_control_capability["radioEnableAvailable"] = true;
-  radio_control_capability["radioBandAvailable"] = true;
-  radio_control_capability["radioFrequencyAvailable"] = true;
-  radio_control_capability["hdChannelAvailable"] = true;
-  radio_control_capability["rdsDataAvailable"] = true;
-  radio_control_capability["availableHDsAvailable"] = true;
-  radio_control_capability["stateAvailable"] = true;
-  radio_control_capability["signalStrengthAvailable"] = true;
-  radio_control_capability["signalChangeThresholdAvailable"] = true;
-
-  remote_control_capability[hmi_response::button_capabilities] =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  remote_control_capability[hmi_response::button_capabilities][0] =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-  smart_objects::SmartObject& button_capability =
-      remote_control_capability[hmi_response::button_capabilities][0];
-
-  button_capability[strings::button_name] = "OK";
-  button_capability["shortPressAvailable"] = true;
-  button_capability["longPressAvailable"] = true;
-  button_capability["upDownAvailable"] = true;
-
-  ResponseFromHMIPtr command(
-      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
-
-  EXPECT_CALL(app_mngr_, hmi_capabilities())
-      .WillOnce(ReturnRef(mock_hmi_capabilities_));
-
-  EXPECT_CALL(mock_hmi_capabilities_,
-              set_rc_capability(remote_control_capability));
 
   command->Run();
 }

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -2112,6 +2112,9 @@
   <param name="phoneCall" type="Boolean" mandatory="false">
     <description>Availability of build in phone. True: Available, False: Not Available</description>
   </param>
+  <param name="videoStreaming" type="Boolean" mandatory="false">
+    <description>Availability of built-in video streaming. True: Available, False: Not Available</description>
+  </param>
 </struct>
 
 <struct name="AudioPassThruCapabilities">


### PR DESCRIPTION
Fixes #1819 

Reverts some changes in #1786, due to them not matching up with the HMI API. The `rc_supported` flag is now set when an `RC.GetCapabilities` response is received.