### PR TITLE
fix - OnWayPointChange notification doesn't come on last point

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -4069,7 +4069,7 @@
   </function>
   <function name="OnWayPointChange" functionID="OnWayPointChangeID" messagetype="notification">
     <description>Notification which provides the entire LocationDetails when there is a change to any waypoints or destination.</description>
-    <param name="wayPoints" type="Common.LocationDetails" mandatory="true" array="true" minsize="1" maxsize="10">
+    <param name="wayPoints" type="Common.LocationDetails" mandatory="true" array="true" minsize="0" maxsize="10">
       <description>See LocationDetails</description>
     </param>
   </function>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -5924,7 +5924,7 @@
     
     <function name="OnWayPointChange" functionID="OnWayPointChangeID" messagetype="notification">
         <description>Notification which provides the entire LocationDetails when there is a change to any waypoints or destination.</description>
-        <param name="wayPoints" type="LocationDetails" mandatory="true" array="true" minsize="1" maxsize="10">
+        <param name="wayPoints" type="LocationDetails" mandatory="true" array="true" minsize="0" maxsize="10">
             <description>See LocationDetails</description>
         </param>
     </function>


### PR DESCRIPTION
@LuxoftAKutsan , @AKalinich-Luxoft , @AByzhynar , @LitvinenkoIra , please review the next change:
in current implementation there is no OnWayPointChange notification on last point due to API restriction.
Proposal owner decided to change a proposal to get this last one notification.