### PR TITLE
Update HMI API interface versions

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -37,7 +37,7 @@
 
 <interfaces name="SmartDeviceLink HMI API">
 
-<interface name="Common" version="1.6.0" date="2017-04-27">
+<interface name="Common" version="1.7.0" date="2017-10-20">
 
 <enum name="Result">
     <element name="SUCCESS" value="0"/>
@@ -2662,7 +2662,7 @@
 
 </interface>
 
-<interface name="Buttons" version="1.2.0" date="2017-04-27">
+<interface name="Buttons" version="1.3.0" date="2017-07-18">
     <function name="GetCapabilities" messagetype="request">
       <description>Method is invoked at system start-up. SDL requests the information about all supported hardware buttons and their capabilities</description>
     </function>
@@ -2746,7 +2746,7 @@
     </function>
 </interface>
 
-<interface name="BasicCommunication" version="1.2.0" date="2017-04-27">
+<interface name="BasicCommunication" version="1.2.1" date="2017-08-02">
     <function name="OnReady" messagetype="notification">
       <description>HMI must notify SDL about its readiness to start communication. In fact, this has to be the first message between SDL and HMI.</description>
     </function>
@@ -3352,7 +3352,7 @@
   </function>
 </interface>
 
-<interface name="UI" version="1.1.0" date="2017-04-27">
+<interface name="UI" version="1.2.0" date="2017-09-05">
   <function name="Alert" messagetype="request">
     <description>Request from SDL to show an alert message on the display.</description>
     <param name="alertStrings" type="Common.TextFieldStruct" mandatory="true" array="true" minsize="0" maxsize="3">
@@ -3864,7 +3864,7 @@
   </function>
 </interface>
 
-<interface name="Navigation" version="1.4.0" date="2017-04-27"> 
+<interface name="Navigation" version="1.5.0" date="2017-08-15"> 
 
   <function name="IsReady" messagetype="request">
     <description>Method is invoked at system startup. Response must provide the information about presence of UI Navigation module and its readiness to cooperate with SDL.</description>
@@ -4887,7 +4887,7 @@
     </function>
 </interface>
 
-<interface name="RC" version="1.1" date="2017-07-18">
+<interface name="RC" version="1.1.0" date="2017-07-18">
   <function name="IsReady" messagetype="request">
     <description>Method is invoked at system startup. Response should provide information about presence of any of remote controllable module and its readiness to cooperate with SDL.</description>
   </function>


### PR DESCRIPTION
HMI API interface versions need to be finalized for the 4.4.0 release.