### PR TITLE
Fix incorrect App ID caused by implicit conversion of smart pointer to integer

### DIFF
--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -949,7 +949,7 @@ void MessageHelper::SendAppDataToHMI(ApplicationConstSharedPtr app,
                                      ApplicationManager& app_man) {
   LOG4CXX_AUTO_TRACE(logger_);
   if (app) {
-    SendSetAppIcon(app, app->app_icon_path(), app_man);
+    SendSetAppIcon(app->app_id(), app->app_icon_path(), app_man);
     SendGlobalPropertiesToHMI(app, app_man);
     SendShowRequestToHMI(app, app_man);
   }


### PR DESCRIPTION
Fix silent bug caused by implicit conversion of smart pointer to integer. Garbage App ID based on pointer value. Lots of symptoms caused by this bug, which could be prevented by not letting smart pointers implicitly convert to boolean or integer.