### PR TITLE
Fix SDL does not send StopAudioStream

### DIFF
--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -477,7 +477,16 @@ void ApplicationImpl::StopStreaming(
 
   SuspendStreaming(service_type);
 
-  if (service_type == ServiceType::kMobileNav && video_streaming_approved()) {
+  if (service_type == ServiceType::kMobileNav && video_streaming_approved() &&
+      audio_streaming_approved()) {
+    StopNaviStreaming();
+    StopAudioStreaming();
+  } else if (service_type == ServiceType::kMobileNav &&
+             video_streaming_approved()) {
+    StopNaviStreaming();
+  } else if (service_type == ServiceType::kAudio &&
+             audio_streaming_approved() && video_streaming_approved()) {
+    StopAudioStreaming();
     StopNaviStreaming();
   } else if (service_type == ServiceType::kAudio &&
              audio_streaming_approved()) {


### PR DESCRIPTION
Fixes #1002 
This PR is ready for review.

### Summary
Fixed problem that SDL does not send StopAudioStream when exiting app if
Video and Audio services are started and approved.
Both StopAudioStreaming and StopNaviStreaming should be sent.


Related PR in another branch: #1381 #1635 
Fix was needed for extended policy functionality branch, so changes were sent to that branch and PR to develop was closed.
Later on code with this fix was declined so PR to develop needs to be re-opened.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)