### PR TITLE
Fix response generation for DeleteFile & PutFile RPCs

### DIFF
--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -223,6 +223,7 @@ void CommandRequestImpl::SendResponse(
     const mobile_apis::Result::eType& result_code,
     const char* info,
     const smart_objects::SmartObject* response_params) {
+  LOG4CXX_AUTO_TRACE(logger_);
   {
     sync_primitives::AutoLock auto_lock(state_lock_);
     if (kTimedOut == current_state_) {

--- a/src/components/application_manager/src/commands/mobile/delete_file_response.cc
+++ b/src/components/application_manager/src/commands/mobile/delete_file_response.cc
@@ -56,11 +56,8 @@ void DeleteFileResponse::Run() {
     return;
   }
 
-  (*message_)[strings::msg_params][strings::space_available] =
-      static_cast<uint32_t>(app->GetAvailableDiskSpace());
   SendResponse((*message_)[strings::msg_params][strings::success].asBool());
 }
 
 }  // namespace commands
-
 }  // namespace application_manager

--- a/src/components/application_manager/src/commands/mobile/put_file_request.cc
+++ b/src/components/application_manager/src/commands/mobile/put_file_request.cc
@@ -62,9 +62,15 @@ void PutFileRequest::Run() {
   smart_objects::SmartObject response_params =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
 
+  response_params[strings::space_available] =
+      static_cast<uint32_t>(application->GetAvailableDiskSpace());
+
   if (!application) {
     LOG4CXX_ERROR(logger_, "Application is not registered");
-    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
+    SendResponse(false,
+                 mobile_apis::Result::APPLICATION_NOT_REGISTERED,
+                 "Application is not registered",
+                 &response_params);
     return;
   }
 
@@ -163,7 +169,7 @@ void PutFileRequest::Run() {
     file_path = application_manager_.get_settings().app_storage_folder();
     file_path += "/" + application->folder_name();
 
-    uint32_t space_available = application->GetAvailableDiskSpace();
+    const uint32_t space_available = application->GetAvailableDiskSpace();
 
     if (binary_data.size() > space_available) {
       response_params[strings::space_available] =


### PR DESCRIPTION
Fixed response generation for DeleteFile & PutFile RPCs
There was added mobile responses check according to smart schema in latest changes of SDL.
Due to these changes  we need to generate correct responses before this check. 
Also responses with all result codes(even not successful) must match Mobile API. Therefore `space_available` parameter was added to all these responses as it is mandatory parameter of `DeleteFile` & `PutFile` responses.