### PR TITLE
Fix/fix engine oil life omitted parameters

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_impl.h
@@ -46,6 +46,10 @@ namespace application_manager {
  * table
  */
 struct CommandParametersPermissions {
+  CommandParametersPermissions()
+      : permit_result(PermitResult::kRpcDisallowed) {}
+
+  PermitResult permit_result;
   RPCParams allowed_params;
   RPCParams disallowed_params;
   RPCParams undefined_params;

--- a/src/components/application_manager/include/application_manager/commands/command_notification_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_notification_impl.h
@@ -44,13 +44,46 @@ class CommandNotificationImpl : public CommandImpl {
  public:
   CommandNotificationImpl(const MessageSharedPtr& message,
                           ApplicationManager& application_manager);
+  /**
+   * @brief CommandNotificationImpl class destructor
+   **/
   virtual ~CommandNotificationImpl();
-  virtual bool Init();
-  virtual bool CleanUp();
-  virtual void Run();
+
+  /**
+   * @brief Init required by command resources
+   **/
+  bool Init() OVERRIDE;
+
+  /**
+   * @brief Cleanup all resources used by command
+   **/
+  bool CleanUp() OVERRIDE;
+
+  /**
+   * @brief Execute corresponding command by calling the action on reciever
+   **/
+  void Run() OVERRIDE;
+
+  /**
+   * @brief Sends notification message to Mobile
+   */
   void SendNotification();
 
  private:
+  /**
+   * @brief Checks message permissions and parameters according to policy table
+   * permissions
+   */
+  bool CheckAllowedParameters(const MessageSharedPtr message) const;
+
+  /**
+   * @brief Remove from current message parameters disallowed by policy table
+   * @param param_permissions Current message permissions structure
+   */
+  void RemoveDisallowedParameters(
+      const MessageSharedPtr message,
+      const CommandParametersPermissions& param_permissions) const;
+
   DISALLOW_COPY_AND_ASSIGN(CommandNotificationImpl);
 };
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3174,6 +3174,7 @@ mobile_apis::Result::eType ApplicationManagerImpl::CheckPolicyPermissions(
   GetPolicyHandler().CheckPermissions(app, function_id, rpc_params, result);
 
   if (NULL != params_permissions) {
+    params_permissions->permit_result = result.hmi_level_permitted;
     params_permissions->allowed_params = result.list_of_allowed_params;
     params_permissions->disallowed_params = result.list_of_disallowed_params;
     params_permissions->undefined_params = result.list_of_undefined_params;
@@ -3199,8 +3200,10 @@ mobile_apis::Result::eType ApplicationManagerImpl::CheckPolicyPermissions(
 
     switch (result.hmi_level_permitted) {
       case policy::kRpcDisallowed:
+      case policy::kRpcAllParamsDisallowed:
         return mobile_apis::Result::DISALLOWED;
       case policy::kRpcUserDisallowed:
+      case policy::kRpcAllParamsUserDisallowed:
         return mobile_apis::Result::USER_DISALLOWED;
       default:
         return mobile_apis::Result::INVALID_ENUM;

--- a/src/components/application_manager/src/commands/command_notification_impl.cc
+++ b/src/components/application_manager/src/commands/command_notification_impl.cc
@@ -34,9 +34,36 @@
 #include "application_manager/application_manager.h"
 #include "application_manager/message_helper.h"
 
+#include "utils/shared_ptr.h"
+#include "utils/make_shared.h"
+
 namespace application_manager {
 
 namespace commands {
+
+namespace {
+
+struct ParamsDeleter {
+  ParamsDeleter(smart_objects::SmartObject& params,
+                const std::string& log_message)
+      : params_(params), log_message_(log_message) {}
+
+  void operator()(const RPCParams::value_type& value) {
+    if (params_.keyExists(value)) {
+      params_.erase(value);
+#ifdef ENABLE_LOG
+      CREATE_LOGGERPTR_LOCAL(logger, "Commands");
+      LOG4CXX_DEBUG(logger, log_message_ << value);
+#endif  // ENABLE_LOG
+    }
+  }
+
+ private:
+  smart_objects::SmartObject& params_;
+  std::string log_message_;
+};
+
+}  // namespace
 
 CommandNotificationImpl::CommandNotificationImpl(
     const MessageSharedPtr& message, ApplicationManager& application_manager)
@@ -52,18 +79,114 @@ bool CommandNotificationImpl::CleanUp() {
   return true;
 }
 
+bool CommandNotificationImpl::CheckAllowedParameters(
+    const MessageSharedPtr message) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const uint32_t connection_key =
+      (*message)[strings::params][strings::connection_key].asUInt();
+  if (0 == connection_key) {
+    LOG4CXX_DEBUG(logger_,
+                  "No app_id was specified. Parameters checking skipped");
+    return true;
+  }
+
+  const ApplicationSharedPtr app =
+      application_manager_.application(connection_key);
+  if (!app) {
+    LOG4CXX_ERROR(logger_,
+                  "There is no registered application with "
+                  "connection key '"
+                      << connection_key << "'");
+    return false;
+  }
+
+  RPCParams params;
+
+  const smart_objects::SmartObject& s_map = (*message)[strings::msg_params];
+  if (smart_objects::SmartType_Map == s_map.getType()) {
+    smart_objects::SmartMap::const_iterator iter = s_map.map_begin();
+    smart_objects::SmartMap::const_iterator iter_end = s_map.map_end();
+
+    for (; iter != iter_end; ++iter) {
+      if (helpers::Compare<smart_objects::SmartType,
+                           helpers::NEQ,
+                           helpers::ALL>(iter->second.getType(),
+                                         smart_objects::SmartType_Null,
+                                         smart_objects::SmartType_Invalid)) {
+        LOG4CXX_DEBUG(logger_, "Notification param: " << iter->first);
+        params.insert(iter->first);
+      }
+    }
+  }
+
+  CommandParametersPermissions params_permissions;
+  mobile_apis::Result::eType check_result =
+      application_manager_.CheckPolicyPermissions(
+          app,
+          MessageHelper::StringifiedFunctionID(
+              static_cast<mobile_api::FunctionID::eType>(function_id())),
+          params,
+          &params_permissions);
+
+  // Check, if RPC is allowed by policy
+  if (mobile_apis::Result::SUCCESS != check_result) {
+    LOG4CXX_ERROR(logger_,
+                  "Notification for app " << app->app_id()
+                                          << " is disallowed by Policies.");
+    return false;
+  }
+
+  // If no parameters specified in policy table, no restriction will be
+  // applied for parameters
+  if (params_permissions.allowed_params.empty() &&
+      params_permissions.disallowed_params.empty() &&
+      params_permissions.undefined_params.empty()) {
+    return true;
+  }
+
+  RemoveDisallowedParameters(message, params_permissions);
+
+  return true;
+}
+
+void CommandNotificationImpl::RemoveDisallowedParameters(
+    const MessageSharedPtr message,
+    const CommandParametersPermissions& param_permissions) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  smart_objects::SmartObject& params = (*message)[strings::msg_params];
+
+  // Remove from request all disallowed parameters
+  ParamsDeleter deleter_user(params,
+                             "Following parameter is disallowed by user: ");
+  std::for_each(param_permissions.disallowed_params.begin(),
+                param_permissions.disallowed_params.end(),
+                deleter_user);
+
+  // Remove from request all undefined yet parameters
+  ParamsDeleter deleter_policy(params,
+                               "Following parameter is disallowed by policy: ");
+  std::for_each(param_permissions.undefined_params.begin(),
+                param_permissions.undefined_params.end(),
+                deleter_policy);
+}
+
 void CommandNotificationImpl::Run() {}
 
 void CommandNotificationImpl::SendNotification() {
-  (*message_)[strings::params][strings::protocol_type] = mobile_protocol_type_;
-  (*message_)[strings::params][strings::protocol_version] = protocol_version_;
-  (*message_)[strings::params][strings::message_type] =
+  MessageSharedPtr message =
+      utils::MakeShared<smart_objects::SmartObject>(*message_);
+  (*message)[strings::params][strings::protocol_type] = mobile_protocol_type_;
+  (*message)[strings::params][strings::protocol_version] = protocol_version_;
+  (*message)[strings::params][strings::message_type] =
       static_cast<int32_t>(application_manager::MessageType::kNotification);
 
   LOG4CXX_INFO(logger_, "SendNotification");
-  MessageHelper::PrintSmartObject(*message_);
+  MessageHelper::PrintSmartObject(*message);
 
-  application_manager_.SendMessageToMobile(message_);
+  if (CheckAllowedParameters(message)) {
+    application_manager_.SendMessageToMobile(message);
+  }
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -578,7 +578,10 @@ bool CommandRequestImpl::CheckAllowedParameters() {
   smart_objects::SmartMap::const_iterator iter_end = s_map.map_end();
 
   for (; iter != iter_end; ++iter) {
-    if (iter->second.asBool()) {
+    if (helpers::Compare<smart_objects::SmartType, helpers::NEQ, helpers::ALL>(
+            iter->second.getType(),
+            smart_objects::SmartType_Null,
+            smart_objects::SmartType_Invalid)) {
       LOG4CXX_DEBUG(logger_, "Request's param: " << iter->first);
       params.insert(iter->first);
     }

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -104,6 +104,25 @@ const std::string CreateInfoForUnsupportedResult(
   }
 }
 
+std::string CreateInfoForPolicyPermitResult(const PermitResult value) {
+  switch (value) {
+    case PermitResult::kRpcDisallowed: {
+      return "RPC is disallowed by Policies";
+    }
+    case PermitResult::kRpcUserDisallowed: {
+      return "RPC is disallowed by the User";
+    }
+    case PermitResult::kRpcAllParamsDisallowed: {
+      return "Requested parameters are disallowed by Policies";
+    }
+    case PermitResult::kRpcAllParamsUserDisallowed: {
+      return "Requested parameters are disallowed by User";
+    }
+    default:
+      return std::string();
+  }
+}
+
 bool CheckResultCode(const ResponseInfo& first, const ResponseInfo& second) {
   if (first.is_ok && second.is_unsupported_resource &&
       second.interface_state == HmiInterfaces::STATE_NOT_AVAILABLE) {
@@ -581,7 +600,11 @@ bool CommandRequestImpl::CheckAllowedParameters() {
             check_result,
             correlation_id(),
             app->app_id());
-
+    std::string info =
+        CreateInfoForPolicyPermitResult(parameters_permissions_.permit_result);
+    if (!info.empty()) {
+      (*response)[strings::msg_params][strings::info] = info;
+    }
     application_manager_.SendMessageToMobile(response);
     return false;
   }
@@ -720,7 +743,11 @@ void CommandRequestImpl::AddDisallowedParametersToInfo(
   }
 
   if (!info.empty()) {
-    info += " disallowed by policies.";
+    const uint32_t params_count =
+        removed_parameters_permissions_.disallowed_params.size() +
+        removed_parameters_permissions_.undefined_params.size();
+    info += params_count > 1 ? " parameters are " : " parameter is ";
+    info += "disallowed by Policies";
 
     if (!response[strings::msg_params][strings::info].asString().empty()) {
       // If we already have info add info about disallowed params to it

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -393,8 +393,14 @@ TEST_F(CommandRequestImplTest,
   EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
       .WillOnce(Return(mobile_apis::Result::INVALID_ENUM));
 
+  smart_objects::SmartObjectSPtr response =
+      utils::MakeShared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  (*response)[strings::msg_params] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
   EXPECT_CALL(mock_message_helper_, CreateBlockedByPoliciesResponse(_, _, _, _))
-      .WillOnce(Return(smart_objects::SmartObjectSPtr()));
+      .WillOnce(Return(response));
 
   EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _));
   EXPECT_FALSE(command->CheckPermissions());

--- a/src/components/application_manager/test/commands/mobile/on_hash_change_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_hash_change_notification_test.cc
@@ -81,10 +81,14 @@ TEST_F(OnHashChangeNotificationTest, Run_ValidApp_SUCCESS) {
   std::string return_string = "1234";
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
   EXPECT_CALL(*mock_app, curHash()).WillOnce(ReturnRef(return_string));
   EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _)).WillOnce(SaveArg<0>(&msg));
 
   command->Run();
 

--- a/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_test.cc
@@ -77,7 +77,10 @@ class OnHMIStatusNotificationTest
   void SetSendNotificationExpectations(MessageSharedPtr& msg) {
     Mock::VerifyAndClearExpectations(&message_helper_);
     EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
-    EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+    EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+        .WillOnce(Return(mobile_apis::Result::SUCCESS));
+    EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _))
+        .WillOnce(SaveArg<0>(&msg));
   }
 
   void VerifySendNotificationData(MessageSharedPtr& msg) {
@@ -119,7 +122,8 @@ TEST_F(OnHMIStatusNotificationTest, Run_InvalidEnum_SUCCESS) {
 
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
 
   SetSendNotificationExpectations(msg);
 
@@ -137,7 +141,8 @@ TEST_F(OnHMIStatusNotificationTest, Run_BackgroundAndFalseProperties_SUCCESS) {
 
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
 
   EXPECT_CALL(*mock_app, tts_properties_in_none()).WillOnce(Return(false));
   EXPECT_CALL(*mock_app, set_tts_properties_in_none(true));
@@ -156,7 +161,8 @@ TEST_F(OnHMIStatusNotificationTest, Run_BackgroundAndTrueProperties_SUCCESS) {
 
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
 
   EXPECT_CALL(*mock_app, tts_properties_in_none()).WillOnce(Return(true));
 
@@ -175,7 +181,8 @@ TEST_F(OnHMIStatusNotificationTest, Run_FullAndFalseProperties_SUCCESS) {
 
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
 
   EXPECT_CALL(*mock_app, tts_properties_in_full()).WillOnce(Return(false));
   EXPECT_CALL(*mock_app, set_tts_properties_in_full(true));
@@ -197,7 +204,8 @@ TEST_F(OnHMIStatusNotificationTest, Run_FullAndTrueProperties_SUCCESS) {
 
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
 
   EXPECT_CALL(*mock_app, tts_properties_in_full()).WillOnce(Return(true));
 

--- a/src/components/application_manager/test/commands/mobile/on_keyboard_input_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_keyboard_input_notification_test.cc
@@ -64,9 +64,12 @@ class OnKeyBoardInputNotificationTest
   OnKeyBoardInputNotificationTest()
       : message_helper_(*MockMessageHelper::message_helper_mock()) {}
 
-  void SetSendNotificationExpectations(MessageSharedPtr msg) {
+  void SetSendNotificationExpectations(MessageSharedPtr& msg) {
     EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
-    EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+    EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+        .WillOnce(Return(mobile_apis::Result::SUCCESS));
+    EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _))
+        .WillOnce(SaveArg<0>(&msg));
   }
 
   void SetSendNotificationVariables(MessageSharedPtr msg) {
@@ -111,8 +114,9 @@ TEST_F(OnKeyBoardInputNotificationTest, Run_ActionActive_SUCCESS) {
   EXPECT_CALL(*mock_app, perform_interaction_layout())
       .WillOnce(Return(mobile_apis::LayoutMode::KEYBOARD));
   EXPECT_CALL(*mock_app, hmi_level()).Times(0);
-
   EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kConnectionKey));
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
 
   SetSendNotificationExpectations(msg);
 
@@ -138,6 +142,9 @@ TEST_F(OnKeyBoardInputNotificationTest, Run_ActionNotActive_SUCCESS) {
       .WillOnce(Return(mobile_apis::HMILevel::eType::HMI_FULL));
 
   EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kConnectionKey));
+
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
 
   SetSendNotificationExpectations(msg);
 

--- a/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
@@ -91,7 +91,10 @@ TEST_F(OnSystemRequestNotificationTest, Run_ProprietaryType_SUCCESS) {
 
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
   MockPolicyHandlerInterface mock_policy_handler;
   EXPECT_CALL(app_mngr_, GetPolicyHandler())
       .WillRepeatedly(ReturnRef(mock_policy_handler));
@@ -108,7 +111,7 @@ TEST_F(OnSystemRequestNotificationTest, Run_ProprietaryType_SUCCESS) {
 #endif  // PROPRIETARY_MODE
 
   EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _)).WillOnce(SaveArg<0>(&msg));
 
   command->Run();
 
@@ -134,7 +137,11 @@ TEST_F(OnSystemRequestNotificationTest, Run_HTTPType_SUCCESS) {
 
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
   MockPolicyHandlerInterface mock_policy_handler;
   EXPECT_CALL(app_mngr_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler));
@@ -144,7 +151,7 @@ TEST_F(OnSystemRequestNotificationTest, Run_HTTPType_SUCCESS) {
       .WillOnce(Return(true));
 
   EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _)).WillOnce(SaveArg<0>(&msg));
 
   command->Run();
 

--- a/src/components/application_manager/test/commands/mobile/on_tbt_client_state_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_tbt_client_state_notification_test.cc
@@ -123,6 +123,11 @@ TEST_F(OnTBTClientStateNotificationTest,
   EXPECT_CALL(app_mngr_, applications_with_navi())
       .WillOnce(Return(applications_with_navi));
 
+  EXPECT_CALL(app_mngr_, application(kAppId)).WillOnce(Return(mock_app));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
   EXPECT_CALL(*mock_app, hmi_level())
       .WillOnce(Return(mobile_apis::HMILevel::HMI_FULL));
 

--- a/src/components/application_manager/test/commands/mobile/on_touch_event_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_touch_event_notification_test.cc
@@ -133,6 +133,14 @@ TEST_F(OnTouchEventNotificationTest, Run_NotEmptyListOfAppsWithNavi_SUCCESS) {
   EXPECT_CALL(app_mngr_, applications_with_mobile_projection())
       .WillOnce(Return(applications_with_mobile_projection));
 
+  EXPECT_CALL(app_mngr_, application(kAppId))
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .Times(2)
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
   EXPECT_CALL(*mock_app, IsFullscreen()).WillRepeatedly(Return(true));
 
   EXPECT_CALL(*mock_app, app_id()).WillRepeatedly(Return(kAppId));

--- a/src/components/application_manager/test/commands/mobile/on_vehicle_data_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_vehicle_data_notification_test.cc
@@ -130,6 +130,11 @@ TEST_F(OnVehicleDataNotificationTest,
               IviInfoUpdated(am::VehicleDataType::FUELLEVEL, kFuelLevel))
       .WillOnce(Return(applications));
 
+  EXPECT_CALL(app_mngr_, application(kAppId)).WillOnce(Return(mock_app));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
   EXPECT_CALL(*mock_app, app_id()).WillRepeatedly(Return(kAppId));
   ::utils::custom_string::CustomString dummy_name("test_app");
   ON_CALL(*mock_app, name()).WillByDefault(ReturnRef(dummy_name));

--- a/src/components/application_manager/test/commands/mobile/on_way_point_change_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_way_point_change_notification_test.cc
@@ -101,6 +101,15 @@ TEST_F(OnWayPointChangeNotificationTest,
   std::set<int32_t> apps_subscribed_for_way_points;
   apps_subscribed_for_way_points.insert(kAppId);
 
+  MockAppPtr mock_app(CreateMockApp());
+
+  EXPECT_CALL(app_mngr_, application(kAppId)).WillOnce(Return(mock_app));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
+  EXPECT_CALL(*mock_app, app_id()).WillRepeatedly(Return(kAppId));
+
   EXPECT_CALL(app_mngr_, GetAppsSubscribedForWayPoints())
       .WillOnce(Return(apps_subscribed_for_way_points));
 

--- a/src/components/application_manager/test/commands/mobile/set_media_clock_timer_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_media_clock_timer_test.cc
@@ -334,7 +334,13 @@ TEST_F(SetMediaClockRequestTest, OnEvent_Success) {
   SharedPtr<SetMediaClockRequest> command(
       CreateCommand<SetMediaClockRequest>(msg));
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
 
   MockAppPtr app(CreateMockApp());
   EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(app));

--- a/src/components/application_manager/test/commands/mobile/show_test.cc
+++ b/src/components/application_manager/test/commands/mobile/show_test.cc
@@ -750,6 +750,10 @@ TEST_F(ShowRequestTest, Run_MainField1_MetadataTagWithNoFieldData) {
       ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
       .WillOnce(DoAll(SaveArg<0>(&ui_command_result), Return(true)));
 
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
   command->on_event(event);
 
   EXPECT_EQ((*ui_command_result)[am::strings::msg_params][am::strings::success]

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -86,8 +86,9 @@ class EventDispatcher;
 
 class Application;
 class StateControllerImpl;
-struct CommandParametersPermissions;
 using policy::RPCParams;
+using policy::PermitResult;
+struct CommandParametersPermissions;
 typedef std::vector<ApplicationSharedPtr> AppSharedPtrs;
 struct ApplicationsAppIdSorter {
   bool operator()(const ApplicationSharedPtr lhs,

--- a/src/components/policy/policy_external/include/policy/policy_types.h
+++ b/src/components/policy/policy_external/include/policy/policy_types.h
@@ -113,7 +113,13 @@ typedef std::vector<std::string> PermissionsList;
  */
 typedef std::vector<std::string> StringArray;
 
-enum PermitResult { kRpcAllowed = 0, kRpcDisallowed, kRpcUserDisallowed };
+enum PermitResult {
+  kRpcAllowed = 0,
+  kRpcDisallowed,
+  kRpcUserDisallowed,
+  kRpcAllParamsDisallowed,
+  kRpcAllParamsUserDisallowed
+};
 
 /**
   * @struct Stores result of check:

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1155,6 +1155,7 @@ void CacheManager::CheckPermissions(const PTString& app_id,
   policy_table::Strings::const_iterator app_groups_iter_end =
       pt_->policy_table.app_policies_section.apps[app_id].groups.end();
 
+  result.hmi_level_permitted = PermitResult::kRpcDisallowed;
   policy_table::FunctionalGroupings::const_iterator concrete_group;
 
   for (; app_groups_iter != app_groups_iter_end; ++app_groups_iter) {

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -673,7 +673,7 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
           .parameter_permissions.any_parameter_disallowed_by_user) {
     LOG4CXX_DEBUG(logger_, "All parameters are disallowed by user.");
     result.list_of_disallowed_params = rpc_params;
-    result.hmi_level_permitted = kRpcUserDisallowed;
+    result.hmi_level_permitted = kRpcAllParamsUserDisallowed;
     return;
   }
 
@@ -681,7 +681,7 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
           .parameter_permissions.any_parameter_disallowed_by_policy) {
     LOG4CXX_DEBUG(logger_, "All parameters are disallowed by policy.");
     result.list_of_undefined_params = rpc_params;
-    result.hmi_level_permitted = kRpcDisallowed;
+    result.hmi_level_permitted = kRpcAllParamsDisallowed;
     return;
   }
 
@@ -717,11 +717,11 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
   }
 
   if (result.DisallowedInclude(rpc_params)) {
-    LOG4CXX_DEBUG(logger_, "All parameters are disallowed.");
-    result.hmi_level_permitted = kRpcUserDisallowed;
+    LOG4CXX_DEBUG(logger_, "All parameters are disallowed by user.");
+    result.hmi_level_permitted = kRpcAllParamsUserDisallowed;
   } else if (!result.IsAnyAllowed(rpc_params)) {
-    LOG4CXX_DEBUG(logger_, "There are no parameters allowed.");
-    result.hmi_level_permitted = kRpcDisallowed;
+    LOG4CXX_DEBUG(logger_, "There are no parameters allowed by policy.");
+    result.hmi_level_permitted = kRpcAllParamsDisallowed;
   }
 
   if (cache_->IsApplicationRevoked(app_id)) {

--- a/src/components/policy/policy_regular/include/policy/policy_types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_types.h
@@ -113,7 +113,13 @@ typedef std::vector<std::string> PermissionsList;
  */
 typedef std::vector<std::string> StringArray;
 
-enum PermitResult { kRpcAllowed = 0, kRpcDisallowed, kRpcUserDisallowed };
+enum PermitResult {
+  kRpcAllowed = 0,
+  kRpcDisallowed,
+  kRpcUserDisallowed,
+  kRpcAllParamsDisallowed,
+  kRpcAllParamsUserDisallowed
+};
 
 /**
   * @struct Stores result of check:

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -457,6 +457,7 @@ void CacheManager::CheckPermissions(const policy_table::Strings& groups,
   policy_table::Strings::const_iterator app_groups_iter = groups.begin();
   policy_table::Strings::const_iterator app_groups_iter_end = groups.end();
 
+  result.hmi_level_permitted = PermitResult::kRpcDisallowed;
   policy_table::FunctionalGroupings::const_iterator concrete_group;
 
   for (; app_groups_iter != app_groups_iter_end; ++app_groups_iter) {
@@ -478,8 +479,6 @@ void CacheManager::CheckPermissions(const policy_table::Strings& groups,
                       hmi_level_e);
 
         if (rpc_param.hmi_levels.end() != hmi_iter) {
-          result.hmi_level_permitted = PermitResult::kRpcAllowed;
-
           policy_table::Parameters::const_iterator params_iter =
               rpc_param.parameters->begin();
           policy_table::Parameters::const_iterator params_iter_end =
@@ -488,6 +487,13 @@ void CacheManager::CheckPermissions(const policy_table::Strings& groups,
           for (; params_iter != params_iter_end; ++params_iter) {
             result.list_of_allowed_params.insert(
                 policy_table::EnumToJsonString(*params_iter));
+          }
+
+          if (rpc_param.parameters.is_initialized() &&
+              result.list_of_allowed_params.empty()) {
+            result.hmi_level_permitted = PermitResult::kRpcAllParamsDisallowed;
+          } else {
+            result.hmi_level_permitted = PermitResult::kRpcAllowed;
           }
         }
       }

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -402,6 +402,44 @@ void PolicyManagerImpl::CheckPermissions(const PTString& device_id,
 #endif  // SDL_REMOTE_CONTROL
 
   cache_->CheckPermissions(groups, hmi_level, rpc, result);
+
+  if (kRpcDisallowed == result.hmi_level_permitted) {
+    LOG4CXX_DEBUG(logger_, "RPC is not allowed. Stop parameters processing.");
+    return;
+  }
+
+  if (kRpcAllParamsDisallowed == result.hmi_level_permitted) {
+    LOG4CXX_DEBUG(logger_, "All parameters are disallowed by policy.");
+    result.list_of_undefined_params = rpc_params;
+    return;
+  }
+
+  if (kRpcAllowed == result.hmi_level_permitted &&
+      result.list_of_allowed_params.empty()) {
+    LOG4CXX_DEBUG(logger_, "All parameters are allowed.");
+    result.list_of_allowed_params = rpc_params;
+    return;
+  }
+
+  RPCParams::const_iterator parameter = rpc_params.begin();
+  RPCParams::const_iterator end = rpc_params.end();
+  for (; end != parameter; ++parameter) {
+    if (!result.HasParameter(*parameter)) {
+      LOG4CXX_DEBUG(logger_,
+                    "Parameter " << *parameter << " is unknown."
+                                                  " Adding to undefined list.");
+      result.list_of_undefined_params.insert(*parameter);
+    }
+  }
+
+  if (result.DisallowedInclude(rpc_params)) {
+    LOG4CXX_DEBUG(logger_, "All parameters are disallowed by user.");
+    result.hmi_level_permitted = kRpcAllParamsUserDisallowed;
+  } else if (!result.IsAnyAllowed(rpc_params)) {
+    LOG4CXX_DEBUG(logger_, "There are no parameters allowed by policy.");
+    result.hmi_level_permitted = kRpcAllParamsDisallowed;
+  }
+
   if (cache_->IsApplicationRevoked(app_id)) {
     // SDL must be able to notify mobile side with its status after app has
     // been revoked by backend


### PR DESCRIPTION
## Note
This is just resend of PR #1799 to another branch

## EXTERNAL_PROPRIETARY
Added new values to `PermitResult` enum for more detailed result description of `CheckPermissions()` call. This values will be used in AM layer for generating info message string.

### PROPRIETARY
Added new values to `PermitResult` enum for more detailed result description of `CheckPermissions()` call. This values will be used in AM layer for generating info message string.
Also there was added missed logic for checking RPC params and returning correct `PermitResult` code and params lists to `CheckPermissions()` function.

### BOTH
Added generating of info message param depending on check permissions result:
- for disallowed rpc
- for all disallowed params in allowed rpc
- for partially disallowed params in allowed rpc

Fixed requests param reading from incoming message. There was a problem that `asBool()` function of smart object returns false for string/array/object types so this params will no be included to params check list and will not be cut off after that. This check was replaced to ignore only null/invalid smart object types.

Fixed affected unit tests logic.

`"GitHub issue link" ~ "https://github.com/SmartDeviceLink/sdl_core/issues/1740"`