### PR TITLE
Fix disallowed info message generating for specific RPC

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_helper.h
+++ b/src/components/application_manager/include/application_manager/commands/command_helper.h
@@ -1,0 +1,85 @@
+/*
+ Copyright (c) 2017, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "application_manager/commands/command_impl.h"
+#include "smart_objects/smart_object.h"
+
+namespace application_manager {
+namespace commands {
+
+namespace command_helper {
+/**
+ * @brief Adds disallowed parameters back to response with appropriate
+ * reasons
+ * @param permissions Structure with info about disallowed parameters
+ * @param response Response message, which should be extended with blocked
+ * parameters reasons
+ */
+void AddDisallowedParameters(const CommandParametersPermissions& permissions,
+                             smart_objects::SmartObject& response);
+
+/**
+ * @brief Adds disallowed parameters to response info
+ * @param permissions Structure with info about disallowed parameters
+ * @param response Response message, which info should be extended
+ */
+void AddDisallowedParametersToInfo(
+    const CommandParametersPermissions& permissions,
+    smart_objects::SmartObject& response);
+
+/**
+ * @brief Remove from current message parameters disallowed by policy table
+ * @param permissions Structure with info about parameters which should be
+ * disallowed
+ * @param removed_permissions Structure with info about parameters which
+ * actually was disallowd in current message
+ * @param msg_params Message params where disallowed params should be removed
+ */
+void RemoveDisallowedParameters(
+    const CommandParametersPermissions& permissions,
+    CommandParametersPermissions& removed_permissions,
+    smart_objects::SmartObject& msg_params);
+
+/**
+ * @brief Checks if any request param was marked as disallowed by policy
+ * @param permissions Structure with info about parameters which actually was
+ * disallowd in current message
+ * @return true if any param was marked as disallowed
+ */
+bool HasDisallowedParams(const CommandParametersPermissions& permissions);
+
+}  // namespace CommandHelper
+
+}  // namespace commands
+}  // namespace application_manager

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -224,36 +224,10 @@ class CommandRequestImpl : public CommandImpl,
   bool CheckHMICapabilities(const mobile_apis::ButtonName::eType button) const;
 
   /**
-   * @brief Remove from current message parameters disallowed by policy table
-   */
-  void RemoveDisallowedParameters();
-
-  /**
-   * @brief Adds disallowed parameters back to response with appropriate
-   * reasons
-   * @param response Response message, which should be extended with blocked
-   * parameters reasons
-   */
-  void AddDisallowedParameters(smart_objects::SmartObject& response);
-
-  /**
-   * @brief Adds disallowed parameters to response info
-   * @param response Response message, which info should be extended
-   */
-  void AddDisallowedParametersToInfo(
-      smart_objects::SmartObject& response) const;
-
-  /**
    * @brief Adds specific message to response info for current RPC
    * @param response Response message, which info should be updated
    */
   virtual void AddSpecificInfoToResponse(smart_objects::SmartObject& response);
-
-  /**
-   * @brief Checks if any request param was marked as disallowed by policy
-   * @return true if any param was marked as disallowed
-   */
-  bool HasDisallowedParams() const;
 
   /**
    * @brief Checks result code from HMI for single RPC
@@ -323,14 +297,6 @@ class CommandRequestImpl : public CommandImpl,
 
  private:
   DISALLOW_COPY_AND_ASSIGN(CommandRequestImpl);
-
-  /**
-   * @brief Adds param to disallowed parameters enumeration
-   * @param info string with disallowed params enumeration
-   * @param param disallowed param
-   */
-  void AddDissalowedParameterToInfoString(std::string& info,
-                                          const std::string& param) const;
 
   bool ProcessHMIInterfacesAvailability(
       const uint32_t hmi_correlation_id,

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -237,6 +237,19 @@ class CommandRequestImpl : public CommandImpl,
   void AddDisallowedParameters(smart_objects::SmartObject& response);
 
   /**
+   * @brief Adds disallowed parameters to response info
+   * @param response Response message, which info should be extended
+   */
+  void AddDisallowedParametersToInfo(
+      smart_objects::SmartObject& response) const;
+
+  /**
+   * @brief Adds specific message to response info for current RPC
+   * @param response Response message, which info should be updated
+   */
+  virtual void AddSpecificInfoToResponse(smart_objects::SmartObject& response);
+
+  /**
    * @brief Checks if any request param was marked as disallowed by policy
    * @return true if any param was marked as disallowed
    */
@@ -318,13 +331,6 @@ class CommandRequestImpl : public CommandImpl,
    */
   void AddDissalowedParameterToInfoString(std::string& info,
                                           const std::string& param) const;
-
-  /**
-   * @brief Adds disallowed parameters to response info
-   * @param response Response message, which info should be extended
-   */
-  void AddDisallowedParametersToInfo(
-      smart_objects::SmartObject& response) const;
 
   bool ProcessHMIInterfacesAvailability(
       const uint32_t hmi_correlation_id,

--- a/src/components/application_manager/include/application_manager/commands/mobile/get_vehicle_data_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/get_vehicle_data_request.h
@@ -64,10 +64,16 @@ class GetVehicleDataRequest : public CommandRequestImpl {
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
+
+  /**
+   * @brief Adds specific message to response info for current RPC
+   * @param response Response message, which info should be updated
+   */
+  void AddSpecificInfoToResponse(smart_objects::SmartObject& response) FINAL;
 
  protected:
-  virtual void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) FINAL;
 
 #ifdef HMI_DBUS_API
  private:

--- a/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
@@ -77,6 +77,12 @@ class SubscribeVehicleDataRequest : public CommandRequestImpl {
    */
   bool Init() FINAL;
 
+  /**
+   * @brief Adds specific message to response info for current RPC
+   * @param response Response message, which info should be updated
+   */
+  void AddSpecificInfoToResponse(smart_objects::SmartObject& response) FINAL;
+
 #ifdef HMI_DBUS_API
  private:
   struct HmiRequest {

--- a/src/components/application_manager/include/application_manager/commands/mobile/unsubscribe_vehicle_data_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/unsubscribe_vehicle_data_request.h
@@ -77,6 +77,12 @@ class UnsubscribeVehicleDataRequest : public CommandRequestImpl {
    */
   bool Init() FINAL;
 
+  /**
+   * @brief Adds specific message to response info for current RPC
+   * @param response Response message, which info should be updated
+   */
+  void AddSpecificInfoToResponse(smart_objects::SmartObject& response) FINAL;
+
 #ifdef HMI_DBUS_API
  private:
   struct HmiRequest {

--- a/src/components/application_manager/src/commands/command_helper.cc
+++ b/src/components/application_manager/src/commands/command_helper.cc
@@ -1,0 +1,201 @@
+/*
+ Copyright (c) 2017, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <algorithm>
+#include <string>
+
+#include "application_manager/commands/command_helper.h"
+#include "application_manager/message_helper.h"
+#include "application_manager/smart_object_keys.h"
+#include "interfaces/MOBILE_API.h"
+#include "utils/make_shared.h"
+
+namespace application_manager {
+namespace commands {
+namespace command_helper {
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "Commands")
+
+namespace {
+
+struct DisallowedParamsInserter {
+  DisallowedParamsInserter(smart_objects::SmartObject& response,
+                           mobile_apis::VehicleDataResultCode::eType code)
+      : response_(response), code_(code) {}
+
+  bool operator()(const std::string& param) {
+    using namespace application_manager;
+    const VehicleData& vehicle_data = MessageHelper::vehicle_data();
+    VehicleData::const_iterator it = vehicle_data.find(param);
+    if (vehicle_data.end() != it) {
+      smart_objects::SmartObjectSPtr disallowed_param =
+          utils::MakeShared<smart_objects::SmartObject>(
+              smart_objects::SmartType_Map);
+      (*disallowed_param)[strings::data_type] = (*it).second;
+      (*disallowed_param)[strings::result_code] = code_;
+      response_[strings::msg_params][param.c_str()] = *disallowed_param;
+      return true;
+    }
+    return false;
+  }
+
+ private:
+  smart_objects::SmartObject& response_;
+  mobile_apis::VehicleDataResultCode::eType code_;
+};
+
+void AddDissalowedParameterToInfoString(const std::string& param,
+                                        std::string& info) {
+  // prepare disallowed params enumeration for response info string
+  if (info.empty()) {
+    info = "\'" + param + "\'";
+  } else {
+    info = info + "," + " " + "\'" + param + "\'";
+  }
+}
+
+}  // namespace
+
+void AddDisallowedParameters(const CommandParametersPermissions& permissions,
+                             smart_objects::SmartObject& response) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  DisallowedParamsInserter disallowed_inserter(
+      response, mobile_apis::VehicleDataResultCode::VDRC_USER_DISALLOWED);
+  std::for_each(permissions.disallowed_params.begin(),
+                permissions.disallowed_params.end(),
+                disallowed_inserter);
+
+  DisallowedParamsInserter undefined_inserter(
+      response, mobile_apis::VehicleDataResultCode::VDRC_DISALLOWED);
+  std::for_each(permissions.undefined_params.begin(),
+                permissions.undefined_params.end(),
+                undefined_inserter);
+}
+
+void AddDisallowedParametersToInfo(
+    const CommandParametersPermissions& permissions,
+    smart_objects::SmartObject& response) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  std::string info;
+  RPCParams::const_iterator it = permissions.disallowed_params.begin();
+  for (; it != permissions.disallowed_params.end(); ++it) {
+    AddDissalowedParameterToInfoString((*it), info);
+  }
+
+  it = permissions.undefined_params.begin();
+  for (; it != permissions.undefined_params.end(); ++it) {
+    AddDissalowedParameterToInfoString((*it), info);
+  }
+
+  if (!info.empty()) {
+    const uint32_t params_count = permissions.disallowed_params.size() +
+                                  permissions.undefined_params.size();
+    info += params_count > 1 ? " parameters are " : " parameter is ";
+    info += "disallowed by Policies";
+
+    if (!response[strings::msg_params][strings::info].asString().empty()) {
+      // If we already have info add info about disallowed params to it
+      response[strings::msg_params][strings::info] =
+          response[strings::msg_params][strings::info].asString() + " " + info;
+    } else {
+      response[strings::msg_params][strings::info] = info;
+    }
+  }
+}
+
+void RemoveDisallowedParameters(
+    const CommandParametersPermissions& permissions,
+    CommandParametersPermissions& removed_permissions,
+    smart_objects::SmartObject& msg_params) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  // Remove from request all disallowed parameters
+  RPCParams::const_iterator it_disallowed =
+      permissions.disallowed_params.begin();
+  RPCParams::const_iterator it_disallowed_end =
+      permissions.disallowed_params.end();
+  for (; it_disallowed != it_disallowed_end; ++it_disallowed) {
+    if (msg_params.keyExists(*it_disallowed)) {
+      const std::string key = *it_disallowed;
+      msg_params.erase(key);
+      removed_permissions.disallowed_params.insert(key);
+      LOG4CXX_INFO(logger_,
+                   "Following parameter is disallowed by user: " << key);
+    }
+  }
+
+  // Remove from request all undefined yet parameters
+  RPCParams::const_iterator it_undefined = permissions.undefined_params.begin();
+  RPCParams::const_iterator it_undefined_end =
+      permissions.undefined_params.end();
+  for (; it_undefined != it_undefined_end; ++it_undefined) {
+    if (msg_params.keyExists(*it_undefined)) {
+      const std::string key = *it_undefined;
+      msg_params.erase(key);
+      removed_permissions.undefined_params.insert(key);
+      LOG4CXX_INFO(logger_,
+                   "Following parameter is disallowed by policy: " << key);
+    }
+  }
+
+  // Remove from request all parameters missed in allowed
+  const VehicleData& vehicle_data = MessageHelper::vehicle_data();
+
+  VehicleData::const_iterator it_vehicle_data = vehicle_data.begin();
+  VehicleData::const_iterator it_vehicle_data_end = vehicle_data.end();
+  for (; it_vehicle_data != it_vehicle_data_end; ++it_vehicle_data) {
+    const std::string key = it_vehicle_data->first;
+    if (msg_params.keyExists(key) &&
+        permissions.allowed_params.end() ==
+            std::find(permissions.allowed_params.begin(),
+                      permissions.allowed_params.end(),
+                      key)) {
+      msg_params.erase(key);
+      removed_permissions.undefined_params.insert(key);
+      LOG4CXX_INFO(logger_,
+                   "Following parameter is not found among allowed parameters '"
+                       << key << "' and will be treated as disallowed.");
+    }
+  }
+}
+
+bool HasDisallowedParams(const CommandParametersPermissions& permissions) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return ((!permissions.disallowed_params.empty()) ||
+          (!permissions.undefined_params.empty()));
+}
+
+}  // namespace command_helper
+}  // namespace commands
+}  // namespace application_manager

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -35,6 +35,7 @@
 #include "utils/macro.h"
 #include "utils/make_shared.h"
 #include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/command_helper.h"
 #include "application_manager/application_manager.h"
 #include "application_manager/message_helper.h"
 #include "smart_objects/smart_object.h"
@@ -153,31 +154,6 @@ bool IsResultCodeUnsupported(const ResponseInfo& first,
           first.is_unsupported_resource) ||
          (first.is_unsupported_resource && second.is_unsupported_resource);
 }
-
-struct DisallowedParamsInserter {
-  DisallowedParamsInserter(smart_objects::SmartObject& response,
-                           mobile_apis::VehicleDataResultCode::eType code)
-      : response_(response), code_(code) {}
-
-  bool operator()(const std::string& param) {
-    const VehicleData& vehicle_data =
-        application_manager::MessageHelper::vehicle_data();
-    VehicleData::const_iterator it = vehicle_data.find(param);
-    if (vehicle_data.end() != it) {
-      smart_objects::SmartObjectSPtr disallowed_param =
-          new smart_objects::SmartObject(smart_objects::SmartType_Map);
-      (*disallowed_param)[strings::data_type] = (*it).second;
-      (*disallowed_param)[strings::result_code] = code_;
-      response_[strings::msg_params][param.c_str()] = *disallowed_param;
-      return true;
-    }
-    return false;
-  }
-
- private:
-  smart_objects::SmartObject& response_;
-  mobile_apis::VehicleDataResultCode::eType code_;
-};
 
 CommandRequestImpl::CommandRequestImpl(const MessageSharedPtr& message,
                                        ApplicationManager& application_manager)
@@ -594,7 +570,9 @@ bool CommandRequestImpl::CheckAllowedParameters() {
           params,
           &parameters_permissions_);
 
-  RemoveDisallowedParameters();
+  command_helper::RemoveDisallowedParameters(parameters_permissions_,
+                                             removed_parameters_permissions_,
+                                             (*message_)[strings::msg_params]);
 
   // Check, if RPC is allowed by policy
   if (mobile_apis::Result::SUCCESS != check_result) {
@@ -664,128 +642,8 @@ bool CommandRequestImpl::CheckHMICapabilities(
   return false;
 }
 
-void CommandRequestImpl::RemoveDisallowedParameters() {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  smart_objects::SmartObject& params = (*message_)[strings::msg_params];
-
-  // Remove from request all disallowed parameters
-  RPCParams::const_iterator it_disallowed =
-      parameters_permissions_.disallowed_params.begin();
-  RPCParams::const_iterator it_disallowed_end =
-      parameters_permissions_.disallowed_params.end();
-  for (; it_disallowed != it_disallowed_end; ++it_disallowed) {
-    if (params.keyExists(*it_disallowed)) {
-      const std::string key = *it_disallowed;
-      params.erase(key);
-      removed_parameters_permissions_.disallowed_params.insert(key);
-      LOG4CXX_INFO(logger_,
-                   "Following parameter is disallowed by user: " << key);
-    }
-  }
-
-  // Remove from request all undefined yet parameters
-  RPCParams::const_iterator it_undefined =
-      parameters_permissions_.undefined_params.begin();
-  RPCParams::const_iterator it_undefined_end =
-      parameters_permissions_.undefined_params.end();
-  for (; it_undefined != it_undefined_end; ++it_undefined) {
-    if (params.keyExists(*it_undefined)) {
-      const std::string key = *it_undefined;
-      params.erase(key);
-      removed_parameters_permissions_.undefined_params.insert(key);
-      LOG4CXX_INFO(logger_,
-                   "Following parameter is disallowed by policy: " << key);
-    }
-  }
-
-  // Remove from request all parameters missed in allowed
-  const VehicleData& vehicle_data =
-      application_manager::MessageHelper::vehicle_data();
-
-  VehicleData::const_iterator it_vehicle_data = vehicle_data.begin();
-  VehicleData::const_iterator it_vehicle_data_end = vehicle_data.end();
-  for (; it_vehicle_data != it_vehicle_data_end; ++it_vehicle_data) {
-    const std::string key = it_vehicle_data->first;
-    if (params.keyExists(key) &&
-        parameters_permissions_.allowed_params.end() ==
-            std::find(parameters_permissions_.allowed_params.begin(),
-                      parameters_permissions_.allowed_params.end(),
-                      key)) {
-      params.erase(key);
-      removed_parameters_permissions_.undefined_params.insert(key);
-      LOG4CXX_INFO(logger_,
-                   "Following parameter is not found among allowed parameters '"
-                       << key << "' and will be treated as disallowed.");
-    }
-  }
-}
-
 void CommandRequestImpl::AddSpecificInfoToResponse(
     smart_objects::SmartObject& response) {}
-
-void CommandRequestImpl::AddDissalowedParameterToInfoString(
-    std::string& info, const std::string& param) const {
-  // prepare disallowed params enumeration for response info string
-  if (info.empty()) {
-    info = "\'" + param + "\'";
-  } else {
-    info = info + "," + " " + "\'" + param + "\'";
-  }
-}
-
-void CommandRequestImpl::AddDisallowedParametersToInfo(
-    smart_objects::SmartObject& response) const {
-  std::string info;
-
-  RPCParams::const_iterator it =
-      removed_parameters_permissions_.disallowed_params.begin();
-  for (; it != removed_parameters_permissions_.disallowed_params.end(); ++it) {
-    AddDissalowedParameterToInfoString(info, (*it));
-  }
-
-  it = removed_parameters_permissions_.undefined_params.begin();
-  for (; it != removed_parameters_permissions_.undefined_params.end(); ++it) {
-    AddDissalowedParameterToInfoString(info, (*it));
-  }
-
-  if (!info.empty()) {
-    const uint32_t params_count =
-        removed_parameters_permissions_.disallowed_params.size() +
-        removed_parameters_permissions_.undefined_params.size();
-    info += params_count > 1 ? " parameters are " : " parameter is ";
-    info += "disallowed by Policies";
-
-    if (!response[strings::msg_params][strings::info].asString().empty()) {
-      // If we already have info add info about disallowed params to it
-      response[strings::msg_params][strings::info] =
-          response[strings::msg_params][strings::info].asString() + " " + info;
-    } else {
-      response[strings::msg_params][strings::info] = info;
-    }
-  }
-}
-
-void CommandRequestImpl::AddDisallowedParameters(
-    smart_objects::SmartObject& response) {
-  DisallowedParamsInserter disallowed_inserter(
-      response, mobile_apis::VehicleDataResultCode::VDRC_USER_DISALLOWED);
-  std::for_each(removed_parameters_permissions_.disallowed_params.begin(),
-                removed_parameters_permissions_.disallowed_params.end(),
-                disallowed_inserter);
-
-  DisallowedParamsInserter undefined_inserter(
-      response, mobile_apis::VehicleDataResultCode::VDRC_DISALLOWED);
-  std::for_each(removed_parameters_permissions_.undefined_params.begin(),
-                removed_parameters_permissions_.undefined_params.end(),
-                undefined_inserter);
-}
-
-bool CommandRequestImpl::HasDisallowedParams() const {
-  LOG4CXX_AUTO_TRACE(logger_);
-  return ((!removed_parameters_permissions_.disallowed_params.empty()) ||
-          (!removed_parameters_permissions_.undefined_params.empty()));
-}
 
 bool CommandRequestImpl::PrepareResultForMobileResponse(
     hmi_apis::Common_Result::eType result_code,

--- a/src/components/application_manager/src/commands/mobile/get_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/get_vehicle_data_request.cc
@@ -217,6 +217,11 @@ GetVehicleDataRequest::GetVehicleDataRequest(
 
 GetVehicleDataRequest::~GetVehicleDataRequest() {}
 
+void GetVehicleDataRequest::AddSpecificInfoToResponse(
+    smart_objects::SmartObject& response) {
+  AddDisallowedParametersToInfo(response);
+}
+
 void GetVehicleDataRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 

--- a/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -302,6 +302,20 @@ void SubscribeVehicleDataRequest::AddAlreadySubscribedVI(
   }
 }
 
+void SubscribeVehicleDataRequest::AddSpecificInfoToResponse(
+    smart_objects::SmartObject& response) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  AddDisallowedParameters(response);
+  if (helpers::Compare<mobile_apis::Result::eType, helpers::EQ, helpers::ONE>(
+          static_cast<mobile_apis::Result::eType>(
+              response[strings::msg_params][strings::result_code].asInt()),
+          mobile_apis::Result::DISALLOWED,
+          mobile_apis::Result::USER_DISALLOWED)) {
+    response[strings::msg_params][strings::info] = std::string();
+    AddDisallowedParametersToInfo(response);
+  }
+}
+
 void SubscribeVehicleDataRequest::UnsubscribeFailedSubscriptions(
     ApplicationSharedPtr app,
     const smart_objects::SmartObject& msg_params) const {

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -35,6 +35,7 @@
 #include "application_manager/commands/command_impl.h"
 
 #include "application_manager/application_impl.h"
+#include "application_manager/commands/command_helper.h"
 #include "application_manager/message_helper.h"
 #include "interfaces/MOBILE_API.h"
 #include "interfaces/HMI_API.h"
@@ -183,7 +184,7 @@ void UnsubscribeVehicleDataRequest::Run() {
           vi_already_unsubscribed_by_this_app_.size();
 
   if (0 == items_to_unsubscribe) {
-    if (HasDisallowedParams()) {
+    if (command_helper::HasDisallowedParams(removed_parameters_permissions_)) {
       SendResponse(false, mobile_apis::Result::DISALLOWED);
     } else {
       SendResponse(
@@ -396,14 +397,17 @@ void UnsubscribeVehicleDataRequest::AddAlreadyUnsubscribedVI(
 void UnsubscribeVehicleDataRequest::AddSpecificInfoToResponse(
     smart_objects::SmartObject& response) {
   LOG4CXX_AUTO_TRACE(logger_);
-  AddDisallowedParameters(response);
   if (helpers::Compare<mobile_apis::Result::eType, helpers::EQ, helpers::ONE>(
           static_cast<mobile_apis::Result::eType>(
               response[strings::msg_params][strings::result_code].asInt()),
+          mobile_apis::Result::SUCCESS,
           mobile_apis::Result::DISALLOWED,
           mobile_apis::Result::USER_DISALLOWED)) {
     response[strings::msg_params][strings::info] = std::string();
-    AddDisallowedParametersToInfo(response);
+    command_helper::AddDisallowedParameters(removed_parameters_permissions_,
+                                            response);
+    command_helper::AddDisallowedParametersToInfo(
+        removed_parameters_permissions_, response);
   }
 }
 

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -393,5 +393,19 @@ void UnsubscribeVehicleDataRequest::AddAlreadyUnsubscribedVI(
   }
 }
 
+void UnsubscribeVehicleDataRequest::AddSpecificInfoToResponse(
+    smart_objects::SmartObject& response) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  AddDisallowedParameters(response);
+  if (helpers::Compare<mobile_apis::Result::eType, helpers::EQ, helpers::ONE>(
+          static_cast<mobile_apis::Result::eType>(
+              response[strings::msg_params][strings::result_code].asInt()),
+          mobile_apis::Result::DISALLOWED,
+          mobile_apis::Result::USER_DISALLOWED)) {
+    response[strings::msg_params][strings::info] = std::string();
+    AddDisallowedParametersToInfo(response);
+  }
+}
+
 }  // namespace commands
 }  // namespace application_manager

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -60,7 +60,7 @@ namespace command_request_impl {
 namespace am = application_manager;
 namespace strings = am::strings;
 namespace hmi_response = am::hmi_response;
-namespace command_helper = am::commands::CommandHelper;
+namespace command_helper = am::commands::command_helper;
 
 using ::testing::_;
 using ::testing::Return;

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -39,6 +39,7 @@
 #include "application_manager/commands/command_request_impl.h"
 #include "application_manager/commands/commands_test.h"
 #include "application_manager/commands/command_request_test.h"
+#include "application_manager/commands/command_helper.h"
 #include "utils/lock.h"
 #include "utils/shared_ptr.h"
 #include "utils/data_accessor.h"
@@ -59,6 +60,7 @@ namespace command_request_impl {
 namespace am = application_manager;
 namespace strings = am::strings;
 namespace hmi_response = am::hmi_response;
+namespace command_helper = am::commands::CommandHelper;
 
 using ::testing::_;
 using ::testing::Return;
@@ -87,11 +89,16 @@ const hmi_apis::FunctionID::eType kInvalidFunctionId =
 const std::string kPolicyAppId = "Test";
 const mobile_apis::Result::eType kMobResultSuccess =
     mobile_apis::Result::SUCCESS;
+const mobile_apis::Result::eType kMobResultDisallowed =
+    mobile_apis::Result::DISALLOWED;
+const am::PermitResult kDisallowedPermitResult =
+    am::PermitResult::kRpcAllParamsDisallowed;
 const std::string kDisallowedParam1 = "disallowed_param1";
 const std::string kDisallowedParam2 = "disallowed_param2";
 const std::string kAllowedParam = "allowed_param";
 const std::string kUndefinedParam = "undefined_params";
 const std::string kMissedParam = "missed_param";
+
 }  // namespace
 
 class CommandRequestImplTest
@@ -100,9 +107,6 @@ class CommandRequestImplTest
   class UnwrappedCommandRequestImpl : public CommandRequestImpl {
    public:
     using CommandRequestImpl::CheckAllowedParameters;
-    using CommandRequestImpl::RemoveDisallowedParameters;
-    using CommandRequestImpl::AddDisallowedParameters;
-    using CommandRequestImpl::HasDisallowedParams;
 
     UnwrappedCommandRequestImpl(const MessageSharedPtr& message,
                                 ApplicationManager& am)
@@ -329,14 +333,18 @@ TEST_F(CommandRequestImplTest, RemoveDisallowedParameters_SUCCESS) {
   permission.allowed_params.insert(kAllowedParam);
   permission.undefined_params.insert(kUndefinedParam);
 
-  command->RemoveDisallowedParameters();
+  command_helper::RemoveDisallowedParameters(
+      command->parameters_permissions(),
+      command->removed_parameters_permissions(),
+      (*msg)[strings::msg_params]);
 
   EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kDisallowedParam1));
   EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kDisallowedParam2));
   EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kUndefinedParam));
   EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kMissedParam));
   EXPECT_TRUE((*msg)[strings::msg_params].keyExists(kAllowedParam));
-  EXPECT_TRUE(command->HasDisallowedParams());
+  EXPECT_TRUE(command_helper::HasDisallowedParams(
+      command->removed_parameters_permissions()));
 }
 
 TEST_F(CommandRequestImplTest,
@@ -372,6 +380,10 @@ TEST_F(CommandRequestImplTest, CheckAllowedParameters_NoMsgParamsMap_SUCCESS) {
   EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
       .WillOnce(Return(kMobResultSuccess));
 
+  am::VehicleData vehicle_data;
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data));
+
   EXPECT_TRUE(command->CheckPermissions());
 }
 
@@ -393,6 +405,10 @@ TEST_F(CommandRequestImplTest,
   EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
       .WillOnce(Return(mobile_apis::Result::INVALID_ENUM));
 
+  am::VehicleData vehicle_data;
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data));
+
   smart_objects::SmartObjectSPtr response =
       utils::MakeShared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
@@ -410,6 +426,43 @@ ACTION_P(GetArg3, output) {
   *output = arg2;
 }
 
+TEST_F(CommandRequestImplTest,
+       CheckAllowedParameters_AddDisallowedParamInfo_UNSUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::connection_key] = kConnectionKey;
+  (*msg)[strings::msg_params][kPolicyAppId] = true;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+  command->parameters_permissions().permit_result = kDisallowedPermitResult;
+
+  MockAppPtr app = CreateMockApp();
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(kMobResultDisallowed));
+
+  am::VehicleData vehicle_data;
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data));
+
+  smart_objects::SmartObjectSPtr response =
+      utils::MakeShared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  (*response)[strings::msg_params] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateBlockedByPoliciesResponse(_, _, _, _))
+      .WillOnce(Return(response));
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(response, _));
+
+  EXPECT_FALSE(command->CheckPermissions());
+
+  EXPECT_TRUE((*response)[strings::msg_params].keyExists(strings::info));
+  EXPECT_FALSE(
+      (*response)[strings::msg_params][strings::info].asString().empty());
+}
+
 TEST_F(CommandRequestImplTest, CheckAllowedParameters_MsgParamsMap_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
   (*msg)[strings::params][strings::connection_key] = kConnectionKey;
@@ -423,6 +476,10 @@ TEST_F(CommandRequestImplTest, CheckAllowedParameters_MsgParamsMap_SUCCESS) {
   RPCParams params;
   EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
       .WillOnce(DoAll(GetArg3(&params), Return(kMobResultSuccess)));
+
+  am::VehicleData vehicle_data;
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data));
 
   EXPECT_TRUE(command->CheckPermissions());
   EXPECT_TRUE(params.end() !=
@@ -444,7 +501,8 @@ TEST_F(CommandRequestImplTest, AddDisallowedParameters_SUCCESS) {
   command->removed_parameters_permissions().disallowed_params.insert(
       kDisallowedParam1);
 
-  command->AddDisallowedParameters(*msg);
+  command_helper::AddDisallowedParameters(
+      command->removed_parameters_permissions(), *msg);
 
   EXPECT_TRUE((*msg)[strings::msg_params].keyExists(kDisallowedParam1));
 }
@@ -478,37 +536,6 @@ TEST_F(CommandRequestImplTest, SendResponse_SUCCESS) {
   EXPECT_EQ(RequestState::kCompleted, command->current_state());
 
   EXPECT_TRUE(smart_objects::SmartType_Map == (*msg).getType());
-}
-
-TEST_F(CommandRequestImplTest,
-       SendResponse_AddDisallowedParametersToInfo_SUCCESS) {
-  am::VehicleData vehicle_data;
-  vehicle_data.insert(am::VehicleData::value_type(kDisallowedParam1,
-                                                  am::VehicleDataType::MYKEY));
-
-  EXPECT_CALL(mock_message_helper_, vehicle_data())
-      .WillOnce(ReturnRef(vehicle_data));
-
-  MessageSharedPtr msg = CreateMessage();
-  (*msg)[strings::params][strings::function_id] =
-      mobile_apis::FunctionID::SubscribeVehicleDataID;
-
-  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
-
-  command->removed_parameters_permissions().disallowed_params.insert(
-      kDisallowedParam1);
-
-  MessageSharedPtr result;
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _))
-      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
-
-  command->SendResponse(true, kMobResultSuccess, NULL, NULL);
-
-  EXPECT_EQ(RequestState::kCompleted, command->current_state());
-
-  EXPECT_TRUE((*result)[strings::msg_params].keyExists(strings::info));
-  EXPECT_FALSE(
-      (*result)[strings::msg_params][strings::info].asString().empty());
 }
 
 TEST_F(CommandRequestImplTest, HashUpdateAllowed_UpdateExpected) {


### PR DESCRIPTION
### NOTE
This is a duplicate of PR #1841 which send to another branch.

There was found a problem that general info message in case of disallowed by policies params is not applicable for all RPCs. For example `SubscribeVehicleData/UnsubscribeVehicleData` has own specific format of info message in this case.
To fix that following changes were done:
- Added virtual function `AddSpecificInfoToResponse()` which could be overriden in child RPCs in case custom info message required
- Removed hardcoded checks of `function_id` from `command_request_impl` - all this checks will be done using polymorphism inside aproriate RPCs
- Fixed affected UT expectation. Invalid unit test was replaced with actual one