### PR TITLE
Activate app sent at wrong time for RC apps

### DIFF
--- a/src/components/remote_control/src/remote_control_plugin.cc
+++ b/src/components/remote_control/src/remote_control_plugin.cc
@@ -284,7 +284,6 @@ bool RemoteControlPlugin::IsAppForPlugin(
   if (service()->IsRemoteControlApplication(app)) {
     RCAppExtensionPtr rc_app_extension = new RCAppExtension(GetModuleID());
     app->AddExtension(rc_app_extension);
-    service()->NotifyHMIAboutHMILevel(app, app->hmi_level());
     return true;
   }
   return false;


### PR DESCRIPTION
This PR is ready for review.

### Risk
No API changes

### Testing Plan
Connect RC app and make sure BC.ActivateApp is not sent to HMI unless app is supposed to be resuming.

### Summary
This function call will cause BC.ActivateApp to be sent to the hmi when a RC app is connected for the first time. Commented out since it seems unnecessary and is causing issues.







### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)