### PR TITLE
Fix core crash in case when HMI sends invalid response

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3115,6 +3115,22 @@ void ApplicationManagerImpl::Handle(const impl::MessageFromHmi message) {
     return;
   }
 
+  Json::Value value;
+  Json::Reader reader;
+  reader.parse(message->json_message(), value);
+  if (value.isMember(("result"))) {
+    if (!value["result"].isObject()) {
+      LOG4CXX_ERROR(logger_, "Invalid type of 'result' field.");
+      return;
+    }
+  }
+  if (value.isMember(("error"))) {
+    if (!value["error"].isObject()) {
+      LOG4CXX_ERROR(logger_, "Invalid type of 'error' field.");
+      return;
+    }
+  }
+
 #ifdef SDL_REMOTE_CONTROL
   if (plugin_manager_.IsHMIMessageForPlugin(message)) {
     functional_modules::ProcessResult result =


### PR DESCRIPTION
Fix core crash in case when HMI sends invalid response with the "result" (or "error") of an integer type 
(or any other type, but **not an object**)

e.g. `HMI->SDL : { jsonrpc = "2.0", result = 0 } `