### PR TITLE
Fix/alert maneuver wrong response

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -621,6 +621,9 @@ class MessageHelper {
 
   static bool PrintSmartObject(const smart_objects::SmartObject& object);
 
+  static std::string SmartObjectToString(
+      const smart_objects::SmartObject& object);
+
   template <typename From, typename To>
   static To ConvertEnumAPINoCheck(const From& input) {
     return static_cast<To>(input);

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -621,6 +621,11 @@ class MessageHelper {
 
   static bool PrintSmartObject(const smart_objects::SmartObject& object);
 
+  /**
+   * @brief Converts common SmartObject to its string representation
+   * @param object SmartObject to convert
+   * @return string representation of given SmartObject
+   */
   static std::string SmartObjectToString(
       const smart_objects::SmartObject& object);
 

--- a/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/src/commands/mobile/alert_maneuver_request.cc
@@ -173,14 +173,10 @@ void AlertManeuverRequest::on_event(const event_engine::Event& event) {
   std::string return_info;
   mobile_apis::Result::eType result_code;
   const bool result = PrepareResponseParameters(result_code, return_info);
-  bool must_be_empty_info = false;
-  if (return_info.find("\n") != std::string::npos ||
-      return_info.find("\t") != std::string::npos) {
-    must_be_empty_info = true;
-  }
+
   SendResponse(result,
                result_code,
-               (must_be_empty_info) ? NULL : return_info.c_str(),
+               return_info.empty() ? NULL : return_info.c_str(),
                &(message[strings::msg_params]));
 }
 

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -61,6 +61,9 @@
 #include "formatters/CFormatterJsonSDLRPCv2.h"
 #include "formatters/CFormatterJsonSDLRPCv1.h"
 
+#include "json/json.h"
+#include "formatters/CFormatterJsonBase.h"
+
 CREATE_LOGGERPTR_GLOBAL(logger_, "ApplicationManager")
 
 namespace application_manager {
@@ -2650,6 +2653,14 @@ void MessageHelper::SubscribeApplicationToSoftButton(
     softbuttons_id.insert(soft_buttons[i][strings::soft_button_id].asUInt());
   }
   app->SubscribeToSoftButtons(function_id, softbuttons_id);
+}
+
+std::string MessageHelper::SmartObjectToString(
+    const smart_objects::SmartObject& object) {
+  Json::Value tmp;
+  namespace Formatters = NsSmartDeviceLink::NsJSONHandler::Formatters;
+  Formatters::CFormatterJsonBase::objToJsonValue(object, tmp);
+  return tmp.toStyledString();
 }
 
 // TODO(AK): change printf to logger

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -255,6 +255,8 @@ class MockMessageHelper {
 
   MOCK_METHOD1(PrintSmartObject,
                bool(const smart_objects::SmartObject& object));
+  MOCK_METHOD1(SmartObjectToString,
+               std::string(const smart_objects::SmartObject& object));
   MOCK_METHOD3(SendTTSGlobalProperties,
                void(ApplicationSharedPtr app,
                     const bool default_help_prompt,

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -482,6 +482,11 @@ bool MessageHelper::PrintSmartObject(const smart_objects::SmartObject& object) {
   return MockMessageHelper::message_helper_mock()->PrintSmartObject(object);
 }
 
+std::string MessageHelper::SmartObjectToString(
+    const smart_objects::SmartObject& object) {
+  return MockMessageHelper::message_helper_mock()->SmartObjectToString(object);
+}
+
 void MessageHelper::SendSetAppIcon(const uint32_t app_id,
                                    const std::string& icon_path,
                                    ApplicationManager& application_manager) {


### PR DESCRIPTION
- Fixed generation of response to mobile app. 
Removed sending of empty info string to mobile app as afterwards SDL checks all responses according
to MobileApi smart schema and info message (if present) can not be empty. 
Therefore in previous implementation SDL (due to adding empty info string to response) converted successful responses from HMI to GENERIC_ERROR.

- Added function to MessageHelper which allows to convert SmartObject to std::string 