### PR TITLE
Fix difference between HMI_API & MOBILE_API in enum TextFieldName

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -164,12 +164,6 @@
                     "rows": 1
                 },
                 {
-                    "name": "turnText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
                     "name": "menuTitle",
                     "characterSet": "TYPE2SET",
                     "width": 500,

--- a/src/components/application_manager/src/commands/mobile/update_turn_list_request.cc
+++ b/src/components/application_manager/src/commands/mobile/update_turn_list_request.cc
@@ -122,7 +122,7 @@ void UpdateTurnListRequest::Run() {
         msg_params[strings::turn_list][i].erase(hmi_request::navi_text);
         msg_params[strings::turn_list][i][hmi_request::navi_text]
                   [hmi_request::field_name] = static_cast<int>(
-                      hmi_apis::Common_TextFieldName::turnText);
+                      hmi_apis::Common_TextFieldName::navigationText);
         msg_params[strings::turn_list][i][hmi_request::navi_text]
                   [hmi_request::field_text] = navigation_text;
       }

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -202,15 +202,11 @@ void InitCapabilities() {
   text_fields_enum_name.insert(
       std::make_pair(std::string("locationDescription"),
                      hmi_apis::Common_TextFieldName::locationDescription));
-  text_fields_enum_name.insert(std::make_pair(
-      std::string("turnText"), hmi_apis::Common_TextFieldName::turnText));
   text_fields_enum_name.insert(
       std::make_pair(std::string("addressLines"),
                      hmi_apis::Common_TextFieldName::addressLines));
   text_fields_enum_name.insert(std::make_pair(
       std::string("phoneNumber"), hmi_apis::Common_TextFieldName::phoneNumber));
-  text_fields_enum_name.insert(std::make_pair(
-      std::string("turnText"), hmi_apis::Common_TextFieldName::turnText));
   text_fields_enum_name.insert(std::make_pair(
       std::string("menuTitle"), hmi_apis::Common_TextFieldName::menuTitle));
 

--- a/src/components/application_manager/test/commands/mobile/update_turn_list_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/update_turn_list_request_test.cc
@@ -240,7 +240,7 @@ TEST_F(UpdateTurnListRequestTest, Run_ValidTurnList_SUCCESS) {
                            [am::hmi_request::navi_text].keyExists(
                                am::hmi_request::field_name));
   EXPECT_EQ(
-      hmi_apis::Common_TextFieldName::turnText,
+      hmi_apis::Common_TextFieldName::navigationText,
       (*result_msg)[am::strings::msg_params][am::strings::turn_list][0]
                    [am::hmi_request::navi_text][am::hmi_request::field_name]
                        .asInt());

--- a/src/components/application_manager/test/hmi_capabilities.json
+++ b/src/components/application_manager/test/hmi_capabilities.json
@@ -200,12 +200,6 @@
                     "rows": 1
                 },
                 {
-                    "name": "turnText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
                     "name": "menuTitle",
                     "characterSet": "TYPE2SET",
                     "width": 500,

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -555,8 +555,6 @@
     <description> Optional hone number of intended location / establishment (if applicable) for SendLocation.</description>
   </element>
   <element name="timeToDestination"/>
-    <!-- TO DO to be removed -->
-    <element name="turnText"/>
 </enum>
 
 <enum name="MetadataType">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -728,7 +728,15 @@
         <element name="menuTitle">
             <description> Optional text to label an app menu button (for certain touchscreen platforms).</description>
         </element>
-        
+
+        <element name="navigationText">
+          <description>Navigation text for UpdateTurnList.</description>
+        </element>
+
+        <element name="notificationText">
+          <description>Text of notification to be displayed on screen.</description>
+        </element>
+
         <element name="locationName">
             <description> Optional name / title of intended location for SendLocation.</description>
         </element>
@@ -744,7 +752,8 @@
         <element name="phoneNumber">
             <description> Optional hone number of intended location / establishment (if applicable) for SendLocation.</description>
         </element>
-        
+
+        <element name="timeToDestination"/>
     </enum>
     
     <enum name="ImageFieldName">


### PR DESCRIPTION
Fix difference between HMI_API & MOBILE_API in enum TextFieldName 
and remove obsolete field "turnText" #1586 