### PR TITLE
Fix application start streaming retry sequence

### DIFF
--- a/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_audio_start_stream_request.cc
@@ -109,6 +109,8 @@ void AudioStartStreamRequest::on_event(const event_engine::Event& event) {
               logger_,
               "StartAudioStreamRequest aborted. Application can not stream");
         }
+        application_manager_.TerminateRequest(
+            connection_key(), correlation_id(), function_id());
         break;
       }
       if (hmi_apis::Common_Result::REJECTED == code) {
@@ -125,14 +127,15 @@ void AudioStartStreamRequest::on_event(const event_engine::Event& event) {
 }
 
 void AudioStartStreamRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
   RetryStartSession();
-
-  application_manager_.TerminateRequest(
-      connection_key(), correlation_id(), function_id());
 }
 
 void AudioStartStreamRequest::RetryStartSession() {
   LOG4CXX_AUTO_TRACE(logger_);
+
+  application_manager_.TerminateRequest(
+      connection_key(), correlation_id(), function_id());
 
   ApplicationSharedPtr app =
       application_manager_.application_by_hmi_app(application_id());
@@ -156,10 +159,11 @@ void AudioStartStreamRequest::RetryStartSession() {
   }
 
   uint32_t curr_retry_number = app->audio_stream_retry_number();
+  LOG4CXX_DEBUG(
+      logger_, "Retry number " << curr_retry_number << " of " << retry_number_);
+
   if (curr_retry_number < retry_number_) {
-    LOG4CXX_DEBUG(
-        logger_,
-        "Send AudioStartStream retry. retry_number = " << curr_retry_number);
+    LOG4CXX_DEBUG(logger_, "Send AudioStartStream retry");
     MessageHelper::SendAudioStartStream(app->app_id(), application_manager_);
     app->set_audio_stream_retry_number(++curr_retry_number);
   } else {

--- a/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/src/commands/hmi/navi_start_stream_request.cc
@@ -109,6 +109,8 @@ void NaviStartStreamRequest::on_event(const event_engine::Event& event) {
               logger_,
               "NaviStartStreamRequest aborted. Application can not stream");
         }
+        application_manager_.TerminateRequest(
+            connection_key(), correlation_id(), function_id());
         break;
       }
       if (hmi_apis::Common_Result::REJECTED == code) {
@@ -125,14 +127,15 @@ void NaviStartStreamRequest::on_event(const event_engine::Event& event) {
 }
 
 void NaviStartStreamRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
   RetryStartSession();
-
-  application_manager_.TerminateRequest(
-      connection_key(), correlation_id(), function_id());
 }
 
 void NaviStartStreamRequest::RetryStartSession() {
   LOG4CXX_AUTO_TRACE(logger_);
+
+  application_manager_.TerminateRequest(
+      connection_key(), correlation_id(), function_id());
 
   ApplicationSharedPtr app =
       application_manager_.application_by_hmi_app(application_id());
@@ -156,10 +159,11 @@ void NaviStartStreamRequest::RetryStartSession() {
   }
 
   uint32_t curr_retry_number = app->video_stream_retry_number();
+  LOG4CXX_DEBUG(
+      logger_, "Retry number " << curr_retry_number << " of " << retry_number_);
+
   if (curr_retry_number < retry_number_) {
-    LOG4CXX_DEBUG(
-        logger_,
-        "Send NaviStartStream retry. retry_number = " << curr_retry_number);
+    LOG4CXX_DEBUG(logger_, "Send NaviStartStream retry");
     MessageHelper::SendNaviStartStream(app->app_id(), application_manager_);
     app->set_video_stream_retry_number(++curr_retry_number);
   } else {


### PR DESCRIPTION
There was a problem with retry sequence which is triggered when user rejecets prompt regarding starting audio streaming on HMI. The problem is when user clicks Cancel then SDL sends new request in the sequence and not removes old one from queue. As a result we have two identical requests and each of them could trigger next iteration of retry sequence at the same time. As a result, next try could be started earlier than expected.

For example if streaming retry sequence has 3 retries with 1 second timeout:
- MOB -> SDL Request to start audio streaming
- SDL -> HMI Prompt user to start streaming for active app (request 1)
- User clicks "No" during 1 sec
- HMI -> SDL User has clicked No (request 1 still in queue!)
- SDL starts streaming retry sequence
- SDL -> HMI First retry and waiting for result during 1 sec (request 2)
- No answer from user during 1 sec
- Tiemout from request 1: trird retry
- Tiemout from request 2: retry limit reached. Streaming not allowed

In this update was added request termination in case user rejects or accepts the request.

Fixes #1004 