### PR TITLE
Feature/enhance video streaming

### DIFF
--- a/src/components/transport_manager/include/transport_manager/usb/libusb/usb_connection.h
+++ b/src/components/transport_manager/include/transport_manager/usb/libusb/usb_connection.h
@@ -80,6 +80,7 @@ class UsbConnection : public Connection {
   uint8_t out_endpoint_;
   uint16_t out_endpoint_max_packet_size_;
   unsigned char* in_buffer_;
+  uint16_t in_buffer_size_;
   libusb_transfer* in_transfer_;
   libusb_transfer* out_transfer_;
 

--- a/src/components/transport_manager/src/usb/libusb/usb_connection.cc
+++ b/src/components/transport_manager/src/usb/libusb/usb_connection.cc
@@ -43,7 +43,8 @@
 
 #include "utils/logger.h"
 
-#define	TRANSPORT_USB_BUFFER_MAX_SIZE		(16*1024)
+// Define the buffer size, because the Android accessory protocol packet support packet buffers up to 16Kbytes
+#define TRANSPORT_USB_BUFFER_MAX_SIZE	(16*1024)
 
 namespace transport_manager {
 namespace transport_adapter {

--- a/src/components/transport_manager/src/usb/libusb/usb_connection.cc
+++ b/src/components/transport_manager/src/usb/libusb/usb_connection.cc
@@ -43,6 +43,8 @@
 
 #include "utils/logger.h"
 
+#define	TRANSPORT_USB_BUFFER_MAX_SIZE		(16*1024)
+
 namespace transport_manager {
 namespace transport_adapter {
 
@@ -64,6 +66,7 @@ UsbConnection::UsbConnection(const DeviceUID& device_uid,
     , out_endpoint_(0)
     , out_endpoint_max_packet_size_(0)
     , in_buffer_(NULL)
+    , in_buffer_size_(0)
     , in_transfer_(NULL)
     , out_transfer_(0)
     , out_messages_()
@@ -96,7 +99,7 @@ bool UsbConnection::PostInTransfer() {
                             device_handle_,
                             in_endpoint_,
                             in_buffer_,
-                            in_endpoint_max_packet_size_,
+                            in_buffer_size_,
                             InTransferCallback,
                             this,
                             0);
@@ -307,7 +310,15 @@ bool UsbConnection::Init() {
     LOG4CXX_TRACE(logger_, "exit with FALSE. Condition: !FindEndpoints()");
     return false;
   }
-  in_buffer_ = new unsigned char[in_endpoint_max_packet_size_];
+
+  if(in_endpoint_max_packet_size_ < TRANSPORT_USB_BUFFER_MAX_SIZE){
+  	in_buffer_size_ = TRANSPORT_USB_BUFFER_MAX_SIZE;
+  }
+  else {
+  	in_buffer_size_ = in_endpoint_max_packet_size_;
+  }
+
+  in_buffer_ = new unsigned char[in_buffer_size_];
   in_transfer_ = libusb_alloc_transfer(0);
   if (NULL == in_transfer_) {
     LOG4CXX_ERROR(logger_, "libusb_alloc_transfer failed");


### PR DESCRIPTION
This PR is to fixe #1863 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR changes `in_buffer_` variable size is to 16384 bytes according to [https://developer.android.com/guide/topics/connectivity/usb/accessory.html](https://developer.android.com/guide/topics/connectivity/usb/accessory.html)

##### Enhancements
* This implementation has much improvement of video streaming capability
* Decrease the video streaming latency
* Keep the frame rate more stable

For more test data, please reference in issue #1863 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)