### PR TITLE
Revert fix for HMI response resultCodes validation

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1761,19 +1761,6 @@ bool ApplicationManagerImpl::ManageMobileCommand(
   }
 
   if (message_type == mobile_apis::messageType::response) {
-    if (!message->isValid()) {
-      LOG4CXX_ERROR(logger_, "Mobile message response is invalid");
-      smart_objects::SmartObjectSPtr response =
-          MessageHelper::CreateNegativeResponse(
-              connection_key,
-              static_cast<int32_t>(function_id),
-              correlation_id,
-              static_cast<int32_t>(mobile_apis::Result::GENERIC_ERROR));
-
-      SendMessageToMobile(response);
-      return false;
-    }
-
     if (command->Init()) {
       command->Run();
       command->CleanUp();

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -526,7 +526,7 @@ mobile_apis::Result::eType CommandRequestImpl::GetMobileResultCode(
       break;
     }
     case hmi_apis::Common_Result::DATA_NOT_AVAILABLE: {
-      mobile_result = mobile_apis::Result::VEHICLE_DATA_NOT_AVAILABLE;
+      mobile_result = mobile_apis::Result::DATA_NOT_AVAILABLE;
       break;
     }
     case hmi_apis::Common_Result::TIMED_OUT: {
@@ -587,6 +587,14 @@ mobile_apis::Result::eType CommandRequestImpl::GetMobileResultCode(
     }
     case hmi_apis::Common_Result::SAVED: {
       mobile_result = mobile_apis::Result::SAVED;
+      break;
+    }
+    case hmi_apis::Common_Result::TRUNCATED_DATA: {
+      mobile_result = mobile_apis::Result::TRUNCATED_DATA;
+      break;
+    }
+    case hmi_apis::Common_Result::READ_ONLY: {
+      mobile_result = mobile_apis::Result::READ_ONLY;
       break;
     }
     default: {

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -216,27 +216,30 @@ TEST_F(CommandRequestImplTest, GetMobileResultCode_SUCCESS) {
 
   CommandPtr command = CreateCommand<UCommandRequestImpl>();
 
+  const std::map<hmi_apis::Common_Result::eType, mobile_apis::Result::eType>
+      mapping_exceptions = {
+          {hmi_apis::Common_Result::NO_DEVICES_CONNECTED,
+           mobile_apis::Result::APPLICATION_NOT_REGISTERED},
+          {hmi_apis::Common_Result::NO_APPS_REGISTERED,
+           mobile_apis::Result::APPLICATION_NOT_REGISTERED},
+          {hmi_apis::Common_Result::DATA_NOT_AVAILABLE,
+           mobile_apis::Result::DATA_NOT_AVAILABLE},
+          {hmi_apis::Common_Result::SAVED, mobile_apis::Result::SAVED}};
+
   // Run thru all possible accordance
   // of HMI and Mobile result codes.
   ResultU result_it;
   for (result_it.hmi_ = hmi_apis::Common_Result::SUCCESS;
-       result_it.value_ < hmi_apis::Common_Result::TRUNCATED_DATA;
+       result_it.value_ < hmi_apis::Common_Result::READ_ONLY;
        ++result_it.value_) {
-    if (result_it.hmi_ != hmi_apis::Common_Result::NO_DEVICES_CONNECTED &&
-        result_it.hmi_ != hmi_apis::Common_Result::NO_APPS_REGISTERED) {
+    if (mapping_exceptions.find(result_it.hmi_) == mapping_exceptions.end()) {
       EXPECT_EQ(result_it.mobile_,
+                command->GetMobileResultCode(result_it.hmi_));
+    } else {
+      EXPECT_EQ(mapping_exceptions.at(result_it.hmi_),
                 command->GetMobileResultCode(result_it.hmi_));
     }
   }
-  EXPECT_EQ(mobile_apis::Result::APPLICATION_NOT_REGISTERED,
-            command->GetMobileResultCode(
-                hmi_apis::Common_Result::NO_DEVICES_CONNECTED));
-  EXPECT_EQ(mobile_apis::Result::APPLICATION_NOT_REGISTERED,
-            command->GetMobileResultCode(
-                hmi_apis::Common_Result::NO_APPS_REGISTERED));
-  EXPECT_EQ(
-      mobile_apis::Result::GENERIC_ERROR,
-      command->GetMobileResultCode(hmi_apis::Common_Result::TRUNCATED_DATA));
 }
 
 TEST_F(CommandRequestImplTest, BasicMethodsOverloads_SUCCESS) {


### PR DESCRIPTION
### Summary
After inner clarifications and discussions was decided to revert that fix. It will be provided as a separate proposal if needed.

Reverts #1787 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)