### PR TITLE
Fix SDL buid with USE_COTIRE=OFF

### DIFF
--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -64,7 +64,6 @@ using ::testing::_;
 using ::testing::Return;
 using ::testing::SaveArg;
 using ::testing::DoAll;
-using ::testing::Mock;
 
 using ::utils::SharedPtr;
 using am::commands::MessageSharedPtr;
@@ -128,14 +127,6 @@ class CommandRequestImplTest
     }
   };
 
-  CommandRequestImplTest()
-      : mock_message_helper_(*am::MockMessageHelper::message_helper_mock()) {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-  ~CommandRequestImplTest() {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
   MockAppPtr InitAppSetDataAccessor(SharedPtr<ApplicationSet>& app_set) {
     app_set = (!app_set ? ::utils::MakeShared<ApplicationSet>() : app_set);
     MockAppPtr app(CreateMockApp());
@@ -147,7 +138,6 @@ class CommandRequestImplTest
   }
 
   sync_primitives::Lock app_set_lock_;
-  am::MockMessageHelper& mock_message_helper_;
 };
 
 typedef CommandRequestImplTest::UnwrappedCommandRequestImpl UCommandRequestImpl;

--- a/src/components/application_manager/test/commands/hmi/get_system_info_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_system_info_response_test.cc
@@ -90,12 +90,6 @@ class GetSystemInfoResponseTest
     return command_msg;
   }
 
-  void SetUp() OVERRIDE {
-    message_helper_mock_ =
-        application_manager::MockMessageHelper::message_helper_mock();
-  }
-
-  am::MockMessageHelper* message_helper_mock_;
   MockHMICapabilities mock_hmi_capabilities_;
   SmartObject capabilities_;
 };
@@ -114,7 +108,7 @@ TEST_F(GetSystemInfoResponseTest, GetSystemInfo_SUCCESS) {
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
 
   std::string language;
-  EXPECT_CALL(*message_helper_mock_,
+  EXPECT_CALL(mock_message_helper_,
               CommonLanguageToString(
                   static_cast<hmi_apis::Common_Language::eType>(lang_code)))
       .WillOnce(Return(language));
@@ -140,7 +134,7 @@ TEST_F(GetSystemInfoResponseTest, GetSystemInfo_UNSUCCESS) {
 
   EXPECT_CALL(app_mngr_, hmi_capabilities()).Times(0);
 
-  EXPECT_CALL(*message_helper_mock_,
+  EXPECT_CALL(mock_message_helper_,
               CommonLanguageToString(
                   static_cast<hmi_apis::Common_Language::eType>(lang_code)))
       .Times(0);

--- a/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
+++ b/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
@@ -136,8 +136,6 @@
 
 namespace am = application_manager;
 
-static am::MockMessageHelper* message_helper_mock_;
-
 namespace test {
 namespace components {
 namespace commands_test {
@@ -150,7 +148,6 @@ using ::testing::Types;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::NiceMock;
-using ::testing::Mock;
 using ::testing::InSequence;
 using ::utils::SharedPtr;
 using ::smart_objects::SmartObject;
@@ -223,16 +220,11 @@ class HMICommandsNotificationsTest
           CommandsTestMocks::kIsNice> {
  public:
   HMICommandsNotificationsTest()
-      : applications_(application_set_, applications_lock_), app_ptr_(NULL) {
-    message_helper_mock_ =
-        application_manager::MockMessageHelper::message_helper_mock();
-    Mock::VerifyAndClearExpectations(message_helper_mock_);
-  }
+      : applications_(application_set_, applications_lock_), app_ptr_(NULL) {}
 
   ~HMICommandsNotificationsTest() {
     // Fix DataAccessor release and WinQt crash
     Mock::VerifyAndClearExpectations(&app_mngr_);
-    Mock::VerifyAndClearExpectations(message_helper_mock_);
   }
   typedef Command CommandType;
 
@@ -842,7 +834,7 @@ TEST_F(HMICommandsNotificationsTest,
   utils::SharedPtr<Command> command =
       CreateCommand<OnSystemInfoChangedNotification>(message);
 
-  EXPECT_CALL(*message_helper_mock_, CommonLanguageToString(_));
+  EXPECT_CALL(mock_message_helper_, CommonLanguageToString(_));
   EXPECT_CALL(app_mngr_, GetPolicyHandler());
   EXPECT_CALL(policy_interface_, OnSystemInfoChanged(_));
   command->Run();
@@ -1116,7 +1108,7 @@ TEST_F(HMICommandsNotificationsTest,
 #endif  // SDL_REMOTE_CONTROL
 
     EXPECT_CALL(app_mngr_, application(kAppId_)).WillRepeatedly(Return(app_));
-    EXPECT_CALL(*message_helper_mock_,
+    EXPECT_CALL(mock_message_helper_,
                 GetOnAppInterfaceUnregisteredNotificationToMobile(
                     kAppId_, *it_mobile_reason)).WillOnce(Return(notification));
     EXPECT_CALL(app_mngr_,
@@ -1441,7 +1433,7 @@ TEST_F(HMICommandsNotificationsTest,
       .WillOnce(ReturnRef(mock_state_controller_));
   EXPECT_CALL(mock_state_controller_,
               SetRegularState(app_, mobile_apis::HMILevel::HMI_NONE, false));
-  EXPECT_CALL(*message_helper_mock_,
+  EXPECT_CALL(mock_message_helper_,
               GetOnAppInterfaceUnregisteredNotificationToMobile(
                   kAppId_,
                   mobile_apis::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE))
@@ -1764,7 +1756,7 @@ TEST_F(HMICommandsNotificationsTest,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   EXPECT_CALL(*app_ptr_, app_id()).WillRepeatedly(Return(kAppId_));
   EXPECT_CALL(*app_ptr_, language()).WillRepeatedly(ReturnRef(kLang));
-  EXPECT_CALL(*message_helper_mock_,
+  EXPECT_CALL(mock_message_helper_,
               GetOnAppInterfaceUnregisteredNotificationToMobile(
                   kAppId_,
                   mobile_apis::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE))
@@ -1872,7 +1864,7 @@ TEST_F(HMICommandsNotificationsTest,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL));
   EXPECT_CALL(*app_ptr_, app_id()).WillRepeatedly(Return(kAppId_));
   EXPECT_CALL(*app_ptr_, ui_language()).WillRepeatedly(ReturnRef(kLang));
-  EXPECT_CALL(*message_helper_mock_,
+  EXPECT_CALL(mock_message_helper_,
               GetOnAppInterfaceUnregisteredNotificationToMobile(
                   kAppId_,
                   mobile_apis::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE))

--- a/src/components/application_manager/test/commands/hmi/rc_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/rc_is_ready_request_test.cc
@@ -55,7 +55,6 @@ using ::testing::ReturnRef;
 namespace am = ::application_manager;
 using am::commands::MessageSharedPtr;
 using am::commands::RCIsReadyRequest;
-using am::MockMessageHelper;
 using am::event_engine::Event;
 
 typedef SharedPtr<RCIsReadyRequest> RCIsReadyRequestPtr;
@@ -102,7 +101,7 @@ class RCIsReadyRequestTest
   void ExpectSendMessagesToHMI() {
     smart_objects::SmartObjectSPtr capabilities(
         new smart_objects::SmartObject(smart_objects::SmartType_Map));
-    EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
+    EXPECT_CALL(mock_message_helper_,
                 CreateModuleInfoSO(hmi_apis::FunctionID::RC_GetCapabilities, _))
         .WillOnce(Return(capabilities));
     EXPECT_CALL(app_mngr_, ManageHMICommand(capabilities));

--- a/src/components/application_manager/test/commands/hmi/sdl_activate_app_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/sdl_activate_app_request_test.cc
@@ -62,7 +62,6 @@ using testing::Return;
 using testing::ReturnRef;
 using testing::Mock;
 using ::testing::NiceMock;
-using am::MockMessageHelper;
 using policy_test::MockPolicyHandlerInterface;
 using am::event_engine::Event;
 
@@ -102,15 +101,9 @@ MATCHER_P2(CheckMsgParams, result, corr_id, "") {
 class SDLActivateAppRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  protected:
-  SDLActivateAppRequestTest()
-      : message_helper_mock_(am::MockMessageHelper::message_helper_mock()) {
-    Mock::VerifyAndClearExpectations(message_helper_mock_);
-  }
-
   ~SDLActivateAppRequestTest() {
     // Fix DataAccessor release and WinQt crash
     Mock::VerifyAndClearExpectations(&app_mngr_);
-    Mock::VerifyAndClearExpectations(message_helper_mock_);
   }
 
   void InitCommand(const uint32_t& timeout) OVERRIDE {
@@ -127,7 +120,6 @@ class SDLActivateAppRequestTest
 
   ApplicationSet app_list_;
   ::sync_primitives::Lock lock_;
-  am::MockMessageHelper* message_helper_mock_;
   policy_test::MockPolicyHandlerInterface policy_handler_;
   application_manager_test::MockStateController mock_state_controller_;
   NiceMock<event_engine_test::MockEventDispatcher> mock_event_dispatcher_;
@@ -220,7 +212,7 @@ TEST_F(SDLActivateAppRequestTest, FindAppToRegister_SUCCESS) {
   const std::string package = "package";
   ON_CALL(*mock_app_first, PackageName()).WillByDefault(Return(package));
 
-  EXPECT_CALL(*message_helper_mock_, SendLaunchApp(_, _, _, _));
+  EXPECT_CALL(mock_message_helper_, SendLaunchApp(_, _, _, _));
 
   command->Run();
 }
@@ -299,7 +291,7 @@ TEST_F(SDLActivateAppRequestTest, FirstAppActive_SUCCESS) {
   ON_CALL(*mock_app_first, device()).WillByDefault(Return(kHandle));
   EXPECT_CALL(*mock_app_first, is_foreground()).WillRepeatedly(Return(true));
 
-  EXPECT_CALL(*message_helper_mock_, SendLaunchApp(_, _, _, _));
+  EXPECT_CALL(mock_message_helper_, SendLaunchApp(_, _, _, _));
 
   command->Run();
 }
@@ -328,7 +320,6 @@ TEST_F(SDLActivateAppRequestTest, FirstAppNotActive_SUCCESS) {
 }
 
 TEST_F(SDLActivateAppRequestTest, FirstAppIsForeground_SUCCESS) {
-  Mock::VerifyAndClearExpectations(&message_helper_mock_);
   MessageSharedPtr msg = CreateMessage();
   SetCorrelationAndAppID(msg);
 
@@ -363,10 +354,9 @@ TEST_F(SDLActivateAppRequestTest, FirstAppIsForeground_SUCCESS) {
   ON_CALL(*mock_app_first, device()).WillByDefault(Return(kHandle));
   EXPECT_CALL(*mock_app_first, is_foreground()).WillOnce(Return(true));
 
-  EXPECT_CALL(*message_helper_mock_, SendLaunchApp(_, schema, package_name, _));
+  EXPECT_CALL(mock_message_helper_, SendLaunchApp(_, schema, package_name, _));
 
   command->Run();
-  Mock::VerifyAndClearExpectations(&message_helper_mock_);
 }
 
 TEST_F(SDLActivateAppRequestTest, FirstAppNotRegisteredAndEmpty_SUCCESS) {
@@ -397,7 +387,7 @@ TEST_F(SDLActivateAppRequestTest, FirstAppNotRegisteredAndEmpty_SUCCESS) {
           Return(protocol_handler::MajorProtocolVersion::PROTOCOL_VERSION_5));
   EXPECT_CALL(*mock_app_first, is_foreground()).WillOnce(Return(false));
 
-  EXPECT_CALL(*message_helper_mock_, SendLaunchApp(_, _, _, _));
+  EXPECT_CALL(mock_message_helper_, SendLaunchApp(_, _, _, _));
 
   command->Run();
 }
@@ -432,7 +422,7 @@ TEST_F(SDLActivateAppRequestTest, FirstAppNotRegistered_SUCCESS) {
           Return(protocol_handler::MajorProtocolVersion::PROTOCOL_VERSION_5));
   EXPECT_CALL(*mock_app_first, is_foreground()).WillRepeatedly(Return(true));
 
-  EXPECT_CALL(*message_helper_mock_, SendLaunchApp(_, _, _, _));
+  EXPECT_CALL(mock_message_helper_, SendLaunchApp(_, _, _, _));
 
   command->Run();
 }

--- a/src/components/application_manager/test/commands/hmi/sdl_get_user_friendly_message_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/sdl_get_user_friendly_message_request_test.cc
@@ -73,10 +73,6 @@ namespace strings = ::application_manager::strings;
 
 class SDLGetUserFriendlyMessageRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
- public:
-  SDLGetUserFriendlyMessageRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock()) {}
-
  protected:
   void SetUp() OVERRIDE {
     mock_app_ = CreateMockApp();
@@ -90,7 +86,6 @@ class SDLGetUserFriendlyMessageRequestTest
   }
   MockAppPtr mock_app_;
   MockPolicyHandlerInterface mock_policy_handler_;
-  MockMessageHelper& mock_message_helper_;
 };
 
 TEST_F(SDLGetUserFriendlyMessageRequestTest, Run_LanguageSet_SUCCESS) {

--- a/src/components/application_manager/test/commands/hmi/ui_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/ui_is_ready_request_test.cc
@@ -54,12 +54,10 @@ namespace ui_is_ready_request {
 namespace am = ::application_manager;
 
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using am::commands::MessageSharedPtr;
 using am::commands::UIIsReadyRequest;
-using am::MockMessageHelper;
 using am::event_engine::Event;
 
 typedef SharedPtr<UIIsReadyRequest> UIIsReadyRequestPtr;
@@ -67,14 +65,11 @@ typedef SharedPtr<UIIsReadyRequest> UIIsReadyRequestPtr;
 class UIIsReadyRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  UIIsReadyRequestTest()
-      : command_(CreateCommand<UIIsReadyRequest>())
-      , mock_message_helper_(*MockMessageHelper::message_helper_mock()) {}
+  UIIsReadyRequestTest() : command_(CreateCommand<UIIsReadyRequest>()) {}
 
   void SetUp() OVERRIDE {
     ON_CALL(app_mngr_, hmi_capabilities())
         .WillByDefault(ReturnRef(mock_hmi_capabilities_));
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }
   void SetUpExpectations(bool is_ui_cooperating_available,
                          bool is_send_message_to_hmi,
@@ -151,7 +146,6 @@ class UIIsReadyRequestTest
   }
 
   UIIsReadyRequestPtr command_;
-  MockMessageHelper& mock_message_helper_;
   application_manager_test::MockHMICapabilities mock_hmi_capabilities_;
   policy_test::MockPolicyHandlerInterface mock_policy_handler_interface_;
 };

--- a/src/components/application_manager/test/commands/hmi/vi_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vi_is_ready_request_test.cc
@@ -57,7 +57,6 @@ using ::testing::Return;
 namespace am = ::application_manager;
 using am::commands::MessageSharedPtr;
 using am::commands::VIIsReadyRequest;
-using am::MockMessageHelper;
 using am::event_engine::Event;
 
 typedef SharedPtr<VIIsReadyRequest> VIIsReadyRequestPtr;
@@ -103,7 +102,7 @@ class VIIsReadyRequestTest
   void ExpectSendMessagesToHMI() {
     smart_objects::SmartObjectSPtr ivi_type;
     EXPECT_CALL(
-        *(MockMessageHelper::message_helper_mock()),
+        mock_message_helper_,
         CreateModuleInfoSO(hmi_apis::FunctionID::VehicleInfo_GetVehicleType, _))
         .WillOnce(Return(ivi_type));
     EXPECT_CALL(app_mngr_, ManageHMICommand(ivi_type));

--- a/src/components/application_manager/test/commands/hmi/vr_is_ready_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/vr_is_ready_request_test.cc
@@ -55,7 +55,6 @@ using ::testing::ReturnRef;
 namespace am = ::application_manager;
 using am::commands::MessageSharedPtr;
 using am::commands::VRIsReadyRequest;
-using am::MockMessageHelper;
 using am::event_engine::Event;
 
 typedef SharedPtr<VRIsReadyRequest> VRIsReadyRequestPtr;
@@ -105,7 +104,7 @@ class VRIsReadyRequestTest
 
     smart_objects::SmartObjectSPtr language(
         new smart_objects::SmartObject(smart_objects::SmartType_Map));
-    EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
+    EXPECT_CALL(mock_message_helper_,
                 CreateModuleInfoSO(hmi_apis::FunctionID::VR_GetLanguage, _))
         .WillOnce(Return(language));
     EXPECT_CALL(mock_hmi_capabilities_, set_handle_response_for(*language));
@@ -114,14 +113,14 @@ class VRIsReadyRequestTest
     smart_objects::SmartObjectSPtr support_language(
         new smart_objects::SmartObject(smart_objects::SmartType_Map));
     EXPECT_CALL(
-        *(MockMessageHelper::message_helper_mock()),
+        mock_message_helper_,
         CreateModuleInfoSO(hmi_apis::FunctionID::VR_GetSupportedLanguages, _))
         .WillOnce(Return(support_language));
     EXPECT_CALL(app_mngr_, ManageHMICommand(support_language));
 
     smart_objects::SmartObjectSPtr capabilities(
         new smart_objects::SmartObject(smart_objects::SmartType_Map));
-    EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
+    EXPECT_CALL(mock_message_helper_,
                 CreateModuleInfoSO(hmi_apis::FunctionID::VR_GetCapabilities, _))
         .WillOnce(Return(capabilities));
     EXPECT_CALL(app_mngr_, ManageHMICommand(capabilities));

--- a/src/components/application_manager/test/commands/mobile/add_command_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/add_command_request_test.cc
@@ -61,11 +61,9 @@ using am::commands::CommandImpl;
 using am::ApplicationManager;
 using am::commands::MessageSharedPtr;
 using am::ApplicationSharedPtr;
-using am::MockMessageHelper;
 using ::testing::_;
 using ::utils::SharedPtr;
 using ::testing::Return;
-using ::testing::Mock;
 using ::testing::InSequence;
 using am::commands::AddCommandRequest;
 using NsSmartDeviceLink::NsSmartObjects::SmartObjectSPtr;
@@ -105,17 +103,11 @@ class AddCommandRequestTest
   AddCommandRequestTest()
       : msg_(CreateMessage())
       , default_app_name_("test_default_app_name_")
-      , mock_message_helper_(*MockMessageHelper::message_helper_mock())
       , mock_app_(CreateMockApp()) {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
     EXPECT_CALL(app_mngr_, application(kConnectionKey))
         .WillRepeatedly(Return(mock_app_));
     InitGetters();
     InitBasicMessage();
-  }
-
-  ~AddCommandRequestTest() {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }
 
  protected:
@@ -227,7 +219,6 @@ class AddCommandRequestTest
   MessageSharedPtr msg_;
   SmartObjectSPtr so_ptr_;
   const utils::custom_string::CustomString default_app_name_;
-  am::MockMessageHelper& mock_message_helper_;
   sync_primitives::Lock lock_;
   MockAppPtr mock_app_;
 };

--- a/src/components/application_manager/test/commands/mobile/add_sub_menu_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/add_sub_menu_request_test.cc
@@ -54,9 +54,7 @@ namespace am = ::application_manager;
 using am::commands::AddSubMenuRequest;
 using am::commands::MessageSharedPtr;
 using am::event_engine::Event;
-using am::MockMessageHelper;
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 
 typedef SharedPtr<AddSubMenuRequest> AddSubMenuPtr;
@@ -66,12 +64,7 @@ const uint32_t kConnectionKey = 2u;
 }  // namespace
 
 class AddSubMenuRequestTest
-    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
- public:
-  AddSubMenuRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock()) {}
-  MockMessageHelper& mock_message_helper_;
-};
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
 
 TEST_F(AddSubMenuRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
   const uint32_t menu_id = 10u;
@@ -119,7 +112,6 @@ TEST_F(AddSubMenuRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
             .asString()
             .empty());
   }
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 }  // namespace add_sub_menu_request

--- a/src/components/application_manager/test/commands/mobile/alert_maneuver_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/alert_maneuver_request_test.cc
@@ -59,21 +59,16 @@ namespace alert_maneuver_request {
 using ::testing::_;
 using ::testing::Return;
 using ::testing::ReturnRef;
-using ::testing::Mock;
 namespace am = ::application_manager;
 using am::commands::AlertManeuverRequest;
 using am::commands::MessageSharedPtr;
 using am::event_engine::Event;
-using am::MockMessageHelper;
 
 typedef SharedPtr<AlertManeuverRequest> CommandPtr;
 
 class AlertManeuverRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  AlertManeuverRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock()) {}
-
   void CheckExpectations(const hmi_apis::Common_Result::eType hmi_response,
                          const mobile_apis::Result::eType mobile_response,
                          const am::HmiInterfaces::InterfaceState state,
@@ -111,16 +106,7 @@ class AlertManeuverRequestTest
         static_cast<int32_t>(mobile_response));
   }
 
-  void SetUp() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
  protected:
-  MockMessageHelper& mock_message_helper_;
   NiceMock<policy_test::MockPolicyHandlerInterface> policy_interface_;
 };
 
@@ -167,8 +153,7 @@ TEST_F(AlertManeuverRequestTest, Run_ProcessingResult_UNSUCCESS) {
   const mobile_apis::Result::eType kProcessingResult =
       mobile_apis::Result::ABORTED;
 
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()),
-              ProcessSoftButtons(_, _, _, _))
+  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _))
       .WillOnce(Return(kProcessingResult));
 
   MessageSharedPtr result_msg(CatchMobileCommandResult(CallRun(*command)));
@@ -215,8 +200,7 @@ TEST_F(AlertManeuverRequestTest, Run_ProcessingResult_SUCCESS) {
   ON_CALL(app_mngr_, GetPolicyHandler())
       .WillByDefault(ReturnRef(policy_interface_));
 
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()),
-              ProcessSoftButtons(_, _, _, _))
+  EXPECT_CALL(mock_message_helper_, ProcessSoftButtons(_, _, _, _))
       .WillOnce(Return(mobile_apis::Result::SUCCESS));
 
   EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceFromFunction(_))
@@ -225,8 +209,7 @@ TEST_F(AlertManeuverRequestTest, Run_ProcessingResult_SUCCESS) {
   EXPECT_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
       .WillRepeatedly(Return(am::HmiInterfaces::STATE_AVAILABLE));
 
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()),
-              SubscribeApplicationToSoftButton(_, _, _));
+  EXPECT_CALL(mock_message_helper_, SubscribeApplicationToSoftButton(_, _, _));
 
   MessageSharedPtr result_msg(CatchHMICommandResult(CallRun(*command)));
   EXPECT_EQ(hmi_apis::FunctionID::Navigation_AlertManeuver,

--- a/src/components/application_manager/test/commands/mobile/alert_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/alert_request_test.cc
@@ -60,7 +60,6 @@ using ::utils::SharedPtr;
 using am::event_engine::Event;
 using policy_test::MockPolicyHandlerInterface;
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -79,10 +78,7 @@ const mobile_apis::FunctionID::eType kFunctionId =
 
 class AlertRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  AlertRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock())
-      , mock_app_(CreateMockApp())
-      , msg_(CreateMessage()) {}
+  AlertRequestTest() : mock_app_(CreateMockApp()), msg_(CreateMessage()) {}
 
  protected:
   MessageSharedPtr CreateFullParamsUISO() {
@@ -114,10 +110,6 @@ class AlertRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
         static_cast<int32_t>(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE));
     EXPECT_EQ((*msg)[am::strings::msg_params][am::strings::info].asString(),
               info);
-  }
-
-  void SetUp() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }
 
   void PreConditions() {
@@ -155,9 +147,6 @@ class AlertRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
         .WillByDefault(Return(mobile_apis::HMILevel::HMI_BACKGROUND));
   }
 
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
   void AddAlertTextsToMsg() {
     (*msg_)[am::strings::msg_params][am::strings::alert_text1] = "alert_text1";
     (*msg_)[am::strings::msg_params][am::strings::alert_text2] = "alert_text2";
@@ -192,7 +181,6 @@ class AlertRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
   }
   sync_primitives::Lock lock_;
 
-  MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
   MessageSharedPtr msg_;
   MockPolicyHandlerInterface mock_policy_handler_;

--- a/src/components/application_manager/test/commands/mobile/change_registration_test.cc
+++ b/src/components/application_manager/test/commands/mobile/change_registration_test.cc
@@ -66,7 +66,6 @@ using am::commands::MessageSharedPtr;
 using am::ApplicationSharedPtr;
 using am::MockMessageHelper;
 using ::testing::_;
-using ::testing::Mock;
 using ::utils::SharedPtr;
 using ::testing::Return;
 using ::testing::ReturnRef;
@@ -89,8 +88,7 @@ class ChangeRegistrationRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
   ChangeRegistrationRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock())
-      , mock_app_(CreateMockApp())
+      : mock_app_(CreateMockApp())
       , supported_languages_(CreateMessage(smart_objects::SmartType_Array)) {}
 
   MessageSharedPtr CreateMsgFromMobile() {
@@ -246,10 +244,6 @@ class ChangeRegistrationRequestTest
         .WillByDefault(ReturnRef(hmi_capabilities_));
   }
 
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
   void ExpectationsHmiCapabilities(
       smart_objects::SmartObjectSPtr supported_languages) {
     EXPECT_CALL(hmi_capabilities_, ui_supported_languages())
@@ -277,7 +271,6 @@ class ChangeRegistrationRequestTest
       MockHMICapabilities;
   sync_primitives::Lock app_set_lock_;
   MockHMICapabilities hmi_capabilities_;
-  MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
   MessageSharedPtr supported_languages_;
   MockPolicyHandlerInterface mock_policy_handler_;

--- a/src/components/application_manager/test/commands/mobile/create_interaction_choice_set_test.cc
+++ b/src/components/application_manager/test/commands/mobile/create_interaction_choice_set_test.cc
@@ -65,7 +65,6 @@ using am::commands::MessageSharedPtr;
 using am::ApplicationSharedPtr;
 using am::MockMessageHelper;
 using ::testing::_;
-using ::testing::Mock;
 using ::utils::SharedPtr;
 using ::testing::Return;
 using ::testing::ReturnRef;
@@ -112,15 +111,9 @@ class CreateInteractionChoiceSetRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
   CreateInteractionChoiceSetRequestTest()
-      : message_helper_mock_(*am::MockMessageHelper::message_helper_mock())
-      , message_(CreateMessage())
+      : message_(CreateMessage())
       , command_(CreateCommand<CreateInteractionChoiceSetRequest>(message_))
-      , mock_app_(CreateMockApp()) {
-    Mock::VerifyAndClearExpectations(&message_helper_mock_);
-  }
-  ~CreateInteractionChoiceSetRequestTest() {
-    Mock::VerifyAndClearExpectations(&message_helper_mock_);
-  }
+      , mock_app_(CreateMockApp()) {}
 
   MessageSharedPtr CreateFullParamsVRSO() {
     MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
@@ -162,7 +155,6 @@ class CreateInteractionChoiceSetRequestTest
               [am::strings::interaction_choice_set_id] = kChoiceSetId;
   }
 
-  MockMessageHelper& message_helper_mock_;
   MessageSharedPtr message_;
   CreateInteractionChoiceSetRequestPtr command_;
   MockAppPtr mock_app_;
@@ -279,7 +271,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest, Run_VerifyImageFail_UNSUCCESS) {
              [am::strings::secondary_image] = kSecondImage;
 
   EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
-  EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::INVALID_DATA));
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
 
@@ -295,7 +287,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest, Run_FindChoiceSetFail_UNSUCCESS) {
       kChoiceSetId;
 
   EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
-  EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* invalid_choice_set_id =
@@ -330,7 +322,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
 
   EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
-  EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
@@ -367,7 +359,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
       .WillRepeatedly(Return(choice_set_id));
   EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(mock_app_));
 
-  EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   if ((*message_)[am::strings::msg_params][am::strings::choice_set][0]
@@ -436,7 +428,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   FillMessageFieldsItem2(message_);
   EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
-  EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
@@ -475,7 +467,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
 
   EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
-  EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
@@ -521,7 +513,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnEvent_ValidVrNoError_SUCCESS) {
 
   EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
-  EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
@@ -554,7 +546,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   FillMessageFieldsItem2(message_);
   EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
-  EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
@@ -588,7 +580,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
       kChoiceSetId;
   ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
 
-  EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
@@ -635,7 +627,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
 
   ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
 
-  EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
@@ -675,7 +667,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeOut_InvalidApp_UNSUCCESS) {
 
   EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(mock_app_));
 
-  EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
@@ -715,7 +707,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   (*message_)[am::strings::msg_params][am::strings::interaction_choice_set_id] =
       kChoiceSetId;
 
-  EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObject* choice_set_id = NULL;
@@ -788,7 +780,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest, Run_ErrorFromHmiFalse_UNSUCCESS) {
       kChoiceSetId;
   ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
 
-  EXPECT_CALL(message_helper_mock_, VerifyImage(_, _, _))
+  EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::GENERIC_ERROR));
 
   smart_objects::SmartObject* choice_set_id = NULL;

--- a/src/components/application_manager/test/commands/mobile/delete_command_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_command_request_test.cc
@@ -53,7 +53,6 @@ namespace mobile_commands_test {
 namespace delete_command_request {
 
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 namespace am = ::application_manager;
@@ -75,9 +74,7 @@ const uint32_t kConnectionKey = 2u;
 class DeleteCommandRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  DeleteCommandRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock())
-      , mock_app_(CreateMockApp()) {}
+  DeleteCommandRequestTest() : mock_app_(CreateMockApp()) {}
   MessageSharedPtr CreateFullParamsUISO() {
     MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
     (*msg)[am::strings::params][am::strings::connection_key] = kConnectionKey;
@@ -134,12 +131,7 @@ class DeleteCommandRequestTest
         .WillByDefault(ReturnRef(hmi_interfaces_));
   }
 
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
   NiceMock<MockHmiInterfaces> hmi_interfaces_;
-  MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
 };
 

--- a/src/components/application_manager/test/commands/mobile/delete_interaction_choice_set_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_interaction_choice_set_test.cc
@@ -53,7 +53,6 @@ namespace mobile_commands_test {
 namespace delete_interaction_choice_set {
 
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::InSequence;
 

--- a/src/components/application_manager/test/commands/mobile/delete_sub_menu_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_sub_menu_test.cc
@@ -51,7 +51,6 @@ namespace mobile_commands_test {
 namespace delete_sub_menu_request {
 
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::InSequence;
@@ -97,22 +96,14 @@ class DeleteSubMenuRequestTest
  public:
   DeleteSubMenuRequestTest()
       : accessor_(commands_map_, commands_lock_)
-      , mock_message_helper_(*MockMessageHelper::message_helper_mock())
       , message_(CreateMessage())
       , command_(CreateCommand<DeleteSubMenuRequest>(message_))
-      , app_(CreateMockApp()) {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
-  ~DeleteSubMenuRequestTest() {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
+      , app_(CreateMockApp()) {}
 
   am::CommandsMap commands_map_;
   mutable sync_primitives::Lock commands_lock_;
   DataAccessor<am::CommandsMap> accessor_;
 
-  MockMessageHelper& mock_message_helper_;
   MessageSharedPtr message_;
   DeleteSubMenuRequestPtr command_;
   MockAppPtr app_;

--- a/src/components/application_manager/test/commands/mobile/diagnostic_message_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/diagnostic_message_request_test.cc
@@ -71,17 +71,7 @@ const uint32_t kDiagnosticMode = 5u;
 }  // namespace
 
 class DiagnosticMessageRequestTest
-    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
- public:
-  DiagnosticMessageRequestTest()
-      : mock_message_helper_(*am::MockMessageHelper::message_helper_mock()) {
-    testing::Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-  ~DiagnosticMessageRequestTest() {
-    testing::Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-  am::MockMessageHelper& mock_message_helper_;
-};
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
 
 TEST_F(DiagnosticMessageRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));

--- a/src/components/application_manager/test/commands/mobile/end_audio_pass_thru_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/end_audio_pass_thru_request_test.cc
@@ -53,7 +53,6 @@ namespace end_audio_pass_thru_request {
 
 namespace am = ::application_manager;
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using am::commands::MessageSharedPtr;
@@ -64,12 +63,7 @@ using am::MockMessageHelper;
 typedef SharedPtr<EndAudioPassThruRequest> EndAudioPassThruRequestPtr;
 
 class EndAudioPassThruRequestTest
-    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
- public:
-  EndAudioPassThruRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock()) {}
-  MockMessageHelper& mock_message_helper_;
-};
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
 
 TEST_F(EndAudioPassThruRequestTest, OnEvent_UI_UNSUPPORTED_RESOUCRE) {
   const uint32_t kConnectionKey = 2u;
@@ -116,7 +110,6 @@ TEST_F(EndAudioPassThruRequestTest, OnEvent_UI_UNSUPPORTED_RESOUCRE) {
             .asString()
             .empty());
   }
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 }  // namespace end_audio_pass_thru_request

--- a/src/components/application_manager/test/commands/mobile/get_dtcs_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/get_dtcs_request_test.cc
@@ -69,9 +69,7 @@ typedef SharedPtr<GetDTCsRequest> GetDTCsRequestPtr;
 class GetDTCsRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  GetDTCsRequestTest() : CommandRequestTest<CommandsTestMocks::kIsNice>() {
-    Mock::VerifyAndClearExpectations(message_helper_mock_);
-  }
+  GetDTCsRequestTest() : CommandRequestTest<CommandsTestMocks::kIsNice>() {}
 };
 
 TEST_F(GetDTCsRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {

--- a/src/components/application_manager/test/commands/mobile/get_vehicle_data_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/get_vehicle_data_request_test.cc
@@ -70,19 +70,7 @@ const uint32_t kConnectionKey = 2u;
 }  // namespace
 
 class GetVehicleDataRequestTest
-    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
- public:
-  GetVehicleDataRequestTest()
-      : mock_message_helper_(*am::MockMessageHelper::message_helper_mock()) {
-    testing::Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
-  ~GetVehicleDataRequestTest() {
-    testing::Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
-  am::MockMessageHelper& mock_message_helper_;
-};
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
 
 class UnwrappedGetVehicleDataRequest : public GetVehicleDataRequest {
  public:

--- a/src/components/application_manager/test/commands/mobile/get_way_points_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/get_way_points_request_test.cc
@@ -53,7 +53,6 @@ namespace get_way_points_request {
 
 using namespace mobile_apis::Result;
 using ::testing::Return;
-using ::testing::Mock;
 using ::testing::_;
 using application_manager::commands::GetWayPointsRequest;
 using application_manager::MockMessageHelper;
@@ -73,14 +72,7 @@ const std::string kMethodName = "Navigation.GetWayPoints";
 class GetWayPointsRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  GetWayPointsRequestTest()
-      : message_helper_mock_(*am::MockMessageHelper::message_helper_mock())
-      , mock_app_(CreateMockApp()) {
-    Mock::VerifyAndClearExpectations(&message_helper_mock_);
-  }
-  ~GetWayPointsRequestTest() {
-    Mock::VerifyAndClearExpectations(&message_helper_mock_);
-  }
+  GetWayPointsRequestTest() : mock_app_(CreateMockApp()) {}
 
   void SetUp() OVERRIDE {
     message_ = utils::MakeShared<SmartObject>(::smart_objects::SmartType_Map);
@@ -93,7 +85,6 @@ class GetWayPointsRequestTest
     ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
   }
 
-  MockMessageHelper& message_helper_mock_;
   MockAppPtr mock_app_;
   MessageSharedPtr message_;
   utils::SharedPtr<application_manager::commands::GetWayPointsRequest>
@@ -103,14 +94,7 @@ class GetWayPointsRequestTest
 class GetWayPointsRequestOnEventTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  GetWayPointsRequestOnEventTest()
-      : message_helper_mock_(*am::MockMessageHelper::message_helper_mock())
-      , app_(CreateMockApp()) {
-    Mock::VerifyAndClearExpectations(&message_helper_mock_);
-  }
-  ~GetWayPointsRequestOnEventTest() {
-    Mock::VerifyAndClearExpectations(&message_helper_mock_);
-  }
+  GetWayPointsRequestOnEventTest() : app_(CreateMockApp()) {}
 
   void CheckOnEventResponse(const std::string& wayPointsParam,
                             const HmiResult ResultCode,
@@ -143,7 +127,6 @@ class GetWayPointsRequestOnEventTest
   }
 
  protected:
-  MockMessageHelper& message_helper_mock_;
   MockAppPtr app_;
   MockHmiInterfaces hmi_interfaces_;
 };

--- a/src/components/application_manager/test/commands/mobile/on_hash_change_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_hash_change_notification_test.cc
@@ -56,19 +56,7 @@ using testing::ReturnRef;
 using testing::_;
 
 class OnHashChangeNotificationTest
-    : public CommandsTest<CommandsTestMocks::kIsNice> {
- public:
-  OnHashChangeNotificationTest()
-      : message_helper_(*MockMessageHelper::message_helper_mock()) {}
-  void SetUp() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&message_helper_);
-  }
-
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&message_helper_);
-  }
-  MockMessageHelper& message_helper_;
-};
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
 
 TEST_F(OnHashChangeNotificationTest, Run_ValidApp_SUCCESS) {
   const uint32_t kConnectionKey = 1u;
@@ -83,7 +71,8 @@ TEST_F(OnHashChangeNotificationTest, Run_ValidApp_SUCCESS) {
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
   EXPECT_CALL(*mock_app, curHash()).WillOnce(ReturnRef(return_string));
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
+  EXPECT_CALL(mock_message_helper_, PrintSmartObject(_))
+      .WillOnce(Return(false));
   EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
 
   command->Run();
@@ -112,7 +101,7 @@ TEST_F(OnHashChangeNotificationTest, Run_InvalidApp_NoNotification) {
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(MockAppPtr()));
   EXPECT_CALL(*mock_app, curHash()).Times(0);
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).Times(0);
+  EXPECT_CALL(mock_message_helper_, PrintSmartObject(_)).Times(0);
   EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _)).Times(0);
 
   command->Run();

--- a/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_from_mobile_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_from_mobile_test.cc
@@ -235,16 +235,12 @@ TEST_F(OnHMIStatusNotificationFromMobileTest,
 
   EXPECT_CALL(*mock_app, is_foreground()).WillOnce(Return(true));
 
-  application_manager::MockMessageHelper& mock_message_helper =
-      *application_manager::MockMessageHelper::message_helper_mock();
-  Mock::VerifyAndClearExpectations(&mock_message_helper);
-  EXPECT_CALL(mock_message_helper, SendQueryApps(kConnectionKey, _));
+  EXPECT_CALL(mock_message_helper_, SendQueryApps(kConnectionKey, _));
 
   command->Run();
 
   ASSERT_EQ(application_manager::MessageType::kNotification,
             (*msg)[strings::params][strings::message_type].asInt());
-  Mock::VerifyAndClearExpectations(&mock_message_helper);
 }
 
 TEST_F(OnHMIStatusNotificationFromMobileTest,

--- a/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_test.cc
@@ -59,9 +59,6 @@ using testing::_;
 class OnHMIStatusNotificationTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
-  OnHMIStatusNotificationTest()
-      : message_helper_(*MockMessageHelper::message_helper_mock()) {}
-
   MessageSharedPtr CreateMsgParams(
       const mobile_apis::HMILevel::eType kHMIState) {
     MessageSharedPtr msg = CreateMessage();
@@ -70,13 +67,9 @@ class OnHMIStatusNotificationTest
     return msg;
   }
 
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&message_helper_);
-  }
-
   void SetSendNotificationExpectations(MessageSharedPtr& msg) {
-    Mock::VerifyAndClearExpectations(&message_helper_);
-    EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
+    EXPECT_CALL(mock_message_helper_, PrintSmartObject(_))
+        .WillOnce(Return(false));
     EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
   }
 
@@ -88,8 +81,6 @@ class OnHMIStatusNotificationTest
     ASSERT_EQ(CommandImpl::protocol_version_,
               (*msg)[strings::params][strings::protocol_version].asInt());
   }
-
-  MockMessageHelper& message_helper_;
 };
 
 TEST_F(OnHMIStatusNotificationTest, Run_InvalidApp_NoNotification) {
@@ -141,7 +132,7 @@ TEST_F(OnHMIStatusNotificationTest, Run_BackgroundAndFalseProperties_SUCCESS) {
 
   EXPECT_CALL(*mock_app, tts_properties_in_none()).WillOnce(Return(false));
   EXPECT_CALL(*mock_app, set_tts_properties_in_none(true));
-  EXPECT_CALL(message_helper_, SendTTSGlobalProperties(_, false, _));
+  EXPECT_CALL(mock_message_helper_, SendTTSGlobalProperties(_, false, _));
 
   command->Run();
 

--- a/src/components/application_manager/test/commands/mobile/on_keyboard_input_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_keyboard_input_notification_test.cc
@@ -61,11 +61,9 @@ using testing::_;
 class OnKeyBoardInputNotificationTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
-  OnKeyBoardInputNotificationTest()
-      : message_helper_(*MockMessageHelper::message_helper_mock()) {}
-
   void SetSendNotificationExpectations(MessageSharedPtr msg) {
-    EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
+    EXPECT_CALL(mock_message_helper_, PrintSmartObject(_))
+        .WillOnce(Return(false));
     EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
   }
 
@@ -78,14 +76,6 @@ class OnKeyBoardInputNotificationTest
               (*msg)[strings::params][strings::protocol_version].asInt());
   }
 
-  void SetUp() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&message_helper_);
-  }
-
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&message_helper_);
-  }
-
   MockAppPtr InitAppSetDataAccessor(SharedPtr<ApplicationSet>& app_set) {
     app_set = (!app_set ? ::utils::MakeShared<ApplicationSet>() : app_set);
     MockAppPtr app(CreateMockApp());
@@ -95,7 +85,6 @@ class OnKeyBoardInputNotificationTest
     return app;
   }
 
-  MockMessageHelper& message_helper_;
   SharedPtr<ApplicationSet> app_set_;
   sync_primitives::Lock lock_;
 };
@@ -162,7 +151,7 @@ TEST_F(OnKeyBoardInputNotificationTest, Run_InvalidApp_NoNotification) {
   EXPECT_CALL(*mock_app, hmi_level())
       .WillOnce(Return(mobile_apis::HMILevel::eType::HMI_BACKGROUND));
 
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).Times(0);
+  EXPECT_CALL(mock_message_helper_, PrintSmartObject(_)).Times(0);
   EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _)).Times(0);
 
   command->Run();

--- a/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
@@ -64,20 +64,7 @@ const uint32_t kConnectionKey = 1u;
 }  // namespace
 
 class OnSystemRequestNotificationTest
-    : public CommandsTest<CommandsTestMocks::kIsNice> {
- public:
-  OnSystemRequestNotificationTest()
-      : message_helper_(*MockMessageHelper::message_helper_mock()) {}
-
-  void SetUp() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&message_helper_);
-  }
-
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&message_helper_);
-  }
-  MockMessageHelper& message_helper_;
-};
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
 
 TEST_F(OnSystemRequestNotificationTest, Run_ProprietaryType_SUCCESS) {
   const RequestType::eType kRequestType = RequestType::PROPRIETARY;
@@ -107,7 +94,8 @@ TEST_F(OnSystemRequestNotificationTest, Run_ProprietaryType_SUCCESS) {
   EXPECT_CALL(mock_policy_handler, TimeoutExchangeSec()).WillOnce(Return(5u));
 #endif  // PROPRIETARY_MODE
 
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
+  EXPECT_CALL(mock_message_helper_, PrintSmartObject(_))
+      .WillOnce(Return(false));
   EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
 
   command->Run();
@@ -143,7 +131,8 @@ TEST_F(OnSystemRequestNotificationTest, Run_HTTPType_SUCCESS) {
   EXPECT_CALL(mock_policy_handler, IsRequestTypeAllowed(_, _))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).WillOnce(Return(false));
+  EXPECT_CALL(mock_message_helper_, PrintSmartObject(_))
+      .WillOnce(Return(false));
   EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
 
   command->Run();
@@ -176,7 +165,7 @@ TEST_F(OnSystemRequestNotificationTest, Run_InvalidApp_NoNotification) {
   MockPolicyHandlerInterface mock_policy_handler;
   EXPECT_CALL(mock_policy_handler, IsRequestTypeAllowed(_, _)).Times(0);
 
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).Times(0);
+  EXPECT_CALL(mock_message_helper_, PrintSmartObject(_)).Times(0);
   EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _)).Times(0);
 
   command->Run();
@@ -203,7 +192,7 @@ TEST_F(OnSystemRequestNotificationTest, Run_RequestNotAllowed_NoNotification) {
   EXPECT_CALL(mock_policy_handler, IsRequestTypeAllowed(_, _))
       .WillOnce(Return(false));
 
-  EXPECT_CALL(message_helper_, PrintSmartObject(_)).Times(0);
+  EXPECT_CALL(mock_message_helper_, PrintSmartObject(_)).Times(0);
   EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _)).Times(0);
   ;
 

--- a/src/components/application_manager/test/commands/mobile/on_vehicle_data_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_vehicle_data_notification_test.cc
@@ -71,11 +71,9 @@ class OnVehicleDataNotificationTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
   OnVehicleDataNotificationTest()
-      : mock_message_helper_(*am::MockMessageHelper::message_helper_mock())
-      , command_msg_(CreateMessage(smart_objects::SmartType_Map))
+      : command_msg_(CreateMessage(smart_objects::SmartType_Map))
       , command_(CreateCommand<OnVehicleDataNotification>(command_msg_)) {}
 
-  am::MockMessageHelper& mock_message_helper_;
   MessageSharedPtr command_msg_;
   NotificationPtr command_;
 };

--- a/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -57,7 +57,6 @@ using am::commands::MessageSharedPtr;
 using am::MockMessageHelper;
 using ::utils::SharedPtr;
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::InSequence;
@@ -80,8 +79,7 @@ class PerformAudioPassThruRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
   PerformAudioPassThruRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock())
-      , mock_app_(CreateMockApp())
+      : mock_app_(CreateMockApp())
       , message_(utils::MakeShared<SmartObject>(::smart_objects::SmartType_Map))
       , msg_params_((*message_)[am::strings::msg_params]) {}
 
@@ -137,10 +135,6 @@ class PerformAudioPassThruRequestTest
     ON_CALL(app_mngr_, application(_)).WillByDefault(Return(application_sptr_));
   }
 
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
   void ResultCommandExpectations(MessageSharedPtr msg,
                                  const std::string& info) {
     EXPECT_EQ((*msg)[am::strings::msg_params][am::strings::success].asBool(),
@@ -153,7 +147,6 @@ class PerformAudioPassThruRequestTest
   }
 
   sync_primitives::Lock lock_;
-  MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
   MessageSharedPtr message_;
   ::smart_objects::SmartObject& msg_params_;
@@ -192,7 +185,6 @@ TEST_F(PerformAudioPassThruRequestTest, OnTimeout_GENERIC_ERROR) {
       (*vr_command_result)[am::strings::msg_params][am::strings::result_code]
           .asInt(),
       static_cast<int32_t>(am::mobile_api::Result::GENERIC_ERROR));
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 TEST_F(PerformAudioPassThruRequestTest,

--- a/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
+++ b/src/components/application_manager/test/commands/mobile/perform_interaction_test.cc
@@ -63,7 +63,6 @@ using am::commands::MessageSharedPtr;
 using am::ApplicationSharedPtr;
 using am::MockMessageHelper;
 using ::testing::_;
-using ::testing::Mock;
 using ::utils::SharedPtr;
 using ::testing::Return;
 using ::testing::ReturnRef;
@@ -82,18 +81,12 @@ const uint32_t kConnectionKey = 2u;
 class PerformInteractionRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  PerformInteractionRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock())
-      , mock_app_(CreateMockApp()) {}
+  PerformInteractionRequestTest() : mock_app_(CreateMockApp()) {}
 
   void SetUp() OVERRIDE {
     ON_CALL(app_mngr_, application(kConnectionKey))
         .WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
-  }
-
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }
 
   void ResultCommandExpectations(MessageSharedPtr msg,
@@ -108,7 +101,6 @@ class PerformInteractionRequestTest
   }
 
   sync_primitives::Lock lock_;
-  MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
 };
 

--- a/src/components/application_manager/test/commands/mobile/read_did_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/read_did_request_test.cc
@@ -90,9 +90,6 @@ TEST_F(ReadDIDRequestTest, OnEvent_SUCCESS) {
 
   event.set_smart_object(*event_msg);
 
-  am::MockMessageHelper& mock_message_helper(
-      *am::MockMessageHelper::message_helper_mock());
-
   EXPECT_CALL(app_mngr_,
               ManageMobileCommand(MobileResultCodeIs(mobile_response_code), _));
 
@@ -100,8 +97,6 @@ TEST_F(ReadDIDRequestTest, OnEvent_SUCCESS) {
   EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(app));
 
   command->on_event(event);
-
-  testing::Mock::VerifyAndClearExpectations(&mock_message_helper);
 }
 
 TEST_F(ReadDIDRequestTest, Run_AppNotRegistered_UNSUCCESS) {

--- a/src/components/application_manager/test/commands/mobile/reset_global_properties_test.cc
+++ b/src/components/application_manager/test/commands/mobile/reset_global_properties_test.cc
@@ -58,7 +58,6 @@ namespace mobile_commands_test {
 namespace reset_global_properties {
 
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -83,11 +82,7 @@ class ResetGlobalPropertiesRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  protected:
   ResetGlobalPropertiesRequestTest()
-      : mock_message_helper_(am::MockMessageHelper::message_helper_mock())
-      , msg_(CreateMessage())
-      , mock_app_(CreateMockApp()) {
-    Mock::VerifyAndClearExpectations(mock_message_helper_);
-  }
+      : msg_(CreateMessage()), mock_app_(CreateMockApp()) {}
 
   void SetUp() OVERRIDE {
     (*msg_)[am::strings::params][am::strings::connection_key] = kConnectionKey;
@@ -102,10 +97,6 @@ class ResetGlobalPropertiesRequestTest
         .WillByDefault(Return(kCorrelationId));
   }
 
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(mock_message_helper_);
-  }
-  am::MockMessageHelper* mock_message_helper_;
   MessageSharedPtr msg_;
   MockAppPtr mock_app_;
   ResetGlobalPropertiesRequestPtr command_;
@@ -177,7 +168,7 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidVrHelp_UNSUCCESS) {
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 
   smart_objects::SmartObjectSPtr vr_help;  // = NULL;
-  EXPECT_CALL(*mock_message_helper_, CreateAppVrHelp(_))
+  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
       .WillOnce(Return(vr_help));
 
   EXPECT_CALL(app_mngr_, ManageHMICommand(_)).Times(0);
@@ -230,7 +221,7 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_SUCCESS) {
   smart_objects::SmartObjectSPtr vr_help =
       ::utils::MakeShared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(*mock_message_helper_, CreateAppVrHelp(_))
+  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
       .WillOnce(Return(vr_help));
 
   smart_objects::SmartObject msg_params =
@@ -283,7 +274,7 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   smart_objects::SmartObjectSPtr vr_help =
       ::utils::MakeShared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(*mock_message_helper_, CreateAppVrHelp(_))
+  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
       .WillOnce(Return(vr_help));
 
   command_->Run();
@@ -368,7 +359,7 @@ TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_InvalidApp_NoHashUpdate) {
   smart_objects::SmartObjectSPtr vr_help =
       ::utils::MakeShared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(*mock_message_helper_, CreateAppVrHelp(_))
+  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
       .WillOnce(Return(vr_help));
 
   EXPECT_CALL(*mock_app_, UpdateHash()).Times(0);
@@ -441,7 +432,7 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       utils::MakeShared<smart_objects::SmartObject>();
   (*response)[am::strings::msg_params][am::strings::result_code] =
       mobile_apis::Result::GENERIC_ERROR;
-  EXPECT_CALL(*mock_message_helper_, CreateNegativeResponse(_, _, _, _))
+  EXPECT_CALL(mock_message_helper_, CreateNegativeResponse(_, _, _, _))
       .WillOnce(Return(response));
   const std::string info = "TTS component does not respond";
   EXPECT_CALL(
@@ -503,7 +494,7 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       utils::MakeShared<smart_objects::SmartObject>();
   (*response)[am::strings::msg_params][am::strings::result_code] =
       mobile_apis::Result::GENERIC_ERROR;
-  EXPECT_CALL(*mock_message_helper_, CreateNegativeResponse(_, _, _, _))
+  EXPECT_CALL(mock_message_helper_, CreateNegativeResponse(_, _, _, _))
       .WillOnce(Return(response));
 
   const std::string info = "UI component does not respond";
@@ -557,7 +548,7 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       utils::MakeShared<smart_objects::SmartObject>();
   (*response)[am::strings::msg_params][am::strings::result_code] =
       mobile_apis::Result::GENERIC_ERROR;
-  EXPECT_CALL(*mock_message_helper_, CreateNegativeResponse(_, _, _, _))
+  EXPECT_CALL(mock_message_helper_, CreateNegativeResponse(_, _, _, _))
       .WillOnce(Return(response));
   EXPECT_CALL(
       app_mngr_,

--- a/src/components/application_manager/test/commands/mobile/scrollable_message_test.cc
+++ b/src/components/application_manager/test/commands/mobile/scrollable_message_test.cc
@@ -65,7 +65,6 @@ using ::utils::SharedPtr;
 using ::testing::_;
 using ::testing::Eq;
 using ::testing::Ref;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -84,9 +83,6 @@ const uint32_t kFunctionID = 3u;
 class ScrollableMessageRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  ScrollableMessageRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock()) {}
-  MockMessageHelper& mock_message_helper_;
   typedef TypeIf<kMocksAreNice,
                  NiceMock<application_manager_test::MockHMICapabilities>,
                  application_manager_test::MockHMICapabilities>::Result
@@ -118,11 +114,6 @@ class ScrollableMessageRequestTest
     ON_CALL(app_mngr_, GetPolicyHandler())
         .WillByDefault(ReturnRef(mock_policy_handler_));
     command_ = CreateCommand<ScrollableMessageRequest>(msg_);
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }
 
   MockPolicyHandlerInterface mock_policy_handler_;
@@ -181,7 +172,6 @@ TEST_F(ScrollableMessageRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
             .asString()
             .empty());
   }
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 TEST_F(ScrollableMessageRequestTest, Init_CorrectTimeout_SUCCESS) {

--- a/src/components/application_manager/test/commands/mobile/send_location_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/send_location_request_test.cc
@@ -54,7 +54,6 @@ using utils::SharedPtr;
 using testing::_;
 using testing::Return;
 using testing::ReturnRef;
-using ::testing::Mock;
 
 namespace strings = application_manager::strings;
 namespace hmi_response = application_manager::hmi_response;
@@ -92,16 +91,11 @@ class SendLocationRequestTest
 
   typedef SharedPtr<UnwrappedSendLocationRequest> CommandSPrt;
 
-  SendLocationRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock()) {
+  SendLocationRequestTest() {
     mock_app_ = CreateMockApp();
     disp_cap_ = utils::MakeShared<SmartObject>(smart_objects::SmartType_Map);
     message_ = CreateMessage();
     command_ = CreateCommand<UnwrappedSendLocationRequest>(message_);
-  }
-
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }
 
   void InitialSetup(MessageSharedPtr message_) {
@@ -158,7 +152,6 @@ class SendLocationRequestTest
 
   MockAppPtr mock_app_;
   MockHMICapabilities mock_hmi_capabilities_;
-  MockMessageHelper& mock_message_helper_;
   SharedPtr<SmartObject> disp_cap_;
   MessageSharedPtr message_;
   CommandSPrt command_;

--- a/src/components/application_manager/test/commands/mobile/set_app_icon_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_app_icon_test.cc
@@ -57,7 +57,6 @@ using am::commands::MessageSharedPtr;
 using am::MockMessageHelper;
 using ::utils::SharedPtr;
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -70,19 +69,6 @@ const uint32_t kConnectionKey = 2u;
 class SetAppIconRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  SetAppIconRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock()) {}
-
-  void SetUp() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
-  MockMessageHelper& mock_message_helper_;
-
   MessageSharedPtr CreateFullParamsUISO() {
     MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
     (*msg)[am::strings::params][am::strings::connection_key] = kConnectionKey;

--- a/src/components/application_manager/test/commands/mobile/set_display_layout_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_display_layout_test.cc
@@ -59,7 +59,6 @@ using am::commands::MessageSharedPtr;
 using am::MockMessageHelper;
 using ::utils::SharedPtr;
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -80,18 +79,10 @@ MATCHER_P(CheckMshCorrId, corr_id, "") {
 class SetDisplayLayoutRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  SetDisplayLayoutRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock())
-      , mock_app_(CreateMockApp()) {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-
+  SetDisplayLayoutRequestTest() : mock_app_(CreateMockApp()) {
     ON_CALL(app_mngr_, application(kConnectionKey))
         .WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
-  }
-
-  ~SetDisplayLayoutRequestTest() {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }
 
   MessageSharedPtr CreateFullParamsUISO() {
@@ -130,7 +121,6 @@ class SetDisplayLayoutRequestTest
   }
 
   sync_primitives::Lock lock_;
-  MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
 };
 

--- a/src/components/application_manager/test/commands/mobile/set_global_properties_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_global_properties_test.cc
@@ -59,7 +59,6 @@ using am::CommandsMap;
 using utils::custom_string::CustomString;
 using ::utils::SharedPtr;
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -75,9 +74,7 @@ const uint32_t kPosition = 1u;
 class SetGlobalPropertiesRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  SetGlobalPropertiesRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock())
-      , mock_app_(CreateMockApp()) {}
+  SetGlobalPropertiesRequestTest() : mock_app_(CreateMockApp()) {}
 
   MessageSharedPtr CreateFullParamsUISO() {
     MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
@@ -220,10 +217,6 @@ class SetGlobalPropertiesRequestTest
         .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   }
 
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
   void ResultCommandExpectations(MessageSharedPtr msg,
                                  const std::string& info) {
     EXPECT_EQ((*msg)[am::strings::msg_params][am::strings::success].asBool(),
@@ -252,7 +245,6 @@ class SetGlobalPropertiesRequestTest
         .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
   }
   sync_primitives::Lock lock_;
-  MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
 };
 

--- a/src/components/application_manager/test/commands/mobile/set_media_clock_timer_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_media_clock_timer_test.cc
@@ -55,7 +55,6 @@ using am::commands::MessageSharedPtr;
 using am::event_engine::Event;
 using am::MockMessageHelper;
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -75,18 +74,12 @@ const uint32_t kSeconds = 1u;
 class SetMediaClockRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  SetMediaClockRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock())
-      , mock_app_(CreateMockApp()) {}
+  SetMediaClockRequestTest() : mock_app_(CreateMockApp()) {}
 
   void SetUp() OVERRIDE {
     ON_CALL(app_mngr_, application(kConnectionKey))
         .WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
-  }
-
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }
 
   void ResultCommandExpectations(MessageSharedPtr msg,
@@ -114,7 +107,6 @@ class SetMediaClockRequestTest
     EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
   }
 
-  MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
 };
 

--- a/src/components/application_manager/test/commands/mobile/show_test.cc
+++ b/src/components/application_manager/test/commands/mobile/show_test.cc
@@ -59,7 +59,6 @@ using am::MockMessageHelper;
 using test::components::policy_test::MockPolicyHandlerInterface;
 using ::utils::SharedPtr;
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -73,8 +72,7 @@ const uint32_t kFunctionID = 3u;
 
 class ShowRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  ShowRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock()) {
+  ShowRequestTest() {
     mock_app_ = CreateMockApp();
   }
   sync_primitives::Lock lock_;
@@ -203,16 +201,7 @@ class ShowRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
     EXPECT_CALL(*mock_app_, set_show_command(msg_params));
   }
 
-  void SetUp() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
   MockAppPtr mock_app_;
-  MockMessageHelper& mock_message_helper_;
   std::string text_field_;
 };
 
@@ -260,12 +249,9 @@ TEST_F(ShowRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
             .asString()
             .empty());
   }
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 TEST_F(ShowRequestTest, Run_SoftButtonExists_SUCCESS) {
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
-
   MessageSharedPtr msg = CreateMsgParams();
 
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -294,13 +280,9 @@ TEST_F(ShowRequestTest, Run_SoftButtonExists_SUCCESS) {
   EXPECT_CALL(*mock_app_, set_show_command(msg_params));
 
   command->Run();
-
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 TEST_F(ShowRequestTest, Run_SoftButtonNotExists_SUCCESS) {
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
-
   MessageSharedPtr msg = CreateMsgParams();
 
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -324,13 +306,9 @@ TEST_F(ShowRequestTest, Run_SoftButtonNotExists_SUCCESS) {
   EXPECT_CALL(*mock_app_, set_show_command(msg_params));
 
   command->Run();
-
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 TEST_F(ShowRequestTest, Run_SoftButtonExists_Canceled) {
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
-
   MessageSharedPtr msg = CreateMsgParams();
 
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -357,13 +335,9 @@ TEST_F(ShowRequestTest, Run_SoftButtonExists_Canceled) {
   EXPECT_CALL(*mock_app_, set_show_command(_)).Times(0);
 
   command->Run();
-
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 TEST_F(ShowRequestTest, Run_Graphic_SUCCESS) {
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
-
   MessageSharedPtr msg = CreateMsgParams();
 
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -388,13 +362,9 @@ TEST_F(ShowRequestTest, Run_Graphic_SUCCESS) {
   EXPECT_CALL(*mock_app_, set_show_command(msg_params));
 
   command->Run();
-
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 TEST_F(ShowRequestTest, Run_Graphic_Canceled) {
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
-
   MessageSharedPtr msg = CreateMsgParams();
 
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -416,13 +386,9 @@ TEST_F(ShowRequestTest, Run_Graphic_Canceled) {
   EXPECT_CALL(*mock_app_, set_show_command(msg_params)).Times(0);
 
   command->Run();
-
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 TEST_F(ShowRequestTest, Run_Graphic_WrongSyntax) {
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
-
   MessageSharedPtr msg = CreateMsgParams();
 
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -443,13 +409,9 @@ TEST_F(ShowRequestTest, Run_Graphic_WrongSyntax) {
   EXPECT_CALL(*mock_app_, set_show_command(msg_params)).Times(0);
 
   command->Run();
-
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 TEST_F(ShowRequestTest, Run_SecondaryGraphic_SUCCESS) {
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
-
   MessageSharedPtr msg = CreateMsgParams();
 
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -474,13 +436,9 @@ TEST_F(ShowRequestTest, Run_SecondaryGraphic_SUCCESS) {
   EXPECT_CALL(*mock_app_, set_show_command(msg_params));
 
   command->Run();
-
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 TEST_F(ShowRequestTest, Run_SecondaryGraphic_Canceled) {
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
-
   MessageSharedPtr msg = CreateMsgParams();
 
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -502,13 +460,9 @@ TEST_F(ShowRequestTest, Run_SecondaryGraphic_Canceled) {
   EXPECT_CALL(*mock_app_, set_show_command(msg_params)).Times(0);
 
   command->Run();
-
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 TEST_F(ShowRequestTest, Run_SecondaryGraphic_WrongSyntax) {
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
-
   MessageSharedPtr msg = CreateMsgParams();
 
   SmartObject msg_params(smart_objects::SmartType_Map);
@@ -529,8 +483,6 @@ TEST_F(ShowRequestTest, Run_SecondaryGraphic_WrongSyntax) {
   EXPECT_CALL(*mock_app_, set_show_command(msg_params)).Times(0);
 
   command->Run();
-
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 TEST_F(ShowRequestTest, Run_MainField1_SUCCESS) {
@@ -716,7 +668,6 @@ TEST_F(ShowRequestTest, Run_MainField4_MetadataTag) {
 }
 
 TEST_F(ShowRequestTest, Run_MainField1_MetadataTagWithNoFieldData) {
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
   MessageSharedPtr msg = CreateMsgParams();
 
   SharedPtr<ShowRequest> command(CreateCommand<ShowRequest>(msg));
@@ -756,8 +707,6 @@ TEST_F(ShowRequestTest, Run_MainField1_MetadataTagWithNoFieldData) {
       (*ui_command_result)[am::strings::msg_params][am::strings::result_code]
           .asInt(),
       static_cast<int32_t>(mobile_apis::Result::WARNINGS));
-
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 TEST_F(ShowRequestTest, Run_MediaClock_SUCCESS) {

--- a/src/components/application_manager/test/commands/mobile/simple_notification_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/simple_notification_commands_test.cc
@@ -58,28 +58,12 @@ namespace commands = am::commands;
 using ::testing::_;
 using ::testing::Types;
 using ::testing::Return;
-using ::testing::Mock;
-
-using am::MockMessageHelper;
 
 template <class Command>
 class MobileNotificationCommandsTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
   typedef Command CommandType;
-
- public:
-  MobileNotificationCommandsTest()
-      : message_helper_(*MockMessageHelper::message_helper_mock()) {
-    Mock::VerifyAndClearExpectations(&message_helper_);
-  }
-
-  ~MobileNotificationCommandsTest() {
-    Mock::VerifyAndClearExpectations(&message_helper_);
-  }
-
- protected:
-  MockMessageHelper& message_helper_;
 };
 
 typedef Types<commands::OnAppInterfaceUnregisteredNotification,

--- a/src/components/application_manager/test/commands/mobile/slider_test.cc
+++ b/src/components/application_manager/test/commands/mobile/slider_test.cc
@@ -59,7 +59,6 @@ using am::MockMessageHelper;
 using policy_test::MockPolicyHandlerInterface;
 using ::utils::SharedPtr;
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -82,8 +81,7 @@ class SliderRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
   SliderRequestTest()
-      : mock_message_helper_(*MockMessageHelper::message_helper_mock())
-      , mock_app_(CreateMockApp())
+      : mock_app_(CreateMockApp())
       , msg_(CreateMessage(smart_objects::SmartType_Map)) {}
 
   MessageSharedPtr CreateFullParamsUISO() {
@@ -123,10 +121,6 @@ class SliderRequestTest
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
   }
 
-  void SetUp() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
   void ExpectManageMobileCommandWithResultCode(
       const mobile_apis::Result::eType code) {
     EXPECT_CALL(
@@ -135,12 +129,8 @@ class SliderRequestTest
                             am::commands::Command::CommandOrigin::ORIGIN_SDL));
   }
 
-  void TearDown() OVERRIDE {
-    Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
   sync_primitives::Lock lock_;
 
-  MockMessageHelper& mock_message_helper_;
   MockAppPtr mock_app_;
   MessageSharedPtr msg_;
   MockPolicyHandlerInterface mock_policy_handler_;
@@ -189,7 +179,6 @@ TEST_F(SliderRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
             .asString()
             .empty());
   }
-  Mock::VerifyAndClearExpectations(&mock_message_helper_);
 }
 
 class CallOnTimeOut {

--- a/src/components/application_manager/test/commands/mobile/speak_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/speak_request_test.cc
@@ -84,16 +84,9 @@ const uint32_t kConnectionKey = 5u;
 class SpeakRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
   SpeakRequestTest()
-      : mock_message_helper_(*am::MockMessageHelper::message_helper_mock())
-      , request_(CreateMessage(smart_objects::SmartType_Map))
+      : request_(CreateMessage(smart_objects::SmartType_Map))
       , response_(CreateMessage(smart_objects::SmartType_Map))
-      , app_(CreateMockApp()) {
-    testing::Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
-  ~SpeakRequestTest() {
-    testing::Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
+      , app_(CreateMockApp()) {}
 
   void CheckExpectations(const hmi_apis::Common_Result::eType hmi_response,
                          const mobile_apis::Result::eType mobile_response,
@@ -130,7 +123,6 @@ class SpeakRequestTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
               static_cast<int32_t>(mobile_response));
   }
 
-  am::MockMessageHelper& mock_message_helper_;
   MessageSharedPtr request_;
   MessageSharedPtr response_;
   MockAppPtr app_;

--- a/src/components/application_manager/test/commands/mobile/subscribe_way_points_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/subscribe_way_points_request_test.cc
@@ -56,11 +56,9 @@ using ::testing::ReturnRef;
 using ::testing::DoAll;
 using ::testing::SaveArg;
 using ::testing::InSequence;
-using ::testing::Mock;
 namespace am = ::application_manager;
 using am::commands::SubscribeWayPointsRequest;
 using am::commands::MessageSharedPtr;
-using am::MockMessageHelper;
 
 typedef SharedPtr<SubscribeWayPointsRequest> CommandPtr;
 
@@ -106,10 +104,6 @@ TEST_F(SubscribeWayPointsRequestTest, OnEvent_SUCCESS) {
 
   event.set_smart_object(*event_msg);
 
-  MockMessageHelper* mock_message_helper =
-      MockMessageHelper::message_helper_mock();
-  Mock::VerifyAndClearExpectations(mock_message_helper);
-
   ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
 
   {
@@ -121,8 +115,6 @@ TEST_F(SubscribeWayPointsRequestTest, OnEvent_SUCCESS) {
 
   command->Init();
   command->on_event(event);
-
-  Mock::VerifyAndClearExpectations(mock_message_helper);
 }
 
 }  // namespace subscribe_way_points_request

--- a/src/components/application_manager/test/commands/mobile/system_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/system_request_test.cc
@@ -59,7 +59,6 @@ using am::event_engine::Event;
 using policy_test::MockPolicyHandlerInterface;
 using ::utils::SharedPtr;
 using ::testing::_;
-using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 

--- a/src/components/application_manager/test/commands/mobile/unregister_app_interface_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unregister_app_interface_request_test.cc
@@ -90,7 +90,7 @@ TEST_F(UnregisterAppInterfaceRequestTest, Run_SUCCESS) {
       mobile_apis::AppInterfaceUnregisteredReason::INVALID_ENUM;
 
   MessageSharedPtr dummy_msg(CreateMessage());
-  EXPECT_CALL(*am::MockMessageHelper::message_helper_mock(),
+  EXPECT_CALL(mock_message_helper_,
               GetOnAppInterfaceUnregisteredNotificationToMobile(
                   kConnectionKey, kUnregisterReason))
       .WillOnce(Return(dummy_msg));

--- a/src/components/application_manager/test/commands/mobile/unsubscribe_vehicle_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unsubscribe_vehicle_request_test.cc
@@ -91,8 +91,7 @@ TEST_F(UnsubscribeVehicleRequestTest,
       kVehicleType;
 
   am::VehicleData data;
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()), vehicle_data())
-      .WillOnce(ReturnRef(data));
+  EXPECT_CALL(mock_message_helper_, vehicle_data()).WillOnce(ReturnRef(data));
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
   MockAppPtr mock_app(CreateMockApp());
@@ -115,7 +114,7 @@ TEST_F(UnsubscribeVehicleRequestTest,
 
   am::VehicleData vehicle_data;
   vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()), vehicle_data())
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
       .WillOnce(ReturnRef(vehicle_data));
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
@@ -139,7 +138,7 @@ TEST_F(UnsubscribeVehicleRequestTest,
 
   am::VehicleData vehicle_data;
   vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()), vehicle_data())
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
       .WillOnce(ReturnRef(vehicle_data));
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
@@ -161,7 +160,7 @@ TEST_F(UnsubscribeVehicleRequestTest, Run_UnsubscribeDataDisabled_UNSUCCESS) {
 
   am::VehicleData vehicle_data;
   vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()), vehicle_data())
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
       .WillOnce(ReturnRef(vehicle_data));
   CommandPtr command(CreateCommand<UnsubscribeVehicleDataRequest>(command_msg));
 
@@ -185,7 +184,7 @@ void UnsubscribeVehicleRequestTest::UnsubscribeSuccessfully() {
   am::VehicleData vehicle_data;
   vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
 
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()), vehicle_data())
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
       .WillOnce(ReturnRef(vehicle_data));
 
   am::ApplicationSet application_set_;
@@ -228,7 +227,7 @@ TEST_F(UnsubscribeVehicleRequestTest, OnEvent_DataNotSubscribed_IGNORED) {
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillRepeatedly(Return(mock_app));
   vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
-  EXPECT_CALL(*(am::MockMessageHelper::message_helper_mock()), vehicle_data())
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
       .WillOnce(ReturnRef(vehicle_data));
   EXPECT_CALL(*mock_app, IsSubscribedToIVI(kVehicleType))
       .WillRepeatedly(Return(false));

--- a/src/components/application_manager/test/commands/mobile/unsubscribe_way_points_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/unsubscribe_way_points_request_test.cc
@@ -72,20 +72,13 @@ class UnSubscribeWayPointsRequestTest
  public:
   UnSubscribeWayPointsRequestTest()
       : command_msg_(CreateMessage(smart_objects::SmartType_Map))
-      , command_(CreateCommand<UnSubscribeWayPointsRequest>(command_msg_))
-      , mock_message_helper_(*am::MockMessageHelper::message_helper_mock()) {
+      , command_(CreateCommand<UnSubscribeWayPointsRequest>(command_msg_)) {
     (*command_msg_)[am::strings::params][am::strings::connection_key] =
         kConnectionKey;
-    testing::Mock::VerifyAndClearExpectations(&mock_message_helper_);
-  }
-
-  ~UnSubscribeWayPointsRequestTest() {
-    testing::Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }
 
   MessageSharedPtr command_msg_;
   ::utils::SharedPtr<UnSubscribeWayPointsRequest> command_;
-  am::MockMessageHelper& mock_message_helper_;
 };
 
 TEST_F(UnSubscribeWayPointsRequestTest,

--- a/src/components/application_manager/test/commands/mobile/update_turn_list_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/update_turn_list_request_test.cc
@@ -79,8 +79,7 @@ class UpdateTurnListRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
   UpdateTurnListRequestTest()
-      : mock_message_helper_(*am::MockMessageHelper::message_helper_mock())
-      , command_msg_(CreateMessage(smart_objects::SmartType_Map))
+      : command_msg_(CreateMessage(smart_objects::SmartType_Map))
       , command_(CreateCommand<UpdateTurnListRequest>(command_msg_)) {
     (*command_msg_)[am::strings::params][am::strings::connection_key] =
         kConnectionKey;
@@ -88,7 +87,6 @@ class UpdateTurnListRequestTest
         kFunctionId;
   }
 
-  am::MockMessageHelper& mock_message_helper_;
   MessageSharedPtr command_msg_;
   ::utils::SharedPtr<UpdateTurnListRequest> command_;
   TypeIf<kMocksAreNice,


### PR DESCRIPTION
**Fix SDL buid with USE_COTIRE=OFF**

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
Move mock_message_helper to the CommandsTest class and delete it in child classes


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)