### PR TITLE
Add DEPRECATED macro, and fix resulting deprecation warnings

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -837,8 +837,7 @@ class ApplicationManagerImpl
   void OnFindNewApplicationsRequest() OVERRIDE;
   void RemoveDevice(
       const connection_handler::DeviceHandle& device_handle) OVERRIDE;
-  // DEPRECATED
-  bool OnServiceStartedCallback(
+  DEPRECATED bool OnServiceStartedCallback(
       const connection_handler::DeviceHandle& device_handle,
       const int32_t& session_key,
       const protocol_handler::ServiceType& type) OVERRIDE;
@@ -1401,9 +1400,8 @@ class ApplicationManagerImpl
    * @param service_type Type of service to start
    * @return True on success, false on fail
    */
-  // DEPRECATED
-  bool StartNaviService(uint32_t app_id,
-                        protocol_handler::ServiceType service_type);
+  DEPRECATED bool StartNaviService(uint32_t app_id,
+                                   protocol_handler::ServiceType service_type);
 
   /**
    * @brief Starts specified navi service for application

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -43,9 +43,8 @@ namespace application_manager {
 namespace commands {
 
 struct ResponseInfo {
-  // DEPRECATED
-  ResponseInfo(hmi_apis::Common_Result::eType result,
-               HmiInterfaces::InterfaceID interface);
+  DEPRECATED ResponseInfo(hmi_apis::Common_Result::eType result,
+                          HmiInterfaces::InterfaceID interface);
   ResponseInfo();
   ResponseInfo(const hmi_apis::Common_Result::eType result,
                const HmiInterfaces::InterfaceID hmi_interface,

--- a/src/components/application_manager/include/application_manager/commands/mobile/alert_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/alert_request.h
@@ -72,16 +72,6 @@ class AlertRequest : public CommandRequestImpl {
    **/
   virtual void Run();
 
-  /*
-   * @brief Will caled by request controller, when default will be expired.
-   * If Alert request has soft buttons, timeout response should not be sent to
-   * mobile
-   */
-  // DEPRECATED
-  virtual void onTimeOut() {
-    CommandRequestImpl::onTimeOut();
-  }
-
   /**
    * @brief Interface method that is called whenever new event received
    *

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -107,10 +107,10 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
    * application
    * @param result_code contains result code for sending to mobile application
    * @return result for sending to mobile application.
+   * @deprecated
    */
-  // DEPRECATED
-  bool PrepareResponseParameters(mobile_apis::Result::eType& result_code,
-                                 std::string& info);
+  DEPRECATED bool PrepareResponseParameters(
+      mobile_apis::Result::eType& result_code, std::string& info);
   /**
    * @brief Prepare result code, 'success' result and info for sending
    * to mobile  application

--- a/src/components/application_manager/include/application_manager/message.h
+++ b/src/components/application_manager/include/application_manager/message.h
@@ -93,8 +93,7 @@ class Message {
   void set_correlation_id(int32_t id);
   void set_connection_key(int32_t key);
   void set_message_type(MessageType type);
-  // DEPRECATED
-  void set_binary_data(BinaryData* data);
+  DEPRECATED void set_binary_data(BinaryData* data);
   void set_binary_data(const BinaryData* data);
   void set_json_message(const std::string& json_message);
   void set_protocol_version(protocol_handler::MajorProtocolVersion version);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1166,8 +1166,7 @@ void ApplicationManagerImpl::ReplaceHMIByMobileAppId(
   }
 }
 
-// DEPRECATED
-bool ApplicationManagerImpl::StartNaviService(
+DEPRECATED bool ApplicationManagerImpl::StartNaviService(
     uint32_t app_id, protocol_handler::ServiceType service_type) {
   using namespace protocol_handler;
   LOG4CXX_AUTO_TRACE(logger_);
@@ -1338,8 +1337,9 @@ void ApplicationManagerImpl::StopNaviService(
   app->StopStreaming(service_type);
 }
 
-// DEPRECATED
-bool ApplicationManagerImpl::OnServiceStartedCallback(
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+DEPRECATED bool ApplicationManagerImpl::OnServiceStartedCallback(
     const connection_handler::DeviceHandle& device_handle,
     const int32_t& session_key,
     const protocol_handler::ServiceType& type) {
@@ -1374,6 +1374,7 @@ bool ApplicationManagerImpl::OnServiceStartedCallback(
   }
   return false;
 }
+#pragma GCC diagnostic pop
 
 void ApplicationManagerImpl::OnServiceStartedCallback(
     const connection_handler::DeviceHandle& device_handle,
@@ -2283,7 +2284,7 @@ bool ApplicationManagerImpl::ConvertSOtoMessage(
   }
 
   if (message.getElement(jhs::S_PARAMS).keyExists(strings::binary_data)) {
-    application_manager::BinaryData binaryData(
+    const application_manager::BinaryData binaryData(
         message.getElement(jhs::S_PARAMS)
             .getElement(strings::binary_data)
             .asBinary());

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1166,7 +1166,7 @@ void ApplicationManagerImpl::ReplaceHMIByMobileAppId(
   }
 }
 
-DEPRECATED bool ApplicationManagerImpl::StartNaviService(
+bool ApplicationManagerImpl::StartNaviService(
     uint32_t app_id, protocol_handler::ServiceType service_type) {
   using namespace protocol_handler;
   LOG4CXX_AUTO_TRACE(logger_);
@@ -1337,9 +1337,10 @@ void ApplicationManagerImpl::StopNaviService(
   app->StopStreaming(service_type);
 }
 
+// Suppress warning for deprecated method used within another deprecated method
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-DEPRECATED bool ApplicationManagerImpl::OnServiceStartedCallback(
+bool ApplicationManagerImpl::OnServiceStartedCallback(
     const connection_handler::DeviceHandle& device_handle,
     const int32_t& session_key,
     const protocol_handler::ServiceType& type) {

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -224,8 +224,7 @@ PerformAudioPassThruRequest::PrepareResponseParameters() {
   return response_params_;
 }
 
-// DEPRECATED
-bool PerformAudioPassThruRequest::PrepareResponseParameters(
+DEPRECATED bool PerformAudioPassThruRequest::PrepareResponseParameters(
     mobile_apis::Result::eType& result_code, std::string& info) {
   LOG4CXX_AUTO_TRACE(logger_);
   NOTREACHED();

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -224,7 +224,7 @@ PerformAudioPassThruRequest::PrepareResponseParameters() {
   return response_params_;
 }
 
-DEPRECATED bool PerformAudioPassThruRequest::PrepareResponseParameters(
+bool PerformAudioPassThruRequest::PrepareResponseParameters(
     mobile_apis::Result::eType& result_code, std::string& info) {
   LOG4CXX_AUTO_TRACE(logger_);
   NOTREACHED();

--- a/src/components/application_manager/src/message.cc
+++ b/src/components/application_manager/src/message.cc
@@ -89,7 +89,7 @@ Message& Message::operator=(const Message& message) {
   set_data_size(message.data_size_);
   set_payload_size(message.payload_size_);
   if (message.binary_data_) {
-    set_binary_data(message.binary_data_);
+    set_binary_data((const BinaryData*)message.binary_data_);
   }
   set_json_message(message.json_message_);
   set_protocol_version(message.protocol_version());
@@ -194,8 +194,7 @@ void Message::set_message_type(MessageType type) {
   type_ = type;
 }
 
-// DEPRECATED
-void Message::set_binary_data(BinaryData* data) {
+DEPRECATED void Message::set_binary_data(BinaryData* data) {
   if (NULL == data) {
     NOTREACHED();
     return;

--- a/src/components/application_manager/src/message.cc
+++ b/src/components/application_manager/src/message.cc
@@ -89,7 +89,7 @@ Message& Message::operator=(const Message& message) {
   set_data_size(message.data_size_);
   set_payload_size(message.payload_size_);
   if (message.binary_data_) {
-    set_binary_data((const BinaryData*)message.binary_data_);
+    set_binary_data(static_cast<const BinaryData*>(message.binary_data_));
   }
   set_json_message(message.json_message_);
   set_protocol_version(message.protocol_version());
@@ -194,7 +194,7 @@ void Message::set_message_type(MessageType type) {
   type_ = type;
 }
 
-DEPRECATED void Message::set_binary_data(BinaryData* data) {
+void Message::set_binary_data(BinaryData* data) {
   if (NULL == data) {
     NOTREACHED();
     return;

--- a/src/components/application_manager/src/mobile_message_handler.cc
+++ b/src/components/application_manager/src/mobile_message_handler.cc
@@ -196,9 +196,8 @@ MobileMessageHandler::HandleIncomingMessageProtocolV2(
   outgoing_message->set_payload_size(message->payload_size());
 
   if (!payload.data.empty()) {
-    BinaryData binary_payload_data(payload.data);
+    const BinaryData binary_payload_data(payload.data);
     outgoing_message->set_binary_data(&binary_payload_data);
-    outgoing_message->set_binary_data(&payload.data);
   }
   return outgoing_message.release();
 }

--- a/src/components/application_manager/test/mobile_message_handler_test.cc
+++ b/src/components/application_manager/test/mobile_message_handler_test.cc
@@ -169,7 +169,7 @@ class MobileMessageHandlerTest : public testing::Test {
       uint32_t correlation_id,
       uint32_t connection_key,
       const std::string& json_msg,
-      application_manager::BinaryData* data = NULL) {
+      const application_manager::BinaryData* data = NULL) {
     MobileMessage message = utils::MakeShared<Message>(
         MessagePriority::FromServiceType(ServiceType::kRpc));
     message->set_function_id(function_id);
@@ -256,10 +256,10 @@ TEST(mobile_message_test, basic_test) {
   MobileMessage message =
       utils::MakeShared<Message>(protocol_handler::MessagePriority::kDefault);
   EXPECT_FALSE(message->has_binary_data());
-  application_manager::BinaryData* binary_data =
-      new application_manager::BinaryData;
-  binary_data->push_back('X');
-  message->set_binary_data(binary_data);
+  application_manager::BinaryData binary_data;
+  binary_data.push_back('X');
+  message->set_binary_data(
+      (const application_manager::BinaryData*)&binary_data);
   EXPECT_TRUE(message->has_binary_data());
 }
 

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -110,9 +110,9 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
 
   /**
    * @brief Returns true, if SDL 4.0 is enabled
+   * @deprecated use max_supported_protocol_version instead
    */
-  // DEPRECATED, use max_supported_protocol_version instead
-  bool enable_protocol_4() const OVERRIDE;
+  DEPRECATED bool enable_protocol_4() const OVERRIDE;
 
   /**
    * @brief Returns application icons folder path

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -451,7 +451,7 @@ const std::string& Profile::app_resource_folder() const {
   return app_resource_folder_;
 }
 
-bool Profile::enable_protocol_4() const {
+DEPRECATED bool Profile::enable_protocol_4() const {
   return max_supported_protocol_version_ >= 4;
 }
 

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -451,7 +451,7 @@ const std::string& Profile::app_resource_folder() const {
   return app_resource_folder_;
 }
 
-DEPRECATED bool Profile::enable_protocol_4() const {
+bool Profile::enable_protocol_4() const {
   return max_supported_protocol_version_ >= 4;
 }
 

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -182,9 +182,9 @@ class ConnectionHandlerImpl
    * \param is_protected would be service protected
    * \param hash_id pointer for session hash identifier
    * \return uint32_t Id (number) of new session if successful, otherwise 0.
+   * \deprecated
    */
-  // DEPRECATED
-  virtual uint32_t OnSessionStartedCallback(
+  DEPRECATED virtual uint32_t OnSessionStartedCallback(
       const transport_manager::ConnectionUID connection_handle,
       const uint8_t session_id,
       const protocol_handler::ServiceType& service_type,
@@ -209,9 +209,18 @@ class ConnectionHandlerImpl
       const protocol_handler::ServiceType& service_type,
       const bool is_protected,
       const BsonObject* params);
-
-  // DEPRECATED
-  uint32_t OnSessionEndedCallback(
+  /**
+   * \brief Callback function used by ProtocolHandler
+   * when Mobile Application initiates session ending.
+   * \param connection_handle Connection identifier within which session exists
+   * \param sessionId Identifier of the session to be ended
+   * \param hashCode Hash used only in second version of SmartDeviceLink
+   * protocol.
+   * If not equal to hash assigned to session on start then operation fails.
+   * \return uint32_t 0 if operation fails, session key otherwise
+   * \deprecated
+   */
+  DEPRECATED uint32_t OnSessionEndedCallback(
       const transport_manager::ConnectionUID connection_handle,
       const uint8_t session_id,
       const uint32_t& hashCode,

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -284,8 +284,7 @@ bool AllowProtection(const ConnectionHandlerSettings& settings,
 }
 #endif  // ENABLE_SECURITY
 
-// DEPRECATED
-uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
+DEPRECATED uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
     const transport_manager::ConnectionUID connection_handle,
     const uint8_t session_id,
     const protocol_handler::ServiceType& service_type,
@@ -542,8 +541,7 @@ void ConnectionHandlerImpl::OnMalformedMessageCallback(
   CloseConnection(connection_handle);
 }
 
-// DEPRECATED
-uint32_t ConnectionHandlerImpl::OnSessionEndedCallback(
+DEPRECATED uint32_t ConnectionHandlerImpl::OnSessionEndedCallback(
     const transport_manager::ConnectionUID connection_handle,
     const uint8_t session_id,
     const uint32_t& hashCode,

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -284,7 +284,7 @@ bool AllowProtection(const ConnectionHandlerSettings& settings,
 }
 #endif  // ENABLE_SECURITY
 
-DEPRECATED uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
+uint32_t ConnectionHandlerImpl::OnSessionStartedCallback(
     const transport_manager::ConnectionUID connection_handle,
     const uint8_t session_id,
     const protocol_handler::ServiceType& service_type,
@@ -541,7 +541,7 @@ void ConnectionHandlerImpl::OnMalformedMessageCallback(
   CloseConnection(connection_handle);
 }
 
-DEPRECATED uint32_t ConnectionHandlerImpl::OnSessionEndedCallback(
+uint32_t ConnectionHandlerImpl::OnSessionEndedCallback(
     const transport_manager::ConnectionUID connection_handle,
     const uint8_t session_id,
     const uint32_t& hashCode,

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -1158,7 +1158,7 @@ TEST_F(ConnectionHandlerTest, SessionStop_CheckHash) {
   for (uint32_t session = 0; session < 0xFF; ++session) {
     AddTestSession();
 
-    const uint32_t hash = connection_key_;
+    uint32_t hash = connection_key_;
     uint32_t wrong_hash = hash + 1;
 
     const uint32_t end_audio_wrong_hash =
@@ -1169,7 +1169,7 @@ TEST_F(ConnectionHandlerTest, SessionStop_CheckHash) {
     CheckSessionExists(uid_, start_session_id_);
 
     const uint32_t end_audio = connection_handler_->OnSessionEndedCallback(
-        uid_, start_session_id_, hash, kRpc);
+        uid_, start_session_id_, &hash, kRpc);
     EXPECT_EQ(connection_key_, end_audio);
     CheckSessionExists(uid_, 0);
   }
@@ -1181,17 +1181,17 @@ TEST_F(ConnectionHandlerTest, SessionStop_CheckSpecificHash) {
     AddTestSession();
 
     uint32_t wrong_hash = protocol_handler::HASH_ID_WRONG;
-    const uint32_t hash = protocol_handler::HASH_ID_NOT_SUPPORTED;
+    uint32_t hash = protocol_handler::HASH_ID_NOT_SUPPORTED;
 
     const uint32_t end_audio_wrong_hash =
         connection_handler_->OnSessionEndedCallback(
-            uid_, start_session_id_, wrong_hash, kRpc);
+            uid_, start_session_id_, &wrong_hash, kRpc);
     EXPECT_EQ(0u, end_audio_wrong_hash);
     EXPECT_EQ(protocol_handler::HASH_ID_WRONG, wrong_hash);
     CheckSessionExists(uid_, start_session_id_);
 
     const uint32_t end_audio = connection_handler_->OnSessionEndedCallback(
-        uid_, start_session_id_, hash, kRpc);
+        uid_, start_session_id_, &hash, kRpc);
     EXPECT_EQ(connection_key_, end_audio);
     CheckSessionExists(uid_, 0);
   }

--- a/src/components/include/protocol_handler/protocol_handler_settings.h
+++ b/src/components/include/protocol_handler/protocol_handler_settings.h
@@ -34,8 +34,11 @@ class ProtocolHandlerSettings {
    */
   virtual uint16_t max_supported_protocol_version() const = 0;
 
-  // DEPRECATED
-  virtual bool enable_protocol_4() const = 0;
+  /*
+   * @brief Returns true, if SDL 4.0 is enabled
+   * @deprecated Use max_supported_protocol_version instead
+   */
+  DEPRECATED virtual bool enable_protocol_4() const = 0;
 
   virtual uint32_t multiframe_waiting_timeout() const = 0;
 #ifdef ENABLE_SECURITY

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -75,9 +75,9 @@ class SessionObserver {
    * \param is_protected would be service protected
    * \param hash_id pointer for session hash identifier, uint32_t* hash_id
    * \return uint32_t Id (number) of new session if successful, otherwise 0.
+   * \deprecated
    */
-  // DEPRECATED
-  virtual uint32_t OnSessionStartedCallback(
+  DEPRECATED virtual uint32_t OnSessionStartedCallback(
       const transport_manager::ConnectionUID connection_handle,
       const uint8_t sessionId,
       const protocol_handler::ServiceType& service_type,
@@ -103,8 +103,19 @@ class SessionObserver {
       const bool is_protected,
       const BsonObject* params) = 0;
 
-  // DEPRECATED
-  virtual uint32_t OnSessionEndedCallback(
+  /**
+   * \brief Callback function used by ProtocolHandler
+   * when Mobile Application initiates session ending.
+   * \param connection_handle Connection identifier within which session exists
+   * \param sessionId Identifier of the session to be ended
+   * \param hashCode Hash used only in second version of SmartDeviceLink
+   * protocol.
+   * If not equal to hash assigned to session on start then operation fails.
+   * \param service_type Type of service
+   * \return uint32_t 0 if operation fails, session key otherwise
+   * \deprecated
+   */
+  DEPRECATED virtual uint32_t OnSessionEndedCallback(
       const transport_manager::ConnectionUID connection_handle,
       const uint8_t sessionId,
       const uint32_t& hashCode,
@@ -116,7 +127,7 @@ class SessionObserver {
    * \param connection_handle Connection identifier within which session exists
    * \param sessionId Identifier of the session to be ended
    * \param hashCode Hash used only in second version of SmartDeviceLink
-   * protocol.
+   * protocol. (Set to HASH_ID_WRONG if the hash is incorrect)
    * If not equal to hash assigned to session on start then operation fails.
    * \param service_type Type of service
    * \return uint32_t 0 if operation fails, session key otherwise

--- a/src/components/include/utils/macro.h
+++ b/src/components/include/utils/macro.h
@@ -145,4 +145,22 @@
 #define FRIEND_TEST(test_case_name, test_name)
 #endif  // BUILD_TESTS
 
+/*
+* @brief deprecate a method declaration, a warning will be thrown by your
+*        compiler if a method with this macro is used
+*/
+#if __cplusplus > 201103L
+#define DEPRECATED [[deprecated]]
+#else
+#ifdef __GNUC__
+#define DEPRECATED __attribute__((deprecated))
+#define DEPRECATED_CLASS __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#define DEPRECATED __declspec(deprecated)
+#else
+#pragma message("WARNING: You need to implement DEPRECATED for this compiler")
+#define DEPRECATED
+#endif
+#endif
+
 #endif  // SRC_COMPONENTS_INCLUDE_UTILS_MACRO_H_

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -553,8 +553,8 @@ class ProtocolHandlerImpl
 
   RESULT_CODE HandleControlMessageEndServiceACK(const ProtocolPacket& packet);
 
-  // DEPRECATED
-  RESULT_CODE HandleControlMessageStartSession(const ProtocolPacket& packet);
+  DEPRECATED RESULT_CODE
+  HandleControlMessageStartSession(const ProtocolPacket& packet);
 
   RESULT_CODE HandleControlMessageStartSession(const ProtocolFramePtr packet);
 

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1307,9 +1307,10 @@ class StartSessionHandler : public security_manager::SecurityManagerListener {
 }  // namespace
 #endif  // ENABLE_SECURITY
 
+// Suppress warning for deprecated method used within another deprecated method
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-DEPRECATED RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(
+RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(
     const ProtocolPacket& packet) {
   LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_DEBUG(

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1173,12 +1173,12 @@ RESULT_CODE ProtocolHandlerImpl::HandleControlMessageEndServiceACK(
   LOG4CXX_AUTO_TRACE(logger_);
 
   const uint8_t current_session_id = packet.session_id();
-  const uint32_t hash_id = get_hash_id(packet);
+  uint32_t hash_id = get_hash_id(packet);
   const ServiceType service_type = ServiceTypeFromByte(packet.service_type());
   const ConnectionID connection_id = packet.connection_id();
 
   const uint32_t session_key = session_observer_.OnSessionEndedCallback(
-      connection_id, current_session_id, hash_id, service_type);
+      connection_id, current_session_id, &hash_id, service_type);
 
   if (0 == session_key) {
     LOG4CXX_WARN(logger_, "Refused to end service");
@@ -1307,8 +1307,9 @@ class StartSessionHandler : public security_manager::SecurityManagerListener {
 }  // namespace
 #endif  // ENABLE_SECURITY
 
-// DEPRECATED
-RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+DEPRECATED RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(
     const ProtocolPacket& packet) {
   LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_DEBUG(
@@ -1461,6 +1462,7 @@ RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(
   }
   return RESULT_OK;
 }
+#pragma GCC diagnostic pop
 
 RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(
     const ProtocolFramePtr packet) {
@@ -1895,11 +1897,11 @@ RESULT_CODE ProtocolHandlerImpl::EncryptFrame(ProtocolFramePtr packet) {
         connection_key,
         security_manager::SecurityManager::ERROR_ENCRYPTION_FAILED,
         error_text);
+
+    uint32_t hash_id = packet->message_id();
     // Close session to prevent usage unprotected service/session
-    session_observer_.OnSessionEndedCallback(packet->connection_id(),
-                                             packet->session_id(),
-                                             packet->message_id(),
-                                             kRpc);
+    session_observer_.OnSessionEndedCallback(
+        packet->connection_id(), packet->session_id(), &hash_id, kRpc);
     return RESULT_OK;
   }
   LOG4CXX_DEBUG(logger_,
@@ -1948,11 +1950,11 @@ RESULT_CODE ProtocolHandlerImpl::DecryptFrame(ProtocolFramePtr packet) {
         connection_key,
         security_manager::SecurityManager::ERROR_DECRYPTION_FAILED,
         error_text);
+
+    uint32_t hash_id = packet->message_id();
     // Close session to prevent usage unprotected service/session
-    session_observer_.OnSessionEndedCallback(packet->connection_id(),
-                                             packet->session_id(),
-                                             packet->message_id(),
-                                             kRpc);
+    session_observer_.OnSessionEndedCallback(
+        packet->connection_id(), packet->session_id(), &hash_id, kRpc);
     return RESULT_ENCRYPTION_FAILED;
   }
   LOG4CXX_DEBUG(logger_,

--- a/src/components/remote_control/test/src/rc_module_test.cc
+++ b/src/components/remote_control/test/src/rc_module_test.cc
@@ -169,7 +169,8 @@ TEST_F(RCModuleTest, ProcessMessagePass) {
   application_manager::BinaryData* data = &buf;
   data->push_back(1);
 
-  message_->set_binary_data((const application_manager::BinaryData*)data);
+  message_->set_binary_data(
+      static_cast<const application_manager::BinaryData*>(data));
 
   Json::Value json_value = MessageHelper::StringToValue(json);
   Json::Value module_type =

--- a/src/components/remote_control/test/src/rc_module_test.cc
+++ b/src/components/remote_control/test/src/rc_module_test.cc
@@ -169,7 +169,7 @@ TEST_F(RCModuleTest, ProcessMessagePass) {
   application_manager::BinaryData* data = &buf;
   data->push_back(1);
 
-  message_->set_binary_data(data);
+  message_->set_binary_data((const application_manager::BinaryData*)data);
 
   Json::Value json_value = MessageHelper::StringToValue(json);
   Json::Value module_type =

--- a/src/components/telemetry_monitor/include/telemetry_monitor/telemetry_monitor.h
+++ b/src/components/telemetry_monitor/include/telemetry_monitor/telemetry_monitor.h
@@ -92,8 +92,7 @@ class TelemetryMonitor {
   virtual void Stop();
   virtual void Start();
   virtual void SendMetric(utils::SharedPtr<MetricWrapper> metric);
-  // DEPRECATED
-  void set_streamer(Streamer* streamer);
+  DEPRECATED void set_streamer(Streamer* streamer);
   void set_streamer(utils::SharedPtr<Streamer> streamer);
   const std::string& ip() const;
   int16_t port() const;

--- a/src/components/telemetry_monitor/src/telemetry_monitor.cc
+++ b/src/components/telemetry_monitor/src/telemetry_monitor.cc
@@ -64,8 +64,7 @@ void TelemetryMonitor::Start() {
   thread_ = threads::CreateThread("TelemetryMonitor", streamer_.get());
 }
 
-// DEPRECATED
-void TelemetryMonitor::set_streamer(Streamer* streamer) {}
+DEPRECATED void TelemetryMonitor::set_streamer(Streamer* streamer) {}
 
 void TelemetryMonitor::set_streamer(utils::SharedPtr<Streamer> streamer) {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/telemetry_monitor/src/telemetry_monitor.cc
+++ b/src/components/telemetry_monitor/src/telemetry_monitor.cc
@@ -64,7 +64,7 @@ void TelemetryMonitor::Start() {
   thread_ = threads::CreateThread("TelemetryMonitor", streamer_.get());
 }
 
-DEPRECATED void TelemetryMonitor::set_streamer(Streamer* streamer) {}
+void TelemetryMonitor::set_streamer(Streamer* streamer) {}
 
 void TelemetryMonitor::set_streamer(utils::SharedPtr<Streamer> streamer) {
   LOG4CXX_AUTO_TRACE(logger_);


### PR DESCRIPTION
Fixes #1758 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
- Added DEPRECATED macro
- Marked all deprecated methods with this new macro
- Fixed any warnings resulting from the use of this new macro

### Changelog

##### Enhancements
* Added DEPRECATED macro. A warning is generated whenever a method marked with this macro is used. 
    * NOTE: because of other warnings in the project without moving to the next c++ standard, the `-Wno-deprecated-declarations` flag is still used in building. This needs to be removed to see the new warnings generated by the DEPRECATED macro.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)