### PR TITLE
Changes implementation of iAP2 transport adapter emulation

### DIFF
--- a/src/components/transport_manager/include/transport_manager/iap2_emulation/iap2_transport_adapter.h
+++ b/src/components/transport_manager/include/transport_manager/iap2_emulation/iap2_transport_adapter.h
@@ -127,7 +127,7 @@ class IAP2USBEmulationTransportAdapter : public TcpTransportAdapter {
      * @brief IAPSignalHandlerDelegate Constructor
      * @param adapter Pointer to iAP2 USB adapter
      */
-    IAPSignalHandlerDelegate(IAP2USBEmulationTransportAdapter* adapter);
+    IAPSignalHandlerDelegate(IAP2USBEmulationTransportAdapter& adapter);
 
     /**
      * @brief threadMain Main loop to track incoming signals
@@ -140,8 +140,19 @@ class IAP2USBEmulationTransportAdapter : public TcpTransportAdapter {
     void exitThreadMain() OVERRIDE;
 
     private:
-    IAP2USBEmulationTransportAdapter* adapter_;
+    /**
+     * @brief adapter_ Reference to owning adapter
+     */
+    IAP2USBEmulationTransportAdapter& adapter_;
+
+    /**
+     * @brief run_flag_ Flag defines whether main loop is active
+     */
     bool run_flag_;
+
+    /**
+     * @brief in_ Input signals channel descriptor
+     */
     int in_;
   };
 

--- a/src/components/transport_manager/include/transport_manager/iap2_emulation/iap2_transport_adapter.h
+++ b/src/components/transport_manager/include/transport_manager/iap2_emulation/iap2_transport_adapter.h
@@ -116,13 +116,13 @@ class IAP2USBEmulationTransportAdapter : public TcpTransportAdapter {
    */
   DeviceType GetDeviceType() const OVERRIDE;
 
-  private:
+ private:
   /**
    * @brief The IAPSignalHandlerDelegate class handles signals from the system
    * to start transport switching flow
    */
   class IAPSignalHandlerDelegate : public threads::ThreadDelegate {
-    public:
+   public:
     /**
      * @brief IAPSignalHandlerDelegate Constructor
      * @param adapter Pointer to iAP2 USB adapter
@@ -139,7 +139,7 @@ class IAP2USBEmulationTransportAdapter : public TcpTransportAdapter {
      */
     void exitThreadMain() OVERRIDE;
 
-    private:
+   private:
     /**
      * @brief adapter_ Reference to owning adapter
      */

--- a/src/components/transport_manager/include/transport_manager/iap2_emulation/iap2_transport_adapter.h
+++ b/src/components/transport_manager/include/transport_manager/iap2_emulation/iap2_transport_adapter.h
@@ -36,6 +36,11 @@
 #include "transport_manager/transport_manager_settings.h"
 #include "resumption/last_state.h"
 #include "utils/macro.h"
+#include "utils/threads/thread_delegate.h"
+
+namespace threads {
+class Thread;
+}
 
 namespace transport_manager {
 namespace transport_adapter {
@@ -93,8 +98,13 @@ class IAP2USBEmulationTransportAdapter : public TcpTransportAdapter {
                                    const TransportManagerSettings& settings);
 
   /**
+    * Destructor
+    */
+  ~IAP2USBEmulationTransportAdapter();
+
+  /**
    * @brief DeviceSwitched is called during switching from iAP2 Bluetooth to
-   * iAP2 USB transport
+   * iAP2 USB transport. Sends ACK signal for switching request.
    * @param device_handle Device handle of switched device
    */
   void DeviceSwitched(const DeviceUID& device_handle) OVERRIDE;
@@ -105,6 +115,38 @@ class IAP2USBEmulationTransportAdapter : public TcpTransportAdapter {
    * @return Device type
    */
   DeviceType GetDeviceType() const OVERRIDE;
+
+  private:
+  /**
+   * @brief The IAPSignalHandlerDelegate class handles signals from the system
+   * to start transport switching flow
+   */
+  class IAPSignalHandlerDelegate : public threads::ThreadDelegate {
+    public:
+    /**
+     * @brief IAPSignalHandlerDelegate Constructor
+     * @param adapter Pointer to iAP2 USB adapter
+     */
+    IAPSignalHandlerDelegate(IAP2USBEmulationTransportAdapter* adapter);
+
+    /**
+     * @brief threadMain Main loop to track incoming signals
+     */
+    void threadMain() OVERRIDE;
+
+    /**
+     * @brief exitThreadMain Stops main loop
+     */
+    void exitThreadMain() OVERRIDE;
+
+    private:
+    IAP2USBEmulationTransportAdapter* adapter_;
+    bool run_flag_;
+    int in_;
+  };
+
+  threads::Thread* signal_handler_;
+  int out_;
 };
 }
 }  // namespace transport_manager::transport_adapter

--- a/src/components/transport_manager/include/transport_manager/tcp/tcp_device.h
+++ b/src/components/transport_manager/include/transport_manager/tcp/tcp_device.h
@@ -66,6 +66,18 @@ class TcpDevice : public Device {
    **/
   TcpDevice(const in_addr_t& in_addr, const std::string& name);
 
+ #if defined (BUILD_TESTS)
+  /**
+   * @brief TcpDevice
+   * @param in_addr IP address of device
+   * @param device_uid Unique device id
+   * @param transport_switch_id Id used for transport switching
+   */
+  TcpDevice(const in_addr_t& in_addr,
+            const std::string& device_uid,
+            const std::string& transport_switch_id);
+#endif
+
   virtual ~TcpDevice();
 
   /**

--- a/src/components/transport_manager/include/transport_manager/tcp/tcp_device.h
+++ b/src/components/transport_manager/include/transport_manager/tcp/tcp_device.h
@@ -66,7 +66,7 @@ class TcpDevice : public Device {
    **/
   TcpDevice(const in_addr_t& in_addr, const std::string& name);
 
- #if defined (BUILD_TESTS)
+#if defined(BUILD_TESTS)
   /**
    * @brief TcpDevice
    * @param in_addr IP address of device

--- a/src/components/transport_manager/src/iap2_emulation/iap2_transport_adapter.cc
+++ b/src/components/transport_manager/src/iap2_emulation/iap2_transport_adapter.cc
@@ -41,11 +41,11 @@
 #include "utils/threads/thread.h"
 #include "utils/file_system.h"
 
-namespace  {
+namespace {
 static const mode_t mode = 0666;
 static const auto in_signals_channel = "iap_signals_in";
 static const auto out_signals_channel = "iap_signals_out";
-} // namespace
+}  // namespace
 
 namespace transport_manager {
 namespace transport_adapter {
@@ -75,8 +75,7 @@ IAP2USBEmulationTransportAdapter::IAP2USBEmulationTransportAdapter(
     const TransportManagerSettings& settings)
     : TcpTransportAdapter(port, last_state, settings), out_(0) {
   auto delegate = new IAPSignalHandlerDelegate(*this);
-  signal_handler_ =
-      threads::CreateThread("iAP signal handler", delegate);
+  signal_handler_ = threads::CreateThread("iAP signal handler", delegate);
   signal_handler_->start();
   const auto result = mkfifo(out_signals_channel, mode);
   LOG4CXX_DEBUG(logger_, "Out signals channel creation result: " << result);
@@ -84,7 +83,7 @@ IAP2USBEmulationTransportAdapter::IAP2USBEmulationTransportAdapter(
 
 IAP2USBEmulationTransportAdapter::~IAP2USBEmulationTransportAdapter() {
   signal_handler_->join();
-  threads::DeleteThread(signal_handler_);  
+  threads::DeleteThread(signal_handler_);
   LOG4CXX_DEBUG(logger_, "Out close result: " << close(out_));
   LOG4CXX_DEBUG(logger_, "Out unlink result: " << unlink(out_signals_channel));
 }
@@ -110,12 +109,9 @@ DeviceType IAP2USBEmulationTransportAdapter::GetDeviceType() const {
   return IOS_USB;
 }
 
-IAP2USBEmulationTransportAdapter::
-IAPSignalHandlerDelegate::IAPSignalHandlerDelegate(
-    IAP2USBEmulationTransportAdapter& adapter)
-  : adapter_(adapter),
-    run_flag_(true),
-    in_(0) {
+IAP2USBEmulationTransportAdapter::IAPSignalHandlerDelegate::
+    IAPSignalHandlerDelegate(IAP2USBEmulationTransportAdapter& adapter)
+    : adapter_(adapter), run_flag_(true), in_(0) {
   const auto result = mkfifo(in_signals_channel, mode);
   LOG4CXX_DEBUG(logger_, "In signals channel creation result: " << result);
 }
@@ -145,14 +141,13 @@ void IAP2USBEmulationTransportAdapter::IAPSignalHandlerDelegate::threadMain() {
   }
 }
 
-void IAP2USBEmulationTransportAdapter::
-IAPSignalHandlerDelegate::exitThreadMain() {
+void IAP2USBEmulationTransportAdapter::IAPSignalHandlerDelegate::
+    exitThreadMain() {
   LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_DEBUG(logger_, "Stopping signal handling.");
   run_flag_ = false;
   LOG4CXX_DEBUG(logger_, "In close result: " << close(in_));
   LOG4CXX_DEBUG(logger_, "In unlink result: " << unlink(in_signals_channel));
 }
-
 }
 }  // namespace transport_manager::transport_adapter

--- a/src/components/transport_manager/src/iap2_emulation/iap2_transport_adapter.cc
+++ b/src/components/transport_manager/src/iap2_emulation/iap2_transport_adapter.cc
@@ -102,6 +102,7 @@ void IAP2USBEmulationTransportAdapter::DeviceSwitched(
 
   const auto bytes =
       write(out_, switch_signal_ack.c_str(), switch_signal_ack.size());
+  UNUSED(bytes);
   LOG4CXX_DEBUG(logger_, "Written bytes to out: " << bytes);
 
   LOG4CXX_DEBUG(logger_, "Switching signal ACK is sent");
@@ -131,6 +132,7 @@ void IAP2USBEmulationTransportAdapter::IAPSignalHandlerDelegate::threadMain() {
   const auto size = 32;
   while (run_flag_) {
     char buffer[size];
+    // TODO: maybe need to check errno
     auto bytes = read(in_, &buffer, size);
     if (!bytes) {
       continue;

--- a/src/components/transport_manager/src/tcp/tcp_client_listener.cc
+++ b/src/components/transport_manager/src/tcp/tcp_client_listener.cc
@@ -235,9 +235,16 @@ void TcpClientListener::Loop() {
     if (enable_keepalive_) {
       SetKeepaliveOptions(connection_fd);
     }
-
+#if defined (BUILD_TESTS)
+    const auto device_uid = device_name +
+        std::string(":") +
+        std::to_string(port_);
+    TcpDevice* tcp_device =
+        new TcpDevice(client_address.sin_addr.s_addr, device_uid, device_name);
+#else
     TcpDevice* tcp_device =
         new TcpDevice(client_address.sin_addr.s_addr, device_name);
+#endif // BUILD_TESTS
     DeviceSptr device = controller_->AddDevice(tcp_device);
     tcp_device = static_cast<TcpDevice*>(device.get());
     const ApplicationHandle app_handle =

--- a/src/components/transport_manager/src/tcp/tcp_client_listener.cc
+++ b/src/components/transport_manager/src/tcp/tcp_client_listener.cc
@@ -235,16 +235,15 @@ void TcpClientListener::Loop() {
     if (enable_keepalive_) {
       SetKeepaliveOptions(connection_fd);
     }
-#if defined (BUILD_TESTS)
-    const auto device_uid = device_name +
-        std::string(":") +
-        std::to_string(port_);
+#if defined(BUILD_TESTS)
+    const auto device_uid =
+        device_name + std::string(":") + std::to_string(port_);
     TcpDevice* tcp_device =
         new TcpDevice(client_address.sin_addr.s_addr, device_uid, device_name);
 #else
     TcpDevice* tcp_device =
         new TcpDevice(client_address.sin_addr.s_addr, device_name);
-#endif // BUILD_TESTS
+#endif  // BUILD_TESTS
     DeviceSptr device = controller_->AddDevice(tcp_device);
     tcp_device = static_cast<TcpDevice*>(device.get());
     const ApplicationHandle app_handle =

--- a/src/components/transport_manager/src/tcp/tcp_device.cc
+++ b/src/components/transport_manager/src/tcp/tcp_device.cc
@@ -46,22 +46,22 @@ TcpDevice::TcpDevice(const in_addr_t& in_addr, const std::string& name)
   LOG4CXX_AUTO_TRACE(logger_);
 }
 
-#if defined (BUILD_TESTS)
+#if defined(BUILD_TESTS)
 TcpDevice::TcpDevice(const in_addr_t& in_addr,
                      const std::string& device_uid,
                      const std::string& transport_switch_id)
-  : Device(device_uid, device_uid, transport_switch_id),
-    applications_mutex_(),
-    in_addr_(in_addr),
-    last_handle_(0) {
+    : Device(device_uid, device_uid, transport_switch_id)
+    , applications_mutex_()
+    , in_addr_(in_addr)
+    , last_handle_(0) {
   LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_DEBUG(logger_,
                 "Device created with transport switch emulation support.");
   LOG4CXX_DEBUG(logger_,
-                "Device parameters: " << device_uid
-                << " / " << transport_switch_id);
+                "Device parameters: " << device_uid << " / "
+                                      << transport_switch_id);
 }
-#endif // BUILD_TESTS
+#endif  // BUILD_TESTS
 
 bool TcpDevice::IsSameAs(const Device* other) const {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/transport_manager/src/tcp/tcp_device.cc
+++ b/src/components/transport_manager/src/tcp/tcp_device.cc
@@ -46,6 +46,23 @@ TcpDevice::TcpDevice(const in_addr_t& in_addr, const std::string& name)
   LOG4CXX_AUTO_TRACE(logger_);
 }
 
+#if defined (BUILD_TESTS)
+TcpDevice::TcpDevice(const in_addr_t& in_addr,
+                     const std::string& device_uid,
+                     const std::string& transport_switch_id)
+  : Device(device_uid, device_uid, transport_switch_id),
+    applications_mutex_(),
+    in_addr_(in_addr),
+    last_handle_(0) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(logger_,
+                "Device created with transport switch emulation support.");
+  LOG4CXX_DEBUG(logger_,
+                "Device parameters: " << device_uid
+                << " / " << transport_switch_id);
+}
+#endif // BUILD_TESTS
+
 bool TcpDevice::IsSameAs(const Device* other) const {
   LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_DEBUG(logger_, "Device: " << other);


### PR DESCRIPTION
New implementation considers external switching flow triggering so no
implementation includes separate thread which manages incoming signals
and starts the flow. Also ACK is being sent back to the system.