### PR TITLE
prevent deadlocks in EventDispatcherImpl::raise_event

### DIFF
--- a/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
+++ b/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
@@ -45,8 +45,10 @@ EventDispatcherImpl::EventDispatcherImpl()
 EventDispatcherImpl::~EventDispatcherImpl() {}
 
 void EventDispatcherImpl::raise_event(const Event& event) {
+  AutoLock observer_lock(observer_lock_);
   {
-    AutoLock auto_lock(state_lock_);
+    AutoLock state_lock(state_lock_);
+
     // check if event is notification
     if (hmi_apis::messageType::notification == event.smart_object_type()) {
       const uint32_t notification_correlation_id = 0;
@@ -61,12 +63,10 @@ void EventDispatcherImpl::raise_event(const Event& event) {
   }
 
   // Call observers
-  EventObserver* temp;
   while (!observers_.empty()) {
-    observer_lock_.Acquire();
-    temp = *observers_.begin();
+    EventObserver* temp = *observers_.begin();
     observers_.erase(observers_.begin());
-    observer_lock_.Release();
+    AutoUnlock unlock_observer(observer_lock);
     temp->on_event(event);
   }
 }


### PR DESCRIPTION
Fixes #1949 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
unlock the observers_lock_ before calling EventObserver::on_event

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)