### PR TITLE
remove deadlock danger when removing Connections from a ConnectionMap

### DIFF
--- a/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
+++ b/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
@@ -491,6 +491,16 @@ class TransportAdapterImpl : public TransportAdapter,
   TransportAdapter::Error ConnectDevice(DeviceSptr device);
 
   /**
+   * @brief Remove a connection from the list without triggering
+   *the connection's destructor inside of a list lock
+   *
+   * @param device_handle Device unique identifier.
+   * @param app_handle Handle of application.
+   */
+  void RemoveConnection(const DeviceUID& device_id, 
+                        const ApplicationHandle& app_handle);
+
+  /**
    * @brief Remove specified device
    * @param device_handle Device unique identifier.
    */


### PR DESCRIPTION
Fixes #1951 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
Created a new "RemoveConnection" method which safely removes a Connection object from the ConnectionMap.  Before calling "erase" on the connection object, the object's ref-count is incremented by assigning it to a local "ConnectionSPtr" variable. We then call "erase", NOT triggering the destructor, then release the "connections_lock_", and then let the local variable go out of scope, thus delaying the destructor until after the lock was released.

### CLA
- [X ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)