### PR TITLE
protect access to ResumptionDataJson during state save

### DIFF
--- a/src/components/application_manager/src/resumption/resumption_data_json.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_json.cc
@@ -480,6 +480,9 @@ bool ResumptionDataJson::DropAppDataResumption(const std::string& device_id,
 }
 
 void ResumptionDataJson::Persist() {
+  // We lock the resumption data because SaveStateToFileSystem accesses
+  // the same dictionary that we use here in ResumptionDataJson
+  sync_primitives::AutoLock autolock(resumption_lock_);
   last_state().SaveStateToFileSystem();
 }
 


### PR DESCRIPTION
Fixes #1953 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
Protect access to the ResumptionDataJson while saving to the file system

### CLA
- [X ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)