### PR TITLE
Fixes random SDL crash on USB disconnect

### DIFF
--- a/src/components/transport_manager/src/usb/libusb/usb_connection.cc
+++ b/src/components/transport_manager/src/usb/libusb/usb_connection.cc
@@ -81,6 +81,7 @@ UsbConnection::~UsbConnection() {
   LOG4CXX_TRACE(logger_, "enter with this" << this);
   Finalise();
   libusb_free_transfer(in_transfer_);
+  libusb_free_transfer(out_transfer_);
   delete[] in_buffer_;
   LOG4CXX_TRACE(logger_, "exit");
 }
@@ -292,9 +293,10 @@ void UsbConnection::Finalise() {
 
 void UsbConnection::AbortConnection() {
   LOG4CXX_TRACE(logger_, "enter");
+  Finalise();
   controller_->ConnectionAborted(
       device_uid_, app_handle_, CommunicationError());
-  Disconnect();
+  controller_->DisconnectDone(device_uid_, app_handle_);
   LOG4CXX_TRACE(logger_, "exit");
 }
 


### PR DESCRIPTION
Fixes #[1854](https://github.com/SmartDeviceLink/sdl_core/issues/1854)

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
Whenever USB device is unplugged there are several concurrent threads
that can remove USB connection instance: call from connection instance to
DisconnectDone() interface while aborting connection and call to
RemoveFinalizedConnections() while processing unexpected disconnect
event. Previously USB connection instance was marking itself as
"finalized" while calling AbortConnection() and than yield execution
because of cancelling the data transfer so the same connection was
being deleted from another thread during RemoveFinalizedConnection()
call which was causing consequent calls to instance members invalid.
To fix the issue order is changed so cancelling of transfer is being
done first and only after that connection is being marked as "finalized"
so it can be safely deleted either from RemoveFinalizedConnection() or
by calling DisconnectDone() in controller (TransportAdapterImpl).

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)