### PR TITLE
Fix/sdl doesnt send generic error if hmi doesnt respond during default timeout plus rp cs internal timeout

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/mobile/alert_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/alert_request.h
@@ -89,7 +89,6 @@ class AlertRequest : public CommandRequestImpl {
    */
   void on_event(const event_engine::Event& event);
 
- protected:
  private:
   /*
    * @brief Checks if request parameters are valid
@@ -102,7 +101,7 @@ class AlertRequest : public CommandRequestImpl {
    *
    * @param app_id Id of application requested this RPC
    */
-  void SendAlertRequest(int32_t app_id);
+  void SendAlertRequest(const int32_t app_id);
 
   /*
    * @brief Sends TTS Speak request

--- a/src/components/application_manager/src/commands/mobile/scrollable_message_request.cc
+++ b/src/components/application_manager/src/commands/mobile/scrollable_message_request.cc
@@ -54,15 +54,11 @@ ScrollableMessageRequest::ScrollableMessageRequest(
 ScrollableMessageRequest::~ScrollableMessageRequest() {}
 
 bool ScrollableMessageRequest::Init() {
-  /* Timeout in milliseconds.
-     If omitted a standard value of 10000 milliseconds is used.*/
-  if ((*message_)[strings::msg_params].keyExists(strings::timeout)) {
-    default_timeout_ =
-        (*message_)[strings::msg_params][strings::timeout].asUInt();
-  } else {
-    const int32_t def_value = 30000;
-    default_timeout_ = def_value;
-  }
+  LOG4CXX_AUTO_TRACE(logger_);
+  // Timeout in milliseconds.
+  // Standard value of 10000 ms(from .ini file) + RPC own default value is used.
+  default_timeout_ +=
+      (*message_)[strings::msg_params][strings::timeout].asUInt();
 
   return true;
 }
@@ -120,8 +116,10 @@ void ScrollableMessageRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_OnResetTimeout: {
       LOG4CXX_INFO(logger_, "Received UI_OnResetTimeout event");
+      const uint32_t new_timeout =
+          application_manager_.get_settings().default_timeout();
       application_manager_.updateRequestTimeout(
-          connection_key(), correlation_id(), default_timeout());
+          connection_key(), correlation_id(), new_timeout);
       break;
     }
     case hmi_apis::FunctionID::UI_ScrollableMessage: {

--- a/src/components/application_manager/src/commands/mobile/slider_request.cc
+++ b/src/components/application_manager/src/commands/mobile/slider_request.cc
@@ -51,13 +51,11 @@ SliderRequest::SliderRequest(const MessageSharedPtr& message,
 SliderRequest::~SliderRequest() {}
 
 bool SliderRequest::Init() {
-  /* Timeout in milliseconds.
-     If omitted a standard value of 10000 milliseconds is used.*/
-  if ((*message_)[strings::msg_params].keyExists(strings::timeout)) {
-    default_timeout_ =
-        application_manager_.get_settings().default_timeout() +
-        (*message_)[strings::msg_params][strings::timeout].asUInt();
-  }
+  LOG4CXX_AUTO_TRACE(logger_);
+  // Timeout in milliseconds.
+  // Standard value of 10000 ms(from .ini file) + RPC own default value is used.
+  default_timeout_ +=
+      (*message_)[strings::msg_params][strings::timeout].asUInt();
 
   return true;
 }
@@ -122,8 +120,10 @@ void SliderRequest::on_event(const event_engine::Event& event) {
   const event_engine::Event::EventID event_id = event.id();
   if (event_id == FunctionID::UI_OnResetTimeout) {
     LOG4CXX_INFO(logger_, "Received UI_OnResetTimeout event");
+    const uint32_t new_timeout =
+        application_manager_.get_settings().default_timeout();
     application_manager_.updateRequestTimeout(
-        connection_key(), correlation_id(), default_timeout());
+        connection_key(), correlation_id(), new_timeout);
     return;
   }
 

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -155,10 +155,10 @@ RequestController::TResult RequestController::addMobileRequest(
     cond_var_.NotifyOne();
     return INVALID_DATA;
   }
-  LOG4CXX_DEBUG(
-      logger_,
-      "correlation_id : " << request->correlation_id()
-                          << "connection_key : " << request->connection_key());
+  LOG4CXX_DEBUG(logger_,
+                "correlation_id : " << request->correlation_id()
+                                    << " , connection_key : "
+                                    << request->connection_key());
   RequestController::TResult result = CheckPosibilitytoAdd(request, hmi_level);
   if (SUCCESS == result) {
     AutoLock auto_lock_list(mobile_request_list_lock_);
@@ -325,14 +325,12 @@ void RequestController::updateRequestTimeout(const uint32_t& app_id,
 
   LOG4CXX_DEBUG(logger_,
                 "app_id : " << app_id
-                            << " mobile_correlation_id : " << correlation_id
-                            << " new_timeout : " << new_timeout);
-  LOG4CXX_DEBUG(logger_,
-                "New_timeout is NULL. RequestCtrl will "
-                "not manage this request any more");
+                            << " , mobile_correlation_id : " << correlation_id
+                            << " , new_timeout : " << new_timeout);
 
   RequestInfoPtr request_info =
       waiting_for_response_.Find(app_id, correlation_id);
+
   if (request_info) {
     waiting_for_response_.RemoveRequest(request_info);
     request_info->updateTimeOut(new_timeout);

--- a/src/components/application_manager/test/commands/mobile/scrollable_message_test.cc
+++ b/src/components/application_manager/test/commands/mobile/scrollable_message_test.cc
@@ -180,15 +180,8 @@ TEST_F(ScrollableMessageRequestTest, Init_CorrectTimeout_SUCCESS) {
       mobile_apis::InteractionMode::MANUAL_ONLY;
   EXPECT_EQ(kDefaultTimeout_, command_->default_timeout());
   command_->Init();
-  EXPECT_EQ(kTimeOut, command_->default_timeout());
-}
-
-TEST_F(ScrollableMessageRequestTest, Init_CorrectTimeout_UNSUCCESS) {
-  (*msg_)[msg_params][interaction_mode] =
-      mobile_apis::InteractionMode::MANUAL_ONLY;
-  EXPECT_EQ(kDefaultTimeout_, command_->default_timeout());
-  command_->Init();
-  EXPECT_EQ(kTimeOut, command_->default_timeout());
+  const uint32_t result_timeout = kTimeOut + kDefaultTimeout_;
+  EXPECT_EQ(result_timeout, command_->default_timeout());
 }
 
 TEST_F(ScrollableMessageRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {
@@ -248,9 +241,13 @@ TEST_F(ScrollableMessageRequestTest,
        OnEvent_ReceivedUIOnResetTimeoutEvent_SUCCESS) {
   (*msg_)[params][connection_key] = kConnectionKey;
   (*msg_)[params][correlation_id] = kCorrelationId;
-  EXPECT_CALL(
-      app_mngr_,
-      updateRequestTimeout(kConnectionKey, kCorrelationId, kDefaultTimeout_));
+  // 100 is default timeout value from CommandTest
+  const uint32_t default_cmd_timeout = 100u;
+  EXPECT_CALL(app_mngr_,
+              updateRequestTimeout(
+                  kConnectionKey, kCorrelationId, default_cmd_timeout));
+  EXPECT_CALL(app_mngr_settings_, default_timeout())
+      .WillOnce(ReturnRef(default_cmd_timeout));
   Event event(hmi_apis::FunctionID::UI_OnResetTimeout);
   event.set_smart_object(*msg_);
   command_->on_event(event);


### PR DESCRIPTION
Fixes #1880 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
Updated appropriate unit tests

### Summary
- Fixed final timeout calculation for RPCs with own timeout

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)