### PR TITLE
Fix session heartbeat starting

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -573,12 +573,6 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
           message[strings::params][strings::protocol_version].asInt());
   application->set_protocol_version(protocol_version);
 
-  if (protocol_handler::MajorProtocolVersion::PROTOCOL_VERSION_UNKNOWN !=
-      protocol_version) {
-    connection_handler().BindProtocolVersionWithSession(
-        connection_key, static_cast<uint8_t>(protocol_version));
-  }
-
   // Keep HMI add id in case app is present in "waiting for registration" list
   apps_to_register_list_lock_.Acquire();
   AppsWaitRegistrationSet::iterator it = apps_to_register_.find(application);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -578,11 +578,6 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
     connection_handler().BindProtocolVersionWithSession(
         connection_key, static_cast<uint8_t>(protocol_version));
   }
-  if ((protocol_version ==
-       protocol_handler::MajorProtocolVersion::PROTOCOL_VERSION_3) &&
-      (get_settings().heart_beat_timeout() != 0)) {
-    connection_handler().StartSessionHeartBeat(connection_key);
-  }
 
   // Keep HMI add id in case app is present in "waiting for registration" list
   apps_to_register_list_lock_.Acquire();

--- a/src/components/connection_handler/include/connection_handler/connection.h
+++ b/src/components/connection_handler/include/connection_handler/connection.h
@@ -229,6 +229,14 @@ class Connection {
   void KeepAlive(uint8_t session_id);
 
   /**
+   * @brief Check is heartbeat monitoring started for specified session
+   * @param  session_id session id
+   * @return returns true if heartbeat monitoring started for specified session
+   * otherwise returns false
+   */
+  bool IsSessionHeartbeatTracked(const uint8_t session_id) const;
+
+  /**
    * @brief Start heartbeat for specified session
    * @param  session_id session id
    */

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -400,6 +400,14 @@ class ConnectionHandlerImpl
   void SendEndService(uint32_t key, uint8_t service_type) OVERRIDE;
 
   /**
+   * @brief Check is heartbeat monitoring started for specified connection key
+   * @param  connection_key pair of connection and session id
+   * @return returns true if heartbeat monitoring started for specified
+   * connection key otherwise returns false
+   */
+  bool IsSessionHeartbeatTracked(const uint32_t connection_key) const OVERRIDE;
+
+  /**
    * \brief Start heartbeat for specified session
    *
    * \param connection_key pair of connection and session id

--- a/src/components/connection_handler/include/connection_handler/heartbeat_monitor.h
+++ b/src/components/connection_handler/include/connection_handler/heartbeat_monitor.h
@@ -69,6 +69,14 @@ class HeartBeatMonitor : public threads::ThreadDelegate {
   void KeepAlive(uint8_t session_id);
 
   /**
+   * @brief Check is heartbeat monitoring started for specified session
+   * @param  session_id session id
+   * @return returns true if heartbeat monitoring started for specified session
+   * otherwise returns false
+   */
+  bool IsSessionHeartbeatTracked(const uint8_t session_id) const;
+
+  /**
    * \brief Thread exit procedure.
    */
   virtual void exitThreadMain();
@@ -111,7 +119,7 @@ class HeartBeatMonitor : public threads::ThreadDelegate {
   typedef std::map<uint8_t, SessionState> SessionMap;
   SessionMap sessions_;
 
-  sync_primitives::Lock sessions_list_lock_;  // recurcive
+  mutable sync_primitives::Lock sessions_list_lock_;  // recurcive
   sync_primitives::Lock main_thread_lock_;
   mutable sync_primitives::Lock heartbeat_timeout_seconds_lock_;
   sync_primitives::ConditionalVariable heartbeat_monitor_;

--- a/src/components/connection_handler/src/connection.cc
+++ b/src/components/connection_handler/src/connection.cc
@@ -369,6 +369,10 @@ bool Connection::ProtocolVersion(uint8_t session_id,
   return true;
 }
 
+bool Connection::IsSessionHeartbeatTracked(const uint8_t session_id) const {
+  return heartbeat_monitor_->IsSessionHeartbeatTracked(session_id);
+}
+
 void Connection::StartHeartBeat(uint8_t session_id) {
   heartbeat_monitor_->AddSession(session_id);
 }

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -1069,6 +1069,21 @@ void ConnectionHandlerImpl::SendEndService(uint32_t key, uint8_t service_type) {
   }
 }
 
+bool ConnectionHandlerImpl::IsSessionHeartbeatTracked(
+    const uint32_t connection_key) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  uint32_t connection_handle = 0;
+  uint8_t session_id = 0;
+  PairFromKey(connection_key, &connection_handle, &session_id);
+
+  sync_primitives::AutoReadLock lock(connection_list_lock_);
+  ConnectionList::const_iterator it = connection_list_.find(connection_handle);
+  if (connection_list_.end() != it) {
+    return it->second->IsSessionHeartbeatTracked(session_id);
+  }
+  return false;
+}
+
 void ConnectionHandlerImpl::StartSessionHeartBeat(uint32_t connection_key) {
   LOG4CXX_AUTO_TRACE(logger_);
   uint32_t connection_handle = 0;

--- a/src/components/connection_handler/src/heartbeat_monitor.cc
+++ b/src/components/connection_handler/src/heartbeat_monitor.cc
@@ -142,6 +142,14 @@ void HeartBeatMonitor::KeepAlive(uint8_t session_id) {
   }
 }
 
+bool HeartBeatMonitor::IsSessionHeartbeatTracked(
+    const uint8_t session_id) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  AutoLock auto_lock(sessions_list_lock_);
+
+  return sessions_.end() != sessions_.find(session_id);
+}
+
 void HeartBeatMonitor::exitThreadMain() {
   // FIXME (dchmerev@luxoft.com): thread requested to stop should stop as soon
   // as possible,

--- a/src/components/connection_handler/src/heartbeat_monitor.cc
+++ b/src/components/connection_handler/src/heartbeat_monitor.cc
@@ -90,18 +90,29 @@ void HeartBeatMonitor::threadMain() {
 }
 
 void HeartBeatMonitor::AddSession(uint8_t session_id) {
+  if (0 == default_heartbeat_timeout_) {
+    LOG4CXX_INFO(logger_,
+                 "Won't add session with id "
+                     << static_cast<uint32_t>(session_id)
+                     << " because Heartbeat is disabled.");
+    return;
+  }
+
   LOG4CXX_DEBUG(logger_,
-                "Add session with id " << static_cast<int32_t>(session_id));
+                "Add session with id " << static_cast<uint32_t>(session_id));
   AutoLock auto_lock(sessions_list_lock_);
   if (sessions_.end() != sessions_.find(session_id)) {
     LOG4CXX_WARN(logger_,
-                 "Session with id " << static_cast<int32_t>(session_id)
+                 "Session with id " << static_cast<uint32_t>(session_id)
                                     << " already exists");
     return;
   }
+
   sessions_.insert(
       std::make_pair(session_id, SessionState(default_heartbeat_timeout_)));
-  LOG4CXX_INFO(logger_, "Start heartbeat for session " << session_id);
+  LOG4CXX_INFO(logger_,
+               "Start heartbeat for session "
+                   << static_cast<uint32_t>(session_id));
 }
 
 void HeartBeatMonitor::RemoveSession(uint8_t session_id) {

--- a/src/components/include/connection_handler/connection_handler.h
+++ b/src/components/include/connection_handler/connection_handler.h
@@ -130,6 +130,15 @@ class ConnectionHandler {
   virtual void SendEndService(uint32_t key, uint8_t service_type) = 0;
 
   /**
+   * @brief Check is heartbeat monitoring started for specified connection key
+   * @param  connection_key pair of connection and session id
+   * @return returns true if heartbeat monitoring started for specified
+   * connection key otherwise returns false
+   */
+  virtual bool IsSessionHeartbeatTracked(
+      const uint32_t connection_key) const = 0;
+
+  /**
    * \brief Start heartbeat for specified session
    *
    * \param connection_key pair of connection and session id

--- a/src/components/include/test/connection_handler/mock_connection_handler.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler.h
@@ -75,6 +75,8 @@ class MockConnectionHandler : public connection_handler::ConnectionHandler {
                     uint8_t session_id,
                     CloseSessionReason close_reason));
   MOCK_METHOD2(SendEndService, void(uint32_t key, uint8_t service_type));
+  MOCK_CONST_METHOD1(IsSessionHeartbeatTracked,
+                     bool(const uint32_t connection_key));
   MOCK_METHOD1(StartSessionHeartBeat, void(uint32_t connection_key));
   MOCK_METHOD2(SendHeartBeat,
                void(ConnectionHandle connection_handle, uint8_t session_id));

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -309,6 +309,11 @@ void ProtocolHandlerImpl::SendStartSessionAck(
   raw_ford_messages_to_mobile_.PostMessage(
       impl::RawFordMessageToMobile(ptr, false));
 
+  const uint32_t connection_key =
+      session_observer_.KeyFromPair(connection_id, session_id);
+  connection_handler_.BindProtocolVersionWithSession(connection_key,
+                                                     ack_protocol_version);
+
   LOG4CXX_DEBUG(logger_,
                 "SendStartSessionAck() for connection "
                     << connection_id << " for service_type "
@@ -1701,7 +1706,12 @@ RESULT_CODE ProtocolHandlerImpl::HandleControlMessageHeartBeat(
         protocol_version <= PROTOCOL_VERSION_5) {
       const uint32_t connection_key =
           session_observer_.KeyFromPair(connection_id, session_id);
-      connection_handler_.StartSessionHeartBeat(connection_key);
+      if (!connection_handler_.IsSessionHeartbeatTracked(connection_key)) {
+        LOG4CXX_DEBUG(logger_,
+                      "Session heartbeat tracking is not started. "
+                          << "Starting it for session " << session_id);
+        connection_handler_.StartSessionHeartBeat(connection_key);
+      }
       return SendHeartBeatAck(connection_id, session_id, packet.message_id());
     } else {
       LOG4CXX_WARN(logger_, "HeartBeat is not supported");


### PR DESCRIPTION
Fixes #1892

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Changes in PR are already covered within existing unit tests.

### Summary
In the current implementation SDL starts session heartbeat right after application registration.
However the correct behavior is to start session heartbeat after first heartbeat request from mobile app.

### Changelog
* Removed starting session heartbeat on app registration
* Added session heartbeat start on frist heartbeat request from mobile app
* Added check to prevent starting of session heartbeat if it was disabled in settings
* Added check if HB tracking for session is already enabled

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)