### PR TITLE
Fix starting behavior of secured services for navi/non-navi applications

### DIFF
--- a/src/appMain/life_cycle.cc
+++ b/src/appMain/life_cycle.cc
@@ -151,6 +151,7 @@ bool LifeCycle::StartComponents() {
   security_manager_->AddListener(app_manager_);
 
   app_manager_->AddPolicyObserver(crypto_manager_);
+  app_manager_->AddPolicyObserver(protocol_handler_);
   if (!crypto_manager_->Init()) {
     LOG4CXX_ERROR(logger_, "CryptoManager initialization fail.");
     return false;

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -921,15 +921,43 @@ class ApplicationManagerImpl
       const connection_handler::CloseSessionReason& close_reason) OVERRIDE;
 
 #ifdef ENABLE_SECURITY
-  // Overriden SecurityManagerListener method
+  /**
+   * @brief Notification about protection result
+   * @param connection_key Unique key of session which triggrs handshake
+   * @param result result of connection protection
+   * @return true on success notification handling or false otherwise
+   */
   bool OnHandshakeDone(
       uint32_t connection_key,
       security_manager::SSLContext::HandshakeResult result) OVERRIDE;
 
+  /**
+   * @brief Notification that certificate update is required.
+   */
   void OnCertificateUpdateRequired() OVERRIDE;
 
+  /**
+   * @brief Get certificate data from policy
+   * @param reference to string where to save certificate data
+   * @return true if listener saved some data to string otherwise false
+   */
+  bool GetPolicyCertificateData(std::string& data) OVERRIDE;
+
+  /**
+   * @brief Get unique handshake context by application id
+   * @param key id of application
+   * @return generated handshake context or empty context if application with
+   * provided id does not exist
+   */
   security_manager::SSLContext::HandshakeContext GetHandshakeContext(
       uint32_t key) const OVERRIDE;
+
+  /**
+   * @brief Check if application with specified app_id has NAVIGATION HMI type
+   * @param app_id id of application to check
+   * @return true if application is navi otherwise returns false
+   */
+  bool CheckAppIsNavi(const uint32_t app_id) OVERRIDE;
 #endif  // ENABLE_SECURITY
 
   /**

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -923,7 +923,7 @@ class ApplicationManagerImpl
 #ifdef ENABLE_SECURITY
   /**
    * @brief Notification about protection result
-   * @param connection_key Unique key of session which triggrs handshake
+   * @param connection_key Unique key of session which triggers handshake
    * @param result result of connection protection
    * @return true on success notification handling or false otherwise
    */
@@ -941,7 +941,7 @@ class ApplicationManagerImpl
    * @param reference to string where to save certificate data
    * @return true if listener saved some data to string otherwise false
    */
-  bool GetPolicyCertificateData(std::string& data) OVERRIDE;
+  bool GetPolicyCertificateData(std::string& data) const OVERRIDE;
 
   /**
    * @brief Get unique handshake context by application id
@@ -957,7 +957,7 @@ class ApplicationManagerImpl
    * @param app_id id of application to check
    * @return true if application is navi otherwise returns false
    */
-  bool CheckAppIsNavi(const uint32_t app_id) OVERRIDE;
+  bool CheckAppIsNavi(const uint32_t app_id) const OVERRIDE;
 #endif  // ENABLE_SECURITY
 
   /**

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1655,6 +1655,12 @@ void ApplicationManagerImpl::OnCertificateUpdateRequired() {
   GetPolicyHandler().OnPTExchangeNeeded();
 }
 
+bool ApplicationManagerImpl::GetPolicyCertificateData(std::string& data) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  data = GetPolicyHandler().RetrieveCertificate();
+  return true;
+}
+
 security_manager::SSLContext::HandshakeContext
 ApplicationManagerImpl::GetHandshakeContext(uint32_t key) const {
   LOG4CXX_AUTO_TRACE(logger_);
@@ -1665,6 +1671,15 @@ ApplicationManagerImpl::GetHandshakeContext(uint32_t key) const {
         custom_str::CustomString(app->policy_app_id()), app->name());
   }
   return SSLContext::HandshakeContext();
+}
+
+bool ApplicationManagerImpl::CheckAppIsNavi(const uint32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  ApplicationSharedPtr app = application(app_id);
+  if (app) {
+    return app->is_navi();
+  }
+  return false;
 }
 #endif  // ENABLE_SECURITY
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1655,7 +1655,7 @@ void ApplicationManagerImpl::OnCertificateUpdateRequired() {
   GetPolicyHandler().OnPTExchangeNeeded();
 }
 
-bool ApplicationManagerImpl::GetPolicyCertificateData(std::string& data) {
+bool ApplicationManagerImpl::GetPolicyCertificateData(std::string& data) const {
   LOG4CXX_AUTO_TRACE(logger_);
   data = GetPolicyHandler().RetrieveCertificate();
   return true;
@@ -1673,7 +1673,7 @@ ApplicationManagerImpl::GetHandshakeContext(uint32_t key) const {
   return SSLContext::HandshakeContext();
 }
 
-bool ApplicationManagerImpl::CheckAppIsNavi(const uint32_t app_id) {
+bool ApplicationManagerImpl::CheckAppIsNavi(const uint32_t app_id) const {
   LOG4CXX_AUTO_TRACE(logger_);
   ApplicationSharedPtr app = application(app_id);
   if (app) {

--- a/src/components/connection_handler/include/connection_handler/connection.h
+++ b/src/components/connection_handler/include/connection_handler/connection.h
@@ -218,9 +218,9 @@ class Connection {
    * @param service_type type of service to check
    * @return true if session contains service with specified service type
    */
-  bool IsSessionServiceExists(
+  bool SessionServiceExists(
       const uint8_t session_id,
-      const protocol_handler::ServiceType& service_type);
+      const protocol_handler::ServiceType& service_type) const;
 
 #endif  // ENABLE_SECURITY
         /**

--- a/src/components/connection_handler/include/connection_handler/connection.h
+++ b/src/components/connection_handler/include/connection_handler/connection.h
@@ -76,8 +76,10 @@ struct Service {
   Service()
       : service_type(protocol_handler::kInvalidServiceType)
       , is_protected_(false) {}
+
   explicit Service(protocol_handler::ServiceType service_type)
       : service_type(service_type), is_protected_(false) {}
+
   bool operator==(const protocol_handler::ServiceType service_type) const {
     return this->service_type == service_type;
   }
@@ -209,6 +211,17 @@ class Connection {
    */
   void SetProtectionFlag(const uint8_t session_id,
                          const protocol_handler::ServiceType& service_type);
+
+  /**
+   * @brief Check if session contains service with specified service type
+   * @param session_id id of session to check
+   * @param service_type type of service to check
+   * @return true if session contains service with specified service type
+   */
+  bool IsSessionServiceExists(
+      const uint8_t session_id,
+      const protocol_handler::ServiceType& service_type);
+
 #endif  // ENABLE_SECURITY
         /**
          * @brief Returns map of sessions which have been opened in

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -212,7 +212,7 @@ class ConnectionHandlerImpl
   /**
    * \brief Callback function used by ProtocolHandler
    * when Mobile Application initiates start of new session.
-   * Result must be notified through NotifySessionStartedResult().
+   * Result must be notified through NotifySessionStartedContext().
    * \param connection_handle Connection identifier within which session
    * has to be started.
    * \param sessionId Identifier of the session to be start

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -350,6 +350,16 @@ class ConnectionHandlerImpl
       const uint32_t& key,
       const protocol_handler::ServiceType& service_type) OVERRIDE;
 
+  /**
+   * @brief Check if session contains service with specified service type
+   * @param connection_key unique id of session to check
+   * @param service_type type of service to check
+   * @return true if session contains service with specified service type
+   */
+  bool IsSessionServiceExists(
+      const uint32_t connection_key,
+      const protocol_handler::ServiceType& service_type) OVERRIDE;
+
   security_manager::SSLContext::HandshakeContext GetHandshakeContext(
       uint32_t key) const OVERRIDE;
 #endif  // ENABLE_SECURITY

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -356,9 +356,9 @@ class ConnectionHandlerImpl
    * @param service_type type of service to check
    * @return true if session contains service with specified service type
    */
-  bool IsSessionServiceExists(
+  bool SessionServiceExists(
       const uint32_t connection_key,
-      const protocol_handler::ServiceType& service_type) OVERRIDE;
+      const protocol_handler::ServiceType& service_type) const OVERRIDE;
 
   security_manager::SSLContext::HandshakeContext GetHandshakeContext(
       uint32_t key) const OVERRIDE;

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -539,19 +539,6 @@ class ConnectionHandlerImpl
 
   void OnConnectionEnded(const transport_manager::ConnectionUID connection_id);
 
-  /**
-   * \brief Convenient method to call NotifySessionStartedResult() with
-   * negative result.
-   * \param connection_handle Identifier of connection within which session
-   * exists
-   * \param session_id session ID passed to OnSessionStartedCallback()
-   * \param is_protected whether the service would be protected
-   **/
-  void NotifySessionStartedFailure(
-      const transport_manager::ConnectionUID connection_handle,
-      const uint8_t session_id,
-      bool is_protected);
-
   const ConnectionHandlerSettings& settings_;
   /**
    * \brief Pointer to observer
@@ -587,7 +574,7 @@ class ConnectionHandlerImpl
   utils::StlMapDeleter<ConnectionList> connection_list_deleter_;
 
   sync_primitives::Lock start_service_context_map_lock_;
-  std::map<uint32_t, protocol_handler::StartingSessionContext>
+  std::map<uint32_t, protocol_handler::SessionContext>
       start_service_context_map_;
 
 #ifdef BUILD_TESTS

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -530,54 +530,6 @@ class ConnectionHandlerImpl
 
  private:
   /**
-   * \brief Struct to keep variables between OnSessionStartedCallback() and
-   * NotifyServiceStartedResult()
-   **/
-  struct ServiceStartedContext {
-    transport_manager::ConnectionUID connection_handle_;
-    uint8_t session_id_;
-    uint32_t new_session_id_;
-    protocol_handler::ServiceType service_type_;
-    uint32_t hash_id_;
-    bool is_protected_;
-
-    /**
-     * \brief Constructor
-     */
-    ServiceStartedContext()
-        : connection_handle_(0)
-        , session_id_(0)
-        , new_session_id_(0)
-        , service_type_(protocol_handler::kInvalidServiceType)
-        , hash_id_(0)
-        , is_protected_(0) {}
-
-    /**
-     * \brief Constructor
-     * \param connection_handle Connection identifier within which session is
-     * started.
-     * \param session_id Session ID specified to OnSessionStartedCallback()
-     * \param new_session_id Session ID generated
-     * \param service_type Type of service
-     * \param hash_id Hash ID generated from connection_handle and
-     * new_session_id
-     * \param is_protected Whether service will be protected
-     **/
-    ServiceStartedContext(transport_manager::ConnectionUID connection_handle,
-                          uint8_t session_id,
-                          uint32_t new_session_id,
-                          protocol_handler::ServiceType service_type,
-                          uint32_t hash_id,
-                          bool is_protected)
-        : connection_handle_(connection_handle)
-        , session_id_(session_id)
-        , new_session_id_(new_session_id)
-        , service_type_(service_type)
-        , hash_id_(hash_id)
-        , is_protected_(is_protected) {}
-  };
-
-  /**
    * \brief Disconnect application.
    *
    * \param device_handle DeviceHandle of disconnected device.
@@ -635,7 +587,8 @@ class ConnectionHandlerImpl
   utils::StlMapDeleter<ConnectionList> connection_list_deleter_;
 
   sync_primitives::Lock start_service_context_map_lock_;
-  std::map<uint32_t, ServiceStartedContext> start_service_context_map_;
+  std::map<uint32_t, protocol_handler::StartingSessionContext>
+      start_service_context_map_;
 
 #ifdef BUILD_TESTS
   // Methods for test usage

--- a/src/components/connection_handler/src/connection.cc
+++ b/src/components/connection_handler/src/connection.cc
@@ -314,19 +314,19 @@ void Connection::SetProtectionFlag(
   }
 }
 
-bool Connection::IsSessionServiceExists(
+bool Connection::SessionServiceExists(
     const uint8_t session_id,
-    const protocol_handler::ServiceType& service_type) {
+    const protocol_handler::ServiceType& service_type) const {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(session_map_lock_);
 
-  SessionMap::iterator session_it = session_map_.find(session_id);
+  SessionMap::const_iterator session_it = session_map_.find(session_id);
   if (session_it == session_map_.end()) {
     LOG4CXX_WARN(logger_, "Session not found in this connection!");
     return false;
   }
 
-  Session& session = session_it->second;
+  const Session& session = session_it->second;
   return session.FindService(service_type);
 }
 

--- a/src/components/connection_handler/src/connection.cc
+++ b/src/components/connection_handler/src/connection.cc
@@ -39,6 +39,7 @@
 #include "protocol_handler/protocol_packet.h"
 #include "utils/logger.h"
 #include "utils/macro.h"
+#include "utils/helpers.h"
 
 #ifdef ENABLE_SECURITY
 #include "security_manager/ssl_context.h"
@@ -148,6 +149,10 @@ bool Connection::AddNewService(uint8_t session_id,
     LOG4CXX_WARN(logger_, "Wrong service " << static_cast<int>(service_type));
     return false;
   }
+
+  LOG4CXX_DEBUG(logger_,
+                "Add service " << service_type << " for session "
+                               << static_cast<uint32_t>(session_id));
   sync_primitives::AutoLock lock(session_map_lock_);
 
   SessionMap::iterator session_it = session_map_.find(session_id);
@@ -156,6 +161,20 @@ bool Connection::AddNewService(uint8_t session_id,
     return false;
   }
   Session& session = session_it->second;
+
+  if (session.protocol_version <= protocol_handler::PROTOCOL_VERSION_2 &&
+      helpers::Compare<protocol_handler::ServiceType,
+                       helpers::EQ,
+                       helpers::ONE>(
+          service_type,
+          protocol_handler::ServiceType::kAudio,
+          protocol_handler::ServiceType::kMobileNav)) {
+    LOG4CXX_WARN(logger_,
+                 "Audio and video services are disallowed for protocol version "
+                 "2 or lower");
+    return false;
+  }
+
   Service* service = session.FindService(service_type);
   // if service already exists
   if (service) {
@@ -294,6 +313,23 @@ void Connection::SetProtectionFlag(
     service_rpc->is_protected_ = true;
   }
 }
+
+bool Connection::IsSessionServiceExists(
+    const uint8_t session_id,
+    const protocol_handler::ServiceType& service_type) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock lock(session_map_lock_);
+
+  SessionMap::iterator session_it = session_map_.find(session_id);
+  if (session_it == session_map_.end()) {
+    LOG4CXX_WARN(logger_, "Session not found in this connection!");
+    return false;
+  }
+
+  Session& session = session_it->second;
+  return session.FindService(service_type);
+}
+
 #endif  // ENABLE_SECURITY
 
 ConnectionHandle Connection::connection_handle() const {

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -875,6 +875,24 @@ void ConnectionHandlerImpl::SetProtectionFlag(
   connection.SetProtectionFlag(session_id, service_type);
 }
 
+bool ConnectionHandlerImpl::IsSessionServiceExists(
+    const uint32_t connection_key,
+    const protocol_handler::ServiceType& service_type) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  transport_manager::ConnectionUID connection_handle = 0;
+  uint8_t session_id = 0;
+  PairFromKey(connection_key, &connection_handle, &session_id);
+
+  sync_primitives::AutoReadLock lock(connection_list_lock_);
+  ConnectionList::iterator it = connection_list_.find(connection_handle);
+  if (connection_list_.end() == it) {
+    LOG4CXX_ERROR(logger_, "Unknown connection!");
+    return false;
+  }
+  Connection& connection = *it->second;
+  return connection.IsSessionServiceExists(session_id, service_type);
+}
+
 security_manager::SSLContext::HandshakeContext
 ConnectionHandlerImpl::GetHandshakeContext(uint32_t key) const {
   return connection_handler_observer_->GetHandshakeContext(key);

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -436,7 +436,7 @@ void ConnectionHandlerImpl::OnSessionStartedCallback(
 
   Connection* connection = it->second;
   context.is_new_service_ =
-      !connection->IsSessionServiceExists(session_id, service_type);
+      !connection->SessionServiceExists(session_id, service_type);
 
   if ((0 == session_id) && (protocol_handler::kRpc == service_type)) {
     context.new_session_id_ = connection->AddNewSession();
@@ -875,22 +875,22 @@ void ConnectionHandlerImpl::SetProtectionFlag(
   connection.SetProtectionFlag(session_id, service_type);
 }
 
-bool ConnectionHandlerImpl::IsSessionServiceExists(
+bool ConnectionHandlerImpl::SessionServiceExists(
     const uint32_t connection_key,
-    const protocol_handler::ServiceType& service_type) {
+    const protocol_handler::ServiceType& service_type) const {
   LOG4CXX_AUTO_TRACE(logger_);
   transport_manager::ConnectionUID connection_handle = 0;
   uint8_t session_id = 0;
   PairFromKey(connection_key, &connection_handle, &session_id);
 
   sync_primitives::AutoReadLock lock(connection_list_lock_);
-  ConnectionList::iterator it = connection_list_.find(connection_handle);
+  ConnectionList::const_iterator it = connection_list_.find(connection_handle);
   if (connection_list_.end() == it) {
     LOG4CXX_ERROR(logger_, "Unknown connection!");
     return false;
   }
-  Connection& connection = *it->second;
-  return connection.IsSessionServiceExists(session_id, service_type);
+  const Connection& connection = *it->second;
+  return connection.SessionServiceExists(session_id, service_type);
 }
 
 security_manager::SSLContext::HandshakeContext

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -61,6 +61,7 @@ using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnRefOfCopy;
 using ::testing::SaveArg;
+using ::testing::SaveArgPointee;
 
 // custom action to call a member function with 3 arguments
 ACTION_P5(InvokeMemberFuncWithArg3, ptr, memberFunc, a, b, c) {
@@ -118,42 +119,51 @@ class ConnectionHandlerTest : public ::testing::Test {
   void AddTestSession() {
     protocol_handler_test::MockProtocolHandler temp_protocol_handler;
     connection_handler_->set_protocol_handler(&temp_protocol_handler);
-    EXPECT_CALL(temp_protocol_handler,
-                NotifySessionStartedResult(_, _, _, _, _, _))
-        .WillOnce(
-            DoAll(SaveArg<2>(&start_session_id_), SaveArg<3>(&out_hash_id_)));
+    EXPECT_CALL(temp_protocol_handler, NotifySessionStarted(_, _))
+        .WillOnce(SaveArg<0>(&out_context_));
 
     connection_handler_->OnSessionStartedCallback(
         uid_, 0, kRpc, PROTECTION_OFF, static_cast<BsonObject*>(NULL));
     connection_handler_->set_protocol_handler(NULL);
-    EXPECT_NE(0u, start_session_id_);
-    EXPECT_EQ(SessionHash(uid_, start_session_id_), out_hash_id_);
-    connection_key_ = connection_handler_->KeyFromPair(uid_, start_session_id_);
-    CheckSessionExists(uid_, start_session_id_);
+    EXPECT_NE(0u, out_context_.new_session_id_);
+    EXPECT_EQ(SessionHash(uid_, out_context_.new_session_id_),
+              out_context_.hash_id_);
+    connection_key_ =
+        connection_handler_->KeyFromPair(uid_, out_context_.new_session_id_);
+    CheckSessionExists(uid_, out_context_.new_session_id_);
   }
   uint32_t SessionHash(const uint32_t connection, const uint32_t session) {
     return connection_handler_->KeyFromPair(connection, session);
   }
   void AddTestService(ServiceType service_type) {
-    EXPECT_NE(0u, start_session_id_);
-    EXPECT_EQ(SessionHash(uid_, start_session_id_), out_hash_id_);
-    connection_key_ = connection_handler_->KeyFromPair(uid_, start_session_id_);
-    CheckSessionExists(uid_, start_session_id_);
+    EXPECT_NE(0u, out_context_.new_session_id_);
+    EXPECT_EQ(SessionHash(uid_, out_context_.new_session_id_),
+              out_context_.hash_id_);
+    connection_key_ =
+        connection_handler_->KeyFromPair(uid_, out_context_.new_session_id_);
+    CheckSessionExists(uid_, out_context_.new_session_id_);
 
-    uint32_t session_id = 0;
+    // Set protocol version to 3 if audio or video service should be tested
+    if (service_type == ServiceType::kAudio ||
+        service_type == ServiceType::kMobileNav) {
+      ChangeProtocol(uid_,
+                     out_context_.new_session_id_,
+                     protocol_handler::PROTOCOL_VERSION_3);
+    }
+
+    SessionContext context;
     protocol_handler_test::MockProtocolHandler temp_protocol_handler;
     connection_handler_->set_protocol_handler(&temp_protocol_handler);
-    EXPECT_CALL(temp_protocol_handler,
-                NotifySessionStartedResult(_, _, _, _, _, _))
-        .WillOnce(SaveArg<2>(&session_id));
+    EXPECT_CALL(temp_protocol_handler, NotifySessionStarted(_, _))
+        .WillOnce(SaveArg<0>(&context));
 
     connection_handler_->OnSessionStartedCallback(uid_,
-                                                  start_session_id_,
+                                                  out_context_.new_session_id_,
                                                   service_type,
                                                   PROTECTION_OFF,
                                                   static_cast<BsonObject*>(0));
     connection_handler_->set_protocol_handler(NULL);
-    EXPECT_EQ(session_id, start_session_id_);
+    EXPECT_EQ(context.new_session_id_, out_context_.new_session_id_);
   }
 
   // Check Service Wrapper
@@ -279,8 +289,7 @@ class ConnectionHandlerTest : public ::testing::Test {
   transport_manager::DeviceHandle device_handle_;
   transport_manager::ConnectionUID uid_;
   uint32_t connection_key_;
-  uint32_t start_session_id_;
-  uint32_t out_hash_id_;
+  protocol_handler::SessionContext out_context_;
 
   std::string connection_type_;
   std::string device_name_;
@@ -295,17 +304,17 @@ TEST_F(ConnectionHandlerTest, StartSession_NoConnection) {
   // Null sessionId for start new session
   const uint8_t sessionID = 0;
   // Start new session with RPC service
-  uint32_t result_fail = 0;
+  protocol_handler::SessionContext context;
+
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, _, _))
-      .WillOnce(DoAll(SaveArg<2>(&result_fail), SaveArg<3>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _))
+      .WillOnce(SaveArg<0>(&context));
 
   connection_handler_->OnSessionStartedCallback(
       uid_, sessionID, kRpc, PROTECTION_ON, static_cast<BsonObject*>(NULL));
   // Unknown connection error is '0'
-  EXPECT_EQ(0u, result_fail);
-  EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
+  EXPECT_EQ(0u, context.new_session_id_);
+  EXPECT_EQ(protocol_handler::HASH_ID_WRONG, context.hash_id_);
   ASSERT_TRUE(connection_handler_->getConnectionList().empty());
 }
 
@@ -340,7 +349,7 @@ TEST_F(ConnectionHandlerTest, GetAppIdOnSessionKey) {
   AddTestSession();
 
   uint32_t app_id = 0;
-  const uint32_t testid = SessionHash(uid_, start_session_id_);
+  const uint32_t testid = SessionHash(uid_, out_context_.new_session_id_);
 
   connection_handler::DeviceHandle null_handle = 0;
   EXPECT_EQ(0,
@@ -407,7 +416,8 @@ TEST_F(ConnectionHandlerTest, GetApplicationsOnDevice) {
       0,
       connection_handler_->GetDataOnDeviceID(handle, NULL, &applications_list));
 
-  uint32_t test_id = connection_handler_->KeyFromPair(uid_, start_session_id_);
+  uint32_t test_id =
+      connection_handler_->KeyFromPair(uid_, out_context_.new_session_id_);
   EXPECT_EQ(1u, applications_list.size());
 
   EXPECT_EQ(test_id, applications_list.front());
@@ -419,7 +429,7 @@ TEST_F(ConnectionHandlerTest, GetDefaultProtocolVersion) {
 
   uint8_t protocol_version = 0;
   EXPECT_TRUE(connection_handler_->ProtocolVersionUsed(
-      uid_, start_session_id_, protocol_version));
+      uid_, out_context_.new_session_id_, protocol_version));
 
   EXPECT_EQ(PROTOCOL_VERSION_2, protocol_version);
 }
@@ -427,11 +437,11 @@ TEST_F(ConnectionHandlerTest, GetDefaultProtocolVersion) {
 TEST_F(ConnectionHandlerTest, GetProtocolVersion) {
   AddTestDeviceConnection();
   AddTestSession();
-  ChangeProtocol(uid_, start_session_id_, PROTOCOL_VERSION_3);
+  ChangeProtocol(uid_, out_context_.new_session_id_, PROTOCOL_VERSION_3);
 
   uint8_t protocol_version = 0;
   EXPECT_TRUE(connection_handler_->ProtocolVersionUsed(
-      uid_, start_session_id_, protocol_version));
+      uid_, out_context_.new_session_id_, protocol_version));
 
   EXPECT_EQ(PROTOCOL_VERSION_3, protocol_version);
 }
@@ -441,14 +451,14 @@ TEST_F(ConnectionHandlerTest, GetProtocolVersionAfterBinding) {
   AddTestSession();
   uint8_t protocol_version = 0;
   EXPECT_TRUE(connection_handler_->ProtocolVersionUsed(
-      uid_, start_session_id_, protocol_version));
+      uid_, out_context_.new_session_id_, protocol_version));
   EXPECT_EQ(PROTOCOL_VERSION_2, protocol_version);
 
   connection_handler_->BindProtocolVersionWithSession(connection_key_,
                                                       PROTOCOL_VERSION_3);
 
   EXPECT_TRUE(connection_handler_->ProtocolVersionUsed(
-      uid_, start_session_id_, protocol_version));
+      uid_, out_context_.new_session_id_, protocol_version));
   EXPECT_EQ(PROTOCOL_VERSION_3, protocol_version);
 }
 
@@ -460,15 +470,15 @@ TEST_F(ConnectionHandlerTest, GetPairFromKey) {
   uint32_t test_uid = 0;
   connection_handler_->PairFromKey(connection_key_, &test_uid, &session_id);
   EXPECT_EQ(uid_, test_uid);
-  EXPECT_EQ(start_session_id_, session_id);
+  EXPECT_EQ(out_context_.new_session_id_, session_id);
 }
 
 TEST_F(ConnectionHandlerTest, IsHeartBeatSupported) {
   AddTestDeviceConnection();
   AddTestSession();
-  ChangeProtocol(uid_, start_session_id_, PROTOCOL_VERSION_3);
-  EXPECT_TRUE(
-      connection_handler_->IsHeartBeatSupported(uid_, start_session_id_));
+  ChangeProtocol(uid_, out_context_.new_session_id_, PROTOCOL_VERSION_3);
+  EXPECT_TRUE(connection_handler_->IsHeartBeatSupported(
+      uid_, out_context_.new_session_id_));
 }
 
 MATCHER_P(SameDevice, device, "") {
@@ -561,8 +571,8 @@ TEST_F(ConnectionHandlerTest, OnApplicationFloodCallBack) {
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
-  EXPECT_CALL(mock_protocol_handler_, SendEndSession(uid_, start_session_id_))
-      .Times(1);
+  EXPECT_CALL(mock_protocol_handler_,
+              SendEndSession(uid_, out_context_.new_session_id_)).Times(1);
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kMobileNav, kCommon));
@@ -588,7 +598,8 @@ TEST_F(ConnectionHandlerTest, OnApplicationFloodCallBack_SessionFound) {
       &mock_connection_handler_observer);
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, SendEndSession(uid_, start_session_id_));
+  EXPECT_CALL(mock_protocol_handler_,
+              SendEndSession(uid_, out_context_.new_session_id_));
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kMobileNav, kFlood));
@@ -862,7 +873,8 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithCommonReason) {
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  EXPECT_CALL(mock_protocol_handler_, SendEndSession(uid_, start_session_id_))
+  EXPECT_CALL(mock_protocol_handler_,
+              SendEndSession(uid_, out_context_.new_session_id_))
       .WillOnce(NotifyTestAsyncWaiter(&waiter));
   times++;
 
@@ -903,7 +915,8 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithFloodReason) {
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  EXPECT_CALL(mock_protocol_handler_, SendEndSession(uid_, start_session_id_))
+  EXPECT_CALL(mock_protocol_handler_,
+              SendEndSession(uid_, out_context_.new_session_id_))
       .WillOnce(NotifyTestAsyncWaiter(&waiter));
   times++;
 
@@ -944,8 +957,8 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithMalformedMessage) {
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  EXPECT_CALL(mock_protocol_handler_, SendEndSession(uid_, start_session_id_))
-      .Times(0);
+  EXPECT_CALL(mock_protocol_handler_,
+              SendEndSession(uid_, out_context_.new_session_id_)).Times(0);
 
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
@@ -984,8 +997,8 @@ TEST_F(ConnectionHandlerTest, CloseConnectionSessionsWithMalformedMessage) {
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  EXPECT_CALL(mock_protocol_handler_, SendEndSession(uid_, start_session_id_))
-      .Times(0);
+  EXPECT_CALL(mock_protocol_handler_,
+              SendEndSession(uid_, out_context_.new_session_id_)).Times(0);
 
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
@@ -1024,7 +1037,8 @@ TEST_F(ConnectionHandlerTest, CloseConnectionSessionsWithCommonReason) {
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
-  EXPECT_CALL(mock_protocol_handler_, SendEndSession(uid_, start_session_id_))
+  EXPECT_CALL(mock_protocol_handler_,
+              SendEndSession(uid_, out_context_.new_session_id_))
       .WillOnce(NotifyTestAsyncWaiter(&waiter));
   times++;
 
@@ -1055,34 +1069,34 @@ TEST_F(ConnectionHandlerTest, StartService_withServices) {
   // Add virtual device and connection
   AddTestDeviceConnection();
   AddTestSession();
+  ChangeProtocol(
+      uid_, out_context_.new_session_id_, protocol_handler::PROTOCOL_VERSION_3);
 
-  uint32_t start_audio = 0;
-  uint32_t start_video = 0;
+  SessionContext audio_context, video_context;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, _, _))
-      .WillOnce(DoAll(SaveArg<2>(&start_audio), SaveArg<3>(&out_hash_id_)))
-      .WillOnce(DoAll(SaveArg<2>(&start_video), SaveArg<3>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _))
+      .WillOnce(SaveArg<0>(&audio_context))
+      .WillOnce(SaveArg<0>(&video_context));
 
   // Start Audio service
   connection_handler_->OnSessionStartedCallback(uid_,
-                                                start_session_id_,
+                                                out_context_.new_session_id_,
                                                 kAudio,
                                                 PROTECTION_OFF,
                                                 static_cast<BsonObject*>(NULL));
-  EXPECT_EQ(start_session_id_, start_audio);
-  CheckServiceExists(uid_, start_session_id_, kAudio, true);
-  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
+  EXPECT_NE(0u, audio_context.new_session_id_);
+  CheckServiceExists(uid_, audio_context.new_session_id_, kAudio, true);
+  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, audio_context.hash_id_);
 
   // Start Audio service
   connection_handler_->OnSessionStartedCallback(uid_,
-                                                start_session_id_,
+                                                out_context_.new_session_id_,
                                                 kMobileNav,
                                                 PROTECTION_OFF,
                                                 static_cast<BsonObject*>(NULL));
-  EXPECT_EQ(start_session_id_, start_video);
-  CheckServiceExists(uid_, start_session_id_, kMobileNav, true);
-  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
+  EXPECT_NE(0u, video_context.new_session_id_);
+  CheckServiceExists(uid_, video_context.new_session_id_, kMobileNav, true);
+  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, video_context.hash_id_);
 
   connection_handler_->set_protocol_handler(NULL);
 }
@@ -1090,22 +1104,27 @@ TEST_F(ConnectionHandlerTest, StartService_withServices) {
 TEST_F(ConnectionHandlerTest, StartService_withServices_withParams) {
   AddTestDeviceConnection();
   AddTestSession();
+  ChangeProtocol(
+      uid_, out_context_.new_session_id_, protocol_handler::PROTOCOL_VERSION_3);
 
-  uint32_t start_video = 0;
+  SessionContext video_context;
+
   // create a dummy pointer
   int dummy = 0;
   std::vector<std::string> empty;
   BsonObject* dummy_param = reinterpret_cast<BsonObject*>(&dummy);
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, _, empty))
-      .WillOnce(DoAll(SaveArg<2>(&start_video), SaveArg<3>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, empty))
+      .WillOnce(SaveArg<0>(&video_context));
 
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kMobileNav, PROTECTION_OFF, dummy_param);
-  EXPECT_EQ(start_session_id_, start_video);
-  CheckServiceExists(uid_, start_session_id_, kMobileNav, true);
-  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                out_context_.new_session_id_,
+                                                kMobileNav,
+                                                PROTECTION_OFF,
+                                                dummy_param);
+  EXPECT_EQ(out_context_.new_session_id_, video_context.new_session_id_);
+  CheckServiceExists(uid_, out_context_.new_session_id_, kMobileNav, true);
+  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, video_context.hash_id_);
 
   connection_handler_->set_protocol_handler(NULL);
 }
@@ -1126,39 +1145,39 @@ TEST_F(ConnectionHandlerTest, ServiceStop_UnExistService) {
   uint32_t dummy_hash = 0u;
   const uint32_t end_session_result =
       connection_handler_->OnSessionEndedCallback(
-          uid_, start_session_id_, &dummy_hash, kAudio);
+          uid_, out_context_.new_session_id_, &dummy_hash, kAudio);
   EXPECT_EQ(0u, end_session_result);
-  CheckServiceExists(uid_, start_session_id_, kAudio, false);
+  CheckServiceExists(uid_, out_context_.new_session_id_, kAudio, false);
 }
 
 TEST_F(ConnectionHandlerTest, ServiceStop) {
   AddTestDeviceConnection();
   AddTestSession();
+  ChangeProtocol(
+      uid_, out_context_.new_session_id_, protocol_handler::PROTOCOL_VERSION_3);
 
-  uint32_t start_audio = 0;
+  SessionContext audio_context;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, _, _))
-      .WillRepeatedly(
-          DoAll(SaveArg<2>(&start_audio), SaveArg<3>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _))
+      .WillRepeatedly(SaveArg<0>(&audio_context));
 
   // Check ignoring hash_id on stop non-rpc service
   for (uint32_t some_hash_id = 0; some_hash_id < 0xFF; ++some_hash_id) {
     // Start audio service
     connection_handler_->OnSessionStartedCallback(
         uid_,
-        start_session_id_,
+        out_context_.new_session_id_,
         kAudio,
         PROTECTION_OFF,
         static_cast<BsonObject*>(NULL));
-    EXPECT_EQ(start_session_id_, start_audio);
-    EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
+    EXPECT_EQ(out_context_.new_session_id_, audio_context.new_session_id_);
+    EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, audio_context.hash_id_);
 
     const uint32_t end_session_result =
         connection_handler_->OnSessionEndedCallback(
-            uid_, start_session_id_, &some_hash_id, kAudio);
+            uid_, out_context_.new_session_id_, &some_hash_id, kAudio);
     EXPECT_EQ(connection_key_, end_session_result);
-    CheckServiceExists(uid_, start_session_id_, kAudio, false);
+    CheckServiceExists(uid_, out_context_.new_session_id_, kAudio, false);
   }
 }
 
@@ -1172,13 +1191,13 @@ TEST_F(ConnectionHandlerTest, SessionStop_CheckHash) {
 
     const uint32_t end_audio_wrong_hash =
         connection_handler_->OnSessionEndedCallback(
-            uid_, start_session_id_, &wrong_hash, kRpc);
+            uid_, out_context_.new_session_id_, &wrong_hash, kRpc);
     EXPECT_EQ(0u, end_audio_wrong_hash);
     EXPECT_EQ(protocol_handler::HASH_ID_WRONG, wrong_hash);
-    CheckSessionExists(uid_, start_session_id_);
+    CheckSessionExists(uid_, out_context_.new_session_id_);
 
     const uint32_t end_audio = connection_handler_->OnSessionEndedCallback(
-        uid_, start_session_id_, &hash, kRpc);
+        uid_, out_context_.new_session_id_, hash, kRpc);
     EXPECT_EQ(connection_key_, end_audio);
     CheckSessionExists(uid_, 0);
   }
@@ -1194,13 +1213,13 @@ TEST_F(ConnectionHandlerTest, SessionStop_CheckSpecificHash) {
 
     const uint32_t end_audio_wrong_hash =
         connection_handler_->OnSessionEndedCallback(
-            uid_, start_session_id_, &wrong_hash, kRpc);
+            uid_, out_context_.new_session_id_, wrong_hash, kRpc);
     EXPECT_EQ(0u, end_audio_wrong_hash);
     EXPECT_EQ(protocol_handler::HASH_ID_WRONG, wrong_hash);
-    CheckSessionExists(uid_, start_session_id_);
+    CheckSessionExists(uid_, out_context_.new_session_id_);
 
     const uint32_t end_audio = connection_handler_->OnSessionEndedCallback(
-        uid_, start_session_id_, &hash, kRpc);
+        uid_, out_context_.new_session_id_, hash, kRpc);
     EXPECT_EQ(connection_key_, end_audio);
     CheckSessionExists(uid_, 0);
   }
@@ -1209,16 +1228,17 @@ TEST_F(ConnectionHandlerTest, SessionStop_CheckSpecificHash) {
 TEST_F(ConnectionHandlerTest, SessionStarted_WithRpc) {
   // Add virtual device and connection
   AddTestDeviceConnection();
+  out_context_.initial_session_id_ = 1u;
   // Expect that rpc service has started
   connection_handler_test::MockConnectionHandlerObserver
       mock_connection_handler_observer;
   connection_handler_->set_connection_handler_observer(
       &mock_connection_handler_observer);
-  uint32_t session_key =
-      connection_handler_->KeyFromPair(uid_, start_session_id_);
   std::vector<std::string> empty;
+  uint32_t session_key =
+      connection_handler_->KeyFromPair(uid_, out_context_.initial_session_id_);
   EXPECT_CALL(mock_connection_handler_observer,
-              OnServiceStartedCallback(device_handle_, session_key, kRpc, NULL))
+              OnServiceStartedCallback(device_handle_, _, kRpc, NULL))
       .WillOnce(InvokeMemberFuncWithArg3(
           connection_handler_,
           &ConnectionHandler::NotifyServiceStartedResult,
@@ -1226,22 +1246,25 @@ TEST_F(ConnectionHandlerTest, SessionStarted_WithRpc) {
           true,
           ByRef(empty)));
 
-  uint32_t new_session_id = 0;
+  EXPECT_CALL(mock_connection_handler_observer, CheckAppIsNavi(_))
+      .WillOnce(Return(true));
+
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, _, _))
-      .WillOnce(DoAll(SaveArg<2>(&new_session_id), SaveArg<3>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _))
+      .WillOnce(SaveArg<0>(&out_context_));
 
   // Start new session with RPC service
   connection_handler_->OnSessionStartedCallback(
       uid_, 0, kRpc, PROTECTION_OFF, static_cast<BsonObject*>(NULL));
 
-  EXPECT_NE(0u, new_session_id);
+  EXPECT_NE(0u, out_context_.new_session_id_);
 }
 
 TEST_F(ConnectionHandlerTest, ServiceStarted_Video_SUCCESS) {
   AddTestDeviceConnection();
   AddTestSession();
+  ChangeProtocol(
+      uid_, out_context_.new_session_id_, protocol_handler::PROTOCOL_VERSION_3);
 
   int dummy = 0;
   BsonObject* dummy_params = reinterpret_cast<BsonObject*>(&dummy);
@@ -1251,7 +1274,7 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_SUCCESS) {
   connection_handler_->set_connection_handler_observer(
       &mock_connection_handler_observer);
   uint32_t session_key =
-      connection_handler_->KeyFromPair(uid_, start_session_id_);
+      connection_handler_->KeyFromPair(uid_, out_context_.new_session_id_);
   std::vector<std::string> empty;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceStartedCallback(
@@ -1262,23 +1285,28 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_SUCCESS) {
           session_key,
           true,
           ByRef(empty)));
+  EXPECT_CALL(mock_connection_handler_observer, CheckAppIsNavi(_))
+      .WillOnce(Return(true));
 
-  // confirm that NotifySessionStartedResult() is called
-  uint32_t new_session_id = 0;
+  // confirm that NotifySessionStarted() is called
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, false, empty))
-      .WillOnce(DoAll(SaveArg<2>(&new_session_id), SaveArg<3>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, empty))
+      .WillOnce(SaveArg<0>(&out_context_));
 
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kMobileNav, PROTECTION_OFF, dummy_params);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                out_context_.new_session_id_,
+                                                kMobileNav,
+                                                PROTECTION_OFF,
+                                                dummy_params);
 
-  EXPECT_NE(0u, new_session_id);
+  EXPECT_NE(0u, out_context_.new_session_id_);
 }
 
 TEST_F(ConnectionHandlerTest, ServiceStarted_Video_FAILURE) {
   AddTestDeviceConnection();
   AddTestSession();
+  ChangeProtocol(
+      uid_, out_context_.new_session_id_, protocol_handler::PROTOCOL_VERSION_3);
 
   int dummy = 0;
   BsonObject* dummy_params = reinterpret_cast<BsonObject*>(&dummy);
@@ -1288,7 +1316,7 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_FAILURE) {
   connection_handler_->set_connection_handler_observer(
       &mock_connection_handler_observer);
   uint32_t session_key =
-      connection_handler_->KeyFromPair(uid_, start_session_id_);
+      connection_handler_->KeyFromPair(uid_, out_context_.new_session_id_);
   std::vector<std::string> empty;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceStartedCallback(
@@ -1299,18 +1327,21 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_FAILURE) {
           session_key,
           false,
           ByRef(empty)));
+  EXPECT_CALL(mock_connection_handler_observer, CheckAppIsNavi(_))
+      .WillOnce(Return(true));
 
-  // confirm that NotifySessionStartedResult() is called
-  uint32_t new_session_id = 0;
+  // confirm that NotifySessionStarted() is called
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, false, empty))
-      .WillOnce(DoAll(SaveArg<2>(&new_session_id), SaveArg<3>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, empty))
+      .WillOnce(SaveArg<0>(&out_context_));
 
-  connection_handler_->OnSessionStartedCallback(
-      uid_, start_session_id_, kMobileNav, PROTECTION_OFF, dummy_params);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                out_context_.new_session_id_,
+                                                kMobileNav,
+                                                PROTECTION_OFF,
+                                                dummy_params);
 
-  EXPECT_EQ(0u, new_session_id);
+  EXPECT_EQ(0u, out_context_.new_session_id_);
 }
 
 /*
@@ -1321,17 +1352,13 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_FAILURE) {
 TEST_F(ConnectionHandlerTest, ServiceStarted_Video_Multiple) {
   AddTestDeviceConnection();
 
-  uint32_t rpc_session_id1;
-  uint32_t rpc_session_id2;
-  uint32_t hash_id1;
-  uint32_t hash_id2;
+  SessionContext context_first, context_second;
 
   protocol_handler_test::MockProtocolHandler temp_protocol_handler;
   connection_handler_->set_protocol_handler(&temp_protocol_handler);
-  EXPECT_CALL(temp_protocol_handler,
-              NotifySessionStartedResult(_, _, _, _, _, _))
-      .WillOnce(DoAll(SaveArg<2>(&rpc_session_id1), SaveArg<3>(&hash_id1)))
-      .WillOnce(DoAll(SaveArg<2>(&rpc_session_id2), SaveArg<3>(&hash_id2)));
+  EXPECT_CALL(temp_protocol_handler, NotifySessionStarted(_, _))
+      .WillOnce(SaveArg<0>(&context_first))
+      .WillOnce(SaveArg<0>(&context_second));
 
   // add two sessions
   connection_handler_->OnSessionStartedCallback(
@@ -1339,12 +1366,14 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_Multiple) {
   connection_handler_->OnSessionStartedCallback(
       uid_, 0, kRpc, PROTECTION_OFF, static_cast<BsonObject*>(NULL));
 
-  EXPECT_NE(0u, rpc_session_id1);
-  EXPECT_NE(0u, rpc_session_id2);
-  EXPECT_EQ(SessionHash(uid_, rpc_session_id1), hash_id1);
-  EXPECT_EQ(SessionHash(uid_, rpc_session_id2), hash_id2);
-  CheckSessionExists(uid_, rpc_session_id1);
-  CheckSessionExists(uid_, rpc_session_id2);
+  EXPECT_NE(0u, context_first.new_session_id_);
+  EXPECT_NE(0u, context_second.new_session_id_);
+  EXPECT_EQ(SessionHash(uid_, context_first.new_session_id_),
+            context_first.hash_id_);
+  EXPECT_EQ(SessionHash(uid_, context_second.new_session_id_),
+            context_second.hash_id_);
+  CheckSessionExists(uid_, context_first.new_session_id_);
+  CheckSessionExists(uid_, context_second.new_session_id_);
 
   connection_handler_->set_protocol_handler(NULL);
 
@@ -1356,11 +1385,17 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_Multiple) {
   connection_handler_->set_connection_handler_observer(
       &mock_connection_handler_observer);
   uint32_t session_key1 =
-      connection_handler_->KeyFromPair(uid_, rpc_session_id1);
+      connection_handler_->KeyFromPair(uid_, context_first.new_session_id_);
   uint32_t session_key2 =
-      connection_handler_->KeyFromPair(uid_, rpc_session_id2);
+      connection_handler_->KeyFromPair(uid_, context_second.new_session_id_);
 
   std::vector<std::string> empty;
+  ChangeProtocol(uid_,
+                 context_first.new_session_id_,
+                 protocol_handler::PROTOCOL_VERSION_3);
+  ChangeProtocol(uid_,
+                 context_second.new_session_id_,
+                 protocol_handler::PROTOCOL_VERSION_3);
 
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceStartedCallback(
@@ -1384,27 +1419,30 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_Multiple) {
                           session_key1,
                           true,
                           ByRef(empty))));
+  EXPECT_CALL(mock_connection_handler_observer, CheckAppIsNavi(_))
+      .Times(2)
+      .WillRepeatedly(Return(true));
 
   // verify that connection handler will not mix up the two results
-  uint32_t new_session_id1 = 0;
-  uint32_t new_session_id2 = 0;
+  SessionContext new_context_first, new_context_second;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(
-      mock_protocol_handler_,
-      NotifySessionStartedResult(_, rpc_session_id1, _, _, false, empty))
-      .WillOnce(SaveArg<2>(&new_session_id1));
-  EXPECT_CALL(
-      mock_protocol_handler_,
-      NotifySessionStartedResult(_, rpc_session_id2, _, _, false, empty))
-      .WillOnce(SaveArg<2>(&new_session_id2));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, empty))
+      .WillOnce(SaveArg<0>(&new_context_second))
+      .WillOnce(SaveArg<0>(&new_context_first));
 
-  connection_handler_->OnSessionStartedCallback(
-      uid_, rpc_session_id1, kMobileNav, PROTECTION_OFF, dummy_params);
-  connection_handler_->OnSessionStartedCallback(
-      uid_, rpc_session_id2, kMobileNav, PROTECTION_OFF, dummy_params);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                context_first.new_session_id_,
+                                                kMobileNav,
+                                                PROTECTION_OFF,
+                                                dummy_params);
+  connection_handler_->OnSessionStartedCallback(uid_,
+                                                context_second.new_session_id_,
+                                                kMobileNav,
+                                                PROTECTION_OFF,
+                                                dummy_params);
 
-  EXPECT_NE(0u, new_session_id1);  // result is positive
-  EXPECT_EQ(0u, new_session_id2);  // result is negative
+  EXPECT_NE(0u, new_context_first.new_session_id_);   // result is positive
+  EXPECT_EQ(0u, new_context_second.new_session_id_);  // result is negative
 }
 
 TEST_F(ConnectionHandlerTest,
@@ -1417,23 +1455,23 @@ TEST_F(ConnectionHandlerTest,
   protected_services_.push_back(kRpc);
   SetSpecificServices();
 
-  uint32_t session_id_fail = 0;
-  uint32_t session_id = 0;
+  SessionContext fail_context;
+  SessionContext positive_context;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, _, _))
-      .WillOnce(DoAll(SaveArg<2>(&session_id_fail), SaveArg<3>(&out_hash_id_)))
-      .WillOnce(DoAll(SaveArg<2>(&session_id), SaveArg<3>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _))
+      .WillOnce(SaveArg<0>(&fail_context))
+      .WillOnce(SaveArg<0>(&positive_context));
 
   // Start new session with RPC service
   connection_handler_->OnSessionStartedCallback(
       uid_, 0, kRpc, PROTECTION_OFF, static_cast<BsonObject*>(NULL));
 #ifdef ENABLE_SECURITY
-  EXPECT_EQ(0u, session_id_fail);
-  EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
+  EXPECT_EQ(0u, fail_context.new_session_id_);
+  EXPECT_EQ(protocol_handler::HASH_ID_WRONG, fail_context.hash_id_);
 #else
-  EXPECT_EQ(1u, session_id_fail);
-  EXPECT_EQ(SessionHash(uid_, session_id_fail), out_hash_id_);
+  EXPECT_EQ(1u, fail_context.new_session_id_);
+  EXPECT_EQ(SessionHash(uid_, fail_context.new_session_id_),
+            fail_context.hash_id_);
 #endif  // ENABLE_SECURITY
 
   // Allow start kRPC without encryption
@@ -1443,9 +1481,11 @@ TEST_F(ConnectionHandlerTest,
   // Start new session with RPC service
   connection_handler_->OnSessionStartedCallback(
       uid_, 0, kRpc, PROTECTION_OFF, static_cast<BsonObject*>(NULL));
-  EXPECT_NE(0u, session_id);
-  CheckService(uid_, session_id, kRpc, NULL, PROTECTION_OFF);
-  EXPECT_EQ(SessionHash(uid_, session_id), out_hash_id_);
+  EXPECT_NE(0u, positive_context.new_session_id_);
+  CheckService(
+      uid_, positive_context.new_session_id_, kRpc, NULL, PROTECTION_OFF);
+  EXPECT_EQ(SessionHash(uid_, positive_context.new_session_id_),
+            positive_context.hash_id_);
 }
 
 TEST_F(ConnectionHandlerTest,
@@ -1459,21 +1499,20 @@ TEST_F(ConnectionHandlerTest,
   unprotected_services_.push_back(kControl);
   SetSpecificServices();
 
-  uint32_t session_id_fail = 0;
-  uint32_t session_id = 0;
+  SessionContext fail_context;
+  SessionContext positive_context;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, _, _))
-      .WillOnce(SaveArg<2>(&session_id_fail))
-      .WillOnce(DoAll(SaveArg<2>(&session_id), SaveArg<3>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _))
+      .WillOnce(SaveArg<0>(&fail_context))
+      .WillOnce(SaveArg<0>(&positive_context));
 
   // Start new session with RPC service
   connection_handler_->OnSessionStartedCallback(
       uid_, 0, kRpc, PROTECTION_ON, static_cast<BsonObject*>(NULL));
 #ifdef ENABLE_SECURITY
-  EXPECT_EQ(0u, session_id_fail);
+  EXPECT_EQ(0u, fail_context.new_session_id_);
 #else
-  EXPECT_EQ(1u, session_id_fail);
+  EXPECT_EQ(1u, fail_context.new_session_id_);
 #endif  // ENABLE_SECURITY
 
   // Allow start kRPC with encryption
@@ -1483,17 +1522,21 @@ TEST_F(ConnectionHandlerTest,
   // Start new session with RPC service
   connection_handler_->OnSessionStartedCallback(
       uid_, 0, kRpc, PROTECTION_ON, static_cast<BsonObject*>(NULL));
-  EXPECT_NE(0u, session_id);
-  EXPECT_EQ(SessionHash(uid_, session_id), out_hash_id_);
+  EXPECT_NE(0u, positive_context.new_session_id_);
+  EXPECT_EQ(SessionHash(uid_, positive_context.new_session_id_),
+            positive_context.hash_id_);
 
   // Protection steal FALSE because of APPlink Protocol implementation
-  CheckService(uid_, session_id, kRpc, NULL, PROTECTION_OFF);
+  CheckService(
+      uid_, positive_context.new_session_id_, kRpc, NULL, PROTECTION_OFF);
 }
 
 TEST_F(ConnectionHandlerTest,
        SessionStarted_StartService_SecureSpecific_Unprotect) {
   AddTestDeviceConnection();
   AddTestSession();
+  ChangeProtocol(
+      uid_, out_context_.new_session_id_, protocol_handler::PROTOCOL_VERSION_3);
 
   // Forbid start kAudio without encryption
   protected_services_.push_back(UnnamedService::kServedService1);
@@ -1502,24 +1545,22 @@ TEST_F(ConnectionHandlerTest,
   protected_services_.push_back(kControl);
   SetSpecificServices();
 
-  uint32_t session_id2 = 0;
-  uint32_t session_id3 = 0;
+  SessionContext context_first, context_second;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, _, _))
-      .WillOnce(SaveArg<2>(&session_id2))
-      .WillOnce(DoAll(SaveArg<2>(&session_id3), SaveArg<3>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _))
+      .WillOnce(SaveArg<0>(&context_first))
+      .WillOnce(SaveArg<0>(&context_second));
 
   // Start new session with Audio service
   connection_handler_->OnSessionStartedCallback(uid_,
-                                                start_session_id_,
+                                                out_context_.new_session_id_,
                                                 kAudio,
                                                 PROTECTION_OFF,
                                                 static_cast<BsonObject*>(NULL));
 #ifdef ENABLE_SECURITY
-  EXPECT_EQ(0u, session_id2);
+  EXPECT_EQ(0u, context_first.new_session_id_);
 #else
-  EXPECT_EQ(1u, session_id2);
+  EXPECT_EQ(1u, context_first.new_session_id_);
 #endif  // ENABLE_SECURITY
   // Allow start kAudio without encryption
   protected_services_.clear();
@@ -1529,18 +1570,19 @@ TEST_F(ConnectionHandlerTest,
   protected_services_.push_back(kControl);
   SetSpecificServices();
   connection_handler_->OnSessionStartedCallback(uid_,
-                                                start_session_id_,
+                                                out_context_.new_session_id_,
                                                 kAudio,
                                                 PROTECTION_OFF,
                                                 static_cast<BsonObject*>(NULL));
 // Returned original session id
 #ifdef ENABLE_SECURITY
-  EXPECT_EQ(start_session_id_, session_id3);
-  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
-  CheckService(uid_, session_id3, kRpc, NULL, PROTECTION_OFF);
+  EXPECT_EQ(out_context_.new_session_id_, context_second.new_session_id_);
+  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, context_second.hash_id_);
+  CheckService(
+      uid_, context_second.new_session_id_, kRpc, NULL, PROTECTION_OFF);
 #else
-  EXPECT_EQ(0u, session_id3);
-  EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
+  EXPECT_EQ(0u, context_second.new_session_id_);
+  EXPECT_EQ(protocol_handler::HASH_ID_WRONG, context_second.hash_id_);
 #endif  // ENABLE_SECURITY
 }
 
@@ -1548,6 +1590,8 @@ TEST_F(ConnectionHandlerTest,
        SessionStarted_StartService_SecureSpecific_Protect) {
   AddTestDeviceConnection();
   AddTestSession();
+  ChangeProtocol(
+      uid_, out_context_.new_session_id_, protocol_handler::PROTOCOL_VERSION_3);
 
   // Forbid start kAudio with encryption
   unprotected_services_.push_back(UnnamedService::kServedService1);
@@ -1556,101 +1600,103 @@ TEST_F(ConnectionHandlerTest,
   unprotected_services_.push_back(kControl);
   SetSpecificServices();
 
-  uint32_t session_id_reject = 0;
-  uint32_t session_id3 = 0;
+  SessionContext rejected_context, positive_context;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, _, _))
-      .WillOnce(SaveArg<2>(&session_id_reject))
-      .WillOnce(DoAll(SaveArg<2>(&session_id3), SaveArg<3>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _))
+      .WillOnce(SaveArg<0>(&rejected_context))
+      .WillOnce(SaveArg<0>(&positive_context));
 
   // Start new session with Audio service
   connection_handler_->OnSessionStartedCallback(uid_,
-                                                start_session_id_,
+                                                out_context_.new_session_id_,
                                                 kAudio,
                                                 PROTECTION_ON,
                                                 static_cast<BsonObject*>(NULL));
 #ifdef ENABLE_SECURITY
-  EXPECT_EQ(0u, session_id_reject);
+  EXPECT_EQ(0u, rejected_context.new_session_id_);
 #else
-  EXPECT_EQ(1u, session_id_reject);
+  EXPECT_EQ(1u, rejected_context.new_session_id_);
 #endif  // ENABLE_SECURITY
   // Allow start kAudio with encryption
   unprotected_services_.clear();
   SetSpecificServices();
   connection_handler_->OnSessionStartedCallback(uid_,
-                                                start_session_id_,
+                                                out_context_.new_session_id_,
                                                 kAudio,
                                                 PROTECTION_ON,
                                                 static_cast<BsonObject*>(NULL));
 // Returned original session id
 #ifdef ENABLE_SECURITY
-  EXPECT_EQ(start_session_id_, session_id3);
-  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
-  CheckService(uid_, session_id3, kAudio, NULL, PROTECTION_ON);
+  EXPECT_EQ(out_context_.new_session_id_, positive_context.new_session_id_);
+  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, positive_context.hash_id_);
+  CheckService(
+      uid_, positive_context.new_session_id_, kAudio, NULL, PROTECTION_ON);
 #else
-  EXPECT_EQ(0u, session_id3);
-  EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
-  CheckService(uid_, start_session_id_, kAudio, NULL, PROTECTION_OFF);
+  EXPECT_EQ(0u, positive_context.new_session_id_);
+  EXPECT_EQ(protocol_handler::HASH_ID_WRONG, positive_context.hash_id_);
+  CheckService(
+      uid_, positive_context.new_session_id_, kAudio, NULL, PROTECTION_OFF);
 #endif  // ENABLE_SECURITY
 }
 
 TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtect) {
   AddTestDeviceConnection();
   AddTestSession();
+  ChangeProtocol(
+      uid_, out_context_.new_session_id_, protocol_handler::PROTOCOL_VERSION_3);
 
-  uint32_t session_id_new = 0;
-  uint32_t session_id2 = 0;
-  uint32_t session_id3 = 0;
+  SessionContext context_new, context_second, context_third;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, _, _))
-      .WillOnce(DoAll(SaveArg<2>(&session_id_new), SaveArg<3>(&out_hash_id_)))
-      .WillOnce(DoAll(SaveArg<2>(&session_id2), SaveArg<3>(&out_hash_id_)))
-      .WillOnce(DoAll(SaveArg<2>(&session_id3), SaveArg<3>(&out_hash_id_)));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _))
+      .WillOnce(SaveArg<0>(&context_new))
+      .WillOnce(SaveArg<0>(&context_second))
+      .WillOnce(SaveArg<0>(&context_third));
 
   // Start RPC protection
   connection_handler_->OnSessionStartedCallback(uid_,
-                                                start_session_id_,
+                                                out_context_.new_session_id_,
                                                 kRpc,
                                                 PROTECTION_ON,
                                                 static_cast<BsonObject*>(NULL));
 #ifdef ENABLE_SECURITY
-  EXPECT_EQ(start_session_id_, session_id_new);
+  EXPECT_EQ(out_context_.new_session_id_, context_new.new_session_id_);
   // Post protection nedd no hash
-  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
-  CheckService(uid_, start_session_id_, kRpc, NULL, PROTECTION_ON);
+  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, context_new.hash_id_);
+  CheckService(uid_, context_new.new_session_id_, kRpc, NULL, PROTECTION_ON);
 #else
-  EXPECT_EQ(0u, session_id_new);
+  EXPECT_EQ(0u, context_new.new_session_id_);
   // Post protection nedd no hash
-  EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
-  CheckService(uid_, start_session_id_, kRpc, NULL, PROTECTION_OFF);
+  EXPECT_EQ(protocol_handler::HASH_ID_WRONG, context_new.hash_id_);
+  CheckService(uid_, context_new.new_session_id_, kRpc, NULL, PROTECTION_OFF);
 #endif  // ENABLE_SECURITY
 
   // Start Audio session without protection
   connection_handler_->OnSessionStartedCallback(uid_,
-                                                start_session_id_,
+                                                out_context_.new_session_id_,
                                                 kAudio,
                                                 PROTECTION_OFF,
                                                 static_cast<BsonObject*>(NULL));
-  EXPECT_EQ(start_session_id_, session_id2);
-  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
-  CheckService(uid_, start_session_id_, kAudio, NULL, PROTECTION_OFF);
+  EXPECT_EQ(out_context_.new_session_id_, context_second.new_session_id_);
+  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, context_second.hash_id_);
+  CheckService(
+      uid_, context_second.new_session_id_, kAudio, NULL, PROTECTION_OFF);
 
   // Start Audio protection
   connection_handler_->OnSessionStartedCallback(uid_,
-                                                start_session_id_,
+                                                out_context_.new_session_id_,
                                                 kAudio,
                                                 PROTECTION_ON,
                                                 static_cast<BsonObject*>(NULL));
 #ifdef ENABLE_SECURITY
-  EXPECT_EQ(start_session_id_, session_id3);
-  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, out_hash_id_);
-  CheckService(uid_, start_session_id_, kAudio, NULL, PROTECTION_ON);
+  EXPECT_EQ(out_context_.new_session_id_, context_third.new_session_id_);
+  EXPECT_EQ(protocol_handler::HASH_ID_NOT_SUPPORTED, context_third.hash_id_);
+  CheckService(
+      uid_, context_third.new_session_id_, kAudio, NULL, PROTECTION_ON);
 #else
-  EXPECT_EQ(0u, session_id3);
-  EXPECT_EQ(protocol_handler::HASH_ID_WRONG, out_hash_id_);
-  CheckService(uid_, start_session_id_, kAudio, NULL, PROTECTION_OFF);
+  EXPECT_EQ(0u, context_third.new_session_id_);
+  EXPECT_EQ(protocol_handler::HASH_ID_WRONG, context_third.hash_id_);
+  CheckService(
+      uid_, context_third.new_session_id_, kAudio, NULL, PROTECTION_OFF);
 #endif  // ENABLE_SECURITY
 }
 
@@ -1658,22 +1704,21 @@ TEST_F(ConnectionHandlerTest, SessionStarted_DealyProtectBulk) {
   AddTestDeviceConnection();
   AddTestSession();
 
-  uint32_t session_id_new = 0;
+  SessionContext new_context;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, _, _))
-      .WillOnce(SaveArg<2>(&session_id_new));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _))
+      .WillOnce(SaveArg<0>(&new_context));
   connection_handler_->OnSessionStartedCallback(uid_,
-                                                start_session_id_,
+                                                out_context_.new_session_id_,
                                                 kBulk,
                                                 PROTECTION_ON,
                                                 static_cast<BsonObject*>(NULL));
 #ifdef ENABLE_SECURITY
-  EXPECT_EQ(start_session_id_, session_id_new);
-  CheckService(uid_, start_session_id_, kRpc, NULL, PROTECTION_ON);
+  EXPECT_EQ(out_context_.new_session_id_, new_context.new_session_id_);
+  CheckService(uid_, new_context.new_session_id_, kRpc, NULL, PROTECTION_ON);
 #else
-  EXPECT_EQ(0u, session_id_new);
-  CheckService(uid_, start_session_id_, kRpc, NULL, PROTECTION_OFF);
+  EXPECT_EQ(0u, new_context.new_session_id_);
+  CheckService(uid_, new_context.new_session_id_, kRpc, NULL, PROTECTION_OFF);
 #endif  // ENABLE_SECURITY
 }
 
@@ -1752,6 +1797,9 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByProtectedService) {
   testing::StrictMock<security_manager_test::MockSSLContext> mock_ssl_context;
   AddTestDeviceConnection();
   AddTestSession();
+  ChangeProtocol(
+      uid_, out_context_.new_session_id_, protocol_handler::PROTOCOL_VERSION_3);
+
   EXPECT_EQ(
       connection_handler_->SetSSLContext(connection_key_, &mock_ssl_context),
       ::security_manager::SecurityManager::ERROR_SUCCESS);
@@ -1763,20 +1811,23 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByProtectedService) {
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kAudio),
             reinterpret_cast<security_manager::SSLContext*>(NULL));
 
-  uint32_t session_id = 0;
+  SessionContext new_context;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, _, _))
-      .WillOnce(SaveArg<2>(&session_id));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _))
+      .WillOnce(SaveArg<0>(&new_context));
 
   // Open kAudio service
   connection_handler_->OnSessionStartedCallback(uid_,
-                                                start_session_id_,
+                                                out_context_.new_session_id_,
                                                 kAudio,
                                                 PROTECTION_ON,
                                                 static_cast<BsonObject*>(NULL));
-  EXPECT_EQ(session_id, start_session_id_);
-  CheckService(uid_, session_id, kAudio, &mock_ssl_context, PROTECTION_ON);
+  EXPECT_EQ(new_context.new_session_id_, out_context_.new_session_id_);
+  CheckService(uid_,
+               new_context.new_session_id_,
+               kAudio,
+               &mock_ssl_context,
+               PROTECTION_ON);
 
   // kAudio is not exists yet
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kAudio),
@@ -1797,20 +1848,23 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedRPC) {
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kRpc),
             reinterpret_cast<security_manager::SSLContext*>(NULL));
 
-  uint32_t session_id = 0;
+  SessionContext new_context;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, _, _))
-      .WillOnce(SaveArg<2>(&session_id));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _))
+      .WillOnce(SaveArg<0>(&new_context));
 
   // Protect kRpc (Bulk will be protect also)
   connection_handler_->OnSessionStartedCallback(uid_,
-                                                start_session_id_,
+                                                out_context_.new_session_id_,
                                                 kRpc,
                                                 PROTECTION_ON,
                                                 static_cast<BsonObject*>(NULL));
-  EXPECT_EQ(start_session_id_, session_id);
-  CheckService(uid_, session_id, kRpc, &mock_ssl_context, PROTECTION_ON);
+  EXPECT_EQ(out_context_.new_session_id_, new_context.new_session_id_);
+  CheckService(uid_,
+               new_context.new_session_id_,
+               kRpc,
+               &mock_ssl_context,
+               PROTECTION_ON);
 
   // kRpc is protected
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kRpc),
@@ -1834,20 +1888,23 @@ TEST_F(ConnectionHandlerTest, GetSSLContext_ByDealyProtectedBulk) {
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kRpc),
             reinterpret_cast<security_manager::SSLContext*>(NULL));
 
-  uint32_t session_id = 0;
+  SessionContext new_context;
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_,
-              NotifySessionStartedResult(_, _, _, _, _, _))
-      .WillOnce(SaveArg<2>(&session_id));
+  EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _))
+      .WillOnce(SaveArg<0>(&new_context));
 
   // Protect Bulk (kRpc will be protected also)
   connection_handler_->OnSessionStartedCallback(uid_,
-                                                start_session_id_,
+                                                out_context_.new_session_id_,
                                                 kBulk,
                                                 PROTECTION_ON,
                                                 static_cast<BsonObject*>(NULL));
-  EXPECT_EQ(start_session_id_, session_id);
-  CheckService(uid_, session_id, kRpc, &mock_ssl_context, PROTECTION_ON);
+  EXPECT_EQ(out_context_.new_session_id_, new_context.new_session_id_);
+  CheckService(uid_,
+               new_context.new_session_id_,
+               kRpc,
+               &mock_ssl_context,
+               PROTECTION_ON);
 
   // kRpc is protected
   EXPECT_EQ(connection_handler_->GetSSLContext(connection_key_, kRpc),
@@ -1863,8 +1920,9 @@ TEST_F(ConnectionHandlerTest, SendHeartBeat) {
   AddTestDeviceConnection();
   AddTestSession();
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
-  EXPECT_CALL(mock_protocol_handler_, SendHeartBeat(uid_, start_session_id_));
-  connection_handler_->SendHeartBeat(uid_, start_session_id_);
+  EXPECT_CALL(mock_protocol_handler_,
+              SendHeartBeat(uid_, out_context_.new_session_id_));
+  connection_handler_->SendHeartBeat(uid_, out_context_.new_session_id_);
 }
 
 TEST_F(ConnectionHandlerTest, RunAppOnDevice_NoAppOnDevice_UNSUCCESS) {

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -1197,7 +1197,7 @@ TEST_F(ConnectionHandlerTest, SessionStop_CheckHash) {
     CheckSessionExists(uid_, out_context_.new_session_id_);
 
     const uint32_t end_audio = connection_handler_->OnSessionEndedCallback(
-        uid_, out_context_.new_session_id_, hash, kRpc);
+        uid_, out_context_.new_session_id_, &hash, kRpc);
     EXPECT_EQ(connection_key_, end_audio);
     CheckSessionExists(uid_, 0);
   }
@@ -1213,13 +1213,13 @@ TEST_F(ConnectionHandlerTest, SessionStop_CheckSpecificHash) {
 
     const uint32_t end_audio_wrong_hash =
         connection_handler_->OnSessionEndedCallback(
-            uid_, out_context_.new_session_id_, wrong_hash, kRpc);
+            uid_, out_context_.new_session_id_, &wrong_hash, kRpc);
     EXPECT_EQ(0u, end_audio_wrong_hash);
     EXPECT_EQ(protocol_handler::HASH_ID_WRONG, wrong_hash);
     CheckSessionExists(uid_, out_context_.new_session_id_);
 
     const uint32_t end_audio = connection_handler_->OnSessionEndedCallback(
-        uid_, out_context_.new_session_id_, hash, kRpc);
+        uid_, out_context_.new_session_id_, &hash, kRpc);
     EXPECT_EQ(connection_key_, end_audio);
     CheckSessionExists(uid_, 0);
   }

--- a/src/components/connection_handler/test/connection_test.cc
+++ b/src/components/connection_handler/test/connection_test.cc
@@ -71,6 +71,11 @@ class ConnectionTest : public ::testing::Test {
     delete connection_handler_;
   }
   void StartSession() {
+    StartDefaultSession();
+    connection_->UpdateProtocolVersionSession(
+        session_id, protocol_handler::PROTOCOL_VERSION_3);
+  }
+  void StartDefaultSession() {
     session_id = connection_->AddNewSession();
     EXPECT_NE(session_id, 0u);
     const SessionMap sessionMap = connection_->session_map();
@@ -142,13 +147,13 @@ TEST_F(ConnectionTest, Session_TryGetProtocolVersionWithoutSession) {
 }
 
 TEST_F(ConnectionTest, Session_GetDefaultProtocolVersion) {
-  StartSession();
+  StartDefaultSession();
   uint8_t protocol_version;
   EXPECT_TRUE(connection_->ProtocolVersion(session_id, protocol_version));
   EXPECT_EQ(static_cast<uint8_t>(PROTOCOL_VERSION_2), protocol_version);
 }
 TEST_F(ConnectionTest, Session_UpdateProtocolVersion) {
-  StartSession();
+  StartDefaultSession();
   uint8_t protocol_version = static_cast<uint8_t>(PROTOCOL_VERSION_3);
   connection_->UpdateProtocolVersionSession(session_id, protocol_version);
   EXPECT_TRUE(connection_->ProtocolVersion(session_id, protocol_version));
@@ -157,7 +162,7 @@ TEST_F(ConnectionTest, Session_UpdateProtocolVersion) {
 
 TEST_F(ConnectionTest, HeartBeat_NotSupported) {
   // Arrange
-  StartSession();
+  StartDefaultSession();
   uint8_t protocol_version;
   EXPECT_TRUE(connection_->ProtocolVersion(session_id, protocol_version));
   EXPECT_EQ(static_cast<uint8_t>(PROTOCOL_VERSION_2), protocol_version);

--- a/src/components/include/connection_handler/connection_handler_observer.h
+++ b/src/components/include/connection_handler/connection_handler_observer.h
@@ -155,7 +155,7 @@ class ConnectionHandlerObserver {
    * @param app_id id of application to check
    * @return true if application is navi otherwise returns false
    */
-  virtual bool CheckAppIsNavi(const uint32_t app_id) = 0;
+  virtual bool CheckAppIsNavi(const uint32_t app_id) const = 0;
 #endif  // ENABLE_SECURITY
  protected:
   /**

--- a/src/components/include/connection_handler/connection_handler_observer.h
+++ b/src/components/include/connection_handler/connection_handler_observer.h
@@ -141,8 +141,21 @@ class ConnectionHandlerObserver {
   virtual void OnDeviceSwitchingFinish(const std::string& device_uid) = 0;
 
 #ifdef ENABLE_SECURITY
+  /**
+   * @brief Get unique handshake context by application id
+   * @param key id of application
+   * @return generated handshake context or empty context if application with
+   * provided id does not exist
+   */
   virtual security_manager::SSLContext::HandshakeContext GetHandshakeContext(
       uint32_t key) const = 0;
+
+  /**
+   * @brief Check if application with specified app_id has NAVIGATION HMI type
+   * @param app_id id of application to check
+   * @return true if application is navi otherwise returns false
+   */
+  virtual bool CheckAppIsNavi(const uint32_t app_id) = 0;
 #endif  // ENABLE_SECURITY
  protected:
   /**

--- a/src/components/include/protocol_handler/protocol_handler.h
+++ b/src/components/include/protocol_handler/protocol_handler.h
@@ -43,7 +43,7 @@ namespace protocol_handler {
 
 class ProtocolObserver;
 class SessionObserver;
-struct StartingSessionContext;
+struct SessionContext;
 
 /**
  * \class ProtocolHandler
@@ -123,12 +123,24 @@ class ProtocolHandler {
    * Only valid when generated_session_id is 0. Note, even if
    * generated_session_id is 0, the list may be empty.
    */
-  virtual void NotifySessionStartedResult(
+  DEPRECATED virtual void NotifySessionStartedResult(
       int32_t connection_id,
       uint8_t session_id,
       uint8_t generated_session_id,
       uint32_t hash_id,
       bool protection,
+      std::vector<std::string>& rejected_params) = 0;
+
+  /**
+   * @brief Called by connection handler to notify the result of
+   * OnSessionStartedCallback().
+   * @param context reference to structure with started session data
+   * @param rejected_params list of parameters name that are rejected.
+   * Only valid when generated_session_id is 0. Note, even if
+   * generated_session_id is 0, the list may be empty.
+   */
+  virtual void NotifySessionStarted(
+      const SessionContext& context,
       std::vector<std::string>& rejected_params) = 0;
 
  protected:

--- a/src/components/include/protocol_handler/protocol_handler.h
+++ b/src/components/include/protocol_handler/protocol_handler.h
@@ -132,7 +132,7 @@ class ProtocolHandler {
       std::vector<std::string>& rejected_params) = 0;
 
   /**
-   * @brief Called by connection handler to notify the result of
+   * @brief Called by connection handler to notify the context of
    * OnSessionStartedCallback().
    * @param context reference to structure with started session data
    * @param rejected_params list of parameters name that are rejected.

--- a/src/components/include/protocol_handler/protocol_handler.h
+++ b/src/components/include/protocol_handler/protocol_handler.h
@@ -43,6 +43,8 @@ namespace protocol_handler {
 
 class ProtocolObserver;
 class SessionObserver;
+struct StartingSessionContext;
+
 /**
  * \class ProtocolHandler
  * \brief Interface for component parsing protocol header

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -327,6 +327,16 @@ class SessionObserver {
       const uint32_t& key,
       const protocol_handler::ServiceType& service_type) = 0;
 
+  /**
+   * @brief Check if session contains service with specified service type
+   * @param connection_key unique id of session to check
+   * @param service_type type of service to check
+   * @return true if session contains service with specified service type
+   */
+  virtual bool IsSessionServiceExists(
+      const uint32_t connection_key,
+      const protocol_handler::ServiceType& service_type) = 0;
+
   virtual security_manager::SSLContext::HandshakeContext GetHandshakeContext(
       uint32_t key) const = 0;
 #endif  // ENABLE_SECURITY

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -58,7 +58,7 @@ enum { HASH_ID_NOT_SUPPORTED = 0, HASH_ID_WRONG = 0xFFFF0000 };
 /**
  * @brief Struct with data containing attributes of starting session
  **/
-struct StartingSessionContext {
+struct SessionContext {
   transport_manager::ConnectionUID connection_id_;
   uint8_t initial_session_id_;
   uint8_t new_session_id_;
@@ -71,7 +71,7 @@ struct StartingSessionContext {
   /**
    * @brief Constructor
    */
-  StartingSessionContext()
+  SessionContext()
       : connection_id_(0)
       , initial_session_id_(0)
       , new_session_id_(0)
@@ -93,12 +93,12 @@ struct StartingSessionContext {
    * @param is_protected Whether service will be protected
    * @param is_new_service Whether service was already established
    **/
-  StartingSessionContext(transport_manager::ConnectionUID connection_id,
-                         uint8_t session_id,
-                         uint8_t new_session_id,
-                         protocol_handler::ServiceType service_type,
-                         uint32_t hash_id,
-                         const bool is_protected)
+  SessionContext(transport_manager::ConnectionUID connection_id,
+                 uint8_t session_id,
+                 uint8_t new_session_id,
+                 protocol_handler::ServiceType service_type,
+                 uint32_t hash_id,
+                 const bool is_protected)
       : connection_id_(connection_id)
       , initial_session_id_(session_id)
       , new_session_id_(new_session_id)

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -142,7 +142,7 @@ class SessionObserver {
   /**
    * \brief Callback function used by ProtocolHandler
    * when Mobile Application initiates start of new session.
-   * Result must be notified through NotifySessionStartedResult().
+   * Result must be notified through NotifySessionStartedContext().
    * \param connection_handle Connection identifier within which session
    * has to be started.
    * \param sessionId Identifier of the session to be start

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -333,9 +333,9 @@ class SessionObserver {
    * @param service_type type of service to check
    * @return true if session contains service with specified service type
    */
-  virtual bool IsSessionServiceExists(
+  virtual bool SessionServiceExists(
       const uint32_t connection_key,
-      const protocol_handler::ServiceType& service_type) = 0;
+      const protocol_handler::ServiceType& service_type) const = 0;
 
   virtual security_manager::SSLContext::HandshakeContext GetHandshakeContext(
       uint32_t key) const = 0;

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -56,6 +56,60 @@ namespace protocol_handler {
 enum { HASH_ID_NOT_SUPPORTED = 0, HASH_ID_WRONG = 0xFFFF0000 };
 
 /**
+ * @brief Struct with data containing attributes of starting session
+ **/
+struct StartingSessionContext {
+  transport_manager::ConnectionUID connection_id_;
+  uint8_t initial_session_id_;
+  uint8_t new_session_id_;
+  protocol_handler::ServiceType service_type_;
+  uint32_t hash_id_;
+  bool is_protected_;
+  bool is_new_service_;
+  bool is_ptu_required_;
+
+  /**
+   * @brief Constructor
+   */
+  StartingSessionContext()
+      : connection_id_(0)
+      , initial_session_id_(0)
+      , new_session_id_(0)
+      , service_type_(protocol_handler::kInvalidServiceType)
+      , hash_id_(0)
+      , is_protected_(false)
+      , is_new_service_(false)
+      , is_ptu_required_(false) {}
+
+  /**
+   * @brief Constructor
+   * @param connection_id_ Connection identifier within which session is
+   * started.
+   * @param session_id Session ID specified to OnSessionStartedCallback()
+   * @param new_session_id Session ID generated
+   * @param service_type Type of service
+   * @param hash_id Hash ID generated from connection_handle and
+   * new_session_id
+   * @param is_protected Whether service will be protected
+   * @param is_new_service Whether service was already established
+   **/
+  StartingSessionContext(transport_manager::ConnectionUID connection_id,
+                         uint8_t session_id,
+                         uint8_t new_session_id,
+                         protocol_handler::ServiceType service_type,
+                         uint32_t hash_id,
+                         const bool is_protected)
+      : connection_id_(connection_id)
+      , initial_session_id_(session_id)
+      , new_session_id_(new_session_id)
+      , service_type_(service_type)
+      , hash_id_(hash_id)
+      , is_protected_(is_protected)
+      , is_new_service_(false)
+      , is_ptu_required_(false) {}
+};
+
+/**
  * \class SessionObserver
  * \brief Interface for making a bridge between ProtocolHandler and
  * ConnectionHandler components.

--- a/src/components/include/security_manager/security_manager.h
+++ b/src/components/include/security_manager/security_manager.h
@@ -137,7 +137,7 @@ class SecurityManager : public protocol_handler::ProtocolObserver {
    * @brief Notify all listeners that certificate update required
    * Allows to notify that certificate should be updated
    */
-  virtual void NotifyOnCertififcateUpdateRequired() = 0;
+  virtual void NotifyOnCertificateUpdateRequired() = 0;
 
   /**
    * @brief Check if policy certificate data is empty

--- a/src/components/include/security_manager/security_manager.h
+++ b/src/components/include/security_manager/security_manager.h
@@ -128,6 +128,24 @@ class SecurityManager : public protocol_handler::ProtocolObserver {
   virtual void StartHandshake(uint32_t connection_key) = 0;
 
   /**
+   * @brief Check whether certificate should be updated
+   * @return true if certificate should be updated otherwise false
+   */
+  virtual bool IsCertificateUpdateRequired() = 0;
+
+  /**
+   * @brief Notify all listeners that certificate update required
+   * Allows to notify that certificate should be updated
+   */
+  virtual void NotifyOnCertififcateUpdateRequired() = 0;
+
+  /**
+   * @brief Check if policy certificate data is empty
+   * @return true if policy certificate data is empty otherwise false
+   */
+  virtual bool IsPolicyCertificateDataEmpty() = 0;
+
+  /**
    * \brief Add/Remove for SecurityManagerListener
    */
   virtual void AddListener(SecurityManagerListener* const listener) = 0;

--- a/src/components/include/security_manager/security_manager_listener.h
+++ b/src/components/include/security_manager/security_manager_listener.h
@@ -57,7 +57,7 @@ class SecurityManagerListener {
    * @param reference to string where to save certificate data
    * @return true if listener saved some data to string otherwise false
    */
-  virtual bool GetPolicyCertificateData(std::string& data) = 0;
+  virtual bool GetPolicyCertificateData(std::string& data) const = 0;
 
   virtual ~SecurityManagerListener() {}
 };

--- a/src/components/include/security_manager/security_manager_listener.h
+++ b/src/components/include/security_manager/security_manager_listener.h
@@ -31,6 +31,9 @@
  */
 #ifndef SRC_COMPONENTS_INCLUDE_SECURITY_MANAGER_SECURITY_MANAGER_LISTENER_H_
 #define SRC_COMPONENTS_INCLUDE_SECURITY_MANAGER_SECURITY_MANAGER_LISTENER_H_
+
+#include <string>
+
 namespace security_manager {
 
 class SecurityManagerListener {
@@ -48,6 +51,14 @@ class SecurityManagerListener {
    * @brief Notify listeners that certificate update is required.
    */
   virtual void OnCertificateUpdateRequired() = 0;
+
+  /**
+   * @brief Get certificate data from policy
+   * @param reference to string where to save certificate data
+   * @return true if listener saved some data to string otherwise false
+   */
+  virtual bool GetPolicyCertificateData(std::string& data) = 0;
+
   virtual ~SecurityManagerListener() {}
 };
 }  // namespace security_manager

--- a/src/components/include/test/connection_handler/mock_connection_handler_observer.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler_observer.h
@@ -48,11 +48,10 @@ class MockConnectionHandlerObserver
   MOCK_METHOD0(OnFindNewApplicationsRequest, void());
   MOCK_METHOD1(RemoveDevice,
                void(const connection_handler::DeviceHandle& device_handle));
-  DEPRECATED MOCK_METHOD3(
-      OnServiceStartedCallback,
-      bool(const connection_handler::DeviceHandle& device_handle,
-           const int32_t& session_key,
-           const protocol_handler::ServiceType& type));
+  DEPRECATED MOCK_METHOD3(OnServiceStartedCallback,
+               bool(const connection_handler::DeviceHandle& device_handle,
+                    const int32_t& session_key,
+                    const protocol_handler::ServiceType& type));
   MOCK_METHOD4(OnServiceStartedCallback,
                void(const connection_handler::DeviceHandle& device_handle,
                     const int32_t& session_key,

--- a/src/components/include/test/connection_handler/mock_connection_handler_observer.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler_observer.h
@@ -71,6 +71,7 @@ class MockConnectionHandlerObserver
                void(const connection_handler::Device& device_from,
                     const connection_handler::Device& device_to));
   MOCK_METHOD1(OnDeviceSwitchingFinish, void(const std::string& device_uid));
+  MOCK_CONST_METHOD1(CheckAppIsNavi, bool(const uint32_t app_id));
 };
 
 }  // namespace connection_handler_test

--- a/src/components/include/test/protocol_handler/mock_protocol_handler.h
+++ b/src/components/include/test/protocol_handler/mock_protocol_handler.h
@@ -62,12 +62,15 @@ class MockProtocolHandler : public ::protocol_handler::ProtocolHandler {
   MOCK_CONST_METHOD0(get_settings,
                      const ::protocol_handler::ProtocolHandlerSettings&());
   MOCK_METHOD0(get_session_observer, protocol_handler::SessionObserver&());
-  MOCK_METHOD6(NotifySessionStartedResult,
+  DEPRECATED MOCK_METHOD6(NotifySessionStartedResult,
                void(int32_t connection_id,
                     uint8_t session_id,
                     uint8_t generated_session_id,
                     uint32_t hash_id,
                     bool protection,
+                    std::vector<std::string>& rejected_params));
+  MOCK_METHOD2(NotifySessionStarted,
+               void(const ::protocol_handler::SessionContext& context,
                     std::vector<std::string>& rejected_params));
 };
 }  // namespace protocol_handler_test

--- a/src/components/include/test/protocol_handler/mock_session_observer.h
+++ b/src/components/include/test/protocol_handler/mock_session_observer.h
@@ -126,6 +126,9 @@ class MockSessionObserver : public ::protocol_handler::SessionObserver {
   MOCK_METHOD2(SetProtectionFlag,
                void(const uint32_t& key,
                     const protocol_handler::ServiceType& service_type));
+  MOCK_CONST_METHOD2(SessionServiceExists,
+                     bool(const uint32_t connection_key,
+                          const protocol_handler::ServiceType& service_type));
   MOCK_CONST_METHOD1(
       GetHandshakeContext,
       security_manager::SSLContext::HandshakeContext(uint32_t key));

--- a/src/components/include/test/security_manager/mock_security_manager.h
+++ b/src/components/include/test/security_manager/mock_security_manager.h
@@ -65,6 +65,9 @@ class MockSecurityManager : public ::security_manager::SecurityManager {
                void(const ::protocol_handler::RawMessagePtr));
   MOCK_METHOD1(OnMobileMessageSent,
                void(const ::protocol_handler::RawMessagePtr));
+  MOCK_METHOD0(IsCertificateUpdateRequired, bool());
+  MOCK_METHOD0(NotifyOnCertificateUpdateRequired, void());
+  MOCK_METHOD0(IsPolicyCertificateDataEmpty, bool());
 };
 
 /*

--- a/src/components/include/test/security_manager/mock_security_manager_listener.h
+++ b/src/components/include/test/security_manager/mock_security_manager_listener.h
@@ -48,6 +48,7 @@ class MockSecurityManagerListener
                bool(uint32_t connection_key,
                     ::security_manager::SSLContext::HandshakeResult result));
   MOCK_METHOD0(OnCertificateUpdateRequired, void());
+  MOCK_CONST_METHOD1(GetPolicyCertificateData, bool(std::string& data));
 };
 }  // namespace security_manager_test
 }  // namespace components

--- a/src/components/protocol_handler/include/protocol_handler/handshake_handler.h
+++ b/src/components/protocol_handler/include/protocol_handler/handshake_handler.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_PROTOCOL_HANDLER_INCLUDE_PROTOCOL_HANDLER_START_SESSION_HANDLER_H_
+#define SRC_COMPONENTS_PROTOCOL_HANDLER_INCLUDE_PROTOCOL_HANDLER_START_SESSION_HANDLER_H_
+
+#include <memory>
+
+#include "protocol_handler/protocol_handler_impl.h"
+#include "protocol_handler/protocol_packet.h"
+#include "protocol_handler/session_observer.h"
+#include "security_manager/security_manager_listener.h"
+
+namespace protocol_handler {
+
+class ProtocolHandlerImpl;
+
+/**
+ * \brief HandshakeHandler class for handling SSL handshake and sending
+ * Ack/Nack on its success or fail
+ */
+class HandshakeHandler : public security_manager::SecurityManagerListener {
+ public:
+  DEPRECATED HandshakeHandler(ProtocolHandlerImpl& protocol_handler,
+                              SessionObserver& session_observer,
+                              uint32_t connection_key,
+                              ConnectionID connection_id,
+                              uint8_t session_id,
+                              uint8_t protocol_version,
+                              uint32_t hash_id,
+                              ServiceType service_type,
+                              const std::vector<int>& force_protected_service,
+                              const bool is_new_service,
+                              ProtocolPacket::ProtocolVersion& full_version,
+                              std::shared_ptr<uint8_t> payload);
+
+  HandshakeHandler(ProtocolHandlerImpl& protocol_handler,
+                   SessionObserver& session_observer,
+                   ProtocolPacket::ProtocolVersion& full_version,
+                   const SessionContext& context,
+                   const uint8_t protocol_version,
+                   std::shared_ptr<uint8_t> payload);
+
+  ~HandshakeHandler();
+
+  /**
+   * @brief Get certificate data from policy
+   * @param reference to string where to save certificate data
+   * @return true if listener saved some data to string otherwise false
+   */
+  bool GetPolicyCertificateData(std::string& data) OVERRIDE;
+
+  /**
+   * \brief Notification about protection result
+   * \param connection_key Unique key of session which triggrs handshake
+   * \param result result of connection protection
+   * \return true on success notification handling or false otherwise
+   */
+  bool OnHandshakeDone(
+      uint32_t connection_key,
+      security_manager::SSLContext::HandshakeResult result) OVERRIDE;
+
+  /**
+   * @brief Notification that certificate update is required.
+   */
+  void OnCertificateUpdateRequired() OVERRIDE;
+
+  /**
+   * @brief Get connection key of this handler
+   * @return connection key
+   */
+  uint32_t connection_key() const;
+
+ private:
+  /**
+   * @brief Performs related actions if handshake was successfully finished
+   * @param connection_key Unique key of session which triggrs handshake
+   * @param params set of params used in bson part of message
+   */
+  void ProcessSuccessfulHandshake(const uint32_t connection_key,
+                                  BsonObject& params);
+
+  /**
+   * @brief Performs related actions if handshake was failed
+   * @param params set of params used in bson part of message
+   */
+  void ProcessFailedHandshake(BsonObject& params);
+
+  ProtocolHandlerImpl& protocol_handler_;
+  SessionObserver& session_observer_;
+  SessionContext context_;
+  ProtocolPacket::ProtocolVersion full_version_;
+  const uint8_t protocol_version_;
+  std::shared_ptr<uint8_t> payload_;
+};
+
+}  // namespace protocol_handler
+
+#endif  // SRC_COMPONENTS_PROTOCOL_HANDLER_INCLUDE_PROTOCOL_HANDLER_START_SESSION_HANDLER_H_

--- a/src/components/protocol_handler/include/protocol_handler/handshake_handler.h
+++ b/src/components/protocol_handler/include/protocol_handler/handshake_handler.h
@@ -45,7 +45,7 @@ namespace protocol_handler {
 class ProtocolHandlerImpl;
 
 /**
- * \brief HandshakeHandler class for handling SSL handshake and sending
+ * @brief HandshakeHandler class for handling SSL handshake and sending
  * Ack/Nack on its success or fail
  */
 class HandshakeHandler : public security_manager::SecurityManagerListener {
@@ -77,13 +77,13 @@ class HandshakeHandler : public security_manager::SecurityManagerListener {
    * @param reference to string where to save certificate data
    * @return true if listener saved some data to string otherwise false
    */
-  bool GetPolicyCertificateData(std::string& data) OVERRIDE;
+  bool GetPolicyCertificateData(std::string& data) const OVERRIDE;
 
   /**
-   * \brief Notification about protection result
-   * \param connection_key Unique key of session which triggrs handshake
-   * \param result result of connection protection
-   * \return true on success notification handling or false otherwise
+   * @brief Notification about protection result
+   * @param connection_key Unique key of session which triggrs handshake
+   * @param result result of connection protection
+   * @return true on success notification handling or false otherwise
    */
   bool OnHandshakeDone(
       uint32_t connection_key,

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -56,6 +56,7 @@
 #include "transport_manager/transport_manager.h"
 #include "transport_manager/transport_manager_listener_empty.h"
 #include "connection_handler/connection_handler.h"
+#include "application_manager/policies/policy_handler_observer.h"
 
 #ifdef TELEMETRY_MONITOR
 #include "protocol_handler/telemetry_observer.h"
@@ -143,6 +144,7 @@ typedef threads::MessageLoopThread<
 class ProtocolHandlerImpl
     : public ProtocolHandler,
       public TransportManagerListenerEmpty,
+      public policy::PolicyHandlerObserver,
       public impl::FromMobileQueue::Handler,
       public impl::ToMobileQueue::Handler
 #ifdef TELEMETRY_MONITOR
@@ -469,6 +471,14 @@ class ProtocolHandlerImpl
 
   void OnConnectionClosed(
       const transport_manager::ConnectionUID connection_id) OVERRIDE;
+
+  /**
+   * @brief OnPTUFinished the callback which signals PTU has finished
+   *
+   * @param ptu_result the result from the PTU - true if successful,
+   * otherwise false.
+   */
+  void OnPTUFinished(const bool ptu_result) OVERRIDE;
 
   /**
    * @brief Notifies subscribers about message

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -64,6 +64,7 @@
 
 #ifdef ENABLE_SECURITY
 #include "security_manager/security_manager.h"
+#include "protocol_handler/handshake_handler.h"
 #endif  // ENABLE_SECURITY
 
 namespace connection_handler {
@@ -77,6 +78,7 @@ class ConnectionHandlerImpl;
 namespace protocol_handler {
 class ProtocolObserver;
 class SessionObserver;
+class HandshakeHandler;
 
 class MessagesFromMobileAppHandler;
 class MessagesToMobileAppHandler;
@@ -660,6 +662,10 @@ class ProtocolHandlerImpl
 
 #ifdef ENABLE_SECURITY
   security_manager::SecurityManager* security_manager_;
+
+  bool is_ptu_triggered_;
+  std::list<std::shared_ptr<HandshakeHandler> > ptu_pending_handlers_;
+  sync_primitives::Lock ptu_handlers_lock_;
 #endif  // ENABLE_SECURITY
 
   // Thread that pumps non-parsed messages coming from mobile side.

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -391,13 +391,24 @@ class ProtocolHandlerImpl
    * Only valid when generated_session_id is 0. Note, even if
    * generated_session_id is 0, the list may be empty.
    */
-  void NotifySessionStartedResult(
+  DEPRECATED void NotifySessionStartedResult(
       int32_t connection_id,
       uint8_t session_id,
       uint8_t generated_session_id,
       uint32_t hash_id,
       bool protection,
       std::vector<std::string>& rejected_params) OVERRIDE;
+
+  /**
+   * @brief Called by connection handler to notify the result of
+   * OnSessionStartedCallback().
+   * @param context reference to structure with started session data
+   * @param rejected_params list of parameters name that are rejected.
+   * Only valid when generated_session_id is 0. Note, even if
+   * generated_session_id is 0, the list may be empty.
+   */
+  void NotifySessionStarted(const SessionContext& context,
+                            std::vector<std::string>& rejected_params) OVERRIDE;
 
 #ifdef BUILD_TESTS
   const impl::FromMobileQueue& get_from_mobile_queue() const {

--- a/src/components/protocol_handler/src/handshake_handler.cc
+++ b/src/components/protocol_handler/src/handshake_handler.cc
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "protocol_handler/handshake_handler.h"
+
+#include <bson_object.h>
+
+#include "protocol_handler/protocol_handler_impl.h"
+#include "protocol_handler/protocol_packet.h"
+#include "security_manager/security_manager.h"
+#include "protocol_handler/session_observer.h"
+
+namespace protocol_handler {
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "ProtocolHandler")
+
+HandshakeHandler::HandshakeHandler(
+    ProtocolHandlerImpl& protocol_handler,
+    SessionObserver& session_observer,
+    uint32_t connection_key,
+    ConnectionID connection_id,
+    uint8_t session_id,
+    uint8_t protocol_version,
+    uint32_t hash_id,
+    ServiceType service_type,
+    const std::vector<int>& force_protected_service,
+    const bool is_new_service,
+    ProtocolPacket::ProtocolVersion& full_version,
+    std::shared_ptr<uint8_t> payload)
+    : protocol_handler_(protocol_handler)
+    , session_observer_(session_observer)
+    , context_()
+    , full_version_(full_version)
+    , protocol_version_(protocol_version)
+    , payload_(payload) {}
+
+HandshakeHandler::HandshakeHandler(
+    ProtocolHandlerImpl& protocol_handler,
+    SessionObserver& session_observer,
+    ProtocolPacket::ProtocolVersion& full_version,
+    const SessionContext& context,
+    const uint8_t protocol_version,
+    std::shared_ptr<uint8_t> payload)
+    : protocol_handler_(protocol_handler)
+    , session_observer_(session_observer)
+    , context_(context)
+    , full_version_(full_version)
+    , protocol_version_(protocol_version)
+    , payload_(payload) {}
+
+HandshakeHandler::~HandshakeHandler() {
+  LOG4CXX_DEBUG(logger_, "Destroying StartSessionHandler: " << this);
+}
+
+uint32_t HandshakeHandler::connection_key() const {
+  return session_observer_.KeyFromPair(context_.connection_id_,
+                                       context_.new_session_id_);
+}
+
+bool HandshakeHandler::GetPolicyCertificateData(std::string& data) {
+  return false;
+}
+
+void HandshakeHandler::OnCertificateUpdateRequired() {}
+
+bool HandshakeHandler::OnHandshakeDone(
+    uint32_t connection_key,
+    security_manager::SSLContext::HandshakeResult result) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (connection_key != this->connection_key()) {
+    LOG4CXX_DEBUG(logger_, "Notification not for handler " << this);
+    return false;
+  }
+
+  const bool success =
+      result == security_manager::SSLContext::Handshake_Result_Success;
+
+  BsonObject params;
+  if (payload_) {
+    params = bson_object_from_bytes(payload_.get());
+  } else {
+    bson_object_initialize_default(&params);
+  }
+
+  if (success) {
+    ProcessSuccessfulHandshake(connection_key, params);
+  } else {
+    ProcessFailedHandshake(params);
+  }
+
+  bson_object_deinitialize(&params);
+  return true;
+}
+
+void HandshakeHandler::ProcessSuccessfulHandshake(const uint32_t connection_key,
+                                                  BsonObject& params) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const std::vector<int>& force_unprotected =
+      protocol_handler_.get_settings().force_unprotected_service();
+
+  const bool can_be_protected =
+      std::find(force_unprotected.begin(),
+                force_unprotected.end(),
+                context_.service_type_) == force_unprotected.end();
+
+  const bool is_service_already_protected =
+      session_observer_.GetSSLContext(connection_key, context_.service_type_) !=
+      NULL;
+
+  LOG4CXX_DEBUG(logger_,
+                "Service can be protected: " << can_be_protected
+                                             << " and service was protected: "
+                                             << is_service_already_protected);
+
+  if (can_be_protected && !is_service_already_protected) {
+    session_observer_.SetProtectionFlag(connection_key, context_.service_type_);
+    protocol_handler_.SendStartSessionAck(context_.connection_id_,
+                                          context_.new_session_id_,
+                                          protocol_version_,
+                                          context_.hash_id_,
+                                          context_.service_type_,
+                                          can_be_protected,
+                                          full_version_,
+                                          params);
+  } else {
+    protocol_handler_.SendStartSessionNAck(context_.connection_id_,
+                                           context_.new_session_id_,
+                                           protocol_version_,
+                                           context_.service_type_);
+  }
+}
+
+void HandshakeHandler::ProcessFailedHandshake(BsonObject& params) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(logger_, "Handshake failed");
+  const std::vector<int>& force_protected =
+      protocol_handler_.get_settings().force_protected_service();
+
+  const bool can_be_unprotected =
+      std::find(force_protected.begin(),
+                force_protected.end(),
+                context_.service_type_) == force_protected.end();
+
+  LOG4CXX_DEBUG(logger_,
+                "Service can be unprotected: " << can_be_unprotected
+                                               << " and this is a new service: "
+                                               << context_.is_new_service_);
+
+  if (can_be_unprotected && context_.is_new_service_) {
+    protocol_handler_.SendStartSessionAck(context_.connection_id_,
+                                          context_.new_session_id_,
+                                          protocol_version_,
+                                          context_.hash_id_,
+                                          context_.service_type_,
+                                          PROTECTION_OFF,
+                                          full_version_,
+                                          params);
+  } else {
+    protocol_handler_.SendStartSessionNAck(context_.connection_id_,
+                                           context_.new_session_id_,
+                                           protocol_version_,
+                                           context_.service_type_);
+  }
+}
+
+}  // namespace protocol_handler

--- a/src/components/protocol_handler/src/handshake_handler.cc
+++ b/src/components/protocol_handler/src/handshake_handler.cc
@@ -78,7 +78,7 @@ HandshakeHandler::HandshakeHandler(
     , payload_(payload) {}
 
 HandshakeHandler::~HandshakeHandler() {
-  LOG4CXX_DEBUG(logger_, "Destroying StartSessionHandler: " << this);
+  LOG4CXX_DEBUG(logger_, "Destroying of HandshakeHandler: " << this);
 }
 
 uint32_t HandshakeHandler::connection_key() const {
@@ -86,7 +86,7 @@ uint32_t HandshakeHandler::connection_key() const {
                                        context_.new_session_id_);
 }
 
-bool HandshakeHandler::GetPolicyCertificateData(std::string& data) {
+bool HandshakeHandler::GetPolicyCertificateData(std::string& data) const {
   return false;
 }
 
@@ -98,7 +98,12 @@ bool HandshakeHandler::OnHandshakeDone(
   LOG4CXX_AUTO_TRACE(logger_);
 
   if (connection_key != this->connection_key()) {
-    LOG4CXX_DEBUG(logger_, "Notification not for handler " << this);
+    LOG4CXX_DEBUG(logger_,
+                  "Listener " << this
+                              << " expects notification for connection id: "
+                              << this->connection_key()
+                              << ". Received notification for connection id "
+                              << connection_key << " will be ignored");
     return false;
   }
 

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1242,6 +1242,9 @@ RESULT_CODE ProtocolHandlerImpl::HandleControlMessageEndServiceACK(
   return RESULT_OK;
 }
 
+// Suppress warning for deprecated method used within another deprecated method
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 RESULT_CODE ProtocolHandlerImpl::HandleControlMessageStartSession(
     const ProtocolPacket& packet) {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1582,7 +1582,7 @@ void ProtocolHandlerImpl::NotifySessionStarted(
 
         ptu_pending_handlers_.push_back(handler);
         is_ptu_triggered_ = true;
-        security_manager_->NotifyOnCertififcateUpdateRequired();
+        security_manager_->NotifyOnCertificateUpdateRequired();
       } else {
         LOG4CXX_DEBUG(logger_, "PTU has been triggered. Added to pending.");
         ptu_pending_handlers_.push_back(handler);

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -105,6 +105,7 @@ using ::testing::An;
 using ::testing::AnyOf;
 using ::testing::ByRef;
 using ::testing::DoAll;
+using ::testing::SaveArg;
 using ::testing::Eq;
 using ::testing::_;
 using ::testing::Invoke;
@@ -114,12 +115,14 @@ using ::testing::SetArgPointee;
 typedef std::vector<uint8_t> UCharDataVector;
 
 // custom action to call a member function with 6 arguments
-ACTION_P8(InvokeMemberFuncWithArg6, ptr, memberFunc, a, b, c, d, e, f) {
-  (ptr->*memberFunc)(a, b, c, d, e, f);
+ACTION_P4(InvokeMemberFuncWithArg2, ptr, memberFunc, a, b) {
+  (ptr->*memberFunc)(a, b);
 }
 
 namespace {
 const uint32_t kAsyncExpectationsTimeout = 10000u;
+const uint32_t kMicrosecondsInMillisecond = 1000u;
+const uint32_t kAddSessionWaitTimeMs = 100u;
 }
 
 class ProtocolHandlerImplTest : public ::testing::Test {
@@ -145,6 +148,13 @@ class ProtocolHandlerImplTest : public ::testing::Test {
         .WillByDefault(Return(malformd_max_messages));
     ON_CALL(protocol_handler_settings_mock, multiframe_waiting_timeout())
         .WillByDefault(Return(multiframe_waiting_timeout));
+#ifdef ENABLE_SECURITY
+    ON_CALL(protocol_handler_settings_mock, force_protected_service())
+        .WillByDefault(ReturnRefOfCopy(force_protected_services));
+    ON_CALL(protocol_handler_settings_mock, force_unprotected_service())
+        .WillByDefault(ReturnRefOfCopy(force_unprotected_services));
+#endif
+
     protocol_handler_impl.reset(
         new ProtocolHandlerImpl(protocol_handler_settings_mock,
                                 session_observer_mock,
@@ -189,6 +199,21 @@ class ProtocolHandlerImplTest : public ::testing::Test {
                                          connection_id);
   }
 
+  protocol_handler::SessionContext GetSessionContext(
+      const transport_manager::ConnectionUID connection_id,
+      const uint8_t initial_session_id,
+      const uint8_t new_session_id,
+      const protocol_handler::ServiceType service_type,
+      const uint32_t hash_id,
+      const bool protection_flag) {
+    return protocol_handler::SessionContext(connection_id,
+                                            initial_session_id,
+                                            new_session_id,
+                                            service_type,
+                                            hash_id,
+                                            protection_flag);
+  }
+
   void AddSession(const ::utils::SharedPtr<TestAsyncWaiter>& waiter,
                   uint32_t& times) {
     using namespace protocol_handler;
@@ -206,6 +231,14 @@ class ProtocolHandlerImplTest : public ::testing::Test {
     const bool callback_protection_flag = PROTECTION_OFF;
 #endif  // ENABLE_SECURITY
 
+    const protocol_handler::SessionContext context =
+        GetSessionContext(connection_id,
+                          NEW_SESSION_ID,
+                          session_id,
+                          start_service,
+                          HASH_ID_WRONG,
+                          callback_protection_flag);
+
     // Expect ConnectionHandler check
     EXPECT_CALL(session_observer_mock,
                 OnSessionStartedCallback(connection_id,
@@ -215,16 +248,12 @@ class ProtocolHandlerImplTest : public ::testing::Test {
                                          An<const BsonObject*>()))
         .
         // Return sessions start success
-        WillOnce(DoAll(NotifyTestAsyncWaiter(waiter),
-                       InvokeMemberFuncWithArg6(
-                           protocol_handler_impl.get(),
-                           &ProtocolHandler::NotifySessionStartedResult,
-                           connection_id,
-                           NEW_SESSION_ID,
-                           session_id,
-                           HASH_ID_WRONG,
-                           callback_protection_flag,
-                           ByRef(empty_rejected_param_))));
+        WillOnce(DoAll(
+            NotifyTestAsyncWaiter(waiter),
+            InvokeMemberFuncWithArg2(protocol_handler_impl.get(),
+                                     &ProtocolHandler::NotifySessionStarted,
+                                     context,
+                                     ByRef(empty_rejected_param_))));
     times++;
 
     // Expect send Ack with PROTECTION_OFF (on no Security Manager)
@@ -236,6 +265,8 @@ class ProtocolHandlerImplTest : public ::testing::Test {
 
     SendControlMessage(
         PROTECTION_ON, start_service, NEW_SESSION_ID, FRAME_DATA_START_SERVICE);
+
+    usleep(kAddSessionWaitTimeMs * kMicrosecondsInMillisecond);
   }
 
 #ifdef ENABLE_SECURITY
@@ -316,6 +347,8 @@ class ProtocolHandlerImplTest : public ::testing::Test {
   testing::NiceMock<security_manager_test::MockSecurityManager>
       security_manager_mock;
   testing::NiceMock<security_manager_test::MockSSLContext> ssl_context_mock;
+  std::vector<int> force_protected_services;
+  std::vector<int> force_unprotected_services;
 #endif  // ENABLE_SECURITY
   std::vector<std::string> empty_rejected_param_;
 };
@@ -371,6 +404,7 @@ TEST_F(ProtocolHandlerImplTest,
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
+  ServiceType service_type;
   // Expect ConnectionHandler check
   EXPECT_CALL(
       session_observer_mock,
@@ -382,16 +416,18 @@ TEST_F(ProtocolHandlerImplTest,
       .Times(call_times)
       .
       // Return sessions start rejection
-      WillRepeatedly(DoAll(
-          NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
-                                   &ProtocolHandler::NotifySessionStartedResult,
-                                   connection_id,
-                                   NEW_SESSION_ID,
-                                   SESSION_START_REJECT,
-                                   HASH_ID_WRONG,
-                                   PROTECTION_OFF,
-                                   ByRef(empty_rejected_param_))));
+      WillRepeatedly(
+          DoAll(NotifyTestAsyncWaiter(&waiter),
+                SaveArg<2>(&service_type),
+                InvokeMemberFuncWithArg2(protocol_handler_impl.get(),
+                                         &ProtocolHandler::NotifySessionStarted,
+                                         GetSessionContext(connection_id,
+                                                           NEW_SESSION_ID,
+                                                           SESSION_START_REJECT,
+                                                           service_type,
+                                                           HASH_ID_WRONG,
+                                                           PROTECTION_OFF),
+                                         ByRef(empty_rejected_param_))));
   times += call_times;
 
   // Expect send NAck
@@ -436,6 +472,7 @@ TEST_F(ProtocolHandlerImplTest, StartSession_Protected_SessionObserverReject) {
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
+  ServiceType service_type;
   // Expect ConnectionHandler check
   EXPECT_CALL(
       session_observer_mock,
@@ -449,13 +486,15 @@ TEST_F(ProtocolHandlerImplTest, StartSession_Protected_SessionObserverReject) {
       // Return sessions start rejection
       WillRepeatedly(DoAll(
           NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
-                                   &ProtocolHandler::NotifySessionStartedResult,
-                                   connection_id,
-                                   NEW_SESSION_ID,
-                                   SESSION_START_REJECT,
-                                   HASH_ID_WRONG,
-                                   callback_protection_flag,
+          SaveArg<2>(&service_type),
+          InvokeMemberFuncWithArg2(protocol_handler_impl.get(),
+                                   &ProtocolHandler::NotifySessionStarted,
+                                   GetSessionContext(connection_id,
+                                                     NEW_SESSION_ID,
+                                                     SESSION_START_REJECT,
+                                                     service_type,
+                                                     HASH_ID_WRONG,
+                                                     callback_protection_flag),
                                    ByRef(empty_rejected_param_))));
   times += call_times;
 
@@ -501,16 +540,17 @@ TEST_F(ProtocolHandlerImplTest,
                                        An<const BsonObject*>()))
       .
       // Return sessions start success
-      WillOnce(DoAll(
-          NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
-                                   &ProtocolHandler::NotifySessionStartedResult,
-                                   connection_id,
-                                   NEW_SESSION_ID,
-                                   session_id,
-                                   HASH_ID_WRONG,
-                                   PROTECTION_OFF,
-                                   ByRef(empty_rejected_param_))));
+      WillOnce(
+          DoAll(NotifyTestAsyncWaiter(&waiter),
+                InvokeMemberFuncWithArg2(protocol_handler_impl.get(),
+                                         &ProtocolHandler::NotifySessionStarted,
+                                         GetSessionContext(connection_id,
+                                                           NEW_SESSION_ID,
+                                                           session_id,
+                                                           start_service,
+                                                           HASH_ID_WRONG,
+                                                           PROTECTION_OFF),
+                                         ByRef(empty_rejected_param_))));
   times++;
 
   SetProtocolVersion2();
@@ -614,7 +654,7 @@ TEST_F(ProtocolHandlerImplTest,
                                        start_service,
                                        PROTECTION_OFF,
                                        An<const BsonObject*>()))
-      // don't call NotifySessionStartedResult() immediately, instead call it
+      // don't call NotifySessionStartedContext() immediately, instead call it
       // after second OnSessionStartedCallback()
       .WillOnce(NotifyTestAsyncWaiter(&waiter));
   times++;
@@ -640,21 +680,23 @@ TEST_F(ProtocolHandlerImplTest,
                                        An<const BsonObject*>()))
       .WillOnce(DoAll(
           NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
-                                   &ProtocolHandler::NotifySessionStartedResult,
-                                   connection_id2,
-                                   session_id2,
-                                   SESSION_START_REJECT,
-                                   HASH_ID_WRONG,
-                                   PROTECTION_OFF,
+          InvokeMemberFuncWithArg2(protocol_handler_impl.get(),
+                                   &ProtocolHandler::NotifySessionStarted,
+                                   GetSessionContext(connection_id2,
+                                                     session_id2,
+                                                     SESSION_START_REJECT,
+                                                     start_service,
+                                                     HASH_ID_WRONG,
+                                                     PROTECTION_OFF),
                                    ByRef(rejected_param_list)),
-          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
-                                   &ProtocolHandler::NotifySessionStartedResult,
-                                   connection_id1,
-                                   session_id1,
-                                   generated_session_id1,
-                                   HASH_ID_WRONG,
-                                   PROTECTION_OFF,
+          InvokeMemberFuncWithArg2(protocol_handler_impl.get(),
+                                   &ProtocolHandler::NotifySessionStarted,
+                                   GetSessionContext(connection_id1,
+                                                     session_id1,
+                                                     generated_session_id1,
+                                                     start_service,
+                                                     HASH_ID_WRONG,
+                                                     PROTECTION_OFF),
                                    ByRef(empty_rejected_param_))));
   times++;
 
@@ -802,10 +844,6 @@ TEST_F(ProtocolHandlerImplTest, EndSession_Success) {
 }
 
 #ifdef ENABLE_SECURITY
-/*
- * ProtocolHandler shall not call Security logics with Protocol version 1
- * Check session_observer with PROTECTION_OFF and Ack with PROTECTION_OFF
- */
 TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtocoloV1) {
   using namespace protocol_handler;
   ::utils::SharedPtr<TestAsyncWaiter> waiter =
@@ -826,16 +864,17 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtocoloV1) {
                                        An<const BsonObject*>()))
       .
       // Return sessions start success
-      WillOnce(DoAll(
-          NotifyTestAsyncWaiter(waiter),
-          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
-                                   &ProtocolHandler::NotifySessionStartedResult,
-                                   connection_id,
-                                   NEW_SESSION_ID,
-                                   session_id,
-                                   HASH_ID_WRONG,
-                                   PROTECTION_OFF,
-                                   ByRef(empty_rejected_param_))));
+      WillOnce(
+          DoAll(NotifyTestAsyncWaiter(waiter),
+                InvokeMemberFuncWithArg2(protocol_handler_impl.get(),
+                                         &ProtocolHandler::NotifySessionStarted,
+                                         GetSessionContext(connection_id,
+                                                           NEW_SESSION_ID,
+                                                           session_id,
+                                                           start_service,
+                                                           HASH_ID_WRONG,
+                                                           PROTECTION_OFF),
+                                         ByRef(empty_rejected_param_))));
   times++;
 
   SetProtocolVersion2();
@@ -881,16 +920,17 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionUnprotected) {
                                        An<const BsonObject*>()))
       .
       // Return sessions start success
-      WillOnce(DoAll(
-          NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
-                                   &ProtocolHandler::NotifySessionStartedResult,
-                                   connection_id,
-                                   NEW_SESSION_ID,
-                                   session_id,
-                                   HASH_ID_WRONG,
-                                   PROTECTION_OFF,
-                                   ByRef(empty_rejected_param_))));
+      WillOnce(
+          DoAll(NotifyTestAsyncWaiter(&waiter),
+                InvokeMemberFuncWithArg2(protocol_handler_impl.get(),
+                                         &ProtocolHandler::NotifySessionStarted,
+                                         GetSessionContext(connection_id,
+                                                           NEW_SESSION_ID,
+                                                           session_id,
+                                                           start_service,
+                                                           HASH_ID_WRONG,
+                                                           PROTECTION_OFF),
+                                         ByRef(empty_rejected_param_))));
   times++;
 
   SetProtocolVersion2();
@@ -917,6 +957,15 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtected_Fail) {
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
+
+  protocol_handler::SessionContext context = GetSessionContext(connection_id,
+                                                               NEW_SESSION_ID,
+                                                               session_id,
+                                                               start_service,
+                                                               HASH_ID_WRONG,
+                                                               PROTECTION_ON);
+  context.is_new_service_ = true;
+
   // Expect ConnectionHandler check
   EXPECT_CALL(session_observer_mock,
               OnSessionStartedCallback(connection_id,
@@ -926,16 +975,12 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtected_Fail) {
                                        An<const BsonObject*>()))
       .
       // Return sessions start success
-      WillOnce(DoAll(
-          NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
-                                   &ProtocolHandler::NotifySessionStartedResult,
-                                   connection_id,
-                                   NEW_SESSION_ID,
-                                   session_id,
-                                   HASH_ID_WRONG,
-                                   PROTECTION_ON,
-                                   ByRef(empty_rejected_param_))));
+      WillOnce(
+          DoAll(NotifyTestAsyncWaiter(&waiter),
+                InvokeMemberFuncWithArg2(protocol_handler_impl.get(),
+                                         &ProtocolHandler::NotifySessionStarted,
+                                         context,
+                                         ByRef(empty_rejected_param_))));
   times++;
 
   SetProtocolVersion2();
@@ -980,16 +1025,17 @@ TEST_F(ProtocolHandlerImplTest,
                                        An<const BsonObject*>()))
       .
       // Return sessions start success
-      WillOnce(DoAll(
-          NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
-                                   &ProtocolHandler::NotifySessionStartedResult,
-                                   connection_id,
-                                   NEW_SESSION_ID,
-                                   session_id,
-                                   HASH_ID_WRONG,
-                                   PROTECTION_ON,
-                                   ByRef(empty_rejected_param_))));
+      WillOnce(
+          DoAll(NotifyTestAsyncWaiter(&waiter),
+                InvokeMemberFuncWithArg2(protocol_handler_impl.get(),
+                                         &ProtocolHandler::NotifySessionStarted,
+                                         GetSessionContext(connection_id,
+                                                           NEW_SESSION_ID,
+                                                           session_id,
+                                                           start_service,
+                                                           HASH_ID_WRONG,
+                                                           PROTECTION_ON),
+                                         ByRef(empty_rejected_param_))));
   times++;
 
   SetProtocolVersion2();
@@ -1038,6 +1084,14 @@ TEST_F(ProtocolHandlerImplTest,
 
   TestAsyncWaiter waiter;
   uint32_t times = 0;
+  protocol_handler::SessionContext context = GetSessionContext(connection_id,
+                                                               NEW_SESSION_ID,
+                                                               session_id,
+                                                               start_service,
+                                                               HASH_ID_WRONG,
+                                                               PROTECTION_ON);
+  context.is_new_service_ = true;
+
   // Expect ConnectionHandler check
   EXPECT_CALL(session_observer_mock,
               OnSessionStartedCallback(connection_id,
@@ -1047,24 +1101,20 @@ TEST_F(ProtocolHandlerImplTest,
                                        An<const BsonObject*>()))
       .
       // Return sessions start success
-      WillOnce(DoAll(
-          NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
-                                   &ProtocolHandler::NotifySessionStartedResult,
-                                   connection_id,
-                                   NEW_SESSION_ID,
-                                   session_id,
-                                   HASH_ID_WRONG,
-                                   PROTECTION_ON,
-                                   ByRef(empty_rejected_param_))));
+      WillOnce(
+          DoAll(NotifyTestAsyncWaiter(&waiter),
+                InvokeMemberFuncWithArg2(protocol_handler_impl.get(),
+                                         &ProtocolHandler::NotifySessionStarted,
+                                         context,
+                                         ByRef(empty_rejected_param_))));
   times++;
 
   std::vector<int> services;
   // TODO(AKutsan) : APPLINK-21398 use named constants instead of magic numbers
   services.push_back(0x0A);
   services.push_back(0x0B);
-  ON_CALL(protocol_handler_settings_mock, force_protected_service())
-      .WillByDefault(ReturnRefOfCopy(services));
+  EXPECT_CALL(protocol_handler_settings_mock, force_protected_service())
+      .WillOnce(ReturnRefOfCopy(services));
 
   // call new SSLContext creation
   EXPECT_CALL(security_manager_mock, CreateSSLContext(connection_key))
@@ -1092,13 +1142,6 @@ TEST_F(ProtocolHandlerImplTest,
       .WillOnce(Invoke(OnHandshakeDoneFunctor(
           connection_key,
           security_manager::SSLContext::Handshake_Result_Fail)));
-
-  // Listener check SSLContext
-  EXPECT_CALL(session_observer_mock,
-              GetSSLContext(connection_key, start_service))
-      .
-      // Emulate protection for service is not enabled
-      WillOnce(ReturnNull());
 
   // Expect send Ack with PROTECTION_OFF (on fail handshake)
   EXPECT_CALL(transport_manager_mock,
@@ -1139,16 +1182,17 @@ TEST_F(ProtocolHandlerImplTest,
                                        An<const BsonObject*>()))
       .
       // Return sessions start success
-      WillOnce(DoAll(
-          NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
-                                   &ProtocolHandler::NotifySessionStartedResult,
-                                   connection_id,
-                                   NEW_SESSION_ID,
-                                   session_id,
-                                   HASH_ID_WRONG,
-                                   PROTECTION_ON,
-                                   ByRef(empty_rejected_param_))));
+      WillOnce(
+          DoAll(NotifyTestAsyncWaiter(&waiter),
+                InvokeMemberFuncWithArg2(protocol_handler_impl.get(),
+                                         &ProtocolHandler::NotifySessionStarted,
+                                         GetSessionContext(connection_id,
+                                                           NEW_SESSION_ID,
+                                                           session_id,
+                                                           start_service,
+                                                           HASH_ID_WRONG,
+                                                           PROTECTION_ON),
+                                         ByRef(empty_rejected_param_))));
   times++;
 
   // call new SSLContext creation
@@ -1236,16 +1280,17 @@ TEST_F(
                                        An<const BsonObject*>()))
       .
       // Return sessions start success
-      WillOnce(DoAll(
-          NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
-                                   &ProtocolHandler::NotifySessionStartedResult,
-                                   connection_id,
-                                   NEW_SESSION_ID,
-                                   session_id,
-                                   HASH_ID_WRONG,
-                                   PROTECTION_ON,
-                                   ByRef(empty_rejected_param_))));
+      WillOnce(
+          DoAll(NotifyTestAsyncWaiter(&waiter),
+                InvokeMemberFuncWithArg2(protocol_handler_impl.get(),
+                                         &ProtocolHandler::NotifySessionStarted,
+                                         GetSessionContext(connection_id,
+                                                           NEW_SESSION_ID,
+                                                           session_id,
+                                                           start_service,
+                                                           HASH_ID_WRONG,
+                                                           PROTECTION_ON),
+                                         ByRef(empty_rejected_param_))));
   times++;
 
   // call new SSLContext creation
@@ -1331,16 +1376,17 @@ TEST_F(ProtocolHandlerImplTest,
                                        An<const BsonObject*>()))
       .
       // Return sessions start success
-      WillOnce(DoAll(
-          NotifyTestAsyncWaiter(&waiter),
-          InvokeMemberFuncWithArg6(protocol_handler_impl.get(),
-                                   &ProtocolHandler::NotifySessionStartedResult,
-                                   connection_id,
-                                   NEW_SESSION_ID,
-                                   session_id,
-                                   HASH_ID_WRONG,
-                                   PROTECTION_ON,
-                                   ByRef(empty_rejected_param_))));
+      WillOnce(
+          DoAll(NotifyTestAsyncWaiter(&waiter),
+                InvokeMemberFuncWithArg2(protocol_handler_impl.get(),
+                                         &ProtocolHandler::NotifySessionStarted,
+                                         GetSessionContext(connection_id,
+                                                           NEW_SESSION_ID,
+                                                           session_id,
+                                                           start_service,
+                                                           HASH_ID_WRONG,
+                                                           PROTECTION_ON),
+                                         ByRef(empty_rejected_param_))));
   times++;
 
   // call new SSLContext creation

--- a/src/components/remote_control/test/src/rc_module_test.cc
+++ b/src/components/remote_control/test/src/rc_module_test.cc
@@ -227,7 +227,6 @@ TEST_F(RCModuleTest, IsAppForPluginSuccess) {
   mobile_apis::HMILevel::eType hmi = mobile_apis::HMILevel::eType::HMI_FULL;
   EXPECT_CALL(*app0_, hmi_level()).WillRepeatedly(Return(hmi));
   ON_CALL(*app0_, device()).WillByDefault(Return(1));
-  EXPECT_CALL(*mock_service_, NotifyHMIAboutHMILevel(Eq(app0_), _));
   EXPECT_CALL(*mock_service_, IsRemoteControlApplication(Eq(app0_)))
       .WillOnce(Return(true));
   ASSERT_TRUE(module_.IsAppForPlugin(app0_));

--- a/src/components/security_manager/include/security_manager/crypto_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/crypto_manager_impl.h
@@ -137,6 +137,11 @@ class CryptoManagerImpl : public CryptoManager {
   int pull_number_from_buf(char* buf, int* idx);
   void asn1_time_to_tm(ASN1_TIME* time);
 
+  /**
+   * @brief Sets initial certificate datetime
+   */
+  void InitCertExpTime();
+
   const utils::SharedPtr<const CryptoManagerSettings> settings_;
   SSL_CTX* context_;
   mutable struct tm expiration_time_;

--- a/src/components/security_manager/include/security_manager/security_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/security_manager_impl.h
@@ -141,6 +141,12 @@ class SecurityManagerImpl : public SecurityManager,
   void StartHandshake(uint32_t connection_key) OVERRIDE;
 
   /**
+   * @brief Checks whether certificate should be updated
+   * @return true if certificate should be updated otherwise false
+   */
+  bool IsCertificateUpdateRequired() OVERRIDE;
+
+  /**
    * \brief Add/Remove for SecurityManagerListener
    */
   void AddListener(SecurityManagerListener* const listener) OVERRIDE;
@@ -158,7 +164,19 @@ class SecurityManagerImpl : public SecurityManager,
    * @brief Notifiers for listeners.
    * Allows to notify that certificate should be updated
    */
-  void NotifyOnCertififcateUpdateRequired();
+  DEPRECATED void NotifyOnCertififcateUpdateRequired();
+
+  /**
+   * @brief Notifiers for listeners.
+   * Allows to notify that certificate should be updated
+   */
+  void NotifyOnCertificateUpdateRequired() OVERRIDE;
+
+  /**
+   * @brief Check is policy certificate data is empty
+   * @return true if policy certificate data is not empty otherwise false
+   */
+  bool IsPolicyCertificateDataEmpty() OVERRIDE;
 
   /**
    * @brief SecurityConfigSection

--- a/src/components/security_manager/src/crypto_manager_impl.cc
+++ b/src/components/security_manager/src/crypto_manager_impl.cc
@@ -343,6 +343,18 @@ bool CryptoManagerImpl::set_certificate(const std::string& cert_data) {
     return false;
   }
 
+  X509_STORE* store = SSL_CTX_get_cert_store(context_);
+  if (store) {
+    X509* extra_cert = NULL;
+    while ((extra_cert = PEM_read_bio_X509(bio_cert, NULL, 0, 0))) {
+      if (extra_cert != cert) {
+        LOG4CXX_DEBUG(logger_,
+                      "Added new certificate to store: " << extra_cert);
+        X509_STORE_add_cert(store, extra_cert);
+      }
+    }
+  }
+
   LOG4CXX_DEBUG(logger_, "Certificate and key successfully updated");
   return true;
 }

--- a/src/components/security_manager/test/security_manager_test.cc
+++ b/src/components/security_manager/test/security_manager_test.cc
@@ -250,14 +250,14 @@ TEST_F(SecurityManagerTest, Listeners_Notifying) {
   security_manager_->AddListener(&mock_listener2);
   // 1st call
   security_manager_->NotifyListenersOnHandshakeDone(key, first_call_value);
-  security_manager_->NotifyOnCertififcateUpdateRequired();
+  security_manager_->NotifyOnCertificateUpdateRequired();
   // 2nd call
   security_manager_->NotifyListenersOnHandshakeDone(key, second_call_value);
-  security_manager_->NotifyOnCertififcateUpdateRequired();
+  security_manager_->NotifyOnCertificateUpdateRequired();
   // 3nd call
   security_manager_->NotifyListenersOnHandshakeDone(
       key, SSLContext::Handshake_Result_Fail);
-  security_manager_->NotifyOnCertififcateUpdateRequired();
+  security_manager_->NotifyOnCertificateUpdateRequired();
 }
 
 /*

--- a/src/components/security_manager/test/security_manager_test.cc
+++ b/src/components/security_manager/test/security_manager_test.cc
@@ -31,6 +31,7 @@
  */
 
 #include <string>
+#include <memory>
 
 #include "gtest/gtest.h"
 #include "utils/byte_order.h"
@@ -98,7 +99,9 @@ class SecurityManagerTest : public ::testing::Test {
     security_manager_.reset(new SecurityManagerImpl());
     security_manager_->set_session_observer(&mock_session_observer);
     security_manager_->set_protocol_handler(&mock_protocol_handler);
-    security_manager_->AddListener(&mock_sm_listener);
+    mock_sm_listener.reset(new testing::StrictMock<
+        security_manager_test::MockSecurityManagerListener>());
+    security_manager_->AddListener(mock_sm_listener.get());
   }
 
   void SetMockCryptoManager() {
@@ -161,8 +164,8 @@ class SecurityManagerTest : public ::testing::Test {
       mock_ssl_context_new;
   testing::StrictMock<security_manager_test::MockSSLContext>
       mock_ssl_context_exists;
-  testing::StrictMock<security_manager_test::MockSecurityManagerListener>
-      mock_sm_listener;
+  std::unique_ptr<testing::StrictMock<
+      security_manager_test::MockSecurityManagerListener> > mock_sm_listener;
 };
 // Test Bodies
 
@@ -190,15 +193,15 @@ TEST_F(SecurityManagerTest, Listeners_NULL) {
  * Twice remove listener
  */
 TEST_F(SecurityManagerTest, Listeners_TwiceRemoveListeners) {
-  security_manager_->RemoveListener(&mock_sm_listener);
-  security_manager_->RemoveListener(&mock_sm_listener);
+  security_manager_->RemoveListener(mock_sm_listener.get());
+  security_manager_->RemoveListener(mock_sm_listener.get());
 }
 /*
  * Add and remove listeners
  */
 TEST_F(SecurityManagerTest, Listeners_NoListeners) {
   // Check correct removing listener
-  security_manager_->RemoveListener(&mock_sm_listener);
+  security_manager_->RemoveListener(mock_sm_listener.get());
 
   // Expect no calls
   testing::StrictMock<MockSecurityManagerListener> mock_listener2;
@@ -215,39 +218,41 @@ TEST_F(SecurityManagerTest, Listeners_NoListeners) {
  */
 TEST_F(SecurityManagerTest, Listeners_Notifying) {
   // Check correct removing listener
-  security_manager_->RemoveListener(&mock_sm_listener);
+  security_manager_->RemoveListener(mock_sm_listener.get());
 
-  testing::StrictMock<MockSecurityManagerListener> mock_listener1;
-  testing::StrictMock<MockSecurityManagerListener> mock_listener2;
+  testing::StrictMock<MockSecurityManagerListener>* mock_listener1 =
+      new testing::StrictMock<MockSecurityManagerListener>();
+  testing::StrictMock<MockSecurityManagerListener>* mock_listener2 =
+      new testing::StrictMock<MockSecurityManagerListener>();
 
   const SSLContext::HandshakeResult first_call_value =
       SSLContext::Handshake_Result_Success;
   // Expect call both listeners on 1st call
-  EXPECT_CALL(mock_listener1, OnHandshakeDone(key, first_call_value))
+  EXPECT_CALL(*mock_listener1, OnHandshakeDone(key, first_call_value))
       .
       // Emulate false (reject) result
       WillOnce(Return(false));
-  EXPECT_CALL(mock_listener2, OnHandshakeDone(key, first_call_value))
+  EXPECT_CALL(*mock_listener2, OnHandshakeDone(key, first_call_value))
       .
       // Emulate true (accept) result
       WillOnce(Return(true));
 
   // First listener was not removed from listener list
   // So this callback wil lbe either call.
-  EXPECT_CALL(mock_listener1, OnCertificateUpdateRequired());
+  EXPECT_CALL(*mock_listener1, OnCertificateUpdateRequired());
 
   const SSLContext::HandshakeResult second_call_value =
       SSLContext::Handshake_Result_Fail;
   // Expect call last listener on 2d call
-  EXPECT_CALL(mock_listener1, OnHandshakeDone(key, second_call_value))
+  EXPECT_CALL(*mock_listener1, OnHandshakeDone(key, second_call_value))
       .
       // Emulate false (reject) result
       WillOnce(Return(true));
 
   // Expect no call 3d call
 
-  security_manager_->AddListener(&mock_listener1);
-  security_manager_->AddListener(&mock_listener2);
+  security_manager_->AddListener(mock_listener1);
+  security_manager_->AddListener(mock_listener2);
   // 1st call
   security_manager_->NotifyListenersOnHandshakeDone(key, first_call_value);
   security_manager_->NotifyOnCertificateUpdateRequired();
@@ -495,7 +500,7 @@ TEST_F(SecurityManagerTest, StartHandshake_ServiceStillUnprotected) {
       SendMessageToMobileApp(
           InternalErrorWithErrId(SecurityManager::ERROR_INTERNAL), is_final));
   // Expect notifying listeners (unsuccess)
-  EXPECT_CALL(mock_sm_listener,
+  EXPECT_CALL(*mock_sm_listener,
               OnHandshakeDone(key, SSLContext::Handshake_Result_Fail))
       .WillOnce(Return(true));
 
@@ -504,6 +509,9 @@ TEST_F(SecurityManagerTest, StartHandshake_ServiceStillUnprotected) {
       .WillOnce(ReturnNull());
 
   security_manager_->StartHandshake(key);
+
+  // Listener was destroyed after OnHandshakeDone call
+  mock_sm_listener.release();
 }
 /*
  * Shall send InternallError on SSL error and notify listeners
@@ -527,7 +535,7 @@ TEST_F(SecurityManagerTest, StartHandshake_SSLInternalError) {
       SendMessageToMobileApp(
           InternalErrorWithErrId(SecurityManager::ERROR_INTERNAL), is_final));
   // Expect notifying listeners (unsuccess)
-  EXPECT_CALL(mock_sm_listener,
+  EXPECT_CALL(*mock_sm_listener,
               OnHandshakeDone(key, SSLContext::Handshake_Result_Fail))
       .WillOnce(Return(true));
 
@@ -543,6 +551,9 @@ TEST_F(SecurityManagerTest, StartHandshake_SSLInternalError) {
                       Return(SSLContext::Handshake_Result_Fail)));
 
   security_manager_->StartHandshake(key);
+
+  // Listener was destroyed after OnHandshakeDone call
+  mock_sm_listener.release();
 }
 /*
  * Shall send data on call StartHandshake
@@ -598,7 +609,7 @@ TEST_F(SecurityManagerTest, StartHandshake_SSLInitIsComplete) {
   SetMockCryptoManager();
   // Expect no message send
   // Expect notifying listeners (success)
-  EXPECT_CALL(mock_sm_listener,
+  EXPECT_CALL(*mock_sm_listener,
               OnHandshakeDone(key, SSLContext::Handshake_Result_Success))
       .WillOnce(Return(true));
 
@@ -607,10 +618,11 @@ TEST_F(SecurityManagerTest, StartHandshake_SSLInitIsComplete) {
       .WillOnce(Return(&mock_ssl_context_exists));
   EXPECT_CALL(mock_ssl_context_exists, IsInitCompleted())
       .WillOnce(Return(true));
-  EXPECT_CALL(mock_crypto_manager, IsCertificateUpdateRequired())
-      .WillOnce(Return(false));
 
   security_manager_->StartHandshake(key);
+
+  // Listener was destroyed after OnHandshakeDone call
+  mock_sm_listener.release();
 }
 /*
  * Shall send InternallError on
@@ -667,7 +679,7 @@ TEST_F(SecurityManagerTest,
   times++;
 
   // Expect notifying listeners (unsuccess)
-  EXPECT_CALL(mock_sm_listener,
+  EXPECT_CALL(*mock_sm_listener,
               OnHandshakeDone(key, SSLContext::Handshake_Result_Fail))
       .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter), Return(true)));
   times++;
@@ -681,6 +693,9 @@ TEST_F(SecurityManagerTest,
   EmulateMobileMessageHandshake(data, sizeof(data) / sizeof(data[0]));
 
   EXPECT_TRUE(waiter.WaitFor(times, kAsyncExpectationsTimeout));
+
+  // Listener was destroyed after OnHandshakeDone call
+  mock_sm_listener.release();
 }
 /*
  * Shall send InternallError on getting
@@ -718,7 +733,7 @@ TEST_F(SecurityManagerTest, ProccessHandshakeData_InvalidData) {
       .WillRepeatedly(NotifyTestAsyncWaiter(&waiter));
   times += handshake_emulates;
   // Expect notifying listeners (unsuccess)
-  EXPECT_CALL(mock_sm_listener,
+  EXPECT_CALL(*mock_sm_listener,
               OnHandshakeDone(key, SSLContext::Handshake_Result_Fail))
       .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter), Return(true)));
   times++;
@@ -761,6 +776,9 @@ TEST_F(SecurityManagerTest, ProccessHandshakeData_InvalidData) {
       handshake_data, handshake_data_size, handshake_emulates);
 
   EXPECT_TRUE(waiter.WaitFor(times, kAsyncExpectationsTimeout));
+
+  // Listener was destroyed after OnHandshakeDone call
+  mock_sm_listener.release();
 }
 /*
  * Shall send HandshakeData on getting SEND_HANDSHAKE_DATA from mobile side
@@ -796,7 +814,7 @@ TEST_F(SecurityManagerTest, ProccessHandshakeData_Answer) {
   times += handshake_emulates;
 
   // Expect notifying listeners (unsuccess)
-  EXPECT_CALL(mock_sm_listener,
+  EXPECT_CALL(*mock_sm_listener,
               OnHandshakeDone(key, SSLContext::Handshake_Result_Fail))
       .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter), Return(true)));
   times++;
@@ -833,6 +851,9 @@ TEST_F(SecurityManagerTest, ProccessHandshakeData_Answer) {
       handshake_data, handshake_data_size, handshake_emulates);
 
   EXPECT_TRUE(waiter.WaitFor(times, kAsyncExpectationsTimeout));
+
+  // Listener was destroyed after OnHandshakeDone call
+  mock_sm_listener.release();
 }
 /*
  * Shall call all listeners on success end handshake
@@ -848,7 +869,7 @@ TEST_F(SecurityManagerTest, ProccessHandshakeData_HandshakeFinished) {
   uint32_t times = 0;
   // Expect no errors
   // Expect notifying listeners (success)
-  EXPECT_CALL(mock_sm_listener,
+  EXPECT_CALL(*mock_sm_listener,
               OnHandshakeDone(key, SSLContext::Handshake_Result_Success))
       .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter), Return(true)));
   times++;
@@ -924,6 +945,9 @@ TEST_F(SecurityManagerTest, ProccessHandshakeData_HandshakeFinished) {
       handshake_data, handshake_data_size, handshake_emulates);
 
   EXPECT_TRUE(waiter.WaitFor(times, kAsyncExpectationsTimeout));
+
+  // Listener was destroyed after OnHandshakeDone call
+  mock_sm_listener.release();
 }
 /*
  * Shall not any query on getting empty SEND_INTERNAL_ERROR

--- a/src/components/security_manager/test/ssl_certificate_handshake_test.cc
+++ b/src/components/security_manager/test/ssl_certificate_handshake_test.cc
@@ -372,11 +372,8 @@ TEST_F(SSLHandshakeTest, CAVerification_ServerSide) {
 }
 
 TEST_F(SSLHandshakeTest, CAVerification_ServerSide_NoCACertificate) {
-  ASSERT_TRUE(InitServerManagers(security_manager::TLSv1_2,
-                                 server_certificate,
-                                 "ALL",
-                                 verify_peer,
-                                 "unex"))
+  ASSERT_TRUE(InitServerManagers(
+      security_manager::TLSv1_2, "", "ALL", verify_peer, "unex"))
       << server_manager->LastError();
   ASSERT_TRUE(InitClientManagers(security_manager::TLSv1_2,
                                  client_certificate,
@@ -423,7 +420,7 @@ TEST_F(SSLHandshakeTest, CAVerification_ClientSide_NoCACertificate) {
                                  ""))
       << server_manager->LastError();
   ASSERT_TRUE(InitClientManagers(security_manager::TLSv1_2,
-                                 client_certificate,
+                                 "",
                                  "ALL",
                                  verify_peer,
                                  "client_ca_cert_filename"))


### PR DESCRIPTION
Fixes #1925, #1924, #1923, #1922, #1912, #1894, #1891, #1888

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Existing unit tests will be updated according to new logic and new unit tests will be provided.

### Summary
There was a wrong logic around processing of `ForceProtectedService` and `ForceUnprotectedService`
params from ini file and sending start service ACK/NACK for secured services. All these test cases could be covered with one pull request. Also there was a wrong logic for triggering PTU when no certificate in local PT and non-navi application is going to start secured service.

### Changelog
- `ServiceStartedContext` were moved to session observer 
`ServiceStartedContext` were moved to session observer and renamed to `StartingSessionContext`. Also new fields were added: `is_new_service` - to check later is this a new service for this session, `is_ptu_required` - to check later is session from this context requires triggering of PTU in case there is no certificate data in local PT
- Old `StartSessionHandler` class moved to a separate unit
Old `StartSessionHandler` class moved to a separate unit and renamed to `HandshakeHandler` according to its logic. Also this class was updated to use `StartingSessionContext` and was updated `OnHandshakeDone` logic according to requirements
- Refactoring in connection/protocol handlers
`NotifySessionStartedResult` function were updated to use `StartingSessionContext` class for accessing to needed data instead of tones of separate parameters. Old implementation were marked as deprecated. Also in protocol handler some raw pointer data were replaced with smart objects.
- Fixes in Crypto/Security managers
There was added `InitCertExpTime` function in crypto manager to set certificate expired data to some initial value because in case of no certificate it will not be inited and contain invalid data. Also in this case `IsCertificateUpdateRequired` sometimes returns wrong result because of not inited certificate
data. In crypto manager were added/updated debug logs for better understanding of it initialization process.
Also added function `IsPolicyCertificateDataEmpty` function for getting information regarding policy certificate presence.
- `ProtocolHandlerImpl` was extended with `PolicyHandlerObserver` logic
`ProtocolHandlerImpl` was extended with `PolicyHandlerObserver` logic and added function with related implementation. Also was updated logic of `NotifySessionStartedResult` with case when PTU should be triggered.
- Updates in connection and handler
Connection and its handler were extended with function `IsSessionServiceExists` to check is specified service exists in session. This function is needed for `ProtocolHandler`. Also there was added check for session protocol version when starting a new service.

### Tasks Remaining:
- [x] Fix failed unit tests
- [x] Provide new unit tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)