### PR TITLE
Remove unused iterator

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1768,7 +1768,7 @@ void PolicyHandler::OnCertificateUpdated(const std::string& certificate_data) {
 void PolicyHandler::OnPTUFinished(const bool ptu_result) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(listeners_lock_);
-  HandlersCollection::const_iterator it = listeners_.begin();
+
   std::for_each(
       listeners_.begin(),
       listeners_.end(),


### PR DESCRIPTION
[Things to note: Pull Requests **must** fix an issue. Discussion about the feature / bug takes place in the issue, discussion of the implementation takes place in the PR. Please also see the [Contributing Guide](https://github.com/smartdevicelink/sdl_core/blob/master/.github/CONTRIBUTING.md) for information on branch naming and the CLA.

Delete the above section when you've read it.]

Fixes #1975 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Removed unused iterator in `policy_handler.cc`

### Changelog

##### Bug Fixes
* Removed unused iterator, which was causing a warning with GCC6

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)