### PR TITLE
Fix deprecated warnings

### DIFF
--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -184,7 +184,7 @@ class ApplicationImpl : public virtual Application,
   void increment_list_files_in_none_count();
   bool set_app_icon_path(const std::string& path);
   void set_app_allowed(const bool allowed);
-  DEPRECATED void set_device(connection_handler::DeviceHandle device);
+  void set_device(connection_handler::DeviceHandle device);
   virtual uint32_t get_grammar_id() const;
   virtual void set_grammar_id(uint32_t value);
   bool is_audio() const OVERRIDE;

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -614,7 +614,7 @@ void ApplicationImpl::set_app_allowed(const bool allowed) {
   is_app_allowed_ = allowed;
 }
 
-DEPRECATED void ApplicationImpl::set_device(
+void ApplicationImpl::set_device(
     connection_handler::DeviceHandle device) {
   device_id_ = device;
 }

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -202,7 +202,7 @@ class ConnectionHandlerImpl
    * \return uint32_t Id (number) of new session if successful, otherwise 0.
    * \deprecated
    */
-  DEPRECATED virtual uint32_t OnSessionStartedCallback(
+  virtual uint32_t OnSessionStartedCallback(
       const transport_manager::ConnectionUID connection_handle,
       const uint8_t session_id,
       const protocol_handler::ServiceType& service_type,
@@ -238,7 +238,7 @@ class ConnectionHandlerImpl
    * \return uint32_t 0 if operation fails, session key otherwise
    * \deprecated
    */
-  DEPRECATED uint32_t OnSessionEndedCallback(
+  uint32_t OnSessionEndedCallback(
       const transport_manager::ConnectionUID connection_handle,
       const uint8_t session_id,
       const uint32_t& hashCode,
@@ -512,10 +512,10 @@ class ConnectionHandlerImpl
    * \param device_id Returned: DeviceID
    * \return int32_t -1 in case of error or 0 in case of success
    */
-  DEPRECATED int32_t GetDataOnSessionKey(uint32_t key,
-                                         uint32_t* app_id,
-                                         std::list<int32_t>* sessions_list,
-                                         uint32_t* device_id) const OVERRIDE;
+  int32_t GetDataOnSessionKey(uint32_t key,
+                              uint32_t* app_id,
+                              std::list<int32_t>* sessions_list,
+                              uint32_t* device_id) const OVERRIDE;
 
   const ConnectionHandlerSettings& get_settings() const OVERRIDE;
 

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -716,13 +716,15 @@ int32_t ConnectionHandlerImpl::GetDataOnSessionKey(
   return 0;
 }
 
-DEPRECATED int32_t
-ConnectionHandlerImpl::GetDataOnSessionKey(uint32_t key,
-                                           uint32_t* app_id,
-                                           std::list<int32_t>* sessions_list,
-                                           uint32_t* device_id) const {
+int32_t ConnectionHandlerImpl::GetDataOnSessionKey(uint32_t key,
+                                                   uint32_t* app_id,
+                                                   std::list<int32_t>* sessions_list,
+                                                   uint32_t* device_id) const {
   LOG4CXX_AUTO_TRACE(logger_);
-  return GetDataOnSessionKey(key, app_id, sessions_list, device_id);
+  DeviceHandle handle;
+  int32_t result = GetDataOnSessionKey(key, app_id, sessions_list, &handle);
+  *device_id = static_cast<uint32_t>(handle);
+  return result;
 }
 
 const ConnectionHandlerSettings& ConnectionHandlerImpl::get_settings() const {

--- a/src/components/include/test/connection_handler/mock_connection_handler.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler.h
@@ -85,7 +85,8 @@ class MockConnectionHandler : public connection_handler::ConnectionHandler {
   MOCK_METHOD2(BindProtocolVersionWithSession,
                void(uint32_t connection_key, uint8_t protocol_version));
 
-  DEPRECATED MOCK_CONST_METHOD4(GetDataOnSessionKey,
+  //DEPRECATED
+  MOCK_CONST_METHOD4(GetDataOnSessionKey,
                                 int32_t(uint32_t key,
                                         uint32_t* app_id,
                                         std::list<int32_t>* sessions_list,


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Fixes several deprecation warnings resulting from the DEPRECATED macro being used several places for the same function

### Changelog
##### Bug Fixes
* Fixed deprecation warnings in `connection_handler_impl.cc` and `application_impl.cc`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)