### PR TITLE
Fix crash and memory leaks in message broker cleanup

### DIFF
--- a/src/appMain/life_cycle.cc
+++ b/src/appMain/life_cycle.cc
@@ -316,7 +316,9 @@ void LifeCycle::StopComponents() {
     DCHECK_OR_RETURN_VOID(hmi_handler_);
     hmi_handler_->RemoveHMIMessageAdapter(dbus_adapter_);
     dbus_adapter_->Shutdown();
-    dbus_adapter_thread_->join();
+    if (dbus_adapter_thread_ != NULL) {
+      dbus_adapter_thread_->join();
+    }
     delete dbus_adapter_;
     dbus_adapter_ = NULL;
     delete dbus_adapter_thread_;
@@ -330,17 +332,19 @@ void LifeCycle::StopComponents() {
     hmi_handler_->RemoveHMIMessageAdapter(mb_adapter_);
     mb_adapter_->unregisterController();
     mb_adapter_->exitReceivingThread();
-    mb_adapter_thread_->join();
+    if (mb_adapter_thread_ != NULL) {
+      mb_adapter_thread_->join();
+    }
     delete mb_adapter_;
     mb_adapter_ = NULL;
+    delete mb_adapter_thread_;
+    mb_adapter_thread_ = NULL;
   }
-
+  LOG4CXX_INFO(logger_, "Destroying Message Broker");
+#endif  // MESSAGEBROKER_HMIADAPTER
   DCHECK_OR_RETURN_VOID(hmi_handler_);
   delete hmi_handler_;
   hmi_handler_ = NULL;
-
-  LOG4CXX_INFO(logger_, "Destroying Message Broker");
-#endif  // MESSAGEBROKER_HMIADAPTER
 
 #ifdef TELEMETRY_MONITOR
   // It's important to delete tester Obcervers after TM adapters destruction


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
* Added check if message broker thread was initialized before closing (for both message broker and DBus adapter)
* Fixed `mb_adapter_thread_` and `hmi_handler_` memory leak

### Changelog
##### Bug Fixes
* Fixed crash and memory leak in cleanup step of `LifeCycle`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)