### PR TITLE
Feat/sdl 0138 audio pass thru array

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -274,11 +274,11 @@
                 "STATIC"
             ]
         },
-        "audioPassThruCapabilities": {
+        "audioPassThruCapabilities": [{
             "samplingRate": "44KHZ",
             "bitsPerSample": "RATE_8_BIT",
             "audioType": "PCM"
-        },
+        }],
         "pcmStreamCapabilities": {
             "samplingRate": "16KHZ",
             "bitsPerSample": "RATE_16_BIT",

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -542,6 +542,18 @@ class HMICapabilitiesImpl : public HMICapabilities {
       const Json::Value& json_languages,
       smart_objects::SmartObject& languages) const OVERRIDE;
 
+  /*
+   * @brief function that converts a single entry of audio pass thru capability
+   *        to smart object
+   *
+   * @param capability json object that represents a single entry of audio pass
+   *        thru capability
+   * @param output_so the converted object
+   */
+  void convert_audio_capability_to_obj(
+      const Json::Value& capability,
+      smart_objects::SmartObject& output_so) const OVERRIDE;
+
  private:
   bool is_vr_cooperating_;
   bool is_tts_cooperating_;

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -169,6 +169,7 @@ extern const char* system_context;
 extern const char* speech_capabilities;
 extern const char* vr_capabilities;
 extern const char* audio_pass_thru_capabilities;
+extern const char* audio_pass_thru_capabilities_list;
 extern const char* pcm_stream_capabilities;
 extern const char* audio_pass_thru_icon;
 extern const char* way_points;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
@@ -78,8 +78,19 @@ void UIGetCapabilitiesResponse::Run() {
     hmi_capabilities.set_audio_pass_thru_capabilities(
         msg_params[strings::audio_pass_thru_capabilities_list]);
   } else if (msg_params.keyExists(strings::audio_pass_thru_capabilities)) {
-    hmi_capabilities.set_audio_pass_thru_capabilities(
-        msg_params[strings::audio_pass_thru_capabilities]);
+    const smart_objects::SmartObject& audio_pass_thru_capabilities =
+        msg_params[strings::audio_pass_thru_capabilities];
+    if (smart_objects::SmartType_Array ==
+        audio_pass_thru_capabilities.getType()) {
+      hmi_capabilities.set_audio_pass_thru_capabilities(
+          audio_pass_thru_capabilities);
+    } else {
+      smart_objects::SmartObject audio_pass_thru_capabilities_list(
+          smart_objects::SmartType_Array);
+      audio_pass_thru_capabilities_list[0] = audio_pass_thru_capabilities;
+      hmi_capabilities.set_audio_pass_thru_capabilities(
+          audio_pass_thru_capabilities_list);
+    }
   }
 
   if (msg_params.keyExists(strings::hmi_capabilities)) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
@@ -73,7 +73,11 @@ void UIGetCapabilitiesResponse::Run() {
         msg_params[hmi_response::soft_button_capabilities]);
   }
 
-  if (msg_params.keyExists(strings::audio_pass_thru_capabilities)) {
+  // use newer parameter "audioPassThruCapabilitiesList" when available
+  if (msg_params.keyExists(strings::audio_pass_thru_capabilities_list)) {
+    hmi_capabilities.set_audio_pass_thru_capabilities(
+        msg_params[strings::audio_pass_thru_capabilities_list]);
+  } else if (msg_params.keyExists(strings::audio_pass_thru_capabilities)) {
     hmi_capabilities.set_audio_pass_thru_capabilities(
         msg_params[strings::audio_pass_thru_capabilities]);
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
@@ -78,19 +78,12 @@ void UIGetCapabilitiesResponse::Run() {
     hmi_capabilities.set_audio_pass_thru_capabilities(
         msg_params[strings::audio_pass_thru_capabilities_list]);
   } else if (msg_params.keyExists(strings::audio_pass_thru_capabilities)) {
-    const smart_objects::SmartObject& audio_pass_thru_capabilities =
+    smart_objects::SmartObject audio_pass_thru_capabilities_list(
+        smart_objects::SmartType_Array);
+    audio_pass_thru_capabilities_list[0] =
         msg_params[strings::audio_pass_thru_capabilities];
-    if (smart_objects::SmartType_Array ==
-        audio_pass_thru_capabilities.getType()) {
-      hmi_capabilities.set_audio_pass_thru_capabilities(
-          audio_pass_thru_capabilities);
-    } else {
-      smart_objects::SmartObject audio_pass_thru_capabilities_list(
-          smart_objects::SmartType_Array);
-      audio_pass_thru_capabilities_list[0] = audio_pass_thru_capabilities;
-      hmi_capabilities.set_audio_pass_thru_capabilities(
-          audio_pass_thru_capabilities_list);
-    }
+    hmi_capabilities.set_audio_pass_thru_capabilities(
+        audio_pass_thru_capabilities_list);
   }
 
   if (msg_params.keyExists(strings::hmi_capabilities)) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -613,15 +613,9 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
   }
 
   if (hmi_capabilities.audio_pass_thru_capabilities()) {
-    if (smart_objects::SmartType_Array ==
-        hmi_capabilities.audio_pass_thru_capabilities()->getType()) {
-      // hmi_capabilities json contains array and HMI response object
-      response_params[strings::audio_pass_thru_capabilities] =
-          *hmi_capabilities.audio_pass_thru_capabilities();
-    } else {
-      response_params[strings::audio_pass_thru_capabilities][0] =
-          *hmi_capabilities.audio_pass_thru_capabilities();
-    }
+    // hmi_capabilities json contains array and HMI response object
+    response_params[strings::audio_pass_thru_capabilities] =
+        *hmi_capabilities.audio_pass_thru_capabilities();
   }
   response_params[strings::hmi_capabilities] =
       smart_objects::SmartObject(smart_objects::SmartType_Map);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -160,6 +160,31 @@ TEST_F(UIGetCapabilitiesResponseTest, SetAudioPassThru_SUCCESS) {
   command->Run();
 }
 
+TEST_F(UIGetCapabilitiesResponseTest, SetAudioPassThruList_SUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+
+  // if both audioPassThruCapabilities and audioPassThruCapabilitiesList are
+  // supplied, audioPassThruCapabilitiesList should be used
+  smart_objects::SmartObject audio_pass_thru_capabilities_so =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  smart_objects::SmartObject audio_pass_thru_capabilities_list_so =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  (*command_msg)[strings::msg_params][strings::audio_pass_thru_capabilities] =
+      audio_pass_thru_capabilities_so;
+  (*command_msg)[strings::msg_params]
+                [strings::audio_pass_thru_capabilities_list] =
+                    audio_pass_thru_capabilities_list_so;
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(
+      mock_hmi_capabilities_,
+      set_audio_pass_thru_capabilities(audio_pass_thru_capabilities_list_so));
+
+  command->Run();
+}
+
 TEST_F(UIGetCapabilitiesResponseTest, SetNavigation_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
   (*command_msg)[strings::msg_params][strings::hmi_capabilities] =

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -145,7 +145,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetHmiZone_SUCCESS) {
 TEST_F(UIGetCapabilitiesResponseTest, SetAudioPassThru_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
   (*command_msg)[strings::msg_params][strings::audio_pass_thru_capabilities] =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
 
   ResponseFromHMIPtr command(
       CreateCommand<UIGetCapabilitiesResponse>(command_msg));
@@ -153,9 +153,15 @@ TEST_F(UIGetCapabilitiesResponseTest, SetAudioPassThru_SUCCESS) {
   smart_objects::SmartObject audio_pass_thru_capabilities_so =
       (*command_msg)[strings::msg_params]
                     [strings::audio_pass_thru_capabilities];
+
+  // hmi_capabilities will receive a list of capabilities, the first element
+  // being audio_pass_thru_capabilities_so
+  smart_objects::SmartObject audio_pass_thru_capabilities_list_so =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  audio_pass_thru_capabilities_list_so[0] = audio_pass_thru_capabilities_so;
   EXPECT_CALL(
       mock_hmi_capabilities_,
-      set_audio_pass_thru_capabilities(audio_pass_thru_capabilities_so));
+      set_audio_pass_thru_capabilities(audio_pass_thru_capabilities_list_so));
 
   command->Run();
 }

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -1066,20 +1066,16 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
       if (check_existing_json_member(ui, "audioPassThruCapabilities")) {
         Json::Value audio_capabilities =
             ui.get("audioPassThruCapabilities", "");
-        smart_objects::SmartObject audio_capabilities_so;
+        smart_objects::SmartObject audio_capabilities_so(
+            smart_objects::SmartType_Array);
         if (audio_capabilities.type() == Json::arrayValue) {
-          audio_capabilities_so =
-              smart_objects::SmartObject(smart_objects::SmartType_Array);
           for (uint32_t i = 0; i < audio_capabilities.size(); i++) {
             convert_audio_capability_to_obj(audio_capabilities[i],
                                             audio_capabilities_so[i]);
           }
         } else if (audio_capabilities.type() == Json::objectValue) {
-          // old format which supports only one capability set
-          audio_capabilities_so =
-              smart_objects::SmartObject(smart_objects::SmartType_Map);
           convert_audio_capability_to_obj(audio_capabilities,
-                                          audio_capabilities_so);
+                                          audio_capabilities_so[0]);
         }
         set_audio_pass_thru_capabilities(audio_capabilities_so);
       }

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -1066,27 +1066,20 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
       if (check_existing_json_member(ui, "audioPassThruCapabilities")) {
         Json::Value audio_capabilities =
             ui.get("audioPassThruCapabilities", "");
-        smart_objects::SmartObject audio_capabilities_so =
-            smart_objects::SmartObject(smart_objects::SmartType_Array);
-        audio_capabilities_so =
-            smart_objects::SmartObject(smart_objects::SmartType_Map);
-        if (check_existing_json_member(audio_capabilities, "samplingRate")) {
-          audio_capabilities_so["samplingRate"] =
-              sampling_rate_enum
-                  .find(audio_capabilities.get("samplingRate", "").asString())
-                  ->second;
-        }
-        if (check_existing_json_member(audio_capabilities, "bitsPerSample")) {
-          audio_capabilities_so["bitsPerSample"] =
-              bit_per_sample_enum
-                  .find(audio_capabilities.get("bitsPerSample", "").asString())
-                  ->second;
-        }
-        if (check_existing_json_member(audio_capabilities, "audioType")) {
-          audio_capabilities_so["audioType"] =
-              audio_type_enum
-                  .find(audio_capabilities.get("audioType", "").asString())
-                  ->second;
+        smart_objects::SmartObject audio_capabilities_so;
+        if (audio_capabilities.type() == Json::arrayValue) {
+          audio_capabilities_so =
+              smart_objects::SmartObject(smart_objects::SmartType_Array);
+          for (uint32_t i = 0; i < audio_capabilities.size(); i++) {
+            convert_audio_capability_to_obj(audio_capabilities[i],
+                                            audio_capabilities_so[i]);
+          }
+        } else if (audio_capabilities.type() == Json::objectValue) {
+          // old format which supports only one capability set
+          audio_capabilities_so =
+              smart_objects::SmartObject(smart_objects::SmartType_Map);
+          convert_audio_capability_to_obj(audio_capabilities,
+                                          audio_capabilities_so);
         }
         set_audio_pass_thru_capabilities(audio_capabilities_so);
       }
@@ -1368,6 +1361,27 @@ void HMICapabilitiesImpl::convert_json_languages_to_obj(
   for (uint32_t i = 0, j = 0; i < json_languages.size(); ++i) {
     languages[j++] =
         MessageHelper::CommonLanguageFromString(json_languages[i].asString());
+  }
+}
+
+void HMICapabilitiesImpl::convert_audio_capability_to_obj(
+    const Json::Value& capability,
+    smart_objects::SmartObject& output_so) const {
+  if (check_existing_json_member(capability, "samplingRate")) {
+    output_so[strings::sampling_rate] =
+        sampling_rate_enum.find(capability.get("samplingRate", "").asString())
+            ->second;
+  }
+  if (check_existing_json_member(capability, "bitsPerSample")) {
+    output_so[strings::bits_per_sample] =
+        bit_per_sample_enum
+            .find(capability.get("bitsPerSample", "").asString())
+            ->second;
+  }
+  if (check_existing_json_member(capability, "audioType")) {
+    output_so[strings::audio_type] =
+        audio_type_enum.find(capability.get("audioType", "").asString())
+            ->second;
   }
 }
 

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -1088,26 +1088,7 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
         Json::Value pcm_capabilities = ui.get("pcmStreamCapabilities", "");
         smart_objects::SmartObject pcm_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-        if (check_existing_json_member(pcm_capabilities, "samplingRate")) {
-          pcm_capabilities_so["samplingRate"] =
-              sampling_rate_enum
-                  .find(pcm_capabilities.get("samplingRate", "").asString())
-                  ->second;
-        }
-        if (check_existing_json_member(pcm_capabilities, "bitsPerSample")) {
-          pcm_capabilities_so["bitsPerSample"] =
-              bit_per_sample_enum
-                  .find(pcm_capabilities.get("bitsPerSample", "").asString())
-                  ->second;
-        }
-        if (check_existing_json_member(pcm_capabilities, "audioType")) {
-          pcm_capabilities_so["audioType"] =
-              audio_type_enum
-                  .find(pcm_capabilities.get("audioType", "").asString())
-                  ->second;
-        }
-
+        convert_audio_capability_to_obj(pcm_capabilities, pcm_capabilities_so);
         set_pcm_stream_capabilities(pcm_capabilities_so);
       }
 

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -136,6 +136,7 @@ const char* system_context = "systemContext";
 const char* speech_capabilities = "speechCapabilities";
 const char* vr_capabilities = "vrCapabilities";
 const char* audio_pass_thru_capabilities = "audioPassThruCapabilities";
+const char* audio_pass_thru_capabilities_list = "audioPassThruCapabilitiesList";
 const char* pcm_stream_capabilities = "pcmStreamCapabilities";
 const char* audio_pass_thru_icon = "audioPassThruIcon";
 const char* way_points = "wayPoints";

--- a/src/components/application_manager/test/CMakeLists.txt
+++ b/src/components/application_manager/test/CMakeLists.txt
@@ -154,6 +154,7 @@ set(ResumptionData_SOURCES
 file(COPY hmi_capabilities.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY hmi_capabilities_sc1.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY hmi_capabilities_sc2.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY hmi_capabilities_old_apt.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY smartDeviceLink_test.ini DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/resumption)

--- a/src/components/application_manager/test/hmi_capabilities.json
+++ b/src/components/application_manager/test/hmi_capabilities.json
@@ -355,11 +355,11 @@
                 "STATIC"
             ]
         },
-        "audioPassThruCapabilities": {
+        "audioPassThruCapabilities": [{
             "samplingRate": "44KHZ",
             "bitsPerSample": "RATE_8_BIT",
             "audioType": "PCM"
-        },
+        }],
         "pcmStreamCapabilities": {
             "samplingRate": "16KHZ",
             "bitsPerSample": "RATE_16_BIT",

--- a/src/components/application_manager/test/hmi_capabilities_old_apt.json
+++ b/src/components/application_manager/test/hmi_capabilities_old_apt.json
@@ -1,0 +1,9 @@
+{
+  "UI": {
+    "audioPassThruCapabilities": {
+      "samplingRate": "22KHZ",
+      "bitsPerSample": "RATE_16_BIT",
+      "audioType": "PCM"
+    }
+  }
+}

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -602,21 +602,25 @@ TEST_F(HMICapabilitiesTest,
       std::make_shared<HMICapabilitiesForTesting>(mock_app_mngr);
   hmi_capabilities->Init(&last_state_);
 
-  // with old audio pass thru format, the object is a map
+  // with old audio pass thru format, the object is an array containing a single
+  // object
   smart_objects::SmartObject audio_pass_thru_capabilities_so =
       *(hmi_capabilities->audio_pass_thru_capabilities());
-  EXPECT_TRUE(audio_pass_thru_capabilities_so.keyExists("samplingRate"));
+  EXPECT_EQ(smart_objects::SmartType_Array,
+            audio_pass_thru_capabilities_so.getType());
+  EXPECT_EQ(1u, audio_pass_thru_capabilities_so.length());
+  EXPECT_TRUE(audio_pass_thru_capabilities_so[0].keyExists("samplingRate"));
   EXPECT_EQ(hmi_apis::Common_SamplingRate::RATE_22KHZ,
             static_cast<hmi_apis::Common_SamplingRate::eType>(
-                audio_pass_thru_capabilities_so["samplingRate"].asInt()));
-  EXPECT_TRUE(audio_pass_thru_capabilities_so.keyExists("bitsPerSample"));
+                audio_pass_thru_capabilities_so[0]["samplingRate"].asInt()));
+  EXPECT_TRUE(audio_pass_thru_capabilities_so[0].keyExists("bitsPerSample"));
   EXPECT_EQ(hmi_apis::Common_BitsPerSample::RATE_16_BIT,
             static_cast<hmi_apis::Common_BitsPerSample::eType>(
-                audio_pass_thru_capabilities_so["bitsPerSample"].asInt()));
-  EXPECT_TRUE(audio_pass_thru_capabilities_so.keyExists("audioType"));
+                audio_pass_thru_capabilities_so[0]["bitsPerSample"].asInt()));
+  EXPECT_TRUE(audio_pass_thru_capabilities_so[0].keyExists("audioType"));
   EXPECT_EQ(hmi_apis::Common_AudioType::PCM,
             static_cast<hmi_apis::Common_AudioType::eType>(
-                audio_pass_thru_capabilities_so["audioType"].asInt()));
+                audio_pass_thru_capabilities_so[0]["audioType"].asInt()));
 }
 
 TEST_F(HMICapabilitiesTest, VerifyImageType) {

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -598,8 +598,8 @@ TEST_F(HMICapabilitiesTest,
     EXPECT_TRUE(::file_system::DeleteFile("./app_info_data"));
   }
 
-  utils::SharedPtr<HMICapabilitiesForTesting> hmi_capabilities =
-      utils::MakeShared<HMICapabilitiesForTesting>(mock_app_mngr);
+  std::shared_ptr<HMICapabilitiesForTesting> hmi_capabilities =
+      std::make_shared<HMICapabilitiesForTesting>(mock_app_mngr);
   hmi_capabilities->Init(&last_state_);
 
   // with old audio pass thru format, the object is a map

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -336,15 +336,18 @@ TEST_F(HMICapabilitiesTest, LoadCapabilitiesFromFile) {
   // Check audio pass thru
   const smart_objects::SmartObject audio_pass_thru_capabilities_so =
       *(hmi_capabilities_test->audio_pass_thru_capabilities());
+  EXPECT_EQ(smart_objects::SmartType_Array,
+            audio_pass_thru_capabilities_so.getType());
+  EXPECT_EQ(1u, audio_pass_thru_capabilities_so.length());
   EXPECT_EQ(hmi_apis::Common_SamplingRate::RATE_44KHZ,
             static_cast<hmi_apis::Common_SamplingRate::eType>(
-                audio_pass_thru_capabilities_so["samplingRate"].asInt()));
+                audio_pass_thru_capabilities_so[0]["samplingRate"].asInt()));
   EXPECT_EQ(hmi_apis::Common_BitsPerSample::RATE_8_BIT,
             static_cast<hmi_apis::Common_BitsPerSample::eType>(
-                audio_pass_thru_capabilities_so["bitsPerSample"].asInt()));
+                audio_pass_thru_capabilities_so[0]["bitsPerSample"].asInt()));
   EXPECT_EQ(hmi_apis::Common_AudioType::PCM,
             static_cast<hmi_apis::Common_AudioType::eType>(
-                audio_pass_thru_capabilities_so["audioType"].asInt()));
+                audio_pass_thru_capabilities_so[0]["audioType"].asInt()));
 
   // Check hmi zone capabilities
   const smart_objects::SmartObject hmi_zone_capabilities_so =
@@ -567,6 +570,53 @@ TEST_F(HMICapabilitiesTest,
   EXPECT_TRUE(navigation_capability_so.keyExists("getWayPointsEnabled"));
   EXPECT_TRUE(navigation_capability_so["sendLocationEnabled"].asBool());
   EXPECT_FALSE(navigation_capability_so["getWayPointsEnabled"].asBool());
+}
+
+TEST_F(HMICapabilitiesTest,
+       LoadCapabilitiesFromFileAndVerifyOldAudioPassThruCapabilities) {
+  MockApplicationManager mock_app_mngr;
+  event_engine_test::MockEventDispatcher mock_dispatcher;
+  MockApplicationManagerSettings mock_application_manager_settings;
+
+  const std::string hmi_capabilities_file = "hmi_capabilities_old_apt.json";
+
+  EXPECT_CALL(mock_app_mngr, event_dispatcher())
+      .WillOnce(ReturnRef(mock_dispatcher));
+  EXPECT_CALL(mock_app_mngr, get_settings())
+      .WillRepeatedly(ReturnRef(mock_application_manager_settings));
+  EXPECT_CALL(mock_application_manager_settings, hmi_capabilities_file_name())
+      .WillOnce(ReturnRef(hmi_capabilities_file));
+  EXPECT_CALL(mock_dispatcher, add_observer(_, _, _)).Times(1);
+  EXPECT_CALL(mock_dispatcher, remove_observer(_)).Times(1);
+  EXPECT_CALL(mock_application_manager_settings, launch_hmi())
+      .WillOnce(Return(false));
+  EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
+              CommonLanguageFromString(_))
+      .WillRepeatedly(Invoke(TestCommonLanguageFromString));
+
+  if (file_system::FileExists("./app_info_data")) {
+    EXPECT_TRUE(::file_system::DeleteFile("./app_info_data"));
+  }
+
+  utils::SharedPtr<HMICapabilitiesForTesting> hmi_capabilities =
+      utils::MakeShared<HMICapabilitiesForTesting>(mock_app_mngr);
+  hmi_capabilities->Init(&last_state_);
+
+  // with old audio pass thru format, the object is a map
+  smart_objects::SmartObject audio_pass_thru_capabilities_so =
+      *(hmi_capabilities->audio_pass_thru_capabilities());
+  EXPECT_TRUE(audio_pass_thru_capabilities_so.keyExists("samplingRate"));
+  EXPECT_EQ(hmi_apis::Common_SamplingRate::RATE_22KHZ,
+            static_cast<hmi_apis::Common_SamplingRate::eType>(
+                audio_pass_thru_capabilities_so["samplingRate"].asInt()));
+  EXPECT_TRUE(audio_pass_thru_capabilities_so.keyExists("bitsPerSample"));
+  EXPECT_EQ(hmi_apis::Common_BitsPerSample::RATE_16_BIT,
+            static_cast<hmi_apis::Common_BitsPerSample::eType>(
+                audio_pass_thru_capabilities_so["bitsPerSample"].asInt()));
+  EXPECT_TRUE(audio_pass_thru_capabilities_so.keyExists("audioType"));
+  EXPECT_EQ(hmi_apis::Common_AudioType::PCM,
+            static_cast<hmi_apis::Common_AudioType::eType>(
+                audio_pass_thru_capabilities_so["audioType"].asInt()));
 }
 
 TEST_F(HMICapabilitiesTest, VerifyImageType) {

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -198,6 +198,9 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
   MOCK_CONST_METHOD2(convert_json_languages_to_obj,
                      void(const Json::Value& json_languages,
                           smart_objects::SmartObject& languages));
+  MOCK_CONST_METHOD2(convert_audio_capability_to_obj,
+                     void(const Json::Value& capability,
+                          smart_objects::SmartObject& output_so));
 };
 
 }  // namespace application_manager_test

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -525,6 +525,18 @@ class HMICapabilities {
   virtual void convert_json_languages_to_obj(
       const Json::Value& json_languages,
       smart_objects::SmartObject& languages) const = 0;
+
+  /*
+   * @brief function that converts a single entry of audio pass thru capability
+   *        to smart object
+   *
+   * @param capability json object that represents a single entry of audio pass
+   *        thru capability
+   * @param output_so the converted object
+   */
+  virtual void convert_audio_capability_to_obj(
+      const Json::Value& capability,
+      smart_objects::SmartObject& output_so) const = 0;
 };
 
 }  //  namespace application_manager

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -4616,7 +4616,7 @@
   </function>
 </interface>
 
-<interface name="UI" version="1.3.0" date="2018-09-05">
+<interface name="UI" version="1.4.0" date="2019-07-24">
   <function name="Alert" messagetype="request">
     <description>Request from SDL to show an alert message on the display.</description>
     <param name="alertStrings" type="Common.TextFieldStruct" mandatory="true" array="true" minsize="0" maxsize="3">
@@ -4853,7 +4853,17 @@
     <param name="displayCapabilities" type="Common.DisplayCapabilities" mandatory="true">
       <description>Information about the capabilities of the display: its type, text field supported, etc. See DisplayCapabilities. </description>
     </param>
-    <param name="audioPassThruCapabilities" type="Common.AudioPassThruCapabilities" mandatory="true"/>
+    <param name="audioPassThruCapabilities" type="Common.AudioPassThruCapabilities" mandatory="true">
+      <description>
+        Describes an audio configuration that the system supports for PerformAudioPassThru.
+        Note: please fill out both audioPassThruCapabilities and audioPassThruCapabilitiesList parameters, as:
+        - Newer SDL Core uses audioPassThruCapabilitiesList instead of audioPassThruCapabilities, and
+        - audioPassThruCapabilities is a mandatory field and cannot be omitted.
+      </description>
+    </param>
+    <param name="audioPassThruCapabilitiesList" type="Common.AudioPassThruCapabilities" minsize="1" maxsize="100" array="true" mandatory="false">
+      <description>Describes the audio configurations that the system supports for PerformAudioPassThru.</description>
+    </param>
     <param name="hmiZoneCapabilities" type="Common.HmiZoneCapabilities" mandatory="true"/>
     <param name="softButtonCapabilities" type="Common.SoftButtonCapabilities" minsize="1" maxsize="100" array="true" mandatory="false">
       <description>Must be returned if the platform supports on-screen SoftButtons.</description>


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/2024

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests are added / updated to cover the scenario.

### Summary
- This PR updates HMI_API.xml according to the proposal https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0138-hmi-audiopassthru-capability.md.
- Core's logic is updated to choose "audioPassThruCapabilitiesList" param in UI.GetCapabilities if it is available.
- Core's implementation is updated to support "audioPassThruCapabilities" entry of an array in hmi_capabilities.json.
- "audioPassThruCapabilities" entry in hmi_capabilities.json is changed to array.

### Changelog
##### Enhancements
* Update HMI_API.xml to add audioPassThruCapabilitiesList 
* Update audioPassThruCapabilities in hmi_capabilities.json to array 
* Use utility method for reading pcmStreamCapabilities also 

##### Bug Fixes
* None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
