### PR TITLE
Erase connection from map

### DIFF
--- a/src/components/transport_manager/src/transport_manager_impl.cc
+++ b/src/components/transport_manager/src/transport_manager_impl.cc
@@ -657,6 +657,7 @@ void TransportManagerImpl::RemoveConnection(
     if (transport_adapter) {
       transport_adapter->RemoveFinalizedConnection(it->device, it->application);
     }
+    connections_.erase(it);
   }
 }
 


### PR DESCRIPTION
Re-Adds a line that was removed from the transport switching feature implementation. I believe this was due to a copy and paste error. 