### PR TITLE
Check result of TransportManager Init function

### DIFF
--- a/src/appMain/life_cycle.cc
+++ b/src/appMain/life_cycle.cc
@@ -180,7 +180,10 @@ bool LifeCycle::StartComponents() {
   // [TM -> CH -> AM], otherwise some events from TM could arrive at nowhere
   app_manager_->set_protocol_handler(protocol_handler_);
 
-  transport_manager_->Init(*last_state_);
+  if (!transport_manager_->Init(*last_state_)) {
+    LOG4CXX_ERROR(logger_, "Transport manager init failed.");
+    return false;
+  }
   // start transport manager
   transport_manager_->Visibility(true);
 


### PR DESCRIPTION

Fixes #34

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Perform check on the result of the `TransportManager::Init` function in `life_cycle.cc`. This is a best-practice change because there is currently no way for the Transport manager to return a non-success value.

### Changelog
##### Enhancements
* Check result of `TransportManager::Init` function for best practice

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)