### PR TITLE
Fix wild pointer in dbus adapter

### DIFF
--- a/src/components/dbus/src/dbus_adapter.cc
+++ b/src/components/dbus/src/dbus_adapter.cc
@@ -518,7 +518,8 @@ bool DBusAdapter::SetValue(
   dbus_int32_t integerValue = 0;
   double floatValue = 0;
   dbus_bool_t booleanValue = false;
-  const char* stringValue;
+  std::string stringValue;
+  const char* cStringValue;
   switch (rules->type) {
     case ford_message_descriptions::ParameterType::Array:
       return SetArrayValue(
@@ -552,8 +553,9 @@ bool DBusAdapter::SetValue(
       break;
     case ford_message_descriptions::ParameterType::String:
       type = DBUS_TYPE_STRING;
-      stringValue = param.asString().c_str();
-      value = &stringValue;
+      stringValue = param.asString();
+      cStringValue = stringValue.c_str();
+      value = &cStringValue;
       break;
     default:
       LOG4CXX_ERROR(logger_, "DBus: Unknown type of argument");


### PR DESCRIPTION
Fixes #860 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Fix wild pointer caused by the destruction of a temporary string before use

### Changelog
##### Bug Fixes
* Fix wild pointer

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)