### PR TITLE
Fix SDL behavior when resource is unsupported

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
@@ -193,11 +193,11 @@ bool RCCommandRequest::AcquireResources() {
 void RCCommandRequest::on_event(const app_mngr::event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  const std::string module_type = ModuleType();
-  SetResourceState(module_type, ResourceState::FREE);
-
   if (event.id() == hmi_apis::FunctionID::RC_GetInteriorVehicleDataConsent) {
     ProcessAccessResponse(event);
+  } else {
+    const std::string module_type = ModuleType();
+    SetResourceState(module_type, ResourceState::FREE);
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_is_ready_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_is_ready_response.cc
@@ -58,5 +58,4 @@ void NaviIsReadyResponse::Run() {
 }
 
 }  // namespace commands
-
 }  // namespace application_manager

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_response.cc
@@ -58,5 +58,4 @@ void RCIsReadyResponse::Run() {
 }
 
 }  // namespace commands
-
 }  // namespace application_manager

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_system_capability_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_system_capability_request.cc
@@ -67,6 +67,7 @@ void GetSystemCapabilityRequest::Run() {
     SendResponse(false, mobile_apis::Result::INVALID_DATA);
     return;
   }
+
   smart_objects::SmartObject response_params(smart_objects::SmartType_Map);
   mobile_apis::SystemCapabilityType::eType response_type =
       static_cast<mobile_apis::SystemCapabilityType::eType>(
@@ -100,6 +101,14 @@ void GetSystemCapabilityRequest::Run() {
       break;
     }
     case mobile_apis::SystemCapabilityType::REMOTE_CONTROL: {
+      if (!app->is_remote_control_supported()) {
+        SendResponse(false, mobile_apis::Result::DISALLOWED);
+        return;
+      }
+      if (!hmi_capabilities.is_rc_cooperating()) {
+        SendResponse(false, mobile_apis::Result::UNSUPPORTED_RESOURCE);
+        return;
+      }
       if (hmi_capabilities.rc_capability()) {
         response_params[strings::system_capability][strings::rc_capability] =
             *hmi_capabilities.rc_capability();
@@ -131,5 +140,4 @@ void GetSystemCapabilityRequest::on_event(const event_engine::Event& event) {
 }
 
 }  // namespace commands
-
 }  // namespace application_manager

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -2060,7 +2060,7 @@
      <element name="EXTERIOR_LEFT_LIGHTS" value="903">
          <description>Include exterior lights located at the left side of the vehicle. For example, left puddle lights and spot lights.</description>
      </element>
-     <element name="EXTERIOR_RIGHT_LIGHTS" value="902">
+     <element name="EXTERIOR_RIGHT_LIGHTS" value="904">
          <description>Include exterior lights located at the right side of the vehicle. For example, right puddle lights and spot lights.</description>
      </element>
  </enum>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -3115,7 +3115,7 @@
         <element name="EXTERIOR_LEFT_LIGHTS" value="903">
             <description>Include exterior lights located at the left side of the vehicle. For example, left puddle lights and spot lights.</description>
         </element>
-        <element name="EXTERIOR_RIGHT_LIGHTS" value="902">
+        <element name="EXTERIOR_RIGHT_LIGHTS" value="904">
             <description>Include exterior lights located at the right side of the vehicle. For example, right puddle lights and spot lights.</description>
         </element>
     </enum>


### PR DESCRIPTION
This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Summary
- Fixed response handling when required resource is unsupported
- Fixed get_system_capabilities request
- Fixed duplicated value in Mobile & Hmi APIs (there was typo: the same value for different entities)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)