### PR TITLE
Remove unused `AllowDeviceToConnect` RPC

### DIFF
--- a/src/components/application_manager/src/hmi_interfaces_impl.cc
+++ b/src/components/application_manager/src/hmi_interfaces_impl.cc
@@ -61,8 +61,6 @@ generate_function_to_interface_convert_map() {
       HmiInterfaces::HMI_INTERFACE_BasicCommunication;
   convert_map[BasicCommunication_OnFileRemoved] =
       HmiInterfaces::HMI_INTERFACE_BasicCommunication;
-  convert_map[BasicCommunication_AllowDeviceToConnect] =
-      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
   convert_map[BasicCommunication_OnDeviceChosen] =
       HmiInterfaces::HMI_INTERFACE_BasicCommunication;
   convert_map[BasicCommunication_OnFindApplications] =

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -2790,13 +2790,6 @@
         <description>ID of the application.</description>
       </param>
     </function>
-    <function name="AllowDeviceToConnect" messagetype="request">
-        <description>Request from SmartDeviceLink to HMI to get the permissions of new device connection.</description>
-        <param name="device" type="Common.DeviceInfo" mandatory="true"/>
-    </function>
-    <function name="AllowDeviceToConnect" messagetype="response">
-      <param name="allow" type="Boolean" mandatory="true"/>
-    </function>
     <function name="OnDeviceChosen" messagetype="notification">
       <description>Notification must be initiated by HMI on user selecting device in the list of devices.</description>
       <param name="deviceInfo" type="Common.DeviceInfo" mandatory="true">


### PR DESCRIPTION
Fixes #494 

This PR is **ready** for review.

### Risk
This PR makes **major?** API changes.

### Testing Plan
Removing functionality which didn't have tests, N/A

### Summary
Removed unused `AllowDeviceToConnect` RPC from the HMI_API

### Changelog
##### Enhancements
* Removed unused `AllowDeviceToConnect` RPC from the HMI_API

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)