### PR TITLE
Fix disabling RC-functionality

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -67,15 +67,14 @@ typedef std::map<std::string, mobile_apis::VehicleDataType::eType> VehicleData;
  **/
 class MessageHelper {
  public:
-
-    /**
-   * @brief CreateNotification creates basic mobile notification smart object
-   * @param function_id Notificaiton function ID
-   * @param app_id application to send notification
-   * @return basic mobile notification smart object
-   */
-  static smart_objects::SmartObjectSPtr CreateNotification(mobile_apis::FunctionID::eType function_id,
-                                                           uint32_t app_id);
+  /**
+ * @brief CreateNotification creates basic mobile notification smart object
+ * @param function_id Notificaiton function ID
+ * @param app_id application to send notification
+ * @return basic mobile notification smart object
+ */
+  static smart_objects::SmartObjectSPtr CreateNotification(
+      mobile_apis::FunctionID::eType function_id, uint32_t app_id);
   /**
  * @brief CreateHMINotification creates basic hmi notification smart object
  * @param function_id Notificaiton function ID

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager.h
@@ -120,6 +120,10 @@ class ResourceAllocationManager {
    */
   virtual void SendOnRCStatusNotification() = 0;
 
+  virtual bool is_rc_enabled() const = 0;
+
+  virtual void set_rc_enabled(const bool value) = 0;
+
   virtual ~ResourceAllocationManager() {}
 };
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager_impl.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager_impl.h
@@ -65,6 +65,10 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
 
   void SendOnRCStatusNotification() FINAL;
 
+  bool is_rc_enabled() const FINAL;
+
+  void set_rc_enabled(const bool value) FINAL;
+
  private:
   typedef std::vector<application_manager::ApplicationSharedPtr> Apps;
 
@@ -138,6 +142,7 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
   void SetResourceFree(const std::string& module_type, const uint32_t app_id);
 
   std::vector<std::string> all_supported_modules();
+
   /**
    * @brief AllocatedResources contains link between resource and application
    * owning that resource
@@ -165,6 +170,7 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
   hmi_apis::Common_RCAccessMode::eType current_access_mode_;
   application_manager::ApplicationManager& app_mngr_;
   application_manager::rpc_service::RPCService& rpc_service_;
+  bool is_rc_enabled_;
 };
 }  // rc_rpc_plugin
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc
@@ -99,6 +99,7 @@ void RCOnRemoteControlSettingsNotification::Run() {
     hmi_apis::Common_RCAccessMode::eType access_mode =
         hmi_apis::Common_RCAccessMode::INVALID_ENUM;
     LOG4CXX_DEBUG(logger_, "Allowing RC Functionality");
+    resource_allocation_manager_.set_rc_enabled(true);
     if ((*message_)[app_mngr::strings::msg_params].keyExists(
             message_params::kAccessMode)) {
       access_mode = static_cast<hmi_apis::Common_RCAccessMode::eType>(
@@ -117,6 +118,7 @@ void RCOnRemoteControlSettingsNotification::Run() {
   } else {
     LOG4CXX_DEBUG(logger_, "Disallowing RC Functionality");
     DisallowRCFunctionality();
+    resource_allocation_manager_.set_rc_enabled(false);
     resource_allocation_manager_.ResetAllAllocations();
   }
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
@@ -143,6 +143,14 @@ void RCCommandRequest::Run() {
     SendResponse(false, mobile_apis::Result::DISALLOWED, "");
     return;
   }
+  if (!resource_allocation_manager_.is_rc_enabled()) {
+    LOG4CXX_WARN(logger_, "Remote control is denied by user");
+    SetResourceState(ModuleType(), ResourceState::FREE);
+    SendResponse(false,
+                 mobile_apis::Result::UNSUPPORTED_RESOURCE,
+                 "Remote control is denied by user");
+    return;
+  }
 
   if (CheckDriverConsent()) {
     if (AcquireResources()) {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -59,7 +59,9 @@ void RCRPCPlugin::OnApplicationEvent(
   switch (event) {
     case plugins::kApplicationRegistered: {
       application->AddExtension(new RCAppExtension(kRCPluginID));
-      resource_allocation_manager_->SendOnRCStatusNotification();
+      if (resource_allocation_manager_->is_rc_enabled()) {
+          resource_allocation_manager_->SendOnRCStatusNotification();
+      }
       break;
     }
     case plugins::kApplicationExit: {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -60,7 +60,7 @@ void RCRPCPlugin::OnApplicationEvent(
     case plugins::kApplicationRegistered: {
       application->AddExtension(new RCAppExtension(kRCPluginID));
       if (resource_allocation_manager_->is_rc_enabled()) {
-          resource_allocation_manager_->SendOnRCStatusNotification();
+        resource_allocation_manager_->SendOnRCStatusNotification();
       }
       break;
     }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
@@ -23,7 +23,8 @@ ResourceAllocationManagerImpl::ResourceAllocationManagerImpl(
     application_manager::rpc_service::RPCService& rpc_service)
     : current_access_mode_(hmi_apis::Common_RCAccessMode::AUTO_ALLOW)
     , app_mngr_(app_mngr)
-    , rpc_service_(rpc_service) {}
+    , rpc_service_(rpc_service)
+    , is_rc_enabled_(true) {}
 
 ResourceAllocationManagerImpl::~ResourceAllocationManagerImpl() {}
 
@@ -282,6 +283,14 @@ void ResourceAllocationManagerImpl::SendOnRCStatusNotification() {
     auto msg_to_hmi = CreateOnRCStatusNotificationToHmi(rc_app);
     rpc_service_.SendMessageToHMI(msg_to_hmi);
   }
+}
+
+bool ResourceAllocationManagerImpl::is_rc_enabled() const {
+  return is_rc_enabled_;
+}
+
+void ResourceAllocationManagerImpl::set_rc_enabled(const bool value) {
+  is_rc_enabled_ = value;
 }
 
 void ResourceAllocationManagerImpl::SetResourceFree(

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
@@ -130,6 +130,8 @@ class ButtonPressRequestTest
             CheckHMIType(kPolicyAppId,
                          mobile_apis::AppHMIType::eType::REMOTE_CONTROL,
                          nullptr)).WillByDefault(Return(true));
+    ON_CALL(mock_allocation_manager_, is_rc_enabled())
+        .WillByDefault(Return(true));
   }
 
   MessageSharedPtr CreateBasicMessage() {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -100,6 +100,8 @@ class GetInteriorVehicleDataRequestTest
             CheckHMIType(
                 _, mobile_apis::AppHMIType::eType::REMOTE_CONTROL, nullptr))
         .WillByDefault(Return(true));
+    ON_CALL(mock_allocation_manager_, is_rc_enabled())
+        .WillByDefault(Return(true));
   }
 
   MessageSharedPtr CreateBasicMessage() {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
@@ -89,6 +89,8 @@ class SetInteriorVehicleDataRequestTest
             CheckHMIType(kPolicyAppId,
                          mobile_apis::AppHMIType::eType::REMOTE_CONTROL,
                          nullptr)).WillByDefault(Return(true));
+    ON_CALL(mock_allocation_manager_, is_rc_enabled())
+        .WillByDefault(Return(true));
   }
 
   MessageSharedPtr CreateBasicMessage() {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_resource_allocation_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_resource_allocation_manager.h
@@ -35,7 +35,7 @@ class MockResourceAllocationManager
   MOCK_METHOD0(ResetAllAllocations, void());
   MOCK_METHOD0(SendOnRCStatusNotification, void());
   MOCK_CONST_METHOD0(is_rc_enabled, bool());
-  MOCK_METHOD1(set_is_rc_enabled, void(const bool value));
+  MOCK_METHOD1(set_rc_enabled, void(const bool value));
 };
 
 }  // namespace rc_rpc_plugin_test

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_resource_allocation_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_resource_allocation_manager.h
@@ -34,6 +34,8 @@ class MockResourceAllocationManager
                    application_manager::ApplicationSharedPtr application));
   MOCK_METHOD0(ResetAllAllocations, void());
   MOCK_METHOD0(SendOnRCStatusNotification, void());
+  MOCK_CONST_METHOD0(is_rc_enabled, bool());
+  MOCK_METHOD1(set_is_rc_enabled, void(const bool value));
 };
 
 }  // namespace rc_rpc_plugin_test

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2123,11 +2123,11 @@ void ApplicationManagerImpl::set_application_id(const int32_t correlation_id,
 }
 
 uint32_t ApplicationManagerImpl::get_current_audio_source() const {
-    return current_audio_source_;
+  return current_audio_source_;
 }
 
 void ApplicationManagerImpl::set_current_audio_source(const uint32_t source) {
-    current_audio_source_ = source;
+  current_audio_source_ = source;
 }
 
 void ApplicationManagerImpl::AddPolicyObserver(

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -45,12 +45,13 @@ namespace application_manager {
 
 class MockMessageHelper {
  public:
-    MOCK_METHOD2(CreateNotification,
-                 smart_objects::SmartObjectSPtr(mobile_apis::FunctionID::eType, uint32_t));
-    MOCK_METHOD1(CreateHMINotification,
-                 smart_objects::SmartObjectSPtr(hmi_apis::FunctionID::eType));
+  MOCK_METHOD2(CreateNotification,
+               smart_objects::SmartObjectSPtr(mobile_apis::FunctionID::eType,
+                                              uint32_t));
+  MOCK_METHOD1(CreateHMINotification,
+               smart_objects::SmartObjectSPtr(hmi_apis::FunctionID::eType));
 
-    MOCK_METHOD1(GetHashUpdateNotification,
+  MOCK_METHOD1(GetHashUpdateNotification,
                smart_objects::SmartObjectSPtr(const uint32_t app_id));
   MOCK_METHOD2(SendHashUpdateNotification,
                void(const uint32_t app_id, ApplicationManager& app_mngr));

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -40,14 +40,14 @@ namespace application_manager {
 
 smart_objects::SmartObjectSPtr MessageHelper::CreateNotification(
     mobile_apis::FunctionID::eType function_id, uint32_t app_id) {
-    return MockMessageHelper::message_helper_mock()->CreateNotification(
-        function_id, app_id);
+  return MockMessageHelper::message_helper_mock()->CreateNotification(
+      function_id, app_id);
 }
 
 smart_objects::SmartObjectSPtr MessageHelper::CreateHMINotification(
-    hmi_apis::FunctionID::eType  function_id) {
-    return MockMessageHelper::message_helper_mock()->CreateHMINotification(
-        function_id);
+    hmi_apis::FunctionID::eType function_id) {
+  return MockMessageHelper::message_helper_mock()->CreateHMINotification(
+      function_id);
 }
 
 void MessageHelper::SendHashUpdateNotification(uint32_t const app_id,


### PR DESCRIPTION
in case when RC functionality is disabled, all RC-requests from applications with REMOTE_CONTROL appHMIType should not be processed
https://github.com/smartdevicelink/sdl_requirements/blob/master/detailed_docs/RC/rc_enabling_disabling.md