### PR TITLE
Allow NULL for initialText in PerformInteraction RPC

### DIFF
--- a/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_interaction_request.cc
@@ -766,7 +766,7 @@ bool PerformInteractionRequest::IsWhiteSpaceExist() {
   const char* str = NULL;
 
   str = (*message_)[strings::msg_params][strings::initial_text].asCharArray();
-  if (!CheckSyntax(str)) {
+  if (!CheckSyntax(str, true)) {
     LOG4CXX_ERROR(logger_, "Invalid initial_text syntax check failed");
     return true;
   }

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -3435,7 +3435,7 @@
     <function name="PerformInteraction" functionID="PerformInteractionID" messagetype="request">
         <description>Triggers an interaction (e.g. "Permit GPS?" - Yes, no, Always Allow).</description>
         
-        <param name="initialText" type="String" maxlength="500"  mandatory="true">
+        <param name="initialText" type="String" maxlength="500"  mandatory="false">
             <description>
                 Text to be displayed first.
             </description>


### PR DESCRIPTION
Fixes #2061

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
I have tested with our internal devboard with app which send null initialText in PerformInteraction.

### Summary
Change MOBILE_API.xm to accept null for initialText.

### Changelog

##### Enhancements
* Allow NULL for initialText in PerfromInteraction RPC

##### Bug Fixes
* [Bug Fix Info]

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)