### PR TITLE
Only use the DEPRECATED macro in top level headers

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -721,12 +721,12 @@ class Application : public virtual InitialApplicationData,
   virtual bool IsAudioApplication() const = 0;
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief GetDeviceId allows to obtain device id which posseses
    * by this application.
    * @return device the device id.
    */
-  std::string GetDeviceId() const {
+  DEPRECATED std::string GetDeviceId() const {
     return device_id_;
   }
 

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -311,7 +311,7 @@ class ApplicationManagerImpl
   bool IsAppTypeExistsInFullOrLimited(ApplicationConstSharedPtr app) const;
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief Checks if Application is subscribed for way points
    * @param Application AppID
    * @return true if Application is subscribed for way points
@@ -320,14 +320,14 @@ class ApplicationManagerImpl
   bool IsAppSubscribedForWayPoints(const uint32_t app_id) const OVERRIDE;
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief Subscribe Application for way points
    * @param Application AppID
    */
   void SubscribeAppForWayPoints(const uint32_t app_id) OVERRIDE;
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief Unsubscribe Application for way points
    * @param Application AppID
    */
@@ -507,7 +507,7 @@ class ApplicationManagerImpl
       const hmi_apis::Common_DriverDistractionState::eType state) OVERRIDE;
 
   /*
-   * DEPRECATED
+   * @deprecated
    * @brief Retrieves if VR session has started
    *
    * @return Current VR session state (started, stopped)
@@ -515,12 +515,13 @@ class ApplicationManagerImpl
   inline bool vr_session_started() const;
 
   /*
-   * DEPRECATED
+   * @deprecated
+   *
    * @brief Sets VR session state
    *
    * @param state Current HMI VR session state
    */
-  void set_vr_session_started(const bool state);
+  DEPRECATED void set_vr_session_started(const bool state);
 
   /*
    * @brief Retrieves SDL access to all mobile apps
@@ -551,7 +552,7 @@ class ApplicationManagerImpl
       mobile_apis::SystemContext::eType system_context) const OVERRIDE;
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief CreateRegularState create regular HMI state for application
    * @param app_id Application id
    * @param hmi_level of returned state
@@ -559,7 +560,7 @@ class ApplicationManagerImpl
    * @param system_context of returned state
    * @return new regular HMI state
    */
-  DEPRECATED HmiStatePtr CreateRegularState(
+  HmiStatePtr CreateRegularState(
       uint32_t app_id,
       mobile_apis::HMILevel::eType hmi_level,
       mobile_apis::AudioStreamingState::eType audio_state,
@@ -1088,14 +1089,14 @@ class ApplicationManagerImpl
   uint32_t GenerateNewHMIAppID() OVERRIDE;
 
   /**
-   * DERPECATED
+   * @deprecated
    * @brief Parse smartObject and replace mobile app Id by HMI app ID
    * @param message Smartobject to be parsed
    */
   void ReplaceMobileByHMIAppId(smart_objects::SmartObject& message);
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief Parse smartObject and replace HMI app ID by mobile app Id
    * @param message Smartobject to be parsed
    */
@@ -1153,7 +1154,7 @@ class ApplicationManagerImpl
   void RemoveAppFromTTSGlobalPropertiesList(const uint32_t app_id) OVERRIDE;
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief method adds application in FULL and LIMITED state
    * to on_phone_call_app_list_.
    * Also OnHMIStateNotification with BACKGROUND state sent for these apps
@@ -1161,7 +1162,7 @@ class ApplicationManagerImpl
   void CreatePhoneCallAppList();
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief method removes application from on_phone_call_app_list_.
    *
    * Also OnHMIStateNotification with previous HMI state sent for these apps
@@ -1534,6 +1535,7 @@ class ApplicationManagerImpl
   void EndNaviStreaming();
 
   /**
+   * @deprecated
    * @brief Starts specified navi service for application
    * @param app_id Application to proceed
    * @param service_type Type of service to start
@@ -1809,7 +1811,7 @@ class ApplicationManagerImpl
 
   volatile bool is_stopping_;
 
-  std::unique_ptr<CommandHolder> commands_holder_;
+  std::auto_ptr<CommandHolder> commands_holder_;
 
 #ifdef BUILD_TESTS
  public:

--- a/src/components/application_manager/include/application_manager/commands/command_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_impl.h
@@ -149,11 +149,11 @@ class CommandImpl : public Command {
   bool ReplaceMobileWithHMIAppId(smart_objects::SmartObject& message);
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief Parses mobile message and replaces mobile app id with HMI app id
    * @param message Message to replace its ids
    */
-  void ReplaceMobileByHMIAppId(smart_objects::SmartObject& message);
+  DEPRECATED void ReplaceMobileByHMIAppId(smart_objects::SmartObject& message);
 
   /**
    * @brief Parses message from HMI and replaces HMI app id with mobile app id
@@ -163,11 +163,11 @@ class CommandImpl : public Command {
   bool ReplaceHMIWithMobileAppId(smart_objects::SmartObject& message);
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief Parses message from HMI and replaces HMI app id with mobile app id
    * @param message Message to replace its ids
    */
-  void ReplaceHMIByMobileAppId(smart_objects::SmartObject& message);
+  DEPRECATED void ReplaceHMIByMobileAppId(smart_objects::SmartObject& message);
 
   MessageSharedPtr message_;
   uint32_t default_timeout_;

--- a/src/components/application_manager/include/application_manager/hmi_state.h
+++ b/src/components/application_manager/include/application_manager/hmi_state.h
@@ -91,23 +91,23 @@ class HmiState {
            StateID state_id);
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief HmiState constructor
    * @param app_id Application id
    * @param app_mngr Application manager
    */
-  HmiState(uint32_t app_id, const ApplicationManager& app_mngr);
+  DEPRECATED HmiState(uint32_t app_id, const ApplicationManager& app_mngr);
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief HmiState constructor
    * @param app_id Application id
    * @param app_mngr Application manager
    * @param state_id HMI state to assign
    */
-  HmiState(uint32_t app_id,
-           const ApplicationManager& app_mngr,
-           StateID state_id);
+  DEPRECATED HmiState(uint32_t app_id,
+                      const ApplicationManager& app_mngr,
+                      StateID state_id);
 
   virtual ~HmiState() {}
 

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
@@ -114,12 +114,12 @@ class ResumptionDataDB : public ResumptionData {
    * @brief Increments ignition counter for all registered applications
    * and remember ign_off time stamp
    */
-  DEPRECATED void OnSuspend() FINAL;
+  void OnSuspend() FINAL;
 
   /**
    * @brief Decrements ignition counter for all registered applications
    */
-  DEPRECATED void OnAwake() FINAL;
+  void OnAwake() FINAL;
 
   /**
    * @brief Increments ignition counter for all registered applications

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_json.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_json.h
@@ -85,12 +85,12 @@ class ResumptionDataJson : public ResumptionData {
    * @brief Increments ignition counter for all registered applications
    * and remember ign_off time stamp
    */
-  DEPRECATED void OnSuspend() FINAL;
+  void OnSuspend() FINAL;
 
   /**
    * @brief Decrements ignition counter for all registered applications
    */
-  DEPRECATED void OnAwake() FINAL;
+  void OnAwake() FINAL;
 
   /**
    * @brief Increments ignition counter for all registered applications

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -641,13 +641,11 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
   return application;
 }
 
-DEPRECATED bool ApplicationManagerImpl::RemoveAppDataFromHMI(
-    ApplicationSharedPtr app) {
+bool ApplicationManagerImpl::RemoveAppDataFromHMI(ApplicationSharedPtr app) {
   return true;
 }
 
-DEPRECATED bool ApplicationManagerImpl::LoadAppDataToHMI(
-    ApplicationSharedPtr app) {
+bool ApplicationManagerImpl::LoadAppDataToHMI(ApplicationSharedPtr app) {
   return true;
 }
 
@@ -804,8 +802,7 @@ void ApplicationManagerImpl::set_driver_distraction_state(
   driver_distraction_state_ = state;
 }
 
-DEPRECATED void ApplicationManagerImpl::set_vr_session_started(
-    const bool state) {
+void ApplicationManagerImpl::set_vr_session_started(const bool state) {
   is_vr_session_strated_ = state;
 }
 
@@ -830,7 +827,7 @@ HmiStatePtr ApplicationManagerImpl::CreateRegularState(
     mobile_apis::HMILevel::eType hmi_level,
     mobile_apis::AudioStreamingState::eType audio_state,
     mobile_apis::SystemContext::eType system_context) const {
-  HmiStatePtr state(new HmiState(app_id, *this));
+  HmiStatePtr state(new HmiState(application(app_id), *this));
   state->set_hmi_level(hmi_level);
   state->set_audio_streaming_state(audio_state);
   state->set_system_context(system_context);

--- a/src/components/application_manager/src/commands/command_impl.cc
+++ b/src/components/application_manager/src/commands/command_impl.cc
@@ -139,7 +139,7 @@ bool CommandImpl::ReplaceMobileWithHMIAppId(
   return true;
 }
 
-DEPRECATED void CommandImpl::ReplaceMobileByHMIAppId(
+void CommandImpl::ReplaceMobileByHMIAppId(
     NsSmartDeviceLink::NsSmartObjects::SmartObject& message) {
   if (!ReplaceMobileWithHMIAppId(message)) {
     LOG4CXX_ERROR(logger_, "Substitution mobile --> HMI id is failed.");
@@ -191,7 +191,7 @@ bool CommandImpl::ReplaceHMIWithMobileAppId(
   return true;
 }
 
-DEPRECATED void CommandImpl::ReplaceHMIByMobileAppId(
+void CommandImpl::ReplaceHMIByMobileAppId(
     NsSmartDeviceLink::NsSmartObjects::SmartObject& message) {
   if (!ReplaceHMIWithMobileAppId(message)) {
     LOG4CXX_ERROR(logger_, "Substitution HMI --> mobile id is failed.");

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -741,11 +741,6 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
   SendChangeRegistrationOnHMI(application);
 }
 
-DEPRECATED void
-RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
-  SendRegisterAppInterfaceResponseToMobile(ApplicationType::kNewApplication);
-}
-
 void RegisterAppInterfaceRequest::SendChangeRegistration(
     const hmi_apis::FunctionID::eType function_id,
     const int32_t language,

--- a/src/components/application_manager/src/hmi_state.cc
+++ b/src/components/application_manager/src/hmi_state.cc
@@ -56,9 +56,9 @@ HmiState::HmiState(utils::SharedPtr<Application> app,
     , audio_streaming_state_(mobile_apis::AudioStreamingState::INVALID_ENUM)
     , system_context_(mobile_apis::SystemContext::INVALID_ENUM) {}
 
-DEPRECATED HmiState::HmiState(uint32_t app_id,
-                              const ApplicationManager& app_mngr,
-                              StateID state_id)
+HmiState::HmiState(uint32_t app_id,
+                   const ApplicationManager& app_mngr,
+                   StateID state_id)
     : state_id_(state_id)
     , app_mngr_(app_mngr)
     , hmi_level_(mobile_apis::HMILevel::INVALID_ENUM)
@@ -67,8 +67,7 @@ DEPRECATED HmiState::HmiState(uint32_t app_id,
   app_ = app_mngr_.application(app_id);
 }
 
-DEPRECATED HmiState::HmiState(uint32_t app_id,
-                              const ApplicationManager& app_mngr)
+HmiState::HmiState(uint32_t app_id, const ApplicationManager& app_mngr)
     : state_id_(STATE_ID_REGULAR)
     , app_mngr_(app_mngr)
     , hmi_level_(mobile_apis::HMILevel::INVALID_ENUM)
@@ -108,17 +107,15 @@ VRHmiState::VRHmiState(utils::SharedPtr<Application> app,
                        const ApplicationManager& app_mngr)
     : HmiState(app, app_mngr, STATE_ID_VR_SESSION) {}
 
-DEPRECATED VRHmiState::VRHmiState(uint32_t app_id,
-                                  const ApplicationManager& app_mngr)
-    : HmiState(app_id, app_mngr, STATE_ID_VR_SESSION) {}
+VRHmiState::VRHmiState(uint32_t app_id, const ApplicationManager& app_mngr)
+    : HmiState(app_mngr.application(app_id), app_mngr, STATE_ID_VR_SESSION) {}
 
 TTSHmiState::TTSHmiState(utils::SharedPtr<Application> app,
                          const ApplicationManager& app_mngr)
     : HmiState(app, app_mngr, STATE_ID_TTS_SESSION) {}
 
-DEPRECATED TTSHmiState::TTSHmiState(uint32_t app_id,
-                                    const ApplicationManager& app_mngr)
-    : HmiState(app_id, app_mngr, STATE_ID_TTS_SESSION) {}
+TTSHmiState::TTSHmiState(uint32_t app_id, const ApplicationManager& app_mngr)
+    : HmiState(app_mngr.application(app_id), app_mngr, STATE_ID_TTS_SESSION) {}
 
 mobile_apis::AudioStreamingState::eType TTSHmiState::audio_streaming_state()
     const {
@@ -139,9 +136,10 @@ NaviStreamingHmiState::NaviStreamingHmiState(utils::SharedPtr<Application> app,
                                              const ApplicationManager& app_mngr)
     : HmiState(app, app_mngr, STATE_ID_NAVI_STREAMING) {}
 
-DEPRECATED NaviStreamingHmiState::NaviStreamingHmiState(
-    uint32_t app_id, const ApplicationManager& app_mngr)
-    : HmiState(app_id, app_mngr, STATE_ID_NAVI_STREAMING) {}
+NaviStreamingHmiState::NaviStreamingHmiState(uint32_t app_id,
+                                             const ApplicationManager& app_mngr)
+    : HmiState(
+          app_mngr.application(app_id), app_mngr, STATE_ID_NAVI_STREAMING) {}
 
 mobile_apis::AudioStreamingState::eType
 NaviStreamingHmiState::audio_streaming_state() const {
@@ -163,9 +161,9 @@ PhoneCallHmiState::PhoneCallHmiState(utils::SharedPtr<Application> app,
                                      const ApplicationManager& app_mngr)
     : HmiState(app, app_mngr, STATE_ID_PHONE_CALL) {}
 
-DEPRECATED PhoneCallHmiState::PhoneCallHmiState(
-    uint32_t app_id, const ApplicationManager& app_mngr)
-    : HmiState(app_id, app_mngr, STATE_ID_PHONE_CALL) {}
+PhoneCallHmiState::PhoneCallHmiState(uint32_t app_id,
+                                     const ApplicationManager& app_mngr)
+    : HmiState(app_mngr.application(app_id), app_mngr, STATE_ID_PHONE_CALL) {}
 
 mobile_apis::HMILevel::eType PhoneCallHmiState::hmi_level() const {
   using namespace helpers;
@@ -188,17 +186,18 @@ SafetyModeHmiState::SafetyModeHmiState(utils::SharedPtr<Application> app,
                                        const ApplicationManager& app_mngr)
     : HmiState(app, app_mngr, STATE_ID_SAFETY_MODE) {}
 
-DEPRECATED SafetyModeHmiState::SafetyModeHmiState(
-    uint32_t app_id, const ApplicationManager& app_mngr)
-    : HmiState(app_id, app_mngr, STATE_ID_SAFETY_MODE) {}
+SafetyModeHmiState::SafetyModeHmiState(uint32_t app_id,
+                                       const ApplicationManager& app_mngr)
+    : HmiState(app_mngr.application(app_id), app_mngr, STATE_ID_SAFETY_MODE) {}
 
 DeactivateHMI::DeactivateHMI(utils::SharedPtr<Application> app,
                              const ApplicationManager& app_mngr)
     : HmiState(app, app_mngr, STATE_ID_DEACTIVATE_HMI) {}
 
-DEPRECATED DeactivateHMI::DeactivateHMI(uint32_t app_id,
-                                        const ApplicationManager& app_mngr)
-    : HmiState(app_id, app_mngr, STATE_ID_DEACTIVATE_HMI) {}
+DeactivateHMI::DeactivateHMI(uint32_t app_id,
+                             const ApplicationManager& app_mngr)
+    : HmiState(
+          app_mngr.application(app_id), app_mngr, STATE_ID_DEACTIVATE_HMI) {}
 
 mobile_apis::HMILevel::eType DeactivateHMI::hmi_level() const {
   using namespace helpers;
@@ -215,9 +214,8 @@ AudioSource::AudioSource(utils::SharedPtr<Application> app,
                          const ApplicationManager& app_mngr)
     : HmiState(app, app_mngr, STATE_ID_AUDIO_SOURCE) {}
 
-DEPRECATED AudioSource::AudioSource(uint32_t app_id,
-                                    const ApplicationManager& app_mngr)
-    : HmiState(app_id, app_mngr, STATE_ID_AUDIO_SOURCE) {}
+AudioSource::AudioSource(uint32_t app_id, const ApplicationManager& app_mngr)
+    : HmiState(app_mngr.application(app_id), app_mngr, STATE_ID_AUDIO_SOURCE) {}
 
 mobile_apis::HMILevel::eType AudioSource::hmi_level() const {
   using namespace mobile_apis;
@@ -240,9 +238,9 @@ EmbeddedNavi::EmbeddedNavi(utils::SharedPtr<Application> app,
                            const ApplicationManager& app_mngr)
     : HmiState(app, app_mngr, STATE_ID_EMBEDDED_NAVI) {}
 
-DEPRECATED EmbeddedNavi::EmbeddedNavi(uint32_t app_id,
-                                      const ApplicationManager& app_mngr)
-    : HmiState(app_id, app_mngr, STATE_ID_EMBEDDED_NAVI) {}
+EmbeddedNavi::EmbeddedNavi(uint32_t app_id, const ApplicationManager& app_mngr)
+    : HmiState(app_mngr.application(app_id), app_mngr, STATE_ID_EMBEDDED_NAVI) {
+}
 
 mobile_apis::HMILevel::eType EmbeddedNavi::hmi_level() const {
   using namespace mobile_apis;

--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -212,7 +212,7 @@ uint32_t ResumptionDataDB::GetHMIApplicationID(
   return hmi_app_id;
 }
 
-DEPRECATED void ResumptionDataDB::OnSuspend() {}
+void ResumptionDataDB::OnSuspend() {}
 
 void ResumptionDataDB::IncrementIgnOffCount() {
   LOG4CXX_AUTO_TRACE(logger_);
@@ -293,7 +293,7 @@ bool ResumptionDataDB::GetHashId(const std::string& policy_app_id,
   return SelectHashId(policy_app_id, device_id, hash_id);
 }
 
-DEPRECATED void ResumptionDataDB::OnAwake() {}
+void ResumptionDataDB::OnAwake() {}
 
 void ResumptionDataDB::DecrementIgnOffCount() {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/application_manager/src/resumption/resumption_data_json.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_json.cc
@@ -143,7 +143,7 @@ uint32_t ResumptionDataJson::GetHMIApplicationID(
   return hmi_app_id;
 }
 
-DEPRECATED void ResumptionDataJson::OnSuspend() {}
+void ResumptionDataJson::OnSuspend() {}
 
 void ResumptionDataJson::IncrementIgnOffCount() {
   using namespace app_mngr;
@@ -169,7 +169,7 @@ void ResumptionDataJson::IncrementIgnOffCount() {
   LOG4CXX_DEBUG(logger_, GetResumptionData().toStyledString());
 }
 
-DEPRECATED void ResumptionDataJson::OnAwake() {}
+void ResumptionDataJson::OnAwake() {}
 
 void ResumptionDataJson::DecrementIgnOffCount() {
   using namespace app_mngr;

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -504,7 +504,7 @@ class ConnectionHandlerImpl
       connection_handler::DeviceHandle* device_id) const OVERRIDE;
 
   /**
-   * DEPRECATED
+   * \deprecated
    * \brief information about given Connection Key.
    * \param key Unique key used by other components as session identifier
    * \param app_id Returned: ApplicationID

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -254,27 +254,29 @@ class ApplicationManager {
       const utils::SharedPtr<Application> app) = 0;
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief Checks if Application is subscribed for way points
    * @param Application AppID
    * @return true if Application is subscribed for way points
    * otherwise false
    */
-  virtual bool IsAppSubscribedForWayPoints(const uint32_t app_id) const = 0;
+  DEPRECATED virtual bool IsAppSubscribedForWayPoints(
+      const uint32_t app_id) const = 0;
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief Subscribe Application for way points
    * @param Application AppID
    */
-  virtual void SubscribeAppForWayPoints(const uint32_t app_id) = 0;
+  DEPRECATED virtual void SubscribeAppForWayPoints(const uint32_t app_id) = 0;
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief Unsubscribe Application for way points
    * @param Application AppID
    */
-  virtual void UnsubscribeAppFromWayPoints(const uint32_t app_id) = 0;
+  DEPRECATED virtual void UnsubscribeAppFromWayPoints(
+      const uint32_t app_id) = 0;
 
   /**
    * @brief Checks if Application is subscribed for way points
@@ -658,7 +660,7 @@ class ApplicationManager {
       mobile_apis::SystemContext::eType system_context) const = 0;
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief CreateRegularState create regular HMI state for application
    * @param app_id Application id
    * @param hmi_level of returned state
@@ -666,7 +668,7 @@ class ApplicationManager {
    * @param system_context of returned state
    * @return new regular HMI state
    */
-  virtual HmiStatePtr CreateRegularState(
+  DEPRECATED virtual HmiStatePtr CreateRegularState(
       uint32_t app_id,
       mobile_apis::HMILevel::eType hmi_level,
       mobile_apis::AudioStreamingState::eType audio_state,

--- a/src/components/include/connection_handler/connection_handler.h
+++ b/src/components/include/connection_handler/connection_handler.h
@@ -183,7 +183,7 @@ class ConnectionHandler {
       connection_handler::DeviceHandle* device_id) const = 0;
 
   /**
-   * DEPRECATED
+   * \deprecated
    * \brief information about given Connection Key.
    * \param key Unique key used by other components as session identifier
    * \param app_id Returned: ApplicationID

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -231,7 +231,7 @@ class SessionObserver {
                            uint8_t* sessionId) const = 0;
 
   /**
-   * DEPRECATED
+   * \deprecated
    * \brief information about given Connection Key.
    * \param key Unique key used by other components as session identifier
    * \param app_id Returned: ApplicationID
@@ -239,10 +239,11 @@ class SessionObserver {
    * \param device_id Returned: DeviceID
    * \return int32_t -1 in case of error or 0 in case of success
    */
-  virtual int32_t GetDataOnSessionKey(uint32_t key,
-                                      uint32_t* app_id,
-                                      std::list<int32_t>* sessions_list,
-                                      uint32_t* device_id) const = 0;
+  DEPRECATED virtual int32_t GetDataOnSessionKey(
+      uint32_t key,
+      uint32_t* app_id,
+      std::list<int32_t>* sessions_list,
+      uint32_t* device_id) const = 0;
 
   /**
    * \brief information about given Connection Key.

--- a/src/components/include/transport_manager/transport_adapter/transport_adapter_event.h
+++ b/src/components/include/transport_manager/transport_adapter/transport_adapter_event.h
@@ -87,7 +87,7 @@ class TransportAdapterEvent {
       , event_error(error) {}
 
   /**
-   * DEPRECATED
+   * @deprecated
    * @brief Constructor.
    *
    * @param type Event type.
@@ -97,12 +97,12 @@ class TransportAdapterEvent {
    * @param data Smart pointer to the raw message.
    * @param error Error class that contains details of this error situation.
    */
-  TransportAdapterEvent(int type,
-                        transport_adapter::TransportAdapter* adapter,
-                        const DeviceUID& device_handle,
-                        const ApplicationHandle& application_id,
-                        ::protocol_handler::RawMessagePtr data,
-                        BaseErrorPtr error)
+  DEPRECATED TransportAdapterEvent(int type,
+                                   transport_adapter::TransportAdapter* adapter,
+                                   const DeviceUID& device_handle,
+                                   const ApplicationHandle& application_id,
+                                   ::protocol_handler::RawMessagePtr data,
+                                   BaseErrorPtr error)
       : event_type(static_cast<EventTypeEnum>(type))
       , application_id(application_id)
       , device_uid(device_handle)

--- a/src/components/transport_manager/include/transport_manager/transport_manager_impl.h
+++ b/src/components/transport_manager/include/transport_manager/transport_manager_impl.h
@@ -245,8 +245,7 @@ class TransportManagerImpl
   int Visibility(const bool& on_off) const OVERRIDE;
 
   /**
-   * DEPRECATED
-   * Must be moved under 'private' section
+   * @deprecated Must be moved under 'private' section
    * @brief Updates total device list with info from specific transport adapter.
    * @param ta Transport adapter
    */


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
* Built with deprecated warnings and verified no new warnings were generated from these changes

### Summary
Unified usages of the DEPRECATED macro, it is now only used in top level header in which a function is defined, with any duplicates in lower levels removed.

### Changelog

##### Enhancements
* Removed unnecessary duplicate usages of the DEPRECATED macro
* Removed improper uses of the DEPRECATED macro
* Updated documentation for several deprecated methods

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)