### PR TITLE
Fix/cut off read only param

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h
@@ -182,6 +182,8 @@ const char kSRGBColor[] = "sRGBColor";
 // AudioControlData
 const char kSource[] = "source";
 const char kKeepContext[] = "keepContext";
+const char kEqualizerSettings[] = "equalizerSettings";
+const char kChannelName[] = "channelName";
 
 // ModuleData struct
 const char kRadioControlData[] = "radioControlData";

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
@@ -460,13 +460,33 @@ bool SetInteriorVehicleDataRequest::AreAllParamsReadOnly(
   return true;
 }
 
+bool CheckReadOnlyParamsForAudio(
+    const smart_objects::SmartObject& module_type_params) {
+  if (module_type_params.keyExists(message_params::kEqualizerSettings)) {
+    const auto& equalizer_settings =
+        module_type_params[message_params::kEqualizerSettings];
+    auto it = equalizer_settings.asArray()->begin();
+    for (; it != equalizer_settings.asArray()->end(); ++it) {
+      if (it->keyExists(message_params::kChannelName)) {
+        LOG4CXX_DEBUG(logger_, " READ ONLY parameter: ");
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 bool SetInteriorVehicleDataRequest::AreReadOnlyParamsPresent(
     const smart_objects::SmartObject& module_data) {
   LOG4CXX_AUTO_TRACE(logger_);
   const smart_objects::SmartObject& module_type_params =
       ControlData(module_data);
   auto it = module_type_params.map_begin();
-  std::vector<std::string> ro_params = GetModuleReadOnlyParams(ModuleType());
+  const std::string module_type = ModuleType();
+  std::vector<std::string> ro_params = GetModuleReadOnlyParams(module_type);
+  if (enums_value::kAudio == module_type) {
+    return CheckReadOnlyParamsForAudio(module_type_params);
+  }
   for (; it != module_type_params.map_end(); ++it) {
     if (helpers::in_range(ro_params, it->first)) {
       return true;
@@ -491,6 +511,20 @@ void SetInteriorVehicleDataRequest::CutOffReadOnlyParams(
       } else if (enums_value::kRadio == module_type) {
         module_data[message_params::kRadioControlData].erase(it);
         LOG4CXX_DEBUG(logger_, "Cutting-off READ ONLY parameter: " << it);
+      }
+    }
+  }
+
+  if (enums_value::kAudio == module_type) {
+    auto& equalizer_settings = module_data[message_params::kAudioControlData]
+                                          [message_params::kEqualizerSettings];
+    auto it = equalizer_settings.asArray()->begin();
+    for (; it != equalizer_settings.asArray()->end(); ++it) {
+      if (it->keyExists(message_params::kChannelName)) {
+        it->erase(message_params::kChannelName);
+        LOG4CXX_DEBUG(logger_,
+                      "Cutting-off READ ONLY parameter: "
+                          << message_params::kChannelName);
       }
     }
   }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2732,21 +2732,20 @@ void ApplicationManagerImpl::ProcessPostponedMessages(const uint32_t app_id) {
   }
   MobileMessageQueue messages;
   app->SwapMobileMessageQueue(messages);
-  auto push_allowed_messages =
-      [this, &app](smart_objects::SmartObjectSPtr message) {
-        const std::string function_id = MessageHelper::StringifiedFunctionID(
-            static_cast<mobile_apis::FunctionID::eType>(
-                (*message)[strings::params][strings::function_id].asUInt()));
-        const RPCParams params;
-        const mobile_apis::Result::eType check_result =
-            CheckPolicyPermissions(app, function_id, params);
-        if (mobile_api::Result::SUCCESS == check_result) {
-          rpc_service_->ManageMobileCommand(message,
-                              commands::Command::SOURCE_SDL);
-        } else {
-          app->PushMobileMessage(message);
-        }
-      };
+  auto push_allowed_messages = [this, &app](
+      smart_objects::SmartObjectSPtr message) {
+    const std::string function_id = MessageHelper::StringifiedFunctionID(
+        static_cast<mobile_apis::FunctionID::eType>(
+            (*message)[strings::params][strings::function_id].asUInt()));
+    const RPCParams params;
+    const mobile_apis::Result::eType check_result =
+        CheckPolicyPermissions(app, function_id, params);
+    if (mobile_api::Result::SUCCESS == check_result) {
+      rpc_service_->ManageMobileCommand(message, commands::Command::SOURCE_SDL);
+    } else {
+      app->PushMobileMessage(message);
+    }
+  };
   std::for_each(messages.begin(), messages.end(), push_allowed_messages);
 }
 

--- a/src/components/transport_manager/src/transport_manager_impl.cc
+++ b/src/components/transport_manager/src/transport_manager_impl.cc
@@ -435,11 +435,10 @@ int TransportManagerImpl::AddTransportAdapter(
     return E_ADAPTER_EXISTS;
   }
 
-  auto listener =
-      new TransportAdapterListenerImpl(this, transport_adapter);
+  auto listener = new TransportAdapterListenerImpl(this, transport_adapter);
 
   transport_adapter->AddListener(listener);
-  
+
   if (transport_adapter->IsInitialised() ||
       transport_adapter->Init() == TransportAdapter::OK) {
     transport_adapter_listeners_[transport_adapter] = listener;


### PR DESCRIPTION
This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
channelName - read-only param in equalizerSettings, so SDL should cut off it from SetInteriorVechicleData request 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
