### PR TITLE
Additional fixes for 2072

### DIFF
--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -559,10 +559,10 @@ void SQLPTRepresentation::GatherModuleConfig(
     LOG4CXX_WARN(logger_, "Incorrect select statement for endpoints");
   } else {
     while (endpoints.Next()) {
-      std::stringstream stream;
-      stream << "0x0" << endpoints.GetInteger(1);
-      config->endpoints[stream.str()][endpoints.GetString(2)].push_back(
-          endpoints.GetString(0));
+      const std::string& url = endpoints.GetString(0);
+      const std::string& service = endpoints.GetString(1);
+      const std::string& app_id = endpoints.GetString(2);
+      config->endpoints[service][app_id].push_back(url);
     }
   }
 

--- a/src/components/utils/test/policy.sql
+++ b/src/components/utils/test/policy.sql
@@ -263,7 +263,7 @@ BEGIN TRANSACTION;
   CREATE INDEX IF NOT EXISTS `consent_group.fk_consent_group_functional_group1_idx` 
     ON `consent_group`(`functional_group_id`); 
   CREATE TABLE IF NOT EXISTS `endpoint`( 
-    `service` INTEGER NOT NULL, 
+    `service` VARCHAR(100) NOT NULL, 
     `url` VARCHAR(100) NOT NULL, 
     `application_id` VARCHAR(45) NOT NULL COLLATE NOCASE,
     CONSTRAINT `fk_endpoint_application1` 


### PR DESCRIPTION
When loading the policy table from backup sql file, service types must be read in a strings.

[Things to note: Pull Requests **must** fix an issue. Discussion about the feature / bug takes place in the issue, discussion of the implementation takes place in the PR. Please also see the [Contributing Guide](https://github.com/smartdevicelink/sdl_core/blob/master/.github/CONTRIBUTING.md) for information on branch naming and the CLA.

Delete the above section when you've read it.]

Fixes #2072 

This PR is ready for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
Connect app, perform ptu, cycle core, connect app, change odometer value to trigger policy table update.

Expected: Policy update occurs.

### Summary
When core restarts and loads the policy table from the sql file, the service endpoint types should be read in as strings from the database.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)