### PR TITLE
Fix SDL sends multiple OnRCStatus notification in case of app unregistration

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
@@ -145,6 +145,7 @@ void ResourceAllocationManagerImpl::ProcessApplicationPolicyUpdate() {
       if (rc_extention) {
         rc_extention->UnsubscribeFromInteriorVehicleData(*module);
       }
+      SendOnRCStatusNotification();
     }
   }
 }
@@ -309,7 +310,6 @@ void ResourceAllocationManagerImpl::SetResourceFree(
   }
   allocated_resources_.erase(allocation);
   LOG4CXX_DEBUG(logger_, "Resource " << module_type << " is released.");
-  SendOnRCStatusNotification();
 }
 
 std::vector<std::string>
@@ -459,7 +459,9 @@ void ResourceAllocationManagerImpl::OnApplicationEvent(
     for (; acquired_modules.end() != module; ++module) {
       ReleaseResource(*module, application->app_id());
     }
-
+    if (!acquired_modules.empty()) {
+      SendOnRCStatusNotification();
+    }
     Apps app_list;
     app_list.push_back(application);
     RemoveAppsSubscriptions(app_list);


### PR DESCRIPTION
This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
In case when several modules were allocated by app and this app starts unregistration,
SDL should send **one** OnRCStatus notification with all module changes.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)