### PR TITLE
fix to initialize 'app' variable in on_button_press_notification

### DIFF
--- a/src/components/application_manager/src/commands/mobile/on_button_press_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_button_press_notification.cc
@@ -129,6 +129,11 @@ void OnButtonPressNotification::Run() {
     }
     // if "appID" is present, send it to named app only if its FULL or
     // LIMITED
+    if (is_app_id_exists) {
+      app = application_manager_.application(
+        (*message_)[strings::msg_params][strings::app_id].asUInt());
+    }
+
     if (app.valid()) {
       if (app->app_id() == subscribed_app->app_id()) {
         SendButtonPress(subscribed_app);

--- a/src/components/application_manager/src/commands/mobile/on_button_press_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_button_press_notification.cc
@@ -131,7 +131,7 @@ void OnButtonPressNotification::Run() {
     // LIMITED
     if (is_app_id_exists) {
       app = application_manager_.application(
-        (*message_)[strings::msg_params][strings::app_id].asUInt());
+          (*message_)[strings::msg_params][strings::app_id].asUInt());
     }
 
     if (app.valid()) {

--- a/src/components/application_manager/test/commands/mobile/on_button_notification_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_button_notification_commands_test.cc
@@ -337,6 +337,7 @@ TYPED_TEST(OnButtonNotificationCommandsTest, Run_SUCCESS) {
       .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
 
   ON_CALL(*mock_app, IsFullscreen()).WillByDefault(Return(true));
+  ON_CALL(this->app_mngr_, application(kAppId)).WillByDefault(Return(mock_app));
 
   EXPECT_CALL(this->app_mngr_, applications_by_button(kButtonName))
       .WillOnce(Return(subscribed_apps_list));


### PR DESCRIPTION
Fixes #2116 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
I confirmed this PR fixes the issue in our internal HU devboard and internal test mobile app (iOS).

### Summary
'app' value is not initialized in OnButtonPressNotification::Run in non-CUSTOM_BUTTON code path. As a result, app.valid() always fails and onButtonPress notification is only sent to FULL state app. LIMITED state app cannot receive onButtonPress notification.

### Changelog

##### Bug Fixes
* Fix a bug that LIMITED state app cannot receive onButtonPress notification.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)