### PR TITLE
Implementation of app icon resumption

### DIFF
--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -178,6 +178,7 @@ extern const char* navigation_capability;
 extern const char* phone_capability;
 extern const char* video_streaming_capability;
 extern const char* rc_capability;
+extern const char* icon_resumed;
 
 // PutFile
 extern const char* sync_file_name;

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -623,6 +623,13 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
     const std::string& bundle_id = app_info[strings::bundle_id].asString();
     application->set_bundle_id(bundle_id);
   }
+
+  const std::string app_icon_dir(settings_.app_icons_folder());
+  const std::string full_icon_path(app_icon_dir + "/" + policy_app_id);
+  if (file_system::FileExists(full_icon_path)) {
+    application->set_app_icon_path(full_icon_path);
+  }
+
   PutDriverDistractionMessageToPostponed(application);
 
   // Stops timer of saving data to resumption in order to

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -50,6 +50,7 @@
 #include "config_profile/profile.h"
 #include "interfaces/MOBILE_API.h"
 #include "interfaces/generated_msg_version.h"
+#include "utils/file_system.h"
 
 namespace {
 namespace custom_str = utils::custom_string;
@@ -710,6 +711,10 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
   }
   policy::StatusNotifier notify_upd_manager = GetPolicyHandler().AddApplication(
       application->policy_app_id(), hmi_types);
+
+  response_params[strings::icon_resumed] =
+      file_system::FileExists(application->app_icon_path());
+
   SendResponse(true, result_code, add_info.c_str(), &response_params);
   SendOnAppRegisteredNotificationToHMI(
       *(application.get()), resumption, need_restore_vr);

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -830,7 +830,9 @@ void RegisterAppInterfaceRequest::SendOnAppRegisteredNotificationToHMI(
   application[strings::app_name] = application_impl.name();
   application[strings::app_id] = application_impl.app_id();
   application[hmi_response::policy_app_id] = application_impl.policy_app_id();
-  application[strings::icon] = application_impl.app_icon_path();
+  if (file_system::FileExists(application_impl.app_icon_path())) {
+    application[strings::icon] = application_impl.app_icon_path();
+  }
 
   const smart_objects::SmartObject* ngn_media_screen_name =
       application_impl.ngn_media_screen_name();

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -142,6 +142,7 @@ const char* navigation_capability = "navigationCapability";
 const char* phone_capability = "phoneCapability";
 const char* video_streaming_capability = "videoStreamingCapability";
 const char* rc_capability = "remoteControlCapability";
+const char* icon_resumed = "iconResumed";
 
 // PutFile
 const char* sync_file_name = "syncFileName";

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -3090,6 +3090,10 @@
         <param name="systemSoftwareVersion" type="String" maxlength="100" mandatory="false" platform="documentation">
             <description>The software version of the system that implements the SmartDeviceLink core.</description>
         </param>
+        <param name="iconResumed" type="Boolean" mandatory="true">
+            <description>Existence of apps icon at system. If true, apps icon
+            was resumed at system. If false, apps icon is not resumed at system</description>
+        </param>
     </function>
     
     <function name="UnregisterAppInterface" functionID="UnregisterAppInterfaceID" messagetype="request">

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -588,8 +588,7 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
     policy_table::FunctionalGroupings functional_groupings;
     cache_->GetFunctionalGroupings(functional_groupings);
 
-    policy_table::Strings app_groups =
-        GetGroupsNames(app_group_permissions);
+    policy_table::Strings app_groups = GetGroupsNames(app_group_permissions);
 
     // Undefined groups (without user consent) disallowed by default, since
     // OnPermissionsChange notification has no "undefined" section
@@ -621,8 +620,7 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
   }
 
   const bool known_rpc = rpc_permissions.end() != rpc_permissions.find(rpc);
-  LOG4CXX_DEBUG(logger_, "Is known rpc " <<
-                (known_rpc ? "true" : "false") );
+  LOG4CXX_DEBUG(logger_, "Is known rpc " << (known_rpc ? "true" : "false"));
   if (!known_rpc) {
     // RPC not found in list == disallowed by backend
     result.hmi_level_permitted = kRpcDisallowed;
@@ -644,7 +642,9 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
              rpc_permissions[rpc].hmi_permissions[kUserDisallowedKey].find(
                  hmi_level)) {
     // RPC found in allowed == allowed by backend, but disallowed by user
-    LOG4CXX_DEBUG(logger_, "RPC found in allowed == allowed by backend, but disallowed by user");
+    LOG4CXX_DEBUG(
+        logger_,
+        "RPC found in allowed == allowed by backend, but disallowed by user");
     result.hmi_level_permitted = kRpcUserDisallowed;
   } else {
     LOG4CXX_DEBUG(logger_,
@@ -983,7 +983,6 @@ void PolicyManagerImpl::NotifyPermissionsChanges(
 void PolicyManagerImpl::SetUserConsentForApp(
     const PermissionConsent& permissions, const NotificationMode mode) {
   LOG4CXX_AUTO_TRACE(logger_);
-
 
   cache_->ResetCalculatedPermissions();
   PermissionConsent verified_permissions =


### PR DESCRIPTION
Fixes #1456

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Automated tests from : https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/1866/

### Summary
Added the *iconResumed* parameter to register app interface response. 

- In case if during application registration icon exist on the file system
  * SDL send a RegisterAppInterface response with iconResumed=true
  * SDL send BC.OnAppregisteres notification to HMI with application::icon = <paht to icon>
- In case if during applicaiton registration icon **not** exist on file system
  * SDL send RegisterAppInterface response with iconResumed=true
  * SDL send BC.OnAppregisteres notification to HMI with **no application::icon** parameter

Proposal : [0041-appicon-resumption.md](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0041-appicon-resumption.md)

### Changelog

##### Enhancements
Fixed coding style with commit  8b65a89629d03e32c2ee2e811db81ae31687d070

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)