### PR TITLE
Removed TLS Handshake App Name String Compare

### DIFF
--- a/src/components/security_manager/src/ssl_context_impl.cc
+++ b/src/components/security_manager/src/ssl_context_impl.cc
@@ -266,16 +266,7 @@ CryptoManagerImpl::SSLContextImpl::CheckCertContext() {
 
   X509_NAME* subj_name = X509_get_subject_name(cert);
 
-  const std::string& cn = GetTextBy(subj_name, NID_commonName);
   const std::string& sn = GetTextBy(subj_name, NID_serialNumber);
-
-  if (!(hsh_context_.expected_cn.CompareIgnoreCase(cn.c_str()))) {
-    LOG4CXX_ERROR(logger_,
-                  "Trying to run handshake with wrong app name: "
-                      << cn << ". Expected app name: "
-                      << hsh_context_.expected_cn.AsMBString());
-    return Handshake_Result_AppNameMismatch;
-  }
 
   if (!(hsh_context_.expected_sn.CompareIgnoreCase(sn.c_str()))) {
     LOG4CXX_ERROR(logger_,

--- a/src/components/security_manager/test/ssl_certificate_handshake_test.cc
+++ b/src/components/security_manager/test/ssl_certificate_handshake_test.cc
@@ -534,15 +534,6 @@ TEST_P(SSLHandshakeTest, AppNameAndAppIDInvalid) {
 
   client_ctx_->SetHandshakeContext(
       security_manager::SSLContext::HandshakeContext(
-          custom_str::CustomString("server"),
-          custom_str::CustomString("Wrong")));
-
-  GTEST_TRACE(HandshakeProcedure_ClientSideFail(
-      security_manager::SSLContext::Handshake_Result_AppNameMismatch));
-
-  ResetConnections();
-  client_ctx_->SetHandshakeContext(
-      security_manager::SSLContext::HandshakeContext(
           custom_str::CustomString("Wrong"),
           custom_str::CustomString("server")));
 


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes no API changes.

### Summary
Fixes #1617 

### Changelog
Removed the TLS handshake app name string compare as it inhibits app nickname functionality as described in the issue linked above.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)