### PR TITLE
fix: invalid memory access in commands_test

### DIFF
--- a/src/components/application_manager/test/include/application_manager/commands/commands_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/commands_test.h
@@ -144,14 +144,16 @@ class CommandsTest : public ::testing::Test {
 
  protected:
   virtual void InitCommand(const uint32_t& timeout) {
+    timeout_ = timeout;
     ON_CALL(app_mngr_, get_settings())
         .WillByDefault(ReturnRef(app_mngr_settings_));
     ON_CALL(app_mngr_settings_, default_timeout())
-        .WillByDefault(ReturnRef(timeout));
+        .WillByDefault(ReturnRef(timeout_));
   }
 
   CommandsTest()
-      : mock_message_helper_(*am::MockMessageHelper::message_helper_mock()) {
+      : mock_message_helper_(*am::MockMessageHelper::message_helper_mock())
+      , timeout_(0) {
     ON_CALL(app_mngr_, hmi_interfaces())
         .WillByDefault(ReturnRef(mock_hmi_interfaces_));
     ON_CALL(mock_hmi_interfaces_, GetInterfaceFromFunction(_))
@@ -209,6 +211,9 @@ class CommandsTest : public ::testing::Test {
                            MobileResult::DATA_NOT_AVAILABLE);
     link_hmi_to_mob_result(HMIResult::READ_ONLY, MobileResult::READ_ONLY);
   }
+
+ private:
+  uint32_t timeout_;
 };
 
 MATCHER_P(MobileResultCodeIs, result_code, "") {


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/2135

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run the steps described in https://github.com/smartdevicelink/sdl_core/issues/2135 and make sure that valgrind doesn't report memory issue.

### Summary
Fixes an invalid memory access in the test code of commands_test

### Changelog
##### Bug Fixes
* Fixes an invalid memory access in the test code of commands_test

### Tasks Remaining:
- None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)