### PR TITLE
Fix infinite PTU when invalid PT, then a valid PT is received

### DIFF
--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1574,8 +1574,7 @@ void PolicyManagerImpl::OnUpdateStarted() {
   uint32_t update_timeout = TimeoutExchangeMSec();
   LOG4CXX_DEBUG(logger_,
                 "Update timeout will be set to (milisec): " << update_timeout);
-  send_on_update_sent_out_ =
-      !wrong_ptu_update_received_ && !update_status_manager_.IsUpdatePending();
+  send_on_update_sent_out_ = !update_status_manager_.IsUpdatePending();
 
   if (send_on_update_sent_out_) {
     update_status_manager_.OnUpdateSentOut(update_timeout);


### PR DESCRIPTION
Fixes #2109

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Fixes case where an infinite PTU occurs after an invalid PT is received from the server, but a valid PT is received on retry.

### Changelog
##### Bug Fixes
* Fixes case where an infinite PTU occurs after an invalid PT is received from the server, but a valid PT is received on retry

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)