### PR TITLE
  Fix the CMake logic error when build with -DBUILD_BT_SUPPORT=OFF

### DIFF
--- a/src/components/transport_manager/CMakeLists.txt
+++ b/src/components/transport_manager/CMakeLists.txt
@@ -69,7 +69,7 @@ endif()
 
 if(BUILD_USB_SUPPORT)
   if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(EXCLUDE_PATHS
+    list(APPEND EXCLUDE_PATHS
       ${COMPONENTS_DIR}/transport_manager/include/transport_manager/usb/qnx
       ${COMPONENTS_DIR}/transport_manager/src/usb/qnx
     )
@@ -77,7 +77,7 @@ if(BUILD_USB_SUPPORT)
       Libusb-1.0.16
     )
   elseif(CMAKE_SYSTEM_NAME STREQUAL "QNX")
-    set(EXCLUDE_PATHS
+    list(APPEND EXCLUDE_PATHS
       ${COMPONENTS_DIR}/transport_manager/include/transport_manager/usb/libusb
       ${COMPONENTS_DIR}/transport_manager/src/usb/libusb
     )


### PR DESCRIPTION
  Fix the issue that still links with Bluez library even if with the BUILD_BT_SUPORT=OFF

  Test & Verification:

  1. build sdl-core with BUILD_BT_SUPPORT=OFF
  2. there should be no any linking behavior with bluez library