### PR TITLE
Add secondaryGraphic to ImageFieldName enum

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -226,9 +226,15 @@
                 },
                 {
                     "name": "graphic",
-                    "imageTypeSupported": [
-
-                    ],
+                    "imageTypeSupported": [],
+                    "imageResolution": {
+                        "resolutionWidth": 35,
+                        "resolutionHeight": 35
+                    }
+                },
+                {
+                    "name": "secondaryGraphic",
+                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -251,7 +257,6 @@
             ],
             "graphicSupported": true,
             "templatesAvailable": [
-
                 "DEFAULT", "MEDIA", "NON-MEDIA", "ONSCREEN_PRESETS", "NAV_FULLSCREEN_MAP", "NAV_KEYBOARD",
                 "GRAPHIC_WITH_TEXT", "TEXT_WITH_GRAPHIC", "TILES_ONLY", "TEXTBUTTONS_ONLY",
                 "GRAPHIC_WITH_TILES", "TILES_WITH_GRAPHIC", "GRAPHIC_WITH_TEXT_AND_SOFTBUTTONS",

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -282,6 +282,9 @@ void InitCapabilities() {
   image_field_name_enum.insert(std::make_pair(
       std::string("graphic"), hmi_apis::Common_ImageFieldName::graphic));
   image_field_name_enum.insert(
+      std::make_pair(std::string("secondaryGraphic"),
+                     hmi_apis::Common_ImageFieldName::secondaryGraphic));
+  image_field_name_enum.insert(
       std::make_pair(std::string("showConstantTBTIcon"),
                      hmi_apis::Common_ImageFieldName::showConstantTBTIcon));
   image_field_name_enum.insert(std::make_pair(

--- a/src/components/application_manager/test/hmi_capabilities.json
+++ b/src/components/application_manager/test/hmi_capabilities.json
@@ -263,7 +263,15 @@
                 },
                 {
                     "name": "graphic",
-          "imageTypeSupported": [],
+                    "imageTypeSupported": [],
+                    "imageResolution": {
+                        "resolutionWidth": 35,
+                        "resolutionHeight": 35
+                    }
+                },
+                {
+                    "name": "secondaryGraphic",
+                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -624,7 +624,10 @@
     <description>The image field for the app icon (set by setAppIcon)</description>
   </element>
   <element name="graphic">
-    <description>The image field for Show</description>
+    <description>The primary image field for Show</description>
+  </element>
+  <element name="secondaryGraphic">
+    <description>The secondary image field for Show</description>
   </element>
   <element name="showConstantTBTIcon">
     <description>The primary image field for ShowConstantTBT</description>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -781,7 +781,11 @@
         </element>
         
         <element name="graphic">
-            <description>The image field for Show</description>
+            <description>The primary image field for Show</description>
+        </element>
+        
+        <element name="secondaryGraphic">
+            <description>The secondary image field for Show</description>
         </element>
         
         <element name="showConstantTBTIcon">


### PR DESCRIPTION
Fixes #2099 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests pass, no tests exist for individual `ImageFieldName` values.

### Summary
Added `secondaryGraphic` to `ImageFieldName` enum.

### Changelog
##### Enhancements
* Added `secondaryGraphic` to `ImageFieldName` enum, allowing it to be included in the `displayCapabilities` of a `RegisterAppInterface` response.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)