### PR TITLE
Bugfix/invalid memory accesses

### DIFF
--- a/src/components/media_manager/src/streamer_adapter.cc
+++ b/src/components/media_manager/src/streamer_adapter.cc
@@ -48,8 +48,8 @@ StreamerAdapter::~StreamerAdapter() {
     streamer_->Close();
   }
   thread_->join();
-  threads::DeleteThread(thread_);
   delete streamer_;
+  threads::DeleteThread(thread_);
 }
 
 void StreamerAdapter::StartActivity(int32_t application_key) {

--- a/src/components/transport_manager/src/bluetooth/bluetooth_device.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_device.cc
@@ -45,6 +45,7 @@
 #include <sys/socket.h>
 
 #include <algorithm>
+#include <iostream>
 #include <limits>
 #include "utils/logger.h"
 
@@ -56,7 +57,8 @@ bool BluetoothDevice::GetRfcommChannel(const ApplicationHandle app_handle,
                                        uint8_t* channel_out) {
   LOG4CXX_TRACE(logger_,
                 "enter. app_handle: " << app_handle
-                                      << ", channel_out: " << channel_out);
+                                      << ", channel_out: " << std::hex
+                                      << reinterpret_cast<void*>(channel_out));
   if (app_handle < 0 || app_handle > std::numeric_limits<uint8_t>::max()) {
     LOG4CXX_TRACE(logger_,
                   "exit with FALSE. Condition: app_handle < 0 || app_handle > "


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/2177

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run the sequence described in https://github.com/smartdevicelink/sdl_core/issues/2177 again and make sure that valgrind does not report invalid memory access.


### Summary
This PR fixes several invalid memory access issues detected by valgrind.

### Changelog
##### Breaking Changes
* None

##### Enhancements
* None

##### Bug Fixes
* fix: invalid memory access in BluetoothDevice log message
* fix: invalid memory access in MediaManager when stopping Core
* fix: invalid memory access in RemoteControl when stopping Core

### Tasks Remaining:
- None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)