### PR TITLE
enforce RAI RPC to wait for HMI capabilities to be updated

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -468,6 +468,9 @@ class ApplicationManagerImpl
   mobile_api::HMILevel::eType IsHmiLevelFullAllowed(ApplicationSharedPtr app);
 
   void ConnectToDevice(const std::string& device_mac) OVERRIDE;
+
+  void SetHMICapabilitiesUpdated(bool updated) OVERRIDE;
+
   void OnHMIStartedCooperation() OVERRIDE;
 
   /*
@@ -1147,6 +1150,11 @@ class ApplicationManagerImpl
    */
   bool IsHMICooperating() const OVERRIDE;
 
+  /*
+   * @brief returns true if HMI capabilities are updated by information from HMI
+   */
+  bool IsHMICapabilitiesUpdated() const OVERRIDE;
+
   /**
    * @brief Method used to send default app tts globalProperties
    * in case they were not provided from mobile side after defined time
@@ -1725,6 +1733,7 @@ class ApplicationManagerImpl
   hmi_apis::Common_DriverDistractionState::eType driver_distraction_state_;
   bool is_vr_session_strated_;
   bool hmi_cooperating_;
+  bool hmi_capabilities_updated_;
   bool is_all_apps_allowed_;
 
   event_engine::EventDispatcherImpl event_dispatcher_;

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -94,6 +94,26 @@ class HMICapabilitiesImpl : public HMICapabilities {
   bool is_rc_cooperating() const OVERRIDE;
   void set_is_rc_cooperating(const bool value) OVERRIDE;
 
+  bool is_vr_capabilities_updated() const OVERRIDE;
+  void set_is_vr_capabilities_updated(const bool value) OVERRIDE;
+
+  bool is_tts_capabilities_updated() const OVERRIDE;
+  void set_is_tts_capabilities_updated(const bool value) OVERRIDE;
+
+  bool is_ui_capabilities_updated() const OVERRIDE;
+  void set_is_ui_capabilities_updated(const bool value) OVERRIDE;
+
+  bool is_button_capabilities_updated() const OVERRIDE;
+  void set_is_button_capabilities_updated(const bool value) OVERRIDE;
+
+  bool is_attenuated_capabilities_updated() const OVERRIDE;
+  void set_is_attenuated_capabilities_updated(const bool value) OVERRIDE;
+
+  bool is_rc_capabilities_updated() const OVERRIDE;
+  void set_is_rc_capabilities_updated(const bool value) OVERRIDE;
+
+  bool is_all_capabilities_updated() const OVERRIDE;
+
   /*
    * @brief Interface used to store information about software version of the
    *target
@@ -549,6 +569,13 @@ class HMICapabilitiesImpl : public HMICapabilities {
   bool is_navi_cooperating_;
   bool is_ivi_cooperating_;
   bool is_rc_cooperating_;
+
+  bool is_vr_capabilities_updated_;
+  bool is_tts_capabilities_updated_;
+  bool is_ui_capabilities_updated_;
+  bool is_button_capabilities_updated_;
+  bool is_attenuated_capabilities_updated_;
+  bool is_rc_capabilities_updated_;
 
   bool attenuated_supported_;
   hmi_apis::Common_Language::eType ui_language_;

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -148,6 +148,7 @@ ApplicationManagerImpl::ApplicationManagerImpl(
           hmi_apis::Common_DriverDistractionState::INVALID_ENUM)
     , is_vr_session_strated_(false)
     , hmi_cooperating_(false)
+    , hmi_capabilities_updated_(false)
     , is_all_apps_allowed_(true)
     , media_manager_(NULL)
     , hmi_handler_(NULL)
@@ -713,6 +714,11 @@ void ApplicationManagerImpl::ConnectToDevice(const std::string& device_mac) {
     return;
   }
   connection_handler().ConnectToDevice(handle);
+}
+
+void ApplicationManagerImpl::SetHMICapabilitiesUpdated(bool updated) {
+  LOG4CXX_DEBUG(logger_, "Setting HMI capabilities updated state to " << updated);
+  hmi_capabilities_updated_ = updated;
 }
 
 void ApplicationManagerImpl::OnHMIStartedCooperation() {
@@ -3082,6 +3088,7 @@ void ApplicationManagerImpl::UnregisterAllApplications() {
   LOG4CXX_DEBUG(logger_, "Unregister reason  " << unregister_reason_);
 
   hmi_cooperating_ = false;
+  hmi_capabilities_updated_ = false;
   bool is_ignition_off = false;
   using namespace mobile_api::AppInterfaceUnregisteredReason;
   using namespace helpers;
@@ -3964,6 +3971,10 @@ uint32_t ApplicationManagerImpl::GetAvailableSpaceForApp(
 
 bool ApplicationManagerImpl::IsHMICooperating() const {
   return hmi_cooperating_;
+}
+
+bool ApplicationManagerImpl::IsHMICapabilitiesUpdated() const {
+  return hmi_capabilities_updated_;
 }
 
 void ApplicationManagerImpl::OnApplicationListUpdateTimer() {

--- a/src/components/application_manager/src/commands/hmi/button_get_capabilities_response.cc
+++ b/src/components/application_manager/src/commands/hmi/button_get_capabilities_response.cc
@@ -49,12 +49,13 @@ void ButtonGetCapabilitiesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
+  HMICapabilities& hmi_capabilities = application_manager_.hmi_capabilities();
+  hmi_capabilities.set_is_button_capabilities_updated(true);
+
   if (hmi_apis::Common_Result::SUCCESS != code) {
     LOG4CXX_ERROR(logger_, "Error is returned. Capabilities won't be updated.");
     return;
   }
-
-  HMICapabilities& hmi_capabilities = application_manager_.hmi_capabilities();
 
   hmi_capabilities.set_button_capabilities(
       (*message_)[strings::msg_params][hmi_response::capabilities]);

--- a/src/components/application_manager/src/commands/hmi/mixing_audio_supported_response.cc
+++ b/src/components/application_manager/src/commands/hmi/mixing_audio_supported_response.cc
@@ -48,6 +48,8 @@ void MixingAudioSupportedResponse::Run() {
   hmi_capabilities.set_attenuated_supported(
       (*message_)[strings::msg_params][hmi_response::attenuated_supported]
           .asBool());
+
+  hmi_capabilities.set_is_attenuated_capabilities_updated(true);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/hmi/rc_get_capabilities_response.cc
+++ b/src/components/application_manager/src/commands/hmi/rc_get_capabilities_response.cc
@@ -53,6 +53,7 @@ void RCGetCapabilitiesResponse::Run() {
         (*message_)[strings::msg_params][strings::rc_capability]);
   }
   hmi_capabilities.set_rc_supported(capability_exists);
+  hmi_capabilities.set_is_rc_capabilities_updated(true);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/hmi/rc_is_ready_request.cc
+++ b/src/components/application_manager/src/commands/hmi/rc_is_ready_request.cc
@@ -70,6 +70,7 @@ void RCIsReadyRequest::on_event(const event_engine::Event& event) {
                                           HmiInterfaces::HMI_INTERFACE_RC)) {
         LOG4CXX_INFO(logger_,
                      "HmiInterfaces::HMI_INTERFACE_RC isn't available");
+        hmi_capabilities.set_is_rc_capabilities_updated(true);
         return;
       }
       SendMessageToHMI();

--- a/src/components/application_manager/src/commands/hmi/tts_get_capabilities_response.cc
+++ b/src/components/application_manager/src/commands/hmi/tts_get_capabilities_response.cc
@@ -56,6 +56,7 @@ void TTSGetCapabilitiesResponse::Run() {
         (*message_)[strings::msg_params]
                    [hmi_response::prerecorded_speech_capabilities]);
   }
+  hmi_capabilities.set_is_tts_capabilities_updated(true);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/hmi/tts_is_ready_request.cc
+++ b/src/components/application_manager/src/commands/hmi/tts_is_ready_request.cc
@@ -67,6 +67,7 @@ void TTSIsReadyRequest::on_event(const event_engine::Event& event) {
                                           HmiInterfaces::HMI_INTERFACE_TTS)) {
         LOG4CXX_INFO(logger_,
                      "HmiInterfaces::HMI_INTERFACE_TTS isn't available");
+        hmi_capabilities.set_is_tts_capabilities_updated(true);
         return;
       }
       SendMessageToHMI();

--- a/src/components/application_manager/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/src/commands/hmi/ui_get_capabilities_response.cc
@@ -105,6 +105,8 @@ void UIGetCapabilitiesResponse::Run() {
                     [strings::video_streaming_capability]);
     }
   }
+
+  hmi_capabilities.set_is_ui_capabilities_updated(true);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/hmi/ui_is_ready_request.cc
+++ b/src/components/application_manager/src/commands/hmi/ui_is_ready_request.cc
@@ -66,6 +66,7 @@ void UIIsReadyRequest::on_event(const event_engine::Event& event) {
                                           HmiInterfaces::HMI_INTERFACE_UI)) {
         LOG4CXX_INFO(logger_,
                      "HmiInterfaces::HMI_INTERFACE_UI isn't available");
+        hmi_capabilities.set_is_ui_capabilities_updated(true);
         return;
       }
       SendMessageToHMI();

--- a/src/components/application_manager/src/commands/hmi/vr_get_capabilities_response.cc
+++ b/src/components/application_manager/src/commands/hmi/vr_get_capabilities_response.cc
@@ -48,6 +48,7 @@ void VRGetCapabilitiesResponse::Run() {
 
   hmi_capabilities.set_vr_capabilities(
       (*message_)[strings::msg_params][strings::vr_capabilities]);
+  hmi_capabilities.set_is_vr_capabilities_updated(true);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/hmi/vr_is_ready_request.cc
+++ b/src/components/application_manager/src/commands/hmi/vr_is_ready_request.cc
@@ -66,6 +66,7 @@ void VRIsReadyRequest::on_event(const event_engine::Event& event) {
                                           HmiInterfaces::HMI_INTERFACE_VR)) {
         LOG4CXX_INFO(logger_,
                      "HmiInterfaces::HMI_INTERFACE_VR isn't available");
+        hmi_capabilities.set_is_vr_capabilities_updated(true);
         return;
       }
       SendMessageToHMI();

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -200,7 +200,7 @@ void RegisterAppInterfaceRequest::Run() {
 
   // wait till HMI started
   while (!application_manager_.IsStopping() &&
-         !application_manager_.IsHMICooperating()) {
+         !application_manager_.IsHMICapabilitiesUpdated()) {
     LOG4CXX_DEBUG(logger_,
                   "Waiting for the HMI... conn_key="
                       << connection_key()
@@ -212,6 +212,7 @@ void RegisterAppInterfaceRequest::Run() {
     sleep(1);
     // TODO(DK): timer_->StartWait(1);
   }
+  LOG4CXX_DEBUG(logger_, "RegisterAppInterfaceRequest::Run waiting finished");
 
   if (application_manager_.IsStopping()) {
     LOG4CXX_WARN(logger_, "The ApplicationManager is stopping!");

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -370,6 +370,16 @@ HMICapabilitiesImpl::HMICapabilitiesImpl(ApplicationManager& app_mngr)
     , is_navi_cooperating_(false)
     , is_ivi_cooperating_(false)
     , is_rc_cooperating_(false)
+    , is_vr_capabilities_updated_(false)
+    , is_tts_capabilities_updated_(false)
+    , is_ui_capabilities_updated_(false)
+    , is_button_capabilities_updated_(false)
+    , is_attenuated_capabilities_updated_(false)
+#ifdef SDL_REMOTE_CONTROL
+    , is_rc_capabilities_updated_(false)
+#else
+    , is_rc_capabilities_updated_(true)
+#endif
     , attenuated_supported_(false)
     , ui_language_(hmi_apis::Common_Language::INVALID_ENUM)
     , vr_language_(hmi_apis::Common_Language::INVALID_ENUM)
@@ -470,6 +480,48 @@ void HMICapabilitiesImpl::set_is_ivi_cooperating(const bool value) {
 
 void HMICapabilitiesImpl::set_is_rc_cooperating(const bool value) {
   is_rc_cooperating_ = value;
+}
+
+void HMICapabilitiesImpl::set_is_vr_capabilities_updated(const bool value) {
+  is_vr_capabilities_updated_ = value;
+  if (is_all_capabilities_updated()) {
+    app_mngr_.SetHMICapabilitiesUpdated(true);
+  }
+}
+
+void HMICapabilitiesImpl::set_is_tts_capabilities_updated(const bool value) {
+  is_tts_capabilities_updated_ = value;
+  if (is_all_capabilities_updated()) {
+    app_mngr_.SetHMICapabilitiesUpdated(true);
+  }
+}
+
+void HMICapabilitiesImpl::set_is_ui_capabilities_updated(const bool value) {
+  is_ui_capabilities_updated_ = value;
+  if (is_all_capabilities_updated()) {
+    app_mngr_.SetHMICapabilitiesUpdated(true);
+  }
+}
+
+void HMICapabilitiesImpl::set_is_button_capabilities_updated(const bool value) {
+  is_button_capabilities_updated_ = value;
+  if (is_all_capabilities_updated()) {
+    app_mngr_.SetHMICapabilitiesUpdated(true);
+  }
+}
+
+void HMICapabilitiesImpl::set_is_attenuated_capabilities_updated(const bool value) {
+  is_attenuated_capabilities_updated_ = value;
+  if (is_all_capabilities_updated()) {
+    app_mngr_.SetHMICapabilitiesUpdated(true);
+  }
+}
+
+void HMICapabilitiesImpl::set_is_rc_capabilities_updated(const bool value) {
+  is_rc_capabilities_updated_ = value;
+  if (is_all_capabilities_updated()) {
+    app_mngr_.SetHMICapabilitiesUpdated(true);
+  }
 }
 
 void HMICapabilitiesImpl::set_attenuated_supported(const bool state) {
@@ -722,6 +774,39 @@ bool HMICapabilitiesImpl::is_ivi_cooperating() const {
 
 bool HMICapabilitiesImpl::is_rc_cooperating() const {
   return is_rc_cooperating_;
+}
+
+bool HMICapabilitiesImpl::is_vr_capabilities_updated() const {
+  return is_vr_capabilities_updated_;
+}
+
+bool HMICapabilitiesImpl::is_tts_capabilities_updated() const {
+  return is_tts_capabilities_updated_;
+}
+
+bool HMICapabilitiesImpl::is_ui_capabilities_updated() const {
+  return is_ui_capabilities_updated_;
+}
+
+bool HMICapabilitiesImpl::is_button_capabilities_updated() const {
+  return is_button_capabilities_updated_;
+}
+
+bool HMICapabilitiesImpl::is_attenuated_capabilities_updated() const {
+  return is_attenuated_capabilities_updated_;
+}
+
+bool HMICapabilitiesImpl::is_rc_capabilities_updated() const {
+  return is_rc_capabilities_updated_;
+}
+
+bool HMICapabilitiesImpl::is_all_capabilities_updated() const {
+  return is_vr_capabilities_updated_ == true &&
+    is_tts_capabilities_updated_ == true &&
+    is_ui_capabilities_updated_ == true &&
+    is_button_capabilities_updated_ == true &&
+    is_attenuated_capabilities_updated_ == true &&
+    is_rc_capabilities_updated_ == true;
 }
 
 const smart_objects::SmartObject* HMICapabilitiesImpl::ui_supported_languages()

--- a/src/components/application_manager/test/commands/hmi/button_get_capabilities_response_test.cc
+++ b/src/components/application_manager/test/commands/hmi/button_get_capabilities_response_test.cc
@@ -87,6 +87,7 @@ TEST_F(ButtonGetCapabilitiesResponseTest, Run_CodeSuccess_SUCCESS) {
   EXPECT_CALL(app_mngr_, hmi_capabilities())
       .WillOnce(ReturnRef(mock_hmi_capabilities_));
   EXPECT_CALL(mock_hmi_capabilities_, set_button_capabilities(capabilities_));
+  EXPECT_CALL(mock_hmi_capabilities_, set_is_button_capabilities_updated(true));
   EXPECT_CALL(mock_hmi_capabilities_,
               set_preset_bank_capabilities(preset_bank_capabilities_));
 
@@ -100,7 +101,9 @@ TEST_F(ButtonGetCapabilitiesResponseTest, Run_CodeAborted_SUCCESS) {
 
   ResponsePtr command(CreateCommand<ButtonGetCapabilitiesResponse>(msg));
 
-  EXPECT_CALL(app_mngr_, hmi_capabilities()).Times(0);
+  EXPECT_CALL(app_mngr_, hmi_capabilities())
+      .WillOnce(ReturnRef(mock_hmi_capabilities_));
+  EXPECT_CALL(mock_hmi_capabilities_, set_is_button_capabilities_updated(true));
   EXPECT_CALL(mock_hmi_capabilities_, set_button_capabilities(capabilities_))
       .Times(0);
   EXPECT_CALL(mock_hmi_capabilities_,

--- a/src/components/application_manager/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/register_app_interface_request_test.cc
@@ -143,6 +143,7 @@ class RegisterAppInterfaceRequestTest
 
   void InitGetters() {
     ON_CALL(app_mngr_, IsHMICooperating()).WillByDefault(Return(true));
+    ON_CALL(app_mngr_, IsHMICapabilitiesUpdated()).WillByDefault(Return(true));
     ON_CALL(app_mngr_, GetPolicyHandler())
         .WillByDefault(ReturnRef(mock_policy_handler_));
     ON_CALL(app_mngr_, resume_controller())
@@ -262,7 +263,7 @@ TEST_F(RegisterAppInterfaceRequestTest, Run_MinimalData_SUCCESS) {
       .WillOnce(Return(false))
       .WillOnce(Return(true))
       .WillOnce(Return(false));
-  ON_CALL(app_mngr_, IsHMICooperating()).WillByDefault(Return(false));
+  ON_CALL(app_mngr_, IsHMICapabilitiesUpdated()).WillByDefault(Return(false));
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
   EXPECT_CALL(app_mngr_, IsApplicationForbidden(_, _)).WillOnce(Return(false));
 
@@ -326,7 +327,7 @@ TEST_F(RegisterAppInterfaceRequestTest,
       .WillOnce(Return(false))
       .WillOnce(Return(true))
       .WillOnce(Return(false));
-  ON_CALL(app_mngr_, IsHMICooperating()).WillByDefault(Return(false));
+  ON_CALL(app_mngr_, IsHMICapabilitiesUpdated()).WillByDefault(Return(false));
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
   EXPECT_CALL(app_mngr_, IsApplicationForbidden(_, _)).WillOnce(Return(false));
 

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -64,6 +64,26 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
   MOCK_CONST_METHOD0(is_rc_cooperating, bool());
   MOCK_METHOD1(set_is_rc_cooperating, void(const bool value));
 
+  MOCK_CONST_METHOD0(is_vr_capabilities_updated, bool());
+  MOCK_METHOD1(set_is_vr_capabilities_updated, void(const bool value));
+
+  MOCK_CONST_METHOD0(is_tts_capabilities_updated, bool());
+  MOCK_METHOD1(set_is_tts_capabilities_updated, void(const bool value));
+
+  MOCK_CONST_METHOD0(is_ui_capabilities_updated, bool());
+  MOCK_METHOD1(set_is_ui_capabilities_updated, void(const bool value));
+
+  MOCK_CONST_METHOD0(is_button_capabilities_updated, bool());
+  MOCK_METHOD1(set_is_button_capabilities_updated, void(const bool value));
+
+  MOCK_CONST_METHOD0(is_attenuated_capabilities_updated, bool());
+  MOCK_METHOD1(set_is_attenuated_capabilities_updated, void(const bool value));
+
+  MOCK_CONST_METHOD0(is_rc_capabilities_updated, bool());
+  MOCK_METHOD1(set_is_rc_capabilities_updated, void(const bool value));
+
+  MOCK_CONST_METHOD0(is_all_capabilities_updated, bool());
+
   MOCK_CONST_METHOD0(attenuated_supported, bool());
 
   MOCK_METHOD1(set_attenuated_supported, void(const bool state));

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -421,9 +421,13 @@ class ApplicationManager {
 
   virtual void ConnectToDevice(const std::string& device_mac) = 0;
 
+  virtual void SetHMICapabilitiesUpdated(bool updated) = 0;
+
   virtual void OnHMIStartedCooperation() = 0;
 
   virtual bool IsHMICooperating() const = 0;
+
+  virtual bool IsHMICapabilitiesUpdated() const = 0;
   /**
    * @brief Notifies all components interested in Vehicle Data update
    * i.e. new value of odometer etc and returns list of applications

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -93,6 +93,25 @@ class HMICapabilities {
   virtual bool is_rc_cooperating() const = 0;
   virtual void set_is_rc_cooperating(const bool value) = 0;
 
+  virtual bool is_vr_capabilities_updated() const = 0;
+  virtual void set_is_vr_capabilities_updated(const bool value) = 0;
+
+  virtual bool is_tts_capabilities_updated() const = 0;
+  virtual void set_is_tts_capabilities_updated(const bool value) = 0;
+
+  virtual bool is_ui_capabilities_updated() const = 0;
+  virtual void set_is_ui_capabilities_updated(const bool value) = 0;
+
+  virtual bool is_button_capabilities_updated() const = 0;
+  virtual void set_is_button_capabilities_updated(const bool value) = 0;
+
+  virtual bool is_attenuated_capabilities_updated() const = 0;
+  virtual void set_is_attenuated_capabilities_updated(const bool value) = 0;
+
+  virtual bool is_rc_capabilities_updated() const = 0;
+  virtual void set_is_rc_capabilities_updated(const bool value) = 0;
+
+  virtual bool is_all_capabilities_updated() const = 0;
   /*
    * @brief Interface used to store information about software version of the
    *target

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -167,7 +167,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD1(EndAudioPassThru, bool(uint32_t app_id));
   MOCK_METHOD1(ConnectToDevice, void(const std::string& device_mac));
   MOCK_METHOD0(OnHMIStartedCooperation, void());
+  MOCK_METHOD1(SetHMICapabilitiesUpdated, void(bool updated));
   MOCK_CONST_METHOD0(IsHMICooperating, bool());
+  MOCK_CONST_METHOD0(IsHMICapabilitiesUpdated, bool());
   MOCK_METHOD2(IviInfoUpdated,
                std::vector<application_manager::ApplicationSharedPtr>(
                    mobile_apis::VehicleDataType::eType vehicle_info,


### PR DESCRIPTION
Fixes #2181 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
I have tested with our internal HMI devboard and SDL apps.

### Summary
Add "IsHMICapabilitiesUpdated" flag to Application Manager. This flag becomes true after all of getCapabilities responses are received from HMI. Make RAI request wait for this flag to become true.

### Changelog
##### Bug Fixes
* Fix not to send HMI capabilities before being updated with responses from HMI.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)