### PR TITLE
fix: some used timer threads are not released

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -197,7 +197,7 @@ ApplicationManagerImpl::ApplicationManagerImpl(
       new TimerTaskImpl<ApplicationManagerImpl>(
           this, &ApplicationManagerImpl::ClearTimerPool)));
   const uint32_t timeout_ms = 10000u;
-  clearing_timer->Start(timeout_ms, timer::kSingleShot);
+  clearing_timer->Start(timeout_ms, timer::kPeriodic);
   timer_pool_.push_back(clearing_timer);
   commands_holder_.reset(new CommandHolderImpl(*this));
 }


### PR DESCRIPTION
Partially fixes https://github.com/smartdevicelink/sdl_core/issues/2192

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Repeat the steps mentioned in https://github.com/smartdevicelink/sdl_core/issues/2192 and confirm that "CloseNaviAppTimer" threads are properly released.

### Summary
This PR makes sure to release used timers by updating the type of "ClearTimerPoolTimer" to `kPeriodic`. Actually, this was "periodic" in the past, but commit f6ebfe59 seemed to update the type to single-shot and cause the issue.

### Changelog
##### Breaking Changes
* None

##### Enhancements
* None

##### Bug Fixes
* Fixes some used timers not being released

### Tasks Remaining:
- None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
