### PR TITLE
Bugfix/resumption data to storage folder

### DIFF
--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -148,7 +148,7 @@ ListFilesRequest = 5
 HelpCommand = Help
 
 [AppInfo]
-; The path for applications info storage.
+; The file name for applications info storage.
 AppInfoStorage = app_info.dat
 
 [Security Manager]

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2996,10 +2996,13 @@ void ApplicationManagerImpl::HeadUnitReset(
 void ApplicationManagerImpl::ClearAppsPersistentData() {
   LOG4CXX_AUTO_TRACE(logger_);
   typedef std::vector<std::string> FilesList;
-  const std::string apps_info_storage_file = get_settings().app_info_storage();
-  file_system::DeleteFile(apps_info_storage_file);
-
   const std::string storage_folder = get_settings().app_storage_folder();
+
+  const std::string apps_info_storage_file =
+      !storage_folder.empty()
+          ? storage_folder + "/" + get_settings().app_info_storage()
+          : get_settings().app_info_storage();
+  file_system::DeleteFile(apps_info_storage_file);
 
   FilesList files = file_system::ListFiles(storage_folder);
   FilesList::iterator element_to_skip =

--- a/src/components/application_manager/test/app_launch/app_launch_data_json_test.cc
+++ b/src/components/application_manager/test/app_launch/app_launch_data_json_test.cc
@@ -60,16 +60,16 @@ using namespace file_system;
 using namespace app_launch;
 
 const std::string kAppStorageFolder = "app_storage_folder";
-const std::string kAppStorageFile = "./app_info.dat";
 const std::string kAppInfoStorage = "app_info_storage";
 
 class AppLaunchDataJsonTest : public ::testing::Test {
  private:
   virtual void SetUp() {
-    ::file_system::DeleteFile(kAppStorageFile);
+    const std::string storage_file = kAppStorageFolder + "/" + kAppInfoStorage;
+    ::file_system::DeleteFile(storage_file);
     test_last_state_ = std::auto_ptr<resumption::LastState>(
         new resumption::LastStateImpl(kAppStorageFolder, kAppInfoStorage));
-    ASSERT_TRUE(::file_system::CreateFile(kAppStorageFile));
+    ASSERT_TRUE(::file_system::CreateFile(storage_file));
 
     NiceMock<app_launch_test::MockAppLaunchSettings> mock_app_launch_settings_;
     ON_CALL(mock_app_launch_settings_, max_number_of_ios_device())
@@ -84,10 +84,14 @@ class AppLaunchDataJsonTest : public ::testing::Test {
     res_json_.get()->Clear();
   }
 
-  static void SetUpTestCase() {}
+  static void SetUpTestCase() {
+    ::file_system::RemoveDirectory(kAppStorageFolder);
+    ::file_system::CreateDirectoryRecursively(kAppStorageFolder);
+  }
 
   static void TearDownTestCase() {
-    ::file_system::DeleteFile(kAppStorageFile);
+    const std::string storage_file = kAppStorageFolder + "/" + kAppInfoStorage;
+    ::file_system::DeleteFile(storage_file);
     ::file_system::RemoveDirectory(kAppStorageFolder);
   }
 

--- a/src/components/resumption/src/last_state_impl.cc
+++ b/src/components/resumption/src/last_state_impl.cc
@@ -53,13 +53,17 @@ LastStateImpl::~LastStateImpl() {
 
 void LastStateImpl::SaveStateToFileSystem() {
   LOG4CXX_AUTO_TRACE(logger_);
+  const std::string full_path =
+      !app_storage_folder_.empty()
+          ? app_storage_folder_ + "/" + app_info_storage_
+          : app_info_storage_;
   const std::string& str = dictionary_.toStyledString();
   const std::vector<uint8_t> char_vector_pdata(str.begin(), str.end());
 
   DCHECK(file_system::CreateDirectoryRecursively(app_storage_folder_));
   LOG4CXX_INFO(logger_,
                "LastState::SaveStateToFileSystem " << app_info_storage_ << str);
-  DCHECK(file_system::Write(app_info_storage_, char_vector_pdata));
+  DCHECK(file_system::Write(full_path, char_vector_pdata));
 }
 
 Json::Value& LastStateImpl::get_dictionary() {
@@ -67,8 +71,12 @@ Json::Value& LastStateImpl::get_dictionary() {
 }
 
 void LastStateImpl::LoadStateFromFileSystem() {
+  const std::string full_path =
+      !app_storage_folder_.empty()
+          ? app_storage_folder_ + "/" + app_info_storage_
+          : app_info_storage_;
   std::string buffer;
-  bool result = file_system::ReadFile(app_info_storage_, buffer);
+  bool result = file_system::ReadFile(full_path, buffer);
   Json::Reader m_reader;
   if (result && m_reader.parse(buffer, dictionary_)) {
     LOG4CXX_INFO(logger_,

--- a/src/components/resumption/test/last_state_test.cc
+++ b/src/components/resumption/test/last_state_test.cc
@@ -50,12 +50,15 @@ class LastStateTest : public ::testing::Test {
  protected:
   LastStateTest()
       : empty_dictionary_("null\n")
-      , app_info_dat_file_("app_info.dat")
+      , app_info_dat_file_(kAppStorageFolder + "/" + kAppInfoStorageFile)
       , last_state_(kAppStorageFolder, kAppInfoStorageFile) {}
 
   static void SetUpTestCase() {
-    file_system::DeleteFile(kAppInfoStorageFile);
+    const std::string storage_file =
+        kAppStorageFolder + "/" + kAppInfoStorageFile;
+    file_system::DeleteFile(storage_file);
     file_system::RemoveDirectory(kAppStorageFolder);
+    file_system::CreateDirectoryRecursively(kAppStorageFolder);
   }
 
   void SetUp() OVERRIDE {


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/2194

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Repeat the steps mentioned in https://github.com/smartdevicelink/sdl_core/issues/2194 and make sure that app_info.dat file is stored in "storage" folder.

### Summary
This PR changes the location of Application info file (app_info.dat) to the directory specified by `AppStorageFolder` in the ini file.

### Changelog
##### Breaking Changes
* None

##### Enhancements
* None

##### Bug Fixes
* The location of Application info file is changed from current directory to the folder specified by `AppStorageFolder`.

### Tasks Remaining:
- None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)