### PR TITLE
Specify a dedicated folder for icon storage

### DIFF
--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -223,7 +223,8 @@ HashStringSize = 32
 [SDL4]
 ; Section for features added in protocol version 4
 ; Path where apps icons must be stored
-AppIconsFolder = storage
+; Specify a dedicated folder, as old files in this folder can be automatically removed
+AppIconsFolder = icons
 ; Max size of the folder in bytes
 AppIconsFolderMaxSize = 104857600
 ; Amount of oldest icons to remove in case of max folder size was reached


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/2200

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
N/A; this PR only updates the .ini configuration.

### Summary
The value of `AppIconsFolder` is updated to specify a dedicated folder. Comment field is updated to describe that it should be a dedicated folder.

### Changelog
##### Breaking Changes
* None.

##### Enhancements
* None.

##### Bug Fixes
* Fix an issue described by https://github.com/smartdevicelink/sdl_core/issues/2200. A file in "storage" folder might be accidentally removed.

### Tasks Remaining:
- None.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)