### PR TITLE
Fixed: app does not activate when policies are disabled.

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1272,7 +1272,6 @@ void PolicyHandler::OnIgnitionCycleOver() {
 void PolicyHandler::OnActivateApp(uint32_t connection_key,
                                   uint32_t correlation_id) {
   LOG4CXX_AUTO_TRACE(logger_);
-  POLICY_LIB_CHECK_VOID();
   ApplicationSharedPtr app = application_manager_.application(connection_key);
   if (!app.valid()) {
     LOG4CXX_WARN(logger_, "Activated App failed: no app found.");


### PR DESCRIPTION
Fixes #842

This PR is ready for review.

### Risk
This PR makes **no** API changes.

### Summary
Removed POLICY_LIB_CHECK_VOID() from PolicyHandler::OnActivateApp 
as redundant, because the case with disabled policy library is already handled 
inside that function. Also, it works incorrectly for the case when the policy is 
disabled - this macro breaks the function at the beginning so applications could 
not be activated when policy library is disabled.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)