### PR TITLE
Fix certificate saving after policy table update

### DIFF
--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -467,14 +467,6 @@ void ConnectionHandlerImpl::OnSessionStartedCallback(
     const uint32_t session_key =
         KeyFromPair(connection_handle, context.new_session_id_);
 
-    uint32_t app_id = 0;
-    GetDataOnSessionKey(
-        session_key, &app_id, NULL, static_cast<DeviceHandle*>(NULL));
-    if (app_id > 0) {
-      context.is_ptu_required_ =
-          !connection_handler_observer_->CheckAppIsNavi(app_id);
-    }
-
     {
       sync_primitives::AutoLock auto_lock(start_service_context_map_lock_);
       start_service_context_map_[session_key] = context;

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -1273,9 +1273,6 @@ TEST_F(ConnectionHandlerTest, SessionStarted_WithRpc) {
           true,
           ByRef(empty)));
 
-  EXPECT_CALL(mock_connection_handler_observer, CheckAppIsNavi(_))
-      .WillOnce(Return(true));
-
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
   EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _))
       .WillOnce(SaveArg<0>(&out_context_));
@@ -1312,8 +1309,6 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_SUCCESS) {
           session_key,
           true,
           ByRef(empty)));
-  EXPECT_CALL(mock_connection_handler_observer, CheckAppIsNavi(_))
-      .WillOnce(Return(true));
 
   // confirm that NotifySessionStarted() is called
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
@@ -1354,8 +1349,6 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_FAILURE) {
           session_key,
           false,
           ByRef(empty)));
-  EXPECT_CALL(mock_connection_handler_observer, CheckAppIsNavi(_))
-      .WillOnce(Return(true));
 
   // confirm that NotifySessionStarted() is called
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
@@ -1446,9 +1439,6 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_Multiple) {
                           session_key1,
                           true,
                           ByRef(empty))));
-  EXPECT_CALL(mock_connection_handler_observer, CheckAppIsNavi(_))
-      .Times(2)
-      .WillOnce(Return(true));
 
   // verify that connection handler will not mix up the two results
   SessionContext new_context_first, new_context_second;

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -66,7 +66,6 @@ struct SessionContext {
   uint32_t hash_id_;
   bool is_protected_;
   bool is_new_service_;
-  bool is_ptu_required_;
 
   /**
    * @brief Constructor
@@ -78,8 +77,7 @@ struct SessionContext {
       , service_type_(protocol_handler::kInvalidServiceType)
       , hash_id_(0)
       , is_protected_(false)
-      , is_new_service_(false)
-      , is_ptu_required_(false) {}
+      , is_new_service_(false) {}
 
   /**
    * @brief Constructor
@@ -105,8 +103,7 @@ struct SessionContext {
       , service_type_(service_type)
       , hash_id_(hash_id)
       , is_protected_(is_protected)
-      , is_new_service_(false)
-      , is_ptu_required_(false) {}
+      , is_new_service_(false) {}
 };
 
 /**

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1790,11 +1790,6 @@ StatusNotifier PolicyManagerImpl::AddApplication(
                                                device_consent);
   } else {
     PromoteExistedApplication(application_id, device_consent);
-    if (helpers::in_range(hmi_types, policy_table::AHT_NAVIGATION) &&
-        !HasCertificate()) {
-      LOG4CXX_DEBUG(logger_, "Certificate does not exist, scheduling update.");
-      update_status_manager_.ScheduleUpdate();
-    }
     return utils::MakeShared<utils::CallNothing>();
   }
 }

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1073,13 +1073,6 @@ StatusNotifier PolicyManagerImpl::AddApplication(
                                                device_consent);
   } else {
     PromoteExistedApplication(application_id, device_consent);
-    const policy_table::AppHMIType type = policy_table::AHT_NAVIGATION;
-    if (helpers::in_range(hmi_types,
-                          (rpc::Enum<policy_table::AppHMIType>)type) &&
-        !HasCertificate()) {
-      LOG4CXX_DEBUG(logger_, "Certificate does not exist, scheduling update.");
-      update_status_manager_.ScheduleUpdate();
-    }
     return utils::MakeShared<utils::CallNothing>();
   }
 }
@@ -1157,6 +1150,10 @@ bool PolicyManagerImpl::InitPT(const std::string& file_name,
   if (ret) {
     RefreshRetrySequence();
     update_status_manager_.OnPolicyInit(cache_->UpdateRequired());
+    const std::string certificate_data = cache_->GetCertificate();
+    if (!certificate_data.empty()) {
+      listener_->OnCertificateUpdated(certificate_data);
+    }
   }
   return ret;
 }

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -475,14 +475,6 @@ class ProtocolHandlerImpl
       const transport_manager::ConnectionUID connection_id) OVERRIDE;
 
   /**
-   * @brief OnPTUFinished the callback which signals PTU has finished
-   *
-   * @param ptu_result the result from the PTU - true if successful,
-   * otherwise false.
-   */
-  void OnPTUFinished(const bool ptu_result) OVERRIDE;
-
-  /**
    * @brief Notifies subscribers about message
    * received from mobile device.
    * @param message Message with already parsed header.
@@ -685,12 +677,6 @@ class ProtocolHandlerImpl
 
 #ifdef ENABLE_SECURITY
   security_manager::SecurityManager* security_manager_;
-
-  bool is_ptu_triggered_;
-  std::list<std::shared_ptr<HandshakeHandler> > ptu_pending_handlers_;
-  std::list<std::shared_ptr<HandshakeHandler> > handshake_handlers_;
-  sync_primitives::Lock ptu_handlers_lock_;
-  sync_primitives::Lock handshake_handlers_lock_;
 #endif  // ENABLE_SECURITY
 
   // Thread that pumps non-parsed messages coming from mobile side.

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -75,7 +75,6 @@ ProtocolHandlerImpl::ProtocolHandlerImpl(
     ,
 #ifdef ENABLE_SECURITY
     security_manager_(NULL)
-    , is_ptu_triggered_(false)
     ,
 #endif  // ENABLE_SECURITY
     raw_ford_messages_from_mobile_(
@@ -149,7 +148,6 @@ ProtocolHandlerImpl::~ProtocolHandlerImpl() {
                  "Not all observers have unsubscribed"
                  " from ProtocolHandlerImpl");
   }
-  handshake_handlers_.clear();
 }
 
 void ProtocolHandlerImpl::AddProtocolObserver(ProtocolObserver* observer) {
@@ -845,61 +843,6 @@ void ProtocolHandlerImpl::NotifyOnFailedHandshake() {
   security_manager_->NotifyListenersOnHandshakeFailed();
 }
 
-void ProtocolHandlerImpl::OnPTUFinished(const bool ptu_result) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-#ifdef ENABLE_SECURITY
-  sync_primitives::AutoLock lock(ptu_handlers_lock_);
-
-  if (!is_ptu_triggered_) {
-    LOG4CXX_ERROR(logger_,
-                  "PTU was not triggered by service starting. Ignored");
-    return;
-  }
-
-  for (auto handler : ptu_pending_handlers_) {
-    const bool is_cert_expired = security_manager_->IsCertificateUpdateRequired(
-        handler->connection_key());
-    security_manager::SSLContext* ssl_context =
-        is_cert_expired ? NULL
-                        : security_manager_->CreateSSLContext(
-                              handler->connection_key(),
-                              security_manager::SecurityManager::kUseExisting);
-
-    if (!ssl_context) {
-      const std::string error("CreateSSLContext failed");
-      LOG4CXX_ERROR(logger_, error);
-      security_manager_->SendInternalError(
-          handler->connection_key(),
-          security_manager::SecurityManager::ERROR_INTERNAL,
-          error);
-
-      handler->OnHandshakeDone(
-          handler->connection_key(),
-          security_manager::SSLContext::Handshake_Result_Fail);
-
-      continue;
-    }
-
-    if (ssl_context->IsInitCompleted()) {
-      handler->OnHandshakeDone(
-          handler->connection_key(),
-          security_manager::SSLContext::Handshake_Result_Success);
-    } else {
-      security_manager_->AddListener(new HandshakeHandler(*handler));
-      if (!ssl_context->IsHandshakePending()) {
-        // Start handshake process
-        security_manager_->StartHandshake(handler->connection_key());
-      }
-    }
-  }
-
-  LOG4CXX_DEBUG(logger_, "Handshake handlers were notified");
-  ptu_pending_handlers_.clear();
-  is_ptu_triggered_ = false;
-#endif  // ENABLE_SECURITY
-}
-
 RESULT_CODE ProtocolHandlerImpl::SendFrame(const ProtocolFramePtr packet) {
   LOG4CXX_AUTO_TRACE(logger_);
   if (!packet) {
@@ -1572,40 +1515,12 @@ void ProtocolHandlerImpl::NotifySessionStarted(
                                            context,
                                            packet->protocol_version(),
                                            bson_object_bytes);
-    handshake_handlers_.push_back(handler);
-
-    const bool is_certificate_empty =
-        security_manager_->IsPolicyCertificateDataEmpty();
-
-    if (context.is_ptu_required_ && is_certificate_empty) {
-      LOG4CXX_DEBUG(logger_,
-                    "PTU for StartSessionHandler "
-                        << handler.get()
-                        << " is required and certificate data is empty");
-
-      sync_primitives::AutoLock lock(ptu_handlers_lock_);
-      if (!is_ptu_triggered_) {
-        LOG4CXX_DEBUG(logger_,
-                      "PTU is not triggered yet. "
-                          << "Starting PTU and postponing SSL handshake");
-
-        ptu_pending_handlers_.push_back(handler);
-        is_ptu_triggered_ = true;
-        security_manager_->NotifyOnCertificateUpdateRequired();
-        security_manager_->PostponeHandshake(connection_key);
-      } else {
-        LOG4CXX_DEBUG(logger_, "PTU has been triggered. Added to pending.");
-        ptu_pending_handlers_.push_back(handler);
-      }
-      return;
-    }
 
     security_manager::SSLContext* ssl_context =
-        is_certificate_empty
-            ? NULL
-            : security_manager_->CreateSSLContext(
-                  connection_key,
-                  security_manager::SecurityManager::kUseExisting);
+        security_manager_->CreateSSLContext(
+            connection_key,
+            security_manager::SecurityManager::ContextCreationStrategy::
+                kUseExisting);
     if (!ssl_context) {
       const std::string error("CreateSSLContext failed");
       LOG4CXX_ERROR(logger_, error);

--- a/src/components/security_manager/include/security_manager/crypto_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/crypto_manager_impl.h
@@ -155,27 +155,12 @@ class CryptoManagerImpl : public CryptoManager {
   bool set_certificate(const std::string& cert_data);
 
   /**
-   * @brief Updates certificate and private key for the current SSL context
-   * @param certificate new certificate to update
-   * @param key new private key to update
-   * @return true if certificate and private key were updated successfully,
-   * otherwise returns false
+   * @brief Saves new certificate data on the file system
+   * @param cert_data certificate data in PEM format
+   * @return true if new certificate data was successfully saved on the file
+   * system, otherwise returns false
    */
-  bool UpdateModuleCertificateData(X509* certificate, EVP_PKEY* key);
-
-  /**
-   * @brief Loads X509 certificate from file specified in CryptoManagerSettings
-   * @return returns pointer to the loaded X509 certificate in case of success
-   * otherwise returns NULL
-   */
-  X509* LoadModuleCertificateFromFile();
-
-  /**
-   * @brief Loads private key from file specified in CryptoManagerSettings
-   * @return returns pointer to the loaded private key in case of success
-   * otherwise returns NULL
-   */
-  EVP_PKEY* LoadModulePrivateKeyFromFile();
+  bool SaveCertificateData(const std::string& cert_data);
 
   /**
    * @brief Updates certificate and private key for the current SSL context
@@ -199,6 +184,47 @@ class CryptoManagerImpl : public CryptoManager {
    * otherwise returns NULL
    */
   EVP_PKEY* LoadModulePrivateKeyFromFile();
+
+  /**
+   * @brief Updates certificate and private key for the current SSL context
+   * @param certificate new certificate to update
+   * @param key new private key to update
+   * @return true if certificate and private key were updated successfully,
+   * otherwise returns false
+   */
+  bool UpdateModuleCertificateData(X509* certificate, EVP_PKEY* key);
+
+  /**
+   * @brief Loads X509 certificate from file specified in CryptoManagerSettings
+   * @return returns pointer to the loaded X509 certificate in case of success
+   * otherwise returns NULL
+   */
+  X509* LoadModuleCertificateFromFile();
+
+  /**
+   * @brief Loads private key from file specified in CryptoManagerSettings
+   * @return returns pointer to the loaded private key in case of success
+   * otherwise returns NULL
+   */
+  EVP_PKEY* LoadModulePrivateKeyFromFile();
+
+  /**
+   * @brief Saves new X509 certificate data to file specified in
+   * CryptoManagerSettings
+   * @param certificate new X509 certificate data
+   * @return true if certificate data was saved to the file system otherwise
+   * returns false
+   */
+  bool SaveModuleCertificateToFile(X509* certificate) const;
+
+  /**
+   * @brief Saves new private key data to file specified in
+   * CryptoManagerSettings
+   * @param key new private key data
+   * @return true if private key data was saved to the file system otherwise
+   * returns false
+   */
+  bool SaveModuleKeyToFile(EVP_PKEY* key) const;
 
   const utils::SharedPtr<const CryptoManagerSettings> settings_;
   SSL_CTX* context_;

--- a/src/components/security_manager/include/security_manager/crypto_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/crypto_manager_impl.h
@@ -160,7 +160,7 @@ class CryptoManagerImpl : public CryptoManager {
    * @return true if new certificate data was successfully saved on the file
    * system, otherwise returns false
    */
-  bool SaveCertificateData(const std::string& cert_data);
+  bool SaveCertificateData(const std::string& cert_data) const;
 
   /**
    * @brief Updates certificate and private key for the current SSL context

--- a/src/components/security_manager/include/security_manager/crypto_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/crypto_manager_impl.h
@@ -177,6 +177,29 @@ class CryptoManagerImpl : public CryptoManager {
    */
   EVP_PKEY* LoadModulePrivateKeyFromFile();
 
+  /**
+   * @brief Updates certificate and private key for the current SSL context
+   * @param certificate new certificate to update
+   * @param key new private key to update
+   * @return true if certificate and private key were updated successfully,
+   * otherwise returns false
+   */
+  bool UpdateModuleCertificateData(X509* certificate, EVP_PKEY* key);
+
+  /**
+   * @brief Loads X509 certificate from file specified in CryptoManagerSettings
+   * @return returns pointer to the loaded X509 certificate in case of success
+   * otherwise returns NULL
+   */
+  X509* LoadModuleCertificateFromFile();
+
+  /**
+   * @brief Loads private key from file specified in CryptoManagerSettings
+   * @return returns pointer to the loaded private key in case of success
+   * otherwise returns NULL
+   */
+  EVP_PKEY* LoadModulePrivateKeyFromFile();
+
   const utils::SharedPtr<const CryptoManagerSettings> settings_;
   SSL_CTX* context_;
   static uint32_t instance_count_;

--- a/src/components/security_manager/include/security_manager/crypto_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/crypto_manager_impl.h
@@ -186,29 +186,6 @@ class CryptoManagerImpl : public CryptoManager {
   EVP_PKEY* LoadModulePrivateKeyFromFile();
 
   /**
-   * @brief Updates certificate and private key for the current SSL context
-   * @param certificate new certificate to update
-   * @param key new private key to update
-   * @return true if certificate and private key were updated successfully,
-   * otherwise returns false
-   */
-  bool UpdateModuleCertificateData(X509* certificate, EVP_PKEY* key);
-
-  /**
-   * @brief Loads X509 certificate from file specified in CryptoManagerSettings
-   * @return returns pointer to the loaded X509 certificate in case of success
-   * otherwise returns NULL
-   */
-  X509* LoadModuleCertificateFromFile();
-
-  /**
-   * @brief Loads private key from file specified in CryptoManagerSettings
-   * @return returns pointer to the loaded private key in case of success
-   * otherwise returns NULL
-   */
-  EVP_PKEY* LoadModulePrivateKeyFromFile();
-
-  /**
    * @brief Saves new X509 certificate data to file specified in
    * CryptoManagerSettings
    * @param certificate new X509 certificate data

--- a/src/components/security_manager/src/crypto_manager_impl.cc
+++ b/src/components/security_manager/src/crypto_manager_impl.cc
@@ -221,7 +221,7 @@ bool CryptoManagerImpl::Init() {
   // Disable SSL2 as deprecated
   SSL_CTX_set_options(context_, SSL_OP_NO_SSLv2);
 
-  set_certificate(get_settings().certificate_data());
+  SaveCertificateData(get_settings().certificate_data());
 
   if (get_settings().ciphers_list().empty()) {
     LOG4CXX_WARN(logger_, "Empty ciphers list");
@@ -288,7 +288,7 @@ bool CryptoManagerImpl::OnCertificateUpdated(const std::string& data) {
     return false;
   }
 
-  if (!set_certificate(data)) {
+  if (!SaveCertificateData(data)) {
     LOG4CXX_ERROR(logger_, "Failed to save certificate data");
     return false;
   }
@@ -362,7 +362,7 @@ const CryptoManagerSettings& CryptoManagerImpl::get_settings() const {
   return *settings_;
 }
 
-bool CryptoManagerImpl::set_certificate(const std::string& cert_data) {
+bool CryptoManagerImpl::SaveCertificateData(const std::string& cert_data) {
   LOG4CXX_AUTO_TRACE(logger_);
 
   if (cert_data.empty()) {
@@ -393,35 +393,10 @@ bool CryptoManagerImpl::set_certificate(const std::string& cert_data) {
     return false;
   }
 
-  if (!SSL_CTX_use_certificate(context_, cert)) {
-    LOG4CXX_WARN(logger_, "Could not use certificate: " << LastError());
-    return false;
-  }
+  utils::ScopeGuard key_guard = utils::MakeGuard(EVP_PKEY_free, pkey);
+  UNUSED(key_guard);
 
-  if (!SSL_CTX_use_PrivateKey(context_, pkey)) {
-    LOG4CXX_ERROR(logger_, "Could not use key: " << LastError());
-    return false;
-  }
-
-  if (!SSL_CTX_check_private_key(context_)) {
-    LOG4CXX_ERROR(logger_, "Could not use certificate: " << LastError());
-    return false;
-  }
-
-  X509_STORE* store = SSL_CTX_get_cert_store(context_);
-  if (store) {
-    X509* extra_cert = NULL;
-    while ((extra_cert = PEM_read_bio_X509(bio_cert, NULL, 0, 0))) {
-      if (extra_cert != cert) {
-        LOG4CXX_DEBUG(logger_,
-                      "Added new certificate to store: " << extra_cert);
-        X509_STORE_add_cert(store, extra_cert);
-      }
-    }
-  }
-
-  LOG4CXX_DEBUG(logger_, "Certificate and key successfully updated");
-  return true;
+  return SaveModuleCertificateToFile(cert) && SaveModuleKeyToFile(pkey);
 }
 
 bool CryptoManagerImpl::UpdateModuleCertificateData(X509* certificate,
@@ -499,6 +474,55 @@ EVP_PKEY* CryptoManagerImpl::LoadModulePrivateKeyFromFile() {
   LOG4CXX_DEBUG(logger_, "Module private key was loaded: " << module_key);
 
   return module_key;
+}
+
+bool CryptoManagerImpl::SaveModuleCertificateToFile(X509* certificate) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (NULL == certificate) {
+    LOG4CXX_WARN(logger_, "Empty certificate. Saving will be skipped");
+    return false;
+  }
+
+  const std::string cert_path = get_settings().module_cert_path();
+  BIO* bio_cert = BIO_new_file(cert_path.c_str(), "w");
+  if (NULL == bio_cert) {
+    LOG4CXX_ERROR(logger_,
+                  "Failed to open " << cert_path << " file: " << LastError());
+    return false;
+  }
+
+  if (0 == PEM_write_bio_X509(bio_cert, certificate)) {
+    LOG4CXX_ERROR(logger_,
+                  "Failed to write certificate to file: " << LastError());
+    return false;
+  }
+
+  return true;
+}
+
+bool CryptoManagerImpl::SaveModuleKeyToFile(EVP_PKEY* key) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (NULL == key) {
+    LOG4CXX_WARN(logger_, "Empty private key. Saving will be skipped");
+    return false;
+  }
+
+  const std::string key_path = get_settings().module_key_path();
+  BIO* bio_key = BIO_new_file(key_path.c_str(), "w");
+  if (NULL == bio_key) {
+    LOG4CXX_ERROR(logger_,
+                  "Failed to open " << key_path << " file: " << LastError());
+    return false;
+  }
+
+  if (0 == PEM_write_bio_PrivateKey(bio_key, key, NULL, NULL, 0, NULL, NULL)) {
+    LOG4CXX_ERROR(logger_, "Failed to write key to file: " << LastError());
+    return false;
+  }
+
+  return true;
 }
 
 }  // namespace security_manager

--- a/src/components/security_manager/src/crypto_manager_impl.cc
+++ b/src/components/security_manager/src/crypto_manager_impl.cc
@@ -386,10 +386,7 @@ bool CryptoManagerImpl::SaveCertificateData(
   utils::ScopeGuard cert_guard = utils::MakeGuard(X509_free, cert);
   UNUSED(cert_guard);
 
-  EVP_PKEY* pkey = NULL;
-  if (1 == BIO_reset(bio_cert)) {
-    PEM_read_bio_PrivateKey(bio_cert, &pkey, 0, 0);
-  } else {
+  if (1 != BIO_reset(bio_cert)) {
     LOG4CXX_WARN(logger_,
                  "Unabled to reset BIO in order to read private key, "
                      << LastError());

--- a/src/components/security_manager/test/crypto_manager_impl_test.cc
+++ b/src/components/security_manager/test/crypto_manager_impl_test.cc
@@ -159,7 +159,6 @@ TEST_F(CryptoManagerTest, WrongInit) {
   EXPECT_FALSE(crypto_manager_->Init());
   EXPECT_NE(std::string(), crypto_manager_->LastError());
 
->>>>>>> Fixed affected mocks and UT's
   EXPECT_CALL(*mock_security_manager_settings_,
               security_manager_protocol_name())
       .WillOnce(Return(security_manager::TLSv1_2));

--- a/src/components/security_manager/test/crypto_manager_impl_test.cc
+++ b/src/components/security_manager/test/crypto_manager_impl_test.cc
@@ -145,26 +145,21 @@ TEST_F(CryptoManagerTest, UsingBeforeInit) {
 }
 
 TEST_F(CryptoManagerTest, WrongInit) {
-  forced_protected_services_.push_back(kServiceNumber);
-  forced_unprotected_services_.push_back(kServiceNumber);
-  EXPECT_CALL(*mock_security_manager_settings_, security_manager_mode())
-      .WillOnce(Return(security_manager::SERVER));
-  EXPECT_CALL(*mock_security_manager_settings_, force_unprotected_service())
-      .WillOnce(ReturnRef(forced_unprotected_services_));
-  EXPECT_CALL(*mock_security_manager_settings_, force_protected_service())
-      .WillOnce(ReturnRef(forced_protected_services_));
-  EXPECT_FALSE(crypto_manager_->Init());
-  forced_protected_services_.pop_back();
-  forced_unprotected_services_.pop_back();
-  EXPECT_NE(std::string(), crypto_manager_->LastError());
+  // We have to cast (-1) to security_manager::Protocol Enum to be accepted by
+  // crypto_manager_->Init(...)
+  // Unknown protocol version
+  security_manager::Protocol UNKNOWN =
+      static_cast<security_manager::Protocol>(-1);
   // Unexistent cipher value
   const std::string invalid_cipher = "INVALID_UNKNOWN_CIPHER";
-  EXPECT_CALL(*mock_security_manager_settings_, security_manager_mode())
-      .WillOnce(Return(security_manager::SERVER));
-  EXPECT_CALL(*mock_security_manager_settings_, force_unprotected_service())
-      .WillOnce(ReturnRef(forced_unprotected_services_));
-  EXPECT_CALL(*mock_security_manager_settings_, force_protected_service())
-      .WillOnce(ReturnRef(forced_protected_services_));
+  const security_manager::Mode mode = security_manager::SERVER;
+
+  SetInitialValues(mode, UNKNOWN, invalid_cipher);
+
+  EXPECT_FALSE(crypto_manager_->Init());
+  EXPECT_NE(std::string(), crypto_manager_->LastError());
+
+>>>>>>> Fixed affected mocks and UT's
   EXPECT_CALL(*mock_security_manager_settings_,
               security_manager_protocol_name())
       .WillOnce(Return(security_manager::TLSv1_2));


### PR DESCRIPTION
Fixes #2191 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Will be tested on the integration branch
Unit tests

### Summary
SDL Core should update the module certificate in the local file system when a policy table update occurs. Currently SDL core is retrieving its certificate directly out of the policy table. This fix provides functionality for saving module certificate to the file system. 

**NOTE**
This fix is closely related to #2217 and should be merged **after** it.
This fix should be merged **after** #2105 and #2068. 

### Changelog
Following changes were done:
- Added getters for `CertificatePath` and `KeyPath` parameters in `SecurityManagerSettings` class to provide another components an access to these properties
- Added methods for saving certificate and private key data to the files specified by `CertificatePath` and `KeyPath` keywords
- `CryptoManager` component implementation was updated. Now this component also saves certificate data to files (if write permission allowed) after PTU

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)