### PR TITLE
Add checks to RAI display capabilities

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -178,7 +178,6 @@
             ],
             "imageFields": [{
                     "name": "softButtonImage",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -186,7 +185,6 @@
                 },
                 {
                     "name": "choiceImage",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -194,7 +192,6 @@
                 },
                 {
                     "name": "choiceSecondaryImage",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -202,7 +199,6 @@
                 },
                 {
                     "name": "menuIcon",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -210,7 +206,6 @@
                 },
                 {
                     "name": "cmdIcon",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -218,7 +213,6 @@
                 },
                 {
                     "name": "appIcon",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -226,7 +220,6 @@
                 },
                 {
                     "name": "graphic",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -234,7 +227,6 @@
                 },
                 {
                     "name": "secondaryGraphic",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1357,6 +1357,9 @@ class ApplicationManagerImpl
 
   app_launch::AppLaunchCtrl& app_launch_ctrl() OVERRIDE;
 
+  bool IsSOStructValid(const hmi_apis::StructIdentifiers::eType struct_id,
+                       const smart_objects::SmartObject& display_capabilities);
+
  private:
   /**
    * @brief PullLanguagesInfo allows to pull information about languages.

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -4456,6 +4456,23 @@ std::vector<std::string> ApplicationManagerImpl::ConvertRejectedParamList(
   return output;
 }
 
+bool ApplicationManagerImpl::IsSOStructValid(
+    const hmi_apis::StructIdentifiers::eType struct_id,
+    const smart_objects::SmartObject& display_capabilities) {
+  smart_objects::SmartObject display_capabilities_so = display_capabilities;
+  if (hmi_so_factory().AttachSchema(struct_id, display_capabilities_so)) {
+    if (display_capabilities_so.isValid()) {
+      return true;
+    } else {
+      return false;
+    }
+  } else {
+    LOG4CXX_ERROR(logger_, "Could not find struct id: " << struct_id);
+    return false;
+  }
+  return true;
+}
+
 #ifdef BUILD_TESTS
 void ApplicationManagerImpl::AddMockApplication(ApplicationSharedPtr mock_app) {
   applications_list_lock_.Acquire();

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -449,11 +449,15 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
     smart_objects::SmartObject& display_caps =
         response_params[hmi_response::display_capabilities];
 
+    bool missing_mandatory_capabilities = false;
+
     if (hmi_capabilities.display_capabilities()->keyExists(
             hmi_response::display_type)) {
       display_caps[hmi_response::display_type] =
           hmi_capabilities.display_capabilities()->getElement(
               hmi_response::display_type);
+    } else {
+      missing_mandatory_capabilities = true;
     }
 
     if (hmi_capabilities.display_capabilities()->keyExists(
@@ -461,6 +465,8 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
       display_caps[hmi_response::text_fields] =
           hmi_capabilities.display_capabilities()->getElement(
               hmi_response::text_fields);
+    } else {
+      missing_mandatory_capabilities = true;
     }
 
     if (hmi_capabilities.display_capabilities()->keyExists(
@@ -475,6 +481,8 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
       display_caps[hmi_response::media_clock_formats] =
           hmi_capabilities.display_capabilities()->getElement(
               hmi_response::media_clock_formats);
+    } else {
+      missing_mandatory_capabilities = true;
     }
 
     if (hmi_capabilities.display_capabilities()->keyExists(
@@ -504,6 +512,11 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
           (hmi_capabilities.display_capabilities()
                ->getElement(hmi_response::image_capabilities)
                .length() > 0);
+    }
+
+    if (missing_mandatory_capabilities) {
+      // Mandatory Display Capability Parameters were missing,
+      response_params.erase(hmi_response::display_capabilities);
     }
   }
 

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -449,50 +449,62 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
     smart_objects::SmartObject& display_caps =
         response_params[hmi_response::display_capabilities];
 
-    display_caps[hmi_response::display_type] =
-        hmi_capabilities.display_capabilities()->getElement(
-            hmi_response::display_type);
+    if (hmi_capabilities.display_capabilities()->keyExists(
+            hmi_response::display_type)) {
+      display_caps[hmi_response::display_type] =
+          hmi_capabilities.display_capabilities()->getElement(
+              hmi_response::display_type);
+    }
 
-    display_caps[hmi_response::text_fields] =
-        hmi_capabilities.display_capabilities()->getElement(
-            hmi_response::text_fields);
+    if (hmi_capabilities.display_capabilities()->keyExists(
+            hmi_response::text_fields)) {
+      display_caps[hmi_response::text_fields] =
+          hmi_capabilities.display_capabilities()->getElement(
+              hmi_response::text_fields);
+    }
 
-    display_caps[hmi_response::image_fields] =
-        hmi_capabilities.display_capabilities()->getElement(
-            hmi_response::image_fields);
+    if (hmi_capabilities.display_capabilities()->keyExists(
+            hmi_response::image_fields)) {
+      display_caps[hmi_response::image_fields] =
+          hmi_capabilities.display_capabilities()->getElement(
+              hmi_response::image_fields);
+    }
 
-    display_caps[hmi_response::media_clock_formats] =
-        hmi_capabilities.display_capabilities()->getElement(
-            hmi_response::media_clock_formats);
+    if (hmi_capabilities.display_capabilities()->keyExists(
+            hmi_response::media_clock_formats)) {
+      display_caps[hmi_response::media_clock_formats] =
+          hmi_capabilities.display_capabilities()->getElement(
+              hmi_response::media_clock_formats);
+    }
 
-    display_caps[hmi_response::templates_available] =
-        hmi_capabilities.display_capabilities()->getElement(
-            hmi_response::templates_available);
+    if (hmi_capabilities.display_capabilities()->keyExists(
+            hmi_response::templates_available)) {
+      display_caps[hmi_response::templates_available] =
+          hmi_capabilities.display_capabilities()->getElement(
+              hmi_response::templates_available);
+    }
 
-    display_caps[hmi_response::screen_params] =
-        hmi_capabilities.display_capabilities()->getElement(
-            hmi_response::screen_params);
+    if (hmi_capabilities.display_capabilities()->keyExists(
+            hmi_response::screen_params)) {
+      display_caps[hmi_response::screen_params] =
+          hmi_capabilities.display_capabilities()->getElement(
+              hmi_response::screen_params);
+    }
 
-    display_caps[hmi_response::num_custom_presets_available] =
-        hmi_capabilities.display_capabilities()->getElement(
-            hmi_response::num_custom_presets_available);
+    if (hmi_capabilities.display_capabilities()->keyExists(
+            hmi_response::num_custom_presets_available)) {
+      display_caps[hmi_response::num_custom_presets_available] =
+          hmi_capabilities.display_capabilities()->getElement(
+              hmi_response::num_custom_presets_available);
+    }
 
-    display_caps[hmi_response::graphic_supported] =
-        (hmi_capabilities.display_capabilities()
-             ->getElement(hmi_response::image_capabilities)
-             .length() > 0);
-
-    display_caps[hmi_response::templates_available] =
-        hmi_capabilities.display_capabilities()->getElement(
-            hmi_response::templates_available);
-
-    display_caps[hmi_response::screen_params] =
-        hmi_capabilities.display_capabilities()->getElement(
-            hmi_response::screen_params);
-
-    display_caps[hmi_response::num_custom_presets_available] =
-        hmi_capabilities.display_capabilities()->getElement(
-            hmi_response::num_custom_presets_available);
+    if (hmi_capabilities.display_capabilities()->keyExists(
+            hmi_response::image_capabilities)) {
+      display_caps[hmi_response::graphic_supported] =
+          (hmi_capabilities.display_capabilities()
+               ->getElement(hmi_response::image_capabilities)
+               .length() > 0);
+    }
   }
 
   if (hmi_capabilities.audio_pass_thru_capabilities()) {

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -449,15 +449,11 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
     smart_objects::SmartObject& display_caps =
         response_params[hmi_response::display_capabilities];
 
-    bool missing_mandatory_capabilities = false;
-
     if (hmi_capabilities.display_capabilities()->keyExists(
             hmi_response::display_type)) {
       display_caps[hmi_response::display_type] =
           hmi_capabilities.display_capabilities()->getElement(
               hmi_response::display_type);
-    } else {
-      missing_mandatory_capabilities = true;
     }
 
     if (hmi_capabilities.display_capabilities()->keyExists(
@@ -465,8 +461,6 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
       display_caps[hmi_response::text_fields] =
           hmi_capabilities.display_capabilities()->getElement(
               hmi_response::text_fields);
-    } else {
-      missing_mandatory_capabilities = true;
     }
 
     if (hmi_capabilities.display_capabilities()->keyExists(
@@ -481,8 +475,6 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
       display_caps[hmi_response::media_clock_formats] =
           hmi_capabilities.display_capabilities()->getElement(
               hmi_response::media_clock_formats);
-    } else {
-      missing_mandatory_capabilities = true;
     }
 
     if (hmi_capabilities.display_capabilities()->keyExists(
@@ -512,11 +504,6 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
           (hmi_capabilities.display_capabilities()
                ->getElement(hmi_response::image_capabilities)
                .length() > 0);
-    }
-
-    if (missing_mandatory_capabilities) {
-      // Mandatory Display Capability Parameters were missing,
-      response_params.erase(hmi_response::display_capabilities);
     }
   }
 

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -744,6 +744,30 @@ const smart_objects::SmartObject* HMICapabilitiesImpl::tts_supported_languages()
 
 const smart_objects::SmartObject* HMICapabilitiesImpl::display_capabilities()
     const {
+  if (!display_capabilities_->keyExists(hmi_response::display_type)) {
+    LOG4CXX_ERROR(
+        logger_,
+        "Core is missing mandatory displayCapability paramter: displayType");
+    return NULL;
+  }
+  if (!display_capabilities_->keyExists(hmi_response::text_fields)) {
+    LOG4CXX_ERROR(
+        logger_,
+        "Core is missing mandatory displayCapability paramter: textFields");
+    return NULL;
+  }
+  if (!display_capabilities_->keyExists(hmi_response::media_clock_formats)) {
+    LOG4CXX_ERROR(logger_,
+                  "Core is missing mandatory displayCapability paramter: "
+                  "mediaClockFormats");
+    return NULL;
+  }
+  if (!display_capabilities_->keyExists(hmi_response::graphic_supported)) {
+    LOG4CXX_ERROR(logger_,
+                  "Core is missing mandatory displayCapability paramter: "
+                  "graphicSupported");
+    return NULL;
+  }
   return display_capabilities_;
 }
 

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -551,10 +551,15 @@ void HMICapabilitiesImpl::set_vr_supported_languages(
 
 void HMICapabilitiesImpl::set_display_capabilities(
     const smart_objects::SmartObject& display_capabilities) {
-  if (display_capabilities_) {
-    delete display_capabilities_;
+  if (app_mngr_.IsSOStructValid(
+          hmi_apis::StructIdentifiers::Common_DisplayCapabilities,
+          display_capabilities)) {
+    if (display_capabilities_) {
+      delete display_capabilities_;
+    }
+    display_capabilities_ =
+        new smart_objects::SmartObject(display_capabilities);
   }
-  display_capabilities_ = new smart_objects::SmartObject(display_capabilities);
 }
 
 void HMICapabilitiesImpl::set_hmi_zone_capabilities(
@@ -744,30 +749,6 @@ const smart_objects::SmartObject* HMICapabilitiesImpl::tts_supported_languages()
 
 const smart_objects::SmartObject* HMICapabilitiesImpl::display_capabilities()
     const {
-  if (!display_capabilities_->keyExists(hmi_response::display_type)) {
-    LOG4CXX_ERROR(
-        logger_,
-        "Core is missing mandatory displayCapability paramter: displayType");
-    return NULL;
-  }
-  if (!display_capabilities_->keyExists(hmi_response::text_fields)) {
-    LOG4CXX_ERROR(
-        logger_,
-        "Core is missing mandatory displayCapability paramter: textFields");
-    return NULL;
-  }
-  if (!display_capabilities_->keyExists(hmi_response::media_clock_formats)) {
-    LOG4CXX_ERROR(logger_,
-                  "Core is missing mandatory displayCapability paramter: "
-                  "mediaClockFormats");
-    return NULL;
-  }
-  if (!display_capabilities_->keyExists(hmi_response::graphic_supported)) {
-    LOG4CXX_ERROR(logger_,
-                  "Core is missing mandatory displayCapability paramter: "
-                  "graphicSupported");
-    return NULL;
-  }
   return display_capabilities_;
 }
 

--- a/src/components/application_manager/test/hmi_capabilities.json
+++ b/src/components/application_manager/test/hmi_capabilities.json
@@ -215,7 +215,6 @@
       "imageFields": [
         {
                     "name": "softButtonImage",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -223,7 +222,6 @@
                 },
                 {
                     "name": "choiceImage",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -231,7 +229,6 @@
                 },
                 {
                     "name": "choiceSecondaryImage",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -239,7 +236,6 @@
                 },
                 {
                     "name": "menuIcon",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -247,7 +243,6 @@
                 },
                 {
                     "name": "cmdIcon",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -255,7 +250,6 @@
                 },
                 {
                     "name": "appIcon",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -263,7 +257,6 @@
                 },
                 {
                     "name": "graphic",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -271,7 +264,6 @@
                 },
                 {
                     "name": "secondaryGraphic",
-                    "imageTypeSupported": [],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35

--- a/src/components/application_manager/test/hmi_capabilities.json
+++ b/src/components/application_manager/test/hmi_capabilities.json
@@ -215,6 +215,9 @@
       "imageFields": [
         {
                     "name": "softButtonImage",
+                    "imageTypeSupported": [
+                        "GRAPHIC_PNG"
+                    ],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -222,6 +225,9 @@
                 },
                 {
                     "name": "choiceImage",
+                    "imageTypeSupported": [
+                        "GRAPHIC_PNG"
+                    ],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -229,6 +235,9 @@
                 },
                 {
                     "name": "choiceSecondaryImage",
+                    "imageTypeSupported": [
+                        "GRAPHIC_PNG"
+                    ],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -236,6 +245,9 @@
                 },
                 {
                     "name": "menuIcon",
+                    "imageTypeSupported": [
+                        "GRAPHIC_PNG"
+                    ],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -243,6 +255,9 @@
                 },
                 {
                     "name": "cmdIcon",
+                    "imageTypeSupported": [
+                        "GRAPHIC_PNG"
+                    ],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -250,6 +265,9 @@
                 },
                 {
                     "name": "appIcon",
+                    "imageTypeSupported": [
+                        "GRAPHIC_PNG"
+                    ],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -257,6 +275,9 @@
                 },
                 {
                     "name": "graphic",
+                    "imageTypeSupported": [
+                        "GRAPHIC_PNG"
+                    ],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
@@ -264,6 +285,9 @@
                 },
                 {
                     "name": "secondaryGraphic",
+                    "imageTypeSupported": [
+                        "GRAPHIC_PNG"
+                    ],
                     "imageResolution": {
                         "resolutionWidth": 35,
                         "resolutionHeight": 35

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -186,6 +186,8 @@ TEST_F(HMICapabilitiesTest, LoadCapabilitiesFromFile) {
   if (file_system::FileExists("./app_info_data")) {
     EXPECT_TRUE(::file_system::DeleteFile("./app_info_data"));
   }
+  EXPECT_CALL(app_mngr_, IsSOStructValid(_, _)).WillOnce(Return(true));
+
   EXPECT_TRUE(hmi_capabilities_test->LoadCapabilitiesFromFile());
 
   // Check active languages
@@ -562,6 +564,7 @@ TEST_F(HMICapabilitiesTest,
 TEST_F(HMICapabilitiesTest, VerifyImageType) {
   const int32_t image_type = 1;
   smart_objects::SmartObject sm_obj;
+  EXPECT_CALL(app_mngr_, IsSOStructValid(_, _)).WillOnce(Return(true));
   sm_obj[hmi_response::image_capabilities][0] = image_type;
   hmi_capabilities_test->set_display_capabilities(sm_obj);
 

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -730,6 +730,10 @@ class ApplicationManager {
   virtual void OnTimerSendTTSGlobalProperties() = 0;
   virtual void OnLowVoltage() = 0;
   virtual void OnWakeUp() = 0;
+
+  virtual bool IsSOStructValid(
+      const hmi_apis::StructIdentifiers::eType struct_id,
+      const smart_objects::SmartObject& display_capabilities) = 0;
 };
 
 }  // namespace application_manager

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -273,6 +273,10 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD0(event_dispatcher,
                application_manager::event_engine::EventDispatcher&());
 
+  MOCK_METHOD2(IsSOStructValid,
+               bool(const hmi_apis::StructIdentifiers::eType struct_id,
+                    const smart_objects::SmartObject& display_capabilities));
+
   DEPRECATED MOCK_CONST_METHOD1(IsAppSubscribedForWayPoints,
                                 bool(const uint32_t));
   DEPRECATED MOCK_METHOD1(SubscribeAppForWayPoints, void(const uint32_t));


### PR DESCRIPTION
Fixes #2220 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Connect app, send registerAppInterface

### Summary
Add "keyExists" checks to display capabilities in RAI response. `getElement` would cause a segfault if a display capability didn't exist.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)