### PR TITLE
Change VideoStreamingState&HMILevel setup for AudioSource event

### DIFF
--- a/src/components/application_manager/include/application_manager/hmi_state.h
+++ b/src/components/application_manager/include/application_manager/hmi_state.h
@@ -397,10 +397,6 @@ class AudioSource : public HmiState {
       const OVERRIDE {
     return mobile_apis::AudioStreamingState::NOT_AUDIBLE;
   }
-  mobile_apis::VideoStreamingState::eType video_streaming_state()
-      const OVERRIDE {
-    return mobile_apis::VideoStreamingState::NOT_STREAMABLE;
-  }
 };
 
 /**

--- a/src/components/application_manager/src/hmi_state.cc
+++ b/src/components/application_manager/src/hmi_state.cc
@@ -252,10 +252,16 @@ DEPRECATED AudioSource::AudioSource(uint32_t app_id,
     : HmiState(app_id, app_mngr, STATE_ID_AUDIO_SOURCE) {}
 
 mobile_apis::HMILevel::eType AudioSource::hmi_level() const {
-  // Checking for NONE  is necessary to avoid issue during
-  // calculation of HMI level during setting default HMI level
-  if (mobile_apis::HMILevel::HMI_NONE == parent()->hmi_level()) {
-    return mobile_apis::HMILevel::HMI_NONE;
+  using namespace helpers;
+  using namespace mobile_apis;
+  if (Compare<HMILevel::eType, EQ, ONE>(parent()->hmi_level(),
+                                        HMILevel::HMI_BACKGROUND,
+                                        HMILevel::HMI_NONE)) {
+    return parent()->hmi_level();
+  }
+
+  if (VideoStreamingState::STREAMABLE == video_streaming_state()) {
+    return mobile_apis::HMILevel::HMI_LIMITED;
   }
 
   return mobile_apis::HMILevel::HMI_BACKGROUND;


### PR DESCRIPTION
Fixes: Changes handling AudioSource event:
PROJECTION | NAVIGATION apps while AudioSource occurred should be STREAMABLE
with HMI Level LIMITED

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Provide ATF tests

### Summary
Changes handling AudioSource event:
PROJECTION | NAVIGATION apps while AudioSource occurred should be STREAMABLE
with HMI Level LIMITED

### Changelog
##### Breaking Changes
* [Breaking change info]

##### Enhancements
* [Enhancement info]

##### Bug Fixes
* [Bug Fix Info]

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)