### PR TITLE
do not set language and hmiDisplayLanguage in RAI response when these are not valid

### DIFF
--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -410,7 +410,12 @@ RegisterAppInterfaceRequest::GetLockScreenIconUrlNotification(
 
 void FillVRRelatedFields(smart_objects::SmartObject& response_params,
                          const HMICapabilities& hmi_capabilities) {
-  response_params[strings::language] = hmi_capabilities.active_vr_language();
+  hmi_apis::Common_Language::eType active_vr_language =
+      hmi_capabilities.active_vr_language();
+  if (active_vr_language != hmi_apis::Common_Language::INVALID_ENUM) {
+    response_params[strings::language] = active_vr_language;
+  }
+
   if (hmi_capabilities.vr_capabilities()) {
     response_params[strings::vr_capabilities] =
         *hmi_capabilities.vr_capabilities();
@@ -427,7 +432,12 @@ void FillVIRelatedFields(smart_objects::SmartObject& response_params,
 
 void FillTTSRelatedFields(smart_objects::SmartObject& response_params,
                           const HMICapabilities& hmi_capabilities) {
-  response_params[strings::language] = hmi_capabilities.active_tts_language();
+  hmi_apis::Common_Language::eType active_tts_language =
+      hmi_capabilities.active_tts_language();
+  if (active_tts_language != hmi_apis::Common_Language::INVALID_ENUM) {
+    response_params[strings::language] = active_tts_language;
+  }
+
   if (hmi_capabilities.speech_capabilities()) {
     response_params[strings::speech_capabilities] =
         *hmi_capabilities.speech_capabilities();
@@ -440,8 +450,12 @@ void FillTTSRelatedFields(smart_objects::SmartObject& response_params,
 
 void FillUIRelatedFields(smart_objects::SmartObject& response_params,
                          const HMICapabilities& hmi_capabilities) {
-  response_params[strings::hmi_display_language] =
+  hmi_apis::Common_Language::eType active_ui_language =
       hmi_capabilities.active_ui_language();
+  if (active_ui_language != hmi_apis::Common_Language::INVALID_ENUM) {
+    response_params[strings::hmi_display_language] = active_ui_language;
+  }
+
   if (hmi_capabilities.display_capabilities()) {
     response_params[hmi_response::display_capabilities] =
         smart_objects::SmartObject(smart_objects::SmartType_Map);


### PR DESCRIPTION
Fixes #2230 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
I tested this fix in our internal devboard HU and testing iOS SDL app.

### Summary
Do not set language and hmiDisplayLanguage in RAI response when these are not valid instead of being set to -1. -1 is the raw value of INVALID_ENUM.

SDL iOS proxy expects string value for language, therefore crash may occur when it receives integer value (-1).

### Changelog
##### Bug Fixes
* do not set language and hmiDisplayLanguage in RAI response when these are not valid

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)