### PR TITLE
Feature/issue 2059 audio streaming indicator

### DIFF
--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -160,6 +160,7 @@ extern const char* hours;
 extern const char* minutes;
 extern const char* seconds;
 extern const char* update_mode;
+extern const char* audioStreamingIndicator;
 extern const char* trigger_source;
 extern const char* hmi_level;
 extern const char* activate_app_hmi_level;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/set_media_clock_timer_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/set_media_clock_timer_test.cc
@@ -59,6 +59,7 @@ using ::testing::Return;
 using ::testing::ReturnRef;
 
 namespace UpdateMode = mobile_apis::UpdateMode;
+namespace AudioStreamingIndicator = mobile_apis::AudioStreamingIndicator;
 
 typedef SharedPtr<SetMediaClockRequest> SetMediaClockRequestPtr;
 
@@ -159,6 +160,8 @@ TEST_F(SetMediaClockRequestTest, Run_UpdateCountUp_SUCCESS) {
       kMinutes;
   (*msg)[am::strings::msg_params][am::strings::end_time][am::strings::seconds] =
       kSeconds;
+  (*msg)[am::strings::msg_params][am::strings::audioStreamingIndicator] =
+      AudioStreamingIndicator::PLAY;
 
   SharedPtr<SetMediaClockRequest> command(
       CreateCommand<SetMediaClockRequest>(msg));
@@ -195,6 +198,8 @@ TEST_F(SetMediaClockRequestTest, Run_UpdateCountDown_SUCCESS) {
       kHours;
   (*msg)[am::strings::msg_params][am::strings::end_time][am::strings::minutes] =
       kMinutes;
+  (*msg)[am::strings::msg_params][am::strings::audioStreamingIndicator] =
+      AudioStreamingIndicator::PLAY;
 
   SharedPtr<SetMediaClockRequest> command(
       CreateCommand<SetMediaClockRequest>(msg));
@@ -231,6 +236,8 @@ TEST_F(SetMediaClockRequestTest, Run_UpdateCountUpWrongTime_Canceled) {
       kHours;
   (*msg)[am::strings::msg_params][am::strings::end_time][am::strings::minutes] =
       kMinutes;
+  (*msg)[am::strings::msg_params][am::strings::audioStreamingIndicator] =
+      AudioStreamingIndicator::PLAY_PAUSE;
 
   SharedPtr<SetMediaClockRequest> command(
       CreateCommand<SetMediaClockRequest>(msg));
@@ -254,6 +261,8 @@ TEST_F(SetMediaClockRequestTest, Run_UpdateCountDownWrongTime_Canceled) {
       kMinutes;
   (*msg)[am::strings::msg_params][am::strings::end_time][am::strings::seconds] =
       kSeconds;
+  (*msg)[am::strings::msg_params][am::strings::audioStreamingIndicator] =
+      AudioStreamingIndicator::PLAY_PAUSE;
 
   SharedPtr<SetMediaClockRequest> command(
       CreateCommand<SetMediaClockRequest>(msg));

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -124,6 +124,7 @@ const char* hours = "hours";
 const char* minutes = "minutes";
 const char* seconds = "seconds";
 const char* update_mode = "updateMode";
+const char* audioStreamingIndicator = "audioStreamingIndicator";
 const char* trigger_source = "triggerSource";
 const char* hmi_level = "hmiLevel";
 const char* activate_app_hmi_level = "level";

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -335,6 +335,20 @@
   <element name="CLEAR" />
   <description>Clears the media clock timer (previously done through Show->mediaClock)</description>
 </enum>
+<enum name="AudioStreamingIndicator">
+  <element name="PLAY_PAUSE">
+    <description>Default playback indicator.</description>
+  </element>
+  <element name="PLAY">
+    <description>Indicates that a button press of the Play/Pause button would start the playback.</description>
+  </element>
+  <element name="PAUSE">
+    <description>Indicates that a button press of the Play/Pause button would pause the current playback.</description>
+  </element>
+  <element name="STOP">
+    <description>Indicates that a button press of the Play/Pause button would stop the current playback.</description>
+  </element>
+</enum> 
 
 <enum name="SystemContext">
   <description>Enumeration that describes possible contexts the application might be in on HU.</description>
@@ -3655,6 +3669,9 @@
     <param name="updateMode" type="Common.ClockUpdateMode" mandatory="true">
       <description>The update method of the media clock.</description>
       <description>In case of pause, resume, or clear, the start time value is ignored and shall be left out.  For resume, the time continues with the same value as it was when paused.</description>
+    </param>
+    <param name="audioStreamingIndicator" type="Common.AudioStreamingIndicator" mandatory="false">
+      <description>Indicates that a button press of the Play/Pause button would play, pause or Stop the current playback.</description>
     </param>
     <param name="appID" type="Integer" mandatory="true">
       <description>ID of application that requested this RPC.</description>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -302,6 +302,20 @@
             <description>Clears the media clock timer (previously done through Show->mediaClock)</description>
         </element>
     </enum>
+    <enum name="AudioStreamingIndicator">
+		<element name="PLAY_PAUSE">
+    		<description>Default playback indicator.</description>
+  		</element>
+  		<element name="PLAY">
+    		<description>Indicates that a button press of the Play/Pause button would start the playback.</description>
+  		</element>
+  		<element name="PAUSE">
+    		<description>Indicates that a button press of the Play/Pause button would pause the current playback.</description>
+  		</element>
+  		<element name="STOP">
+    		<description>Indicates that a button press of the Play/Pause button would stop the current playback.</description>
+  		</element>
+	</enum> 
     
     <enum name="TimerMode">
         <element name="UP" >
@@ -3970,6 +3984,9 @@
                 In case of pause, resume, or clear, the start time value is ignored and shall be left out.  For resume, the time continues with the same value as it was when paused.
             </description>
         </param>
+       <param name="audioStreamingIndicator" type="AudioStreamingIndicator" mandatory="false">
+      		<description>Indicates that a button press of the Play/Pause button would play, pause or Stop the current playback.</description>
+    	</param>
     </function>
     
     <function name="SetMediaClockTimer" functionID="SetMediaClockTimerID" messagetype="response">


### PR DESCRIPTION
Fixes #2059 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
ATF and unit tests

### Summary
Added AudioStreamingIndicator parameter in SetMediaClockTimer RPC

### Changelog
##### Breaking Changes
* [NA]

##### Enhancements
* [NA]

##### Bug Fixes
* [NA]

### Tasks Remaining:
- [X] [ATF scripts ] https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/1924
- [X] [Unit Tests]

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)