### PR TITLE
Fix policy issues

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_helper.h
+++ b/src/components/application_manager/include/application_manager/commands/command_helper.h
@@ -1,0 +1,85 @@
+/*
+ Copyright (c) 2017, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "application_manager/commands/command_impl.h"
+#include "smart_objects/smart_object.h"
+
+namespace application_manager {
+namespace commands {
+
+namespace command_helper {
+/**
+ * @brief Adds disallowed parameters back to response with appropriate
+ * reasons
+ * @param permissions Structure with info about disallowed parameters
+ * @param response Response message, which should be extended with blocked
+ * parameters reasons
+ */
+void AddDisallowedParameters(const CommandParametersPermissions& permissions,
+                             smart_objects::SmartObject& response);
+
+/**
+ * @brief Adds disallowed parameters to response info
+ * @param permissions Structure with info about disallowed parameters
+ * @param response Response message, which info should be extended
+ */
+void AddDisallowedParametersToInfo(
+    const CommandParametersPermissions& permissions,
+    smart_objects::SmartObject& response);
+
+/**
+ * @brief Remove from current message parameters disallowed by policy table
+ * @param permissions Structure with info about parameters which should be
+ * disallowed
+ * @param removed_permissions Structure with info about parameters which
+ * actually was disallowd in current message
+ * @param msg_params Message params where disallowed params should be removed
+ */
+void RemoveDisallowedParameters(
+    const CommandParametersPermissions& permissions,
+    CommandParametersPermissions& removed_permissions,
+    smart_objects::SmartObject& msg_params);
+
+/**
+ * @brief Checks if any request param was marked as disallowed by policy
+ * @param permissions Structure with info about parameters which actually was
+ * disallowd in current message
+ * @return true if any param was marked as disallowed
+ */
+bool HasDisallowedParams(const CommandParametersPermissions& permissions);
+
+}  // namespace CommandHelper
+
+}  // namespace commands
+}  // namespace application_manager

--- a/src/components/application_manager/include/application_manager/commands/command_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_impl.h
@@ -46,6 +46,10 @@ namespace application_manager {
  * table
  */
 struct CommandParametersPermissions {
+  CommandParametersPermissions()
+      : permit_result(PermitResult::kRpcDisallowed) {}
+
+  PermitResult permit_result;
   RPCParams allowed_params;
   RPCParams disallowed_params;
   RPCParams undefined_params;

--- a/src/components/application_manager/include/application_manager/commands/command_notification_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_notification_impl.h
@@ -44,13 +44,46 @@ class CommandNotificationImpl : public CommandImpl {
  public:
   CommandNotificationImpl(const MessageSharedPtr& message,
                           ApplicationManager& application_manager);
+  /**
+   * @brief CommandNotificationImpl class destructor
+   **/
   virtual ~CommandNotificationImpl();
-  virtual bool Init();
-  virtual bool CleanUp();
-  virtual void Run();
+
+  /**
+   * @brief Init required by command resources
+   **/
+  bool Init() OVERRIDE;
+
+  /**
+   * @brief Cleanup all resources used by command
+   **/
+  bool CleanUp() OVERRIDE;
+
+  /**
+   * @brief Execute corresponding command by calling the action on reciever
+   **/
+  void Run() OVERRIDE;
+
+  /**
+   * @brief Sends notification message to Mobile
+   */
   void SendNotification();
 
  private:
+  /**
+   * @brief Checks message permissions and parameters according to policy table
+   * permissions
+   */
+  bool CheckAllowedParameters(const MessageSharedPtr message) const;
+
+  /**
+   * @brief Remove from current message parameters disallowed by policy table
+   * @param param_permissions Current message permissions structure
+   */
+  void RemoveDisallowedParameters(
+      const MessageSharedPtr message,
+      const CommandParametersPermissions& param_permissions) const;
+
   DISALLOW_COPY_AND_ASSIGN(CommandNotificationImpl);
 };
 

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -228,6 +228,19 @@ class CommandRequestImpl : public CommandImpl,
   void AddDisallowedParameters(smart_objects::SmartObject& response);
 
   /**
+   * @brief Adds disallowed parameters to response info
+   * @param response Response message, which info should be extended
+   */
+  void AddDisallowedParametersToInfo(
+      smart_objects::SmartObject& response) const;
+
+  /**
+   * @brief Adds specific message to response info for current RPC
+   * @param response Response message, which info should be updated
+   */
+  virtual void AddSpecificInfoToResponse(smart_objects::SmartObject& response);
+
+  /**
    * @brief Checks if any request param was marked as disallowed by policy
    * @return true if any param was marked as disallowed
    */
@@ -351,13 +364,6 @@ class CommandRequestImpl : public CommandImpl,
    */
   void AddDissalowedParameterToInfoString(std::string& info,
                                           const std::string& param) const;
-
-  /**
-   * @brief Adds disallowed parameters to response info
-   * @param response Response message, which info should be extended
-   */
-  void AddDisallowedParametersToInfo(
-      smart_objects::SmartObject& response) const;
 
   bool ProcessHMIInterfacesAvailability(
       const uint32_t hmi_correlation_id,

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -215,36 +215,10 @@ class CommandRequestImpl : public CommandImpl,
   bool CheckHMICapabilities(const mobile_apis::ButtonName::eType button) const;
 
   /**
-   * @brief Remove from current message parameters disallowed by policy table
-   */
-  void RemoveDisallowedParameters();
-
-  /**
-   * @brief Adds disallowed parameters back to response with appropriate
-   * reasons
-   * @param response Response message, which should be extended with blocked
-   * parameters reasons
-   */
-  void AddDisallowedParameters(smart_objects::SmartObject& response);
-
-  /**
-   * @brief Adds disallowed parameters to response info
-   * @param response Response message, which info should be extended
-   */
-  void AddDisallowedParametersToInfo(
-      smart_objects::SmartObject& response) const;
-
-  /**
    * @brief Adds specific message to response info for current RPC
    * @param response Response message, which info should be updated
    */
   virtual void AddSpecificInfoToResponse(smart_objects::SmartObject& response);
-
-  /**
-   * @brief Checks if any request param was marked as disallowed by policy
-   * @return true if any param was marked as disallowed
-   */
-  bool HasDisallowedParams() const;
 
   /**
    * @brief Checks result code from HMI for single RPC
@@ -356,14 +330,6 @@ class CommandRequestImpl : public CommandImpl,
 
  private:
   DISALLOW_COPY_AND_ASSIGN(CommandRequestImpl);
-
-  /**
-   * @brief Adds param to disallowed parameters enumeration
-   * @param info string with disallowed params enumeration
-   * @param param disallowed param
-   */
-  void AddDissalowedParameterToInfoString(std::string& info,
-                                          const std::string& param) const;
 
   bool ProcessHMIInterfacesAvailability(
       const uint32_t hmi_correlation_id,

--- a/src/components/application_manager/include/application_manager/commands/mobile/get_vehicle_data_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/get_vehicle_data_request.h
@@ -64,10 +64,16 @@ class GetVehicleDataRequest : public CommandRequestImpl {
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
+
+  /**
+   * @brief Adds specific message to response info for current RPC
+   * @param response Response message, which info should be updated
+   */
+  void AddSpecificInfoToResponse(smart_objects::SmartObject& response) FINAL;
 
  protected:
-  virtual void on_event(const event_engine::Event& event);
+  void on_event(const event_engine::Event& event) FINAL;
 
 #ifdef HMI_DBUS_API
  private:

--- a/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/subscribe_vehicle_data_request.h
@@ -80,6 +80,12 @@ class SubscribeVehicleDataRequest : public CommandRequestImpl {
    */
   bool Init() FINAL;
 
+  /**
+   * @brief Adds specific message to response info for current RPC
+   * @param response Response message, which info should be updated
+   */
+  void AddSpecificInfoToResponse(smart_objects::SmartObject& response) FINAL;
+
 #ifdef HMI_DBUS_API
  private:
   struct HmiRequest {

--- a/src/components/application_manager/include/application_manager/commands/mobile/unsubscribe_vehicle_data_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/unsubscribe_vehicle_data_request.h
@@ -77,6 +77,12 @@ class UnsubscribeVehicleDataRequest : public CommandRequestImpl {
    */
   bool Init() FINAL;
 
+  /**
+   * @brief Adds specific message to response info for current RPC
+   * @param response Response message, which info should be updated
+   */
+  void AddSpecificInfoToResponse(smart_objects::SmartObject& response) FINAL;
+
 #ifdef HMI_DBUS_API
  private:
   struct HmiRequest {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3424,6 +3424,7 @@ mobile_apis::Result::eType ApplicationManagerImpl::CheckPolicyPermissions(
   GetPolicyHandler().CheckPermissions(app, function_id, rpc_params, result);
 
   if (NULL != params_permissions) {
+    params_permissions->permit_result = result.hmi_level_permitted;
     params_permissions->allowed_params = result.list_of_allowed_params;
     params_permissions->disallowed_params = result.list_of_disallowed_params;
     params_permissions->undefined_params = result.list_of_undefined_params;
@@ -3449,8 +3450,10 @@ mobile_apis::Result::eType ApplicationManagerImpl::CheckPolicyPermissions(
 
     switch (result.hmi_level_permitted) {
       case policy::kRpcDisallowed:
+      case policy::kRpcAllParamsDisallowed:
         return mobile_apis::Result::DISALLOWED;
       case policy::kRpcUserDisallowed:
+      case policy::kRpcAllParamsUserDisallowed:
         return mobile_apis::Result::USER_DISALLOWED;
       default:
         return mobile_apis::Result::INVALID_ENUM;

--- a/src/components/application_manager/src/commands/command_helper.cc
+++ b/src/components/application_manager/src/commands/command_helper.cc
@@ -1,0 +1,201 @@
+/*
+ Copyright (c) 2017, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <algorithm>
+#include <string>
+
+#include "application_manager/commands/command_helper.h"
+#include "application_manager/message_helper.h"
+#include "application_manager/smart_object_keys.h"
+#include "interfaces/MOBILE_API.h"
+#include "utils/make_shared.h"
+
+namespace application_manager {
+namespace commands {
+namespace command_helper {
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "Commands")
+
+namespace {
+
+struct DisallowedParamsInserter {
+  DisallowedParamsInserter(smart_objects::SmartObject& response,
+                           mobile_apis::VehicleDataResultCode::eType code)
+      : response_(response), code_(code) {}
+
+  bool operator()(const std::string& param) {
+    using namespace application_manager;
+    const VehicleData& vehicle_data = MessageHelper::vehicle_data();
+    VehicleData::const_iterator it = vehicle_data.find(param);
+    if (vehicle_data.end() != it) {
+      smart_objects::SmartObjectSPtr disallowed_param =
+          utils::MakeShared<smart_objects::SmartObject>(
+              smart_objects::SmartType_Map);
+      (*disallowed_param)[strings::data_type] = (*it).second;
+      (*disallowed_param)[strings::result_code] = code_;
+      response_[strings::msg_params][param.c_str()] = *disallowed_param;
+      return true;
+    }
+    return false;
+  }
+
+ private:
+  smart_objects::SmartObject& response_;
+  mobile_apis::VehicleDataResultCode::eType code_;
+};
+
+void AddDissalowedParameterToInfoString(const std::string& param,
+                                        std::string& info) {
+  // prepare disallowed params enumeration for response info string
+  if (info.empty()) {
+    info = "\'" + param + "\'";
+  } else {
+    info = info + "," + " " + "\'" + param + "\'";
+  }
+}
+
+}  // namespace
+
+void AddDisallowedParameters(const CommandParametersPermissions& permissions,
+                             smart_objects::SmartObject& response) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  DisallowedParamsInserter disallowed_inserter(
+      response, mobile_apis::VehicleDataResultCode::VDRC_USER_DISALLOWED);
+  std::for_each(permissions.disallowed_params.begin(),
+                permissions.disallowed_params.end(),
+                disallowed_inserter);
+
+  DisallowedParamsInserter undefined_inserter(
+      response, mobile_apis::VehicleDataResultCode::VDRC_DISALLOWED);
+  std::for_each(permissions.undefined_params.begin(),
+                permissions.undefined_params.end(),
+                undefined_inserter);
+}
+
+void AddDisallowedParametersToInfo(
+    const CommandParametersPermissions& permissions,
+    smart_objects::SmartObject& response) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  std::string info;
+  RPCParams::const_iterator it = permissions.disallowed_params.begin();
+  for (; it != permissions.disallowed_params.end(); ++it) {
+    AddDissalowedParameterToInfoString((*it), info);
+  }
+
+  it = permissions.undefined_params.begin();
+  for (; it != permissions.undefined_params.end(); ++it) {
+    AddDissalowedParameterToInfoString((*it), info);
+  }
+
+  if (!info.empty()) {
+    const uint32_t params_count = permissions.disallowed_params.size() +
+                                  permissions.undefined_params.size();
+    info += params_count > 1 ? " parameters are " : " parameter is ";
+    info += "disallowed by Policies";
+
+    if (!response[strings::msg_params][strings::info].asString().empty()) {
+      // If we already have info add info about disallowed params to it
+      response[strings::msg_params][strings::info] =
+          response[strings::msg_params][strings::info].asString() + " " + info;
+    } else {
+      response[strings::msg_params][strings::info] = info;
+    }
+  }
+}
+
+void RemoveDisallowedParameters(
+    const CommandParametersPermissions& permissions,
+    CommandParametersPermissions& removed_permissions,
+    smart_objects::SmartObject& msg_params) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  // Remove from request all disallowed parameters
+  RPCParams::const_iterator it_disallowed =
+      permissions.disallowed_params.begin();
+  RPCParams::const_iterator it_disallowed_end =
+      permissions.disallowed_params.end();
+  for (; it_disallowed != it_disallowed_end; ++it_disallowed) {
+    if (msg_params.keyExists(*it_disallowed)) {
+      const std::string key = *it_disallowed;
+      msg_params.erase(key);
+      removed_permissions.disallowed_params.insert(key);
+      LOG4CXX_INFO(logger_,
+                   "Following parameter is disallowed by user: " << key);
+    }
+  }
+
+  // Remove from request all undefined yet parameters
+  RPCParams::const_iterator it_undefined = permissions.undefined_params.begin();
+  RPCParams::const_iterator it_undefined_end =
+      permissions.undefined_params.end();
+  for (; it_undefined != it_undefined_end; ++it_undefined) {
+    if (msg_params.keyExists(*it_undefined)) {
+      const std::string key = *it_undefined;
+      msg_params.erase(key);
+      removed_permissions.undefined_params.insert(key);
+      LOG4CXX_INFO(logger_,
+                   "Following parameter is disallowed by policy: " << key);
+    }
+  }
+
+  // Remove from request all parameters missed in allowed
+  const VehicleData& vehicle_data = MessageHelper::vehicle_data();
+
+  VehicleData::const_iterator it_vehicle_data = vehicle_data.begin();
+  VehicleData::const_iterator it_vehicle_data_end = vehicle_data.end();
+  for (; it_vehicle_data != it_vehicle_data_end; ++it_vehicle_data) {
+    const std::string key = it_vehicle_data->first;
+    if (msg_params.keyExists(key) &&
+        permissions.allowed_params.end() ==
+            std::find(permissions.allowed_params.begin(),
+                      permissions.allowed_params.end(),
+                      key)) {
+      msg_params.erase(key);
+      removed_permissions.undefined_params.insert(key);
+      LOG4CXX_INFO(logger_,
+                   "Following parameter is not found among allowed parameters '"
+                       << key << "' and will be treated as disallowed.");
+    }
+  }
+}
+
+bool HasDisallowedParams(const CommandParametersPermissions& permissions) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return ((!permissions.disallowed_params.empty()) ||
+          (!permissions.undefined_params.empty()));
+}
+
+}  // namespace command_helper
+}  // namespace commands
+}  // namespace application_manager

--- a/src/components/application_manager/src/commands/command_notification_impl.cc
+++ b/src/components/application_manager/src/commands/command_notification_impl.cc
@@ -34,9 +34,36 @@
 #include "application_manager/application_manager.h"
 #include "application_manager/message_helper.h"
 
+#include "utils/shared_ptr.h"
+#include "utils/make_shared.h"
+
 namespace application_manager {
 
 namespace commands {
+
+namespace {
+
+struct ParamsDeleter {
+  ParamsDeleter(smart_objects::SmartObject& params,
+                const std::string& log_message)
+      : params_(params), log_message_(log_message) {}
+
+  void operator()(const RPCParams::value_type& value) {
+    if (params_.keyExists(value)) {
+      params_.erase(value);
+#ifdef ENABLE_LOG
+      CREATE_LOGGERPTR_LOCAL(logger, "Commands");
+      LOG4CXX_DEBUG(logger, log_message_ << value);
+#endif  // ENABLE_LOG
+    }
+  }
+
+ private:
+  smart_objects::SmartObject& params_;
+  std::string log_message_;
+};
+
+}  // namespace
 
 CommandNotificationImpl::CommandNotificationImpl(
     const MessageSharedPtr& message, ApplicationManager& application_manager)
@@ -52,18 +79,114 @@ bool CommandNotificationImpl::CleanUp() {
   return true;
 }
 
+bool CommandNotificationImpl::CheckAllowedParameters(
+    const MessageSharedPtr message) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const uint32_t connection_key =
+      (*message)[strings::params][strings::connection_key].asUInt();
+  if (0 == connection_key) {
+    LOG4CXX_DEBUG(logger_,
+                  "No app_id was specified. Parameters checking skipped");
+    return true;
+  }
+
+  const ApplicationSharedPtr app =
+      application_manager_.application(connection_key);
+  if (!app) {
+    LOG4CXX_ERROR(logger_,
+                  "There is no registered application with "
+                  "connection key '"
+                      << connection_key << "'");
+    return false;
+  }
+
+  RPCParams params;
+
+  const smart_objects::SmartObject& s_map = (*message)[strings::msg_params];
+  if (smart_objects::SmartType_Map == s_map.getType()) {
+    smart_objects::SmartMap::const_iterator iter = s_map.map_begin();
+    smart_objects::SmartMap::const_iterator iter_end = s_map.map_end();
+
+    for (; iter != iter_end; ++iter) {
+      if (helpers::Compare<smart_objects::SmartType,
+                           helpers::NEQ,
+                           helpers::ALL>(iter->second.getType(),
+                                         smart_objects::SmartType_Null,
+                                         smart_objects::SmartType_Invalid)) {
+        LOG4CXX_DEBUG(logger_, "Notification param: " << iter->first);
+        params.insert(iter->first);
+      }
+    }
+  }
+
+  CommandParametersPermissions params_permissions;
+  mobile_apis::Result::eType check_result =
+      application_manager_.CheckPolicyPermissions(
+          app,
+          MessageHelper::StringifiedFunctionID(
+              static_cast<mobile_api::FunctionID::eType>(function_id())),
+          params,
+          &params_permissions);
+
+  // Check, if RPC is allowed by policy
+  if (mobile_apis::Result::SUCCESS != check_result) {
+    LOG4CXX_ERROR(logger_,
+                  "Notification for app " << app->app_id()
+                                          << " is disallowed by Policies.");
+    return false;
+  }
+
+  // If no parameters specified in policy table, no restriction will be
+  // applied for parameters
+  if (params_permissions.allowed_params.empty() &&
+      params_permissions.disallowed_params.empty() &&
+      params_permissions.undefined_params.empty()) {
+    return true;
+  }
+
+  RemoveDisallowedParameters(message, params_permissions);
+
+  return true;
+}
+
+void CommandNotificationImpl::RemoveDisallowedParameters(
+    const MessageSharedPtr message,
+    const CommandParametersPermissions& param_permissions) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  smart_objects::SmartObject& params = (*message)[strings::msg_params];
+
+  // Remove from request all disallowed parameters
+  ParamsDeleter deleter_user(params,
+                             "Following parameter is disallowed by user: ");
+  std::for_each(param_permissions.disallowed_params.begin(),
+                param_permissions.disallowed_params.end(),
+                deleter_user);
+
+  // Remove from request all undefined yet parameters
+  ParamsDeleter deleter_policy(params,
+                               "Following parameter is disallowed by policy: ");
+  std::for_each(param_permissions.undefined_params.begin(),
+                param_permissions.undefined_params.end(),
+                deleter_policy);
+}
+
 void CommandNotificationImpl::Run() {}
 
 void CommandNotificationImpl::SendNotification() {
-  (*message_)[strings::params][strings::protocol_type] = mobile_protocol_type_;
-  (*message_)[strings::params][strings::protocol_version] = protocol_version_;
-  (*message_)[strings::params][strings::message_type] =
+  MessageSharedPtr message =
+      utils::MakeShared<smart_objects::SmartObject>(*message_);
+  (*message)[strings::params][strings::protocol_type] = mobile_protocol_type_;
+  (*message)[strings::params][strings::protocol_version] = protocol_version_;
+  (*message)[strings::params][strings::message_type] =
       static_cast<int32_t>(application_manager::MessageType::kNotification);
 
   LOG4CXX_INFO(logger_, "SendNotification");
-  MessageHelper::PrintSmartObject(*message_);
+  MessageHelper::PrintSmartObject(*message);
 
-  application_manager_.SendMessageToMobile(message_);
+  if (CheckAllowedParameters(message)) {
+    application_manager_.SendMessageToMobile(message);
+  }
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -625,8 +625,13 @@ bool CommandRequestImpl::CheckAllowedParameters() {
   smart_objects::SmartMap::const_iterator iter_end = s_map.map_end();
 
   for (; iter != iter_end; ++iter) {
-    LOG4CXX_DEBUG(logger_, "Request's param: " << iter->first);
-    params.insert(iter->first);
+    if (helpers::Compare<smart_objects::SmartType, helpers::NEQ, helpers::ALL>(
+            iter->second.getType(),
+            smart_objects::SmartType_Null,
+            smart_objects::SmartType_Invalid)) {
+      LOG4CXX_DEBUG(logger_, "Request's param: " << iter->first);
+      params.insert(iter->first);
+    }
   }
 
   mobile_apis::Result::eType check_result =

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -107,6 +107,25 @@ const std::string CreateInfoForUnsupportedResult(
   }
 }
 
+std::string CreateInfoForPolicyPermitResult(const PermitResult value) {
+  switch (value) {
+    case PermitResult::kRpcDisallowed: {
+      return "RPC is disallowed by Policies";
+    }
+    case PermitResult::kRpcUserDisallowed: {
+      return "RPC is disallowed by the User";
+    }
+    case PermitResult::kRpcAllParamsDisallowed: {
+      return "Requested parameters are disallowed by Policies";
+    }
+    case PermitResult::kRpcAllParamsUserDisallowed: {
+      return "Requested parameters are disallowed by User";
+    }
+    default:
+      return std::string();
+  }
+}
+
 bool CheckResultCode(const ResponseInfo& first, const ResponseInfo& second) {
   if (first.is_ok && second.is_unsupported_resource) {
     return true;
@@ -626,7 +645,11 @@ bool CommandRequestImpl::CheckAllowedParameters() {
             check_result,
             correlation_id(),
             app->app_id());
-
+    std::string info =
+        CreateInfoForPolicyPermitResult(parameters_permissions_.permit_result);
+    if (!info.empty()) {
+      (*response)[strings::msg_params][strings::info] = info;
+    }
     application_manager_.SendMessageToMobile(response);
     return false;
   }
@@ -765,7 +788,11 @@ void CommandRequestImpl::AddDisallowedParametersToInfo(
   }
 
   if (!info.empty()) {
-    info += " disallowed by policies.";
+    const uint32_t params_count =
+        removed_parameters_permissions_.disallowed_params.size() +
+        removed_parameters_permissions_.undefined_params.size();
+    info += params_count > 1 ? " parameters are " : " parameter is ";
+    info += "disallowed by Policies";
 
     if (!response[strings::msg_params][strings::info].asString().empty()) {
       // If we already have info add info about disallowed params to it

--- a/src/components/application_manager/src/commands/mobile/get_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/get_vehicle_data_request.cc
@@ -217,6 +217,11 @@ GetVehicleDataRequest::GetVehicleDataRequest(
 
 GetVehicleDataRequest::~GetVehicleDataRequest() {}
 
+void GetVehicleDataRequest::AddSpecificInfoToResponse(
+    smart_objects::SmartObject& response) {
+  AddDisallowedParametersToInfo(response);
+}
+
 void GetVehicleDataRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 

--- a/src/components/application_manager/src/commands/mobile/get_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/get_vehicle_data_request.cc
@@ -35,6 +35,7 @@
 #include "application_manager/commands/mobile/get_vehicle_data_request.h"
 
 #include "application_manager/application_impl.h"
+#include "application_manager/commands/command_helper.h"
 #include "application_manager/message_helper.h"
 #include "interfaces/MOBILE_API.h"
 #include "interfaces/HMI_API.h"
@@ -219,7 +220,17 @@ GetVehicleDataRequest::~GetVehicleDataRequest() {}
 
 void GetVehicleDataRequest::AddSpecificInfoToResponse(
     smart_objects::SmartObject& response) {
-  AddDisallowedParametersToInfo(response);
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (helpers::Compare<mobile_apis::Result::eType, helpers::EQ, helpers::ONE>(
+          static_cast<mobile_apis::Result::eType>(
+              response[strings::msg_params][strings::result_code].asInt()),
+          mobile_apis::Result::SUCCESS,
+          mobile_apis::Result::DISALLOWED,
+          mobile_apis::Result::USER_DISALLOWED)) {
+    response[strings::msg_params][strings::info] = std::string();
+    command_helper::AddDisallowedParametersToInfo(
+        removed_parameters_permissions_, response);
+  }
 }
 
 void GetVehicleDataRequest::Run() {
@@ -259,7 +270,8 @@ void GetVehicleDataRequest::Run() {
     SendHMIRequest(
         hmi_apis::FunctionID::VehicleInfo_GetVehicleData, &msg_params, true);
     return;
-  } else if (HasDisallowedParams()) {
+  } else if (command_helper::HasDisallowedParams(
+                 removed_parameters_permissions_)) {
     SendResponse(false, mobile_apis::Result::DISALLOWED);
   } else {
     SendResponse(false, mobile_apis::Result::INVALID_DATA);

--- a/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -319,6 +319,20 @@ void SubscribeVehicleDataRequest::AddAlreadySubscribedVI(
   }
 }
 
+void SubscribeVehicleDataRequest::AddSpecificInfoToResponse(
+    smart_objects::SmartObject& response) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  AddDisallowedParameters(response);
+  if (helpers::Compare<mobile_apis::Result::eType, helpers::EQ, helpers::ONE>(
+          static_cast<mobile_apis::Result::eType>(
+              response[strings::msg_params][strings::result_code].asInt()),
+          mobile_apis::Result::DISALLOWED,
+          mobile_apis::Result::USER_DISALLOWED)) {
+    response[strings::msg_params][strings::info] = std::string();
+    AddDisallowedParametersToInfo(response);
+  }
+}
+
 void SubscribeVehicleDataRequest::UnsubscribeFailedSubscriptions(
     ApplicationSharedPtr app,
     const smart_objects::SmartObject& msg_params) const {

--- a/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -37,6 +37,7 @@
 #include "application_manager/commands/mobile/subscribe_vehicle_data_request.h"
 
 #include "application_manager/application_impl.h"
+#include "application_manager/commands/command_helper.h"
 #include "application_manager/message_helper.h"
 #include "utils/helpers.h"
 
@@ -322,14 +323,17 @@ void SubscribeVehicleDataRequest::AddAlreadySubscribedVI(
 void SubscribeVehicleDataRequest::AddSpecificInfoToResponse(
     smart_objects::SmartObject& response) {
   LOG4CXX_AUTO_TRACE(logger_);
-  AddDisallowedParameters(response);
   if (helpers::Compare<mobile_apis::Result::eType, helpers::EQ, helpers::ONE>(
           static_cast<mobile_apis::Result::eType>(
               response[strings::msg_params][strings::result_code].asInt()),
+          mobile_apis::Result::SUCCESS,
           mobile_apis::Result::DISALLOWED,
           mobile_apis::Result::USER_DISALLOWED)) {
     response[strings::msg_params][strings::info] = std::string();
-    AddDisallowedParametersToInfo(response);
+    command_helper::AddDisallowedParameters(removed_parameters_permissions_,
+                                            response);
+    command_helper::AddDisallowedParametersToInfo(
+        removed_parameters_permissions_, response);
   }
 }
 
@@ -481,7 +485,7 @@ void SubscribeVehicleDataRequest::CheckVISubscriptions(
           vi_already_subscribed_by_this_app_.size();
 
   if (0 == items_to_subscribe) {
-    if (HasDisallowedParams()) {
+    if (command_helper::HasDisallowedParams(removed_parameters_permissions_)) {
       out_result_code = mobile_apis::Result::DISALLOWED;
     } else {
       out_result_code = mobile_apis::Result::INVALID_DATA;

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -403,5 +403,19 @@ void UnsubscribeVehicleDataRequest::AddAlreadyUnsubscribedVI(
   }
 }
 
+void UnsubscribeVehicleDataRequest::AddSpecificInfoToResponse(
+    smart_objects::SmartObject& response) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  AddDisallowedParameters(response);
+  if (helpers::Compare<mobile_apis::Result::eType, helpers::EQ, helpers::ONE>(
+          static_cast<mobile_apis::Result::eType>(
+              response[strings::msg_params][strings::result_code].asInt()),
+          mobile_apis::Result::DISALLOWED,
+          mobile_apis::Result::USER_DISALLOWED)) {
+    response[strings::msg_params][strings::info] = std::string();
+    AddDisallowedParametersToInfo(response);
+  }
+}
+
 }  // namespace commands
 }  // namespace application_manager

--- a/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -35,6 +35,7 @@
 #include "application_manager/commands/command_impl.h"
 
 #include "application_manager/application_impl.h"
+#include "application_manager/commands/command_helper.h"
 #include "application_manager/message_helper.h"
 #include "interfaces/MOBILE_API.h"
 #include "interfaces/HMI_API.h"
@@ -183,7 +184,7 @@ void UnsubscribeVehicleDataRequest::Run() {
           vi_already_unsubscribed_by_this_app_.size();
 
   if (0 == items_to_unsubscribe) {
-    if (HasDisallowedParams()) {
+    if (command_helper::HasDisallowedParams(removed_parameters_permissions_)) {
       SendResponse(false, mobile_apis::Result::DISALLOWED);
     } else {
       SendResponse(
@@ -406,14 +407,17 @@ void UnsubscribeVehicleDataRequest::AddAlreadyUnsubscribedVI(
 void UnsubscribeVehicleDataRequest::AddSpecificInfoToResponse(
     smart_objects::SmartObject& response) {
   LOG4CXX_AUTO_TRACE(logger_);
-  AddDisallowedParameters(response);
   if (helpers::Compare<mobile_apis::Result::eType, helpers::EQ, helpers::ONE>(
           static_cast<mobile_apis::Result::eType>(
               response[strings::msg_params][strings::result_code].asInt()),
+          mobile_apis::Result::SUCCESS,
           mobile_apis::Result::DISALLOWED,
           mobile_apis::Result::USER_DISALLOWED)) {
     response[strings::msg_params][strings::info] = std::string();
-    AddDisallowedParametersToInfo(response);
+    command_helper::AddDisallowedParameters(removed_parameters_permissions_,
+                                            response);
+    command_helper::AddDisallowedParametersToInfo(
+        removed_parameters_permissions_, response);
   }
 }
 

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -39,6 +39,7 @@
 #include "application_manager/commands/command_request_impl.h"
 #include "application_manager/commands/commands_test.h"
 #include "application_manager/commands/command_request_test.h"
+#include "application_manager/commands/command_helper.h"
 #include "utils/lock.h"
 #include "utils/shared_ptr.h"
 #include "utils/data_accessor.h"
@@ -59,6 +60,7 @@ namespace command_request_impl {
 namespace am = application_manager;
 namespace strings = am::strings;
 namespace hmi_response = am::hmi_response;
+namespace command_helper = am::commands::CommandHelper;
 
 using ::testing::_;
 using ::testing::Return;
@@ -86,11 +88,16 @@ const hmi_apis::FunctionID::eType kInvalidFunctionId =
 const std::string kPolicyAppId = "Test";
 const mobile_apis::Result::eType kMobResultSuccess =
     mobile_apis::Result::SUCCESS;
+const mobile_apis::Result::eType kMobResultDisallowed =
+    mobile_apis::Result::DISALLOWED;
+const am::PermitResult kDisallowedPermitResult =
+    am::PermitResult::kRpcAllParamsDisallowed;
 const std::string kDisallowedParam1 = "disallowed_param1";
 const std::string kDisallowedParam2 = "disallowed_param2";
 const std::string kAllowedParam = "allowed_param";
 const std::string kUndefinedParam = "undefined_params";
 const std::string kMissedParam = "missed_param";
+
 }  // namespace
 
 class CommandRequestImplTest
@@ -99,9 +106,6 @@ class CommandRequestImplTest
   class UnwrappedCommandRequestImpl : public CommandRequestImpl {
    public:
     using CommandRequestImpl::CheckAllowedParameters;
-    using CommandRequestImpl::RemoveDisallowedParameters;
-    using CommandRequestImpl::AddDisallowedParameters;
-    using CommandRequestImpl::HasDisallowedParams;
 
     UnwrappedCommandRequestImpl(const MessageSharedPtr& message,
                                 ApplicationManager& am)
@@ -319,14 +323,18 @@ TEST_F(CommandRequestImplTest, RemoveDisallowedParameters_SUCCESS) {
   permission.allowed_params.insert(kAllowedParam);
   permission.undefined_params.insert(kUndefinedParam);
 
-  command->RemoveDisallowedParameters();
+  command_helper::RemoveDisallowedParameters(
+      command->parameters_permissions(),
+      command->removed_parameters_permissions(),
+      (*msg)[strings::msg_params]);
 
   EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kDisallowedParam1));
   EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kDisallowedParam2));
   EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kUndefinedParam));
   EXPECT_FALSE((*msg)[strings::msg_params].keyExists(kMissedParam));
   EXPECT_TRUE((*msg)[strings::msg_params].keyExists(kAllowedParam));
-  EXPECT_TRUE(command->HasDisallowedParams());
+  EXPECT_TRUE(command_helper::HasDisallowedParams(
+      command->removed_parameters_permissions()));
 }
 
 TEST_F(CommandRequestImplTest,
@@ -362,6 +370,10 @@ TEST_F(CommandRequestImplTest, CheckAllowedParameters_NoMsgParamsMap_SUCCESS) {
   EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
       .WillOnce(Return(kMobResultSuccess));
 
+  am::VehicleData vehicle_data;
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data));
+
   EXPECT_TRUE(command->CheckPermissions());
 }
 
@@ -383,6 +395,10 @@ TEST_F(CommandRequestImplTest,
   EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
       .WillOnce(Return(mobile_apis::Result::INVALID_ENUM));
 
+  am::VehicleData vehicle_data;
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data));
+
   smart_objects::SmartObjectSPtr response =
       utils::MakeShared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
@@ -400,6 +416,43 @@ ACTION_P(GetArg3, output) {
   *output = arg2;
 }
 
+TEST_F(CommandRequestImplTest,
+       CheckAllowedParameters_AddDisallowedParamInfo_UNSUCCESS) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::connection_key] = kConnectionKey;
+  (*msg)[strings::msg_params][kPolicyAppId] = true;
+
+  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
+  command->parameters_permissions().permit_result = kDisallowedPermitResult;
+
+  MockAppPtr app = CreateMockApp();
+  EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(kMobResultDisallowed));
+
+  am::VehicleData vehicle_data;
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data));
+
+  smart_objects::SmartObjectSPtr response =
+      utils::MakeShared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  (*response)[strings::msg_params] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateBlockedByPoliciesResponse(_, _, _, _))
+      .WillOnce(Return(response));
+
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(response, _));
+
+  EXPECT_FALSE(command->CheckPermissions());
+
+  EXPECT_TRUE((*response)[strings::msg_params].keyExists(strings::info));
+  EXPECT_FALSE(
+      (*response)[strings::msg_params][strings::info].asString().empty());
+}
+
 TEST_F(CommandRequestImplTest, CheckAllowedParameters_MsgParamsMap_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
   (*msg)[strings::params][strings::connection_key] = kConnectionKey;
@@ -413,6 +466,10 @@ TEST_F(CommandRequestImplTest, CheckAllowedParameters_MsgParamsMap_SUCCESS) {
   RPCParams params;
   EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
       .WillOnce(DoAll(GetArg3(&params), Return(kMobResultSuccess)));
+
+  am::VehicleData vehicle_data;
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
+      .WillOnce(ReturnRef(vehicle_data));
 
   EXPECT_TRUE(command->CheckPermissions());
   EXPECT_TRUE(params.end() !=
@@ -434,7 +491,8 @@ TEST_F(CommandRequestImplTest, AddDisallowedParameters_SUCCESS) {
   command->removed_parameters_permissions().disallowed_params.insert(
       kDisallowedParam1);
 
-  command->AddDisallowedParameters(*msg);
+  command_helper::AddDisallowedParameters(
+      command->removed_parameters_permissions(), *msg);
 
   EXPECT_TRUE((*msg)[strings::msg_params].keyExists(kDisallowedParam1));
 }
@@ -468,37 +526,6 @@ TEST_F(CommandRequestImplTest, SendResponse_SUCCESS) {
   EXPECT_EQ(RequestState::kCompleted, command->current_state());
 
   EXPECT_TRUE(smart_objects::SmartType_Map == (*msg).getType());
-}
-
-TEST_F(CommandRequestImplTest,
-       SendResponse_AddDisallowedParametersToInfo_SUCCESS) {
-  am::VehicleData vehicle_data;
-  vehicle_data.insert(am::VehicleData::value_type(
-      kDisallowedParam1, mobile_apis::VehicleDataType::VEHICLEDATA_MYKEY));
-
-  EXPECT_CALL(mock_message_helper_, vehicle_data())
-      .WillOnce(ReturnRef(vehicle_data));
-
-  MessageSharedPtr msg = CreateMessage();
-  (*msg)[strings::params][strings::function_id] =
-      mobile_apis::FunctionID::SubscribeVehicleDataID;
-
-  CommandPtr command = CreateCommand<UCommandRequestImpl>(msg);
-
-  command->removed_parameters_permissions().disallowed_params.insert(
-      kDisallowedParam1);
-
-  MessageSharedPtr result;
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _))
-      .WillOnce(DoAll(SaveArg<0>(&result), Return(true)));
-
-  command->SendResponse(true, kMobResultSuccess, NULL, NULL);
-
-  EXPECT_EQ(RequestState::kCompleted, command->current_state());
-
-  EXPECT_TRUE((*result)[strings::msg_params].keyExists(strings::info));
-  EXPECT_FALSE(
-      (*result)[strings::msg_params][strings::info].asString().empty());
 }
 
 TEST_F(CommandRequestImplTest, HashUpdateAllowed_UpdateExpected) {

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -60,7 +60,7 @@ namespace command_request_impl {
 namespace am = application_manager;
 namespace strings = am::strings;
 namespace hmi_response = am::hmi_response;
-namespace command_helper = am::commands::CommandHelper;
+namespace command_helper = am::commands::command_helper;
 
 using ::testing::_;
 using ::testing::Return;

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -383,8 +383,14 @@ TEST_F(CommandRequestImplTest,
   EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
       .WillOnce(Return(mobile_apis::Result::INVALID_ENUM));
 
+  smart_objects::SmartObjectSPtr response =
+      utils::MakeShared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  (*response)[strings::msg_params] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
   EXPECT_CALL(mock_message_helper_, CreateBlockedByPoliciesResponse(_, _, _, _))
-      .WillOnce(Return(smart_objects::SmartObjectSPtr()));
+      .WillOnce(Return(response));
 
   EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _));
   EXPECT_FALSE(command->CheckPermissions());

--- a/src/components/application_manager/test/commands/mobile/on_hash_change_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_hash_change_notification_test.cc
@@ -69,11 +69,13 @@ TEST_F(OnHashChangeNotificationTest, Run_ValidApp_SUCCESS) {
   std::string return_string = "1234";
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
   EXPECT_CALL(*mock_app, curHash()).WillOnce(ReturnRef(return_string));
-  EXPECT_CALL(mock_message_helper_, PrintSmartObject(_))
-      .WillOnce(Return(false));
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _)).WillOnce(SaveArg<0>(&msg));
 
   command->Run();
 

--- a/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_hmi_status_notification_test.cc
@@ -68,9 +68,10 @@ class OnHMIStatusNotificationTest
   }
 
   void SetSendNotificationExpectations(MessageSharedPtr& msg) {
-    EXPECT_CALL(mock_message_helper_, PrintSmartObject(_))
-        .WillOnce(Return(false));
-    EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+    EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+        .WillOnce(Return(mobile_apis::Result::SUCCESS));
+    EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _))
+        .WillOnce(SaveArg<0>(&msg));
   }
 
   void VerifySendNotificationData(MessageSharedPtr& msg) {
@@ -110,7 +111,8 @@ TEST_F(OnHMIStatusNotificationTest, Run_InvalidEnum_SUCCESS) {
 
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
 
   SetSendNotificationExpectations(msg);
 
@@ -128,7 +130,8 @@ TEST_F(OnHMIStatusNotificationTest, Run_BackgroundAndFalseProperties_SUCCESS) {
 
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
 
   EXPECT_CALL(*mock_app, tts_properties_in_none()).WillOnce(Return(false));
   EXPECT_CALL(*mock_app, set_tts_properties_in_none(true));
@@ -147,7 +150,8 @@ TEST_F(OnHMIStatusNotificationTest, Run_BackgroundAndTrueProperties_SUCCESS) {
 
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
 
   EXPECT_CALL(*mock_app, tts_properties_in_none()).WillOnce(Return(true));
 
@@ -166,7 +170,8 @@ TEST_F(OnHMIStatusNotificationTest, Run_FullAndFalseProperties_SUCCESS) {
 
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
 
   EXPECT_CALL(*mock_app, tts_properties_in_full()).WillOnce(Return(false));
   EXPECT_CALL(*mock_app, set_tts_properties_in_full(true));
@@ -188,7 +193,8 @@ TEST_F(OnHMIStatusNotificationTest, Run_FullAndTrueProperties_SUCCESS) {
 
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
 
   EXPECT_CALL(*mock_app, tts_properties_in_full()).WillOnce(Return(true));
 

--- a/src/components/application_manager/test/commands/mobile/on_keyboard_input_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_keyboard_input_notification_test.cc
@@ -61,10 +61,13 @@ using testing::_;
 class OnKeyBoardInputNotificationTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
-  void SetSendNotificationExpectations(MessageSharedPtr msg) {
-    EXPECT_CALL(mock_message_helper_, PrintSmartObject(_))
-        .WillOnce(Return(false));
-    EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+  OnKeyBoardInputNotificationTest() {}
+
+  void SetSendNotificationExpectations(MessageSharedPtr& msg) {
+    EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+        .WillOnce(Return(mobile_apis::Result::SUCCESS));
+    EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _))
+        .WillOnce(SaveArg<0>(&msg));
   }
 
   void SetSendNotificationVariables(MessageSharedPtr msg) {
@@ -100,8 +103,9 @@ TEST_F(OnKeyBoardInputNotificationTest, Run_ActionActive_SUCCESS) {
   EXPECT_CALL(*mock_app, perform_interaction_layout())
       .WillOnce(Return(mobile_apis::LayoutMode::KEYBOARD));
   EXPECT_CALL(*mock_app, hmi_level()).Times(0);
-
   EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kConnectionKey));
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
 
   SetSendNotificationExpectations(msg);
 
@@ -127,6 +131,9 @@ TEST_F(OnKeyBoardInputNotificationTest, Run_ActionNotActive_SUCCESS) {
       .WillOnce(Return(mobile_apis::HMILevel::eType::HMI_FULL));
 
   EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kConnectionKey));
+
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
 
   SetSendNotificationExpectations(msg);
 

--- a/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_system_request_notification_test.cc
@@ -97,7 +97,10 @@ TEST_F(OnSystemRequestNotificationTest, Run_ProprietaryType_SUCCESS) {
 
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
   MockPolicyHandlerInterface mock_policy_handler;
   EXPECT_CALL(app_mngr_, GetPolicyHandler())
       .WillRepeatedly(ReturnRef(mock_policy_handler));
@@ -113,9 +116,7 @@ TEST_F(OnSystemRequestNotificationTest, Run_ProprietaryType_SUCCESS) {
   EXPECT_CALL(mock_policy_handler, TimeoutExchangeSec()).WillOnce(Return(5u));
 #endif  // PROPRIETARY_MODE
 
-  EXPECT_CALL(mock_message_helper_, PrintSmartObject(_))
-      .WillOnce(Return(false));
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _)).WillOnce(SaveArg<0>(&msg));
 
   command->Run();
 
@@ -142,7 +143,11 @@ TEST_F(OnSystemRequestNotificationTest, Run_HTTPType_SUCCESS) {
 
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
   MockPolicyHandlerInterface mock_policy_handler;
   EXPECT_CALL(app_mngr_, GetPolicyHandler())
       .WillOnce(ReturnRef(mock_policy_handler));
@@ -151,9 +156,7 @@ TEST_F(OnSystemRequestNotificationTest, Run_HTTPType_SUCCESS) {
   EXPECT_CALL(mock_policy_handler, IsRequestTypeAllowed(_, _))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(mock_message_helper_, PrintSmartObject(_))
-      .WillOnce(Return(false));
-  EXPECT_CALL(app_mngr_, SendMessageToMobile(msg, _));
+  EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _)).WillOnce(SaveArg<0>(&msg));
 
   command->Run();
 
@@ -267,6 +270,8 @@ TEST_F(OnSystemRequestNotificationTest,
   EXPECT_CALL(mock_policy_handler_,
               IsRequestSubTypeAllowed(kPolicyAppId, request_subtype))
       .WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
 
   smart_objects::SmartObjectSPtr result;
   EXPECT_CALL(app_mngr_, SendMessageToMobile(_, _))

--- a/src/components/application_manager/test/commands/mobile/on_tbt_client_state_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_tbt_client_state_notification_test.cc
@@ -123,6 +123,11 @@ TEST_F(OnTBTClientStateNotificationTest,
   EXPECT_CALL(app_mngr_, applications_with_navi())
       .WillOnce(Return(applications_with_navi));
 
+  EXPECT_CALL(app_mngr_, application(kAppId)).WillOnce(Return(mock_app));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
   EXPECT_CALL(*mock_app, hmi_level())
       .WillOnce(Return(mobile_apis::HMILevel::HMI_FULL));
 

--- a/src/components/application_manager/test/commands/mobile/on_touch_event_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_touch_event_notification_test.cc
@@ -133,6 +133,14 @@ TEST_F(OnTouchEventNotificationTest, Run_NotEmptyListOfAppsWithNavi_SUCCESS) {
   EXPECT_CALL(app_mngr_, applications_with_mobile_projection())
       .WillOnce(Return(applications_with_mobile_projection));
 
+  EXPECT_CALL(app_mngr_, application(kAppId))
+      .Times(2)
+      .WillRepeatedly(Return(mock_app));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .Times(2)
+      .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+
   EXPECT_CALL(*mock_app, IsFullscreen()).WillRepeatedly(Return(true));
 
   EXPECT_CALL(*mock_app, app_id()).WillRepeatedly(Return(kAppId));

--- a/src/components/application_manager/test/commands/mobile/on_vehicle_data_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_vehicle_data_notification_test.cc
@@ -130,6 +130,11 @@ TEST_F(OnVehicleDataNotificationTest,
       IviInfoUpdated(mobile_apis::VehicleDataType::VEHICLEDATA_FUELLEVEL,
                      kFuelLevel)).WillOnce(Return(applications));
 
+  EXPECT_CALL(app_mngr_, application(kAppId)).WillOnce(Return(mock_app));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
   EXPECT_CALL(*mock_app, app_id()).WillRepeatedly(Return(kAppId));
   ::utils::custom_string::CustomString dummy_name("test_app");
   ON_CALL(*mock_app, name()).WillByDefault(ReturnRef(dummy_name));

--- a/src/components/application_manager/test/commands/mobile/on_way_point_change_notification_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_way_point_change_notification_test.cc
@@ -101,6 +101,15 @@ TEST_F(OnWayPointChangeNotificationTest,
   std::set<int32_t> apps_subscribed_for_way_points;
   apps_subscribed_for_way_points.insert(kAppId);
 
+  MockAppPtr mock_app(CreateMockApp());
+
+  EXPECT_CALL(app_mngr_, application(kAppId)).WillOnce(Return(mock_app));
+
+  EXPECT_CALL(app_mngr_, CheckPolicyPermissions(_, _, _, _))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
+  EXPECT_CALL(*mock_app, app_id()).WillRepeatedly(Return(kAppId));
+
   EXPECT_CALL(app_mngr_, GetAppsSubscribedForWayPoints())
       .WillOnce(Return(apps_subscribed_for_way_points));
 

--- a/src/components/application_manager/test/commands/mobile/set_media_clock_timer_test.cc
+++ b/src/components/application_manager/test/commands/mobile/set_media_clock_timer_test.cc
@@ -319,7 +319,13 @@ TEST_F(SetMediaClockRequestTest, OnEvent_Success) {
       hmi_apis::Common_Result::SUCCESS;
   (*msg)[am::strings::msg_params] = SmartObject(smart_objects::SmartType_Null);
 
-  EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _));
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
+  EXPECT_CALL(
+      app_mngr_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _));
 
   MockAppPtr app(CreateMockApp());
   EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(app));

--- a/src/components/application_manager/test/commands/mobile/show_test.cc
+++ b/src/components/application_manager/test/commands/mobile/show_test.cc
@@ -698,6 +698,10 @@ TEST_F(ShowRequestTest, Run_MainField1_MetadataTagWithNoFieldData) {
       ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))
       .WillOnce(DoAll(SaveArg<0>(&ui_command_result), Return(true)));
 
+  EXPECT_CALL(mock_message_helper_,
+              HMIToMobileResult(hmi_apis::Common_Result::SUCCESS))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
+
   command->on_event(event);
 
   EXPECT_EQ((*ui_command_result)[am::strings::msg_params][am::strings::success]

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -85,8 +85,9 @@ class EventDispatcher;
 
 class Application;
 class StateControllerImpl;
-struct CommandParametersPermissions;
 using policy::RPCParams;
+using policy::PermitResult;
+struct CommandParametersPermissions;
 typedef std::vector<ApplicationSharedPtr> AppSharedPtrs;
 struct ApplicationsAppIdSorter {
   bool operator()(const ApplicationSharedPtr lhs,

--- a/src/components/policy/policy_external/include/policy/policy_types.h
+++ b/src/components/policy/policy_external/include/policy/policy_types.h
@@ -115,7 +115,13 @@ typedef std::vector<std::string> PermissionsList;
  */
 typedef std::vector<std::string> StringArray;
 
-enum PermitResult { kRpcAllowed = 0, kRpcDisallowed, kRpcUserDisallowed };
+enum PermitResult {
+  kRpcAllowed = 0,
+  kRpcDisallowed,
+  kRpcUserDisallowed,
+  kRpcAllParamsDisallowed,
+  kRpcAllParamsUserDisallowed
+};
 
 /**
   * @struct Stores result of check:

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1174,6 +1174,7 @@ void CacheManager::CheckPermissions(const PTString& app_id,
   policy_table::Strings::const_iterator app_groups_iter_end =
       pt_->policy_table.app_policies_section.apps[app_id].groups.end();
 
+  result.hmi_level_permitted = PermitResult::kRpcDisallowed;
   policy_table::FunctionalGroupings::const_iterator concrete_group;
 
   for (; app_groups_iter != app_groups_iter_end; ++app_groups_iter) {

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -698,7 +698,7 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
           .parameter_permissions.any_parameter_disallowed_by_user) {
     LOG4CXX_DEBUG(logger_, "All parameters are disallowed by user.");
     result.list_of_disallowed_params = rpc_params;
-    result.hmi_level_permitted = kRpcUserDisallowed;
+    result.hmi_level_permitted = kRpcAllParamsUserDisallowed;
     return;
   }
 
@@ -706,7 +706,7 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
           .parameter_permissions.any_parameter_disallowed_by_policy) {
     LOG4CXX_DEBUG(logger_, "All parameters are disallowed by policy.");
     result.list_of_undefined_params = rpc_params;
-    result.hmi_level_permitted = kRpcDisallowed;
+    result.hmi_level_permitted = kRpcAllParamsDisallowed;
     return;
   }
 
@@ -742,11 +742,11 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
   }
 
   if (result.DisallowedInclude(rpc_params)) {
-    LOG4CXX_DEBUG(logger_, "All parameters are disallowed.");
-    result.hmi_level_permitted = kRpcUserDisallowed;
+    LOG4CXX_DEBUG(logger_, "All parameters are disallowed by user.");
+    result.hmi_level_permitted = kRpcAllParamsUserDisallowed;
   } else if (!result.IsAnyAllowed(rpc_params)) {
-    LOG4CXX_DEBUG(logger_, "There are no parameters allowed.");
-    result.hmi_level_permitted = kRpcDisallowed;
+    LOG4CXX_DEBUG(logger_, "There are no parameters allowed by policy.");
+    result.hmi_level_permitted = kRpcAllParamsDisallowed;
   }
 }
 

--- a/src/components/policy/policy_regular/include/policy/policy_types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_types.h
@@ -115,7 +115,13 @@ typedef std::vector<std::string> PermissionsList;
  */
 typedef std::vector<std::string> StringArray;
 
-enum PermitResult { kRpcAllowed = 0, kRpcDisallowed, kRpcUserDisallowed };
+enum PermitResult {
+  kRpcAllowed = 0,
+  kRpcDisallowed,
+  kRpcUserDisallowed,
+  kRpcAllParamsDisallowed,
+  kRpcAllParamsUserDisallowed
+};
 
 /**
   * @struct Stores result of check:

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -482,6 +482,7 @@ void CacheManager::CheckPermissions(const policy_table::Strings& groups,
   policy_table::Strings::const_iterator app_groups_iter = groups.begin();
   policy_table::Strings::const_iterator app_groups_iter_end = groups.end();
 
+  result.hmi_level_permitted = PermitResult::kRpcDisallowed;
   policy_table::FunctionalGroupings::const_iterator concrete_group;
 
   for (; app_groups_iter != app_groups_iter_end; ++app_groups_iter) {
@@ -510,8 +511,6 @@ void CacheManager::CheckPermissions(const policy_table::Strings& groups,
                       hmi_level_e);
 
         if (rpc_param.hmi_levels.end() != hmi_iter) {
-          result.hmi_level_permitted = PermitResult::kRpcAllowed;
-
           policy_table::Parameters::const_iterator params_iter =
               rpc_param.parameters->begin();
           policy_table::Parameters::const_iterator params_iter_end =
@@ -520,6 +519,13 @@ void CacheManager::CheckPermissions(const policy_table::Strings& groups,
           for (; params_iter != params_iter_end; ++params_iter) {
             result.list_of_allowed_params.insert(
                 policy_table::EnumToJsonString(*params_iter));
+          }
+
+          if (rpc_param.parameters.is_initialized() &&
+              result.list_of_allowed_params.empty()) {
+            result.hmi_level_permitted = PermitResult::kRpcAllParamsDisallowed;
+          } else {
+            result.hmi_level_permitted = PermitResult::kRpcAllowed;
           }
         }
       }


### PR DESCRIPTION
Fixes #2245 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests
ATF tests

### Summary
Added generating of info message param depending on check permissions result:
- for disallowed rpc
- for all disallowed params in allowed rpc
- for partially disallowed params in allowed rpc
Fixed requests param reading from incoming message. There was a problem that asBool() function of smart object returns false for string/array/object types so this params will not be included to params check list and will not be cut off after that. This check was replaced to ignore only null/invalid smart object types.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)