### PR TITLE
fix: memory leak in DynamicApplicationDataImpl class

### DIFF
--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -212,6 +212,21 @@ DynamicApplicationDataImpl::~DynamicApplicationDataImpl() {
     show_command_ = NULL;
   }
 
+  if (keyboard_props_) {
+    delete keyboard_props_;
+    keyboard_props_ = NULL;
+  }
+
+  if (menu_title_) {
+    delete menu_title_;
+    menu_title_ = NULL;
+  }
+
+  if (menu_icon_) {
+    delete menu_icon_;
+    menu_icon_ = NULL;
+  }
+
   if (tbt_show_command_) {
     delete tbt_show_command_;
     tbt_show_command_ = NULL;


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/2258

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run the procedure described in https://github.com/smartdevicelink/sdl_core/issues/2258 and confirm that the memory leaks are not detected.

### Summary
This PR releases member variables `keyboard_props_`, `menu_title_`, `menu_icon_` in the destructor of DynamicApplicationDataImpl instance.

### Changelog
##### Breaking Changes
* None

##### Enhancements
* None

##### Bug Fixes
* fix: memory leak in DynamicApplicationDataImpl class

### Tasks Remaining:
- None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)