### PR TITLE
Fix processing of receiving empty 'gpsData' struct

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/get_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/get_vehicle_data_request.cc
@@ -111,6 +111,18 @@ void GetVehicleDataRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::VehicleInfo_GetVehicleData: {
       EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
+      smart_objects::SmartObject& incoming_msg_params =
+          message[strings::msg_params];
+
+      if (incoming_msg_params.keyExists(strings::gps) &&
+          incoming_msg_params[strings::gps].empty()) {
+        LOG4CXX_ERROR(logger_, "Invalid response received from system");
+        SendResponse(false,
+                     mobile_apis::Result::GENERIC_ERROR,
+                     "Invalid response received from system");
+        return;
+      }
+
       hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());
@@ -120,11 +132,10 @@ void GetVehicleDataRequest::on_event(const event_engine::Event& event) {
       GetInfo(message, response_info);
       result = result ||
                ((hmi_apis::Common_Result::DATA_NOT_AVAILABLE == result_code) &&
-                (message[strings::msg_params].length() > 1));
+                !incoming_msg_params.empty());
 
-      if (true ==
-          message[strings::msg_params].keyExists(hmi_response::method)) {
-        message[strings::msg_params].erase(hmi_response::method);
+      if (incoming_msg_params.keyExists(hmi_response::method)) {
+        incoming_msg_params.erase(hmi_response::method);
       }
       if (true == message[strings::params].keyExists(strings::error_msg)) {
         response_info = message[strings::params][strings::error_msg].asString();
@@ -132,7 +143,7 @@ void GetVehicleDataRequest::on_event(const event_engine::Event& event) {
       SendResponse(result,
                    MessageHelper::HMIToMobileResult(result_code),
                    response_info.empty() ? NULL : response_info.c_str(),
-                   &(message[strings::msg_params]));
+                   &incoming_msg_params);
       break;
     }
     default: {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1949,7 +1949,7 @@ bool ApplicationManagerImpl::Stop() {
   application_list_update_timer_.Stop();
   try {
     SetUnregisterAllApplicationsReason(
-      mobile_api::AppInterfaceUnregisteredReason::IGNITION_OFF);
+        mobile_api::AppInterfaceUnregisteredReason::IGNITION_OFF);
     UnregisterAllApplications();
   } catch (...) {
     LOG4CXX_ERROR(logger_,


### PR DESCRIPTION
Fixes #1876

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
[x] ATF

### Summary
In case HMI sends empty 'gpsData' structure SDL forwards it to mobile.
But the right flow - SDL should sends GENERIC_ERROR with info 'Invalid response received from system'.
That was implemented

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)