### PR TITLE
fix: build breaks when ENABLE_SECURITY is OFF

### DIFF
--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -859,7 +859,9 @@ void ProtocolHandlerImpl::OnConnectionClosed(
 
 void ProtocolHandlerImpl::NotifyOnFailedHandshake() {
   LOG4CXX_AUTO_TRACE(logger_);
+#ifdef ENABLE_SECURITY
   security_manager_->NotifyListenersOnHandshakeFailed();
+#endif  // ENABLE_SECURITY
 }
 
 RESULT_CODE ProtocolHandlerImpl::SendFrame(const ProtocolFramePtr packet) {

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -99,9 +99,11 @@ using transport_manager::TransportManagerListener;
 using test::components::security_manager_test::MockSystemTimeHandler;
 using transport_manager::E_SUCCESS;
 using transport_manager::DeviceInfo;
+#ifdef ENABLE_SECURITY
 // For security
 using ContextCreationStrategy =
     security_manager::SecurityManager::ContextCreationStrategy;
+#endif  // ENABLE_SECURITY
 // For CH entities
 using connection_handler::DeviceHandle;
 // Google Testing Framework Entities


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/2279

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Retry build with ENABLE_SECURITY=OFF and BUILD_TESTS=ON, and confirm that the build succeeds.

### Summary
This PR fixes `security_manager` being exposed even when ENABLE_SECURITY is OFF.

### Changelog
##### Breaking Changes
* None

##### Enhancements
* None

##### Bug Fixes
* fix: build breaks when ENABLE_SECURITY is OFF

### Tasks Remaining:
- None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
