### PR TITLE
Update OnRCStatus with a new allowed parameter

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager.h
@@ -56,6 +56,19 @@ enum eType { FREE = 0, BUSY };
 }
 
 /**
+ * Defines triggers for OnRCStatus notification sending
+ */
+namespace NotificationTrigger {
+/**
+ * @brief The eType
+ * APP_REGISTRATION RC app registation event
+ * RC_STATE_CHANGING enabling/disabling RC on HMI event
+ * MODULE_ALLOCATION module allocation/deallocation event
+ */
+enum eType { APP_REGISTRATION = 0, MODULE_ALLOCATION, RC_STATE_CHANGING };
+}
+
+/**
  * @brief Resources defines list of resources
  */
 typedef std::vector<std::string> Resources;
@@ -146,9 +159,10 @@ class ResourceAllocationManager {
 
   /**
    * @brief Create and send OnRCStatusNotification to mobile and HMI
-   * @param application
+   * @param event trigger for notification sending
    */
-  virtual void SendOnRCStatusNotification() = 0;
+  virtual void SendOnRCStatusNotifications(
+      NotificationTrigger::eType event) = 0;
 
   virtual bool is_rc_enabled() const = 0;
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager_impl.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager_impl.h
@@ -118,7 +118,7 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
   RCAppExtensionPtr GetApplicationExtention(
       application_manager::ApplicationSharedPtr application) FINAL;
 
-  void SendOnRCStatusNotification() FINAL;
+  void SendOnRCStatusNotifications(NotificationTrigger::eType event) FINAL;
 
   bool is_rc_enabled() const FINAL;
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -91,9 +91,8 @@ void RCRPCPlugin::OnApplicationEvent(
   switch (event) {
     case plugins::kApplicationRegistered: {
       application->AddExtension(new RCAppExtension(kRCPluginID));
-      if (resource_allocation_manager_->is_rc_enabled()) {
-        resource_allocation_manager_->SendOnRCStatusNotification();
-      }
+      resource_allocation_manager_->SendOnRCStatusNotifications(
+          NotificationTrigger::APP_REGISTRATION);
       break;
     }
     case plugins::kApplicationExit: {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_resource_allocation_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_resource_allocation_manager.h
@@ -65,7 +65,8 @@ class MockResourceAllocationManager
                rc_rpc_plugin::RCAppExtensionPtr(
                    application_manager::ApplicationSharedPtr application));
   MOCK_METHOD0(ResetAllAllocations, void());
-  MOCK_METHOD0(SendOnRCStatusNotification, void());
+  MOCK_METHOD1(SendOnRCStatusNotifications,
+               void(rc_rpc_plugin::NotificationTrigger::eType));
   MOCK_CONST_METHOD0(is_rc_enabled, bool());
   MOCK_METHOD1(set_rc_enabled, void(const bool value));
 };

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -6113,6 +6113,13 @@
 
     <function name="OnRCStatus" functionID="OnRCStatusID" messagetype="notification">
       <description>Issued by SDL to notify the application about remote control status change on SDL</description>
+      <param name="allowed" type="Boolean" mandatory="false">
+        <description>
+            If "true" - RC is allowed; if "false" - RC is disallowed.
+            Not present in notification in case by module allocation/deallocation.
+            Present in notification in cases enabling/disabling RC or RC-app registration.
+        </description>
+      </param>
       <param name="allocatedModules" type="ModuleData" minsize="0" maxsize="100" array="true" mandatory="true">
         <description>Contains a list (zero or more) of module types that are allocated to the application.</description>
       </param>


### PR DESCRIPTION
Implementation of https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0172-onRcStatus-allowed.md 
clarification: https://github.com/smartdevicelink/sdl_requirements/issues/84

now we send OnRCStatus in following cases:

1. When we register RC app and _RC disabled_ on HMI:
    SDL->mob (_only to mob_) OnRCStatus with _allowed = false_

2. When we register RC app and _RC enabled_ on HMI:
    SDL->mob OnRCStatus with _allowed = true_
    SDL->HMI  OnRCStatus 

3. When we enable/disable RC:
     SDL->mob(_only to mob_)  OnRCStatus with _allowed = true/false_

4. Module allocation:
    SDL->mob OnRCStatus _without allowed param_
    SDL->HMI  OnRCStatus 

and when _allowed = false_ : allocatedModules, freeModules - empty arrays