### PR TITLE
avoid returning null hmiLevel

### DIFF
--- a/src/components/application_manager/src/commands/mobile/on_hmi_status_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_hmi_status_notification.cc
@@ -57,6 +57,16 @@ void OnHMIStatusNotification::Run() {
     return;
   }
 
+  // If the RPC was bad, give up now and don't try to check hmi level
+  if ((*message_)[strings::msg_params][strings::result_code] ==
+      mobile_apis::Result::INVALID_DATA) {
+    SendNotification();
+    // we failed due to invalid data, don't do anything else
+    return;
+  }
+
+  // NOTE c++ maps default-construct on the [] operator, so if there is no
+  // hmiLevel field this will create one that is invalid
   mobile_apis::HMILevel::eType hmi_level =
       static_cast<mobile_apis::HMILevel::eType>(
           (*message_)[strings::msg_params][strings::hmi_level].asInt());

--- a/src/components/application_manager/src/commands/mobile/on_hmi_status_notification.cc
+++ b/src/components/application_manager/src/commands/mobile/on_hmi_status_notification.cc
@@ -57,11 +57,10 @@ void OnHMIStatusNotification::Run() {
     return;
   }
 
-  // If the RPC was bad, give up now and don't try to check hmi level
-  if ((*message_)[strings::msg_params][strings::result_code] ==
-      mobile_apis::Result::INVALID_DATA) {
-    SendNotification();
-    // we failed due to invalid data, don't do anything else
+  // If the response has no hmi level, return and don't send the notification
+  if (!(*message_)[strings::msg_params].keyExists(strings::hmi_level)) {
+    // our notification clearly isn't well-formed
+    LOG4CXX_ERROR(logger_, "OnHMIStatusNotification has no hmiLevel field");
     return;
   }
 


### PR DESCRIPTION
Fixes #2285.

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
run smoke tests, unit tests, verify correct behavior on both Android and iOS with poorly-formed OnHMIStatus calls.

### Summary
Add validity check to avoid default-constructed invalid hmi level.

##### Bug Fixes
* Stops core from inadvertently returning ```{
   "hmiLevel" : null
}``` JSON as an OnHMIStatus notification.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)