### PR TITLE
Sdl use incorrect url on system request

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -83,7 +83,8 @@ class PolicyHandler : public PolicyHandlerInterface,
   bool ResetPolicyTable() OVERRIDE;
   bool ClearUserConsent() OVERRIDE;
   bool SendMessageToSDK(const BinaryMessage& pt_string,
-                        const std::string& url) OVERRIDE;
+                        const std::string& url,
+                        const uint32_t app_id) OVERRIDE;
   bool ReceiveMessageFromSDK(const std::string& file,
                              const BinaryMessage& pt_string) OVERRIDE;
   bool UnloadPolicyLibrary() OVERRIDE;

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1494,12 +1494,14 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
   }
 
   const uint32_t app_id = GetAppIdForSending();
-  const std::string app_policy_id = application_manager_.application(app_id)->policy_app_id();
+  const std::string app_policy_id =
+      application_manager_.application(app_id)->policy_app_id();
 
   size_t app_idx = 0;
   for (; app_idx < urls.size(); ++app_idx) {
-    if ((urls[app_idx].app_id == policy::kDefaultId || urls[app_idx].app_id == app_policy_id)
-      && IsUrlAppIdValid(app_idx, urls))
+    if ((urls[app_idx].app_id == policy::kDefaultId ||
+         urls[app_idx].app_id == app_policy_id) &&
+        IsUrlAppIdValid(app_idx, urls))
       break;
   }
 
@@ -1510,7 +1512,7 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
 
   for (size_t url_idx = 0; url_idx < urls[app_idx].url.size(); ++url_idx) {
     const std::string& url = urls[app_idx].url[url_idx];
-    if(SendMessageToSDK(pt_string, url, app_id))
+    if (SendMessageToSDK(pt_string, url, app_id))
       break;
   }
 #endif  // PROPRIETARY_MODE

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1032,11 +1032,11 @@ void PolicyHandler::OnPendingPermissionChange(
 }
 
 bool PolicyHandler::SendMessageToSDK(const BinaryMessage& pt_string,
-                                     const std::string& url) {
+                                     const std::string& url,
+                                     const uint32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK(false);
 
-  const uint32_t app_id = GetAppIdForSending();
   ApplicationSharedPtr app = application_manager_.application(app_id);
 
   if (!app) {
@@ -1493,12 +1493,26 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
     return;
   }
 
-  AppIdURL app_url = policy_manager_->GetNextUpdateUrl(urls);
-  while (!IsUrlAppIdValid(app_url.first, urls)) {
-    app_url = policy_manager_->GetNextUpdateUrl(urls);
+  const uint32_t app_id = GetAppIdForSending();
+  const std::string app_policy_id = application_manager_.application(app_id)->policy_app_id();
+
+  size_t app_idx = 0;
+  for (; app_idx < urls.size(); ++app_idx) {
+    if ((urls[app_idx].app_id == policy::kDefaultId || urls[app_idx].app_id == app_policy_id)
+      && IsUrlAppIdValid(app_idx, urls))
+      break;
   }
-  const std::string& url = urls[app_url.first].url[app_url.second];
-  SendMessageToSDK(pt_string, url);
+
+  if (app_idx >= urls.size()) {
+    LOG4CXX_ERROR(logger_, "All applications unavailable!");
+    return;
+  }
+
+  for (size_t url_idx = 0; url_idx < urls[app_idx].url.size(); ++url_idx) {
+    const std::string& url = urls[app_idx].url[url_idx];
+    if(SendMessageToSDK(pt_string, url, app_id))
+      break;
+  }
 #endif  // PROPRIETARY_MODE
   // reset update required false
   OnUpdateRequestSentToMobile();

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1499,8 +1499,11 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
 
   size_t app_idx = 0;
   for (; app_idx < urls.size(); ++app_idx) {
-    if ((urls[app_idx].app_id == policy::kDefaultId ||
-         urls[app_idx].app_id == app_policy_id) &&
+    if (helpers::Compare<std::string, helpers::EQ, helpers::ONE>(
+            policy::kDefaulgit tId,
+            urls[app_idx].app_id,
+            urls[app_idx].app_id,
+            app_policy_id) &&
         IsUrlAppIdValid(app_idx, urls))
       break;
   }

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -1683,11 +1683,8 @@ TEST_F(PolicyHandlerTest, DISABLED_OnSnapshotCreated_UrlAdded) {
 #ifdef PROPRIETARY_MODE
   ExtendedPolicyExpectations();
 #else
-  AppIdURL next_app_url = std::make_pair(0, 0);
   EXPECT_CALL(*mock_policy_manager_, GetUpdateUrls("0x07", _))
       .WillRepeatedly(SetArgReferee<1>(test_data));
-  EXPECT_CALL(*mock_policy_manager_, GetNextUpdateUrl(_))
-      .WillOnce(Return(next_app_url));
   EXPECT_CALL(app_manager_, application_by_policy_id(_))
       .WillOnce(Return(mock_app));
   EXPECT_CALL(app_manager_, connection_handler())
@@ -2052,7 +2049,8 @@ TEST_F(PolicyHandlerTest,
   // Act
   EXPECT_CALL(mock_message_helper_,
               SendPolicySnapshotNotification(kAppId1_, msg, url, _));
-  EXPECT_TRUE(policy_handler_.SendMessageToSDK(msg, url));
+  const uint32_t app_id = policy_handler_.GetAppIdForSending();
+  EXPECT_TRUE(policy_handler_.SendMessageToSDK(msg, url, app_id));
 }
 
 TEST_F(PolicyHandlerTest,
@@ -2082,7 +2080,8 @@ TEST_F(PolicyHandlerTest,
       .WillOnce(Return(
           utils::SharedPtr<application_manager_test::MockApplication>()));
 
-  EXPECT_FALSE(policy_handler_.SendMessageToSDK(msg, url));
+  const uint32_t app_id = policy_handler_.GetAppIdForSending();
+  EXPECT_FALSE(policy_handler_.SendMessageToSDK(msg, url, app_id));
 }
 
 TEST_F(PolicyHandlerTest, CanUpdate) {

--- a/src/components/application_manager/test/rc_policy_handler_test.cc
+++ b/src/components/application_manager/test/rc_policy_handler_test.cc
@@ -175,7 +175,8 @@ TEST_F(RCPolicyHandlerTest,
 
   EXPECT_CALL(mock_message_helper_, SendPolicySnapshotNotification(_, _, _, _))
       .Times(0);
-  EXPECT_FALSE(policy_handler_.SendMessageToSDK(msg, kUrl_));
+  const uint32_t app_id = policy_handler_.GetAppIdForSending();
+  EXPECT_FALSE(policy_handler_.SendMessageToSDK(msg, kUrl_, app_id));
 }
 
 TEST_F(RCPolicyHandlerTest, SendMessageToSDK_RemoteControl_SUCCESS) {
@@ -199,7 +200,8 @@ TEST_F(RCPolicyHandlerTest, SendMessageToSDK_RemoteControl_SUCCESS) {
 
   EXPECT_CALL(mock_message_helper_,
               SendPolicySnapshotNotification(kAppId1_, _, kUrl_, _));
-  EXPECT_TRUE(policy_handler_.SendMessageToSDK(msg, kUrl_));
+  const uint32_t app_id = policy_handler_.GetAppIdForSending();
+  EXPECT_TRUE(policy_handler_.SendMessageToSDK(msg, kUrl_, app_id));
 }
 
 TEST_F(RCPolicyHandlerTest, OnUpdateHMILevel_InvalidApp_UNSUCCESS) {

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -64,7 +64,8 @@ class PolicyHandlerInterface {
   virtual bool ResetPolicyTable() = 0;
   virtual bool ClearUserConsent() = 0;
   virtual bool SendMessageToSDK(const BinaryMessage& pt_string,
-                                const std::string& url) = 0;
+                                const std::string& url,
+                                const uint32_t app_id) = 0;
   virtual bool ReceiveMessageFromSDK(const std::string& file,
                                      const BinaryMessage& pt_string) = 0;
   virtual bool UnloadPolicyLibrary() = 0;

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -532,14 +532,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    */
   virtual const PolicySettings& get_settings() const = 0;
 
-  /**
-   * @brief Finds the next URL that must be sent on OnSystemRequest retry
-   * @param urls vector of vectors that contain urls for each application
-   * @return Pair of policy application id and application url id from the
-   * urls vector
-   */
-  virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) = 0;
-
 #ifdef SDL_REMOTE_CONTROL
   /**
    * @brief Assigns new HMI types for specified application
@@ -590,18 +582,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void set_access_remote(
       utils::SharedPtr<AccessRemote> access_remote) = 0;
 #endif  // SDL_REMOTE_CONTROL
-
-  /**
-   * @brief Checks if there is existing URL in the EndpointUrls vector with
-   * index saved in the policy manager and if not, it moves to the next
-   * application index
-   * @param rs contains the application index and url index from the
-   * urls vector that are to be sent on the next OnSystemRequest
-   * @param urls vector of vectors that contain urls for each application
-   * @return Pair of application index and url index
-   */
-  virtual AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
-                                    const EndpointUrls& urls) const = 0;
 
   /**
    * @brief  Checks, if SDL needs to update it's policy table section

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -510,13 +510,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    */
   virtual const PolicySettings& get_settings() const = 0;
 
-  /**
-   * @brief Finds the next URL that must be sent on OnSystemRequest retry
-   * @param urls vector of vectors that contain urls for each application
-   * @return Pair of policy application id and application url id from the
-   * urls vector
-   */
-  virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) = 0;
 #ifdef SDL_REMOTE_CONTROL
   /**
    * @brief Assigns new HMI types for specified application
@@ -568,18 +561,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void set_access_remote(
       utils::SharedPtr<AccessRemote> access_remote) = 0;
 #endif  // SDL_REMOTE_CONTROL
-
-  /**
-   * @brief Checks if there is existing URL in the EndpointUrls vector with
-   * index saved in the policy manager and if not, it moves to the next
-   * application index
-   * @param rs contains the application index and url index from the
-   * urls vector that are to be sent on the next OnSystemRequest
-   * @param urls vector of vectors that contain urls for each application
-   * @return Pair of application index and url index
-   */
-  virtual AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
-                                    const EndpointUrls& urls) const = 0;
 
  protected:
   /**

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -50,9 +50,10 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD0(InitPolicyTable, bool());
   MOCK_METHOD0(ResetPolicyTable, bool());
   MOCK_METHOD0(ClearUserConsent, bool());
-  MOCK_METHOD2(SendMessageToSDK,
+  MOCK_METHOD3(SendMessageToSDK,
                bool(const policy::BinaryMessage& pt_string,
-                    const std::string& url));
+                    const std::string& url,
+                    const uint32_t app_id));
   MOCK_METHOD2(ReceiveMessageFromSDK,
                bool(const std::string& file,
                     const policy::BinaryMessage& pt_string));

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -207,10 +207,6 @@ class MockPolicyManager : public PolicyManager {
                     int32_t timespan_seconds));
   MOCK_CONST_METHOD0(get_settings, const PolicySettings&());
   MOCK_METHOD1(set_settings, void(const PolicySettings* get_settings));
-  MOCK_METHOD1(GetNextUpdateUrl, AppIdURL(const EndpointUrls& urls));
-  MOCK_CONST_METHOD2(RetrySequenceUrl,
-                     AppIdURL(const struct RetrySequenceURL&,
-                              const EndpointUrls& urls));
   MOCK_METHOD1(SetExternalConsentStatus, bool(const ExternalConsentStatus&));
   MOCK_METHOD0(GetExternalConsentStatus, ExternalConsentStatus());
   MOCK_CONST_METHOD1(IsNeedToUpdateExternalConsentStatus,

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -207,10 +207,6 @@ class MockPolicyManager : public PolicyManager {
   MOCK_CONST_METHOD0(get_settings, const PolicySettings&());
   MOCK_METHOD1(set_settings, void(const PolicySettings* get_settings));
   MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
-  MOCK_METHOD1(GetNextUpdateUrl, AppIdURL(const EndpointUrls& urls));
-  MOCK_CONST_METHOD2(RetrySequenceUrl,
-                     AppIdURL(const struct RetrySequenceURL&,
-                              const EndpointUrls& urls));
   MOCK_METHOD6(CheckPermissions,
                void(const PTString& device_id,
                     const PTString& app_id,

--- a/src/components/policy/policy_external/include/policy/policy_types.h
+++ b/src/components/policy/policy_external/include/policy/policy_types.h
@@ -367,26 +367,6 @@ struct MetaInfo {
   std::string language;
 };
 
-/**
- * @brief The index of the application, the index of its URL
- * and the policy application id from the Endpoints vector
- * that will be sent on the next OnSystemRequest retry sequence
- */
-struct RetrySequenceURL {
-  uint32_t app_idx_;
-  uint32_t url_idx_;
-  std::string policy_app_id_;
-  RetrySequenceURL(uint32_t app, uint32_t url, const std::string& app_id)
-      : app_idx_(app), url_idx_(url), policy_app_id_(app_id) {}
-  RetrySequenceURL() : app_idx_(0), url_idx_(0) {}
-};
-
-/**
- * @brief Index of the application, index of its URL
- * from the Endpoints vector
- */
-typedef std::pair<uint32_t, uint32_t> AppIdURL;
-
 enum EntityStatus { kStatusOn, kStatusOff };
 
 enum ReturnValue { kZero, kNonZero };

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -222,8 +222,7 @@ PolicyManagerImpl::PolicyManagerImpl()
 #endif  // SDL_REMOTE_CONTROL
     , retry_sequence_timeout_(60)
     , retry_sequence_index_(0)
-    , ignition_check(true)
-    , retry_sequence_url_(0, 0, "") {
+    , ignition_check(true) {
 }
 
 PolicyManagerImpl::PolicyManagerImpl(bool in_memory)
@@ -237,7 +236,6 @@ PolicyManagerImpl::PolicyManagerImpl(bool in_memory)
     , retry_sequence_timeout_(60)
     , retry_sequence_index_(0)
     , ignition_check(true)
-    , retry_sequence_url_(0, 0, "")
     , wrong_ptu_update_received_(false)
     , send_on_update_sent_out_(false)
     , trigger_ptu_(false) {
@@ -1697,46 +1695,6 @@ void PolicyManagerImpl::SetDecryptedCertificate(
     const std::string& certificate) {
   LOG4CXX_AUTO_TRACE(logger_);
   cache_->SetDecryptedCertificate(certificate);
-}
-
-AppIdURL PolicyManagerImpl::GetNextUpdateUrl(const EndpointUrls& urls) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  const AppIdURL next_app_url = RetrySequenceUrl(retry_sequence_url_, urls);
-
-  retry_sequence_url_.url_idx_ = next_app_url.second + 1;
-  retry_sequence_url_.app_idx_ = next_app_url.first;
-  retry_sequence_url_.policy_app_id_ = urls[next_app_url.first].app_id;
-
-  return next_app_url;
-}
-
-AppIdURL PolicyManagerImpl::RetrySequenceUrl(const struct RetrySequenceURL& rs,
-                                             const EndpointUrls& urls) const {
-  uint32_t url_idx = rs.url_idx_;
-  uint32_t app_idx = rs.app_idx_;
-  const std::string& app_id = rs.policy_app_id_;
-
-  if (urls.size() <= app_idx) {
-    // Index of current application doesn't exist any more due to app(s)
-    // unregistration
-    url_idx = 0;
-    app_idx = 0;
-  } else if (urls[app_idx].app_id != app_id) {
-    // Index of current application points to another one due to app(s)
-    // registration/unregistration
-    url_idx = 0;
-  } else if (url_idx >= urls[app_idx].url.size()) {
-    // Index of current application is OK, but all of its URL are sent,
-    // move to the next application
-    url_idx = 0;
-    if (++app_idx >= urls.size()) {
-      app_idx = 0;
-    }
-  }
-  const AppIdURL next_app_url = std::make_pair(app_idx, url_idx);
-
-  return next_app_url;
 }
 
 /**

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -570,26 +570,6 @@ class PolicyManagerImpl : public PolicyManager {
    */
   bool HasCertificate() const OVERRIDE;
 
-  /**
-   * @brief Finds the next URL that must be sent on OnSystemRequest retry
-   * @param urls vector of vectors that contain urls for each application
-   * @return Pair of policy application id and application url id from the
-   * urls vector
-   */
-  AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) OVERRIDE;
-
-  /**
-   * @brief Checks if there is existing URL in the EndpointUrls vector with
-   * index saved in the policy manager and if not, it moves to the next
-   * application index
-   * @param rs contains the application index and url index from the
-   * urls vector that are to be sent on the next OnSystemRequest
-   * @param urls vector of vectors that contain urls for each application
-   * @return Pair of application index and url index
-   */
-  AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
-                            const EndpointUrls& urls) const OVERRIDE;
-
 #ifdef BUILD_TESTS
   /**
    * @brief Getter for cache_manager instance
@@ -911,12 +891,6 @@ class PolicyManagerImpl : public PolicyManager {
   const PolicySettings* settings_;
   friend struct CheckAppPolicy;
   friend struct ProccessAppGroups;
-
-  /**
-   * @brief Pair of app index and url index from Endpoints vector
-   * that contains all application URLs
-   */
-  RetrySequenceURL retry_sequence_url_;
 
   /**
    * @brief Flag for notifying that invalid PTU was received

--- a/src/components/policy/policy_regular/include/policy/policy_types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_types.h
@@ -368,26 +368,6 @@ struct MetaInfo {
 };
 
 /**
- * @brief The index of the application, the index of its URL
- * and the policy application id from the Endpoints vector
- * that will be sent on the next OnSystemRequest retry sequence
- */
-struct RetrySequenceURL {
-  uint32_t app_idx_;
-  uint32_t url_idx_;
-  std::string policy_app_id_;
-  RetrySequenceURL(uint32_t app, uint32_t url, const std::string& app_id)
-      : app_idx_(app), url_idx_(url), policy_app_id_(app_id) {}
-  RetrySequenceURL() : app_idx_(0), url_idx_(0) {}
-};
-
-/**
- * @brief Index of the application, index of its URL
- * from the Endpoints vector
- */
-typedef std::pair<uint32_t, uint32_t> AppIdURL;
-
-/**
  * @brief Represents ExternalConsent entity status received from the system
  */
 enum EntityStatus { kStatusOn, kStatusOff };
@@ -480,12 +460,6 @@ enum PermissionsCheckResult {
  */
 typedef std::set<std::pair<std::string, PermissionsCheckResult> >
     CheckAppPolicyResults;
-
-/**
- * @brief Index of the application, index of its URL
- * from the Endpoints vector
- */
-typedef std::pair<uint32_t, uint32_t> AppIdURL;
 
 }  //  namespace policy
 

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -86,7 +86,6 @@ PolicyManagerImpl::PolicyManagerImpl()
                             new timer::TimerTaskImpl<PolicyManagerImpl>(
                                 this, &PolicyManagerImpl::RetrySequence))
     , ignition_check(true)
-    , retry_sequence_url_(0, 0, "")
     , wrong_ptu_update_received_(false)
     , send_on_update_sent_out_(false)
     , trigger_ptu_(false) {
@@ -981,46 +980,6 @@ void PolicyManagerImpl::MarkUnpairedDevice(const std::string& device_id) {}
 std::string PolicyManagerImpl::RetrieveCertificate() const {
   LOG4CXX_AUTO_TRACE(logger_);
   return cache_->GetCertificate();
-}
-
-AppIdURL PolicyManagerImpl::GetNextUpdateUrl(const EndpointUrls& urls) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  const AppIdURL next_app_url = RetrySequenceUrl(retry_sequence_url_, urls);
-
-  retry_sequence_url_.url_idx_ = next_app_url.second + 1;
-  retry_sequence_url_.app_idx_ = next_app_url.first;
-  retry_sequence_url_.policy_app_id_ = urls[next_app_url.first].app_id;
-
-  return next_app_url;
-}
-
-AppIdURL PolicyManagerImpl::RetrySequenceUrl(const struct RetrySequenceURL& rs,
-                                             const EndpointUrls& urls) const {
-  uint32_t url_idx = rs.url_idx_;
-  uint32_t app_idx = rs.app_idx_;
-  const std::string& app_id = rs.policy_app_id_;
-
-  if (urls.size() <= app_idx) {
-    // Index of current application doesn't exist any more due to app(s)
-    // unregistration
-    url_idx = 0;
-    app_idx = 0;
-  } else if (urls[app_idx].app_id != app_id) {
-    // Index of current application points to another one due to app(s)
-    // registration/unregistration
-    url_idx = 0;
-  } else if (url_idx >= urls[app_idx].url.size()) {
-    // Index of current application is OK, but all of its URL are sent,
-    // move to the next application
-    url_idx = 0;
-    if (++app_idx >= urls.size()) {
-      app_idx = 0;
-    }
-  }
-  const AppIdURL next_app_url = std::make_pair(app_idx, url_idx);
-
-  return next_app_url;
 }
 
 bool PolicyManagerImpl::HasCertificate() const {


### PR DESCRIPTION
Fixes [#1246](https://github.com/SmartDeviceLink/sdl_core/issues/1219)

This PR is **ready** for review.

### Risk

This PR **not makes** API changes.

### Testing Plan

TODO: Provide ATF tests.

### Summary

In the existing implementation, there is a choice of an url from all available, then randomly select an application to send messages by policyHandler. It can be possible to selected url and applications that are not related. It happen when application tries to get the policy on the url available to another application.

It was implemented to choose of the application and then url from the available to current app.

### CLA
- [x]  I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
  