### PR TITLE
fix section consumer_friendly_messages #1222

### DIFF
--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -609,8 +609,9 @@ const std::string kInsertLanguage =
     "INSERT OR IGNORE INTO `language` (`code`) VALUES (?)";
 
 const std::string kInsertMessageString =
-    "INSERT INTO `message` (`language_code`, `message_type_name`) "
-    "VALUES (?, ?)";
+    "INSERT INTO `message` (`tts`,`label`,`line1`,`line2`,`textBody`,"
+    "`language_code`, `message_type_name`) "
+    "VALUES (?,?,?,?,?,?,?)";
 
 const std::string kUpdateModuleConfig =
     "UPDATE `module_config` SET `preloaded_pt` = ?, "

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -1320,6 +1320,7 @@ bool SQLPTRepresentation::SaveConsumerFriendlyMessages(
     if (!SaveMessageType(it->first)) {
       return false;
     }
+
     const policy_table::Languages& langs = it->second.languages;
     policy_table::Languages::const_iterator lang_it;
     for (lang_it = langs.begin(); lang_it != langs.end(); ++lang_it) {
@@ -1377,8 +1378,13 @@ bool SQLPTRepresentation::SaveMessageString(
     return false;
   }
 
-  query.Bind(0, lang);
-  query.Bind(1, type);
+  query.Bind(0, *strings.tts);
+  query.Bind(1, *strings.label);
+  query.Bind(2, *strings.line1);
+  query.Bind(3, *strings.line2);
+  query.Bind(4, *strings.textBody);
+  query.Bind(5, lang);
+  query.Bind(6, type);
 
   if (!query.Exec() || !query.Reset()) {
     LOG4CXX_WARN(logger_, "Incorrect insert into message.");


### PR DESCRIPTION
Fixes  #1222

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF script: [083_ATF_PTU_UTF8_Encoding_Check_HTTP](https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/develop/test_scripts/Policies/build_options/083_ATF_PTU_UTF8_Encoding_Check_HTTP.lua)

### Summary
SDL updates consumer_friendly_messages.messages section,
insert rows with tts, label, line1, line2 and textBody fields.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)