### PR TITLE
fix: invalid memory access in Policy Manager when HMI level is invalid

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1527,6 +1527,13 @@ void PolicyHandler::CheckPermissions(
   POLICY_LIB_CHECK_VOID();
   const std::string hmi_level =
       MessageHelper::StringifiedHMILevel(app->hmi_level());
+  if (hmi_level.empty()) {
+    LOG4CXX_WARN(logger_,
+                 "HMI level for " << app->policy_app_id() << " is invalid, rpc "
+                                  << rpc << " is not allowed.");
+    result.hmi_level_permitted = policy::kRpcDisallowed;
+    return;
+  }
   const std::string device_id = MessageHelper::GetDeviceMacAddressForHandle(
       app->device(), application_manager_);
   LOG4CXX_INFO(logger_,


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/2298

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Make sure existing unit tests pass.

### Summary
This PR adds sanitization of `app->hmi_level()` value in `PolicyHandler::CheckPermissions()`. This will prevent further methods accessing to empty `hmi_level` and making an invalid memory access.

### Changelog
##### Breaking Changes
* None

##### Enhancements
* None

##### Bug Fixes
* fix: invalid memory access in Policy Manager when HMI level is invalid

### Tasks Remaining:
- None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)