### PR TITLE
Create third-party cmake targets if none exists

### DIFF
--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -201,6 +201,7 @@ if (${BSON_LIB} MATCHES "BSON_LIB-NOTFOUND")
       BUILD_COMMAND make
       INSTALL_COMMAND ${BSON_INSTALL_COMMAND})
 else()
+  add_custom_target(libbson) # empty target, bson is already installed
   get_filename_component(BSON_LIBS_DIRECTORY ${BSON_LIB} DIRECTORY)
   get_filename_component(EMHASHMAP_LIBS_DIRECTORY ${EMHASHMAP_LIB} DIRECTORY)
   set(BSON_LIBS_DIRECTORY ${BSON_LIBS_DIRECTORY} CACHE INTERNAL "Installation path of bson libraries" FORCE)
@@ -234,6 +235,8 @@ if (HMIADAPTER STREQUAL "messagebroker")
 
     set(BOOST_INCLUDE_DIR ${BOOST_ROOT_DIR}/Boost-prefix/src/Boost)
     set(BOOST_LIB_DIR ${BOOST_ROOT_DIR}/Boost-prefix/src/Boost/stage/lib/)
+  else()
+  add_custom_target(Boost) # empty target, Boost is already installed
   endif()
 endif()
 


### PR DESCRIPTION
Fixes #2301 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Try different make targets to ensure they all build correctly with dependencies.
Shouldn't need to test core itself since it only affects configuration

### Summary
If Boost or libbson are found on a system, a default CMake target is created to match the one that would have been created in their absence. This allows other targets (Utils, etc.) to list Boost/libbson as dependencies for proper Makefile ordering. 
Should have no portability concerns.

##### Bug Fixes
* fixes documented bug

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)