### PR TITLE
Impl/get interior data using cache

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_button_press_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_button_press_request.h
@@ -35,6 +35,7 @@
 
 #include "application_manager/commands/request_to_hmi.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -58,7 +59,8 @@ class RCButtonPressRequest
                        app_mngr::rpc_service::RPCService& rpc_service,
                        app_mngr::HMICapabilities& hmi_capabilities,
                        policy::PolicyHandlerInterface& policy_handle,
-                       ResourceAllocationManager& resource_allocation_manager);
+                       ResourceAllocationManager& resource_allocation_manager,
+                       InteriorDataCache& interior_data_cache);
   /**
    * @brief Execute command
    */

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_button_press_response.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_button_press_response.h
@@ -35,6 +35,7 @@
 
 #include "application_manager/commands/response_from_hmi.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -58,7 +59,8 @@ class RCButtonPressResponse
                         app_mngr::rpc_service::RPCService& rpc_service,
                         app_mngr::HMICapabilities& hmi_capabilities,
                         policy::PolicyHandlerInterface& policy_handle,
-                        ResourceAllocationManager& resource_allocation_manager);
+                        ResourceAllocationManager& resource_allocation_manager,
+                        InteriorDataCache& interior_data_cache);
 
   void Run() OVERRIDE;
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_consent_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_consent_request.h
@@ -35,6 +35,7 @@
 
 #include "application_manager/commands/request_to_hmi.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -50,7 +51,8 @@ class RCGetInteriorVehicleDataConsentRequest
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handle,
-      ResourceAllocationManager& resource_allocation_manager);
+      ResourceAllocationManager& resource_allocation_manager,
+      InteriorDataCache& interior_data_cache);
 
   void Run() OVERRIDE;
   ~RCGetInteriorVehicleDataConsentRequest();

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_consent_response.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_consent_response.h
@@ -35,6 +35,7 @@
 
 #include "application_manager/commands/response_from_hmi.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -59,7 +60,8 @@ class RCGetInteriorVehicleDataConsentResponse
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handle,
-      ResourceAllocationManager& resource_allocation_manager);
+      ResourceAllocationManager& resource_allocation_manager,
+      InteriorDataCache& interior_data_cache);
 
   void Run() OVERRIDE;
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_request.h
@@ -35,6 +35,7 @@
 
 #include "application_manager/commands/request_to_hmi.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -50,7 +51,8 @@ class RCGetInteriorVehicleDataRequest
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handle,
-      ResourceAllocationManager& resource_allocation_manager);
+      ResourceAllocationManager& resource_allocation_manager,
+      InteriorDataCache& interior_data_cache);
 
   void Run() OVERRIDE;
   ~RCGetInteriorVehicleDataRequest();

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_response.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_response.h
@@ -35,6 +35,7 @@
 
 #include "application_manager/commands/response_from_hmi.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -50,7 +51,8 @@ class RCGetInteriorVehicleDataResponse
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handle,
-      ResourceAllocationManager& resource_allocation_manager);
+      ResourceAllocationManager& resource_allocation_manager,
+      InteriorDataCache& interior_data_cache);
 
   void Run() OVERRIDE;
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_on_interior_vehicle_data_notification.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_on_interior_vehicle_data_notification.h
@@ -35,6 +35,7 @@
 
 #include "application_manager/commands/notification_from_hmi.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -59,7 +60,8 @@ class RCOnInteriorVehicleDataNotification
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handle,
-      ResourceAllocationManager& resource_allocation_manager);
+      ResourceAllocationManager& resource_allocation_manager,
+      InteriorDataCache& interior_data_cache);
 
   ~RCOnInteriorVehicleDataNotification();
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_on_remote_control_settings_notification.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_on_remote_control_settings_notification.h
@@ -34,6 +34,7 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_COMMANDS_HMI_RC_ON_REMOTE_CONTROL_SETTINGS_NOTIFICATION_H
 
 #include "application_manager/commands/notification_from_hmi.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
 #include "utils/macro.h"
 
@@ -59,7 +60,8 @@ class RCOnRemoteControlSettingsNotification
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handle,
-      rc_rpc_plugin::ResourceAllocationManager& resource_allocation_manager);
+      rc_rpc_plugin::ResourceAllocationManager& resource_allocation_manager,
+      InteriorDataCache& interior_data_cache);
   /**
    * @brief Execute command
    **/

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_set_interior_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_set_interior_vehicle_data_request.h
@@ -35,6 +35,7 @@
 
 #include "application_manager/commands/request_to_hmi.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -59,7 +60,8 @@ class RCSetInteriorVehicleDataRequest
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handle,
-      ResourceAllocationManager& resource_allocation_manager);
+      ResourceAllocationManager& resource_allocation_manager,
+      InteriorDataCache& interior_data_cache);
   void Run() OVERRIDE;
   ~RCSetInteriorVehicleDataRequest();
 };

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_set_interior_vehicle_data_response.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_set_interior_vehicle_data_response.h
@@ -35,6 +35,7 @@
 
 #include "application_manager/commands/response_from_hmi.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -59,7 +60,8 @@ class RCSetInteriorVehicleDataResponse
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handle,
-      ResourceAllocationManager& resource_allocation_manager);
+      ResourceAllocationManager& resource_allocation_manager,
+      InteriorDataCache& interior_data_cache);
 
   void Run() OVERRIDE;
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/button_press_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/button_press_request.h
@@ -46,7 +46,8 @@ class ButtonPressRequest : public RCCommandRequest {
                      app_mngr::rpc_service::RPCService& rpc_service,
                      app_mngr::HMICapabilities& hmi_capabilities,
                      policy::PolicyHandlerInterface& policy_handle,
-                     ResourceAllocationManager& resource_allocation_manager);
+                     ResourceAllocationManager& resource_allocation_manager,
+                     InteriorDataCache& interior_data_cache);
 
   /**
    * @brief Execute command

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/button_press_response.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/button_press_response.h
@@ -35,6 +35,7 @@
 
 #include "application_manager/commands/command_response_impl.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -49,7 +50,8 @@ class ButtonPressResponse
                       app_mngr::rpc_service::RPCService& rpc_service,
                       app_mngr::HMICapabilities& hmi_capabilities,
                       policy::PolicyHandlerInterface& policy_handle,
-                      ResourceAllocationManager& resource_allocation_manager);
+                      ResourceAllocationManager& resource_allocation_manager,
+                      InteriorDataCache& interior_data_cache);
   void Run() OVERRIDE;
   /**
    * @brief ButtonPressResponse class destructor

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/get_interior_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/get_interior_vehicle_data_request.h
@@ -48,7 +48,8 @@ class GetInteriorVehicleDataRequest : public RCCommandRequest {
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handle,
-      ResourceAllocationManager& resource_allocation_manager);
+      ResourceAllocationManager& resource_allocation_manager,
+      InteriorDataCache& interior_data_cache);
   /**
    * @brief Execute command
    */

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/get_interior_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/get_interior_vehicle_data_request.h
@@ -68,6 +68,9 @@ class GetInteriorVehicleDataRequest : public RCCommandRequest {
   ~GetInteriorVehicleDataRequest();
 
  private:
+  std::vector<application_manager::ApplicationSharedPtr>
+  AppsSubscribedToModuleType(const std::string& module_type);
+
   /**
    * @brief Check if app wants to proceed with already setup subscription
    * @param request_params request parameters to check

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/get_interior_vehicle_data_response.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/get_interior_vehicle_data_response.h
@@ -35,6 +35,7 @@
 
 #include "application_manager/commands/command_response_impl.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -50,7 +51,8 @@ class GetInteriorVehicleDataResponse
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handle,
-      ResourceAllocationManager& resource_allocation_manager);
+      ResourceAllocationManager& resource_allocation_manager,
+      InteriorDataCache& interior_data_cache);
 
   void Run() OVERRIDE;
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/on_interior_vehicle_data_notification.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/on_interior_vehicle_data_notification.h
@@ -36,6 +36,7 @@
 #include <string>
 #include "application_manager/commands/command_notification_impl.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -51,13 +52,17 @@ class OnInteriorVehicleDataNotification
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handler,
-      ResourceAllocationManager& resource_allocation_manager);
+      ResourceAllocationManager& resource_allocation_manager,
+      InteriorDataCache& interior_data_cache);
 
   void Run() OVERRIDE;
 
   std::string ModuleType();
 
   ~OnInteriorVehicleDataNotification();
+
+ private:
+  InteriorDataCache& interior_data_cache_;
 };
 }  // namespace commands
 }  // namespace rc_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/set_interior_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/set_interior_vehicle_data_request.h
@@ -47,7 +47,8 @@ class SetInteriorVehicleDataRequest : public RCCommandRequest {
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handle,
-      rc_rpc_plugin::ResourceAllocationManager& resource_allocation_manager);
+      rc_rpc_plugin::ResourceAllocationManager& resource_allocation_manager,
+      InteriorDataCache& interior_data_cache);
 
   /**
    * @brief Execute command

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/set_interior_vehicle_data_response.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/set_interior_vehicle_data_response.h
@@ -35,6 +35,7 @@
 
 #include "application_manager/commands/command_response_impl.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -50,7 +51,8 @@ class SetInteriorVehicleDataResponse
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handle,
-      ResourceAllocationManager& resource_allocation_manager);
+      ResourceAllocationManager& resource_allocation_manager,
+      InteriorDataCache& interior_data_cache);
 
   void Run() OVERRIDE;
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/rc_command_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/rc_command_request.h
@@ -75,8 +75,10 @@ class RCCommandRequest : public app_mngr::commands::CommandRequestImpl {
 
  protected:
   bool is_subscribed;
-  ResourceAllocationManager& resource_allocation_manager_;
   bool auto_allowed_;
+
+  ResourceAllocationManager& resource_allocation_manager_;
+  InteriorDataCache& interior_data_cache_;
 
   /**
    * @brief AcquireResource try to allocate resource for application
@@ -167,7 +169,6 @@ class RCCommandRequest : public app_mngr::commands::CommandRequestImpl {
       const app_mngr::HmiInterfaces::InterfaceID interface) const;
 
   std::string disallowed_info_;
-  InteriorDataCache& interior_data_cache_;
 };
 }
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/rc_command_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/rc_command_request.h
@@ -36,6 +36,7 @@
 #include "rc_rpc_plugin/resource_allocation_manager.h"
 #include "rc_rpc_plugin/rc_app_extension.h"
 #include "application_manager/commands/command_request_impl.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 
 namespace rc_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -61,7 +62,8 @@ class RCCommandRequest : public app_mngr::commands::CommandRequestImpl {
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handl,
-      rc_rpc_plugin::ResourceAllocationManager& resource_allocation_manager);
+      rc_rpc_plugin::ResourceAllocationManager& resource_allocation_manager,
+      rc_rpc_plugin::InteriorDataCache& interior_data_cache);
 
   virtual ~RCCommandRequest();
 
@@ -165,6 +167,7 @@ class RCCommandRequest : public app_mngr::commands::CommandRequestImpl {
       const app_mngr::HmiInterfaces::InterfaceID interface) const;
 
   std::string disallowed_info_;
+  InteriorDataCache& interior_data_cache_;
 };
 }
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/interior_data_cache_impl.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/interior_data_cache_impl.h
@@ -1,5 +1,37 @@
-#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_INTERIORDATACACHE_IMPL_H
-#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_INTERIORDATACACHE_IMPL_H
+/*
+ * Copyright (c) 2018, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_INTERIOR_DATA_CACHE_IMPL_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_INTERIOR_DATA_CACHE_IMPL_H_
 
 #include <map>
 #include "utils/macro.h"
@@ -7,20 +39,20 @@
 #include "rc_rpc_plugin/interior_data_cache.h"
 namespace rc_rpc_plugin {
 class InteriorDataCacheImpl : public InteriorDataCache {
+ public:
+  InteriorDataCacheImpl();
+  void Add(const std::string& module_type,
+           const smart_objects::SmartObject& module_data) OVERRIDE;
+  smart_objects::SmartObject Retrieve(
+      const std::string& module_type) const OVERRIDE;
+  bool Contains(const std::string& module_type) const OVERRIDE;
+  void ClearCache() OVERRIDE;
 
-public:
-    InteriorDataCacheImpl();
-    void Add(const std::string &module_type, const smart_objects::SmartObject &module_data) OVERRIDE;
-    smart_objects::SmartObject Retrive(const std::string &module_type) const OVERRIDE;
-    bool Check(const std::string &module_type) const OVERRIDE;
-    void Clear() OVERRIDE;
-private:
-    std::map<std::string, smart_objects::SmartObject> subscriptions_;
-    mutable sync_primitives::Lock subscriptions_lock_;
+ private:
+  std::map<std::string, smart_objects::SmartObject> subscriptions_;
+  mutable sync_primitives::Lock subscriptions_lock_;
 };
-
 
 }  // rc_rpc_plugin
 
-
-#endif // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_INTERIORDATACACHE_H
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_INTERIOR_DATA_CACHE_IMPL_H_

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_command_factory.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_command_factory.h
@@ -41,6 +41,7 @@
 #include "application_manager/hmi_capabilities.h"
 #include "application_manager/policies/policy_handler_interface.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -60,7 +61,8 @@ class RCCommandFactory : public application_manager::CommandFactory {
                    app_mngr::rpc_service::RPCService& rpc_service,
                    app_mngr::HMICapabilities& hmi_capabilities,
                    policy::PolicyHandlerInterface& policy_handler,
-                   ResourceAllocationManager& allocation_manager);
+                   ResourceAllocationManager& allocation_manager,
+                   InteriorDataCache& interior_data_cache);
   application_manager::CommandSharedPtr CreateCommand(
       const app_mngr::commands::MessageSharedPtr& message,
       app_mngr::commands::Command::CommandSource source) OVERRIDE;
@@ -89,6 +91,7 @@ class RCCommandFactory : public application_manager::CommandFactory {
   app_mngr::HMICapabilities& hmi_capabilities_;
   PolicyHandlerInterface& policy_handler_;
   ResourceAllocationManager& allocation_manager_;
+  InteriorDataCache& interior_data_cache_;
 };
 }  // namespace rc_rpc_plugin
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_RC_COMMAND_FACTORY_H

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_rpc_plugin.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_rpc_plugin.h
@@ -32,9 +32,13 @@
 
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_RC_PLUGIN_H
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_RC_PLUGIN_H
+
+#include <memory>
+
 #include "application_manager/plugin_manager/rpc_plugin.h"
 #include "application_manager/command_factory.h"
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 
 namespace rc_rpc_plugin {
 namespace plugins = application_manager::plugin_manager;
@@ -94,6 +98,7 @@ class RCRPCPlugin : public plugins::RPCPlugin {
  private:
   std::unique_ptr<application_manager::CommandFactory> command_factory_;
   std::unique_ptr<ResourceAllocationManager> resource_allocation_manager_;
+  std::unique_ptr<InteriorDataCache> interior_data_cache_;
 };
 }  // namespace rc_rpc_plugin
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_button_press_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_button_press_request.cc
@@ -31,6 +31,8 @@
  */
 
 #include "rc_rpc_plugin/commands/hmi/rc_button_press_request.h"
+#include "rc_rpc_plugin/resource_allocation_manager_impl.h"
+
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -42,7 +44,8 @@ RCButtonPressRequest::RCButtonPressRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : application_manager::commands::RequestToHMI(message,
                                                   application_manager,
                                                   rpc_service,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_button_press_response.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_button_press_response.cc
@@ -42,13 +42,15 @@ RCButtonPressResponse::RCButtonPressResponse(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : application_manager::commands::ResponseFromHMI(message,
                                                      application_manager,
                                                      rpc_service,
                                                      hmi_capabilities,
                                                      policy_handle) {
   UNUSED(resource_allocation_manager);
+  UNUSED(interior_data_cache);
 }
 
 void RCButtonPressResponse::Run() {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_consent_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_consent_request.cc
@@ -42,7 +42,8 @@ RCGetInteriorVehicleDataConsentRequest::RCGetInteriorVehicleDataConsentRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : application_manager::commands::RequestToHMI(message,
                                                   application_manager,
                                                   rpc_service,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_consent_response.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_consent_response.cc
@@ -43,13 +43,15 @@ RCGetInteriorVehicleDataConsentResponse::
         app_mngr::rpc_service::RPCService& rpc_service,
         app_mngr::HMICapabilities& hmi_capabilities,
         policy::PolicyHandlerInterface& policy_handle,
-        ResourceAllocationManager& resource_allocation_manager)
+        ResourceAllocationManager& resource_allocation_manager,
+        InteriorDataCache& interior_data_cache)
     : application_manager::commands::ResponseFromHMI(message,
                                                      application_manager,
                                                      rpc_service,
                                                      hmi_capabilities,
                                                      policy_handle) {
   UNUSED(resource_allocation_manager);
+  UNUSED(interior_data_cache);
 }
 
 void RCGetInteriorVehicleDataConsentResponse::Run() {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_request.cc
@@ -42,7 +42,8 @@ RCGetInteriorVehicleDataRequest::RCGetInteriorVehicleDataRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : application_manager::commands::RequestToHMI(message,
                                                   application_manager,
                                                   rpc_service,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_response.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_response.cc
@@ -43,13 +43,15 @@ RCGetInteriorVehicleDataResponse::RCGetInteriorVehicleDataResponse(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : application_manager::commands::ResponseFromHMI(message,
                                                      application_manager,
                                                      rpc_service,
                                                      hmi_capabilities,
                                                      policy_handle) {
   UNUSED(resource_allocation_manager);
+  UNUSED(interior_data_cache);
 }
 
 void RCGetInteriorVehicleDataResponse::Run() {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_interior_vehicle_data_notification.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_interior_vehicle_data_notification.cc
@@ -43,7 +43,8 @@ RCOnInteriorVehicleDataNotification::RCOnInteriorVehicleDataNotification(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : application_manager::commands::NotificationFromHMI(message,
                                                          application_manager,
                                                          rpc_service,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc
@@ -53,7 +53,8 @@ RCOnRemoteControlSettingsNotification::RCOnRemoteControlSettingsNotification(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : application_manager::commands::NotificationFromHMI(message,
                                                          application_manager,
                                                          rpc_service,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_set_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_set_interior_vehicle_data_request.cc
@@ -42,7 +42,8 @@ RCSetInteriorVehicleDataRequest::RCSetInteriorVehicleDataRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : application_manager::commands::RequestToHMI(message,
                                                   application_manager,
                                                   rpc_service,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_set_interior_vehicle_data_response.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_set_interior_vehicle_data_response.cc
@@ -42,13 +42,15 @@ RCSetInteriorVehicleDataResponse::RCSetInteriorVehicleDataResponse(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : application_manager::commands::ResponseFromHMI(message,
                                                      application_manager,
                                                      rpc_service,
                                                      hmi_capabilities,
                                                      policy_handle) {
   UNUSED(resource_allocation_manager);
+  UNUSED(interior_data_cache);
 }
 
 void RCSetInteriorVehicleDataResponse::Run() {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/button_press_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/button_press_request.cc
@@ -54,13 +54,15 @@ ButtonPressRequest::ButtonPressRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : RCCommandRequest(message,
                        application_manager,
                        rpc_service,
                        hmi_capabilities,
                        policy_handle,
-                       resource_allocation_manager) {}
+                       resource_allocation_manager,
+                       interior_data_cache) {}
 
 ButtonPressRequest::~ButtonPressRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/button_press_response.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/button_press_response.cc
@@ -42,7 +42,8 @@ ButtonPressResponse::ButtonPressResponse(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : application_manager::commands::CommandResponseImpl(message,
                                                          application_manager,
                                                          rpc_service,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -50,13 +50,15 @@ GetInteriorVehicleDataRequest::GetInteriorVehicleDataRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : RCCommandRequest(message,
                        application_manager,
                        rpc_service,
                        hmi_capabilities,
                        policy_handle,
-                       resource_allocation_manager)
+                       resource_allocation_manager,
+                       interior_data_cache)
     , excessive_subscription_occured_(false) {}
 
 bool CheckIfModuleTypeExistInCapabilities(

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -109,9 +109,6 @@ void GetInteriorVehicleDataRequest::Execute() {
     RemoveExcessiveSubscription();
   }
 
-  (*message_)[app_mngr::strings::msg_params][app_mngr::strings::app_id] =
-      app->app_id();
-
   SendHMIRequest(hmi_apis::FunctionID::RC_GetInteriorVehicleData,
                  &(*message_)[app_mngr::strings::msg_params],
                  true);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_response.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_response.cc
@@ -42,7 +42,8 @@ GetInteriorVehicleDataResponse::GetInteriorVehicleDataResponse(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : application_manager::commands::CommandResponseImpl(message,
                                                          application_manager,
                                                          rpc_service,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/on_interior_vehicle_data_notification.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/on_interior_vehicle_data_notification.cc
@@ -47,12 +47,14 @@ OnInteriorVehicleDataNotification::OnInteriorVehicleDataNotification(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : app_mngr::commands::CommandNotificationImpl(message,
                                                   application_manager,
                                                   rpc_service,
                                                   hmi_capabilities,
-                                                  policy_handler) {
+                                                  policy_handler)
+    , interior_data_cache_(interior_data_cache) {
   UNUSED(resource_allocation_manager);
 }
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
@@ -129,13 +129,15 @@ SetInteriorVehicleDataRequest::SetInteriorVehicleDataRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : RCCommandRequest(message,
                        application_manager,
                        rpc_service,
                        hmi_capabilities,
                        policy_handle,
-                       resource_allocation_manager) {}
+                       resource_allocation_manager,
+                       interior_data_cache) {}
 
 SetInteriorVehicleDataRequest::~SetInteriorVehicleDataRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_response.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_response.cc
@@ -1,4 +1,5 @@
 #include "rc_rpc_plugin/commands/mobile/set_interior_vehicle_data_response.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -10,7 +11,8 @@ SetInteriorVehicleDataResponse::SetInteriorVehicleDataResponse(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    ResourceAllocationManager& resource_allocation_manager)
+    ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : application_manager::commands::CommandResponseImpl(message,
                                                          application_manager,
                                                          rpc_service,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
@@ -35,6 +35,7 @@
 #include "application_manager/message_helper.h"
 #include "application_manager/hmi_interfaces.h"
 #include "smart_objects/enum_schema_item.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "RemoteControlModule")
 
@@ -47,14 +48,16 @@ RCCommandRequest::RCCommandRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handle,
-    rc_rpc_plugin::ResourceAllocationManager& resource_allocation_manager)
+    rc_rpc_plugin::ResourceAllocationManager& resource_allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : application_manager::commands::CommandRequestImpl(message,
                                                         application_manager,
                                                         rpc_service,
                                                         hmi_capabilities,
                                                         policy_handle)
     , is_subscribed(false)
-    , resource_allocation_manager_(resource_allocation_manager) {}
+    , resource_allocation_manager_(resource_allocation_manager)
+    , interior_data_cache_(interior_data_cache) {}
 
 RCCommandRequest::~RCCommandRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/interior_data_cache_impl.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/interior_data_cache_impl.cc
@@ -1,41 +1,72 @@
-#include "rc_rpc_plugin/interior_data_cache_impl.h"
+/*
+ * Copyright (c) 2018, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
+#include "utils/logger.h"
+#include "rc_rpc_plugin/interior_data_cache_impl.h"
 
 namespace rc_rpc_plugin {
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "RemoteControlModule");
 
-InteriorDataCacheImpl::InteriorDataCacheImpl() {
+InteriorDataCacheImpl::InteriorDataCacheImpl() {}
 
+void InteriorDataCacheImpl::Add(const std::string& module_type,
+                                const smart_objects::SmartObject& module_data) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock autolock(subscriptions_lock_);
+  subscriptions_[module_type] = module_data;
 }
 
-void InteriorDataCacheImpl::Add(const std::string &module_type, const smart_objects::SmartObject &module_data) {
-    LOG4CXX_AUTO_TRACE(logger_);
-    sync_primitives::AutoLock autolock(subscriptions_lock_);
-    subscriptions_[module_type] = module_data;
+smart_objects::SmartObject InteriorDataCacheImpl::Retrieve(
+    const std::string& module_type) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock autolock(subscriptions_lock_);
+  auto it = subscriptions_.find(module_type);
+  if (it == subscriptions_.end()) {
+    return smart_objects::SmartObject(smart_objects::SmartType_Null);
+  }
+  return it->second;
 }
 
-smart_objects::SmartObject InteriorDataCacheImpl::Retrive(const std::string &module_type) const {
-    LOG4CXX_AUTO_TRACE(logger_);
-    sync_primitives::AutoLock autolock(subscriptions_lock_);
-    auto it = subscriptions_.find(module_type);
-    if (it == subscriptions_.end()) {
-        return smart_objects::SmartObject(smart_objects::SmartType_Null);
-    }
-    return it->second;
+bool InteriorDataCacheImpl::Contains(const std::string& module_type) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock autolock(subscriptions_lock_);
+  auto it = subscriptions_.find(module_type);
+  return it != subscriptions_.end();
 }
 
-bool InteriorDataCacheImpl::Check(const std::string &module_type) const{
-    LOG4CXX_AUTO_TRACE(logger_);
-    sync_primitives::AutoLock autolock(subscriptions_lock_);
-    auto it = subscriptions_.find(module_type);
-    return it != subscriptions_.end();
+void InteriorDataCacheImpl::ClearCache() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock autolock(subscriptions_lock_);
+  subscriptions_.clear();
 }
-
-void InteriorDataCacheImpl::Clear() {
-    LOG4CXX_AUTO_TRACE(logger_);
-    sync_primitives::AutoLock autolock(subscriptions_lock_);
-    subscriptions_.clear();
-}
-
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_command_factory.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_command_factory.cc
@@ -53,10 +53,12 @@
 #include "interfaces/HMI_API.h"
 
 #include "rc_rpc_plugin/resource_allocation_manager.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "RemoteControlModule")
 namespace application_manager {
 using rc_rpc_plugin::ResourceAllocationManager;
+using rc_rpc_plugin::InteriorDataCache;
 
 template <typename RCCommandType>
 class RCCommandCreator : public CommandCreator {
@@ -65,12 +67,14 @@ class RCCommandCreator : public CommandCreator {
                    rpc_service::RPCService& rpc_service,
                    HMICapabilities& hmi_capabilities,
                    PolicyHandlerInterface& policy_handler,
-                   ResourceAllocationManager& resource_allocation_manager)
+                   ResourceAllocationManager& resource_allocation_manager,
+                   InteriorDataCache& interior_data_cache)
       : application_manager_(application_manager)
       , rpc_service_(rpc_service)
       , hmi_capabilities_(hmi_capabilities)
       , policy_handler_(policy_handler)
-      , resource_allocation_manager_(resource_allocation_manager) {}
+      , resource_allocation_manager_(resource_allocation_manager)
+      , interior_data_cache_(interior_data_cache) {}
 
  private:
   bool CanBeCreated() const override {
@@ -84,7 +88,8 @@ class RCCommandCreator : public CommandCreator {
                                                rpc_service_,
                                                hmi_capabilities_,
                                                policy_handler_,
-                                               resource_allocation_manager_));
+                                               resource_allocation_manager_,
+                                               interior_data_cache_));
     return command;
   }
 
@@ -93,6 +98,7 @@ class RCCommandCreator : public CommandCreator {
   HMICapabilities& hmi_capabilities_;
   PolicyHandlerInterface& policy_handler_;
   ResourceAllocationManager& resource_allocation_manager_;
+  InteriorDataCache& interior_data_cache_;
 };
 
 struct RCInvalidCommand {};
@@ -104,12 +110,14 @@ class RCCommandCreator<RCInvalidCommand> : public CommandCreator {
                    RPCService& rpc_service,
                    HMICapabilities& hmi_capabilities,
                    PolicyHandlerInterface& policy_handler,
-                   ResourceAllocationManager& resource_allocation_manager) {
+                   ResourceAllocationManager& resource_allocation_manager,
+                   InteriorDataCache& interior_data_cache) {
     UNUSED(application_manager);
     UNUSED(rpc_service);
     UNUSED(hmi_capabilities);
     UNUSED(policy_handler);
     UNUSED(resource_allocation_manager);
+    UNUSED(interior_data_cache);
   }
 
  private:
@@ -130,12 +138,14 @@ struct RCCommandCreatorFactory {
       rpc_service::RPCService& rpc_service,
       HMICapabilities& hmi_capabilities,
       PolicyHandlerInterface& policy_handler,
-      ResourceAllocationManager& resource_allocation_manager)
+      ResourceAllocationManager& resource_allocation_manager,
+      InteriorDataCache& interior_data_cache)
       : application_manager_(application_manager)
       , rpc_service_(rpc_service)
       , hmi_capabilities_(hmi_capabilities)
       , policy_handler_(policy_handler)
-      , resource_allocation_manager_(resource_allocation_manager) {}
+      , resource_allocation_manager_(resource_allocation_manager)
+      , interior_data_cache_(interior_data_cache) {}
 
   template <typename RCCommandType>
   CommandCreator& GetCreator() {
@@ -143,7 +153,8 @@ struct RCCommandCreatorFactory {
                                                rpc_service_,
                                                hmi_capabilities_,
                                                policy_handler_,
-                                               resource_allocation_manager_);
+                                               resource_allocation_manager_,
+                                               interior_data_cache_);
     return res;
   }
   ApplicationManager& application_manager_;
@@ -151,6 +162,7 @@ struct RCCommandCreatorFactory {
   HMICapabilities& hmi_capabilities_;
   PolicyHandlerInterface& policy_handler_;
   ResourceAllocationManager& resource_allocation_manager_;
+  InteriorDataCache& interior_data_cache_;
 };
 }
 
@@ -162,12 +174,14 @@ RCCommandFactory::RCCommandFactory(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler,
-    ResourceAllocationManager& allocation_manager)
+    ResourceAllocationManager& allocation_manager,
+    InteriorDataCache& interior_data_cache)
     : app_manager_(app_manager)
     , rpc_service_(rpc_service)
     , hmi_capabilities_(hmi_capabilities)
     , policy_handler_(policy_handler)
-    , allocation_manager_(allocation_manager) {}
+    , allocation_manager_(allocation_manager)
+    , interior_data_cache_(interior_data_cache) {}
 
 CommandSharedPtr RCCommandFactory::CreateCommand(
     const app_mngr::commands::MessageSharedPtr& message,
@@ -222,7 +236,8 @@ CommandCreator& RCCommandFactory::get_mobile_creator_factory(
                                      rpc_service_,
                                      hmi_capabilities_,
                                      policy_handler_,
-                                     allocation_manager_);
+                                     allocation_manager_,
+                                     interior_data_cache_);
 
   switch (id) {
     case mobile_apis::FunctionID::ButtonPressID: {
@@ -263,7 +278,8 @@ CommandCreator& RCCommandFactory::get_hmi_creator_factory(
                                      rpc_service_,
                                      hmi_capabilities_,
                                      policy_handler_,
-                                     allocation_manager_);
+                                     allocation_manager_,
+                                     interior_data_cache_);
 
   switch (id) {
     case hmi_apis::FunctionID::Buttons_ButtonPress: {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -34,6 +34,7 @@
 #include "rc_rpc_plugin/rc_command_factory.h"
 #include "rc_rpc_plugin/rc_app_extension.h"
 #include "rc_rpc_plugin/resource_allocation_manager_impl.h"
+#include "rc_rpc_plugin/interior_data_cache_impl.h"
 #include "utils/helpers.h"
 
 namespace rc_rpc_plugin {
@@ -51,7 +52,9 @@ bool RCRPCPlugin::Init(
                                           rpc_service,
                                           hmi_capabilities,
                                           policy_handler,
-                                          *resource_allocation_manager_));
+                                          *resource_allocation_manager_,
+                                          *interior_data_cache_));
+  interior_data_cache_.reset(new InteriorDataCacheImpl());
   return true;
 }
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
@@ -37,6 +37,7 @@
 #include "rc_rpc_plugin/rc_rpc_plugin.h"
 #include "rc_rpc_plugin/rc_module_constants.h"
 #include "rc_rpc_plugin/mock/mock_resource_allocation_manager.h"
+#include "rc_rpc_plugin/mock/mock_interior_data_cache.h"
 #include "application_manager/mock_application.h"
 #include "application_manager/mock_application_manager.h"
 #include "application_manager/commands/command_request_test.h"
@@ -153,7 +154,8 @@ class ButtonPressRequestTest
                                         mock_rpc_service_,
                                         mock_hmi_capabilities_,
                                         mock_policy_handler_,
-                                        mock_allocation_manager_);
+                                        mock_allocation_manager_,
+                                        mock_interior_data_cache_);
   }
 
  protected:
@@ -164,6 +166,8 @@ class ButtonPressRequestTest
       mock_policy_handler_;
   testing::NiceMock<rc_rpc_plugin_test::MockResourceAllocationManager>
       mock_allocation_manager_;
+  testing::NiceMock<rc_rpc_plugin_test::MockInteriorDataCache>
+      mock_interior_data_cache_;
 };
 
 TEST_F(ButtonPressRequestTest,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -40,6 +40,7 @@
 #include "application_manager/event_engine/event_dispatcher.h"
 #include "application_manager/commands/command_request_test.h"
 #include "rc_rpc_plugin/mock/mock_resource_allocation_manager.h"
+#include "rc_rpc_plugin/mock/mock_interior_data_cache.h"
 #include "utils/shared_ptr.h"
 #include "utils/make_shared.h"
 
@@ -122,7 +123,8 @@ class GetInteriorVehicleDataRequestTest
                                         mock_rpc_service_,
                                         mock_hmi_capabilities_,
                                         mock_policy_handler_,
-                                        mock_allocation_manager_);
+                                        mock_allocation_manager_,
+                                        mock_interior_data_cache_);
   }
 
  protected:
@@ -131,6 +133,8 @@ class GetInteriorVehicleDataRequestTest
   utils::SharedPtr<RCAppExtension> rc_app_extention_;
   testing::NiceMock<rc_rpc_plugin_test::MockResourceAllocationManager>
       mock_allocation_manager_;
+  testing::NiceMock<rc_rpc_plugin_test::MockInteriorDataCache>
+      mock_interior_data_cache_;
 };
 TEST_F(GetInteriorVehicleDataRequestTest,
        Execute_MessageValidationOk_ExpectCorrectMessageSentToHMI) {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_interior_vehicle_data_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_interior_vehicle_data_notification_test.cc
@@ -37,6 +37,7 @@
 #include "rc_rpc_plugin/rc_rpc_plugin.h"
 #include "rc_rpc_plugin/rc_module_constants.h"
 #include "rc_rpc_plugin/mock/mock_resource_allocation_manager.h"
+#include "rc_rpc_plugin/mock/mock_interior_data_cache.h"
 #include "gtest/gtest.h"
 #include "interfaces/MOBILE_API.h"
 
@@ -93,13 +94,16 @@ class OnInteriorVehicleDataNotificationTest
                                         mock_rpc_service_,
                                         mock_hmi_capabilities_,
                                         mock_policy_handler_,
-                                        mock_allocation_manager_);
+                                        mock_allocation_manager_,
+                                        mock_interior_data_cache_);
   }
 
  protected:
   utils::SharedPtr<MockApplication> mock_app_;
   testing::NiceMock<rc_rpc_plugin_test::MockResourceAllocationManager>
       mock_allocation_manager_;
+  testing::NiceMock<rc_rpc_plugin_test::MockInteriorDataCache>
+      mock_interior_data_cache_;
 };
 
 TEST_F(OnInteriorVehicleDataNotificationTest,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_remote_control_settings_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_remote_control_settings_test.cc
@@ -38,6 +38,7 @@
 #include "rc_rpc_plugin/rc_rpc_plugin.h"
 #include "rc_rpc_plugin/rc_module_constants.h"
 #include "rc_rpc_plugin/mock/mock_resource_allocation_manager.h"
+#include "rc_rpc_plugin/mock/mock_interior_data_cache.h"
 #include "gtest/gtest.h"
 #include "interfaces/MOBILE_API.h"
 
@@ -93,13 +94,16 @@ class RCOnRemoteControlSettingsNotificationTest
                                         mock_rpc_service_,
                                         mock_hmi_capabilities_,
                                         mock_policy_handler_,
-                                        mock_allocation_manager_);
+                                        mock_allocation_manager_,
+                                        mock_interior_data_cache_);
   }
 
  protected:
   utils::SharedPtr<MockApplication> mock_app_;
   testing::NiceMock<rc_rpc_plugin_test::MockResourceAllocationManager>
       mock_allocation_manager_;
+  testing::NiceMock<rc_rpc_plugin_test::MockInteriorDataCache>
+      mock_interior_data_cache_;
 };
 
 TEST_F(RCOnRemoteControlSettingsNotificationTest,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
@@ -46,6 +46,7 @@
 #include "rc_rpc_plugin/rc_rpc_plugin.h"
 #include "rc_rpc_plugin/rc_module_constants.h"
 #include "rc_rpc_plugin/mock/mock_resource_allocation_manager.h"
+#include "rc_rpc_plugin/mock/mock_interior_data_cache.h"
 #include "rc_rpc_plugin/commands/mobile/button_press_request.h"
 #include "rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_consent_response.h"
 #include "rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_consent_request.h"
@@ -123,6 +124,8 @@ class RCGetInteriorVehicleDataConsentTest
     ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(mock_app_));
     ON_CALL(mock_allocation_manager_, GetApplicationExtention(_))
         .WillByDefault(Return(rc_app_extention_));
+    testing::NiceMock<rc_rpc_plugin_test::MockInteriorDataCache>
+        mock_interior_data_cache_;
     ON_CALL(app_mngr_, GetPolicyHandler())
         .WillByDefault(ReturnRef(mock_policy_handler_));
     ON_CALL(app_mngr_, hmi_capabilities())
@@ -152,7 +155,8 @@ class RCGetInteriorVehicleDataConsentTest
                                         rpc_service,
                                         mock_hmi_capabilities_,
                                         mock_policy_handler_,
-                                        mock_allocation_manager_);
+                                        mock_allocation_manager_,
+                                        mock_interior_data_cache_);
   }
 
   MessageSharedPtr CreateBasicMessage() {
@@ -175,6 +179,8 @@ class RCGetInteriorVehicleDataConsentTest
   am::CommandHolderImpl command_holder;
   testing::NiceMock<rc_rpc_plugin_test::MockResourceAllocationManager>
       mock_allocation_manager_;
+  testing::NiceMock<rc_rpc_plugin_test::MockInteriorDataCache>
+      mock_interior_data_cache_;
   smart_objects::SmartObject rc_capabilities_;
   MockRPCPlugin mock_rpc_plugin;
   MockCommandFactory mock_command_factory;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
@@ -37,6 +37,7 @@
 #include "rc_rpc_plugin/rc_rpc_plugin.h"
 #include "rc_rpc_plugin/rc_module_constants.h"
 #include "rc_rpc_plugin/mock/mock_resource_allocation_manager.h"
+#include "rc_rpc_plugin/mock/mock_interior_data_cache.h"
 #include "gtest/gtest.h"
 #include "interfaces/MOBILE_API.h"
 
@@ -112,12 +113,15 @@ class SetInteriorVehicleDataRequestTest
                                         mock_rpc_service_,
                                         mock_hmi_capabilities_,
                                         mock_policy_handler_,
-                                        mock_allocation_manager_);
+                                        mock_allocation_manager_,
+                                        mock_interior_data_cache_);
   }
 
  protected:
   testing::NiceMock<rc_rpc_plugin_test::MockResourceAllocationManager>
       mock_allocation_manager_;
+  testing::NiceMock<rc_rpc_plugin_test::MockInteriorDataCache>
+      mock_interior_data_cache_;
   utils::SharedPtr<MockApplication> mock_app_;
   utils::SharedPtr<RCAppExtension> rc_app_extention_;
 };

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_interior_data_cache.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_interior_data_cache.h
@@ -45,7 +45,6 @@ class MockInteriorDataCache : public rc_rpc_plugin::InteriorDataCache {
                     const NsSmartDeviceLink::NsSmartObjects::SmartObject&));
   MOCK_CONST_METHOD1(Retrieve, smart_objects::SmartObject(const std::string&));
   MOCK_CONST_METHOD1(Contains, bool(const std::string&));
-
   MOCK_METHOD0(ClearCache, void());
 };
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_interior_data_cache.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_interior_data_cache.h
@@ -29,47 +29,26 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_INTERIOR_DATA_CACHE_H_
-#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_INTERIOR_DATA_CACHE_H_
-#include <string>
-#include "smart_objects/smart_object.h"
 
-namespace rc_rpc_plugin {
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_TEST_INCLUDE_RC_RPC_PLUGIN_MOCK_MOCK_INTERIOR_DATA_CACHE_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_TEST_INCLUDE_RC_RPC_PLUGIN_MOCK_MOCK_INTERIOR_DATA_CACHE_H_
 
-/**
- * @brief The InteriorDataCache interface for caching data class
- * Provide ability to cache module data by module type name and clear cache
- */
-class InteriorDataCache {
+#include "gmock/gmock.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
+
+namespace rc_rpc_plugin_test {
+
+class MockInteriorDataCache : public rc_rpc_plugin::InteriorDataCache {
  public:
-  /**
-   * @brief Add add module data to cache
-   * @param module_type module type name
-   * @param module_data data to be cached
-   */
-  virtual void Add(const std::string& module_type,
-                   const smart_objects::SmartObject& module_data) = 0;
+  MOCK_METHOD2(Add,
+               void(const std::string&,
+                    const NsSmartDeviceLink::NsSmartObjects::SmartObject&));
+  MOCK_CONST_METHOD1(Retrieve, smart_objects::SmartObject(const std::string&));
+  MOCK_CONST_METHOD1(Contains, bool(const std::string&));
 
-  /**
-   * @brief Retrieve Get cached data
-   * @param module_type data type to get from cache
-   * @return smart object with cached data, or nulll smart object
-   */
-  virtual smart_objects::SmartObject Retrieve(
-      const std::string& module_type) const = 0;
-
-  /**
-   * @brief Contains check if data exists in cache
-   * @param module_type module type name to check in cache
-   * @return true if cached, false otherwize
-   */
-  virtual bool Contains(const std::string& module_type) const = 0;
-
-  /**
-   * @brief ClearCache clear all cached data
-   */
-  virtual void ClearCache() = 0;
+  MOCK_METHOD0(ClearCache, void());
 };
-}  // rc_rpc_plugin
 
-#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_INTERIOR_DATA_CACHE_H_
+}  // namespace rc_rpc_plugin_test
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_TEST_INCLUDE_RC_RPC_PLUGIN_MOCK_MOCK_INTERIOR_DATA_CACHE_H_

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/interior_data_cache_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/interior_data_cache_test.cc
@@ -41,11 +41,11 @@ TEST_F(InteriorDataCacheTest,
   const rc_rpc_plugin::InteriorDataCacheImpl cache;
   std::string module_type_key = "random_module_type";
   EXPECT_FALSE(cache.Contains(module_type_key));
-  auto Retrieved_data = cache.Retrieve(module_type_key);
-  EXPECT_EQ(Retrieved_data.getType(), smart_objects::SmartType_Null);
+  auto retrieved_data = cache.Retrieve(module_type_key);
+  EXPECT_EQ(smart_objects::SmartType_Null, retrieved_data.getType());
 }
 
-TEST_F(InteriorDataCacheTest, CheckExstingSubscribed) {
+TEST_F(InteriorDataCacheTest, CheckThatCacheContansDataAfterAdding) {
   rc_rpc_plugin::InteriorDataCacheImpl cache;
   const std::string module_type_key = "random_module_type";
   smart_objects::SmartObject data;
@@ -53,8 +53,8 @@ TEST_F(InteriorDataCacheTest, CheckExstingSubscribed) {
 
   cache.Add(module_type_key, data);
   EXPECT_TRUE(cache.Contains(module_type_key));
-  auto Retrieved_data = cache.Retrieve(module_type_key);
-  EXPECT_EQ(Retrieved_data, data);
+  auto retrieved_data = cache.Retrieve(module_type_key);
+  EXPECT_EQ(data, retrieved_data);
 }
 
 TEST_F(InteriorDataCacheTest, DataDoesNotExistAfterClear) {
@@ -69,8 +69,7 @@ TEST_F(InteriorDataCacheTest, DataDoesNotExistAfterClear) {
   EXPECT_EQ(Retrieved_data, data);
   cache.ClearCache();
   auto Retrieved_data_after_clear = cache.Retrieve(module_type_key);
-  EXPECT_EQ(Retrieved_data_after_clear.getType(),
-            smart_objects::SmartType_Null);
+  EXPECT_EQ(smart_objects::SmartType_Null, Retrieved_data_after_clear.getType());
 }
 
 TEST_F(InteriorDataCacheTest, MultipleDataCached) {
@@ -81,20 +80,20 @@ TEST_F(InteriorDataCacheTest, MultipleDataCached) {
   data1["key"] = "value1";
   cache.Add(module_type_key1, data1);
   EXPECT_TRUE(cache.Contains(module_type_key1));
-  auto Retrieved_data1 = cache.Retrieve(module_type_key1);
-  EXPECT_EQ(Retrieved_data1, data1);
+  auto retrieved_data1 = cache.Retrieve(module_type_key1);
+  EXPECT_EQ(data1, retrieved_data1);
 
   std::string module_type_key2 = "random_module_type2";
   smart_objects::SmartObject data2;
   data2["key"] = "value2";
   cache.Add(module_type_key2, data2);
   EXPECT_TRUE(cache.Contains(module_type_key2));
-  auto Retrieved_data2 = cache.Retrieve(module_type_key2);
-  EXPECT_EQ(Retrieved_data2, data2);
+  auto retrieved_data2 = cache.Retrieve(module_type_key2);
+  EXPECT_EQ(retrieved_data2, data2);
 
   ASSERT_TRUE(data1 != data2);
-  EXPECT_TRUE(Retrieved_data1 != data2);
-  EXPECT_TRUE(Retrieved_data2 != data1);
+  EXPECT_TRUE(data2 != retrieved_data1);
+  EXPECT_TRUE(data1 != retrieved_data2);
 }
 
 }  // rc_rpc_plugin_test

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/interior_data_cache_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/interior_data_cache_test.cc
@@ -34,67 +34,67 @@
 
 namespace rc_rpc_plugin_test {
 
-class InteriorDataCacheTest : public ::testing::Test  {
-};
+class InteriorDataCacheTest : public ::testing::Test {};
 
-TEST_F(InteriorDataCacheTest, InteriorDataCacheDoesNotContainRandomDataInitialy) {
-    const rc_rpc_plugin::InteriorDataCacheImpl cache;
-    std::string module_type_key = "random_module_type";
-    EXPECT_FALSE(cache.Check(module_type_key));
-    auto retrived_data = cache.Retrive(module_type_key);
-    EXPECT_EQ(retrived_data.getType(), smart_objects::SmartType_Null);
+TEST_F(InteriorDataCacheTest,
+       InteriorDataCacheDoesNotContainRandomDataInitialy) {
+  const rc_rpc_plugin::InteriorDataCacheImpl cache;
+  std::string module_type_key = "random_module_type";
+  EXPECT_FALSE(cache.Contains(module_type_key));
+  auto Retrieved_data = cache.Retrieve(module_type_key);
+  EXPECT_EQ(Retrieved_data.getType(), smart_objects::SmartType_Null);
 }
 
-TEST_F(InteriorDataCacheTest, CheckExstingSubscribed ) {
-    rc_rpc_plugin::InteriorDataCacheImpl cache;
-    const std::string module_type_key = "random_module_type";
-    smart_objects::SmartObject data;
-    data["key"] = "value";
+TEST_F(InteriorDataCacheTest, CheckExstingSubscribed) {
+  rc_rpc_plugin::InteriorDataCacheImpl cache;
+  const std::string module_type_key = "random_module_type";
+  smart_objects::SmartObject data;
+  data["key"] = "value";
 
-    cache.Add(module_type_key, data);
-    EXPECT_TRUE(cache.Check(module_type_key));
-    auto retrived_data = cache.Retrive(module_type_key);
-    EXPECT_EQ(retrived_data, data);
+  cache.Add(module_type_key, data);
+  EXPECT_TRUE(cache.Contains(module_type_key));
+  auto Retrieved_data = cache.Retrieve(module_type_key);
+  EXPECT_EQ(Retrieved_data, data);
 }
 
 TEST_F(InteriorDataCacheTest, DataDoesNotExistAfterClear) {
-    rc_rpc_plugin::InteriorDataCacheImpl cache;
-    const std::string module_type_key = "random_module_type";
-    smart_objects::SmartObject data;
-    data["key"] = "value";
+  rc_rpc_plugin::InteriorDataCacheImpl cache;
+  const std::string module_type_key = "random_module_type";
+  smart_objects::SmartObject data;
+  data["key"] = "value";
 
-    cache.Add(module_type_key, data);
-    EXPECT_TRUE(cache.Check(module_type_key));
-    auto retrived_data = cache.Retrive(module_type_key);
-    EXPECT_EQ(retrived_data, data);
-    cache.Clear();
-    auto retrived_data_after_clear = cache.Retrive(module_type_key);
-    EXPECT_EQ(retrived_data_after_clear.getType(), smart_objects::SmartType_Null);
+  cache.Add(module_type_key, data);
+  EXPECT_TRUE(cache.Contains(module_type_key));
+  auto Retrieved_data = cache.Retrieve(module_type_key);
+  EXPECT_EQ(Retrieved_data, data);
+  cache.ClearCache();
+  auto Retrieved_data_after_clear = cache.Retrieve(module_type_key);
+  EXPECT_EQ(Retrieved_data_after_clear.getType(),
+            smart_objects::SmartType_Null);
 }
 
 TEST_F(InteriorDataCacheTest, MultipleDataCached) {
-    rc_rpc_plugin::InteriorDataCacheImpl cache;
+  rc_rpc_plugin::InteriorDataCacheImpl cache;
 
-    const std::string module_type_key1 = "random_module_type";
-    smart_objects::SmartObject data1;
-    data1["key"] = "value1";
-    cache.Add(module_type_key1, data1);
-    EXPECT_TRUE(cache.Check(module_type_key1));
-    auto retrived_data1 = cache.Retrive(module_type_key1);
-    EXPECT_EQ(retrived_data1, data1);
+  const std::string module_type_key1 = "random_module_type";
+  smart_objects::SmartObject data1;
+  data1["key"] = "value1";
+  cache.Add(module_type_key1, data1);
+  EXPECT_TRUE(cache.Contains(module_type_key1));
+  auto Retrieved_data1 = cache.Retrieve(module_type_key1);
+  EXPECT_EQ(Retrieved_data1, data1);
 
-    std::string module_type_key2 = "random_module_type2";
-    smart_objects::SmartObject data2;
-    data2["key"] = "value2";
-    cache.Add(module_type_key2, data2);
-    EXPECT_TRUE(cache.Check(module_type_key2));
-    auto retrived_data2 = cache.Retrive(module_type_key2);
-    EXPECT_EQ(retrived_data2, data2);
+  std::string module_type_key2 = "random_module_type2";
+  smart_objects::SmartObject data2;
+  data2["key"] = "value2";
+  cache.Add(module_type_key2, data2);
+  EXPECT_TRUE(cache.Contains(module_type_key2));
+  auto Retrieved_data2 = cache.Retrieve(module_type_key2);
+  EXPECT_EQ(Retrieved_data2, data2);
 
-    ASSERT_TRUE(data1 != data2);
-    EXPECT_TRUE(retrived_data1 != data2);
-    EXPECT_TRUE(retrived_data2 != data1);
-
+  ASSERT_TRUE(data1 != data2);
+  EXPECT_TRUE(Retrieved_data1 != data2);
+  EXPECT_TRUE(Retrieved_data2 != data1);
 }
 
 }  // rc_rpc_plugin_test

--- a/src/components/include/utils/make_shared.h
+++ b/src/components/include/utils/make_shared.h
@@ -124,6 +124,25 @@ SharedPtr<T> MakeShared(
   return Initialize(t);
 }
 
+template <typename T,
+          typename Arg1,
+          typename Arg2,
+          typename Arg3,
+          typename Arg4,
+          typename Arg5,
+          typename Arg6,
+          typename Arg7>
+SharedPtr<T> MakeShared(Arg1& arg1,
+                        Arg2& arg2,
+                        Arg3& arg3,
+                        Arg4& arg4,
+                        Arg5& arg5,
+                        Arg6& arg6,
+                        Arg7& arg7) {
+  T* t = new (std::nothrow) T(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+  return Initialize(t);
+}
+
 template <typename T, typename Arg1>
 SharedPtr<T> MakeShared(const Arg1& arg1) {
   T* t = new (std::nothrow) T(arg1);
@@ -184,6 +203,25 @@ SharedPtr<T> MakeShared(const Arg1& arg1,
                         const Arg5& arg5,
                         const Arg6& arg6) {
   T* t = new (std::nothrow) T(arg1, arg2, arg3, arg4, arg5, arg6);
+  return Initialize(t);
+}
+
+template <typename T,
+          typename Arg1,
+          typename Arg2,
+          typename Arg3,
+          typename Arg4,
+          typename Arg5,
+          typename Arg6,
+          typename Arg7>
+SharedPtr<T> MakeShared(const Arg1& arg1,
+                        const Arg2& arg2,
+                        const Arg3& arg3,
+                        const Arg4& arg4,
+                        const Arg5& arg5,
+                        const Arg6& arg6,
+                        const Arg7& arg7) {
+  T* t = new (std::nothrow) T(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
   return Initialize(t);
 }
 

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -5416,9 +5416,6 @@
   <param name="subscribe" type="Boolean" mandatory="false">
     <description>If subscribe is true, the head unit will send onInteriorVehicleData notifications for the module type</description>
   </param>
-  <param name="appID" type="Integer" mandatory="true">
-    <description>Internal SDL-assigned ID of the related application</description>
-  </param>
 </function>
 
 <function name="GetInteriorVehicleData" messagetype="response">


### PR DESCRIPTION
Related to Proposal https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0178-GetInteriorVehicleData.md 

 - Injecting CacheManager to all RC commands for usage.
 - Also added additional argument for MakeShared 
 - Add getting data from cache in GetINteriorVehicleData