### PR TITLE
Update OnRCStatus with a new allowed parameter

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager.h
@@ -160,9 +160,15 @@ class ResourceAllocationManager {
   /**
    * @brief Create and send OnRCStatusNotification to mobile and HMI
    * @param event trigger for notification sending
+   * @param application - app that should receive notification
+   * in case of registration; in cases of RC enabling/disabling
+   * or module allocation - application is just empty shared ptr,
+   * because in these cases all registered RC apps should
+   * receive a notification
    */
   virtual void SendOnRCStatusNotifications(
-      NotificationTrigger::eType event) = 0;
+      NotificationTrigger::eType event,
+      application_manager::ApplicationSharedPtr application) = 0;
 
   virtual bool is_rc_enabled() const = 0;
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager.h
@@ -56,6 +56,19 @@ enum eType { FREE = 0, BUSY };
 }
 
 /**
+ * Defines triggers for OnRCStatus notification sending
+ */
+namespace NotificationTrigger {
+/**
+ * @brief The eType
+ * APP_REGISTRATION RC app registation event
+ * RC_STATE_CHANGING enabling/disabling RC on HMI event
+ * MODULE_ALLOCATION module allocation/deallocation event
+ */
+enum eType { APP_REGISTRATION = 0, MODULE_ALLOCATION, RC_STATE_CHANGING };
+}
+
+/**
  * @brief Resources defines list of resources
  */
 typedef std::vector<std::string> Resources;
@@ -146,9 +159,10 @@ class ResourceAllocationManager {
 
   /**
    * @brief Create and send OnRCStatusNotification to mobile and HMI
-   * @param application
+   * @param event trigger for notification sending
    */
-  virtual void SendOnRCStatusNotification() = 0;
+  virtual void SendOnRCStatusNotifications(
+      NotificationTrigger::eType event) = 0;
 
   virtual bool is_rc_enabled() const = 0;
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager_impl.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager_impl.h
@@ -118,7 +118,7 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
   RCAppExtensionPtr GetApplicationExtention(
       application_manager::ApplicationSharedPtr application) FINAL;
 
-  void SendOnRCStatusNotification() FINAL;
+  void SendOnRCStatusNotifications(NotificationTrigger::eType event) FINAL;
 
   bool is_rc_enabled() const FINAL;
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager_impl.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager_impl.h
@@ -118,7 +118,9 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
   RCAppExtensionPtr GetApplicationExtention(
       application_manager::ApplicationSharedPtr application) FINAL;
 
-  void SendOnRCStatusNotifications(NotificationTrigger::eType event) FINAL;
+  void SendOnRCStatusNotifications(
+      NotificationTrigger::eType event,
+      application_manager::ApplicationSharedPtr application) FINAL;
 
   bool is_rc_enabled() const FINAL;
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc
@@ -150,8 +150,8 @@ void RCOnRemoteControlSettingsNotification::Run() {
   } else {
     LOG4CXX_DEBUG(logger_, "Disallowing RC Functionality");
     DisallowRCFunctionality();
-    resource_allocation_manager_.set_rc_enabled(false);
     resource_allocation_manager_.ResetAllAllocations();
+    resource_allocation_manager_.set_rc_enabled(false);
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -92,7 +92,7 @@ void RCRPCPlugin::OnApplicationEvent(
     case plugins::kApplicationRegistered: {
       application->AddExtension(new RCAppExtension(kRCPluginID));
       resource_allocation_manager_->SendOnRCStatusNotifications(
-          NotificationTrigger::APP_REGISTRATION);
+          NotificationTrigger::APP_REGISTRATION, application);
       break;
     }
     case plugins::kApplicationExit: {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -91,9 +91,8 @@ void RCRPCPlugin::OnApplicationEvent(
   switch (event) {
     case plugins::kApplicationRegistered: {
       application->AddExtension(new RCAppExtension(kRCPluginID));
-      if (resource_allocation_manager_->is_rc_enabled()) {
-        resource_allocation_manager_->SendOnRCStatusNotification();
-      }
+      resource_allocation_manager_->SendOnRCStatusNotifications(
+          NotificationTrigger::APP_REGISTRATION);
       break;
     }
     case plugins::kApplicationExit: {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
@@ -326,10 +326,8 @@ void ResourceAllocationManagerImpl::SendOnRCStatusNotifications(
     auto rc_apps = RCRPCPlugin::GetRCApplications(app_mngr_);
     for (const auto& rc_app : rc_apps) {
       msg_to_mobile = CreateOnRCStatusNotificationToMobile(rc_app);
-      if (NotificationTrigger::RC_STATE_CHANGING == event) {
-        (*msg_to_mobile)[application_manager::strings::msg_params]
-                        [message_params::kAllowed] = is_rc_enabled();
-      }
+      (*msg_to_mobile)[application_manager::strings::msg_params]
+                      [message_params::kAllowed] = is_rc_enabled();
       rpc_service_.SendMessageToMobile(msg_to_mobile);
       msg_to_hmi = CreateOnRCStatusNotificationToHmi(rc_app);
       rpc_service_.SendMessageToHMI(msg_to_hmi);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
@@ -174,6 +174,8 @@ void ResourceAllocationManagerImpl::ProcessApplicationPolicyUpdate() {
       if (rc_extention) {
         rc_extention->UnsubscribeFromInteriorVehicleData(*module);
       }
+    }
+    if (!disallowed_modules.empty()) {
       SendOnRCStatusNotifications(
           NotificationTrigger::MODULE_ALLOCATION,
           utils::SharedPtr<application_manager::Application>());

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
@@ -174,7 +174,7 @@ void ResourceAllocationManagerImpl::ProcessApplicationPolicyUpdate() {
       if (rc_extention) {
         rc_extention->UnsubscribeFromInteriorVehicleData(*module);
       }
-      SendOnRCStatusNotification();
+      SendOnRCStatusNotifications(NotificationTrigger::MODULE_ALLOCATION);
     }
   }
 }
@@ -227,34 +227,36 @@ void ConstructOnRCStatusNotificationParams(
     smart_objects::SmartObject& msg_params,
     const std::map<std::string, uint32_t>& allocated_resources,
     const std::vector<std::string>& supported_resources,
-    const uint32_t app_id) {
+    const uint32_t app_id,
+    const bool is_rc_enabled) {
   namespace strings = application_manager::strings;
   namespace message_params = rc_rpc_plugin::message_params;
   using smart_objects::SmartObject;
   using smart_objects::SmartType_Map;
   using smart_objects::SmartType_Array;
   LOG4CXX_AUTO_TRACE(logger_);
-
-  auto modules_inserter = [](SmartObject& result_modules) {
-    return [&result_modules](const std::string& module_name) {
-      smart_objects::SmartObject module_data =
-          SmartObject(smart_objects::SmartType_Map);
-      auto module_type =
-          StringToEnum<mobile_apis::ModuleType::eType>(module_name);
-      module_data[message_params::kModuleType] = module_type;
-      result_modules.asArray()->push_back(module_data);
-    };
-  };
   SmartObject allocated_modules = SmartObject(SmartType_Array);
-  for (const auto& module : allocated_resources) {
-    if (module.second == app_id) {
-      modules_inserter(allocated_modules)(module.first);
-    }
-  }
   SmartObject free_modules = SmartObject(SmartType_Array);
-  for (auto& module : supported_resources) {
-    if (allocated_resources.find(module) == allocated_resources.end()) {
-      modules_inserter(free_modules)(module);
+  if (is_rc_enabled) {
+    auto modules_inserter = [](SmartObject& result_modules) {
+      return [&result_modules](const std::string& module_name) {
+        smart_objects::SmartObject module_data =
+            SmartObject(smart_objects::SmartType_Map);
+        auto module_type =
+            StringToEnum<mobile_apis::ModuleType::eType>(module_name);
+        module_data[message_params::kModuleType] = module_type;
+        result_modules.asArray()->push_back(module_data);
+      };
+    };
+    for (const auto& module : allocated_resources) {
+      if (module.second == app_id) {
+        modules_inserter(allocated_modules)(module.first);
+      }
+    }
+    for (auto& module : supported_resources) {
+      if (allocated_resources.find(module) == allocated_resources.end()) {
+        modules_inserter(free_modules)(module);
+      }
     }
   }
   msg_params[message_params::kAllocatedModules] = allocated_modules;
@@ -269,8 +271,11 @@ ResourceAllocationManagerImpl::CreateOnRCStatusNotificationToMobile(
   auto msg_to_mobile = MessageHelper::CreateNotification(
       mobile_apis::FunctionID::OnRCStatusID, app->app_id());
   auto& msg_params = (*msg_to_mobile)[application_manager::strings::msg_params];
-  ConstructOnRCStatusNotificationParams(
-      msg_params, allocated_resources_, all_supported_modules(), app->app_id());
+  ConstructOnRCStatusNotificationParams(msg_params,
+                                        allocated_resources_,
+                                        all_supported_modules(),
+                                        app->app_id(),
+                                        is_rc_enabled());
   return msg_to_mobile;
 }
 
@@ -282,8 +287,11 @@ ResourceAllocationManagerImpl::CreateOnRCStatusNotificationToHmi(
   auto msg_to_hmi =
       MessageHelper::CreateHMINotification(hmi_apis::FunctionID::RC_OnRCStatus);
   auto& msg_params = (*msg_to_hmi)[application_manager::strings::msg_params];
-  ConstructOnRCStatusNotificationParams(
-      msg_params, allocated_resources_, all_supported_modules(), app->app_id());
+  ConstructOnRCStatusNotificationParams(msg_params,
+                                        allocated_resources_,
+                                        all_supported_modules(),
+                                        app->app_id(),
+                                        is_rc_enabled());
   msg_params[application_manager::strings::app_id] = app->hmi_app_id();
   return msg_to_hmi;
 }
@@ -292,17 +300,40 @@ void ResourceAllocationManagerImpl::SetResourceAquired(
     const std::string& module_type, const uint32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   allocated_resources_[module_type] = app_id;
-  SendOnRCStatusNotification();
+  SendOnRCStatusNotifications(NotificationTrigger::MODULE_ALLOCATION);
 }
 
-void ResourceAllocationManagerImpl::SendOnRCStatusNotification() {
+void ResourceAllocationManagerImpl::SendOnRCStatusNotifications(
+    NotificationTrigger::eType event) {
   LOG4CXX_AUTO_TRACE(logger_);
   auto rc_apps = RCRPCPlugin::GetRCApplications(app_mngr_);
   for (const auto& rc_app : rc_apps) {
-    auto msg_to_mobile = CreateOnRCStatusNotificationToMobile(rc_app);
-    rpc_service_.SendMessageToMobile(msg_to_mobile);
-    auto msg_to_hmi = CreateOnRCStatusNotificationToHmi(rc_app);
-    rpc_service_.SendMessageToHMI(msg_to_hmi);
+    smart_objects::SmartObjectSPtr msg_to_mobile;
+    smart_objects::SmartObjectSPtr msg_to_hmi;
+    switch (event) {
+      case NotificationTrigger::APP_REGISTRATION:
+        msg_to_mobile = CreateOnRCStatusNotificationToMobile(rc_app);
+        (*msg_to_mobile)[application_manager::strings::msg_params]
+                        [message_params::kAllowed] = is_rc_enabled();
+        rpc_service_.SendMessageToMobile(msg_to_mobile);
+        if (is_rc_enabled()) {
+          msg_to_hmi = CreateOnRCStatusNotificationToHmi(rc_app);
+          rpc_service_.SendMessageToHMI(msg_to_hmi);
+        }
+        break;
+      case NotificationTrigger::MODULE_ALLOCATION:
+        msg_to_mobile = CreateOnRCStatusNotificationToMobile(rc_app);
+        rpc_service_.SendMessageToMobile(msg_to_mobile);
+        msg_to_hmi = CreateOnRCStatusNotificationToHmi(rc_app);
+        rpc_service_.SendMessageToHMI(msg_to_hmi);
+        break;
+      case NotificationTrigger::RC_STATE_CHANGING:
+        msg_to_mobile = CreateOnRCStatusNotificationToMobile(rc_app);
+        (*msg_to_mobile)[application_manager::strings::msg_params]
+                        [message_params::kAllowed] = is_rc_enabled();
+        rpc_service_.SendMessageToMobile(msg_to_mobile);
+        break;
+    }
   }
 }
 
@@ -312,6 +343,7 @@ bool ResourceAllocationManagerImpl::is_rc_enabled() const {
 
 void ResourceAllocationManagerImpl::set_rc_enabled(const bool value) {
   is_rc_enabled_ = value;
+  SendOnRCStatusNotifications(NotificationTrigger::RC_STATE_CHANGING);
 }
 
 void ResourceAllocationManagerImpl::SetResourceFree(
@@ -476,7 +508,7 @@ void ResourceAllocationManagerImpl::OnApplicationEvent(
       ReleaseResource(*module, application->app_id());
     }
     if (!acquired_modules.empty()) {
-      SendOnRCStatusNotification();
+      SendOnRCStatusNotifications(NotificationTrigger::MODULE_ALLOCATION);
     }
     Apps app_list;
     app_list.push_back(application);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_resource_allocation_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_resource_allocation_manager.h
@@ -65,8 +65,9 @@ class MockResourceAllocationManager
                rc_rpc_plugin::RCAppExtensionPtr(
                    application_manager::ApplicationSharedPtr application));
   MOCK_METHOD0(ResetAllAllocations, void());
-  MOCK_METHOD1(SendOnRCStatusNotifications,
-               void(rc_rpc_plugin::NotificationTrigger::eType));
+  MOCK_METHOD2(SendOnRCStatusNotifications,
+               void(rc_rpc_plugin::NotificationTrigger::eType,
+                    application_manager::ApplicationSharedPtr application));
   MOCK_CONST_METHOD0(is_rc_enabled, bool());
   MOCK_METHOD1(set_rc_enabled, void(const bool value));
 };

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_resource_allocation_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_resource_allocation_manager.h
@@ -65,7 +65,8 @@ class MockResourceAllocationManager
                rc_rpc_plugin::RCAppExtensionPtr(
                    application_manager::ApplicationSharedPtr application));
   MOCK_METHOD0(ResetAllAllocations, void());
-  MOCK_METHOD0(SendOnRCStatusNotification, void());
+  MOCK_METHOD1(SendOnRCStatusNotifications,
+               void(rc_rpc_plugin::NotificationTrigger::eType));
   MOCK_CONST_METHOD0(is_rc_enabled, bool());
   MOCK_METHOD1(set_rc_enabled, void(const bool value));
 };

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/resource_allocation_manager_impl_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/resource_allocation_manager_impl_test.cc
@@ -666,7 +666,7 @@ TEST_F(RAManagerTest, OnRCStatus_ModuleAllocation) {
   auto msg_to_hmi_params =
       (*message_to_hmi)[application_manager::strings::msg_params];
   // Assert
-  EXPECT_EQ(msg_to_mob_params.keyExists(message_params::kAllowed), false);
+  EXPECT_EQ(msg_to_mob_params[message_params::kAllowed].asBool(), true);
   EXPECT_EQ(
       msg_to_mob_params[message_params::kAllocatedModules].asArray()->size(),
       1u);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/resource_allocation_manager_impl_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/resource_allocation_manager_impl_test.cc
@@ -517,16 +517,14 @@ TEST_F(RAManagerTest, OnRCStatus_AppRegistation_RC_allowed) {
   EXPECT_CALL(mock_rpc_service_, SendMessageToMobile(_, false))
       .WillOnce(SaveArg<0>(&message_to_mob));
   application_manager::commands::MessageSharedPtr message_to_hmi;
-  EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(_))
-      .WillOnce(SaveArg<0>(&message_to_hmi));
+  EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(_)).Times(0);
 
   // Act
-  ra_manager.SendOnRCStatusNotifications(NotificationTrigger::APP_REGISTRATION);
+  ra_manager.SendOnRCStatusNotifications(NotificationTrigger::APP_REGISTRATION,
+                                         mock_app_1_);
 
   auto msg_to_mob_params =
       (*message_to_mob)[application_manager::strings::msg_params];
-  auto msg_to_hmi_params =
-      (*message_to_hmi)[application_manager::strings::msg_params];
 
   // Assert
   EXPECT_EQ(msg_to_mob_params[message_params::kAllowed].asBool(), true);
@@ -535,13 +533,6 @@ TEST_F(RAManagerTest, OnRCStatus_AppRegistation_RC_allowed) {
       0u);
   EXPECT_EQ(msg_to_mob_params[message_params::kFreeModules].asArray()->size(),
             kSizeOfModules);
-  EXPECT_EQ(
-      msg_to_hmi_params[message_params::kAllocatedModules].asArray()->size(),
-      0u);
-  EXPECT_EQ(msg_to_hmi_params[message_params::kFreeModules].asArray()->size(),
-            kSizeOfModules);
-  EXPECT_EQ(msg_to_hmi_params[application_manager::strings::app_id].asInt(),
-            kHMIAppId1);
 }
 
 TEST_F(RAManagerTest, OnRCStatus_AppRegistation_RC_disallowed) {
@@ -558,7 +549,8 @@ TEST_F(RAManagerTest, OnRCStatus_AppRegistation_RC_disallowed) {
   EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(_)).Times(0);
 
   // Act
-  ra_manager.SendOnRCStatusNotifications(NotificationTrigger::APP_REGISTRATION);
+  ra_manager.SendOnRCStatusNotifications(NotificationTrigger::APP_REGISTRATION,
+                                         mock_app_1_);
 
   auto msg_to_mob_params =
       (*message_to_mob)[application_manager::strings::msg_params];
@@ -576,17 +568,22 @@ TEST_F(RAManagerTest, OnRCStatus_RCStateChanging_RC_disabling) {
   ResourceAllocationManagerImpl ra_manager(mock_app_mngr_, mock_rpc_service_);
   ON_CALL((*mock_app_1_), is_remote_control_supported())
       .WillByDefault(Return(true));
+  ON_CALL((*mock_app_1_), hmi_app_id()).WillByDefault(Return(kHMIAppId1));
 
   application_manager::commands::MessageSharedPtr message_to_mob;
   EXPECT_CALL(mock_rpc_service_, SendMessageToMobile(_, false))
       .WillOnce(SaveArg<0>(&message_to_mob));
-  EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(_)).Times(0);
+  application_manager::commands::MessageSharedPtr message_to_hmi;
+  EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(_))
+      .WillOnce(SaveArg<0>(&message_to_hmi));
 
   // Act
   ra_manager.set_rc_enabled(false);
 
   auto msg_to_mob_params =
       (*message_to_mob)[application_manager::strings::msg_params];
+  auto msg_to_hmi_params =
+      (*message_to_hmi)[application_manager::strings::msg_params];
   // Assert
   EXPECT_EQ(msg_to_mob_params[message_params::kAllowed].asBool(), false);
   EXPECT_EQ(
@@ -594,6 +591,13 @@ TEST_F(RAManagerTest, OnRCStatus_RCStateChanging_RC_disabling) {
       0u);
   EXPECT_EQ(msg_to_mob_params[message_params::kFreeModules].asArray()->size(),
             0u);
+  EXPECT_EQ(
+      msg_to_hmi_params[message_params::kAllocatedModules].asArray()->size(),
+      0u);
+  EXPECT_EQ(msg_to_hmi_params[message_params::kFreeModules].asArray()->size(),
+            kSizeOfModules);
+  EXPECT_EQ(msg_to_hmi_params[application_manager::strings::app_id].asInt(),
+            kHMIAppId1);
 }
 
 TEST_F(RAManagerTest, OnRCStatus_RCStateChanging_RC_enabling) {
@@ -601,17 +605,22 @@ TEST_F(RAManagerTest, OnRCStatus_RCStateChanging_RC_enabling) {
   ResourceAllocationManagerImpl ra_manager(mock_app_mngr_, mock_rpc_service_);
   ON_CALL((*mock_app_1_), is_remote_control_supported())
       .WillByDefault(Return(true));
+  ON_CALL((*mock_app_1_), hmi_app_id()).WillByDefault(Return(kHMIAppId1));
 
   application_manager::commands::MessageSharedPtr message_to_mob;
   EXPECT_CALL(mock_rpc_service_, SendMessageToMobile(_, false))
       .WillOnce(SaveArg<0>(&message_to_mob));
-  EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(_)).Times(0);
+  application_manager::commands::MessageSharedPtr message_to_hmi;
+  EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(_))
+      .WillOnce(SaveArg<0>(&message_to_hmi));
 
   // Act
   ra_manager.set_rc_enabled(true);
 
   auto msg_to_mob_params =
       (*message_to_mob)[application_manager::strings::msg_params];
+  auto msg_to_hmi_params =
+      (*message_to_hmi)[application_manager::strings::msg_params];
   // Assert
   EXPECT_EQ(msg_to_mob_params[message_params::kAllowed].asBool(), true);
   EXPECT_EQ(
@@ -619,6 +628,13 @@ TEST_F(RAManagerTest, OnRCStatus_RCStateChanging_RC_enabling) {
       0u);
   EXPECT_EQ(msg_to_mob_params[message_params::kFreeModules].asArray()->size(),
             kSizeOfModules);
+  EXPECT_EQ(
+      msg_to_hmi_params[message_params::kAllocatedModules].asArray()->size(),
+      0u);
+  EXPECT_EQ(msg_to_hmi_params[message_params::kFreeModules].asArray()->size(),
+            kSizeOfModules);
+  EXPECT_EQ(msg_to_hmi_params[application_manager::strings::app_id].asInt(),
+            kHMIAppId1);
 }
 
 TEST_F(RAManagerTest, OnRCStatus_ModuleAllocation) {
@@ -642,7 +658,8 @@ TEST_F(RAManagerTest, OnRCStatus_ModuleAllocation) {
 
   // Act
   ra_manager.SendOnRCStatusNotifications(
-      NotificationTrigger::MODULE_ALLOCATION);
+      NotificationTrigger::MODULE_ALLOCATION,
+      utils::SharedPtr<application_manager::Application>());
 
   auto msg_to_mob_params =
       (*message_to_mob)[application_manager::strings::msg_params];

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -6345,6 +6345,13 @@
 
     <function name="OnRCStatus" functionID="OnRCStatusID" messagetype="notification">
       <description>Issued by SDL to notify the application about remote control status change on SDL</description>
+      <param name="allowed" type="Boolean" mandatory="false">
+        <description>
+            If "true" - RC is allowed; if "false" - RC is disallowed.
+            Not present in notification in case by module allocation/deallocation.
+            Present in notification in cases enabling/disabling RC or RC-app registration.
+        </description>
+      </param>
       <param name="allocatedModules" type="ModuleData" minsize="0" maxsize="100" array="true" mandatory="true">
         <description>Contains a list (zero or more) of module types that are allocated to the application.</description>
       </param>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -6348,8 +6348,6 @@
       <param name="allowed" type="Boolean" mandatory="false">
         <description>
             If "true" - RC is allowed; if "false" - RC is disallowed.
-            Not present in notification in case by module allocation/deallocation.
-            Present in notification in cases enabling/disabling RC or RC-app registration.
         </description>
       </param>
       <param name="allocatedModules" type="ModuleData" minsize="0" maxsize="100" array="true" mandatory="true">


### PR DESCRIPTION
### This implementation is based on OnRCStatus notification, so this PR should be merged after https://github.com/smartdevicelink/sdl_core/pull/2209

Technical task : #2244 

This pull request contains the implementation of Remote Control - Update OnRCStatus with a new allowed parameter
(proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0172-onRcStatus-allowed.md)

Test scripts: https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/1952
For testing use the following test set:
https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/feature/onRcStatus_allowed/test_sets/rc_OnRCStatus.txt