### PR TITLE
Set unregister reason before UnregisterAllApplications()

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2272,6 +2272,8 @@ bool ApplicationManagerImpl::Stop() {
   stopping_application_mng_lock_.Release();
   application_list_update_timer_.Stop();
   try {
+    SetUnregisterAllApplicationsReason(
+      mobile_api::AppInterfaceUnregisteredReason::IGNITION_OFF);
     UnregisterAllApplications();
   } catch (...) {
     LOG4CXX_ERROR(logger_,


### PR DESCRIPTION
Fixes #2300 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
I confirmed with Xevo's internal HU devboard and testing SDL iOS app.

### Summary
SDL iOS proxy 6.0.0 crashes when receiving SDLOnAppInterfaceUnregistered notification with reason -1 (INVALID_ENUM). Reason -1 is sent when ApplicationManager is stopped, When stopping ApplicationManager, it calls UnregisterAllApplications() WITHOUT calling SetUnregisterAllApplicationsReason(). I fixed to call SetUnregisterAllApplicationsReason() with reason IGNITION_OFF.

### Changelog
##### Bug Fixes
* Fix not to send SDLOnAppInterfaceUnregistered notification with invalid reason.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)