### PR TITLE
Remove defunct `appID` parameter from UnsubscribeVehicleData

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -4500,9 +4500,6 @@
     <description>
       This function is used to unsubscribe the notifications from the subscribeVehicleData function.
     </description>
-    <param name="appID" type="Integer" mandatory="true">
-      <description>ID of application that requested this RPC.</description>
-    </param>
     <param name="gps" type="Boolean" mandatory="false">
       <description>See GPSData</description>
     </param>


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **major** API changes.

### Summary
Remove `appID` from UnsubscribeVehicleData which hasn't been included since the changes in #152

### Changelog
##### Breaking Changes
* Removal of `appID` parameter from `VehicleInfo.UnsubscribeVehicleData` request

##### Bug Fixes
* Removed defunct parameter from HMI_API.xml

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)