### PR TITLE
Fix/get interior data cache corner cases

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/get_interior_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/get_interior_vehicle_data_request.h
@@ -95,6 +95,10 @@ class GetInteriorVehicleDataRequest : public RCCommandRequest {
 
   std::string ModuleType() FINAL;
   bool excessive_subscription_occured_;
+  bool ProcessCapabilities();
+  void ProcessResponseToMobileFromCache(app_mngr::ApplicationSharedPtr app);
+  bool AppShouldBeUnsubscribed();
+  bool TheLastAppShouldBeUnsubscribed(app_mngr::ApplicationSharedPtr app);
 };
 }  // namespace commands
 }  // namespace rc_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -53,6 +53,7 @@ using ::testing::ReturnRef;
 using ::testing::SaveArg;
 using ::application_manager::Message;
 using ::application_manager::MessageType;
+using application_manager::ApplicationSet;
 using application_manager::commands::MessageSharedPtr;
 using ::application_manager::ApplicationSharedPtr;
 using ::protocol_handler::MessagePriority;
@@ -78,7 +79,10 @@ class GetInteriorVehicleDataRequestTest
  public:
   GetInteriorVehicleDataRequestTest()
       : mock_app_(utils::MakeShared<NiceMock<MockApplication> >())
-      , rc_app_extention_(utils::MakeShared<RCAppExtension>(kModuleId)) {
+      , mock_app2_(utils::MakeShared<NiceMock<MockApplication> >())
+      , rc_app_extention_(utils::MakeShared<RCAppExtension>(kModuleId))
+      , rc_app_extention2_(utils::MakeShared<RCAppExtension>(kModuleId))
+      , apps_da_(apps_, apps_lock_) {
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId));
     ON_CALL(app_mngr_, hmi_interfaces())
         .WillByDefault(ReturnRef(mock_hmi_interfaces_));
@@ -130,15 +134,26 @@ class GetInteriorVehicleDataRequestTest
  protected:
   smart_objects::SmartObject rc_capabilities_;
   utils::SharedPtr<MockApplication> mock_app_;
+  utils::SharedPtr<MockApplication> mock_app2_;
   utils::SharedPtr<RCAppExtension> rc_app_extention_;
+  utils::SharedPtr<RCAppExtension> rc_app_extention2_;
   testing::NiceMock<rc_rpc_plugin_test::MockResourceAllocationManager>
       mock_allocation_manager_;
   testing::NiceMock<rc_rpc_plugin_test::MockInteriorDataCache>
       mock_interior_data_cache_;
+  application_manager::ApplicationSet apps_;
+  const sync_primitives::Lock apps_lock_;
+  DataAccessor<application_manager::ApplicationSet> apps_da_;
 };
+
 TEST_F(GetInteriorVehicleDataRequestTest,
-       Execute_MessageValidationOk_ExpectCorrectMessageSentToHMI) {
+       Execute_ExpectCorrectMessageSentToHMI_NoSubscriptionNoCache) {
   // Arrange
+  auto module_type = mobile_apis::ModuleType::RADIO;
+  MessageSharedPtr mobile_message = CreateBasicMessage();
+  (*mobile_message)[application_manager::strings::msg_params]
+                   [message_params::kModuleType] = module_type;
+  // Expectations
   ON_CALL(mock_policy_handler_, CheckModule(_, _)).WillByDefault(Return(true));
   EXPECT_CALL(mock_hmi_capabilities_, rc_capability())
       .WillOnce(Return(nullptr));
@@ -146,7 +161,116 @@ TEST_F(GetInteriorVehicleDataRequestTest,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::RC_GetInteriorVehicleData)))
       .WillOnce(Return(true));
+  // Assertions
+  application_manager::SharedPtr<
+      rc_rpc_plugin::commands::GetInteriorVehicleDataRequest> command =
+      CreateRCCommand<rc_rpc_plugin::commands::GetInteriorVehicleDataRequest>(
+          mobile_message);
+  command->Run();
+}
+
+TEST_F(
+    GetInteriorVehicleDataRequestTest,
+    Execute_ExpectMessageNotSentToHMI_AndSuccessSentToMobile_AppSubscribed_DataFromCache) {
+  // Arrange
+  auto module_type = mobile_apis::ModuleType::RADIO;
   MessageSharedPtr mobile_message = CreateBasicMessage();
+  (*mobile_message)[application_manager::strings::msg_params]
+                   [message_params::kModuleType] = module_type;
+  rc_app_extention_->SubscribeToInteriorVehicleData(enums_value::kRadio);
+  smart_objects::SmartObject radio_data;
+  radio_data[message_params::kBand] = enums_value::kAM;
+  // Expectations
+  ON_CALL(mock_policy_handler_, CheckModule(_, enums_value::kRadio))
+      .WillByDefault(Return(true));
+  EXPECT_CALL(mock_hmi_capabilities_, rc_capability())
+      .WillOnce(Return(nullptr));
+  ON_CALL(*mock_app_, QueryInterface(_))
+      .WillByDefault(Return(rc_app_extention_));
+  EXPECT_CALL(mock_interior_data_cache_, Contains(enums_value::kRadio))
+      .WillOnce(Return(true));
+  EXPECT_CALL(mock_interior_data_cache_, Retrieve(enums_value::kRadio))
+      .WillOnce(Return(radio_data));
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _))
+      .WillOnce(Return(true));
+  // Assertions
+  application_manager::SharedPtr<
+      rc_rpc_plugin::commands::GetInteriorVehicleDataRequest> command =
+      CreateRCCommand<rc_rpc_plugin::commands::GetInteriorVehicleDataRequest>(
+          mobile_message);
+
+  command->Run();
+}
+
+TEST_F(
+    GetInteriorVehicleDataRequestTest,
+    Execute_ExpectCorrectMessageSentToHMI_AppSubscribedUnsubscibe_ClearCache) {
+  // Arrange
+  auto module_type = mobile_apis::ModuleType::RADIO;
+  MessageSharedPtr mobile_message = CreateBasicMessage();
+  (*mobile_message)[application_manager::strings::msg_params]
+                   [message_params::kModuleType] = module_type;
+  (*mobile_message)[application_manager::strings::msg_params]
+                   [message_params::kSubscribe] = false;
+  // Expectations
+  ON_CALL(mock_policy_handler_, CheckModule(_, enums_value::kRadio))
+      .WillByDefault(Return(true));
+  EXPECT_CALL(mock_hmi_capabilities_, rc_capability())
+      .WillOnce(Return(nullptr));
+  ON_CALL(*mock_app_, QueryInterface(_))
+      .WillByDefault(Return(rc_app_extention_));
+  EXPECT_CALL(mock_rpc_service_,
+              ManageHMICommand(HMIResultCodeIs(
+                  hmi_apis::FunctionID::RC_GetInteriorVehicleData)))
+      .WillOnce(Return(true));
+  EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);
+  // Assertions
+  application_manager::SharedPtr<
+      rc_rpc_plugin::commands::GetInteriorVehicleDataRequest> command =
+      CreateRCCommand<rc_rpc_plugin::commands::GetInteriorVehicleDataRequest>(
+          mobile_message);
+  command->Run();
+}
+
+TEST_F(GetInteriorVehicleDataRequestTest,
+       Execute_ExpectCorrectMessageSentToHMI_TwoApps_OneUnsubscribed) {
+  // Arrange
+  auto module_type = mobile_apis::ModuleType::RADIO;
+  MessageSharedPtr mobile_message = CreateBasicMessage();
+  (*mobile_message)[application_manager::strings::msg_params]
+                   [message_params::kModuleType] = module_type;
+  (*mobile_message)[application_manager::strings::msg_params]
+                   [message_params::kSubscribe] = false;
+  apps_.insert(mock_app_);
+  apps_.insert(mock_app2_);
+  rc_app_extention_->SubscribeToInteriorVehicleData(enums_value::kRadio);
+  rc_app_extention2_->SubscribeToInteriorVehicleData(enums_value::kRadio);
+  smart_objects::SmartObject radio_data;
+  radio_data[message_params::kBand] = enums_value::kAM;
+
+  // Expectations
+  ON_CALL(mock_policy_handler_, CheckModule(_, enums_value::kRadio))
+      .WillByDefault(Return(true));
+  EXPECT_CALL(mock_hmi_capabilities_, rc_capability())
+      .WillOnce(Return(nullptr));
+  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(apps_da_));
+  ON_CALL(*mock_app_, QueryInterface(_))
+      .WillByDefault(Return(rc_app_extention_));
+  ON_CALL(*mock_app2_, QueryInterface(_))
+      .WillByDefault(Return(rc_app_extention2_));
+  EXPECT_CALL(mock_interior_data_cache_, Contains(enums_value::kRadio))
+      .WillOnce(Return(true));
+  EXPECT_CALL(mock_interior_data_cache_, Retrieve(enums_value::kRadio))
+      .WillOnce(Return(radio_data));
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _))
+      .WillOnce(Return(true));
+  // Assertions
   application_manager::SharedPtr<
       rc_rpc_plugin::commands::GetInteriorVehicleDataRequest> command =
       CreateRCCommand<rc_rpc_plugin::commands::GetInteriorVehicleDataRequest>(
@@ -162,16 +286,16 @@ TEST_F(
   NsSmartDeviceLink::NsSmartObjects::SmartObject& msg_params =
       (*mobile_message)[application_manager::strings::msg_params];
   msg_params[message_params::kModuleType] = mobile_apis::ModuleType::RADIO;
+  // Expectations
   ON_CALL(mock_policy_handler_, CheckModule(_, _)).WillByDefault(Return(true));
-  MessageSharedPtr command_result;
   EXPECT_CALL(mock_rpc_service_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::RC_GetInteriorVehicleData))).Times(0);
-  EXPECT_CALL(
-      mock_rpc_service_,
-      ManageMobileCommand(
-          MobileResultCodeIs(mobile_apis::Result::UNSUPPORTED_RESOURCE), _))
-      .WillOnce(DoAll(SaveArg<0>(&command_result), Return(true)));
+  EXPECT_CALL(mock_rpc_service_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_apis::Result::UNSUPPORTED_RESOURCE),
+                  _)).WillOnce((Return(true)));
+  // Assertions
   application_manager::SharedPtr<
       rc_rpc_plugin::commands::GetInteriorVehicleDataRequest> command =
       CreateRCCommand<rc_rpc_plugin::commands::GetInteriorVehicleDataRequest>(
@@ -194,12 +318,12 @@ TEST_F(GetInteriorVehicleDataRequestTest,
       hmi_apis::Common_Result::SUCCESS;
   hmi_msg_params[application_manager::hmi_response::code] = response_code;
   hmi_msg_params[application_manager::strings::connection_key] = kConnectionKey;
-
+  // Expectations
   EXPECT_CALL(
       mock_rpc_service_,
       ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::SUCCESS), _))
       .WillOnce(Return(true));
-
+  // Assertions
   application_manager::event_engine::Event event(
       hmi_apis::FunctionID::RC_GetInteriorVehicleData);
   event.set_smart_object(*hmi_message);
@@ -225,11 +349,12 @@ TEST_F(GetInteriorVehicleDataRequestTest,
       hmi_apis::Common_Result::READ_ONLY;
   hmi_msg_params[application_manager::hmi_response::code] = response_code;
   hmi_msg_params[application_manager::strings::connection_key] = kConnectionKey;
+  // Expectations
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(
                   MobileResultCodeIs(mobile_apis::Result::GENERIC_ERROR), _))
       .WillOnce(Return(false));
-
+  // Assertions
   application_manager::event_engine::Event event(
       hmi_apis::FunctionID::RC_GetInteriorVehicleData);
   event.set_smart_object(*hmi_message);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -84,11 +84,12 @@ class GetInteriorVehicleDataRequestTest
       , rc_app_extention_(utils::MakeShared<RCAppExtension>(kModuleId))
       , rc_app_extention2_(utils::MakeShared<RCAppExtension>(kModuleId))
       , apps_da_(apps_, apps_lock_) {
-
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId2));
-    ON_CALL(*mock_app_, is_remote_control_supported()).WillByDefault(Return(true));
-    ON_CALL(*mock_app2_, is_remote_control_supported()).WillByDefault(Return(true));
+    ON_CALL(*mock_app_, is_remote_control_supported())
+        .WillByDefault(Return(true));
+    ON_CALL(*mock_app2_, is_remote_control_supported())
+        .WillByDefault(Return(true));
     ON_CALL(*mock_app_, QueryInterface(_))
         .WillByDefault(Return(rc_app_extention_));
     ON_CALL(*mock_app2_, QueryInterface(_))
@@ -167,7 +168,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
   ON_CALL(mock_hmi_capabilities_, rc_capability())
       .WillByDefault(Return(nullptr));
   ON_CALL(mock_interior_data_cache_, Contains(enums_value::kRadio))
-          .WillByDefault(Return(false));
+      .WillByDefault(Return(false));
 
   application_manager::SharedPtr<
       rc_rpc_plugin::commands::GetInteriorVehicleDataRequest> command =
@@ -203,7 +204,6 @@ TEST_F(
       .WillByDefault(Return(nullptr));
   ON_CALL(*mock_app_, QueryInterface(_))
       .WillByDefault(Return(rc_app_extention_));
-
 
   application_manager::SharedPtr<
       rc_rpc_plugin::commands::GetInteriorVehicleDataRequest> command =
@@ -243,7 +243,7 @@ TEST_F(
 
   MessageSharedPtr hmi_response = CreateBasicMessage();
   NsSmartDeviceLink::NsSmartObjects::SmartObject& hmi_msg_params =
-      (*hmi_response )[application_manager::strings::msg_params];
+      (*hmi_response)[application_manager::strings::msg_params];
   hmi_apis::Common_Result::eType response_code =
       hmi_apis::Common_Result::SUCCESS;
   hmi_msg_params[application_manager::hmi_response::code] = response_code;
@@ -260,7 +260,6 @@ TEST_F(
   ON_CALL(mock_hmi_capabilities_, rc_capability())
       .WillByDefault(Return(nullptr));
 
-
   // Expectations
   EXPECT_CALL(mock_rpc_service_,
               ManageHMICommand(HMIResultCodeIs(
@@ -273,7 +272,6 @@ TEST_F(
       .WillOnce(Return(true));
 
   EXPECT_CALL(mock_interior_data_cache_, ClearCache());
-
 
   // Act
   application_manager::SharedPtr<
@@ -333,14 +331,14 @@ TEST_F(GetInteriorVehicleDataRequestTest,
   // Act
   command->Run();
 
-  //Assert
-  EXPECT_FALSE(rc_app_extention_->IsSubscibedToInteriorVehicleData(enums_value::kRadio));
+  // Assert
+  EXPECT_FALSE(
+      rc_app_extention_->IsSubscibedToInteriorVehicleData(enums_value::kRadio));
 }
 
 TEST_F(
     GetInteriorVehicleDataRequestTest,
     Execute_CapabilitiesValidationFailed_ExpectMessageNotSentToHMI_AndFalseSentToMobile) {
-
   // Arrange
   MessageSharedPtr mobile_message = CreateBasicMessage();
   NsSmartDeviceLink::NsSmartObjects::SmartObject& msg_params =
@@ -355,7 +353,7 @@ TEST_F(
   // Used empty rc capabilities
 
   // Expectations
-  EXPECT_CALL(mock_rpc_service_,ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).Times(0);
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(
                   MobileResultCodeIs(mobile_apis::Result::UNSUPPORTED_RESOURCE),
@@ -385,9 +383,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
   ON_CALL(mock_hmi_capabilities_, rc_capability())
       .WillByDefault(Return(nullptr));
 
-  ON_CALL(mock_interior_data_cache_, Contains(_))
-      .WillByDefault(Return(false));
-
+  ON_CALL(mock_interior_data_cache_, Contains(_)).WillByDefault(Return(false));
 
   // Expectations
   EXPECT_CALL(
@@ -411,14 +407,14 @@ TEST_F(GetInteriorVehicleDataRequestTest,
 
 TEST_F(GetInteriorVehicleDataRequestTest,
        OnEvent_InvalidHmiResponse_ExpectGenericErrorResponseSentToMobile) {
-    using rc_rpc_plugin::commands::GetInteriorVehicleDataRequest;
-    namespace hmi_response = application_manager::hmi_response;
-    namespace strings = application_manager::strings;
-
+  using rc_rpc_plugin::commands::GetInteriorVehicleDataRequest;
+  namespace hmi_response = application_manager::hmi_response;
+  namespace strings = application_manager::strings;
 
   // Arrange
   MessageSharedPtr mobile_message = CreateBasicMessage();
-  auto& msg_params = (*mobile_message)[application_manager::strings::msg_params];
+  auto& msg_params =
+      (*mobile_message)[application_manager::strings::msg_params];
   msg_params[message_params::kModuleType] = mobile_apis::ModuleType::CLIMATE;
 
   MessageSharedPtr hmi_message = CreateBasicMessage();
@@ -426,13 +422,11 @@ TEST_F(GetInteriorVehicleDataRequestTest,
   hmi_msg_params[hmi_response::code] = hmi_apis::Common_Result::READ_ONLY;
   hmi_msg_params[strings::connection_key] = kConnectionKey;
 
-
   ON_CALL(mock_policy_handler_, CheckModule(_, enums_value::kClimate))
       .WillByDefault(Return(true));
   ON_CALL(mock_hmi_capabilities_, rc_capability())
       .WillByDefault(Return(nullptr));
-  ON_CALL(mock_interior_data_cache_, Contains(_))
-      .WillByDefault(Return(false));
+  ON_CALL(mock_interior_data_cache_, Contains(_)).WillByDefault(Return(false));
 
   // Expectations
   EXPECT_CALL(mock_rpc_service_,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -350,7 +350,6 @@ TEST_F(
           mobile_message);
 
   ON_CALL(mock_policy_handler_, CheckModule(_, _)).WillByDefault(Return(true));
-  // Used empty rc capabilities
 
   // Expectations
   EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).Times(0);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/interior_data_cache_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/interior_data_cache_test.cc
@@ -69,7 +69,8 @@ TEST_F(InteriorDataCacheTest, DataDoesNotExistAfterClear) {
   EXPECT_EQ(Retrieved_data, data);
   cache.ClearCache();
   auto Retrieved_data_after_clear = cache.Retrieve(module_type_key);
-  EXPECT_EQ(smart_objects::SmartType_Null, Retrieved_data_after_clear.getType());
+  EXPECT_EQ(smart_objects::SmartType_Null,
+            Retrieved_data_after_clear.getType());
 }
 
 TEST_F(InteriorDataCacheTest, MultipleDataCached) {

--- a/src/components/application_manager/test/include/application_manager/commands/commands_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/commands_test.h
@@ -151,8 +151,10 @@ class CommandsTest : public ::testing::Test {
 
   MockAppManager app_mngr_;
   MockRPCService mock_rpc_service_;
-  testing::NiceMock<application_manager_test::MockHMICapabilities> mock_hmi_capabilities_;
-  testing::NiceMock<policy_test::MockPolicyHandlerInterface> mock_policy_handler_;
+  testing::NiceMock<application_manager_test::MockHMICapabilities>
+      mock_hmi_capabilities_;
+  testing::NiceMock<policy_test::MockPolicyHandlerInterface>
+      mock_policy_handler_;
   MockAppManagerSettings app_mngr_settings_;
   MOCK(am::MockHmiInterfaces) mock_hmi_interfaces_;
   am::MockMessageHelper& mock_message_helper_;

--- a/src/components/application_manager/test/include/application_manager/commands/commands_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/commands_test.h
@@ -45,6 +45,7 @@
 #include "application_manager/test/include/application_manager/mock_hmi_interface.h"
 #include "application_manager/test/include/application_manager/mock_application.h"
 #include "application_manager/test/include/application_manager/mock_message_helper.h"
+#include "application_manager/mock_application_manager_settings.h"
 #include "application_manager/mock_rpc_service.h"
 #include "application_manager/mock_hmi_capabilities.h"
 #include "application_manager/policies/mock_policy_handler_interface.h"
@@ -150,8 +151,8 @@ class CommandsTest : public ::testing::Test {
 
   MockAppManager app_mngr_;
   MockRPCService mock_rpc_service_;
-  application_manager_test::MockHMICapabilities mock_hmi_capabilities_;
-  policy_test::MockPolicyHandlerInterface mock_policy_handler_;
+  testing::NiceMock<application_manager_test::MockHMICapabilities> mock_hmi_capabilities_;
+  testing::NiceMock<policy_test::MockPolicyHandlerInterface> mock_policy_handler_;
   MockAppManagerSettings app_mngr_settings_;
   MOCK(am::MockHmiInterfaces) mock_hmi_interfaces_;
   am::MockMessageHelper& mock_message_helper_;


### PR DESCRIPTION
Rework of GetnteriorData logic. Extract common functions. Fix defects found by unit tests.
Rework unit tests : 
  - Add missed expectations
  - Make ON_CALLs arangments 