### PR TITLE
On interior vehicle data update cache

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/on_interior_vehicle_data_notification.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/on_interior_vehicle_data_notification.h
@@ -63,6 +63,7 @@ class OnInteriorVehicleDataNotification
 
  private:
   InteriorDataCache& interior_data_cache_;
+  void AddDataToCache(const std::string& module_type);
 };
 }  // namespace commands
 }  // namespace rc_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_helpers.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_helpers.h
@@ -1,0 +1,36 @@
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_HELPERS_H
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_HELPERS_H
+
+#include <map>
+#include <string>
+#include "application_manager/application.h"
+#include "rc_rpc_plugin/rc_app_extension.h"
+
+namespace rc_rpc_plugin {
+
+/**
+ * @brief The RCHelpers class this contains frequently used static data
+ * structures related strictly to RC
+ * Converters, mapping, factory functions
+ */
+class RCHelpers {
+ public:
+  /**
+  * @brief GetModuleTypeToDataMapping get mapping of module type enum naming to
+  * actual module data filed name
+  * @return module mapping from enum naming to filed name
+  */
+  static const std::map<std::string, std::string>& GetModuleTypeToDataMapping();
+
+  /**
+   * @brief GetRCExtension extract RC extension from application
+   * @param app application to extract extension
+   * @return rc extension of app is rc applicaiton, otherwise return emty shared
+   * pointer.
+   */
+  static RCAppExtensionPtr GetRCExtension(
+      application_manager::Application& app);
+};
+
+}  // rc_rpc_plugin
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_HELPERS_H

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager.h
@@ -141,9 +141,6 @@ class ResourceAllocationManager {
    */
   virtual void ResetAllAllocations() = 0;
 
-  virtual RCAppExtensionPtr GetApplicationExtention(
-      application_manager::ApplicationSharedPtr application) = 0;
-
   virtual ~ResourceAllocationManager() {}
 };
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager_impl.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager_impl.h
@@ -110,14 +110,6 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
 
   void ResetAllAllocations() FINAL;
 
-  /**
-   * @brief GetApplicationExtention Provides access to application RC extention
-   * @param application Application
-   * @return Pointer to RC extention of application or NULL if not available
-   */
-  RCAppExtensionPtr GetApplicationExtention(
-      application_manager::ApplicationSharedPtr application) FINAL;
-
  private:
   /**
    * @brief IsModuleTypeRejected check if current resource was rejected by

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc
@@ -33,6 +33,7 @@
 #include "rc_rpc_plugin/commands/hmi/rc_on_remote_control_settings_notification.h"
 #include "rc_rpc_plugin/rc_rpc_plugin.h"
 #include "rc_rpc_plugin/rc_module_constants.h"
+#include "rc_rpc_plugin/rc_helpers.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -105,9 +106,7 @@ void RCOnRemoteControlSettingsNotification::DisallowRCFunctionality() {
     application_manager_.ChangeAppsHMILevel(
         app->app_id(), mobile_apis::HMILevel::eType::HMI_NONE);
 
-    const RCAppExtensionPtr extension =
-        application_manager::AppExtensionPtr::static_pointer_cast<
-            RCAppExtension>(app->QueryInterface(RCRPCPlugin::kRCPluginID));
+    const auto extension = RCHelpers::GetRCExtension(*app);
     if (extension) {
       UnsubscribeFromInteriorVehicleDataForAllModules(extension);
     }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -32,6 +32,7 @@
 
 #include "rc_rpc_plugin/commands/mobile/get_interior_vehicle_data_request.h"
 #include "rc_rpc_plugin/rc_module_constants.h"
+#include "rc_rpc_plugin/rc_helpers.h"
 #include "rc_rpc_plugin/rc_rpc_plugin.h"
 #include "smart_objects/enum_schema_item.h"
 #include "utils/macro.h"
@@ -254,8 +255,7 @@ void GetInteriorVehicleDataRequest::ProccessSubscription(
 
   app_mngr::ApplicationSharedPtr app =
       application_manager_.application(CommandRequestImpl::connection_key());
-  RCAppExtensionPtr extension =
-      resource_allocation_manager_.GetApplicationExtention(app);
+  const auto extension = RCHelpers::GetRCExtension(*app);
   const char* module_type;
   NsSmartDeviceLink::NsSmartObjects::
       EnumConversionHelper<mobile_apis::ModuleType::eType>::EnumToCString(
@@ -334,8 +334,7 @@ bool GetInteriorVehicleDataRequest::HasRequestExcessiveSubscription() {
   if (is_subscribe_present_in_request) {
     app_mngr::ApplicationSharedPtr app =
         application_manager_.application(CommandRequestImpl::connection_key());
-    RCAppExtensionPtr extension =
-        resource_allocation_manager_.GetApplicationExtention(app);
+    const auto extension = RCHelpers::GetRCExtension(*app);
 
     const bool is_app_already_subscribed =
         extension->IsSubscibedToInteriorVehicleData(ModuleType());

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/on_interior_vehicle_data_notification.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/on_interior_vehicle_data_notification.cc
@@ -33,6 +33,7 @@
 #include "rc_rpc_plugin/commands/mobile/on_interior_vehicle_data_notification.h"
 #include "rc_rpc_plugin/rc_rpc_plugin.h"
 #include "rc_rpc_plugin/rc_module_constants.h"
+#include "rc_rpc_plugin/rc_helpers.h"
 #include "smart_objects/enum_schema_item.h"
 #include "utils/macro.h"
 
@@ -60,11 +61,20 @@ OnInteriorVehicleDataNotification::OnInteriorVehicleDataNotification(
 
 OnInteriorVehicleDataNotification::~OnInteriorVehicleDataNotification() {}
 
+void OnInteriorVehicleDataNotification::AddDataToCache(
+    const std::string& module_type) {
+  const auto& data_mapping = RCHelpers::GetModuleTypeToDataMapping();
+  const auto module_data =
+      (*message_)[app_mngr::strings::msg_params][message_params::kModuleData]
+                 [data_mapping.at(module_type)];
+  interior_data_cache_.Add(module_type, module_data);
+}
+
 void OnInteriorVehicleDataNotification::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   const std::string module_type = ModuleType();
-
+  AddDataToCache(module_type);
   typedef std::vector<application_manager::ApplicationSharedPtr> AppPtrs;
   AppPtrs apps = RCRPCPlugin::GetRCApplications(application_manager_);
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/on_interior_vehicle_data_notification.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/on_interior_vehicle_data_notification.cc
@@ -72,9 +72,7 @@ void OnInteriorVehicleDataNotification::Run() {
     DCHECK(*it);
     application_manager::Application& app = **it;
 
-    RCAppExtensionPtr extension =
-        application_manager::AppExtensionPtr::static_pointer_cast<
-            RCAppExtension>(app.QueryInterface(RCRPCPlugin::kRCPluginID));
+    const auto extension = RCHelpers::GetRCExtension(app);
     DCHECK(extension);
     LOG4CXX_TRACE(logger_,
                   "Check subscription for "

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
@@ -82,12 +82,6 @@ bool RCCommandRequest::CheckDriverConsent() {
   LOG4CXX_AUTO_TRACE(logger_);
   app_mngr::ApplicationSharedPtr app =
       application_manager_.application(CommandRequestImpl::connection_key());
-  RCAppExtensionPtr extension =
-      resource_allocation_manager_.GetApplicationExtention(app);
-  if (!extension) {
-    LOG4CXX_ERROR(logger_, "NULL pointer.");
-    return false;
-  }
 
   const std::string module_type = ModuleType();
   rc_rpc_plugin::TypeAccess access = CheckModule(module_type, app);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_helpers.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_helpers.cc
@@ -1,0 +1,25 @@
+#include "rc_rpc_plugin/rc_helpers.h"
+#include "rc_rpc_plugin/rc_module_constants.h"
+#include "rc_rpc_plugin/rc_rpc_plugin.h"
+
+namespace rc_rpc_plugin {
+const std::map<std::string, std::string>&
+RCHelpers::GetModuleTypeToDataMapping() {
+  static std::map<std::string, std::string> mapping = {
+      {enums_value::kRadio, message_params::kRadioControlData},
+      {enums_value::kClimate, message_params::kClimateControlData},
+      {enums_value::kAudio, message_params::kAudioControlData},
+      {enums_value::kLight, message_params::kLightControlData},
+      {enums_value::kHmiSettings, message_params::kHmiSettingsControlData}};
+  return mapping;
+}
+
+RCAppExtensionPtr RCHelpers::GetRCExtension(
+    application_manager::Application& app) {
+  auto extension_interface = app.QueryInterface(RCRPCPlugin::kRCPluginID);
+  RCAppExtensionPtr extension =
+      application_manager::AppExtensionPtr::static_pointer_cast<RCAppExtension>(
+          extension_interface);
+  return extension;
+}
+}

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
@@ -36,9 +36,10 @@
 #include "interfaces/HMI_API.h"
 #include "interfaces/MOBILE_API.h"
 #include "smart_objects/enum_schema_item.h"
-#include "rc_rpc_plugin/rc_rpc_plugin.h"
 #include "application_manager/message_helper.h"
+#include "rc_rpc_plugin/rc_rpc_plugin.h"
 #include "rc_rpc_plugin/rc_module_constants.h"
+#include "rc_rpc_plugin/rc_helpers.h"
 #include "json/json.h"
 #include "utils/helpers.h"
 #include "utils/make_shared.h"
@@ -166,7 +167,7 @@ void ResourceAllocationManagerImpl::ProcessApplicationPolicyUpdate() {
                         allowed_modules.end(),
                         std::back_inserter(disallowed_modules));
 
-    RCAppExtensionPtr rc_extention = GetApplicationExtention(app_ptr);
+    auto rc_extention = RCHelpers::GetRCExtension(**app);
     Resources::const_iterator module = disallowed_modules.begin();
     for (; disallowed_modules.end() != module; ++module) {
       ReleaseResource(*module, application_id);
@@ -177,27 +178,6 @@ void ResourceAllocationManagerImpl::ProcessApplicationPolicyUpdate() {
   }
 }
 
-RCAppExtensionPtr ResourceAllocationManagerImpl::GetApplicationExtention(
-    application_manager::ApplicationSharedPtr application) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  RCAppExtensionPtr rc_app_extension;
-  if (!application) {
-    return rc_app_extension;
-  }
-
-  application_manager::AppExtensionPtr app_extension =
-      application->QueryInterface(RCRPCPlugin::kRCPluginID);
-  if (!app_extension) {
-    return rc_app_extension;
-  }
-
-  rc_app_extension =
-      application_manager::AppExtensionPtr::static_pointer_cast<RCAppExtension>(
-          app_extension);
-
-  return rc_app_extension;
-}
-
 void ResourceAllocationManagerImpl::RemoveAppsSubscriptions(const Apps& apps) {
   LOG4CXX_AUTO_TRACE(logger_);
   Apps::const_iterator app = apps.begin();
@@ -206,9 +186,9 @@ void ResourceAllocationManagerImpl::RemoveAppsSubscriptions(const Apps& apps) {
     if (!app_ptr) {
       continue;
     }
-    RCAppExtensionPtr rc_extention = GetApplicationExtention(app_ptr);
-    if (rc_extention) {
-      rc_extention->UnsubscribeFromInteriorVehicleData();
+    auto extention = RCHelpers::GetRCExtension(*app_ptr);
+    if (extention) {
+      extention->UnsubscribeFromInteriorVehicleData();
     }
   }
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
@@ -118,7 +118,7 @@ class ButtonPressRequestTest
     }
     rc_capabilities_[strings::kbuttonCapabilities] = button_caps;
     ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
-    ON_CALL(mock_allocation_manager_, GetApplicationExtention(_))
+    ON_CALL(*mock_app_, QueryInterface(RCRPCPlugin::kRCPluginID))
         .WillByDefault(Return(rc_app_extention_));
     ON_CALL(app_mngr_, GetPolicyHandler())
         .WillByDefault(ReturnRef(mock_policy_handler_));

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -35,6 +35,7 @@
 #include "application_manager/mock_application.h"
 #include "rc_rpc_plugin/rc_app_extension.h"
 #include "rc_rpc_plugin/rc_module_constants.h"
+#include "rc_rpc_plugin/rc_rpc_plugin.h"
 #include "application_manager/message_helper.h"
 #include "rc_rpc_plugin/rc_command_factory.h"
 #include "application_manager/event_engine/event_dispatcher.h"
@@ -104,7 +105,7 @@ class GetInteriorVehicleDataRequestTest
         .WillByDefault(Return(application_manager::HmiInterfaces::
                                   InterfaceState::STATE_AVAILABLE));
     ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(mock_app_));
-    ON_CALL(mock_allocation_manager_, GetApplicationExtention(_))
+    ON_CALL(*mock_app_, QueryInterface(RCRPCPlugin::kRCPluginID))
         .WillByDefault(Return(rc_app_extention_));
     ON_CALL(app_mngr_, GetPolicyHandler())
         .WillByDefault(ReturnRef(mock_policy_handler_));

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
@@ -122,7 +122,7 @@ class RCGetInteriorVehicleDataConsentTest
         .WillByDefault(Return(application_manager::HmiInterfaces::
                                   InterfaceState::STATE_AVAILABLE));
     ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(mock_app_));
-    ON_CALL(mock_allocation_manager_, GetApplicationExtention(_))
+    ON_CALL(*mock_app_, QueryInterface(RCRPCPlugin::kRCPluginID))
         .WillByDefault(Return(rc_app_extention_));
     testing::NiceMock<rc_rpc_plugin_test::MockInteriorDataCache>
         mock_interior_data_cache_;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
@@ -77,7 +77,7 @@ class SetInteriorVehicleDataRequestTest
         .WillByDefault(Return(application_manager::HmiInterfaces::
                                   InterfaceState::STATE_AVAILABLE));
     ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(mock_app_));
-    ON_CALL(mock_allocation_manager_, GetApplicationExtention(_))
+    ON_CALL(*mock_app_, QueryInterface(RCRPCPlugin::kRCPluginID))
         .WillByDefault(Return(rc_app_extention_));
 
     ON_CALL(*mock_app_, policy_app_id()).WillByDefault(Return(kPolicyAppId));

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_resource_allocation_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_resource_allocation_manager.h
@@ -61,9 +61,6 @@ class MockResourceAllocationManager
                     const uint32_t app_id,
                     const rc_rpc_plugin::ResourceState::eType state));
   MOCK_CONST_METHOD1(IsResourceFree, bool(const std::string& module_type));
-  MOCK_METHOD1(GetApplicationExtention,
-               rc_rpc_plugin::RCAppExtensionPtr(
-                   application_manager::ApplicationSharedPtr application));
   MOCK_METHOD0(ResetAllAllocations, void());
 };
 


### PR DESCRIPTION
Should be merged after https://github.com/smartdevicelink/sdl_core/pull/2332 
Update Hash on OnInteriorDataNotification from HMI.
Add RC Helper class to keep common static RC functions  