### PR TITLE
Fix sdl sends OnSystemRequest (QUERY_APPS) to the app

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -651,6 +651,9 @@ class ApplicationManagerImpl
                         const uint32_t corr_id,
                         const int32_t function_id) OVERRIDE;
 
+  void OnQueryAppsRequest(
+      const connection_handler::DeviceHandle device) OVERRIDE;
+
   // Overriden ConnectionHandlerObserver method
   void OnDeviceListUpdated(
       const connection_handler::DeviceMap& device_list) OVERRIDE;
@@ -1487,11 +1490,12 @@ class ApplicationManagerImpl
    * will send TTS global properties to HMI after timeout
    */
   std::map<uint32_t, date_time::TimeDuration> tts_global_properties_app_list_;
-
+  std::set<connection_handler::DeviceHandle> query_apps_devices_;
   bool audio_pass_thru_active_;
   uint32_t audio_pass_thru_app_id_;
   sync_primitives::Lock audio_pass_thru_lock_;
   sync_primitives::Lock tts_global_properties_app_list_lock_;
+  mutable sync_primitives::Lock query_apps_devices_lock_;
   hmi_apis::Common_DriverDistractionState::eType driver_distraction_state_;
   bool is_vr_session_strated_;
   bool hmi_cooperating_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
@@ -612,7 +612,7 @@ void SystemRequest::Run() {
     return;
   } else if (mobile_apis::RequestType::QUERY_APPS == request_type) {
     using namespace ns_smart_device_link::ns_json_handler::formatters;
-
+    application_manager_.OnQueryAppsRequest(application->device());
     smart_objects::SmartObject sm_object;
     Json::Reader reader;
     std::string json(binary_data.begin(), binary_data.end());
@@ -623,6 +623,7 @@ void SystemRequest::Run() {
     }
 
     CFormatterJsonBase::jsonValueToObj(root, sm_object);
+
     if (!ValidateQueryAppData(sm_object)) {
       SendResponse(false, mobile_apis::Result::GENERIC_ERROR);
       return;

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -170,6 +170,8 @@ class ApplicationManager {
 
   virtual ApplicationSharedPtr application(uint32_t app_id) const = 0;
   virtual ApplicationSharedPtr active_application() const = 0;
+  virtual void OnQueryAppsRequest(
+      const connection_handler::DeviceHandle device) = 0;
 
   virtual ApplicationSharedPtr get_full_or_limited_application() const = 0;
 

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -241,6 +241,8 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                void(const uint32_t connection_key,
                     const uint32_t corr_id,
                     const int32_t function_id));
+  MOCK_METHOD1(OnQueryAppsRequest,
+               void(const connection_handler::DeviceHandle));
   MOCK_METHOD4(UnregisterApplication,
                void(const uint32_t&, mobile_apis::Result::eType, bool, bool));
   MOCK_METHOD3(updateRequestTimeout,


### PR DESCRIPTION
Fixes #995

This PR is ready for review.

### Risk
This PR makes no API changes.

### Plan
Provide ATF tests.

### Summary
In the current implementation SDL does not send OnSystemRequest(QUERY_APPS) to the same app after bringing it to foreground and also to new registered app after unsuccessful attempt to send query json.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)