### PR TITLE
Unsubscribe interior vehicle data on app unregister

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_app_extension.h
@@ -67,6 +67,12 @@ class RCAppExtension : public application_manager::AppExtension {
    */
   bool IsSubscibedToInteriorVehicleData(const std::string& module_type);
 
+  /**
+   * @brief get list of subscriptions of application
+   * @return list of subscriptions of application
+   */
+  std::set<std::string> InteriorVehicleDataSubscriptions() const;
+
  private:
   std::set<std::string> subscribed_interior_vehicle_data_;
 };

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_helpers.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_helpers.h
@@ -7,6 +7,7 @@
 #include "rc_rpc_plugin/rc_app_extension.h"
 
 namespace rc_rpc_plugin {
+class RCRPCPlugin;
 
 /**
  * @brief The RCHelpers class this contains frequently used static data
@@ -30,6 +31,13 @@ class RCHelpers {
    */
   static RCAppExtensionPtr GetRCExtension(
       application_manager::Application& app);
+
+  static smart_objects::SmartObjectSPtr CreateUnsubscribeRequestToHMI(
+      const std::string& module_type, const uint32_t correlation_id);
+
+  static std::vector<application_manager::ApplicationSharedPtr>
+  AppsSubscribedTo(application_manager::ApplicationManager& app_mngr,
+                   const std::string& module_type);
 };
 
 }  // rc_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_rpc_plugin.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_rpc_plugin.h
@@ -96,6 +96,11 @@ class RCRPCPlugin : public plugins::RPCPlugin {
       application_manager::ApplicationManager& app_mngr);
 
  private:
+  void UpdateHMISubscriptionsOnAppUnregistered(
+      application_manager::Application& app);
+
+  application_manager::RPCService* rpc_service_;
+  application_manager::ApplicationManager* app_mngr_;
   std::unique_ptr<application_manager::CommandFactory> command_factory_;
   std::unique_ptr<ResourceAllocationManager> resource_allocation_manager_;
   std::unique_ptr<InteriorDataCache> interior_data_cache_;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_app_extension.cc
@@ -58,5 +58,9 @@ bool RCAppExtension::IsSubscibedToInteriorVehicleData(
   return (it != subscribed_interior_vehicle_data_.end());
 }
 
+std::set<std::string> RCAppExtension::InteriorVehicleDataSubscriptions() const {
+  return subscribed_interior_vehicle_data_;
+}
+
 RCAppExtension::~RCAppExtension() {}
 }  //  namespace rc_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_helpers.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_helpers.cc
@@ -1,8 +1,14 @@
 #include "rc_rpc_plugin/rc_helpers.h"
 #include "rc_rpc_plugin/rc_module_constants.h"
 #include "rc_rpc_plugin/rc_rpc_plugin.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/command_impl.h"
+#include "application_manager/message.h"
+#include "utils/make_shared.h"
 
 namespace rc_rpc_plugin {
+CREATE_LOGGERPTR_GLOBAL(logger_, "RemoteControlModule");
+
 const std::map<std::string, std::string>&
 RCHelpers::GetModuleTypeToDataMapping() {
   static std::map<std::string, std::string> mapping = {
@@ -21,5 +27,43 @@ RCAppExtensionPtr RCHelpers::GetRCExtension(
       application_manager::AppExtensionPtr::static_pointer_cast<RCAppExtension>(
           extension_interface);
   return extension;
+}
+
+smart_objects::SmartObjectSPtr RCHelpers::CreateUnsubscribeRequestToHMI(
+    const std::string& module_type, const uint32_t correlation_id) {
+  using namespace smart_objects;
+  namespace commands = application_manager::commands;
+  namespace am_strings = application_manager::strings;
+
+  SmartObjectSPtr message = utils::MakeShared<SmartObject>(SmartType_Map);
+  SmartObject& params = (*message)[am_strings::params];
+  SmartObject& msg_params = (*message)[am_strings::msg_params];
+
+  params[am_strings::message_type] =
+      static_cast<int>(application_manager::kRequest);
+  params[am_strings::protocol_version] =
+      commands::CommandImpl::protocol_version_;
+  params[am_strings::protocol_type] = commands::CommandImpl::hmi_protocol_type_;
+  params[am_strings::correlation_id] = correlation_id;
+  params[am_strings::function_id] =
+      hmi_apis::FunctionID::RC_GetInteriorVehicleData;
+  msg_params[message_params::kSubscribe] = false;
+  msg_params[message_params::kModuleType] = module_type;
+  return message;
+}
+
+std::vector<application_manager::ApplicationSharedPtr>
+RCHelpers::AppsSubscribedTo(application_manager::ApplicationManager& app_mngr,
+                            const std::string& module_type) {
+  std::vector<application_manager::ApplicationSharedPtr> result;
+  auto rc_apps = RCRPCPlugin::GetRCApplications(app_mngr);
+  for (auto& app : rc_apps) {
+    auto rc_ext = RCHelpers::GetRCExtension(*app);
+    DCHECK_OR_RETURN(rc_ext, result);
+    if (rc_ext->IsSubscibedToInteriorVehicleData(module_type)) {
+      result.push_back(app);
+    }
+  }
+  return result;
 }
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -35,10 +35,13 @@
 #include "rc_rpc_plugin/rc_app_extension.h"
 #include "rc_rpc_plugin/resource_allocation_manager_impl.h"
 #include "rc_rpc_plugin/interior_data_cache_impl.h"
+#include "rc_rpc_plugin/rc_helpers.h"
 #include "utils/helpers.h"
 #include "utils/date_time.h"
 
 namespace rc_rpc_plugin {
+CREATE_LOGGERPTR_GLOBAL(logger_, "RemoteControlModule");
+
 namespace plugins = application_manager::plugin_manager;
 
 bool RCRPCPlugin::Init(
@@ -60,6 +63,8 @@ bool RCRPCPlugin::Init(
                                           policy_handler,
                                           *resource_allocation_manager_,
                                           *interior_data_cache_));
+  rpc_service_ = &rpc_service;
+  app_mngr_ = &app_manager;
   return true;
 }
 
@@ -102,10 +107,12 @@ void RCRPCPlugin::OnApplicationEvent(
       break;
     }
     case plugins::kApplicationExit: {
+      UpdateHMISubscriptionsOnAppUnregistered(*application);
       resource_allocation_manager_->OnApplicationEvent(event, application);
       break;
     }
     case plugins::kApplicationUnregistered: {
+      UpdateHMISubscriptionsOnAppUnregistered(*application);
       resource_allocation_manager_->OnApplicationEvent(event, application);
       break;
     }
@@ -127,6 +134,32 @@ RCRPCPlugin::Apps RCRPCPlugin::GetRCApplications(
     }
   }
   return result;
+}
+
+void RCRPCPlugin::UpdateHMISubscriptionsOnAppUnregistered(
+    application_manager::Application& app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  auto unsubscribe_from_interior_data = [this](const std::string& module_type) {
+    auto unsubscribe_request = RCHelpers::CreateUnsubscribeRequestToHMI(
+        module_type, app_mngr_->GetNextHMICorrelationID());
+    DCHECK_OR_RETURN_VOID(rpc_service_);
+    LOG4CXX_DEBUG(logger_, "Send Unsubscribe from " << module_type);
+    rpc_service_->ManageHMICommand(unsubscribe_request);
+  };
+
+  auto rc_extension = RCHelpers::GetRCExtension(app);
+  auto subscribed_data = rc_extension->InteriorVehicleDataSubscriptions();
+  for (auto& data : subscribed_data) {
+    auto apps_subscribed = RCHelpers::AppsSubscribedTo(*app_mngr_, data);
+    if (apps_subscribed.empty()) {
+      unsubscribe_from_interior_data(data);
+    }
+    if (apps_subscribed.size() == 1 &&
+        apps_subscribed.front()->hmi_app_id() == app.hmi_app_id()) {
+      unsubscribe_from_interior_data(data);
+    }
+  }
 }
 
 }  // namespace rc_rpc_plugin


### PR DESCRIPTION
In case if the last subscribed to module data application was unregistered, SDL should send an unsubscribe request from this module data. 