### PR TITLE
Send Driver Distraction notification immediately upon registration

### DIFF
--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -141,7 +141,8 @@
                     "OnDriverDistraction": {
                         "hmi_levels": ["BACKGROUND",
                         "FULL",
-                        "LIMITED"]
+                        "LIMITED",
+                        "NONE"]
                     },
                     "OnEncodedSyncPData": {
                         "hmi_levels": ["BACKGROUND",
@@ -713,7 +714,8 @@
                     "OnDriverDistraction": {
                         "hmi_levels": ["BACKGROUND",
                         "FULL",
-                        "LIMITED"]
+                        "LIMITED",
+                        "NONE"]
                     },
                     "OnEncodedSyncPData": {
                         "hmi_levels": ["BACKGROUND",

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -188,6 +188,8 @@ class ApplicationManagerImpl
   void SendHMIStatusNotification(
       const utils::SharedPtr<Application> app) OVERRIDE;
 
+  void SendDriverDistractionState(ApplicationSharedPtr application);
+
   ApplicationSharedPtr application(
       const std::string& device_id,
       const std::string& policy_app_id) const OVERRIDE;
@@ -1347,14 +1349,6 @@ class ApplicationManagerImpl
    * @param app_id Application to proceed
    */
   void DisallowStreaming(uint32_t app_id);
-
-  /**
-   * @brief Checks if driver distraction state is valid, creates message
-   * and puts it to postponed message.
-   * @param application contains registered application.
-   */
-  void PutDriverDistractionMessageToPostponed(
-      ApplicationSharedPtr application) const;
 
   /**
    * @brief Types of directories used by Application Manager

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -411,6 +411,7 @@ void RegisterAppInterfaceRequest::Run() {
   smart_objects::SmartObjectSPtr so =
       GetLockScreenIconUrlNotification(connection_key(), application);
   rpc_service_.ManageMobileCommand(so, SOURCE_SDL);
+  application_manager_.SendDriverDistractionState(application);
 }
 
 smart_objects::SmartObjectSPtr

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
@@ -295,6 +295,7 @@ TEST_F(RegisterAppInterfaceRequestTest, Run_MinimalData_SUCCESS) {
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(_, am::commands::Command::SOURCE_SDL))
       .Times(2);
+  EXPECT_CALL(app_mngr_, SendDriverDistractionState(_));
   command_->Run();
 }
 
@@ -408,6 +409,7 @@ TEST_F(RegisterAppInterfaceRequestTest,
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(_, am::commands::Command::SOURCE_SDL))
       .Times(2);
+  EXPECT_CALL(app_mngr_, SendDriverDistractionState(_));
 
   command_->Run();
 }

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -263,6 +263,14 @@ class ApplicationManager {
       const utils::SharedPtr<Application> app) = 0;
 
   /**
+   * @brief Checks if driver distraction state is valid, creates message
+   * which is sent to the application if allowed, otherwise it is added
+   * to a list of postponed messages.
+   * @param application contains registered application.
+   */
+  virtual void SendDriverDistractionState(ApplicationSharedPtr application) = 0;
+
+  /**
    * DEPRECATED
    * @brief Checks if Application is subscribed for way points
    * @param Application AppID

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -122,6 +122,8 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD1(
       SendHMIStatusNotification,
       void(const utils::SharedPtr<application_manager::Application> app));
+  MOCK_METHOD1(SendDriverDistractionState,
+               void(application_manager::ApplicationSharedPtr app));
   MOCK_METHOD1(RemoveHMIFakeParameters,
                void(application_manager::commands::MessageSharedPtr& message));
   MOCK_CONST_METHOD1(


### PR DESCRIPTION

Fixes #2054 

This PR is **ready** for review.

### Risk
This PR makes **major** API changes.

### Testing Plan
Added new expectations for modified files

### Summary
Allows `OnDriverDistraction` in the `NONE` HMILevel and sends this notification immediately upon registering an app. If no `OnDriverDistraction` is received from the HMI, a default value of `DD_OFF` is sent

### Changelog
##### Enhancements
* Allows `OnDriverDistraction` in HMILevel `NONE`
* Core now sends `OnDriverDistraction` to the app immediately upon app registration, rather than being postponed until the app reaches an HMILevel other than `NONE`
* Sets a default value of `DD_OFF` for the driver distraction state

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)