### PR TITLE
Add the conditions for cache updating and fix rate limits

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/interior_data_cache.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/interior_data_cache.h
@@ -72,13 +72,16 @@ class InteriorDataCache {
 
   /**
    * @brief Get current value of requests in time frame
+   * @param module_type - module type for calculation statistic
    */
-  virtual uint32_t GetCurrentAmountOfRequests() const = 0;
+  virtual uint32_t GetCurrentAmountOfRequests(
+      const std::string& module_type) const = 0;
 
   /**
    * @brief Do increment of request in time frame
+   * @param module_type - module type for calculation statistic
    */
-  virtual void IncrementAmountOfRequests() = 0;
+  virtual void IncrementAmountOfRequests(const std::string& module_type) = 0;
 
  private:
   /**

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/interior_data_cache_impl.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/interior_data_cache_impl.h
@@ -53,8 +53,9 @@ class InteriorDataCacheImpl : public InteriorDataCache {
       const std::string& module_type) const OVERRIDE;
   bool Contains(const std::string& module_type) const OVERRIDE;
   void ClearCache() OVERRIDE;
-  uint32_t GetCurrentAmountOfRequests() const OVERRIDE;
-  void IncrementAmountOfRequests() OVERRIDE;
+  uint32_t GetCurrentAmountOfRequests(
+      const std::string& module_type) const OVERRIDE;
+  void IncrementAmountOfRequests(const std::string& module_type) OVERRIDE;
 
  private:
   void ResetRequestCountOnTimer() OVERRIDE;
@@ -63,7 +64,9 @@ class InteriorDataCacheImpl : public InteriorDataCache {
   mutable sync_primitives::Lock subscriptions_lock_;
 
   timer::Timer reset_request_count_timer_;
-  std::atomic<uint32_t> amount_of_request_in_this_time_frame_;
+
+  mutable sync_primitives::Lock amount_of_requests_lock_;
+  std::map<std::string, uint32_t> amount_of_request_in_this_time_frame_;
 };
 
 }  // rc_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -188,12 +188,6 @@ void GetInteriorVehicleDataRequest::Execute() {
     return;
   }
 
-  if (!CheckRateLimits()) {
-    LOG4CXX_WARN(logger_, "GetInteriorVehicleData frequency is too high.");
-    SendResponse(false, mobile_apis::Result::REJECTED);
-    return;
-  }
-
   app_mngr::ApplicationSharedPtr app =
       application_manager_.application(connection_key());
 
@@ -206,7 +200,11 @@ void GetInteriorVehicleDataRequest::Execute() {
               .asBool();
       RemoveExcessiveSubscription();
     }
-
+    if (!CheckRateLimits()) {
+      LOG4CXX_WARN(logger_, "GetInteriorVehicleData frequency is too high.");
+      SendResponse(false, mobile_apis::Result::REJECTED);
+      return;
+    }
     SendHMIRequest(hmi_apis::FunctionID::RC_GetInteriorVehicleData,
                    &(*message_)[app_mngr::strings::msg_params],
                    true);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -145,12 +145,12 @@ void GetInteriorVehicleDataRequest::ProcessResponseToMobileFromCache(
 bool GetInteriorVehicleDataRequest::CheckRateLimits() {
   LOG4CXX_AUTO_TRACE(logger_);
   const uint32_t current_requests_amount =
-      interior_data_cache_.GetCurrentAmountOfRequests();
+      interior_data_cache_.GetCurrentAmountOfRequests(ModuleType());
   LOG4CXX_DEBUG(logger_,
                 "Current amount of requests in the same time frame is: "
                     << current_requests_amount);
   if (current_requests_amount < max_request_in_time_frame_) {
-    interior_data_cache_.IncrementAmountOfRequests();
+    interior_data_cache_.IncrementAmountOfRequests(ModuleType());
     return true;
   }
   return false;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/on_interior_vehicle_data_notification.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/on_interior_vehicle_data_notification.cc
@@ -74,7 +74,11 @@ void OnInteriorVehicleDataNotification::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   const std::string module_type = ModuleType();
-  AddDataToCache(module_type);
+  auto apps_subscribed =
+      RCHelpers::AppsSubscribedTo(application_manager_, module_type);
+  if (!apps_subscribed.empty()) {
+    AddDataToCache(module_type);
+  }
   typedef std::vector<application_manager::ApplicationSharedPtr> AppPtrs;
   AppPtrs apps = RCRPCPlugin::GetRCApplications(application_manager_);
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/interior_data_cache_impl.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/interior_data_cache_impl.cc
@@ -87,14 +87,22 @@ void InteriorDataCacheImpl::ClearCache() {
 
 void InteriorDataCacheImpl::ResetRequestCountOnTimer() {
   LOG4CXX_AUTO_TRACE(logger_);
-  amount_of_request_in_this_time_frame_ = 0;
+  sync_primitives::AutoLock autolock(amount_of_requests_lock_);
+  amount_of_request_in_this_time_frame_.clear();
 }
 
-uint32_t InteriorDataCacheImpl::GetCurrentAmountOfRequests() const {
-  return amount_of_request_in_this_time_frame_;
+uint32_t InteriorDataCacheImpl::GetCurrentAmountOfRequests(
+    const std::string& module_type) const {
+  sync_primitives::AutoLock autolock(amount_of_requests_lock_);
+  auto it = amount_of_request_in_this_time_frame_.find(module_type);
+  auto amount =
+      amount_of_request_in_this_time_frame_.end() != it ? it->second : 0;
+  return amount;
 }
 
-void InteriorDataCacheImpl::IncrementAmountOfRequests() {
-  ++amount_of_request_in_this_time_frame_;
+void InteriorDataCacheImpl::IncrementAmountOfRequests(
+    const std::string& module_type) {
+  sync_primitives::AutoLock autolock(amount_of_requests_lock_);
+  (amount_of_request_in_this_time_frame_[module_type])++;
 }
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_interior_data_cache.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_interior_data_cache.h
@@ -33,19 +33,21 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_TEST_INCLUDE_RC_RPC_PLUGIN_MOCK_MOCK_INTERIOR_DATA_CACHE_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_TEST_INCLUDE_RC_RPC_PLUGIN_MOCK_MOCK_INTERIOR_DATA_CACHE_H_
 
+#include <string>
 #include "gmock/gmock.h"
 #include "rc_rpc_plugin/interior_data_cache.h"
-
 namespace rc_rpc_plugin_test {
 
 class MockInteriorDataCache : public rc_rpc_plugin::InteriorDataCache {
  public:
   MOCK_METHOD2(Add,
-               void(const std::string&,
-                    const NsSmartDeviceLink::NsSmartObjects::SmartObject&));
+               void(const std::string&, const smart_objects::SmartObject&));
   MOCK_CONST_METHOD1(Retrieve, smart_objects::SmartObject(const std::string&));
   MOCK_CONST_METHOD1(Contains, bool(const std::string&));
   MOCK_METHOD0(ClearCache, void());
+
+  MOCK_CONST_METHOD1(GetCurrentAmountOfRequests, uint32_t(const std::string&));
+  MOCK_METHOD1(IncrementAmountOfRequests, void(const std::string&));
 };
 
 }  // namespace rc_rpc_plugin_test


### PR DESCRIPTION
- Add check for subscriptions before cache updating

- Add check for interior data requests frequency by module types

- Check limits only in case when we resend request to HMI