### PR TITLE
SDL forwards `OnButtonEvent` notification of `CUSTOM_BUTTON` to `BACKGROUND` App.

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_event_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_event_notification.cc
@@ -105,11 +105,10 @@ void OnButtonEventNotification::Run() {
     const auto window_id = app->GetSoftButtonWindowID(custom_btn_id);
     (*message_)[strings::msg_params][strings::window_id] = window_id;
     const auto window_hmi_level = app->hmi_level(window_id);
-    if ((mobile_api::HMILevel::HMI_FULL != window_hmi_level) &&
-        (mobile_api::HMILevel::HMI_LIMITED != window_hmi_level)) {
+    if ((mobile_api::HMILevel::HMI_NONE == window_hmi_level)) {
       LOG4CXX_WARN(logger_,
                    "CUSTOM_BUTTON OnButtonEvent notification is allowed only "
-                       << "in FULL or LIMITED hmi level");
+                       << "in FULL, LIMITED or BACKGROUND hmi level");
       return;
     }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_event_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_event_notification.cc
@@ -107,8 +107,8 @@ void OnButtonEventNotification::Run() {
     const auto window_hmi_level = app->hmi_level(window_id);
     if ((mobile_api::HMILevel::HMI_NONE == window_hmi_level)) {
       LOG4CXX_WARN(logger_,
-                   "CUSTOM_BUTTON OnButtonEvent notification is allowed only "
-                       << "in FULL, LIMITED or BACKGROUND hmi level");
+                   "CUSTOM_BUTTON OnButtonEvent notification is not allowed in "
+                   "NONE hmi level");
       return;
     }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_press_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_press_notification.cc
@@ -110,8 +110,8 @@ void OnButtonPressNotification::Run() {
     const auto window_hmi_level = app->hmi_level(window_id);
     if ((mobile_api::HMILevel::HMI_NONE == window_hmi_level)) {
       LOG4CXX_WARN(logger_,
-                   "CUSTOM_BUTTON OnButtonPress notification is allowed only "
-                       << "in FULL, LIMITED or BACKGROUND hmi level");
+                   "CUSTOM_BUTTON OnButtonPress notification is not allowed in "
+                   "NONE hmi level");
       return;
     }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_press_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_press_notification.cc
@@ -108,11 +108,10 @@ void OnButtonPressNotification::Run() {
     app->hmi_level(mobile_apis::PredefinedWindows::DEFAULT_WINDOW);
     (*message_)[strings::msg_params][strings::window_id] = window_id;
     const auto window_hmi_level = app->hmi_level(window_id);
-    if ((mobile_api::HMILevel::HMI_FULL != window_hmi_level) &&
-        (mobile_api::HMILevel::HMI_LIMITED != window_hmi_level)) {
+    if ((mobile_api::HMILevel::HMI_NONE == window_hmi_level)) {
       LOG4CXX_WARN(logger_,
                    "CUSTOM_BUTTON OnButtonPress notification is allowed only "
-                       << "in FULL or LIMITED hmi level");
+                       << "in FULL, LIMITED or BACKGROUND hmi level");
       return;
     }
 


### PR DESCRIPTION
Fixes #967 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR provided bugfixing when SDL doesn't send notification `onButtonEvent` notification to mobile of `CUSTOM_BUTTON` in `BACKGROUND` app.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)