### PR TITLE
Include allowed param in OnRCStatus notification in case of resource allocation

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
@@ -326,10 +326,8 @@ void ResourceAllocationManagerImpl::SendOnRCStatusNotifications(
     auto rc_apps = RCRPCPlugin::GetRCApplications(app_mngr_);
     for (const auto& rc_app : rc_apps) {
       msg_to_mobile = CreateOnRCStatusNotificationToMobile(rc_app);
-      if (NotificationTrigger::RC_STATE_CHANGING == event) {
-        (*msg_to_mobile)[application_manager::strings::msg_params]
-                        [message_params::kAllowed] = is_rc_enabled();
-      }
+      (*msg_to_mobile)[application_manager::strings::msg_params]
+                      [message_params::kAllowed] = is_rc_enabled();
       rpc_service_.SendMessageToMobile(msg_to_mobile);
       msg_to_hmi = CreateOnRCStatusNotificationToHmi(rc_app);
       rpc_service_.SendMessageToHMI(msg_to_hmi);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/resource_allocation_manager_impl_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/resource_allocation_manager_impl_test.cc
@@ -666,7 +666,7 @@ TEST_F(RAManagerTest, OnRCStatus_ModuleAllocation) {
   auto msg_to_hmi_params =
       (*message_to_hmi)[application_manager::strings::msg_params];
   // Assert
-  EXPECT_EQ(msg_to_mob_params.keyExists(message_params::kAllowed), false);
+  EXPECT_EQ(msg_to_mob_params[message_params::kAllowed].asBool(), true);
   EXPECT_EQ(
       msg_to_mob_params[message_params::kAllocatedModules].asArray()->size(),
       1u);


### PR DESCRIPTION
update the implementation of Remote Control - Update OnRCStatus with a new allowed parameter
(proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0172-onRcStatus-allowed.md) according to discussion https://github.com/smartdevicelink/sdl_core/pull/2306#discussion_r202067957

Fix for ATF scripts: https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/1972