### PR TITLE
Add SEAT module to all supported modules

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
@@ -337,6 +337,7 @@ ResourceAllocationManagerImpl::all_supported_modules() {
   std::vector<std::string> result;
   result.push_back(enums_value::kClimate);
   result.push_back(enums_value::kRadio);
+  result.push_back(enums_value::kSeat);
   return result;
 }
 


### PR DESCRIPTION
Fixes  https://github.com/smartdevicelink/sdl_core/issues/2368

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
The OnRCStatus notification shall contain an array of the RC modules allocated to the application and an array of the free RC modules. After merge https://github.com/smartdevicelink/sdl_core/pull/2208 into develop, OnRCStatus notification should contain tree modules: CLIMATE, RADIO and SEAT.

### Changes 
Add SEAT module to all supported modules

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)