### PR TITLE
SDL shall not put RC applications to HMI level NONE when user disables RC in HMI

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc
@@ -101,9 +101,6 @@ void RCOnRemoteControlSettingsNotification::DisallowRCFunctionality() {
   for (Apps::iterator it = apps.begin(); it != apps.end(); ++it) {
     application_manager::ApplicationSharedPtr app = *it;
     DCHECK(app);
-    application_manager_.ChangeAppsHMILevel(
-        app->app_id(), mobile_apis::HMILevel::eType::HMI_NONE);
-
     const RCAppExtensionPtr extension =
         application_manager::AppExtensionPtr::static_pointer_cast<
             RCAppExtension>(app->QueryInterface(RCRPCPlugin::kRCPluginID));
@@ -115,44 +112,38 @@ void RCOnRemoteControlSettingsNotification::DisallowRCFunctionality() {
 
 void RCOnRemoteControlSettingsNotification::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
-
-  if (!(*message_)[app_mngr::strings::msg_params].keyExists(
+  if ((*message_)[app_mngr::strings::msg_params].keyExists(
           message_params::kAllowed)) {
-    LOG4CXX_DEBUG(logger_,
-                  "Notification is ignored due to \"allow\" parameter absense");
-    LOG4CXX_DEBUG(logger_, "RC Functionality remains unchanged");
-    return;
-  }
-
-  const bool is_allowed =
-      (*message_)[app_mngr::strings::msg_params][message_params::kAllowed]
-          .asBool();
-  if (is_allowed) {
-    hmi_apis::Common_RCAccessMode::eType access_mode =
-        hmi_apis::Common_RCAccessMode::INVALID_ENUM;
-    LOG4CXX_DEBUG(logger_, "Allowing RC Functionality");
-    resource_allocation_manager_.set_rc_enabled(true);
-    if ((*message_)[app_mngr::strings::msg_params].keyExists(
-            message_params::kAccessMode)) {
-      access_mode = static_cast<hmi_apis::Common_RCAccessMode::eType>(
-          (*message_)[app_mngr::strings::msg_params]
-                     [message_params::kAccessMode].asUInt());
-      LOG4CXX_DEBUG(
-          logger_,
-          "Setting up access mode : " << AccessModeToString(access_mode));
+    const bool is_allowed =
+        (*message_)[app_mngr::strings::msg_params][message_params::kAllowed]
+            .asBool();
+    if (is_allowed) {
+      LOG4CXX_DEBUG(logger_, "Allowing RC Functionality");
+      resource_allocation_manager_.set_rc_enabled(true);
     } else {
-      access_mode = resource_allocation_manager_.GetAccessMode();
-      LOG4CXX_DEBUG(logger_,
-                    "No access mode received. Using last known: "
-                        << AccessModeToString(access_mode));
+      LOG4CXX_DEBUG(logger_, "Disallowing RC Functionality");
+      DisallowRCFunctionality();
+      resource_allocation_manager_.set_rc_enabled(false);
+      resource_allocation_manager_.ResetAllAllocations();
     }
-    resource_allocation_manager_.SetAccessMode(access_mode);
-  } else {
-    LOG4CXX_DEBUG(logger_, "Disallowing RC Functionality");
-    DisallowRCFunctionality();
-    resource_allocation_manager_.ResetAllAllocations();
-    resource_allocation_manager_.set_rc_enabled(false);
   }
+  hmi_apis::Common_RCAccessMode::eType access_mode =
+      hmi_apis::Common_RCAccessMode::INVALID_ENUM;
+  if ((*message_)[app_mngr::strings::msg_params].keyExists(
+          message_params::kAccessMode)) {
+    access_mode = static_cast<hmi_apis::Common_RCAccessMode::eType>(
+        (*message_)[app_mngr::strings::msg_params][message_params::kAccessMode]
+            .asUInt());
+    LOG4CXX_DEBUG(
+        logger_,
+        "Setting up access mode : " << AccessModeToString(access_mode));
+  } else {
+    access_mode = resource_allocation_manager_.GetAccessMode();
+    LOG4CXX_DEBUG(logger_,
+                  "No access mode received. Using last known: "
+                      << AccessModeToString(access_mode));
+  }
+  resource_allocation_manager_.SetAccessMode(access_mode);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_remote_control_settings_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_remote_control_settings_test.cc
@@ -146,6 +146,11 @@ TEST_F(RCOnRemoteControlSettingsNotificationTest,
   rc_extention_ptr->SubscribeToInteriorVehicleData(enums_value::kClimate);
   ON_CALL(*mock_app_, QueryInterface(_))
       .WillByDefault(Return(rc_extention_ptr));
+  ON_CALL(mock_allocation_manager_, GetAccessMode())
+      .WillByDefault(Return(hmi_apis::Common_RCAccessMode::ASK_DRIVER));
+
+  EXPECT_CALL(mock_allocation_manager_,
+              SetAccessMode(hmi_apis::Common_RCAccessMode::ASK_DRIVER));
 
   EXPECT_CALL(mock_allocation_manager_, ResetAllAllocations());
 


### PR DESCRIPTION
**Fixes #2173**
https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0181-keep-rc-app-hmi-level-when-disable-rc.md

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan

test set: https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/fix/rc_disabling/test_sets/rc_CLIMATE_RADIO.txt
PR for scripts: https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/1979

### Summary
Fix behavior in case when RC functionality is disabled from HMI


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)