### PR TITLE
Include deprecated warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR})
 set(ARCHIVE_OUTPUT_DIRECTORY ./bin)
 
-set(CMAKE_CXX_FLAGS "-fPIC -std=gnu++0x -Wall -Werror -Wno-deprecated-declarations -Wuninitialized -Wvla")
+set(CMAKE_CXX_FLAGS "-fPIC -std=gnu++0x -Wall -Werror -Wuninitialized -Wvla")
 
 if (USE_GOLD_LD)
   execute_process(COMMAND ld -v OUTPUT_VARIABLE result)


### PR DESCRIPTION

Related #1493 (some deprecated elements were used which couldn't be fixed before moving to C++11)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Build with deprecated warnings enabled, fixing any warnings that appear as a result

### Summary
Include deprecated warnings during build

### Changelog
##### Enhancements
* Deprecated warnings are no longer ignored in the project

##### Bug Fixes
* Fixes use of deprecated `validate()` method in project


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)