### PR TITLE
Handle wrong message type from HMI was added

### DIFF
--- a/src/components/application_manager/include/application_manager/rpc_handler_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_handler_impl.h
@@ -162,8 +162,18 @@ class RPCHandlerImpl : public RPCHandler,
                      bool allow_unknown_parameters) OVERRIDE;
 
  private:
-  void ProcessMessageFromMobile(const std::shared_ptr<Message> message);
-  void ProcessMessageFromHMI(const std::shared_ptr<Message> message);
+
+  /**
+   * @brief Checks if message has to be sent to mobile or not
+   * update output message according to checks
+   * @param output - message to check
+   * @returns true if message type is response otherwise false
+   */
+  bool HandleWrongMessageType(smart_objects::SmartObject& output) const;
+
+  void ProcessMessageFromMobile(const utils::SharedPtr<Message> message);
+  void ProcessMessageFromHMI(const utils::SharedPtr<Message> message);
+
   bool ConvertMessageToSO(const Message& message,
                           smart_objects::SmartObject& output,
                           const bool allow_unknown_parameters = false,

--- a/src/components/application_manager/include/application_manager/rpc_handler_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_handler_impl.h
@@ -162,17 +162,17 @@ class RPCHandlerImpl : public RPCHandler,
                      bool allow_unknown_parameters) OVERRIDE;
 
  private:
-
   /**
    * @brief Checks if message has to be sent to mobile or not
    * update output message according to checks
    * @param output - message to check
    * @returns true if message type is response otherwise false
    */
-  bool HandleWrongMessageType(smart_objects::SmartObject& output) const;
+  bool HandleWrongMessageType(smart_objects::SmartObject& output,
+                              rpc::ValidationReport report) const;
 
-  void ProcessMessageFromMobile(const utils::SharedPtr<Message> message);
-  void ProcessMessageFromHMI(const utils::SharedPtr<Message> message);
+  void ProcessMessageFromMobile(const std::shared_ptr<Message> message);
+  void ProcessMessageFromHMI(const std::shared_ptr<Message> message);
 
   bool ConvertMessageToSO(const Message& message,
                           smart_objects::SmartObject& output,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
@@ -154,10 +154,6 @@ void SDLActivateAppRequest::Run() {
       application_manager_.application(application_id);
 
   if (!app_to_activate) {
-    LOG4CXX_WARN(
-        logger_,
-        "Can't find application within regular apps: " << application_id);
-
     // Here is the hack - in fact SDL gets hmi_app_id in appID field and
     // replaces it with connection_key only for normally registered apps, but
     // for apps_to_be_registered (waiting) it keeps original value (hmi_app_id)

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -419,7 +419,7 @@ bool RPCHandlerImpl::ConvertMessageToSO(
                     "Convertion result: "
                         << result << " function id "
                         << output[jhs::S_PARAMS][jhs::S_FUNCTION_ID].asInt());
-      if (!hmi_so_factory().attachSchema(output, false)) {
+      if (!hmi_so_factory().attachSchema(output, true)) {
         LOG4CXX_WARN(logger_, "Failed to attach schema to object.");
         return false;
       }
@@ -435,11 +435,7 @@ bool RPCHandlerImpl::ConvertMessageToSO(
             logger_,
             "Incorrect parameter from HMI - " << rpc::PrettyFormat(report));
 
-        output.erase(strings::msg_params);
-        output[strings::params][hmi_response::code] =
-            hmi_apis::Common_Result::INVALID_DATA;
-        output[strings::msg_params][strings::info] = rpc::PrettyFormat(report);
-        return false;
+        return HandleWrongMessageType(output);
       }
       break;
     }
@@ -489,6 +485,47 @@ bool RPCHandlerImpl::ConvertMessageToSO(
   output[strings::params][strings::protection] = message.is_message_encrypted();
 
   LOG4CXX_DEBUG(logger_, "Successfully parsed message into smart object");
+  return true;
+}
+
+bool RPCHandlerImpl::HandleWrongMessageType(
+    smart_objects::SmartObject& output) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  switch (output[strings::params][strings::message_type].asInt()) {
+    case application_manager::MessageType::kNotification: {
+      LOG4CXX_ERROR(logger_, "Ignore wrong HMI notification");
+      return false;
+    }
+    case application_manager::MessageType::kRequest: {
+      LOG4CXX_ERROR(logger_, "Ignore wrong HMI request");
+      output.erase(strings::msg_params);
+      output[strings::params].erase(hmi_response::message);
+      output[strings::params][hmi_response::code] =
+          hmi_apis::Common_Result::INVALID_DATA;
+      output[strings::params][strings::message_type] =
+          MessageType::kErrorResponse;
+      output[strings::params][strings::error_msg] = "";
+      return false;
+    }
+    case application_manager::MessageType::kResponse: {
+      LOG4CXX_ERROR(logger_, "Received invalid data on HMI response");
+      break;
+    }
+    case application_manager::MessageType::kUnknownType: {
+      LOG4CXX_ERROR(logger_, "Received unknown type data on HMI");
+      break;
+    }
+    default: {
+      LOG4CXX_ERROR(logger_, "Received error response on HMI");
+      break;
+    }
+  }
+  output.erase(strings::msg_params);
+  output[strings::params].erase(hmi_response::message);
+  output[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::GENERIC_ERROR;
+  output[strings::msg_params][strings::info] =
+      std::string("Invalid message received from vehicle");
   return true;
 }
 


### PR DESCRIPTION
Fixes [#1865](https://github.com/smartdevicelink/sdl_core/issues/1865)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Provide unit tests
- Provide ATF scripts

### Summary
* In case: SDL cuts off fake parameters from response (request) that SDL
should use internally and this response (request) is invalid by any
reason, SDL log the corresponding error and ignore this response
(request)

* In case: HMI sends request (response, notification) with fake
parameters, SDL cut off fake parameters.

* In case: SDL cuts off fake parameters AND RPC becomes is invalid,
SDL send GENERIC_ERROR.

* In case: HMI sends request without at least one mandatory param,
SDL log corresponding error internally and respond with 'INVALID_DATA'
to HMI

* In case: HMI sends request to SDL and this request has at least one
empty String param, SDL log corresponding error internally and respond
with 'INVALID_DATA' to HMI

Invalid response means the response contains:
- params out of bounds
- mandatory params are missing
- params of wrong type
- invalid json

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)