### PR TITLE
Fix build with EXTERNAL PROPRIETARY policy flag

### DIFF
--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -967,7 +967,7 @@ TEST_F(MessageHelperTest, SendGetListOfPermissionsResponse_SUCCESS) {
                                                   correlation_id,
                                                   mock_application_manager);
 
-  ASSERT_TRUE(result);
+  ASSERT_TRUE(result.get());
 
   EXPECT_EQ(hmi_apis::FunctionID::SDL_GetListOfPermissions,
             (*result)[strings::params][strings::function_id].asInt());
@@ -1007,7 +1007,7 @@ TEST_F(MessageHelperTest,
                                                   correlation_id,
                                                   mock_application_manager);
 
-  ASSERT_TRUE(result);
+  ASSERT_TRUE(result.get());
 
   smart_objects::SmartObject& msg_params = (*result)[strings::msg_params];
   const std::string external_consent_status_key = "externalConsentStatus";

--- a/src/components/policy/policy_external/include/policy/policy_types.h
+++ b/src/components/policy/policy_external/include/policy/policy_types.h
@@ -39,6 +39,7 @@
 #include <map>
 #include <set>
 #include <utility>
+#include <memory>
 
 #include "utils/helpers.h"
 #include "transport_manager/common.h"

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1752,7 +1752,7 @@ bool CacheManager::IsPermissionsCalculated(const std::string& device_id,
 
 std::shared_ptr<policy_table::Table> CacheManager::GenerateSnapshot() {
   CACHE_MANAGER_CHECK(snapshot_);
-  snapshot_ = new policy_table::Table();
+  snapshot_ = std::make_shared<policy_table::Table>();
   sync_primitives::AutoLock auto_lock(cache_lock_);
   snapshot_->policy_table = pt_->policy_table;
 

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -245,9 +245,9 @@ std::shared_ptr<policy_table::Table> PolicyManagerImpl::Parse(
   Json::Value value;
   Json::Reader reader;
   if (reader.parse(json.c_str(), value)) {
-    return new policy_table::Table(&value);
+    return std::make_shared<policy_table::Table>(&value);
   } else {
-    return std::shared_ptr<policy_table::Table>();
+    return std::make_shared<policy_table::Table>();
   }
 }
 
@@ -1909,7 +1909,7 @@ void PolicyManagerImpl::SaveUpdateStatusRequired(bool is_update_needed) {
 
 void PolicyManagerImpl::set_cache_manager(
     CacheManagerInterface* cache_manager) {
-  cache_ = cache_manager;
+  cache_ = std::shared_ptr<CacheManagerInterface>(cache_manager);
 }
 
 std::ostream& operator<<(std::ostream& output,

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -516,7 +516,7 @@ bool SQLPTRepresentation::RefreshDB() {
 std::shared_ptr<policy_table::Table> SQLPTRepresentation::GenerateSnapshot()
     const {
   LOG4CXX_AUTO_TRACE(logger_);
-  std::shared_ptr<policy_table::Table> table = new policy_table::Table();
+  auto table = std::make_shared<policy_table::Table>();
   GatherModuleMeta(&*table->policy_table.module_meta);
   GatherModuleConfig(&table->policy_table.module_config);
   GatherUsageAndErrorCounts(&*table->policy_table.usage_and_error_counts);

--- a/src/components/policy/policy_external/test/counter_test.cc
+++ b/src/components/policy/policy_external/test/counter_test.cc
@@ -28,6 +28,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include "gtest/gtest.h"
 #include "policy/usage_statistics/mock_statistics_manager.h"
 #include "policy/usage_statistics/counter.h"
@@ -45,7 +46,7 @@ TEST(
     StatisticsManagerIncrementMethod1Arg,
     GlobalCounterOverloadedIncrement_CallONCE_StatisticsManagerIncrementCalledONCE) {
   // Arrange
-  MockStatisticsManager* msm = new StrictMock<MockStatisticsManager>();
+  auto msm = std::make_shared<StrictMock<MockStatisticsManager> >();
   GlobalCounter reboots_counter(msm, SYNC_REBOOTS);
 
   // Assert
@@ -59,7 +60,7 @@ TEST(
     StatisticsManagerIncrementMethod1Arg,
     GlobalCounterOverloadedIncrement_CallTWICE_StatisticsManagerIncrementCalledTWICE) {
   // Arrange
-  MockStatisticsManager* msm = new StrictMock<MockStatisticsManager>();
+  auto msm = std::make_shared<StrictMock<MockStatisticsManager> >();
   GlobalCounter reboots_counter(msm, SYNC_REBOOTS);
 
   // Assert
@@ -74,7 +75,7 @@ TEST(
     StatisticsManagerIncrementMethod2Args,
     AppCounterOverloadedIncrement_CallONCE_StatisticsManagerIncrementCalledONCE) {
   // Arrange
-  MockStatisticsManager* msm = new StrictMock<MockStatisticsManager>();
+  auto msm = std::make_shared<StrictMock<MockStatisticsManager> >();
   AppCounter user_selections_counter(msm, "HelloApp", USER_SELECTIONS);
 
   // Assert
@@ -88,7 +89,7 @@ TEST(
     StatisticsManagerIncrementMethod2Args,
     AppCounterOverloadedIncrement_CallTWICE_StatisticsManagerIncrementCalledTWICE) {
   // Arrange
-  MockStatisticsManager* msm = new StrictMock<MockStatisticsManager>();
+  auto msm = std::make_shared<StrictMock<MockStatisticsManager> >();
   AppCounter user_selections_counter(msm, "HelloApp", USER_SELECTIONS);
 
   // Assert
@@ -102,7 +103,7 @@ TEST(
 TEST(StatisticsManagerSetMethod,
      AppInfoUpdateMethod_CallONCE_StatisticsManagerSetMethodCalledONCE) {
   // Arrange
-  MockStatisticsManager* msm = new StrictMock<MockStatisticsManager>();
+  auto msm = std::make_shared<StrictMock<MockStatisticsManager> >();
   AppInfo gui_language_info(msm, "HelloApp", LANGUAGE_GUI);
 
   // Assert
@@ -115,7 +116,7 @@ TEST(StatisticsManagerSetMethod,
 TEST(StatisticsManagerSetMethod,
      AppInfoUpdateMethod_CallTWICE_StatisticsManagerSetMethodCalledTWICE) {
   // Arrange
-  MockStatisticsManager* msm = new StrictMock<MockStatisticsManager>();
+  auto msm = std::make_shared<StrictMock<MockStatisticsManager> >();
   AppInfo gui_language_info(msm, "HelloApp", LANGUAGE_GUI);
 
   // Assert
@@ -130,7 +131,7 @@ TEST(StatisticsManagerSetMethod,
 TEST(StatisticsManagerAddMethod,
      AppStopwatchStartMethod_CallONCE_StatisticsManagerAddMethodCalledONCE) {
   // Arrange
-  MockStatisticsManager* msm = new StrictMock<MockStatisticsManager>();
+  auto msm = std::make_shared<StrictMock<MockStatisticsManager> >();
   const std::uint32_t time_out = 1;
   AppStopwatchImpl hmi_full_stopwatch(msm, "HelloApp", time_out);
 
@@ -145,7 +146,7 @@ TEST(StatisticsManagerAddMethod,
 TEST(StatisticsManagerAddMethod,
      AppStopwatchSwitchMethod_Call_StatisticsManagerAddMethodCalled) {
   // Arrange
-  MockStatisticsManager* msm = new StrictMock<MockStatisticsManager>();
+  auto msm = std::make_shared<StrictMock<MockStatisticsManager> >();
   AppStopwatchImpl hmi_full_stopwatch(msm, "HelloApp");
   hmi_full_stopwatch.Start(SECONDS_HMI_FULL);
 
@@ -161,7 +162,7 @@ TEST(
     StatisticsManagerAddMethod,
     AppStopwatchSwitchMethod_CallAnd1SecSleepAfter_StatisticsManagerAddMethodCalledWith1SecTimespan) {
   // Arrange
-  MockStatisticsManager* msm = new StrictMock<MockStatisticsManager>();
+  auto msm = std::make_shared<StrictMock<MockStatisticsManager> >();
   const std::uint32_t time_out = 1;
   AppStopwatchImpl hmi_full_stopwatch(msm, "HelloApp", time_out);
 

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -147,7 +147,7 @@ TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
   ::policy::BinaryMessage msg(json.begin(), json.end());
 
   std::shared_ptr<policy_table::Table> snapshot =
-      new policy_table::Table(update.policy_table);
+      std::make_shared<policy_table::Table>(update.policy_table);
   // Assert
   EXPECT_CALL(*cache_manager_, GenerateSnapshot()).WillOnce(Return(snapshot));
   EXPECT_CALL(*cache_manager_, ApplyUpdate(_)).WillOnce(Return(true));
@@ -236,7 +236,7 @@ TEST_F(PolicyManagerImplTest,
   Json::Value table = createPTforLoad();
   std::shared_ptr<policy_table::Table> p_table =
       std::make_shared<policy_table::Table>(&table);
-  ASSERT_TRUE(p_table);
+  ASSERT_TRUE(p_table.get());
   p_table->SetPolicyTableType(rpc::policy_table_interface_base::PT_UPDATE);
   EXPECT_TRUE(IsValid(*p_table));
 
@@ -249,7 +249,7 @@ TEST_F(PolicyManagerImplTest,
 TEST_F(PolicyManagerImplTest, RequestPTUpdate_InvalidPT_PTUpdateFail) {
   std::shared_ptr<policy_table::Table> p_table =
       std::make_shared<policy_table::Table>();
-  ASSERT_TRUE(p_table);
+  ASSERT_TRUE(p_table.get());
   EXPECT_FALSE(IsValid(*p_table));
 
   EXPECT_CALL(listener_, OnSnapshotCreated(_, _, _)).Times(0);


### PR DESCRIPTION
Fixes #2403 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
 Replace utils::SharedPtr with std::shared_ptr and fix its usage for external policy

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)