### PR TITLE
Fix wrong policy permissions calculation in EXTERNAL_PROPRIETARY

### DIFF
--- a/src/components/policy/policy_external/include/policy/policy_helper.h
+++ b/src/components/policy/policy_external/include/policy/policy_helper.h
@@ -255,8 +255,26 @@ struct FillNotificationData {
                              const std::set<Parameter>& target);
   void InitRpcKeys(const std::string& rpc_name);
   bool RpcParametersEmpty(RpcPermissions& rpc);
-  bool IsSectionEmpty(ParameterPermissions& permissions,
-                      const std::string& section);
+
+  /**
+   * @brief Checks if specific section in specified permissions is empty
+   * @param permissions reference to the permissions structure
+   * @param section reference to the section name
+   * @return true if specified section in permissions is empty otherwise returns
+   * false
+   */
+  bool IsSectionEmpty(const ParameterPermissions& permissions,
+                      const std::string& section) const;
+
+  /**
+   * @brief Checks if at least one parameter is allowed for the specified
+   * permissions
+   * @param permissions reference to the permissions structure
+   * @return true if at least one parameter is allowed for the specified
+   * permissions otherwise returns false
+   */
+  bool IsSomeParametersAllowed(const ParameterPermissions& permissions) const;
+
   std::string current_key_;
   Permissions& data_;
   const bool does_require_user_consent_;

--- a/src/components/policy/policy_external/include/policy/policy_helper.h
+++ b/src/components/policy/policy_external/include/policy/policy_helper.h
@@ -273,7 +273,7 @@ struct FillNotificationData {
    * @return true if at least one parameter is allowed for the specified
    * permissions otherwise returns false
    */
-  bool IsSomeParametersAllowed(const ParameterPermissions& permissions) const;
+  bool IsSomeParameterAllowed(const ParameterPermissions& permissions) const;
 
   std::string current_key_;
   Permissions& data_;

--- a/src/components/policy/policy_external/src/policy_helper.cc
+++ b/src/components/policy/policy_external/src/policy_helper.cc
@@ -620,7 +620,6 @@ void FillNotificationData::UpdateParameters(
   ParametersConstItr it_parameters = in_parameters.begin();
   ParametersConstItr it_parameters_end = in_parameters.end();
 
-  // From AppLink Policies Manager specification:
   // To determine consent for a particular RPC in a particular HMI level with
   // particular parameters (if applicable), the system shall find all of the
   // functional groups the RPC is included in. If user consent is needed as

--- a/src/components/policy/policy_external/src/policy_helper.cc
+++ b/src/components/policy/policy_external/src/policy_helper.cc
@@ -630,26 +630,24 @@ void FillNotificationData::UpdateParameters(
   // amongst all of the possible allowed permissions scenarios for the RPC (and
   // parameter/or HMI level) defined by each of the functional groups.
 
-  if (!IsSomeParametersAllowed(out_parameter)) {
-    // Due to APPLINK-24201 SDL must consider cases when 'parameters' section is
-    // not present for RPC or present, but is empty.
+  // Due to requirements SDL must consider cases when 'parameters' section is
+  // not present for RPC or present, but is empty.
 
-    // If 'parameters' section is like: 'parameters' : []
-    if (in_parameters.is_initialized() && in_parameters.empty()) {
-      if (!does_require_user_consent_) {
-        out_parameter.any_parameter_disallowed_by_policy = true;
-      }
-      if (does_require_user_consent_ && kAllowedKey == current_key_) {
-        out_parameter.any_parameter_disallowed_by_user = true;
-      }
+  // If 'parameters' section is like: 'parameters' : []
+  if (in_parameters.is_initialized() && in_parameters.empty()) {
+    if (!does_require_user_consent_) {
+      out_parameter.any_parameter_disallowed_by_policy = true;
     }
+    if (does_require_user_consent_ && kAllowedKey == current_key_) {
+      out_parameter.any_parameter_disallowed_by_user = true;
+    }
+  }
 
-    // If 'parameters' section is omitted
-    if (!in_parameters.is_initialized()) {
-      if (!does_require_user_consent_ ||
-          (does_require_user_consent_ && kAllowedKey == current_key_)) {
-        out_parameter.any_parameter_allowed = true;
-      }
+  // If 'parameters' section is omitted
+  if (!in_parameters.is_initialized()) {
+    if (!does_require_user_consent_ ||
+        (does_require_user_consent_ && kAllowedKey == current_key_)) {
+      out_parameter.any_parameter_allowed = true;
     }
   }
 
@@ -660,7 +658,7 @@ void FillNotificationData::UpdateParameters(
 
   // We should reset ALL DISALLOWED flags if at least one parameter is allowed
   // due to a logical OR permissions check
-  if (IsSomeParametersAllowed(out_parameter)) {
+  if (IsSomeParameterAllowed(out_parameter)) {
     out_parameter.any_parameter_disallowed_by_policy = false;
     out_parameter.any_parameter_disallowed_by_user = false;
   }
@@ -796,11 +794,12 @@ bool FillNotificationData::IsSectionEmpty(
   return true;
 }
 
-bool FillNotificationData::IsSomeParametersAllowed(
+bool FillNotificationData::IsSomeParameterAllowed(
     const ParameterPermissions& permissions) const {
+  const bool are_any_consented_parameters_allowed =
+      kAllowedKey == current_key_ && !IsSectionEmpty(permissions, current_key_);
   return permissions.any_parameter_allowed ||
-         (kAllowedKey == current_key_ &&
-          !IsSectionEmpty(permissions, kAllowedKey));
+         are_any_consented_parameters_allowed;
 }
 
 ProcessFunctionalGroup::ProcessFunctionalGroup(

--- a/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
@@ -757,18 +757,18 @@ TEST_F(PolicyManagerImplTest2,
   policy_manager_->CheckPermissions(
       application_id_, kHmiLevelFull, "SendLocation", input_params, output);
 
-  EXPECT_EQ(::policy::kRpcDisallowed, output.hmi_level_permitted);
-  EXPECT_TRUE(output.list_of_allowed_params.empty());
-  EXPECT_EQ(10u, output.list_of_undefined_params.size());
+  EXPECT_EQ(::policy::kRpcAllowed, output.hmi_level_permitted);
+  EXPECT_TRUE(output.list_of_undefined_params.empty());
+  EXPECT_EQ(10u, output.list_of_allowed_params.size());
   ResetOutputList(output);
 
   // Rpc in LIMITED level
   policy_manager_->CheckPermissions(
       application_id_, kHmiLevelLimited, "SendLocation", input_params, output);
 
-  EXPECT_EQ(::policy::kRpcDisallowed, output.hmi_level_permitted);
-  EXPECT_TRUE(output.list_of_allowed_params.empty());
-  EXPECT_EQ(10u, output.list_of_undefined_params.size());
+  EXPECT_EQ(::policy::kRpcAllowed, output.hmi_level_permitted);
+  EXPECT_TRUE(output.list_of_undefined_params.empty());
+  EXPECT_EQ(10u, output.list_of_allowed_params.size());
   ResetOutputList(output);
 
   // Rpc in BACKGROUND level
@@ -778,9 +778,9 @@ TEST_F(PolicyManagerImplTest2,
                                     input_params,
                                     output);
 
-  EXPECT_EQ(::policy::kRpcDisallowed, output.hmi_level_permitted);
-  EXPECT_TRUE(output.list_of_allowed_params.empty());
-  EXPECT_EQ(10u, output.list_of_undefined_params.size());
+  EXPECT_EQ(::policy::kRpcAllowed, output.hmi_level_permitted);
+  EXPECT_TRUE(output.list_of_undefined_params.empty());
+  EXPECT_EQ(10u, output.list_of_allowed_params.size());
   // Reset output
   ResetOutputList(output);
 
@@ -845,17 +845,17 @@ TEST_F(PolicyManagerImplTest2,
   policy_manager_->CheckPermissions(
       application_id_, kHmiLevelFull, "SendLocation", input_params, output);
 
-  EXPECT_EQ(::policy::kRpcDisallowed, output.hmi_level_permitted);
-  EXPECT_TRUE(output.list_of_allowed_params.empty());
-  EXPECT_EQ(10u, output.list_of_undefined_params.size());
+  EXPECT_EQ(::policy::kRpcAllowed, output.hmi_level_permitted);
+  EXPECT_TRUE(output.list_of_undefined_params.empty());
+  EXPECT_EQ(10u, output.list_of_allowed_params.size());
   ResetOutputList(output);
 
   // Rpc in LIMITED level
   policy_manager_->CheckPermissions(
       application_id_, kHmiLevelLimited, "SendLocation", input_params, output);
-  EXPECT_EQ(::policy::kRpcDisallowed, output.hmi_level_permitted);
-  EXPECT_TRUE(output.list_of_allowed_params.empty());
-  EXPECT_EQ(10u, output.list_of_undefined_params.size());
+  EXPECT_EQ(::policy::kRpcAllowed, output.hmi_level_permitted);
+  EXPECT_TRUE(output.list_of_undefined_params.empty());
+  EXPECT_EQ(10u, output.list_of_allowed_params.size());
   ResetOutputList(output);
 
   // Rpc in BACKGROUND level
@@ -864,9 +864,9 @@ TEST_F(PolicyManagerImplTest2,
                                     "SendLocation",
                                     input_params,
                                     output);
-  EXPECT_EQ(::policy::kRpcDisallowed, output.hmi_level_permitted);
-  EXPECT_TRUE(output.list_of_allowed_params.empty());
-  EXPECT_EQ(10u, output.list_of_undefined_params.size());
+  EXPECT_EQ(::policy::kRpcAllowed, output.hmi_level_permitted);
+  EXPECT_TRUE(output.list_of_undefined_params.empty());
+  EXPECT_EQ(10u, output.list_of_allowed_params.size());
   // Reset output
   ResetOutputList(output);
 


### PR DESCRIPTION
Fixes #2405 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered with unit tests
ATF test scripts

### Summary
There was a problem when application has several allowed functional groups with the same RPC included. In case when some of functional groups have RPC with all parameters disallowed option, SDL ignores all allowed parameters for this RPC in other functional groups.

According to AppLink Policies Manager specification SDL should perform a logical OR amongst all of the possible allowed permissions scenarios for the RPC defined by each of the functional groups.

Current logic was updated to fit this requirement.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)