### PR TITLE
Feature/nicer travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ script:
   - ./tools/infrastructure/check_style.sh
   - mkdir build && cd build
   - cmake ../ -DBUILD_TESTS=ON
-  - make install && sudo ldconfig
-after_success:
+  - make install-3rd_party && make -j `nproc` install && sudo ldconfig 
   - make test
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ script:
   - ./tools/infrastructure/check_style.sh
   - mkdir build && cd build
   - cmake ../ -DBUILD_TESTS=ON
-  - make install-3rd_party && make -j `nproc` install && sudo ldconfig 
-  - make test
+  - make install-3rd_party && make -j `nproc` install && sudo ldconfig && make test
 env:
   global:
   - LC_CTYPE=en_US.UTF-8


### PR DESCRIPTION
Occasionally Travis builds have been failing due to overrunning time constraints. This fixes that by building core's dependencies serially and the core itself multi-threaded. This speeds the build up by ~10 minutes, solving most of the timeout issue. It also ensures that Travis doesn't mask any failures in unit tests by making them part of the main build cycle (Travis will fail if a test fails). 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.
This does create a risk that a safe build will fail due to spurious unit test failures. However, this risk is small, especially since travis builds fail for other issues like formatting or server issues. 

### Testing Plan
Just changes to Travis, shouldn't need any extra testing

### Summary
Moves unit tests to main travis build since they get hidden otherwise
build multithreaded

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)