### PR TITLE
Set absolute path for linking boost libraries to utils

### DIFF
--- a/src/appMain/CMakeLists.txt
+++ b/src/appMain/CMakeLists.txt
@@ -141,7 +141,8 @@ add_executable(${PROJECT} ${SOURCES})
 
 if (HMIADAPTER STREQUAL "messagebroker")
   add_dependencies(${PROJECT} Boost)
-  list(APPEND LIBRARIES libboost_system.so)
+  GET_PROPERTY(BOOST_LIBS_DIRECTORY GLOBAL PROPERTY GLOBAL_BOOST_LIBS)
+  list(APPEND LIBRARIES boost_system -L${BOOST_LIBS_DIRECTORY})
 endif()
 
 target_link_libraries(${PROJECT} ${LIBRARIES})

--- a/src/components/hmi_message_handler/test/CMakeLists.txt
+++ b/src/components/hmi_message_handler/test/CMakeLists.txt
@@ -56,7 +56,7 @@ collect_sources(SOURCES "${CMAKE_CURRENT_SOURCE_DIR}" "${EXCLUDE_PATHS}")
 
 if (HMIADAPTER STREQUAL "messagebroker")
   GET_PROPERTY(BOOST_LIBS_DIRECTORY GLOBAL PROPERTY GLOBAL_BOOST_LIBS)
-  list(APPEND LIBRARIES ${BOOST_LIBS_DIRECTORY}/libboost_system.so)
+  list(APPEND LIBRARIES boost_system -L${BOOST_LIBS_DIRECTORY})
 endif()
 
 create_test(hmi_message_handler_test "${SOURCES}" "${LIBRARIES}")

--- a/src/components/utils/CMakeLists.txt
+++ b/src/components/utils/CMakeLists.txt
@@ -114,7 +114,9 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 endif()
 
 add_library("Utils" ${SOURCES})
-list(APPEND LIBRARIES -lboost_system -lboost_thread)
+GET_PROPERTY(BOOST_LIBS_DIRECTORY GLOBAL PROPERTY GLOBAL_BOOST_LIBS)
+list(APPEND LIBRARIES boost_system -L${BOOST_LIBS_DIRECTORY})
+list(APPEND LIBRARIES boost_thread -L${BOOST_LIBS_DIRECTORY})
 target_link_libraries("Utils" ${LIBRARIES})
 add_dependencies("Utils" Boost)
 


### PR DESCRIPTION
Fixes #[issue number]

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Check SDL build with THIRD_PARTY_PREFIX environment variables set up 

### Summary
Compilation failed if it configured to install third party libraries not in the system but by custom, path specifies with THIRD_PARTY_INSTALL_PREFIX environment variable. 

Set absolute path for linking boost libraries to utils.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)