### PR TITLE
Fix invalid iteration segfault on shutdown

### DIFF
--- a/src/components/hmi_message_handler/src/mb_controller.cc
+++ b/src/components/hmi_message_handler/src/mb_controller.cc
@@ -222,7 +222,7 @@ void CMessageBrokerController::exitReceivingThread() {
       it;
   for (it = mConnectionList.begin(); it != mConnectionList.end();) {
     (*it)->Shutdown();
-    mConnectionList.erase(it++);
+    it = mConnectionList.erase(it);
   }
   mConnectionListLock.Release();
 


### PR DESCRIPTION
Fixes #2106 (the issue either remained or reappeared, but this indeed fixes it)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Standard regression testing

### Summary
Removes increment-erase usage for standard vector since `vector<>::erase()` invalidates all iterators after the erased one, including the one created by the `iter++` operator,

##### Bug Fixes
* Fixes bug on shutdown

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)