### PR TITLE
Fix for media app resumtion to previous hmi level

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2835,7 +2835,7 @@ void ApplicationManagerImpl::OnAppStreaming(
     media_manager_->StartStreaming(app_id, service_type);
   } else {
     media_manager_->StopStreaming(app_id, service_type);
-    state_ctrl_.OnVideoStreamingStarted(app);
+    state_ctrl_.OnVideoStreamingStopped(app);
   }
 }
 


### PR DESCRIPTION
Fixes [#1915](https://github.com/SmartDeviceLink/sdl_core/issues/1915)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF test was provided in [PR #1976](https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/1976)

### Summary
Media app must get ATTENUATED streaming state when navi app starts streaming

Expected result:
SDL must send OnHMIStatus (<current_HMILevel>, ATTENUATED) to media app (and return media app to AUDIBLE right after navi app stops streaming)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)