### PR TITLE
make videostreamingstate optional

### DIFF
--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -6115,7 +6115,7 @@
         <param name="systemContext" type="SystemContext" mandatory="true">
             <description>See SystemContext</description>
         </param>
-        <param name="videoStreamingState" type="VideoStreamingState" mandatory="true">
+        <param name="videoStreamingState" type="VideoStreamingState" mandatory="false" defvalue="STREAMABLE">
             <description>See VideoStreamingState. If it is NOT_STREAMABLE, the app must stop streaming video to SDL.</description>
         </param>
     </function>


### PR DESCRIPTION
Fixes #2129

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit and ATF smoke tests pass
### Summary
Makes the videoStreamingState parameter optional in accordance with https://github.com/smartdevicelink/sdl_evolution/pull/548

### Changelog
##### Breaking Changes
* videoStreamingState is now optional

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)