### PR TITLE
Added negative reponse to HMI upon unsuccessful validation of SO

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -577,6 +577,12 @@ class MessageHelper {
       const uint32_t correlation_id,
       int32_t result_code);
 
+  static smart_objects::SmartObjectSPtr CreateNegativeResponseToHMI(
+      const int32_t function_id,
+      const uint32_t correlation_id,
+      const hmi_apis::Common_Result::eType result_code,
+      const std::string& error_message);
+
   /**
    * @brief Get the full file path of an app file
    *

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1991,6 +1991,26 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateNegativeResponse(
   return std::make_shared<smart_objects::SmartObject>(response_data);
 }
 
+smart_objects::SmartObjectSPtr MessageHelper::CreateNegativeResponseToHMI(
+    const int32_t function_id,
+    const uint32_t correlation_id,
+    const hmi_apis::Common_Result::eType result_code,
+    const std::string & error_message) {
+  smart_objects::SmartObject response_data(smart_objects::SmartType_Map);
+
+  response_data[strings::params][strings::function_id] = function_id;
+  response_data[strings::params][strings::correlation_id] = correlation_id;
+  response_data[strings::params][strings::protocol_type] = commands::CommandImpl::hmi_protocol_type_;
+  response_data[strings::params][strings::protocol_version] = commands::CommandImpl::protocol_version_;
+
+  response_data[strings::params][strings::message_type] =
+      MessageType::kErrorResponse;
+  response_data[strings::params][hmi_response::code] = result_code;
+  response_data[strings::params][strings::error_msg] = error_message;
+
+  return std::make_shared<smart_objects::SmartObject>(response_data);
+}
+
 void MessageHelper::SendNaviSetVideoConfig(
     int32_t app_id,
     ApplicationManager& app_mngr,

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -223,6 +223,12 @@ class MockMessageHelper {
                                               int32_t function_id,
                                               const uint32_t correlation_id,
                                               int32_t result_code));
+  MOCK_METHOD4(CreateNegativeResponseToHMI,
+               smart_objects::SmartObjectSPtr(const int32_t function_id,
+                                              const uint32_t correlation_id,
+                                              const int32_t result_code,
+                                              const std::string& error_message));
+                                              
   MOCK_METHOD4(
       CreateBlockedByPoliciesResponse,
       smart_objects::SmartObjectSPtr(mobile_apis::FunctionID::eType function_id,

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -404,6 +404,15 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateNegativeResponse(
       connection_key, function_id, correlation_id, result_code);
 }
 
+smart_objects::SmartObjectSPtr MessageHelper::CreateNegativeResponseToHMI(
+    const int32_t function_id,
+    const uint32_t correlation_id,
+    const hmi_apis::Common_Result::eType result_code,
+    const std::string& error_message) {
+  return MockMessageHelper::message_helper_mock()->CreateNegativeResponseToHMI(
+      function_id, correlation_id, result_code, error_message);
+}
+
 smart_objects::SmartObjectSPtr MessageHelper::CreateBlockedByPoliciesResponse(
     mobile_apis::FunctionID::eType function_id,
     mobile_apis::Result::eType result,


### PR DESCRIPTION
Fixes #1868 

This PR is ready for review.

### Risk
This PR makes minor API changes.

### Testing Plan
ATF scripts are provided smartdevicelink/sdl_atf_test_scripts#1951

### Summary
Added creation and sending of a negative response if validation of SO obtained from message fails

### CLA
- [x ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)