### PR TITLE
Return shared_ptr in PolicyManagerImpl::ParseArray()

### DIFF
--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -116,9 +116,9 @@ std::shared_ptr<policy_table::Table> PolicyManagerImpl::ParseArray(
     // For PT Update received from SDL Server.
     if (value["data"].size() != 0) {
       Json::Value data = value["data"];
-      return new policy_table::Table(&data[0]);
+      return std::make_shared<policy_table::Table>(&data[0]);
     } else {
-      return new policy_table::Table(&value);
+      return std::make_shared<policy_table::Table>(&value);
     }
   } else {
     return std::shared_ptr<policy_table::Table>();


### PR DESCRIPTION
Fixes #2471 
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
check build with ENABLE_HMI_PTU_DECRYPTION=OFF to make sure it fixes the issue

### Summary
uses correct return type for PolicyManagerImpl::ParseArray()
One cannot assign a `shared_ptr` from a raw pointer

##### Bug Fixes
* fixes build

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)