### PR TITLE
raise functional group parameters limit

### DIFF
--- a/src/components/policy/policy_external/include/policy/policy_table_interface_ext.xml
+++ b/src/components/policy/policy_external/include/policy/policy_table_interface_ext.xml
@@ -98,8 +98,7 @@
 
     <typedef name="HmiLevels" type="HmiLevel" array="true"
         maxsize="4" />
-    <typedef name="Parameters" type="Parameter" array="true"
-        maxsize="24" />
+    <typedef name="Parameters" type="Parameter" array="true"/>
 
     <struct name="RpcParameters">
         <!-- maxsizes are equal to number of currently known elements of

--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -65,7 +65,7 @@ typedef Array<Enum<AppHMIType>, 0, 255> AppHMITypes;
 
 typedef Array<Enum<HmiLevel>, 0, 4> HmiLevels;
 
-typedef Array<Enum<Parameter>, 0, 24> Parameters;
+typedef Array<Enum<Parameter>, 0, 255> Parameters;
 
 typedef Map<RpcParameters, 0, UINT_MAX> Rpc;
 

--- a/src/components/policy/policy_regular/policy_table_interface_ext.xml
+++ b/src/components/policy/policy_regular/policy_table_interface_ext.xml
@@ -94,8 +94,7 @@
 
     <typedef name="HmiLevels" type="HmiLevel" array="true"
         maxsize="4" />
-    <typedef name="Parameters" type="Parameter" array="true"
-        maxsize="24" />
+    <typedef name="Parameters" type="Parameter" array="true"/>
 
     <struct name="RpcParameters">
         <!-- maxsizes are equal to number of currently known elements of


### PR DESCRIPTION
Fixes #2470 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
check for no regressions, verify it works as intended

### Summary
Removes the maxsize field for functional grouping parameters in `policy_table_interface_ext.xml` files (they don't seem to be used, however). Also raises the same limit in the policy table validation code to 255.

Note that this choice of 255 is equally arbitrary to that of the old 24. The issue is that there are currently >30 types of vehicle data, so 24 is clearly too low.

### Changelog
##### Bug Fixes
* allows >24 parameters in a policy table functional group (current policy server supports 25)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)