### PR TITLE
Feature/icon resumed optional

### DIFF
--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -3410,7 +3410,7 @@
         <param name="systemSoftwareVersion" type="String" maxlength="100" mandatory="false" platform="documentation">
             <description>The software version of the system that implements the SmartDeviceLink core.</description>
         </param>
-        <param name="iconResumed" type="Boolean" mandatory="true">
+        <param name="iconResumed" type="Boolean" mandatory="false">
             <description>Existence of apps icon at system. If true, apps icon
             was resumed at system. If false, apps icon is not resumed at system</description>
         </param>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -3411,8 +3411,10 @@
             <description>The software version of the system that implements the SmartDeviceLink core.</description>
         </param>
         <param name="iconResumed" type="Boolean" mandatory="false">
-            <description>Existence of apps icon at system. If true, apps icon
-            was resumed at system. If false, apps icon is not resumed at system</description>
+            <description>
+                Existence of apps icon at system. If true, apps icon
+                was resumed at system. If false, apps icon is not resumed at system
+            </description>
         </param>
     </function>
     


### PR DESCRIPTION
Applies revisions on #1456 .

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Ensure no regressions via unit tests and ATF

### Summary
Makes iconResumed parameter in `RegisterAppInterface` response optional

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)