### PR TITLE
Fix/sdl_does_not_send SDL.OnStatusUpdate(UPDATE_NEEDED)

### DIFF
--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2521,6 +2521,7 @@ void MessageHelper::SendUpdateSDLResponse(const std::string& result,
 
 void MessageHelper::SendOnStatusUpdate(const std::string& status,
                                        ApplicationManager& app_mngr) {
+  LOG4CXX_AUTO_TRACE(logger_);
   smart_objects::SmartObjectSPtr message =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
@@ -2533,6 +2534,7 @@ void MessageHelper::SendOnStatusUpdate(const std::string& status,
   (*message)[strings::params][strings::message_type] =
       MessageType::kNotification;
 
+  LOG4CXX_DEBUG(logger_, "Sending new status:" << status);
   (*message)[strings::msg_params]["status"] = status;
 
   app_mngr.GetRPCService().ManageHMICommand(message);

--- a/src/components/policy/policy_external/include/policy/update_status_manager.h
+++ b/src/components/policy/policy_external/include/policy/update_status_manager.h
@@ -114,6 +114,12 @@ class UpdateStatusManager {
   void OnResetRetrySequence();
 
   /**
+   * @brief Update status handler on existed application registering
+   * @param is_update_required Update necessity flag
+   */
+  void OnExistedApplicationAdded(const bool is_update_required);
+
+  /**
    * @brief Update status handler on new application registering
    */
   void OnNewApplicationAdded(const DeviceConsent consent);

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1922,13 +1922,15 @@ StatusNotifier PolicyManagerImpl::AddApplication(
   DeviceConsent device_consent = GetUserConsentForDevice(device_id);
   sync_primitives::AutoLock lock(apps_registration_lock_);
   if (IsNewApplication(application_id)) {
+    LOG4CXX_DEBUG(logger_, "Adding new application");
     AddNewApplication(application_id, device_consent);
     return std::make_shared<CallStatusChange>(update_status_manager_,
                                               device_consent);
-  } else {
-    PromoteExistedApplication(application_id, device_consent);
-    return std::make_shared<utils::CallNothing>();
   }
+  LOG4CXX_DEBUG(logger_, "Promote existed application");
+  PromoteExistedApplication(application_id, device_consent);
+  update_status_manager_.OnExistedApplicationAdded(cache_->UpdateRequired());
+  return std::make_shared<utils::CallNothing>();
 }
 
 void PolicyManagerImpl::RemoveAppConsentForGroup(
@@ -2042,7 +2044,6 @@ bool PolicyManagerImpl::InitPT(const std::string& file_name,
   const bool ret = cache_->Init(file_name, settings);
   if (ret) {
     RefreshRetrySequence();
-    update_status_manager_.OnPolicyInit(cache_->UpdateRequired());
   }
   return ret;
 }

--- a/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
@@ -897,6 +897,9 @@ bool SQLPTExtRepresentation::GatherApplicationPoliciesSection(
     if (!GatherRequestType(app_id, &*params.RequestType)) {
       return false;
     }
+    if (!GatherRequestSubType(app_id, &*params.RequestSubType)) {
+      return false;
+    }
     GatherPreconsentedGroup(app_id, &*params.preconsented_groups);
     (*policies).apps[app_id] = params;
   }

--- a/src/components/policy/policy_external/src/update_status_manager.cc
+++ b/src/components/policy/policy_external/src/update_status_manager.cc
@@ -118,12 +118,23 @@ void UpdateStatusManager::OnResetRetrySequence() {
   ProcessEvent(kOnResetRetrySequence);
 }
 
+void UpdateStatusManager::OnExistedApplicationAdded(
+    const bool is_update_required) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (is_update_required) {
+    current_status_.reset(new UpToDateStatus());
+    ProcessEvent(kScheduleUpdate);
+  }
+}
+
 void UpdateStatusManager::OnNewApplicationAdded(const DeviceConsent consent) {
   LOG4CXX_AUTO_TRACE(logger_);
   if (kDeviceAllowed != consent) {
+    LOG4CXX_DEBUG(logger_, "Application registered from non-consented device");
     app_registered_from_non_consented_device_ = true;
     return;
   }
+  LOG4CXX_DEBUG(logger_, "Application registered from consented device");
   app_registered_from_non_consented_device_ = false;
   ProcessEvent(kOnNewAppRegistered);
 }

--- a/src/components/policy/policy_external/test/include/policy/mock_update_status_manager.h
+++ b/src/components/policy/policy_external/test/include/policy/mock_update_status_manager.h
@@ -33,7 +33,6 @@
 #define SRC_COMPONENTS_POLICY_POLICY_EXTERNAL_TEST_INCLUDE_POLICY_MOCK_UPDATE_STATUS_MANAGER_H_
 
 #include "gmock/gmock.h"
-
 #include "policy/update_status_manager.h"
 
 namespace test {
@@ -49,6 +48,7 @@ class MockUpdateStatusManager : public ::policy::UpdateStatusManager {
   MOCK_METHOD0(OnWrongUpdateReceived, void());
   MOCK_METHOD1(OnResetDefaultPT, void(bool is_update_required));
   MOCK_METHOD0(OnResetRetrySequence, void());
+  MOCK_METHOD1(OnExistedApplicationAdded, void(const bool is_update_required));
   MOCK_METHOD1(OnNewApplicationAdded, void(const DeviceConsent));
   MOCK_METHOD1(OnPolicyInit, void(bool is_update_required));
   MOCK_METHOD0(GetUpdateStatus, PolicyTableStatus());

--- a/src/components/policy/policy_regular/include/policy/update_status_manager.h
+++ b/src/components/policy/policy_regular/include/policy/update_status_manager.h
@@ -118,6 +118,12 @@ class UpdateStatusManager : public UpdateStatusManagerInterface {
   void OnNewApplicationAdded(const DeviceConsent consent);
 
   /**
+   * @brief Update status handler on existed application registering
+   * @param is_update_required Update necessity flag
+   */
+  void OnExistedApplicationAdded(const bool is_update_required);
+
+  /**
    * @brief Update status handler for policy initialization
    * @param is_update_required Update necessity flag
    */

--- a/src/components/policy/policy_regular/include/policy/update_status_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/update_status_manager_interface.h
@@ -105,6 +105,12 @@ class UpdateStatusManagerInterface {
   virtual void OnNewApplicationAdded(DeviceConsent device_consent) = 0;
 
   /**
+   * @brief Update status handler on existed application registering
+   * @param is_update_required Update necessity flag
+   */
+  virtual void OnExistedApplicationAdded(const bool is_update_required) = 0;
+
+  /**
    * @brief Update status handler for policy initialization
    * @param is_update_required Update necessity flag
    */

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -1453,10 +1453,13 @@ bool CacheManager::Init(const std::string& file_name,
 void CacheManager::FillDeviceSpecificData() {}
 
 bool CacheManager::LoadFromBackup() {
+  LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(cache_lock_);
   pt_ = backup_->GenerateSnapshot();
   update_required = backup_->UpdateRequired();
-
+  LOG4CXX_DEBUG(logger_,
+                "Update required flag from backup: " << std::boolalpha
+                                                     << update_required);
   FillDeviceSpecificData();
 
   return true;

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1211,10 +1211,10 @@ StatusNotifier PolicyManagerImpl::AddApplication(
     AddNewApplication(application_id, device_consent);
     return std::make_shared<CallStatusChange>(update_status_manager_,
                                               device_consent);
-  } else {
-    PromoteExistedApplication(application_id, device_consent);
-    return std::make_shared<utils::CallNothing>();
   }
+  PromoteExistedApplication(application_id, device_consent);
+  update_status_manager_.OnExistedApplicationAdded(cache_->UpdateRequired());
+  return std::make_shared<utils::CallNothing>();
 }
 
 void PolicyManagerImpl::RemoveAppConsentForGroup(
@@ -1237,6 +1237,7 @@ void PolicyManagerImpl::AddNewApplication(const std::string& application_id,
 
 void PolicyManagerImpl::PromoteExistedApplication(
     const std::string& application_id, DeviceConsent device_consent) {
+  LOG4CXX_AUTO_TRACE(logger_);
   // If device consent changed to allowed during application being
   // disconnected, app permissions should be changed also
   if (kDeviceAllowed == device_consent &&
@@ -1289,7 +1290,6 @@ bool PolicyManagerImpl::InitPT(const std::string& file_name,
   const bool ret = cache_->Init(file_name, settings);
   if (ret) {
     RefreshRetrySequence();
-    update_status_manager_.OnPolicyInit(cache_->UpdateRequired());
     const std::string certificate_data = cache_->GetCertificate();
     if (!certificate_data.empty()) {
       listener_->OnCertificateUpdated(certificate_data);

--- a/src/components/policy/policy_regular/src/update_status_manager.cc
+++ b/src/components/policy/policy_regular/src/update_status_manager.cc
@@ -100,6 +100,15 @@ void UpdateStatusManager::OnResetRetrySequence() {
   ProcessEvent(kOnResetRetrySequence);
 }
 
+void UpdateStatusManager::OnExistedApplicationAdded(
+    const bool is_update_required) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (is_update_required) {
+    current_status_.reset(new UpToDateStatus());
+    ProcessEvent(kScheduleUpdate);
+  }
+}
+
 void UpdateStatusManager::OnNewApplicationAdded(const DeviceConsent consent) {
   LOG4CXX_AUTO_TRACE(logger_);
   if (kDeviceAllowed != consent) {

--- a/src/components/policy/policy_regular/test/include/policy/mock_update_status_manager.h
+++ b/src/components/policy/policy_regular/test/include/policy/mock_update_status_manager.h
@@ -47,6 +47,7 @@ class MockUpdateStatusManager : public UpdateStatusManager {
   MOCK_METHOD0(OnWrongUpdateReceived, void());
   MOCK_METHOD1(OnResetDefaultPT, void(bool is_update_required));
   MOCK_METHOD0(OnResetRetrySequence, void());
+  MOCK_METHOD1(OnExistedApplicationAdded, void(const bool is_update_required));
   MOCK_METHOD0(OnNewApplicationAdded, void());
   MOCK_METHOD1(OnPolicyInit, void(bool is_update_required));
   MOCK_METHOD0(GetUpdateStatus, PolicyTableStatus());


### PR DESCRIPTION
**NOTE** This PR must be merged after PR: #2488  ONLY
as it based on changes provided in PR specified above.

Fixes #2489 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
* HTTP:
  - [Defects/4_5/1206_REQUEST_PTU_Trigger_PTU_failed_previous_IGN_ON](https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/develop/test_scripts/Defects/4_5/1206_REQUEST_PTU_Trigger_PTU_failed_previous_IGN_ON.lua)
  - [Policies/build_options/050_ATF_Request_PTU_Trigger_PTU_failed_previous_IGN_ON_HTTP](https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/develop/test_scripts/Policies/build_options/050_ATF_Request_PTU_Trigger_PTU_failed_previous_IGN_ON_HTTP.lua)
  - [Policies/build_options/098_ATF_PTU_Unsuccessful_Even_After_Retry_Strategy_HTTP](https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/develop/test_scripts/Policies/build_options/098_ATF_PTU_Unsuccessful_Even_After_Retry_Strategy_HTTP.lua)
* PROPRIETARY:
  - [Policies/build_options/107_ATF_PTU_in_case_of_failed_retry_strategy_during_previous_IGN_ON_PROPRIETARY](https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/develop/test_scripts/Policies/build_options/107_ATF_PTU_in_case_of_failed_retry_strategy_during_previous_IGN_ON_PROPRIETARY.lua)
* EXTERNAL_PROPRIETARY:
  - [Policies/Policy_Table_Update/122_ATF_PTU_NotSuccessful_AppID_ListedPT_NewIgnCycle](https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/develop/test_scripts/Policies/Policy_Table_Update/122_ATF_PTU_NotSuccessful_AppID_ListedPT_NewIgnCycle.lua)

### Summary
Added missed call of UpdateStatusManager::OnStausUpdate (UPDATE_NEEDED) to all Policy Flows:
HTTP, PROPRIETARY and  EXTERNAL_PROPRIETARY 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)