### PR TITLE
Fix/sdl must send generic error hmi doesnt respond during timeout

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_alert_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_alert_request.cc
@@ -47,7 +47,11 @@ UIAlertRequest::UIAlertRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle) {}
+                   policy_handle) {
+  const auto& msg_params = (*message_)[strings::msg_params];
+  uint32_t request_timeout = msg_params[strings::duration].asUInt();
+  default_timeout_ += request_timeout;
+}
 
 UIAlertRequest::~UIAlertRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_perform_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_perform_interaction_request.cc
@@ -47,7 +47,11 @@ UIPerformInteractionRequest::UIPerformInteractionRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle) {}
+                   policy_handle) {
+  const auto& msg_params = (*message_)[strings::msg_params];
+  uint32_t request_timeout = msg_params[strings::timeout].asUInt();
+  default_timeout_ += request_timeout;
+}
 
 UIPerformInteractionRequest::~UIPerformInteractionRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_scrollable_message_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_scrollable_message_request.cc
@@ -47,7 +47,11 @@ UIScrollableMessageRequest::UIScrollableMessageRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle) {}
+                   policy_handle) {
+  const auto& msg_params = (*message_)[strings::msg_params];
+  uint32_t request_timeout = msg_params[strings::timeout].asUInt();
+  default_timeout_ += request_timeout;
+}
 
 UIScrollableMessageRequest::~UIScrollableMessageRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_slider_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_slider_request.cc
@@ -47,7 +47,11 @@ UISliderRequest::UISliderRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle) {}
+                   policy_handle) {
+  const auto& msg_params = (*message_)[strings::msg_params];
+  uint32_t request_timeout = msg_params[strings::timeout].asUInt();
+  default_timeout_ += request_timeout;
+}
 
 UISliderRequest::~UISliderRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_perform_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_perform_interaction_request.cc
@@ -47,7 +47,11 @@ VRPerformInteractionRequest::VRPerformInteractionRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle) {}
+                   policy_handle) {
+  const auto& msg_params = (*message_)[strings::msg_params];
+  uint32_t request_timeout = msg_params[strings::timeout].asUInt();
+  default_timeout_ += request_timeout;
+}
 
 VRPerformInteractionRequest::~VRPerformInteractionRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_request.cc
@@ -73,18 +73,15 @@ AlertRequest::~AlertRequest() {}
 
 bool AlertRequest::Init() {
   /* Timeout in milliseconds.
-     If omitted a standard value of 10000 milliseconds is used.*/
-  if ((*message_)[strings::msg_params].keyExists(strings::duration)) {
-    default_timeout_ =
-        (*message_)[strings::msg_params][strings::duration].asUInt();
-  } else {
-    const int32_t def_value = 5000;
-    default_timeout_ = def_value;
-  }
+    If omitted a standard value of 10000 milliseconds is used.*/
+  auto& msg_params = (*message_)[strings::msg_params];
+  uint32_t duration_timeout = msg_params[strings::duration].asUInt();
+
+  default_timeout_ += duration_timeout;
 
   // If soft buttons are present, SDL will not use initiate timeout tracking for
   // response.
-  if ((*message_)[strings::msg_params].keyExists(strings::soft_buttons)) {
+  if (msg_params.keyExists(strings::soft_buttons)) {
     LOG4CXX_INFO(logger_,
                  "Request contains soft buttons - request timeout "
                  "will be set to 0.");
@@ -352,7 +349,8 @@ void AlertRequest::SendAlertRequest(int32_t app_id) {
   }
   // app_id
   msg_params[strings::app_id] = app_id;
-  msg_params[strings::duration] = default_timeout_;
+  msg_params[strings::duration] =
+      (*message_)[strings::msg_params][strings::duration].asUInt();
 
   // NAVI platform progressIndicator
   if ((*message_)[strings::msg_params].keyExists(strings::progress_indicator)) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
@@ -82,17 +82,18 @@ PerformInteractionRequest::~PerformInteractionRequest() {}
 bool PerformInteractionRequest::Init() {
   /* Timeout in milliseconds.
      If omitted a standard value of 10000 milliseconds is used.*/
-  if ((*message_)[strings::msg_params].keyExists(strings::timeout)) {
-    default_timeout_ =
-        (*message_)[strings::msg_params][strings::timeout].asUInt();
-  }
+  const auto& msg_params = (*message_)[strings::msg_params];
+  uint32_t request_timeout = msg_params[strings::timeout].asUInt();
 
   interaction_mode_ = static_cast<mobile_apis::InteractionMode::eType>(
-      (*message_)[strings::msg_params][strings::interaction_mode].asInt());
+      msg_params[strings::interaction_mode].asInt());
 
   if (mobile_apis::InteractionMode::BOTH == interaction_mode_ ||
       mobile_apis::InteractionMode::MANUAL_ONLY == interaction_mode_) {
-    default_timeout_ *= 2;
+    const uint32_t increase_value = 2;
+    default_timeout_ += request_timeout * increase_value;
+  } else {
+    default_timeout_ += request_timeout;
   }
   return true;
 }
@@ -284,7 +285,7 @@ void PerformInteractionRequest::onTimeOut() {
         CommandRequestImpl::onTimeOut();
       } else {
         application_manager_.updateRequestTimeout(
-            connection_key(), correlation_id(), default_timeout());
+            connection_key(), correlation_id(), default_timeout_);
       }
       break;
     }
@@ -341,7 +342,7 @@ bool PerformInteractionRequest::ProcessVRResponse(
     }
     LOG4CXX_DEBUG(logger_, "Update timeout for UI");
     application_manager_.updateRequestTimeout(
-        connection_key(), correlation_id(), default_timeout());
+        connection_key(), correlation_id(), default_timeout_);
     return false;
   }
 
@@ -356,6 +357,13 @@ bool PerformInteractionRequest::ProcessVRResponse(
       return true;
     }
     msg_params[strings::choice_id] = choice_id;
+  }
+
+  if (mobile_apis::InteractionMode::BOTH == interaction_mode_ ||
+      mobile_apis::InteractionMode::MANUAL_ONLY == interaction_mode_) {
+    LOG4CXX_DEBUG(logger_, "Update timeout for UI");
+    application_manager_.updateRequestTimeout(
+        connection_key(), correlation_id(), default_timeout_);
   }
 
   const bool is_vr_result_success = Compare<Common_Result::eType, EQ, ONE>(
@@ -471,12 +479,8 @@ void PerformInteractionRequest::SendUIPerformInteractionRequest(
     }
   }
 
-  if (mobile_apis::InteractionMode::BOTH == mode ||
-      mobile_apis::InteractionMode::MANUAL_ONLY == mode) {
-    msg_params[strings::timeout] = default_timeout_ / 2;
-  } else {
-    msg_params[strings::timeout] = default_timeout_;
-  }
+  msg_params[strings::timeout] =
+      (*message_)[strings::msg_params][strings::timeout].asUInt();
   msg_params[strings::app_id] = app->app_id();
   if (mobile_apis::InteractionMode::VR_ONLY != mode) {
     msg_params[strings::choice_set] =
@@ -652,16 +656,9 @@ void PerformInteractionRequest::SendVRPerformInteractionRequest(
     return;
   }
 
-  mobile_apis::InteractionMode::eType mode =
-      static_cast<mobile_apis::InteractionMode::eType>(
-          (*message_)[strings::msg_params][strings::interaction_mode].asInt());
-
-  if (mobile_apis::InteractionMode::BOTH == mode ||
-      mobile_apis::InteractionMode::MANUAL_ONLY == mode) {
-    msg_params[strings::timeout] = default_timeout_ / 2;
-  } else {
-    msg_params[strings::timeout] = default_timeout_;
-  }
+  msg_params[strings::timeout] =
+      (*message_)[strings::msg_params][strings::timeout].asUInt();
+  ;
   msg_params[strings::app_id] = app->app_id();
   StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
   SendHMIRequest(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/scrollable_message_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/scrollable_message_request.cc
@@ -65,13 +65,9 @@ ScrollableMessageRequest::~ScrollableMessageRequest() {}
 bool ScrollableMessageRequest::Init() {
   /* Timeout in milliseconds.
      If omitted a standard value of 10000 milliseconds is used.*/
-  if ((*message_)[strings::msg_params].keyExists(strings::timeout)) {
-    default_timeout_ =
-        (*message_)[strings::msg_params][strings::timeout].asUInt();
-  } else {
-    const int32_t def_value = 30000;
-    default_timeout_ = def_value;
-  }
+  uint32_t request_timeout =
+      (*message_)[strings::msg_params][strings::timeout].asUInt();
+  default_timeout_ += request_timeout;
 
   return true;
 }
@@ -110,7 +106,8 @@ void ScrollableMessageRequest::Run() {
   msg_params[hmi_request::message_text][hmi_request::field_text] =
       (*message_)[strings::msg_params][strings::scroll_message_body];
   msg_params[strings::app_id] = app->app_id();
-  msg_params[strings::timeout] = default_timeout_;
+  msg_params[strings::timeout] =
+      (*message_)[strings::msg_params][strings::timeout].asUInt();
 
   if ((*message_)[strings::msg_params].keyExists(strings::soft_buttons)) {
     msg_params[strings::soft_buttons] =

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/scrollable_message_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/scrollable_message_test.cc
@@ -175,7 +175,7 @@ TEST_F(ScrollableMessageRequestTest, Init_CorrectTimeout_SUCCESS) {
       mobile_apis::InteractionMode::MANUAL_ONLY;
   EXPECT_EQ(kDefaultTimeout_, command_->default_timeout());
   command_->Init();
-  EXPECT_EQ(kTimeOut, command_->default_timeout());
+  EXPECT_EQ(kTimeOut + kDefaultTimeout_, command_->default_timeout());
 }
 
 TEST_F(ScrollableMessageRequestTest, Init_CorrectTimeout_UNSUCCESS) {
@@ -183,7 +183,7 @@ TEST_F(ScrollableMessageRequestTest, Init_CorrectTimeout_UNSUCCESS) {
       mobile_apis::InteractionMode::MANUAL_ONLY;
   EXPECT_EQ(kDefaultTimeout_, command_->default_timeout());
   command_->Init();
-  EXPECT_EQ(kTimeOut, command_->default_timeout());
+  EXPECT_EQ(kDefaultTimeout_, command_->default_timeout());
 }
 
 TEST_F(ScrollableMessageRequestTest, Run_ApplicationIsNotRegistered_UNSUCCESS) {


### PR DESCRIPTION
Fixes #1880 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.


### Summary
This PR provided bugfix when SDL doesn't respond during `DefaultTimeout`+`RPCs_internal_timeout` for all RPCs with own timer.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)