### PR TITLE
SDL does not send UnsubscribeVehicleData request to HMI after unregister last app.

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
@@ -72,6 +72,8 @@ class VehicleInfoPlugin : public plugins::RPCPlugin {
                                      VehicleInfoAppExtension& ext);
 
  private:
+  smart_objects::SmartObjectSPtr GetUnsubscribeIVIRequest(
+      const std::vector<std::string>& ivi_names);
   void DeleteSubscriptions(app_mngr::ApplicationSharedPtr app);
 
   std::unique_ptr<app_mngr::CommandFactory> command_factory_;


### PR DESCRIPTION
Fixes #2282

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
Covered by ATF script.

### Summary
This PR fixes defect, when SDL does not send UnsubscribeVehicleData request to HMI when the last application was unregistered.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)