### PR TITLE
moved ResetGlobalProperties to ApplicationManager

### DIFF
--- a/src/components/application_manager/include/application_manager/app_extension.h
+++ b/src/components/application_manager/include/application_manager/app_extension.h
@@ -49,7 +49,7 @@ using Subscriber = std::function<void(const int32_t, const ResumptionRequest)>;
 }  // namespace resumption
 
 namespace application_manager {
-    
+
 typedef int AppExtensionUID;
 
 class AppExtension {

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -927,6 +927,25 @@ class ApplicationManagerImpl
   void RemoveAppFromTTSGlobalPropertiesList(const uint32_t app_id) OVERRIDE;
 
   /**
+   * @brief Resets application's global properties to default values
+   * returning struct that indicates which properties have been
+   * successfully reset.
+   * @param container with global properties to reset
+   * @return struct with flags indicating global properties reset
+   */
+  ResetGlobalPropertiesResult ResetGlobalProperties(
+      const smart_objects::SmartObject& global_properties_ids,
+      const uint32_t app_id) OVERRIDE;
+
+  /**
+    * @brief Resets all application's global properties to default values
+    * @param id of app which properties to reset
+    * @return struct with flags indicating success global properties reset
+    */
+  ResetGlobalPropertiesResult ResetAllApplicationGlobalProperties(
+      const uint32_t app_id) OVERRIDE;
+
+  /**
    * DEPRECATED
    * @brief method adds application in FULL and LIMITED state
    * to on_phone_call_app_list_.
@@ -1265,6 +1284,39 @@ class ApplicationManagerImpl
    */
   void SendMobileMessage(smart_objects::SmartObjectSPtr message);
 
+  /*
+   * @brief Sets default value of the HELPPROMT global property
+   * to the first vrCommand of each Command Menu registered in application
+   *
+   * @param app Registered application
+   * @param is_timeout_promp Flag indicating that timeout prompt
+   * should be reset
+   *
+   * @return TRUE on success, otherwise FALSE
+   */
+  bool ResetHelpPromt(ApplicationSharedPtr app) const;
+
+  /*
+   * @brief  Sets default value of the TIMEOUTPROMT global property
+   * to the first vrCommand of each Command Menu registered in application
+   *
+   * @param app Registered application
+   *
+   * @return TRUE on success, otherwise FALSE
+   */
+  bool ResetTimeoutPromt(ApplicationSharedPtr app) const;
+
+  /*
+   * @brief Sets default value of the VRHELPTITLE global property
+   * to the application name and value of the VRHELPITEMS global property
+   * to value equal to registered command -1(default command “Help / Cancel”.)
+   *
+   * @param app Registered application
+   *
+   * @return TRUE on success, otherwise FALSE
+   */
+  bool ResetVrHelpTitleItems(ApplicationSharedPtr app) const;
+
  private:
   /*
    * NaviServiceStatusMap shows which navi service (audio/video) is opened
@@ -1287,6 +1339,16 @@ class ApplicationManagerImpl
    */
   std::string GetHashedAppID(uint32_t connection_key,
                              const std::string& policy_app_id) const;
+
+  /**
+   * @brief CreateAllAppGlobalPropsIDList creates an array of all application
+   * global properties IDs. Used as utility to call
+   * ApplicationManger::ResetGlobalProperties
+   * with all global properties.
+   * @return array smart object with global properties identifiers.
+   */
+  const smart_objects::SmartObjectSPtr CreateAllAppGlobalPropsIDList(
+      const uint32_t app_id) const;
 
   /**
    * @brief Removes suspended and stopped timers from timer pool

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -56,7 +56,39 @@ class PolicyHandlerInterface;
 }
 
 namespace application_manager {
-namespace mobile_api = mobile_apis;
+
+/**
+ * @brief ResetGlobalPropertiesResult
+ * contains flags indicating success of
+ * ResetGlobalProperties operation.
+ * Used in MessageHelper functions
+ * to construct relevant requests
+ **/
+struct ResetGlobalPropertiesResult {
+  bool help_prompt;
+  bool timeout_prompt;
+  bool vr_help_title_items;
+  bool menu_name;
+  bool menu_icon;
+  bool keyboard_properties;
+  int number_of_reset_vr;
+
+  ResetGlobalPropertiesResult()
+      : help_prompt(false)
+      , timeout_prompt(false)
+      , vr_help_title_items(false)
+      , menu_name(false)
+      , menu_icon(false)
+      , keyboard_properties(false)
+      , number_of_reset_vr(0) {}
+  bool HasUIPropertiesReset() const {
+    return vr_help_title_items || menu_name || menu_icon || keyboard_properties;
+  }
+
+  bool HasTTSPropertiesReset() const {
+    return timeout_prompt || help_prompt;
+  }
+};
 
 /*
  * @brief Typedef for VehicleData
@@ -174,7 +206,7 @@ class MessageHelper {
    * @return mobile Result enum value if succedeed, otherwise - INVALID_ENUM
    * value
    */
-  static mobile_api::Result::eType MobileResultFromString(
+  static mobile_apis::Result::eType MobileResultFromString(
       const std::string& mobile_result);
 
   /**
@@ -183,7 +215,7 @@ class MessageHelper {
    * @return mobile Result enum value if succedeed, otherwise - INVALID_ENUM
    * value
    */
-  static mobile_api::Result::eType HMIToMobileResult(
+  static mobile_apis::Result::eType HMIToMobileResult(
       const hmi_apis::Common_Result::eType hmi_result);
 
   /**
@@ -192,7 +224,7 @@ class MessageHelper {
    * @return HMI Result enum value
    */
   static hmi_apis::Common_Result::eType MobileToHMIResult(
-      const mobile_api::Result::eType mobile_result);
+      const mobile_apis::Result::eType mobile_result);
 
   /**
    * @brief Convert string to HMI level, if possible
@@ -200,7 +232,7 @@ class MessageHelper {
    * @return Appropriate enum from HMI level, or INVALID_ENUM, if conversiion
    * is not possible
    */
-  static mobile_api::HMILevel::eType StringToHMILevel(
+  static mobile_apis::HMILevel::eType StringToHMILevel(
       const std::string& hmi_level);
 
   /*
@@ -765,7 +797,7 @@ class MessageHelper {
   static smart_objects::SmartObjectSPtr
   GetOnAppInterfaceUnregisteredNotificationToMobile(
       int32_t connection_key,
-      mobile_api::AppInterfaceUnregisteredReason::eType reason);
+      mobile_apis::AppInterfaceUnregisteredReason::eType reason);
 
   /**
    * @brief SendDeleteCommandRequest sends requests to HMI to remove UI/VR
@@ -853,6 +885,28 @@ class MessageHelper {
    */
   static smart_objects::SmartObjectSPtr CreateMessageForHMI(
       hmi_apis::messageType::eType message_type, const uint32_t correlation_id);
+
+  /**
+   * @brief CreateUIResetGlobalPropertiesRequest Creates request
+   * to reset global properties for UI
+   * @param struct containing result of global properties reset procedure
+   * @param application which properties are to be reset
+   * @return filled smart object with relevant request data
+   */
+  static smart_objects::SmartObjectSPtr CreateUIResetGlobalPropertiesRequest(
+      const ResetGlobalPropertiesResult& reset_result,
+      const ApplicationSharedPtr application);
+
+  /**
+   * @brief CreateTTSResetGlobalPropertiesRequest Creates request
+   * to reset global properties for TTS
+   * @param struct containing result of global properties reset procedure
+   * @param application which properties are to be reset
+   * @return filled smart object with relevant request data
+   */
+  static smart_objects::SmartObjectSPtr CreateTTSResetGlobalPropertiesRequest(
+      const ResetGlobalPropertiesResult& reset_result,
+      const ApplicationSharedPtr application);
 
  private:
   /**

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -217,7 +217,7 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
   * @param saved_app application specific section from backup file
   */
   void AddButtonsSubscriptions(app_mngr::ApplicationSharedPtr application,
-                        const smart_objects::SmartObject& saved_app);
+                               const smart_objects::SmartObject& saved_app);
 
   /**
   * @brief AddSubscriptions allows to restore subscriptions
@@ -225,7 +225,7 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
   * @param saved_app application specific section from backup file
   */
   void AddPluginsSubscriptions(app_mngr::ApplicationSharedPtr application,
-                        const smart_objects::SmartObject& saved_app);
+                               const smart_objects::SmartObject& saved_app);
 
   /**
    * @brief Deleting subscriptions have been resumed

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -243,7 +243,7 @@ class RegisterAppInterfaceRequest
    * @return true if application os not allowed to register, othervise return
    * false.
    */
-  bool IsApplicationForbidden();
+  bool IsApplicationForbidden() const;
 
   /**
    * @brief ProcessApplicationTransportSwitching process checking if application

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/reset_global_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/reset_global_properties_request.h
@@ -42,7 +42,6 @@ namespace sdl_rpc_plugin {
 namespace app_mngr = application_manager;
 
 namespace commands {
-
 /**
  * @brief ResetGlobalPropertiesRequest command class
  **/
@@ -85,40 +84,6 @@ class ResetGlobalPropertiesRequest
 
  private:
   /*
-   * @brief Sets default value of the HELPPROMT global property
-   * to the first vrCommand of each Command Menu registered in application
-   *
-   * @param app Registered application
-   * @param is_timeout_promp Flag indicating that timeout prompt
-   * should be reset
-   *
-   * @return TRUE on success, otherwise FALSE
-   */
-  bool ResetHelpPromt(app_mngr::ApplicationSharedPtr app);
-
-  /*
-   * @brief  Sets default value of the TIMEOUTPROMT global property
-   * to the first vrCommand of each Command Menu registered in application
-   *
-   * @param app Registered application
-   *
-   * @return TRUE on success, otherwise FALSE
-   */
-  bool ResetTimeoutPromt(application_manager::ApplicationSharedPtr const app);
-
-  /*
-   * @brief Sets default value of the VRHELPTITLE global property
-   * to the application name and value of the VRHELPITEMS global property
-   * to value equal to registered command -1(default command “Help / Cancel”.)
-   *
-   * @param app Registered application
-   *
-   * @return TRUE on success, otherwise FALSE
-   */
-  bool ResetVrHelpTitleItems(
-      application_manager::ApplicationSharedPtr const app);
-
-  /*
    * @brief Prepare result for sending to mobile application
    * @param out_result_code contains result code for sending to mobile
    * application
@@ -134,6 +99,12 @@ class ResetGlobalPropertiesRequest
    * @return true if all responses received
    */
   bool IsPendingResponseExist();
+
+  /*
+   * @brief ResetGlobalProperties gets global properties data from message_
+   * and passes it to ApplicationManager::ResetGlobalProperties
+   */
+  void ResetGlobalProperties();
 
   DISALLOW_COPY_AND_ASSIGN(ResetGlobalPropertiesRequest);
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
@@ -61,186 +61,7 @@ ResetGlobalPropertiesRequest::ResetGlobalPropertiesRequest(
 ResetGlobalPropertiesRequest::~ResetGlobalPropertiesRequest() {}
 
 void ResetGlobalPropertiesRequest::Run() {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  uint32_t app_id =
-      (*message_)[strings::params][strings::connection_key].asUInt();
-  ApplicationSharedPtr app = application_manager_.application(app_id);
-
-  if (!app) {
-    LOG4CXX_ERROR(logger_, "No application associated with session key");
-    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
-    return;
-  }
-
-  size_t obj_length =
-      (*message_)[strings::msg_params][strings::properties].length();
-  // if application waits for sending ttsGlobalProperties need to remove this
-  // application from tts_global_properties_app_list_
-  LOG4CXX_INFO(logger_, "RemoveAppFromTTSGlobalPropertiesList");
-  application_manager_.RemoveAppFromTTSGlobalPropertiesList(app_id);
-
-  bool helpt_promt = false;
-  bool timeout_prompt = false;
-  bool vr_help_title_items = false;
-  bool menu_name = false;
-  bool menu_icon = false;
-  bool is_key_board_properties = false;
-  int number_of_reset_vr = 0;
-  mobile_apis::GlobalProperty::eType global_property =
-      mobile_apis::GlobalProperty::INVALID_ENUM;
-
-  for (size_t i = 0; i < obj_length; ++i) {
-    global_property = static_cast<mobile_apis::GlobalProperty::eType>(
-        (*message_)[strings::msg_params][strings::properties][i].asInt());
-
-    if (mobile_apis::GlobalProperty::HELPPROMPT == global_property) {
-      helpt_promt = ResetHelpPromt(app);
-    } else if (mobile_apis::GlobalProperty::TIMEOUTPROMPT == global_property) {
-      timeout_prompt = ResetTimeoutPromt(app);
-    } else if (((mobile_apis::GlobalProperty::VRHELPTITLE == global_property) ||
-                (mobile_apis::GlobalProperty::VRHELPITEMS ==
-                 global_property)) &&
-               (0 == number_of_reset_vr)) {
-      ++number_of_reset_vr;
-      vr_help_title_items = ResetVrHelpTitleItems(app);
-    } else if (mobile_apis::GlobalProperty::MENUNAME == global_property) {
-      menu_name = true;
-    } else if (mobile_apis::GlobalProperty::MENUICON == global_property) {
-      menu_icon = true;
-    } else if (mobile_apis::GlobalProperty::KEYBOARDPROPERTIES ==
-               global_property) {
-      is_key_board_properties = true;
-    }
-  }
-
-  if (vr_help_title_items || menu_name || menu_icon ||
-      is_key_board_properties) {
-    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
-  }
-
-  if (timeout_prompt || helpt_promt) {
-    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
-  }
-
-  app->set_reset_global_properties_active(true);
-
-  if (vr_help_title_items || menu_name || menu_icon ||
-      is_key_board_properties) {
-    smart_objects::SmartObject msg_params =
-        smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-    if (vr_help_title_items) {
-      smart_objects::SmartObjectSPtr vr_help =
-          MessageHelper::CreateAppVrHelp(app);
-      if (!vr_help) {
-        return;
-      }
-      msg_params = *vr_help;
-    }
-    if (menu_name) {
-      msg_params[hmi_request::menu_title] = "";
-      app->set_menu_title(msg_params[hmi_request::menu_title]);
-    }
-    // TODO(DT): clarify the sending parameter menuIcon
-    // if (menu_icon) {
-    //}
-    if (is_key_board_properties) {
-      smart_objects::SmartObject key_board_properties =
-          smart_objects::SmartObject(smart_objects::SmartType_Map);
-      key_board_properties[strings::language] =
-          static_cast<int32_t>(hmi_apis::Common_Language::EN_US);
-      key_board_properties[hmi_request::keyboard_layout] =
-          static_cast<int32_t>(hmi_apis::Common_KeyboardLayout::QWERTY);
-
-      // Look for APPLINK-4432 for details.
-      /*smart_objects::SmartObject limited_character_list =
-      smart_objects::SmartObject(
-            smart_objects::SmartType_Array);
-      limited_character_list[0] = "";
-      key_board_properties[hmi_request::limited_character_list] =
-        limited_character_list;*/
-
-      key_board_properties[hmi_request::auto_complete_text] = "";
-      msg_params[hmi_request::keyboard_properties] = key_board_properties;
-    }
-
-    msg_params[strings::app_id] = app->app_id();
-    SendHMIRequest(
-        hmi_apis::FunctionID::UI_SetGlobalProperties, &msg_params, true);
-  }
-
-  if (timeout_prompt || helpt_promt) {
-    // create ui request
-    smart_objects::SmartObject msg_params =
-        smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-    if (helpt_promt) {
-      msg_params[strings::help_prompt] = (*app->help_prompt());
-    }
-
-    if (timeout_prompt) {
-      msg_params[strings::timeout_prompt] = (*app->timeout_prompt());
-    }
-
-    msg_params[strings::app_id] = app->app_id();
-
-    SendHMIRequest(
-        hmi_apis::FunctionID::TTS_SetGlobalProperties, &msg_params, true);
-  }
-}
-
-bool ResetGlobalPropertiesRequest::ResetHelpPromt(
-    application_manager::ApplicationSharedPtr app) {
-  if (!app) {
-    LOG4CXX_ERROR(logger_, "Null pointer");
-    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
-    return false;
-  }
-  smart_objects::SmartObject so_help_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-  app->set_help_prompt(so_help_prompt);
-  return true;
-}
-
-bool ResetGlobalPropertiesRequest::ResetTimeoutPromt(
-    application_manager::ApplicationSharedPtr const app) {
-  if (!app) {
-    LOG4CXX_ERROR(logger_, "Null pointer");
-    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
-    return false;
-  }
-
-  const std::vector<std::string>& time_out_promt =
-      application_manager_.get_settings().time_out_promt();
-
-  smart_objects::SmartObject so_time_out_promt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  for (uint32_t i = 0; i < time_out_promt.size(); ++i) {
-    smart_objects::SmartObject timeoutPrompt =
-        smart_objects::SmartObject(smart_objects::SmartType_Map);
-    timeoutPrompt[strings::text] = time_out_promt[i];
-    timeoutPrompt[strings::type] = hmi_apis::Common_SpeechCapabilities::SC_TEXT;
-    so_time_out_promt[i] = timeoutPrompt;
-  }
-
-  app->set_timeout_prompt(so_time_out_promt);
-
-  return true;
-}
-
-bool ResetGlobalPropertiesRequest::ResetVrHelpTitleItems(
-    application_manager::ApplicationSharedPtr const app) {
-  if (!app) {
-    LOG4CXX_ERROR(logger_, "Null pointer");
-    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
-    return false;
-  }
-  app->reset_vr_help_title();
-  app->reset_vr_help();
-
-  return true;
+  ResetGlobalProperties();
 }
 
 void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
@@ -329,6 +150,56 @@ bool ResetGlobalPropertiesRequest::PrepareResponseParameters(
 bool ResetGlobalPropertiesRequest::IsPendingResponseExist() {
   return IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_TTS) ||
          IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_UI);
+}
+
+void ResetGlobalPropertiesRequest::ResetGlobalProperties() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  uint32_t app_id =
+      (*message_)[strings::params][strings::connection_key].asUInt();
+  ApplicationSharedPtr app = application_manager_.application(app_id);
+
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "No application associated with session key");
+    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
+    return;
+  }
+
+  const auto& global_properties =
+      (*message_)[strings::msg_params][strings::properties];
+
+  auto reset_global_props_result =
+      application_manager_.ResetGlobalProperties(global_properties, app_id);
+
+  if (reset_global_props_result.HasUIPropertiesReset()) {
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
+  }
+
+  if (reset_global_props_result.HasTTSPropertiesReset()) {
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
+  }
+
+  app->set_reset_global_properties_active(true);
+
+  if (reset_global_props_result.HasUIPropertiesReset()) {
+    // create ui request
+    smart_objects::SmartObjectSPtr msg_params =
+        MessageHelper::CreateUIResetGlobalPropertiesRequest(
+            reset_global_props_result, app);
+    if (msg_params.get()) {
+      SendHMIRequest(
+          hmi_apis::FunctionID::UI_SetGlobalProperties, msg_params.get(), true);
+    }
+  }
+
+  if (reset_global_props_result.HasTTSPropertiesReset()) {
+    smart_objects::SmartObjectSPtr msg_params =
+        MessageHelper::CreateTTSResetGlobalPropertiesRequest(
+            reset_global_props_result, app);
+
+    SendHMIRequest(
+        hmi_apis::FunctionID::TTS_SetGlobalProperties, msg_params.get(), true);
+  }
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
@@ -125,117 +125,50 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidApp_UNSUCCESS) {
 }
 
 TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidVrHelp_UNSUCCESS) {
-  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
-      mobile_apis::GlobalProperty::HELPPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][1] =
-      mobile_apis::GlobalProperty::TIMEOUTPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][2] =
-      mobile_apis::GlobalProperty::VRHELPTITLE;
-  (*msg_)[am::strings::msg_params][am::strings::properties][3] =
-      mobile_apis::GlobalProperty::MENUNAME;
-  (*msg_)[am::strings::msg_params][am::strings::properties][4] =
-      mobile_apis::GlobalProperty::MENUICON;
-  (*msg_)[am::strings::msg_params][am::strings::properties][5] =
-      mobile_apis::GlobalProperty::KEYBOARDPROPERTIES;
+  am::ResetGlobalPropertiesResult result;
+  result.help_prompt = true;
+  result.timeout_prompt = true;
+  result.vr_help_title_items = true;
+  result.menu_name = true;
+  result.menu_icon = true;
+  result.keyboard_properties = true;
 
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
-  smart_objects::SmartObject so_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-  EXPECT_CALL(*mock_app_, set_help_prompt(so_prompt));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(smart_objects::SmartObjectSPtr()));
 
-  smart_objects::SmartObject timeout_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  timeout_prompt[am::strings::text] = time_out_prompt[0];
-  timeout_prompt[am::strings::type] =
-      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+  ON_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillByDefault(Return(std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map)));
 
-  smart_objects::SmartObject so_time_out_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  so_time_out_prompt[0] = timeout_prompt;
-
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(so_time_out_prompt));
-
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
-
-  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
-
-  smart_objects::SmartObjectSPtr vr_help;  // = NULL;
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
-
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).Times(1);
 
   command_->Run();
 }
 
 TEST_F(ResetGlobalPropertiesRequestTest, Run_SUCCESS) {
-  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
-      mobile_apis::GlobalProperty::HELPPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][1] =
-      mobile_apis::GlobalProperty::TIMEOUTPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][2] =
-      mobile_apis::GlobalProperty::VRHELPTITLE;
-  (*msg_)[am::strings::msg_params][am::strings::properties][3] =
-      mobile_apis::GlobalProperty::MENUNAME;
-  (*msg_)[am::strings::msg_params][am::strings::properties][4] =
-      mobile_apis::GlobalProperty::MENUICON;
-  (*msg_)[am::strings::msg_params][am::strings::properties][5] =
-      mobile_apis::GlobalProperty::KEYBOARDPROPERTIES;
+  am::ResetGlobalPropertiesResult result;
+  result.help_prompt = true;
+  result.timeout_prompt = true;
+  result.vr_help_title_items = true;
+  result.menu_name = true;
+  result.menu_icon = true;
+  result.keyboard_properties = true;
+  result.number_of_reset_vr = 1;
 
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
-  smart_objects::SmartObject so_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-  EXPECT_CALL(*mock_app_, set_help_prompt(so_prompt));
-
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
-
-  smart_objects::SmartObject timeout_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  timeout_prompt[am::strings::text] = time_out_prompt[0];
-  timeout_prompt[am::strings::type] =
-      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
-
-  smart_objects::SmartObject so_time_out_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  so_time_out_prompt[0] = timeout_prompt;
-
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(so_time_out_prompt));
-
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
+  ON_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillByDefault(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 
-  smart_objects::SmartObjectSPtr vr_help =
+  smart_objects::SmartObjectSPtr msg_params =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
 
-  smart_objects::SmartObject msg_params =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  msg_params[am::hmi_request::menu_title] = "";
-
-  EXPECT_CALL(*mock_app_,
-              set_menu_title(msg_params[am::hmi_request::menu_title]));
-
-  const smart_objects::SmartObjectSPtr so_help_prompt =
-      std::make_shared<smart_objects::SmartObject>(
-          smart_objects::SmartType_Map);
-  EXPECT_CALL(*mock_app_, help_prompt()).WillOnce(Return(so_help_prompt.get()));
-  EXPECT_CALL(*mock_app_, timeout_prompt())
-      .WillOnce(Return(so_help_prompt.get()));
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(mock_rpc_service_,
               ManageHMICommand(HMIResultCodeIs(
@@ -262,18 +195,25 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       hmi_apis::Common_Result::SUCCESS;
   (*msg_)[am::strings::params][am::hmi_response::code] = result_code;
 
-  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
-      mobile_apis::GlobalProperty::VRHELPTITLE;
+  am::ResetGlobalPropertiesResult result;
+  result.vr_help_title_items = true;
 
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
-  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  ON_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillByDefault(Return(msg_params));
+
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   smart_objects::SmartObjectSPtr vr_help =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
+
   EXPECT_CALL(mock_rpc_service_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::UI_SetGlobalProperties)))
@@ -301,20 +241,22 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
-
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
-
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   MessageSharedPtr ui_msg = CreateMessage();
   (*ui_msg)[am::strings::params][am::strings::correlation_id] = kCorrelationId;
@@ -358,10 +300,22 @@ TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_InvalidApp_NoHashUpdate) {
   (*msg_)[am::strings::msg_params][am::strings::properties][0] =
       mobile_apis::GlobalProperty::VRHELPTITLE;
 
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
+  am::ResetGlobalPropertiesResult result;
+  result.vr_help_title_items = true;
+
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .Times(0);
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+
   EXPECT_CALL(mock_rpc_service_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::UI_SetGlobalProperties)))
@@ -369,8 +323,6 @@ TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_InvalidApp_NoHashUpdate) {
   smart_objects::SmartObjectSPtr vr_help =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
 
   EXPECT_CALL(*mock_app_, UpdateHash()).Times(0);
 
@@ -397,20 +349,22 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
-
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
-
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(mock_rpc_service_,
               ManageHMICommand(HMIResultCodeIs(
@@ -462,18 +416,20 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
 
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 
@@ -526,18 +482,20 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
 
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2974,6 +2974,54 @@ void ApplicationManagerImpl::ProcessApp(const uint32_t app_id,
   }
 }
 
+bool ApplicationManagerImpl::ResetHelpPromt(ApplicationSharedPtr app) const {
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "Null pointer");
+    return false;
+  }
+  smart_objects::SmartObject so_help_prompt =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  app->set_help_prompt(so_help_prompt);
+  return true;
+}
+
+bool ApplicationManagerImpl::ResetTimeoutPromt(ApplicationSharedPtr app) const {
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "Null pointer");
+    return false;
+  }
+
+  const std::vector<std::string>& time_out_promt =
+      get_settings().time_out_promt();
+
+  smart_objects::SmartObject so_time_out_promt =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  for (uint32_t i = 0; i < time_out_promt.size(); ++i) {
+    smart_objects::SmartObject timeoutPrompt =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    timeoutPrompt[strings::text] = time_out_promt[i];
+    timeoutPrompt[strings::type] = hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+    so_time_out_promt[i] = timeoutPrompt;
+  }
+
+  app->set_timeout_prompt(so_time_out_promt);
+
+  return true;
+}
+
+bool ApplicationManagerImpl::ResetVrHelpTitleItems(
+    ApplicationSharedPtr app) const {
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "Null pointer");
+    return false;
+  }
+  app->reset_vr_help_title();
+  app->reset_vr_help();
+
+  return true;
+}
+
 void ApplicationManagerImpl::SendHMIStatusNotification(
     const std::shared_ptr<Application> app) {
   LOG4CXX_AUTO_TRACE(logger_);
@@ -3308,6 +3356,99 @@ void ApplicationManagerImpl::RemoveAppFromTTSGlobalPropertiesList(
     }
   }
   tts_global_properties_app_list_lock_.Release();
+}
+
+ResetGlobalPropertiesResult ApplicationManagerImpl::ResetGlobalProperties(
+    const smart_objects::SmartObject& global_properties_ids,
+    const uint32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  ApplicationSharedPtr application =
+      ApplicationManagerImpl::application(app_id);
+  // if application waits for sending ttsGlobalProperties need to remove this
+  // application from tts_global_properties_app_list_
+  LOG4CXX_INFO(logger_, "RemoveAppFromTTSGlobalPropertiesList");
+  RemoveAppFromTTSGlobalPropertiesList(app_id);
+
+  ResetGlobalPropertiesResult result;
+
+  for (size_t i = 0; i < global_properties_ids.length(); ++i) {
+    mobile_apis::GlobalProperty::eType global_property =
+        static_cast<mobile_apis::GlobalProperty::eType>(
+            global_properties_ids[i].asInt());
+    switch (global_property) {
+      case mobile_apis::GlobalProperty::HELPPROMPT: {
+        result.help_prompt = ResetHelpPromt(application);
+        break;
+      }
+      case mobile_apis::GlobalProperty::TIMEOUTPROMPT: {
+        result.timeout_prompt = ResetTimeoutPromt(application);
+        break;
+      }
+      case mobile_apis::GlobalProperty::VRHELPTITLE:
+      case mobile_apis::GlobalProperty::VRHELPITEMS: {
+        if (0 == result.number_of_reset_vr) {
+          result.number_of_reset_vr++;
+          result.vr_help_title_items = ResetVrHelpTitleItems(application);
+        }
+        break;
+      }
+      case mobile_apis::GlobalProperty::MENUNAME: {
+        result.menu_name = true;
+        break;
+      }
+      case mobile_apis::GlobalProperty::MENUICON: {
+        result.menu_icon = true;
+        break;
+      }
+      case mobile_apis::GlobalProperty::KEYBOARDPROPERTIES: {
+        result.keyboard_properties = true;
+        break;
+      }
+      default: {
+        LOG4CXX_TRACE(logger_, "Unknown global property: " << global_property);
+        break;
+      }
+    }
+  }
+
+  return result;
+}
+
+ResetGlobalPropertiesResult
+ApplicationManagerImpl::ResetAllApplicationGlobalProperties(
+    const uint32_t app_id) {
+  const smart_objects::SmartObjectSPtr application_gl_props =
+      CreateAllAppGlobalPropsIDList(app_id);
+  return ResetGlobalProperties(*application_gl_props, app_id);
+}
+
+const smart_objects::SmartObjectSPtr
+ApplicationManagerImpl::CreateAllAppGlobalPropsIDList(
+    const uint32_t app_id) const {
+  smart_objects::SmartObjectSPtr ret_gl_props =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Array);
+  using namespace mobile_apis;
+
+  ApplicationConstSharedPtr application =
+      ApplicationManagerImpl::application(app_id);
+  int32_t i = 0;
+
+  if (application->help_prompt())
+    (*ret_gl_props)[i++] = GlobalProperty::HELPPROMPT;
+  if (application->timeout_prompt())
+    (*ret_gl_props)[i++] = GlobalProperty::TIMEOUTPROMPT;
+  if (application->vr_help_title())
+    (*ret_gl_props)[i++] = GlobalProperty::VRHELPTITLE;
+  if (application->menu_title())
+    (*ret_gl_props)[i++] = GlobalProperty::MENUNAME;
+  if (application->menu_icon())
+    (*ret_gl_props)[i++] = GlobalProperty::MENUICON;
+  if (application->keyboard_props())
+    (*ret_gl_props)[i++] = GlobalProperty::KEYBOARDPROPERTIES;
+
+  return ret_gl_props;
 }
 
 mobile_apis::AppHMIType::eType ApplicationManagerImpl::StringToAppHMIType(

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -844,6 +844,70 @@ void MessageHelper::CreateGetVehicleDataRequest(
   app_mngr.GetRPCService().ManageHMICommand(request);
 }
 
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateTTSResetGlobalPropertiesRequest(
+    const ResetGlobalPropertiesResult& reset_result,
+    const ApplicationSharedPtr application) {
+  smart_objects::SmartObjectSPtr ui_reset_global_prop_request =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  if (reset_result.help_prompt) {
+    (*ui_reset_global_prop_request)[strings::help_prompt] =
+        application->help_prompt();
+  }
+
+  if (reset_result.timeout_prompt) {
+    (*ui_reset_global_prop_request)[strings::timeout_prompt] =
+        application->timeout_prompt();
+  }
+
+  (*ui_reset_global_prop_request)[strings::app_id] = application->app_id();
+
+  return ui_reset_global_prop_request;
+}
+
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateUIResetGlobalPropertiesRequest(
+    const ResetGlobalPropertiesResult& reset_result,
+    const ApplicationSharedPtr application) {
+  smart_objects::SmartObjectSPtr tts_reset_global_prop_request =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  if (reset_result.vr_help_title_items) {
+    smart_objects::SmartObjectSPtr vr_help = CreateAppVrHelp(application);
+    if (!vr_help.get()) {
+      LOG4CXX_WARN(logger_, "Failed to create vr_help");
+      return smart_objects::SmartObjectSPtr();
+    } else {
+      tts_reset_global_prop_request = vr_help;
+    }
+  }
+  if (reset_result.menu_name) {
+    (*tts_reset_global_prop_request)[hmi_request::menu_title] = "";
+    application->set_menu_title(
+        (*tts_reset_global_prop_request)[hmi_request::menu_title]);
+  }
+
+  if (reset_result.keyboard_properties) {
+    smart_objects::SmartObject key_board_properties =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    key_board_properties[strings::language] =
+        static_cast<int32_t>(hmi_apis::Common_Language::EN_US);
+    key_board_properties[hmi_request::keyboard_layout] =
+        static_cast<int32_t>(hmi_apis::Common_KeyboardLayout::QWERTY);
+
+    key_board_properties[hmi_request::auto_complete_text] = "";
+    (*tts_reset_global_prop_request)[hmi_request::keyboard_properties] =
+        key_board_properties;
+  }
+
+  (*tts_reset_global_prop_request)[strings::app_id] = application->app_id();
+
+  return tts_reset_global_prop_request;
+}
+
 smart_objects::SmartObjectSPtr MessageHelper::CreateBlockedByPoliciesResponse(
     mobile_apis::FunctionID::eType function_id,
     mobile_apis::Result::eType result,

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -162,11 +162,11 @@ void ResumptionDataProcessor::ProcessHMIRequest(
 
 void ResumptionDataProcessor::ProcessHMIRequests(
     const smart_objects::SmartObjectList& requests) {
-  LOG4CXX_AUTO_TRACE(logger_);    
-  if(requests.empty()){
-    LOG4CXX_DEBUG(logger_,"requests list is empty");
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (requests.empty()) {
+    LOG4CXX_DEBUG(logger_, "requests list is empty");
     return;
-  } 
+  }
 
   for (const auto& it : requests) {
     ProcessHMIRequest(it, /*subscribe_on_response = */ true);
@@ -417,6 +417,26 @@ void ResumptionDataProcessor::SetGlobalProperties(
 
 void ResumptionDataProcessor::DeleteGlobalProperties(const int32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
+
+  const auto application = application_manager_.application(app_id);
+
+  const auto result =
+      application_manager_.ResetAllApplicationGlobalProperties(app_id);
+
+  if (result.HasUIPropertiesReset()) {
+    smart_objects::SmartObjectSPtr ui_gl_props_reset_req =
+        MessageHelper::CreateUIResetGlobalPropertiesRequest(result,
+                                                            application);
+
+    ProcessHMIRequest(ui_gl_props_reset_req, false);
+  }
+  if (result.HasTTSPropertiesReset()) {
+    smart_objects::SmartObjectSPtr tts_gl_props_reset_req =
+        MessageHelper::CreateUIResetGlobalPropertiesRequest(result,
+                                                            application);
+
+    ProcessHMIRequest(tts_gl_props_reset_req, false);
+  }
 }
 
 void ResumptionDataProcessor::AddWayPointsSubscription(

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -306,6 +306,25 @@ class MockMessageHelper {
                     ApplicationSharedPtr application,
                     ApplicationManager& app_mngr));
 
+  MOCK_METHOD2(CreateUIResetGlobalPropertiesRequest,
+               smart_objects::SmartObjectSPtr(
+                   const ResetGlobalPropertiesResult& reset_result,
+                   ApplicationSharedPtr application));
+
+  MOCK_METHOD2(CreateTTSResetGlobalPropertiesRequest,
+               smart_objects::SmartObjectSPtr(
+                   const ResetGlobalPropertiesResult& reset_result,
+                   ApplicationSharedPtr application));
+  MOCK_METHOD2(CreateGlobalPropertiesRequestsToHMI,
+               smart_objects::SmartObjectList(ApplicationConstSharedPtr app,
+                                              const uint32_t correlation_id));
+
+  MOCK_METHOD4(SendOnButtonSubscriptionNotification,
+               void(uint32_t app_id,
+                    hmi_apis::Common_ButtonName::eType button,
+                    bool is_subscribed,
+                    ApplicationManager& app_mngr));
+
   static MockMessageHelper* message_helper_mock();
 };
 

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -565,4 +565,37 @@ void MessageHelper::SendUnsubscribeButtonNotification(
       ->SendUnsubscribeButtonNotification(button, application, app_mngr);
 }
 
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateUIResetGlobalPropertiesRequest(
+    const ResetGlobalPropertiesResult& reset_result,
+    ApplicationSharedPtr application) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateUIResetGlobalPropertiesRequest(reset_result, application);
+}
+
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateTTSResetGlobalPropertiesRequest(
+    const ResetGlobalPropertiesResult& reset_result,
+    ApplicationSharedPtr application) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateTTSResetGlobalPropertiesRequest(reset_result, application);
+}
+
+smart_objects::SmartObjectList
+MessageHelper::CreateGlobalPropertiesRequestsToHMI(
+    ApplicationConstSharedPtr app, const uint32_t correlation_id) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateGlobalPropertiesRequestsToHMI(app, correlation_id);
+}
+
+void MessageHelper::SendOnButtonSubscriptionNotification(
+    uint32_t app_id,
+    hmi_apis::Common_ButtonName::eType button,
+    bool is_subscribed,
+    ApplicationManager& app_mngr) {
+  return MockMessageHelper::message_helper_mock()
+      ->SendOnButtonSubscriptionNotification(
+          app_id, button, is_subscribed, app_mngr);
+}
+
 }  // namespace application_manager

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -491,7 +491,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscribeOnButtons) {
 
   EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
-  EXPECT_CALL(*mock_app_extension_, ProcessResumption(test_subscriptions));
+  EXPECT_CALL(*mock_app_extension_, ProcessResumption(test_subscriptions, _));
 
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
               SendAllOnButtonSubscriptionNotificationsForApp(_, _)).Times(2);
@@ -540,7 +540,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToIVI) {
 
   EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
-  EXPECT_CALL(*mock_app_extension_, ProcessResumption(test_subscriptions));
+  EXPECT_CALL(*mock_app_extension_, ProcessResumption(test_subscriptions, _));
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
   EXPECT_TRUE(res);
 }

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -90,6 +90,7 @@ class RPCHandler;
 class Application;
 class StateControllerImpl;
 struct CommandParametersPermissions;
+struct ResetGlobalPropertiesResult;
 using policy::RPCParams;
 typedef std::vector<ApplicationSharedPtr> AppSharedPtrs;
 struct ApplicationsAppIdSorter {
@@ -489,6 +490,27 @@ class ApplicationManager {
   virtual bool IsLowVoltage() = 0;
 
   virtual void RemoveAppFromTTSGlobalPropertiesList(const uint32_t app_id) = 0;
+
+  /**
+   * @brief Resets application's global properties to default values
+   * @param container with global properties IDs to reset
+   * @param id of app which properties to reset
+   * @return struct with flags indicating success global properties reset
+   */
+  virtual ResetGlobalPropertiesResult ResetGlobalProperties(
+      const smart_objects::SmartObject& global_properties_ids,
+      const uint32_t app_id) = 0;
+
+  /**
+   * @brief Resets all application's global properties to default values
+   * returning struct that indicates which properties have been
+   * successfully reset.
+   * @param container with global properties to reset
+   * @param id of app which properties to reset
+   * @return struct with flags indicating global properties reset
+   */
+  virtual ResetGlobalPropertiesResult ResetAllApplicationGlobalProperties(
+      const uint32_t app_id) = 0;
 
   virtual mobile_apis::Result::eType SaveBinary(
       const std::vector<uint8_t>& binary_data,

--- a/src/components/include/test/application_manager/mock_app_extension.h
+++ b/src/components/include/test/application_manager/mock_app_extension.h
@@ -50,9 +50,14 @@ class MockAppExtension : public application_manager::AppExtension {
   MOCK_METHOD1(
       SaveResumptionData,
       void(NsSmartDeviceLink::NsSmartObjects::SmartObject& resumption_data));
-  MOCK_METHOD1(ProcessResumption,
+  MOCK_METHOD2(ProcessResumption,
                void(const NsSmartDeviceLink::NsSmartObjects::SmartObject&
-                        resumption_data));
+                        resumption_data,
+                    resumption::Subscriber subscriber));
+
+  MOCK_METHOD1(RevertResumption,
+               void(const NsSmartDeviceLink::NsSmartObjects::SmartObject&
+                        subscriptions));
 };
 
 }  // namespace application_manager_test

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -318,6 +318,13 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD1(IsAppInReconnectMode,
                      bool(const std::string& policy_app_id));
   MOCK_CONST_METHOD0(GetCommandFactory, application_manager::CommandFactory&());
+  MOCK_METHOD1(
+      ResetAllApplicationGlobalProperties,
+      application_manager::ResetGlobalPropertiesResult(const uint32_t app_id));
+  MOCK_METHOD2(ResetGlobalProperties,
+               application_manager::ResetGlobalPropertiesResult(
+                   const smart_objects::SmartObject& global_properties,
+                   const uint32_t app_id));
 };
 
 }  // namespace application_manager_test


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary

- moved ResetGlobalProperties to app manager. Since ResetGlobalPropertiesRequest's
behavior was changed, modification of its unit test was also required.

- Added methods CreateUIResetGlobalPropertiesRequest() and 
CreateTTSResetGlobalPropertiesRequest to MessageHelper.

- Added mocked methods to fix unit test build

### CLA
- [x ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)