### PR TITLE
Fix SDL doesn't close mobile session in case heartbeat timeout.

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -599,7 +599,7 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
     connection_handler().BindProtocolVersionWithSession(
         connection_key, static_cast<uint8_t>(protocol_version));
   }
-  if ((protocol_version ==
+  if ((protocol_version >=
        protocol_handler::MajorProtocolVersion::PROTOCOL_VERSION_3) &&
       (get_settings().heart_beat_timeout() != 0)) {
     connection_handler().StartSessionHeartBeat(connection_key);


### PR DESCRIPTION
Fixes #2491

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
Covered by ATF tests.

### Summary
According to Functional Requirement "SDL must support Heartbeat over protocol v3 or higher":
In case
mobile app connects over protocol v3 or higher to SDL
SDL must: 
respond ACK to Heartbeat_request from mobile app
send Heartbeat_request to mobile app

Information: 
a. Every session (app) is responsible for its own Heartbeat

Than why this changes was did.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)