### PR TITLE
Fix sdl does not restore subscription status on waypoint related data

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -605,6 +605,13 @@ class MessageHelper {
    */
   static bool SendUnsubscribedWayPoints(ApplicationManager& app_mngr);
 
+  /**
+   * @brief Creates SubscribeWayPointsMessage to be sent to HMI
+   * @return filled smart object with relevant message data
+   */
+  static smart_objects::SmartObjectSPtr CreateSubscribeWayPointsMessageToHMI(
+      const uint32_t correlation_id);
+
   static smart_objects::SmartObjectSPtr CreateNegativeResponse(
       uint32_t connection_key,
       int32_t function_id,

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -605,13 +605,6 @@ class MessageHelper {
    */
   static bool SendUnsubscribedWayPoints(ApplicationManager& app_mngr);
 
-  /**
-   * @brief Creates SubscribeWayPointsMessage to be sent to HMI
-   * @return filled smart object with relevant message data
-   */
-  static smart_objects::SmartObjectSPtr CreateSubscribeWayPointsMessageToHMI(
-      const uint32_t correlation_id);
-
   static smart_objects::SmartObjectSPtr CreateNegativeResponse(
       uint32_t connection_key,
       int32_t function_id,
@@ -894,6 +887,16 @@ class MessageHelper {
    */
   static smart_objects::SmartObjectSPtr CreateMessageForHMI(
       hmi_apis::messageType::eType message_type, const uint32_t correlation_id);
+
+  /**
+   * @brief CreateMessageForHMI Creates HMI message with prepared header
+   * acccoring to message type
+   * @param function_id function id
+   * @param correlation_id Correlation id
+   * @return HMI message object with filled header
+   */
+  static smart_objects::SmartObjectSPtr CreateMessageForHMI(
+      hmi_apis::FunctionID::eType function_id, const uint32_t correlation_id);
 
   /**
    * @brief CreateUIResetGlobalPropertiesRequest Creates request

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2246,6 +2246,17 @@ bool MessageHelper::SendUnsubscribedWayPoints(ApplicationManager& app_mngr) {
   return app_mngr.GetRPCService().ManageHMICommand(result);
 }
 
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateSubscribeWayPointsMessageToHMI(
+    const uint32_t correlation_id) {
+  const smart_objects::SmartObjectSPtr msg =
+      CreateMessageForHMI(hmi_apis::messageType::request, correlation_id);
+  (*msg)[strings::params][strings::function_id] =
+      hmi_apis::FunctionID::Navigation_SubscribeWayPoints;
+
+  return msg;
+}
+
 void MessageHelper::SendPolicySnapshotNotification(
     uint32_t connection_key,
     const std::vector<uint8_t>& policy_data,

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2249,7 +2249,7 @@ bool MessageHelper::SendUnsubscribedWayPoints(ApplicationManager& app_mngr) {
 smart_objects::SmartObjectSPtr
 MessageHelper::CreateSubscribeWayPointsMessageToHMI(
     const uint32_t correlation_id) {
-  const smart_objects::SmartObjectSPtr msg =
+  auto msg =
       CreateMessageForHMI(hmi_apis::messageType::request, correlation_id);
   (*msg)[strings::params][strings::function_id] =
       hmi_apis::FunctionID::Navigation_SubscribeWayPoints;

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -323,6 +323,22 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateMessageForHMI(
   return message;
 }
 
+smart_objects::SmartObjectSPtr MessageHelper::CreateMessageForHMI(
+    hmi_apis::FunctionID::eType function_id, const uint32_t correlation_id) {
+  using namespace smart_objects;
+
+  SmartObjectSPtr message = std::make_shared<SmartObject>(SmartType_Map);
+  SmartObject& ref = *message;
+
+  ref[strings::params][strings::function_id] = static_cast<int>(function_id);
+  ref[strings::params][strings::protocol_version] =
+      commands::CommandImpl::protocol_version_;
+  ref[strings::params][strings::protocol_type] =
+      commands::CommandImpl::hmi_protocol_type_;
+  ref[strings::params][strings::correlation_id] = correlation_id;
+  return message;
+}
+
 smart_objects::SmartObjectSPtr MessageHelper::CreateHashUpdateNotification(
     const uint32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
@@ -2244,17 +2260,6 @@ bool MessageHelper::SendUnsubscribedWayPoints(ApplicationManager& app_mngr) {
       hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints;
 
   return app_mngr.GetRPCService().ManageHMICommand(result);
-}
-
-smart_objects::SmartObjectSPtr
-MessageHelper::CreateSubscribeWayPointsMessageToHMI(
-    const uint32_t correlation_id) {
-  auto msg =
-      CreateMessageForHMI(hmi_apis::messageType::request, correlation_id);
-  (*msg)[strings::params][strings::function_id] =
-      hmi_apis::FunctionID::Navigation_SubscribeWayPoints;
-
-  return msg;
 }
 
 void MessageHelper::SendPolicySnapshotNotification(

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -516,6 +516,11 @@ void ResumptionDataProcessor::AddWayPointsSubscription(
       saved_app[strings::subscribed_for_way_points];
   if (true == subscribed_for_way_points_so.asBool()) {
     application_manager_.SubscribeAppForWayPoints(application);
+    auto subscribe_waypoints_msg =
+        MessageHelper::CreateSubscribeWayPointsMessageToHMI(
+            application_manager_.GetNextHMICorrelationID());
+    application_manager_.GetRPCService().ManageHMICommand(
+        subscribe_waypoints_msg);
   }
 }
 

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -517,10 +517,12 @@ void ResumptionDataProcessor::AddWayPointsSubscription(
   if (true == subscribed_for_way_points_so.asBool()) {
     application_manager_.SubscribeAppForWayPoints(application);
     auto subscribe_waypoints_msg =
-        MessageHelper::CreateSubscribeWayPointsMessageToHMI(
-            application_manager_.GetNextHMICorrelationID());
-    application_manager_.GetRPCService().ManageHMICommand(
-        subscribe_waypoints_msg);
+        MessageHelper::CreateMessageForHMI(
+          hmi_apis::FunctionID::Navigation_SubscribeWayPoints,
+          application_manager_.GetNextHMICorrelationID());
+    (*subscribe_waypoints_msg)[strings::params][strings::message_type] = 
+    hmi_apis::messageType::request;
+    ProcessHMIRequest(subscribe_waypoints_msg, true);
   }
 }
 

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -128,6 +128,10 @@ class MockMessageHelper {
   MOCK_METHOD2(CreateMessageForHMI,
                smart_objects::SmartObjectSPtr(hmi_apis::messageType::eType,
                                               const uint32_t));
+
+  MOCK_METHOD2(CreateMessageForHMI,
+               smart_objects::SmartObjectSPtr(hmi_apis::FunctionID::eType,
+                                              const uint32_t));
   MOCK_METHOD2(SendHMIStatusNotification,
                void(const Application& application_impl,
                     ApplicationManager& application_manager));

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -259,6 +259,9 @@ class MockMessageHelper {
                     ApplicationManager& app_man));
   MOCK_METHOD1(SendUnsubscribedWayPoints, bool(ApplicationManager& app_mngr));
 
+  MOCK_METHOD1(CreateSubscribeWayPointsMessageToHMI,
+               smart_objects::SmartObjectSPtr(const uint32_t correlation_id));
+
   MOCK_METHOD2(SendQueryApps,
                void(const uint32_t connection_key,
                     ApplicationManager& app_man));

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -257,6 +257,12 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateMessageForHMI(
       message_type, correlation_id);
 }
 
+smart_objects::SmartObjectSPtr MessageHelper::CreateMessageForHMI(
+    hmi_apis::FunctionID::eType function_id, const uint32_t correlation_id) {
+  return MockMessageHelper::message_helper_mock()->CreateMessageForHMI(
+      function_id, correlation_id);
+}
+
 void MessageHelper::SendHMIStatusNotification(
     const Application& application_impl,
     ApplicationManager& application_manager) {
@@ -474,13 +480,6 @@ void MessageHelper::SendLaunchApp(const uint32_t connection_key,
 bool MessageHelper::SendUnsubscribedWayPoints(ApplicationManager& app_mngr) {
   return MockMessageHelper::message_helper_mock()->SendUnsubscribedWayPoints(
       app_mngr);
-}
-
-smart_objects::SmartObjectSPtr
-MessageHelper::CreateSubscribeWayPointsMessageToHMI(
-    const uint32_t correlation_id) {
-  return MockMessageHelper::message_helper_mock()
-      ->CreateSubscribeWayPointsMessageToHMI(correlation_id);
 }
 
 void MessageHelper::SendQueryApps(const uint32_t connection_key,

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -476,6 +476,13 @@ bool MessageHelper::SendUnsubscribedWayPoints(ApplicationManager& app_mngr) {
       app_mngr);
 }
 
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateSubscribeWayPointsMessageToHMI(
+    const uint32_t correlation_id) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateSubscribeWayPointsMessageToHMI(correlation_id);
+}
+
 void MessageHelper::SendQueryApps(const uint32_t connection_key,
                                   ApplicationManager& app_man) {
   MockMessageHelper::message_helper_mock()->SendQueryApps(connection_key,


### PR DESCRIPTION
Fixes #2445 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF test scripts are attached to issue

### Summary

- Added MessageHelper method that constructs message on WayPoints Subscription

- Added sending mentioned message to HMI on WayPoint Subscription added

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)