### PR TITLE
Change default HeartBeat value

### DIFF
--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -309,7 +309,7 @@ const uint32_t kDefaultBeforeUpdateHours = 24;
 #endif  // ENABLE_SECURITY
 
 const uint32_t kDefaultHubProtocolIndex = 0;
-const uint32_t kDefaultHeartBeatTimeout = 0;
+const uint32_t kDefaultHeartBeatTimeout = 5000;
 const uint16_t kDefaultMaxSupportedProtocolVersion = 5;
 const uint16_t kDefautTransportManagerTCPPort = 12345;
 const uint16_t kDefaultServerPort = 8087;

--- a/src/components/config_profile/test/profile_test.cc
+++ b/src/components/config_profile/test/profile_test.cc
@@ -373,7 +373,7 @@ TEST_F(ProfileTest, IntInsteadOfPair) {
 
 TEST_F(ProfileTest, WrongIntValue) {
   // Default value
-  uint32_t heart_beat_timeout = 0;
+  uint32_t heart_beat_timeout = 5000;
   EXPECT_EQ(heart_beat_timeout, profile_.heart_beat_timeout());
 
   // Change config file
@@ -381,7 +381,7 @@ TEST_F(ProfileTest, WrongIntValue) {
   EXPECT_EQ("smartDeviceLink_invalid_int.ini", profile_.config_file_name());
 
   // Value in file includes letters. Check that value is default
-  heart_beat_timeout = 0;
+  heart_beat_timeout = 5000;
   EXPECT_EQ(heart_beat_timeout, profile_.heart_beat_timeout());
 
   // Update config file


### PR DESCRIPTION
Fixes #1895 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
kDefaultHeartBeatTimeout = 5000ms

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)