### PR TITLE
Sdl must process system request for request type climate

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_request_notification.cc
@@ -106,6 +106,8 @@ void OnSystemRequestNotification::Run() {
     }
   }
 
+  const std::string filename =
+      (*message_)[strings::msg_params][strings::file_name].asString();
   if (mobile_apis::RequestType::PROPRIETARY == request_type) {
     /* According to requirements:
        "If the requestType = PROPRIETARY, add to mobile API fileType = JSON
@@ -113,10 +115,9 @@ void OnSystemRequestNotification::Run() {
        Also in Genivi SDL we don't save the PT to file - we put it directly in
        binary_data */
 
-    const std::string filename =
-        (*message_)[strings::msg_params][strings::file_name].asString();
     BinaryMessage binary_data;
-    file_system::ReadBinaryFile(filename, binary_data);
+    file_system::ReadBinaryFile(file_name, binary_data);
+
 #if defined(PROPRIETARY_MODE)
     AddHeader(binary_data);
 #endif  // PROPRIETARY_MODE
@@ -132,6 +133,10 @@ void OnSystemRequestNotification::Run() {
       (*message_)[strings::msg_params][strings::timeout] =
           policy_handler.TimeoutExchangeSec();
     }
+  } else {
+    BinaryMessage binary_data;
+    file_system::ReadBinaryFile(file_name, binary_data);
+    (*message_)[strings::params][strings::binary_data] = binary_data;
   }
 
   SendNotification();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_request_notification.cc
@@ -106,7 +106,7 @@ void OnSystemRequestNotification::Run() {
     }
   }
 
-  const std::string filename =
+  const std::string file_name =
       (*message_)[strings::msg_params][strings::file_name].asString();
   if (mobile_apis::RequestType::PROPRIETARY == request_type) {
     /* According to requirements:

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/system_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/system_request_test.cc
@@ -246,7 +246,7 @@ TEST_F(SystemRequestTest, Run_FileWithBinaryDataSaveUnsuccessful_GenericError) {
   PreConditions();
 
   ON_CALL(mock_policy_handler_,
-              IsRequestTypeAllowed(kAppPolicyId, request_type))
+          IsRequestTypeAllowed(kAppPolicyId, request_type))
       .WillByDefault(Return(true));
 
   const std::string binary_folder = "test_binary_folder";
@@ -280,7 +280,7 @@ TEST_F(SystemRequestTest,
   PreConditions();
 
   ON_CALL(mock_policy_handler_,
-              IsRequestTypeAllowed(kAppPolicyId, request_type))
+          IsRequestTypeAllowed(kAppPolicyId, request_type))
       .WillByDefault(Return(true));
 
   EXPECT_CALL(app_mngr_, SaveBinary(_, _, _, _)).Times(0);
@@ -311,7 +311,7 @@ TEST_F(SystemRequestTest, Run_TypeDisallowed_DisallowedResult) {
   PreConditions();
 
   ON_CALL(mock_policy_handler_,
-              IsRequestTypeAllowed(kAppPolicyId, request_type))
+          IsRequestTypeAllowed(kAppPolicyId, request_type))
       .WillByDefault(Return(false));
 
   const std::string info;
@@ -334,15 +334,14 @@ TEST_F(SystemRequestTest, Run_FileNameContainSlash_InvalidData) {
   PreConditions();
 
   ON_CALL(mock_policy_handler_,
-              IsRequestTypeAllowed(kAppPolicyId, request_type))
+          IsRequestTypeAllowed(kAppPolicyId, request_type))
       .WillByDefault(Return(true));
 
   const std::string info = "Sync file name contains forbidden symbols.";
   EXPECT_CALL(
       mock_rpc_service_,
       ManageMobileCommand(
-          MobileResponseIs(mobile_apis::Result::INVALID_DATA, info, false),
-          _));
+          MobileResponseIs(mobile_apis::Result::INVALID_DATA, info, false), _));
   std::shared_ptr<SystemRequest> command(CreateCommand<SystemRequest>(msg));
   ASSERT_TRUE(command->Init());
   command->Run();


### PR DESCRIPTION
Fixes #2426 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- atf script is provided in PR [#2017](https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2017)

### Summary
According to requirements:
       "If the requestType = PROPRIETARY, add to mobile API fileType = JSON
        If the requestType = HTTP, add to mobile API fileType = BINARY"
Also in SDL we don't save the PT to file - we put it directly in binary_data - this functionality was provided in current pull request.

### Tasks Remaining:
- [x] implementation
- [x] provide unit tests
- [x] provide atf script

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)