### PR TITLE
Update malformed message's criterias according the documentation

### DIFF
--- a/src/components/protocol_handler/src/protocol_packet.cc
+++ b/src/components/protocol_handler/src/protocol_packet.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Ford Motor Company
+ * Copyright (c) 2019, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -360,7 +360,7 @@ RESULT_CODE ProtocolPacket::ProtocolHeaderValidator::validate(
       }
 
       if (wrongDataSize) {
-        std::string str_frame_type = StringifyFrameType(header.frameType);
+        const std::string str_frame_type = StringifyFrameType(header.frameType);
         LOG4CXX_WARN(
             logger_,
             "Packet data size of "

--- a/src/components/protocol_handler/src/protocol_packet.cc
+++ b/src/components/protocol_handler/src/protocol_packet.cc
@@ -349,22 +349,16 @@ RESULT_CODE ProtocolPacket::ProtocolHeaderValidator::validate(
     case FRAME_TYPE_SINGLE:
     case FRAME_TYPE_CONSECUTIVE:
     case FRAME_TYPE_CONTROL: {
-      bool wrongDataSize = false;
-
-      if (header.dataSize > payload_size) {
-        wrongDataSize = true;
-      }
-
-      if (FRAME_TYPE_CONTROL != header.frameType && header.dataSize <= 0u) {
-        wrongDataSize = true;
-      }
+      bool wrongDataSize =
+          (header.dataSize > payload_size) ||
+          (FRAME_TYPE_CONTROL != header.frameType && header.dataSize == 0u);
 
       if (wrongDataSize) {
-        const std::string str_frame_type = StringifyFrameType(header.frameType);
+        UNUSED(StringifyFrameType);
         LOG4CXX_WARN(
             logger_,
             "Packet data size of "
-                << str_frame_type
+                << StringifyFrameType(header.frameType)
                 << " frame must be in range (0, payload_size=" << payload_size
                 << "], but actual value is " << header.dataSize);
         return RESULT_FAIL;

--- a/src/components/protocol_handler/src/protocol_packet.cc
+++ b/src/components/protocol_handler/src/protocol_packet.cc
@@ -360,10 +360,11 @@ RESULT_CODE ProtocolPacket::ProtocolHeaderValidator::validate(
       }
 
       if (wrongDataSize) {
+        std::string str_frame_type = StringifyFrameType(header.frameType);
         LOG4CXX_WARN(
             logger_,
             "Packet data size of "
-                << StringifyFrameType(header.frameType)
+                << str_frame_type
                 << " frame must be in range (0, payload_size=" << payload_size
                 << "], but actual value is " << header.dataSize);
         return RESULT_FAIL;

--- a/src/components/protocol_handler/src/protocol_packet.cc
+++ b/src/components/protocol_handler/src/protocol_packet.cc
@@ -30,9 +30,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <algorithm>
 #include <memory.h>
 #include <stdint.h>
+#include <algorithm>
 #include <cstring>
 #include <limits>
 #include <memory>

--- a/src/components/protocol_handler/src/protocol_packet.cc
+++ b/src/components/protocol_handler/src/protocol_packet.cc
@@ -349,11 +349,8 @@ RESULT_CODE ProtocolPacket::ProtocolHeaderValidator::validate(
     case FRAME_TYPE_SINGLE:
     case FRAME_TYPE_CONSECUTIVE:
     case FRAME_TYPE_CONTROL: {
-      bool wrongDataSize =
-          (header.dataSize > payload_size) ||
-          (FRAME_TYPE_CONTROL != header.frameType && header.dataSize == 0u);
-
-      if (wrongDataSize) {
+      if (header.dataSize > payload_size ||
+          (FRAME_TYPE_CONTROL != header.frameType && header.dataSize == 0u)) {
         UNUSED(StringifyFrameType);
         LOG4CXX_WARN(
             logger_,

--- a/src/components/protocol_handler/test/protocol_header_validator_test.cc
+++ b/src/components/protocol_handler/test/protocol_header_validator_test.cc
@@ -491,8 +491,10 @@ TEST_F(ProtocolHeaderValidatorTest, Malformed_MessageID) {
 
   message_header.frameType = FRAME_TYPE_FIRST;
   message_header.version = PROTOCOL_VERSION_1;
+  message_header.dataSize = FIRST_FRAME_DATA_SIZE;
   EXPECT_EQ(RESULT_OK, header_validator.validate(message_header));
 
+  message_header.dataSize = 0u;
   message_header.version = PROTOCOL_VERSION_2;
   EXPECT_EQ(RESULT_FAIL, header_validator.validate(message_header));
   message_header.version = PROTOCOL_VERSION_3;


### PR DESCRIPTION
Fixes #2384

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Provide ATF tests

### Summary
Was added new criteria for malformed message, so this is updating validation code according to the documentation.
New criteria is data size of First Frame shall be equal 0x08 (payload of this packet will be 8 bytes).

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)