### PR TITLE
Update mobile version negotiation

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -322,11 +322,11 @@ void RegisterAppInterfaceRequest::Run() {
   }
 
   // Version negotiation
-  utils::SemanticVersion ver_4_5(4,5,0);
+  utils::SemanticVersion ver_4_5(4, 5, 0);
   utils::SemanticVersion module_version(
       major_version, minor_version, patch_version);
   if (mobile_version <= ver_4_5) {
-    // Mobile versioning did not exist for 
+    // Mobile versioning did not exist for
     // versions 4.5 and prior.
     application->set_msg_version(ver_4_5);
   } else if (mobile_version < module_version) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -322,9 +322,14 @@ void RegisterAppInterfaceRequest::Run() {
   }
 
   // Version negotiation
+  utils::SemanticVersion ver_4_5(4,5,0);
   utils::SemanticVersion module_version(
       major_version, minor_version, patch_version);
-  if (mobile_version < module_version) {
+  if (mobile_version <= ver_4_5) {
+    // Mobile versioning did not exist for 
+    // versions 4.5 and prior.
+    application->set_msg_version(ver_4_5);
+  } else if (mobile_version < module_version) {
     // Use mobile RPC version as negotiated version
     application->set_msg_version(mobile_version);
   } else {

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -219,7 +219,8 @@ void RPCHandlerImpl::GetMessageVersion(
     }
     utils::SemanticVersion temp_version(major, minor, patch);
     if (temp_version.isValid()) {
-      message_version = temp_version;
+      utils::SemanticVersion ver_4_5(4,5,0);
+      message_version = (temp_version > ver_4_5) ? temp_version : ver_4_5;
     }
   }
 }
@@ -251,10 +252,7 @@ bool RPCHandlerImpl::ConvertMessageToSO(
       // Attach RPC version to SmartObject if it does not exist yet.
       auto app_ptr = app_manager_.application(message.connection_key());
       utils::SemanticVersion msg_version(0, 0, 0);
-      if (app_ptr &&
-          (output[NsSmartDeviceLink::NsJSONHandler::strings::S_PARAMS]
-               .keyExists(NsSmartDeviceLink::NsJSONHandler::strings::
-                              S_RPC_MSG_VERSION) == false)) {
+      if (app_ptr) {
         msg_version = app_ptr->msg_version();
       } else if (mobile_apis::FunctionID::RegisterAppInterfaceID ==
                  static_cast<mobile_apis::FunctionID::eType>(

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -219,7 +219,7 @@ void RPCHandlerImpl::GetMessageVersion(
     }
     utils::SemanticVersion temp_version(major, minor, patch);
     if (temp_version.isValid()) {
-      utils::SemanticVersion ver_4_5(4,5,0);
+      utils::SemanticVersion ver_4_5(4, 5, 0);
       message_version = (temp_version > ver_4_5) ? temp_version : ver_4_5;
     }
   }


### PR DESCRIPTION


This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run ATF test set mobile_api_versioning.txt

### Summary
Because mobile versioning did not exist prior to core 5.0, and IOS was using a hardcoded 1.0.0 for syncMsgVersion, all apps using version 1.0 to 4.5 will be negotiated to core RPC version 4.5.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)