### PR TITLE
Fix/sdl send success true for vehicle data not available

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/get_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/get_vehicle_data_request.cc
@@ -114,6 +114,8 @@ void GetVehicleDataRequest::on_event(const event_engine::Event& event) {
       hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());
+      mobile_apis::Result::eType mobile_result_code =
+          GetMobileResultCode(result_code);
       bool result = PrepareResultForMobileResponse(
           result_code, HmiInterfaces::HMI_INTERFACE_VehicleInfo);
       std::string response_info;
@@ -130,7 +132,7 @@ void GetVehicleDataRequest::on_event(const event_engine::Event& event) {
         response_info = message[strings::params][strings::error_msg].asString();
       }
       SendResponse(result,
-                   MessageHelper::HMIToMobileResult(result_code),
+                   mobile_result_code,
                    response_info.empty() ? NULL : response_info.c_str(),
                    &(message[strings::msg_params]));
       break;

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/mobile/get_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/mobile/get_vehicle_data_request_test.cc
@@ -226,7 +226,7 @@ TEST_F(GetVehicleDataRequestTest, OnEvent_DataNotAvailable_SUCCESS) {
   const hmi_apis::Common_Result::eType hmi_response_code =
       hmi_apis::Common_Result::DATA_NOT_AVAILABLE;
   const mobile_result::eType mobile_response_code =
-      mobile_result::DATA_NOT_AVAILABLE;
+      mobile_result::VEHICLE_DATA_NOT_AVAILABLE;
 
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
   (*command_msg)[am::strings::params][am::strings::connection_key] =

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -188,7 +188,8 @@ ResponseInfo::ResponseInfo(const hmi_apis::Common_Result::eType result,
       hmi_apis::Common_Result::WARNINGS,
       hmi_apis::Common_Result::WRONG_LANGUAGE,
       hmi_apis::Common_Result::RETRY,
-      hmi_apis::Common_Result::SAVED);
+      hmi_apis::Common_Result::SAVED,
+      hmi_apis::Common_Result::DATA_NOT_AVAILABLE);
 
   is_not_used = hmi_apis::Common_Result::INVALID_ENUM == result_code;
 
@@ -482,6 +483,7 @@ void CommandRequestImpl::CreateHMINotification(
 mobile_apis::Result::eType CommandRequestImpl::GetMobileResultCode(
     const hmi_apis::Common_Result::eType& hmi_code) const {
   mobile_apis::Result::eType mobile_result = mobile_apis::Result::GENERIC_ERROR;
+
   switch (hmi_code) {
     case hmi_apis::Common_Result::SUCCESS: {
       mobile_result = mobile_apis::Result::SUCCESS;
@@ -822,7 +824,8 @@ bool CommandRequestImpl::PrepareResultForMobileResponse(
           hmi_apis::Common_Result::WARNINGS,
           hmi_apis::Common_Result::WRONG_LANGUAGE,
           hmi_apis::Common_Result::RETRY,
-          hmi_apis::Common_Result::SAVED)) {
+          hmi_apis::Common_Result::SAVED,
+          hmi_apis::Common_Result::DATA_NOT_AVAILABLE)) {
     return true;
   }
 


### PR DESCRIPTION
Fixes #2439 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
Changes in PR are already covered within existing unit tests.

### Summary
Fixed SDL sends VEHICLE_DATA_NOT_AVAILABLE instead of DATA_NOT_AVAILABLE with succes: true  to mobile

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)