### PR TITLE
Flush logger before deleting message loop thread

### DIFF
--- a/src/components/utils/include/utils/log_message_loop_thread.h
+++ b/src/components/utils/include/utils/log_message_loop_thread.h
@@ -56,18 +56,14 @@ typedef std::queue<LogMessage> LogMessageQueue;
 typedef threads::MessageLoopThread<LogMessageQueue>
     LogMessageLoopThreadTemplate;
 
-class LogMessageHandler : public LogMessageLoopThreadTemplate::Handler {
- public:
-  virtual void Handle(const LogMessage message) OVERRIDE;
-};
-
-class LogMessageLoopThread : public LogMessageLoopThreadTemplate {
+class LogMessageLoopThread : public LogMessageLoopThreadTemplate,
+                             public LogMessageLoopThreadTemplate::Handler {
  public:
   LogMessageLoopThread();
   ~LogMessageLoopThread();
+  void Handle(const LogMessage message) OVERRIDE;
 
  private:
-  LogMessageHandler* handler_;
   DISALLOW_COPY_AND_ASSIGN(LogMessageLoopThread);
 };
 

--- a/src/components/utils/src/log_message_loop_thread.cc
+++ b/src/components/utils/src/log_message_loop_thread.cc
@@ -35,7 +35,7 @@
 
 namespace logger {
 
-void LogMessageHandler::Handle(const LogMessage message) {
+void LogMessageLoopThread::Handle(const LogMessage message) {
   message.logger->forcedLog(message.level,
                             message.entry,
                             message.timeStamp,
@@ -44,14 +44,12 @@ void LogMessageHandler::Handle(const LogMessage message) {
 }
 
 LogMessageLoopThread::LogMessageLoopThread()
-    : LogMessageLoopThreadTemplate("Logger",
-                                   handler_ = new LogMessageHandler()) {}
+    : LogMessageLoopThreadTemplate("Logger", this) {}
 
 LogMessageLoopThread::~LogMessageLoopThread() {
   // we'll have to drop messages
   // while deleting logger thread
   logger_status = DeletingLoggerThread;
-  delete handler_;
 }
 
 }  // namespace logger

--- a/src/components/utils/src/logger.cc
+++ b/src/components/utils/src/logger.cc
@@ -39,7 +39,9 @@ void deinit_logger() {
   CREATE_LOGGERPTR_LOCAL(logger_, "Utils")
   LOG4CXX_DEBUG(logger_, "Logger deinitialization");
   logger::set_logs_enabled(false);
-  logger::flush_logger();
+  if (logger::logger_status == logger::LoggerThreadCreated) {
+    logger::flush_logger();
+  }
   logger::delete_log_message_loop_thread();
   log4cxx::LoggerPtr rootLogger = log4cxx::Logger::getRootLogger();
   log4cxx::spi::LoggerRepositoryPtr repository =

--- a/src/components/utils/src/logger.cc
+++ b/src/components/utils/src/logger.cc
@@ -39,6 +39,7 @@ void deinit_logger() {
   CREATE_LOGGERPTR_LOCAL(logger_, "Utils")
   LOG4CXX_DEBUG(logger_, "Logger deinitialization");
   logger::set_logs_enabled(false);
+  logger::flush_logger();
   logger::delete_log_message_loop_thread();
   log4cxx::LoggerPtr rootLogger = log4cxx::Logger::getRootLogger();
   log4cxx::spi::LoggerRepositoryPtr repository =

--- a/src/components/utils/test/log_message_loop_thread_test.cc
+++ b/src/components/utils/test/log_message_loop_thread_test.cc
@@ -57,7 +57,7 @@ TEST(LogMessageLoopThread, DestroyLogMessage_loggerStatusDeletingLogger) {
   logger::logger_status = LoggerThreadNotCreated;
 }
 
-class MockLogMessageTest : public LogMessageHandler {
+class MockLogMessageTest : public LogMessageLoopThread {
  public:
   MOCK_CONST_METHOD1(Handle, void(const LogMessage message));
 };


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Start SDL, Stop SDL. Check that all logs are printed. Last Log should be:
 `LOG4CXX_DEBUG(logger_, "Logger deinitialization");`

### Summary
Flushes the logger before deleting the message loop thread. Old messages pushed to the message loop thread were still processing when the thread was deleted causing a segfault.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)