### PR TITLE
Fix/release delegate only after full thread stopping

### DIFF
--- a/src/components/utils/src/timer.cc
+++ b/src/components/utils/src/timer.cc
@@ -64,8 +64,8 @@ timer::Timer::~Timer() {
   StopDelegate();
   single_shot_ = true;
 
-  delegate_.reset();
   DeleteThread(thread_);
+  delegate_.reset();
   DCHECK(task_);
   delete task_;
   LOG4CXX_DEBUG(logger_, "Timer " << name_ << " has been destroyed");


### PR DESCRIPTION
Fixes #2434 #2435 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
For some reason there is a possibility to get `OnTimeout()` call even after timer has been stopped by `Timer::Stop()` call. So, to prevent accessing already destroyed delegate from `OnTimeout()` method it should be destructed only after thread joining with `DeleteThread()`.

### Tasks Remaining:
- [x] fix implementation

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)