### PR TITLE
Move app launcher stop before unregister app

### DIFF
--- a/src/components/application_manager/include/application_manager/app_launch/app_launch_ctrl.h
+++ b/src/components/application_manager/include/application_manager/app_launch/app_launch_ctrl.h
@@ -49,23 +49,29 @@ namespace app_launch {
 class AppLaunchCtrl {
  public:
   /**
- * @brief OnAppRegistered should be called when application registered
- * Save application parameters to database
- * @param app application to save
- */
+   * @brief OnAppRegistered should be called when application registered
+   * Save application parameters to database
+   * @param app application to save
+   */
   virtual void OnAppRegistered(const application_manager::Application& app) = 0;
 
   /**
- * @brief OnDeviceConnected shoudl be called on device connected event
- * Start launching saaved applications on ios device
- * @param device_mac
- */
+   * @brief OnDeviceConnected should be called on device connected event
+   * Start launching saved applications on ios device
+   * @param device_mac
+   */
   virtual void OnDeviceConnected(const std::string& device_mac) = 0;
 
   /**
- * @brief OnMasterReset clear database of saved applications
- */
+   * @brief OnMasterReset clear database of saved applications
+   */
   virtual void OnMasterReset() = 0;
+
+  /**
+   * @brief Stop - allows to stop app launcher.
+   */
+  virtual void Stop() = 0;
+
   virtual ~AppLaunchCtrl() {}
 };
 

--- a/src/components/application_manager/include/application_manager/app_launch/app_launch_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/app_launch/app_launch_ctrl_impl.h
@@ -69,6 +69,7 @@ class AppLaunchCtrlImpl : public AppLaunchCtrl {
   void OnAppRegistered(const application_manager::Application& app) OVERRIDE;
   void OnDeviceConnected(const std::string& device_mac) OVERRIDE;
   void OnMasterReset() OVERRIDE;
+  void Stop() OVERRIDE;
 
  private:
   const AppLaunchSettings& settings_;
@@ -77,6 +78,7 @@ class AppLaunchCtrlImpl : public AppLaunchCtrl {
 
   AppsLauncher apps_launcher_;
   DeviceAppsLauncher device_apps_launcher_;
+  sync_primitives::Lock launch_ctrl_lock_;
 
   DISALLOW_COPY_AND_ASSIGN(AppLaunchCtrlImpl);
 };

--- a/src/components/application_manager/include/application_manager/app_launch/device_apps_launcher.h
+++ b/src/components/application_manager/include/application_manager/app_launch/device_apps_launcher.h
@@ -35,8 +35,11 @@ class DeviceAppsLauncherImpl {
   };
 
   bool StopLaunchingAppsOnDevice(const std::string& device_mac);
+  void StopLaunchingAppsOnAllDevices();
 
  private:
+  void StopLauncher(std::shared_ptr<Launcher> launcher);
+
   sync_primitives::Lock launchers_lock_;
   std::vector<std::shared_ptr<Launcher> > free_launchers_;
   std::vector<std::shared_ptr<Launcher> > works_launchers_;
@@ -60,6 +63,7 @@ class DeviceAppsLauncher {
       const std::string& device_mac,
       const std::vector<ApplicationDataPtr>& applications_to_launch);
   bool StopLaunchingAppsOnDevice(const std::string& device_mac);
+  void StopLaunchingAppsOnAllDevices();
 
   const AppLaunchSettings& settings() const;
 

--- a/src/components/application_manager/src/app_launch/app_launch_ctrl_impl.cc
+++ b/src/components/application_manager/src/app_launch/app_launch_ctrl_impl.cc
@@ -83,6 +83,7 @@ bool HmiLevelSorter(const std::pair<int32_t, ApplicationDataPtr>& lval,
 
 void AppLaunchCtrlImpl::OnDeviceConnected(const std::string& device_mac) {
   LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock lock(launch_ctrl_lock_);
   std::vector<ApplicationDataPtr> apps_on_device =
       app_launch_data_.GetApplicationDataByDevice(device_mac);
   std::vector<std::pair<int32_t, ApplicationDataPtr> > apps_hmi_levels;
@@ -111,5 +112,11 @@ void AppLaunchCtrlImpl::OnDeviceConnected(const std::string& device_mac) {
 void AppLaunchCtrlImpl::OnMasterReset() {
   LOG4CXX_AUTO_TRACE(logger_);
   app_launch_data_.Clear();
+}
+
+void AppLaunchCtrlImpl::Stop() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock lock(launch_ctrl_lock_);
+  device_apps_launcher_.StopLaunchingAppsOnAllDevices();
 }
 }  // namespace app_launch

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1755,6 +1755,11 @@ bool ApplicationManagerImpl::Stop() {
   stopping_application_mng_lock_.Acquire();
   is_stopping_ = true;
   stopping_application_mng_lock_.Release();
+
+  if (app_launch_ctrl_) {
+    app_launch_ctrl_->Stop();
+  }
+
   application_list_update_timer_.Stop();
   try {
     SetUnregisterAllApplicationsReason(
@@ -1765,6 +1770,8 @@ bool ApplicationManagerImpl::Stop() {
                   "An error occurred during unregistering applications.");
   }
   request_ctrl_.DestroyThreadpool();
+
+  hmi_handler_ = nullptr;
 
   // for PASA customer policy backup should happen :AllApp(SUSPEND)
   LOG4CXX_DEBUG(logger_, "Unloading policy library.");


### PR DESCRIPTION
Fixes #2444

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
The applauncher has to be stopped before appropriate application will be unregistered. Otherwise it could lead to core crash, when Launch controller will try to run already non existed application

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)