### PR TITLE
Fix sdl core dumb

### DIFF
--- a/src/appMain/life_cycle_impl.cc
+++ b/src/appMain/life_cycle_impl.cc
@@ -163,7 +163,7 @@ bool LifeCycleImpl::StartComponents() {
   // It's important to initialise TM after setting up listener chain
   // [TM -> CH -> AM], otherwise some events from TM could arrive at nowhere
   app_manager_->set_protocol_handler(protocol_handler_);
-  if (!transport_manager_->Init(*last_state_)) {
+  if (transport_manager::E_SUCCESS != transport_manager_->Init(*last_state_)) {
     LOG4CXX_ERROR(logger_, "Transport manager init failed.");
     return false;
   }


### PR DESCRIPTION
Fix sdl core dump.
After the commit e270c439516585793e6693892fd848d0948cf560 the plugins in application manager began to not boot up.