### PR TITLE
Fix mem. seg. fault error in jsoncpp lib

### DIFF
--- a/src/3rd_party-static/jsoncpp/include/json/reader.h
+++ b/src/3rd_party-static/jsoncpp/include/json/reader.h
@@ -135,9 +135,9 @@ namespace Json {
       bool readCppStyleComment();
       bool readString();
       void readNumber();
-      bool readValue();
-      bool readObject( Token &token );
-      bool readArray( Token &token );
+      bool readValue( int& depth_level );
+      bool readObject( Token &token, int& depth_level );
+      bool readArray( Token &token, int& depth_level );
       bool decodeNumber( Token &token );
       bool decodeString( Token &token );
       bool decodeString( Token &token, std::string &decoded );

--- a/src/3rd_party-static/jsoncpp/include/json/reader.h
+++ b/src/3rd_party-static/jsoncpp/include/json/reader.h
@@ -4,211 +4,218 @@
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
 #ifndef CPPTL_JSON_READER_H_INCLUDED
-# define CPPTL_JSON_READER_H_INCLUDED
+#define CPPTL_JSON_READER_H_INCLUDED
 
 #if !defined(JSON_IS_AMALGAMATION)
-# include "features.h"
-# include "value.h"
-#endif // if !defined(JSON_IS_AMALGAMATION)
-# include <deque>
-# include <stack>
-# include <string>
-# include <iostream>
+#include "features.h"
+#include "value.h"
+#endif  // if !defined(JSON_IS_AMALGAMATION)
+#include <deque>
+#include <stack>
+#include <string>
+#include <iostream>
 
 namespace Json {
 
-   /** \brief Unserialize a <a HREF="http://www.json.org">JSON</a> document into a Value.
-    *
-    */
-   class JSON_API Reader
-   {
-   public:
-      typedef char Char;
-      typedef const Char *Location;
+/** \brief Unserialize a <a HREF="http://www.json.org">JSON</a> document into a
+ *Value.
+ *
+ */
+class JSON_API Reader {
+ public:
+  typedef char Char;
+  typedef const Char* Location;
 
-      /** \brief Constructs a Reader allowing all features
-       * for parsing.
-       */
-      Reader();
-
-      /** \brief Constructs a Reader allowing the specified feature set
-       * for parsing.
-       */
-      Reader( const Features &features );
-
-      /** \brief Read a Value from a <a HREF="http://www.json.org">JSON</a> document.
-       * \param document UTF-8 encoded string containing the document to read.
-       * \param root [out] Contains the root value of the document if it was
-       *             successfully parsed.
-       * \param collectComments \c true to collect comment and allow writing them back during
-       *                        serialization, \c false to discard comments.
-       *                        This parameter is ignored if Features::allowComments_
-       *                        is \c false.
-       * \return \c true if the document was successfully parsed, \c false if an error occurred.
-       */
-      bool parse( const std::string &document, 
-                  Value &root,
-                  bool collectComments = true );
-
-      /** \brief Read a Value from a <a HREF="http://www.json.org">JSON</a> document.
-       * \param beginDoc Pointer on the beginning of the UTF-8 encoded string of the document to read.
-       * \param endDoc Pointer on the end of the UTF-8 encoded string of the document to read. 
-       \               Must be >= beginDoc.
-       * \param root [out] Contains the root value of the document if it was
-       *             successfully parsed.
-       * \param collectComments \c true to collect comment and allow writing them back during
-       *                        serialization, \c false to discard comments.
-       *                        This parameter is ignored if Features::allowComments_
-       *                        is \c false.
-       * \return \c true if the document was successfully parsed, \c false if an error occurred.
-       */
-      bool parse( const char *beginDoc, const char *endDoc, 
-                  Value &root,
-                  bool collectComments = true );
-
-      /// \brief Parse from input stream.
-      /// \see Json::operator>>(std::istream&, Json::Value&).
-      bool parse( std::istream &is,
-                  Value &root,
-                  bool collectComments = true );
-
-      /** \brief Returns a user friendly string that list errors in the parsed document.
-       * \return Formatted error message with the list of errors with their location in 
-       *         the parsed document. An empty string is returned if no error occurred
-       *         during parsing.
-       * \deprecated Use getFormattedErrorMessages() instead (typo fix).
-       */
-      JSONCPP_DEPRECATED("Use getFormattedErrorMessages instead") 
-      std::string getFormatedErrorMessages() const;
-
-      /** \brief Returns a user friendly string that list errors in the parsed document.
-       * \return Formatted error message with the list of errors with their location in 
-       *         the parsed document. An empty string is returned if no error occurred
-       *         during parsing.
-       */
-      std::string getFormattedErrorMessages() const;
-
-   private:
-      enum TokenType
-      {
-         tokenEndOfStream = 0,
-         tokenObjectBegin,
-         tokenObjectEnd,
-         tokenArrayBegin,
-         tokenArrayEnd,
-         tokenString,
-         tokenNumber,
-         tokenTrue,
-         tokenFalse,
-         tokenNull,
-         tokenArraySeparator,
-         tokenMemberSeparator,
-         tokenComment,
-         tokenError
-      };
-
-      class Token
-      {
-      public:
-         TokenType type_;
-         Location start_;
-         Location end_;
-      };
-
-      class ErrorInfo
-      {
-      public:
-         Token token_;
-         std::string message_;
-         Location extra_;
-      };
-
-      typedef std::deque<ErrorInfo> Errors;
-
-      bool expectToken( TokenType type, Token &token, const char *message );
-      bool readToken( Token &token );
-      void skipSpaces();
-      bool match( Location pattern, 
-                  int patternLength );
-      bool readComment();
-      bool readCStyleComment();
-      bool readCppStyleComment();
-      bool readString();
-      void readNumber();
-      bool readValue( int& depth_level );
-      bool readObject( Token &token, int& depth_level );
-      bool readArray( Token &token, int& depth_level );
-      bool decodeNumber( Token &token );
-      bool decodeString( Token &token );
-      bool decodeString( Token &token, std::string &decoded );
-      bool decodeDouble( Token &token );
-      bool decodeUnicodeCodePoint( Token &token, 
-                                   Location &current, 
-                                   Location end, 
-                                   unsigned int &unicode );
-      bool decodeUnicodeEscapeSequence( Token &token, 
-                                        Location &current, 
-                                        Location end, 
-                                        unsigned int &unicode );
-      bool addError( const std::string &message, 
-                     Token &token,
-                     Location extra = 0 );
-      bool recoverFromError( TokenType skipUntilToken );
-      bool addErrorAndRecover( const std::string &message, 
-                               Token &token,
-                               TokenType skipUntilToken );
-      void skipUntilSpace();
-      Value &currentValue();
-      Char getNextChar();
-      void getLocationLineAndColumn( Location location,
-                                     int &line,
-                                     int &column ) const;
-      std::string getLocationLineAndColumn( Location location ) const;
-      void addComment( Location begin, 
-                       Location end, 
-                       CommentPlacement placement );
-      void skipCommentTokens( Token &token );
-   
-      typedef std::stack<Value *> Nodes;
-      Nodes nodes_;
-      Errors errors_;
-      std::string document_;
-      Location begin_;
-      Location end_;
-      Location current_;
-      Location lastValueEnd_;
-      Value *lastValue_;
-      std::string commentsBefore_;
-      Features features_;
-      bool collectComments_;
-   };
-
-   /** \brief Read from 'sin' into 'root'.
-
-    Always keep comments from the input JSON.
-
-    This can be used to read a file into a particular sub-object.
-    For example:
-    \code
-    Json::Value root;
-    cin >> root["dir"]["file"];
-    cout << root;
-    \endcode
-    Result:
-    \verbatim
-    {
-    "dir": {
-        "file": {
-        // The input stream JSON would be nested here.
-        }
-    }
-    }
-    \endverbatim
-    \throw std::exception on parse error.
-    \see Json::operator<<()
+  /** \brief Constructs a Reader allowing all features
+   * for parsing.
    */
-   std::istream& operator>>( std::istream&, Value& );
+  Reader();
 
-} // namespace Json
+  /** \brief Constructs a Reader allowing the specified feature set
+   * for parsing.
+   */
+  Reader(const Features& features);
 
-#endif // CPPTL_JSON_READER_H_INCLUDED
+  /** \brief Read a Value from a <a HREF="http://www.json.org">JSON</a>
+   * document.
+   * \param document UTF-8 encoded string containing the document to read.
+   * \param root [out] Contains the root value of the document if it was
+   *             successfully parsed.
+   * \param collectComments \c true to collect comment and allow writing them
+   * back during
+   *                        serialization, \c false to discard comments.
+   *                        This parameter is ignored if
+   * Features::allowComments_
+   *                        is \c false.
+   * \return \c true if the document was successfully parsed, \c false if an
+   * error occurred.
+   */
+  bool parse(const std::string& document,
+             Value& root,
+             bool collectComments = true);
+
+  /** \brief Read a Value from a <a HREF="http://www.json.org">JSON</a>
+   document.
+   * \param beginDoc Pointer on the beginning of the UTF-8 encoded string of the
+   document to read.
+   * \param endDoc Pointer on the end of the UTF-8 encoded string of the
+   document to read.
+   \               Must be >= beginDoc.
+   * \param root [out] Contains the root value of the document if it was
+   *             successfully parsed.
+   * \param collectComments \c true to collect comment and allow writing them
+   back during
+   *                        serialization, \c false to discard comments.
+   *                        This parameter is ignored if
+   Features::allowComments_
+   *                        is \c false.
+   * \return \c true if the document was successfully parsed, \c false if an
+   error occurred.
+   */
+  bool parse(const char* beginDoc,
+             const char* endDoc,
+             Value& root,
+             bool collectComments = true);
+
+  /// \brief Parse from input stream.
+  /// \see Json::operator>>(std::istream&, Json::Value&).
+  bool parse(std::istream& is, Value& root, bool collectComments = true);
+
+  /** \brief Returns a user friendly string that list errors in the parsed
+   * document.
+   * \return Formatted error message with the list of errors with their location
+   * in
+   *         the parsed document. An empty string is returned if no error
+   * occurred
+   *         during parsing.
+   * \deprecated Use getFormattedErrorMessages() instead (typo fix).
+   */
+  JSONCPP_DEPRECATED("Use getFormattedErrorMessages instead")
+  std::string getFormatedErrorMessages() const;
+
+  /** \brief Returns a user friendly string that list errors in the parsed
+   * document.
+   * \return Formatted error message with the list of errors with their location
+   * in
+   *         the parsed document. An empty string is returned if no error
+   * occurred
+   *         during parsing.
+   */
+  std::string getFormattedErrorMessages() const;
+
+ private:
+  enum TokenType {
+    tokenEndOfStream = 0,
+    tokenObjectBegin,
+    tokenObjectEnd,
+    tokenArrayBegin,
+    tokenArrayEnd,
+    tokenString,
+    tokenNumber,
+    tokenTrue,
+    tokenFalse,
+    tokenNull,
+    tokenArraySeparator,
+    tokenMemberSeparator,
+    tokenComment,
+    tokenError
+  };
+
+  class Token {
+   public:
+    TokenType type_;
+    Location start_;
+    Location end_;
+  };
+
+  class ErrorInfo {
+   public:
+    Token token_;
+    std::string message_;
+    Location extra_;
+  };
+
+  typedef std::deque<ErrorInfo> Errors;
+
+  bool expectToken(TokenType type, Token& token, const char* message);
+  bool readToken(Token& token);
+  void skipSpaces();
+  bool match(Location pattern, int patternLength);
+  bool readComment();
+  bool readCStyleComment();
+  bool readCppStyleComment();
+  bool readString();
+  void readNumber();
+  bool readValue(int& depth_level);
+  bool readObject(Token& token, int& depth_level);
+  bool readArray(Token& token, int& depth_level);
+  bool decodeNumber(Token& token);
+  bool decodeString(Token& token);
+  bool decodeString(Token& token, std::string& decoded);
+  bool decodeDouble(Token& token);
+  bool decodeUnicodeCodePoint(Token& token,
+                              Location& current,
+                              Location end,
+                              unsigned int& unicode);
+  bool decodeUnicodeEscapeSequence(Token& token,
+                                   Location& current,
+                                   Location end,
+                                   unsigned int& unicode);
+  bool addError(const std::string& message, Token& token, Location extra = 0);
+  bool recoverFromError(TokenType skipUntilToken);
+  bool addErrorAndRecover(const std::string& message,
+                          Token& token,
+                          TokenType skipUntilToken);
+  void skipUntilSpace();
+  Value& currentValue();
+  Char getNextChar();
+  void getLocationLineAndColumn(Location location,
+                                int& line,
+                                int& column) const;
+  std::string getLocationLineAndColumn(Location location) const;
+  void addComment(Location begin, Location end, CommentPlacement placement);
+  void skipCommentTokens(Token& token);
+
+  typedef std::stack<Value*> Nodes;
+  Nodes nodes_;
+  Errors errors_;
+  std::string document_;
+  Location begin_;
+  Location end_;
+  Location current_;
+  Location lastValueEnd_;
+  Value* lastValue_;
+  std::string commentsBefore_;
+  Features features_;
+  bool collectComments_;
+};
+
+/** \brief Read from 'sin' into 'root'.
+
+ Always keep comments from the input JSON.
+
+ This can be used to read a file into a particular sub-object.
+ For example:
+ \code
+ Json::Value root;
+ cin >> root["dir"]["file"];
+ cout << root;
+ \endcode
+ Result:
+ \verbatim
+ {
+ "dir": {
+     "file": {
+     // The input stream JSON would be nested here.
+     }
+ }
+ }
+ \endverbatim
+ \throw std::exception on parse error.
+ \see Json::operator<<()
+*/
+std::istream& operator>>(std::istream&, Value&);
+
+}  // namespace Json
+
+#endif  // CPPTL_JSON_READER_H_INCLUDED

--- a/src/3rd_party-static/jsoncpp/include/json/reader.h
+++ b/src/3rd_party-static/jsoncpp/include/json/reader.h
@@ -146,9 +146,9 @@ class JSON_API Reader {
   bool readCppStyleComment();
   bool readString();
   void readNumber();
-  bool readValue(int& depth_level);
-  bool readObject(Token& token, int& depth_level);
-  bool readArray(Token& token, int& depth_level);
+  bool readValue(int& out_depth_level);
+  bool readObject(Token& token, int& out_depth_level);
+  bool readArray(Token& token, int& out_depth_level);
   bool decodeNumber(Token& token);
   bool decodeString(Token& token);
   bool decodeString(Token& token, std::string& decoded);

--- a/src/3rd_party-static/jsoncpp/src/lib_json/json_reader.cpp
+++ b/src/3rd_party-static/jsoncpp/src/lib_json/json_reader.cpp
@@ -4,10 +4,10 @@
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
 #if !defined(JSON_IS_AMALGAMATION)
-# include <json/reader.h>
-# include <json/value.h>
-# include "json_tool.h"
-#endif // if !defined(JSON_IS_AMALGAMATION)
+#include <json/reader.h>
+#include <json/value.h>
+#include "json_tool.h"
+#endif  // if !defined(JSON_IS_AMALGAMATION)
 #include <utility>
 #include <cstdio>
 #include <cassert>
@@ -15,8 +15,9 @@
 #include <iostream>
 #include <stdexcept>
 
-#if _MSC_VER >= 1400 // VC++ 8.0
-#pragma warning( disable : 4996 )   // disable warning about strdup being deprecated.
+#if _MSC_VER >= 1400  // VC++ 8.0
+#pragma warning( \
+    disable : 4996)  // disable warning about strdup being deprecated.
 #endif
 
 namespace Json {
@@ -24,882 +25,745 @@ namespace Json {
 // Implementation of class Features
 // ////////////////////////////////
 
-Features::Features()
-   : allowComments_( true )
-   , strictRoot_( false )
-{
+Features::Features() : allowComments_(true), strictRoot_(false) {}
+
+Features Features::all() {
+  return Features();
 }
 
-
-Features 
-Features::all()
-{
-   return Features();
-}
-
-
-Features 
-Features::strictMode()
-{
-   Features features;
-   features.allowComments_ = false;
-   features.strictRoot_ = true;
-   return features;
+Features Features::strictMode() {
+  Features features;
+  features.allowComments_ = false;
+  features.strictRoot_ = true;
+  return features;
 }
 
 // Implementation of class Reader
 // ////////////////////////////////
 
-
-static inline bool 
-in( Reader::Char c, Reader::Char c1, Reader::Char c2, Reader::Char c3, Reader::Char c4 )
-{
-   return c == c1  ||  c == c2  ||  c == c3  ||  c == c4;
+static inline bool in(Reader::Char c,
+                      Reader::Char c1,
+                      Reader::Char c2,
+                      Reader::Char c3,
+                      Reader::Char c4) {
+  return c == c1 || c == c2 || c == c3 || c == c4;
 }
 
-static inline bool 
-in( Reader::Char c, Reader::Char c1, Reader::Char c2, Reader::Char c3, Reader::Char c4, Reader::Char c5 )
-{
-   return c == c1  ||  c == c2  ||  c == c3  ||  c == c4  ||  c == c5;
+static inline bool in(Reader::Char c,
+                      Reader::Char c1,
+                      Reader::Char c2,
+                      Reader::Char c3,
+                      Reader::Char c4,
+                      Reader::Char c5) {
+  return c == c1 || c == c2 || c == c3 || c == c4 || c == c5;
 }
 
-
-static bool 
-containsNewLine( Reader::Location begin, 
-                 Reader::Location end )
-{
-   for ( ;begin < end; ++begin )
-      if ( *begin == '\n'  ||  *begin == '\r' )
-         return true;
-   return false;
+static bool containsNewLine(Reader::Location begin, Reader::Location end) {
+  for (; begin < end; ++begin)
+    if (*begin == '\n' || *begin == '\r')
+      return true;
+  return false;
 }
-
 
 // Class Reader
 // //////////////////////////////////////////////////////////////////
 
-Reader::Reader()
-   : features_( Features::all() )
-{
+Reader::Reader() : features_(Features::all()) {}
+
+Reader::Reader(const Features& features) : features_(features) {}
+
+bool Reader::parse(const std::string& document,
+                   Value& root,
+                   bool collectComments) {
+  document_ = document;
+  const char* begin = document_.c_str();
+  const char* end = begin + document_.length();
+  return parse(begin, end, root, collectComments);
 }
 
+bool Reader::parse(std::istream& sin, Value& root, bool collectComments) {
+  // std::istream_iterator<char> begin(sin);
+  // std::istream_iterator<char> end;
+  // Those would allow streamed input from a file, if parse() were a
+  // template function.
 
-Reader::Reader( const Features &features )
-   : features_( features )
-{
+  // Since std::string is reference-counted, this at least does not
+  // create an extra copy.
+  std::string doc;
+  std::getline(sin, doc, (char)EOF);
+  return parse(doc, root, collectComments);
 }
 
+bool Reader::parse(const char* beginDoc,
+                   const char* endDoc,
+                   Value& root,
+                   bool collectComments) {
+  if (!features_.allowComments_) {
+    collectComments = false;
+  }
 
-bool
-Reader::parse( const std::string &document, 
-               Value &root,
-               bool collectComments )
-{
-   document_ = document;
-   const char *begin = document_.c_str();
-   const char *end = begin + document_.length();
-   return parse( begin, end, root, collectComments );
+  begin_ = beginDoc;
+  end_ = endDoc;
+  collectComments_ = collectComments;
+  current_ = begin_;
+  lastValueEnd_ = 0;
+  lastValue_ = 0;
+  commentsBefore_ = "";
+  errors_.clear();
+  while (!nodes_.empty())
+    nodes_.pop();
+  nodes_.push(&root);
+
+  int depth_level = 0;
+  bool successful = readValue(depth_level);
+  Token token;
+  skipCommentTokens(token);
+  if (collectComments_ && !commentsBefore_.empty())
+    root.setComment(commentsBefore_, commentAfter);
+  if (features_.strictRoot_) {
+    if (!root.isArray() && !root.isObject()) {
+      // Set error location to start of doc, ideally should be first token found
+      // in doc
+      token.type_ = tokenError;
+      token.start_ = beginDoc;
+      token.end_ = endDoc;
+      addError(
+          "A valid JSON document must be either an array or an object value.",
+          token);
+      return false;
+    }
+  }
+  return successful;
 }
 
+bool Reader::readValue(int& depth_level) {
+  Token token;
+  skipCommentTokens(token);
+  bool successful = true;
+  const int max_allowed_depth_level = 50;
 
-bool
-Reader::parse( std::istream& sin,
-               Value &root,
-               bool collectComments )
-{
-   //std::istream_iterator<char> begin(sin);
-   //std::istream_iterator<char> end;
-   // Those would allow streamed input from a file, if parse() were a
-   // template function.
+  if (collectComments_ && !commentsBefore_.empty()) {
+    currentValue().setComment(commentsBefore_, commentBefore);
+    commentsBefore_ = "";
+  }
 
-   // Since std::string is reference-counted, this at least does not
-   // create an extra copy.
-   std::string doc;
-   std::getline(sin, doc, (char)EOF);
-   return parse( doc, root, collectComments );
-}
+  switch (token.type_) {
+    case tokenObjectBegin:
 
-bool
-Reader::parse( const char *beginDoc, const char *endDoc,
-               Value &root,
-               bool collectComments )
-{
-
-   if ( !features_.allowComments_ )
-   {
-      collectComments = false;
-   }
-
-   begin_ = beginDoc;
-   end_ = endDoc;
-   collectComments_ = collectComments;
-   current_ = begin_;
-   lastValueEnd_ = 0;
-   lastValue_ = 0;
-   commentsBefore_ = "";
-   errors_.clear();
-   while ( !nodes_.empty() )
-      nodes_.pop();
-   nodes_.push( &root );
-
-   int depth_level = 0;
-   bool successful = readValue(depth_level);
-   Token token;
-   skipCommentTokens( token );
-   if ( collectComments_  &&  !commentsBefore_.empty() )
-      root.setComment( commentsBefore_, commentAfter );
-   if ( features_.strictRoot_ )
-   {
-      if ( !root.isArray()  &&  !root.isObject() )
-      {
-         // Set error location to start of doc, ideally should be first token found in doc
-         token.type_ = tokenError;
-         token.start_ = beginDoc;
-         token.end_ = endDoc;
-         addError( "A valid JSON document must be either an array or an object value.",
-                   token );
-         return false;
-      }
-   }
-   return successful;
-}
-
-
-bool
-Reader::readValue(int& depth_level)
-{
-   Token token;
-   skipCommentTokens( token );
-   bool successful = true;
-   const int max_allowed_depth_level = 50;
-
-   if ( collectComments_  &&  !commentsBefore_.empty() )
-   {
-      currentValue().setComment( commentsBefore_, commentBefore );
-      commentsBefore_ = "";
-   }
-
-   switch ( token.type_ )
-   {
-   case tokenObjectBegin:
-
-      if(max_allowed_depth_level <= depth_level){
+      if (max_allowed_depth_level <= depth_level) {
         successful = false;
         break;
       }
 
       ++depth_level;
-      successful = readObject( token, depth_level );
+      successful = readObject(token, depth_level);
       break;
-   case tokenArrayBegin:
+    case tokenArrayBegin:
 
-      if(max_allowed_depth_level <= depth_level){
+      if (max_allowed_depth_level <= depth_level) {
         successful = false;
         break;
       }
 
       ++depth_level;
-      successful = readArray( token , depth_level);
+      successful = readArray(token, depth_level);
       break;
-   case tokenNumber:
+    case tokenNumber:
       depth_level = 0;
-      successful = decodeNumber( token );
+      successful = decodeNumber(token);
       break;
-   case tokenString:
+    case tokenString:
       depth_level = 0;
-      successful = decodeString( token );
+      successful = decodeString(token);
       break;
-   case tokenTrue:
+    case tokenTrue:
       depth_level = 0;
       currentValue() = true;
       break;
-   case tokenFalse:
+    case tokenFalse:
       depth_level = 0;
       currentValue() = false;
       break;
-   case tokenNull:
+    case tokenNull:
       depth_level = 0;
       currentValue() = Value();
       break;
-   default:
-      return addError( "Syntax error: value, object or array expected.", token );
-   }
+    default:
+      return addError("Syntax error: value, object or array expected.", token);
+  }
 
-   if ( collectComments_ )
-   {
-      lastValueEnd_ = current_;
-      lastValue_ = &currentValue();
-   }
+  if (collectComments_) {
+    lastValueEnd_ = current_;
+    lastValue_ = &currentValue();
+  }
 
-   return successful;
+  return successful;
 }
 
-
-void 
-Reader::skipCommentTokens( Token &token )
-{
-   if ( features_.allowComments_ )
-   {
-      do
-      {
-         readToken( token );
-      }
-      while ( token.type_ == tokenComment );
-   }
-   else
-   {
-      readToken( token );
-   }
+void Reader::skipCommentTokens(Token& token) {
+  if (features_.allowComments_) {
+    do {
+      readToken(token);
+    } while (token.type_ == tokenComment);
+  } else {
+    readToken(token);
+  }
 }
 
-
-bool 
-Reader::expectToken( TokenType type, Token &token, const char *message )
-{
-   readToken( token );
-   if ( token.type_ != type )
-      return addError( message, token );
-   return true;
+bool Reader::expectToken(TokenType type, Token& token, const char* message) {
+  readToken(token);
+  if (token.type_ != type)
+    return addError(message, token);
+  return true;
 }
 
-
-bool 
-Reader::readToken( Token &token )
-{
-   skipSpaces();
-   token.start_ = current_;
-   Char c = getNextChar();
-   bool ok = true;
-   switch ( c )
-   {
-   case '{':
+bool Reader::readToken(Token& token) {
+  skipSpaces();
+  token.start_ = current_;
+  Char c = getNextChar();
+  bool ok = true;
+  switch (c) {
+    case '{':
       token.type_ = tokenObjectBegin;
       break;
-   case '}':
+    case '}':
       token.type_ = tokenObjectEnd;
       break;
-   case '[':
+    case '[':
       token.type_ = tokenArrayBegin;
       break;
-   case ']':
+    case ']':
       token.type_ = tokenArrayEnd;
       break;
-   case '"':
+    case '"':
       token.type_ = tokenString;
       ok = readString();
       break;
-   case '/':
+    case '/':
       token.type_ = tokenComment;
       ok = readComment();
       break;
-   case '0':
-   case '1':
-   case '2':
-   case '3':
-   case '4':
-   case '5':
-   case '6':
-   case '7':
-   case '8':
-   case '9':
-   case '-':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case '-':
       token.type_ = tokenNumber;
       readNumber();
       break;
-   case 'T':
-   case 't':
+    case 'T':
+    case 't':
       token.type_ = tokenTrue;
-      ok = match( "rue", 3 );
+      ok = match("rue", 3);
       break;
-   case 'F':
-   case 'f':
+    case 'F':
+    case 'f':
       token.type_ = tokenFalse;
-      ok = match( "alse", 4 );
+      ok = match("alse", 4);
       break;
-   case 'N':
-   case 'n':
+    case 'N':
+    case 'n':
       token.type_ = tokenNull;
-      ok = match( "ull", 3 );
+      ok = match("ull", 3);
       break;
-   case ',':
+    case ',':
       token.type_ = tokenArraySeparator;
       break;
-   case ':':
+    case ':':
       token.type_ = tokenMemberSeparator;
       break;
-   case 0:
+    case 0:
       token.type_ = tokenEndOfStream;
       break;
-   default:
+    default:
       ok = false;
       break;
-   }
-   if ( !ok )
-      token.type_ = tokenError;
-   token.end_ = current_;
-   return true;
+  }
+  if (!ok)
+    token.type_ = tokenError;
+  token.end_ = current_;
+  return true;
 }
 
-
-void 
-Reader::skipSpaces()
-{
-   while ( current_ != end_ )
-   {
-      Char c = *current_;
-      if ( c == ' '  ||  c == '\t'  ||  c == '\r'  ||  c == '\n' )
-         ++current_;
-      else
-         break;
-   }
-}
-
-
-bool 
-Reader::match( Location pattern, 
-               int patternLength )
-{
-   if ( end_ - current_ < patternLength )
-      return false;
-   int index = patternLength;
-   while ( index-- )
-      if ( current_[index] != pattern[index] )
-         return false;
-   current_ += patternLength;
-   return true;
-}
-
-
-bool
-Reader::readComment()
-{
-   Location commentBegin = current_ - 1;
-   Char c = getNextChar();
-   bool successful = false;
-   if ( c == '*' )
-      successful = readCStyleComment();
-   else if ( c == '/' )
-      successful = readCppStyleComment();
-   if ( !successful )
-      return false;
-
-   if ( collectComments_ )
-   {
-      CommentPlacement placement = commentBefore;
-      if ( lastValueEnd_  &&  !containsNewLine( lastValueEnd_, commentBegin ) )
-      {
-         if ( c != '*'  ||  !containsNewLine( commentBegin, current_ ) )
-            placement = commentAfterOnSameLine;
-      }
-
-      addComment( commentBegin, current_, placement );
-   }
-   return true;
-}
-
-
-void 
-Reader::addComment( Location begin, 
-                    Location end, 
-                    CommentPlacement placement )
-{
-   assert( collectComments_ );
-   if ( placement == commentAfterOnSameLine )
-   {
-      assert( lastValue_ != 0 );
-      lastValue_->setComment( std::string( begin, end ), placement );
-   }
-   else
-   {
-      if ( !commentsBefore_.empty() )
-         commentsBefore_ += "\n";
-      commentsBefore_ += std::string( begin, end );
-   }
-}
-
-
-bool 
-Reader::readCStyleComment()
-{
-   while ( current_ != end_ )
-   {
-      Char c = getNextChar();
-      if ( c == '*'  &&  *current_ == '/' )
-         break;
-   }
-   return getNextChar() == '/';
-}
-
-
-bool 
-Reader::readCppStyleComment()
-{
-   while ( current_ != end_ )
-   {
-      Char c = getNextChar();
-      if (  c == '\r'  ||  c == '\n' )
-         break;
-   }
-   return true;
-}
-
-
-void 
-Reader::readNumber()
-{
-   while ( current_ != end_ )
-   {
-      if ( !(*current_ >= '0'  &&  *current_ <= '9')  &&
-           !in( *current_, '.', 'e', 'E', '+', '-' ) )
-         break;
+void Reader::skipSpaces() {
+  while (current_ != end_) {
+    Char c = *current_;
+    if (c == ' ' || c == '\t' || c == '\r' || c == '\n')
       ++current_;
-   }
+    else
+      break;
+  }
 }
 
-bool
-Reader::readString()
-{
-   Char c = 0;
-   while ( current_ != end_ )
-   {
-      c = getNextChar();
-      if ( c == '\\' )
-         getNextChar();
-      else if ( c == '"' )
-         break;
-   }
-   return c == '"';
+bool Reader::match(Location pattern, int patternLength) {
+  if (end_ - current_ < patternLength)
+    return false;
+  int index = patternLength;
+  while (index--)
+    if (current_[index] != pattern[index])
+      return false;
+  current_ += patternLength;
+  return true;
 }
 
+bool Reader::readComment() {
+  Location commentBegin = current_ - 1;
+  Char c = getNextChar();
+  bool successful = false;
+  if (c == '*')
+    successful = readCStyleComment();
+  else if (c == '/')
+    successful = readCppStyleComment();
+  if (!successful)
+    return false;
 
-bool
-Reader::readObject( Token &/*tokenStart*/, int& depth_level )
-{
-   Token tokenName;
-   std::string name;
-   currentValue() = Value( objectValue );
-   while ( readToken( tokenName ) )
-   {
-      bool initialTokenOk = true;
-      while ( tokenName.type_ == tokenComment  &&  initialTokenOk )
-         initialTokenOk = readToken( tokenName );
-      if  ( !initialTokenOk )
-         break;
-      if ( tokenName.type_ == tokenObjectEnd  &&  name.empty() )  // empty object
-         return true;
-      if ( tokenName.type_ != tokenString )
-         break;
-      
-      name = "";
-      if ( !decodeString( tokenName, name ) )
-         return recoverFromError( tokenObjectEnd );
+  if (collectComments_) {
+    CommentPlacement placement = commentBefore;
+    if (lastValueEnd_ && !containsNewLine(lastValueEnd_, commentBegin)) {
+      if (c != '*' || !containsNewLine(commentBegin, current_))
+        placement = commentAfterOnSameLine;
+    }
 
-      Token colon;
-      if ( !readToken( colon ) ||  colon.type_ != tokenMemberSeparator )
-      {
-         return addErrorAndRecover( "Missing ':' after object member name", 
-                                    colon, 
-                                    tokenObjectEnd );
-      }
-      Value &value = currentValue()[ name ];
-      nodes_.push( &value );
-      const bool ok = readValue(depth_level);
-      nodes_.pop();
-      if ( !ok ) // error already set
-         return recoverFromError( tokenObjectEnd );
-
-      Token comma;
-      if ( !readToken( comma )
-            ||  ( comma.type_ != tokenObjectEnd  &&  
-                  comma.type_ != tokenArraySeparator &&
-                  comma.type_ != tokenComment ) )
-      {
-         return addErrorAndRecover( "Missing ',' or '}' in object declaration", 
-                                    comma, 
-                                    tokenObjectEnd );
-      }
-      bool finalizeTokenOk = true;
-      while ( comma.type_ == tokenComment &&
-              finalizeTokenOk )
-         finalizeTokenOk = readToken( comma );
-      if ( comma.type_ == tokenObjectEnd )
-         return true;
-   }
-   return addErrorAndRecover( "Missing '}' or object member name", 
-                              tokenName, 
-                              tokenObjectEnd );
+    addComment(commentBegin, current_, placement);
+  }
+  return true;
 }
 
+void Reader::addComment(Location begin,
+                        Location end,
+                        CommentPlacement placement) {
+  assert(collectComments_);
+  if (placement == commentAfterOnSameLine) {
+    assert(lastValue_ != 0);
+    lastValue_->setComment(std::string(begin, end), placement);
+  } else {
+    if (!commentsBefore_.empty())
+      commentsBefore_ += "\n";
+    commentsBefore_ += std::string(begin, end);
+  }
+}
 
-bool
-Reader::readArray( Token &/*tokenStart*/, int& depth_level )
-{
-   currentValue() = Value( arrayValue );
-   skipSpaces();
-   if ( *current_ == ']' ) // empty array
-   {
-      Token endArray;
-      readToken( endArray );
+bool Reader::readCStyleComment() {
+  while (current_ != end_) {
+    Char c = getNextChar();
+    if (c == '*' && *current_ == '/')
+      break;
+  }
+  return getNextChar() == '/';
+}
+
+bool Reader::readCppStyleComment() {
+  while (current_ != end_) {
+    Char c = getNextChar();
+    if (c == '\r' || c == '\n')
+      break;
+  }
+  return true;
+}
+
+void Reader::readNumber() {
+  while (current_ != end_) {
+    if (!(*current_ >= '0' && *current_ <= '9') &&
+        !in(*current_, '.', 'e', 'E', '+', '-'))
+      break;
+    ++current_;
+  }
+}
+
+bool Reader::readString() {
+  Char c = 0;
+  while (current_ != end_) {
+    c = getNextChar();
+    if (c == '\\')
+      getNextChar();
+    else if (c == '"')
+      break;
+  }
+  return c == '"';
+}
+
+bool Reader::readObject(Token& /*tokenStart*/, int& depth_level) {
+  Token tokenName;
+  std::string name;
+  currentValue() = Value(objectValue);
+  while (readToken(tokenName)) {
+    bool initialTokenOk = true;
+    while (tokenName.type_ == tokenComment && initialTokenOk)
+      initialTokenOk = readToken(tokenName);
+    if (!initialTokenOk)
+      break;
+    if (tokenName.type_ == tokenObjectEnd && name.empty())  // empty object
       return true;
-   }
-   int index = 0;
-   for (;;)
-   {
-      Value &value = currentValue()[ index++ ];
-      nodes_.push( &value );
-      const bool ok = readValue(depth_level);
-      nodes_.pop();
-      if ( !ok ) // error already set
-         return recoverFromError( tokenArrayEnd );
+    if (tokenName.type_ != tokenString)
+      break;
 
-      Token token;
-      // Accept Comment after last item in the array.
-      ok = readToken( token );
-      while ( token.type_ == tokenComment  &&  ok )
-      {
-         ok = readToken( token );
-      }
-      bool badTokenType = ( token.type_ != tokenArraySeparator  &&
-                            token.type_ != tokenArrayEnd );
-      if ( !ok  ||  badTokenType )
-      {
-         return addErrorAndRecover( "Missing ',' or ']' in array declaration", 
-                                    token, 
-                                    tokenArrayEnd );
-      }
-      if ( token.type_ == tokenArrayEnd )
-         break;
-   }
-   return true;
+    name = "";
+    if (!decodeString(tokenName, name))
+      return recoverFromError(tokenObjectEnd);
+
+    Token colon;
+    if (!readToken(colon) || colon.type_ != tokenMemberSeparator) {
+      return addErrorAndRecover(
+          "Missing ':' after object member name", colon, tokenObjectEnd);
+    }
+    Value& value = currentValue()[name];
+    nodes_.push(&value);
+    const bool ok = readValue(depth_level);
+    nodes_.pop();
+    if (!ok)  // error already set
+      return recoverFromError(tokenObjectEnd);
+
+    Token comma;
+    if (!readToken(comma) ||
+        (comma.type_ != tokenObjectEnd && comma.type_ != tokenArraySeparator &&
+         comma.type_ != tokenComment)) {
+      return addErrorAndRecover(
+          "Missing ',' or '}' in object declaration", comma, tokenObjectEnd);
+    }
+    bool finalizeTokenOk = true;
+    while (comma.type_ == tokenComment && finalizeTokenOk)
+      finalizeTokenOk = readToken(comma);
+    if (comma.type_ == tokenObjectEnd)
+      return true;
+  }
+  return addErrorAndRecover(
+      "Missing '}' or object member name", tokenName, tokenObjectEnd);
 }
 
+bool Reader::readArray(Token& /*tokenStart*/, int& depth_level) {
+  currentValue() = Value(arrayValue);
+  skipSpaces();
+  if (*current_ == ']')  // empty array
+  {
+    Token endArray;
+    readToken(endArray);
+    return true;
+  }
+  int index = 0;
+  for (;;) {
+    Value& value = currentValue()[index++];
+    nodes_.push(&value);
+    const bool ok = readValue(depth_level);
+    nodes_.pop();
+    if (!ok)  // error already set
+      return recoverFromError(tokenArrayEnd);
 
-bool 
-Reader::decodeNumber( Token &token )
-{
-   bool isDouble = false;
-   for ( Location inspect = token.start_; inspect != token.end_; ++inspect )
-   {
-      isDouble = isDouble  
-                 ||  in( *inspect, '.', 'e', 'E', '+' )  
-                 ||  ( *inspect == '-'  &&  inspect != token.start_ );
-   }
-   if ( isDouble )
-      return decodeDouble( token );
-   // Attempts to parse the number as an integer. If the number is
-   // larger than the maximum supported value of an integer then
-   // we decode the number as a double.
-   Location current = token.start_;
-   bool isNegative = *current == '-';
-   if ( isNegative )
-      ++current;
-   Value::LargestUInt maxIntegerValue = isNegative ? Value::LargestUInt(-Value::minLargestInt) 
-                                                   : Value::maxLargestUInt;
-   Value::LargestUInt threshold = maxIntegerValue / 10;
-   Value::UInt lastDigitThreshold = Value::UInt( maxIntegerValue % 10 );
-   assert(lastDigitThreshold <= 9 );
-   Value::LargestUInt value = 0;
-   while ( current < token.end_ )
-   {
-      Char c = *current++;
-      if ( c < '0'  ||  c > '9' )
-         return addError( "'" + std::string( token.start_, token.end_ ) + "' is not a number.", token );
-      Value::UInt digit(c - '0');
-      if ( value >= threshold )
-      {
-         // If the current digit is not the last one, or if it is
-         // greater than the last digit of the maximum integer value,
-         // the parse the number as a double.
-         if ( current != token.end_  ||  digit > lastDigitThreshold )
-         {
-            return decodeDouble( token );
-         }
+    Token token;
+    // Accept Comment after last item in the array.
+    ok = readToken(token);
+    while (token.type_ == tokenComment && ok) {
+      ok = readToken(token);
+    }
+    bool badTokenType =
+        (token.type_ != tokenArraySeparator && token.type_ != tokenArrayEnd);
+    if (!ok || badTokenType) {
+      return addErrorAndRecover(
+          "Missing ',' or ']' in array declaration", token, tokenArrayEnd);
+    }
+    if (token.type_ == tokenArrayEnd)
+      break;
+  }
+  return true;
+}
+
+bool Reader::decodeNumber(Token& token) {
+  bool isDouble = false;
+  for (Location inspect = token.start_; inspect != token.end_; ++inspect) {
+    isDouble = isDouble || in(*inspect, '.', 'e', 'E', '+') ||
+               (*inspect == '-' && inspect != token.start_);
+  }
+  if (isDouble)
+    return decodeDouble(token);
+  // Attempts to parse the number as an integer. If the number is
+  // larger than the maximum supported value of an integer then
+  // we decode the number as a double.
+  Location current = token.start_;
+  bool isNegative = *current == '-';
+  if (isNegative)
+    ++current;
+  Value::LargestUInt maxIntegerValue =
+      isNegative ? Value::LargestUInt(-Value::minLargestInt)
+                 : Value::maxLargestUInt;
+  Value::LargestUInt threshold = maxIntegerValue / 10;
+  Value::UInt lastDigitThreshold = Value::UInt(maxIntegerValue % 10);
+  assert(lastDigitThreshold <= 9);
+  Value::LargestUInt value = 0;
+  while (current < token.end_) {
+    Char c = *current++;
+    if (c < '0' || c > '9')
+      return addError(
+          "'" + std::string(token.start_, token.end_) + "' is not a number.",
+          token);
+    Value::UInt digit(c - '0');
+    if (value >= threshold) {
+      // If the current digit is not the last one, or if it is
+      // greater than the last digit of the maximum integer value,
+      // the parse the number as a double.
+      if (current != token.end_ || digit > lastDigitThreshold) {
+        return decodeDouble(token);
       }
-      value = value * 10 + digit;
-   }
-   if ( isNegative )
-      currentValue() = -Value::LargestInt( value );
-   else if ( value <= Value::LargestUInt(Value::maxInt) )
-      currentValue() = Value::LargestInt( value );
-   else
-      currentValue() = value;
-   return true;
+    }
+    value = value * 10 + digit;
+  }
+  if (isNegative)
+    currentValue() = -Value::LargestInt(value);
+  else if (value <= Value::LargestUInt(Value::maxInt))
+    currentValue() = Value::LargestInt(value);
+  else
+    currentValue() = value;
+  return true;
 }
 
+bool Reader::decodeDouble(Token& token) {
+  double value = 0;
+  const int bufferSize = 32;
+  int count;
+  int length = int(token.end_ - token.start_);
+  if (length <= bufferSize) {
+    Char buffer[bufferSize + 1];
+    memcpy(buffer, token.start_, length);
+    buffer[length] = 0;
+    count = sscanf(buffer, "%lf", &value);
+  } else {
+    std::string buffer(token.start_, token.end_);
+    count = sscanf(buffer.c_str(), "%lf", &value);
+  }
 
-bool 
-Reader::decodeDouble( Token &token )
-{
-   double value = 0;
-   const int bufferSize = 32;
-   int count;
-   int length = int(token.end_ - token.start_);
-   if ( length <= bufferSize )
-   {
-      Char buffer[bufferSize+1];
-      memcpy( buffer, token.start_, length );
-      buffer[length] = 0;
-      count = sscanf( buffer, "%lf", &value );
-   }
-   else
-   {
-      std::string buffer( token.start_, token.end_ );
-      count = sscanf( buffer.c_str(), "%lf", &value );
-   }
-
-   if ( count != 1 )
-      return addError( "'" + std::string( token.start_, token.end_ ) + "' is not a number.", token );
-   currentValue() = value;
-   return true;
+  if (count != 1)
+    return addError(
+        "'" + std::string(token.start_, token.end_) + "' is not a number.",
+        token);
+  currentValue() = value;
+  return true;
 }
 
-
-bool 
-Reader::decodeString( Token &token )
-{
-   std::string decoded;
-   if ( !decodeString( token, decoded ) )
-      return false;
-   currentValue() = decoded;
-   return true;
+bool Reader::decodeString(Token& token) {
+  std::string decoded;
+  if (!decodeString(token, decoded))
+    return false;
+  currentValue() = decoded;
+  return true;
 }
 
-
-bool 
-Reader::decodeString( Token &token, std::string &decoded )
-{
-   decoded.reserve( token.end_ - token.start_ - 2 );
-   Location current = token.start_ + 1; // skip '"'
-   Location end = token.end_ - 1;      // do not include '"'
-   while ( current != end )
-   {
-      Char c = *current++;
-      if ( c == '"' )
-         break;
-      else if ( c == '\\' )
-      {
-         if ( current == end )
-            return addError( "Empty escape sequence in string", token, current );
-         Char escape = *current++;
-         switch ( escape )
-         {
-         case '"': decoded += '"'; break;
-         case '\'': decoded += '\''; break;
-         case '/': decoded += '/'; break;
-         case '\\': decoded += '\\'; break;
-         case 'b': decoded += '\b'; break;
-         case 'f': decoded += '\f'; break;
-         case 'n': decoded += '\n'; break;
-         case 'r': decoded += '\r'; break;
-         case 't': decoded += '\t'; break;
-         case 'u':
-            {
-               unsigned int unicode;
-               if ( !decodeUnicodeCodePoint( token, current, end, unicode ) )
-                  return false;
-               decoded += codePointToUTF8(unicode);
-            }
-            break;
-         default:
-            return addError( "Bad escape sequence in string", token, current );
-         }
-      }
-      else
-      {
-         decoded += c;
-      }
-   }
-   return true;
-}
-
-bool
-Reader::decodeUnicodeCodePoint( Token &token, 
-                                     Location &current, 
-                                     Location end, 
-                                     unsigned int &unicode )
-{
-
-   if ( !decodeUnicodeEscapeSequence( token, current, end, unicode ) )
-      return false;
-   if (unicode >= 0xD800 && unicode <= 0xDBFF)
-   {
-      // surrogate pairs
-      if (end - current < 6)
-         return addError( "additional six characters expected to parse unicode surrogate pair.", token, current );
-      unsigned int surrogatePair;
-      if (*(current++) == '\\' && *(current++)== 'u')
-      {
-         if (decodeUnicodeEscapeSequence( token, current, end, surrogatePair ))
-         {
-            unicode = 0x10000 + ((unicode & 0x3FF) << 10) + (surrogatePair & 0x3FF);
-         } 
-         else
+bool Reader::decodeString(Token& token, std::string& decoded) {
+  decoded.reserve(token.end_ - token.start_ - 2);
+  Location current = token.start_ + 1;  // skip '"'
+  Location end = token.end_ - 1;        // do not include '"'
+  while (current != end) {
+    Char c = *current++;
+    if (c == '"')
+      break;
+    else if (c == '\\') {
+      if (current == end)
+        return addError("Empty escape sequence in string", token, current);
+      Char escape = *current++;
+      switch (escape) {
+        case '"':
+          decoded += '"';
+          break;
+        case '\'':
+          decoded += '\'';
+          break;
+        case '/':
+          decoded += '/';
+          break;
+        case '\\':
+          decoded += '\\';
+          break;
+        case 'b':
+          decoded += '\b';
+          break;
+        case 'f':
+          decoded += '\f';
+          break;
+        case 'n':
+          decoded += '\n';
+          break;
+        case 'r':
+          decoded += '\r';
+          break;
+        case 't':
+          decoded += '\t';
+          break;
+        case 'u': {
+          unsigned int unicode;
+          if (!decodeUnicodeCodePoint(token, current, end, unicode))
             return false;
-      } 
-      else
-         return addError( "expecting another \\u token to begin the second half of a unicode surrogate pair", token, current );
-   }
-   return true;
-}
-
-bool 
-Reader::decodeUnicodeEscapeSequence( Token &token, 
-                                     Location &current, 
-                                     Location end, 
-                                     unsigned int &unicode )
-{
-   if ( end - current < 4 )
-      return addError( "Bad unicode escape sequence in string: four digits expected.", token, current );
-   unicode = 0;
-   for ( int index =0; index < 4; ++index )
-   {
-      Char c = *current++;
-      unicode *= 16;
-      if ( c >= '0'  &&  c <= '9' )
-         unicode += c - '0';
-      else if ( c >= 'a'  &&  c <= 'f' )
-         unicode += c - 'a' + 10;
-      else if ( c >= 'A'  &&  c <= 'F' )
-         unicode += c - 'A' + 10;
-      else
-         return addError( "Bad unicode escape sequence in string: hexadecimal digit expected.", token, current );
-   }
-   return true;
-}
-
-
-bool 
-Reader::addError( const std::string &message, 
-                  Token &token,
-                  Location extra )
-{
-   ErrorInfo info;
-   info.token_ = token;
-   info.message_ = message;
-   info.extra_ = extra;
-   errors_.push_back( info );
-   return false;
-}
-
-
-bool 
-Reader::recoverFromError( TokenType skipUntilToken )
-{
-   int errorCount = int(errors_.size());
-   Token skip;
-   for (;;)
-   {
-      if ( !readToken(skip) )
-         errors_.resize( errorCount ); // discard errors caused by recovery
-      if ( skip.type_ == skipUntilToken  ||  skip.type_ == tokenEndOfStream )
-         break;
-   }
-   errors_.resize( errorCount );
-   return false;
-}
-
-
-bool 
-Reader::addErrorAndRecover( const std::string &message, 
-                            Token &token,
-                            TokenType skipUntilToken )
-{
-   addError( message, token );
-   return recoverFromError( skipUntilToken );
-}
-
-
-Value &
-Reader::currentValue()
-{
-   return *(nodes_.top());
-}
-
-
-Reader::Char 
-Reader::getNextChar()
-{
-   if ( current_ == end_ )
-      return 0;
-   return *current_++;
-}
-
-
-void 
-Reader::getLocationLineAndColumn( Location location,
-                                  int &line,
-                                  int &column ) const
-{
-   Location current = begin_;
-   Location lastLineStart = current;
-   line = 0;
-   while ( current < location  &&  current != end_ )
-   {
-      Char c = *current++;
-      if ( c == '\r' )
-      {
-         if ( *current == '\n' )
-            ++current;
-         lastLineStart = current;
-         ++line;
+          decoded += codePointToUTF8(unicode);
+        } break;
+        default:
+          return addError("Bad escape sequence in string", token, current);
       }
-      else if ( c == '\n' )
-      {
-         lastLineStart = current;
-         ++line;
-      }
-   }
-   // column & line start at 1
-   column = int(location - lastLineStart) + 1;
-   ++line;
+    } else {
+      decoded += c;
+    }
+  }
+  return true;
 }
 
-
-std::string
-Reader::getLocationLineAndColumn( Location location ) const
-{
-   int line, column;
-   getLocationLineAndColumn( location, line, column );
-   char buffer[18+16+16+1];
-   sprintf( buffer, "Line %d, Column %d", line, column );
-   return buffer;
+bool Reader::decodeUnicodeCodePoint(Token& token,
+                                    Location& current,
+                                    Location end,
+                                    unsigned int& unicode) {
+  if (!decodeUnicodeEscapeSequence(token, current, end, unicode))
+    return false;
+  if (unicode >= 0xD800 && unicode <= 0xDBFF) {
+    // surrogate pairs
+    if (end - current < 6)
+      return addError(
+          "additional six characters expected to parse unicode surrogate pair.",
+          token,
+          current);
+    unsigned int surrogatePair;
+    if (*(current++) == '\\' && *(current++) == 'u') {
+      if (decodeUnicodeEscapeSequence(token, current, end, surrogatePair)) {
+        unicode = 0x10000 + ((unicode & 0x3FF) << 10) + (surrogatePair & 0x3FF);
+      } else
+        return false;
+    } else
+      return addError(
+          "expecting another \\u token to begin the second half of a unicode "
+          "surrogate pair",
+          token,
+          current);
+  }
+  return true;
 }
 
+bool Reader::decodeUnicodeEscapeSequence(Token& token,
+                                         Location& current,
+                                         Location end,
+                                         unsigned int& unicode) {
+  if (end - current < 4)
+    return addError(
+        "Bad unicode escape sequence in string: four digits expected.",
+        token,
+        current);
+  unicode = 0;
+  for (int index = 0; index < 4; ++index) {
+    Char c = *current++;
+    unicode *= 16;
+    if (c >= '0' && c <= '9')
+      unicode += c - '0';
+    else if (c >= 'a' && c <= 'f')
+      unicode += c - 'a' + 10;
+    else if (c >= 'A' && c <= 'F')
+      unicode += c - 'A' + 10;
+    else
+      return addError(
+          "Bad unicode escape sequence in string: hexadecimal digit expected.",
+          token,
+          current);
+  }
+  return true;
+}
+
+bool Reader::addError(const std::string& message,
+                      Token& token,
+                      Location extra) {
+  ErrorInfo info;
+  info.token_ = token;
+  info.message_ = message;
+  info.extra_ = extra;
+  errors_.push_back(info);
+  return false;
+}
+
+bool Reader::recoverFromError(TokenType skipUntilToken) {
+  int errorCount = int(errors_.size());
+  Token skip;
+  for (;;) {
+    if (!readToken(skip))
+      errors_.resize(errorCount);  // discard errors caused by recovery
+    if (skip.type_ == skipUntilToken || skip.type_ == tokenEndOfStream)
+      break;
+  }
+  errors_.resize(errorCount);
+  return false;
+}
+
+bool Reader::addErrorAndRecover(const std::string& message,
+                                Token& token,
+                                TokenType skipUntilToken) {
+  addError(message, token);
+  return recoverFromError(skipUntilToken);
+}
+
+Value& Reader::currentValue() {
+  return *(nodes_.top());
+}
+
+Reader::Char Reader::getNextChar() {
+  if (current_ == end_)
+    return 0;
+  return *current_++;
+}
+
+void Reader::getLocationLineAndColumn(Location location,
+                                      int& line,
+                                      int& column) const {
+  Location current = begin_;
+  Location lastLineStart = current;
+  line = 0;
+  while (current < location && current != end_) {
+    Char c = *current++;
+    if (c == '\r') {
+      if (*current == '\n')
+        ++current;
+      lastLineStart = current;
+      ++line;
+    } else if (c == '\n') {
+      lastLineStart = current;
+      ++line;
+    }
+  }
+  // column & line start at 1
+  column = int(location - lastLineStart) + 1;
+  ++line;
+}
+
+std::string Reader::getLocationLineAndColumn(Location location) const {
+  int line, column;
+  getLocationLineAndColumn(location, line, column);
+  char buffer[18 + 16 + 16 + 1];
+  sprintf(buffer, "Line %d, Column %d", line, column);
+  return buffer;
+}
 
 // Deprecated. Preserved for backward compatibility
-std::string 
-Reader::getFormatedErrorMessages() const
-{
-    return getFormattedErrorMessages();
+std::string Reader::getFormatedErrorMessages() const {
+  return getFormattedErrorMessages();
 }
 
-
-std::string 
-Reader::getFormattedErrorMessages() const
-{
-   std::string formattedMessage;
-   for ( Errors::const_iterator itError = errors_.begin();
-         itError != errors_.end();
-         ++itError )
-   {
-      const ErrorInfo &error = *itError;
-      formattedMessage += "* " + getLocationLineAndColumn( error.token_.start_ ) + "\n";
-      formattedMessage += "  " + error.message_ + "\n";
-      if ( error.extra_ )
-         formattedMessage += "See " + getLocationLineAndColumn( error.extra_ ) + " for detail.\n";
-   }
-   return formattedMessage;
+std::string Reader::getFormattedErrorMessages() const {
+  std::string formattedMessage;
+  for (Errors::const_iterator itError = errors_.begin();
+       itError != errors_.end();
+       ++itError) {
+    const ErrorInfo& error = *itError;
+    formattedMessage +=
+        "* " + getLocationLineAndColumn(error.token_.start_) + "\n";
+    formattedMessage += "  " + error.message_ + "\n";
+    if (error.extra_)
+      formattedMessage +=
+          "See " + getLocationLineAndColumn(error.extra_) + " for detail.\n";
+  }
+  return formattedMessage;
 }
 
-
-std::istream& operator>>( std::istream &sin, Value &root )
-{
-    Json::Reader reader;
-    bool ok = reader.parse(sin, root, true);
-    //JSON_ASSERT( ok );
-    if (!ok) throw std::runtime_error(reader.getFormattedErrorMessages());
-    return sin;
+std::istream& operator>>(std::istream& sin, Value& root) {
+  Json::Reader reader;
+  bool ok = reader.parse(sin, root, true);
+  // JSON_ASSERT( ok );
+  if (!ok)
+    throw std::runtime_error(reader.getFormattedErrorMessages());
+  return sin;
 }
 
-
-} // namespace Json
+}  // namespace Json

--- a/src/3rd_party-static/jsoncpp/src/lib_json/json_reader.cpp
+++ b/src/3rd_party-static/jsoncpp/src/lib_json/json_reader.cpp
@@ -114,8 +114,8 @@ bool Reader::parse(const char* beginDoc,
     nodes_.pop();
   nodes_.push(&root);
 
-  int depth_level = 0;
-  bool successful = readValue(depth_level);
+  int out_depth_level = 0;
+  bool successful = readValue(out_depth_level);
   Token token;
   skipCommentTokens(token);
   if (collectComments_ && !commentsBefore_.empty())
@@ -136,7 +136,7 @@ bool Reader::parse(const char* beginDoc,
   return successful;
 }
 
-bool Reader::readValue(int& depth_level) {
+bool Reader::readValue(int& out_depth_level) {
   Token token;
   skipCommentTokens(token);
   bool successful = true;
@@ -150,42 +150,42 @@ bool Reader::readValue(int& depth_level) {
   switch (token.type_) {
     case tokenObjectBegin:
 
-      if (max_allowed_depth_level <= depth_level) {
+      if (max_allowed_depth_level <= out_depth_level) {
         successful = false;
         break;
       }
 
-      ++depth_level;
-      successful = readObject(token, depth_level);
+      ++out_depth_level;
+      successful = readObject(token, out_depth_level);
       break;
     case tokenArrayBegin:
 
-      if (max_allowed_depth_level <= depth_level) {
+      if (max_allowed_depth_level <= out_depth_level) {
         successful = false;
         break;
       }
 
-      ++depth_level;
-      successful = readArray(token, depth_level);
+      ++out_depth_level;
+      successful = readArray(token, out_depth_level);
       break;
     case tokenNumber:
-      depth_level = 0;
+      out_depth_level = 0;
       successful = decodeNumber(token);
       break;
     case tokenString:
-      depth_level = 0;
+      out_depth_level = 0;
       successful = decodeString(token);
       break;
     case tokenTrue:
-      depth_level = 0;
+      out_depth_level = 0;
       currentValue() = true;
       break;
     case tokenFalse:
-      depth_level = 0;
+      out_depth_level = 0;
       currentValue() = false;
       break;
     case tokenNull:
-      depth_level = 0;
+      out_depth_level = 0;
       currentValue() = Value();
       break;
     default:
@@ -388,7 +388,7 @@ bool Reader::readString() {
   return c == '"';
 }
 
-bool Reader::readObject(Token& /*tokenStart*/, int& depth_level) {
+bool Reader::readObject(Token& /*tokenStart*/, int& out_depth_level) {
   Token tokenName;
   std::string name;
   currentValue() = Value(objectValue);
@@ -414,7 +414,7 @@ bool Reader::readObject(Token& /*tokenStart*/, int& depth_level) {
     }
     Value& value = currentValue()[name];
     nodes_.push(&value);
-    const bool ok = readValue(depth_level);
+    const bool ok = readValue(out_depth_level);
     nodes_.pop();
     if (!ok)  // error already set
       return recoverFromError(tokenObjectEnd);
@@ -436,7 +436,7 @@ bool Reader::readObject(Token& /*tokenStart*/, int& depth_level) {
       "Missing '}' or object member name", tokenName, tokenObjectEnd);
 }
 
-bool Reader::readArray(Token& /*tokenStart*/, int& depth_level) {
+bool Reader::readArray(Token& /*tokenStart*/, int& out_depth_level) {
   currentValue() = Value(arrayValue);
   skipSpaces();
   if (*current_ == ']')  // empty array
@@ -449,7 +449,7 @@ bool Reader::readArray(Token& /*tokenStart*/, int& depth_level) {
   for (;;) {
     Value& value = currentValue()[index++];
     nodes_.push(&value);
-    const bool ok = readValue(depth_level);
+    const bool ok = readValue(out_depth_level);
     nodes_.pop();
     if (!ok)  // error already set
       return recoverFromError(tokenArrayEnd);


### PR DESCRIPTION
Fixes #2442 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
The root cause of the issue is a stack overflow which is occurring
due to recursive call of deeply nested areas and objects. We have
readValue(..)  which calls readObject(..) or readArray(..),
which call readValue(...). The starting point is a call to parse(..).
In order to fix the issue a count var. is implemented, which
measure how deep is our recursion. When recursion threshold is
exceeded we return invalid messege.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)