### PR TITLE
Fix defect: revoked app still be resumed as FULL.

### DIFF
--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -482,15 +482,19 @@ void ResumeCtrlImpl::StartAppHmiStateResumption(
     LOG4CXX_DEBUG(logger_, "No applicable HMI level found for resuming");
     return;
   }
-
   const bool is_resume_allowed_by_low_voltage =
       CheckLowVoltageRestrictions(saved_app);
 
   const bool is_hmi_level_allowed_by_ign_cycle =
       CheckIgnCycleRestrictions(saved_app);
 
-  const bool restore_hmi_level_allowed =
-      is_resume_allowed_by_low_voltage && is_hmi_level_allowed_by_ign_cycle;
+  const bool is_app_revoked =
+      application_manager_.GetPolicyHandler().IsApplicationRevoked(
+          application->policy_app_id());
+
+  const bool restore_hmi_level_allowed = is_resume_allowed_by_low_voltage &&
+                                         is_hmi_level_allowed_by_ign_cycle &&
+                                         !is_app_revoked;
 
   if (restore_hmi_level_allowed) {
     LOG4CXX_INFO(logger_,

--- a/src/components/application_manager/test/include/application_manager/resumption_data_test.h
+++ b/src/components/application_manager/test/include/application_manager/resumption_data_test.h
@@ -151,7 +151,8 @@ class ResumptionDataTest : public ::testing::Test {
   std::shared_ptr<sync_primitives::Lock> ivilock_ptr_;
   application_manager_test::MockApplicationManagerSettings
       mock_application_manager_settings_;
-  application_manager_test::MockApplicationManager mock_application_manager_;
+  NiceMock<application_manager_test::MockApplicationManager>
+      mock_application_manager_;
   std::shared_ptr<NiceMock<application_manager_test::MockAppExtension> >
       mock_app_extension_;
   std::list<application_manager::AppExtensionPtr> extensions_;

--- a/src/components/application_manager/test/include/application_manager/test_resumption_data_db.h
+++ b/src/components/application_manager/test/include/application_manager/test_resumption_data_db.h
@@ -44,13 +44,16 @@ namespace test {
 namespace components {
 namespace resumption_test {
 
+using ::testing::NiceMock;
+
 class TestResumptionDataDB : public ResumptionDataDB {
  public:
   utils::dbms::SQLDatabase* get_db_handle() {
     return db();
   }
 
-  application_manager_test::MockApplicationManager mock_application_manager_;
+  NiceMock<application_manager_test::MockApplicationManager>
+      mock_application_manager_;
   TestResumptionDataDB(DbStorage db_storage)
       : ResumptionDataDB(db_storage, mock_application_manager_) {}
 };


### PR DESCRIPTION
Fixes #2447 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
Covered by ATF tests.

### Summary
This changes did according to:

In case PolicesManager receives SDL.ActivateApp from HMI AND the Local PT contains the revoked permissions for the named application, PoliciesManager must respond with "isAppPermissionRevoked:true" AND "AppRevokedPermissions" param containing the list of revoked permissions to HMI.

HMI Information: 
If isAppPermissionsRevoked is set to "true", HMI is expected to send a request to SDL to get messages for specified permissions using GetUserFriendlyMessage and notifies user that provided permissions of application were decreased.

If app permissions were reduced after PTU, SDL sends OnAppPermissionChanged (isAppPermissionsRevoked: true) when app is in FULL or LIMITED
SDL doesn't notify HMI about revoked permissions twice

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)