### PR TITLE
Set initialize state for the Interger type

### DIFF
--- a/src/components/rpc_base/include/rpc_base/rpc_base_inl.h
+++ b/src/components/rpc_base/include/rpc_base/rpc_base_inl.h
@@ -186,12 +186,14 @@ Integer<T, minval, maxval>& Integer<T, minval, maxval>::operator=(
 template <typename T, T minval, T maxval>
 Integer<T, minval, maxval>& Integer<T, minval, maxval>::operator++() {
   ++value_;
+  value_state_ = range_.Includes(value_) ? kValid : kInvalid;
   return *this;
 }
 
 template <typename T, T minval, T maxval>
 Integer<T, minval, maxval>& Integer<T, minval, maxval>::operator+=(int value) {
   value_ += value;
+  value_state_ = range_.Includes(value_) ? kValid : kInvalid;
   return *this;
 }
 


### PR DESCRIPTION
Fixes #2440 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
The default constructor of Interger class assigns the min value
for the wrapped variable, hoowever it keeps the initialize state us
`Uninitialized`. So in case when latter user apply such operations as
`++`, `+=` the value will be changed but the state is not.

The commit adds ability to change initialize state for the class
after mentioned operations. So user does not have to call additionaly
`initialize` method.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)