### PR TITLE
Allow empty moduleType array in PT

### DIFF
--- a/src/components/policy/policy_external/include/policy/policy_table/enums.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/enums.h
@@ -173,7 +173,8 @@ enum ModuleType {
   MT_SEAT,
   MT_AUDIO,
   MT_LIGHT,
-  MT_HMI_SETTINGS
+  MT_HMI_SETTINGS,
+  MT_EMPTY
 };
 bool IsValidEnum(ModuleType val);
 const char* EnumToJsonString(ModuleType val);

--- a/src/components/policy/policy_external/src/policy_table/enums.cc
+++ b/src/components/policy/policy_external/src/policy_table/enums.cc
@@ -779,6 +779,8 @@ bool IsValidEnum(ModuleType val) {
       return true;
     case MT_SEAT:
       return true;
+    case MT_EMPTY:
+      return true;
     default:
       return false;
   }
@@ -797,6 +799,8 @@ const char* EnumToJsonString(ModuleType val) {
       return "HMI_SETTINGS";
     case MT_SEAT:
       return "SEAT";
+    case MT_EMPTY:
+      return "EMPTY";
     default:
       return "";
   }
@@ -820,6 +824,9 @@ bool EnumFromJsonString(const std::string& literal, ModuleType* result) {
     return true;
   } else if ("HMI_SETTINGS" == literal) {
     *result = MT_HMI_SETTINGS;
+    return true;
+  } else if ("EMPTY" == literal) {
+    *result = MT_EMPTY;
     return true;
   } else {
     return false;

--- a/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
@@ -761,6 +761,13 @@ bool SQLPTExtRepresentation::SaveSpecificAppPolicy(
   if (!SaveAppGroup(app.first, app.second.groups)) {
     return false;
   }
+
+  bool denied = !app.second.moduleType->is_initialized();
+  if (!SaveRemoteControlDenied(app.first, denied) ||
+      !SaveModuleType(app.first, *app.second.moduleType)) {
+    return false;
+  }
+
   if (!SaveNickname(app.first, *app.second.nicknames)) {
     return false;
   }
@@ -870,6 +877,17 @@ bool SQLPTExtRepresentation::GatherApplicationPoliciesSection(
     if (!GatherAppGroup(app_id, &params.groups)) {
       return false;
     }
+
+    bool denied = false;
+    if (!GatherRemoteControlDenied(app_id, &denied)) {
+      return false;
+    }
+    if (!denied) {
+      if (!GatherModuleType(app_id, &*params.moduleType)) {
+        return false;
+      }
+    }
+
     if (!GatherNickName(app_id, &*params.nicknames)) {
       return false;
     }

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -1740,6 +1740,10 @@ bool SQLPTRepresentation::GatherModuleType(
     if (!policy_table::EnumFromJsonString(query.GetString(0), &type)) {
       return false;
     }
+    if (policy_table::ModuleType::MT_EMPTY == type) {
+      app_types->mark_initialized();
+      continue;
+    }
     app_types->push_back(type);
   }
   return true;
@@ -1772,18 +1776,30 @@ bool SQLPTRepresentation::SaveModuleType(
   }
 
   policy_table::ModuleTypes::const_iterator it;
-  for (it = types.begin(); it != types.end(); ++it) {
-    query.Bind(0, app_id);
-    std::string module(policy_table::EnumToJsonString(*it));
-    query.Bind(1, module);
-    LOG4CXX_DEBUG(logger_,
-                  "Module(app: " << app_id << ", type: " << module << ")");
-    if (!query.Exec() || !query.Reset()) {
-      LOG4CXX_WARN(logger_, "Incorrect insert into module type.");
-      return false;
+  if (!types.empty()) {
+    for (it = types.begin(); it != types.end(); ++it) {
+      query.Bind(0, app_id);
+      std::string module(policy_table::EnumToJsonString(*it));
+      query.Bind(1, module);
+      LOG4CXX_DEBUG(logger_,
+                    "Module(app: " << app_id << ", type: " << module << ")");
+      if (!query.Exec() || !query.Reset()) {
+        LOG4CXX_WARN(logger_, "Incorrect insert into module type.");
+        return false;
+      }
     }
+  } else if (types.is_initialized()) {
+    query.Bind(0, app_id);
+    query.Bind(1,
+               std::string(policy_table::EnumToJsonString(
+                   policy_table::ModuleType::MT_EMPTY)));
+    if (!query.Exec() || !query.Reset()) {
+      LOG4CXX_WARN(logger_, "Incorrect insert into module types.");
+      return false;
+    }    
+  } else {
+    LOG4CXX_WARN(logger_, "Module Type omitted.");
   }
-
   return true;
 }
 

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -1796,7 +1796,7 @@ bool SQLPTRepresentation::SaveModuleType(
     if (!query.Exec() || !query.Reset()) {
       LOG4CXX_WARN(logger_, "Incorrect insert into module types.");
       return false;
-    }    
+    }
   } else {
     LOG4CXX_WARN(logger_, "Module Type omitted.");
   }

--- a/src/components/policy/policy_regular/include/policy/policy_table/enums.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/enums.h
@@ -159,7 +159,8 @@ enum ModuleType {
   MT_SEAT,
   MT_AUDIO,
   MT_LIGHT,
-  MT_HMI_SETTINGS
+  MT_HMI_SETTINGS,
+  MT_EMPTY
 };
 bool IsValidEnum(ModuleType val);
 const char* EnumToJsonString(ModuleType val);

--- a/src/components/policy/policy_regular/src/policy_table/enums.cc
+++ b/src/components/policy/policy_regular/src/policy_table/enums.cc
@@ -649,6 +649,8 @@ bool IsValidEnum(ModuleType val) {
       return true;
     case MT_HMI_SETTINGS:
       return true;
+    case MT_EMPTY:
+      return true;
     default:
       return false;
   }
@@ -667,6 +669,8 @@ const char* EnumToJsonString(ModuleType val) {
       return "LIGHT";
     case MT_HMI_SETTINGS:
       return "HMI_SETTINGS";
+    case MT_EMPTY:
+      return "EMPTY";
     default:
       return "";
   }
@@ -690,6 +694,9 @@ bool EnumFromJsonString(const std::string& literal, ModuleType* result) {
     return true;
   } else if ("HMI_SETTINGS" == literal) {
     *result = MT_HMI_SETTINGS;
+    return true;
+  } else if ("EMPTY" == literal) {
+    *result = MT_EMPTY;
     return true;
   }
   return false;

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -1752,7 +1752,7 @@ bool SQLPTRepresentation::SaveModuleType(
     if (!query.Exec() || !query.Reset()) {
       LOG4CXX_WARN(logger_, "Incorrect insert into module types.");
       return false;
-    }    
+    }
   } else {
     LOG4CXX_WARN(logger_, "Module Type omitted.");
   }


### PR DESCRIPTION
Fixes #2547 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Start Core
Connect app
Perform RC RPC, expect success
Cycle Core and reconnect app
Perform RC RPC, expect success

### Summary
Updates the SQL related code to allow for empty moduleType in the SQL database.  If there is a module type array present in the PT but it is empty, then it will allow all module types. These changes fix an issue where empty moduleType array would work on the initial cycle on core, but would not work on future ignition cycles.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)