### PR TITLE
SDL sends twice UPDATE_NEEDED for invalid PTU

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1089,6 +1089,7 @@ bool PolicyHandler::ReceiveMessageFromSDK(const std::string& file,
         correlation_id, vehicle_data_args, application_manager_);
   } else {
     LOG4CXX_WARN(logger_, "Exchange wasn't successful");
+    policy_manager_->ForcePTExchange();
   }
   OnPTUFinished(ret);
   return ret;


### PR DESCRIPTION
Fixes #2453 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF [test](https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/develop/test_scripts/Policies/Validation_of_PolicyTables/266_ATF_pt_update_validation_rules_optional_parameters_type.lua) 

### Summary
In case when invalid PTU happened SDL notifies system two times with the same status.
It happens because  because wrong method is using to trigger the new update.
`OnPTExchangeNeeded()` method has to be called only during `OnPolicyUpdate` notification
as it immediately notifies the system about current status.
In case of regular update `UpdateStatusManager` is care about system notifying so `PolicyHandler`
has to call ForcePTExchange directly  to start retry

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)