### PR TITLE
SDL does not respond NACK to second request

### DIFF
--- a/src/components/connection_handler/src/connection.cc
+++ b/src/components/connection_handler/src/connection.cc
@@ -220,6 +220,15 @@ bool Connection::AddNewService(uint8_t session_id,
                               << static_cast<int>(service_type));
       return false;
     }
+    if (helpers::Compare<protocol_handler::ServiceType,
+                         helpers::EQ,
+                         helpers::ONE>(
+            service_type,
+            protocol_handler::ServiceType::kAudio,
+            protocol_handler::ServiceType::kMobileNav)) {
+      return false;
+    }
+
     // For unproteced service could be start protection
     return true;
 #else


### PR DESCRIPTION
Fixes #[issue number]

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
   - service is already exists
   - service require the protection
   - service don't protected
   - service_type is Audio (or Video)

in this case SDL starts new protection with the same service_type on the same connection_key but shouldn't.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)