### PR TITLE
fixup! remove struct timeval and use boost time_duration instead

### DIFF
--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1498,7 +1498,7 @@ bool PolicyManagerImpl::ExceededDays() {
 
   date_time::TimeDuration current_time = date_time::getCurrentTime();
   const int kSecondsInDay = 60 * 60 * 24;
-  const int days = current_time.tv_sec / kSecondsInDay;
+  const int days = date_time::getSecs(current_time) / kSecondsInDay;
 
   DCHECK(std::numeric_limits<uint16_t>::max() >= days);
 

--- a/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
@@ -926,7 +926,7 @@ TEST_F(
 uint32_t GetCurrentDaysCount() {
   date_time::TimeDuration current_time = date_time::getCurrentTime();
   const uint32_t kSecondsInDay = 60 * 60 * 24;
-  return current_time.tv_sec / kSecondsInDay;
+  return date_time::getSecs(current_time) / kSecondsInDay;
 }
 
 TEST_F(PolicyManagerImplTest2,

--- a/src/components/policy/policy_external/test/policy_manager_impl_user_consent_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_user_consent_test.cc
@@ -71,7 +71,7 @@ TEST_F(
 
   const date_time::TimeDuration current_time = date_time::getCurrentTime();
   const int kSecondsInDay = 60 * 60 * 24;
-  const int days_after_epoch = current_time.tv_sec / kSecondsInDay;
+  const int days_after_epoch = date_time::getSecs(current_time) / kSecondsInDay;
 
   policy_manager_->PTUpdatedAt(DAYS_AFTER_EPOCH, days_after_epoch);
   policy_manager_->PTUpdatedAt(KILOMETERS, 1000);


### PR DESCRIPTION
Fixes #2403 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
Add missing changes regarding using boost time_duration instead of timeval struct 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)