### PR TITLE
Fix policy DB corruption on ignition cycle

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -201,7 +201,7 @@ class PolicyHandler : public PolicyHandlerInterface,
    */
   uint32_t TimeoutExchangeMSec() const OVERRIDE;
   void OnExceededTimeout() OVERRIDE;
-  void OnSystemReady() OVERRIDE;
+  void OnSystemStateChanged(policy::SystemState state) OVERRIDE;
   void PTUpdatedAt(Counters counter, int value) OVERRIDE;
   void add_listener(PolicyHandlerObserver* listener) OVERRIDE;
   void remove_listener(PolicyHandlerObserver* listener) OVERRIDE;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/basic_communication_on_awake_sdl.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/basic_communication_on_awake_sdl.cc
@@ -75,6 +75,11 @@ void OnAwakeSDLNotification::Run() {
   }
 
   application_manager_.resume_controller().OnAwake();
+
+  event_engine::Event event(
+      hmi_apis::FunctionID::BasicCommunication_OnAwakeSDL);
+  event.set_smart_object(*message_);
+  event.raise(application_manager_.event_dispatcher());
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_exit_all_applications_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_exit_all_applications_notification.cc
@@ -68,6 +68,11 @@ void OnExitAllApplicationsNotification::Run() {
           (*message_)[strings::msg_params][hmi_request::reason].asInt());
   LOG4CXX_DEBUG(logger_, "Reason " << reason);
 
+  event_engine::Event event(
+      hmi_apis::FunctionID::BasicCommunication_OnExitAllApplications);
+  event.set_smart_object(*message_);
+  event.raise(application_manager_.event_dispatcher());
+
   mobile_api::AppInterfaceUnregisteredReason::eType mob_reason =
       mobile_api::AppInterfaceUnregisteredReason::INVALID_ENUM;
 

--- a/src/components/application_manager/src/policies/policy_event_observer.cc
+++ b/src/components/application_manager/src/policies/policy_event_observer.cc
@@ -69,8 +69,24 @@ void PolicyEventObserver::on_event(const event_engine::Event& event) {
       break;
     }
     case hmi_apis::FunctionID::BasicCommunication_OnReady: {
-      policy_handler_->OnSystemReady();
+      policy_handler_->OnSystemStateChanged(policy::SystemState::kStateReady);
       unsubscribe_from_event(hmi_apis::FunctionID::BasicCommunication_OnReady);
+      break;
+    }
+    case hmi_apis::FunctionID::BasicCommunication_OnExitAllApplications: {
+      const hmi_apis::Common_ApplicationsCloseReason::eType reason =
+          static_cast<hmi_apis::Common_ApplicationsCloseReason::eType>(
+              event.smart_object()[strings::msg_params]
+                                  [application_manager::hmi_request::reason]
+                                      .asInt());
+      if (hmi_apis::Common_ApplicationsCloseReason::SUSPEND == reason) {
+        policy_handler_->OnSystemStateChanged(
+            policy::SystemState::kStateSuspended);
+      }
+      break;
+    }
+    case hmi_apis::FunctionID::BasicCommunication_OnAwakeSDL: {
+      policy_handler_->OnSystemStateChanged(policy::SystemState::kStateAwaken);
       break;
     }
     default: { break; }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -392,6 +392,10 @@ bool PolicyHandler::InitPolicyTable() {
   // info necessary for policy table
   event_observer_->subscribe_on_event(
       hmi_apis::FunctionID::BasicCommunication_OnReady);
+  event_observer_->subscribe_on_event(
+      hmi_apis::FunctionID::BasicCommunication_OnExitAllApplications);
+  event_observer_->subscribe_on_event(
+      hmi_apis::FunctionID::BasicCommunication_OnAwakeSDL);
   std::string preloaded_file = get_settings().preloaded_pt_file();
   if (file_system::FileExists(preloaded_file)) {
     return policy_manager_->InitPT(preloaded_file, &get_settings());
@@ -1599,9 +1603,9 @@ void PolicyHandler::OnExceededTimeout() {
   policy_manager_->OnExceededTimeout();
 }
 
-void PolicyHandler::OnSystemReady() {
+void PolicyHandler::OnSystemStateChanged(SystemState state) {
   POLICY_LIB_CHECK_VOID();
-  policy_manager_->OnSystemReady();
+  policy_manager_->OnSystemStateChanged(SystemState::kStateReady);
 }
 
 void PolicyHandler::PTUpdatedAt(Counters counter, int value) {

--- a/src/components/application_manager/test/policy_event_observer_test.cc
+++ b/src/components/application_manager/test/policy_event_observer_test.cc
@@ -89,7 +89,8 @@ class PolicyEventObserverTest : public ::testing::Test {
     EXPECT_CALL(policy_handler_mock_,
                 PTUpdatedAt(Counters::KILOMETERS, field_value))
         .Times(pt_updated_calls_number);
-    EXPECT_CALL(policy_handler_mock_, OnSystemReady())
+    EXPECT_CALL(policy_handler_mock_,
+                OnSystemStateChanged(policy::SystemState::kStateReady))
         .Times(on_system_ready_calls_number);
     policy_event_observer_->on_event(*event_);
   }

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -685,13 +685,14 @@ TEST_F(PolicyHandlerTest, OnExceededTimeout) {
   policy_handler_.OnExceededTimeout();
 }
 
-TEST_F(PolicyHandlerTest, OnSystemReady) {
+TEST_F(PolicyHandlerTest, OnSystemStateChanged_Ready) {
   // Arrange
   EnablePolicyAndPolicyManagerMock();
   // Check expectations
-  EXPECT_CALL(*mock_policy_manager_, OnSystemReady());
+  EXPECT_CALL(*mock_policy_manager_,
+              OnSystemStateChanged(policy::SystemState::kStateReady));
   // Act
-  policy_handler_.OnSystemReady();
+  policy_handler_.OnSystemStateChanged(policy::SystemState::kStateReady);
 }
 
 TEST_F(PolicyHandlerTest, PTUpdatedAt_method_UseCounter_KILOMETERS) {

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -48,6 +48,7 @@
 #include "smart_objects/smart_object.h"
 #include "policy/policy_types.h"
 #include "policy/policy_table/types.h"
+#include "policy/policy_types.h"
 #include "policy/cache_manager_interface.h"
 
 using namespace ::rpc::policy_table_interface_base;
@@ -119,7 +120,7 @@ class PolicyHandlerInterface {
    */
   virtual uint32_t TimeoutExchangeMSec() const = 0;
   virtual void OnExceededTimeout() = 0;
-  virtual void OnSystemReady() = 0;
+  virtual void OnSystemStateChanged(SystemState state) = 0;
   virtual void PTUpdatedAt(Counters counter, int value) = 0;
   virtual void add_listener(PolicyHandlerObserver* listener) = 0;
   virtual void remove_listener(PolicyHandlerObserver* listener) = 0;

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -421,11 +421,11 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual bool CanAppStealFocus(const std::string& app_id) const = 0;
 
   /**
-   * @brief Runs necessary operations, which is depends on external system
-   * state, e.g. getting system-specific parameters which are need to be
-   * filled into policy table
+   * @brief OnSystemStateChanged makes policy manager aware of current system
+   * state, so it can do necessary preparation steps
+   * @param state System state
    */
-  virtual void OnSystemReady() = 0;
+  virtual void OnSystemStateChanged(SystemState state) = 0;
 
   /**
    * @brief Get number of notification by priority

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -412,11 +412,11 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual bool CanAppStealFocus(const std::string& app_id) const = 0;
 
   /**
-   * @brief Runs necessary operations, which is depends on external system
-   * state, e.g. getting system-specific parameters which are need to be
-   * filled into policy table
+   * @brief OnSystemStateChanged makes policy manager aware of current system
+   * state, so it can do necessary preparation steps
+   * @param state System state
    */
-  virtual void OnSystemReady() = 0;
+  virtual void OnSystemStateChanged(SystemState state) = 0;
 
   /**
    * @brief Get number of notification by priority

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -107,7 +107,7 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_CONST_METHOD0(TimeoutExchangeSec, uint32_t());
   MOCK_CONST_METHOD0(TimeoutExchangeMSec, uint32_t());
   MOCK_METHOD0(OnExceededTimeout, void());
-  MOCK_METHOD0(OnSystemReady, void());
+  MOCK_METHOD1(OnSystemStateChanged, void(policy::SystemState));
   MOCK_METHOD2(PTUpdatedAt, void(policy::Counters counter, int value));
   MOCK_METHOD1(add_listener, void(policy::PolicyHandlerObserver* listener));
   MOCK_METHOD1(remove_listener, void(policy::PolicyHandlerObserver* listener));

--- a/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
@@ -250,6 +250,7 @@ class MockCacheManagerInterface : public ::policy::CacheManagerInterface {
   MOCK_METHOD2(OnDeviceSwitching,
                void(const std::string& device_id_from,
                     const std::string& device_id_to));
+  MOCK_METHOD1(OnSystemStateChanged, void(::policy::SystemState));
   MOCK_CONST_METHOD2(GetAppRequestSubTypes,
                      void(const std::string& policy_app_id,
                           std::vector<std::string>& request_subtypes));

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -168,7 +168,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(CleanupUnpairedDevices, bool());
   MOCK_CONST_METHOD1(CanAppKeepContext, bool(const std::string& app_id));
   MOCK_CONST_METHOD1(CanAppStealFocus, bool(const std::string& app_id));
-  MOCK_METHOD0(OnSystemReady, void());
+  MOCK_METHOD1(OnSystemStateChanged, void(policy::SystemState));
   MOCK_CONST_METHOD1(GetNotificationsNumber,
                      uint32_t(const std::string& priority));
   MOCK_METHOD1(SetVINValue, void(const std::string& value));

--- a/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
@@ -213,6 +213,7 @@ class MockCacheManagerInterface : public CacheManagerInterface {
   MOCK_METHOD2(OnDeviceSwitching,
                void(const std::string& device_id_from,
                     const std::string& device_id_to));
+  MOCK_METHOD1(OnSystemStateChanged, void(::policy::SystemState));
   MOCK_CONST_METHOD2(GetAppRequestSubTypes,
                      void(const std::string& policy_app_id,
                           std::vector<std::string>& request_subtypes));

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -166,7 +166,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(CleanupUnpairedDevices, bool());
   MOCK_CONST_METHOD1(CanAppKeepContext, bool(const std::string& app_id));
   MOCK_CONST_METHOD1(CanAppStealFocus, bool(const std::string& app_id));
-  MOCK_METHOD0(OnSystemReady, void());
+  MOCK_METHOD1(OnSystemStateChanged, void(policy::SystemState));
   MOCK_CONST_METHOD1(GetNotificationsNumber,
                      uint32_t(const std::string& priority));
   MOCK_METHOD1(SetVINValue, void(const std::string& value));

--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -735,6 +735,8 @@ class CacheManager : public CacheManagerInterface {
   void OnDeviceSwitching(const std::string& device_id_from,
                          const std::string& device_id_to) OVERRIDE;
 
+  void OnSystemStateChanged(SystemState state) OVERRIDE;
+
  private:
   std::string currentDateTime();
   struct AppHMITypeToString {
@@ -910,6 +912,7 @@ class CacheManager : public CacheManagerInterface {
                 policy_table::PolicyTable& pt);
 
   void InitBackupThread();
+  void StopBackupTread();
 
   /**
    * @brief Processes the PTU process by distinguishing the policy type.

--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -958,6 +958,7 @@ class CacheManager : public CacheManagerInterface {
   sync_primitives::Lock backuper_locker_;
   BackgroundBackuper* backuper_;
   const PolicySettings* settings_;
+  volatile bool is_policy_table_loaded_;
 
   friend class AccessRemoteImpl;
 

--- a/src/components/policy/policy_external/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager_interface.h
@@ -821,6 +821,8 @@ class CacheManagerInterface {
   virtual void OnDeviceSwitching(const std::string& device_id_from,
                                  const std::string& device_id_to) = 0;
 
+  virtual void OnSystemStateChanged(SystemState state) = 0;
+
 #ifdef BUILD_TESTS
   /**
    * @brief GetPT allows to obtain std::shared_ptr to PT.

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -373,11 +373,13 @@ class PolicyManagerImpl : public PolicyManager {
                      const std::string& language) OVERRIDE;
 
   /**
-   * @brief Runs necessary operations, which is depends on external system
-   * state, e.g. getting system-specific parameters which are need to be
-   * filled into policy table
+   * @brief OnSystemStateChanged does preparation steps according to system
+   * state. In case of 'start' state requests information needed by policy
+   * manager from system. In case of 'suspend/awake' starts/stops backup of
+   * data appropiately.
+   * @param state System state
    */
-  void OnSystemReady() OVERRIDE;
+  void OnSystemStateChanged(SystemState state) FINAL;
 
   /**
    * @brief Get number of notification by priority

--- a/src/components/policy/policy_external/include/policy/policy_types.h
+++ b/src/components/policy/policy_external/include/policy/policy_types.h
@@ -531,6 +531,16 @@ enum ConsentPriorityType { kUserConsentPrio, kExternalConsentPrio };
  */
 enum ConsentProcessingPolicy { kTimestampBased, kExternalConsentBased };
 
+/**
+ * @brief The SystemState enum defines possible system state what policy has to
+ * be aware of
+ */
+enum class SystemState : uint32_t {
+  kStateReady,
+  kStateSuspended,
+  kStateAwaken
+};
+
 }  //  namespace policy
 
 #endif  // SRC_COMPONENTS_POLICY_POLICY_EXTERNAL_INCLUDE_POLICY_POLICY_TYPES_H_

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1258,10 +1258,18 @@ void PolicyManagerImpl::SetSystemInfo(const std::string& ccpu_version,
   cache_->SetMetaInfo(ccpu_version, wers_country_code, language);
 }
 
-void PolicyManagerImpl::OnSystemReady() {
-  // Update policy table for the first time with system information
-  if (!cache_->IsMetaInfoPresent()) {
-    listener()->OnSystemInfoUpdateRequired();
+void PolicyManagerImpl::OnSystemStateChanged(SystemState state) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  switch (state) {
+    case SystemState::kStateReady: {
+      // Update policy table for the first time with system information
+      if (!cache_->IsMetaInfoPresent()) {
+        listener()->OnSystemInfoUpdateRequired();
+      }
+    } break;
+    default:
+      cache_->OnSystemStateChanged(state);
+      break;
   }
 }
 

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -193,7 +193,7 @@ TEST_F(PolicyManagerImplTest2, OnSystemReady) {
   CreateLocalPT(preloaded_pt_filename_);
   // Check
   EXPECT_CALL(listener_, OnSystemInfoUpdateRequired());
-  policy_manager_->OnSystemReady();
+  policy_manager_->OnSystemStateChanged(policy::SystemState::kStateReady);
 }
 
 TEST_F(PolicyManagerImplTest2, ResetRetrySequence) {

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -735,6 +735,8 @@ class CacheManager : public CacheManagerInterface {
   void OnDeviceSwitching(const std::string& device_id_from,
                          const std::string& device_id_to) OVERRIDE;
 
+  void OnSystemStateChanged(SystemState state) OVERRIDE;
+
  private:
   std::string currentDateTime();
   struct AppHMITypeToString {
@@ -772,6 +774,8 @@ class CacheManager : public CacheManagerInterface {
   bool IsPermissionsCalculated(const std::string& device_id,
                                const std::string& policy_app_id,
                                policy::Permissions& permission);
+  void InitBackupThread();
+  void StopBackupTread();
 
  private:
   std::shared_ptr<policy_table::Table> pt_;

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -817,6 +817,7 @@ class CacheManager : public CacheManagerInterface {
   sync_primitives::Lock backuper_locker_;
   BackgroundBackuper* backuper_;
   const PolicySettings* settings_;
+  volatile bool is_policy_table_loaded_;
 
 #ifdef BUILD_TESTS
   friend class AccessRemoteImpl;

--- a/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
@@ -684,6 +684,8 @@ class CacheManagerInterface {
    */
   virtual void OnDeviceSwitching(const std::string& device_id_from,
                                  const std::string& device_id_to) = 0;
+
+  virtual void OnSystemStateChanged(SystemState state) = 0;
 };
 
 typedef std::shared_ptr<CacheManagerInterface> CacheManagerInterfaceSPtr;

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -367,11 +367,13 @@ class PolicyManagerImpl : public PolicyManager {
                      const std::string& language) OVERRIDE;
 
   /**
-   * @brief Runs necessary operations, which is depends on external system
-   * state, e.g. getting system-specific parameters which are need to be
-   * filled into policy table
+   * @brief OnSystemStateChanged does preparation steps according to system
+   * state. In case of 'start' state requests information needed by policy
+   * manager from system. In case of 'suspend/awake' starts/stops backup of
+   * data appropiately.
+   * @param state System state
    */
-  void OnSystemReady() OVERRIDE;
+  void OnSystemStateChanged(SystemState state) FINAL;
 
   /**
    * @brief Get number of notification by priority

--- a/src/components/policy/policy_regular/include/policy/policy_types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_types.h
@@ -492,6 +492,16 @@ typedef std::set<std::pair<std::string, PermissionsCheckResult> >
  */
 typedef std::pair<uint32_t, uint32_t> AppIdURL;
 
+/**
+ * @brief The SystemState enum defines possible system state what policy has to
+ * be aware of
+ */
+enum class SystemState : uint32_t {
+  kStateReady,
+  kStateSuspended,
+  kStateAwaken
+};
+
 }  //  namespace policy
 
 #endif  // SRC_COMPONENTS_POLICY_POLICY_EXTERNAL_INCLUDE_POLICY_POLICY_TYPES_H_

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -787,11 +787,18 @@ void PolicyManagerImpl::SetSystemInfo(const std::string& ccpu_version,
   LOG4CXX_AUTO_TRACE(logger_);
 }
 
-void PolicyManagerImpl::OnSystemReady() {
-  // Update policy table for the first time with system information
-  if (cache_->IsPTPreloaded()) {
-    listener()->OnSystemInfoUpdateRequired();
-    return;
+void PolicyManagerImpl::OnSystemStateChanged(SystemState state) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  switch (state) {
+    case SystemState::kStateReady: {
+      // Update policy table for the first time with system information
+      if (cache_->IsPTPreloaded()) {
+        listener()->OnSystemInfoUpdateRequired();
+      }
+    } break;
+    default:
+      cache_->OnSystemStateChanged(state);
+      break;
   }
 }
 

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -871,7 +871,7 @@ TEST_F(PolicyManagerImplTest2, OnSystemReady) {
   CreateLocalPT("sdl_preloaded_pt.json");
   // Check
   EXPECT_CALL(listener, OnSystemInfoUpdateRequired());
-  manager->OnSystemReady();
+  manager->OnSystemStateChanged(policy::SystemState::kStateReady);
 }
 
 TEST_F(PolicyManagerImplTest2, ResetRetrySequence) {


### PR DESCRIPTION
Fixes #2467

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
Due to data races on ignition on because of SDL starts getting messages in the middle of policy initialization and on ignition off because of backup thread wasn't stopped after OnSDLPersistenceComplete policy database was occasionally corrupting.
In order to prevent that handling of SUSPEND/AWAKE signals has been added as well as policy loading state check in ignition on.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)