### PR TITLE
Avoid deadlock in delete buttons

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -598,7 +598,6 @@ class MessageHelper {
    */
   static bool SendStopAudioPathThru(ApplicationManager& app_mngr);
 
-
   /**
    * @brief Sends UnsubscribeWayPoints request
    * @return true if UnSubscribedWayPoints is send otherwise false

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -737,7 +737,7 @@ void FinishSendingRegisterAppInterfaceToMobile(
 
   if (msg_params.keyExists(strings::app_hmi_type)) {
     policy_handler.SetDefaultHmiTypes(application->policy_app_id(),
-                                       &(msg_params[strings::app_hmi_type]));
+                                      &(msg_params[strings::app_hmi_type]));
   }
 
   // Default HMI level should be set before any permissions validation, since it

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -775,12 +775,14 @@ const AppFile* ApplicationImpl::GetFile(const std::string& file_name) {
 
 bool ApplicationImpl::SubscribeToButton(
     mobile_apis::ButtonName::eType btn_name) {
+  LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(button_lock_ptr_);
   return subscribed_buttons_.insert(btn_name).second;
 }
 
 bool ApplicationImpl::IsSubscribedToButton(
     mobile_apis::ButtonName::eType btn_name) {
+  LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(button_lock_ptr_);
   std::set<mobile_apis::ButtonName::eType>::iterator it =
       subscribed_buttons_.find(btn_name);
@@ -789,6 +791,7 @@ bool ApplicationImpl::IsSubscribedToButton(
 
 bool ApplicationImpl::UnsubscribeFromButton(
     mobile_apis::ButtonName::eType btn_name) {
+  LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(button_lock_ptr_);
   return subscribed_buttons_.erase(btn_name);
 }

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -595,18 +595,16 @@ void ResumptionDataProcessor::DeleteSubscriptions(const int32_t app_id) {
 void ResumptionDataProcessor::DeleteButtonsSubscriptions(
     ApplicationSharedPtr application) {
   LOG4CXX_AUTO_TRACE(logger_);
-  DataAccessor<ButtonSubscriptions> button_accessor =
-      application->SubscribedButtons();
-  ButtonSubscriptions button_subscriptions = button_accessor.GetData();
-  while (!button_subscriptions.empty()) {
-    auto btn = button_subscriptions.begin();
+  ButtonSubscriptions button_subscriptions =
+      application->SubscribedButtons().GetData();
+  for (auto btn : button_subscriptions) {
+    const auto hmi_btn = static_cast<hmi_apis::Common_ButtonName::eType>(btn);
     MessageHelper::SendOnButtonSubscriptionNotification(
         application->hmi_app_id(),
-        static_cast<hmi_apis::Common_ButtonName::eType>(*btn),
+        hmi_btn,
         /*is_subscribed = */ false,
         application_manager_);
-    application->UnsubscribeFromButton(
-        static_cast<mobile_apis::ButtonName::eType>(*btn));
+    application->UnsubscribeFromButton(btn);
   }
 
   MessageHelper::SendOnButtonSubscriptionNotification(

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -83,9 +83,9 @@ void ResumptionDataProcessor::on_event(const event_engine::Event& event) {
   ResumptionRequestIDs request_ids;
   request_ids.function_id = event.id();
   request_ids.correlation_id = event.smart_object_correlation_id();
-  //TODO i suppose it can be optimised with moving app id into
-  //ResumptionRequest struct, so that we don't have to perform
-  //basically the same search twice
+  // TODO i suppose it can be optimised with moving app id into
+  // ResumptionRequest struct, so that we don't have to perform
+  // basically the same search twice
   auto predicate =
       [&event](const std::pair<ResumptionRequestIDs, std::uint32_t>& item) {
         return item.first.function_id == event.id() &&
@@ -93,9 +93,7 @@ void ResumptionDataProcessor::on_event(const event_engine::Event& event) {
       };
 
   auto app_id_ptr =
-      std::find_if(request_app_ids_.begin(),
-                   request_app_ids_.end(),
-                   predicate);
+      std::find_if(request_app_ids_.begin(), request_app_ids_.end(), predicate);
 
   if (app_id_ptr == request_app_ids_.end()) {
     LOG4CXX_ERROR(logger_,
@@ -140,7 +138,7 @@ void ResumptionDataProcessor::on_event(const event_engine::Event& event) {
 
   const hmi_apis::Common_Result::eType result_code =
       static_cast<hmi_apis::Common_Result::eType>(
-      response[strings::params][application_manager::hmi_response::code]
+          response[strings::params][application_manager::hmi_response::code]
               .asInt());
 
   if (result_code == hmi_apis::Common_Result::SUCCESS) {
@@ -516,12 +514,11 @@ void ResumptionDataProcessor::AddWayPointsSubscription(
       saved_app[strings::subscribed_for_way_points].asBool();
   if (subscribed_for_way_points_so) {
     application_manager_.SubscribeAppForWayPoints(application);
-    auto subscribe_waypoints_msg =
-        MessageHelper::CreateMessageForHMI(
-          hmi_apis::FunctionID::Navigation_SubscribeWayPoints,
-          application_manager_.GetNextHMICorrelationID());
-    (*subscribe_waypoints_msg)[strings::params][strings::message_type] = 
-    hmi_apis::messageType::request;
+    auto subscribe_waypoints_msg = MessageHelper::CreateMessageForHMI(
+        hmi_apis::FunctionID::Navigation_SubscribeWayPoints,
+        application_manager_.GetNextHMICorrelationID());
+    (*subscribe_waypoints_msg)[strings::params][strings::message_type] =
+        hmi_apis::messageType::request;
     ProcessHMIRequest(subscribe_waypoints_msg, true);
   }
 }


### PR DESCRIPTION
Reduce the scope of ButtonSubscriptions to avoid Deadlock un function ApplicationManager::UnsubscribeFromButton