### PR TITLE
Fix/restore vehicle info subscriptions

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -506,6 +506,13 @@ void RegisterAppInterfaceRequest::Run() {
   SendSubscribeCustomButtonNotification();
   SendChangeRegistrationOnHMI(application);
 
+  std::function<void(plugin_manager::RPCPlugin&)> on_app_registered =
+      [application](plugin_manager::RPCPlugin& plugin) {
+        plugin.OnApplicationEvent(plugin_manager::kApplicationRegistered,
+                                  application);
+      };
+  application_manager_.GetPluginManager().ForEachPlugin(on_app_registered);
+
   if (DataResumeResult::RESUME_DATA == resume_data_result) {
     auto& resume_ctrl = application_manager_.resume_controller();
     const auto& msg_params = (*message_)[strings::msg_params];

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
@@ -97,6 +97,7 @@ void VehicleInfoAppExtension::SaveResumptionData(
 void VehicleInfoAppExtension::ProcessResumption(
     const smart_objects::SmartObject& saved_app,
     resumption::Subscriber subscriber) {
+  LOG4CXX_AUTO_TRACE(logger_);
   if (!saved_app.keyExists(strings::application_subscriptions)) {
     LOG4CXX_DEBUG(logger_, "application_subscriptions section is not exists");
     return;
@@ -118,7 +119,9 @@ void VehicleInfoAppExtension::ProcessResumption(
             (subscriptions_ivi[i]).asInt());
     subscribeToVehicleInfo(ivi);
   }
-  plugin_.ProcessResumptionSubscription(app_, *this, subscriber);
+  if (subscriptions_ivi.length() > 0) {
+    plugin_.ProcessResumptionSubscription(app_, *this, subscriber);
+  }
 }
 
 void VehicleInfoAppExtension::RevertResumption(

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -74,6 +74,7 @@ void VehicleInfoPlugin::OnPolicyEvent(plugins::PolicyEvent event) {}
 void VehicleInfoPlugin::OnApplicationEvent(
     plugins::ApplicationEvent event,
     app_mngr::ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
   if (plugins::ApplicationEvent::kApplicationRegistered == event) {
     application->AddExtension(
         std::make_shared<VehicleInfoAppExtension>(*this, *application));
@@ -90,7 +91,7 @@ void VehicleInfoPlugin::ProcessResumptionSubscription(
 
   resumption::ResumptionRequest resumption_request;
   resumption_request.request_ids.correlation_id =
-      (*request)[strings::msg_params][strings::correlation_id].asInt();
+      (*request)[strings::params][strings::correlation_id].asInt();
   resumption_request.request_ids.function_id =
       hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData;
   resumption_request.message = *request;
@@ -114,7 +115,6 @@ smart_objects::SmartObjectSPtr VehicleInfoPlugin::CreateSubscriptionRequest(
   LOG4CXX_AUTO_TRACE(logger_);
   smart_objects::SmartObject msg_params =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
-  msg_params[strings::app_id] = app_id;
   const auto& subscriptions = ext.Subscriptions();
   for (auto& ivi_data : application_manager::MessageHelper::vehicle_data()) {
     mobile_apis::VehicleDataType::eType type_id = ivi_data.second;
@@ -123,11 +123,13 @@ smart_objects::SmartObjectSPtr VehicleInfoPlugin::CreateSubscriptionRequest(
       msg_params[key_name] = subscribe_status == SUBSCRIBE;
     }
   }
+
   smart_objects::SmartObjectSPtr request =
       application_manager::MessageHelper::CreateModuleInfoSO(
           hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData,
           *application_manager_);
   (*request)[strings::msg_params] = msg_params;
+  (*request)[strings::params][strings::app_id] = app_id;
 
   return request;
 }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -375,12 +375,6 @@ void ApplicationManagerImpl::OnApplicationRegistered(ApplicationSharedPtr app) {
   const mobile_apis::HMILevel::eType default_level = GetDefaultHmiLevel(app);
   state_ctrl_.OnApplicationRegistered(app, default_level);
 
-  std::function<void(plugin_manager::RPCPlugin&)> on_app_registered =
-      [app](plugin_manager::RPCPlugin& plugin) {
-        plugin.OnApplicationEvent(plugin_manager::kApplicationRegistered, app);
-      };
-  plugin_manager_->ForEachPlugin(on_app_registered);
-
   // TODO(AOleynik): Is neccessary to be able to know that registration process
   // has been completed and default HMI level is set, otherwise policy will
   // block all the requests/notifications to mobile

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -604,7 +604,8 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToIVI) {
   EXPECT_TRUE(res);
 }
 
-TEST_F(ResumeCtrlTest, DISABLED_StartResumption_AppWithSubscriptionToWayPoints) {
+TEST_F(ResumeCtrlTest,
+       DISABLED_StartResumption_AppWithSubscriptionToWayPoints) {
   smart_objects::SmartObject saved_app;
   saved_app[application_manager::strings::hash_id] = kHash_;
   saved_app[application_manager::strings::grammar_id] = kTestGrammarId_;


### PR DESCRIPTION
Register plugins of application before resumption

Move app_id and corr_id to `params` of the request but not in `msg_params`
Avoid sending SubscribeVehicleData during resumption in case if no vehicle data restored 