### PR TITLE
Add additional check for non-manadatory parameters

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/put_file_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/put_file_request.cc
@@ -302,18 +302,16 @@ void PutFileRequest::SendOnPutFileNotification() {
   smart_objects::SmartObjectSPtr notification =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-
   smart_objects::SmartObject& message = *notification;
   message[strings::params][strings::function_id] =
       hmi_apis::FunctionID::BasicCommunication_OnPutFile;
-
   message[strings::params][strings::message_type] = MessageType::kNotification;
   message[strings::msg_params][strings::app_id] = connection_key();
   message[strings::msg_params][strings::sync_file_name] = sync_file_name_;
   message[strings::msg_params][strings::offset] = offset_;
-  if (0 == offset_) {
-    message[strings::msg_params][strings::file_size] =
-        (*message_)[strings::msg_params][strings::length];
+  if (0 == offset_ &&
+      !(*message_)[strings::msg_params].keyExists(strings::length)) {
+    message[strings::msg_params][strings::file_size] = length_;
   }
   message[strings::msg_params][strings::length] = length_;
   message[strings::msg_params][strings::persistent_file] = is_persistent_file_;


### PR DESCRIPTION
Fixes #2443 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF script - https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2020

### Summary
The OnPutFile notification has non mandatory parameters
`fileSize` and `length`. If the mobile application has no provided
appropriate parameters SDL sends `fileSize`: null as json value to HMI.

The commit fixes the issue and simply remove non mandatory parameter in
case mobile app sends nothing for one.

### Tasks Remaining:
- [x] fix implementation
- [x] atf script

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)