### PR TITLE
Fix/fix sdl crash on boot

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1036,6 +1036,10 @@ class ApplicationManagerImpl
    */
   protocol_handler::MajorProtocolVersion SupportedSDLVersion() const OVERRIDE;
 
+  hmi_apis::HMI_API& hmi_so_factory() const OVERRIDE;
+
+  mobile_apis::MOBILE_API& mobile_so_factory() const OVERRIDE;
+
  private:
   /**
    * @brief PullLanguagesInfo allows to pull information about languages.
@@ -1072,9 +1076,6 @@ class ApplicationManagerImpl
    */
   bool CompareAppHMIType(const smart_objects::SmartObject& from_policy,
                          const smart_objects::SmartObject& from_application);
-
-  hmi_apis::HMI_API& hmi_so_factory();
-  mobile_apis::MOBILE_API& mobile_so_factory();
 
   bool ConvertSOtoMessage(const smart_objects::SmartObject& message,
                           Message& output);

--- a/src/components/application_manager/include/application_manager/rpc_handler_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_handler_impl.h
@@ -168,8 +168,7 @@ class RPCHandlerImpl : public RPCHandler,
   // Thread that pumps messages coming from HMI.
   impl::FromHmiQueue messages_from_hmi_;
 
-  ns_smart_device_link_rpc::V1::v4_protocol_v1_2_no_extra
-      v4_protocol_so_factory_;
+  ns_smart_device_link_rpc::V1::v4_protocol_v1_2_no_extra smart_schema_factory_;
 #ifdef TELEMETRY_MONITOR
   AMTelemetryObserver* metric_observer_;
 #endif  // TELEMETRY_MONITOR

--- a/src/components/application_manager/include/application_manager/rpc_handler_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_handler_impl.h
@@ -161,8 +161,6 @@ class RPCHandlerImpl : public RPCHandler,
                           smart_objects::SmartObject& output);
   std::shared_ptr<Message> ConvertRawMsgToMessage(
       const ::protocol_handler::RawMessagePtr message);
-  hmi_apis::HMI_API& hmi_so_factory();
-  mobile_apis::MOBILE_API& mobile_so_factory();
 
   ApplicationManager& app_manager_;
   // Thread that pumps messages coming from mobile side.
@@ -170,8 +168,8 @@ class RPCHandlerImpl : public RPCHandler,
   // Thread that pumps messages coming from HMI.
   impl::FromHmiQueue messages_from_hmi_;
 
-  hmi_apis::HMI_API hmi_so_factory_;
-  mobile_apis::MOBILE_API mobile_so_factory_;
+  ns_smart_device_link_rpc::V1::v4_protocol_v1_2_no_extra
+      v4_protocol_so_factory_;
 #ifdef TELEMETRY_MONITOR
   AMTelemetryObserver* metric_observer_;
 #endif  // TELEMETRY_MONITOR

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -371,7 +371,7 @@ bool RPCHandlerImpl::ConvertMessageToSO(
 
           smart_objects::SmartObjectSPtr msg_to_send =
               std::make_shared<smart_objects::SmartObject>(output);
-          v4_protocol_so_factory_.attachSchema(*msg_to_send, false);
+          smart_schema_factory_.attachSchema(*msg_to_send, false);
           app_manager_.GetRPCService().SendMessageToMobile(msg_to_send);
           return false;
         }

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -51,6 +51,9 @@
 #include "application_manager/hmi_interfaces.h"
 #include "policy/policy_types.h"
 #include "application_manager/plugin_manager/rpc_plugin_manager.h"
+#include "interfaces/HMI_API_schema.h"
+#include "interfaces/MOBILE_API_schema.h"
+
 namespace resumption {
 class LastState;
 }
@@ -726,6 +729,18 @@ class ApplicationManager {
   virtual bool IsSOStructValid(
       const hmi_apis::StructIdentifiers::eType struct_id,
       const smart_objects::SmartObject& display_capabilities) = 0;
+
+  /**
+   * @brief Function returns reference to HMI factory instance.
+   * @return Reference to HMI factory instance.
+   */
+  virtual hmi_apis::HMI_API& hmi_so_factory() const = 0;
+
+  /**
+   * @brief Function returns reference to MOBILE factory instance.
+   * @return Reference to MOBILE factory instance.
+   */
+  virtual mobile_apis::MOBILE_API& mobile_so_factory() const = 0;
 };
 
 }  // namespace application_manager

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -310,6 +310,8 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD0(GetCommandFactory, application_manager::CommandFactory&());
   MOCK_CONST_METHOD0(get_current_audio_source, uint32_t());
   MOCK_METHOD1(set_current_audio_source, void(const uint32_t));
+  MOCK_CONST_METHOD0(hmi_so_factory, hmi_apis::HMI_API&());
+  MOCK_CONST_METHOD0(mobile_so_factory, mobile_apis::MOBILE_API&());
 };
 
 }  // namespace application_manager_test


### PR DESCRIPTION
Fixes #2569

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
Manual testing.

### Summary
The root cause of the core crash could be related to lazy initialization of the HMI/Mobile API classes.
These classes are initializated on demand when some of threads are trying to get the object of that class first time. Most likely at SDL start could be a situation when HMI/Mobile API classes are constructing in one thread
and at that moment another thread is trying to get access to the inner data of not-yet-fully-constructed object and this causes a core crash with ~ISchemaItem() calls in stack trace.

In this PR initialization of HMI/Mobile/V4 classes were moved to AM ctor and were removed useless getters.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)