### PR TITLE
Set proper function id in removeHMIFakeParameters

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -553,7 +553,8 @@ class ApplicationManagerImpl
   void StartDevicesDiscovery();
 
   void RemoveHMIFakeParameters(
-      application_manager::commands::MessageSharedPtr& message) OVERRIDE;
+      application_manager::commands::MessageSharedPtr& message,
+      const hmi_apis::FunctionID::eType& function_id) OVERRIDE;
 
   /**
    * @brief TerminateRequest forces termination of request

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
@@ -488,7 +488,8 @@ void SetInteriorVehicleDataRequest::Execute() {
       CutOffReadOnlyParams(module_data);
     }
 
-    application_manager_.RemoveHMIFakeParameters(message_);
+    application_manager_.RemoveHMIFakeParameters(
+        message_, hmi_apis::FunctionID::RC_SetInteriorVehicleData);
 
     app_mngr::ApplicationSharedPtr app =
         application_manager_.application(connection_key());

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
@@ -184,7 +184,7 @@ TEST_F(
   EXPECT_CALL(mock_hmi_capabilities_, rc_capability())
       .WillOnce(Return(nullptr));
 
-  EXPECT_CALL(app_mngr_, RemoveHMIFakeParameters(_));
+  EXPECT_CALL(app_mngr_, RemoveHMIFakeParameters(_, _));
 
   EXPECT_CALL(
       mock_rpc_service_,

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1693,10 +1693,21 @@ void ApplicationManagerImpl::TerminateRequest(const uint32_t connection_key,
 }
 
 void ApplicationManagerImpl::RemoveHMIFakeParameters(
-    application_manager::commands::MessageSharedPtr& message) {
+    application_manager::commands::MessageSharedPtr& message,
+    const hmi_apis::FunctionID::eType& function_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   hmi_apis::HMI_API factory;
+  if (!(*message)[jhs::S_PARAMS].keyExists(jhs::S_FUNCTION_ID)) {
+    LOG4CXX_ERROR(logger_,
+                  "RemoveHMIFakeParameters message missing function id");
+    return;
+  }
+  mobile_apis::FunctionID::eType mobile_function_id =
+      static_cast<mobile_apis::FunctionID::eType>(
+          (*message)[jhs::S_PARAMS][jhs::S_FUNCTION_ID].asInt());
+  (*message)[jhs::S_PARAMS][jhs::S_FUNCTION_ID] = function_id;
   factory.attachSchema(*message, true);
+  (*message)[jhs::S_PARAMS][jhs::S_FUNCTION_ID] = mobile_function_id;
 }
 
 bool ApplicationManagerImpl::Init(resumption::LastState& last_state,

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -316,7 +316,8 @@ class ApplicationManager {
   virtual const std::set<int32_t> GetAppsSubscribedForWayPoints() const = 0;
 
   virtual void RemoveHMIFakeParameters(
-      application_manager::commands::MessageSharedPtr& message) = 0;
+      application_manager::commands::MessageSharedPtr& message,
+      const hmi_apis::FunctionID::eType& function_id) = 0;
 
   virtual mobile_api::HMILevel::eType GetDefaultHmiLevel(
       ApplicationConstSharedPtr application) const = 0;

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -124,8 +124,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
       void(const std::shared_ptr<application_manager::Application> app));
   MOCK_METHOD1(SendDriverDistractionState,
                void(application_manager::ApplicationSharedPtr app));
-  MOCK_METHOD1(RemoveHMIFakeParameters,
-               void(application_manager::commands::MessageSharedPtr& message));
+  MOCK_METHOD2(RemoveHMIFakeParameters,
+               void(application_manager::commands::MessageSharedPtr& message,
+                    const hmi_apis::FunctionID::eType& function_id));
   MOCK_CONST_METHOD1(
       GetDefaultHmiLevel,
       mobile_apis::HMILevel::eType(


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF RC tests.

### Summary
Adds a functionId parameter to "removeHMIFakeParameters". There was an issue where the mobile SetInteriorVehicleData functionID was not the same as the hmi api InteriorVehicleData functionID. This caused all moduleData parameters to be removed from the message.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)