### PR TITLE
Rework usage of PrintSmartObject function

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -700,6 +700,14 @@ class MessageHelper {
       ApplicationSharedPtr app,
       int32_t function_id);
 
+  /**
+   * @brief Prints SmartObject contents to log file
+   * @param object - SmartObject to print
+   * @return always True as this function is used for internal debug purposes
+   * only
+   * @note Function prints SmartObject only in DEBUG build mode. There will not
+   * be any print in RELEASE build mode
+   */
   static bool PrintSmartObject(const smart_objects::SmartObject& object);
 
   template <typename From, typename To>

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1305,9 +1305,7 @@ bool ApplicationManagerImpl::StartNaviService(
         return false;
       } else if (!converted_params.empty()) {
         LOG4CXX_INFO(logger_, "Sending video configuration params");
-#ifdef DEBUG
         MessageHelper::PrintSmartObject(converted_params);
-#endif
         bool request_sent =
             application(app_id)->SetVideoConfig(service_type, converted_params);
         if (request_sent) {

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2221,11 +2221,7 @@ void MessageHelper::SendSystemRequestNotification(
       commands::CommandImpl::protocol_version_;
 
   content[strings::params][strings::connection_key] = connection_key;
-
-#ifdef DEBUG
   PrintSmartObject(content);
-#endif
-
   DCHECK(app_mngr.GetRPCService().ManageMobileCommand(
       std::make_shared<smart_objects::SmartObject>(content),
       commands::Command::SOURCE_SDL));
@@ -2876,11 +2872,12 @@ void MessageHelper::SubscribeApplicationToSoftButton(
 }
 
 bool MessageHelper::PrintSmartObject(const smart_objects::SmartObject& object) {
+#ifdef DEBUG
   Json::Value tmp;
   namespace Formatters = ns_smart_device_link::ns_json_handler::formatters;
   Formatters::CFormatterJsonBase::objToJsonValue(object, tmp);
   LOG4CXX_DEBUG(logger_, "SMART OBJECT: " << tmp.toStyledString());
-
+#endif
   return true;
 }
 

--- a/src/components/application_manager/src/rpc_service_impl.cc
+++ b/src/components/application_manager/src/rpc_service_impl.cc
@@ -71,9 +71,8 @@ bool RPCServiceImpl::ManageMobileCommand(
     LOG4CXX_WARN(logger_, "Low Voltage is active");
     return false;
   }
-#ifdef DEBUG
+
   MessageHelper::PrintSmartObject(*message);
-#endif
 
   const uint32_t connection_key = static_cast<uint32_t>(
       (*message)[strings::params][strings::connection_key].asUInt());


### PR DESCRIPTION
Set SmartObject contents to be printed in DEBUG build mode only

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
There is nothing to test as this function is used for internal purposes only. 
It does not affect any SDL functionality.

### Summary
Removed redundant wrappers `#IFDEF DEBUG` from all PrintSmartObject() function calls 
as this wrapper was  implemented inside function body. Therefore all other wrappers became redundant.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)