### PR TITLE
Fixed behavior when request from HMI received with invalid parameters.

### DIFF
--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -338,6 +338,14 @@ bool RPCHandlerImpl::ConvertMessageToSO(
         output[strings::params][hmi_response::code] =
             hmi_apis::Common_Result::INVALID_DATA;
         output[strings::msg_params][strings::info] = rpc::PrettyFormat(report);
+
+        smart_objects::SmartObjectSPtr msg_to_send =
+            std::make_shared<smart_objects::SmartObject>(output);
+
+        (*msg_to_send)[strings::params][strings::message_type] =
+            hmi_apis::messageType::response;
+
+        app_manager_.GetRPCService().SendMessageToHMI(msg_to_send);
         return false;
       }
       break;


### PR DESCRIPTION
Fixes: #1866 #1867 #1868
 
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Added sending INVALID_DATA response to HMI in case when request with:
1. missed mandatory params;
2. wrong type of parameters;
3. empty string parameter.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)