### PR TITLE
Fix EndService being sent to the wrong connection

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -589,6 +589,18 @@ class Application : public virtual InitialApplicationData,
    * @return flag tts_properties_in_full
    */
   virtual bool tts_properties_in_full() = 0;
+  /**
+   * @brief sets true if application should keep it's HMI Level after an audio
+   * source change
+   * @param value of keep context
+   */
+  virtual void set_keep_context(bool keep_context) = 0;
+  /**
+   * @brief  returns true if application should keep keep it's HMI Level after
+   * an audio source change, otherwise return false
+   * @return value of keep_context flag
+   */
+  virtual bool keep_context() = 0;
   virtual void set_version(const Version& version) = 0;
   virtual void set_name(const custom_str::CustomString& name) = 0;
   virtual void set_is_media_application(bool is_media) = 0;

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -177,6 +177,8 @@ class ApplicationImpl : public virtual Application,
   bool tts_properties_in_none();
   void set_tts_properties_in_full(bool active);
   bool tts_properties_in_full();
+  void set_keep_context(bool keep_context);
+  bool keep_context();
   void set_version(const Version& ver);
   void set_name(const custom_str::CustomString& name);
   void set_is_media_application(bool is_media);
@@ -481,6 +483,7 @@ class ApplicationImpl : public virtual Application,
   bool has_been_activated_;
   bool tts_properties_in_none_;
   bool tts_properties_in_full_;
+  bool keep_context_;
   bool is_foreground_;
   bool is_application_data_changed_;
   uint32_t put_file_in_none_count_;

--- a/src/components/application_manager/include/application_manager/hmi_state.h
+++ b/src/components/application_manager/include/application_manager/hmi_state.h
@@ -368,6 +368,9 @@ class AudioSource : public HmiState {
       const OVERRIDE {
     return mobile_apis::VideoStreamingState::NOT_STREAMABLE;
   }
+
+ private:
+  bool keep_context_;
 };
 
 /**

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -116,6 +116,7 @@ ApplicationImpl::ApplicationImpl(
     , has_been_activated_(false)
     , tts_properties_in_none_(false)
     , tts_properties_in_full_(false)
+    , keep_context_(false)
     , is_foreground_(false)
     , is_application_data_changed_(false)
     , put_file_in_none_count_(0)
@@ -436,6 +437,14 @@ void ApplicationImpl::set_tts_properties_in_full(bool active) {
 
 bool ApplicationImpl::tts_properties_in_full() {
   return tts_properties_in_full_;
+}
+
+void ApplicationImpl::set_keep_context(bool keep_context) {
+  keep_context_ = keep_context;
+}
+
+bool ApplicationImpl::keep_context() {
+  return keep_context_;
 }
 
 void ApplicationImpl::set_video_streaming_approved(bool state) {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2698,7 +2698,7 @@ void ApplicationManagerImpl::OnAppStreaming(
     media_manager_->StartStreaming(app_id, service_type);
   } else {
     media_manager_->StopStreaming(app_id, service_type);
-    state_ctrl_.OnVideoStreamingStarted(app);
+    state_ctrl_.OnVideoStreamingStopped(app);
   }
 }
 

--- a/src/components/application_manager/src/hmi_state.cc
+++ b/src/components/application_manager/src/hmi_state.cc
@@ -207,9 +207,6 @@ mobile_apis::HMILevel::eType AudioSource::hmi_level() const {
   if (mobile_apis::HMILevel::HMI_NONE == parent()->hmi_level()) {
     return mobile_apis::HMILevel::HMI_NONE;
   }
-  if (mobile_apis::HMILevel::HMI_FULL == parent()->hmi_level()) {
-    return mobile_apis::HMILevel::HMI_FULL;
-  }
 
   return mobile_apis::HMILevel::HMI_BACKGROUND;
 }

--- a/src/components/application_manager/src/hmi_state.cc
+++ b/src/components/application_manager/src/hmi_state.cc
@@ -199,13 +199,17 @@ mobile_apis::HMILevel::eType DeactivateHMI::hmi_level() const {
 
 AudioSource::AudioSource(std::shared_ptr<Application> app,
                          const ApplicationManager& app_mngr)
-    : HmiState(app, app_mngr, STATE_ID_AUDIO_SOURCE) {}
+    : HmiState(app, app_mngr, STATE_ID_AUDIO_SOURCE)
+    , keep_context_(app->keep_context()) {
+  app_->set_keep_context(false);
+}
 
 mobile_apis::HMILevel::eType AudioSource::hmi_level() const {
   // Checking for NONE  is necessary to avoid issue during
   // calculation of HMI level during setting default HMI level
-  if (mobile_apis::HMILevel::HMI_NONE == parent()->hmi_level()) {
-    return mobile_apis::HMILevel::HMI_NONE;
+  if (keep_context_ ||
+      mobile_apis::HMILevel::HMI_NONE == parent()->hmi_level()) {
+    return parent()->hmi_level();
   }
 
   return mobile_apis::HMILevel::HMI_BACKGROUND;

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -118,6 +118,8 @@ class MockApplication : public ::application_manager::Application {
   MOCK_METHOD0(tts_properties_in_none, bool());
   MOCK_METHOD1(set_tts_properties_in_full, void(bool active));
   MOCK_METHOD0(tts_properties_in_full, bool());
+  MOCK_METHOD1(set_keep_context, void(bool keep_context));
+  MOCK_METHOD0(keep_context, bool());
   MOCK_METHOD1(set_version,
                void(const ::application_manager::Version& version));
   MOCK_METHOD1(set_name, void(const custom_str::CustomString& name));

--- a/src/components/application_manager/test/state_controller/state_controller_test.cc
+++ b/src/components/application_manager/test/state_controller/state_controller_test.cc
@@ -2830,7 +2830,8 @@ TEST_F(StateControllerImplTest,
   state_ctrl_->SetRegularState(navi_app_, hmi_state, true);
 }
 
-TEST_F(StateControllerImplTest, OnEventChangedAudioSourceAppRemainInFull) {
+TEST_F(StateControllerImplTest,
+       OnEventChangedAudioSource_KeepContext_AppRemainInFull) {
   const uint32_t app_id = simple_app_->app_id();
   InsertApplication(simple_app_);
   smart_objects::SmartObject msg;
@@ -2849,11 +2850,14 @@ TEST_F(StateControllerImplTest, OnEventChangedAudioSourceAppRemainInFull) {
                      mobile_apis::AudioStreamingState::AUDIBLE,
                      mobile_apis::VideoStreamingState::NOT_STREAMABLE,
                      mobile_apis::SystemContext::SYSCTXT_MAIN);
+
+  EXPECT_CALL(*simple_app_ptr_, keep_context()).WillOnce(Return(true));
   EXPECT_CALL(*simple_app_ptr_, RegularHmiState()).WillOnce(Return(state));
   EXPECT_CALL(*simple_app_ptr_, IsAudioApplication())
       .WillRepeatedly(Return(true));
   EXPECT_CALL(*simple_app_ptr_, CurrentHmiState())
       .WillOnce(Return(FullAudibleState()));
+  EXPECT_CALL(*simple_app_ptr_, set_keep_context(false));
 
   HmiStatePtr new_state;
   EXPECT_CALL(*simple_app_ptr_, AddHMIState(_))

--- a/src/components/include/connection_handler/connection_handler.h
+++ b/src/components/include/connection_handler/connection_handler.h
@@ -57,6 +57,7 @@ class ConnectionHandlerObserver;
 typedef struct {
   transport_manager::ConnectionUID primary_transport;
   transport_manager::ConnectionUID secondary_transport;
+  std::vector<protocol_handler::ServiceType> secondary_transport_services;
 } SessionTransports;
 typedef std::map<uint8_t, SessionTransports> SessionConnectionMap;
 

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -621,9 +621,9 @@ void ProtocolHandlerImpl::SendEndServicePrivate(int32_t primary_connection_id,
         impl::RawFordMessageToMobile(ptr, false));
     LOG4CXX_DEBUG(logger_,
                   "SendEndServicePrivate() for connection "
-                      << primary_connection_id << " for service_type "
+                      << connection_id << " for service_type "
                       << static_cast<int>(service_type)
-                      << " service connection " << connection_id
+                      << " primary connection " << primary_connection_id
                       << " session_id " << static_cast<int32_t>(session_id));
   } else {
     LOG4CXX_WARN(


### PR DESCRIPTION
Also fix issue where app remained in FULL after AUDIO_SOURCE event

Fixes #2423 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Fixes ATF test failures with https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/develop/test_scripts/MobileProjection/Phase2/019_SDL_stop_audio_video.lua

### Summary
SendEndService was being always using the secondary transport, this message should be sent on the same connection that it was established on. This PR adds logic to keep track of which connection a service was established on.

In addition, the incorrect HMI level was being set when the audio source was changed if the app was in FULL.

### Changelog
##### Bug Fixes
* EndService is sent over correct connection
* App enters BACKGROUND if the user chooses another audio source in the HMI.
* Fix `OnVideoStreamingStopped` typo

### Tasks Remaining:
- [x] Fix Unit Tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)