### PR TITLE
Fix/sdl use incorrect url on system request

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -83,7 +83,8 @@ class PolicyHandler : public PolicyHandlerInterface,
   bool ResetPolicyTable() OVERRIDE;
   bool ClearUserConsent() OVERRIDE;
   bool SendMessageToSDK(const BinaryMessage& pt_string,
-                        const std::string& url) OVERRIDE;
+                        const std::string& url,
+                        const uint32_t app_id) OVERRIDE;
   bool ReceiveMessageFromSDK(const std::string& file,
                              const BinaryMessage& pt_string) OVERRIDE;
   bool UnloadPolicyLibrary() OVERRIDE;
@@ -755,13 +756,21 @@ class PolicyHandler : public PolicyHandlerInterface,
    */
   std::map<std::string, std::string> app_to_device_link_;
 
-  // Lock for app to device list
-  sync_primitives::RecursiveLock app_to_device_link_lock_;
+  /**
+   * @brief Lock for app to device list
+   */
+  sync_primitives::Lock app_to_device_link_lock_;
 
   std::shared_ptr<StatisticManagerImpl> statistic_manager_impl_;
   const PolicySettings& settings_;
   application_manager::ApplicationManager& application_manager_;
   friend class AppPermissionDelegate;
+
+  /**
+   * @brief Contains pair of app index and url index from Endpoints.
+   * That will be used for sent on the next OnSystemRequest retry sequence
+   */
+  std::map<uint32_t, uint32_t> retry_sequence_;
 
   /**
    * @brief Checks if the application with the given policy

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -772,16 +772,6 @@ class PolicyHandler : public PolicyHandlerInterface,
    */
   std::map<uint32_t, uint32_t> retry_sequence_;
 
-  /**
-   * @brief Checks if the application with the given policy
-   * application id is registered or it is default id
-   * @param app_idx Application idx from EndpointUrls vector
-   * @param urls EndpointUrls vector
-   * @return TRUE if the vector with URLs with given idx is not empty
-   * and is related to a registered application or these are default URLs,
-   * otherwise FALSE
-   */
-  bool IsUrlAppIdValid(const uint32_t app_idx, const EndpointUrls& urls) const;
   DISALLOW_COPY_AND_ASSIGN(PolicyHandler);
 };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/get_urls.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/get_urls.cc
@@ -96,9 +96,9 @@ void GetUrls::ProcessServiceURLs(const policy::EndpointUrls& endpoints) {
   SmartObject& urls = (*message_)[strings::msg_params][hmi_response::urls];
 
   size_t index = 0;
-  for (policy::EndpointData epdata : endpoints) {
-      ApplicationSharedPtr app = application_manager_.application_by_policy_id(
-          epdata.app_policy_id);
+  for (const policy::EndpointData& epdata : endpoints) {
+    ApplicationSharedPtr app =
+        application_manager_.application_by_policy_id(epdata.app_policy_id);
 
 #ifndef PROPRIETARY_MODE
     bool registered_not_default = false;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/get_urls_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/get_urls_test.cc
@@ -245,7 +245,7 @@ TEST_F(GetUrlsTest, ProcessPolicyServiceURLs_FoundURLForApplication_SUCCESS) {
 
   EndpointUrls endpoints_;
   EndpointData data(kDefaultUrl);
-  data.app_id = kPolicyAppId;
+  data.app_policy_id = kPolicyAppId;
   endpoints_.push_back(data);
 
   EXPECT_CALL(mock_policy_handler_, GetUpdateUrls(kPolicyService, _))
@@ -286,7 +286,7 @@ TEST_F(GetUrlsTest, DISABLED_ProcessServiceURLs_SUCCESS) {
 
   EndpointUrls endpoints_;
   EndpointData data(kDefaultUrl);
-  data.app_id = "1";
+  data.app_policy_id = "1";
   endpoints_.push_back(data);
   EXPECT_CALL(mock_policy_handler_, GetUpdateUrls(kServiceType, _))
       .WillOnce(SetArgReferee<1>(endpoints_));
@@ -298,7 +298,7 @@ TEST_F(GetUrlsTest, DISABLED_ProcessServiceURLs_SUCCESS) {
   EXPECT_EQ(kDefaultUrl,
             (*command_msg_)[am::strings::msg_params][am::hmi_response::urls][0]
                            [am::strings::url].asString());
-  EXPECT_EQ(endpoints_[0].app_id,
+  EXPECT_EQ(endpoints_[0].app_policy_id,
             (*command_msg_)[am::strings::msg_params][am::hmi_response::urls][0]
                            [am::hmi_response::policy_app_id].asString());
 }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1485,8 +1485,9 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
   }
 
   const uint32_t app_id = GetAppIdForSending();
+  const ApplicationSharedPtr app = application_manager_.application(app_id);
   const std::string app_policy_id =
-      application_manager_.application(app_id)->policy_app_id();
+      app != nullptr ? app->policy_app_id() : policy::kDefaultId;
 
   const auto is_appid_or_default = [app_policy_id](const EndpointData& ed) {
     return helpers::Compare<std::string, helpers::EQ, helpers::ONE>(
@@ -1501,7 +1502,7 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string) {
     return;
   }
 
-   // Set the ulr index to zero if this is the last ulr in the app queue
+  // Set the URL index to zero if this is the last URL in the app queue
   if (retry_sequence_[app_id] >= app_item->url.size()) {
     retry_sequence_[app_id] = 0;
   }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -2031,20 +2031,6 @@ void PolicyHandler::Add(const std::string& app_id,
   policy_manager_->Add(app_id, type, timespan_seconds);
 }
 
-bool PolicyHandler::IsUrlAppIdValid(const uint32_t app_idx,
-                                    const EndpointUrls& urls) const {
-  const EndpointData& app_data = urls[app_idx];
-  const std::vector<std::string> app_urls = app_data.url;
-  const ApplicationSharedPtr app =
-      application_manager_.application_by_policy_id(app_data.app_policy_id);
-
-  const bool is_registered = (app && (app->IsRegistered()));
-  const bool is_default = (app_data.app_policy_id == policy::kDefaultId);
-  const bool is_empty_urls = app_urls.empty();
-
-  return ((is_registered && !is_empty_urls) || is_default);
-}
-
 std::vector<std::string> PolicyHandler::GetDevicesIds(
     const std::string& policy_app_id) {
   return application_manager_.devices(policy_app_id);

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -2108,8 +2108,8 @@ TEST_F(PolicyHandlerTest,
   // Expected to get 0 as application id so SDL does not have valid application
   // with such id
   EXPECT_CALL(app_manager_, application(0))
-      .WillOnce(Return(
-          utils::SharedPtr<application_manager_test::MockApplication>()));
+      .WillOnce(
+          Return(std::shared_ptr<application_manager_test::MockApplication>()));
   const uint32_t app_id = policy_handler_.GetAppIdForSending();
   EXPECT_FALSE(policy_handler_.SendMessageToSDK(msg, url, app_id));
 }

--- a/src/components/application_manager/test/rc_policy_handler_test.cc
+++ b/src/components/application_manager/test/rc_policy_handler_test.cc
@@ -176,7 +176,8 @@ TEST_F(RCPolicyHandlerTest,
 
   EXPECT_CALL(mock_message_helper_, SendPolicySnapshotNotification(_, _, _, _))
       .Times(0);
-  EXPECT_FALSE(policy_handler_.SendMessageToSDK(msg, kUrl_));
+  const uint32_t app_id = policy_handler_.GetAppIdForSending();
+  EXPECT_FALSE(policy_handler_.SendMessageToSDK(msg, kUrl_, app_id));
 }
 
 TEST_F(RCPolicyHandlerTest, SendMessageToSDK_RemoteControl_SUCCESS) {
@@ -200,7 +201,8 @@ TEST_F(RCPolicyHandlerTest, SendMessageToSDK_RemoteControl_SUCCESS) {
 
   EXPECT_CALL(mock_message_helper_,
               SendPolicySnapshotNotification(kAppId1_, _, kUrl_, _));
-  EXPECT_TRUE(policy_handler_.SendMessageToSDK(msg, kUrl_));
+  const uint32_t app_id = policy_handler_.GetAppIdForSending();
+  EXPECT_TRUE(policy_handler_.SendMessageToSDK(msg, kUrl_, app_id));
 }
 
 TEST_F(RCPolicyHandlerTest, OnUpdateHMILevel_InvalidApp_UNSUCCESS) {

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -64,7 +64,8 @@ class PolicyHandlerInterface {
   virtual bool ResetPolicyTable() = 0;
   virtual bool ClearUserConsent() = 0;
   virtual bool SendMessageToSDK(const BinaryMessage& pt_string,
-                                const std::string& url) = 0;
+                                const std::string& url,
+                                const uint32_t app_id) = 0;
   virtual bool ReceiveMessageFromSDK(const std::string& file,
                                      const BinaryMessage& pt_string) = 0;
   virtual bool UnloadPolicyLibrary() = 0;

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -554,13 +554,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    */
   virtual const PolicySettings& get_settings() const = 0;
 
-  /**
-   * @brief Finds the next URL that must be sent on OnSystemRequest retry
-   * @param urls vector of vectors that contain urls for each application
-   * @return Pair of policy application id and application url id from the
-   * urls vector
-   */
-  virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) = 0;
 
   /**
    * @brief Assigns new HMI types for specified application
@@ -610,18 +603,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    */
   virtual void set_access_remote(
       std::shared_ptr<AccessRemote> access_remote) = 0;
-
-  /**
-   * @brief Checks if there is existing URL in the EndpointUrls vector with
-   * index saved in the policy manager and if not, it moves to the next
-   * application index
-   * @param rs contains the application index and url index from the
-   * urls vector that are to be sent on the next OnSystemRequest
-   * @param urls vector of vectors that contain urls for each application
-   * @return Pair of application index and url index
-   */
-  virtual AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
-                                    const EndpointUrls& urls) const = 0;
 
   /**
    * @brief  Checks, if SDL needs to update it's policy table section

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -554,7 +554,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    */
   virtual const PolicySettings& get_settings() const = 0;
 
-
   /**
    * @brief Assigns new HMI types for specified application
    * @param application_id Unique application id

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -534,14 +534,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual const PolicySettings& get_settings() const = 0;
 
   /**
-   * @brief Finds the next URL that must be sent on OnSystemRequest retry
-   * @param urls vector of vectors that contain urls for each application
-   * @return Pair of policy application id and application url id from the
-   * urls vector
-   */
-  virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) = 0;
-
-  /**
    * @brief Assigns new HMI types for specified application
    * @param application_id Unique application id
    * @param hmi_types new HMI types list
@@ -590,18 +582,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    */
   virtual void set_access_remote(
       std::shared_ptr<AccessRemote> access_remote) = 0;
-
-  /**
-   * @brief Checks if there is existing URL in the EndpointUrls vector with
-   * index saved in the policy manager and if not, it moves to the next
-   * application index
-   * @param rs contains the application index and url index from the
-   * urls vector that are to be sent on the next OnSystemRequest
-   * @param urls vector of vectors that contain urls for each application
-   * @return Pair of application index and url index
-   */
-  virtual AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
-                                    const EndpointUrls& urls) const = 0;
 
  protected:
   /**

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -50,9 +50,10 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD0(InitPolicyTable, bool());
   MOCK_METHOD0(ResetPolicyTable, bool());
   MOCK_METHOD0(ClearUserConsent, bool());
-  MOCK_METHOD2(SendMessageToSDK,
+  MOCK_METHOD3(SendMessageToSDK,
                bool(const policy::BinaryMessage& pt_string,
-                    const std::string& url));
+                    const std::string& url,
+                    const uint32_t app_id));
   MOCK_METHOD2(ReceiveMessageFromSDK,
                bool(const std::string& file,
                     const policy::BinaryMessage& pt_string));

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -205,10 +205,6 @@ class MockPolicyManager : public PolicyManager {
                     int32_t timespan_seconds));
   MOCK_CONST_METHOD0(get_settings, const PolicySettings&());
   MOCK_METHOD1(set_settings, void(const PolicySettings* get_settings));
-  MOCK_METHOD1(GetNextUpdateUrl, AppIdURL(const EndpointUrls& urls));
-  MOCK_CONST_METHOD2(RetrySequenceUrl,
-                     AppIdURL(const struct RetrySequenceURL&,
-                              const EndpointUrls& urls));
   MOCK_METHOD1(SetExternalConsentStatus, bool(const ExternalConsentStatus&));
   MOCK_METHOD0(GetExternalConsentStatus, ExternalConsentStatus());
   MOCK_CONST_METHOD1(IsNeedToUpdateExternalConsentStatus,

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -177,6 +177,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD1(OnAppsSearchCompleted, void(const bool trigger_ptu));
   MOCK_METHOD1(OnAppRegisteredOnMobile,
                void(const std::string& application_id));
+  MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
   MOCK_CONST_METHOD1(
       GetAppRequestTypes,
       const std::vector<std::string>(const std::string policy_app_id));
@@ -203,11 +204,7 @@ class MockPolicyManager : public PolicyManager {
                     int32_t timespan_seconds));
   MOCK_CONST_METHOD0(get_settings, const PolicySettings&());
   MOCK_METHOD1(set_settings, void(const PolicySettings* get_settings));
-  MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
-  MOCK_METHOD1(GetNextUpdateUrl, AppIdURL(const EndpointUrls& urls));
-  MOCK_CONST_METHOD2(RetrySequenceUrl,
-                     AppIdURL(const struct RetrySequenceURL&,
-                              const EndpointUrls& urls));
+  
   MOCK_METHOD6(CheckPermissions,
                void(const PTString& device_id,
                     const PTString& app_id,

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -204,7 +204,7 @@ class MockPolicyManager : public PolicyManager {
                     int32_t timespan_seconds));
   MOCK_CONST_METHOD0(get_settings, const PolicySettings&());
   MOCK_METHOD1(set_settings, void(const PolicySettings* get_settings));
-  
+
   MOCK_METHOD6(CheckPermissions,
                void(const PTString& device_id,
                     const PTString& app_id,

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -614,26 +614,6 @@ class PolicyManagerImpl : public PolicyManager {
   const PolicySettings& get_settings() const OVERRIDE;
 
   /**
-   * @brief Finds the next URL that must be sent on OnSystemRequest retry
-   * @param urls vector of vectors that contain urls for each application
-   * @return Pair of policy application id and application url id from the
-   * urls vector
-   */
-  AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) OVERRIDE;
-
-  /**
-   * @brief Checks if there is existing URL in the EndpointUrls vector with
-   * index saved in the policy manager and if not, it moves to the next
-   * application index
-   * @param rs contains the application index and url index from the
-   * urls vector that are to be sent on the next OnSystemRequest
-   * @param urls vector of vectors that contain urls for each application
-   * @return Pair of application index and url index
-   */
-  AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
-                            const EndpointUrls& urls) const OVERRIDE;
-
-  /**
    * @brief  Checks, if SDL needs to update it's policy table section
              "external_consent_status"
    * @param  ExternalConsent status
@@ -1074,11 +1054,6 @@ class PolicyManagerImpl : public PolicyManager {
   const PolicySettings* settings_;
   friend struct CheckAppPolicy;
 
-  /**
-   * @brief Pair of app index and url index from Endpoints vector
-   * that contains all application URLs
-   */
-  RetrySequenceURL retry_sequence_url_;
   friend struct ProccessAppGroups;
 
   /**

--- a/src/components/policy/policy_external/include/policy/policy_types.h
+++ b/src/components/policy/policy_external/include/policy/policy_types.h
@@ -169,13 +169,13 @@ struct CheckPermissionResult {
   */
 struct EndpointData {
   explicit EndpointData(const std::string& url_string = "")
-      : app_id("default") {
+      : app_policy_id("default") {
     if (false == url_string.empty()) {
       url.push_back(url_string);
     }
   }
   std::vector<std::string> url;
-  std::string app_id;
+  std::string app_policy_id;
 };
 
 typedef std::vector<EndpointData> EndpointUrls;
@@ -370,26 +370,6 @@ struct MetaInfo {
   std::string wers_country_code;
   std::string language;
 };
-
-/**
- * @brief The index of the application, the index of its URL
- * and the policy application id from the Endpoints vector
- * that will be sent on the next OnSystemRequest retry sequence
- */
-struct RetrySequenceURL {
-  uint32_t app_idx_;
-  uint32_t url_idx_;
-  std::string policy_app_id_;
-  RetrySequenceURL(uint32_t app, uint32_t url, const std::string& app_id)
-      : app_idx_(app), url_idx_(url), policy_app_id_(app_id) {}
-  RetrySequenceURL() : app_idx_(0), url_idx_(0) {}
-};
-
-/**
- * @brief Index of the application, index of its URL
- * from the Endpoints vector
- */
-typedef std::pair<uint32_t, uint32_t> AppIdURL;
 
 enum EntityStatus { kStatusOn, kStatusOff };
 

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1474,7 +1474,7 @@ void CacheManager::GetUpdateUrls(const std::string& service_type,
         (*iter).second.end();
     for (; url_list_iter != url_list_iter_end; ++url_list_iter) {
       EndpointData data;
-      data.app_id = (*url_list_iter).first;
+      data.app_policy_id = (*url_list_iter).first;
       std::copy((*url_list_iter).second.begin(),
                 (*url_list_iter).second.end(),
                 std::back_inserter(data.url));

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -217,8 +217,8 @@ PolicyManagerImpl::PolicyManagerImpl()
           new AccessRemoteImpl(std::static_pointer_cast<CacheManager>(cache_)))
     , retry_sequence_timeout_(60)
     , retry_sequence_index_(0)
-    , ignition_check(true)
-    , retry_sequence_url_(0, 0, "") {}
+    , ignition_check(true) {
+}
 
 PolicyManagerImpl::PolicyManagerImpl(bool in_memory)
     : PolicyManager()
@@ -229,7 +229,6 @@ PolicyManagerImpl::PolicyManagerImpl(bool in_memory)
     , retry_sequence_timeout_(60)
     , retry_sequence_index_(0)
     , ignition_check(true)
-    , retry_sequence_url_(0, 0, "")
     , wrong_ptu_update_received_(false)
     , send_on_update_sent_out_(false)
     , trigger_ptu_(false) {}
@@ -1842,46 +1841,6 @@ void PolicyManagerImpl::SetDecryptedCertificate(
     const std::string& certificate) {
   LOG4CXX_AUTO_TRACE(logger_);
   cache_->SetDecryptedCertificate(certificate);
-}
-
-AppIdURL PolicyManagerImpl::GetNextUpdateUrl(const EndpointUrls& urls) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  const AppIdURL next_app_url = RetrySequenceUrl(retry_sequence_url_, urls);
-
-  retry_sequence_url_.url_idx_ = next_app_url.second + 1;
-  retry_sequence_url_.app_idx_ = next_app_url.first;
-  retry_sequence_url_.policy_app_id_ = urls[next_app_url.first].app_id;
-
-  return next_app_url;
-}
-
-AppIdURL PolicyManagerImpl::RetrySequenceUrl(const struct RetrySequenceURL& rs,
-                                             const EndpointUrls& urls) const {
-  uint32_t url_idx = rs.url_idx_;
-  uint32_t app_idx = rs.app_idx_;
-  const std::string& app_id = rs.policy_app_id_;
-
-  if (urls.size() <= app_idx) {
-    // Index of current application doesn't exist any more due to app(s)
-    // unregistration
-    url_idx = 0;
-    app_idx = 0;
-  } else if (urls[app_idx].app_id != app_id) {
-    // Index of current application points to another one due to app(s)
-    // registration/unregistration
-    url_idx = 0;
-  } else if (url_idx >= urls[app_idx].url.size()) {
-    // Index of current application is OK, but all of its URL are sent,
-    // move to the next application
-    url_idx = 0;
-    if (++app_idx >= urls.size()) {
-      app_idx = 0;
-    }
-  }
-  const AppIdURL next_app_url = std::make_pair(app_idx, url_idx);
-
-  return next_app_url;
 }
 
 /**

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -217,8 +217,7 @@ PolicyManagerImpl::PolicyManagerImpl()
           new AccessRemoteImpl(std::static_pointer_cast<CacheManager>(cache_)))
     , retry_sequence_timeout_(60)
     , retry_sequence_index_(0)
-    , ignition_check(true) {
-}
+    , ignition_check(true) {}
 
 PolicyManagerImpl::PolicyManagerImpl(bool in_memory)
     : PolicyManager()

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -279,7 +279,7 @@ EndpointUrls SQLPTRepresentation::GetUpdateUrls(int service_type) {
 
       data.url.push_back(query.GetString(0));
       if (!query.IsNull(1)) {
-        data.app_id = query.GetString(1);
+        data.app_policy_id = query.GetString(1);
       }
       ret.push_back(data);
     }

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -589,26 +589,6 @@ class PolicyManagerImpl : public PolicyManager {
    */
   bool HasCertificate() const OVERRIDE;
 
-  /**
-   * @brief Finds the next URL that must be sent on OnSystemRequest retry
-   * @param urls vector of vectors that contain urls for each application
-   * @return Pair of policy application id and application url id from the
-   * urls vector
-   */
-  AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) OVERRIDE;
-
-  /**
-   * @brief Checks if there is existing URL in the EndpointUrls vector with
-   * index saved in the policy manager and if not, it moves to the next
-   * application index
-   * @param rs contains the application index and url index from the
-   * urls vector that are to be sent on the next OnSystemRequest
-   * @param urls vector of vectors that contain urls for each application
-   * @return Pair of application index and url index
-   */
-  AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
-                            const EndpointUrls& urls) const OVERRIDE;
-
 #ifdef BUILD_TESTS
   /**
    * @brief Getter for cache_manager instance
@@ -928,12 +908,6 @@ class PolicyManagerImpl : public PolicyManager {
   const PolicySettings* settings_;
   friend struct CheckAppPolicy;
   friend struct ProccessAppGroups;
-
-  /**
-   * @brief Pair of app index and url index from Endpoints vector
-   * that contains all application URLs
-   */
-  RetrySequenceURL retry_sequence_url_;
 
   /**
    * @brief Flag for notifying that invalid PTU was received

--- a/src/components/policy/policy_regular/include/policy/policy_types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_types.h
@@ -169,13 +169,13 @@ struct CheckPermissionResult {
   */
 struct EndpointData {
   explicit EndpointData(const std::string& url_string = "")
-      : app_id("default") {
+      : app_policy_id("default") {
     if (false == url_string.empty()) {
       url.push_back(url_string);
     }
   }
   std::vector<std::string> url;
-  std::string app_id;
+  std::string app_policy_id;
 };
 
 typedef std::vector<EndpointData> EndpointUrls;

--- a/src/components/policy/policy_regular/include/policy/policy_types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_types.h
@@ -372,26 +372,6 @@ struct MetaInfo {
 };
 
 /**
- * @brief The index of the application, the index of its URL
- * and the policy application id from the Endpoints vector
- * that will be sent on the next OnSystemRequest retry sequence
- */
-struct RetrySequenceURL {
-  uint32_t app_idx_;
-  uint32_t url_idx_;
-  std::string policy_app_id_;
-  RetrySequenceURL(uint32_t app, uint32_t url, const std::string& app_id)
-      : app_idx_(app), url_idx_(url), policy_app_id_(app_id) {}
-  RetrySequenceURL() : app_idx_(0), url_idx_(0) {}
-};
-
-/**
- * @brief Index of the application, index of its URL
- * from the Endpoints vector
- */
-typedef std::pair<uint32_t, uint32_t> AppIdURL;
-
-/**
  * @brief Represents ExternalConsent entity status received from the system
  */
 enum EntityStatus { kStatusOn, kStatusOff };
@@ -485,12 +465,6 @@ enum PermissionsCheckResult {
  */
 typedef std::set<std::pair<std::string, PermissionsCheckResult> >
     CheckAppPolicyResults;
-
-/**
- * @brief Index of the application, index of its URL
- * from the Endpoints vector
- */
-typedef std::pair<uint32_t, uint32_t> AppIdURL;
 
 }  //  namespace policy
 

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -761,7 +761,7 @@ void CacheManager::GetUpdateUrls(const std::string& service_type,
         (*iter).second.end();
     for (; url_list_iter != url_list_iter_end; ++url_list_iter) {
       EndpointData data;
-      data.app_id = (*url_list_iter).first;
+      data.app_policy_id = (*url_list_iter).first;
       std::copy((*url_list_iter).second.begin(),
                 (*url_list_iter).second.end(),
                 std::back_inserter(data.url));

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -81,7 +81,6 @@ PolicyManagerImpl::PolicyManagerImpl()
                             new timer::TimerTaskImpl<PolicyManagerImpl>(
                                 this, &PolicyManagerImpl::RetrySequence))
     , ignition_check(true)
-    , retry_sequence_url_(0, 0, "")
     , wrong_ptu_update_received_(false)
     , send_on_update_sent_out_(false)
     , trigger_ptu_(false) {}
@@ -1138,46 +1137,6 @@ void PolicyManagerImpl::MarkUnpairedDevice(const std::string& device_id) {}
 std::string PolicyManagerImpl::RetrieveCertificate() const {
   LOG4CXX_AUTO_TRACE(logger_);
   return cache_->GetCertificate();
-}
-
-AppIdURL PolicyManagerImpl::GetNextUpdateUrl(const EndpointUrls& urls) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  const AppIdURL next_app_url = RetrySequenceUrl(retry_sequence_url_, urls);
-
-  retry_sequence_url_.url_idx_ = next_app_url.second + 1;
-  retry_sequence_url_.app_idx_ = next_app_url.first;
-  retry_sequence_url_.policy_app_id_ = urls[next_app_url.first].app_policy_id;
-
-  return next_app_url;
-}
-
-AppIdURL PolicyManagerImpl::RetrySequenceUrl(const struct RetrySequenceURL& rs,
-                                             const EndpointUrls& urls) const {
-  uint32_t url_idx = rs.url_idx_;
-  uint32_t app_idx = rs.app_idx_;
-  const std::string& app_id = rs.policy_app_id_;
-
-  if (urls.size() <= app_idx) {
-    // Index of current application doesn't exist any more due to app(s)
-    // unregistration
-    url_idx = 0;
-    app_idx = 0;
-  } else if (urls[app_idx].app_policy_id != app_id) {
-    // Index of current application points to another one due to app(s)
-    // registration/unregistration
-    url_idx = 0;
-  } else if (url_idx >= urls[app_idx].url.size()) {
-    // Index of current application is OK, but all of its URL are sent,
-    // move to the next application
-    url_idx = 0;
-    if (++app_idx >= urls.size()) {
-      app_idx = 0;
-    }
-  }
-  const AppIdURL next_app_url = std::make_pair(app_idx, url_idx);
-
-  return next_app_url;
 }
 
 bool PolicyManagerImpl::HasCertificate() const {

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1147,7 +1147,7 @@ AppIdURL PolicyManagerImpl::GetNextUpdateUrl(const EndpointUrls& urls) {
 
   retry_sequence_url_.url_idx_ = next_app_url.second + 1;
   retry_sequence_url_.app_idx_ = next_app_url.first;
-  retry_sequence_url_.policy_app_id_ = urls[next_app_url.first].app_id;
+  retry_sequence_url_.policy_app_id_ = urls[next_app_url.first].app_policy_id;
 
   return next_app_url;
 }
@@ -1163,7 +1163,7 @@ AppIdURL PolicyManagerImpl::RetrySequenceUrl(const struct RetrySequenceURL& rs,
     // unregistration
     url_idx = 0;
     app_idx = 0;
-  } else if (urls[app_idx].app_id != app_id) {
+  } else if (urls[app_idx].app_policy_id != app_id) {
     // Index of current application points to another one due to app(s)
     // registration/unregistration
     url_idx = 0;

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -231,7 +231,7 @@ EndpointUrls SQLPTRepresentation::GetUpdateUrls(int service_type) {
 
       data.url.push_back(query.GetString(0));
       if (!query.IsNull(1)) {
-        data.app_id = query.GetString(1);
+        data.app_policy_id = query.GetString(1);
       }
       ret.push_back(data);
     }


### PR DESCRIPTION
Fixes [#1219](https://github.com/SmartDeviceLink/sdl_core/issues/1219)

This PR is **ready** for review.

### Risk

This PR **not makes** API changes.

### Testing Plan

TODO: Provide ATF tests.

### Summary

The SDL sometimes chooses an inconsistent app and url for policies updating. In the current implementation the url from pool of all urls available for all applications is chosen and then select the application randomly. The problem is that url should be selected from the pool of concrete application.

Implemented the functionality of selecting a random application and then select the url from the pool of allowed urls for the chosen app.

### CLA
- [x]  I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)