### PR TITLE
Fix incorrectly saved RequestType and RequestSubType

### DIFF
--- a/src/components/policy/policy_external/include/policy/sql_pt_queries.h
+++ b/src/components/policy/policy_external/include/policy/sql_pt_queries.h
@@ -79,8 +79,6 @@ extern const std::string kInsertAppGroup;
 extern const std::string kInsertNickname;
 extern const std::string kInsertAppType;
 extern const std::string kInsertRequestType;
-extern const std::string kInsertOmittedRequestType;
-extern const std::string kInsertOmittedRequestSubType;
 extern const std::string kInsertRequestSubType;
 extern const std::string kInsertMessageType;
 extern const std::string kInsertLanguage;

--- a/src/components/policy/policy_external/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_queries.cc
@@ -645,18 +645,10 @@ const std::string kInsertRequestType =
     "INSERT OR IGNORE INTO `request_type` (`application_id`, `request_type`) "
     "VALUES (?, ?)";
 
-const std::string kInsertOmittedRequestType =
-    "INSERT INTO `request_type` (`application_id`) "
-    "VALUES (?)";
-
 const std::string kInsertRequestSubType =
     "INSERT INTO `request_subtype` (`application_id`, "
     "`request_subtype`) "
     "VALUES (?, ?)";
-
-const std::string kInsertOmittedRequestSubType =
-    "INSERT INTO `request_subtype` (`application_id`) "
-    "VALUES (?)";
 
 const std::string kUpdateVersion = "UPDATE `version` SET `number`= ?";
 

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -1193,18 +1193,6 @@ bool SQLPTRepresentation::SaveRequestType(
       LOG4CXX_WARN(logger_, "Incorrect insert into request types.");
       return false;
     }
-  } else {
-    utils::dbms::SQLQuery query_omitted(db());
-    if (!query_omitted.Prepare(sql_pt::kInsertOmittedRequestType)) {
-      LOG4CXX_WARN(logger_, "Incorrect insert statement for request types.");
-      return false;
-    }
-    LOG4CXX_WARN(logger_, "Request types omitted.");
-    query_omitted.Bind(0, app_id);
-    if (!query_omitted.Exec() || !query_omitted.Reset()) {
-      LOG4CXX_WARN(logger_, "Incorrect insert into request types.");
-      return false;
-    }
   }
   return true;
 }
@@ -1234,18 +1222,6 @@ bool SQLPTRepresentation::SaveRequestSubType(
     query.Bind(0, app_id);
     query.Bind(1, std::string("EMPTY"));
     if (!query.Exec() || !query.Reset()) {
-      LOG4CXX_WARN(logger_, "Incorrect insert into request subtypes.");
-      return false;
-    }
-  } else {
-    utils::dbms::SQLQuery query_omitted(db());
-    if (!query_omitted.Prepare(sql_pt::kInsertOmittedRequestSubType)) {
-      LOG4CXX_WARN(logger_, "Incorrect insert statement for request subtypes.");
-      return false;
-    }
-    LOG4CXX_WARN(logger_, "Request subtypes omitted.");
-    query_omitted.Bind(0, app_id);
-    if (!query_omitted.Exec() || !query_omitted.Reset()) {
       LOG4CXX_WARN(logger_, "Incorrect insert into request subtypes.");
       return false;
     }

--- a/src/components/policy/policy_regular/include/policy/sql_pt_queries.h
+++ b/src/components/policy/policy_regular/include/policy/sql_pt_queries.h
@@ -79,8 +79,6 @@ extern const std::string kInsertAppGroup;
 extern const std::string kInsertNickname;
 extern const std::string kInsertAppType;
 extern const std::string kInsertRequestType;
-extern const std::string kInsertOmittedRequestType;
-extern const std::string kInsertOmittedRequestSubType;
 extern const std::string kInsertRequestSubType;
 extern const std::string kInsertMessageType;
 extern const std::string kInsertLanguage;

--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -595,18 +595,10 @@ const std::string kInsertRequestType =
     "INSERT INTO `request_type` (`application_id`, `request_type`) "
     "VALUES (?, ?)";
 
-const std::string kInsertOmittedRequestType =
-    "INSERT INTO `request_type` (`application_id`) "
-    "VALUES (?)";
-
 const std::string kInsertRequestSubType =
     "INSERT INTO `request_subtype` (`application_id`, "
     "`request_subtype`) "
     "VALUES (?, ?)";
-
-const std::string kInsertOmittedRequestSubType =
-    "INSERT INTO `request_subtype` (`application_id`) "
-    "VALUES (?)";
 
 const std::string kUpdateVersion = "UPDATE `version` SET `number`= ?";
 

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -1137,18 +1137,6 @@ bool SQLPTRepresentation::SaveRequestType(
       LOG4CXX_WARN(logger_, "Incorrect insert into request types.");
       return false;
     }
-  } else {
-    utils::dbms::SQLQuery query_omitted(db());
-    if (!query_omitted.Prepare(sql_pt::kInsertOmittedRequestType)) {
-      LOG4CXX_WARN(logger_, "Incorrect insert statement for request types.");
-      return false;
-    }
-    LOG4CXX_WARN(logger_, "Request types omitted.");
-    query_omitted.Bind(0, app_id);
-    if (!query_omitted.Exec() || !query_omitted.Reset()) {
-      LOG4CXX_WARN(logger_, "Incorrect insert into request types.");
-      return false;
-    }
   }
   return true;
 }
@@ -1178,18 +1166,6 @@ bool SQLPTRepresentation::SaveRequestSubType(
     query.Bind(0, app_id);
     query.Bind(1, std::string("EMPTY"));
     if (!query.Exec() || !query.Reset()) {
-      LOG4CXX_WARN(logger_, "Incorrect insert into request subtypes.");
-      return false;
-    }
-  } else {
-    utils::dbms::SQLQuery query_omitted(db());
-    if (!query_omitted.Prepare(sql_pt::kInsertOmittedRequestSubType)) {
-      LOG4CXX_WARN(logger_, "Incorrect insert statement for request subtypes.");
-      return false;
-    }
-    LOG4CXX_WARN(logger_, "Request subtypes omitted.");
-    query_omitted.Bind(0, app_id);
-    if (!query_omitted.Exec() || !query_omitted.Reset()) {
       LOG4CXX_WARN(logger_, "Incorrect insert into request subtypes.");
       return false;
     }


### PR DESCRIPTION
Which caused silent errors while loading application policies on startup

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Restart Core after policy table update, verify app policy changes are still present.

### Summary
Removes unnecessary query for writing omitted RequestType and RequestSubType. This caused a silent failure when reading the app policies on startup.

### Changelog
##### Bug Fixes
* Remove unnecessary logic inserting an uninitialized RequestType and RequestSubType if the array is omitted in an app policy.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)