### PR TITLE
Fix PerformInteractionChoiceSet request behavior.

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -394,22 +394,22 @@ class DynamicApplicationData {
   virtual bool is_reset_global_properties_active() const = 0;
 
   /**
-  * @brief Set allow mode for choice_set allow: allowed/disallowed.
-  * Allow mode means, than choice_set not fully stored or not fully deleted
-  * (in both times, request processes on HMI side, HMI didn't send yet
-  * response with result)
+  * @brief Set allowed mode for specified choice_set_id.
   * @param choice_set_id Choice set id.
   * @param is_allowed TRUE if choice set is have to be allowed to perform,
   * otherwise FALSE.
+  * Allow mode means, than choice_set not fully processed or not fully deleted
+  * (in both times, request processes on HMI side, HMI didn't send yet response
+  * with result)
   */
-  virtual void set_choice_set_allow_mode(const std::uint32_t choice_set_id,
+  virtual void set_choice_set_allow_mode(const uint32_t choice_set_id,
                                          const bool is_allowed) = 0;
   /**
-  * @brief Check choice set allowing.
+  * @brief Check if choice set allowed.
   * @param choice_set_id Choice set id.
+  * @return TRUE if choice set is allowed to perform, otherwise ELSE.
   */
-  virtual bool is_choice_set_allowed_to_perform(
-      std::uint32_t choice_set_id) const = 0;
+  virtual bool is_choice_set_allowed(const uint32_t choice_set_id) const = 0;
 };
 
 class Application : public virtual InitialApplicationData,

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -392,6 +392,24 @@ class DynamicApplicationData {
    * @return TRUE if perform interaction active, otherwise FALSE
    */
   virtual bool is_reset_global_properties_active() const = 0;
+
+  /**
+  * @brief Set allow mode for choice_set allow: allowed/disallowed.
+  * Allow mode means, than choice_set not fully stored or not fully deleted
+  * (in both times, request processes on HMI side, HMI didn't send yet
+  * response with result)
+  * @param choice_set_id Choice set id.
+  * @param is_allowed TRUE if choice set is have to be allowed to perform,
+  * otherwise FALSE.
+  */
+  virtual void set_choice_set_allow_mode(const std::uint32_t choice_set_id,
+                                         const bool is_allowed) = 0;
+  /**
+  * @brief Check choice set allowing.
+  * @param choice_set_id Choice set id.
+  */
+  virtual bool is_choice_set_allowed_to_perform(
+      std::uint32_t choice_set_id) const = 0;
 };
 
 class Application : public virtual InitialApplicationData,

--- a/src/components/application_manager/include/application_manager/application_data_impl.h
+++ b/src/components/application_manager/include/application_manager/application_data_impl.h
@@ -36,6 +36,7 @@
 #include <string>
 #include <map>
 #include <cstdint>
+
 #include "utils/lock.h"
 #include "utils/semantic_version.h"
 #include "smart_objects/smart_object.h"
@@ -45,7 +46,7 @@
 namespace application_manager {
 
 namespace mobile_api = mobile_apis;
-typedef std::map<std::uint32_t, bool> ChoiceSetAllowedMap;
+typedef std::map<uint32_t, bool> ChoiceSetAllowedMap;
 
 class InitialApplicationDataImpl : public virtual Application {
  public:
@@ -266,9 +267,9 @@ class DynamicApplicationDataImpl : public virtual Application {
    */
   inline bool is_reset_global_properties_active() const;
 
-  virtual void set_choice_set_allow_mode(const std::uint32_t choice_set_id,
+  virtual void set_choice_set_allow_mode(const uint32_t choice_set_id,
                                          const bool is_allowed);
-  bool is_choice_set_allowed_to_perform(std::uint32_t choice_set_id) const;
+  bool is_choice_set_allowed(const uint32_t choice_set_id) const;
 
  protected:
   smart_objects::SmartObject* help_prompt_;

--- a/src/components/application_manager/include/application_manager/application_data_impl.h
+++ b/src/components/application_manager/include/application_manager/application_data_impl.h
@@ -267,8 +267,8 @@ class DynamicApplicationDataImpl : public virtual Application {
    */
   inline bool is_reset_global_properties_active() const;
 
-  virtual void set_choice_set_allow_mode(const uint32_t choice_set_id,
-                                         const bool is_allowed);
+  void set_choice_set_allow_mode(const uint32_t choice_set_id,
+                                 const bool is_allowed) FINAL;
   bool is_choice_set_allowed(const uint32_t choice_set_id) const;
 
  protected:

--- a/src/components/application_manager/include/application_manager/application_data_impl.h
+++ b/src/components/application_manager/include/application_manager/application_data_impl.h
@@ -34,6 +34,8 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_APPLICATION_DATA_IMPL_H_
 
 #include <string>
+#include <map>
+#include <cstdint>
 #include "utils/lock.h"
 #include "utils/semantic_version.h"
 #include "smart_objects/smart_object.h"
@@ -43,6 +45,7 @@
 namespace application_manager {
 
 namespace mobile_api = mobile_apis;
+typedef std::map<std::uint32_t, bool> ChoiceSetAllowedMap;
 
 class InitialApplicationDataImpl : public virtual Application {
  public:
@@ -263,6 +266,10 @@ class DynamicApplicationDataImpl : public virtual Application {
    */
   inline bool is_reset_global_properties_active() const;
 
+  virtual void set_choice_set_allow_mode(const std::uint32_t choice_set_id,
+                                         const bool is_allowed);
+  bool is_choice_set_allowed_to_perform(std::uint32_t choice_set_id) const;
+
  protected:
   smart_objects::SmartObject* help_prompt_;
   smart_objects::SmartObject* timeout_prompt_;
@@ -290,6 +297,7 @@ class DynamicApplicationDataImpl : public virtual Application {
   uint32_t is_perform_interaction_active_;
   bool is_reset_global_properties_active_;
   int32_t perform_interaction_mode_;
+  ChoiceSetAllowedMap choice_set_allowed_map_;
 
  private:
   void SetGlobalProperties(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_interaction_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_interaction_request.h
@@ -232,6 +232,19 @@ class PerformInteractionRequest
    */
   void SendBothModeResponse(const smart_objects::SmartObject& msg_param);
 
+  /**
+   * @brief Checks for all choice set ids are allowed to perform.
+   * @param app Contains pointer to application.
+   * @param choice_set_id_list_length Contains amount of choice set ids.
+   * @param choice_set_id_list Array of choice set ids
+   * @return If all at-least one choice list is disallowed to perform returns
+   * false, otherwise returns true.
+   */
+  bool IsAllChoiceSetAllowedToPerform(
+      app_mngr::ApplicationSharedPtr app,
+      const size_t choice_set_id_list_length,
+      const smart_objects::SmartObject& choice_set_id_list) const;
+
   mobile_apis::InteractionMode::eType interaction_mode_;
   bool ui_response_received_;
   bool vr_response_received_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_interaction_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_interaction_request.h
@@ -235,14 +235,12 @@ class PerformInteractionRequest
   /**
    * @brief Checks for all choice set ids are allowed to perform.
    * @param app Contains pointer to application.
-   * @param choice_set_id_list_length Contains amount of choice set ids.
    * @param choice_set_id_list Array of choice set ids
    * @return If all at-least one choice list is disallowed to perform returns
    * false, otherwise returns true.
    */
-  bool IsAllChoiceSetAllowedToPerform(
+  bool IsAllChoiceSetIdsAllowed(
       app_mngr::ApplicationSharedPtr app,
-      const size_t choice_set_id_list_length,
       const smart_objects::SmartObject& choice_set_id_list) const;
 
   mobile_apis::InteractionMode::eType interaction_mode_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -152,7 +152,7 @@ void CreateInteractionChoiceSetRequest::Run() {
     // we have VR commands
     SendVRAddCommandRequests(app);
   } else {
-    if (vr_status == MessageHelper::ChoiceSetVRCommandsStatus::NONE) {
+    if (MessageHelper::ChoiceSetVRCommandsStatus::NONE == vr_status) {
       // Because on_event will not be called for this choice, we set is allowed
       // right after added.
       app->set_choice_set_allow_mode(choice_set_id_, true);
@@ -479,7 +479,7 @@ void CreateInteractionChoiceSetRequest::OnAllHMIResponsesReceived() {
                   "Choice set with id " << choice_set_id_
                                         << " is allowed to perform.");
   }
-  if (!error_from_hmi_ && should_send_warnings) {
+  if (!error_from_hmi_ && should_send_warnings_) {
     SendResponse(true, mobile_apis::Result::WARNINGS, kInvalidImageWarningInfo);
   } else if (!error_from_hmi_) {
     SendResponse(true, mobile_apis::Result::SUCCESS);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -466,7 +466,15 @@ void CreateInteractionChoiceSetRequest::DeleteChoices() {
 void CreateInteractionChoiceSetRequest::OnAllHMIResponsesReceived() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  if (!error_from_hmi_ && should_send_warnings_) {
+  ApplicationSharedPtr application =
+      application_manager_.application(connection_key());
+  if (!error_from_hmi_) {
+    application->set_choice_set_allow_mode(choice_set_id_, true);
+    LOG4CXX_DEBUG(logger_,
+                  "Choice set with id " << choice_set_id_
+                                        << " is allowed to perform.");
+  }
+  if (!error_from_hmi_ && should_send_warnings) {
     SendResponse(true, mobile_apis::Result::WARNINGS, kInvalidImageWarningInfo);
   } else if (!error_from_hmi_) {
     SendResponse(true, mobile_apis::Result::SUCCESS);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -153,8 +153,8 @@ void CreateInteractionChoiceSetRequest::Run() {
     SendVRAddCommandRequests(app);
   } else {
     if (vr_status == MessageHelper::ChoiceSetVRCommandsStatus::NONE) {
-      // We not wait for calling on_event and choice set is allowed just after
-      // added.
+      // Because on_event will not be called for this choice, we set is allowed
+      // right after added.
       app->set_choice_set_allow_mode(choice_set_id_, true);
     }
     // we have none, just return with success

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -152,6 +152,11 @@ void CreateInteractionChoiceSetRequest::Run() {
     // we have VR commands
     SendVRAddCommandRequests(app);
   } else {
+    if (vr_status == MessageHelper::ChoiceSetVRCommandsStatus::NONE) {
+      // We not wait for calling on_event and choice set is allowed just after
+      // added.
+      app->set_choice_set_allow_mode(choice_set_id_, true);
+    }
     // we have none, just return with success
     SendResponse(true, Result::SUCCESS);
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_interaction_choice_set_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_interaction_choice_set_request.cc
@@ -87,6 +87,18 @@ void DeleteInteractionChoiceSetRequest::Run() {
     return;
   }
   SendVrDeleteCommand(app);
+
+  smart_objects::SmartObject msg_params =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  msg_params[strings::interaction_choice_set_id] = choice_set_id;
+  msg_params[strings::app_id] = app->app_id();
+
+  app->RemoveChoiceSet(choice_set_id);
+
+  // Checking of HMI responses will be implemented with APPLINK-14600
+  const bool result = true;
+  SendResponse(result, mobile_apis::Result::SUCCESS);
 }
 
 bool DeleteInteractionChoiceSetRequest::Init() {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_interaction_choice_set_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_interaction_choice_set_request.cc
@@ -87,18 +87,6 @@ void DeleteInteractionChoiceSetRequest::Run() {
     return;
   }
   SendVrDeleteCommand(app);
-
-  smart_objects::SmartObject msg_params =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-  msg_params[strings::interaction_choice_set_id] = choice_set_id;
-  msg_params[strings::app_id] = app->app_id();
-
-  app->RemoveChoiceSet(choice_set_id);
-
-  // Checking of HMI responses will be implemented with APPLINK-14600
-  const bool result = true;
-  SendResponse(result, mobile_apis::Result::SUCCESS);
 }
 
 bool DeleteInteractionChoiceSetRequest::Init() {
@@ -151,6 +139,7 @@ void DeleteInteractionChoiceSetRequest::SendVrDeleteCommand(
     return;
   }
 
+  app->set_choice_set_allow_mode(choice_set_id, false);
   smart_objects::SmartObject msg_params =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
   msg_params[strings::app_id] = app->app_id();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
@@ -166,6 +166,7 @@ void PerformInteractionRequest::Run() {
 
   if (!IsAllChoiceSetIdsAllowed(
           app, msg_params[strings::interaction_choice_set_id_list])) {
+    LOG4CXX_WARN(logger_, "One of choice sets is disallowed.");
     SendResponse(false, mobile_apis::Result::REJECTED);
     return;
   }
@@ -1081,7 +1082,7 @@ bool PerformInteractionRequest::IsAllChoiceSetIdsAllowed(
     if (!is_allowed) {
       LOG4CXX_DEBUG(logger_,
                     "Choice set with id " << choice_set_id_list[i].asInt()
-                                          << "dosn't allowed.");
+                                          << " dosn't allowed.");
       return false;
     }
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
@@ -164,12 +164,10 @@ void PerformInteractionRequest::Run() {
     return;
   }
 
-  if (!IsAllChoiceSetAllowedToPerform(
-          app,
-          choice_set_id_list_length,
-          msg_params[strings::interaction_choice_set_id_list])) {
-    LOG4CXX_ERROR(logger_, "Choice set is not ready to perform.");
+  if (!IsAllChoiceSetIdsAllowed(
+          app, msg_params[strings::interaction_choice_set_id_list])) {
     SendResponse(false, mobile_apis::Result::REJECTED);
+    return;
   }
 
   if (msg_params.keyExists(strings::vr_help)) {
@@ -1071,16 +1069,19 @@ void PerformInteractionRequest::SendBothModeResponse(
                response_params);
 }
 
-bool PerformInteractionRequest::IsAllChoiceSetAllowedToPerform(
+bool PerformInteractionRequest::IsAllChoiceSetIdsAllowed(
     ApplicationSharedPtr app,
-    const size_t choice_set_id_list_length,
     const ns_smart_device_link::ns_smart_objects::SmartObject&
         choice_set_id_list) const {
   LOG4CXX_AUTO_TRACE(logger_);
+  const size_t choice_set_id_list_length = choice_set_id_list.length();
   for (size_t i = 0; i < choice_set_id_list_length; ++i) {
     const bool is_allowed =
-        app->is_choice_set_allowed_to_perform(choice_set_id_list[i].asInt());
+        app->is_choice_set_allowed(choice_set_id_list[i].asInt());
     if (!is_allowed) {
+      LOG4CXX_DEBUG(logger_,
+                    "Choice set with id " << choice_set_id_list[i].asInt()
+                                          << "dosn't allowed.");
       return false;
     }
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
@@ -164,6 +164,14 @@ void PerformInteractionRequest::Run() {
     return;
   }
 
+  if (!IsAllChoiceSetAllowedToPerform(
+          app,
+          choice_set_id_list_length,
+          msg_params[strings::interaction_choice_set_id_list])) {
+    LOG4CXX_ERROR(logger_, "Choice set is not ready to perform.");
+    SendResponse(false, mobile_apis::Result::REJECTED);
+  }
+
   if (msg_params.keyExists(strings::vr_help)) {
     if (mobile_apis::Result::INVALID_DATA ==
         MessageHelper::VerifyImageVrHelpItems(
@@ -1063,6 +1071,21 @@ void PerformInteractionRequest::SendBothModeResponse(
                response_params);
 }
 
+bool PerformInteractionRequest::IsAllChoiceSetAllowedToPerform(
+    ApplicationSharedPtr app,
+    const size_t choice_set_id_list_length,
+    const ns_smart_device_link::ns_smart_objects::SmartObject&
+        choice_set_id_list) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  for (size_t i = 0; i < choice_set_id_list_length; ++i) {
+    const bool is_allowed =
+        app->is_choice_set_allowed_to_perform(choice_set_id_list[i].asInt());
+    if (!is_allowed) {
+      return false;
+    }
+  }
+  return true;
+}
 }  // namespace commands
 
 }  // namespace application_manager

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/create_interaction_choice_set_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/create_interaction_choice_set_test.cc
@@ -833,14 +833,17 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   FillMessageFieldsItem2(message_);
 
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _)).Times(0);
-  EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(mock_app_));
+  EXPECT_CALL(*mock_app_, set_choice_set_allow_mode(kChoiceSetId, true));
+  EXPECT_CALL(app_mngr_, TerminateRequest(kConnectionKey, kCorrelationId, _));
 
   Event event(hmi_apis::FunctionID::VR_AddCommand);
   event.set_smart_object(*message_);
 
   command_->on_event(event);
 
-  EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
+  EXPECT_CALL(app_mngr_, TerminateRequest(kConnectionKey, kCorrelationId, _));
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_app_, RemoveChoiceSet(_));

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/delete_interaction_choice_set_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/delete_interaction_choice_set_test.cc
@@ -192,7 +192,7 @@ TEST_F(DeleteInteractionChoiceSetRequestTest,
   smart_objects::SmartObject* choice_set_id =
       &((*message_)[am::strings::msg_params]
                    [am::strings::interaction_choice_set_id]);
-  smart_objects::SmartObject* invalid_choice_set_id = NULL;
+  smart_objects::SmartObject* invalid_choice_set_id = nullptr;
 
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillRepeatedly(Return(app_));
@@ -207,10 +207,6 @@ TEST_F(DeleteInteractionChoiceSetRequestTest,
 
     EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
         .WillOnce(Return(invalid_choice_set_id));
-
-    EXPECT_CALL(*app_, app_id()).WillOnce(Return(kConnectionKey));
-    EXPECT_CALL(*app_, RemoveChoiceSet(kChoiceSetId));
-    EXPECT_CALL(*app_, UpdateHash());
   }
 
   DeleteInteractionChoiceSetRequestPtr command =
@@ -245,15 +241,11 @@ TEST_F(DeleteInteractionChoiceSetRequestTest, Run_SendVrDeleteCommand_SUCCESS) {
     EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
         .WillOnce(Return(choice_set_id));
 
-    EXPECT_CALL(*app_, app_id())
-        .WillOnce(Return(kConnectionKey))
-        .WillOnce(Return(kConnectionKey));
-    EXPECT_CALL(*app_, RemoveChoiceSet(kChoiceSetId));
-    EXPECT_CALL(*app_, UpdateHash());
+    EXPECT_CALL(*app_, set_choice_set_allow_mode(kChoiceSetId, false));
+    EXPECT_CALL(*app_, app_id()).WillOnce(Return(kConnectionKey));
   }
 
   EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).WillOnce(Return(true));
-  EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _));
 
   DeleteInteractionChoiceSetRequestPtr command =
       CreateCommand<DeleteInteractionChoiceSetRequest>(message_);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/delete_interaction_choice_set_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/delete_interaction_choice_set_test.cc
@@ -242,7 +242,6 @@ TEST_F(DeleteInteractionChoiceSetRequestTest, Run_SendVrDeleteCommand_SUCCESS) {
         .WillOnce(Return(choice_set_id));
 
     EXPECT_CALL(*app_, set_choice_set_allow_mode(kChoiceSetId, false));
-    EXPECT_CALL(*app_, app_id()).WillOnce(Return(kConnectionKey));
   }
 
   EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).WillOnce(Return(true));

--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -561,6 +561,7 @@ void DynamicApplicationDataImpl::AddChoiceSet(
   ChoiceSetMap::const_iterator it = choice_set_map_.find(choice_set_id);
   if (choice_set_map_.end() == it) {
     choice_set_map_[choice_set_id] = new smart_objects::SmartObject(choice_set);
+    choice_set_allowed_map_.insert(std::make_pair(choice_set_id, false));
   }
 }
 
@@ -572,6 +573,10 @@ void DynamicApplicationDataImpl::RemoveChoiceSet(uint32_t choice_set_id) {
     delete it->second;
     choice_set_map_.erase(choice_set_id);
   }
+
+  ChoiceSetAllowedMap::iterator choise_id_it =
+      choice_set_allowed_map_.find(choice_set_id);
+  choice_set_allowed_map_.erase(choise_id_it);
 }
 
 smart_objects::SmartObject* DynamicApplicationDataImpl::FindChoiceSet(
@@ -614,6 +619,21 @@ void DynamicApplicationDataImpl::set_perform_interaction_active(
 void DynamicApplicationDataImpl::set_reset_global_properties_active(
     bool active) {
   is_reset_global_properties_active_ = active;
+}
+
+void DynamicApplicationDataImpl::set_choice_set_allow_mode(
+    const uint32_t choice_set_id, const bool is_allowed) {
+  auto choice_set = choice_set_allowed_map_.find(choice_set_id);
+  if (choice_set == choice_set_allowed_map_.end()) {
+    LOG4CXX_WARN(logger_,
+                 "Choice set with id " << choice_set_id << " is not found.");
+  }
+  choice_set->second = is_allowed;
+}
+
+bool DynamicApplicationDataImpl::is_choice_set_allowed_to_perform(
+    uint32_t choice_set_id) const {
+  return choice_set_allowed_map_.find(choice_set_id)->second;
 }
 
 void DynamicApplicationDataImpl::set_perform_interaction_mode(int32_t mode) {

--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -578,8 +578,7 @@ void DynamicApplicationDataImpl::RemoveChoiceSet(uint32_t choice_set_id) {
       choice_set_allowed_map_.find(choice_set_id);
   if (choice_set_allowed_map_.end() == choise_id_it) {
     LOG4CXX_WARN(logger_,
-                 "Not exists info about choice set " << choice_set_id
-                                                     << " allow");
+                 "Choice set with id " << choice_set_id << " is not found");
     return;
   }
   choice_set_allowed_map_.erase(choise_id_it);
@@ -637,8 +636,9 @@ void DynamicApplicationDataImpl::set_choice_set_allow_mode(
   }
   choice_set->second = is_allowed;
   LOG4CXX_DEBUG(logger_,
-                "choice_set_id: " << choice_set_id << " is_allowed: "
-                                  << std::boolalpha << is_allowed);
+                "choice_set_id: "
+                    << choice_set_id
+                    << (choice_set->second ? " is allowed" : " disallowed"));
 }
 
 bool DynamicApplicationDataImpl::is_choice_set_allowed(

--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -574,8 +574,7 @@ void DynamicApplicationDataImpl::RemoveChoiceSet(uint32_t choice_set_id) {
     choice_set_map_.erase(choice_set_id);
   }
 
-  ChoiceSetAllowedMap::iterator choise_id_it =
-      choice_set_allowed_map_.find(choice_set_id);
+  auto choise_id_it = choice_set_allowed_map_.find(choice_set_id);
   if (choice_set_allowed_map_.end() == choise_id_it) {
     LOG4CXX_WARN(logger_,
                  "Choice set with id " << choice_set_id << " is not found");
@@ -644,7 +643,7 @@ void DynamicApplicationDataImpl::set_choice_set_allow_mode(
 bool DynamicApplicationDataImpl::is_choice_set_allowed(
     const uint32_t choice_set_id) const {
   LOG4CXX_DEBUG(logger_, "Choice setID: " << choice_set_id);
-  auto it = choice_set_allowed_map_.find(choice_set_id);
+  const auto it = choice_set_allowed_map_.find(choice_set_id);
   if (choice_set_allowed_map_.end() == it) {
     LOG4CXX_ERROR(logger_,
                   "Choice set with id " << choice_set_id << " is not found.");

--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -576,6 +576,12 @@ void DynamicApplicationDataImpl::RemoveChoiceSet(uint32_t choice_set_id) {
 
   ChoiceSetAllowedMap::iterator choise_id_it =
       choice_set_allowed_map_.find(choice_set_id);
+  if (choice_set_allowed_map_.end() == choise_id_it) {
+    LOG4CXX_WARN(logger_,
+                 "Not exists info about choice set " << choice_set_id
+                                                     << " allow");
+    return;
+  }
   choice_set_allowed_map_.erase(choise_id_it);
 }
 
@@ -624,16 +630,27 @@ void DynamicApplicationDataImpl::set_reset_global_properties_active(
 void DynamicApplicationDataImpl::set_choice_set_allow_mode(
     const uint32_t choice_set_id, const bool is_allowed) {
   auto choice_set = choice_set_allowed_map_.find(choice_set_id);
-  if (choice_set == choice_set_allowed_map_.end()) {
+  if (choice_set_allowed_map_.end() == choice_set) {
     LOG4CXX_WARN(logger_,
                  "Choice set with id " << choice_set_id << " is not found.");
+    return;
   }
   choice_set->second = is_allowed;
+  LOG4CXX_DEBUG(logger_,
+                "choice_set_id: " << choice_set_id << " is_allowed: "
+                                  << std::boolalpha << is_allowed);
 }
 
-bool DynamicApplicationDataImpl::is_choice_set_allowed_to_perform(
-    uint32_t choice_set_id) const {
-  return choice_set_allowed_map_.find(choice_set_id)->second;
+bool DynamicApplicationDataImpl::is_choice_set_allowed(
+    const uint32_t choice_set_id) const {
+  LOG4CXX_DEBUG(logger_, "Choice setID: " << choice_set_id);
+  auto it = choice_set_allowed_map_.find(choice_set_id);
+  if (choice_set_allowed_map_.end() == it) {
+    LOG4CXX_ERROR(logger_,
+                  "Choice set with id " << choice_set_id << " is not found.");
+    return false;
+  }
+  return it->second;
 }
 
 void DynamicApplicationDataImpl::set_perform_interaction_mode(int32_t mode) {

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -698,6 +698,7 @@ void ResumeCtrlImpl::AddChoicesets(
       const int32_t choice_set_id =
           choice_set[strings::interaction_choice_set_id].asInt();
       application->AddChoiceSet(choice_set_id, choice_set);
+      application->set_choice_set_allow_mode(choice_set_id, true);
     }
     ProcessHMIRequests(MessageHelper::CreateAddVRCommandRequestFromChoiceToHMI(
         application, application_manager_));

--- a/src/components/application_manager/test/include/application_manager/commands/commands_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/commands_test.h
@@ -97,9 +97,10 @@ class CommandsTest : public ::testing::Test {
 
   typedef NiceMock<MockApplicationManagerSettings> MockAppManagerSettings;
   typedef NiceMock<application_manager_test::MockRPCService> MockRPCService;
-  typedef typename TypeIf<kIsNice,
-                          NiceMock<MockApplicationManager>,
-                          MockApplicationManager>::Result MockAppManager;
+  typedef
+      typename TypeIf<kIsNice,
+                      NiceMock<MockApplicationManager>,
+                      NiceMock<MockApplicationManager> >::Result MockAppManager;
   typedef typename TypeIf<kIsNice,
                           NiceMock<MockApplication>,
                           MockApplication>::Result MockApp;

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -299,6 +299,8 @@ class MockApplication : public ::application_manager::Application {
                      mobile_apis::LayoutMode::eType());
   MOCK_METHOD1(set_reset_global_properties_active, void(bool active));
   MOCK_CONST_METHOD0(is_reset_global_properties_active, bool());
+  MOCK_METHOD2(set_choice_set_allow_mode, void(std::uint32_t, bool));
+  MOCK_CONST_METHOD1(is_choice_set_allowed_to_perform, bool(std::uint32_t));
   MOCK_CONST_METHOD0(app_id, uint32_t());
   MOCK_CONST_METHOD0(mac_address, const std::string&());
   MOCK_CONST_METHOD0(bundle_id, const std::string&());

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -300,7 +300,7 @@ class MockApplication : public ::application_manager::Application {
   MOCK_METHOD1(set_reset_global_properties_active, void(bool active));
   MOCK_CONST_METHOD0(is_reset_global_properties_active, bool());
   MOCK_METHOD2(set_choice_set_allow_mode, void(std::uint32_t, bool));
-  MOCK_CONST_METHOD1(is_choice_set_allowed_to_perform, bool(std::uint32_t));
+  MOCK_CONST_METHOD1(is_choice_set_allowed, bool(std::uint32_t));
   MOCK_CONST_METHOD0(app_id, uint32_t());
   MOCK_CONST_METHOD0(mac_address, const std::string&());
   MOCK_CONST_METHOD0(bundle_id, const std::string&());


### PR DESCRIPTION
Fixes #1883 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by Unit test.

### Summary
Exists case:
DeleteInteractionChoiceSet request with ChoiceSet_ID was received and
has sent VR.DeleteCommand requests to HMI. HMI still process that requests
and hasn't sent responses yet.
In this case, if Mobile will sends PerformInteractionChoiceSet with
ChoiceSet_ID to SDL, SDL has to sents PerformInteractionChoiceSet response
{result_code = REJECTED, success = false} to Mobile.
This PR rpovides changes, where DynamicApplicationDataImpl stores
choise_set ids and their allow states to perform. PerformInteractionChoiceSet
request checks this information and at-least one choice set dosn't allowed
it sents to Mobile response {result_code = REJECTED, success = false}.
This changes covered by unit test case ChoiceProcessesOnHHMI_REJECT.
According to this changes, was amended several unit test cases:
- CreateInteractionChoiceSetRequestTest.OnTimeOut_SuccessfulResponseReceived_UNSUCCESS;
DeleteInteractionChoiceSetRequestTest.Run_SendVrDeleteCommand_PerformInteractionFalse_UNSUCCESS;

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)