### PR TITLE
Add override for IAP emulated transport

### DIFF
--- a/src/components/transport_manager/include/transport_manager/iap2_emulation/iap2_transport_adapter.h
+++ b/src/components/transport_manager/include/transport_manager/iap2_emulation/iap2_transport_adapter.h
@@ -74,6 +74,15 @@ class IAP2BluetoothEmulationTransportAdapter : public TcpTransportAdapter {
    */
   void DeviceSwitched(const DeviceUID& device_handle) OVERRIDE;
 
+  /**
+   * @brief Notification that transport's configuration is updated. This
+   * override is needed so that a OnTransportConfigUpdated is not sent to the
+   * mobile device for the emulated transport.
+   *
+   * @param new_config The new configuration of the transport
+   */
+  void TransportConfigUpdated(const TransportConfig& new_config) OVERRIDE;
+
  protected:
   /**
    * @brief GetDeviceType Provides SDL device type for transport adapter
@@ -109,6 +118,15 @@ class IAP2USBEmulationTransportAdapter : public TcpTransportAdapter {
    * @param device_handle Device handle of switched device
    */
   void DeviceSwitched(const DeviceUID& device_handle) OVERRIDE;
+
+  /**
+   * @brief Notification that transport's configuration is updated. This
+   * override is needed so that a OnTransportConfigUpdated is not sent to the
+   * mobile device for the emulated transport.
+   *
+   * @param new_config The new configuration of the transport
+   */
+  void TransportConfigUpdated(const TransportConfig& new_config) OVERRIDE;
 
  protected:
   /**

--- a/src/components/transport_manager/src/iap2_emulation/iap2_transport_adapter.cc
+++ b/src/components/transport_manager/src/iap2_emulation/iap2_transport_adapter.cc
@@ -69,6 +69,11 @@ DeviceType IAP2BluetoothEmulationTransportAdapter::GetDeviceType() const {
   return IOS_BT;
 }
 
+void IAP2BluetoothEmulationTransportAdapter::TransportConfigUpdated(
+    const TransportConfig& new_config) {
+  return;
+}
+
 IAP2USBEmulationTransportAdapter::IAP2USBEmulationTransportAdapter(
     const uint16_t port,
     resumption::LastState& last_state,
@@ -118,6 +123,11 @@ void IAP2USBEmulationTransportAdapter::DeviceSwitched(
 
 DeviceType IAP2USBEmulationTransportAdapter::GetDeviceType() const {
   return IOS_USB;
+}
+
+void IAP2USBEmulationTransportAdapter::TransportConfigUpdated(
+    const TransportConfig& new_config) {
+  return;
 }
 
 IAP2USBEmulationTransportAdapter::IAPSignalHandlerDelegate::


### PR DESCRIPTION
Fixes #2615 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Connect app over BT with core configured to use wifi as secondary bluetooth transport.

### Summary
Adds an override to TransportConfigUpdated for IAP emulated transport adapters. Because these emulated transport adapters inherit from TcpTransportAdapter, their IP/port information was being sent to the mobile device. The override stops this transport event since the IAP emulated transports are not true Tcp transport adapters.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)