### PR TITLE
Fix/fix module types saving into db

### DIFF
--- a/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
@@ -1739,6 +1739,20 @@ bool SQLPTExtRepresentation::SetDefaultPolicy(const std::string& app_id) {
 
   SetPreloaded(false);
 
+  bool rc_denied = false;
+  if (!GatherRemoteControlDenied(kDefaultId, &rc_denied) ||
+      !SaveRemoteControlDenied(app_id, rc_denied)) {
+    return false;
+  }
+
+  if (!rc_denied) {
+    policy_table::ModuleTypes module_types;
+    if (!GatherModuleType(kDefaultId, &module_types) ||
+        !SaveModuleType(app_id, module_types)) {
+      return false;
+    }
+  }
+
   policy_table::Strings default_groups;
   policy_table::Strings default_preconsented_groups;
   GatherAppGroup(kDefaultId, &default_groups);

--- a/src/components/policy/policy_external/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_queries.cc
@@ -859,13 +859,14 @@ const std::string kInsertApplicationFull =
     "INSERT OR IGNORE INTO `application` (`id`, `keep_context`, `steal_focus`, "
     "  `default_hmi`, `priority_value`, `is_revoked`, `is_default`, "
     "`is_predata`, "
-    " `memory_kb`, `heart_beat_timeout_ms`) "
-    "  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    " `memory_kb`, `heart_beat_timeout_ms`, `remote_control_denied`) "
+    "  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 const std::string kSelectApplicationFull =
     "SELECT `keep_context`, `steal_focus`, `default_hmi`, `priority_value`, "
     "  `is_revoked`, `is_default`, `is_predata`, `memory_kb`,"
-    "  `heart_beat_timeout_ms` FROM `application` WHERE `id` = ?";
+    "  `heart_beat_timeout_ms`, `remote_control_denied` "
+    "FROM `application` WHERE `id` = ?";
 
 const std::string kSelectDBVersion =
     "SELECT `db_version_hash` from `_internal_data`";

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -2024,6 +2024,20 @@ bool SQLPTRepresentation::SetDefaultPolicy(const std::string& app_id) {
     return false;
   }
 
+  bool rc_denied = false;
+  if (!GatherRemoteControlDenied(kDefaultId, &rc_denied) ||
+      !SaveRemoteControlDenied(app_id, rc_denied)) {
+    return false;
+  }
+
+  if (!rc_denied) {
+    policy_table::ModuleTypes module_types;
+    if (!GatherModuleType(kDefaultId, &module_types) ||
+        !SaveModuleType(app_id, module_types)) {
+      return false;
+    }
+  }
+
   policy_table::Strings default_groups;
   bool ret = (GatherAppGroup(kDefaultId, &default_groups) &&
               SaveAppGroup(app_id, default_groups));
@@ -2143,6 +2157,7 @@ bool SQLPTRepresentation::CopyApplication(const std::string& source,
                        : query.Bind(7, source_app.GetBoolean(6));
   query.Bind(8, source_app.GetInteger(7));
   query.Bind(9, source_app.GetInteger(8));
+  query.Bind(10, source_app.GetInteger(9));
 
   if (!query.Exec()) {
     LOG4CXX_WARN(logger_, "Failed inserting into application.");

--- a/src/components/policy/policy_external/test/sql_pt_ext_representation_test.cc
+++ b/src/components/policy/policy_external/test/sql_pt_ext_representation_test.cc
@@ -870,10 +870,17 @@ TEST_F(
       "VALUES (129372391, '', 'pre_DataConsent')";
   ASSERT_TRUE(query_wrapper_->Exec(query_insert_functional_group));
 
+  const std::string query_insert_default_application =
+      "INSERT INTO `application` (`id`, `memory_kb`,"
+      " `heart_beat_timeout_ms`, `is_predata`, `keep_context`, "
+      "`remote_control_denied`) "
+      "VALUES ('default', 5, 10, 1, 0, 0)";
+  ASSERT_TRUE(query_wrapper_->Exec(query_insert_default_application));
+
   const std::string query_insert_application =
       "INSERT INTO `application` (`id`, `memory_kb`,"
-      " `heart_beat_timeout_ms`, `is_predata`, `keep_context`) VALUES ('1234', "
-      "5, 10, 1, 0)";
+      " `heart_beat_timeout_ms`, `is_predata`, `keep_context`) "
+      "VALUES ('1234', 5, 10, 1, 0)";
 
   // Assert
   ASSERT_TRUE(query_wrapper_->Exec(query_insert_application));
@@ -1374,6 +1381,13 @@ TEST_F(
     SQLPTExtRepresentationTest,
     SetDefaultPolicy_SetPredataThenChangeToDefaultPolicy_ExpectDefaultPolicySet) {
   // Arrange
+  const std::string query_insert_default_application =
+      "INSERT INTO `application` (`id`, `memory_kb`,"
+      " `heart_beat_timeout_ms`, `is_predata`, `keep_context`, "
+      "`remote_control_denied`) "
+      "VALUES ('default', 5, 10, 1, 0, 0)";
+  ASSERT_TRUE(query_wrapper_->Exec(query_insert_default_application));
+
   const std::string query_insert_app =
       "INSERT OR IGNORE INTO `application`(`id`, `keep_context`, "
       "`steal_focus`, "

--- a/src/components/policy/policy_external/test/sql_pt_representation_test.cc
+++ b/src/components/policy/policy_external/test/sql_pt_representation_test.cc
@@ -1484,9 +1484,8 @@ TEST_F(SQLPTRepresentationTest,
       "`steal_focus`, "
       " `default_hmi`, `priority_value`, `is_revoked`, `is_default`, "
       "`is_predata`, `memory_kb`, "
-      " `heart_beat_timeout_ms`) VALUES( 'default', 0, 0, 'NONE', 'NONE', 0, "
-      "0, "
-      "0, 64, 10) ";
+      " `heart_beat_timeout_ms`, `remote_control_denied`) "
+      "VALUES( 'default', 0, 0, 'NONE', 'NONE', 0, 0, 0, 64, 10, 0) ";
   ASSERT_TRUE(query_wrapper_->Exec(query_insert_app_default));
 
   const std::string query_insert_app_1234567 =

--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -794,15 +794,16 @@ const std::string kDeleteAppGroupByApplicationId =
 const std::string kInsertApplicationFull =
     "INSERT OR IGNORE INTO `application` (`id`, `keep_context`, `steal_focus`, "
     "  `default_hmi`, `priority_value`, `is_revoked`, `is_default`, "
-    "`is_predata`, "
-    " `memory_kb`, `heart_beat_timeout_ms`, `certificate`) "
-    "  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    "  `is_predata`, "
+    "  `memory_kb`, `heart_beat_timeout_ms`, `certificate`, "
+    "  `remote_control_denied`) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 const std::string kSelectApplicationFull =
     "SELECT `keep_context`, `steal_focus`, `default_hmi`, `priority_value`, "
     "  `is_revoked`, `is_default`, `is_predata`, `memory_kb`,"
-    "  `heart_beat_timeout_ms`, `certificate` FROM `application` WHERE `id` = "
-    "?";
+    "  `heart_beat_timeout_ms`, `certificate`, `remote_control_denied` "
+    "FROM `application` WHERE `id` = ?";
 
 const std::string kSelectDBVersion =
     "SELECT `db_version_hash` from `_internal_data`";

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -1985,6 +1985,20 @@ bool SQLPTRepresentation::SetDefaultPolicy(const std::string& app_id) {
     return false;
   }
 
+  bool rc_denied = false;
+  if (!GatherRemoteControlDenied(kDefaultId, &rc_denied) ||
+      !SaveRemoteControlDenied(app_id, rc_denied)) {
+    return false;
+  }
+
+  if (!rc_denied) {
+    policy_table::ModuleTypes module_types;
+    if (!GatherModuleType(kDefaultId, &module_types) ||
+        !SaveModuleType(app_id, module_types)) {
+      return false;
+    }
+  }
+
   return SetIsDefault(app_id, true);
 }
 
@@ -2100,6 +2114,7 @@ bool SQLPTRepresentation::CopyApplication(const std::string& source,
   query.Bind(9, source_app.GetInteger(8));
   source_app.IsNull(9) ? query.Bind(10)
                        : query.Bind(10, source_app.GetString(9));
+  query.Bind(11, source_app.GetInteger(10));
   if (!query.Exec()) {
     LOG4CXX_WARN(logger_, "Failed inserting into application.");
     return false;

--- a/src/components/policy/policy_regular/test/sql_pt_representation_test.cc
+++ b/src/components/policy/policy_regular/test/sql_pt_representation_test.cc
@@ -1402,9 +1402,9 @@ TEST_F(SQLPTRepresentationTest,
       "`steal_focus`, "
       " `default_hmi`, `priority_value`, `is_revoked`, `is_default`, "
       "`is_predata`, `memory_kb`, "
-      " `heart_beat_timeout_ms`) "
+      " `heart_beat_timeout_ms`, `remote_control_denied`) "
       "VALUES( '" +
-      kDefaultId + "', 0, 0, 'NONE', 'NONE', 0, 0, 0, 64, 10) ";
+      kDefaultId + "', 0, 0, 'NONE', 'NONE', 0, 0, 0, 64, 10, 0) ";
 
   ASSERT_TRUE(dbms->Exec(query_insert_default_app.c_str()));
 


### PR DESCRIPTION
Fixes #2616 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manual testing on HMI

### Summary
There was a missed logic of saving of moduleType parameter of application into the database. SDL does not save this parameter into the database when application get default policy permissions. As a result, on the next ignition circle SDL loads nothing from database for this application as nothing was saved. As a result SDL rejects all RC related requests due to wrongly set moduleType parameter.
In this PR was added missing logic of saving this parameter into the database.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)