### PR TITLE
Feature/resumption data error handling

### DIFF
--- a/src/components/application_manager/include/application_manager/app_extension.h
+++ b/src/components/application_manager/include/application_manager/app_extension.h
@@ -33,11 +33,20 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_APP_EXTENSION_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_APP_EXTENSION_H_
 
+#include <functional>
+
 namespace ns_smart_device_link {
 namespace ns_smart_objects {
 class SmartObject;
 }
 }
+
+namespace smart_objects = ns_smart_device_link::ns_smart_objects;
+
+namespace resumption {
+struct ResumptionRequest;
+using Subscriber = std::function<void(const int32_t, const ResumptionRequest)>;
+}  // namespace resumption
 
 namespace application_manager {
 
@@ -58,15 +67,23 @@ class AppExtension {
    * plugin
    */
   virtual void SaveResumptionData(
-      ns_smart_device_link::ns_smart_objects::SmartObject& resumption_data) = 0;
+      smart_objects::SmartObject& resumption_data) = 0;
 
   /**
    * @brief ProcessResumption Method called by SDL during resumption.
    * @param resumption_data list of resumption data
+   * @param subscriber callbacks for subscribing
    */
   virtual void ProcessResumption(
-      const ns_smart_device_link::ns_smart_objects::SmartObject&
-          resumption_data) = 0;
+      const smart_objects::SmartObject& resumption_data,
+      resumption::Subscriber subscriber) = 0;
+
+  /**
+   * @brief RevertResumption Method called by SDL during revert resumption.
+   * @param subscriptions Subscriptions from which must discard
+   */
+  virtual void RevertResumption(
+      const smart_objects::SmartObject& subscriptions) = 0;
 
  private:
   const AppExtensionUID kUid_;

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -653,7 +653,7 @@ class Application : public virtual InitialApplicationData,
    * @param is_persistent Bollean describes is file persistent?
    * @param is_download_complete Bollean describes is file downloaded fully on
    * need to finish downloading?
-   * @return TRUE if file exist and updated sucsesfuly, othervise return false
+   * @return TRUE if file exist and updated sucsesfuly, otherwise return false
    */
   virtual bool UpdateFile(const AppFile& file) = 0;
   virtual bool DeleteFile(const std::string& file_name) = 0;

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -228,12 +228,12 @@ class ApplicationManagerImpl
   bool IsAppTypeExistsInFullOrLimited(ApplicationConstSharedPtr app) const;
 
   /**
-   * @brief Checks if Application is subscribed for way points
-   * @param Application pointer
+   * @brief Checks if application is subscribed for way points
+   * @param app - application reference
    * @return true if Application is subscribed for way points
    * otherwise false
    */
-  bool IsAppSubscribedForWayPoints(ApplicationSharedPtr app) const OVERRIDE;
+  bool IsAppSubscribedForWayPoints(Application& app) const OVERRIDE;
 
   /**
    * @brief Subscribe Application for way points
@@ -862,7 +862,6 @@ class ApplicationManagerImpl
     */
   ResetGlobalPropertiesResult ResetAllApplicationGlobalProperties(
       const uint32_t app_id) OVERRIDE;
-
 
   // TODO(AOleynik): Temporary added, to fix build. Should be reworked.
   connection_handler::ConnectionHandler& connection_handler() const OVERRIDE;

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -346,6 +346,10 @@ class ApplicationManagerImpl
    * @brief Closes all registered applications
    */
   void UnregisterAllApplications();
+
+  DEPRECATED bool RemoveAppDataFromHMI(ApplicationSharedPtr app);
+
+  DEPRECATED bool LoadAppDataToHMI(ApplicationSharedPtr app);
   bool ActivateApplication(ApplicationSharedPtr app) OVERRIDE;
 
   /**
@@ -840,6 +844,26 @@ class ApplicationManagerImpl
    */
   void RemoveAppFromTTSGlobalPropertiesList(const uint32_t app_id) OVERRIDE;
 
+  /**
+   * @brief Resets application's global properties to default values
+   * returning struct that indicates which properties have been
+   * successfully reset.
+   * @param container with global properties to reset
+   * @return struct with flags indicating global properties reset
+   */
+  ResetGlobalPropertiesResult ResetGlobalProperties(
+      const smart_objects::SmartObject& global_properties_ids,
+      const uint32_t app_id) OVERRIDE;
+
+  /**
+    * @brief Resets all application's global properties to default values
+    * @param id of app which properties to reset
+    * @return struct with flags indicating success global properties reset
+    */
+  ResetGlobalPropertiesResult ResetAllApplicationGlobalProperties(
+      const uint32_t app_id) OVERRIDE;
+
+
   // TODO(AOleynik): Temporary added, to fix build. Should be reworked.
   connection_handler::ConnectionHandler& connection_handler() const OVERRIDE;
   protocol_handler::ProtocolHandler& protocol_handler() const OVERRIDE;
@@ -1165,6 +1189,39 @@ class ApplicationManagerImpl
    */
   void SendMobileMessage(smart_objects::SmartObjectSPtr message);
 
+  /*
+   * @brief Sets default value of the HELPPROMT global property
+   * to the first vrCommand of each Command Menu registered in application
+   *
+   * @param app Registered application
+   * @param is_timeout_promp Flag indicating that timeout prompt
+   * should be reset
+   *
+   * @return TRUE on success, otherwise FALSE
+   */
+  bool ResetHelpPromt(ApplicationSharedPtr app) const;
+
+  /*
+   * @brief  Sets default value of the TIMEOUTPROMT global property
+   * to the first vrCommand of each Command Menu registered in application
+   *
+   * @param app Registered application
+   *
+   * @return TRUE on success, otherwise FALSE
+   */
+  bool ResetTimeoutPromt(ApplicationSharedPtr app) const;
+
+  /*
+   * @brief Sets default value of the VRHELPTITLE global property
+   * to the application name and value of the VRHELPITEMS global property
+   * to value equal to registered command -1(default command “Help / Cancel”.)
+   *
+   * @param app Registered application
+   *
+   * @return TRUE on success, otherwise FALSE
+   */
+  bool ResetVrHelpTitleItems(ApplicationSharedPtr app) const;
+
  private:
   /*
    * NaviServiceStatusMap shows which navi service (audio/video) is opened
@@ -1187,6 +1244,16 @@ class ApplicationManagerImpl
    */
   std::string GetHashedAppID(uint32_t connection_key,
                              const std::string& policy_app_id) const;
+
+  /**
+   * @brief CreateAllAppGlobalPropsIDList creates an array of all application
+   * global properties IDs. Used as utility to call
+   * ApplicationManger::ResetGlobalProperties
+   * with all global properties.
+   * @return array smart object with global properties identifiers.
+   */
+  const smart_objects::SmartObjectSPtr CreateAllAppGlobalPropsIDList(
+      const uint32_t app_id) const;
 
   /**
    * @brief Removes suspended and stopped timers from timer pool

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -57,7 +57,39 @@ class PolicyHandlerInterface;
 }
 
 namespace application_manager {
-namespace mobile_api = mobile_apis;
+
+/**
+ * @brief ResetGlobalPropertiesResult
+ * contains flags indicating success of
+ * ResetGlobalProperties operation.
+ * Used in MessageHelper functions
+ * to construct relevant requests
+ **/
+struct ResetGlobalPropertiesResult {
+  bool help_prompt;
+  bool timeout_prompt;
+  bool vr_help_title_items;
+  bool menu_name;
+  bool menu_icon;
+  bool keyboard_properties;
+  int number_of_reset_vr;
+
+  ResetGlobalPropertiesResult()
+      : help_prompt(false)
+      , timeout_prompt(false)
+      , vr_help_title_items(false)
+      , menu_name(false)
+      , menu_icon(false)
+      , keyboard_properties(false)
+      , number_of_reset_vr(0) {}
+  bool HasUIPropertiesReset() const {
+    return vr_help_title_items || menu_name || menu_icon || keyboard_properties;
+  }
+
+  bool HasTTSPropertiesReset() const {
+    return timeout_prompt || help_prompt;
+  }
+};
 
 /*
  * @brief Typedef for VehicleData
@@ -175,7 +207,7 @@ class MessageHelper {
    * @return mobile Result enum value if succedeed, otherwise - INVALID_ENUM
    * value
    */
-  static mobile_api::Result::eType MobileResultFromString(
+  static mobile_apis::Result::eType MobileResultFromString(
       const std::string& mobile_result);
 
   /**
@@ -184,7 +216,7 @@ class MessageHelper {
    * @return mobile Result enum value if succedeed, otherwise - INVALID_ENUM
    * value
    */
-  static mobile_api::Result::eType HMIToMobileResult(
+  static mobile_apis::Result::eType HMIToMobileResult(
       const hmi_apis::Common_Result::eType hmi_result);
 
   /**
@@ -193,7 +225,7 @@ class MessageHelper {
    * @return HMI Result enum value
    */
   static hmi_apis::Common_Result::eType MobileToHMIResult(
-      const mobile_api::Result::eType mobile_result);
+      const mobile_apis::Result::eType mobile_result);
 
   /**
    * @brief Convert string to HMI level, if possible
@@ -201,7 +233,7 @@ class MessageHelper {
    * @return Appropriate enum from HMI level, or INVALID_ENUM, if conversiion
    * is not possible
    */
-  static mobile_api::HMILevel::eType StringToHMILevel(
+  static mobile_apis::HMILevel::eType StringToHMILevel(
       const std::string& hmi_level);
 
   /*
@@ -789,7 +821,7 @@ class MessageHelper {
   static smart_objects::SmartObjectSPtr
   GetOnAppInterfaceUnregisteredNotificationToMobile(
       int32_t connection_key,
-      mobile_api::AppInterfaceUnregisteredReason::eType reason);
+      mobile_apis::AppInterfaceUnregisteredReason::eType reason);
 
   /**
    * @brief SendDeleteCommandRequest sends requests to HMI to remove UI/VR
@@ -877,6 +909,28 @@ class MessageHelper {
    */
   static smart_objects::SmartObjectSPtr CreateMessageForHMI(
       hmi_apis::messageType::eType message_type, const uint32_t correlation_id);
+
+  /**
+   * @brief CreateUIResetGlobalPropertiesRequest Creates request
+   * to reset global properties for UI
+   * @param struct containing result of global properties reset procedure
+   * @param application which properties are to be reset
+   * @return filled smart object with relevant request data
+   */
+  static smart_objects::SmartObjectSPtr CreateUIResetGlobalPropertiesRequest(
+      const ResetGlobalPropertiesResult& reset_result,
+      const ApplicationSharedPtr application);
+
+  /**
+   * @brief CreateTTSResetGlobalPropertiesRequest Creates request
+   * to reset global properties for TTS
+   * @param struct containing result of global properties reset procedure
+   * @param application which properties are to be reset
+   * @return filled smart object with relevant request data
+   */
+  static smart_objects::SmartObjectSPtr CreateTTSResetGlobalPropertiesRequest(
+      const ResetGlobalPropertiesResult& reset_result,
+      const ApplicationSharedPtr application);
 
  private:
   /**

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -296,7 +296,7 @@ class MessageHelper {
   static void SendGlobalPropertiesToHMI(ApplicationConstSharedPtr app,
                                         ApplicationManager& app_mngr);
   static smart_objects::SmartObjectList CreateGlobalPropertiesRequestsToHMI(
-      ApplicationConstSharedPtr app, const uint32_t correlation_id);
+      ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
 
   static smart_objects::SmartObjectSPtr CreateAppVrHelp(
       ApplicationConstSharedPtr app);
@@ -309,6 +309,10 @@ class MessageHelper {
                                               ApplicationManager& app_man);
   static void SendAddCommandRequestToHMI(ApplicationConstSharedPtr app,
                                          ApplicationManager& app_man);
+
+  static smart_objects::SmartObjectList CreateAddSubMenuRequestToHMI(
+      ApplicationConstSharedPtr app, const uint32_t correlation_id);
+
   static smart_objects::SmartObjectList CreateAddCommandRequestToHMI(
       ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
 
@@ -367,7 +371,7 @@ class MessageHelper {
 
   static void SendAddSubMenuRequestToHMI(ApplicationConstSharedPtr app,
                                          ApplicationManager& app_mngr);
-  static smart_objects::SmartObjectList CreateAddSubMenuRequestToHMI(
+  static smart_objects::SmartObjectList CreateAddSubMenuRequestsToHMI(
       ApplicationConstSharedPtr app, const uint32_t correlation_id);
 
   /*
@@ -597,6 +601,16 @@ class MessageHelper {
    * @return TRUE on SUCCES otherwise return FALSE
    */
   static bool SendStopAudioPathThru(ApplicationManager& app_mngr);
+
+
+  /**
+   * @brief CreateSubscribeWayPointsMessageToHMI
+   * @param correlation_id
+   * @return
+   */
+  static smart_objects::SmartObjectSPtr CreateSubscribeWayPointsMessageToHMI(
+      const uint32_t correlation_id);
+
 
   /**
    * @brief Sends UnsubscribeWayPoints request

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -372,7 +372,7 @@ class MessageHelper {
   static void SendAddSubMenuRequestToHMI(ApplicationConstSharedPtr app,
                                          ApplicationManager& app_mngr);
   static smart_objects::SmartObjectList CreateAddSubMenuRequestsToHMI(
-      ApplicationConstSharedPtr app, const uint32_t correlation_id);
+      ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
 
   /*
    * @brief Creates BasicCommunication.OnAppUnregistered notification

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -278,8 +278,7 @@ class MessageHelper {
   /**
    * @brief Creates button subscription notification
    */
-  static smart_objects::SmartObjectSPtr
-  CreateOnButtonSubscriptionNotification(
+  static smart_objects::SmartObjectSPtr CreateOnButtonSubscriptionNotification(
       const uint32_t app_id,
       const hmi_apis::Common_ButtonName::eType button,
       const bool is_subscribed,

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -599,7 +599,6 @@ class MessageHelper {
    */
   static bool SendStopAudioPathThru(ApplicationManager& app_mngr);
 
-
   /**
    * @brief Sends UnsubscribeWayPoints request
    * @return true if UnsubscribedWayPoints is send otherwise false

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -606,13 +606,6 @@ class MessageHelper {
    */
   static bool SendUnsubscribedWayPoints(ApplicationManager& app_mngr);
 
-  /**
-   * @brief Creates SubscribeWayPointsMessage to be sent to HMI
-   * @return filled smart object with relevant message data
-   */
-  static smart_objects::SmartObjectSPtr CreateSubscribeWayPointsMessageToHMI(
-      const uint32_t correlation_id);
-
   static smart_objects::SmartObjectSPtr CreateNegativeResponse(
       uint32_t connection_key,
       int32_t function_id,
@@ -918,6 +911,16 @@ class MessageHelper {
    */
   static smart_objects::SmartObjectSPtr CreateMessageForHMI(
       hmi_apis::messageType::eType message_type, const uint32_t correlation_id);
+
+  /**
+   * @brief CreateMessageForHMI Creates HMI message with prepared header
+   * acccoring to message type
+   * @param function_id function id
+   * @param correlation_id Correlation id
+   * @return HMI message object with filled header
+   */
+  static smart_objects::SmartObjectSPtr CreateMessageForHMI(
+      hmi_apis::FunctionID::eType function_id, const uint32_t correlation_id);
 
   /**
    * @brief CreateUIResetGlobalPropertiesRequest Creates request

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -288,8 +288,10 @@ class MessageHelper {
    * @brief Sends button subscription notifications for all buttons
    * that application is subscribed on
    */
-  static void SendAllOnButtonSubscriptionNotificationsForApp(
-      ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
+  static void SendOnButtonSubscriptionNotificationsForApp(
+      ApplicationConstSharedPtr app,
+      ApplicationManager& app_mngr,
+      const ButtonSubscriptions& button_subscriptions);
 
   static void SendAppDataToHMI(ApplicationConstSharedPtr app,
                                ApplicationManager& app_man);

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -276,19 +276,21 @@ class MessageHelper {
       const std::string& path_to_icon, uint32_t app_id);
 
   /**
-   * @brief Sends button subscription notification
+   * @brief Creates button subscription notification
    */
-  static void SendOnButtonSubscriptionNotification(
+  static smart_objects::SmartObjectSPtr
+  CreateOnButtonSubscriptionNotification(
       const uint32_t app_id,
       const hmi_apis::Common_ButtonName::eType button,
       const bool is_subscribed,
       ApplicationManager& app_mngr);
 
   /**
-   * @brief Sends button subscription notifications for all buttons
+   * @brief Creates button subscription notifications for buttons
    * that application is subscribed on
    */
-  static void SendOnButtonSubscriptionNotificationsForApp(
+  static smart_objects::SmartObjectList
+  CreateOnButtonSubscriptionNotificationsForApp(
       ApplicationConstSharedPtr app,
       ApplicationManager& app_mngr,
       const ButtonSubscriptions& button_subscriptions);

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -310,9 +310,6 @@ class MessageHelper {
   static void SendAddCommandRequestToHMI(ApplicationConstSharedPtr app,
                                          ApplicationManager& app_man);
 
-  static smart_objects::SmartObjectList CreateAddSubMenuRequestToHMI(
-      ApplicationConstSharedPtr app, const uint32_t correlation_id);
-
   static smart_objects::SmartObjectList CreateAddCommandRequestToHMI(
       ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
 
@@ -604,19 +601,17 @@ class MessageHelper {
 
 
   /**
-   * @brief CreateSubscribeWayPointsMessageToHMI
-   * @param correlation_id
-   * @return
-   */
-  static smart_objects::SmartObjectSPtr CreateSubscribeWayPointsMessageToHMI(
-      const uint32_t correlation_id);
-
-
-  /**
    * @brief Sends UnsubscribeWayPoints request
    * @return true if UnsubscribedWayPoints is send otherwise false
    */
   static bool SendUnsubscribedWayPoints(ApplicationManager& app_mngr);
+
+  /**
+   * @brief Creates SubscribeWayPointsMessage to be sent to HMI
+   * @return filled smart object with relevant message data
+   */
+  static smart_objects::SmartObjectSPtr CreateSubscribeWayPointsMessageToHMI(
+      const uint32_t correlation_id);
 
   static smart_objects::SmartObjectSPtr CreateNegativeResponse(
       uint32_t connection_key,

--- a/src/components/application_manager/include/application_manager/resumption/extension_pending_resumption_handler.h
+++ b/src/components/application_manager/include/application_manager/resumption/extension_pending_resumption_handler.h
@@ -1,0 +1,40 @@
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_EXTENSION_PENDING_RESUMPTION_HANDLER_H
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_EXTENSION_PENDING_RESUMPTION_HANDLER_H
+#include "application_manager/event_engine/event_observer.h"
+#include "application_manager/application_manager.h"
+#include "application_manager/app_extension.h"
+
+namespace resumption {
+
+namespace app_mngr = application_manager;
+
+class ExtensionPendingResumptionHandler
+    : public application_manager::event_engine::EventObserver {
+ public:
+  ExtensionPendingResumptionHandler(
+      app_mngr::ApplicationManager& application_manager);
+
+  virtual ~ExtensionPendingResumptionHandler() {}
+
+  // EventObserver interface
+  virtual void on_event(
+      const application_manager::event_engine::Event& event) = 0;
+
+  virtual void HandleResumptionSubscriptionRequest(
+      app_mngr::AppExtension& extension,
+      Subscriber& subscriber,
+      application_manager::Application& app) = 0;
+
+  virtual void ClearPendingResumptionRequests() = 0;
+
+ protected:
+  virtual ResumptionRequest MakeResumptionRequest(
+      const uint32_t corr_id,
+      const hmi_apis::FunctionID::eType function_id,
+      const smart_objects::SmartObject& message);
+
+  app_mngr::ApplicationManager& application_manager_;
+};
+}  //  namespace resumption
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_EXTENSION_PENDING_RESUMPTION_HANDLER_H

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -56,6 +56,14 @@ class LastState;
 class ResumeCtrl {
  public:
   /**
+  * @brief ResumptionCallBack Function signature to be called whe
+  * DataResumptionFinished
+  * @param result_code result code for sending to mobile
+  * @param info additional info for sending to mobile
+  */
+  typedef std::function<void(mobile_apis::Result::eType result_code,
+                             const std::string& info)> ResumptionCallBack;
+  /**
    * @brief allows to destroy ResumeCtrl object
    */
   virtual ~ResumeCtrl() {}
@@ -163,7 +171,8 @@ class ResumeCtrl {
    * @return true if it was saved, otherwise return false
    */
   virtual bool StartResumption(app_mngr::ApplicationSharedPtr application,
-                               const std::string& hash) = 0;
+                               const std::string& hash,
+                               ResumptionCallBack callback) = 0;
   /**
    * @brief Start timer for resumption applications
    *        Does not restore D1-D5 data

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -173,6 +173,13 @@ class ResumeCtrl {
   virtual bool StartResumption(app_mngr::ApplicationSharedPtr application,
                                const std::string& hash,
                                ResumptionCallBack callback) = 0;
+
+  /**
+   * @brief Handle restored data when timeout appeared
+   * @param application id - const int32_t
+   */
+  virtual void HandleOnTimeOut(const int32_t app_id) = 0;
+
   /**
    * @brief Start timer for resumption applications
    *        Does not restore D1-D5 data

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -176,9 +176,12 @@ class ResumeCtrl {
 
   /**
    * @brief Handle restored data when timeout appeared
-   * @param application id - const int32_t
+   * @param correlation_id - const int32_t
+   * @param function id hmi_apis::FunctionID::eType
    */
-  virtual void HandleOnTimeOut(const int32_t app_id) = 0;
+
+  virtual void HandleOnTimeOut(const uint32_t correlation_id,
+                               const hmi_apis::FunctionID::eType) = 0;
 
   /**
    * @brief Start timer for resumption applications

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -160,7 +160,8 @@ class ResumeCtrlImpl : public ResumeCtrl {
    * @return true if it was saved, otherwise return false
    */
   bool StartResumption(app_mngr::ApplicationSharedPtr application,
-                       const std::string& hash) OVERRIDE;
+                       const std::string& hash,
+                       ResumptionCallBack callback) OVERRIDE;
 
   /**
    * @brief Start timer for resumption applications
@@ -308,7 +309,8 @@ class ResumeCtrlImpl : public ResumeCtrl {
    * @param application contains application for which restores data
    * @return true if success, otherwise return false
    */
-  bool RestoreApplicationData(app_mngr::ApplicationSharedPtr application);
+  bool RestoreApplicationData(app_mngr::ApplicationSharedPtr application,
+                              ResumptionCallBack callback);
 
   /**
    * @brief SaveDataOnTimer :

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -163,6 +163,8 @@ class ResumeCtrlImpl : public ResumeCtrl {
                        const std::string& hash,
                        ResumptionCallBack callback) OVERRIDE;
 
+  void HandleOnTimeOut(const int32_t app_id) OVERRIDE;
+
   /**
    * @brief Start timer for resumption applications
    *        Does not restore D1-D5 data

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -175,7 +175,8 @@ class ResumeCtrlImpl : public ResumeCtrl {
                        const std::string& hash,
                        ResumptionCallBack callback) OVERRIDE;
 
-  void HandleOnTimeOut(const int32_t app_id) OVERRIDE;
+  void HandleOnTimeOut(const uint32_t correlation_id,
+                       const hmi_apis::FunctionID::eType) OVERRIDE;
 
   /**
    * @brief Start timer for resumption applications

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -96,6 +96,12 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
    */
   void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
+  /**
+   * @brief Handle restored data when timeout appeared
+   * @param application id - const int32_t
+   */
+  void HandleOnTimeOut(const int32_t app_id);
+
  private:
   /**
    * @brief Revert the data to the state before Resumption

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -99,9 +99,9 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
  private:
   /**
    * @brief Revert the data to the state before Resumption
-   * @param app_id application id
+   * @param shared ptr to application
    */
-  void RevertRestoredData(const int32_t app_id);
+  void RevertRestoredData(app_mngr::ApplicationSharedPtr application);
 
   /**
    * @brief subscribe to events for the application and save request
@@ -136,9 +136,9 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
 
   /**
    * @brief Deleting files that have been resumed
-   * @param app_id application id
+   * @param shared ptr to application
    */
-  void DeleteFiles(const int32_t app_id);
+  void DeleteFiles(app_mngr::ApplicationSharedPtr application);
 
   /**
   * @brief AddSubmenues allows to add sub-menus for the application
@@ -151,9 +151,9 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
 
   /**
    * @brief Deleting sub-menus that have been resumed
-   * @param app_id application id
+   * @param shared ptr to application
    */
-  void DeleteSubmenues(const int32_t app_id);
+  void DeleteSubmenues(app_mngr::ApplicationSharedPtr application);
 
   /**
    * @brief AddCommands allows to add commands for the application
@@ -166,13 +166,13 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
 
   /**
    * @brief Deleting all commands that have been resumed
-   * @param app_id application id
+   * @param shared ptr to application
    */
-  void DeleteCommands(const int32_t app_id);
+  void DeleteCommands(app_mngr::ApplicationSharedPtr application);
 
   /**
    * @brief Deleting UI commands that have been resumed
-   * @param app_id application id
+   * @param shared ptr to application
    */
   void DeleteUICommands(const ResumptionRequest& request);
 
@@ -193,9 +193,9 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
 
   /**
    * @brief Deleting choice sets that have been resumed
-   * @param app_id application id
+   * @param shared ptr to application
    */
-  void DeleteChoicesets(const int32_t app_id);
+  void DeleteChoicesets(app_mngr::ApplicationSharedPtr application);
 
   /**
   * @brief SetGlobalProperties allows to restore global properties.
@@ -207,9 +207,9 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
 
   /**
    * @brief Reset global properties that have been resumed
-   * @param app_id application id
+   * @param shared ptr to application
    */
-  void DeleteGlobalProperties(const int32_t app_id);
+  void DeleteGlobalProperties(app_mngr::ApplicationSharedPtr application);
 
   /**
   * @brief AddSubscriptions allows to restore subscriptions
@@ -237,13 +237,13 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
 
   /**
    * @brief Deleting subscriptions have been resumed
-   * @param app_id application id
+   * @param shared ptr to application
    */
-  void DeleteSubscriptions(const int32_t app_id);
+  void DeleteSubscriptions(app_mngr::ApplicationSharedPtr application);
 
   /**
    * @brief Deleting buttons subscriptions have been resumed
-   * @param app_id application id
+   * @param shared ptr to application
    */
   void DeleteButtonsSubscriptions(app_mngr::ApplicationSharedPtr application);
 
@@ -264,15 +264,15 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
 
   /**
    * @brief Deleting subscription for WayPoints have been resumed
-   * @param app_id application id
+   * @param shared ptr to application
    */
-  void DeleteWayPointsSubscription(const int32_t app_id);
+  void DeleteWayPointsSubscription(app_mngr::ApplicationSharedPtr application);
 
   /**
    * @brief Get button subscriptions that need to be resumed.
-   * Since some subscriptions can be set by default during 
+   * Since some subscriptions can be set by default during
    * app registration, this function is needed to discard subscriptions
-   * that do not need to be resumed 
+   * that do not need to be resumed
    * @param application which subscriptions to resume
    */
   app_mngr::ButtonSubscriptions GetButtonSubscriptionsToResume(

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -279,6 +279,13 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
       app_mngr::ApplicationSharedPtr application) const;
 
   /**
+   * @brief Determines whether request is successful
+   * judging from result code received from HMI
+   * @param response from HMI with request's result code
+   */
+  bool IsRequestSuccessful(const smart_objects::SmartObject& response) const;
+
+  /**
    * @brief A map of the IDs and Application Resumption Status for these ID
    **/
   app_mngr::ApplicationManager& application_manager_;

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -217,7 +217,7 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
   * @param saved_app application specific section from backup file
   */
   void AddButtonsSubscriptions(app_mngr::ApplicationSharedPtr application,
-                        const smart_objects::SmartObject& saved_app);
+                               const smart_objects::SmartObject& saved_app);
 
   /**
   * @brief AddSubscriptions allows to restore subscriptions
@@ -225,7 +225,7 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
   * @param saved_app application specific section from backup file
   */
   void AddPluginsSubscriptions(app_mngr::ApplicationSharedPtr application,
-                        const smart_objects::SmartObject& saved_app);
+                               const smart_objects::SmartObject& saved_app);
 
   /**
    * @brief Deleting subscriptions have been resumed

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -269,6 +269,16 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
   void DeleteWayPointsSubscription(const int32_t app_id);
 
   /**
+   * @brief Get button subscriptions that need to be resumed.
+   * Since some subscriptions can be set by default during 
+   * app registration, this function is needed to discard subscriptions
+   * that do not need to be resumed 
+   * @param application which subscriptions to resume
+   */
+  app_mngr::ButtonSubscriptions GetButtonSubscriptionsToResume(
+      app_mngr::ApplicationSharedPtr application) const;
+
+  /**
    * @brief A map of the IDs and Application Resumption Status for these ID
    **/
   app_mngr::ApplicationManager& application_manager_;

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -1,0 +1,272 @@
+/*
+ Copyright (c) 2018, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_RESUMPTION_PROCESS_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_RESUMPTION_PROCESS_
+
+#include <map>
+#include <vector>
+#include <functional>
+
+#include "smart_objects/smart_object.h"
+#include "application_manager/application.h"
+#include "application_manager/event_engine/event_observer.h"
+
+namespace resumption {
+
+namespace app_mngr = application_manager;
+
+struct ResumptionRequest {
+  hmi_apis::FunctionID::eType function_id;
+  int32_t correlation_id;
+  smart_objects::SmartObject message;
+};
+
+struct ApplicationResumptionStatus {
+  std::vector<ResumptionRequest> list_of_sent_requests;
+  std::vector<ResumptionRequest> error_requests;
+  std::vector<ResumptionRequest> successful_requests;
+};
+
+/**
+ * @brief Contains logic for the resumption and revert resumption data of
+ *  applications.
+ */
+class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
+ public:
+  /**
+  * @brief allows to create ResumptionDataProcessor object
+  */
+  explicit ResumptionDataProcessor(
+      application_manager::ApplicationManager& application_manager);
+
+  /**
+   * @brief allows to destroy ResumptionDataProcessor object
+   */
+  ~ResumptionDataProcessor();
+
+  /**
+  * @brief Running resumption data process from saved_app to application.
+  * @param application application which will be resumed
+  * @param saved_app application specific section from backup file
+  */
+  void Restore(app_mngr::ApplicationSharedPtr application,
+               smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief Event, that raised if application get resumption response from HMI
+   * @param event : event object, that contains smart_object HMI response
+   * message
+   */
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
+
+ private:
+  /**
+   * @brief Revert the data to the state before Resumption
+   * @param app_id application id
+   */
+  void RevertRestoredData(const int32_t app_id);
+
+  /**
+   * @brief subscribe to events for the application and save request
+   * @param app_id application id
+   * @param request for saving
+   */
+  void WaitForResponse(const int32_t app_id, const ResumptionRequest& request);
+
+  /**
+   * @brief Process specified HMI request
+   * @param request Request to process
+   * @param use_events Process request events or not flag
+   * @return TRUE on success, otherwise FALSE
+   */
+  void ProcessHMIRequest(smart_objects::SmartObjectSPtr request,
+                         bool subscribe_on_response);
+
+  /**
+   * @brief Process list of HMI requests using ProcessHMIRequest method
+   * @param requests List of requests to process
+   */
+  void ProcessHMIRequests(const smart_objects::SmartObjectList& requests);
+
+  /**
+   * @brief AddFiles allows to add files for the application
+   * which should be resumed
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddFiles(app_mngr::ApplicationSharedPtr application,
+                const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief Deleting files that have been resumed
+   * @param app_id application id
+   */
+  void DeleteFiles(const int32_t app_id);
+
+  /**
+  * @brief AddSubmenues allows to add sub-menus for the application
+  * which should be resumed
+  * @param application application which will be resumed
+  * @param saved_app application specific section from backup file
+  */
+  void AddSubmenues(app_mngr::ApplicationSharedPtr application,
+                    const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief Deleting sub-menus that have been resumed
+   * @param app_id application id
+   */
+  void DeleteSubmenues(const int32_t app_id);
+
+  /**
+   * @brief AddCommands allows to add commands for the application
+   * which should be resumed
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddCommands(app_mngr::ApplicationSharedPtr application,
+                   const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief Deleting all commands that have been resumed
+   * @param app_id application id
+   */
+  void DeleteCommands(const int32_t app_id);
+
+  /**
+   * @brief Deleting UI commands that have been resumed
+   * @param app_id application id
+   */
+  void DeleteUICommands(const ResumptionRequest& request);
+
+  /**
+ * @brief Deleting VR commands that have been resumed
+ * @param app_id application id
+ */
+  void DeleteVRCommands(const ResumptionRequest& request);
+
+  /**
+  * @brief AddChoicesets allows to add choice sets for the application
+  * which should be resumed
+  * @param application application which will be resumed
+  * @param saved_app application specific section from backup file
+  */
+  void AddChoicesets(app_mngr::ApplicationSharedPtr application,
+                     const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief Deleting choice sets that have been resumed
+   * @param app_id application id
+   */
+  void DeleteChoicesets(const int32_t app_id);
+
+  /**
+  * @brief SetGlobalProperties allows to restore global properties.
+  * @param application application which will be resumed
+  * @param saved_app application specific section from backup file
+  */
+  void SetGlobalProperties(app_mngr::ApplicationSharedPtr application,
+                           const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief Reset global properties that have been resumed
+   * @param app_id application id
+   */
+  void DeleteGlobalProperties(const int32_t app_id);
+
+  /**
+  * @brief AddSubscriptions allows to restore subscriptions
+  * @param application application which will be resumed
+  * @param saved_app application specific section from backup file
+  */
+  void AddSubscriptions(app_mngr::ApplicationSharedPtr application,
+                        const smart_objects::SmartObject& saved_app);
+
+  /**
+  * @brief AddSubscriptions allows to restore subscriptions
+  * @param application application which will be resumed
+  * @param saved_app application specific section from backup file
+  */
+  void AddButtonsSubscriptions(app_mngr::ApplicationSharedPtr application,
+                        const smart_objects::SmartObject& saved_app);
+
+  /**
+  * @brief AddSubscriptions allows to restore subscriptions
+  * @param application application which will be resumed
+  * @param saved_app application specific section from backup file
+  */
+  void AddPluginsSubscriptions(app_mngr::ApplicationSharedPtr application,
+                        const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief Deleting subscriptions have been resumed
+   * @param app_id application id
+   */
+  void DeleteSubscriptions(const int32_t app_id);
+
+  /**
+   * @brief Deleting buttons subscriptions have been resumed
+   * @param app_id application id
+   */
+  void DeleteButtonsSubscriptions(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief Deleting plugins subscriptions have been resumed
+   * @param app_id application id
+   */
+  void DeletePluginsSubscriptions(app_mngr::ApplicationSharedPtr application);
+
+  /**
+  * @brief AddWayPointsSubscription allows to restore subscription
+  * for WayPoints
+  * @param application application which will be resumed
+  * @param saved_app application specific section from backup file
+  */
+  void AddWayPointsSubscription(app_mngr::ApplicationSharedPtr application,
+                                const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief Deleting subscription for WayPoints have been resumed
+   * @param app_id application id
+   */
+  void DeleteWayPointsSubscription(const int32_t app_id);
+
+  /**
+   * @brief A map of the IDs and Application Resumption Status for these ID
+   **/
+  app_mngr::ApplicationManager& application_manager_;
+  std::map<std::int32_t, ApplicationResumptionStatus> resumption_status_;
+};
+
+}  // namespace resumption
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_RESUMPTION_PROCESS_

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -61,6 +61,8 @@ struct ApplicationResumptionStatus {
   std::vector<ResumptionRequest> list_of_sent_requests;
   std::vector<ResumptionRequest> error_requests;
   std::vector<ResumptionRequest> successful_requests;
+  std::vector<std::string> unsuccesfull_vehicle_data_subscriptions_;
+  std::vector<std::string> succesfull_vehicle_data_subscriptions_;
 };
 
 /**
@@ -291,6 +293,9 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
    */
   bool IsRequestSuccessful(const smart_objects::SmartObject& response) const;
 
+  void CheckVehicleDataResponse(const smart_objects::SmartObject& request,
+                                const smart_objects::SmartObject& response,
+                                ApplicationResumptionStatus& status);
   /**
    * @brief A map of the IDs and Application Resumption Status for these ID
    **/

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -39,14 +39,21 @@
 #include "smart_objects/smart_object.h"
 #include "application_manager/application.h"
 #include "application_manager/event_engine/event_observer.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace resumption {
 
 namespace app_mngr = application_manager;
 
-struct ResumptionRequest {
+struct ResumptionRequestIDs {
   hmi_apis::FunctionID::eType function_id;
   int32_t correlation_id;
+
+  bool operator<(const ResumptionRequestIDs& other) const;
+};
+
+struct ResumptionRequest {
+  ResumptionRequestIDs request_ids;
   smart_objects::SmartObject message;
 };
 
@@ -79,7 +86,8 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
   * @param saved_app application specific section from backup file
   */
   void Restore(app_mngr::ApplicationSharedPtr application,
-               smart_objects::SmartObject& saved_app);
+               smart_objects::SmartObject& saved_app,
+               ResumeCtrl::ResumptionCallBack callback);
 
   /**
    * @brief Event, that raised if application get resumption response from HMI
@@ -265,6 +273,8 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
    **/
   app_mngr::ApplicationManager& application_manager_;
   std::map<std::int32_t, ApplicationResumptionStatus> resumption_status_;
+  std::map<std::int32_t, ResumeCtrl::ResumptionCallBack> register_callbacks_;
+  std::map<ResumptionRequestIDs, std::uint32_t> request_app_ids_;
 };
 
 }  // namespace resumption

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_app_extension.h
@@ -80,11 +80,26 @@ class RCAppExtension : public application_manager::AppExtension {
 
   // AppExtension interface
  public:
-  void SaveResumptionData(ns_smart_device_link::ns_smart_objects::SmartObject&
-                              resumption_data) OVERRIDE;
-  void ProcessResumption(
-      const ns_smart_device_link::ns_smart_objects::SmartObject&
-          resumption_data) OVERRIDE;
+  /**
+    * @brief Save resumption data
+    * @param resumption_data data for saving
+    **/
+  void SaveResumptionData(smart_objects::SmartObject& resumption_data) OVERRIDE;
+
+  /**
+  * @brief Running resumption data process.
+  * @param saved_app saved data for resumption
+  * @param subscriber callback for subscription
+  **/
+  void ProcessResumption(const smart_objects::SmartObject& saved_app,
+                         resumption::Subscriber subscriber) OVERRIDE;
+
+  /**
+   * @brief Revert the data to the state before Resumption.
+   * @param subscriptions Subscriptions to be returned
+   **/
+  void RevertResumption(
+      const smart_objects::SmartObject& subscriptions) OVERRIDE;
 };
 
 typedef std::shared_ptr<RCAppExtension> RCAppExtensionPtr;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_app_extension.cc
@@ -59,11 +59,14 @@ bool RCAppExtension::IsSubscibedToInteriorVehicleData(
 }
 
 void RCAppExtension::SaveResumptionData(
-    ns_smart_device_link::ns_smart_objects::SmartObject& resumption_data) {}
+    smart_objects::SmartObject& resumption_data) {}
 
 void RCAppExtension::ProcessResumption(
-    const ns_smart_device_link::ns_smart_objects::SmartObject&
-        resumption_data) {}
+    const smart_objects::SmartObject& saved_app,
+    resumption::Subscriber subscriber) {}
+
+void RCAppExtension::RevertResumption(
+    const smart_objects::SmartObject& subscriptions) {}
 
 std::set<std::string> RCAppExtension::InteriorVehicleDataSubscriptions() const {
   return subscribed_interior_vehicle_data_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_subscribe_way_points_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_subscribe_way_points_request.h
@@ -65,6 +65,8 @@ class NaviSubscribeWayPointsRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run() OVERRIDE;
 
+  void onTimeOut() OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(NaviSubscribeWayPointsRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_set_global_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_set_global_properties_request.h
@@ -67,6 +67,8 @@ class TTSSetGlobalPropertiesRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
+  virtual void onTimeOut() OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(TTSSetGlobalPropertiesRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_add_command_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_add_command_request.h
@@ -66,6 +66,8 @@ class UIAddCommandRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
+  virtual void onTimeOut() OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(UIAddCommandRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_add_submenu_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_add_submenu_request.h
@@ -66,6 +66,8 @@ class UIAddSubmenuRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
+  virtual void onTimeOut() OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(UIAddSubmenuRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_set_global_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_set_global_properties_request.h
@@ -67,6 +67,8 @@ class UISetGlobalPropertiesRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
+  virtual void onTimeOut() OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(UISetGlobalPropertiesRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_add_command_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_add_command_request.h
@@ -61,6 +61,8 @@ class VRAddCommandRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual ~VRAddCommandRequest();
 
+  void onTimeOut() OVERRIDE;
+
   /**
    * @brief Execute command
    **/

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -83,7 +83,28 @@ class RegisterAppInterfaceRequest
    **/
   virtual void Run();
 
+  /**
+   * @brief Prepares and sends RegisterAppInterface response to mobile
+   * considering application type
+   **/
+  void SendRegisterAppInterfaceResponseToMobile();
+
  private:
+  /**
+   * @brief FinishSendingRegisterAppInterfaceToMobile
+   * used to safely conclude sending notification to mobile
+   * to prevent SDL crash
+   * @param msg_params - copy of msg_params stored in message_ member
+   * @param app_manager - application manager to get policy handler and resume controller
+   * @param connection_key to get app from app manager
+   * @param notify_upd_manager callback to call after app registered
+   */
+
+  void FinishSendingRegisterAppInterfaceToMobile(
+      const smart_objects::SmartObject& msg_params,
+      application_manager::ApplicationManager& app_manager,
+      const uint32_t connection_key,
+      policy::StatusNotifier notify_upd_manager);
   /**
    * @brief FillApplicationParams set app application attributes from the RAI
    * request

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -84,6 +84,11 @@ class RegisterAppInterfaceRequest
   virtual void Run();
 
   /**
+   * @brief onTimeOut from requrst Controller
+   **/
+  void onTimeOut() OVERRIDE;
+
+  /**
    * @brief Prepares and sends RegisterAppInterface response to mobile
    * considering application type
    **/
@@ -292,6 +297,7 @@ class RegisterAppInterfaceRequest
    */
   void CheckLanguage();
 
+  bool is_data_resumption_;
   std::string response_info_;
   mobile_apis::Result::eType result_code_;
   DISALLOW_COPY_AND_ASSIGN(RegisterAppInterfaceRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -237,7 +237,7 @@ class RegisterAppInterfaceRequest
    * @return true if application os not allowed to register, othervise return
    * false.
    */
-  bool IsApplicationForbidden();
+  bool IsApplicationForbidden() const;
 
   /**
    * @brief ProcessApplicationTransportSwitching process checking if application

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -85,6 +85,14 @@ class RegisterAppInterfaceRequest
 
  private:
   /**
+   * @brief FillApplicationParams set app application attributes from the RAI
+   * request
+   * @param application applicaiton to fill params
+   */
+  void FillApplicationParams(
+      application_manager::ApplicationSharedPtr application);
+
+  /**
    * @brief The AppicationType enum defines whether application is newly
    * registered or existing and being switched over another transport
    */
@@ -99,7 +107,9 @@ class RegisterAppInterfaceRequest
    * considering application type
    * @param app_type Type of application
    **/
-  void SendRegisterAppInterfaceResponseToMobile(ApplicationType app_type);
+  void SendRegisterAppInterfaceResponseToMobile(ApplicationType app_type,
+                                                const std::string& add_info,
+                                                bool need_restore_vr);
 
   smart_objects::SmartObjectSPtr GetLockScreenIconUrlNotification(
       const uint32_t connection_key, app_mngr::ApplicationSharedPtr app);
@@ -129,16 +139,15 @@ class RegisterAppInterfaceRequest
    **/
   void SendOnAppRegisteredNotificationToHMI(
       const app_mngr::Application& application_impl,
-      bool resumption = false,
       bool need_restore_vr = false);
-  /*
+  /**
    * @brief Check new ID along with known mobile application ID
    *
    * return TRUE if ID is known already, otherwise - FALSE
    */
   bool IsApplicationWithSameAppIdRegistered();
 
-  /*
+  /**
    * @brief Check new application parameters (name, tts, vr) for
    * coincidence with already known parameters of registered applications
    *
@@ -147,7 +156,7 @@ class RegisterAppInterfaceRequest
   */
   mobile_apis::Result::eType CheckCoincidence();
 
-  /*
+  /**
   * @brief Predicate for using with CheckCoincidence method to compare with VR
   * synonym SO
   *
@@ -209,11 +218,76 @@ class RegisterAppInterfaceRequest
    */
   bool IsApplicationSwitched();
 
- private:
+  /**
+   * @brief TransformPolicyAppIdToUpper make policy app_id  in msg_params
+   * uppercase.
+   * SDL compare policy appid in not case sensitive mode.
+   */
+  void TransformPolicyAppIdToUpper();
+
+  /**
+   * @brief WaitForHMIIsReady blocking function. Waits for HMI be ready for
+   * requests processing
+   */
+  void WaitForHMIIsReady();
+
+  /**
+   * @brief IsApplicationForbidden check if application is in list of forbidden
+   * applications
+   * @return true if application os not allowed to register, othervise return
+   * false.
+   */
+  bool IsApplicationForbidden();
+
+  /**
+   * @brief ProcessApplicationTransportSwitching process checking if application
+   * is switching transport.
+   * If applicaiton is in switching mode, function will send response to mobile
+   * If no switching required response wont be send
+   * @return true if response to mobile was sent, otherwise return false.
+   */
+  bool ProcessApplicationTransportSwitching();
+
+  /**
+   * @brief IncrementDuplicateNameCounter increments internal counter of
+   * duplicate name during registration
+   * @param coincidence_result result of name checking
+   */
+  void IncrementDuplicateNameCounter(
+      mobile_apis::Result::eType coincidence_result);
+
+  /**
+   * @brief SetupAppDeviceInfo add applicaiton device information to policies
+   * @param application applicaiton to process
+   */
+  void SetupAppDeviceInfo(
+      application_manager::ApplicationSharedPtr application);
+
+  /**
+   * @brief The DataResumeResult enum relust of resumption data check
+   * RESUME_DATA : applicaiton data should be resumed
+   * NO_HASH : hash_id is ommited in RAI. No data resumption required
+   * WRONG_HASH : hash_id frim RAI does not match to savedhash id, resumption
+   * should be failed.
+   * MISSED_DATA : Some data was missed on SDL side.
+   */
+  enum class DataResumeResult { RESUME_DATA, NO_HASH, WRONG_HASH, MISSED_DATA };
+
+  /**
+   * @brief ApplicationDataShouldBeResumed check if application data should be
+   * resumed
+   * @return result of possible conditions for resumptions
+   */
+  DataResumeResult ApplicationDataShouldBeResumed();
+
+  /**
+   * @brief CheckLanguage check if language in RAI matches hmi_capabilities
+   * Setup result_code variable in case of does not match
+   */
+  void CheckLanguage();
+
   std::string response_info_;
   mobile_apis::Result::eType result_code_;
-
-  policy::PolicyHandlerInterface& GetPolicyHandler();
   DISALLOW_COPY_AND_ASSIGN(RegisterAppInterfaceRequest);
 };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -91,21 +91,6 @@ class RegisterAppInterfaceRequest
 
  private:
   /**
-   * @brief FinishSendingRegisterAppInterfaceToMobile
-   * used to safely conclude sending notification to mobile
-   * to prevent SDL crash
-   * @param msg_params - copy of msg_params stored in message_ member
-   * @param app_manager - application manager to get policy handler and resume controller
-   * @param connection_key to get app from app manager
-   * @param notify_upd_manager callback to call after app registered
-   */
-
-  void FinishSendingRegisterAppInterfaceToMobile(
-      const smart_objects::SmartObject& msg_params,
-      application_manager::ApplicationManager& app_manager,
-      const uint32_t connection_key,
-      policy::StatusNotifier notify_upd_manager);
-  /**
    * @brief FillApplicationParams set app application attributes from the RAI
    * request
    * @param application applicaiton to fill params

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -297,6 +297,7 @@ class RegisterAppInterfaceRequest
    */
   void CheckLanguage();
 
+  application_manager::ApplicationSharedPtr application_;
   bool is_data_resumption_;
   std::string response_info_;
   mobile_apis::Result::eType result_code_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -84,11 +84,6 @@ class RegisterAppInterfaceRequest
   virtual void Run();
 
   /**
-   * @brief onTimeOut from requrst Controller
-   **/
-  void onTimeOut() OVERRIDE;
-
-  /**
    * @brief Prepares and sends RegisterAppInterface response to mobile
    * considering application type
    **/
@@ -117,10 +112,10 @@ class RegisterAppInterfaceRequest
    * @brief Prepares and sends RegisterAppInterface response to mobile
    * considering application type
    * @param app_type Type of application
+   * @param add_info - additional information to be sent to mobile app
    **/
   void SendRegisterAppInterfaceResponseToMobile(ApplicationType app_type,
-                                                const std::string& add_info,
-                                                bool need_restore_vr);
+                                                const std::string& add_info);
 
   smart_objects::SmartObjectSPtr GetLockScreenIconUrlNotification(
       const uint32_t connection_key, app_mngr::ApplicationSharedPtr app);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/reset_global_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/reset_global_properties_request.h
@@ -42,7 +42,6 @@ namespace sdl_rpc_plugin {
 namespace app_mngr = application_manager;
 
 namespace commands {
-
 /**
  * @brief ResetGlobalPropertiesRequest command class
  **/
@@ -85,40 +84,6 @@ class ResetGlobalPropertiesRequest
 
  private:
   /*
-   * @brief Sets default value of the HELPPROMT global property
-   * to the first vrCommand of each Command Menu registered in application
-   *
-   * @param app Registered application
-   * @param is_timeout_promp Flag indicating that timeout prompt
-   * should be reset
-   *
-   * @return TRUE on success, otherwise FALSE
-   */
-  bool ResetHelpPromt(app_mngr::ApplicationSharedPtr app);
-
-  /*
-   * @brief  Sets default value of the TIMEOUTPROMT global property
-   * to the first vrCommand of each Command Menu registered in application
-   *
-   * @param app Registered application
-   *
-   * @return TRUE on success, otherwise FALSE
-   */
-  bool ResetTimeoutPromt(application_manager::ApplicationSharedPtr const app);
-
-  /*
-   * @brief Sets default value of the VRHELPTITLE global property
-   * to the application name and value of the VRHELPITEMS global property
-   * to value equal to registered command -1(default command “Help / Cancel”.)
-   *
-   * @param app Registered application
-   *
-   * @return TRUE on success, otherwise FALSE
-   */
-  bool ResetVrHelpTitleItems(
-      application_manager::ApplicationSharedPtr const app);
-
-  /*
    * @brief Prepare result for sending to mobile application
    * @param out_result_code contains result code for sending to mobile
    * application
@@ -134,6 +99,12 @@ class ResetGlobalPropertiesRequest
    * @return true if all responses received
    */
   bool IsPendingResponseExist();
+
+  /*
+   * @brief ResetGlobalProperties gets global properties data from message_
+   * and passes it to ApplicationManager::ResetGlobalProperties
+   */
+  void ResetGlobalProperties();
 
   DISALLOW_COPY_AND_ASSIGN(ResetGlobalPropertiesRequest);
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_app_extension.h
@@ -1,0 +1,86 @@
+/*
+ Copyright (c) 2018, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_PLUGIN_INCLUDE_SDL_PLUGIN_SDL_APP_EXTENSION_H
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_PLUGIN_INCLUDE_SDL_PLUGIN_SDL_APP_EXTENSION_H
+
+#include <application_manager/application_manager.h>
+
+namespace sdl_rpc_plugin {
+class SDLRPCPlugin;
+
+namespace app_mngr = application_manager;
+
+class SDLAppExtension : public app_mngr::AppExtension {
+ public:
+  /**
+   * @brief SDLAppExtension constructor
+   * @param plugin sdl info plugin
+   * @param app application that contains this plugin
+   */
+  SDLAppExtension(SDLRPCPlugin& plugin, app_mngr::Application& app);
+  virtual ~SDLAppExtension();
+
+  /**
+  * @brief SaveResumptionData saves vehicle info data
+  * @param resumption_data plase to store resumption data
+  */
+  void SaveResumptionData(smart_objects::SmartObject& resumption_data) OVERRIDE;
+
+  /**
+  * @brief ProcessResumption load resumtion data back to plugin during
+  * resumption
+  * @param resumption_data resumption data
+  * @param subscriber callback for subscription
+  */
+  void ProcessResumption(const smart_objects::SmartObject& saved_app,
+                         resumption::Subscriber subscriber) OVERRIDE;
+
+  /**
+  * @brief Revert the data to the state before Resumption.
+  * @param subscriptions Subscriptions to be returned
+  **/
+  void RevertResumption(
+      const smart_objects::SmartObject& subscriptions) OVERRIDE;
+
+  /**
+   * @brief SDLAppExtensionUID unique identifier of VehicleInfo
+   * aplication extension
+   */
+  static unsigned SDLAppExtensionUID;
+
+ private:
+  SDLRPCPlugin& plugin_;
+  app_mngr::Application& app_;
+};
+}
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_PLUGIN_INCLUDE_SDL_PLUGIN_SDL_APP_EXTENSION_H

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_pending_resumption_handler.h
@@ -1,0 +1,83 @@
+/*
+ Copyright (c) 2018, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_PLUGIN_INCLUDE_SDL_PLUGIN_SDL_PENDING_RESUMPTION_HANDLER_H
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_PLUGIN_INCLUDE_SDL_PLUGIN_SDL_PENDING_RESUMPTION_HANDLER_H
+
+#include "application_manager/event_engine/event_observer.h"
+#include "application_manager/resumption/extension_pending_resumption_handler.h"
+#include "sdl_rpc_plugin/sdl_app_extension.h"
+
+namespace sdl_rpc_plugin {
+
+namespace app_mngr = application_manager;
+
+class SDLPendingResumptionHandler
+    : public resumption::ExtensionPendingResumptionHandler {
+ public:
+  SDLPendingResumptionHandler(
+      app_mngr::ApplicationManager& application_manager);
+
+  // EventObserver interface
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
+
+  void HandleResumptionSubscriptionRequest(
+      app_mngr::AppExtension& extension,
+      resumption::Subscriber& subscriber,
+      application_manager::Application& app) OVERRIDE;
+
+  void ClearPendingResumptionRequests() OVERRIDE;
+
+ private:
+  smart_objects::SmartObjectSPtr CreateSubscriptionRequest();
+
+  struct ResumptionAwaitingHandling {
+    const uint32_t app_id;
+    SDLAppExtension& ext;
+    resumption::Subscriber subscriber;
+
+    ResumptionAwaitingHandling(const uint32_t application_id,
+                               SDLAppExtension& extension,
+                               resumption::Subscriber subscriber_callback)
+        : app_id(application_id)
+        , ext(extension)
+        , subscriber(subscriber_callback) {}
+  };
+
+  typedef std::pair<SDLAppExtension, resumption::Subscriber> FreezedResumption;
+  std::queue<ResumptionAwaitingHandling> freezed_resumptions_;
+  std::map<uint32_t, smart_objects::SmartObject> pending_requests_;
+  std::queue<uint32_t> app_ids_;
+};
+}
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_PLUGIN_INCLUDE_SDL_PLUGIN_SDL_PENDING_RESUMPTION_HANDLER_H

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_rpc_plugin.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_rpc_plugin.h
@@ -34,12 +34,16 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_SDL_RPC_PLUGIN_H
 #include "application_manager/plugin_manager/rpc_plugin.h"
 #include "application_manager/command_factory.h"
+#include "application_manager/resumption/extension_pending_resumption_handler.h"
 
 namespace sdl_rpc_plugin {
+class SDLAppExtension;
 namespace plugins = application_manager::plugin_manager;
 class SDLRPCPlugin : public plugins::RPCPlugin {
   // RPCPlugin interface
  public:
+  SDLRPCPlugin();
+
   bool Init(application_manager::ApplicationManager& app_manager,
             application_manager::rpc_service::RPCService& rpc_service,
             application_manager::HMICapabilities& hmi_capabilities,
@@ -58,8 +62,36 @@ class SDLRPCPlugin : public plugins::RPCPlugin {
       application_manager::plugin_manager::ApplicationEvent event,
       application_manager::ApplicationSharedPtr application) OVERRIDE;
 
+  /**
+   * @brief ProcessResumptionSubscription send appropriate subscribe requests
+   * to HMI
+   * @param app application for subscription
+   * @param ext application extension
+   * @param subscriber callback for subscription
+   */
+  void ProcessResumptionSubscription(application_manager::Application& app,
+                                     SDLAppExtension& ext,
+                                     resumption::Subscriber subscriber);
+
+  /**
+   * @brief Revert the data to the state before Resumption.
+   * @param subscriptions Subscriptions to be returned
+   **/
+  void RevertResumption(application_manager::Application& app);
+
+  /**
+   * @brief SaveResumptionData saves subscription data
+   * @param resumption_data plase to store resumption data
+   */
+  void SaveResumptionData(application_manager::Application& app,
+                          smart_objects::SmartObject& resumption_data);
+
  private:
   std::unique_ptr<application_manager::CommandFactory> command_factory_;
+  application_manager::ApplicationManager* application_manager_;
+  using ExtensionPendingResumptionHandlerSPtr =
+      std::shared_ptr<resumption::ExtensionPendingResumptionHandler>;
+  ExtensionPendingResumptionHandlerSPtr pending_resumption_handler_;
 };
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_subscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_subscribe_way_points_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/navi_subscribe_way_points_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -55,6 +56,14 @@ void NaviSubscribeWayPointsRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void NaviSubscribeWayPointsRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_set_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_set_global_properties_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/tts_set_global_properties_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -55,6 +56,13 @@ void TTSSetGlobalPropertiesRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void TTSSetGlobalPropertiesRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_add_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_add_command_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/ui_add_command_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -55,6 +56,14 @@ void UIAddCommandRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void UIAddCommandRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_add_submenu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_add_submenu_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/ui_add_submenu_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -55,6 +56,13 @@ void UIAddSubmenuRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void UIAddSubmenuRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_set_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_set_global_properties_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/ui_set_global_properties_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -55,6 +56,13 @@ void UISetGlobalPropertiesRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void UISetGlobalPropertiesRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_add_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_add_command_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/vr_add_command_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -55,6 +56,14 @@ void VRAddCommandRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void VRAddCommandRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_command_request.cc
@@ -36,6 +36,7 @@
 
 #include "application_manager/application.h"
 #include "application_manager/message_helper.h"
+#include "application_manager/resumption/resume_ctrl.h"
 #include "utils/file_system.h"
 #include "utils/helpers.h"
 #include "utils/custom_string.h"
@@ -71,6 +72,12 @@ void AddCommandRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
   RemoveCommand();
   CommandRequestImpl::onTimeOut();
+
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 bool AddCommandRequest::Init() {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -39,6 +39,7 @@
 
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
+#include "application_manager/resumption/resume_ctrl.h"
 #include "utils/gen_hash.h"
 #include "utils/helpers.h"
 
@@ -419,6 +420,12 @@ void CreateInteractionChoiceSetRequest::onTimeOut() {
   }
   CommandRequestImpl::onTimeOut();
   DeleteChoices();
+
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 
   // We have to keep request alive until receive all responses from HMI
   // according to SDLAQ-CRS-2976

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -568,6 +568,13 @@ void RegisterAppInterfaceRequest::Run() {
   SendSubscribeCustomButtonNotification();
   SendChangeRegistrationOnHMI(application);
 
+  std::function<void(plugin_manager::RPCPlugin&)> on_app_registered =
+      [application](plugin_manager::RPCPlugin& plugin) {
+        plugin.OnApplicationEvent(plugin_manager::kApplicationRegistered,
+                                  application);
+      };
+  application_manager_.GetPluginManager().ForEachPlugin(on_app_registered);
+
   if (DataResumeResult::RESUME_DATA == resume_data_result) {
     auto& resume_ctrl = application_manager_.resume_controller();
     const auto& msg_params = (*message_)[strings::msg_params];

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -597,15 +597,15 @@ void RegisterAppInterfaceRequest::Run() {
     const auto& msg_params = (*message_)[strings::msg_params];
     const auto& hash_id = msg_params[strings::hash_id].asString();
     LOG4CXX_WARN(logger_, "Start Data Resumption");
-    auto send_response = [this, application](
-        mobile_apis::Result::eType result_code, const std::string& info) {
+    auto send_response = [this](mobile_apis::Result::eType result_code,
+                                const std::string& info) {
       result_code_ = result_code;
       SendRegisterAppInterfaceResponseToMobile(
           ApplicationType::kNewApplication, info, true);
-      application->UpdateHash();
+      application_->UpdateHash();
     };
 
-    resume_ctrl.StartResumption(application, hash_id, send_response);
+    resume_ctrl.StartResumption(application_, hash_id, send_response);
     return;
   }
 
@@ -822,8 +822,8 @@ void FinishSendingRegisterAppInterfaceToMobile(
   auto application = app_manager.application(connection_key);
 
   if (msg_params.keyExists(strings::app_hmi_type)) {
-    policy_handler_.SetDefaultHmiTypes(application->policy_app_id(),
-                                       &(msg_params[strings::app_hmi_type]));
+    policy_handler.SetDefaultHmiTypes(application->policy_app_id(),
+                                      &(msg_params[strings::app_hmi_type]));
   }
 
   // Default HMI level should be set before any permissions validation, since

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -473,7 +473,7 @@ void RegisterAppInterfaceRequest::Run() {
   const std::string app_id_short = msg_params[strings::app_id].asString();
   std::string new_app_id_short = app_id_short;
   std::transform(app_id_short.begin(),
-                 app_id_short.en
+                 app_id_short.end(),
                  new_app_id_short.begin(),
                  ::tolower);
   (*message_)[strings::msg_params][strings::app_id] = new_app_id_short;
@@ -487,7 +487,7 @@ void RegisterAppInterfaceRequest::Run() {
                    ::tolower);
     (*message_)[strings::msg_params][strings::full_app_id] = new_app_id_full;
   }
-  
+
   if (IsApplicationForbidden()) {
     LOG4CXX_WARN(logger_, "Application is Forbidden ");
     SendResponse(false, mobile_apis::Result::TOO_MANY_PENDING_REQUESTS);
@@ -820,6 +820,9 @@ void FinishSendingRegisterAppInterfaceToMobile(
     policy::StatusNotifier notify_upd_manager) {
   resumption::ResumeCtrl& resume_ctrl = app_manager.resume_controller();
   auto application = app_manager.application(connection_key);
+
+  policy::PolicyHandlerInterface& policy_handler =
+      app_manager.GetPolicyHandler();
 
   if (msg_params.keyExists(strings::app_hmi_type)) {
     policy_handler.SetDefaultHmiTypes(application->policy_app_id(),

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -193,159 +193,93 @@ bool RegisterAppInterfaceRequest::Init() {
   return true;
 }
 
-void RegisterAppInterfaceRequest::Run() {
-  using namespace helpers;
-  LOG4CXX_AUTO_TRACE(logger_);
-  LOG4CXX_DEBUG(logger_, "Connection key is " << connection_key());
-
-  // Fix problem with SDL and HMI HTML. This problem is not actual for HMI PASA.
-  // Flag conditional compilation specific to customer is used in order to
-  // exclude hit code
-  // to RTC
-  // FIXME(EZamakhov): on shutdown - get freez
-
-  // wait till HMI started
+void RegisterAppInterfaceRequest::WaitForHMIIsReady() {
   while (!application_manager_.IsStopping() &&
          !application_manager_.IsHMICooperating()) {
     LOG4CXX_DEBUG(logger_,
-                  "Waiting for the HMI... conn_key="
-                      << connection_key()
-                      << ", correlation_id=" << correlation_id()
-                      << ", default_timeout=" << default_timeout()
-                      << ", thread=" << pthread_self());
-    application_manager_.updateRequestTimeout(
-        connection_key(), correlation_id(), default_timeout());
+                   "Waiting for the HMI... conn_key="
+                       << connection_key()
+                       << ", correlation_id=" << correlation_id()
+                       << ", default_timeout=" << default_timeout()
+                       << ", thread=" << pthread_self());
+     application_manager_.updateRequestTimeout(
+         connection_key(), correlation_id(), default_timeout());
     sleep(1);
     // TODO(DK): timer_->StartWait(1);
   }
+}
 
-  if (application_manager_.IsStopping()) {
-    LOG4CXX_WARN(logger_, "The ApplicationManager is stopping!");
-    return;
+<<<<<<< HEAD
+=======
+bool RegisterAppInterfaceRequest::IsApplicationForbidden() const {
+  const auto& msg_params = (*message_)[strings::msg_params];
+  const std::string policy_app_id = msg_params[strings::app_id].asString();
+  return application_manager_.IsApplicationForbidden(connection_key(),
+                                                     policy_app_id);
+}
+
+bool RegisterAppInterfaceRequest::ProcessApplicationTransportSwitching() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!IsApplicationSwitched()) {
+    return false;
   }
+  const auto& msg_params = (*message_)[strings::msg_params];
 
-  if (IsApplicationSwitched()) {
-    return;
-  }
-
-  ApplicationSharedPtr application =
-      application_manager_.application(connection_key());
-
-  if (application) {
+  const auto& policy_app_id = msg_params[strings::app_id].asString();
+  auto app = application_manager_.application_by_policy_id(policy_app_id);
+  DCHECK_OR_RETURN(app, false);
+  if (!application_manager_.IsAppInReconnectMode(policy_app_id)) {
+    LOG4CXX_DEBUG(logger_,
+                  "Policy id " << policy_app_id
+                               << " is not found in reconnection list.");
     SendResponse(false, mobile_apis::Result::APPLICATION_REGISTERED_ALREADY);
-    return;
+    return true;
   }
-  // cache the original app ID (for legacy behavior)
-  const std::string policy_app_id =
-      application_manager_.GetCorrectMobileIDFromMessage(message_);
 
+  LOG4CXX_DEBUG(logger_, "Application is found in reconnection list.");
+
+  auto app_type = ApplicationType::kSwitchedApplicationWrongHashId;
+  if ((*message_)[strings::msg_params].keyExists(strings::hash_id)) {
+    const auto hash_id =
+        (*message_)[strings::msg_params][strings::hash_id].asString();
+
+    auto& resume_ctrl = application_manager_.resume_controller();
+    if (resume_ctrl.CheckApplicationHash(app, hash_id)) {
+      app_type = ApplicationType::kSwitchedApplicationHashOk;
+    }
+  }
+
+  application_manager_.ProcessReconnection(app, connection_key());
+  result_code_ = mobile_apis::Result::SUCCESS;
+  SendRegisterAppInterfaceResponseToMobile(app_type, "", false);
+
+  application_manager_.SendHMIStatusNotification(app);
+
+  application_manager_.OnApplicationSwitched(app);
+
+  return true;
+}
+
+void RegisterAppInterfaceRequest::IncrementDuplicateNameCounter(
+    mobile_apis::Result::eType coincidence_result) {
   const smart_objects::SmartObject& msg_params =
       (*message_)[strings::msg_params];
-
-  // transform app IDs to lowercase for usage in policy checks later
-  const std::string app_id_short = msg_params[strings::app_id].asString();
-  std::string new_app_id_short = app_id_short;
-  std::transform(app_id_short.begin(),
-                 app_id_short.end(),
-                 new_app_id_short.begin(),
-                 ::tolower);
-  (*message_)[strings::msg_params][strings::app_id] = new_app_id_short;
-  // If full ID is present, shift that to lowercase too
-  if (msg_params.keyExists(strings::full_app_id)) {
-    const std::string app_id_full = msg_params[strings::full_app_id].asString();
-    std::string new_app_id_full = app_id_full;
-    std::transform(app_id_full.begin(),
-                   app_id_full.end(),
-                   new_app_id_full.begin(),
-                   ::tolower);
-    (*message_)[strings::msg_params][strings::full_app_id] = new_app_id_full;
+  const std::string& policy_app_id = msg_params[strings::app_id].asString();
+  if (mobile_apis::Result::DUPLICATE_NAME == coincidence_result) {
+    usage_statistics::AppCounter count_of_rejections_duplicate_name(
+        policy_handler_.GetStatisticManager(),
+        policy_app_id,
+        usage_statistics::REJECTIONS_DUPLICATE_NAME);
+    ++count_of_rejections_duplicate_name;
   }
-  if (application_manager_.IsApplicationForbidden(connection_key(),
-                                                  policy_app_id)) {
-    SendResponse(false, mobile_apis::Result::TOO_MANY_PENDING_REQUESTS);
-    return;
-  }
+}
 
-  if (IsApplicationWithSameAppIdRegistered()) {
-    SendResponse(false, mobile_apis::Result::DISALLOWED);
-    return;
-  }
-
-  mobile_apis::Result::eType policy_result = CheckWithPolicyData();
-
-  if (Compare<mobile_apis::Result::eType, NEQ, ALL>(
-          policy_result,
-          mobile_apis::Result::SUCCESS,
-          mobile_apis::Result::WARNINGS)) {
-    SendResponse(false, policy_result);
-    return;
-  }
-
-  mobile_apis::Result::eType coincidence_result = CheckCoincidence();
-
-  if (mobile_apis::Result::SUCCESS != coincidence_result) {
-    LOG4CXX_ERROR(logger_, "Coincidence check failed.");
-    if (mobile_apis::Result::DUPLICATE_NAME == coincidence_result) {
-      usage_statistics::AppCounter count_of_rejections_duplicate_name(
-          GetPolicyHandler().GetStatisticManager(),
-          policy_app_id,
-          usage_statistics::REJECTIONS_DUPLICATE_NAME);
-      ++count_of_rejections_duplicate_name;
-    }
-    SendResponse(false, coincidence_result);
-    return;
-  }
-
-  if (IsWhiteSpaceExist()) {
-    LOG4CXX_INFO(logger_,
-                 "Incoming register app interface has contains \t\n \\t \\n");
-    SendResponse(false, mobile_apis::Result::INVALID_DATA);
-    return;
-  }
-
-  uint16_t major =
-      msg_params[strings::sync_msg_version][strings::major_version].asUInt();
-  uint16_t minor =
-      msg_params[strings::sync_msg_version][strings::minor_version].asUInt();
-  uint16_t patch = 0;
-  // Check if patch exists since it is not mandatory.
-  if (msg_params[strings::sync_msg_version].keyExists(strings::patch_version)) {
-    patch =
-        msg_params[strings::sync_msg_version][strings::patch_version].asUInt();
-  }
-
-  utils::SemanticVersion mobile_version(major, minor, patch);
-  utils::SemanticVersion min_module_version(
-      minimum_major_version, minimum_minor_version, minimum_patch_version);
-
-  if (mobile_version < min_module_version) {
-    LOG4CXX_WARN(logger_,
-                 "Application RPC Version does not meet minimum requirement");
-    SendResponse(false, mobile_apis::Result::REJECTED);
-  }
-
-  application = application_manager_.RegisterApplication(message_);
-
-  if (!application) {
-    LOG4CXX_ERROR(logger_, "Application hasn't been registered!");
-    return;
-  }
-
-  // Version negotiation
-  utils::SemanticVersion module_version(
-      major_version, minor_version, patch_version);
-  if (mobile_version < utils::rpc_version_5) {
-    // Mobile versioning did not exist for
-    // versions before 5.0
-    application->set_msg_version(utils::base_rpc_version);
-  } else if (mobile_version < module_version) {
-    // Use mobile RPC version as negotiated version
-    application->set_msg_version(mobile_version);
-  } else {
-    // Use module version as negotiated version
-    application->set_msg_version(module_version);
-  }
-
+>>>>>>> fixup! Refactor register app interface request logic
+void RegisterAppInterfaceRequest::FillApplicationParams(
+    ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const auto& msg_params = (*message_)[strings::msg_params];
+  const std::string policy_app_id = msg_params[strings::app_id].asString();
   // For resuming application need to restore hmi_app_id from resumeCtrl
   resumption::ResumeCtrl& resumer = application_manager_.resume_controller();
   const std::string& device_mac = application->mac_address();
@@ -430,28 +364,287 @@ void RegisterAppInterfaceRequest::Run() {
     application->set_night_color_scheme(
         msg_params[strings::night_color_scheme]);
   }
+}
 
-  // Add device to policy table and set device info, if any
-  policy::DeviceParams dev_params;
-  if (-1 ==
-      application_manager_.connection_handler()
-          .get_session_observer()
-          .GetDataOnDeviceID(application->device(),
-                             &dev_params.device_name,
-                             NULL,
-                             &dev_params.device_mac_address,
-                             &dev_params.device_connection_type)) {
+void RegisterAppInterfaceRequest::IncrementDuplicateNameCounter(
+    mobile_apis::Result::eType coincidence_result) {
+  const smart_objects::SmartObject& msg_params =
+      (*message_)[strings::msg_params];
+  const std::string& policy_app_id = msg_params[strings::app_id].asString();
+  if (mobile_apis::Result::DUPLICATE_NAME == coincidence_result) {
+    usage_statistics::AppCounter count_of_rejections_duplicate_name(
+        policy_handler_.GetStatisticManager(),
+        policy_app_id,
+        usage_statistics::REJECTIONS_DUPLICATE_NAME);
+    ++count_of_rejections_duplicate_name;
+  }
+}
+
+bool RegisterAppInterfaceRequest::ProcessApplicationTransportSwitching() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!IsApplicationSwitched()) {
+    return false;
+  }
+  const auto& msg_params = (*message_)[strings::msg_params];
+
+  const auto& policy_app_id = msg_params[strings::app_id].asString();
+  auto app = application_manager_.application_by_policy_id(policy_app_id);
+  DCHECK_OR_RETURN(app, false);
+  if (!application_manager_.IsAppInReconnectMode(policy_app_id)) {
+    LOG4CXX_DEBUG(logger_,
+                  "Policy id " << policy_app_id
+                               << " is not found in reconnection list.");
+    SendResponse(false, mobile_apis::Result::APPLICATION_REGISTERED_ALREADY);
+    return true;
+  }
+
+  LOG4CXX_DEBUG(logger_, "Application is found in reconnection list.");
+
+  auto app_type = ApplicationType::kSwitchedApplicationWrongHashId;
+  if ((*message_)[strings::msg_params].keyExists(strings::hash_id)) {
+    const auto hash_id =
+        (*message_)[strings::msg_params][strings::hash_id].asString();
+
+    auto& resume_ctrl = application_manager_.resume_controller();
+    if (resume_ctrl.CheckApplicationHash(app, hash_id)) {
+      app_type = ApplicationType::kSwitchedApplicationHashOk;
+    }
+  }
+
+  application_manager_.ProcessReconnection(app, connection_key());
+  result_code_ = mobile_apis::Result::SUCCESS;
+  SendRegisterAppInterfaceResponseToMobile(app_type, "", false);
+
+  application_manager_.SendHMIStatusNotification(app);
+
+  application_manager_.OnApplicationSwitched(app);
+
+  return true;
+}
+
+void RegisterAppInterfaceRequest::CheckLanguage() {
+  ApplicationSharedPtr application =
+      application_manager_.application(connection_key());
+  DCHECK_OR_RETURN_VOID(application);
+  const auto& msg_params = (*message_)[strings::msg_params];
+  if (msg_params[strings::language_desired].asInt() !=
+          hmi_capabilities_.active_vr_language() ||
+      msg_params[strings::hmi_display_language_desired].asInt() !=
+          hmi_capabilities_.active_ui_language()) {
+    LOG4CXX_WARN(logger_,
+                 "Wrong language on registering application "
+                     << application->name().c_str());
+    LOG4CXX_ERROR(
+        logger_,
+        "VR language desired code is "
+            << msg_params[strings::language_desired].asInt()
+            << " , active VR language code is "
+            << hmi_capabilities_.active_vr_language()
+            << ", UI language code is "
+            << msg_params[strings::hmi_display_language_desired].asInt()
+            << " , active UI language code is "
+            << hmi_capabilities_.active_ui_language());
+    result_code_ = mobile_apis::Result::WRONG_LANGUAGE;
+  }
+}
+
+RegisterAppInterfaceRequest::DataResumeResult
+RegisterAppInterfaceRequest::ApplicationDataShouldBeResumed() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const auto& msg_params = (*message_)[strings::msg_params];
+  resumption::ResumeCtrl& resume_ctrl =
+      application_manager_.resume_controller();
+  bool resumption = msg_params.keyExists(strings::hash_id);
+  if (!resumption) {
+    LOG4CXX_DEBUG(logger_, "Hash id is missing, no resumption required");
+    return DataResumeResult::NO_HASH;
+  }
+  ApplicationSharedPtr application =
+      application_manager_.application(connection_key());
+  const auto& hash_id = msg_params[strings::hash_id].asString();
+  if (!resume_ctrl.CheckApplicationHash(application, hash_id)) {
+    LOG4CXX_DEBUG(logger_,
+                  "Hash from RAI does not match to saved resume data.");
+    return DataResumeResult::WRONG_HASH;
+  }
+  DCHECK(application);
+  if (!resume_ctrl.CheckPersistenceFilesForResumption(application)) {
+    LOG4CXX_DEBUG(logger_,
+                  "Persistent data is missing for "
+                      << application->policy_app_id());
+    return DataResumeResult::MISSED_DATA;
+  }
+  return DataResumeResult::RESUME_DATA;
+}
+
+void RegisterAppInterfaceRequest::Run() {
+  using namespace helpers;
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(logger_, "Connection key is " << connection_key());
+
+  WaitForHMIIsReady();
+
+  if (application_manager_.IsStopping()) {
+    LOG4CXX_WARN(logger_, "The ApplicationManager is stopping!");
+    return;
+  }
+
+  if (ProcessApplicationTransportSwitching()) {
+    LOG4CXX_DEBUG(logger_, "Application is switching!");
+    return;
+  }
+
+  if (application_manager_.application(connection_key())) {
+    LOG4CXX_WARN(logger_,
+                 "Application with the same app_id already registered "
+                     << connection_key());
+    SendResponse(false, mobile_apis::Result::APPLICATION_REGISTERED_ALREADY);
+    return;
+  }
+
+  // cache the original app ID (for legacy behavior)
+  const std::string policy_app_id =
+      application_manager_.GetCorrectMobileIDFromMessage(message_);
+
+  const smart_objects::SmartObject& msg_params =
+      (*message_)[strings::msg_params];
+
+  // transform app IDs to lowercase for usage in policy checks later
+  const std::string app_id_short = msg_params[strings::app_id].asString();
+  std::string new_app_id_short = app_id_short;
+  std::transform(app_id_short.begin(),
+                 app_id_short.en
+                 new_app_id_short.begin(),
+                 ::tolower);
+  (*message_)[strings::msg_params][strings::app_id] = new_app_id_short;
+  // If full ID is present, shift that to lowercase too
+  if (msg_params.keyExists(strings::full_app_id)) {
+    const std::string app_id_full = msg_params[strings::full_app_id].asString();
+    std::string new_app_id_full = app_id_full;
+    std::transform(app_id_full.begin(),
+                   app_id_full.end(),
+                   new_app_id_full.begin(),
+                   ::tolower);
+    (*message_)[strings::msg_params][strings::full_app_id] = new_app_id_full;
+  }
+  
+  if (IsApplicationForbidden()) {
+    LOG4CXX_WARN(logger_, "Application is Forbidden ");
+    SendResponse(false, mobile_apis::Result::TOO_MANY_PENDING_REQUESTS);
+    return;
+  }
+
+  if (IsApplicationWithSameAppIdRegistered()) {
+    LOG4CXX_WARN(logger_,
+                 "Application with the policy same app_id already registered ");
+    SendResponse(false, mobile_apis::Result::DISALLOWED);
+    return;
+  }
+
+  mobile_apis::Result::eType policy_result = CheckWithPolicyData();
+
+  if (Compare<mobile_apis::Result::eType, NEQ, ALL>(
+         policy_result,
+         mobile_apis::Result::SUCCESS,
+         mobile_apis::Result::WARNINGS)) {
+    LOG4CXX_WARN(logger_, "Policy check failed " << policy_result);
+    SendResponse(false, policy_result);
+    return;
+  }
+
+  mobile_apis::Result::eType coincidence_result = CheckCoincidence();
+
+  if (mobile_apis::Result::SUCCESS != coincidence_result) {
+    LOG4CXX_ERROR(logger_, "Coincidence check failed.");
+    IncrementDuplicateNameCounter(coincidence_result);
+    SendResponse(false, coincidence_result);
+    return;
+  }
+
+  if (IsWhiteSpaceExist()) {
     LOG4CXX_ERROR(logger_,
-                  "Failed to extract information for device "
-                      << application->device());
-  }
-  policy::DeviceInfo device_info;
-  device_info.AdoptDeviceType(dev_params.device_connection_type);
-  if (msg_params.keyExists(strings::device_info)) {
-    FillDeviceInfo(&device_info);
+                  "Incoming register app interface has contains tabulations or "
+                  "new lines");
+    SendResponse(false, mobile_apis::Result::INVALID_DATA);
+    return;
   }
 
-  GetPolicyHandler().SetDeviceInfo(device_mac, device_info);
+  uint16_t major =
+      msg_params[strings::sync_msg_version][strings::major_version].asUInt();
+  uint16_t minor =
+      msg_params[strings::sync_msg_version][strings::minor_version].asUInt();
+  uint16_t patch = 0;
+  // Check if patch exists since it is not mandatory.
+  if (msg_params[strings::sync_msg_version].keyExists(strings::patch_version)) {
+    patch =
+        msg_params[strings::sync_msg_version][strings::patch_version].asUInt();
+  }
+
+  utils::SemanticVersion mobile_version(major, minor, patch);
+  utils::SemanticVersion min_module_version(
+      minimum_major_version, minimum_minor_version, minimum_patch_version);
+
+  if (mobile_version < min_module_version) {
+    LOG4CXX_WARN(logger_,
+                 "Application RPC Version does not meet minimum requirement");
+    SendResponse(false, mobile_apis::Result::REJECTED);
+  }
+
+  application = application_manager_.RegisterApplication(message_);
+
+  if (!application) {
+    LOG4CXX_ERROR(logger_, "Application hasn't been registered!");
+    return;
+  }
+
+  // Version negotiation
+  utils::SemanticVersion module_version(
+      major_version, minor_version, patch_version);
+  if (mobile_version < utils::rpc_version_5) {
+    // Mobile versioning did not exist for
+    // versions before 5.0
+    application->set_msg_version(utils::base_rpc_version);
+  } else if (mobile_version < module_version) {
+    // Use mobile RPC version as negotiated version
+    application->set_msg_version(mobile_version);
+  } else {
+    // Use module version as negotiated version
+    application->set_msg_version(module_version);
+  }
+
+  FillApplicationParams(application);
+
+  SetupAppDeviceInfo(application);
+
+  const auto resume_data_result = ApplicationDataShouldBeResumed();
+  if (DataResumeResult::RESUME_DATA == resume_data_result) {
+    auto& resume_ctrl = application_manager_.resume_controller();
+    const auto& msg_params = (*message_)[strings::msg_params];
+    const auto& hash_id = msg_params[strings::hash_id].asString();
+    LOG4CXX_WARN(logger_, "Start Data Resumption");
+    resume_ctrl.StartResumption(application, hash_id);
+    return;
+  }
+
+  std::string add_info;
+  if (mobile_apis::Result::INVALID_ENUM == result_code_) {
+    result_code_ = mobile_apis::Result::SUCCESS;
+  }
+
+  if (DataResumeResult::WRONG_HASH == resume_data_result) {
+    add_info = "Hash from RAI does not match to saved resume data.";
+    result_code_ = mobile_apis::Result::RESUME_FAILED;
+  }
+
+  if (DataResumeResult::MISSED_DATA == resume_data_result) {
+    add_info = "Persistent data is missing.";
+    result_code_ = mobile_apis::Result::RESUME_FAILED;
+  }
+
+  const bool need_to_restore_vr =
+      resume_data_result == DataResumeResult::RESUME_DATA;
+  
+  CheckLanguage();
 
   SendRegisterAppInterfaceResponseToMobile(ApplicationType::kNewApplication);
   smart_objects::SmartObjectSPtr so =
@@ -477,7 +670,7 @@ RegisterAppInterfaceRequest::GetLockScreenIconUrlNotification(
   (*message)[strings::msg_params][strings::request_type] =
       mobile_apis::RequestType::LOCK_SCREEN_ICON_URL;
   (*message)[strings::msg_params][strings::url] =
-      GetPolicyHandler().GetLockScreenIconUrl();
+      policy_handler_.GetLockScreenIconUrl();
   return message;
 }
 
@@ -611,59 +804,26 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
 }
 
 void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
-    ApplicationType app_type) {
+    ApplicationType app_type,
+    const std::string& add_info,
+    bool need_restore_vr) {
   LOG4CXX_AUTO_TRACE(logger_);
   smart_objects::SmartObject response_params(smart_objects::SmartType_Map);
-
-  mobile_apis::Result::eType result_code = mobile_apis::Result::SUCCESS;
 
   const HMICapabilities& hmi_capabilities = hmi_capabilities_;
 
   const uint32_t key = connection_key();
   ApplicationSharedPtr application = application_manager_.application(key);
 
-  resumption::ResumeCtrl& resumer = application_manager_.resume_controller();
-
-  if (!application) {
-    LOG4CXX_ERROR(logger_,
-                  "There is no application for such connection key" << key);
-    LOG4CXX_DEBUG(logger_, "Need to start resume data persistent timer");
-    resumer.OnAppRegistrationEnd();
-    return;
-  }
-
-  utils::SemanticVersion negotiated_version = application->msg_version();
-
   response_params[strings::sync_msg_version][strings::major_version] =
-      negotiated_version.major_version_;
+      major_version;  // From generated file interfaces/generated_msg_version.h
   response_params[strings::sync_msg_version][strings::minor_version] =
-      negotiated_version.minor_version_;
+      minor_version;  // From generated file interfaces/generated_msg_version.h
   response_params[strings::sync_msg_version][strings::patch_version] =
-      negotiated_version.patch_version_;
+      patch_version;  // From generated file interfaces/generated_msg_version.h
 
   const smart_objects::SmartObject& msg_params =
       (*message_)[strings::msg_params];
-
-  if (msg_params[strings::language_desired].asInt() !=
-          hmi_capabilities.active_vr_language() ||
-      msg_params[strings::hmi_display_language_desired].asInt() !=
-          hmi_capabilities.active_ui_language()) {
-    LOG4CXX_WARN(logger_,
-                 "Wrong language on registering application "
-                     << application->name().c_str());
-
-    LOG4CXX_ERROR(
-        logger_,
-        "VR language desired code is "
-            << msg_params[strings::language_desired].asInt()
-            << " , active VR language code is "
-            << hmi_capabilities.active_vr_language() << ", UI language code is "
-            << msg_params[strings::hmi_display_language_desired].asInt()
-            << " , active UI language code is "
-            << hmi_capabilities.active_ui_language());
-
-    result_code = mobile_apis::Result::WRONG_LANGUAGE;
-  }
 
   if (HmiInterfaces::STATE_NOT_AVAILABLE !=
       application_manager_.hmi_interfaces().GetInterfaceState(
@@ -760,41 +920,7 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
     return;
   }
 
-  bool resumption =
-      (*message_)[strings::msg_params].keyExists(strings::hash_id);
-
-  bool need_restore_vr = resumption;
-
-  std::string hash_id;
-  std::string add_info;
-  if (resumption) {
-    hash_id = (*message_)[strings::msg_params][strings::hash_id].asString();
-    if (!resumer.CheckApplicationHash(application, hash_id)) {
-      LOG4CXX_WARN(logger_,
-                   "Hash from RAI does not match to saved resume data.");
-      result_code = mobile_apis::Result::RESUME_FAILED;
-      add_info = "Hash from RAI does not match to saved resume data.";
-      need_restore_vr = false;
-    } else if (!resumer.CheckPersistenceFilesForResumption(application)) {
-      LOG4CXX_WARN(logger_, "Persistent data is missing.");
-      result_code = mobile_apis::Result::RESUME_FAILED;
-      add_info = "Persistent data is missing.";
-      need_restore_vr = false;
-    } else {
-      add_info = "Resume succeeded.";
-    }
-  }
-  if ((mobile_apis::Result::SUCCESS == result_code) &&
-      (mobile_apis::Result::INVALID_ENUM != result_code_)) {
-    add_info += response_info_;
-    result_code = result_code_;
-  }
-
-  // in case application exist in resumption we need to send resumeVrgrammars
-  if (false == resumption) {
-    resumption = resumer.IsApplicationSaved(application->policy_app_id(),
-                                            application->mac_address());
-  }
+  response_info_ += add_info;
 
   AppHmiTypes hmi_types;
   if ((*message_)[strings::msg_params].keyExists(strings::app_hmi_type)) {
@@ -809,18 +935,17 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
                      extractor);
     }
   }
-  policy::StatusNotifier notify_upd_manager = GetPolicyHandler().AddApplication(
-      application->policy_app_id(), hmi_types);
+  policy::StatusNotifier notify_upd_manager =
+      policy_handler_.AddApplication(application->policy_app_id(), hmi_types);
 
   response_params[strings::icon_resumed] =
       file_system::FileExists(application->app_icon_path());
 
-  SendResponse(true, result_code, add_info.c_str(), &response_params);
-  SendOnAppRegisteredNotificationToHMI(
-      *(application.get()), resumption, need_restore_vr);
+  SendResponse(true, result_code_, response_info_.c_str(), &response_params);
+  SendOnAppRegisteredNotificationToHMI(*(application.get()), need_restore_vr);
   if (msg_params.keyExists(strings::app_hmi_type)) {
-    GetPolicyHandler().SetDefaultHmiTypes(application->policy_app_id(),
-                                          &(msg_params[strings::app_hmi_type]));
+    policy_handler_.SetDefaultHmiTypes(application->policy_app_id(),
+                                       &(msg_params[strings::app_hmi_type]));
   }
 
   // Default HMI level should be set before any permissions validation, since it
@@ -831,17 +956,21 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
   // Start PTU after successfull registration
   // Sends OnPermissionChange notification to mobile right after RAI response
   // and HMI level set-up
-  GetPolicyHandler().OnAppRegisteredOnMobile(application->policy_app_id());
+  policy_handler_.OnAppRegisteredOnMobile(application->policy_app_id());
 
-  if (result_code != mobile_apis::Result::RESUME_FAILED) {
-    resumer.StartResumption(application, hash_id);
-  } else {
-    resumer.StartResumptionOnlyHMILevel(application);
-  }
+  resumption::ResumeCtrl& resume_ctrl =
+      application_manager_.resume_controller();
+  resume_ctrl.StartResumptionOnlyHMILevel(application);
 
   // By default app subscribed to CUSTOM_BUTTON
   SendSubscribeCustomButtonNotification();
   SendChangeRegistrationOnHMI(application);
+}
+
+DEPRECATED void
+RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
+  SendRegisterAppInterfaceResponseToMobile(
+      ApplicationType::kNewApplication, "", false);
 }
 
 void RegisterAppInterfaceRequest::SendChangeRegistration(
@@ -877,9 +1006,7 @@ void RegisterAppInterfaceRequest::SendChangeRegistrationOnHMI(
 }
 
 void RegisterAppInterfaceRequest::SendOnAppRegisteredNotificationToHMI(
-    const app_mngr::Application& application_impl,
-    bool resumption,
-    bool need_restore_vr) {
+    const app_mngr::Application& application_impl, bool need_restore_vr) {
   using namespace smart_objects;
   SmartObjectSPtr notification = std::make_shared<SmartObject>(SmartType_Map);
   if (!notification) {
@@ -899,7 +1026,7 @@ void RegisterAppInterfaceRequest::SendOnAppRegisteredNotificationToHMI(
   smart_objects::SmartObject& msg_params = (*notification)[strings::msg_params];
   // Due to current requirements in case when we're in resumption mode
   // we have to always send resumeVRGrammar field.
-  if (resumption) {
+  if (need_restore_vr) {
     msg_params[strings::resume_vr_grammars] = need_restore_vr;
   }
 
@@ -913,7 +1040,7 @@ void RegisterAppInterfaceRequest::SendOnAppRegisteredNotificationToHMI(
 
   const std::string policy_app_id = application_impl.policy_app_id();
   std::string priority;
-  GetPolicyHandler().GetPriority(policy_app_id, &priority);
+  policy_handler_.GetPriority(policy_app_id, &priority);
 
   if (!priority.empty()) {
     msg_params[strings::priority] = MessageHelper::GetPriorityCode(priority);
@@ -946,10 +1073,10 @@ void RegisterAppInterfaceRequest::SendOnAppRegisteredNotificationToHMI(
   }
 
   const policy::RequestType::State app_request_types_state =
-      GetPolicyHandler().GetAppRequestTypeState(policy_app_id);
+      policy_handler_.GetAppRequestTypeState(policy_app_id);
   if (policy::RequestType::State::AVAILABLE == app_request_types_state) {
     const auto request_types =
-        GetPolicyHandler().GetAppRequestTypes(policy_app_id);
+        policy_handler_.GetAppRequestTypes(policy_app_id);
     application[strings::request_type] = SmartObject(SmartType_Array);
     smart_objects::SmartObject& request_types_array =
         application[strings::request_type];
@@ -964,10 +1091,10 @@ void RegisterAppInterfaceRequest::SendOnAppRegisteredNotificationToHMI(
   }
 
   const policy::RequestSubType::State app_request_subtypes_state =
-      GetPolicyHandler().GetAppRequestSubTypeState(policy_app_id);
+      policy_handler_.GetAppRequestSubTypeState(policy_app_id);
   if (policy::RequestSubType::State::AVAILABLE == app_request_subtypes_state) {
     const auto request_subtypes =
-        GetPolicyHandler().GetAppRequestSubTypes(policy_app_id);
+        policy_handler_.GetAppRequestSubTypes(policy_app_id);
     application[strings::request_subtype] = SmartObject(SmartType_Array);
     smart_objects::SmartObject& request_subtypes_array =
         application[strings::request_subtype];
@@ -989,7 +1116,7 @@ void RegisterAppInterfaceRequest::SendOnAppRegisteredNotificationToHMI(
   smart_objects::SmartObject& device_info = application[strings::device_info];
   MessageHelper::CreateDeviceInfo(application_impl.device(),
                                   session_observer,
-                                  GetPolicyHandler(),
+                                  policy_handler_,
                                   application_manager_,
                                   &device_info);
 
@@ -999,7 +1126,7 @@ void RegisterAppInterfaceRequest::SendOnAppRegisteredNotificationToHMI(
         application[strings::secondary_device_info];
     MessageHelper::CreateDeviceInfo(application_impl.secondary_device(),
                                     session_observer,
-                                    GetPolicyHandler(),
+                                    policy_handler_,
                                     application_manager_,
                                     &secondary_device_info);
   }
@@ -1072,7 +1199,7 @@ mobile_apis::Result::eType RegisterAppInterfaceRequest::CheckWithPolicyData() {
   // TODO(AOleynik): Check is necessary to allow register application in case
   // of disabled policy
   // Remove this check, when HMI will support policy
-  if (!GetPolicyHandler().PolicyEnabled()) {
+  if (!policy_handler_.PolicyEnabled()) {
     return mobile_apis::Result::WARNINGS;
   }
 
@@ -1082,7 +1209,7 @@ mobile_apis::Result::eType RegisterAppInterfaceRequest::CheckWithPolicyData() {
 
   const std::string mobile_app_id =
       application_manager_.GetCorrectMobileIDFromMessage(message_);
-  const bool init_result = GetPolicyHandler().GetInitialAppData(
+  const bool init_result = policy_handler_.GetInitialAppData(
       mobile_app_id, &app_nicknames, &app_hmi_types);
 
   if (!init_result) {
@@ -1101,7 +1228,7 @@ mobile_apis::Result::eType RegisterAppInterfaceRequest::CheckWithPolicyData() {
       // App should be unregistered, if its name is not present in nicknames
       // list
       usage_statistics::AppCounter count_of_rejections_nickname_mismatch(
-          GetPolicyHandler().GetStatisticManager(),
+          policy_handler_.GetStatisticManager(),
           mobile_app_id,
           usage_statistics::REJECTIONS_NICKNAME_MISMATCH);
       ++count_of_rejections_nickname_mismatch;
@@ -1416,11 +1543,6 @@ bool RegisterAppInterfaceRequest::IsApplicationSwitched() {
   application_manager_.OnApplicationSwitched(app);
 
   return true;
-}
-
-policy::PolicyHandlerInterface&
-RegisterAppInterfaceRequest::GetPolicyHandler() {
-  return policy_handler_;
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -184,6 +184,7 @@ RegisterAppInterfaceRequest::RegisterAppInterfaceRequest(
                          rpc_service,
                          hmi_capabilities,
                          policy_handler)
+    , is_data_resumption_(false)
     , result_code_(mobile_apis::Result::INVALID_ENUM) {}
 
 RegisterAppInterfaceRequest::~RegisterAppInterfaceRequest() {}
@@ -421,6 +422,18 @@ RegisterAppInterfaceRequest::ApplicationDataShouldBeResumed() {
   return DataResumeResult::RESUME_DATA;
 }
 
+void RegisterAppInterfaceRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!is_data_resumption_) {
+    app_mngr::commands::CommandRequestImpl::onTimeOut();
+    return;
+  }
+  result_code_ = mobile_api::Result::RESUME_FAILED;
+  const std::string info = "HMI does not respond during timeout.";
+  SendRegisterAppInterfaceResponseToMobile(
+      ApplicationType::kNewApplication, info, true);
+}
+
 void RegisterAppInterfaceRequest::Run() {
   using namespace helpers;
   LOG4CXX_AUTO_TRACE(logger_);
@@ -576,6 +589,7 @@ void RegisterAppInterfaceRequest::Run() {
   application_manager_.GetPluginManager().ForEachPlugin(on_app_registered);
 
   if (DataResumeResult::RESUME_DATA == resume_data_result) {
+    is_data_resumption_ = true;
     auto& resume_ctrl = application_manager_.resume_controller();
     const auto& msg_params = (*message_)[strings::msg_params];
     const auto& hash_id = msg_params[strings::hash_id].asString();
@@ -809,7 +823,8 @@ void FinishSendingRegisterAppInterfaceToMobile(
                                        &(msg_params[strings::app_hmi_type]));
   }
 
-  // Default HMI level should be set before any permissions validation, since it
+  // Default HMI level should be set before any permissions validation, since
+  // it
   // relies on HMI level.
   app_manager.OnApplicationRegistered(application);
   (*notify_upd_manager)();
@@ -835,11 +850,14 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
   ApplicationSharedPtr application = application_manager_.application(key);
 
   response_params[strings::sync_msg_version][strings::major_version] =
-      major_version;  // From generated file interfaces/generated_msg_version.h
+      major_version;  // From generated file
+                      // interfaces/generated_msg_version.h
   response_params[strings::sync_msg_version][strings::minor_version] =
-      minor_version;  // From generated file interfaces/generated_msg_version.h
+      minor_version;  // From generated file
+                      // interfaces/generated_msg_version.h
   response_params[strings::sync_msg_version][strings::patch_version] =
-      patch_version;  // From generated file interfaces/generated_msg_version.h
+      patch_version;  // From generated file
+                      // interfaces/generated_msg_version.h
 
   const smart_objects::SmartObject& msg_params =
       (*message_)[strings::msg_params];
@@ -1275,7 +1293,8 @@ mobile_apis::Result::eType RegisterAppInterfaceRequest::CheckWithPolicyData() {
   // If AppHMIType is not included in policy - allow any type
   if (!app_hmi_types.empty()) {
     if (message[strings::msg_params].keyExists(strings::app_hmi_type)) {
-      // If AppHmiTypes are partially same, the system should allow those listed
+      // If AppHmiTypes are partially same, the system should allow those
+      // listed
       // in the policy table and send warning info on missed values
       smart_objects::SmartArray app_types =
           *(message[strings::msg_params][strings::app_hmi_type].asArray());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -793,8 +793,6 @@ void FinishSendingRegisterAppInterfaceToMobile(
     ApplicationManager& app_manager,
     const uint32_t connection_key,
     policy::StatusNotifier notify_upd_manager) {
-  policy::PolicyHandlerInterface& policy_handler =
-      app_manager.GetPolicyHandler();
   resumption::ResumeCtrl& resume_ctrl = app_manager.resume_controller();
   auto application = app_manager.application(connection_key);
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -197,20 +197,18 @@ void RegisterAppInterfaceRequest::WaitForHMIIsReady() {
   while (!application_manager_.IsStopping() &&
          !application_manager_.IsHMICooperating()) {
     LOG4CXX_DEBUG(logger_,
-                   "Waiting for the HMI... conn_key="
-                       << connection_key()
-                       << ", correlation_id=" << correlation_id()
-                       << ", default_timeout=" << default_timeout()
-                       << ", thread=" << pthread_self());
-     application_manager_.updateRequestTimeout(
-         connection_key(), correlation_id(), default_timeout());
+                  "Waiting for the HMI... conn_key="
+                      << connection_key()
+                      << ", correlation_id=" << correlation_id()
+                      << ", default_timeout=" << default_timeout()
+                      << ", thread=" << pthread_self());
+    application_manager_.updateRequestTimeout(
+        connection_key(), correlation_id(), default_timeout());
     sleep(1);
     // TODO(DK): timer_->StartWait(1);
   }
 }
 
-<<<<<<< HEAD
-=======
 bool RegisterAppInterfaceRequest::IsApplicationForbidden() const {
   const auto& msg_params = (*message_)[strings::msg_params];
   const std::string policy_app_id = msg_params[strings::app_id].asString();
@@ -274,7 +272,6 @@ void RegisterAppInterfaceRequest::IncrementDuplicateNameCounter(
   }
 }
 
->>>>>>> fixup! Refactor register app interface request logic
 void RegisterAppInterfaceRequest::FillApplicationParams(
     ApplicationSharedPtr application) {
   LOG4CXX_AUTO_TRACE(logger_);
@@ -366,86 +363,32 @@ void RegisterAppInterfaceRequest::FillApplicationParams(
   }
 }
 
-void RegisterAppInterfaceRequest::IncrementDuplicateNameCounter(
-    mobile_apis::Result::eType coincidence_result) {
-  const smart_objects::SmartObject& msg_params =
-      (*message_)[strings::msg_params];
-  const std::string& policy_app_id = msg_params[strings::app_id].asString();
-  if (mobile_apis::Result::DUPLICATE_NAME == coincidence_result) {
-    usage_statistics::AppCounter count_of_rejections_duplicate_name(
-        policy_handler_.GetStatisticManager(),
-        policy_app_id,
-        usage_statistics::REJECTIONS_DUPLICATE_NAME);
-    ++count_of_rejections_duplicate_name;
-  }
-}
-
-bool RegisterAppInterfaceRequest::ProcessApplicationTransportSwitching() {
+void RegisterAppInterfaceRequest::SetupAppDeviceInfo(
+    ApplicationSharedPtr application) {
   LOG4CXX_AUTO_TRACE(logger_);
-  if (!IsApplicationSwitched()) {
-    return false;
-  }
   const auto& msg_params = (*message_)[strings::msg_params];
-
-  const auto& policy_app_id = msg_params[strings::app_id].asString();
-  auto app = application_manager_.application_by_policy_id(policy_app_id);
-  DCHECK_OR_RETURN(app, false);
-  if (!application_manager_.IsAppInReconnectMode(policy_app_id)) {
-    LOG4CXX_DEBUG(logger_,
-                  "Policy id " << policy_app_id
-                               << " is not found in reconnection list.");
-    SendResponse(false, mobile_apis::Result::APPLICATION_REGISTERED_ALREADY);
-    return true;
+  const std::string& device_mac = application->mac_address();
+  // Add device to policy table and set device info, if any
+  policy::DeviceParams dev_params;
+  if (-1 ==
+      application_manager_.connection_handler()
+          .get_session_observer()
+          .GetDataOnDeviceID(application->device(),
+                             &dev_params.device_name,
+                             NULL,
+                             &dev_params.device_mac_address,
+                             &dev_params.device_connection_type)) {
+    LOG4CXX_ERROR(logger_,
+                  "Failed to extract information for device "
+                      << application->device());
+  }
+  policy::DeviceInfo device_info;
+  device_info.AdoptDeviceType(dev_params.device_connection_type);
+  if (msg_params.keyExists(strings::device_info)) {
+    FillDeviceInfo(&device_info);
   }
 
-  LOG4CXX_DEBUG(logger_, "Application is found in reconnection list.");
-
-  auto app_type = ApplicationType::kSwitchedApplicationWrongHashId;
-  if ((*message_)[strings::msg_params].keyExists(strings::hash_id)) {
-    const auto hash_id =
-        (*message_)[strings::msg_params][strings::hash_id].asString();
-
-    auto& resume_ctrl = application_manager_.resume_controller();
-    if (resume_ctrl.CheckApplicationHash(app, hash_id)) {
-      app_type = ApplicationType::kSwitchedApplicationHashOk;
-    }
-  }
-
-  application_manager_.ProcessReconnection(app, connection_key());
-  result_code_ = mobile_apis::Result::SUCCESS;
-  SendRegisterAppInterfaceResponseToMobile(app_type, "", false);
-
-  application_manager_.SendHMIStatusNotification(app);
-
-  application_manager_.OnApplicationSwitched(app);
-
-  return true;
-}
-
-void RegisterAppInterfaceRequest::CheckLanguage() {
-  ApplicationSharedPtr application =
-      application_manager_.application(connection_key());
-  DCHECK_OR_RETURN_VOID(application);
-  const auto& msg_params = (*message_)[strings::msg_params];
-  if (msg_params[strings::language_desired].asInt() !=
-          hmi_capabilities_.active_vr_language() ||
-      msg_params[strings::hmi_display_language_desired].asInt() !=
-          hmi_capabilities_.active_ui_language()) {
-    LOG4CXX_WARN(logger_,
-                 "Wrong language on registering application "
-                     << application->name().c_str());
-    LOG4CXX_ERROR(
-        logger_,
-        "VR language desired code is "
-            << msg_params[strings::language_desired].asInt()
-            << " , active VR language code is "
-            << hmi_capabilities_.active_vr_language()
-            << ", UI language code is "
-            << msg_params[strings::hmi_display_language_desired].asInt()
-            << " , active UI language code is "
-            << hmi_capabilities_.active_ui_language());
-    result_code_ = mobile_apis::Result::WRONG_LANGUAGE;
-  }
+  policy_handler_.SetDeviceInfo(device_mac, device_info);
 }
 
 RegisterAppInterfaceRequest::DataResumeResult
@@ -454,6 +397,7 @@ RegisterAppInterfaceRequest::ApplicationDataShouldBeResumed() {
   const auto& msg_params = (*message_)[strings::msg_params];
   resumption::ResumeCtrl& resume_ctrl =
       application_manager_.resume_controller();
+
   bool resumption = msg_params.keyExists(strings::hash_id);
   if (!resumption) {
     LOG4CXX_DEBUG(logger_, "Hash id is missing, no resumption required");
@@ -544,9 +488,9 @@ void RegisterAppInterfaceRequest::Run() {
   mobile_apis::Result::eType policy_result = CheckWithPolicyData();
 
   if (Compare<mobile_apis::Result::eType, NEQ, ALL>(
-         policy_result,
-         mobile_apis::Result::SUCCESS,
-         mobile_apis::Result::WARNINGS)) {
+          policy_result,
+          mobile_apis::Result::SUCCESS,
+          mobile_apis::Result::WARNINGS)) {
     LOG4CXX_WARN(logger_, "Policy check failed " << policy_result);
     SendResponse(false, policy_result);
     return;
@@ -617,12 +561,22 @@ void RegisterAppInterfaceRequest::Run() {
   SetupAppDeviceInfo(application);
 
   const auto resume_data_result = ApplicationDataShouldBeResumed();
+  SendOnAppRegisteredNotificationToHMI(*application,
+                                       resume_data_result == DataResumeResult::RESUME_DATA);
+
   if (DataResumeResult::RESUME_DATA == resume_data_result) {
     auto& resume_ctrl = application_manager_.resume_controller();
     const auto& msg_params = (*message_)[strings::msg_params];
     const auto& hash_id = msg_params[strings::hash_id].asString();
     LOG4CXX_WARN(logger_, "Start Data Resumption");
-    resume_ctrl.StartResumption(application, hash_id);
+    auto send_response = [this](mobile_apis::Result::eType result_code,
+            const std::string& info) {
+        result_code_ = result_code;
+        SendRegisterAppInterfaceResponseToMobile(
+            ApplicationType::kNewApplication, info, true);
+    };
+
+    resume_ctrl.StartResumption(application, hash_id, send_response);
     return;
   }
 
@@ -641,12 +595,12 @@ void RegisterAppInterfaceRequest::Run() {
     result_code_ = mobile_apis::Result::RESUME_FAILED;
   }
 
+  CheckLanguage();
   const bool need_to_restore_vr =
       resume_data_result == DataResumeResult::RESUME_DATA;
-  
-  CheckLanguage();
 
-  SendRegisterAppInterfaceResponseToMobile(ApplicationType::kNewApplication);
+  SendRegisterAppInterfaceResponseToMobile(
+      ApplicationType::kNewApplication, add_info, need_to_restore_vr);
   smart_objects::SmartObjectSPtr so =
       GetLockScreenIconUrlNotification(connection_key(), application);
   rpc_service_.ManageMobileCommand(so, SOURCE_SDL);
@@ -803,6 +757,33 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
       hmi_capabilities.rc_supported();
 }
 
+void RegisterAppInterfaceRequest::CheckLanguage() {
+  ApplicationSharedPtr application =
+      application_manager_.application(connection_key());
+  DCHECK_OR_RETURN_VOID(application);
+  const auto& msg_params = (*message_)[strings::msg_params];
+  if (msg_params[strings::language_desired].asInt() !=
+          hmi_capabilities_.active_vr_language() ||
+      msg_params[strings::hmi_display_language_desired].asInt() !=
+          hmi_capabilities_.active_ui_language()) {
+    LOG4CXX_WARN(logger_,
+                 "Wrong language on registering application "
+                     << application->name().c_str());
+
+    LOG4CXX_ERROR(
+        logger_,
+        "VR language desired code is "
+            << msg_params[strings::language_desired].asInt()
+            << " , active VR language code is "
+            << hmi_capabilities_.active_vr_language()
+            << ", UI language code is "
+            << msg_params[strings::hmi_display_language_desired].asInt()
+            << " , active UI language code is "
+            << hmi_capabilities_.active_ui_language());
+    result_code_ = mobile_apis::Result::WRONG_LANGUAGE;
+  }
+}
+
 void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
     ApplicationType app_type,
     const std::string& add_info,
@@ -941,8 +922,27 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
   response_params[strings::icon_resumed] =
       file_system::FileExists(application->app_icon_path());
 
+  // copying is needed because by the time
+  // SendRegisterAppInterfaceResponseToMobile() is called from callback
+  // in Run(), request object is deleted, which results in SDL crash.
+  // to prevent that, FinishSendingRegisterAppInterfaceToMobile() method
+  // is created which safely concludes this operation
+  smart_objects::SmartObject msg_params_copy = msg_params;
+
   SendResponse(true, result_code_, response_info_.c_str(), &response_params);
-  SendOnAppRegisteredNotificationToHMI(*(application.get()), need_restore_vr);
+
+  FinishSendingRegisterAppInterfaceToMobile(
+      msg_params_copy, application_manager_, key, notify_upd_manager);
+}
+
+void RegisterAppInterfaceRequest::FinishSendingRegisterAppInterfaceToMobile(
+    const smart_objects::SmartObject& msg_params,
+    ApplicationManager& app_manager,
+    const uint32_t connection_key,
+    policy::StatusNotifier notify_upd_manager) {
+  resumption::ResumeCtrl& resume_ctrl = app_manager.resume_controller();
+  auto application = app_manager.application(connection_key);
+
   if (msg_params.keyExists(strings::app_hmi_type)) {
     policy_handler_.SetDefaultHmiTypes(application->policy_app_id(),
                                        &(msg_params[strings::app_hmi_type]));
@@ -950,7 +950,7 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
 
   // Default HMI level should be set before any permissions validation, since it
   // relies on HMI level.
-  application_manager_.OnApplicationRegistered(application);
+  app_manager.OnApplicationRegistered(application);
   (*notify_upd_manager)();
 
   // Start PTU after successfull registration
@@ -959,7 +959,7 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
   policy_handler_.OnAppRegisteredOnMobile(application->policy_app_id());
 
   resumption::ResumeCtrl& resume_ctrl =
-      application_manager_.resume_controller();
+      app_manager.resume_controller();
   resume_ctrl.StartResumptionOnlyHMILevel(application);
 
   // By default app subscribed to CUSTOM_BUTTON
@@ -1514,35 +1514,18 @@ bool RegisterAppInterfaceRequest::IsApplicationSwitched() {
 
   LOG4CXX_DEBUG(logger_,
                 "Application with policy id " << policy_app_id << " is found.");
-  if (!application_manager_.IsAppInReconnectMode(policy_app_id)) {
-    LOG4CXX_DEBUG(logger_,
-                  "Policy id " << policy_app_id
-                               << " is not found in reconnection list.");
-    SendResponse(false, mobile_apis::Result::APPLICATION_REGISTERED_ALREADY);
-    return false;
-  }
-
-  LOG4CXX_DEBUG(logger_, "Application is found in reconnection list.");
-
-  auto app_type = ApplicationType::kSwitchedApplicationWrongHashId;
-  if ((*message_)[strings::msg_params].keyExists(strings::hash_id)) {
-    const auto hash_id =
-        (*message_)[strings::msg_params][strings::hash_id].asString();
-
-    auto& resume_ctrl = application_manager_.resume_controller();
-    if (resume_ctrl.CheckApplicationHash(app, hash_id)) {
-      app_type = ApplicationType::kSwitchedApplicationHashOk;
-    }
-  }
-
-  application_manager_.ProcessReconnection(app, connection_key());
-  SendRegisterAppInterfaceResponseToMobile(app_type);
-
-  application_manager_.SendHMIStatusNotification(app);
-
-  application_manager_.OnApplicationSwitched(app);
-
   return true;
+}
+
+void RegisterAppInterfaceRequest::TransformPolicyAppIdToUpper() {
+  auto& msg_params = (*message_)[strings::msg_params];
+  const std::string policy_app_id = msg_params[strings::app_id].asString();
+  std::string new_policy_app_id = policy_app_id;
+  std::transform(policy_app_id.begin(),
+                 policy_app_id.end(),
+                 new_policy_app_id.begin(),
+                 ::tolower);
+  msg_params[strings::app_id] = new_policy_app_id;
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -580,11 +580,12 @@ void RegisterAppInterfaceRequest::Run() {
     const auto& msg_params = (*message_)[strings::msg_params];
     const auto& hash_id = msg_params[strings::hash_id].asString();
     LOG4CXX_WARN(logger_, "Start Data Resumption");
-    auto send_response = [this](mobile_apis::Result::eType result_code,
-                                const std::string& info) {
+    auto send_response = [this, application](
+        mobile_apis::Result::eType result_code, const std::string& info) {
       result_code_ = result_code;
       SendRegisterAppInterfaceResponseToMobile(
           ApplicationType::kNewApplication, info, true);
+      application->UpdateHash();
     };
 
     resume_ctrl.StartResumption(application, hash_id, send_response);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
@@ -61,186 +61,7 @@ ResetGlobalPropertiesRequest::ResetGlobalPropertiesRequest(
 ResetGlobalPropertiesRequest::~ResetGlobalPropertiesRequest() {}
 
 void ResetGlobalPropertiesRequest::Run() {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  uint32_t app_id =
-      (*message_)[strings::params][strings::connection_key].asUInt();
-  ApplicationSharedPtr app = application_manager_.application(app_id);
-
-  if (!app) {
-    LOG4CXX_ERROR(logger_, "No application associated with session key");
-    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
-    return;
-  }
-
-  size_t obj_length =
-      (*message_)[strings::msg_params][strings::properties].length();
-  // if application waits for sending ttsGlobalProperties need to remove this
-  // application from tts_global_properties_app_list_
-  LOG4CXX_INFO(logger_, "RemoveAppFromTTSGlobalPropertiesList");
-  application_manager_.RemoveAppFromTTSGlobalPropertiesList(app_id);
-
-  bool helpt_promt = false;
-  bool timeout_prompt = false;
-  bool vr_help_title_items = false;
-  bool menu_name = false;
-  bool menu_icon = false;
-  bool is_key_board_properties = false;
-  int number_of_reset_vr = 0;
-  mobile_apis::GlobalProperty::eType global_property =
-      mobile_apis::GlobalProperty::INVALID_ENUM;
-
-  for (size_t i = 0; i < obj_length; ++i) {
-    global_property = static_cast<mobile_apis::GlobalProperty::eType>(
-        (*message_)[strings::msg_params][strings::properties][i].asInt());
-
-    if (mobile_apis::GlobalProperty::HELPPROMPT == global_property) {
-      helpt_promt = ResetHelpPromt(app);
-    } else if (mobile_apis::GlobalProperty::TIMEOUTPROMPT == global_property) {
-      timeout_prompt = ResetTimeoutPromt(app);
-    } else if (((mobile_apis::GlobalProperty::VRHELPTITLE == global_property) ||
-                (mobile_apis::GlobalProperty::VRHELPITEMS ==
-                 global_property)) &&
-               (0 == number_of_reset_vr)) {
-      ++number_of_reset_vr;
-      vr_help_title_items = ResetVrHelpTitleItems(app);
-    } else if (mobile_apis::GlobalProperty::MENUNAME == global_property) {
-      menu_name = true;
-    } else if (mobile_apis::GlobalProperty::MENUICON == global_property) {
-      menu_icon = true;
-    } else if (mobile_apis::GlobalProperty::KEYBOARDPROPERTIES ==
-               global_property) {
-      is_key_board_properties = true;
-    }
-  }
-
-  if (vr_help_title_items || menu_name || menu_icon ||
-      is_key_board_properties) {
-    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
-  }
-
-  if (timeout_prompt || helpt_promt) {
-    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
-  }
-
-  app->set_reset_global_properties_active(true);
-
-  if (vr_help_title_items || menu_name || menu_icon ||
-      is_key_board_properties) {
-    smart_objects::SmartObject msg_params =
-        smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-    if (vr_help_title_items) {
-      smart_objects::SmartObjectSPtr vr_help =
-          MessageHelper::CreateAppVrHelp(app);
-      if (!vr_help) {
-        return;
-      }
-      msg_params = *vr_help;
-    }
-    if (menu_name) {
-      msg_params[hmi_request::menu_title] = "";
-      app->set_menu_title(msg_params[hmi_request::menu_title]);
-    }
-    // TODO(DT): clarify the sending parameter menuIcon
-    // if (menu_icon) {
-    //}
-    if (is_key_board_properties) {
-      smart_objects::SmartObject key_board_properties =
-          smart_objects::SmartObject(smart_objects::SmartType_Map);
-      key_board_properties[strings::language] =
-          static_cast<int32_t>(hmi_apis::Common_Language::EN_US);
-      key_board_properties[hmi_request::keyboard_layout] =
-          static_cast<int32_t>(hmi_apis::Common_KeyboardLayout::QWERTY);
-
-      // Look for APPLINK-4432 for details.
-      /*smart_objects::SmartObject limited_character_list =
-      smart_objects::SmartObject(
-            smart_objects::SmartType_Array);
-      limited_character_list[0] = "";
-      key_board_properties[hmi_request::limited_character_list] =
-        limited_character_list;*/
-
-      key_board_properties[hmi_request::auto_complete_text] = "";
-      msg_params[hmi_request::keyboard_properties] = key_board_properties;
-    }
-
-    msg_params[strings::app_id] = app->app_id();
-    SendHMIRequest(
-        hmi_apis::FunctionID::UI_SetGlobalProperties, &msg_params, true);
-  }
-
-  if (timeout_prompt || helpt_promt) {
-    // create ui request
-    smart_objects::SmartObject msg_params =
-        smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-    if (helpt_promt) {
-      msg_params[strings::help_prompt] = (*app->help_prompt());
-    }
-
-    if (timeout_prompt) {
-      msg_params[strings::timeout_prompt] = (*app->timeout_prompt());
-    }
-
-    msg_params[strings::app_id] = app->app_id();
-
-    SendHMIRequest(
-        hmi_apis::FunctionID::TTS_SetGlobalProperties, &msg_params, true);
-  }
-}
-
-bool ResetGlobalPropertiesRequest::ResetHelpPromt(
-    application_manager::ApplicationSharedPtr app) {
-  if (!app) {
-    LOG4CXX_ERROR(logger_, "Null pointer");
-    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
-    return false;
-  }
-  smart_objects::SmartObject so_help_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-  app->set_help_prompt(so_help_prompt);
-  return true;
-}
-
-bool ResetGlobalPropertiesRequest::ResetTimeoutPromt(
-    application_manager::ApplicationSharedPtr const app) {
-  if (!app) {
-    LOG4CXX_ERROR(logger_, "Null pointer");
-    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
-    return false;
-  }
-
-  const std::vector<std::string>& time_out_promt =
-      application_manager_.get_settings().time_out_promt();
-
-  smart_objects::SmartObject so_time_out_promt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  for (uint32_t i = 0; i < time_out_promt.size(); ++i) {
-    smart_objects::SmartObject timeoutPrompt =
-        smart_objects::SmartObject(smart_objects::SmartType_Map);
-    timeoutPrompt[strings::text] = time_out_promt[i];
-    timeoutPrompt[strings::type] = hmi_apis::Common_SpeechCapabilities::SC_TEXT;
-    so_time_out_promt[i] = timeoutPrompt;
-  }
-
-  app->set_timeout_prompt(so_time_out_promt);
-
-  return true;
-}
-
-bool ResetGlobalPropertiesRequest::ResetVrHelpTitleItems(
-    application_manager::ApplicationSharedPtr const app) {
-  if (!app) {
-    LOG4CXX_ERROR(logger_, "Null pointer");
-    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
-    return false;
-  }
-  app->reset_vr_help_title();
-  app->reset_vr_help();
-
-  return true;
+  ResetGlobalProperties();
 }
 
 void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
@@ -329,6 +150,56 @@ bool ResetGlobalPropertiesRequest::PrepareResponseParameters(
 bool ResetGlobalPropertiesRequest::IsPendingResponseExist() {
   return IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_TTS) ||
          IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_UI);
+}
+
+void ResetGlobalPropertiesRequest::ResetGlobalProperties() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  uint32_t app_id =
+      (*message_)[strings::params][strings::connection_key].asUInt();
+  ApplicationSharedPtr app = application_manager_.application(app_id);
+
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "No application associated with session key");
+    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
+    return;
+  }
+
+  const auto& global_properties =
+      (*message_)[strings::msg_params][strings::properties];
+
+  auto reset_global_props_result =
+      application_manager_.ResetGlobalProperties(global_properties, app_id);
+
+  if (reset_global_props_result.HasUIPropertiesReset()) {
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
+  }
+
+  if (reset_global_props_result.HasTTSPropertiesReset()) {
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
+  }
+
+  app->set_reset_global_properties_active(true);
+
+  if (reset_global_props_result.HasUIPropertiesReset()) {
+    // create ui request
+    smart_objects::SmartObjectSPtr msg_params =
+        MessageHelper::CreateUIResetGlobalPropertiesRequest(
+            reset_global_props_result, app);
+    if (msg_params.get()) {
+      SendHMIRequest(
+          hmi_apis::FunctionID::UI_SetGlobalProperties, msg_params.get(), true);
+    }
+  }
+
+  if (reset_global_props_result.HasTTSPropertiesReset()) {
+    smart_objects::SmartObjectSPtr msg_params =
+        MessageHelper::CreateTTSResetGlobalPropertiesRequest(
+            reset_global_props_result, app);
+
+    SendHMIRequest(
+        hmi_apis::FunctionID::TTS_SetGlobalProperties, msg_params.get(), true);
+  }
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_button_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_button_request.cc
@@ -77,7 +77,9 @@ void SubscribeButtonRequest::Run() {
     return;
   }
 
-  if (app->msg_version() < utils::rpc_version_5 &&
+  const utils::SemanticVersion app_msg_version = app->msg_version();
+
+  if (app_msg_version <= utils::base_rpc_version &&
       btn_id == mobile_apis::ButtonName::OK && app->is_media_application()) {
     bool ok_supported = CheckHMICapabilities(mobile_apis::ButtonName::OK);
     bool play_pause_supported =

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_way_points_request.cc
@@ -66,7 +66,7 @@ void SubscribeWayPointsRequest::Run() {
     return;
   }
 
-  if (application_manager_.IsAppSubscribedForWayPoints(app)) {
+  if (application_manager_.IsAppSubscribedForWayPoints(*app)) {
     SendResponse(false, mobile_apis::Result::IGNORED);
     return;
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_way_points_request.cc
@@ -66,7 +66,7 @@ void UnsubscribeWayPointsRequest::Run() {
     return;
   }
 
-  if (!application_manager_.IsAppSubscribedForWayPoints(app)) {
+  if (!application_manager_.IsAppSubscribedForWayPoints(*app)) {
     SendResponse(false, mobile_apis::Result::IGNORED);
     return;
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_app_extension.cc
@@ -1,0 +1,78 @@
+/*
+ Copyright (c) 2018, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sdl_rpc_plugin/sdl_app_extension.h"
+#include "sdl_rpc_plugin/sdl_rpc_plugin.h"
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "SDLAppExtension")
+
+namespace sdl_rpc_plugin {
+namespace strings = application_manager::strings;
+unsigned SDLAppExtension::SDLAppExtensionUID = 138;
+
+SDLAppExtension::SDLAppExtension(SDLRPCPlugin& plugin,
+                                 application_manager::Application& app)
+    : app_mngr::AppExtension(SDLAppExtension::SDLAppExtensionUID)
+    , plugin_(plugin)
+    , app_(app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+}
+
+SDLAppExtension::~SDLAppExtension() {
+  LOG4CXX_AUTO_TRACE(logger_);
+}
+
+void SDLAppExtension::SaveResumptionData(
+    smart_objects::SmartObject& resumption_data) {
+  plugin_.SaveResumptionData(app_, resumption_data);
+}
+
+void SDLAppExtension::ProcessResumption(
+    const smart_objects::SmartObject& saved_app,
+    resumption::Subscriber subscriber) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!saved_app.keyExists(strings::subscribed_for_way_points)) {
+    LOG4CXX_ERROR(logger_, "subscribed_for_way_points section does not exist");
+    return;
+  }
+  const bool subscribed_for_way_points_so =
+      saved_app[strings::subscribed_for_way_points].asBool();
+  if (subscribed_for_way_points_so) {
+    plugin_.ProcessResumptionSubscription(app_, *this, subscriber);
+  }
+}
+
+void SDLAppExtension::RevertResumption(
+    const smart_objects::SmartObject& subscriptions) {
+  plugin_.RevertResumption(app_);
+}
+}

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_pending_resumption_handler.cc
@@ -1,0 +1,171 @@
+#include "sdl_rpc_plugin/sdl_pending_resumption_handler.h"
+#include "application_manager/event_engine/event_observer.h"
+#include "application_manager/resumption/resumption_data_processor.h"
+#include "application_manager/message_helper.h"
+#include "utils/helpers.h"
+
+namespace sdl_rpc_plugin {
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "VehicleInfoPendingResumptionHandler")
+
+SDLPendingResumptionHandler::SDLPendingResumptionHandler(
+    application_manager::ApplicationManager& application_manager)
+    : ExtensionPendingResumptionHandler(application_manager) {}
+
+smart_objects::SmartObjectSPtr
+SDLPendingResumptionHandler::CreateSubscriptionRequest() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  auto subscribe_waypoints_msg =
+      application_manager::MessageHelper::CreateMessageForHMI(
+          hmi_apis::FunctionID::Navigation_SubscribeWayPoints,
+          application_manager_.GetNextHMICorrelationID());
+  (*subscribe_waypoints_msg)[application_manager::strings::params]
+                            [application_manager::strings::message_type] =
+                                hmi_apis::messageType::request;
+  return subscribe_waypoints_msg;
+}
+
+void SDLPendingResumptionHandler::ClearPendingResumptionRequests() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  using namespace application_manager;
+  const hmi_apis::FunctionID::eType timed_out_pending_request_fid =
+      static_cast<hmi_apis::FunctionID::eType>(
+          pending_requests_.begin()
+              ->second[strings::params][strings::function_id]
+              .asInt());
+  unsubscribe_from_event(timed_out_pending_request_fid);
+  pending_requests_.clear();
+
+  if (!freezed_resumptions_.empty()) {
+    ResumptionAwaitingHandling freezed_resumption =
+        freezed_resumptions_.front();
+    freezed_resumptions_.pop();
+
+    auto request = CreateSubscriptionRequest();
+    const uint32_t cid =
+        (*request)[strings::params][strings::correlation_id].asUInt();
+    const hmi_apis::FunctionID::eType fid =
+        static_cast<hmi_apis::FunctionID::eType>(
+            (*request)[strings::params][strings::function_id].asInt());
+    auto resumption_req = MakeResumptionRequest(cid, fid, *request);
+    auto subscriber = freezed_resumption.subscriber;
+    subscriber(freezed_resumption.app_id, resumption_req);
+    LOG4CXX_DEBUG(logger_,
+                  "Subscribing for event with function id: "
+                      << fid << " correlation id: " << cid);
+    subscribe_on_event(fid, cid);
+    pending_requests_[cid] = *request;
+    LOG4CXX_DEBUG(logger_,
+                  "Sending request with fid: " << fid << " and cid: " << cid);
+    application_manager_.GetRPCService().ManageHMICommand(request);
+  }
+}
+
+void SDLPendingResumptionHandler::on_event(
+    const application_manager::event_engine::Event& event) {
+  using namespace application_manager;
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const smart_objects::SmartObject& response = event.smart_object();
+  const uint32_t corr_id = event.smart_object_correlation_id();
+
+  smart_objects::SmartObject pending_request;
+  if (pending_requests_.find(corr_id) == pending_requests_.end()) {
+    LOG4CXX_DEBUG(logger_, "corr id" << corr_id << " NOT found");
+    return;
+  }
+  pending_request = pending_requests_[corr_id];
+  pending_requests_.erase(corr_id);
+
+  LOG4CXX_DEBUG(logger_,
+                "Received event with function id: "
+                    << event.id() << " and correlation id: " << corr_id);
+
+  const hmi_apis::Common_Result::eType result_code =
+      static_cast<hmi_apis::Common_Result::eType>(
+          response[strings::params][application_manager::hmi_response::code]
+              .asInt());
+  const bool succesfull_response =
+      (result_code == hmi_apis::Common_Result::SUCCESS ||
+       result_code == hmi_apis::Common_Result::WARNINGS);
+  if (succesfull_response) {
+    LOG4CXX_DEBUG(logger_, "Resumption of subscriptions is successful");
+  } else {
+    LOG4CXX_DEBUG(logger_, "Resumption of subscriptions is NOT successful");
+    uint32_t app_id = 0;
+    if (app_ids_.empty()) {
+      LOG4CXX_ERROR(logger_, "app_ids is empty");
+      return;
+    }
+    app_id = app_ids_.front();
+    auto app = application_manager_.application(app_id);
+    if (!app) {
+      LOG4CXX_ERROR(logger_, "Application NOT found");
+      return;
+    }
+    application_manager_.UnsubscribeAppFromWayPoints(app);
+    if (freezed_resumptions_.empty()) {
+      LOG4CXX_DEBUG(logger_, "freezed resumptions is empty");
+      return;
+    }
+
+    ResumptionAwaitingHandling freezed_resumption =
+        freezed_resumptions_.front();
+    freezed_resumptions_.pop();
+    resumption::Subscriber subscriber = freezed_resumption.subscriber;
+
+    auto request = CreateSubscriptionRequest();
+    const uint32_t cid =
+        (*request)[strings::params][strings::correlation_id].asUInt();
+    const hmi_apis::FunctionID::eType fid =
+        static_cast<hmi_apis::FunctionID::eType>(
+            (*request)[strings::params][strings::function_id].asInt());
+    auto resumption_req = MakeResumptionRequest(cid, fid, *request);
+    subscribe_on_event(fid, cid);
+    subscriber(freezed_resumption.app_id, resumption_req);
+    LOG4CXX_DEBUG(logger_,
+                  "Subscribing for event with function id: "
+                      << fid << " correlation id: " << cid);
+    pending_requests_[cid] = *request;
+    LOG4CXX_DEBUG(logger_,
+                  "Sending request with fid: " << fid << " and cid: " << cid);
+    application_manager_.GetRPCService().ManageHMICommand(request);
+  }
+}
+
+void SDLPendingResumptionHandler::HandleResumptionSubscriptionRequest(
+    application_manager::AppExtension& extension,
+    resumption::Subscriber& subscriber,
+    application_manager::Application& app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  SDLAppExtension& ext = dynamic_cast<SDLAppExtension&>(extension);
+  smart_objects::SmartObjectSPtr request = CreateSubscriptionRequest();
+  smart_objects::SmartObject& request_ref = *request;
+  const auto function_id = static_cast<hmi_apis::FunctionID::eType>(
+      request_ref[application_manager::strings::params]
+                 [application_manager::strings::function_id].asInt());
+  const uint32_t corr_id =
+      request_ref[application_manager::strings::params]
+                 [application_manager::strings::correlation_id].asUInt();
+
+  auto resumption_request =
+      MakeResumptionRequest(corr_id, function_id, *request);
+  app_ids_.push(app.app_id());
+  if (pending_requests_.empty()) {
+    LOG4CXX_DEBUG(logger_,
+                  "There are no pending requests for app_id: " << app.app_id());
+    pending_requests_[corr_id] = request_ref;
+    subscribe_on_event(function_id, corr_id);
+    subscriber(app.app_id(), resumption_request);
+    LOG4CXX_DEBUG(logger_,
+                  "Sending request with function id: "
+                      << function_id << " and correlation_id: " << corr_id);
+    application_manager_.GetRPCService().ManageHMICommand(request);
+    return;
+  }
+  LOG4CXX_DEBUG(logger_,
+                "There are pending requests for app_id: " << app.app_id());
+  ResumptionAwaitingHandling frozen_res(app.app_id(), ext, subscriber);
+  freezed_resumptions_.push(frozen_res);
+}
+}

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/add_command_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/add_command_request_test.cc
@@ -51,6 +51,7 @@
 #include "application_manager/event_engine/event.h"
 #include "application_manager/mock_hmi_interface.h"
 #include "application_manager/mock_help_prompt_manager.h"
+#include "application_manager/mock_resume_ctrl.h"
 
 namespace test {
 namespace components {
@@ -221,6 +222,9 @@ class AddCommandRequestTest
         mock_rpc_service_,
         ManageMobileCommand(response,
                             am::commands::Command::CommandSource::SOURCE_SDL));
+    ON_CALL(app_mngr_, resume_controller())
+        .WillByDefault(ReturnRef(mock_resume_ctrl_));
+    EXPECT_CALL(mock_resume_ctrl_, HandleOnTimeOut(_, _));
     std::shared_ptr<CommandRequestImpl> base_class_request =
         static_cast<std::shared_ptr<CommandRequestImpl> >(request_ptr);
     base_class_request->onTimeOut();
@@ -232,6 +236,7 @@ class AddCommandRequestTest
   std::shared_ptr<sync_primitives::Lock> lock_ptr_;
   std::shared_ptr<am_test::MockHelpPromptManager> mock_help_prompt_manager_;
   MockAppPtr mock_app_;
+  resumprion_test::MockResumeCtrl mock_resume_ctrl_;
 };
 
 TEST_F(AddCommandRequestTest, Run_AppNotExisted_EXPECT_AppNotRegistered) {
@@ -1092,6 +1097,9 @@ TEST_F(AddCommandRequestTest,
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(
                   response, am::commands::Command::CommandSource::SOURCE_SDL));
+  ON_CALL(app_mngr_, resume_controller())
+      .WillByDefault(ReturnRef(mock_resume_ctrl_));
+  EXPECT_CALL(mock_resume_ctrl_, HandleOnTimeOut(_, _));
   std::shared_ptr<CommandRequestImpl> base_class_request =
       static_cast<std::shared_ptr<CommandRequestImpl> >(
           CreateCommand<AddCommandRequest>(msg_));
@@ -1142,6 +1150,9 @@ TEST_F(AddCommandRequestTest, OnTimeOut_AppRemoveCommandCalled) {
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(
                   response, am::commands::Command::CommandSource::SOURCE_SDL));
+  ON_CALL(app_mngr_, resume_controller())
+      .WillByDefault(ReturnRef(mock_resume_ctrl_));
+  EXPECT_CALL(mock_resume_ctrl_, HandleOnTimeOut(_, _));
   std::shared_ptr<CommandRequestImpl> base_class_request =
       static_cast<std::shared_ptr<CommandRequestImpl> >(request_ptr);
   base_class_request->onTimeOut();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
@@ -43,6 +43,7 @@
 #include "application_manager/mock_application_manager.h"
 #include "application_manager/mock_application.h"
 #include "application_manager/mock_application_helper.h"
+#include "application_manager/mock_rpc_plugin_manager.h"
 #include "interfaces/MOBILE_API.h"
 #include "application_manager/smart_object_keys.h"
 #include "application_manager/policies/mock_policy_handler_interface.h"
@@ -72,6 +73,7 @@ namespace am = ::application_manager;
 
 using am::commands::MessageSharedPtr;
 using sdl_rpc_plugin::commands::RegisterAppInterfaceRequest;
+using am::plugin_manager::MockRPCPluginManager;
 
 namespace {
 const uint32_t kConnectionKey = 1u;
@@ -97,13 +99,21 @@ class RegisterAppInterfaceRequestTest
       , lock_ptr_(std::make_shared<sync_primitives::Lock>())
       , mock_application_helper_(
             application_manager_test::MockApplicationHelper::
-                application_helper_mock()) {
+                application_helper_mock())
+      , mock_rpc_plugin_manager_(
+          std::make_shared<NiceMock<MockRPCPluginManager> >()) {
     InitGetters();
     InitLanguage();
   }
 
   void SetUp() OVERRIDE {
     testing::Mock::VerifyAndClearExpectations(&mock_application_helper_);
+
+    ON_CALL(app_mngr_, GetPluginManager())
+      .WillByDefault(ReturnRef(*mock_rpc_plugin_manager_));
+
+    ON_CALL(app_mngr_, GetPolicyHandler())
+      .WillByDefault(ReturnRef(mock_policy_handler_));
   }
 
   void TearDown() OVERRIDE {
@@ -261,6 +271,7 @@ class RegisterAppInterfaceRequestTest
   MockConnectionHandler mock_connection_handler_;
   MockSessionObserver mock_session_observer_;
   application_manager_test::MockApplicationHelper& mock_application_helper_;
+  std::shared_ptr<am::plugin_manager::MockRPCPluginManager> mock_rpc_plugin_manager_;
 };
 
 TEST_F(RegisterAppInterfaceRequestTest, Init_SUCCESS) {
@@ -293,7 +304,7 @@ TEST_F(RegisterAppInterfaceRequestTest, Run_MinimalData_SUCCESS) {
       std::make_shared<utils::CallNothing>();
   ON_CALL(mock_policy_handler_, AddApplication(_, _))
       .WillByDefault(Return(notify_upd_manager));
-
+  
   EXPECT_CALL(app_mngr_, RegisterApplication(msg_)).WillOnce(Return(mock_app));
 
   EXPECT_CALL(mock_rpc_service_,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
@@ -101,7 +101,7 @@ class RegisterAppInterfaceRequestTest
             application_manager_test::MockApplicationHelper::
                 application_helper_mock())
       , mock_rpc_plugin_manager_(
-          std::make_shared<NiceMock<MockRPCPluginManager> >()) {
+            std::make_shared<NiceMock<MockRPCPluginManager> >()) {
     InitGetters();
     InitLanguage();
   }
@@ -110,10 +110,10 @@ class RegisterAppInterfaceRequestTest
     testing::Mock::VerifyAndClearExpectations(&mock_application_helper_);
 
     ON_CALL(app_mngr_, GetPluginManager())
-      .WillByDefault(ReturnRef(*mock_rpc_plugin_manager_));
+        .WillByDefault(ReturnRef(*mock_rpc_plugin_manager_));
 
     ON_CALL(app_mngr_, GetPolicyHandler())
-      .WillByDefault(ReturnRef(mock_policy_handler_));
+        .WillByDefault(ReturnRef(mock_policy_handler_));
   }
 
   void TearDown() OVERRIDE {
@@ -271,7 +271,8 @@ class RegisterAppInterfaceRequestTest
   MockConnectionHandler mock_connection_handler_;
   MockSessionObserver mock_session_observer_;
   application_manager_test::MockApplicationHelper& mock_application_helper_;
-  std::shared_ptr<am::plugin_manager::MockRPCPluginManager> mock_rpc_plugin_manager_;
+  std::shared_ptr<am::plugin_manager::MockRPCPluginManager>
+      mock_rpc_plugin_manager_;
 };
 
 TEST_F(RegisterAppInterfaceRequestTest, Init_SUCCESS) {
@@ -304,7 +305,7 @@ TEST_F(RegisterAppInterfaceRequestTest, Run_MinimalData_SUCCESS) {
       std::make_shared<utils::CallNothing>();
   ON_CALL(mock_policy_handler_, AddApplication(_, _))
       .WillByDefault(Return(notify_upd_manager));
-  
+
   EXPECT_CALL(app_mngr_, RegisterApplication(msg_)).WillOnce(Return(mock_app));
 
   EXPECT_CALL(mock_rpc_service_,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
@@ -125,117 +125,50 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidApp_UNSUCCESS) {
 }
 
 TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidVrHelp_UNSUCCESS) {
-  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
-      mobile_apis::GlobalProperty::HELPPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][1] =
-      mobile_apis::GlobalProperty::TIMEOUTPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][2] =
-      mobile_apis::GlobalProperty::VRHELPTITLE;
-  (*msg_)[am::strings::msg_params][am::strings::properties][3] =
-      mobile_apis::GlobalProperty::MENUNAME;
-  (*msg_)[am::strings::msg_params][am::strings::properties][4] =
-      mobile_apis::GlobalProperty::MENUICON;
-  (*msg_)[am::strings::msg_params][am::strings::properties][5] =
-      mobile_apis::GlobalProperty::KEYBOARDPROPERTIES;
+  am::ResetGlobalPropertiesResult result;
+  result.help_prompt = true;
+  result.timeout_prompt = true;
+  result.vr_help_title_items = true;
+  result.menu_name = true;
+  result.menu_icon = true;
+  result.keyboard_properties = true;
 
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
-  smart_objects::SmartObject so_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-  EXPECT_CALL(*mock_app_, set_help_prompt(so_prompt));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(smart_objects::SmartObjectSPtr()));
 
-  smart_objects::SmartObject timeout_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  timeout_prompt[am::strings::text] = time_out_prompt[0];
-  timeout_prompt[am::strings::type] =
-      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+  ON_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillByDefault(Return(std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map)));
 
-  smart_objects::SmartObject so_time_out_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  so_time_out_prompt[0] = timeout_prompt;
-
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(so_time_out_prompt));
-
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
-
-  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
-
-  smart_objects::SmartObjectSPtr vr_help;  // = NULL;
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
-
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).Times(0);
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).Times(1);
 
   command_->Run();
 }
 
 TEST_F(ResetGlobalPropertiesRequestTest, Run_SUCCESS) {
-  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
-      mobile_apis::GlobalProperty::HELPPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][1] =
-      mobile_apis::GlobalProperty::TIMEOUTPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][2] =
-      mobile_apis::GlobalProperty::VRHELPTITLE;
-  (*msg_)[am::strings::msg_params][am::strings::properties][3] =
-      mobile_apis::GlobalProperty::MENUNAME;
-  (*msg_)[am::strings::msg_params][am::strings::properties][4] =
-      mobile_apis::GlobalProperty::MENUICON;
-  (*msg_)[am::strings::msg_params][am::strings::properties][5] =
-      mobile_apis::GlobalProperty::KEYBOARDPROPERTIES;
+  am::ResetGlobalPropertiesResult result;
+  result.help_prompt = true;
+  result.timeout_prompt = true;
+  result.vr_help_title_items = true;
+  result.menu_name = true;
+  result.menu_icon = true;
+  result.keyboard_properties = true;
+  result.number_of_reset_vr = 1;
 
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
-  smart_objects::SmartObject so_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-  EXPECT_CALL(*mock_app_, set_help_prompt(so_prompt));
-
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
-
-  smart_objects::SmartObject timeout_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  timeout_prompt[am::strings::text] = time_out_prompt[0];
-  timeout_prompt[am::strings::type] =
-      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
-
-  smart_objects::SmartObject so_time_out_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  so_time_out_prompt[0] = timeout_prompt;
-
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(so_time_out_prompt));
-
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
+  ON_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillByDefault(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 
-  smart_objects::SmartObjectSPtr vr_help =
+  smart_objects::SmartObjectSPtr msg_params =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
 
-  smart_objects::SmartObject msg_params =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  msg_params[am::hmi_request::menu_title] = "";
-
-  EXPECT_CALL(*mock_app_,
-              set_menu_title(msg_params[am::hmi_request::menu_title]));
-
-  const smart_objects::SmartObjectSPtr so_help_prompt =
-      std::make_shared<smart_objects::SmartObject>(
-          smart_objects::SmartType_Map);
-  EXPECT_CALL(*mock_app_, help_prompt()).WillOnce(Return(so_help_prompt.get()));
-  EXPECT_CALL(*mock_app_, timeout_prompt())
-      .WillOnce(Return(so_help_prompt.get()));
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(mock_rpc_service_,
               ManageHMICommand(HMIResultCodeIs(
@@ -262,18 +195,25 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       hmi_apis::Common_Result::SUCCESS;
   (*msg_)[am::strings::params][am::hmi_response::code] = result_code;
 
-  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
-      mobile_apis::GlobalProperty::VRHELPTITLE;
+  am::ResetGlobalPropertiesResult result;
+  result.vr_help_title_items = true;
 
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
-  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  ON_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillByDefault(Return(msg_params));
+
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   smart_objects::SmartObjectSPtr vr_help =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
+
   EXPECT_CALL(mock_rpc_service_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::UI_SetGlobalProperties)))
@@ -301,20 +241,22 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
-
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
-
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   MessageSharedPtr ui_msg = CreateMessage();
   (*ui_msg)[am::strings::params][am::strings::correlation_id] = kCorrelationId;
@@ -358,10 +300,22 @@ TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_InvalidApp_NoHashUpdate) {
   (*msg_)[am::strings::msg_params][am::strings::properties][0] =
       mobile_apis::GlobalProperty::VRHELPTITLE;
 
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
+  am::ResetGlobalPropertiesResult result;
+  result.vr_help_title_items = true;
+
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .Times(0);
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+
   EXPECT_CALL(mock_rpc_service_,
               ManageHMICommand(HMIResultCodeIs(
                   hmi_apis::FunctionID::UI_SetGlobalProperties)))
@@ -369,8 +323,6 @@ TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_InvalidApp_NoHashUpdate) {
   smart_objects::SmartObjectSPtr vr_help =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
 
   EXPECT_CALL(*mock_app_, UpdateHash()).Times(0);
 
@@ -397,20 +349,22 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
-
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
-
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(mock_rpc_service_,
               ManageHMICommand(HMIResultCodeIs(
@@ -462,18 +416,20 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
 
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 
@@ -526,18 +482,20 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
 
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/subscribe_way_points_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/subscribe_way_points_request_test.cc
@@ -56,6 +56,7 @@ using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::DoAll;
 using ::testing::SaveArg;
+using ::testing::Eq;
 using ::testing::InSequence;
 namespace am = ::application_manager;
 using sdl_rpc_plugin::commands::SubscribeWayPointsRequest;
@@ -71,7 +72,7 @@ TEST_F(SubscribeWayPointsRequestTest, Run_SUCCESS) {
   MockAppPtr app(CreateMockApp());
 
   ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
-  ON_CALL(app_mngr_, IsAppSubscribedForWayPoints(A<am::ApplicationSharedPtr>()))
+  ON_CALL(app_mngr_, IsAppSubscribedForWayPoints(Ref(*app)))
       .WillByDefault(Return(false));
   ON_CALL(app_mngr_, IsAnyAppSubscribedForWayPoints())
       .WillByDefault(Return(true));

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/unsubscribe_way_points_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/unsubscribe_way_points_request_test.cc
@@ -100,9 +100,7 @@ TEST_F(UnsubscribeWayPointsRequestTest,
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
-  EXPECT_CALL(app_mngr_,
-              IsAppSubscribedForWayPoints(
-                  ::testing::Matcher<am::ApplicationSharedPtr>(mock_app)))
+  EXPECT_CALL(app_mngr_, IsAppSubscribedForWayPoints(Ref(*mock_app)))
       .WillOnce(Return(false));
 
   EXPECT_CALL(
@@ -117,9 +115,7 @@ TEST_F(UnsubscribeWayPointsRequestTest, Run_AppSubscribedForWayPoints_SUCCESS) {
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
-  EXPECT_CALL(app_mngr_,
-              IsAppSubscribedForWayPoints(
-                  ::testing::Matcher<am::ApplicationSharedPtr>(mock_app)))
+  EXPECT_CALL(app_mngr_, IsAppSubscribedForWayPoints(Ref(*mock_app)))
       .WillOnce(Return(true));
 
   EXPECT_CALL(mock_rpc_service_,

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/hmi/vi_subscribe_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/hmi/vi_subscribe_vehicle_data_request.h
@@ -67,6 +67,8 @@ class VISubscribeVehicleDataRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
+  void onTimeOut() OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(VISubscribeVehicleDataRequest);
 };

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
@@ -99,16 +99,23 @@ class VehicleInfoAppExtension : public app_mngr::AppExtension {
    * @brief SaveResumptionData saves vehicle info data
    * @param resumption_data plase to store resumption data
    */
-  void SaveResumptionData(ns_smart_device_link::ns_smart_objects::SmartObject&
-                              resumption_data) OVERRIDE;
+  void SaveResumptionData(smart_objects::SmartObject& resumption_data) OVERRIDE;
 
   /**
    * @brief ProcessResumption load resumtion data back to plugin during
    * resumption
    * @param resumption_data resumption data
+   * @param subscriber callback for subscription
    */
-  void ProcessResumption(
-      const smart_objects::SmartObject& resumption_data) OVERRIDE;
+  void ProcessResumption(const smart_objects::SmartObject& saved_app,
+                         resumption::Subscriber subscriber) OVERRIDE;
+
+  /**
+   * @brief Revert the data to the state before Resumption.
+   * @param subscriptions Subscriptions to be returned
+   **/
+  void RevertResumption(
+      const smart_objects::SmartObject& subscriptions) OVERRIDE;
 
   /**
    * @brief VehicleInfoAppExtensionUID unique identifier of VehicleInfo

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
@@ -93,7 +93,7 @@ class VehicleInfoAppExtension : public app_mngr::AppExtension {
    * @brief Subscriptions get list of subscriptions for application extension
    * @return list of subscriptions for application extension
    */
-  VehicleInfoSubscriptions Subscriptions();
+  const VehicleInfoSubscriptions& Subscriptions();
 
   /**
    * @brief SaveResumptionData saves vehicle info data

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
@@ -1,0 +1,63 @@
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_VEHICLE_INFO_PLUGIN_INCLUDE_VEHICLE_INFO_PLUGIN_PENDING_RESUMPTION_HANDLER_H
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_VEHICLE_INFO_PLUGIN_INCLUDE_VEHICLE_INFO_PLUGIN_PENDING_RESUMPTION_HANDLER_H
+#include "application_manager/event_engine/event_observer.h"
+#include "application_manager/resumption/extension_pending_resumption_handler.h"
+#include "vehicle_info_app_extension.h"
+
+namespace vehicle_info_plugin {
+
+namespace app_mngr = application_manager;
+
+class VehicleInfoPendingResumptionHandler
+    : public resumption::ExtensionPendingResumptionHandler {
+ public:
+  VehicleInfoPendingResumptionHandler(
+      app_mngr::ApplicationManager& application_manager);
+
+  // EventObserver interface
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
+
+  void HandleResumptionSubscriptionRequest(app_mngr::AppExtension& extension,
+                                           resumption::Subscriber& subscriber,
+                                           app_mngr::Application& app) OVERRIDE;
+
+  std::map<std::string, bool> ExtractSubscribeResults(
+      const smart_objects::SmartObject& response,
+      const smart_objects::SmartObject& request) const;
+
+  bool IsResumptionResultSuccessful(
+      std::map<std::string, bool>& subscription_results);
+
+  void RemoveSucessfulSubscriptions(
+      std::set<std::string>& subscriptions,
+      std::set<std::string>& successful_subscriptions);
+
+  std::set<std::string> GetExtensionSubscriptions(
+      VehicleInfoAppExtension& extension);
+
+  smart_objects::SmartObjectSPtr CreateSubscribeRequestToHMI(
+      const std::set<std::string>& subscriptions);
+
+  void ClearPendingResumptionRequests() OVERRIDE;
+
+ private:
+  struct ResumptionAwaitingHandling {
+    const uint32_t app_id;
+    VehicleInfoAppExtension& ext;
+    resumption::Subscriber subscriber;
+
+    ResumptionAwaitingHandling(const uint32_t application_id,
+                               VehicleInfoAppExtension& extension,
+                               resumption::Subscriber subscriber_callback)
+        : app_id(application_id)
+        , ext(extension)
+        , subscriber(subscriber_callback) {}
+  };
+
+  typedef std::pair<VehicleInfoAppExtension, resumption::Subscriber>
+      FreezedResumption;
+  std::queue<ResumptionAwaitingHandling> freezed_resumptions_;
+  std::map<uint32_t, smart_objects::SmartObject> pending_requests_;
+};
+}  // namespace vehicle_info_plugin
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_VEHICLE_INFO_PLUGIN_INCLUDE_VEHICLE_INFO_PLUGIN_PENDING_RESUMPTION_HANDLER_H

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
@@ -40,6 +40,8 @@ class VehicleInfoAppExtension;
 namespace app_mngr = application_manager;
 namespace plugins = application_manager::plugin_manager;
 
+enum SubscribeStatus { SUBSCRIBE, UNSUBSCRIBE };
+
 class VehicleInfoPlugin : public plugins::RPCPlugin {
  public:
   VehicleInfoPlugin();
@@ -65,9 +67,23 @@ class VehicleInfoPlugin : public plugins::RPCPlugin {
    * to HMI
    * @param app application for subscription
    * @param ext application extension
+   * @param subscriber callback for subscription
    */
   void ProcessResumptionSubscription(app_mngr::Application& app,
-                                     VehicleInfoAppExtension& ext);
+                                     VehicleInfoAppExtension& ext,
+                                     resumption::Subscriber subscriber);
+
+  /**
+   * @brief Revert the data to the state before Resumption.
+   * @param subscriptions Subscriptions to be returned
+   **/
+  void RevertResumption(app_mngr::Application& app,
+                        VehicleInfoAppExtension& ext);
+
+  smart_objects::SmartObjectSPtr CreateSubscriptionRequest(
+      const uint32_t app_id,
+      VehicleInfoAppExtension& ext,
+      const SubscribeStatus subscribe_status);
 
  private:
   void DeleteSubscriptions(app_mngr::ApplicationSharedPtr app);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
@@ -78,14 +78,16 @@ class VehicleInfoPlugin : public plugins::RPCPlugin {
    * @param subscriptions Subscriptions to be returned
    **/
   void RevertResumption(app_mngr::Application& app,
-                        std::set<std::string> list_of_subscriptions);
+                        const std::set<std::string>& list_of_subscriptions);
 
   smart_objects::SmartObjectSPtr CreateSubscriptionRequest(
-      const uint32_t app_id,
-      std::set<std::string> list_of_subscriptions,
-      const SubscribeStatus subscribe_status);
+      const std::set<std::string>& list_of_subscriptions);
+
+  smart_objects::SmartObjectSPtr CreateUnsubscriptionRequest(
+      const std::set<std::string>& list_of_subscriptions);
 
  private:
+  bool IsSubscribedAppExist(const std::string& ivi);
   void DeleteSubscriptions(app_mngr::ApplicationSharedPtr app);
 
   std::unique_ptr<app_mngr::CommandFactory> command_factory_;

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
@@ -34,6 +34,7 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_VEHICLE_INFO_PLUGIN_INCLUDE_VEHICLE_INFO_PLUGIN_VEHICLE_INFO_PLUGIN_H
 
 #include "application_manager/command_factory.h"
+#include "application_manager/resumption/extension_pending_resumption_handler.h"
 
 namespace vehicle_info_plugin {
 class VehicleInfoAppExtension;
@@ -92,6 +93,9 @@ class VehicleInfoPlugin : public plugins::RPCPlugin {
 
   std::unique_ptr<app_mngr::CommandFactory> command_factory_;
   app_mngr::ApplicationManager* application_manager_;
+  using ExtensionPendingResumptionHandlerSPtr =
+      std::shared_ptr<resumption::ExtensionPendingResumptionHandler>;
+  ExtensionPendingResumptionHandlerSPtr pending_resumption_handler_;
 };
 }
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
@@ -78,11 +78,11 @@ class VehicleInfoPlugin : public plugins::RPCPlugin {
    * @param subscriptions Subscriptions to be returned
    **/
   void RevertResumption(app_mngr::Application& app,
-                        VehicleInfoAppExtension& ext);
+                        std::set<std::string> list_of_subscriptions);
 
   smart_objects::SmartObjectSPtr CreateSubscriptionRequest(
       const uint32_t app_id,
-      VehicleInfoAppExtension& ext,
+      std::set<std::string> list_of_subscriptions,
       const SubscribeStatus subscribe_status);
 
  private:

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_subscribe_vehicle_data_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "vehicle_info_plugin/commands/hmi/vi_subscribe_vehicle_data_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace vehicle_info_plugin {
 using namespace application_manager;
@@ -55,6 +56,14 @@ void VISubscribeVehicleDataRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void VISubscribeVehicleDataRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
@@ -80,7 +80,7 @@ bool VehicleInfoAppExtension::isSubscribedToVehicleInfo(
   return subscribed_data_.find(vehicle_data) != subscribed_data_.end();
 }
 
-VehicleInfoSubscriptions VehicleInfoAppExtension::Subscriptions() {
+const VehicleInfoSubscriptions& VehicleInfoAppExtension::Subscriptions() {
   return subscribed_data_;
 }
 
@@ -126,12 +126,8 @@ void VehicleInfoAppExtension::ProcessResumption(
 
 void VehicleInfoAppExtension::RevertResumption(
     const smart_objects::SmartObject& subscriptions) {
-  if (!subscriptions.keyExists(strings::application_vehicle_info)) {
-    LOG4CXX_DEBUG(logger_, "application_vehicle_info section is not exists");
-    return;
-  }
-  plugin_.RevertResumption(app_, *this);
   unsubscribeFromVehicleInfo();
+  plugin_.RevertResumption(app_, subscriptions.enumerate());
 }
 
 VehicleInfoAppExtension& VehicleInfoAppExtension::ExtractVIExtension(

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
@@ -97,6 +97,7 @@ void VehicleInfoAppExtension::SaveResumptionData(
 void VehicleInfoAppExtension::ProcessResumption(
     const smart_objects::SmartObject& saved_app,
     resumption::Subscriber subscriber) {
+  LOG4CXX_AUTO_TRACE(logger_);
   if (!saved_app.keyExists(strings::application_subscriptions)) {
     LOG4CXX_DEBUG(logger_, "application_subscriptions section is not exists");
     return;
@@ -118,7 +119,9 @@ void VehicleInfoAppExtension::ProcessResumption(
             (subscriptions_ivi[i]).asInt());
     subscribeToVehicleInfo(ivi);
   }
-  plugin_.ProcessResumptionSubscription(app_, *this, subscriber);
+  if (subscriptions_ivi.length() > 0) {
+    plugin_.ProcessResumptionSubscription(app_, *this, subscriber);
+  }
 }
 
 void VehicleInfoAppExtension::RevertResumption(

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -1,0 +1,275 @@
+#include "vehicle_info_plugin/vehicle_info_pending_resumption_handler.h"
+#include "application_manager/event_engine/event_observer.h"
+#include "application_manager/resumption/resumption_data_processor.h"
+#include "application_manager/message_helper.h"
+#include "utils/helpers.h"
+
+namespace vehicle_info_plugin {
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "VehicleInfoPendingResumptionHandler")
+
+VehicleInfoPendingResumptionHandler::VehicleInfoPendingResumptionHandler(
+    application_manager::ApplicationManager& application_manager)
+    : ExtensionPendingResumptionHandler(application_manager) {}
+
+template <class Key, class Value>
+std::set<Key> EnumerateKeys(std::map<Key, Value>& container) {
+  std::set<std::string> keys;
+
+  std::transform(
+      container.begin(),
+      container.end(),
+      std::inserter(keys, keys.end()),
+      [&](const std::pair<std::string, bool>& pair) { return pair.first; });
+
+  return keys;
+}
+
+bool VehicleInfoPendingResumptionHandler::IsResumptionResultSuccessful(
+    std::map<std::string, bool>& subscription_results) {
+  for (auto ivi_status : subscription_results) {
+    if (!ivi_status.second) {
+      return false;
+      break;
+    }
+  }
+
+  return true;
+}
+
+void VehicleInfoPendingResumptionHandler::RemoveSucessfulSubscriptions(
+    std::set<std::string>& subscriptions,
+    std::set<std::string>& successful_subscriptions) {
+  for (auto subscription : subscriptions) {
+    if (helpers::in_range(successful_subscriptions, subscription)) {
+      subscriptions.erase(subscription);
+    }
+  }
+}
+
+void VehicleInfoPendingResumptionHandler::ClearPendingResumptionRequests() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  using namespace application_manager;
+  const hmi_apis::FunctionID::eType timed_out_pending_request_fid =
+      static_cast<hmi_apis::FunctionID::eType>(
+          pending_requests_.begin()
+              ->second[strings::params][strings::function_id]
+              .asInt());
+  unsubscribe_from_event(timed_out_pending_request_fid);
+  pending_requests_.clear();
+
+  if (!freezed_resumptions_.empty()) {
+    ResumptionAwaitingHandling freezed_resumption =
+        freezed_resumptions_.front();
+    freezed_resumptions_.pop();
+
+    std::set<std::string> subscriptions =
+        GetExtensionSubscriptions(freezed_resumption.ext);
+
+    auto request = CreateSubscribeRequestToHMI(subscriptions);
+    const uint32_t cid =
+        (*request)[strings::params][strings::correlation_id].asUInt();
+    const hmi_apis::FunctionID::eType fid =
+        static_cast<hmi_apis::FunctionID::eType>(
+            (*request)[strings::params][strings::function_id].asInt());
+    auto resumption_req = MakeResumptionRequest(cid, fid, *request);
+    auto subscriber = freezed_resumption.subscriber;
+    subscriber(freezed_resumption.app_id, resumption_req);
+    LOG4CXX_DEBUG(logger_,
+                  "Subscribing for event with function id: "
+                      << fid << " correlation id: " << cid);
+    subscribe_on_event(fid, cid);
+    pending_requests_[cid] = *request;
+    LOG4CXX_DEBUG(logger_,
+                  "Sending request with fid: " << fid << " and cid: " << cid);
+    application_manager_.GetRPCService().ManageHMICommand(request);
+  }
+}
+
+void VehicleInfoPendingResumptionHandler::on_event(
+    const application_manager::event_engine::Event& event) {
+  using namespace application_manager;
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const smart_objects::SmartObject& response = event.smart_object();
+  const uint32_t corr_id = event.smart_object_correlation_id();
+
+  smart_objects::SmartObject pending_request;
+  if (pending_requests_.find(corr_id) == pending_requests_.end()) {
+    LOG4CXX_DEBUG(logger_, "corr id" << corr_id << " NOT found");
+    return;
+  }
+  pending_request = pending_requests_[corr_id];
+  pending_requests_.erase(corr_id);
+
+  LOG4CXX_DEBUG(logger_,
+                "Received event with function id: "
+                    << event.id() << " and correlation id: " << corr_id);
+
+  if (freezed_resumptions_.empty()) {
+    LOG4CXX_DEBUG(logger_, "freezed resumptions is empty");
+    return;
+  }
+
+  std::map<std::string, bool> subscription_results =
+      ExtractSubscribeResults(pending_request, response);
+
+  LOG4CXX_DEBUG(logger_,
+                "pending_requests_.size()" << pending_requests_.size());
+
+  std::set<std::string> successful_subscriptions =
+      EnumerateKeys(subscription_results);
+
+  ResumptionAwaitingHandling freezed_resumption = freezed_resumptions_.front();
+  freezed_resumptions_.pop();
+  resumption::Subscriber subscriber = freezed_resumption.subscriber;
+
+  std::set<std::string> subscriptions =
+      GetExtensionSubscriptions(freezed_resumption.ext);
+
+  if (!IsResumptionResultSuccessful(subscription_results)) {
+    LOG4CXX_DEBUG(logger_, "Resumption of subscriptions is NOT successful");
+  } else {
+    LOG4CXX_DEBUG(logger_, "Resumption of subscriptions is successful");
+    RemoveSucessfulSubscriptions(subscriptions, successful_subscriptions);
+  }
+
+  auto request = CreateSubscribeRequestToHMI(subscriptions);
+  const uint32_t cid =
+      (*request)[strings::params][strings::correlation_id].asUInt();
+  const hmi_apis::FunctionID::eType fid =
+      static_cast<hmi_apis::FunctionID::eType>(
+          (*request)[strings::params][strings::function_id].asInt());
+  auto resumption_req = MakeResumptionRequest(cid, fid, *request);
+  subscribe_on_event(fid, cid);
+  subscriber(freezed_resumption.app_id, resumption_req);
+  LOG4CXX_DEBUG(logger_,
+                "Subscribing for event with function id: "
+                    << fid << " correlation id: " << cid);
+  pending_requests_[cid] = *request;
+  LOG4CXX_DEBUG(logger_,
+                "Sending request with fid: " << fid << " and cid: " << cid);
+  application_manager_.GetRPCService().ManageHMICommand(request);
+}
+
+std::map<std::string, bool>
+VehicleInfoPendingResumptionHandler::ExtractSubscribeResults(
+    const smart_objects::SmartObject& response,
+    const smart_objects::SmartObject& request) const {
+  using namespace application_manager;
+  const hmi_apis::Common_Result::eType result_code =
+      static_cast<hmi_apis::Common_Result::eType>(
+          response[strings::params][application_manager::hmi_response::code]
+              .asInt());
+  bool succesfull_response = (result_code == hmi_apis::Common_Result::SUCCESS ||
+                              result_code == hmi_apis::Common_Result::WARNINGS);
+  const auto response_keys =
+      response[application_manager::strings::msg_params].enumerate();
+  const auto request_keys =
+      request[application_manager::strings::msg_params].enumerate();
+
+  auto response_params = response[strings::msg_params];
+
+  std::map<std::string, bool> subscription_results;
+
+  if (!succesfull_response) {
+    for (auto key : request_keys) {
+      subscription_results[key] = false;
+    }
+  }
+
+  if (succesfull_response) {
+    for (auto key : request_keys) {
+      if (!helpers::in_range(response_keys, key)) {
+        subscription_results[key] = true;
+      } else {
+        const auto kSuccess =
+            hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS;
+        const auto vd_result_code =
+            response_params[key][application_manager::strings::result_code]
+                .asInt();
+        subscription_results[key] = vd_result_code == kSuccess;
+      }
+    }
+  }
+  return subscription_results;
+}
+
+void VehicleInfoPendingResumptionHandler::HandleResumptionSubscriptionRequest(
+    application_manager::AppExtension& extension,
+    resumption::Subscriber& subscriber,
+    application_manager::Application& app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  VehicleInfoAppExtension& ext =
+      dynamic_cast<VehicleInfoAppExtension&>(extension);
+
+  std::set<std::string> subscriptions = GetExtensionSubscriptions(ext);
+
+  smart_objects::SmartObjectSPtr request =
+      CreateSubscribeRequestToHMI(subscriptions);
+
+  smart_objects::SmartObject& request_ref = *request;
+  const auto function_id = static_cast<hmi_apis::FunctionID::eType>(
+      request_ref[application_manager::strings::params]
+                 [application_manager::strings::function_id].asInt());
+  const uint32_t corr_id =
+      request_ref[application_manager::strings::params]
+                 [application_manager::strings::correlation_id].asUInt();
+
+  auto resumption_request =
+      MakeResumptionRequest(corr_id, function_id, *request);
+
+  if (pending_requests_.empty()) {
+    LOG4CXX_DEBUG(logger_,
+                  "There are no pending requests for app_id: " << app.app_id());
+    pending_requests_[corr_id] = request_ref;
+    subscribe_on_event(function_id, corr_id);
+    subscriber(app.app_id(), resumption_request);
+    LOG4CXX_DEBUG(logger_,
+                  "Sending request with function id: "
+                      << function_id << " and correlation_id: " << corr_id);
+    application_manager_.GetRPCService().ManageHMICommand(request);
+    return;
+  } else {
+    LOG4CXX_DEBUG(logger_,
+                  "There are pending requests for app_id: " << app.app_id());
+    ResumptionAwaitingHandling frozen_res(app.app_id(), ext, subscriber);
+    freezed_resumptions_.push(frozen_res);
+  }
+}
+
+std::set<std::string>
+VehicleInfoPendingResumptionHandler::GetExtensionSubscriptions(
+    VehicleInfoAppExtension& extension) {
+  std::set<std::string> subscriptions;
+  for (auto& ivi : application_manager::MessageHelper::vehicle_data()) {
+    const auto it = extension.Subscriptions().find(ivi.second);
+    if (extension.Subscriptions().end() != it) {
+      subscriptions.insert(ivi.first);
+    }
+  }
+  return subscriptions;
+}
+
+smart_objects::SmartObjectSPtr
+VehicleInfoPendingResumptionHandler::CreateSubscribeRequestToHMI(
+    const std::set<std::string>& subscriptions) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  using namespace application_manager;
+  smart_objects::SmartObject msg_params =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  for (const auto& ivi_data : subscriptions) {
+    msg_params[ivi_data] = true;
+  }
+
+  smart_objects::SmartObjectSPtr request =
+      application_manager::MessageHelper::CreateModuleInfoSO(
+          hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData,
+          application_manager_);
+  (*request)[strings::msg_params] = msg_params;
+
+  return request;
+}
+}

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -126,14 +126,14 @@ smart_objects::SmartObjectSPtr VehicleInfoPlugin::CreateSubscriptionRequest(
       msg_params[key_name] = true;
     }
   }
-  const auto function_id = (subscribe_status == SUBSCRIBE) ?
-          hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData:
-          hmi_apis::FunctionID::VehicleInfo_UnsubscribeVehicleData;
+  const auto function_id =
+      (subscribe_status == SUBSCRIBE)
+          ? hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData
+          : hmi_apis::FunctionID::VehicleInfo_UnsubscribeVehicleData;
 
   smart_objects::SmartObjectSPtr request =
       application_manager::MessageHelper::CreateModuleInfoSO(
-          function_id,
-          *application_manager_);
+          function_id, *application_manager_);
   (*request)[strings::msg_params] = msg_params;
   (*request)[strings::params][strings::app_id] = app_id;
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -88,8 +88,17 @@ void VehicleInfoPlugin::ProcessResumptionSubscription(
     VehicleInfoAppExtension& ext,
     resumption::Subscriber subscriber) {
   LOG4CXX_AUTO_TRACE(logger_);
+
+  std::set<std::string> subscriptions;
+  for (auto& ivi : application_manager::MessageHelper::vehicle_data()) {
+    const auto it = ext.Subscriptions().find(ivi.second);
+    if (ext.Subscriptions().end() != it) {
+      subscriptions.insert(ivi.first);
+    }
+  }
+
   smart_objects::SmartObjectSPtr request =
-      CreateSubscriptionRequest(app.app_id(), ext, SUBSCRIBE);
+      CreateSubscriptionRequest(app.app_id(), subscriptions, SUBSCRIBE);
 
   resumption::ResumptionRequest resumption_request;
   resumption_request.request_ids.correlation_id =
@@ -103,28 +112,29 @@ void VehicleInfoPlugin::ProcessResumptionSubscription(
   application_manager_->GetRPCService().ManageHMICommand(request);
 }
 
-void VehicleInfoPlugin::RevertResumption(application_manager::Application& app,
-                                         VehicleInfoAppExtension& ext) {
+void VehicleInfoPlugin::RevertResumption(
+    application_manager::Application& app,
+    std::set<std::string> list_of_subscriptions) {
   LOG4CXX_AUTO_TRACE(logger_);
-  smart_objects::SmartObjectSPtr request =
-      CreateSubscriptionRequest(app.app_id(), ext, UNSUBSCRIBE);
+
+  if (list_of_subscriptions.empty()) {
+    LOG4CXX_DEBUG(logger_, "No data to unsubscribe");
+    return;
+  }
+  smart_objects::SmartObjectSPtr request = CreateSubscriptionRequest(
+      app.app_id(), list_of_subscriptions, UNSUBSCRIBE);
   application_manager_->GetRPCService().ManageHMICommand(request);
 }
 
 smart_objects::SmartObjectSPtr VehicleInfoPlugin::CreateSubscriptionRequest(
     const uint32_t app_id,
-    VehicleInfoAppExtension& ext,
+    std::set<std::string> list_of_subscriptions,
     const SubscribeStatus subscribe_status) {
   LOG4CXX_AUTO_TRACE(logger_);
   smart_objects::SmartObject msg_params =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
-  const auto& subscriptions = ext.Subscriptions();
-  for (auto& ivi_data : application_manager::MessageHelper::vehicle_data()) {
-    mobile_apis::VehicleDataType::eType type_id = ivi_data.second;
-    if (subscriptions.end() != subscriptions.find(type_id)) {
-      std::string key_name = ivi_data.first;
-      msg_params[key_name] = true;
-    }
+  for (auto& ivi_data : list_of_subscriptions) {
+    msg_params[ivi_data] = true;
   }
   const auto function_id =
       (subscribe_status == SUBSCRIBE)

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -98,7 +98,7 @@ void VehicleInfoPlugin::ProcessResumptionSubscription(
   }
 
   smart_objects::SmartObjectSPtr request =
-      CreateSubscriptionRequest(app.app_id(), subscriptions, SUBSCRIBE);
+      CreateSubscriptionRequest(subscriptions);
 
   resumption::ResumptionRequest resumption_request;
   resumption_request.request_ids.correlation_id =
@@ -114,40 +114,76 @@ void VehicleInfoPlugin::ProcessResumptionSubscription(
 
 void VehicleInfoPlugin::RevertResumption(
     application_manager::Application& app,
-    std::set<std::string> list_of_subscriptions) {
+    const std::set<std::string>& list_of_subscriptions) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  if (list_of_subscriptions.empty()) {
+  std::set<std::string> subscriptions_to_revert;
+  for (auto& ivi_data : list_of_subscriptions) {
+    if (!IsSubscribedAppExist(ivi_data)) {
+      subscriptions_to_revert.insert(ivi_data);
+    }
+  }
+
+  if (subscriptions_to_revert.empty()) {
     LOG4CXX_DEBUG(logger_, "No data to unsubscribe");
     return;
   }
-  smart_objects::SmartObjectSPtr request = CreateSubscriptionRequest(
-      app.app_id(), list_of_subscriptions, UNSUBSCRIBE);
+  smart_objects::SmartObjectSPtr request =
+      CreateUnsubscriptionRequest(subscriptions_to_revert);
   application_manager_->GetRPCService().ManageHMICommand(request);
 }
 
 smart_objects::SmartObjectSPtr VehicleInfoPlugin::CreateSubscriptionRequest(
-    const uint32_t app_id,
-    std::set<std::string> list_of_subscriptions,
-    const SubscribeStatus subscribe_status) {
+    const std::set<std::string>& list_of_subscriptions) {
   LOG4CXX_AUTO_TRACE(logger_);
   smart_objects::SmartObject msg_params =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
+
   for (auto& ivi_data : list_of_subscriptions) {
     msg_params[ivi_data] = true;
   }
-  const auto function_id =
-      (subscribe_status == SUBSCRIBE)
-          ? hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData
-          : hmi_apis::FunctionID::VehicleInfo_UnsubscribeVehicleData;
 
   smart_objects::SmartObjectSPtr request =
       application_manager::MessageHelper::CreateModuleInfoSO(
-          function_id, *application_manager_);
+          hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData,
+          *application_manager_);
   (*request)[strings::msg_params] = msg_params;
-  (*request)[strings::params][strings::app_id] = app_id;
 
   return request;
+}
+
+smart_objects::SmartObjectSPtr VehicleInfoPlugin::CreateUnsubscriptionRequest(
+    const std::set<std::string>& list_of_subscriptions) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  smart_objects::SmartObject msg_params =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  for (auto& ivi_data : list_of_subscriptions) {
+    msg_params[ivi_data] = true;
+  }
+
+  smart_objects::SmartObjectSPtr request =
+      application_manager::MessageHelper::CreateModuleInfoSO(
+          hmi_apis::FunctionID::VehicleInfo_UnsubscribeVehicleData,
+          *application_manager_);
+  (*request)[strings::msg_params] = msg_params;
+
+  return request;
+}
+
+bool VehicleInfoPlugin::IsSubscribedAppExist(const std::string& ivi) {
+  auto applications = application_manager_->applications();
+  const auto it = application_manager::MessageHelper::vehicle_data().find(ivi);
+  DCHECK_OR_RETURN(
+      it != application_manager::MessageHelper::vehicle_data().end(), false);
+  auto ivi_enum = it->second;
+  for (auto& app : applications.GetData()) {
+    auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
+    if (ext.isSubscribedToVehicleInfo(ivi_enum)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 application_manager::ApplicationSharedPtr FindAppSubscribedToIVI(

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -37,13 +37,15 @@
 #include "application_manager/message_helper.h"
 #include "application_manager/message_helper.h"
 #include "application_manager/resumption/resumption_data_processor.h"
+#include "vehicle_info_plugin/vehicle_info_pending_resumption_handler.h"
 
 namespace vehicle_info_plugin {
 CREATE_LOGGERPTR_GLOBAL(logger_, "VehicleInfoPlugin")
 
 namespace strings = application_manager::strings;
 
-VehicleInfoPlugin::VehicleInfoPlugin() : application_manager_(nullptr) {}
+VehicleInfoPlugin::VehicleInfoPlugin()
+    : application_manager_(nullptr), pending_resumption_handler_(nullptr) {}
 
 bool VehicleInfoPlugin::Init(
     application_manager::ApplicationManager& app_manager,
@@ -51,6 +53,8 @@ bool VehicleInfoPlugin::Init(
     application_manager::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler) {
   application_manager_ = &app_manager;
+  pending_resumption_handler_ =
+      std::make_shared<VehicleInfoPendingResumptionHandler>(app_manager);
   command_factory_.reset(new vehicle_info_plugin::VehicleInfoCommandFactory(
       app_manager, rpc_service, hmi_capabilities, policy_handler));
   return true;
@@ -89,33 +93,16 @@ void VehicleInfoPlugin::ProcessResumptionSubscription(
     resumption::Subscriber subscriber) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  std::set<std::string> subscriptions;
-  for (auto& ivi : application_manager::MessageHelper::vehicle_data()) {
-    const auto it = ext.Subscriptions().find(ivi.second);
-    if (ext.Subscriptions().end() != it) {
-      subscriptions.insert(ivi.first);
-    }
-  }
-
-  smart_objects::SmartObjectSPtr request =
-      CreateSubscriptionRequest(subscriptions);
-
-  resumption::ResumptionRequest resumption_request;
-  resumption_request.request_ids.correlation_id =
-      (*request)[strings::params][strings::correlation_id].asInt();
-  resumption_request.request_ids.function_id =
-      hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData;
-  resumption_request.message = *request;
-
-  subscriber(app.app_id(), resumption_request);
-
-  application_manager_->GetRPCService().ManageHMICommand(request);
+  pending_resumption_handler_->HandleResumptionSubscriptionRequest(
+      ext, subscriber, app);
 }
 
 void VehicleInfoPlugin::RevertResumption(
     application_manager::Application& app,
     const std::set<std::string>& list_of_subscriptions) {
   LOG4CXX_AUTO_TRACE(logger_);
+
+  pending_resumption_handler_->ClearPendingResumptionRequests();
 
   std::set<std::string> subscriptions_to_revert;
   for (auto& ivi_data : list_of_subscriptions) {
@@ -172,6 +159,7 @@ smart_objects::SmartObjectSPtr VehicleInfoPlugin::CreateUnsubscriptionRequest(
 }
 
 bool VehicleInfoPlugin::IsSubscribedAppExist(const std::string& ivi) {
+  LOG4CXX_AUTO_TRACE(logger_);
   auto applications = application_manager_->applications();
   const auto it = application_manager::MessageHelper::vehicle_data().find(ivi);
   DCHECK_OR_RETURN(

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -74,6 +74,7 @@ void VehicleInfoPlugin::OnPolicyEvent(plugins::PolicyEvent event) {}
 void VehicleInfoPlugin::OnApplicationEvent(
     plugins::ApplicationEvent event,
     app_mngr::ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
   if (plugins::ApplicationEvent::kApplicationRegistered == event) {
     application->AddExtension(
         std::make_shared<VehicleInfoAppExtension>(*this, *application));
@@ -92,7 +93,7 @@ void VehicleInfoPlugin::ProcessResumptionSubscription(
 
   resumption::ResumptionRequest resumption_request;
   resumption_request.request_ids.correlation_id =
-      (*request)[strings::msg_params][strings::correlation_id].asInt();
+      (*request)[strings::params][strings::correlation_id].asInt();
   resumption_request.request_ids.function_id =
       hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData;
   resumption_request.message = *request;
@@ -116,7 +117,6 @@ smart_objects::SmartObjectSPtr VehicleInfoPlugin::CreateSubscriptionRequest(
   LOG4CXX_AUTO_TRACE(logger_);
   smart_objects::SmartObject msg_params =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
-  msg_params[strings::app_id] = app_id;
   const auto& subscriptions = ext.Subscriptions();
   for (auto& ivi_data : application_manager::MessageHelper::vehicle_data()) {
     mobile_apis::VehicleDataType::eType type_id = ivi_data.second;
@@ -125,11 +125,13 @@ smart_objects::SmartObjectSPtr VehicleInfoPlugin::CreateSubscriptionRequest(
       msg_params[key_name] = subscribe_status == SUBSCRIBE;
     }
   }
+
   smart_objects::SmartObjectSPtr request =
       application_manager::MessageHelper::CreateModuleInfoSO(
           hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData,
           *application_manager_);
   (*request)[strings::msg_params] = msg_params;
+  (*request)[strings::params][strings::app_id] = app_id;
 
   return request;
 }

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -105,6 +105,7 @@ void VehicleInfoPlugin::ProcessResumptionSubscription(
 
 void VehicleInfoPlugin::RevertResumption(application_manager::Application& app,
                                          VehicleInfoAppExtension& ext) {
+  LOG4CXX_AUTO_TRACE(logger_);
   smart_objects::SmartObjectSPtr request =
       CreateSubscriptionRequest(app.app_id(), ext, UNSUBSCRIBE);
   application_manager_->GetRPCService().ManageHMICommand(request);
@@ -122,13 +123,16 @@ smart_objects::SmartObjectSPtr VehicleInfoPlugin::CreateSubscriptionRequest(
     mobile_apis::VehicleDataType::eType type_id = ivi_data.second;
     if (subscriptions.end() != subscriptions.find(type_id)) {
       std::string key_name = ivi_data.first;
-      msg_params[key_name] = subscribe_status == SUBSCRIBE;
+      msg_params[key_name] = true;
     }
   }
+  const auto function_id = (subscribe_status == SUBSCRIBE) ?
+          hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData:
+          hmi_apis::FunctionID::VehicleInfo_UnsubscribeVehicleData;
 
   smart_objects::SmartObjectSPtr request =
       application_manager::MessageHelper::CreateModuleInfoSO(
-          hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData,
+          function_id,
           *application_manager_);
   (*request)[strings::msg_params] = msg_params;
   (*request)[strings::params][strings::app_id] = app_id;

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -91,9 +91,9 @@ void VehicleInfoPlugin::ProcessResumptionSubscription(
       CreateSubscriptionRequest(app.app_id(), ext, SUBSCRIBE);
 
   resumption::ResumptionRequest resumption_request;
-  resumption_request.correlation_id =
+  resumption_request.request_ids.correlation_id =
       (*request)[strings::msg_params][strings::correlation_id].asInt();
-  resumption_request.function_id =
+  resumption_request.request_ids.function_id =
       hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData;
   resumption_request.message = *request;
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/mobile/unsubscribe_vehicle_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/mobile/unsubscribe_vehicle_request_test.cc
@@ -78,6 +78,8 @@ class UnsubscribeVehicleRequestTest
  protected:
   void UnsubscribeSuccessfully();
   void SetUp() OVERRIDE {
+    ON_CALL(app_mngr_, event_dispatcher())
+        .WillByDefault(ReturnRef(event_dispatcher_));
     vi_plugin_.Init(app_mngr_,
                     mock_rpc_service_,
                     mock_hmi_capabilities_,
@@ -107,7 +109,6 @@ TEST_F(UnsubscribeVehicleRequestTest, Run_AppNotRegistered_UNSUCCESS) {
       mock_rpc_service_,
       ManageMobileCommand(
           MobileResultCodeIs(mobile_result::APPLICATION_NOT_REGISTERED), _));
-
   command->Run();
 }
 

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -787,12 +787,14 @@ const AppFile* ApplicationImpl::GetFile(const std::string& file_name) {
 
 bool ApplicationImpl::SubscribeToButton(
     mobile_apis::ButtonName::eType btn_name) {
+  LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(button_lock_ptr_);
   return subscribed_buttons_.insert(btn_name).second;
 }
 
 bool ApplicationImpl::IsSubscribedToButton(
     mobile_apis::ButtonName::eType btn_name) {
+  LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(button_lock_ptr_);
   std::set<mobile_apis::ButtonName::eType>::iterator it =
       subscribed_buttons_.find(btn_name);
@@ -801,6 +803,7 @@ bool ApplicationImpl::IsSubscribedToButton(
 
 bool ApplicationImpl::UnsubscribeFromButton(
     mobile_apis::ButtonName::eType btn_name) {
+  LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(button_lock_ptr_);
   return subscribed_buttons_.erase(btn_name);
 }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2395,6 +2395,7 @@ void ApplicationManagerImpl::UnregisterApplication(
   }
   if (1 == subscribed_for_way_points_app_count) {
     LOG4CXX_ERROR(logger_, "Send UnsubscribeWayPoints");
+    UnsubscribeAppFromWayPoints(app_id);
     MessageHelper::SendUnsubscribedWayPoints(*this);
   }
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -374,12 +374,6 @@ void ApplicationManagerImpl::OnApplicationRegistered(ApplicationSharedPtr app) {
   const mobile_apis::HMILevel::eType default_level = GetDefaultHmiLevel(app);
   state_ctrl_.OnApplicationRegistered(app, default_level);
 
-  std::function<void(plugin_manager::RPCPlugin&)> on_app_registered =
-      [app](plugin_manager::RPCPlugin& plugin) {
-        plugin.OnApplicationEvent(plugin_manager::kApplicationRegistered, app);
-      };
-  plugin_manager_->ForEachPlugin(on_app_registered);
-
   // TODO(AOleynik): Is neccessary to be able to know that registration process
   // has been completed and default HMI level is set, otherwise policy will
   // block all the requests/notifications to mobile
@@ -2395,7 +2389,9 @@ void ApplicationManagerImpl::UnregisterApplication(
   }
   if (1 == subscribed_for_way_points_app_count) {
     LOG4CXX_ERROR(logger_, "Send UnsubscribeWayPoints");
-    UnsubscribeAppFromWayPoints(app_id);
+    if (!is_unexpected_disconnect) {
+      UnsubscribeAppFromWayPoints(app_id);
+    }
     MessageHelper::SendUnsubscribedWayPoints(*this);
   }
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2388,8 +2388,9 @@ void ApplicationManagerImpl::UnregisterApplication(
         subscribed_way_points_apps_list_.size();
   }
   if (1 == subscribed_for_way_points_app_count) {
-    LOG4CXX_ERROR(logger_, "Send UnsubscribeWayPoints");
-    if (!is_unexpected_disconnect) {
+    LOG4CXX_DEBUG(logger_, "Send UnsubscribeWayPoints");
+    if (!is_resuming) {
+      LOG4CXX_DEBUG(logger_, "Unsubscribe App from WayPoints");
       UnsubscribeAppFromWayPoints(app_id);
     }
     MessageHelper::SendUnsubscribedWayPoints(*this);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2414,11 +2414,12 @@ void ApplicationManagerImpl::UnregisterApplication(
     subscribed_for_way_points_app_count =
         subscribed_way_points_apps_list_.size();
   }
+  ApplicationSharedPtr app_ptr = application(app_id);
   if (1 == subscribed_for_way_points_app_count) {
     LOG4CXX_DEBUG(logger_, "Send UnsubscribeWayPoints");
     if (!is_resuming) {
       LOG4CXX_DEBUG(logger_, "Unsubscribe App from WayPoints");
-      UnsubscribeAppFromWayPoints(app_id);
+      UnsubscribeAppFromWayPoints(app_ptr);
     }
     MessageHelper::SendUnsubscribedWayPoints(*this);
   }
@@ -2447,7 +2448,6 @@ void ApplicationManagerImpl::UnregisterApplication(
     case mobile_apis::Result::EXPIRED_CERT:
       break;
     case mobile_apis::Result::TOO_MANY_PENDING_REQUESTS: {
-      ApplicationSharedPtr app_ptr = application(app_id);
       if (app_ptr) {
         app_ptr->usage_report().RecordRemovalsForBadBehavior();
         if (reason == mobile_apis::Result::TOO_MANY_PENDING_REQUESTS) {
@@ -2491,7 +2491,7 @@ void ApplicationManagerImpl::UnregisterApplication(
 
     if (is_resuming) {
       resume_controller().SaveApplication(app_to_remove);
-      UnsubscribeAppFromWayPoints(app_id);
+      UnsubscribeAppFromWayPoints(app_ptr);
     } else {
       resume_controller().RemoveApplicationFromSaved(app_to_remove);
     }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2840,6 +2840,54 @@ void ApplicationManagerImpl::ProcessApp(const uint32_t app_id,
   }
 }
 
+bool ApplicationManagerImpl::ResetHelpPromt(ApplicationSharedPtr app) const {
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "Null pointer");
+    return false;
+  }
+  smart_objects::SmartObject so_help_prompt =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  app->set_help_prompt(so_help_prompt);
+  return true;
+}
+
+bool ApplicationManagerImpl::ResetTimeoutPromt(ApplicationSharedPtr app) const {
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "Null pointer");
+    return false;
+  }
+
+  const std::vector<std::string>& time_out_promt =
+      get_settings().time_out_promt();
+
+  smart_objects::SmartObject so_time_out_promt =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  for (uint32_t i = 0; i < time_out_promt.size(); ++i) {
+    smart_objects::SmartObject timeoutPrompt =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    timeoutPrompt[strings::text] = time_out_promt[i];
+    timeoutPrompt[strings::type] = hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+    so_time_out_promt[i] = timeoutPrompt;
+  }
+
+  app->set_timeout_prompt(so_time_out_promt);
+
+  return true;
+}
+
+bool ApplicationManagerImpl::ResetVrHelpTitleItems(
+    ApplicationSharedPtr app) const {
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "Null pointer");
+    return false;
+  }
+  app->reset_vr_help_title();
+  app->reset_vr_help();
+
+  return true;
+}
+
 void ApplicationManagerImpl::SendHMIStatusNotification(
     const std::shared_ptr<Application> app) {
   LOG4CXX_AUTO_TRACE(logger_);
@@ -3168,6 +3216,99 @@ void ApplicationManagerImpl::RemoveAppFromTTSGlobalPropertiesList(
     }
   }
   tts_global_properties_app_list_lock_.Release();
+}
+
+ResetGlobalPropertiesResult ApplicationManagerImpl::ResetGlobalProperties(
+    const smart_objects::SmartObject& global_properties_ids,
+    const uint32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  ApplicationSharedPtr application =
+      ApplicationManagerImpl::application(app_id);
+  // if application waits for sending ttsGlobalProperties need to remove this
+  // application from tts_global_properties_app_list_
+  LOG4CXX_INFO(logger_, "RemoveAppFromTTSGlobalPropertiesList");
+  RemoveAppFromTTSGlobalPropertiesList(app_id);
+
+  ResetGlobalPropertiesResult result;
+
+  for (size_t i = 0; i < global_properties_ids.length(); ++i) {
+    mobile_apis::GlobalProperty::eType global_property =
+        static_cast<mobile_apis::GlobalProperty::eType>(
+            global_properties_ids[i].asInt());
+    switch (global_property) {
+      case mobile_apis::GlobalProperty::HELPPROMPT: {
+        result.help_prompt = ResetHelpPromt(application);
+        break;
+      }
+      case mobile_apis::GlobalProperty::TIMEOUTPROMPT: {
+        result.timeout_prompt = ResetTimeoutPromt(application);
+        break;
+      }
+      case mobile_apis::GlobalProperty::VRHELPTITLE:
+      case mobile_apis::GlobalProperty::VRHELPITEMS: {
+        if (0 == result.number_of_reset_vr) {
+          result.number_of_reset_vr++;
+          result.vr_help_title_items = ResetVrHelpTitleItems(application);
+        }
+        break;
+      }
+      case mobile_apis::GlobalProperty::MENUNAME: {
+        result.menu_name = true;
+        break;
+      }
+      case mobile_apis::GlobalProperty::MENUICON: {
+        result.menu_icon = true;
+        break;
+      }
+      case mobile_apis::GlobalProperty::KEYBOARDPROPERTIES: {
+        result.keyboard_properties = true;
+        break;
+      }
+      default: {
+        LOG4CXX_TRACE(logger_, "Unknown global property: " << global_property);
+        break;
+      }
+    }
+  }
+
+  return result;
+}
+
+ResetGlobalPropertiesResult
+ApplicationManagerImpl::ResetAllApplicationGlobalProperties(
+    const uint32_t app_id) {
+  const smart_objects::SmartObjectSPtr application_gl_props =
+      CreateAllAppGlobalPropsIDList(app_id);
+  return ResetGlobalProperties(*application_gl_props, app_id);
+}
+
+const smart_objects::SmartObjectSPtr
+ApplicationManagerImpl::CreateAllAppGlobalPropsIDList(
+    const uint32_t app_id) const {
+  smart_objects::SmartObjectSPtr ret_gl_props =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Array);
+  using namespace mobile_apis;
+
+  ApplicationConstSharedPtr application =
+      ApplicationManagerImpl::application(app_id);
+  int32_t i = 0;
+
+  if (application->help_prompt())
+    (*ret_gl_props)[i++] = GlobalProperty::HELPPROMPT;
+  if (application->timeout_prompt())
+    (*ret_gl_props)[i++] = GlobalProperty::TIMEOUTPROMPT;
+  if (application->vr_help_title())
+    (*ret_gl_props)[i++] = GlobalProperty::VRHELPTITLE;
+  if (application->menu_title())
+    (*ret_gl_props)[i++] = GlobalProperty::MENUNAME;
+  if (application->menu_icon())
+    (*ret_gl_props)[i++] = GlobalProperty::MENUICON;
+  if (application->keyboard_props())
+    (*ret_gl_props)[i++] = GlobalProperty::KEYBOARDPROPERTIES;
+
+  return ret_gl_props;
 }
 
 mobile_apis::AppHMIType::eType ApplicationManagerImpl::StringToAppHMIType(

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1147,7 +1147,7 @@ void ApplicationManagerImpl::SwitchApplication(ApplicationSharedPtr app,
                                       << ". Changing device id to "
                                       << device_id);
 
-  bool is_subscribed_to_way_points = IsAppSubscribedForWayPoints(app);
+  bool is_subscribed_to_way_points = IsAppSubscribedForWayPoints(*app);
   if (is_subscribed_to_way_points) {
     UnsubscribeAppFromWayPoints(app);
   }
@@ -3639,13 +3639,13 @@ void ApplicationManagerImpl::ClearTTSGlobalPropertiesList() {
 }
 
 bool ApplicationManagerImpl::IsAppSubscribedForWayPoints(
-    ApplicationSharedPtr app) const {
+    Application& app) const {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(subscribed_way_points_apps_lock_);
   LOG4CXX_DEBUG(logger_,
                 "There are applications subscribed: "
                     << subscribed_way_points_apps_list_.size());
-  if (subscribed_way_points_apps_list_.find(app->app_id()) ==
+  if (subscribed_way_points_apps_list_.find(app.app_id()) ==
       subscribed_way_points_apps_list_.end()) {
     return false;
   }

--- a/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
+++ b/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
@@ -62,12 +62,11 @@ void EventDispatcherImpl::raise_event(const Event& event) {
   }
 
   // Call observers
-  while (!observers_.empty()) {
-    EventObserver* temp = *observers_.begin();
-    observers_.erase(observers_.begin());
+  for (auto observer : observers_) {
     AutoUnlock unlock_observer(observer_lock);
-    temp->on_event(event);
+    observer->on_event(event);
   }
+  observers_.clear();
 }
 
 void EventDispatcherImpl::add_observer(const Event::EventID& event_id,

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -325,6 +325,22 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateMessageForHMI(
   return message;
 }
 
+smart_objects::SmartObjectSPtr MessageHelper::CreateMessageForHMI(
+    hmi_apis::FunctionID::eType function_id, const uint32_t correlation_id) {
+  using namespace smart_objects;
+
+  SmartObjectSPtr message = std::make_shared<SmartObject>(SmartType_Map);
+  SmartObject& ref = *message;
+
+  ref[strings::params][strings::function_id] = static_cast<int>(function_id);
+  ref[strings::params][strings::protocol_version] =
+      commands::CommandImpl::protocol_version_;
+  ref[strings::params][strings::protocol_type] =
+      commands::CommandImpl::hmi_protocol_type_;
+  ref[strings::params][strings::correlation_id] = correlation_id;
+  return message;
+}
+
 smart_objects::SmartObjectSPtr MessageHelper::CreateHashUpdateNotification(
     const uint32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
@@ -2246,17 +2262,6 @@ bool MessageHelper::SendUnsubscribedWayPoints(ApplicationManager& app_mngr) {
       hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints;
 
   return app_mngr.GetRPCService().ManageHMICommand(result);
-}
-
-smart_objects::SmartObjectSPtr
-MessageHelper::CreateSubscribeWayPointsMessageToHMI(
-    const uint32_t correlation_id) {
-  auto msg =
-      CreateMessageForHMI(hmi_apis::messageType::request, correlation_id);
-  (*msg)[strings::params][strings::function_id] =
-      hmi_apis::FunctionID::Navigation_SubscribeWayPoints;
-
-  return msg;
 }
 
 void MessageHelper::SendPolicySnapshotNotification(

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1083,7 +1083,7 @@ MessageHelper::CreateOnButtonSubscriptionNotificationsForApp(
 
     button_subscription_requests.push_back(
         CreateOnButtonSubscriptionNotification(
-        app->hmi_app_id(), btn, true, app_mngr));
+            app->hmi_app_id(), btn, true, app_mngr));
   }
 
   return button_subscription_requests;

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1337,10 +1337,11 @@ smart_objects::SmartObjectList MessageHelper::CreateAddCommandRequestToHMI(
 
     // VR Interface
     if ((*i->second).keyExists(strings::vr_commands)) {
-      SendAddVRCommandToHMI(i->first,
-                            (*i->second)[strings::vr_commands],
-                            app->app_id(),
-                            app_mngr);
+      requests.push_back(
+          CreateAddVRCommandToHMI(/*cmd_id = */ i->first,
+                                  (*i->second)[strings::vr_commands],
+                                  app->app_id(),
+                                  app_mngr));
     }
   }
   return requests;

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1689,7 +1689,7 @@ void MessageHelper::SendAddSubMenuRequestToHMI(ApplicationConstSharedPtr app,
   }
 
   smart_objects::SmartObjectList requests =
-      CreateAddSubMenuRequestsToHMI(app, app_mngr.GetNextHMICorrelationID());
+      CreateAddSubMenuRequestsToHMI(app, app_mngr);
   for (smart_objects::SmartObjectList::iterator it = requests.begin();
        it != requests.end();
        ++it) {
@@ -1698,14 +1698,14 @@ void MessageHelper::SendAddSubMenuRequestToHMI(ApplicationConstSharedPtr app,
 }
 
 smart_objects::SmartObjectList MessageHelper::CreateAddSubMenuRequestsToHMI(
-    ApplicationConstSharedPtr app, const uint32_t correlation_id) {
+    ApplicationConstSharedPtr app, ApplicationManager& app_mngr) {
   smart_objects::SmartObjectList requsets;
   const DataAccessor<SubMenuMap> accessor = app->sub_menu_map();
   const SubMenuMap& sub_menu = accessor.GetData();
   SubMenuMap::const_iterator i = sub_menu.begin();
   for (; sub_menu.end() != i; ++i) {
-    smart_objects::SmartObjectSPtr ui_sub_menu =
-        CreateMessageForHMI(hmi_apis::messageType::request, correlation_id);
+    smart_objects::SmartObjectSPtr ui_sub_menu = CreateMessageForHMI(
+        hmi_apis::messageType::request, app_mngr.GetNextHMICorrelationID());
     if (!ui_sub_menu) {
       return requsets;
     }

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1061,8 +1061,10 @@ void MessageHelper::SendOnButtonSubscriptionNotification(
   }
 }
 
-void MessageHelper::SendAllOnButtonSubscriptionNotificationsForApp(
-    ApplicationConstSharedPtr app, ApplicationManager& app_mngr) {
+void MessageHelper::SendOnButtonSubscriptionNotificationsForApp(
+    ApplicationConstSharedPtr app,
+    ApplicationManager& app_mngr,
+    const ButtonSubscriptions& button_subscriptions) {
   using namespace smart_objects;
   using namespace hmi_apis;
   using namespace mobile_apis;
@@ -1073,15 +1075,12 @@ void MessageHelper::SendAllOnButtonSubscriptionNotificationsForApp(
     return;
   }
 
-  DataAccessor<ButtonSubscriptions> button_accessor = app->SubscribedButtons();
-  ButtonSubscriptions subscriptions = button_accessor.GetData();
-  ButtonSubscriptions::iterator it = subscriptions.begin();
-  for (; subscriptions.end() != it; ++it) {
+  for (auto& it : button_subscriptions) {
+    const Common_ButtonName::eType btn =
+        static_cast<Common_ButtonName::eType>(it);
+
     SendOnButtonSubscriptionNotification(
-        app->hmi_app_id(),
-        static_cast<Common_ButtonName::eType>(*it),
-        true,
-        app_mngr);
+        app->hmi_app_id(), btn, true, app_mngr);
   }
 }
 

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2251,8 +2251,7 @@ bool MessageHelper::SendUnsubscribedWayPoints(ApplicationManager& app_mngr) {
 smart_objects::SmartObjectSPtr
 MessageHelper::CreateSubscribeWayPointsMessageToHMI(
     const uint32_t correlation_id) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  const smart_objects::SmartObjectSPtr msg =
+  auto msg =
       CreateMessageForHMI(hmi_apis::messageType::request, correlation_id);
   (*msg)[strings::params][strings::function_id] =
       hmi_apis::FunctionID::Navigation_SubscribeWayPoints;

--- a/src/components/application_manager/src/resumption/extension_pending_resumption_handler.cc
+++ b/src/components/application_manager/src/resumption/extension_pending_resumption_handler.cc
@@ -1,0 +1,29 @@
+#include "application_manager/resumption/extension_pending_resumption_handler.h"
+#include "application_manager/resumption/resumption_data_processor.h"
+#include "smart_objects/smart_object.h"
+
+namespace resumption {
+
+namespace app_mngr = application_manager;
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "ExtensionPenndingResumptionHandler")
+
+ExtensionPendingResumptionHandler::ExtensionPendingResumptionHandler(
+    app_mngr::ApplicationManager& application_manager)
+    : application_manager::event_engine::EventObserver(
+          application_manager.event_dispatcher())
+    , application_manager_(application_manager) {}
+
+ResumptionRequest ExtensionPendingResumptionHandler::MakeResumptionRequest(
+    const uint32_t corr_id,
+    const hmi_apis::FunctionID::eType function_id,
+    const smart_objects::SmartObject& message) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  resumption::ResumptionRequest resumption_request;
+  resumption_request.request_ids.correlation_id = corr_id;
+  resumption_request.request_ids.function_id = function_id;
+  resumption_request.message = message;
+  return resumption_request;
+}
+
+}  //  namespace resumption

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -408,9 +408,10 @@ bool ResumeCtrlImpl::StartResumption(ApplicationSharedPtr application,
   return result;
 }
 
-void ResumeCtrlImpl::HandleOnTimeOut(const int32_t app_id) {
+void ResumeCtrlImpl::HandleOnTimeOut(
+    const uint32_t cor_id, const hmi_apis::FunctionID::eType function_id) {
   LOG4CXX_AUTO_TRACE(logger_);
-  resumption_data_processor_.HandleOnTimeOut(app_id);
+  resumption_data_processor_.HandleOnTimeOut(cor_id, function_id);
 }
 
 bool ResumeCtrlImpl::StartResumptionOnlyHMILevel(

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -76,7 +76,7 @@ ResumeCtrlImpl::ResumeCtrlImpl(ApplicationManager& application_manager)
     , launch_time_(time(nullptr))
     , low_voltage_time_(0)
     , wake_up_time_(0)
-    , application_manager_(application_manager) 
+    , application_manager_(application_manager)
     , resumption_data_processor_(application_manager) {}
 #ifdef BUILD_TESTS
 void ResumeCtrlImpl::set_resumption_storage(
@@ -352,7 +352,7 @@ void ResumeCtrlImpl::SaveLowVoltageTime() {
 }
 
 void ResumeCtrlImpl::SaveWakeUpTime() {
-  wake_up_time_ = std::time(nullptr);
+  wake_up_time_ = time(nullptr);
   LOG4CXX_DEBUG(logger_, "Wake Up timestamp : " << wake_up_time_ << " saved");
 }
 
@@ -650,7 +650,7 @@ bool ResumeCtrlImpl::CheckLowVoltageRestrictions(
   return true;
 }
 
-bool ResumeCtrlImpl::CheckDelayBeforeIgnOff(	
+bool ResumeCtrlImpl::CheckDelayBeforeIgnOff(
     const smart_objects::SmartObject& saved_app) const {
   using namespace date_time;
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -409,8 +409,8 @@ bool ResumeCtrlImpl::StartResumption(ApplicationSharedPtr application,
 }
 
 void ResumeCtrlImpl::HandleOnTimeOut(const int32_t app_id) {
-    LOG4CXX_AUTO_TRACE(logger_);
-    resumption_data_processor_.HandleOnTimeOut(app_id);
+  LOG4CXX_AUTO_TRACE(logger_);
+  resumption_data_processor_.HandleOnTimeOut(app_id);
 }
 
 bool ResumeCtrlImpl::StartResumptionOnlyHMILevel(

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -396,7 +396,6 @@ bool ResumeCtrlImpl::StartResumption(ApplicationSharedPtr application,
                           << " hmi_app_id = " << application->hmi_app_id()
                           << " policy_id = " << application->policy_app_id()
                           << " received hash = " << hash);
-  SetupDefaultHMILevel(application);
   smart_objects::SmartObject saved_app;
   const std::string& device_mac = application->mac_address();
   bool result = resumption_storage_->GetSavedApplication(
@@ -405,8 +404,6 @@ bool ResumeCtrlImpl::StartResumption(ApplicationSharedPtr application,
     const std::string& saved_hash = saved_app[strings::hash_id].asString();
     result = saved_hash == hash ? RestoreApplicationData(application, callback)
                                 : false;
-
-    AddToResumptionTimerQueue(application->app_id());
   }
   return result;
 }

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -545,13 +545,15 @@ bool ResumeCtrlImpl::CheckApplicationHash(ApplicationSharedPtr application,
                                           const std::string& hash) {
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK_OR_RETURN(application, false);
-  LOG4CXX_DEBUG(logger_,
-                "app_id : " << application->app_id() << " hash : " << hash);
   smart_objects::SmartObject saved_app;
   const std::string& device_mac = application->mac_address();
   bool result = resumption_storage_->GetSavedApplication(
       application->policy_app_id(), device_mac, saved_app);
-  return result ? saved_app[strings::hash_id].asString() == hash : false;
+  const auto& saved_hash = saved_app[strings::hash_id].asString();
+  LOG4CXX_DEBUG(logger_,
+                "app_id : " << application->app_id() << " hash : " << hash
+                            << "; saved hash = " << saved_hash);
+  return result ? saved_hash == hash : false;
 }
 
 void ResumeCtrlImpl::SaveDataOnTimer() {

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -63,8 +63,7 @@ static mobile_api::HMILevel::eType ConvertHmiLevelString(const std::string str);
 CREATE_LOGGERPTR_GLOBAL(logger_, "Resumption")
 
 ResumeCtrlImpl::ResumeCtrlImpl(ApplicationManager& application_manager)
-    : event_engine::EventObserver(application_manager.event_dispatcher())
-    , restore_hmi_level_timer_(
+    : restore_hmi_level_timer_(
           "RsmCtrlRstore",
           new timer::TimerTaskImpl<ResumeCtrlImpl>(
               this, &ResumeCtrlImpl::ApplicationResumptiOnTimer))
@@ -156,10 +155,6 @@ void ResumeCtrlImpl::SaveApplication(ApplicationSharedPtr application) {
                 "application with appID " << application->app_id()
                                           << " will be saved");
   resumption_storage_->SaveApplication(application);
-}
-
-void ResumeCtrlImpl::on_event(const event_engine::Event& event) {
-  LOG4CXX_DEBUG(logger_, "Event received" << event.id());
 }
 
 bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
@@ -599,13 +594,7 @@ bool ResumeCtrlImpl::RestoreApplicationData(ApplicationSharedPtr application) {
     if (saved_app.keyExists(strings::grammar_id)) {
       const uint32_t app_grammar_id = saved_app[strings::grammar_id].asUInt();
       application->set_grammar_id(app_grammar_id);
-      AddFiles(application, saved_app);
-      AddSubmenues(application, saved_app);
-      AddCommands(application, saved_app);
-      AddChoicesets(application, saved_app);
-      SetGlobalProperties(application, saved_app);
-      AddSubscriptions(application, saved_app);
-      AddWayPointsSubscription(application, saved_app);
+      resumption_data_processor_.Restore(application, saved_app);
       result = true;
     } else {
       LOG4CXX_WARN(logger_,
@@ -616,150 +605,6 @@ bool ResumeCtrlImpl::RestoreApplicationData(ApplicationSharedPtr application) {
     LOG4CXX_WARN(logger_, "Application not saved");
   }
   return result;
-}
-
-void ResumeCtrlImpl::AddFiles(ApplicationSharedPtr application,
-                              const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  if (saved_app.keyExists(strings::application_files)) {
-    const smart_objects::SmartObject& application_files =
-        saved_app[strings::application_files];
-    for (size_t i = 0; i < application_files.length(); ++i) {
-      const smart_objects::SmartObject& file_data = application_files[i];
-      const bool is_persistent =
-          file_data.keyExists(strings::persistent_file) &&
-          file_data[strings::persistent_file].asBool();
-      if (is_persistent) {
-        AppFile file;
-        file.is_persistent = is_persistent;
-        file.is_download_complete =
-            file_data[strings::is_download_complete].asBool();
-        file.file_name = file_data[strings::sync_file_name].asString();
-        file.file_type = static_cast<mobile_apis::FileType::eType>(
-            file_data[strings::file_type].asInt());
-        application->AddFile(file);
-      }
-    }
-  } else {
-    LOG4CXX_FATAL(logger_, "application_files section is not exists");
-  }
-}
-
-void ResumeCtrlImpl::AddSubmenues(ApplicationSharedPtr application,
-                                  const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  if (saved_app.keyExists(strings::application_submenus)) {
-    const smart_objects::SmartObject& app_submenus =
-        saved_app[strings::application_submenus];
-    for (size_t i = 0; i < app_submenus.length(); ++i) {
-      const smart_objects::SmartObject& submenu = app_submenus[i];
-      application->AddSubMenu(submenu[strings::menu_id].asUInt(), submenu);
-    }
-    ProcessHMIRequests(MessageHelper::CreateAddSubMenuRequestToHMI(
-        application, application_manager_.GetNextHMICorrelationID()));
-  } else {
-    LOG4CXX_FATAL(logger_, "application_submenus section is not exists");
-  }
-}
-
-void ResumeCtrlImpl::AddCommands(ApplicationSharedPtr application,
-                                 const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  if (saved_app.keyExists(strings::application_commands)) {
-    const smart_objects::SmartObject& app_commands =
-        saved_app[strings::application_commands];
-    for (size_t i = 0; i < app_commands.length(); ++i) {
-      const smart_objects::SmartObject& command = app_commands[i];
-      const uint32_t cmd_id = command[strings::cmd_id].asUInt();
-      const bool is_resumption = true;
-
-      application->AddCommand(cmd_id, command);
-      application->help_prompt_manager().OnVrCommandAdded(
-          cmd_id, command, is_resumption);
-    }
-    ProcessHMIRequests(MessageHelper::CreateAddCommandRequestToHMI(
-        application, application_manager_));
-  } else {
-    LOG4CXX_FATAL(logger_, "application_commands section is not exists");
-  }
-}
-
-void ResumeCtrlImpl::AddChoicesets(
-    ApplicationSharedPtr application,
-    const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  if (saved_app.keyExists(strings::application_choice_sets)) {
-    const smart_objects::SmartObject& app_choice_sets =
-        saved_app[strings::application_choice_sets];
-    for (size_t i = 0; i < app_choice_sets.length(); ++i) {
-      const smart_objects::SmartObject& choice_set = app_choice_sets[i];
-      const int32_t choice_set_id =
-          choice_set[strings::interaction_choice_set_id].asInt();
-      application->AddChoiceSet(choice_set_id, choice_set);
-    }
-    ProcessHMIRequests(MessageHelper::CreateAddVRCommandRequestFromChoiceToHMI(
-        application, application_manager_));
-  } else {
-    LOG4CXX_FATAL(logger_, "There is no any choicesets");
-  }
-}
-
-void ResumeCtrlImpl::SetGlobalProperties(
-    ApplicationSharedPtr application,
-    const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  if (saved_app.keyExists(strings::application_global_properties)) {
-    const smart_objects::SmartObject& properties_so =
-        saved_app[strings::application_global_properties];
-    application->load_global_properties(properties_so);
-    MessageHelper::SendGlobalPropertiesToHMI(application, application_manager_);
-  }
-}
-
-void ResumeCtrlImpl::AddWayPointsSubscription(
-    app_mngr::ApplicationSharedPtr application,
-    const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  if (saved_app.keyExists(strings::subscribed_for_way_points)) {
-    const smart_objects::SmartObject& subscribed_for_way_points_so =
-        saved_app[strings::subscribed_for_way_points];
-    if (true == subscribed_for_way_points_so.asBool()) {
-      application_manager_.SubscribeAppForWayPoints(application);
-    }
-  }
-}
-
-void ResumeCtrlImpl::AddSubscriptions(
-    ApplicationSharedPtr application,
-    const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  if (saved_app.keyExists(strings::application_subscriptions)) {
-    const smart_objects::SmartObject& subscriptions =
-        saved_app[strings::application_subscriptions];
-
-    if (subscriptions.keyExists(strings::application_buttons)) {
-      const smart_objects::SmartObject& subscriptions_buttons =
-          subscriptions[strings::application_buttons];
-      mobile_apis::ButtonName::eType btn;
-      for (size_t i = 0; i < subscriptions_buttons.length(); ++i) {
-        btn = static_cast<mobile_apis::ButtonName::eType>(
-            (subscriptions_buttons[i]).asInt());
-        application->SubscribeToButton(btn);
-      }
-    }
-    MessageHelper::SendAllOnButtonSubscriptionNotificationsForApp(
-        application, application_manager_);
-
-    for (auto& extension : application->Extensions()) {
-      extension->ProcessResumption(subscriptions);
-    }
-  }
 }
 
 bool ResumeCtrlImpl::CheckIgnCycleRestrictions(
@@ -984,35 +829,6 @@ time_t ResumeCtrlImpl::GetIgnOffTime() const {
   return resumption_storage_->GetIgnOffTime();
 }
 
-bool ResumeCtrlImpl::ProcessHMIRequest(smart_objects::SmartObjectSPtr request,
-                                       bool use_events) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  if (use_events) {
-    const hmi_apis::FunctionID::eType function_id =
-        static_cast<hmi_apis::FunctionID::eType>(
-            (*request)[strings::function_id].asInt());
-
-    const int32_t hmi_correlation_id =
-        (*request)[strings::correlation_id].asInt();
-    subscribe_on_event(function_id, hmi_correlation_id);
-  }
-  if (!application_manager_.GetRPCService().ManageHMICommand(request)) {
-    LOG4CXX_ERROR(logger_, "Unable to send request");
-    return false;
-  }
-  return true;
-}
-
-void ResumeCtrlImpl::ProcessHMIRequests(
-    const smart_objects::SmartObjectList& requests) {
-  for (smart_objects::SmartObjectList::const_iterator it = requests.begin(),
-                                                      total = requests.end();
-       it != total;
-       ++it) {
-    ProcessHMIRequest(*it, true);
-  }
-}
-
 void ResumeCtrlImpl::AddToResumptionTimerQueue(const uint32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   bool run_resumption = false;
@@ -1187,4 +1003,4 @@ static mobile_api::HMILevel::eType ConvertHmiLevelString(
   }
 }
 
-}  // namespce resumption
+}  // namespace resumption

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -411,6 +411,11 @@ bool ResumeCtrlImpl::StartResumption(ApplicationSharedPtr application,
   return result;
 }
 
+void ResumeCtrlImpl::HandleOnTimeOut(const int32_t app_id) {
+    LOG4CXX_AUTO_TRACE(logger_);
+    resumption_data_processor_.HandleOnTimeOut(app_id);
+}
+
 bool ResumeCtrlImpl::StartResumptionOnlyHMILevel(
     ApplicationSharedPtr application) {
   // sync_primitives::AutoLock lock(resumtion_lock_);

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -405,7 +405,7 @@ bool ResumeCtrlImpl::StartResumption(ApplicationSharedPtr application,
     const std::string& saved_hash = saved_app[strings::hash_id].asString();
     result = saved_hash == hash ? RestoreApplicationData(application, callback)
                                 : false;
-    application->UpdateHash();
+
     AddToResumptionTimerQueue(application->app_id());
   }
   return result;

--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -2619,7 +2619,7 @@ bool ResumptionDataDB::InsertApplicationData(
   const mobile_apis::HMILevel::eType hmi_level = application.m_hmi_level;
   bool is_media_application = application.m_is_media_application;
   bool is_subscribed_for_way_points =
-      application_manager_.IsAppSubscribedForWayPoints(application.app_ptr);
+      application_manager_.IsAppSubscribedForWayPoints(*(application.app_ptr));
 
   if (!query.Prepare(kInsertApplication)) {
     LOG4CXX_WARN(logger_,

--- a/src/components/application_manager/src/resumption/resumption_data_json.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_json.cc
@@ -66,7 +66,7 @@ void ResumptionDataJson::SaveApplication(
   const std::string device_mac = application->mac_address();
   const mobile_apis::HMILevel::eType hmi_level = application->hmi_level();
   const bool is_subscribed_for_way_points =
-      application_manager_.IsAppSubscribedForWayPoints(application);
+      application_manager_.IsAppSubscribedForWayPoints(*application);
 
   sync_primitives::AutoLock autolock(resumption_lock_);
   Json::Value tmp;

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -1,0 +1,549 @@
+/*
+ Copyright (c) 2018, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <algorithm>
+
+#include "application_manager/resumption/resumption_data_processor.h"
+#include "application_manager/application_manager.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/message_helper.h"
+#include "application_manager/event_engine/event_observer.h"
+
+namespace resumption {
+
+using app_mngr::ApplicationSharedPtr;
+using app_mngr::AppFile;
+using app_mngr::MessageHelper;
+using app_mngr::ChoiceSetMap;
+using app_mngr::ButtonSubscriptions;
+namespace strings = app_mngr::strings;
+namespace event_engine = app_mngr::event_engine;
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "Resumption")
+
+ResumptionDataProcessor::ResumptionDataProcessor(
+    app_mngr::ApplicationManager& application_manager)
+    : event_engine::EventObserver(application_manager.event_dispatcher())
+    , application_manager_(application_manager) {}
+
+ResumptionDataProcessor::~ResumptionDataProcessor() {}
+
+void ResumptionDataProcessor::Restore(ApplicationSharedPtr application,
+                                      smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  AddFiles(application, saved_app);
+  AddSubmenues(application, saved_app);
+  AddCommands(application, saved_app);
+  AddChoicesets(application, saved_app);
+  SetGlobalProperties(application, saved_app);
+  AddSubscriptions(application, saved_app);
+  AddWayPointsSubscription(application, saved_app);
+}
+
+void ResumptionDataProcessor::on_event(const event_engine::Event& event) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const smart_objects::SmartObject& response = event.smart_object();
+
+  const int32_t app_id =
+      response[strings::msg_params][strings::app_id].asUInt();
+
+  ApplicationResumptionStatus& status = resumption_status_[app_id];
+  std::vector<ResumptionRequest>& list_of_sent_requests =
+      status.list_of_sent_requests;
+
+  auto request_ptr = std::find_if(
+      list_of_sent_requests.begin(),
+      list_of_sent_requests.end(),
+      [&event](const ResumptionRequest& request) {
+        return request.correlation_id == event.smart_object_correlation_id() &&
+               request.function_id == event.id();
+      });
+
+  if (list_of_sent_requests.end() == request_ptr) {
+    LOG4CXX_ERROR(logger_, "Request not found");
+    return;
+  }
+
+  const bool is_success = response[strings::params][strings::success].asBool();
+
+  if (is_success) {
+    status.successful_requests.push_back(*request_ptr);
+  } else {
+    status.error_requests.push_back(*request_ptr);
+  }
+  list_of_sent_requests.erase(request_ptr);
+
+  if (!list_of_sent_requests.empty()) {
+    LOG4CXX_DEBUG(logger_, "is not the last response for this application");
+    return;
+  }
+
+  if (status.error_requests.empty()) {
+    LOG4CXX_DEBUG(logger_, "Resumption for app " << app_id << "successful");
+  }
+  if (!status.error_requests.empty()) {
+    LOG4CXX_ERROR(logger_, "Resumption for app " << app_id << "failed");
+    RevertRestoredData(app_id);
+  }
+  resumption_status_.erase(app_id);
+}
+
+void ResumptionDataProcessor::RevertRestoredData(const int32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  DeleteFiles(app_id);
+  DeleteSubmenues(app_id);
+  DeleteCommands(app_id);
+  DeleteChoicesets(app_id);
+  DeleteGlobalProperties(app_id);
+  DeleteSubscriptions(app_id);
+  DeleteWayPointsSubscription(app_id);
+}
+
+void ResumptionDataProcessor::WaitForResponse(
+    const int32_t app_id, const ResumptionRequest& request) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  subscribe_on_event(request.function_id, request.correlation_id);
+  resumption_status_[app_id].list_of_sent_requests.push_back(request);
+}
+
+void ResumptionDataProcessor::ProcessHMIRequest(
+    smart_objects::SmartObjectSPtr request, bool subscribe_on_response) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (subscribe_on_response) {
+    auto function_id = static_cast<hmi_apis::FunctionID::eType>(
+        (*request)[strings::function_id].asInt());
+
+    const int32_t hmi_correlation_id =
+        (*request)[strings::correlation_id].asInt();
+
+    const int32_t app_id =
+        (*request)[strings::msg_params][strings::app_id].asInt();
+
+    ResumptionRequest wait_for_response;
+    wait_for_response.correlation_id = hmi_correlation_id;
+    wait_for_response.function_id = function_id;
+    wait_for_response.message = *request;
+
+    WaitForResponse(app_id, wait_for_response);
+  }
+  if (!application_manager_.GetRPCService().ManageHMICommand(request)) {
+    LOG4CXX_ERROR(logger_, "Unable to send request");
+  }
+}
+
+void ResumptionDataProcessor::ProcessHMIRequests(
+    const smart_objects::SmartObjectList& requests) {
+  LOG4CXX_AUTO_TRACE(logger_);    
+  if(requests.empty()){
+    LOG4CXX_DEBUG(logger_,"requests list is empty");
+    return;
+  } 
+
+  for (const auto& it : requests) {
+    ProcessHMIRequest(it, /*subscribe_on_response = */ true);
+  }
+}
+
+void ResumptionDataProcessor::AddFiles(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!saved_app.keyExists(strings::application_files)) {
+    LOG4CXX_ERROR(logger_, "application_files section is not exists");
+    return;
+  }
+
+  const smart_objects::SmartObject& application_files =
+      saved_app[strings::application_files];
+
+  for (size_t i = 0; i < application_files.length(); ++i) {
+    const smart_objects::SmartObject& file_data = application_files[i];
+    const bool is_persistent = file_data.keyExists(strings::persistent_file) &&
+                               file_data[strings::persistent_file].asBool();
+    if (is_persistent) {
+      AppFile file;
+      file.is_persistent = is_persistent;
+      file.is_download_complete =
+          file_data[strings::is_download_complete].asBool();
+      file.file_name = file_data[strings::sync_file_name].asString();
+      file.file_type = static_cast<mobile_apis::FileType::eType>(
+          file_data[strings::file_type].asInt());
+      application->AddFile(file);
+    }
+  }
+}
+
+void ResumptionDataProcessor::DeleteFiles(const int32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  ApplicationSharedPtr application = application_manager_.application(app_id);
+  while (!application->getAppFiles().empty()) {
+    application->DeleteFile(application->getAppFiles().begin()->first);
+  }
+}
+
+void ResumptionDataProcessor::AddSubmenues(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (!saved_app.keyExists(strings::application_submenus)) {
+    LOG4CXX_ERROR(logger_, "application_submenus section is not exists");
+    return;
+  }
+
+  const smart_objects::SmartObject& app_submenus =
+      saved_app[strings::application_submenus];
+
+  for (size_t i = 0; i < app_submenus.length(); ++i) {
+    const smart_objects::SmartObject& submenu = app_submenus[i];
+    application->AddSubMenu(submenu[strings::menu_id].asUInt(), submenu);
+  }
+
+  ProcessHMIRequests(MessageHelper::CreateAddSubMenuRequestToHMI(
+      application, application_manager_.GetNextHMICorrelationID()));
+}
+
+void ResumptionDataProcessor::DeleteSubmenues(const int32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  ApplicationResumptionStatus& status = resumption_status_[app_id];
+  ApplicationSharedPtr application = application_manager_.application(app_id);
+  for (auto request : status.successful_requests) {
+    if (hmi_apis::FunctionID::UI_AddSubMenu == request.function_id) {
+      smart_objects::SmartObjectSPtr ui_sub_menu =
+          MessageHelper::CreateMessageForHMI(
+              hmi_apis::messageType::request,
+              application_manager_.GetNextHMICorrelationID());
+
+      (*ui_sub_menu)[strings::params][strings::function_id] =
+          hmi_apis::FunctionID::UI_DeleteSubMenu;
+
+      smart_objects::SmartObject msg_params =
+          smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+      msg_params[strings::menu_id] =
+          request.message[strings::msg_params][strings::menu_id];
+      msg_params[strings::app_id] =
+          request.message[strings::msg_params][strings::app_id];
+
+      (*ui_sub_menu)[strings::msg_params] = msg_params;
+
+      application->RemoveSubMenu(msg_params[strings::menu_id].asInt());
+      ProcessHMIRequest(ui_sub_menu, /*subscribe_on_response = */ false);
+    }
+  }
+}
+
+void ResumptionDataProcessor::AddCommands(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!saved_app.keyExists(strings::application_commands)) {
+    LOG4CXX_ERROR(logger_, "application_commands section is not exists");
+  }
+
+  const smart_objects::SmartObject& app_commands =
+      saved_app[strings::application_commands];
+
+  for (size_t i = 0; i < app_commands.length(); ++i) {
+    const smart_objects::SmartObject& command = app_commands[i];
+    const uint32_t cmd_id = command[strings::cmd_id].asUInt();
+
+    application->AddCommand(cmd_id, command);
+    application->help_prompt_manager().OnVrCommandAdded(
+        cmd_id, command, /*is_resumption =*/true);
+  }
+
+  ProcessHMIRequests(MessageHelper::CreateAddCommandRequestToHMI(
+      application, application_manager_));
+}
+
+void ResumptionDataProcessor::DeleteCommands(const int32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  ApplicationSharedPtr application = application_manager_.application(app_id);
+  ApplicationResumptionStatus& status = resumption_status_[app_id];
+
+  for (auto request : status.successful_requests) {
+    const uint32_t cmd_id =
+        request.message[strings::msg_params][strings::cmd_id].asUInt();
+
+    if (hmi_apis::FunctionID::UI_AddCommand == request.function_id) {
+      DeleteUICommands(request);
+    }
+    if (hmi_apis::FunctionID::VR_AddCommand == request.function_id) {
+      DeleteVRCommands(request);
+    }
+
+    application->RemoveCommand(cmd_id);
+    application->help_prompt_manager().OnVrCommandDeleted(
+        cmd_id, /*is_resumption = */ true);
+  }
+}
+
+void ResumptionDataProcessor::DeleteUICommands(
+    const ResumptionRequest& request) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  smart_objects::SmartObjectSPtr ui_command =
+      MessageHelper::CreateMessageForHMI(
+          hmi_apis::messageType::request,
+          application_manager_.GetNextHMICorrelationID());
+
+  (*ui_command)[strings::params][strings::function_id] =
+      hmi_apis::FunctionID::UI_DeleteCommand;
+
+  smart_objects::SmartObject msg_params =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  const uint32_t cmd_id =
+      request.message[strings::msg_params][strings::cmd_id].asUInt();
+
+  msg_params[strings::cmd_id] = cmd_id;
+  msg_params[strings::app_id] =
+      request.message[strings::msg_params][strings::app_id];
+
+  (*ui_command)[strings::msg_params] = msg_params;
+
+  ProcessHMIRequest(ui_command, /*subscribe_on_response = */ false);
+}
+
+void ResumptionDataProcessor::DeleteVRCommands(
+    const ResumptionRequest& request) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  smart_objects::SmartObjectSPtr vr_command =
+      MessageHelper::CreateMessageForHMI(
+          hmi_apis::messageType::request,
+          application_manager_.GetNextHMICorrelationID());
+
+  (*vr_command)[strings::params][strings::function_id] =
+      hmi_apis::FunctionID::VR_DeleteCommand;
+
+  smart_objects::SmartObject msg_params =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  const uint32_t cmd_id =
+      request.message[strings::msg_params][strings::cmd_id].asUInt();
+
+  msg_params[strings::cmd_id] = cmd_id;
+  msg_params[strings::app_id] =
+      request.message[strings::msg_params][strings::app_id];
+  msg_params[strings::type] =
+      request.message[strings::msg_params][strings::type];
+  msg_params[strings::grammar_id] =
+      request.message[strings::msg_params][strings::grammar_id];
+
+  (*vr_command)[strings::msg_params] = msg_params;
+
+  ProcessHMIRequest(vr_command, /*subscribe_on_response = */ false);
+}
+
+void ResumptionDataProcessor::AddChoicesets(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!saved_app.keyExists(strings::application_choice_sets)) {
+    LOG4CXX_ERROR(logger_, "There is no any choicesets");
+  }
+
+  const smart_objects::SmartObject& app_choice_sets =
+      saved_app[strings::application_choice_sets];
+
+  for (size_t i = 0; i < app_choice_sets.length(); ++i) {
+    const smart_objects::SmartObject& choice_set = app_choice_sets[i];
+    const int32_t choice_set_id =
+        choice_set[strings::interaction_choice_set_id].asInt();
+    application->AddChoiceSet(choice_set_id, choice_set);
+  }
+
+  ProcessHMIRequests(MessageHelper::CreateAddVRCommandRequestFromChoiceToHMI(
+      application, application_manager_));
+}
+
+void ResumptionDataProcessor::DeleteChoicesets(const int32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  ApplicationSharedPtr application = application_manager_.application(app_id);
+
+  const DataAccessor<ChoiceSetMap> accessor = application->choice_set_map();
+  const ChoiceSetMap& choices = accessor.GetData();
+  while (!choices.empty()) {
+    application->RemoveChoiceSet(choices.begin()->first);
+  }
+}
+
+void ResumptionDataProcessor::SetGlobalProperties(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!saved_app.keyExists(strings::application_global_properties)) {
+    LOG4CXX_DEBUG(logger_,
+                  "application_global_properties section is not exists");
+    return;
+  }
+
+  const smart_objects::SmartObject& properties_so =
+      saved_app[strings::application_global_properties];
+  application->load_global_properties(properties_so);
+
+  ProcessHMIRequests(MessageHelper::CreateGlobalPropertiesRequestsToHMI(
+      application, application_manager_.GetNextHMICorrelationID()));
+}
+
+void ResumptionDataProcessor::DeleteGlobalProperties(const int32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+}
+
+void ResumptionDataProcessor::AddWayPointsSubscription(
+    app_mngr::ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (saved_app.keyExists(strings::subscribed_for_way_points)) {
+    LOG4CXX_DEBUG(logger_, "subscribed_for_way_points section is not exists");
+    return;
+  }
+
+  const smart_objects::SmartObject& subscribed_for_way_points_so =
+      saved_app[strings::subscribed_for_way_points];
+  if (true == subscribed_for_way_points_so.asBool()) {
+    application_manager_.SubscribeAppForWayPoints(application);
+  }
+}
+
+void ResumptionDataProcessor::DeleteWayPointsSubscription(
+    const int32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (application_manager_.IsAppSubscribedForWayPoints(app_id)) {
+    application_manager_.UnsubscribeAppFromWayPoints(app_id);
+  }
+}
+
+void ResumptionDataProcessor::AddSubscriptions(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  AddButtonsSubscriptions(application, saved_app);
+  AddPluginsSubscriptions(application, saved_app);
+}
+
+void ResumptionDataProcessor::AddButtonsSubscriptions(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (!saved_app.keyExists(strings::application_subscriptions)) {
+    LOG4CXX_DEBUG(logger_, "application_subscriptions section is not exists");
+    return;
+  }
+
+  const smart_objects::SmartObject& subscriptions =
+      saved_app[strings::application_subscriptions];
+
+  if (subscriptions.keyExists(strings::application_buttons)) {
+    const smart_objects::SmartObject& subscriptions_buttons =
+        subscriptions[strings::application_buttons];
+    mobile_apis::ButtonName::eType btn;
+    for (size_t i = 0; i < subscriptions_buttons.length(); ++i) {
+      btn = static_cast<mobile_apis::ButtonName::eType>(
+          (subscriptions_buttons[i]).asInt());
+      application->SubscribeToButton(btn);
+    }
+  }
+
+  MessageHelper::SendAllOnButtonSubscriptionNotificationsForApp(
+      application, application_manager_);
+}
+
+void ResumptionDataProcessor::AddPluginsSubscriptions(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  for (auto& extension : application->Extensions()) {
+    extension->ProcessResumption(
+        saved_app,
+        [this](const int32_t app_id, const ResumptionRequest request) {
+          this->WaitForResponse(app_id, request);
+        });
+  }
+}
+
+void ResumptionDataProcessor::DeleteSubscriptions(const int32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  ApplicationSharedPtr application = application_manager_.application(app_id);
+  DeleteButtonsSubscriptions(application);
+  DeletePluginsSubscriptions(application);
+}
+
+void ResumptionDataProcessor::DeleteButtonsSubscriptions(
+    ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  DataAccessor<ButtonSubscriptions> button_accessor =
+      application->SubscribedButtons();
+  ButtonSubscriptions button_subscriptions = button_accessor.GetData();
+  while (!button_subscriptions.empty()) {
+    auto btn = button_subscriptions.begin();
+    MessageHelper::SendOnButtonSubscriptionNotification(
+        application->hmi_app_id(),
+        static_cast<hmi_apis::Common_ButtonName::eType>(*btn),
+        /*is_subscribed = */ false,
+        application_manager_);
+    application->UnsubscribeFromButton(
+        static_cast<mobile_apis::ButtonName::eType>(*btn));
+  }
+
+  MessageHelper::SendOnButtonSubscriptionNotification(
+      application->hmi_app_id(),
+      hmi_apis::Common_ButtonName::CUSTOM_BUTTON,
+      /*is_subscribed = */ false,
+      application_manager_);
+  application->SubscribeToButton(mobile_apis::ButtonName::CUSTOM_BUTTON);
+}
+
+void ResumptionDataProcessor::DeletePluginsSubscriptions(
+    application_manager::ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  smart_objects::SmartObject extension_subscriptions;
+
+  ApplicationResumptionStatus& status =
+      resumption_status_[application->app_id()];
+  for (auto request : status.successful_requests) {
+    if (hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData ==
+        request.function_id) {
+      extension_subscriptions[strings::application_vehicle_info] =
+          request.message;
+    }
+  }
+
+  for (auto& extension : application->Extensions()) {
+    extension->RevertResumption(extension_subscriptions);
+  }
+}
+
+}  // namespce resumption

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -162,11 +162,11 @@ void ResumptionDataProcessor::ProcessHMIRequest(
 
 void ResumptionDataProcessor::ProcessHMIRequests(
     const smart_objects::SmartObjectList& requests) {
-  LOG4CXX_AUTO_TRACE(logger_);    
-  if(requests.empty()){
-    LOG4CXX_DEBUG(logger_,"requests list is empty");
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (requests.empty()) {
+    LOG4CXX_DEBUG(logger_, "requests list is empty");
     return;
-  } 
+  }
 
   for (const auto& it : requests) {
     ProcessHMIRequest(it, /*subscribe_on_response = */ true);
@@ -417,6 +417,26 @@ void ResumptionDataProcessor::SetGlobalProperties(
 
 void ResumptionDataProcessor::DeleteGlobalProperties(const int32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
+
+  const auto application = application_manager_.application(app_id);
+
+  const auto result =
+      application_manager_.ResetAllApplicationGlobalProperties(app_id);
+
+  if (result.HasUIPropertiesReset()) {
+    smart_objects::SmartObjectSPtr ui_gl_props_reset_req =
+        MessageHelper::CreateUIResetGlobalPropertiesRequest(result,
+                                                            application);
+
+    ProcessHMIRequest(ui_gl_props_reset_req, false);
+  }
+  if (result.HasTTSPropertiesReset()) {
+    smart_objects::SmartObjectSPtr tts_gl_props_reset_req =
+        MessageHelper::CreateUIResetGlobalPropertiesRequest(result,
+                                                            application);
+
+    ProcessHMIRequest(tts_gl_props_reset_req, false);
+  }
 }
 
 void ResumptionDataProcessor::AddWayPointsSubscription(

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -111,8 +111,6 @@ void ResumptionDataProcessor::on_event(const event_engine::Event& event) {
 
   const uint32_t app_id = app_id_ptr->second;
 
-  LOG4CXX_DEBUG(logger_, "app_id is: " << app_id);
-
   LOG4CXX_DEBUG(logger_,
                 "Found function id: " << app_id_ptr->first.function_id
                                       << " correlation id: "
@@ -146,21 +144,33 @@ void ResumptionDataProcessor::on_event(const event_engine::Event& event) {
   } else {
     status.error_requests.push_back(*request_ptr);
   }
+
+  if (hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData ==
+      request_ids.function_id) {
+    CheckVehicleDataResponse(request_ptr->message, response, status);
+  }
+
   list_of_sent_requests.erase(request_ptr);
 
   if (!list_of_sent_requests.empty()) {
-    LOG4CXX_DEBUG(logger_, "is not the last response for this application");
+    LOG4CXX_DEBUG(logger_,
+                  "Resumption app "
+                      << app_id << " not finished . Amount of requests left : "
+                      << list_of_sent_requests.size());
     return;
   }
 
   auto it = register_callbacks_.find(app_id);
   DCHECK_OR_RETURN_VOID(it != register_callbacks_.end());
   auto callback = it->second;
-  if (status.error_requests.empty()) {
+  const bool successful_resumption =
+      status.error_requests.empty() &&
+      status.unsuccesfull_vehicle_data_subscriptions_.empty();
+  if (successful_resumption) {
     LOG4CXX_DEBUG(logger_, "Resumption for app " << app_id << " successful");
     callback(mobile_apis::Result::SUCCESS, "Data resumption succesful");
   }
-  if (!status.error_requests.empty()) {
+  if (!successful_resumption) {
     LOG4CXX_ERROR(logger_, "Resumption for app " << app_id << "failed");
     RevertRestoredData(application_manager_.application(app_id));
     callback(mobile_apis::Result::RESUME_FAILED, "Data resumption failed");
@@ -185,7 +195,7 @@ void ResumptionDataProcessor::WaitForResponse(
     const int32_t app_id, const ResumptionRequest& request) {
   LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_DEBUG(logger_,
-                "app " << app_id << "Subscribe on "
+                "App " << app_id << " subscribe on "
                        << request.request_ids.function_id << " "
                        << request.request_ids.correlation_id);
   subscribe_on_event(request.request_ids.function_id,
@@ -674,16 +684,15 @@ void ResumptionDataProcessor::DeleteButtonsSubscriptions(
 void ResumptionDataProcessor::DeletePluginsSubscriptions(
     application_manager::ApplicationSharedPtr application) {
   LOG4CXX_AUTO_TRACE(logger_);
-  smart_objects::SmartObject extension_subscriptions;
 
-  const ApplicationResumptionStatus& status =
-      resumption_status_[application->app_id()];
-  for (auto& request : status.successful_requests) {
-    if (hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData ==
-        request.request_ids.function_id) {
-      extension_subscriptions[strings::application_vehicle_info] =
-          request.message;
-    }
+  auto it = resumption_status_.find(application->app_id());
+  DCHECK_OR_RETURN_VOID(it != resumption_status_.end());
+
+  const ApplicationResumptionStatus& status = it->second;
+  smart_objects::SmartObject extension_subscriptions;
+  for (auto ivi : status.succesfull_vehicle_data_subscriptions_) {
+    LOG4CXX_DEBUG(logger_, "ivi " << ivi << " should be deleted");
+    extension_subscriptions[ivi] = true;
   }
 
   for (auto& extension : application->Extensions()) {
@@ -699,6 +708,47 @@ bool ResumptionDataProcessor::IsRequestSuccessful(
               .asInt());
   return result_code == hmi_apis::Common_Result::SUCCESS ||
          result_code == hmi_apis::Common_Result::WARNINGS;
+}
+
+void ResumptionDataProcessor::CheckVehicleDataResponse(
+    const smart_objects::SmartObject& request,
+    const smart_objects::SmartObject& response,
+    ApplicationResumptionStatus& status) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!IsRequestSuccessful(response)) {
+    LOG4CXX_TRACE(logger_, "Vehicle data request not succesfull");
+    const auto keys = request[strings::msg_params].enumerate();
+    for (const auto key : keys) {
+      status.unsuccesfull_vehicle_data_subscriptions_.push_back(key);
+    }
+    return;
+  }
+
+  const auto& msg_params = response[strings::msg_params];
+  const auto keys = msg_params.enumerate();
+  if (keys.empty()) {
+    LOG4CXX_TRACE(logger_, "Successful subscription to all requested data");
+    const auto keys = request[strings::msg_params].enumerate();
+    for (const auto key : keys) {
+      status.succesfull_vehicle_data_subscriptions_.push_back(key);
+    }
+    return;
+  }
+  LOG4CXX_DEBUG(logger_, "keys size " << keys.size());
+  for (auto& ivi : keys) {
+    const auto& vd_response = msg_params[ivi];
+    const auto vd_result_code = vd_response[strings::result_code].asInt();
+    const auto kSuccess = hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS;
+    if (kSuccess != vd_result_code) {
+      LOG4CXX_DEBUG(logger_,
+                    "ivi " << ivi << " was not successfuly subscribed");
+
+      status.unsuccesfull_vehicle_data_subscriptions_.push_back(ivi);
+    } else {
+      status.succesfull_vehicle_data_subscriptions_.push_back(ivi);
+      LOG4CXX_DEBUG(logger_, "ivi " << ivi << " was successfuly subscribed");
+    }
+  }
 }
 
 }  // namespce resumption

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -570,8 +570,9 @@ void ResumptionDataProcessor::AddButtonsSubscriptions(
     ButtonSubscriptions button_subscriptions =
         GetButtonSubscriptionsToResume(application);
 
-    MessageHelper::SendOnButtonSubscriptionNotificationsForApp(
-        application, application_manager_, button_subscriptions);
+    ProcessHMIRequests(
+      MessageHelper::CreateOnButtonSubscriptionNotificationsForApp(
+        application, application_manager_, button_subscriptions));
   }
  }
 
@@ -614,21 +615,24 @@ void ResumptionDataProcessor::AddButtonsSubscriptions(
     LOG4CXX_AUTO_TRACE(logger_);
     const ButtonSubscriptions button_subscriptions =
         application->SubscribedButtons().GetData();
+    smart_objects::SmartObjectSPtr notification;
     for (auto& btn : button_subscriptions) {
       const auto hmi_btn = static_cast<hmi_apis::Common_ButtonName::eType>(btn);
-      MessageHelper::SendOnButtonSubscriptionNotification(
+      notification = MessageHelper::CreateOnButtonSubscriptionNotification(
           application->hmi_app_id(),
           hmi_btn,
           /*is_subscribed = */ false,
           application_manager_);
+      ProcessHMIRequest(notification, false);
       application->UnsubscribeFromButton(btn);
     }
 
-    MessageHelper::SendOnButtonSubscriptionNotification(
+    notification = MessageHelper::CreateOnButtonSubscriptionNotification(
         application->hmi_app_id(),
         hmi_apis::Common_ButtonName::CUSTOM_BUTTON,
         /*is_subscribed = */ false,
         application_manager_);
+    ProcessHMIRequest(notification, false);
     application->SubscribeToButton(mobile_apis::ButtonName::CUSTOM_BUTTON);
   }
 

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -83,9 +83,9 @@ void ResumptionDataProcessor::on_event(const event_engine::Event& event) {
   ResumptionRequestIDs request_ids;
   request_ids.function_id = event.id();
   request_ids.correlation_id = event.smart_object_correlation_id();
-  //TODO i suppose it can be optimised with moving app id into
-  //ResumptionRequest struct, so that we don't have to perform
-  //basically the same search twice
+  // TODO i suppose it can be optimised with moving app id into
+  // ResumptionRequest struct, so that we don't have to perform
+  // basically the same search twice
   auto predicate =
       [&event](const std::pair<ResumptionRequestIDs, std::uint32_t>& item) {
         return item.first.function_id == event.id() &&
@@ -93,9 +93,7 @@ void ResumptionDataProcessor::on_event(const event_engine::Event& event) {
       };
 
   auto app_id_ptr =
-      std::find_if(request_app_ids_.begin(),
-                   request_app_ids_.end(),
-                   predicate);
+      std::find_if(request_app_ids_.begin(), request_app_ids_.end(), predicate);
 
   if (app_id_ptr == request_app_ids_.end()) {
     LOG4CXX_ERROR(logger_,
@@ -140,7 +138,7 @@ void ResumptionDataProcessor::on_event(const event_engine::Event& event) {
 
   const hmi_apis::Common_Result::eType result_code =
       static_cast<hmi_apis::Common_Result::eType>(
-      response[strings::params][application_manager::hmi_response::code]
+          response[strings::params][application_manager::hmi_response::code]
               .asInt());
 
   if (result_code == hmi_apis::Common_Result::SUCCESS) {
@@ -518,12 +516,11 @@ void ResumptionDataProcessor::AddWayPointsSubscription(
       saved_app[strings::subscribed_for_way_points].asBool();
   if (subscribed_for_way_points_so) {
     application_manager_.SubscribeAppForWayPoints(application);
-    auto subscribe_waypoints_msg =
-        MessageHelper::CreateMessageForHMI(
-          hmi_apis::FunctionID::Navigation_SubscribeWayPoints,
-          application_manager_.GetNextHMICorrelationID());
-    (*subscribe_waypoints_msg)[strings::params][strings::message_type] = 
-    hmi_apis::messageType::request;
+    auto subscribe_waypoints_msg = MessageHelper::CreateMessageForHMI(
+        hmi_apis::FunctionID::Navigation_SubscribeWayPoints,
+        application_manager_.GetNextHMICorrelationID());
+    (*subscribe_waypoints_msg)[strings::params][strings::message_type] =
+        hmi_apis::messageType::request;
     ProcessHMIRequest(subscribe_waypoints_msg, true);
   }
 }
@@ -597,18 +594,16 @@ void ResumptionDataProcessor::DeleteSubscriptions(const int32_t app_id) {
 void ResumptionDataProcessor::DeleteButtonsSubscriptions(
     ApplicationSharedPtr application) {
   LOG4CXX_AUTO_TRACE(logger_);
-  DataAccessor<ButtonSubscriptions> button_accessor =
-      application->SubscribedButtons();
-  ButtonSubscriptions button_subscriptions = button_accessor.GetData();
-  while (!button_subscriptions.empty()) {
-    auto btn = button_subscriptions.begin();
+  ButtonSubscriptions button_subscriptions =
+      application->SubscribedButtons().GetData();
+  for (auto btn : button_subscriptions) {
+    const auto hmi_btn = static_cast<hmi_apis::Common_ButtonName::eType>(btn);
     MessageHelper::SendOnButtonSubscriptionNotification(
         application->hmi_app_id(),
-        static_cast<hmi_apis::Common_ButtonName::eType>(*btn),
+        hmi_btn,
         /*is_subscribed = */ false,
         application_manager_);
-    application->UnsubscribeFromButton(
-        static_cast<mobile_apis::ButtonName::eType>(*btn));
+    application->UnsubscribeFromButton(btn);
   }
 
   MessageHelper::SendOnButtonSubscriptionNotification(

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -454,10 +454,9 @@ void ResumptionDataProcessor::DeleteChoicesets(
     ApplicationSharedPtr application) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  const DataAccessor<ChoiceSetMap> accessor = application->choice_set_map();
-  const ChoiceSetMap& choices = accessor.GetData();
-  while (!choices.empty()) {
-    application->RemoveChoiceSet(choices.begin()->first);
+  auto choices = application->choice_set_map().GetData();
+  for (auto& choice : choices) {
+    application->RemoveChoiceSet(choice.first);
   }
 }
 

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -521,6 +521,8 @@ void ResumptionDataProcessor::AddWayPointsSubscription(
         application_manager_.GetNextHMICorrelationID());
     (*subscribe_waypoints_msg)[strings::params][strings::message_type] =
         hmi_apis::messageType::request;
+    (*subscribe_waypoints_msg)[strings::msg_params][strings::app_id] =
+        application->app_id();
     ProcessHMIRequest(subscribe_waypoints_msg, true);
   }
 }
@@ -564,74 +566,90 @@ void ResumptionDataProcessor::AddButtonsSubscriptions(
           (subscriptions_buttons[i]).asInt());
       application->SubscribeToButton(btn);
     }
+
+    ButtonSubscriptions button_subscriptions =
+        GetButtonSubscriptionsToResume(application);
+
+    MessageHelper::SendOnButtonSubscriptionNotificationsForApp(
+        application, application_manager_, button_subscriptions);
+  }
+ }
+
+  ButtonSubscriptions ResumptionDataProcessor::GetButtonSubscriptionsToResume(
+      ApplicationSharedPtr application) const {
+    ButtonSubscriptions button_subscriptions =
+        application->SubscribedButtons().GetData();
+    auto it = button_subscriptions.find(mobile_apis::ButtonName::CUSTOM_BUTTON);
+    
+    if (it != button_subscriptions.end()) {
+      button_subscriptions.erase(it);
+    }
+
+    return button_subscriptions;
   }
 
-  MessageHelper::SendAllOnButtonSubscriptionNotificationsForApp(
-      application, application_manager_);
-}
+  void ResumptionDataProcessor::AddPluginsSubscriptions(
+      ApplicationSharedPtr application,
+      const smart_objects::SmartObject& saved_app) {
+    LOG4CXX_AUTO_TRACE(logger_);
 
-void ResumptionDataProcessor::AddPluginsSubscriptions(
-    ApplicationSharedPtr application,
-    const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  for (auto& extension : application->Extensions()) {
-    extension->ProcessResumption(
-        saved_app,
-        [this](const int32_t app_id, const ResumptionRequest request) {
-          this->WaitForResponse(app_id, request);
-        });
-  }
-}
-
-void ResumptionDataProcessor::DeleteSubscriptions(const int32_t app_id) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  ApplicationSharedPtr application = application_manager_.application(app_id);
-  DeleteButtonsSubscriptions(application);
-  DeletePluginsSubscriptions(application);
-}
-
-void ResumptionDataProcessor::DeleteButtonsSubscriptions(
-    ApplicationSharedPtr application) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  ButtonSubscriptions button_subscriptions =
-      application->SubscribedButtons().GetData();
-  for (auto btn : button_subscriptions) {
-    const auto hmi_btn = static_cast<hmi_apis::Common_ButtonName::eType>(btn);
-    MessageHelper::SendOnButtonSubscriptionNotification(
-        application->hmi_app_id(),
-        hmi_btn,
-        /*is_subscribed = */ false,
-        application_manager_);
-    application->UnsubscribeFromButton(btn);
-  }
-
-  MessageHelper::SendOnButtonSubscriptionNotification(
-      application->hmi_app_id(),
-      hmi_apis::Common_ButtonName::CUSTOM_BUTTON,
-      /*is_subscribed = */ false,
-      application_manager_);
-  application->SubscribeToButton(mobile_apis::ButtonName::CUSTOM_BUTTON);
-}
-
-void ResumptionDataProcessor::DeletePluginsSubscriptions(
-    application_manager::ApplicationSharedPtr application) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  smart_objects::SmartObject extension_subscriptions;
-
-  ApplicationResumptionStatus& status =
-      resumption_status_[application->app_id()];
-  for (auto request : status.successful_requests) {
-    if (hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData ==
-        request.request_ids.function_id) {
-      extension_subscriptions[strings::application_vehicle_info] =
-          request.message;
+    for (auto& extension : application->Extensions()) {
+      extension->ProcessResumption(
+          saved_app,
+          [this](const int32_t app_id, const ResumptionRequest request) {
+            this->WaitForResponse(app_id, request);
+          });
     }
   }
 
-  for (auto& extension : application->Extensions()) {
-    extension->RevertResumption(extension_subscriptions);
+  void ResumptionDataProcessor::DeleteSubscriptions(const int32_t app_id) {
+    LOG4CXX_AUTO_TRACE(logger_);
+    ApplicationSharedPtr application = application_manager_.application(app_id);
+    DeleteButtonsSubscriptions(application);
+    DeletePluginsSubscriptions(application);
   }
-}
+
+  void ResumptionDataProcessor::DeleteButtonsSubscriptions(
+      ApplicationSharedPtr application) {
+    LOG4CXX_AUTO_TRACE(logger_);
+    const ButtonSubscriptions button_subscriptions =
+        application->SubscribedButtons().GetData();
+    for (auto& btn : button_subscriptions) {
+      const auto hmi_btn = static_cast<hmi_apis::Common_ButtonName::eType>(btn);
+      MessageHelper::SendOnButtonSubscriptionNotification(
+          application->hmi_app_id(),
+          hmi_btn,
+          /*is_subscribed = */ false,
+          application_manager_);
+      application->UnsubscribeFromButton(btn);
+    }
+
+    MessageHelper::SendOnButtonSubscriptionNotification(
+        application->hmi_app_id(),
+        hmi_apis::Common_ButtonName::CUSTOM_BUTTON,
+        /*is_subscribed = */ false,
+        application_manager_);
+    application->SubscribeToButton(mobile_apis::ButtonName::CUSTOM_BUTTON);
+  }
+
+  void ResumptionDataProcessor::DeletePluginsSubscriptions(
+      application_manager::ApplicationSharedPtr application) {
+    LOG4CXX_AUTO_TRACE(logger_);
+    smart_objects::SmartObject extension_subscriptions;
+
+    const ApplicationResumptionStatus& status =
+        resumption_status_[application->app_id()];
+    for (auto& request : status.successful_requests) {
+      if (hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData ==
+          request.request_ids.function_id) {
+        extension_subscriptions[strings::application_vehicle_info] =
+            request.message;
+      }
+    }
+
+    for (auto& extension : application->Extensions()) {
+      extension->RevertResumption(extension_subscriptions);
+    }
+  }
 
 }  // namespce resumption

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -139,11 +139,12 @@ void ResumptionDataProcessor::on_event(const event_engine::Event& event) {
     return;
   }
 
-  const int32_t result_code =
+  const hmi_apis::Common_Result::eType result_code =
+      static_cast<hmi_apis::Common_Result::eType>(
       response[strings::params][application_manager::hmi_response::code]
-          .asInt();
+              .asInt());
 
-  if (result_code == 0) {
+  if (result_code == hmi_apis::Common_Result::SUCCESS) {
     status.successful_requests.push_back(*request_ptr);
   } else {
     status.error_requests.push_back(*request_ptr);
@@ -156,7 +157,7 @@ void ResumptionDataProcessor::on_event(const event_engine::Event& event) {
   }
 
   auto it = register_callbacks_.find(app_id);
-  DCHECK_OR_RETURN_VOID(it !=register_callbacks_.end());
+  DCHECK_OR_RETURN_VOID(it != register_callbacks_.end());
   auto callback = it->second;
   if (status.error_requests.empty()) {
     LOG4CXX_DEBUG(logger_, "Resumption for app " << app_id << "successful");
@@ -518,7 +519,8 @@ void ResumptionDataProcessor::AddWayPointsSubscription(
     auto subscribe_waypoints_msg =
         MessageHelper::CreateSubscribeWayPointsMessageToHMI(
             application_manager_.GetNextHMICorrelationID());
-    ProcessHMIRequest(subscribe_waypoints_msg, true);
+    application_manager_.GetRPCService().ManageHMICommand(
+        subscribe_waypoints_msg);
   }
 }
 

--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -454,30 +454,33 @@ bool StateControllerImpl::IsResumptionAllowed(ApplicationSharedPtr app,
 }
 
 mobile_apis::HMILevel::eType StateControllerImpl::GetAvailableHmiLevel(
-    ApplicationSharedPtr app, mobile_apis::HMILevel::eType hmi_level) const {
+    ApplicationSharedPtr app,
+    mobile_apis::HMILevel::eType desired_hmi_level) const {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  mobile_apis::HMILevel::eType result = hmi_level;
-  LOG4CXX_DEBUG(logger_, "HMI Level: " << hmi_level);
-
-  if (!IsStreamableHMILevel(hmi_level)) {
+  mobile_apis::HMILevel::eType result = desired_hmi_level;
+  if (!IsStreamableHMILevel(desired_hmi_level)) {
     return result;
   }
 
   const bool is_audio_app = app->IsAudioApplication();
   const bool does_audio_app_with_same_type_exist =
       app_mngr_.IsAppTypeExistsInFullOrLimited(app);
-
-  if (mobile_apis::HMILevel::HMI_LIMITED == hmi_level) {
+  if (mobile_apis::HMILevel::HMI_LIMITED == desired_hmi_level) {
     if (!is_audio_app || does_audio_app_with_same_type_exist) {
+      LOG4CXX_DEBUG(logger_,
+                    "Not audio application trying to resume in limmited or "
+                    "audio application with the same type active");
       result = app_mngr_.GetDefaultHmiLevel(app);
     }
     return result;
   }
 
   const bool is_active_app_exist = (bool)app_mngr_.active_application();
+
   if (is_audio_app) {
     if (does_audio_app_with_same_type_exist) {
+      LOG4CXX_DEBUG(logger_, "Audio application with the same type active");
       result = app_mngr_.GetDefaultHmiLevel(app);
     } else if (is_active_app_exist) {
       result = mobile_apis::HMILevel::HMI_LIMITED;

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -235,16 +235,16 @@ TEST_F(ApplicationManagerImplTest,
        SubscribeAppForWayPoints_ExpectSubscriptionApp) {
   auto app_ptr = std::static_pointer_cast<am::Application>(mock_app_ptr_);
   app_manager_impl_->SubscribeAppForWayPoints(app_ptr);
-  EXPECT_TRUE(app_manager_impl_->IsAppSubscribedForWayPoints(app_ptr));
+  EXPECT_TRUE(app_manager_impl_->IsAppSubscribedForWayPoints(*app_ptr));
 }
 
 TEST_F(ApplicationManagerImplTest,
        UnsubscribeAppForWayPoints_ExpectUnsubscriptionApp) {
   auto app_ptr = std::static_pointer_cast<am::Application>(mock_app_ptr_);
   app_manager_impl_->SubscribeAppForWayPoints(app_ptr);
-  EXPECT_TRUE(app_manager_impl_->IsAppSubscribedForWayPoints(app_ptr));
+  EXPECT_TRUE(app_manager_impl_->IsAppSubscribedForWayPoints(*app_ptr));
   app_manager_impl_->UnsubscribeAppFromWayPoints(app_ptr);
-  EXPECT_FALSE(app_manager_impl_->IsAppSubscribedForWayPoints(app_ptr));
+  EXPECT_FALSE(app_manager_impl_->IsAppSubscribedForWayPoints(*app_ptr));
   const std::set<uint32_t> result =
       app_manager_impl_->GetAppsSubscribedForWayPoints();
   EXPECT_TRUE(result.empty());

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -173,8 +173,8 @@ class MockMessageHelper {
   MOCK_METHOD2(CreateModuleInfoSO,
                smart_objects::SmartObjectSPtr(uint32_t function_id,
                                               ApplicationManager& app_mngr));
-  MOCK_METHOD3(SendOnButtonSubscriptionNotificationsForApp,
-               void(ApplicationConstSharedPtr app,
+  MOCK_METHOD3(CreateOnButtonSubscriptionNotificationsForApp,
+               smart_objects::SmartObjectList(ApplicationConstSharedPtr app,
                     ApplicationManager& app_mngr,
                     const ButtonSubscriptions& button_subscriptions));
   MOCK_METHOD2(SendOnResumeAudioSourceToHMI,
@@ -330,8 +330,8 @@ class MockMessageHelper {
                smart_objects::SmartObjectList(ApplicationConstSharedPtr app,
                                               ApplicationManager& app_mngr));
 
-  MOCK_METHOD4(SendOnButtonSubscriptionNotification,
-               void(uint32_t app_id,
+  MOCK_METHOD4(CreateOnButtonSubscriptionNotification,
+               smart_objects::SmartObjectSPtr(uint32_t app_id,
                     hmi_apis::Common_ButtonName::eType button,
                     bool is_subscribed,
                     ApplicationManager& app_mngr));

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -128,6 +128,10 @@ class MockMessageHelper {
   MOCK_METHOD2(CreateMessageForHMI,
                smart_objects::SmartObjectSPtr(hmi_apis::messageType::eType,
                                               const uint32_t));
+
+  MOCK_METHOD2(CreateMessageForHMI,
+               smart_objects::SmartObjectSPtr(hmi_apis::FunctionID::eType,
+                                              const uint32_t));
   MOCK_METHOD2(SendHMIStatusNotification,
                void(const Application& application_impl,
                     ApplicationManager& application_manager));

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -182,7 +182,7 @@ class MockMessageHelper {
                void(uint32_t app_id, ApplicationManager& app_mngr));
   MOCK_METHOD2(CreateAddSubMenuRequestsToHMI,
                smart_objects::SmartObjectList(ApplicationConstSharedPtr app,
-                                              const uint32_t correlation_id));
+                                              ApplicationManager& app_mngr));
   MOCK_METHOD2(CreateAddCommandRequestToHMI,
                smart_objects::SmartObjectList(ApplicationConstSharedPtr app,
                                               ApplicationManager& app_mngr));

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -173,9 +173,10 @@ class MockMessageHelper {
   MOCK_METHOD2(CreateModuleInfoSO,
                smart_objects::SmartObjectSPtr(uint32_t function_id,
                                               ApplicationManager& app_mngr));
-  MOCK_METHOD2(SendAllOnButtonSubscriptionNotificationsForApp,
+  MOCK_METHOD3(SendOnButtonSubscriptionNotificationsForApp,
                void(ApplicationConstSharedPtr app,
-                    ApplicationManager& app_mngr));
+                    ApplicationManager& app_mngr,
+                    const ButtonSubscriptions& button_subscriptions));
   MOCK_METHOD2(SendOnResumeAudioSourceToHMI,
                void(uint32_t app_id, ApplicationManager& app_mngr));
   MOCK_METHOD2(CreateAddSubMenuRequestsToHMI,

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -320,7 +320,7 @@ class MockMessageHelper {
                    ApplicationSharedPtr application));
   MOCK_METHOD2(CreateGlobalPropertiesRequestsToHMI,
                smart_objects::SmartObjectList(ApplicationConstSharedPtr app,
-                                              const uint32_t correlation_id));
+                                              ApplicationManager& app_mngr));
 
   MOCK_METHOD4(SendOnButtonSubscriptionNotification,
                void(uint32_t app_id,

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -309,6 +309,25 @@ class MockMessageHelper {
                     ApplicationSharedPtr application,
                     ApplicationManager& app_mngr));
 
+  MOCK_METHOD2(CreateUIResetGlobalPropertiesRequest,
+               smart_objects::SmartObjectSPtr(
+                   const ResetGlobalPropertiesResult& reset_result,
+                   ApplicationSharedPtr application));
+
+  MOCK_METHOD2(CreateTTSResetGlobalPropertiesRequest,
+               smart_objects::SmartObjectSPtr(
+                   const ResetGlobalPropertiesResult& reset_result,
+                   ApplicationSharedPtr application));
+  MOCK_METHOD2(CreateGlobalPropertiesRequestsToHMI,
+               smart_objects::SmartObjectList(ApplicationConstSharedPtr app,
+                                              const uint32_t correlation_id));
+
+  MOCK_METHOD4(SendOnButtonSubscriptionNotification,
+               void(uint32_t app_id,
+                    hmi_apis::Common_ButtonName::eType button,
+                    bool is_subscribed,
+                    ApplicationManager& app_mngr));
+
   static MockMessageHelper* message_helper_mock();
 };
 

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -174,7 +174,7 @@ class MockMessageHelper {
                     ApplicationManager& app_mngr));
   MOCK_METHOD2(SendOnResumeAudioSourceToHMI,
                void(uint32_t app_id, ApplicationManager& app_mngr));
-  MOCK_METHOD2(CreateAddSubMenuRequestToHMI,
+  MOCK_METHOD2(CreateAddSubMenuRequestsToHMI,
                smart_objects::SmartObjectList(ApplicationConstSharedPtr app,
                                               const uint32_t correlation_id));
   MOCK_METHOD2(CreateAddCommandRequestToHMI,
@@ -261,6 +261,9 @@ class MockMessageHelper {
                     const std::string& packageName,
                     ApplicationManager& app_man));
   MOCK_METHOD1(SendUnsubscribedWayPoints, bool(ApplicationManager& app_mngr));
+
+  MOCK_METHOD1(CreateSubscribeWayPointsMessageToHMI,
+               smart_objects::SmartObjectSPtr(const uint32_t correlation_id));
 
   MOCK_METHOD2(SendQueryApps,
                void(const uint32_t connection_key,

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -174,9 +174,10 @@ class MockMessageHelper {
                smart_objects::SmartObjectSPtr(uint32_t function_id,
                                               ApplicationManager& app_mngr));
   MOCK_METHOD3(CreateOnButtonSubscriptionNotificationsForApp,
-               smart_objects::SmartObjectList(ApplicationConstSharedPtr app,
-                    ApplicationManager& app_mngr,
-                    const ButtonSubscriptions& button_subscriptions));
+               smart_objects::SmartObjectList(
+                   ApplicationConstSharedPtr app,
+                   ApplicationManager& app_mngr,
+                   const ButtonSubscriptions& button_subscriptions));
   MOCK_METHOD2(SendOnResumeAudioSourceToHMI,
                void(uint32_t app_id, ApplicationManager& app_mngr));
   MOCK_METHOD2(CreateAddSubMenuRequestsToHMI,
@@ -330,11 +331,12 @@ class MockMessageHelper {
                smart_objects::SmartObjectList(ApplicationConstSharedPtr app,
                                               ApplicationManager& app_mngr));
 
-  MOCK_METHOD4(CreateOnButtonSubscriptionNotification,
-               smart_objects::SmartObjectSPtr(uint32_t app_id,
-                    hmi_apis::Common_ButtonName::eType button,
-                    bool is_subscribed,
-                    ApplicationManager& app_mngr));
+  MOCK_METHOD4(
+      CreateOnButtonSubscriptionNotification,
+      smart_objects::SmartObjectSPtr(uint32_t app_id,
+                                     hmi_apis::Common_ButtonName::eType button,
+                                     bool is_subscribed,
+                                     ApplicationManager& app_mngr));
 
   static MockMessageHelper* message_helper_mock();
 };

--- a/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
@@ -61,7 +61,8 @@ class MockResumeCtrl : public resumption::ResumeCtrl {
   MOCK_METHOD0(StartSavePersistentDataTimer, void());
   MOCK_METHOD2(StartResumption,
                bool(app_mngr::ApplicationSharedPtr application,
-                    const std::string& hash));
+                    const std::string& hash,
+                    resumption::ResumeCtrl::ResumptionCallBack));
   MOCK_METHOD1(StartResumptionOnlyHMILevel,
                bool(app_mngr::ApplicationSharedPtr application));
   MOCK_METHOD1(RetryResumption, void(const uint32_t app_id));

--- a/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
@@ -63,6 +63,7 @@ class MockResumeCtrl : public resumption::ResumeCtrl {
                bool(app_mngr::ApplicationSharedPtr application,
                     const std::string& hash,
                     resumption::ResumeCtrl::ResumptionCallBack));
+  MOCK_METHOD1(HandleOnTimeOut, void(const int32_t app_id));
   MOCK_METHOD1(StartResumptionOnlyHMILevel,
                bool(app_mngr::ApplicationSharedPtr application));
   MOCK_METHOD1(RetryResumption, void(const uint32_t app_id));

--- a/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
@@ -59,7 +59,7 @@ class MockResumeCtrl : public resumption::ResumeCtrl {
   MOCK_CONST_METHOD0(is_suspended, bool());
   MOCK_METHOD0(StopSavePersistentDataTimer, void());
   MOCK_METHOD0(StartSavePersistentDataTimer, void());
-  MOCK_METHOD2(StartResumption,
+  MOCK_METHOD3(StartResumption,
                bool(app_mngr::ApplicationSharedPtr application,
                     const std::string& hash,
                     resumption::ResumeCtrl::ResumptionCallBack));

--- a/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
@@ -63,7 +63,9 @@ class MockResumeCtrl : public resumption::ResumeCtrl {
                bool(app_mngr::ApplicationSharedPtr application,
                     const std::string& hash,
                     resumption::ResumeCtrl::ResumptionCallBack));
-  MOCK_METHOD1(HandleOnTimeOut, void(const int32_t app_id));
+  MOCK_METHOD2(HandleOnTimeOut,
+               void(const uint32_t cor_id,
+                    const hmi_apis::FunctionID::eType function_id));
   MOCK_METHOD1(StartResumptionOnlyHMILevel,
                bool(app_mngr::ApplicationSharedPtr application));
   MOCK_METHOD1(RetryResumption, void(const uint32_t app_id));

--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -156,8 +156,10 @@ TEST(MessageHelperTestCreate,
   EXPECT_CALL(*mock_help_prompt_manager, GetSendingType())
       .WillRepeatedly(Return(HelpPromptManager::SendingType::kSendBoth));
 
+  application_manager_test::MockApplicationManager mock_application_manager;
   smart_objects::SmartObjectList ptr =
-      MessageHelper::CreateGlobalPropertiesRequestsToHMI(appSharedMock, 0u);
+      MessageHelper::CreateGlobalPropertiesRequestsToHMI(
+          appSharedMock, mock_application_manager);
 
   EXPECT_TRUE(ptr.empty());
 }
@@ -206,8 +208,10 @@ TEST(MessageHelperTestCreate,
   EXPECT_CALL(*mock_help_prompt_manager, GetSendingType())
       .WillRepeatedly(Return(HelpPromptManager::SendingType::kSendBoth));
 
+  application_manager_test::MockApplicationManager mock_application_manager;
   smart_objects::SmartObjectList ptr =
-      MessageHelper::CreateGlobalPropertiesRequestsToHMI(appSharedMock, 0u);
+      MessageHelper::CreateGlobalPropertiesRequestsToHMI(
+          appSharedMock, mock_application_manager);
 
   EXPECT_FALSE(ptr.empty());
 

--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -395,7 +395,7 @@ TEST(MessageHelperTestCreate, CreateAddSubMenuRequestToHMI_SendObject_Equal) {
 
   const uint32_t cor_id = 0u;
   smart_objects::SmartObjectList ptr =
-      MessageHelper::CreateAddSubMenuRequestToHMI(appSharedMock, cor_id);
+      MessageHelper::CreateAddSubMenuRequestsToHMI(appSharedMock, cor_id);
 
   EXPECT_FALSE(ptr.empty());
 
@@ -425,7 +425,7 @@ TEST(MessageHelperTestCreate,
 
   const uint32_t cor_id = 0u;
   smart_objects::SmartObjectList ptr =
-      MessageHelper::CreateAddSubMenuRequestToHMI(appSharedMock, cor_id);
+      MessageHelper::CreateAddSubMenuRequestsToHMI(appSharedMock, cor_id);
 
   EXPECT_TRUE(ptr.empty());
 }

--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -393,9 +393,10 @@ TEST(MessageHelperTestCreate, CreateAddSubMenuRequestToHMI_SendObject_Equal) {
   EXPECT_CALL(*appSharedMock, sub_menu_map()).WillOnce(Return(data_accessor));
   EXPECT_CALL(*appSharedMock, app_id()).Times(AtLeast(1)).WillOnce(Return(1u));
 
-  const uint32_t cor_id = 0u;
+  application_manager_test::MockApplicationManager mock_application_manager;
   smart_objects::SmartObjectList ptr =
-      MessageHelper::CreateAddSubMenuRequestsToHMI(appSharedMock, cor_id);
+      MessageHelper::CreateAddSubMenuRequestsToHMI(appSharedMock,
+                                                   mock_application_manager);
 
   EXPECT_FALSE(ptr.empty());
 
@@ -423,9 +424,10 @@ TEST(MessageHelperTestCreate,
 
   EXPECT_CALL(*appSharedMock, sub_menu_map()).WillOnce(Return(data_accessor));
 
-  const uint32_t cor_id = 0u;
+  application_manager_test::MockApplicationManager mock_application_manager;
   smart_objects::SmartObjectList ptr =
-      MessageHelper::CreateAddSubMenuRequestsToHMI(appSharedMock, cor_id);
+      MessageHelper::CreateAddSubMenuRequestsToHMI(appSharedMock,
+                                                   mock_application_manager);
 
   EXPECT_TRUE(ptr.empty());
 }

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -572,4 +572,37 @@ void MessageHelper::SendUnsubscribeButtonNotification(
       ->SendUnsubscribeButtonNotification(button, application, app_mngr);
 }
 
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateUIResetGlobalPropertiesRequest(
+    const ResetGlobalPropertiesResult& reset_result,
+    ApplicationSharedPtr application) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateUIResetGlobalPropertiesRequest(reset_result, application);
+}
+
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateTTSResetGlobalPropertiesRequest(
+    const ResetGlobalPropertiesResult& reset_result,
+    ApplicationSharedPtr application) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateTTSResetGlobalPropertiesRequest(reset_result, application);
+}
+
+smart_objects::SmartObjectList
+MessageHelper::CreateGlobalPropertiesRequestsToHMI(
+    ApplicationConstSharedPtr app, const uint32_t correlation_id) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateGlobalPropertiesRequestsToHMI(app, correlation_id);
+}
+
+void MessageHelper::SendOnButtonSubscriptionNotification(
+    uint32_t app_id,
+    hmi_apis::Common_ButtonName::eType button,
+    bool is_subscribed,
+    ApplicationManager& app_mngr) {
+  return MockMessageHelper::message_helper_mock()
+      ->SendOnButtonSubscriptionNotification(
+          app_id, button, is_subscribed, app_mngr);
+}
+
 }  // namespace application_manager

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -301,8 +301,8 @@ void MessageHelper::SendOnResumeAudioSourceToHMI(const uint32_t app_id,
 
 smart_objects::SmartObjectList MessageHelper::CreateAddSubMenuRequestToHMI(
     ApplicationConstSharedPtr app, const uint32_t correlation_id) {
-  return MockMessageHelper::message_helper_mock()->CreateAddSubMenuRequestToHMI(
-      app, correlation_id);
+  return MockMessageHelper::message_helper_mock()
+      ->CreateAddSubMenuRequestsToHMI(app, correlation_id);
 }
 
 smart_objects::SmartObjectList MessageHelper::CreateAddCommandRequestToHMI(
@@ -590,9 +590,9 @@ MessageHelper::CreateTTSResetGlobalPropertiesRequest(
 
 smart_objects::SmartObjectList
 MessageHelper::CreateGlobalPropertiesRequestsToHMI(
-    ApplicationConstSharedPtr app, const uint32_t correlation_id) {
+    ApplicationConstSharedPtr app, ApplicationManager& app_mngr) {
   return MockMessageHelper::message_helper_mock()
-      ->CreateGlobalPropertiesRequestsToHMI(app, correlation_id);
+      ->CreateGlobalPropertiesRequestsToHMI(app, app_mngr);
 }
 
 void MessageHelper::SendOnButtonSubscriptionNotification(

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -293,10 +293,13 @@ MockMessageHelper* MockMessageHelper::message_helper_mock() {
   static ::testing::NiceMock<MockMessageHelper> message_helper_mock;
   return &message_helper_mock;
 }
-void MessageHelper::SendAllOnButtonSubscriptionNotificationsForApp(
-    ApplicationConstSharedPtr app, ApplicationManager& app_mngr) {
+void MessageHelper::SendOnButtonSubscriptionNotificationsForApp(
+    ApplicationConstSharedPtr app,
+    ApplicationManager& app_mngr,
+    const ButtonSubscriptions& button_subscriptions) {
   MockMessageHelper::message_helper_mock()
-      ->SendAllOnButtonSubscriptionNotificationsForApp(app, app_mngr);
+      ->SendOnButtonSubscriptionNotificationsForApp(
+          app, app_mngr, button_subscriptions);
 }
 
 void MessageHelper::SendOnResumeAudioSourceToHMI(const uint32_t app_id,

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -299,7 +299,7 @@ void MessageHelper::SendOnResumeAudioSourceToHMI(const uint32_t app_id,
       app_id, app_mngr);
 }
 
-smart_objects::SmartObjectList MessageHelper::CreateAddSubMenuRequestToHMI(
+smart_objects::SmartObjectList MessageHelper::CreateAddSubMenuRequestsToHMI(
     ApplicationConstSharedPtr app, const uint32_t correlation_id) {
   return MockMessageHelper::message_helper_mock()
       ->CreateAddSubMenuRequestsToHMI(app, correlation_id);
@@ -481,6 +481,13 @@ void MessageHelper::SendLaunchApp(const uint32_t connection_key,
 bool MessageHelper::SendUnsubscribedWayPoints(ApplicationManager& app_mngr) {
   return MockMessageHelper::message_helper_mock()->SendUnsubscribedWayPoints(
       app_mngr);
+}
+
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateSubscribeWayPointsMessageToHMI(
+    const uint32_t correlation_id) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateSubscribeWayPointsMessageToHMI(correlation_id);
 }
 
 void MessageHelper::SendQueryApps(const uint32_t connection_key,

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -293,12 +293,13 @@ MockMessageHelper* MockMessageHelper::message_helper_mock() {
   static ::testing::NiceMock<MockMessageHelper> message_helper_mock;
   return &message_helper_mock;
 }
-void MessageHelper::SendOnButtonSubscriptionNotificationsForApp(
+smart_objects::SmartObjectList
+MessageHelper::CreateOnButtonSubscriptionNotificationsForApp(
     ApplicationConstSharedPtr app,
     ApplicationManager& app_mngr,
     const ButtonSubscriptions& button_subscriptions) {
-  MockMessageHelper::message_helper_mock()
-      ->SendOnButtonSubscriptionNotificationsForApp(
+  return MockMessageHelper::message_helper_mock()
+      ->CreateOnButtonSubscriptionNotificationsForApp(
           app, app_mngr, button_subscriptions);
 }
 
@@ -604,13 +605,14 @@ MessageHelper::CreateGlobalPropertiesRequestsToHMI(
       ->CreateGlobalPropertiesRequestsToHMI(app, app_mngr);
 }
 
-void MessageHelper::SendOnButtonSubscriptionNotification(
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateOnButtonSubscriptionNotification(
     uint32_t app_id,
     hmi_apis::Common_ButtonName::eType button,
     bool is_subscribed,
     ApplicationManager& app_mngr) {
   return MockMessageHelper::message_helper_mock()
-      ->SendOnButtonSubscriptionNotification(
+      ->CreateOnButtonSubscriptionNotification(
           app_id, button, is_subscribed, app_mngr);
 }
 

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -257,6 +257,12 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateMessageForHMI(
       message_type, correlation_id);
 }
 
+smart_objects::SmartObjectSPtr MessageHelper::CreateMessageForHMI(
+    hmi_apis::FunctionID::eType function_id, const uint32_t correlation_id) {
+  return MockMessageHelper::message_helper_mock()->CreateMessageForHMI(
+      function_id, correlation_id);
+}
+
 void MessageHelper::SendHMIStatusNotification(
     const Application& application_impl,
     ApplicationManager& application_manager) {
@@ -481,13 +487,6 @@ void MessageHelper::SendLaunchApp(const uint32_t connection_key,
 bool MessageHelper::SendUnsubscribedWayPoints(ApplicationManager& app_mngr) {
   return MockMessageHelper::message_helper_mock()->SendUnsubscribedWayPoints(
       app_mngr);
-}
-
-smart_objects::SmartObjectSPtr
-MessageHelper::CreateSubscribeWayPointsMessageToHMI(
-    const uint32_t correlation_id) {
-  return MockMessageHelper::message_helper_mock()
-      ->CreateSubscribeWayPointsMessageToHMI(correlation_id);
 }
 
 void MessageHelper::SendQueryApps(const uint32_t connection_key,

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -310,9 +310,9 @@ void MessageHelper::SendOnResumeAudioSourceToHMI(const uint32_t app_id,
 }
 
 smart_objects::SmartObjectList MessageHelper::CreateAddSubMenuRequestsToHMI(
-    ApplicationConstSharedPtr app, const uint32_t correlation_id) {
+    ApplicationConstSharedPtr app, ApplicationManager& app_mngr) {
   return MockMessageHelper::message_helper_mock()
-      ->CreateAddSubMenuRequestsToHMI(app, correlation_id);
+      ->CreateAddSubMenuRequestsToHMI(app, app_mngr);
 }
 
 smart_objects::SmartObjectList MessageHelper::CreateAddCommandRequestToHMI(

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -497,7 +497,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscribeOnButtons) {
 
   EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
-  EXPECT_CALL(*mock_app_extension_, ProcessResumption(test_subscriptions));
+  EXPECT_CALL(*mock_app_extension_, ProcessResumption(test_subscriptions, _));
 
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
               SendAllOnButtonSubscriptionNotificationsForApp(_, _)).Times(2);
@@ -546,7 +546,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToIVI) {
 
   EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
-  EXPECT_CALL(*mock_app_extension_, ProcessResumption(test_subscriptions));
+  EXPECT_CALL(*mock_app_extension_, ProcessResumption(test_subscriptions, _));
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
   EXPECT_TRUE(res);
 }

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -349,7 +349,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubmenues) {
   EXPECT_CALL(mock_app_mngr_, GetNextHMICorrelationID())
       .WillRepeatedly(Return(kCorId_));
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
-              CreateAddSubMenuRequestsToHMI(_, kCorId_))
+              CreateAddSubMenuRequestsToHMI(_, _))
       .WillRepeatedly(Return(requests));
 
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -184,6 +184,7 @@ class ResumeCtrlTest : public ::testing::Test {
   const std::string kNaviLowbandwidthLevel_;
   const std::string kProjectionLowbandwidthLevel_;
   const std::string kMediaLowbandwidthLevel_;
+  resumption::ResumeCtrl::ResumptionCallBack callback_;
 };
 
 /**
@@ -206,7 +207,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithGrammarId) {
   EXPECT_CALL(*mock_app_, UpdateHash());
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
 
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -231,7 +232,7 @@ TEST_F(ResumeCtrlTest, StartResumption_WithoutGrammarId) {
   EXPECT_CALL(*mock_app_, UpdateHash());
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_)).Times(0);
 
-  bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_FALSE(res);
 }
 
@@ -286,7 +287,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithFiles) {
                     static_cast<mobile_apis::FileType::eType>(file_types[i]))));
   }
 
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -324,11 +325,11 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubmenues) {
   EXPECT_CALL(mock_app_mngr_, GetNextHMICorrelationID())
       .WillRepeatedly(Return(kCorId_));
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
-              CreateAddSubMenuRequestToHMI(_, kCorId_))
+              CreateAddSubMenuRequestsToHMI(_, kCorId_))
       .WillRepeatedly(Return(requests));
 
   EXPECT_CALL(*mock_app_, UpdateHash());
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -371,7 +372,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithCommands) {
               CreateAddCommandRequestToHMI(_, _))
       .WillRepeatedly(Return(requests));
 
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -423,7 +424,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithChoiceSet) {
               CreateAddVRCommandRequestFromChoiceToHMI(_))
       .WillRepeatedly(Return(requests));
 
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -452,7 +453,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithGlobalProperties) {
   EXPECT_CALL(*mock_app_, load_global_properties(test_global_properties));
 
   EXPECT_CALL(*mock_app_, UpdateHash());
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -502,7 +503,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscribeOnButtons) {
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
               SendAllOnButtonSubscriptionNotificationsForApp(_, _)).Times(2);
 
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -547,7 +548,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToIVI) {
   EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
   EXPECT_CALL(*mock_app_extension_, ProcessResumption(test_subscriptions, _));
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -572,7 +573,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToWayPoints) {
       .WillByDefault(Return(hmi_test_level));
   EXPECT_CALL(mock_state_controller_, SetRegularState(_, hmi_test_level));
 
-  const bool result = res_ctrl_->StartResumption(mock_app_, kHash_);
+  const bool result = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(result);
 }
 

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -559,7 +559,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscribeOnButtons) {
   EXPECT_CALL(*mock_app_extension_, ProcessResumption(saved_app, _));
 
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
-              SendOnButtonSubscriptionNotificationsForApp(_, _, _)).Times(2);
+              CreateOnButtonSubscriptionNotificationsForApp(_, _, _)).Times(2);
 
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -535,18 +535,18 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscribeOnButtons) {
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
 
-  std::shared_ptr<sync_primitives::Lock> button_lock_ptr = 
-  std::make_shared<sync_primitives::Lock>();
+  std::shared_ptr<sync_primitives::Lock> button_lock_ptr =
+      std::make_shared<sync_primitives::Lock>();
   ButtonSubscriptions button_subscriptions;
-  DataAccessor<ButtonSubscriptions> button_subscription_accessor(button_subscriptions, button_lock_ptr);
-  ON_CALL(*mock_app_,
-          SubscribedButtons()).WillByDefault(Return(button_subscription_accessor));
+  DataAccessor<ButtonSubscriptions> button_subscription_accessor(
+      button_subscriptions, button_lock_ptr);
+  ON_CALL(*mock_app_, SubscribedButtons())
+      .WillByDefault(Return(button_subscription_accessor));
 
   smart_objects::SmartObjectList button_subscription_notifications;
   ON_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
-              CreateOnButtonSubscriptionNotificationsForApp(_, _, _))
-              .WillByDefault(Return(button_subscription_notifications));
-
+          CreateOnButtonSubscriptionNotificationsForApp(_, _, _))
+      .WillByDefault(Return(button_subscription_notifications));
 
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
 
@@ -564,7 +564,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscribeOnButtons) {
   EXPECT_CALL(*mock_app_extension_, ProcessResumption(saved_app, _));
 
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
-             CreateOnButtonSubscriptionNotificationsForApp(_, _, _));
+              CreateOnButtonSubscriptionNotificationsForApp(_, _, _));
 
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -559,7 +559,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscribeOnButtons) {
   EXPECT_CALL(*mock_app_extension_, ProcessResumption(saved_app, _));
 
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
-              SendAllOnButtonSubscriptionNotificationsForApp(_, _)).Times(2);
+              SendOnButtonSubscriptionNotificationsForApp(_, _, _)).Times(2);
 
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
@@ -610,7 +610,8 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToIVI) {
   EXPECT_TRUE(res);
 }
 
-TEST_F(ResumeCtrlTest, DISABLED_StartResumption_AppWithSubscriptionToWayPoints) {
+TEST_F(ResumeCtrlTest,
+       DISABLED_StartResumption_AppWithSubscriptionToWayPoints) {
   smart_objects::SmartObject saved_app;
   saved_app[application_manager::strings::hash_id] = kHash_;
   saved_app[application_manager::strings::grammar_id] = kTestGrammarId_;

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -143,6 +143,9 @@ class ResumeCtrlTest : public ::testing::Test {
     EXPECT_CALL(*mock_app_, deferred_resumption_hmi_level())
         .Times(AtLeast(0))
         .WillRepeatedly(Return(kDefaultDeferredTestLevel_));
+
+    callback_ =
+        [](mobile_apis::Result::eType result_code, const std::string& info) {};
   }
   void TearDown() OVERRIDE {
     Mock::VerifyAndClearExpectations(&mock_app_mngr_);
@@ -156,12 +159,12 @@ class ResumeCtrlTest : public ::testing::Test {
   }
 
   NiceMock<event_engine_test::MockEventDispatcher> mock_event_dispatcher_;
-  application_manager_test::MockApplicationManagerSettings
+  NiceMock<application_manager_test::MockApplicationManagerSettings>
       mock_application_manager_settings_;
   NiceMock<application_manager_test::MockApplicationManager> mock_app_mngr_;
   std::shared_ptr<NiceMock<application_manager_test::MockAppExtension> >
       mock_app_extension_;
-  MockStateController mock_state_controller_;
+  NiceMock<MockStateController> mock_state_controller_;
   std::shared_ptr<ResumeCtrl> res_ctrl_;
   std::shared_ptr<NiceMock<resumption_test::MockResumptionData> > mock_storage_;
   std::shared_ptr<NiceMock<MockApplication> > mock_app_;
@@ -204,6 +207,18 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithGrammarId) {
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
+
+  smart_objects::SmartObjectList requests;
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddCommandRequestToHMI(_, _))
+      .WillRepeatedly(Return(requests));
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddVRCommandRequestFromChoiceToHMI(_))
+      .WillRepeatedly(Return(requests));
+  std::list<application_manager::AppExtensionPtr> extensions;
+  extensions.insert(extensions.begin(), mock_app_extension_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+
   EXPECT_CALL(*mock_app_, UpdateHash());
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
 
@@ -276,6 +291,18 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithFiles) {
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
+
+  smart_objects::SmartObjectList requests;
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddCommandRequestToHMI(_, _))
+      .WillRepeatedly(Return(requests));
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddVRCommandRequestFromChoiceToHMI(_))
+      .WillRepeatedly(Return(requests));
+  std::list<application_manager::AppExtensionPtr> extensions;
+  extensions.insert(extensions.begin(), mock_app_extension_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+
   EXPECT_CALL(*mock_app_, UpdateHash());
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
   for (uint32_t i = 0; i < count_of_files; ++i) {
@@ -328,6 +355,16 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubmenues) {
               CreateAddSubMenuRequestsToHMI(_, kCorId_))
       .WillRepeatedly(Return(requests));
 
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddCommandRequestToHMI(_, _))
+      .WillRepeatedly(Return(requests));
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddVRCommandRequestFromChoiceToHMI(_))
+      .WillRepeatedly(Return(requests));
+  std::list<application_manager::AppExtensionPtr> extensions;
+  extensions.insert(extensions.begin(), mock_app_extension_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+
   EXPECT_CALL(*mock_app_, UpdateHash());
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
@@ -371,6 +408,12 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithCommands) {
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
               CreateAddCommandRequestToHMI(_, _))
       .WillRepeatedly(Return(requests));
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddVRCommandRequestFromChoiceToHMI(_))
+      .WillRepeatedly(Return(requests));
+  std::list<application_manager::AppExtensionPtr> extensions;
+  extensions.insert(extensions.begin(), mock_app_extension_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
@@ -423,6 +466,13 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithChoiceSet) {
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
               CreateAddVRCommandRequestFromChoiceToHMI(_))
       .WillRepeatedly(Return(requests));
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddCommandRequestToHMI(_, _))
+      .WillRepeatedly(Return(requests));
+
+  std::list<application_manager::AppExtensionPtr> extensions;
+  extensions.insert(extensions.begin(), mock_app_extension_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
@@ -447,10 +497,18 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithGlobalProperties) {
 
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
 
-  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
-              SendGlobalPropertiesToHMI(_));
-
   EXPECT_CALL(*mock_app_, load_global_properties(test_global_properties));
+
+  smart_objects::SmartObjectList requests;
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateGlobalPropertiesRequestsToHMI(_, _))
+      .WillRepeatedly(Return(requests));
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddCommandRequestToHMI(_, _))
+      .WillRepeatedly(Return(requests));
+  std::list<application_manager::AppExtensionPtr> extensions;
+  extensions.insert(extensions.begin(), mock_app_extension_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
   EXPECT_CALL(*mock_app_, UpdateHash());
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
@@ -498,7 +556,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscribeOnButtons) {
 
   EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
-  EXPECT_CALL(*mock_app_extension_, ProcessResumption(test_subscriptions, _));
+  EXPECT_CALL(*mock_app_extension_, ProcessResumption(saved_app, _));
 
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
               SendAllOnButtonSubscriptionNotificationsForApp(_, _)).Times(2);
@@ -547,12 +605,12 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToIVI) {
 
   EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
-  EXPECT_CALL(*mock_app_extension_, ProcessResumption(test_subscriptions, _));
+  EXPECT_CALL(*mock_app_extension_, ProcessResumption(saved_app, _));
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
-TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToWayPoints) {
+TEST_F(ResumeCtrlTest, DISABLED_StartResumption_AppWithSubscriptionToWayPoints) {
   smart_objects::SmartObject saved_app;
   saved_app[application_manager::strings::hash_id] = kHash_;
   saved_app[application_manager::strings::grammar_id] = kTestGrammarId_;
@@ -572,6 +630,14 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToWayPoints) {
   ON_CALL(mock_app_mngr_, GetDefaultHmiLevel(const_app_))
       .WillByDefault(Return(hmi_test_level));
   EXPECT_CALL(mock_state_controller_, SetRegularState(_, hmi_test_level));
+
+  smart_objects::SmartObjectSPtr subscribe_waypoints_msg;
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateSubscribeWayPointsMessageToHMI(_))
+      .WillRepeatedly(Return(subscribe_waypoints_msg));
+  std::list<application_manager::AppExtensionPtr> extensions;
+  extensions.insert(extensions.begin(), mock_app_extension_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
   const bool result = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(result);

--- a/src/components/hmi_message_handler/src/mb_controller.cc
+++ b/src/components/hmi_message_handler/src/mb_controller.cc
@@ -220,7 +220,7 @@ void CMessageBrokerController::exitReceivingThread() {
   mConnectionListLock.Acquire();
   std::vector<std::shared_ptr<hmi_message_handler::WebsocketSession> >::iterator
       it;
-  while(!mConnectionList.empty()){
+  while (!mConnectionList.empty()) {
     mConnectionList.back()->Shutdown();
     mConnectionList.pop_back();
   }

--- a/src/components/hmi_message_handler/src/mb_controller.cc
+++ b/src/components/hmi_message_handler/src/mb_controller.cc
@@ -220,9 +220,9 @@ void CMessageBrokerController::exitReceivingThread() {
   mConnectionListLock.Acquire();
   std::vector<std::shared_ptr<hmi_message_handler::WebsocketSession> >::iterator
       it;
-  for (it = mConnectionList.begin(); it != mConnectionList.end();) {
-    (*it)->Shutdown();
-    it = mConnectionList.erase(it);
+  while(!mConnectionList.empty()){
+    mConnectionList.back()->Shutdown();
+    mConnectionList.pop_back();
   }
   mConnectionListLock.Release();
 

--- a/src/components/hmi_message_handler/src/websocket_session.cc
+++ b/src/components/hmi_message_handler/src/websocket_session.cc
@@ -60,9 +60,11 @@ void WebsocketSession::Accept() {
 
 void WebsocketSession::Shutdown() {
   shutdown_ = true;
+  DCHECK(thread_delegate_);
   thread_delegate_->SetShutdown();
   thread_->join();
   delete thread_delegate_;
+  thread_delegate_ = NULL;
   threads::DeleteThread(thread_);
 }
 

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -286,11 +286,11 @@ class ApplicationManager {
 
   /**
    * @brief Checks if Application is subscribed for way points
-   * @param Application pointer
+   * @param Application reference
    * @return true if Application is subscribed for way points
    * otherwise false
    */
-  virtual bool IsAppSubscribedForWayPoints(ApplicationSharedPtr app) const = 0;
+  virtual bool IsAppSubscribedForWayPoints(Application& app) const = 0;
 
   /**
    * @brief Subscribe Application for way points

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -91,6 +91,7 @@ class RPCHandler;
 class Application;
 class StateControllerImpl;
 struct CommandParametersPermissions;
+struct ResetGlobalPropertiesResult;
 using policy::RPCParams;
 typedef std::vector<ApplicationSharedPtr> AppSharedPtrs;
 struct ApplicationsAppIdSorter {
@@ -468,6 +469,27 @@ class ApplicationManager {
   virtual bool IsStopping() const = 0;
 
   virtual void RemoveAppFromTTSGlobalPropertiesList(const uint32_t app_id) = 0;
+
+  /**
+   * @brief Resets application's global properties to default values
+   * @param container with global properties IDs to reset
+   * @param id of app which properties to reset
+   * @return struct with flags indicating success global properties reset
+   */
+  virtual ResetGlobalPropertiesResult ResetGlobalProperties(
+      const smart_objects::SmartObject& global_properties_ids,
+      const uint32_t app_id) = 0;
+
+  /**
+   * @brief Resets all application's global properties to default values
+   * returning struct that indicates which properties have been
+   * successfully reset.
+   * @param container with global properties to reset
+   * @param id of app which properties to reset
+   * @return struct with flags indicating global properties reset
+   */
+  virtual ResetGlobalPropertiesResult ResetAllApplicationGlobalProperties(
+      const uint32_t app_id) = 0;
 
   virtual mobile_apis::Result::eType SaveBinary(
       const std::vector<uint8_t>& binary_data,

--- a/src/components/include/test/application_manager/mock_app_extension.h
+++ b/src/components/include/test/application_manager/mock_app_extension.h
@@ -47,12 +47,17 @@ static unsigned MockAppExtensionUID = 123;
 class MockAppExtension : public application_manager::AppExtension {
  public:
   MockAppExtension() : AppExtension(MockAppExtensionUID) {}
-  MOCK_METHOD1(SaveResumptionData,
-               void(ns_smart_device_link::ns_smart_objects::SmartObject&
-                        resumption_data));
+  MOCK_METHOD1(
+      SaveResumptionData,
+      void(ns_smart_device_link::ns_smart_objects::SmartObject& resumption_data));
   MOCK_METHOD1(ProcessResumption,
                void(const ns_smart_device_link::ns_smart_objects::SmartObject&
-                        resumption_data));
+                        resumption_data,
+                    resumption::Subscriber subscriber));
+
+  MOCK_METHOD1(RevertResumption,
+               void(const ns_smart_device_link::ns_smart_objects::SmartObject&
+                        subscriptions));
 };
 
 }  // namespace application_manager_test

--- a/src/components/include/test/application_manager/mock_app_extension.h
+++ b/src/components/include/test/application_manager/mock_app_extension.h
@@ -47,10 +47,10 @@ static unsigned MockAppExtensionUID = 123;
 class MockAppExtension : public application_manager::AppExtension {
  public:
   MockAppExtension() : AppExtension(MockAppExtensionUID) {}
-  MOCK_METHOD1(
-      SaveResumptionData,
-      void(ns_smart_device_link::ns_smart_objects::SmartObject& resumption_data));
-  MOCK_METHOD1(ProcessResumption,
+  MOCK_METHOD1(SaveResumptionData,
+               void(ns_smart_device_link::ns_smart_objects::SmartObject&
+                        resumption_data));
+  MOCK_METHOD2(ProcessResumption,
                void(const ns_smart_device_link::ns_smart_objects::SmartObject&
                         resumption_data,
                     resumption::Subscriber subscriber));

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -255,7 +255,7 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                          mobile_apis::AudioStreamingState::eType audio_state,
                          mobile_apis::VideoStreamingState::eType video_state,
                          mobile_apis::SystemContext::eType system_context));
- 
+
   MOCK_METHOD2(SendAudioPassThroughNotification,
                void(uint32_t session_key, std::vector<uint8_t>& binary_data));
   MOCK_CONST_METHOD2(CanAppStream,
@@ -275,7 +275,7 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                bool(const hmi_apis::StructIdentifiers::eType struct_id,
                     const smart_objects::SmartObject& display_capabilities));
   MOCK_CONST_METHOD1(IsAppSubscribedForWayPoints,
-                     bool(application_manager::ApplicationSharedPtr));
+                     bool(application_manager::Application&));
   MOCK_METHOD1(SubscribeAppForWayPoints,
                void(application_manager::ApplicationSharedPtr));
   MOCK_METHOD1(UnsubscribeAppFromWayPoints,

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -255,7 +255,7 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                          mobile_apis::AudioStreamingState::eType audio_state,
                          mobile_apis::VideoStreamingState::eType video_state,
                          mobile_apis::SystemContext::eType system_context));
-
+ 
   MOCK_METHOD2(SendAudioPassThroughNotification,
                void(uint32_t session_key, std::vector<uint8_t>& binary_data));
   MOCK_CONST_METHOD2(CanAppStream,
@@ -311,6 +311,13 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD0(GetCommandFactory, application_manager::CommandFactory&());
   MOCK_CONST_METHOD0(get_current_audio_source, uint32_t());
   MOCK_METHOD1(set_current_audio_source, void(const uint32_t));
+  MOCK_METHOD1(
+      ResetAllApplicationGlobalProperties,
+      application_manager::ResetGlobalPropertiesResult(const uint32_t app_id));
+  MOCK_METHOD2(ResetGlobalProperties,
+               application_manager::ResetGlobalPropertiesResult(
+                   const smart_objects::SmartObject& global_properties,
+                   const uint32_t app_id));
 };
 
 }  // namespace application_manager_test


### PR DESCRIPTION
:exclamation:  **NOTE**  :exclamation:  :  **This PR should be merged BEFORE #2674 and #2740 as it is the basis for implementation of [Interior Vehicle Data resumption](https://github.com/smartdevicelink/sdl_evolution/issues/554) and [Button Subscription response from HMI](https://github.com/smartdevicelink/sdl_evolution/issues/568)**

Fixes #2486 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF test scripts provided in [feature/resumption_data_error_handling](https://github.com/smartdevicelink/sdl_atf_test_scripts/tree/feature/resumption_data_error_handling)

### HMI implementation
HMI implementation provided in https://github.com/smartdevicelink/sdl_hmi/pull/114

### Summary
Implemented logic of HMI erroneous responses handling during resumption process

### Tasks Remaining:
- [ ] [Update unit tests for commands]

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)