### PR TITLE
SDL crash during cleanup.

### DIFF
--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -336,6 +336,10 @@ void ResumeCtrlImpl::OnSuspend() {
 void ResumeCtrlImpl::OnIgnitionOff() {
   LOG4CXX_AUTO_TRACE(logger_);
   if (!application_manager_.IsLowVoltage()) {
+    if (!resumption_storage_) {
+      LOG4CXX_ERROR(logger_, "resumption_storage_ is not initialized");
+      return;
+    }
     resumption_storage_->IncrementIgnOffCount();
     resumption_storage_->ResetGlobalIgnOnCount();
     FinalPersistData();
@@ -572,6 +576,10 @@ void ResumeCtrlImpl::SaveDataOnTimer() {
 
 void ResumeCtrlImpl::FinalPersistData() {
   LOG4CXX_AUTO_TRACE(logger_);
+  if (!resumption_storage_) {
+    LOG4CXX_ERROR(logger_, "resumption_storage_ is not initialized");
+    return;
+  }
   StopSavePersistentDataTimer();
   SaveAllApplications();
   resumption_storage_->Persist();

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -335,11 +335,8 @@ void ResumeCtrlImpl::OnSuspend() {
 
 void ResumeCtrlImpl::OnIgnitionOff() {
   LOG4CXX_AUTO_TRACE(logger_);
+  DCHECK_OR_RETURN_VOID(resumption_storage_);
   if (!application_manager_.IsLowVoltage()) {
-    if (!resumption_storage_) {
-      LOG4CXX_ERROR(logger_, "resumption_storage_ is not initialized");
-      return;
-    }
     resumption_storage_->IncrementIgnOffCount();
     resumption_storage_->ResetGlobalIgnOnCount();
     FinalPersistData();
@@ -576,10 +573,7 @@ void ResumeCtrlImpl::SaveDataOnTimer() {
 
 void ResumeCtrlImpl::FinalPersistData() {
   LOG4CXX_AUTO_TRACE(logger_);
-  if (!resumption_storage_) {
-    LOG4CXX_ERROR(logger_, "resumption_storage_ is not initialized");
-    return;
-  }
+  DCHECK_OR_RETURN_VOID(resumption_storage_);
   StopSavePersistentDataTimer();
   SaveAllApplications();
   resumption_storage_->Persist();


### PR DESCRIPTION
Fixes #2428 #1829

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manually tested

### Summary
If resumption_storage_ in ResumeCtrlImpl is failed to initialize,
SDL will try to stop components and exit with error code.
At this time application manager tries to unregister all applications and
call ResumeCtrlImpl::OnIgnitionOff() where resumption_storage_ is used. As a result, a crash will occur.

As an example, if AppStorageFolder have no read/write access, resumption_storage_
fails to initialize.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)