### PR TITLE
Fix messages protocol version check

### DIFF
--- a/src/components/protocol_handler/include/protocol_handler/incoming_data_handler.h
+++ b/src/components/protocol_handler/include/protocol_handler/incoming_data_handler.h
@@ -67,7 +67,7 @@ class IncomingDataHandler {
    * \return list of complete, correct packets
    */
   ProtocolFramePtrList ProcessData(const RawMessage& tm_message,
-                                   RESULT_CODE* result,
+                                   RESULT_CODE& out_result,
                                    size_t* malformed_occurrence);
   /**
    * @brief Add connection for data handling and verification

--- a/src/components/protocol_handler/include/protocol_handler/protocol_packet.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_packet.h
@@ -103,12 +103,14 @@ class ProtocolPacket {
     void set_max_rpc_payload_size(const size_t max_payload_size);
     void set_max_audio_payload_size(const size_t max_payload_size);
     void set_max_video_payload_size(const size_t max_payload_size);
+    void set_max_protocol_version_supported(const uint16_t max_payload_size);
 
     size_t max_payload_size() const;
     size_t max_control_payload_size() const;
     size_t max_rpc_payload_size() const;
     size_t max_audio_payload_size() const;
     size_t max_video_payload_size() const;
+    uint16_t max_protocol_version_supported() const;
 
     size_t max_payload_size_by_service_type(const ServiceType type) const;
 
@@ -123,6 +125,7 @@ class ProtocolPacket {
     size_t max_rpc_payload_size_;
     size_t max_audio_payload_size_;
     size_t max_video_payload_size_;
+    uint16_t max_protocol_version_supported_;
   };
 
   /**

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -103,6 +103,8 @@ ProtocolHandlerImpl::ProtocolHandlerImpl(
       get_settings().maximum_audio_payload_size());
   protocol_header_validator_.set_max_video_payload_size(
       get_settings().maximum_video_payload_size());
+  protocol_header_validator_.set_max_protocol_version_supported(
+      get_settings().max_supported_protocol_version());
   incoming_data_handler_.set_validator(&protocol_header_validator_);
 
   const size_t& message_frequency_count =
@@ -957,17 +959,17 @@ void ProtocolHandlerImpl::OnTMMessageReceived(const RawMessagePtr tm_message) {
   size_t malformed_occurs = 0u;
   const ProtocolFramePtrList protocol_frames =
       incoming_data_handler_.ProcessData(
-          *tm_message, &result, &malformed_occurs);
-  LOG4CXX_DEBUG(logger_, "Proccessed " << protocol_frames.size() << " frames");
+          *tm_message, result, &malformed_occurs);
+  LOG4CXX_DEBUG(logger_, "Processed " << protocol_frames.size() << " frames");
   if (result != RESULT_OK) {
     if (result == RESULT_MALFORMED_OCCURS) {
       LOG4CXX_WARN(logger_,
                    "Malformed message occurs, connection id "
                        << connection_key);
       if (!get_settings().malformed_message_filtering()) {
-        LOG4CXX_DEBUG(logger_, "Malformed message filterign disabled");
+        LOG4CXX_DEBUG(logger_, "Malformed message filtering disabled");
         session_observer_.OnMalformedMessageCallback(connection_key);
-        // For tracking only malformed occurrence check outpute
+        // For tracking only malformed occurrence check output
       } else {
         if (malformed_occurs > 0) {
           TrackMalformedMessage(connection_key, malformed_occurs);

--- a/src/components/protocol_handler/src/protocol_packet.cc
+++ b/src/components/protocol_handler/src/protocol_packet.cc
@@ -137,7 +137,8 @@ ProtocolPacket::ProtocolHeaderValidator::ProtocolHeaderValidator()
     , max_control_payload_size_(0)
     , max_rpc_payload_size_(0)
     , max_audio_payload_size_(0)
-    , max_video_payload_size_(0) {}
+    , max_video_payload_size_(0)
+    , max_protocol_version_supported_(PROTOCOL_VERSION_MAX) {}
 
 void ProtocolPacket::ProtocolHeaderValidator::set_max_payload_size(
     const size_t max_payload_size) {
@@ -173,6 +174,15 @@ void ProtocolPacket::ProtocolHeaderValidator::set_max_video_payload_size(
   max_video_payload_size_ = max_payload_size;
 }
 
+void ProtocolPacket::ProtocolHeaderValidator::
+    set_max_protocol_version_supported(
+        const uint16_t max_protocol_version_supported) {
+  LOG4CXX_DEBUG(logger_,
+                "New maximum protocol version supported is "
+                    << max_protocol_version_supported);
+  max_protocol_version_supported_ = max_protocol_version_supported;
+}
+
 size_t ProtocolPacket::ProtocolHeaderValidator::max_payload_size() const {
   return max_payload_size_;
 }
@@ -192,6 +202,12 @@ size_t ProtocolPacket::ProtocolHeaderValidator::max_audio_payload_size() const {
 
 size_t ProtocolPacket::ProtocolHeaderValidator::max_video_payload_size() const {
   return max_video_payload_size_;
+}
+
+uint16_t
+ProtocolPacket::ProtocolHeaderValidator::max_protocol_version_supported()
+    const {
+  return max_protocol_version_supported_;
 }
 
 size_t
@@ -233,6 +249,9 @@ RESULT_CODE ProtocolPacket::ProtocolHeaderValidator::validate(
   // on used protocol version and service type
   size_t payload_size = MAXIMUM_FRAME_DATA_V2_SIZE;
   // Protocol version shall be from 1 to 4
+  if (max_protocol_version_supported_ < header.version) {
+    return RESULT_FAIL;
+  }
   switch (header.version) {
     case PROTOCOL_VERSION_1:
     case PROTOCOL_VERSION_2:

--- a/src/components/protocol_handler/test/incoming_data_handler_test.cc
+++ b/src/components/protocol_handler/test/incoming_data_handler_test.cc
@@ -69,7 +69,7 @@ class IncomingDataHandlerTest : public ::testing::Test {
                    const uint8_t* const data,
                    const uint32_t data_size) {
     actual_frames = data_handler.ProcessData(
-        RawMessage(uid, 0, data, data_size), &result_code, &malformed_occurs);
+        RawMessage(uid, 0, data, data_size), result_code, &malformed_occurs);
   }
 
   void AppendPacketToTMData(const ProtocolPacket& packet) {
@@ -118,7 +118,7 @@ TEST_F(IncomingDataHandlerTest, NullData) {
 TEST_F(IncomingDataHandlerTest, DataForUnknownConnection) {
   size_t malformed_count = 0;
   actual_frames = data_handler.ProcessData(
-      RawMessage(uid_unknown, 0, NULL, 0), &result_code, &malformed_count);
+      RawMessage(uid_unknown, 0, NULL, 0), result_code, &malformed_count);
   EXPECT_EQ(RESULT_FAIL, result_code);
   EXPECT_EQ(malformed_count, 0u);
   EXPECT_TRUE(actual_frames.empty());
@@ -126,7 +126,7 @@ TEST_F(IncomingDataHandlerTest, DataForUnknownConnection) {
   AppendPacketToTMData(ProtocolPacket());
   actual_frames = data_handler.ProcessData(
       RawMessage(uid_unknown, 0, tm_data.data(), tm_data.size()),
-      &result_code,
+      result_code,
       &malformed_count);
   EXPECT_EQ(RESULT_FAIL, result_code);
   EXPECT_EQ(malformed_count, 0u);
@@ -1034,6 +1034,24 @@ TEST_F(
   EXPECT_EQ(RESULT_MALFORMED_OCCURS, result_code);
   EXPECT_EQ(1u, malformed_occurs);
   EXPECT_EQ(1u, actual_frames.size());
+}
+
+TEST_F(IncomingDataHandlerTest,
+       ProcessData_ProtocolVersionBiggerThanSupported_MalformedOccurs) {
+  header_validator.set_max_protocol_version_supported(PROTOCOL_VERSION_2);
+  const ProtocolPacket packet(uid1,
+                              PROTOCOL_VERSION_3,
+                              PROTECTION_OFF,
+                              FRAME_TYPE_CONTROL,
+                              kControl,
+                              FRAME_DATA_SINGLE,
+                              some_session_id,
+                              0u,
+                              some_message_id,
+                              NULL);
+  const auto raw_message_ptr = packet.serializePacket();
+  data_handler.ProcessData(*raw_message_ptr, result_code, &malformed_occurs);
+  EXPECT_EQ(RESULT_CODE::RESULT_MALFORMED_OCCURS, result_code);
 }
 
 // TODO(EZamakhov): add tests for handling 2+ connection data

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -174,6 +174,8 @@ class ProtocolHandlerImplTest : public ::testing::Test {
         .WillByDefault(Return(malformd_max_messages));
     ON_CALL(protocol_handler_settings_mock, multiframe_waiting_timeout())
         .WillByDefault(Return(multiframe_waiting_timeout));
+    ON_CALL(protocol_handler_settings_mock, max_supported_protocol_version())
+        .WillByDefault(Return(PROTOCOL_VERSION_MAX));
 #ifdef ENABLE_SECURITY
     ON_CALL(protocol_handler_settings_mock, force_protected_service())
         .WillByDefault(ReturnRefOfCopy(force_protected_services));


### PR DESCRIPTION
Fixes [#2430](https://github.com/SmartDeviceLink/sdl_core/issues/2430)

This PR is ready for review.

### Risk
This PR makes [no] API changes.

### Testing Plan
ATF script provided at PR

### Summary
The protocol version checking was absent. This commit added all the necessary conditions to solve this problem.(SDL  disconnect connection with app if its value of protocol version is more then the value of protocol version in ini file). The name of ProcessData method parameter 'result' was changed
to 'out_result' for more clarity.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)