### PR TITLE
4.1LTS Patch: Add Policy Table Filtering

### DIFF
--- a/src/components/policy/include/policy/policy_table/enums.h
+++ b/src/components/policy/include/policy/policy_table/enums.h
@@ -109,330 +109,330 @@ bool EnumFromJsonString(const std::string& literal, RequestType* result);
   * Enumeration linking function names with function IDs in AppLink protocol.
   *Assumes enumeration starts at value 0.
   */
- enum FunctionID {
-   /**
-    * @brief RESERVED.
-    */
-   RESERVED = 0,
+enum FunctionID {
+  /**
+   * @brief RESERVED.
+   */
+  RESERVED = 0,
 
-   /**
-    * @brief RegisterAppInterfaceID.
-    */
-   RegisterAppInterfaceID = 1,
+  /**
+   * @brief RegisterAppInterfaceID.
+   */
+  RegisterAppInterfaceID = 1,
 
-   /**
-    * @brief UnregisterAppInterfaceID.
-    */
-   UnregisterAppInterfaceID = 2,
+  /**
+   * @brief UnregisterAppInterfaceID.
+   */
+  UnregisterAppInterfaceID = 2,
 
-   /**
-    * @brief SetGlobalPropertiesID.
-    */
-   SetGlobalPropertiesID = 3,
+  /**
+   * @brief SetGlobalPropertiesID.
+   */
+  SetGlobalPropertiesID = 3,
 
-   /**
-    * @brief ResetGlobalPropertiesID.
-    */
-   ResetGlobalPropertiesID = 4,
+  /**
+   * @brief ResetGlobalPropertiesID.
+   */
+  ResetGlobalPropertiesID = 4,
 
-   /**
-    * @brief AddCommandID.
-    */
-   AddCommandID = 5,
+  /**
+   * @brief AddCommandID.
+   */
+  AddCommandID = 5,
 
-   /**
-    * @brief DeleteCommandID.
-    */
-   DeleteCommandID = 6,
+  /**
+   * @brief DeleteCommandID.
+   */
+  DeleteCommandID = 6,
 
-   /**
-    * @brief AddSubMenuID.
-    */
-   AddSubMenuID = 7,
+  /**
+   * @brief AddSubMenuID.
+   */
+  AddSubMenuID = 7,
 
-   /**
-    * @brief DeleteSubMenuID.
-    */
-   DeleteSubMenuID = 8,
+  /**
+   * @brief DeleteSubMenuID.
+   */
+  DeleteSubMenuID = 8,
 
-   /**
-    * @brief CreateInteractionChoiceSetID.
-    */
-   CreateInteractionChoiceSetID = 9,
+  /**
+   * @brief CreateInteractionChoiceSetID.
+   */
+  CreateInteractionChoiceSetID = 9,
 
-   /**
-    * @brief PerformInteractionID.
-    */
-   PerformInteractionID = 10,
+  /**
+   * @brief PerformInteractionID.
+   */
+  PerformInteractionID = 10,
 
-   /**
-    * @brief DeleteInteractionChoiceSetID.
-    */
-   DeleteInteractionChoiceSetID = 11,
+  /**
+   * @brief DeleteInteractionChoiceSetID.
+   */
+  DeleteInteractionChoiceSetID = 11,
 
-   /**
-    * @brief AlertID.
-    */
-   AlertID = 12,
+  /**
+   * @brief AlertID.
+   */
+  AlertID = 12,
 
-   /**
-    * @brief ShowID.
-    */
-   ShowID = 13,
+  /**
+   * @brief ShowID.
+   */
+  ShowID = 13,
 
-   /**
-    * @brief SpeakID.
-    */
-   SpeakID = 14,
+  /**
+   * @brief SpeakID.
+   */
+  SpeakID = 14,
 
-   /**
-    * @brief SetMediaClockTimerID.
-    */
-   SetMediaClockTimerID = 15,
+  /**
+   * @brief SetMediaClockTimerID.
+   */
+  SetMediaClockTimerID = 15,
 
-   /**
-    * @brief PerformAudioPassThruID.
-    */
-   PerformAudioPassThruID = 16,
+  /**
+   * @brief PerformAudioPassThruID.
+   */
+  PerformAudioPassThruID = 16,
 
-   /**
-    * @brief EndAudioPassThruID.
-    */
-   EndAudioPassThruID = 17,
+  /**
+   * @brief EndAudioPassThruID.
+   */
+  EndAudioPassThruID = 17,
 
-   /**
-    * @brief SubscribeButtonID.
-    */
-   SubscribeButtonID = 18,
+  /**
+   * @brief SubscribeButtonID.
+   */
+  SubscribeButtonID = 18,
 
-   /**
-    * @brief UnsubscribeButtonID.
-    */
-   UnsubscribeButtonID = 19,
+  /**
+   * @brief UnsubscribeButtonID.
+   */
+  UnsubscribeButtonID = 19,
 
-   /**
-    * @brief SubscribeVehicleDataID.
-    */
-   SubscribeVehicleDataID = 20,
+  /**
+   * @brief SubscribeVehicleDataID.
+   */
+  SubscribeVehicleDataID = 20,
 
-   /**
-    * @brief UnsubscribeVehicleDataID.
-    */
-   UnsubscribeVehicleDataID = 21,
+  /**
+   * @brief UnsubscribeVehicleDataID.
+   */
+  UnsubscribeVehicleDataID = 21,
 
-   /**
-    * @brief GetVehicleDataID.
-    */
-   GetVehicleDataID = 22,
+  /**
+   * @brief GetVehicleDataID.
+   */
+  GetVehicleDataID = 22,
 
-   /**
-    * @brief ReadDIDID.
-    */
-   ReadDIDID = 23,
+  /**
+   * @brief ReadDIDID.
+   */
+  ReadDIDID = 23,
 
-   /**
-    * @brief GetDTCsID.
-    */
-   GetDTCsID = 24,
+  /**
+   * @brief GetDTCsID.
+   */
+  GetDTCsID = 24,
 
-   /**
-    * @brief ScrollableMessageID.
-    */
-   ScrollableMessageID = 25,
+  /**
+   * @brief ScrollableMessageID.
+   */
+  ScrollableMessageID = 25,
 
-   /**
-    * @brief SliderID.
-    */
-   SliderID = 26,
+  /**
+   * @brief SliderID.
+   */
+  SliderID = 26,
 
-   /**
-    * @brief ShowConstantTBTID.
-    */
-   ShowConstantTBTID = 27,
+  /**
+   * @brief ShowConstantTBTID.
+   */
+  ShowConstantTBTID = 27,
 
-   /**
-    * @brief AlertManeuverID.
-    */
-   AlertManeuverID = 28,
+  /**
+   * @brief AlertManeuverID.
+   */
+  AlertManeuverID = 28,
 
-   /**
-    * @brief UpdateTurnListID.
-    */
-   UpdateTurnListID = 29,
+  /**
+   * @brief UpdateTurnListID.
+   */
+  UpdateTurnListID = 29,
 
-   /**
-    * @brief ChangeRegistrationID.
-    */
-   ChangeRegistrationID = 30,
+  /**
+   * @brief ChangeRegistrationID.
+   */
+  ChangeRegistrationID = 30,
 
-   /**
-    * @brief GenericResponseID.
-    */
-   GenericResponseID = 31,
+  /**
+   * @brief GenericResponseID.
+   */
+  GenericResponseID = 31,
 
-   /**
-    * @brief PutFileID.
-    */
-   PutFileID = 32,
+  /**
+   * @brief PutFileID.
+   */
+  PutFileID = 32,
 
-   /**
-    * @brief DeleteFileID.
-    */
-   DeleteFileID = 33,
+  /**
+   * @brief DeleteFileID.
+   */
+  DeleteFileID = 33,
 
-   /**
-    * @brief ListFilesID.
-    */
-   ListFilesID = 34,
+  /**
+   * @brief ListFilesID.
+   */
+  ListFilesID = 34,
 
-   /**
-    * @brief SetAppIconID.
-    */
-   SetAppIconID = 35,
+  /**
+   * @brief SetAppIconID.
+   */
+  SetAppIconID = 35,
 
-   /**
-    * @brief SetDisplayLayoutID.
-    */
-   SetDisplayLayoutID = 36,
+  /**
+   * @brief SetDisplayLayoutID.
+   */
+  SetDisplayLayoutID = 36,
 
-   /**
-    * @brief DiagnosticMessageID.
-    */
-   DiagnosticMessageID = 37,
+  /**
+   * @brief DiagnosticMessageID.
+   */
+  DiagnosticMessageID = 37,
 
-   /**
-    * @brief SystemRequestID.
-    */
-   SystemRequestID = 38,
+  /**
+   * @brief SystemRequestID.
+   */
+  SystemRequestID = 38,
 
-   /**
-    * @brief SendLocationID.
-    */
-   SendLocationID = 39,
+  /**
+   * @brief SendLocationID.
+   */
+  SendLocationID = 39,
 
-   /**
-    * @brief DialNumberID.
-    */
-   DialNumberID = 40,
+  /**
+   * @brief DialNumberID.
+   */
+  DialNumberID = 40,
 
-   /**
-    * @brief GetWayPointsID.
-    */
-   GetWayPointsID = 45,
+  /**
+   * @brief GetWayPointsID.
+   */
+  GetWayPointsID = 45,
 
-   /**
-    * @brief SubscribeWayPointsID.
-    */
-   SubscribeWayPointsID = 46,
+  /**
+   * @brief SubscribeWayPointsID.
+   */
+  SubscribeWayPointsID = 46,
 
-   /**
-    * @brief UnsubscribeWayPointsID.
-    */
-   UnsubscribeWayPointsID = 47,
+  /**
+   * @brief UnsubscribeWayPointsID.
+   */
+  UnsubscribeWayPointsID = 47,
 
-   /**
-    * @brief OnHMIStatusID.
-    */
-   OnHMIStatusID = 32768,
+  /**
+   * @brief OnHMIStatusID.
+   */
+  OnHMIStatusID = 32768,
 
-   /**
-    * @brief OnAppInterfaceUnregisteredID.
-    */
-   OnAppInterfaceUnregisteredID = 32769,
+  /**
+   * @brief OnAppInterfaceUnregisteredID.
+   */
+  OnAppInterfaceUnregisteredID = 32769,
 
-   /**
-    * @brief OnButtonEventID.
-    */
-   OnButtonEventID = 32770,
+  /**
+   * @brief OnButtonEventID.
+   */
+  OnButtonEventID = 32770,
 
-   /**
-    * @brief OnButtonPressID.
-    */
-   OnButtonPressID = 32771,
+  /**
+   * @brief OnButtonPressID.
+   */
+  OnButtonPressID = 32771,
 
-   /**
-    * @brief OnVehicleDataID.
-    */
-   OnVehicleDataID = 32772,
+  /**
+   * @brief OnVehicleDataID.
+   */
+  OnVehicleDataID = 32772,
 
-   /**
-    * @brief OnCommandID.
-    */
-   OnCommandID = 32773,
+  /**
+   * @brief OnCommandID.
+   */
+  OnCommandID = 32773,
 
-   /**
-    * @brief OnTBTClientStateID.
-    */
-   OnTBTClientStateID = 32774,
+  /**
+   * @brief OnTBTClientStateID.
+   */
+  OnTBTClientStateID = 32774,
 
-   /**
-    * @brief OnDriverDistractionID.
-    */
-   OnDriverDistractionID = 32775,
+  /**
+   * @brief OnDriverDistractionID.
+   */
+  OnDriverDistractionID = 32775,
 
-   /**
-    * @brief OnPermissionsChangeID.
-    */
-   OnPermissionsChangeID = 32776,
+  /**
+   * @brief OnPermissionsChangeID.
+   */
+  OnPermissionsChangeID = 32776,
 
-   /**
-    * @brief OnAudioPassThruID.
-    */
-   OnAudioPassThruID = 32777,
+  /**
+   * @brief OnAudioPassThruID.
+   */
+  OnAudioPassThruID = 32777,
 
-   /**
-    * @brief OnLanguageChangeID.
-    */
-   OnLanguageChangeID = 32778,
+  /**
+   * @brief OnLanguageChangeID.
+   */
+  OnLanguageChangeID = 32778,
 
-   /**
-    * @brief OnKeyboardInputID.
-    */
-   OnKeyboardInputID = 32779,
+  /**
+   * @brief OnKeyboardInputID.
+   */
+  OnKeyboardInputID = 32779,
 
-   /**
-    * @brief OnTouchEventID.
-    */
-   OnTouchEventID = 32780,
+  /**
+   * @brief OnTouchEventID.
+   */
+  OnTouchEventID = 32780,
 
-   /**
-    * @brief OnSystemRequestID.
-    */
-   OnSystemRequestID = 32781,
+  /**
+   * @brief OnSystemRequestID.
+   */
+  OnSystemRequestID = 32781,
 
-   /**
-    * @brief OnHashChangeID.
-    */
-   OnHashChangeID = 32782,
+  /**
+   * @brief OnHashChangeID.
+   */
+  OnHashChangeID = 32782,
 
-   /**
-    * @brief OnWayPointChangeID.
-    */
-   OnWayPointChangeID = 32784,
+  /**
+   * @brief OnWayPointChangeID.
+   */
+  OnWayPointChangeID = 32784,
 
-   /**
-    * @brief EncodedSyncPDataID.
-    */
-   EncodedSyncPDataID = 65536,
+  /**
+   * @brief EncodedSyncPDataID.
+   */
+  EncodedSyncPDataID = 65536,
 
-   /**
-    * @brief SyncPDataID.
-    */
-   SyncPDataID = 65537,
+  /**
+   * @brief SyncPDataID.
+   */
+  SyncPDataID = 65537,
 
-   /**
-    * @brief OnEncodedSyncPDataID.
-    */
-   OnEncodedSyncPDataID = 98304,
+  /**
+   * @brief OnEncodedSyncPDataID.
+   */
+  OnEncodedSyncPDataID = 98304,
 
-   /**
-    * @brief OnSyncPDataID.
-    */
-   OnSyncPDataID = 98305
- };
- bool IsValidEnum(FunctionID val);
- const char* EnumToJsonString(FunctionID val);
- bool EnumFromJsonString(const std::string& literal, FunctionID* result);
+  /**
+   * @brief OnSyncPDataID.
+   */
+  OnSyncPDataID = 98305
+};
+bool IsValidEnum(FunctionID val);
+const char* EnumToJsonString(FunctionID val);
+bool EnumFromJsonString(const std::string& literal, FunctionID* result);
 
 extern const std::string kDefaultApp;
 extern const std::string kPreDataConsentApp;

--- a/src/components/policy/include/policy/policy_table/enums.h
+++ b/src/components/policy/include/policy/policy_table/enums.h
@@ -103,6 +103,337 @@ bool IsValidEnum(RequestType val);
 const char* EnumToJsonString(RequestType val);
 bool EnumFromJsonString(const std::string& literal, RequestType* result);
 
+/**
+  * @brief Enumeration FunctionID.
+  *
+  * Enumeration linking function names with function IDs in AppLink protocol.
+  *Assumes enumeration starts at value 0.
+  */
+ enum FunctionID {
+   /**
+    * @brief RESERVED.
+    */
+   RESERVED = 0,
+
+   /**
+    * @brief RegisterAppInterfaceID.
+    */
+   RegisterAppInterfaceID = 1,
+
+   /**
+    * @brief UnregisterAppInterfaceID.
+    */
+   UnregisterAppInterfaceID = 2,
+
+   /**
+    * @brief SetGlobalPropertiesID.
+    */
+   SetGlobalPropertiesID = 3,
+
+   /**
+    * @brief ResetGlobalPropertiesID.
+    */
+   ResetGlobalPropertiesID = 4,
+
+   /**
+    * @brief AddCommandID.
+    */
+   AddCommandID = 5,
+
+   /**
+    * @brief DeleteCommandID.
+    */
+   DeleteCommandID = 6,
+
+   /**
+    * @brief AddSubMenuID.
+    */
+   AddSubMenuID = 7,
+
+   /**
+    * @brief DeleteSubMenuID.
+    */
+   DeleteSubMenuID = 8,
+
+   /**
+    * @brief CreateInteractionChoiceSetID.
+    */
+   CreateInteractionChoiceSetID = 9,
+
+   /**
+    * @brief PerformInteractionID.
+    */
+   PerformInteractionID = 10,
+
+   /**
+    * @brief DeleteInteractionChoiceSetID.
+    */
+   DeleteInteractionChoiceSetID = 11,
+
+   /**
+    * @brief AlertID.
+    */
+   AlertID = 12,
+
+   /**
+    * @brief ShowID.
+    */
+   ShowID = 13,
+
+   /**
+    * @brief SpeakID.
+    */
+   SpeakID = 14,
+
+   /**
+    * @brief SetMediaClockTimerID.
+    */
+   SetMediaClockTimerID = 15,
+
+   /**
+    * @brief PerformAudioPassThruID.
+    */
+   PerformAudioPassThruID = 16,
+
+   /**
+    * @brief EndAudioPassThruID.
+    */
+   EndAudioPassThruID = 17,
+
+   /**
+    * @brief SubscribeButtonID.
+    */
+   SubscribeButtonID = 18,
+
+   /**
+    * @brief UnsubscribeButtonID.
+    */
+   UnsubscribeButtonID = 19,
+
+   /**
+    * @brief SubscribeVehicleDataID.
+    */
+   SubscribeVehicleDataID = 20,
+
+   /**
+    * @brief UnsubscribeVehicleDataID.
+    */
+   UnsubscribeVehicleDataID = 21,
+
+   /**
+    * @brief GetVehicleDataID.
+    */
+   GetVehicleDataID = 22,
+
+   /**
+    * @brief ReadDIDID.
+    */
+   ReadDIDID = 23,
+
+   /**
+    * @brief GetDTCsID.
+    */
+   GetDTCsID = 24,
+
+   /**
+    * @brief ScrollableMessageID.
+    */
+   ScrollableMessageID = 25,
+
+   /**
+    * @brief SliderID.
+    */
+   SliderID = 26,
+
+   /**
+    * @brief ShowConstantTBTID.
+    */
+   ShowConstantTBTID = 27,
+
+   /**
+    * @brief AlertManeuverID.
+    */
+   AlertManeuverID = 28,
+
+   /**
+    * @brief UpdateTurnListID.
+    */
+   UpdateTurnListID = 29,
+
+   /**
+    * @brief ChangeRegistrationID.
+    */
+   ChangeRegistrationID = 30,
+
+   /**
+    * @brief GenericResponseID.
+    */
+   GenericResponseID = 31,
+
+   /**
+    * @brief PutFileID.
+    */
+   PutFileID = 32,
+
+   /**
+    * @brief DeleteFileID.
+    */
+   DeleteFileID = 33,
+
+   /**
+    * @brief ListFilesID.
+    */
+   ListFilesID = 34,
+
+   /**
+    * @brief SetAppIconID.
+    */
+   SetAppIconID = 35,
+
+   /**
+    * @brief SetDisplayLayoutID.
+    */
+   SetDisplayLayoutID = 36,
+
+   /**
+    * @brief DiagnosticMessageID.
+    */
+   DiagnosticMessageID = 37,
+
+   /**
+    * @brief SystemRequestID.
+    */
+   SystemRequestID = 38,
+
+   /**
+    * @brief SendLocationID.
+    */
+   SendLocationID = 39,
+
+   /**
+    * @brief DialNumberID.
+    */
+   DialNumberID = 40,
+
+   /**
+    * @brief GetWayPointsID.
+    */
+   GetWayPointsID = 45,
+
+   /**
+    * @brief SubscribeWayPointsID.
+    */
+   SubscribeWayPointsID = 46,
+
+   /**
+    * @brief UnsubscribeWayPointsID.
+    */
+   UnsubscribeWayPointsID = 47,
+
+   /**
+    * @brief OnHMIStatusID.
+    */
+   OnHMIStatusID = 32768,
+
+   /**
+    * @brief OnAppInterfaceUnregisteredID.
+    */
+   OnAppInterfaceUnregisteredID = 32769,
+
+   /**
+    * @brief OnButtonEventID.
+    */
+   OnButtonEventID = 32770,
+
+   /**
+    * @brief OnButtonPressID.
+    */
+   OnButtonPressID = 32771,
+
+   /**
+    * @brief OnVehicleDataID.
+    */
+   OnVehicleDataID = 32772,
+
+   /**
+    * @brief OnCommandID.
+    */
+   OnCommandID = 32773,
+
+   /**
+    * @brief OnTBTClientStateID.
+    */
+   OnTBTClientStateID = 32774,
+
+   /**
+    * @brief OnDriverDistractionID.
+    */
+   OnDriverDistractionID = 32775,
+
+   /**
+    * @brief OnPermissionsChangeID.
+    */
+   OnPermissionsChangeID = 32776,
+
+   /**
+    * @brief OnAudioPassThruID.
+    */
+   OnAudioPassThruID = 32777,
+
+   /**
+    * @brief OnLanguageChangeID.
+    */
+   OnLanguageChangeID = 32778,
+
+   /**
+    * @brief OnKeyboardInputID.
+    */
+   OnKeyboardInputID = 32779,
+
+   /**
+    * @brief OnTouchEventID.
+    */
+   OnTouchEventID = 32780,
+
+   /**
+    * @brief OnSystemRequestID.
+    */
+   OnSystemRequestID = 32781,
+
+   /**
+    * @brief OnHashChangeID.
+    */
+   OnHashChangeID = 32782,
+
+   /**
+    * @brief OnWayPointChangeID.
+    */
+   OnWayPointChangeID = 32784,
+
+   /**
+    * @brief EncodedSyncPDataID.
+    */
+   EncodedSyncPDataID = 65536,
+
+   /**
+    * @brief SyncPDataID.
+    */
+   SyncPDataID = 65537,
+
+   /**
+    * @brief OnEncodedSyncPDataID.
+    */
+   OnEncodedSyncPDataID = 98304,
+
+   /**
+    * @brief OnSyncPDataID.
+    */
+   OnSyncPDataID = 98305
+ };
+ bool IsValidEnum(FunctionID val);
+ const char* EnumToJsonString(FunctionID val);
+ bool EnumFromJsonString(const std::string& literal, FunctionID* result);
+
 extern const std::string kDefaultApp;
 extern const std::string kPreDataConsentApp;
 extern const std::string kDeviceApp;

--- a/src/components/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy_manager_impl.cc
@@ -221,6 +221,10 @@ void FilterInvalidApplicationParameters(
   } else {
     app_params.RequestType->swap(valid_request_types);
   }
+  // Filter priority
+  if (!app_params.priority.is_valid()) {
+    app_params.priority = policy_table::Priority();
+  }
 }
 
 /**

--- a/src/components/policy/src/policy_table/enums.cc
+++ b/src/components/policy/src/policy_table/enums.cc
@@ -569,6 +569,329 @@ bool EnumFromJsonString(const std::string& literal, RequestType* result) {
   }
 }
 
+bool EnumFromJsonString(const std::string& literal, FunctionID* result) {
+   if ("RESERVE" == literal) {
+     *result = RESERVED;
+     return true;
+   }
+
+   if ("RegisterAppInterface" == literal) {
+     *result = RegisterAppInterfaceID;
+     return true;
+   }
+
+   if ("UnregisterAppInterface" == literal) {
+     *result = UnregisterAppInterfaceID;
+     return true;
+   }
+
+   if ("SetGlobalProperties" == literal) {
+     *result = SetGlobalPropertiesID;
+     return true;
+   }
+
+   if ("ResetGlobalProperties" == literal) {
+     *result = ResetGlobalPropertiesID;
+     return true;
+   }
+
+   if ("AddCommand" == literal) {
+     *result = AddCommandID;
+     return true;
+   }
+
+   if ("DeleteCommand" == literal) {
+     *result = DeleteCommandID;
+     return true;
+   }
+
+   if ("AddSubMenu" == literal) {
+     *result = AddSubMenuID;
+     return true;
+   }
+
+   if ("DeleteSubMenu" == literal) {
+     *result = DeleteSubMenuID;
+     return true;
+   }
+
+   if ("CreateInteractionChoiceSet" == literal) {
+     *result = CreateInteractionChoiceSetID;
+     return true;
+   }
+
+   if ("PerformInteraction" == literal) {
+     *result = PerformInteractionID;
+     return true;
+   }
+
+   if ("DeleteInteractionChoiceSet" == literal) {
+     *result = DeleteInteractionChoiceSetID;
+     return true;
+   }
+
+   if ("Alert" == literal) {
+     *result = AlertID;
+     return true;
+   }
+
+   if ("Show" == literal) {
+     *result = ShowID;
+     return true;
+   }
+
+   if ("Speak" == literal) {
+     *result = SpeakID;
+     return true;
+   }
+
+   if ("SetMediaClockTimer" == literal) {
+     *result = SetMediaClockTimerID;
+     return true;
+   }
+
+   if ("PerformAudioPassThru" == literal) {
+     *result = PerformAudioPassThruID;
+     return true;
+   }
+
+   if ("EndAudioPassThru" == literal) {
+     *result = EndAudioPassThruID;
+     return true;
+   }
+
+   if ("SubscribeButton" == literal) {
+     *result = SubscribeButtonID;
+     return true;
+   }
+
+   if ("UnsubscribeButton" == literal) {
+     *result = UnsubscribeButtonID;
+     return true;
+   }
+
+   if ("SubscribeVehicleData" == literal) {
+     *result = SubscribeVehicleDataID;
+     return true;
+   }
+
+   if ("UnsubscribeVehicleData" == literal) {
+     *result = UnsubscribeVehicleDataID;
+     return true;
+   }
+
+   if ("GetVehicleData" == literal) {
+     *result = GetVehicleDataID;
+     return true;
+   }
+
+   if ("ReadD" == literal) {
+     *result = ReadDIDID;
+     return true;
+   }
+
+   if ("GetDTCs" == literal) {
+     *result = GetDTCsID;
+     return true;
+   }
+
+   if ("ScrollableMessage" == literal) {
+     *result = ScrollableMessageID;
+     return true;
+   }
+
+   if ("Slider" == literal) {
+     *result = SliderID;
+     return true;
+   }
+
+   if ("ShowConstantTBT" == literal) {
+     *result = ShowConstantTBTID;
+     return true;
+   }
+
+   if ("AlertManeuver" == literal) {
+     *result = AlertManeuverID;
+     return true;
+   }
+
+   if ("UpdateTurnList" == literal) {
+     *result = UpdateTurnListID;
+     return true;
+   }
+
+   if ("ChangeRegistration" == literal) {
+     *result = ChangeRegistrationID;
+     return true;
+   }
+
+   if ("GenericResponse" == literal) {
+     *result = GenericResponseID;
+     return true;
+   }
+
+   if ("PutFile" == literal) {
+     *result = PutFileID;
+     return true;
+   }
+
+   if ("DeleteFile" == literal) {
+     *result = DeleteFileID;
+     return true;
+   }
+
+   if ("ListFiles" == literal) {
+     *result = ListFilesID;
+     return true;
+   }
+
+   if ("SetAppIcon" == literal) {
+     *result = SetAppIconID;
+     return true;
+   }
+
+   if ("SetDisplayLayout" == literal) {
+     *result = SetDisplayLayoutID;
+     return true;
+   }
+
+   if ("DiagnosticMessage" == literal) {
+     *result = DiagnosticMessageID;
+     return true;
+   }
+
+   if ("SystemRequest" == literal) {
+     *result = SystemRequestID;
+     return true;
+   }
+
+   if ("SendLocation" == literal) {
+     *result = SendLocationID;
+     return true;
+   }
+
+   if ("DialNumber" == literal) {
+     *result = DialNumberID;
+     return true;
+   }
+
+   if ("GetWayPoints" == literal) {
+     *result = GetWayPointsID;
+     return true;
+   }
+
+   if ("SubscribeWayPoints" == literal) {
+     *result = SubscribeWayPointsID;
+     return true;
+   }
+
+   if ("UnsubscribeWayPoints" == literal) {
+     *result = UnsubscribeWayPointsID;
+     return true;
+   }
+
+   if ("OnHMIStatus" == literal) {
+     *result = OnHMIStatusID;
+     return true;
+   }
+
+   if ("OnAppInterfaceUnregistered" == literal) {
+     *result = OnAppInterfaceUnregisteredID;
+     return true;
+   }
+
+   if ("OnButtonEvent" == literal) {
+     *result = OnButtonEventID;
+     return true;
+   }
+
+   if ("OnButtonPress" == literal) {
+     *result = OnButtonPressID;
+     return true;
+   }
+
+   if ("OnVehicleData" == literal) {
+     *result = OnVehicleDataID;
+     return true;
+   }
+
+   if ("OnCommand" == literal) {
+     *result = OnCommandID;
+     return true;
+   }
+
+   if ("OnTBTClientState" == literal) {
+     *result = OnTBTClientStateID;
+     return true;
+   }
+
+   if ("OnDriverDistraction" == literal) {
+     *result = OnDriverDistractionID;
+     return true;
+   }
+
+   if ("OnPermissionsChange" == literal) {
+     *result = OnPermissionsChangeID;
+     return true;
+   }
+
+   if ("OnAudioPassThru" == literal) {
+     *result = OnAudioPassThruID;
+     return true;
+   }
+
+   if ("OnLanguageChange" == literal) {
+     *result = OnLanguageChangeID;
+     return true;
+   }
+
+   if ("OnKeyboardInput" == literal) {
+     *result = OnKeyboardInputID;
+     return true;
+   }
+
+   if ("OnTouchEvent" == literal) {
+     *result = OnTouchEventID;
+     return true;
+   }
+
+   if ("OnSystemRequest" == literal) {
+     *result = OnSystemRequestID;
+     return true;
+   }
+
+   if ("OnHashChange" == literal) {
+     *result = OnHashChangeID;
+     return true;
+   }
+
+   if ("OnWayPointChange" == literal) {
+     *result = OnWayPointChangeID;
+     return true;
+   }
+
+   if ("EncodedSyncPData" == literal) {
+     *result = EncodedSyncPDataID;
+     return true;
+   }
+
+   if ("SyncPData" == literal) {
+     *result = SyncPDataID;
+     return true;
+   }
+
+   if ("OnEncodedSyncPData" == literal) {
+     *result = OnEncodedSyncPDataID;
+     return true;
+   }
+
+   if ("OnSyncPData" == literal) {
+     *result = OnSyncPDataID;
+     return true;
+   }
+   return false;
+ };
+
 const std::string kDefaultApp = "default";
 const std::string kPreDataConsentApp = "pre_DataConsent";
 const std::string kDeviceApp = "device";

--- a/src/components/policy/src/policy_table/enums.cc
+++ b/src/components/policy/src/policy_table/enums.cc
@@ -570,327 +570,327 @@ bool EnumFromJsonString(const std::string& literal, RequestType* result) {
 }
 
 bool EnumFromJsonString(const std::string& literal, FunctionID* result) {
-   if ("RESERVE" == literal) {
-     *result = RESERVED;
-     return true;
-   }
+  if ("RESERVE" == literal) {
+    *result = RESERVED;
+    return true;
+  }
 
-   if ("RegisterAppInterface" == literal) {
-     *result = RegisterAppInterfaceID;
-     return true;
-   }
+  if ("RegisterAppInterface" == literal) {
+    *result = RegisterAppInterfaceID;
+    return true;
+  }
 
-   if ("UnregisterAppInterface" == literal) {
-     *result = UnregisterAppInterfaceID;
-     return true;
-   }
+  if ("UnregisterAppInterface" == literal) {
+    *result = UnregisterAppInterfaceID;
+    return true;
+  }
 
-   if ("SetGlobalProperties" == literal) {
-     *result = SetGlobalPropertiesID;
-     return true;
-   }
+  if ("SetGlobalProperties" == literal) {
+    *result = SetGlobalPropertiesID;
+    return true;
+  }
 
-   if ("ResetGlobalProperties" == literal) {
-     *result = ResetGlobalPropertiesID;
-     return true;
-   }
+  if ("ResetGlobalProperties" == literal) {
+    *result = ResetGlobalPropertiesID;
+    return true;
+  }
 
-   if ("AddCommand" == literal) {
-     *result = AddCommandID;
-     return true;
-   }
+  if ("AddCommand" == literal) {
+    *result = AddCommandID;
+    return true;
+  }
 
-   if ("DeleteCommand" == literal) {
-     *result = DeleteCommandID;
-     return true;
-   }
+  if ("DeleteCommand" == literal) {
+    *result = DeleteCommandID;
+    return true;
+  }
 
-   if ("AddSubMenu" == literal) {
-     *result = AddSubMenuID;
-     return true;
-   }
+  if ("AddSubMenu" == literal) {
+    *result = AddSubMenuID;
+    return true;
+  }
 
-   if ("DeleteSubMenu" == literal) {
-     *result = DeleteSubMenuID;
-     return true;
-   }
+  if ("DeleteSubMenu" == literal) {
+    *result = DeleteSubMenuID;
+    return true;
+  }
 
-   if ("CreateInteractionChoiceSet" == literal) {
-     *result = CreateInteractionChoiceSetID;
-     return true;
-   }
+  if ("CreateInteractionChoiceSet" == literal) {
+    *result = CreateInteractionChoiceSetID;
+    return true;
+  }
 
-   if ("PerformInteraction" == literal) {
-     *result = PerformInteractionID;
-     return true;
-   }
+  if ("PerformInteraction" == literal) {
+    *result = PerformInteractionID;
+    return true;
+  }
 
-   if ("DeleteInteractionChoiceSet" == literal) {
-     *result = DeleteInteractionChoiceSetID;
-     return true;
-   }
+  if ("DeleteInteractionChoiceSet" == literal) {
+    *result = DeleteInteractionChoiceSetID;
+    return true;
+  }
 
-   if ("Alert" == literal) {
-     *result = AlertID;
-     return true;
-   }
+  if ("Alert" == literal) {
+    *result = AlertID;
+    return true;
+  }
 
-   if ("Show" == literal) {
-     *result = ShowID;
-     return true;
-   }
+  if ("Show" == literal) {
+    *result = ShowID;
+    return true;
+  }
 
-   if ("Speak" == literal) {
-     *result = SpeakID;
-     return true;
-   }
+  if ("Speak" == literal) {
+    *result = SpeakID;
+    return true;
+  }
 
-   if ("SetMediaClockTimer" == literal) {
-     *result = SetMediaClockTimerID;
-     return true;
-   }
+  if ("SetMediaClockTimer" == literal) {
+    *result = SetMediaClockTimerID;
+    return true;
+  }
 
-   if ("PerformAudioPassThru" == literal) {
-     *result = PerformAudioPassThruID;
-     return true;
-   }
+  if ("PerformAudioPassThru" == literal) {
+    *result = PerformAudioPassThruID;
+    return true;
+  }
 
-   if ("EndAudioPassThru" == literal) {
-     *result = EndAudioPassThruID;
-     return true;
-   }
+  if ("EndAudioPassThru" == literal) {
+    *result = EndAudioPassThruID;
+    return true;
+  }
 
-   if ("SubscribeButton" == literal) {
-     *result = SubscribeButtonID;
-     return true;
-   }
+  if ("SubscribeButton" == literal) {
+    *result = SubscribeButtonID;
+    return true;
+  }
 
-   if ("UnsubscribeButton" == literal) {
-     *result = UnsubscribeButtonID;
-     return true;
-   }
+  if ("UnsubscribeButton" == literal) {
+    *result = UnsubscribeButtonID;
+    return true;
+  }
 
-   if ("SubscribeVehicleData" == literal) {
-     *result = SubscribeVehicleDataID;
-     return true;
-   }
+  if ("SubscribeVehicleData" == literal) {
+    *result = SubscribeVehicleDataID;
+    return true;
+  }
 
-   if ("UnsubscribeVehicleData" == literal) {
-     *result = UnsubscribeVehicleDataID;
-     return true;
-   }
+  if ("UnsubscribeVehicleData" == literal) {
+    *result = UnsubscribeVehicleDataID;
+    return true;
+  }
 
-   if ("GetVehicleData" == literal) {
-     *result = GetVehicleDataID;
-     return true;
-   }
+  if ("GetVehicleData" == literal) {
+    *result = GetVehicleDataID;
+    return true;
+  }
 
-   if ("ReadD" == literal) {
-     *result = ReadDIDID;
-     return true;
-   }
+  if ("ReadD" == literal) {
+    *result = ReadDIDID;
+    return true;
+  }
 
-   if ("GetDTCs" == literal) {
-     *result = GetDTCsID;
-     return true;
-   }
+  if ("GetDTCs" == literal) {
+    *result = GetDTCsID;
+    return true;
+  }
 
-   if ("ScrollableMessage" == literal) {
-     *result = ScrollableMessageID;
-     return true;
-   }
+  if ("ScrollableMessage" == literal) {
+    *result = ScrollableMessageID;
+    return true;
+  }
 
-   if ("Slider" == literal) {
-     *result = SliderID;
-     return true;
-   }
+  if ("Slider" == literal) {
+    *result = SliderID;
+    return true;
+  }
 
-   if ("ShowConstantTBT" == literal) {
-     *result = ShowConstantTBTID;
-     return true;
-   }
+  if ("ShowConstantTBT" == literal) {
+    *result = ShowConstantTBTID;
+    return true;
+  }
 
-   if ("AlertManeuver" == literal) {
-     *result = AlertManeuverID;
-     return true;
-   }
+  if ("AlertManeuver" == literal) {
+    *result = AlertManeuverID;
+    return true;
+  }
 
-   if ("UpdateTurnList" == literal) {
-     *result = UpdateTurnListID;
-     return true;
-   }
+  if ("UpdateTurnList" == literal) {
+    *result = UpdateTurnListID;
+    return true;
+  }
 
-   if ("ChangeRegistration" == literal) {
-     *result = ChangeRegistrationID;
-     return true;
-   }
+  if ("ChangeRegistration" == literal) {
+    *result = ChangeRegistrationID;
+    return true;
+  }
 
-   if ("GenericResponse" == literal) {
-     *result = GenericResponseID;
-     return true;
-   }
+  if ("GenericResponse" == literal) {
+    *result = GenericResponseID;
+    return true;
+  }
 
-   if ("PutFile" == literal) {
-     *result = PutFileID;
-     return true;
-   }
+  if ("PutFile" == literal) {
+    *result = PutFileID;
+    return true;
+  }
 
-   if ("DeleteFile" == literal) {
-     *result = DeleteFileID;
-     return true;
-   }
+  if ("DeleteFile" == literal) {
+    *result = DeleteFileID;
+    return true;
+  }
 
-   if ("ListFiles" == literal) {
-     *result = ListFilesID;
-     return true;
-   }
+  if ("ListFiles" == literal) {
+    *result = ListFilesID;
+    return true;
+  }
 
-   if ("SetAppIcon" == literal) {
-     *result = SetAppIconID;
-     return true;
-   }
+  if ("SetAppIcon" == literal) {
+    *result = SetAppIconID;
+    return true;
+  }
 
-   if ("SetDisplayLayout" == literal) {
-     *result = SetDisplayLayoutID;
-     return true;
-   }
+  if ("SetDisplayLayout" == literal) {
+    *result = SetDisplayLayoutID;
+    return true;
+  }
 
-   if ("DiagnosticMessage" == literal) {
-     *result = DiagnosticMessageID;
-     return true;
-   }
+  if ("DiagnosticMessage" == literal) {
+    *result = DiagnosticMessageID;
+    return true;
+  }
 
-   if ("SystemRequest" == literal) {
-     *result = SystemRequestID;
-     return true;
-   }
+  if ("SystemRequest" == literal) {
+    *result = SystemRequestID;
+    return true;
+  }
 
-   if ("SendLocation" == literal) {
-     *result = SendLocationID;
-     return true;
-   }
+  if ("SendLocation" == literal) {
+    *result = SendLocationID;
+    return true;
+  }
 
-   if ("DialNumber" == literal) {
-     *result = DialNumberID;
-     return true;
-   }
+  if ("DialNumber" == literal) {
+    *result = DialNumberID;
+    return true;
+  }
 
-   if ("GetWayPoints" == literal) {
-     *result = GetWayPointsID;
-     return true;
-   }
+  if ("GetWayPoints" == literal) {
+    *result = GetWayPointsID;
+    return true;
+  }
 
-   if ("SubscribeWayPoints" == literal) {
-     *result = SubscribeWayPointsID;
-     return true;
-   }
+  if ("SubscribeWayPoints" == literal) {
+    *result = SubscribeWayPointsID;
+    return true;
+  }
 
-   if ("UnsubscribeWayPoints" == literal) {
-     *result = UnsubscribeWayPointsID;
-     return true;
-   }
+  if ("UnsubscribeWayPoints" == literal) {
+    *result = UnsubscribeWayPointsID;
+    return true;
+  }
 
-   if ("OnHMIStatus" == literal) {
-     *result = OnHMIStatusID;
-     return true;
-   }
+  if ("OnHMIStatus" == literal) {
+    *result = OnHMIStatusID;
+    return true;
+  }
 
-   if ("OnAppInterfaceUnregistered" == literal) {
-     *result = OnAppInterfaceUnregisteredID;
-     return true;
-   }
+  if ("OnAppInterfaceUnregistered" == literal) {
+    *result = OnAppInterfaceUnregisteredID;
+    return true;
+  }
 
-   if ("OnButtonEvent" == literal) {
-     *result = OnButtonEventID;
-     return true;
-   }
+  if ("OnButtonEvent" == literal) {
+    *result = OnButtonEventID;
+    return true;
+  }
 
-   if ("OnButtonPress" == literal) {
-     *result = OnButtonPressID;
-     return true;
-   }
+  if ("OnButtonPress" == literal) {
+    *result = OnButtonPressID;
+    return true;
+  }
 
-   if ("OnVehicleData" == literal) {
-     *result = OnVehicleDataID;
-     return true;
-   }
+  if ("OnVehicleData" == literal) {
+    *result = OnVehicleDataID;
+    return true;
+  }
 
-   if ("OnCommand" == literal) {
-     *result = OnCommandID;
-     return true;
-   }
+  if ("OnCommand" == literal) {
+    *result = OnCommandID;
+    return true;
+  }
 
-   if ("OnTBTClientState" == literal) {
-     *result = OnTBTClientStateID;
-     return true;
-   }
+  if ("OnTBTClientState" == literal) {
+    *result = OnTBTClientStateID;
+    return true;
+  }
 
-   if ("OnDriverDistraction" == literal) {
-     *result = OnDriverDistractionID;
-     return true;
-   }
+  if ("OnDriverDistraction" == literal) {
+    *result = OnDriverDistractionID;
+    return true;
+  }
 
-   if ("OnPermissionsChange" == literal) {
-     *result = OnPermissionsChangeID;
-     return true;
-   }
+  if ("OnPermissionsChange" == literal) {
+    *result = OnPermissionsChangeID;
+    return true;
+  }
 
-   if ("OnAudioPassThru" == literal) {
-     *result = OnAudioPassThruID;
-     return true;
-   }
+  if ("OnAudioPassThru" == literal) {
+    *result = OnAudioPassThruID;
+    return true;
+  }
 
-   if ("OnLanguageChange" == literal) {
-     *result = OnLanguageChangeID;
-     return true;
-   }
+  if ("OnLanguageChange" == literal) {
+    *result = OnLanguageChangeID;
+    return true;
+  }
 
-   if ("OnKeyboardInput" == literal) {
-     *result = OnKeyboardInputID;
-     return true;
-   }
+  if ("OnKeyboardInput" == literal) {
+    *result = OnKeyboardInputID;
+    return true;
+  }
 
-   if ("OnTouchEvent" == literal) {
-     *result = OnTouchEventID;
-     return true;
-   }
+  if ("OnTouchEvent" == literal) {
+    *result = OnTouchEventID;
+    return true;
+  }
 
-   if ("OnSystemRequest" == literal) {
-     *result = OnSystemRequestID;
-     return true;
-   }
+  if ("OnSystemRequest" == literal) {
+    *result = OnSystemRequestID;
+    return true;
+  }
 
-   if ("OnHashChange" == literal) {
-     *result = OnHashChangeID;
-     return true;
-   }
+  if ("OnHashChange" == literal) {
+    *result = OnHashChangeID;
+    return true;
+  }
 
-   if ("OnWayPointChange" == literal) {
-     *result = OnWayPointChangeID;
-     return true;
-   }
+  if ("OnWayPointChange" == literal) {
+    *result = OnWayPointChangeID;
+    return true;
+  }
 
-   if ("EncodedSyncPData" == literal) {
-     *result = EncodedSyncPDataID;
-     return true;
-   }
+  if ("EncodedSyncPData" == literal) {
+    *result = EncodedSyncPDataID;
+    return true;
+  }
 
-   if ("SyncPData" == literal) {
-     *result = SyncPDataID;
-     return true;
-   }
+  if ("SyncPData" == literal) {
+    *result = SyncPDataID;
+    return true;
+  }
 
-   if ("OnEncodedSyncPData" == literal) {
-     *result = OnEncodedSyncPDataID;
-     return true;
-   }
+  if ("OnEncodedSyncPData" == literal) {
+    *result = OnEncodedSyncPDataID;
+    return true;
+  }
 
-   if ("OnSyncPData" == literal) {
-     *result = OnSyncPDataID;
-     return true;
-   }
-   return false;
- };
+  if ("OnSyncPData" == literal) {
+    *result = OnSyncPDataID;
+    return true;
+  }
+  return false;
+};
 
 const std::string kDefaultApp = "default";
 const std::string kPreDataConsentApp = "pre_DataConsent";

--- a/src/components/policy/test/policy_manager_impl_test.cc
+++ b/src/components/policy/test/policy_manager_impl_test.cc
@@ -375,12 +375,12 @@ Json::Value CreatePTforLoad() {
       "}"
       "},"
       "\"notifications_per_minute_by_priority\": {"
-      "\"emergency\": 1,"
-      "\"navigation\": 2,"
-      "\"VOICECOMM\": 3,"
-      "\"communication\": 4,"
-      "\"normal\": 5,"
-      "\"none\": 6"
+      "\"EMERGENCY\": 1,"
+      "\"NAVIGATION\": 2,"
+      "\"VOICECOM\": 3,"
+      "\"COMMUNICATION\": 4,"
+      "\"NORMAL\": 5,"
+      "\"NONE\": 6"
       "},"
       "\"vehicle_make\" : \"MakeT\","
       "\"vehicle_model\" : \"ModelT\","
@@ -469,27 +469,27 @@ TEST_F(PolicyManagerImplTest2, GetNotificationsNumberAfterPTUpdate) {
   EXPECT_CALL(listener, OnUpdateStatusChanged(_));
   EXPECT_TRUE(manager->LoadPT("file_pt_update.json", msg));
 
-  std::string priority = "emergency";
+  std::string priority = "EMERGENCY";
   uint32_t notif_number = manager->GetNotificationsNumber(priority);
   EXPECT_EQ(1u, notif_number);
 
-  priority = "navigation";
+  priority = "NAVIGATION";
   notif_number = manager->GetNotificationsNumber(priority);
   EXPECT_EQ(2u, notif_number);
 
-  priority = "emergency";
+  priority = "EMERGENCY";
   notif_number = manager->GetNotificationsNumber(priority);
   EXPECT_EQ(1u, notif_number);
 
-  priority = "VOICECOMM";
+  priority = "VOICECOM";
   notif_number = manager->GetNotificationsNumber(priority);
   EXPECT_EQ(3u, notif_number);
 
-  priority = "normal";
+  priority = "NORMAL";
   notif_number = manager->GetNotificationsNumber(priority);
   EXPECT_EQ(5u, notif_number);
 
-  priority = "none";
+  priority = "NONE";
   notif_number = manager->GetNotificationsNumber(priority);
   EXPECT_EQ(6u, notif_number);
 }


### PR DESCRIPTION
[Things to note: Pull Requests **must** fix an issue. Discussion about the feature / bug takes place in the issue, discussion of the implementation takes place in the PR. Please also see the [Contributing Guide](https://github.com/smartdevicelink/sdl_core/blob/master/.github/CONTRIBUTING.md) for information on branch naming and the CLA.

Delete the above section when you've read it.]

Fixes #1921 For 4.1 Release. Separate PR for 5.0 release.

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Perform a policy table update with unknown parameters to 4.1. Check that the PTU was performed successfully.

### Summary
Adds policy table filtering for fields that might be unknown or invalid to Core 4.1LTS. These changes protect version 4.1LTS of SDL Core against newer versions of the policy server that might contain new RPCs, parameters, HMILevels, or HMIAppTypes.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)