### PR TITLE
Check if app uses default policy for requestType and requestSubType

### DIFF
--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -696,6 +696,8 @@ const std::vector<std::string> PolicyManagerImpl::GetAppRequestTypes(
   if (kDeviceDisallowed ==
       cache_->GetDeviceConsent(GetCurrentDeviceId(policy_app_id))) {
     cache_->GetAppRequestTypes(kPreDataConsentId, request_types);
+  } else if (cache_->IsDefaultPolicy(policy_app_id)) {
+    cache_->GetAppRequestTypes(kDefaultId, request_types);
   } else {
     cache_->GetAppRequestTypes(policy_app_id, request_types);
   }
@@ -705,19 +707,29 @@ const std::vector<std::string> PolicyManagerImpl::GetAppRequestTypes(
 RequestType::State PolicyManagerImpl::GetAppRequestTypesState(
     const std::string& policy_app_id) const {
   LOG4CXX_AUTO_TRACE(logger_);
+  if (cache_->IsDefaultPolicy(policy_app_id)) {
+    return cache_->GetAppRequestTypesState(kDefaultId);
+  }
   return cache_->GetAppRequestTypesState(policy_app_id);
 }
 
 RequestSubType::State PolicyManagerImpl::GetAppRequestSubTypesState(
     const std::string& policy_app_id) const {
   LOG4CXX_AUTO_TRACE(logger_);
+  if (cache_->IsDefaultPolicy(policy_app_id)) {
+    return cache_->GetAppRequestSubTypesState(kDefaultId);
+  }
   return cache_->GetAppRequestSubTypesState(policy_app_id);
 }
 
 const std::vector<std::string> PolicyManagerImpl::GetAppRequestSubTypes(
     const std::string& policy_app_id) const {
   std::vector<std::string> request_subtypes;
-  cache_->GetAppRequestSubTypes(policy_app_id, request_subtypes);
+  if (cache_->IsDefaultPolicy(policy_app_id)) {
+    cache_->GetAppRequestSubTypes(kDefaultId, request_subtypes);
+  } else {
+    cache_->GetAppRequestSubTypes(policy_app_id, request_subtypes);
+  }
   return request_subtypes;
 }
 


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Set SDL Server PTU Default policies to:
```
        "default": {
          "keep_context": false,
          "steal_focus": false,
          "priority": "NONE",
          "default_hmi": "NONE",
          "groups": [
            "Base-4", "Location-1"
          ],
          "RequestType": ["OEM_SPECIFIC"],
          "RequestSubType": ["TEST"]
        }
```
Connect app to trigger PTU.
After PTU attempt a SystemRequest from phone.
Only RequestType `OEM_SPECIFIC` and RequestSubType `TEST` should be allowed.

### Summary
Checks if an app is set to default policies before gathering an app's allowed request and request sub types. The problem before was that the previously empty default request types array in the preloaded PT were not getting updated by the PTU's default policies section for a specific app that inherited the default policies. 
### CLA

- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)