### PR TITLE
Check if app uses default policies for moduleType

### DIFF
--- a/src/components/policy/policy_external/src/access_remote_impl.cc
+++ b/src/components/policy/policy_external/src/access_remote_impl.cc
@@ -99,8 +99,13 @@ bool AccessRemoteImpl::CheckModuleType(const PTString& app_id,
     return false;
   }
 
-  const policy_table::ApplicationParams& app =
-      cache_->pt_->policy_table.app_policies_section.apps[app_id];
+  policy_table::ApplicationParams app;
+  if (cache_->IsDefaultPolicy(app_id)) {
+    app = cache_->pt_->policy_table.app_policies_section.apps[kDefaultId];
+  } else {
+    app = cache_->pt_->policy_table.app_policies_section.apps[app_id];
+  }
+
   if (!app.moduleType.is_initialized()) {
     return false;
   }


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Set default policies section in SDL Server:
```
        "default": {
          "keep_context": false,
          "steal_focus": false,
          "priority": "NONE",
          "default_hmi": "NONE",
          "groups": [
            "Base-4", "Location-1", "RemoteControl"
          ],
          "RequestType": [],
          "RequestSubType": [],
          "moduleType" : ["CLIMATE", "RADIO", "SEAT", "AUDIO", "LIGHT"]
        },
```
Connect  RC App and perform PTU.
Send any RC RPC, Expect Success.

### Summary
If an app uses default policies that has a populated moduleType array, CheckModuleType was incorrectly returning that the app did not have an initialized moduleType field. These changes check if an app uses default policies and then grabs the module type set in the default app policies section.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)