### PR TITLE
Remove keepContextAvailable from API

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -476,7 +476,6 @@
                         "sourceAvailable": true,
                         "volumeAvailable": true,
                         "equalizerAvailable": true,
-                        "keepContextAvailable" : true,
                         "equalizerMaxChannelId": 10
                     }
                 ],

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
@@ -128,7 +128,6 @@ const std::map<std::string, std::string> GetModuleDataToCapabilitiesMapping() {
 
   // audio
   mapping["source"] = "sourceAvailable";
-  mapping["keepContext"] = "keepContextAvailable";
   mapping["volume"] = "volumeAvailable";
   mapping["equalizerSettings"] = "equalizerAvailable";
 
@@ -309,7 +308,8 @@ ModuleCapability GetControlDataCapabilities(
 
   for (auto it = control_data.map_begin(); it != control_data.map_end(); ++it) {
     const std::string& request_parameter = it->first;
-    if (message_params::kId == request_parameter) {
+    if (message_params::kId == request_parameter ||
+        message_params::kKeepContext == request_parameter) {
       continue;
     }
     if (message_params::kLightState == request_parameter) {

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -2167,9 +2167,6 @@
      <param name="sourceAvailable" type="Boolean" mandatory="false">
          <description>Availability of the control of audio source. </description>
      </param>
-     <param name="keepContextAvailable" type="Boolean" mandatory="false">
-         <description>Availability of the keepContext paramter. </description>
-     </param>
      <param name="volumeAvailable" type="Boolean" mandatory="false">
          <description>Availability of the control of audio volume.</description>
      </param>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -3344,9 +3344,6 @@
         <param name="sourceAvailable" type="Boolean" mandatory="false">
             <description>Availability of the control of audio source. </description>
         </param>
-        <param name="keepContextAvailable" type="Boolean" mandatory="false">
-            <description>Availability of the keepContext paramter. </description>
-        </param>
         <param name="volumeAvailable" type="Boolean" mandatory="false">
             <description>Availability of the control of audio volume.</description>
         </param>


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
keepContext is a special case where there is no data attached to the parameter, therefore a capability for this parameter is not needed. Since it was not in the original proposal for the feature, it must be removed.

### Changelog

##### Bug Fixes
* Remove extra `keepContextAvailable` parameter introduced in #2207 (not present in original proposal)


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)