### PR TITLE
Allows User Consent for Default Functional Groups

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -951,6 +951,7 @@ void PolicyHandler::OnVehicleDataUpdated(
 
 void PolicyHandler::OnPendingPermissionChange(
     const std::string& policy_app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_DEBUG(logger_,
                 "PolicyHandler::OnPendingPermissionChange for "
                     << policy_app_id);
@@ -989,8 +990,6 @@ void PolicyHandler::OnPendingPermissionChange(
       if (permissions.appPermissionsConsentNeeded) {
         MessageHelper::SendOnAppPermissionsChangedNotification(
             app->app_id(), permissions, application_manager_);
-
-        policy_manager_->RemovePendingPermissionChanges(policy_app_id);
         // "Break" statement has to be here to continue processing in case of
         // there is another "true" flag in permissions struct
         break;
@@ -1000,8 +999,6 @@ void PolicyHandler::OnPendingPermissionChange(
       if (permissions.isAppPermissionsRevoked) {
         MessageHelper::SendOnAppPermissionsChangedNotification(
             app->app_id(), permissions, application_manager_);
-
-        policy_manager_->RemovePendingPermissionChanges(policy_app_id);
       }
       break;
     }
@@ -1022,15 +1019,14 @@ void PolicyHandler::OnPendingPermissionChange(
         commands::Command::SOURCE_SDL);
 
     application_manager_.OnAppUnauthorized(app->app_id());
-
-    policy_manager_->RemovePendingPermissionChanges(policy_app_id);
   }
 
   if (permissions.requestTypeChanged || permissions.requestSubTypeChanged) {
     MessageHelper::SendOnAppPermissionsChangedNotification(
         app->app_id(), permissions, application_manager_);
-    policy_manager_->RemovePendingPermissionChanges(policy_app_id);
   }
+
+  policy_manager_->RemovePendingPermissionChanges(policy_app_id);
 }
 
 bool PolicyHandler::SendMessageToSDK(const BinaryMessage& pt_string,

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -921,7 +921,7 @@ TEST_F(PolicyHandlerTest,
   EXPECT_CALL(*mock_policy_manager_, GetAppPermissionsChanges(_))
       .WillOnce(Return(permissions));
   EXPECT_CALL(*mock_policy_manager_,
-              RemovePendingPermissionChanges(kPolicyAppId_)).Times(0);
+              RemovePendingPermissionChanges(kPolicyAppId_));
   // Act
   policy_handler_.OnPendingPermissionChange(kPolicyAppId_);
 }

--- a/src/components/policy/policy_external/include/policy/policy_helper.h
+++ b/src/components/policy/policy_external/include/policy/policy_helper.h
@@ -100,7 +100,8 @@ struct CheckAppPolicy {
    * @param result Result of check of updated policy
    */
   void SetPendingPermissions(const AppPoliciesValueType& app_policy,
-                             PermissionsCheckResult result) const;
+                             PermissionsCheckResult result,
+                             AppPermissions& permissions_diff) const;
   /**
    * @brief Analyzes updated application policy whether any changes received. If
    * yes - provides appropriate result code
@@ -199,6 +200,18 @@ struct CheckAppPolicy {
    * @return True if changed, otherwise - false
    */
   bool IsRequestSubTypeChanged(const AppPoliciesValueType& app_policy) const;
+
+  /**
+   * @brief Helper function that inserts permissions into app_permissions_diff_
+   * map.
+   * udpated
+   * @param app_policy Reference to updated application policy
+   * @param permissions_diff Reference to app permissions to be inserted into
+   * map.
+   * @return void
+   */
+  void InsertPermission(const std::string& app_id,
+                        const AppPermissions& permissions_diff);
 
  private:
   PolicyManagerImpl* pm_;

--- a/src/components/policy/policy_external/src/policy_helper.cc
+++ b/src/components/policy/policy_external/src/policy_helper.cc
@@ -345,6 +345,8 @@ bool CheckAppPolicy::operator()(const AppPoliciesValueType& app_policy) {
       SetPendingPermissions(
           app_policy, RESULT_REQUEST_TYPE_CHANGED, permissions_diff);
       AddResult(app_id, RESULT_REQUEST_TYPE_CHANGED);
+      result =
+          (RESULT_NO_CHANGES == result) ? RESULT_REQUEST_TYPE_CHANGED : result;
     }
     if (is_request_subtype_changed) {
       LOG4CXX_TRACE(
@@ -352,6 +354,8 @@ bool CheckAppPolicy::operator()(const AppPoliciesValueType& app_policy) {
       SetPendingPermissions(
           app_policy, RESULT_REQUEST_SUBTYPE_CHANGED, permissions_diff);
       AddResult(app_id, RESULT_REQUEST_SUBTYPE_CHANGED);
+      result = (RESULT_NO_CHANGES == result) ? RESULT_REQUEST_SUBTYPE_CHANGED
+                                             : result;
     }
   }
 

--- a/src/components/policy/policy_external/src/policy_helper.cc
+++ b/src/components/policy/policy_external/src/policy_helper.cc
@@ -299,9 +299,16 @@ void CheckAppPolicy::AddResult(const std::string& app_id,
   out_results_.insert(std::make_pair(app_id, result));
 }
 
+void CheckAppPolicy::InsertPermission(const std::string& app_id,
+                                      const AppPermissions& permissions_diff) {
+  pm_->app_permissions_diff_lock_.Acquire();
+  pm_->app_permissions_diff_.insert(std::make_pair(app_id, permissions_diff));
+  pm_->app_permissions_diff_lock_.Release();
+}
+
 bool CheckAppPolicy::operator()(const AppPoliciesValueType& app_policy) {
   const std::string app_id = app_policy.first;
-
+  AppPermissions permissions_diff(app_id);
   if (!IsKnownAppication(app_id)) {
     LOG4CXX_WARN(logger_,
                  "Application:" << app_id << " is not present in snapshot.");
@@ -309,14 +316,17 @@ bool CheckAppPolicy::operator()(const AppPoliciesValueType& app_policy) {
   }
 
   if (!IsPredefinedApp(app_policy) && IsAppRevoked(app_policy)) {
-    SetPendingPermissions(app_policy, RESULT_APP_REVOKED);
+    SetPendingPermissions(app_policy, RESULT_APP_REVOKED, permissions_diff);
     AddResult(app_id, RESULT_APP_REVOKED);
+    InsertPermission(app_id, permissions_diff);
     return true;
   }
 
   if (!IsPredefinedApp(app_policy) && !NicknamesMatch(app_policy)) {
-    SetPendingPermissions(app_policy, RESULT_NICKNAME_MISMATCH);
+    SetPendingPermissions(
+        app_policy, RESULT_NICKNAME_MISMATCH, permissions_diff);
     AddResult(app_id, RESULT_NICKNAME_MISMATCH);
+    InsertPermission(app_id, permissions_diff);
     return true;
   }
 
@@ -328,13 +338,15 @@ bool CheckAppPolicy::operator()(const AppPoliciesValueType& app_policy) {
     if (is_request_type_changed) {
       LOG4CXX_TRACE(logger_,
                     "Request types were changed for application: " << app_id);
-      SetPendingPermissions(app_policy, RESULT_REQUEST_TYPE_CHANGED);
+      SetPendingPermissions(
+          app_policy, RESULT_REQUEST_TYPE_CHANGED, permissions_diff);
       AddResult(app_id, RESULT_REQUEST_TYPE_CHANGED);
     }
     if (is_request_subtype_changed) {
       LOG4CXX_TRACE(
           logger_, "Request subtypes were changed for application: " << app_id);
-      SetPendingPermissions(app_policy, RESULT_REQUEST_SUBTYPE_CHANGED);
+      SetPendingPermissions(
+          app_policy, RESULT_REQUEST_SUBTYPE_CHANGED, permissions_diff);
       AddResult(app_id, RESULT_REQUEST_SUBTYPE_CHANGED);
     }
   }
@@ -344,6 +356,7 @@ bool CheckAppPolicy::operator()(const AppPoliciesValueType& app_policy) {
                  "Permissions for application:" << app_id
                                                 << " wasn't changed.");
     AddResult(app_id, result);
+    InsertPermission(app_id, permissions_diff);
     return true;
   }
 
@@ -352,19 +365,20 @@ bool CheckAppPolicy::operator()(const AppPoliciesValueType& app_policy) {
                                               << " have been changed.");
 
   if (!IsPredefinedApp(app_policy)) {
-    SetPendingPermissions(app_policy, result);
+    SetPendingPermissions(app_policy, result, permissions_diff);
     AddResult(app_id, result);
   }
 
+  InsertPermission(app_id, permissions_diff);
   return true;
 }
 
 void policy::CheckAppPolicy::SetPendingPermissions(
     const AppPoliciesValueType& app_policy,
-    PermissionsCheckResult result) const {
+    PermissionsCheckResult result,
+    AppPermissions& permissions_diff) const {
   using namespace rpc::policy_table_interface_base;
   const std::string app_id = app_policy.first;
-  AppPermissions permissions_diff(app_id);
 
   const std::string priority =
       policy_table::EnumToJsonString(app_policy.second.priority);
@@ -421,10 +435,6 @@ void policy::CheckAppPolicy::SetPendingPermissions(
   if (need_send_priority) {
     permissions_diff.priority = priority;
   }
-
-  pm_->app_permissions_diff_lock_.Acquire();
-  pm_->app_permissions_diff_.insert(std::make_pair(app_id, permissions_diff));
-  pm_->app_permissions_diff_lock_.Release();
 }
 
 PermissionsCheckResult CheckAppPolicy::CheckPermissionsChanges(

--- a/src/components/policy/policy_external/src/policy_helper.cc
+++ b/src/components/policy/policy_external/src/policy_helper.cc
@@ -302,7 +302,9 @@ void CheckAppPolicy::AddResult(const std::string& app_id,
 void CheckAppPolicy::InsertPermission(const std::string& app_id,
                                       const AppPermissions& permissions_diff) {
   pm_->app_permissions_diff_lock_.Acquire();
-  pm_->app_permissions_diff_.insert(std::make_pair(app_id, permissions_diff));
+  if (!pm_->app_permissions_diff_.insert(std::make_pair(app_id, permissions_diff)).second) {
+    LOG4CXX_ERROR(logger_, "App ID: " << app_id << " already exists in map.");
+  }
   pm_->app_permissions_diff_lock_.Release();
 }
 
@@ -356,7 +358,6 @@ bool CheckAppPolicy::operator()(const AppPoliciesValueType& app_policy) {
                  "Permissions for application:" << app_id
                                                 << " wasn't changed.");
     AddResult(app_id, result);
-    InsertPermission(app_id, permissions_diff);
     return true;
   }
 

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1261,15 +1261,8 @@ void PolicyManagerImpl::GetUserConsentForApp(
   FunctionalGroupIDs allowed_groups =
       Merge(consent_allowed_groups, preconsented_wo_disallowed_auto);
 
-  FunctionalGroupIDs merged_stage_1 =
-      Merge(default_groups, predataconsented_groups);
-
-  FunctionalGroupIDs merged_stage_2 = Merge(merged_stage_1, device_groups);
-
-  FunctionalGroupIDs merged_stage_3 =
-      Merge(merged_stage_2, auto_allowed_groups);
-
-  FunctionalGroupIDs excluded_stage_1 = ExcludeSame(all_groups, merged_stage_3);
+  FunctionalGroupIDs excluded_stage_1 =
+      ExcludeSame(all_groups, auto_allowed_groups);
 
   FunctionalGroupIDs excluded_stage_2 =
       ExcludeSame(excluded_stage_1, consent_disallowed_groups);


### PR DESCRIPTION
Fixes #2146 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Build core with external_proprietary policies.

Set up SDL Server with  a similar app_policies section
```
      "app_policies": {
        "default": {
          "keep_context": false,
          "steal_focus": false,
          "priority": "NONE",
          "default_hmi": "NONE",
          "groups": [
            "Base-4", "Location-1", "RemoteControl"
          ],
          "RequestType": ["PROPRIETARY"],
          "RequestSubType": ["TEST"],
          "moduleType" : ["CLIMATE", "RADIO", "SEAT", "AUDIO", "LIGHT"]
        },
        "device": {
          "keep_context": false,
          "steal_focus": false,
          "priority": "NONE",
          "default_hmi": "NONE",
          "groups": [
            "DataConsent-2"
          ]
        },
        "pre_DataConsent": {
          "keep_context": false,
          "steal_focus": false,
          "priority": "NONE",
          "default_hmi": "NONE",
          "groups": [
            "BaseBeforeDataConsent"
          ]
        },
          "584421907": {
          "keep_context": false,
          "steal_focus": false,
          "priority": "NONE",
          "default_hmi": "NONE",
          "groups": [
            "Base-4", "Location-1", "DrivingCharacteristics-3", "SendLocation"
          ],
          "RequestType": ["PROPRIETARY"],
          "RequestSubType": ["TEST"],
          "moduleType" : []
        }
      }
```

Connect an app and make sure HMI prompts user to consent to Location and Driving Characteristics functional groups.

### Summary
Functional groups for an app that were also listed in the default policies were getting filtered out from a getListOfPermissions response. These changes make sure a user will be prompted to consent to app permissions even if a functional group is listed in the default policies. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)