### PR TITLE
[SDL4.0]SDL does not create icons folder in case it was removed

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_app_icon_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_app_icon_request.cc
@@ -60,6 +60,14 @@ SetAppIconRequest::SetAppIconRequest(
     , is_icons_saving_enabled_(false) {
   const std::string path =
       application_manager_.get_settings().app_icons_folder();
+
+  if (!file_system::DirectoryExists(path)) {
+    LOG4CXX_WARN(logger_, "App icons folder doesn't exist.");
+    if (!file_system::CreateDirectoryRecursively(path)) {
+      LOG4CXX_ERROR(logger_, "Unable to create app icons directory: " << path);
+    }
+  }
+
   is_icons_saving_enabled_ = file_system::IsWritingAllowed(path) &&
                              file_system::IsReadingAllowed(path);
 }


### PR DESCRIPTION
Fixes #1003

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test

### Summary
There was a problem if SDL4.0 feature is enabled in `.ini` file. ' Icons' values is set as `AppIconsFolder` value. If remove this folder after start SDL and register app with 4th protocol
 SDL should creates this folder.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)