### PR TITLE
Remove OnPolicyInit Unused Function

### DIFF
--- a/src/components/policy/policy_external/include/policy/update_status_manager.h
+++ b/src/components/policy/policy_external/include/policy/update_status_manager.h
@@ -125,12 +125,6 @@ class UpdateStatusManager {
   void OnNewApplicationAdded(const DeviceConsent consent);
 
   /**
-   * @brief Update status handler for policy initialization
-   * @param is_update_required Update necessity flag
-   */
-  void OnPolicyInit(bool is_update_required);
-
-  /**
    * @brief In case application from non-consented device has been registered
    * before and and no updated happened then triggers status change
    */

--- a/src/components/policy/policy_external/src/update_status_manager.cc
+++ b/src/components/policy/policy_external/src/update_status_manager.cc
@@ -139,14 +139,6 @@ void UpdateStatusManager::OnNewApplicationAdded(const DeviceConsent consent) {
   ProcessEvent(kOnNewAppRegistered);
 }
 
-void UpdateStatusManager::OnPolicyInit(bool is_update_required) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  if (is_update_required) {
-    current_status_.reset(new UpToDateStatus());
-    ProcessEvent(kScheduleUpdate);
-  }
-}
-
 void UpdateStatusManager::OnDeviceConsented() {
   LOG4CXX_AUTO_TRACE(logger_);
   if (app_registered_from_non_consented_device_) {

--- a/src/components/policy/policy_external/test/include/policy/mock_update_status_manager.h
+++ b/src/components/policy/policy_external/test/include/policy/mock_update_status_manager.h
@@ -50,7 +50,6 @@ class MockUpdateStatusManager : public ::policy::UpdateStatusManager {
   MOCK_METHOD0(OnResetRetrySequence, void());
   MOCK_METHOD1(OnExistedApplicationAdded, void(const bool is_update_required));
   MOCK_METHOD1(OnNewApplicationAdded, void(const DeviceConsent));
-  MOCK_METHOD1(OnPolicyInit, void(bool is_update_required));
   MOCK_METHOD0(GetUpdateStatus, PolicyTableStatus());
 };
 

--- a/src/components/policy/policy_external/test/update_status_manager_test.cc
+++ b/src/components/policy/policy_external/test/update_status_manager_test.cc
@@ -287,42 +287,6 @@ TEST_F(UpdateStatusManagerTest, ScheduleUpdate_ExpectStatusUpdateNeeded) {
 }
 
 TEST_F(UpdateStatusManagerTest,
-       OnPolicyInit_SetUpdateRequired_ExpectStatusUpdateNeeded) {
-  // Arrange
-  manager_->OnPolicyInit(true);
-  status_ = manager_->GetLastUpdateStatus();
-  // Checks
-  EXPECT_EQ(StatusUpdateRequired, status_);
-  EXPECT_FALSE(manager_->IsUpdatePending());
-  EXPECT_TRUE(manager_->IsUpdateRequired());
-}
-
-TEST_F(UpdateStatusManagerTest,
-       OnPolicyInit_SetUpdateNotRequired_ExpectStatusUpToDate) {
-  // Arrange
-  manager_->OnPolicyInit(false);
-  status_ = manager_->GetLastUpdateStatus();
-  // Checks
-  EXPECT_EQ(StatusUpToDate, status_);
-  EXPECT_FALSE(manager_->IsUpdatePending());
-  EXPECT_FALSE(manager_->IsUpdateRequired());
-}
-
-TEST_F(UpdateStatusManagerTest,
-       StringifiedUpdateStatus_SetStatuses_ExpectCorrectStringifiedStatuses) {
-  // Arrange
-  manager_->OnPolicyInit(false);
-  // Check
-  EXPECT_EQ("UP_TO_DATE", manager_->StringifiedUpdateStatus());
-  manager_->OnPolicyInit(true);
-  // Check
-  EXPECT_EQ("UPDATE_NEEDED", manager_->StringifiedUpdateStatus());
-  manager_->OnUpdateSentOut(k_timeout_);
-  // Check
-  EXPECT_EQ("UPDATING", manager_->StringifiedUpdateStatus());
-}
-
-TEST_F(UpdateStatusManagerTest,
        OnAppSearchStartedCompleted_ExpectAppSearchCorrectStatus) {
   // Arrange
   manager_->OnAppsSearchStarted();

--- a/src/components/policy/policy_regular/include/policy/update_status_manager.h
+++ b/src/components/policy/policy_regular/include/policy/update_status_manager.h
@@ -124,12 +124,6 @@ class UpdateStatusManager : public UpdateStatusManagerInterface {
   void OnExistedApplicationAdded(const bool is_update_required);
 
   /**
-   * @brief Update status handler for policy initialization
-   * @param is_update_required Update necessity flag
-   */
-  void OnPolicyInit(bool is_update_required);
-
-  /**
    * @brief In case application from non-consented device has been registered
    * before and and no updated happened then triggers status change
    */

--- a/src/components/policy/policy_regular/include/policy/update_status_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/update_status_manager_interface.h
@@ -109,12 +109,6 @@ class UpdateStatusManagerInterface {
    * @param is_update_required Update necessity flag
    */
   virtual void OnExistedApplicationAdded(const bool is_update_required) = 0;
-
-  /**
-   * @brief Update status handler for policy initialization
-   * @param is_update_required Update necessity flag
-   */
-  virtual void OnPolicyInit(bool is_update_required) = 0;
 };
 
 typedef std::shared_ptr<UpdateStatusManagerInterface>

--- a/src/components/policy/policy_regular/src/update_status_manager.cc
+++ b/src/components/policy/policy_regular/src/update_status_manager.cc
@@ -119,14 +119,6 @@ void UpdateStatusManager::OnNewApplicationAdded(const DeviceConsent consent) {
   ProcessEvent(kOnNewAppRegistered);
 }
 
-void UpdateStatusManager::OnPolicyInit(bool is_update_required) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  if (is_update_required) {
-    current_status_.reset(new UpToDateStatus());
-    ProcessEvent(kScheduleUpdate);
-  }
-}
-
 void UpdateStatusManager::OnDeviceConsented() {
   LOG4CXX_AUTO_TRACE(logger_);
   if (app_registered_from_non_consented_device_) {

--- a/src/components/policy/policy_regular/test/include/policy/mock_update_status_manager.h
+++ b/src/components/policy/policy_regular/test/include/policy/mock_update_status_manager.h
@@ -49,7 +49,6 @@ class MockUpdateStatusManager : public UpdateStatusManager {
   MOCK_METHOD0(OnResetRetrySequence, void());
   MOCK_METHOD1(OnExistedApplicationAdded, void(const bool is_update_required));
   MOCK_METHOD0(OnNewApplicationAdded, void());
-  MOCK_METHOD1(OnPolicyInit, void(bool is_update_required));
   MOCK_METHOD0(GetUpdateStatus, PolicyTableStatus());
 };
 

--- a/src/components/policy/policy_regular/test/update_status_manager_test.cc
+++ b/src/components/policy/policy_regular/test/update_status_manager_test.cc
@@ -62,20 +62,6 @@ class UpdateStatusManagerTest : public ::testing::Test {
 };
 
 TEST_F(UpdateStatusManagerTest,
-       StringifiedUpdateStatus_SetStatuses_ExpectCorrectStringifiedStatuses) {
-  // Arrange
-  manager_->OnPolicyInit(false);
-  // Check
-  EXPECT_EQ("UP_TO_DATE", manager_->StringifiedUpdateStatus());
-  manager_->OnPolicyInit(true);
-  // Check
-  EXPECT_EQ("UPDATE_NEEDED", manager_->StringifiedUpdateStatus());
-  manager_->OnUpdateSentOut();
-  // Check
-  EXPECT_EQ("UPDATING", manager_->StringifiedUpdateStatus());
-}
-
-TEST_F(UpdateStatusManagerTest,
        OnAppSearchStartedCompleted_ExpectAppSearchCorrectStatus) {
   // Arrange
   manager_->OnAppsSearchStarted();


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Build Core, Run unit tests.

### Summary
Removes OnPolicyInit function declaration and mentions in unit tests. Function is not used by core.
### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)