### PR TITLE
Remove defvalue from keepContext

### DIFF
--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -3327,7 +3327,7 @@
                 If the value is MOBILE_APP, the system shall switch to the mobile media app that issues the setter RPC.
             </description>
         </param>
-        <param name="keepContext" type="Boolean" defvalue="false" mandatory="false">
+        <param name="keepContext" type="Boolean" mandatory="false">
             <description>
                 This parameter shall not be present in any getter responses or notifications.
                 This parameter is optional in a setter request. The default value is false if it is not included.


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
RC ATF Test Set

### Summary
`keepContext` should not have a default value parameter because `keepContext` should not be present in getInteriorVehicleData and onInteriorVehicleData.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)