### PR TITLE
Fix issue where Vehicle Data and WayPoints were not unsubscribed

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -257,7 +257,7 @@ class ApplicationManagerImpl
    * @brief Get subscribed for way points
    * @return reference to set of subscribed apps for way points
    */
-  const std::set<int32_t> GetAppsSubscribedForWayPoints() const OVERRIDE;
+  const std::set<uint32_t> GetAppsSubscribedForWayPoints() const OVERRIDE;
 
   /**
    * @brief Notifies all components interested in Vehicle Data update
@@ -1355,7 +1355,7 @@ class ApplicationManagerImpl
   /**
    * @brief Set AppIDs of subscribed apps for way points
    */
-  std::set<int32_t> subscribed_way_points_apps_list_;
+  std::set<uint32_t> subscribed_way_points_apps_list_;
 
   /**
    * @brief Map contains applications which

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_way_point_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_way_point_change_notification.cc
@@ -55,10 +55,10 @@ OnWayPointChangeNotification::~OnWayPointChangeNotification() {}
 void OnWayPointChangeNotification::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  std::set<int32_t> subscribed_for_way_points =
+  std::set<uint32_t> subscribed_for_way_points =
       application_manager_.GetAppsSubscribedForWayPoints();
 
-  for (std::set<int32_t>::const_iterator app_id =
+  for (std::set<uint32_t>::const_iterator app_id =
            subscribed_for_way_points.begin();
        app_id != subscribed_for_way_points.end();
        ++app_id) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_way_point_change_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_way_point_change_notification_test.cc
@@ -98,7 +98,7 @@ MATCHER(CheckMessageData, "") {
 
 TEST_F(OnWayPointChangeNotificationTest,
        Run_NotEmptyListOfAppsSubscribedForWayPoints_SUCCESS) {
-  std::set<int32_t> apps_subscribed_for_way_points;
+  std::set<uint32_t> apps_subscribed_for_way_points;
   apps_subscribed_for_way_points.insert(kAppId);
 
   EXPECT_CALL(app_mngr_, GetAppsSubscribedForWayPoints())

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -76,6 +76,8 @@ void VehicleInfoPlugin::OnApplicationEvent(
   if (plugins::ApplicationEvent::kApplicationRegistered == event) {
     application->AddExtension(
         std::make_shared<VehicleInfoAppExtension>(*this, *application));
+  } else if (plugins::ApplicationEvent::kDeleteApplicationData == event) {
+    DeleteSubscriptions(application);
   }
 }
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1126,7 +1126,14 @@ void ApplicationManagerImpl::SwitchApplication(ApplicationSharedPtr app,
                                       << ". Changing device id to "
                                       << device_id);
 
+  bool is_subscribed_to_way_points = IsAppSubscribedForWayPoints(app);
+  if (is_subscribed_to_way_points) {
+    UnsubscribeAppFromWayPoints(app);
+  }
   SwitchApplicationParameters(app, connection_key, device_id, mac_address);
+  if (is_subscribed_to_way_points) {
+    SubscribeAppForWayPoints(app);
+  }
 
   // Normally this is done during registration, however since switched apps are
   // not being registered again need to set protocol version on session.
@@ -3482,6 +3489,7 @@ void ApplicationManagerImpl::SubscribeAppForWayPoints(
     ApplicationSharedPtr app) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(subscribed_way_points_apps_lock_);
+  LOG4CXX_DEBUG(logger_, "Subscribing " << app->app_id());
   subscribed_way_points_apps_list_.insert(app->app_id());
   LOG4CXX_DEBUG(logger_,
                 "There are applications subscribed: "
@@ -3492,6 +3500,7 @@ void ApplicationManagerImpl::UnsubscribeAppFromWayPoints(
     ApplicationSharedPtr app) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(subscribed_way_points_apps_lock_);
+  LOG4CXX_DEBUG(logger_, "Unsubscribing " << app->app_id());
   subscribed_way_points_apps_list_.erase(app->app_id());
   LOG4CXX_DEBUG(logger_,
                 "There are applications subscribed: "
@@ -3507,7 +3516,7 @@ bool ApplicationManagerImpl::IsAnyAppSubscribedForWayPoints() const {
   return !subscribed_way_points_apps_list_.empty();
 }
 
-const std::set<int32_t> ApplicationManagerImpl::GetAppsSubscribedForWayPoints()
+const std::set<uint32_t> ApplicationManagerImpl::GetAppsSubscribedForWayPoints()
     const {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(subscribed_way_points_apps_lock_);

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -245,7 +245,7 @@ TEST_F(ApplicationManagerImplTest,
   EXPECT_TRUE(app_manager_impl_->IsAppSubscribedForWayPoints(app_ptr));
   app_manager_impl_->UnsubscribeAppFromWayPoints(app_ptr);
   EXPECT_FALSE(app_manager_impl_->IsAppSubscribedForWayPoints(app_ptr));
-  const std::set<int32_t> result =
+  const std::set<uint32_t> result =
       app_manager_impl_->GetAppsSubscribedForWayPoints();
   EXPECT_TRUE(result.empty());
 }
@@ -264,7 +264,8 @@ TEST_F(
     GetAppsSubscribedForWayPoints_SubcribeAppForWayPoints_ExpectCorrectResult) {
   auto app_ptr = std::static_pointer_cast<am::Application>(mock_app_ptr_);
   app_manager_impl_->SubscribeAppForWayPoints(app_ptr);
-  std::set<int32_t> result = app_manager_impl_->GetAppsSubscribedForWayPoints();
+  std::set<uint32_t> result =
+      app_manager_impl_->GetAppsSubscribedForWayPoints();
   EXPECT_EQ(1u, result.size());
   EXPECT_TRUE(result.find(app_ptr->app_id()) != result.end());
 }

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -313,7 +313,7 @@ class ApplicationManager {
    * @brief Get subscribed for way points
    * @return reference to set of subscribed apps for way points
    */
-  virtual const std::set<int32_t> GetAppsSubscribedForWayPoints() const = 0;
+  virtual const std::set<uint32_t> GetAppsSubscribedForWayPoints() const = 0;
 
   virtual void RemoveHMIFakeParameters(
       application_manager::commands::MessageSharedPtr& message,

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -281,7 +281,7 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD1(UnsubscribeAppFromWayPoints,
                void(application_manager::ApplicationSharedPtr));
   MOCK_CONST_METHOD0(IsAnyAppSubscribedForWayPoints, bool());
-  MOCK_CONST_METHOD0(GetAppsSubscribedForWayPoints, const std::set<int32_t>());
+  MOCK_CONST_METHOD0(GetAppsSubscribedForWayPoints, const std::set<uint32_t>());
   MOCK_CONST_METHOD1(
       WaitingApplicationByID,
       application_manager::ApplicationConstSharedPtr(const uint32_t));


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **major** API changes.

### Testing Plan
Run ATF Test: `test_scripts/iAP2TransportSwitch/003_resume_failed_remove_data_check.lua`

### Summary
Fixes case where data was not unsubscribe on failed resumption during transport switching

### Changelog
##### Breaking Changes
* Changes signature of `GetAppsSubscribedForWayPoints`.

##### Bug Fixes
* App unsubscribes from Vehicle Data and Way Points on failed resumption

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)