### PR TITLE
Fix Display Capability Definitions in HMI_API

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -4280,11 +4280,11 @@
     <description>Method is invoked at system startup by SDL to request information about UI capabilities of HMI.</description>
   </function>
   <function name="GetCapabilities" messagetype="response">
-    <param name="displayCapabilities" type="Common.DisplayCapabilities" mandatory="true">
+    <param name="displayCapabilities" type="Common.DisplayCapabilities" mandatory="false">
       <description>Information about the capabilities of the display: its type, text field supported, etc. See DisplayCapabilities. </description>
     </param>
-    <param name="audioPassThruCapabilities" type="Common.AudioPassThruCapabilities" mandatory="true"/>
-    <param name="hmiZoneCapabilities" type="Common.HmiZoneCapabilities" mandatory="true"/>
+    <param name="audioPassThruCapabilities" type="Common.AudioPassThruCapabilities" minsize="1" maxsize="100" array="true" mandatory="false"/>
+    <param name="hmiZoneCapabilities" type="Common.HmiZoneCapabilities" minsize="1" maxsize="100" array="true" mandatory="false"/>
     <param name="softButtonCapabilities" type="Common.SoftButtonCapabilities" minsize="1" maxsize="100" array="true" mandatory="false">
       <description>Must be returned if the platform supports on-screen SoftButtons.</description>
     </param>


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Omit the audioPassThruCapability struct from the HMI UI.getCapabilities response.

### Summary
Update displayCapabilities, audioPassThruCapabilities, and hmiZoneCapabilities in the HMI API to better reflect definitions in the mobile api.

These parameters used to be mandatory only in the HMI_API which could cause issues. For example if an hmi didn't support audioPassThru, it would still be required to send a response for that capability. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)