### PR TITLE
Update base rpc version to 4.5.1

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_event_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_event_notification.cc
@@ -166,7 +166,7 @@ void OnButtonEventNotification::SendButtonEvent(ApplicationConstSharedPtr app) {
           (*message_)[strings::msg_params][hmi_response::button_name].asInt());
 
   if (btn_id == mobile_apis::ButtonName::PLAY_PAUSE &&
-      app->msg_version() <= utils::version_4_5) {
+      app->msg_version() <= utils::base_rpc_version) {
     btn_id = mobile_apis::ButtonName::OK;
   }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_press_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_press_notification.cc
@@ -174,7 +174,7 @@ void OnButtonPressNotification::SendButtonPress(ApplicationConstSharedPtr app) {
           (*message_)[strings::msg_params][hmi_response::button_name].asInt());
 
   if (btn_id == mobile_apis::ButtonName::PLAY_PAUSE &&
-      app->msg_version() <= utils::version_4_5) {
+      app->msg_version() <= utils::base_rpc_version) {
     btn_id = mobile_apis::ButtonName::OK;
   }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -332,13 +332,12 @@ void RegisterAppInterfaceRequest::Run() {
   }
 
   // Version negotiation
-  utils::SemanticVersion ver_4_5(4, 5, 0);
   utils::SemanticVersion module_version(
       major_version, minor_version, patch_version);
-  if (mobile_version <= ver_4_5) {
+  if (mobile_version <= utils::base_rpc_version) {
     // Mobile versioning did not exist for
     // versions 4.5 and prior.
-    application->set_msg_version(ver_4_5);
+    application->set_msg_version(utils::base_rpc_version);
   } else if (mobile_version < module_version) {
     // Use mobile RPC version as negotiated version
     application->set_msg_version(mobile_version);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_response.cc
@@ -63,7 +63,7 @@ void RegisterAppInterfaceResponse::Run() {
   application_manager::ApplicationSharedPtr app =
       application_manager_.application(connection_key());
 
-  if (app && app->msg_version() <= utils::version_4_5 &&
+  if (app && app->msg_version() <= utils::base_rpc_version &&
       app->is_media_application() &&
       (*message_)[strings::msg_params].keyExists(
           hmi_response::button_capabilities)) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_button_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_button_request.cc
@@ -77,7 +77,7 @@ void SubscribeButtonRequest::Run() {
     return;
   }
 
-  if (app->msg_version() <= utils::version_4_5 &&
+  if (app->msg_version() <= utils::base_rpc_version &&
       btn_id == mobile_apis::ButtonName::OK && app->is_media_application()) {
     bool ok_supported = CheckHMICapabilities(mobile_apis::ButtonName::OK);
     bool play_pause_supported =

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_button_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_button_request.cc
@@ -72,7 +72,7 @@ void UnsubscribeButtonRequest::Run() {
       static_cast<mobile_apis::ButtonName::eType>(
           (*message_)[str::msg_params][str::button_name].asInt());
 
-  if (app->msg_version() <= utils::version_4_5 &&
+  if (app->msg_version() <= utils::base_rpc_version &&
       btn_id == mobile_apis::ButtonName::OK && app->is_media_application()) {
     bool ok_supported = CheckHMICapabilities(mobile_apis::ButtonName::OK);
     bool play_pause_supported =

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/subscribe_button_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/subscribe_button_request_test.cc
@@ -212,8 +212,7 @@ TEST_F(SubscribeButtonRequestTest, Run_SUCCESS_App_Base_RPC_Version) {
 
   MockAppPtr app(CreateMockApp());
   ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
-  ON_CALL(*app, msg_version())
-      .WillByDefault(ReturnRef(mock_base_rpc_version));
+  ON_CALL(*app, msg_version()).WillByDefault(ReturnRef(mock_base_rpc_version));
   ON_CALL(*app, is_media_application()).WillByDefault(Return(true));
 
   ON_CALL(mock_hmi_capabilities_, is_ui_cooperating())

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/subscribe_button_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/subscribe_button_request_test.cc
@@ -74,7 +74,7 @@ class SubscribeButtonRequestTest
 
 typedef SubscribeButtonRequestTest::MockHMICapabilities MockHMICapabilities;
 const utils::SemanticVersion mock_semantic_version(5, 0, 0);
-const utils::SemanticVersion mock_semantic_version_4_5(4, 5, 0);
+const utils::SemanticVersion mock_base_rpc_version(4, 5, 1);
 
 TEST_F(SubscribeButtonRequestTest, Run_AppNotRegistered_UNSUCCESS) {
   CommandPtr command(CreateCommand<SubscribeButtonRequest>());
@@ -202,7 +202,7 @@ TEST_F(SubscribeButtonRequestTest, Run_SUCCESS) {
                                     [am::strings::result_code].asInt()));
 }
 
-TEST_F(SubscribeButtonRequestTest, Run_SUCCESS_App_Version_4_5) {
+TEST_F(SubscribeButtonRequestTest, Run_SUCCESS_App_Base_RPC_Version) {
   const mobile_apis::ButtonName::eType kButtonName =
       mobile_apis::ButtonName::OK;
 
@@ -213,7 +213,7 @@ TEST_F(SubscribeButtonRequestTest, Run_SUCCESS_App_Version_4_5) {
   MockAppPtr app(CreateMockApp());
   ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
   ON_CALL(*app, msg_version())
-      .WillByDefault(ReturnRef(mock_semantic_version_4_5));
+      .WillByDefault(ReturnRef(mock_base_rpc_version));
   ON_CALL(*app, is_media_application()).WillByDefault(Return(true));
 
   ON_CALL(mock_hmi_capabilities_, is_ui_cooperating())

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/unsubscribe_button_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/unsubscribe_button_request_test.cc
@@ -29,7 +29,7 @@ namespace {
 const uint32_t kConnectionKey = 1u;
 const mobile_apis::ButtonName::eType kButtonId = mobile_apis::ButtonName::OK;
 const utils::SemanticVersion mock_semantic_version(5, 0, 0);
-const utils::SemanticVersion mock_semantic_version_4_5(4, 5, 0);
+const utils::SemanticVersion mock_base_rpc_version(4, 5, 1);
 }  // namespace
 
 class UnsubscribeButtonRequestTest
@@ -151,7 +151,7 @@ TEST_F(UnsubscribeButtonRequestTest, Run_SUCCESS) {
   command->Run();
 }
 
-TEST_F(UnsubscribeButtonRequestTest, Run_SUCCESS_Version_4_5) {
+TEST_F(UnsubscribeButtonRequestTest, Run_SUCCESS_Base_RPC_Version) {
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
   (*command_msg)[am::strings::params][am::strings::connection_key] =
       kConnectionKey;
@@ -176,7 +176,7 @@ TEST_F(UnsubscribeButtonRequestTest, Run_SUCCESS_Version_4_5) {
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillRepeatedly(Return(mock_app));
   ON_CALL(*mock_app, msg_version())
-      .WillByDefault(ReturnRef(mock_semantic_version_4_5));
+      .WillByDefault(ReturnRef(mock_base_rpc_version));
   ON_CALL(*mock_app, is_media_application()).WillByDefault(Return(true));
 
   EXPECT_CALL(*mock_app,

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -219,8 +219,9 @@ void RPCHandlerImpl::GetMessageVersion(
     }
     utils::SemanticVersion temp_version(major, minor, patch);
     if (temp_version.isValid()) {
-      utils::SemanticVersion ver_4_5(4, 5, 0);
-      message_version = (temp_version > ver_4_5) ? temp_version : ver_4_5;
+      message_version = (temp_version > utils::base_rpc_version)
+                            ? temp_version
+                            : utils::base_rpc_version;
     }
   }
 }

--- a/src/components/include/utils/semantic_version.h
+++ b/src/components/include/utils/semantic_version.h
@@ -118,7 +118,7 @@ struct SemanticVersion {
   uint16_t patch_version_ = 0;
 };
 
-extern const SemanticVersion version_4_5;
+extern const SemanticVersion base_rpc_version;
 }
 
 #endif  // SRC_COMPONENTS_INCLUDE_UTILS_CALLABLE_H

--- a/src/components/utils/src/semantic_version.cc
+++ b/src/components/utils/src/semantic_version.cc
@@ -33,6 +33,6 @@
 
 namespace utils {
 
-const SemanticVersion version_4_5(4, 5, 0);
+const SemanticVersion base_rpc_version(4, 5, 1);
 
 }  // namespace utils


### PR DESCRIPTION
Supplemental Fix to #2657 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests and atf smoke tests

### Summary
Bumps the default rpc msg version to 4.5.1 due to the removal of defvalue for the subscribe parameter which created the 4.5.1 history since tag.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)