### PR TITLE
Feature/interior vehicle data resumption

### DIFF
--- a/src/components/application_manager/include/application_manager/app_extension.h
+++ b/src/components/application_manager/include/application_manager/app_extension.h
@@ -45,7 +45,9 @@ namespace smart_objects = ns_smart_device_link::ns_smart_objects;
 
 namespace resumption {
 struct ResumptionRequest;
+struct ResumptionHandlingCallbacks;
 using Subscriber = std::function<void(const int32_t, const ResumptionRequest)>;
+using ConcludeResumptionCallback = std::function<void(const int32_t)>;
 }  // namespace resumption
 
 namespace application_manager {
@@ -76,7 +78,7 @@ class AppExtension {
    */
   virtual void ProcessResumption(
       const smart_objects::SmartObject& resumption_data,
-      resumption::Subscriber subscriber) = 0;
+      resumption::ResumptionHandlingCallbacks) = 0;
 
   /**
    * @brief RevertResumption Method called by SDL during revert resumption.

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -347,9 +347,9 @@ class ApplicationManagerImpl
    */
   void UnregisterAllApplications();
 
-  DEPRECATED bool RemoveAppDataFromHMI(ApplicationSharedPtr app);
+  bool RemoveAppDataFromHMI(ApplicationSharedPtr app);
 
-  DEPRECATED bool LoadAppDataToHMI(ApplicationSharedPtr app);
+  bool LoadAppDataToHMI(ApplicationSharedPtr app);
   bool ActivateApplication(ApplicationSharedPtr app) OVERRIDE;
 
   /**

--- a/src/components/application_manager/include/application_manager/resumption/extension_pending_resumption_handler.h
+++ b/src/components/application_manager/include/application_manager/resumption/extension_pending_resumption_handler.h
@@ -6,6 +6,8 @@
 
 namespace resumption {
 
+struct ResumptionHandlingCallbacks;
+
 namespace app_mngr = application_manager;
 
 class ExtensionPendingResumptionHandler
@@ -22,8 +24,8 @@ class ExtensionPendingResumptionHandler
 
   virtual void HandleResumptionSubscriptionRequest(
       app_mngr::AppExtension& extension,
-      Subscriber& subscriber,
-      application_manager::Application& app) = 0;
+      app_mngr::Application& app,
+      ResumptionHandlingCallbacks callbacks) = 0;
 
   virtual void ClearPendingResumptionRequests() = 0;
 

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -64,6 +64,13 @@ struct ApplicationResumptionStatus {
   std::vector<ResumptionRequest> successful_requests;
   std::vector<std::string> unsuccesfull_vehicle_data_subscriptions_;
   std::vector<std::string> succesfull_vehicle_data_subscriptions_;
+
+struct ResumptionHandlingCallbacks {
+  using Subscriber =
+      std::function<void(const int32_t, const ResumptionRequest)>;
+  using ConcludeResumptionCallback = std::function<void(const int32_t)>;
+  Subscriber subscriber_;
+  ConcludeResumptionCallback conclude_resumption_callback_;
 };
 
 /**
@@ -298,6 +305,49 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
   void CheckVehicleDataResponse(const smart_objects::SmartObject& request,
                                 const smart_objects::SmartObject& response,
                                 ApplicationResumptionStatus& status);
+
+  /**
+   * @brief Determines whether application has saved data, including
+   * submenues, commands and choice sets, to restore. This does not include
+   * global properties and subscriptions
+   * @param saved_app smart object containing saved app data
+   * @return bool value stating whether app has mentioned data to restore
+   */
+  bool HasDataToRestore(const smart_objects::SmartObject& saved_app) const;
+
+  /**
+   * @brief Determines whether application has saved global properties
+   * to restore
+   * @param saved_app smart object containing saved app data
+   * @return bool value stating whether app has mentioned data to restore
+   */
+  bool HasGlobalPropertiesToRestore(
+      const smart_objects::SmartObject& saved_app) const;
+
+  /**
+   * @brief Determines whether application has saved subscriptions
+   * to restore
+   * @param saved_app smart object containing saved app data
+   * @return bool value stating whether app has mentioned data to restore
+   */
+  bool HasSubscriptionsToRestore(
+      const smart_objects::SmartObject& saved_app) const;
+
+  /**
+   * @brief Get button subscriptions that need to be resumed.
+   * Since some subscriptions can be set by default during 
+   * app registration, this function is needed to discard subscriptions
+   * that do not need to be resumed 
+   * @param application which subscriptions to resume
+   */
+  app_mngr::ButtonSubscriptions GetButtonSubscriptionsToResume(
+      app_mngr::ApplicationSharedPtr application) const;
+
+  void ConcludeResumption(const uint32_t app_id,
+                          const ApplicationResumptionStatus& status);
+
+  ResumptionHandlingCallbacks GetResumptionHandlingCallbacks();
+
   /**
    * @brief A map of the IDs and Application Resumption Status for these ID
    **/

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -64,6 +64,8 @@ struct ApplicationResumptionStatus {
   std::vector<ResumptionRequest> successful_requests;
   std::vector<std::string> unsuccesfull_vehicle_data_subscriptions_;
   std::vector<std::string> succesfull_vehicle_data_subscriptions_;
+  std::vector<std::string> successful_ivd_subscriptions_;
+};
 
 struct ResumptionHandlingCallbacks {
   using Subscriber =

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -298,34 +298,6 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
   void CheckVehicleDataResponse(const smart_objects::SmartObject& request,
                                 const smart_objects::SmartObject& response,
                                 ApplicationResumptionStatus& status);
-
-  /**
-   * @brief Determines whether application has saved data, including
-   * submenues, commands and choice sets, to restore. This does not include
-   * global properties and subscriptions
-   * @param saved_app smart object containing saved app data
-   * @return bool value stating whether app has mentioned data to restore
-   */
-  bool HasDataToRestore(const smart_objects::SmartObject& saved_app) const;
-
-  /**
-   * @brief Determines whether application has saved global properties
-   * to restore
-   * @param saved_app smart object containing saved app data
-   * @return bool value stating whether app has mentioned data to restore
-   */
-  bool HasGlobalPropertiesToRestore(
-      const smart_objects::SmartObject& saved_app) const;
-
-  /**
-   * @brief Determines whether application has saved subscriptions
-   * to restore
-   * @param saved_app smart object containing saved app data
-   * @return bool value stating whether app has mentioned data to restore
-   */
-  bool HasSubscriptionsToRestore(
-      const smart_objects::SmartObject& saved_app) const;
-
   /**
    * @brief A map of the IDs and Application Resumption Status for these ID
    **/

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -335,16 +335,6 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
   bool HasSubscriptionsToRestore(
       const smart_objects::SmartObject& saved_app) const;
 
-  /**
-   * @brief Get button subscriptions that need to be resumed.
-   * Since some subscriptions can be set by default during 
-   * app registration, this function is needed to discard subscriptions
-   * that do not need to be resumed 
-   * @param application which subscriptions to resume
-   */
-  app_mngr::ButtonSubscriptions GetButtonSubscriptionsToResume(
-      app_mngr::ApplicationSharedPtr application) const;
-
   void ConcludeResumption(const uint32_t app_id,
                           const ApplicationResumptionStatus& status);
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_app_extension.h
@@ -38,11 +38,16 @@
 #include <memory>
 #include "utils/macro.h"
 #include "application_manager/app_extension.h"
+#include "application_manager/application.h"
 
 namespace rc_rpc_plugin {
+class RCRPCPlugin;
+
 class RCAppExtension : public application_manager::AppExtension {
  public:
-  explicit RCAppExtension(application_manager::AppExtensionUID uid);
+  RCAppExtension(application_manager::AppExtensionUID uid,
+                 RCRPCPlugin* plugin,
+                 application_manager::Application& app);
   ~RCAppExtension();
 
   /**
@@ -73,10 +78,12 @@ class RCAppExtension : public application_manager::AppExtension {
    * @brief get list of subscriptions of application
    * @return list of subscriptions of application
    */
-  std::set<std::string> InteriorVehicleDataSubscriptions() const;
+  std::set<std::string> Subscriptions() const;
 
  private:
   std::set<std::string> subscribed_interior_vehicle_data_;
+  RCRPCPlugin* plugin_;
+  application_manager::Application& app_;
 
   // AppExtension interface
  public:

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_app_extension.h
@@ -96,10 +96,11 @@ class RCAppExtension : public application_manager::AppExtension {
   /**
   * @brief Running resumption data process.
   * @param saved_app saved data for resumption
-  * @param subscriber callback for subscription
+  * @param callbacks callback for handling resumption
   **/
-  void ProcessResumption(const smart_objects::SmartObject& saved_app,
-                         resumption::Subscriber subscriber) OVERRIDE;
+  void ProcessResumption(
+      const smart_objects::SmartObject& saved_app,
+      resumption::ResumptionHandlingCallbacks callbacks) OVERRIDE;
 
   /**
    * @brief Revert the data to the state before Resumption.

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_helpers.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_helpers.h
@@ -41,6 +41,15 @@
 namespace rc_rpc_plugin {
 class RCRPCPlugin;
 
+enum class RCModuleTypeIDs {
+  CLIMATE = 0,
+  RADIO,
+  SEAT,
+  AUDIO,
+  LIGHT,
+  HMI_SETTINGS
+};
+
 /**
  * @brief The RCHelpers class contains frequently used static data
  * structures related strictly to RC
@@ -63,6 +72,9 @@ class RCHelpers {
   */
   static const std::function<std::string(const std::string& module_type)>
   GetModuleTypeToCapabilitiesMapping();
+
+  static const std::function<std::string(const RCModuleTypeIDs module_type)>
+  GetModuleTypeToEnumMapping();
 
   /**
    * @brief GetModulesList get list of all known modules

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_pending_resumption_handler.h
@@ -1,0 +1,63 @@
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_PENDING_RESUMPTION_HANDLER_H
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_PENDING_RESUMPTION_HANDLER_H
+
+#include "application_manager/resumption/extension_pending_resumption_handler.h"
+#include "application_manager/resumption/resumption_data_processor.h"
+#include "rc_rpc_plugin.h"
+
+namespace rc_rpc_plugin {
+
+namespace app_mngr = application_manager;
+
+using InteriorDataCacheSptr = std::shared_ptr<InteriorDataCache>;
+
+class RCPendingResumptionHandler
+    : public resumption::ExtensionPendingResumptionHandler {
+ public:
+  RCPendingResumptionHandler(app_mngr::ApplicationManager& application_manager,
+                             InteriorDataCacheSptr interior_data_cache);
+
+  ~RCPendingResumptionHandler() {}
+
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
+
+  void HandleResumptionSubscriptionRequest(
+      app_mngr::AppExtension& extension,
+      app_mngr::Application& app,
+      resumption::ResumptionHandlingCallbacks callbacks) OVERRIDE;
+
+  void ClearPendingResumptionRequests() OVERRIDE;
+
+ private:
+  struct ResumptionAwaitingHandling {
+    app_mngr::AppExtension& extension;
+    const uint32_t application_id;
+    resumption::ResumptionHandlingCallbacks callbacks;
+    std::map<std::string, bool> handled_subscriptions;
+
+    ResumptionAwaitingHandling(const uint32_t app_id,
+                               app_mngr::AppExtension& ext,
+                               resumption::ResumptionHandlingCallbacks cb);
+  };
+
+  smart_objects::SmartObjectList CreateSubscriptionRequests(
+      const std::set<std::string> subscriptions, const uint32_t application_id);
+
+  void ProcessSubscriptionRequests(
+      const smart_objects::SmartObjectList& subscription_requests,
+      const ResumptionAwaitingHandling& resumption);
+
+  std::set<std::string> GetFrozenResumptionUnhandledSubscriptions(
+      const ResumptionAwaitingHandling& frozen_resumption);
+
+  bool NeedsToConcludeResumption(
+      const ResumptionAwaitingHandling& resumption_awaiting_handling) const;
+
+  std::shared_ptr<InteriorDataCache> interior_data_cache_;
+  std::map<uint32_t, smart_objects::SmartObject> pending_subscription_requests_;
+  std::deque<ResumptionAwaitingHandling> frozen_resumptions_;
+};
+
+}  // namespace rc_rpc_plugin
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_PENDING_RESUMPTION_HANDLER_H

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -135,8 +135,17 @@ void GetInteriorVehicleDataRequest::ProcessResponseToMobileFromCache(
     response_msg_params[message_params::kIsSubscribed] =
         request_msg_params[message_params::kSubscribe].asBool();
     if (request_msg_params[message_params::kSubscribe].asBool()) {
-      auto extension = RCHelpers::GetRCExtension(*app);
+      const auto extension = RCHelpers::GetRCExtension(*app);
       DCHECK(extension);
+      const bool is_app_already_subscribed =
+          extension->IsSubscibedToInteriorVehicleData(ModuleType());
+      if (is_app_already_subscribed) {
+        LOG4CXX_WARN(logger_, "Application is already subscribed");
+        SendResponse(
+            true, mobile_apis::Result::WARNINGS, nullptr, &response_msg_params);
+        return;
+      }
+
       extension->SubscribeToInteriorVehicleData(ModuleType());
       app->UpdateHash();
     }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/interior_data_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/interior_data_manager_impl.cc
@@ -101,7 +101,7 @@ void InteriorDataManagerImpl::UpdateHMISubscriptionsOnAppUnregistered(
     application_manager::Application& app) {
   LOG4CXX_AUTO_TRACE(logger_);
   auto rc_extension = RCHelpers::GetRCExtension(app);
-  auto subscribed_data = rc_extension->InteriorVehicleDataSubscriptions();
+  auto subscribed_data = rc_extension->Subscriptions();
   rc_extension->UnsubscribeFromInteriorVehicleData();
   for (auto& data : subscribed_data) {
     auto apps_subscribed =
@@ -147,7 +147,7 @@ InteriorDataManagerImpl::AppsSubscribedModules() {
   InteriorDataManagerImpl::AppsModules result;
   for (auto& app_ptr : apps_list) {
     const auto rc_extension = RCHelpers::GetRCExtension(*app_ptr);
-    auto app_subscriptions = rc_extension->InteriorVehicleDataSubscriptions();
+    auto app_subscriptions = rc_extension->Subscriptions();
     result[app_ptr] = std::vector<std::string>(app_subscriptions.size());
     std::copy(app_subscriptions.begin(),
               app_subscriptions.end(),

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_app_extension.cc
@@ -31,10 +31,21 @@
  */
 
 #include "rc_rpc_plugin/rc_app_extension.h"
+#include "smart_objects/smart_object.h"
+#include "rc_rpc_plugin/rc_rpc_plugin.h"
+#include "application_manager/message_helper.h"
+#include "application_manager/resumption/resumption_data_processor.h"
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "RCAppExtension")
 
 namespace rc_rpc_plugin {
-RCAppExtension::RCAppExtension(application_manager::AppExtensionUID uid)
-    : AppExtension(uid) {}
+
+namespace strings = application_manager::strings;
+
+RCAppExtension::RCAppExtension(application_manager::AppExtensionUID uid,
+                               RCRPCPlugin* plugin,
+                               application_manager::Application& app)
+    : AppExtension(uid), plugin_(plugin), app_(app) {}
 
 void RCAppExtension::SubscribeToInteriorVehicleData(
     const std::string& module_type) {
@@ -59,16 +70,64 @@ bool RCAppExtension::IsSubscibedToInteriorVehicleData(
 }
 
 void RCAppExtension::SaveResumptionData(
-    smart_objects::SmartObject& resumption_data) {}
+    smart_objects::SmartObject& resumption_data) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const char* application_interior_data = "moduleData";
+  resumption_data[application_interior_data] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  int i = 0;
+  LOG4CXX_DEBUG(logger_,
+                "subscribed_interior_vehicle_data_.size(): "
+                    << subscribed_interior_vehicle_data_.size());
+  for (const auto& module_type : subscribed_interior_vehicle_data_) {
+    LOG4CXX_DEBUG(logger_, "Saving module type: " << module_type.c_str());
+    resumption_data[application_interior_data][i++] = module_type;
+  }
+}
 
 void RCAppExtension::ProcessResumption(
     const smart_objects::SmartObject& saved_app,
-    resumption::Subscriber subscriber) {}
+    resumption::ResumptionHandlingCallbacks callbacks) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!saved_app.keyExists(strings::application_subscriptions)) {
+    LOG4CXX_DEBUG(logger_, "application_subscriptions section is not exists");
+    return;
+  }
+
+  const smart_objects::SmartObject& resumption_data =
+      saved_app[strings::application_subscriptions];
+
+  const char* application_interior_data = "moduleData";
+  if (resumption_data.keyExists(application_interior_data)) {
+    const smart_objects::SmartObject& interior_data_subscriptions =
+        resumption_data[application_interior_data];
+
+    std::set<std::string> hmi_requests;
+
+    for (size_t i = 0; i < interior_data_subscriptions.length(); ++i) {
+      const std::string module_type(
+          (interior_data_subscriptions[i]).asString());
+      if (!plugin_->IsSubscribedAppExist(module_type)) {
+        hmi_requests.insert(module_type);
+      }
+
+      LOG4CXX_DEBUG(logger_,
+                    "Subscribing for module type: " << module_type.c_str());
+      SubscribeToInteriorVehicleData(module_type);
+    }
+    plugin_->ProcessResumptionSubscription(app_, *this, callbacks);
+  }
+}
 
 void RCAppExtension::RevertResumption(
-    const smart_objects::SmartObject& subscriptions) {}
+    const smart_objects::SmartObject& subscriptions) {
+  LOG4CXX_AUTO_TRACE(logger_);
 
-std::set<std::string> RCAppExtension::InteriorVehicleDataSubscriptions() const {
+  UnsubscribeFromInteriorVehicleData();
+  plugin_->RevertResumption(app_, subscriptions["ivd"].enumerate());
+}
+
+std::set<std::string> RCAppExtension::Subscriptions() const {
   return subscribed_interior_vehicle_data_;
 }
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_helpers.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_helpers.cc
@@ -50,6 +50,28 @@ RCHelpers::GetModuleTypeToCapabilitiesMapping() {
   return mapping_lambda;
 }
 
+const std::function<std::string(const RCModuleTypeIDs module_type)>
+RCHelpers::GetModuleTypeToEnumMapping() {
+  auto mapping_lambda = [](const RCModuleTypeIDs module_type) -> std::string {
+    static std::map<RCModuleTypeIDs, std::string> mapping = {
+        {RCModuleTypeIDs::CLIMATE, enums_value::kClimate},
+        {RCModuleTypeIDs::RADIO, enums_value::kRadio},
+        {RCModuleTypeIDs::SEAT, enums_value::kSeat},
+        {RCModuleTypeIDs::AUDIO, enums_value::kAudio},
+        {RCModuleTypeIDs::LIGHT, enums_value::kLight},
+        {RCModuleTypeIDs::HMI_SETTINGS, enums_value::kHmiSettings}};
+    auto it = mapping.find(module_type);
+    if (mapping.end() == it) {
+      LOG4CXX_ERROR(logger_,
+                    "Unknown module type" << static_cast<int32_t>(module_type));
+      return std::string();
+    }
+    return it->second;
+  };
+
+  return mapping_lambda;
+}
+
 const std::vector<std::string> RCHelpers::GetModulesList() {
   using namespace enums_value;
   return {kClimate, kRadio, kSeat, kAudio, kLight, kHmiSettings};

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_pending_resumption_handler.cc
@@ -1,0 +1,290 @@
+#include "rc_rpc_plugin/rc_pending_resumption_handler.h"
+#include "rc_rpc_plugin/rc_module_constants.h"
+#include "rc_rpc_plugin/rc_app_extension.h"
+#include "rc_rpc_plugin/rc_helpers.h"
+#include "application_manager/message_helper.h"
+#include "application_manager/resumption/resumption_data_processor.h"
+#include "smart_objects/smart_object.h"
+#include "utils/helpers.h"
+
+#include <vector>
+
+namespace rc_rpc_plugin {
+
+namespace app_mngr = application_manager;
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "RCPendingResumptionHandler")
+
+static const char* module_type_key = "moduleType";
+static const char* intended_action_key = "subscribe";
+
+RCPendingResumptionHandler::ResumptionAwaitingHandling::
+    ResumptionAwaitingHandling(const uint32_t app_id,
+                               app_mngr::AppExtension& ext,
+                               resumption::ResumptionHandlingCallbacks cb)
+    : extension(ext), application_id(app_id), callbacks(cb) {
+  RCAppExtension& rc_app_extension = dynamic_cast<RCAppExtension&>(extension);
+  std::set<std::string> subscriptions = rc_app_extension.Subscriptions();
+
+  for (const auto& subscription : subscriptions) {
+    handled_subscriptions[subscription] = false;
+  }
+}
+
+RCPendingResumptionHandler::RCPendingResumptionHandler(
+    app_mngr::ApplicationManager& application_manager,
+    InteriorDataCacheSptr interior_data_cache)
+    : ExtensionPendingResumptionHandler(application_manager)
+    , interior_data_cache_(interior_data_cache) {}
+
+void RCPendingResumptionHandler::on_event(
+    const app_mngr::event_engine::Event& event) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const smart_objects::SmartObject& response = event.smart_object();
+  const uint32_t correlation_id = event.smart_object_correlation_id();
+
+  LOG4CXX_DEBUG(logger_, "Received corr id: " << correlation_id);
+
+  if (pending_subscription_requests_.find(correlation_id) ==
+      pending_subscription_requests_.end()) {
+    LOG4CXX_WARN(logger_,
+                 "pending subscription request for correlation id"
+                     << correlation_id << " not found");
+    return;
+  }
+
+  smart_objects::SmartObject pending_subscription_request =
+      pending_subscription_requests_[correlation_id];
+
+  const hmi_apis::Common_Result::eType result_code =
+      static_cast<hmi_apis::Common_Result::eType>(
+          response[app_mngr::strings::params]
+                  [application_manager::hmi_response::code].asInt());
+
+  const bool is_subscription_successful =
+      (result_code == hmi_apis::Common_Result::SUCCESS ||
+       result_code == hmi_apis::Common_Result::WARNINGS);
+
+  LOG4CXX_DEBUG(logger_,
+                "is_subscription_successful: " << is_subscription_successful);
+
+  LOG4CXX_DEBUG(logger_, "result_code: " << result_code);
+
+  const std::string subscription_module_type =
+      pending_subscription_request[app_mngr::strings::msg_params]
+                                  [module_type_key].asString();
+
+  if (!frozen_resumptions_.empty()) {
+    if (is_subscription_successful) {
+      LOG4CXX_DEBUG(logger_,
+                    "subscription for " << subscription_module_type
+                                        << " successful");
+
+      for (auto& frozen_resumption : frozen_resumptions_) {
+        if (frozen_resumption.handled_subscriptions.find(
+                subscription_module_type) !=
+            frozen_resumption.handled_subscriptions.end()) {
+          frozen_resumption.handled_subscriptions[subscription_module_type];
+        }
+      }
+      pending_subscription_requests_.erase(correlation_id);
+    } else {
+      pending_subscription_requests_.clear();
+      ResumptionAwaitingHandling freezed_resumption =
+          frozen_resumptions_.front();
+      frozen_resumptions_.pop_front();
+      std::set<std::string> unhandled_subscriptions =
+          GetFrozenResumptionUnhandledSubscriptions(freezed_resumption);
+      ProcessSubscriptionRequests(
+          CreateSubscriptionRequests(unhandled_subscriptions,
+                                     freezed_resumption.application_id),
+          freezed_resumption);
+    }
+  }
+
+  if (is_subscription_successful) {
+    const auto& data_mapping = RCHelpers::GetModuleTypeToDataMapping();
+    auto& moduleData =
+        response[app_mngr::strings::msg_params][message_params::kModuleData]
+                [data_mapping(subscription_module_type)];
+    app_mngr::MessageHelper::PrintSmartObject(moduleData);
+    interior_data_cache_->Add(subscription_module_type, moduleData);
+  }
+  LOG4CXX_DEBUG(logger_, "There are no frozen resumptions");
+  pending_subscription_requests_.erase(correlation_id);
+  return;
+}
+
+void RCPendingResumptionHandler::HandleResumptionSubscriptionRequest(
+    app_mngr::AppExtension& extension,
+    app_mngr::Application& app,
+    resumption::ResumptionHandlingCallbacks callbacks) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  LOG4CXX_DEBUG(logger_, "received app_id: " << app.app_id());
+
+  // TODO create Subscriptions method in AppExtension
+  RCAppExtension& rc_app_extension = dynamic_cast<RCAppExtension&>(extension);
+  std::set<std::string> subscriptions = rc_app_extension.Subscriptions();
+  ResumptionAwaitingHandling resumption_awaiting_handling(
+      app.app_id(), rc_app_extension, callbacks);
+
+  if (pending_subscription_requests_.empty()) {
+    LOG4CXX_DEBUG(logger_, "There are NO pending resumptions");
+    smart_objects::SmartObjectList subscription_requests =
+        CreateSubscriptionRequests(subscriptions, app.app_id());
+    ProcessSubscriptionRequests(subscription_requests,
+                                resumption_awaiting_handling);
+  } else {
+    LOG4CXX_DEBUG(logger_, "There are pending resumptions");
+    frozen_resumptions_.push_back(resumption_awaiting_handling);
+  }
+}
+
+void RCPendingResumptionHandler::ClearPendingResumptionRequests() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const hmi_apis::FunctionID::eType timed_out_pending_request_fid = static_cast<
+      hmi_apis::FunctionID::eType>(
+      pending_subscription_requests_.begin()
+          ->second[app_mngr::strings::params][app_mngr::strings::function_id]
+          .asInt());
+  unsubscribe_from_event(timed_out_pending_request_fid);
+  pending_subscription_requests_.clear();
+
+  if (!frozen_resumptions_.empty()) {
+    ResumptionAwaitingHandling freezed_resumption = frozen_resumptions_.front();
+    frozen_resumptions_.pop_front();
+
+    std::set<std::string> unhandled_subscriptions =
+        GetFrozenResumptionUnhandledSubscriptions(freezed_resumption);
+    ProcessSubscriptionRequests(
+        CreateSubscriptionRequests(unhandled_subscriptions,
+                                   freezed_resumption.application_id),
+        freezed_resumption);
+  }
+}
+
+smart_objects::SmartObjectList
+RCPendingResumptionHandler::CreateSubscriptionRequests(
+    const std::set<std::string> subscriptions, const uint32_t application_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  smart_objects::SmartObjectList subscription_requests;
+
+  smart_objects::SmartObject msg_params =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  msg_params[app_mngr::strings::app_id] = application_id;
+
+  for (auto& module_type : subscriptions) {
+    LOG4CXX_DEBUG(logger_, "processing module type: " << module_type.c_str());
+    msg_params[module_type_key] = module_type;
+    msg_params[intended_action_key] = true;
+
+    smart_objects::SmartObjectSPtr request =
+        application_manager::MessageHelper::CreateModuleInfoSO(
+            hmi_apis::FunctionID::RC_GetInteriorVehicleData,
+            application_manager_);
+
+    smart_objects::SmartObject& object = *request;
+    object[app_mngr::strings::params][app_mngr::strings::message_type] =
+        static_cast<int>(app_mngr::kRequest);
+    object[app_mngr::strings::params][app_mngr::strings::function_id] =
+        static_cast<int>(hmi_apis::FunctionID::RC_GetInteriorVehicleData);
+    object[app_mngr::strings::params][app_mngr::strings::correlation_id] =
+        application_manager_.GetNextHMICorrelationID();
+    object[app_mngr::strings::msg_params] =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+    (*request)[app_mngr::strings::msg_params] = msg_params;
+    subscription_requests.push_back(request);
+  }
+
+  return subscription_requests;
+}
+
+void RCPendingResumptionHandler::ProcessSubscriptionRequests(
+    const smart_objects::SmartObjectList& subscription_requests,
+    const ResumptionAwaitingHandling& resumption) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  using namespace resumption;
+
+  for (const auto& subscription_request : subscription_requests) {
+    auto it = pending_subscription_requests_.end();
+    std::find_if(
+        pending_subscription_requests_.begin(),
+        pending_subscription_requests_.end(),
+        [&subscription_request](
+            const std::pair<uint32_t, smart_objects::SmartObject>& item) {
+          return (*subscription_request)[app_mngr::strings::msg_params]
+                                        [module_type_key].asString() ==
+                 item.second[app_mngr::strings::msg_params][module_type_key]
+                     .asString();
+        });
+    if (it == pending_subscription_requests_.end()) {
+      if (NeedsToConcludeResumption(resumption)) {
+        LOG4CXX_DEBUG(
+            logger_,
+            "application "
+                << resumption.application_id
+                << " will conclude resumption without sending HMI requests");
+        resumption.callbacks.conclude_resumption_callback_(
+            resumption.application_id);
+        return;
+      }
+      const uint32_t correlation_id =
+          (*subscription_request)[app_mngr::strings::params]
+                                 [app_mngr::strings::correlation_id].asUInt();
+      pending_subscription_requests_[correlation_id] = *subscription_request;
+      const auto function_id = static_cast<hmi_apis::FunctionID::eType>(
+          (*subscription_request)[application_manager::strings::params]
+                                 [application_manager::strings::function_id]
+                                     .asInt());
+      auto resumption_request =
+          ExtensionPendingResumptionHandler::MakeResumptionRequest(
+              correlation_id, function_id, *subscription_request);
+
+      subscribe_on_event(function_id, correlation_id);
+
+      resumption.callbacks.subscriber_(resumption.application_id,
+                                       resumption_request);
+
+      application_manager_.GetRPCService().ManageHMICommand(
+          subscription_request);
+    }
+  }
+}
+
+std::set<std::string>
+RCPendingResumptionHandler::GetFrozenResumptionUnhandledSubscriptions(
+    const ResumptionAwaitingHandling& frozen_resumption) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  std::set<std::string> unhandled_subscriptions;
+
+  for (const auto& subscription : frozen_resumption.handled_subscriptions) {
+    if (!subscription.second) {
+      unhandled_subscriptions.insert(subscription.first);
+    }
+  }
+
+  return unhandled_subscriptions;
+}
+
+bool RCPendingResumptionHandler::NeedsToConcludeResumption(
+    const ResumptionAwaitingHandling& resumption_awaiting_handling) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  RCAppExtension& ext =
+      dynamic_cast<RCAppExtension&>(resumption_awaiting_handling.extension);
+
+  for (const auto& subscription : ext.Subscriptions()) {
+    if (!interior_data_cache_->Contains(subscription))
+      return false;
+  }
+
+  return true;
+}
+
+}  // namespace rc_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -31,6 +31,7 @@
  */
 
 #include "rc_rpc_plugin/rc_rpc_plugin.h"
+#include <memory>
 #include "rc_rpc_plugin/rc_command_factory.h"
 #include "rc_rpc_plugin/rc_app_extension.h"
 #include "rc_rpc_plugin/resource_allocation_manager_impl.h"
@@ -38,12 +39,18 @@
 #include "rc_rpc_plugin/interior_data_manager_impl.h"
 #include "rc_rpc_plugin/rc_helpers.h"
 #include "utils/helpers.h"
-#include <memory>
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/message_helper.h"
+#include "rc_rpc_plugin/rc_pending_resumption_handler.h"
 
 namespace rc_rpc_plugin {
 CREATE_LOGGERPTR_GLOBAL(logger_, "RemoteControlModule");
 
+static const char* module_type_key = "moduleType";
+static const char* intended_action_key = "subscribe";
+
 namespace plugins = application_manager::plugin_manager;
+namespace strings = application_manager::strings;
 
 bool RCRPCPlugin::Init(
     application_manager::ApplicationManager& app_manager,
@@ -66,6 +73,8 @@ bool RCRPCPlugin::Init(
   command_factory_.reset(new rc_rpc_plugin::RCCommandFactory(params));
   rpc_service_ = &rpc_service;
   app_mngr_ = &app_manager;
+  pending_resumption_handler_ = std::make_shared<RCPendingResumptionHandler>(
+      app_manager, interior_data_cache_);
   return true;
 }
 
@@ -98,8 +107,8 @@ void RCRPCPlugin::OnApplicationEvent(
   }
   switch (event) {
     case plugins::kApplicationRegistered: {
-      application->AddExtension(
-          std::shared_ptr<RCAppExtension>(new RCAppExtension(kRCPluginID)));
+      application->AddExtension(std::shared_ptr<RCAppExtension>(
+          new RCAppExtension(kRCPluginID, this, *application)));
       resource_allocation_manager_->SendOnRCStatusNotifications(
           NotificationTrigger::APP_REGISTRATION, application);
       break;
@@ -117,6 +126,81 @@ void RCRPCPlugin::OnApplicationEvent(
     default:
       break;
   }
+}
+
+void RCRPCPlugin::ProcessResumptionSubscription(
+    application_manager::Application& app,
+    RCAppExtension& ext,
+    resumption::ResumptionHandlingCallbacks callbacks) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  pending_resumption_handler_->HandleResumptionSubscriptionRequest(
+      ext, app, callbacks);
+}
+
+void RCRPCPlugin::RevertResumption(
+    application_manager::Application& app,
+    const std::set<std::string>& list_of_subscriptions) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+
+  pending_resumption_handler_->ClearPendingResumptionRequests();
+
+  const auto& mapping = RCHelpers::GetModuleTypeToEnumMapping();
+
+  for (auto& module_type : list_of_subscriptions) {
+    std::string module_type_str =
+        mapping(static_cast<RCModuleTypeIDs>(std::stoi(module_type)));
+    LOG4CXX_DEBUG(logger_, "Processing unsubscription of " << module_type_str);
+    if (!IsSubscribedAppExist(module_type_str)) {
+      LOG4CXX_DEBUG(logger_,
+                    "Creating unsubscription request for " << module_type_str);
+      interior_data_cache_->Remove(module_type_str);
+      smart_objects::SmartObjectSPtr request =
+          CreateUnsubscriptionRequest(module_type_str);
+      app_mngr_->GetRPCService().ManageHMICommand(request);
+    }
+  }
+}
+
+bool RCRPCPlugin::IsSubscribedAppExist(const std::string& module_type) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  auto applications = app_mngr_->applications();
+
+  for (auto& app : applications.GetData()) {
+    auto& ext = ExtractInteriorVehicleDataExtension(*app);
+    if (ext.IsSubscibedToInteriorVehicleData(module_type)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+RCAppExtension& RCRPCPlugin::ExtractInteriorVehicleDataExtension(
+    application_manager::Application& app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  auto ext_ptr = app.QueryInterface(kRCPluginID);
+  DCHECK(ext_ptr);
+  DCHECK(dynamic_cast<RCAppExtension*>(ext_ptr.get()));
+  auto rc_app_extension = std::static_pointer_cast<RCAppExtension>(ext_ptr);
+  DCHECK(rc_app_extension);
+  return *rc_app_extension;
+}
+
+smart_objects::SmartObjectSPtr RCRPCPlugin::CreateUnsubscriptionRequest(
+    const std::string& module_type) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  smart_objects::SmartObject msg_params =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  msg_params[module_type_key] = module_type;
+  msg_params[intended_action_key] = false;
+  smart_objects::SmartObjectSPtr request =
+      application_manager::MessageHelper::CreateModuleInfoSO(
+          hmi_apis::FunctionID::RC_GetInteriorVehicleData, *app_mngr_);
+  (*request)[strings::msg_params] = msg_params;
+
+  return request;
 }
 
 RCRPCPlugin::Apps RCRPCPlugin::GetRCApplications(

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
@@ -79,8 +79,8 @@ class ButtonPressRequestTest
   ButtonPressRequestTest()
       : rc_capabilities_(smart_objects::SmartType_Map)
       , mock_app_(std::make_shared<NiceMock<MockApplication> >())
-      , rc_app_extention_(
-            std::make_shared<rc_rpc_plugin::RCAppExtension>(kModuleId)) {}
+      , rc_app_extention_(std::make_shared<rc_rpc_plugin::RCAppExtension>(
+            kModuleId, nullptr, *mock_app_)) {}
 
   smart_objects::SmartObject ButtonCapability(
       const mobile_apis::ButtonName::eType button_name) {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -87,8 +87,10 @@ class GetInteriorVehicleDataRequestTest
   GetInteriorVehicleDataRequestTest()
       : mock_app_(std::make_shared<NiceMock<MockApplication> >())
       , mock_app2_(std::make_shared<NiceMock<MockApplication> >())
-      , rc_app_extention_(std::make_shared<RCAppExtension>(kModuleId))
-      , rc_app_extention2_(std::make_shared<RCAppExtension>(kModuleId))
+      , rc_app_extention_(
+            std::make_shared<RCAppExtension>(kModuleId, nullptr, *mock_app_))
+      , rc_app_extention2_(
+            std::make_shared<RCAppExtension>(kModuleId, nullptr, *mock_app2_))
       , apps_lock_(std::make_shared<sync_primitives::Lock>())
       , apps_da_(apps_, apps_lock_) {
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId));

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_interior_vehicle_data_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_interior_vehicle_data_notification_test.cc
@@ -70,7 +70,8 @@ class OnInteriorVehicleDataNotificationTest
  public:
   OnInteriorVehicleDataNotificationTest()
       : mock_app_(std::make_shared<NiceMock<MockApplication> >())
-      , rc_app_extention_(std::make_shared<RCAppExtension>(kModuleId))
+      , rc_app_extention_(
+            std::make_shared<RCAppExtension>(kModuleId, nullptr, *mock_app_))
       , apps_lock_(std::make_shared<sync_primitives::Lock>())
       , apps_da_(apps_, apps_lock_) {
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId));

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
@@ -107,7 +107,8 @@ class RCGetInteriorVehicleDataConsentTest
                      &mock_protocol_handler,
                      &mock_hmi_handler,
                      command_holder)
-      , rc_app_extention_(std::make_shared<RCAppExtension>(kPluginID))
+      , rc_app_extention_(
+            std::make_shared<RCAppExtension>(kPluginID, nullptr, *mock_app_))
       , mock_rpc_plugin_manager(
             std::make_shared<NiceMock<MockRPCPluginManager> >())
       , rpc_plugin(mock_rpc_plugin)

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
@@ -67,7 +67,8 @@ class SetInteriorVehicleDataRequestTest
  public:
   SetInteriorVehicleDataRequestTest()
       : mock_app_(std::make_shared<NiceMock<MockApplication> >())
-      , rc_app_extention_(std::make_shared<RCAppExtension>(kModuleId)) {}
+      , rc_app_extention_(
+            std::make_shared<RCAppExtension>(kModuleId, nullptr, *mock_app_)) {}
 
   void SetUp() OVERRIDE {
     ON_CALL(app_mngr_, hmi_interfaces())

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/resource_allocation_manager_impl_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/resource_allocation_manager_impl_test.cc
@@ -90,7 +90,8 @@ class RAManagerTest : public ::testing::Test {
     ON_CALL(mock_app_mngr_, GetPolicyHandler())
         .WillByDefault(ReturnRef(mock_policy_handler_));
     auto plugin_id = rc_rpc_plugin::RCRPCPlugin::kRCPluginID;
-    app_ext_ptr_ = std::make_shared<rc_rpc_plugin::RCAppExtension>(plugin_id);
+    app_ext_ptr_ = std::make_shared<rc_rpc_plugin::RCAppExtension>(
+        plugin_id, nullptr, *(mock_app_1_.get()));
     ON_CALL(*mock_app_1_, app_id()).WillByDefault(Return(kAppId1));
 
     OnRCStatusNotificationExpectations();
@@ -317,9 +318,11 @@ TEST_F(RAManagerTest, AppUnregistered_ReleaseResource) {
   ResourceAllocationManagerImpl ra_manager(mock_app_mngr_, mock_rpc_service_);
   ra_manager.SetAccessMode(hmi_apis::Common_RCAccessMode::eType::AUTO_DENY);
 
-  RCAppExtensionPtr rc_extention_ptr =
-      std::make_shared<RCAppExtension>(application_manager::AppExtensionUID(
-          rc_rpc_plugin::RCRPCPlugin::kRCPluginID));
+  RCAppExtensionPtr rc_extention_ptr = std::make_shared<RCAppExtension>(
+      application_manager::AppExtensionUID(
+          rc_rpc_plugin::RCRPCPlugin::kRCPluginID),
+      nullptr,
+      *(mock_app_1_.get()));
 
   EXPECT_EQ(rc_rpc_plugin::AcquireResult::ALLOWED,
             ra_manager.AcquireResource(kModuleType1, kAppId1));
@@ -387,9 +390,11 @@ TEST_F(RAManagerTest, AppsDisallowed_ReleaseAllResources) {
 
   EXPECT_CALL(mock_app_mngr_, applications()).WillRepeatedly(Return(apps_da));
 
-  RCAppExtensionPtr rc_extention_ptr =
-      std::make_shared<RCAppExtension>(application_manager::AppExtensionUID(
-          rc_rpc_plugin::RCRPCPlugin::kRCPluginID));
+  RCAppExtensionPtr rc_extention_ptr = std::make_shared<RCAppExtension>(
+      application_manager::AppExtensionUID(
+          rc_rpc_plugin::RCRPCPlugin::kRCPluginID),
+      nullptr,
+      *(mock_app_1_.get()));
 
   EXPECT_CALL(*mock_app_1_, QueryInterface(RCRPCPlugin::kRCPluginID))
       .WillRepeatedly(Return(rc_extention_ptr));
@@ -420,7 +425,9 @@ TEST_F(RAManagerTest, AppGotRevokedModulesWithPTU_ReleaseRevokedResource) {
   RCAppExtensionPtr rc_extention_ptr =
       std::make_shared<rc_rpc_plugin::RCAppExtension>(
           application_manager::AppExtensionUID(
-              rc_rpc_plugin::RCRPCPlugin::kRCPluginID));
+              rc_rpc_plugin::RCRPCPlugin::kRCPluginID),
+          nullptr,
+          *(mock_app_1_.get()));
 
   EXPECT_CALL(*mock_app_1_, QueryInterface(RCRPCPlugin::kRCPluginID))
       .WillRepeatedly(Return(rc_extention_ptr));

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_app_extension.h
@@ -62,8 +62,9 @@ class SDLAppExtension : public app_mngr::AppExtension {
   * @param resumption_data resumption data
   * @param subscriber callback for subscription
   */
-  void ProcessResumption(const smart_objects::SmartObject& saved_app,
-                         resumption::Subscriber subscriber) OVERRIDE;
+  void ProcessResumption(
+      const smart_objects::SmartObject& saved_app,
+      resumption::ResumptionHandlingCallbacks callbacks) OVERRIDE;
 
   /**
   * @brief Revert the data to the state before Resumption.

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_pending_resumption_handler.h
@@ -52,8 +52,8 @@ class SDLPendingResumptionHandler
 
   void HandleResumptionSubscriptionRequest(
       app_mngr::AppExtension& extension,
-      resumption::Subscriber& subscriber,
-      application_manager::Application& app) OVERRIDE;
+      app_mngr::Application& app,
+      resumption::ResumptionHandlingCallbacks callbacks) OVERRIDE;
 
   void ClearPendingResumptionRequests() OVERRIDE;
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_rpc_plugin.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_rpc_plugin.h
@@ -69,9 +69,10 @@ class SDLRPCPlugin : public plugins::RPCPlugin {
    * @param ext application extension
    * @param subscriber callback for subscription
    */
-  void ProcessResumptionSubscription(application_manager::Application& app,
-                                     SDLAppExtension& ext,
-                                     resumption::Subscriber subscriber);
+  void ProcessResumptionSubscription(
+      application_manager::Application& app,
+      SDLAppExtension& ext,
+      resumption::ResumptionHandlingCallbacks callbacks);
 
   /**
    * @brief Revert the data to the state before Resumption.

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -223,7 +223,6 @@ bool RegisterAppInterfaceRequest::ProcessApplicationTransportSwitching() {
   if (!IsApplicationSwitched()) {
     return false;
   }
-  const auto& msg_params = (*message_)[strings::msg_params];
 
   const std::string& policy_app_id =
       application_manager_.GetCorrectMobileIDFromMessage(message_);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -223,6 +223,7 @@ bool RegisterAppInterfaceRequest::ProcessApplicationTransportSwitching() {
   if (!IsApplicationSwitched()) {
     return false;
   }
+  const auto& msg_params = (*message_)[strings::msg_params];
 
   const std::string& policy_app_id =
       application_manager_.GetCorrectMobileIDFromMessage(message_);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_app_extension.cc
@@ -32,6 +32,7 @@
 
 #include "sdl_rpc_plugin/sdl_app_extension.h"
 #include "sdl_rpc_plugin/sdl_rpc_plugin.h"
+#include "application_manager/resumption/resumption_data_processor.h"
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "SDLAppExtension")
 
@@ -58,7 +59,7 @@ void SDLAppExtension::SaveResumptionData(
 
 void SDLAppExtension::ProcessResumption(
     const smart_objects::SmartObject& saved_app,
-    resumption::Subscriber subscriber) {
+    resumption::ResumptionHandlingCallbacks callbacks) {
   LOG4CXX_AUTO_TRACE(logger_);
   if (!saved_app.keyExists(strings::subscribed_for_way_points)) {
     LOG4CXX_ERROR(logger_, "subscribed_for_way_points section does not exist");
@@ -67,7 +68,7 @@ void SDLAppExtension::ProcessResumption(
   const bool subscribed_for_way_points_so =
       saved_app[strings::subscribed_for_way_points].asBool();
   if (subscribed_for_way_points_so) {
-    plugin_.ProcessResumptionSubscription(app_, *this, subscriber);
+    plugin_.ProcessResumptionSubscription(app_, *this, callbacks);
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_pending_resumption_handler.cc
@@ -135,8 +135,8 @@ void SDLPendingResumptionHandler::on_event(
 
 void SDLPendingResumptionHandler::HandleResumptionSubscriptionRequest(
     application_manager::AppExtension& extension,
-    resumption::Subscriber& subscriber,
-    application_manager::Application& app) {
+    app_mngr::Application& app,
+    resumption::ResumptionHandlingCallbacks callbacks) {
   LOG4CXX_AUTO_TRACE(logger_);
   SDLAppExtension& ext = dynamic_cast<SDLAppExtension&>(extension);
   smart_objects::SmartObjectSPtr request = CreateSubscriptionRequest();
@@ -156,7 +156,7 @@ void SDLPendingResumptionHandler::HandleResumptionSubscriptionRequest(
                   "There are no pending requests for app_id: " << app.app_id());
     pending_requests_[corr_id] = request_ref;
     subscribe_on_event(function_id, corr_id);
-    subscriber(app.app_id(), resumption_request);
+    callbacks.subscriber_(app.app_id(), resumption_request);
     LOG4CXX_DEBUG(logger_,
                   "Sending request with function id: "
                       << function_id << " and correlation_id: " << corr_id);
@@ -165,7 +165,8 @@ void SDLPendingResumptionHandler::HandleResumptionSubscriptionRequest(
   }
   LOG4CXX_DEBUG(logger_,
                 "There are pending requests for app_id: " << app.app_id());
-  ResumptionAwaitingHandling frozen_res(app.app_id(), ext, subscriber);
+  ResumptionAwaitingHandling frozen_res(
+      app.app_id(), ext, callbacks.subscriber_);
   freezed_resumptions_.push(frozen_res);
 }
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
@@ -35,6 +35,7 @@
 #include "sdl_rpc_plugin/sdl_app_extension.h"
 #include "sdl_rpc_plugin/sdl_pending_resumption_handler.h"
 #include "application_manager/message_helper.h"
+#include "application_manager/resumption/resumption_data_processor.h"
 
 namespace sdl_rpc_plugin {
 CREATE_LOGGERPTR_GLOBAL(logger_, "SDLRPCPlugin")
@@ -87,7 +88,7 @@ void SDLRPCPlugin::OnApplicationEvent(
 void SDLRPCPlugin::ProcessResumptionSubscription(
     application_manager::Application& app,
     SDLAppExtension& ext,
-    resumption::Subscriber subscriber) {
+    resumption::ResumptionHandlingCallbacks callbacks) {
   LOG4CXX_AUTO_TRACE(logger_);
   application_manager::ApplicationSharedPtr application =
       application_manager_->application(app.app_id());
@@ -95,7 +96,7 @@ void SDLRPCPlugin::ProcessResumptionSubscription(
       application_manager_->GetAppsSubscribedForWayPoints();
   application_manager_->SubscribeAppForWayPoints(application);
   pending_resumption_handler_->HandleResumptionSubscriptionRequest(
-      ext, subscriber, app);
+      ext, app, callbacks);
 }
 
 void SDLRPCPlugin::SaveResumptionData(

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
@@ -107,8 +107,9 @@ class VehicleInfoAppExtension : public app_mngr::AppExtension {
    * @param resumption_data resumption data
    * @param subscriber callback for subscription
    */
-  void ProcessResumption(const smart_objects::SmartObject& saved_app,
-                         resumption::Subscriber subscriber) OVERRIDE;
+  void ProcessResumption(
+      const smart_objects::SmartObject& saved_app,
+      resumption::ResumptionHandlingCallbacks callbacks) OVERRIDE;
 
   /**
    * @brief Revert the data to the state before Resumption.

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
@@ -17,9 +17,10 @@ class VehicleInfoPendingResumptionHandler
   // EventObserver interface
   void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
-  void HandleResumptionSubscriptionRequest(app_mngr::AppExtension& extension,
-                                           resumption::Subscriber& subscriber,
-                                           app_mngr::Application& app) OVERRIDE;
+  void HandleResumptionSubscriptionRequest(
+      app_mngr::AppExtension& extension,
+      app_mngr::Application& app,
+      resumption::ResumptionHandlingCallbacks callbacks) OVERRIDE;
 
   std::map<std::string, bool> ExtractSubscribeResults(
       const smart_objects::SmartObject& response,

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
@@ -70,9 +70,10 @@ class VehicleInfoPlugin : public plugins::RPCPlugin {
    * @param ext application extension
    * @param subscriber callback for subscription
    */
-  void ProcessResumptionSubscription(app_mngr::Application& app,
-                                     VehicleInfoAppExtension& ext,
-                                     resumption::Subscriber subscriber);
+  void ProcessResumptionSubscription(
+      app_mngr::Application& app,
+      VehicleInfoAppExtension& ext,
+      resumption::ResumptionHandlingCallbacks callbacks);
 
   /**
    * @brief Revert the data to the state before Resumption.

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
@@ -32,6 +32,7 @@
 
 #include "vehicle_info_plugin/vehicle_info_app_extension.h"
 #include "vehicle_info_plugin/vehicle_info_plugin.h"
+#include "application_manager/resumption/resumption_data_processor.h"
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "VehicleInfoPlugin")
 
@@ -96,7 +97,7 @@ void VehicleInfoAppExtension::SaveResumptionData(
 
 void VehicleInfoAppExtension::ProcessResumption(
     const smart_objects::SmartObject& saved_app,
-    resumption::Subscriber subscriber) {
+    resumption::ResumptionHandlingCallbacks callbacks) {
   LOG4CXX_AUTO_TRACE(logger_);
   if (!saved_app.keyExists(strings::application_subscriptions)) {
     LOG4CXX_DEBUG(logger_, "application_subscriptions section is not exists");
@@ -120,14 +121,14 @@ void VehicleInfoAppExtension::ProcessResumption(
     subscribeToVehicleInfo(ivi);
   }
   if (subscriptions_ivi.length() > 0) {
-    plugin_.ProcessResumptionSubscription(app_, *this, subscriber);
+    plugin_.ProcessResumptionSubscription(app_, *this, callbacks);
   }
 }
 
 void VehicleInfoAppExtension::RevertResumption(
     const smart_objects::SmartObject& subscriptions) {
   unsubscribeFromVehicleInfo();
-  plugin_.RevertResumption(app_, subscriptions.enumerate());
+  plugin_.RevertResumption(app_, subscriptions["ivi"].enumerate());
 }
 
 VehicleInfoAppExtension& VehicleInfoAppExtension::ExtractVIExtension(

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -197,8 +197,8 @@ VehicleInfoPendingResumptionHandler::ExtractSubscribeResults(
 
 void VehicleInfoPendingResumptionHandler::HandleResumptionSubscriptionRequest(
     application_manager::AppExtension& extension,
-    resumption::Subscriber& subscriber,
-    application_manager::Application& app) {
+    app_mngr::Application& app,
+    resumption::ResumptionHandlingCallbacks callbacks) {
   LOG4CXX_AUTO_TRACE(logger_);
 
   VehicleInfoAppExtension& ext =
@@ -225,7 +225,7 @@ void VehicleInfoPendingResumptionHandler::HandleResumptionSubscriptionRequest(
                   "There are no pending requests for app_id: " << app.app_id());
     pending_requests_[corr_id] = request_ref;
     subscribe_on_event(function_id, corr_id);
-    subscriber(app.app_id(), resumption_request);
+    callbacks.subscriber_(app.app_id(), resumption_request);
     LOG4CXX_DEBUG(logger_,
                   "Sending request with function id: "
                       << function_id << " and correlation_id: " << corr_id);
@@ -234,7 +234,8 @@ void VehicleInfoPendingResumptionHandler::HandleResumptionSubscriptionRequest(
   } else {
     LOG4CXX_DEBUG(logger_,
                   "There are pending requests for app_id: " << app.app_id());
-    ResumptionAwaitingHandling frozen_res(app.app_id(), ext, subscriber);
+    ResumptionAwaitingHandling frozen_res(
+        app.app_id(), ext, callbacks.subscriber_);
     freezed_resumptions_.push(frozen_res);
   }
 }

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -90,11 +90,11 @@ void VehicleInfoPlugin::OnApplicationEvent(
 void VehicleInfoPlugin::ProcessResumptionSubscription(
     application_manager::Application& app,
     VehicleInfoAppExtension& ext,
-    resumption::Subscriber subscriber) {
+    resumption::ResumptionHandlingCallbacks callbacks) {
   LOG4CXX_AUTO_TRACE(logger_);
 
   pending_resumption_handler_->HandleResumptionSubscriptionRequest(
-      ext, subscriber, app);
+      ext, app, callbacks);
 }
 
 void VehicleInfoPlugin::RevertResumption(

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -48,6 +48,9 @@ using app_mngr::ButtonSubscriptions;
 namespace strings = app_mngr::strings;
 namespace event_engine = app_mngr::event_engine;
 
+const char* kModuleData = "moduleData";
+const char* kModuleType = "moduleType";
+
 CREATE_LOGGERPTR_GLOBAL(logger_, "Resumption")
 
 ResumptionDataProcessor::ResumptionDataProcessor(

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -142,9 +142,12 @@ bool ResumptionDataProcessor::HasSubscriptionsToRestore(
   const bool has_waypoints_subscriptions =
       subscriptions[strings::subscribed_for_way_points].asBool();
 
-  const bool has_subscriptions_to_restore = has_ivi_subscriptions ||
-                                            has_button_subscriptions ||
-                                            has_waypoints_subscriptions;
+  const bool has_interior_vehicle_data_to_restore =
+      !subscriptions[kModuleData].empty();
+
+  const bool has_subscriptions_to_restore =
+      has_ivi_subscriptions || has_button_subscriptions ||
+      has_waypoints_subscriptions || has_interior_vehicle_data_to_restore;
 
   LOG4CXX_DEBUG(logger_,
                 std::boolalpha << "Application has subscriptions to restore: "

--- a/src/components/include/test/application_manager/mock_app_extension.h
+++ b/src/components/include/test/application_manager/mock_app_extension.h
@@ -35,6 +35,7 @@
 
 #include "gmock/gmock.h"
 #include "application_manager/app_extension.h"
+#include "application_manager/resumption/resumption_data_processor.h"
 
 namespace test {
 namespace components {
@@ -53,7 +54,7 @@ class MockAppExtension : public application_manager::AppExtension {
   MOCK_METHOD2(ProcessResumption,
                void(const ns_smart_device_link::ns_smart_objects::SmartObject&
                         resumption_data,
-                    resumption::Subscriber subscriber));
+                    resumption::ResumptionHandlingCallbacks callbacks));
 
   MOCK_METHOD1(RevertResumption,
                void(const ns_smart_device_link::ns_smart_objects::SmartObject&

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -1619,16 +1619,23 @@ bool SQLPTRepresentation::GatherAppType(
 bool SQLPTRepresentation::GatherRequestType(
     const std::string& app_id,
     policy_table::RequestTypes* request_types) const {
+  LOG4CXX_AUTO_TRACE(logger_);
   utils::dbms::SQLQuery query(db());
   if (!query.Prepare(sql_pt::kSelectRequestTypes)) {
     LOG4CXX_WARN(logger_, "Incorrect select from request types.");
     return false;
   }
 
+  LOG4CXX_DEBUG(logger_, "Gathering request types for app id: " << app_id);
   query.Bind(0, app_id);
   while (query.Next()) {
+    const std::string request_type = query.GetString(0);
+    if (request_type.empty()) {
+      LOG4CXX_DEBUG(logger_, "Request types is omitted for app id: " << app_id);
+      return true;
+    }
     policy_table::RequestType type;
-    if (!policy_table::EnumFromJsonString(query.GetString(0), &type)) {
+    if (!policy_table::EnumFromJsonString(request_type, &type)) {
       return false;
     }
     if (policy_table::RequestType::RT_EMPTY == type) {
@@ -1643,15 +1650,22 @@ bool SQLPTRepresentation::GatherRequestType(
 bool SQLPTRepresentation::GatherRequestSubType(
     const std::string& app_id,
     policy_table::RequestSubTypes* request_subtypes) const {
+  LOG4CXX_AUTO_TRACE(logger_);
   utils::dbms::SQLQuery query(db());
   if (!query.Prepare(sql_pt::kSelectRequestSubTypes)) {
     LOG4CXX_WARN(logger_, "Incorrect select from request subtypes.");
     return false;
   }
 
+  LOG4CXX_DEBUG(logger_, "Gathering request subtypes for app id: " << app_id);
   query.Bind(0, app_id);
   while (query.Next()) {
     const std::string request_subtype = query.GetString(0);
+    if (request_subtype.empty()) {
+      LOG4CXX_DEBUG(logger_,
+                    "Request subtypes is omitted for app id: " << app_id);
+      return true;
+    }
     if ("EMPTY" == request_subtype) {
       request_subtypes->mark_initialized();
       continue;

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -1583,8 +1583,14 @@ bool SQLPTRepresentation::GatherRequestType(
     return false;
   }
 
+  LOG4CXX_DEBUG(logger_, "Gathering request types for app id: " << app_id);
   query.Bind(0, app_id);
   while (query.Next()) {
+    const std::string request_type = query.GetString(0);
+    if (request_type.empty()) {
+      LOG4CXX_DEBUG(logger_, "Request types is omitted for app id: " << app_id);
+      return true;
+    }
     policy_table::RequestType type;
     if (!policy_table::EnumFromJsonString(query.GetString(0), &type)) {
       return false;
@@ -1606,10 +1612,15 @@ bool SQLPTRepresentation::GatherRequestSubType(
     LOG4CXX_WARN(logger_, "Incorrect select from request subtypes.");
     return false;
   }
-
+  LOG4CXX_DEBUG(logger_, "Gathering request subtypes for app id: " << app_id);
   query.Bind(0, app_id);
   while (query.Next()) {
     const std::string request_subtype = query.GetString(0);
+    if (request_subtype.empty()) {
+      LOG4CXX_DEBUG(logger_,
+                    "Request subtypes is omitted for app id: " << app_id);
+      return true;
+    }
     if ("EMPTY" == request_subtype) {
       request_subtypes->mark_initialized();
       continue;


### PR DESCRIPTION
:exclamation:  **NOTE**  :exclamation:  :  **This implementation is based on [Handle response from HMI during resumption data](https://github.com/smartdevicelink/sdl_evolution/issues/562), so this PR should be merged AFTER #2619**

Fixes #2661 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
ATF tests provided [feature/interior_vehicle_data_resumption](https://github.com/smartdevicelink/sdl_atf_test_scripts/tree/feature/interior_vehicle_data_resumption)

### HMI Implementation
HMI Implementation provided in [smartdevicelink/sdl_hmi#139](https://github.com/smartdevicelink/sdl_hmi/pull/139)

### Summary
This feature is based on [feature/resumption data error handling](https://github.com/smartdevicelink/sdl_core/pull/2619). Apart from changes concerning handling errors from hmi during resumption, this feature introduces following changes:

- handling resumption of interior vehicle data subscriptions

- handling pending subscriptions to interior vehicle data during resumption

- added UpdateHash() call on each internal subscription to interior vehicle data

- response with code WARNINGS is sent if application repeatedly tries to subscribe to the same interior vehicle data module

### Tasks Remaining:
- [ ] Update unit tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)