### PR TITLE
Update versioning logic to check for < version 5.0.0

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_event_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_event_notification.cc
@@ -166,7 +166,7 @@ void OnButtonEventNotification::SendButtonEvent(ApplicationConstSharedPtr app) {
           (*message_)[strings::msg_params][hmi_response::button_name].asInt());
 
   if (btn_id == mobile_apis::ButtonName::PLAY_PAUSE &&
-      app->msg_version() <= utils::base_rpc_version) {
+      app->msg_version() < utils::rpc_version_5) {
     btn_id = mobile_apis::ButtonName::OK;
   }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_press_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_press_notification.cc
@@ -174,7 +174,7 @@ void OnButtonPressNotification::SendButtonPress(ApplicationConstSharedPtr app) {
           (*message_)[strings::msg_params][hmi_response::button_name].asInt());
 
   if (btn_id == mobile_apis::ButtonName::PLAY_PAUSE &&
-      app->msg_version() <= utils::base_rpc_version) {
+      app->msg_version() < utils::rpc_version_5) {
     btn_id = mobile_apis::ButtonName::OK;
   }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -334,9 +334,9 @@ void RegisterAppInterfaceRequest::Run() {
   // Version negotiation
   utils::SemanticVersion module_version(
       major_version, minor_version, patch_version);
-  if (mobile_version <= utils::base_rpc_version) {
+  if (mobile_version < utils::rpc_version_5) {
     // Mobile versioning did not exist for
-    // versions 4.5 and prior.
+    // versions before 5.0
     application->set_msg_version(utils::base_rpc_version);
   } else if (mobile_version < module_version) {
     // Use mobile RPC version as negotiated version

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_response.cc
@@ -63,7 +63,7 @@ void RegisterAppInterfaceResponse::Run() {
   application_manager::ApplicationSharedPtr app =
       application_manager_.application(connection_key());
 
-  if (app && app->msg_version() <= utils::base_rpc_version &&
+  if (app && app->msg_version() < utils::rpc_version_5 &&
       app->is_media_application() &&
       (*message_)[strings::msg_params].keyExists(
           hmi_response::button_capabilities)) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_button_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_button_request.cc
@@ -77,7 +77,7 @@ void SubscribeButtonRequest::Run() {
     return;
   }
 
-  if (app->msg_version() <= utils::base_rpc_version &&
+  if (app->msg_version() < utils::rpc_version_5 &&
       btn_id == mobile_apis::ButtonName::OK && app->is_media_application()) {
     bool ok_supported = CheckHMICapabilities(mobile_apis::ButtonName::OK);
     bool play_pause_supported =

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_button_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_button_request.cc
@@ -72,7 +72,7 @@ void UnsubscribeButtonRequest::Run() {
       static_cast<mobile_apis::ButtonName::eType>(
           (*message_)[str::msg_params][str::button_name].asInt());
 
-  if (app->msg_version() <= utils::base_rpc_version &&
+  if (app->msg_version() < utils::rpc_version_5 &&
       btn_id == mobile_apis::ButtonName::OK && app->is_media_application()) {
     bool ok_supported = CheckHMICapabilities(mobile_apis::ButtonName::OK);
     bool play_pause_supported =

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -219,7 +219,7 @@ void RPCHandlerImpl::GetMessageVersion(
     }
     utils::SemanticVersion temp_version(major, minor, patch);
     if (temp_version.isValid()) {
-      message_version = (temp_version > utils::base_rpc_version)
+      message_version = (temp_version >= utils::rpc_version_5)
                             ? temp_version
                             : utils::base_rpc_version;
     }

--- a/src/components/include/utils/semantic_version.h
+++ b/src/components/include/utils/semantic_version.h
@@ -119,6 +119,7 @@ struct SemanticVersion {
 };
 
 extern const SemanticVersion base_rpc_version;
+extern const SemanticVersion rpc_version_5;
 }
 
 #endif  // SRC_COMPONENTS_INCLUDE_UTILS_CALLABLE_H

--- a/src/components/utils/src/semantic_version.cc
+++ b/src/components/utils/src/semantic_version.cc
@@ -34,5 +34,6 @@
 namespace utils {
 
 const SemanticVersion base_rpc_version(4, 5, 1);
+const SemanticVersion rpc_version_5(5, 0, 0);
 
 }  // namespace utils


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF Mobile Versioning Test Set

### Summary
Changes mobile versioning logic to check if apps version is < 5.0.0 instead of <= 4.5.1. This change is to ensure if an app registers with version 4.6, it would not get access to 5.0.0 version features.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)