### PR TITLE
Remove some unsed methods from MediaManager

### DIFF
--- a/src/components/include/media_manager/media_manager.h
+++ b/src/components/include/media_manager/media_manager.h
@@ -40,9 +40,6 @@ namespace media_manager {
 
 class MediaManager {
  public:
-  virtual void PlayA2DPSource(int32_t application_key) = 0;
-  virtual void StopA2DPSource(int32_t application_key) = 0;
-
   virtual void StartMicrophoneRecording(int32_t application_key,
                                         const std::string& outputFileName,
                                         int32_t duration) = 0;

--- a/src/components/include/test/media_manager/mock_media_manager.h
+++ b/src/components/include/test/media_manager/mock_media_manager.h
@@ -41,8 +41,6 @@ namespace media_manager_test {
 
 class MockMediaManager : public media_manager::MediaManager {
  public:
-  MOCK_METHOD1(PlayA2DPSource, void(int32_t application_key));
-  MOCK_METHOD1(StopA2DPSource, void(int32_t application_key));
   MOCK_METHOD3(StartMicrophoneRecording,
                void(int32_t application_key,
                     const std::string& outputFileName,

--- a/src/components/media_manager/include/media_manager/media_manager_impl.h
+++ b/src/components/media_manager/include/media_manager/media_manager_impl.h
@@ -58,9 +58,6 @@ class MediaManagerImpl : public MediaManager,
                    const MediaManagerSettings& settings);
   virtual ~MediaManagerImpl();
 
-  virtual void PlayA2DPSource(int32_t application_key);
-  virtual void StopA2DPSource(int32_t application_key);
-
   virtual void StartMicrophoneRecording(int32_t application_key,
                                         const std::string& outputFileName,
                                         int32_t duration);
@@ -82,7 +79,6 @@ class MediaManagerImpl : public MediaManager,
   virtual const MediaManagerSettings& settings() const OVERRIDE;
 
 #ifdef BUILD_TESTS
-  void set_mock_a2dp_player(MediaAdapter* media_adapter);
   void set_mock_mic_listener(MediaListenerPtr media_listener);
   void set_mock_mic_recorder(MediaAdapterImpl* media_adapter);
   void set_mock_streamer(protocol_handler::ServiceType stype,
@@ -98,7 +94,6 @@ class MediaManagerImpl : public MediaManager,
   const MediaManagerSettings& settings_;
 
   protocol_handler::ProtocolHandler* protocol_handler_;
-  MediaAdapter* a2dp_player_;
 
   MediaAdapterImpl* from_mic_recorder_;
   MediaListenerPtr from_mic_listener_;

--- a/src/components/media_manager/src/media_manager_impl.cc
+++ b/src/components/media_manager/src/media_manager_impl.cc
@@ -62,18 +62,12 @@ MediaManagerImpl::MediaManagerImpl(
     const MediaManagerSettings& settings)
     : settings_(settings)
     , protocol_handler_(NULL)
-    , a2dp_player_(NULL)
     , from_mic_recorder_(NULL)
     , application_manager_(application_manager) {
   Init();
 }
 
 MediaManagerImpl::~MediaManagerImpl() {
-  if (a2dp_player_) {
-    delete a2dp_player_;
-    a2dp_player_ = NULL;
-  }
-
   if (from_mic_recorder_) {
     delete from_mic_recorder_;
     from_mic_recorder_ = NULL;
@@ -81,10 +75,6 @@ MediaManagerImpl::~MediaManagerImpl() {
 }
 
 #ifdef BUILD_TESTS
-void MediaManagerImpl::set_mock_a2dp_player(MediaAdapter* media_adapter) {
-  a2dp_player_ = media_adapter;
-}
-
 void MediaManagerImpl::set_mock_mic_listener(MediaListenerPtr media_listener) {
   from_mic_listener_ = media_listener;
 }
@@ -159,28 +149,6 @@ void MediaManagerImpl::Init() {
   if (streamer_[ServiceType::kAudio]) {
     streamer_[ServiceType::kAudio]->AddListener(
         streamer_listener_[ServiceType::kAudio]);
-  }
-}
-
-void MediaManagerImpl::PlayA2DPSource(int32_t application_key) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-#if defined(EXTENDED_MEDIA_MODE)
-  if (!a2dp_player_ && protocol_handler_) {
-    a2dp_player_ =
-        new A2DPSourcePlayerAdapter(protocol_handler_->get_session_observer());
-  }
-#endif
-
-  if (a2dp_player_) {
-    a2dp_player_->StartActivity(application_key);
-  }
-}
-
-void MediaManagerImpl::StopA2DPSource(int32_t application_key) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  if (a2dp_player_) {
-    a2dp_player_->StopActivity(application_key);
   }
 }
 

--- a/src/components/media_manager/test/media_manager_impl_test.cc
+++ b/src/components/media_manager/test/media_manager_impl_test.cc
@@ -272,21 +272,6 @@ TEST_F(MediaManagerImplTest, Init_Settings_ExpectFileValue) {
   InitMediaManagerFileServerType();
 }
 
-TEST_F(MediaManagerImplTest, PlayA2DPSource_WithCorrectA2DP_SUCCESS) {
-  // media_adapter_mock_ will be deleted in media_manager_impl (dtor)
-  MockMediaAdapter* media_adapter_mock = new MockMediaAdapter();
-  media_manager_impl_->set_mock_a2dp_player(media_adapter_mock);
-  EXPECT_CALL(*media_adapter_mock, StartActivity(kApplicationKey));
-  media_manager_impl_->PlayA2DPSource(kApplicationKey);
-}
-
-TEST_F(MediaManagerImplTest, StopA2DPSource_WithCorrectA2DP_SUCCESS) {
-  MockMediaAdapter* media_adapter_mock = new MockMediaAdapter();
-  media_manager_impl_->set_mock_a2dp_player(media_adapter_mock);
-  EXPECT_CALL(*media_adapter_mock, StopActivity(kApplicationKey));
-  media_manager_impl_->StopA2DPSource(kApplicationKey);
-}
-
 TEST_F(MediaManagerImplTest,
        StartMicrophoneRecording_SourceFileIsWritable_ExpectTrue) {
   StartMicrophoneCheckHelper();


### PR DESCRIPTION
Fixes [#2450](https://github.com/SmartDeviceLink/sdl_core/issues/2450)

This PR is **[ready]** for review.

### Risk
This PR makes **[no ]** API changes.

### Summary
There are some unused methods in base class MediaManager which are redefined in MediaManagerImpl. These methods(PlayA2DPSource, StopA2DPSource) aren't used in any place.  Based on this, the methods were removed

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)