### PR TITLE
Fix the Light Name conversion from string to enum value in default capabilities

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -786,6 +786,14 @@ class MessageHelper {
   static hmi_apis::Common_Language::eType CommonLanguageFromString(
       const std::string& language);
 
+  /**
+   * @brief CommonLightNameFromString convert string to LightName enum value
+   * @param lightName string to convert
+   * @return value LightName enum value
+   */
+  static hmi_apis::Common_LightName::eType CommonLightNameFromString(
+      const std::string& lightName);
+
   static smart_objects::SmartObjectSPtr
   GetOnAppInterfaceUnregisteredNotificationToMobile(
       int32_t connection_key,

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -1170,6 +1170,20 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
           smart_objects::SmartObject rc_capability_so;
           formatters::CFormatterJsonBase::jsonValueToObj(rc_capability,
                                                          rc_capability_so);
+          if (rc_capability_so.keyExists("lightControlCapabilities")) {
+            if (rc_capability_so["lightControlCapabilities"].keyExists(
+                    "supportedLights")) {
+              auto& lights = rc_capability_so["lightControlCapabilities"]
+                                             ["supportedLights"];
+              auto it = lights.asArray()->begin();
+              for (; it != lights.asArray()->end(); ++it) {
+                smart_objects::SmartObject& light_name_so = (*it)["name"];
+                auto light_name = MessageHelper::CommonLightNameFromString(
+                    light_name_so.asString());
+                light_name_so = light_name;
+              }
+            }
+          }
           set_rc_capability(rc_capability_so);
           if (!rc_capability_so.empty()) {
             set_rc_supported(true);

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -288,6 +288,17 @@ hmi_apis::Common_Language::eType MessageHelper::CommonLanguageFromString(
   return hmi_apis::Common_Language::INVALID_ENUM;
 }
 
+hmi_apis::Common_LightName::eType MessageHelper::CommonLightNameFromString(
+    const std::string& lightName) {
+  using namespace ns_smart_device_link::ns_smart_objects;
+  hmi_apis::Common_LightName::eType value;
+  if (EnumConversionHelper<hmi_apis::Common_LightName::eType>::StringToEnum(
+          lightName, &value)) {
+    return value;
+  }
+  return hmi_apis::Common_LightName::INVALID_ENUM;
+}
+
 std::string MessageHelper::GetDeviceMacAddressForHandle(
     const transport_manager::DeviceHandle device_handle,
     const ApplicationManager& app_mngr) {

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -164,6 +164,8 @@ class MockMessageHelper {
                     ApplicationManager& app_mngr));
   MOCK_METHOD1(CommonLanguageFromString,
                hmi_apis::Common_Language::eType(const std::string& language));
+  MOCK_METHOD1(CommonLightNameFromString,
+               hmi_apis::Common_LightName::eType(const std::string& lightName));
   MOCK_METHOD1(CommonLanguageToString,
                std::string(hmi_apis::Common_Language::eType));
   MOCK_METHOD2(CreateModuleInfoSO,

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -277,6 +277,12 @@ hmi_apis::Common_Language::eType MessageHelper::CommonLanguageFromString(
       language);
 }
 
+hmi_apis::Common_LightName::eType MessageHelper::CommonLightNameFromString(
+    const std::string& lightName) {
+  return MockMessageHelper::message_helper_mock()->CommonLightNameFromString(
+      lightName);
+}
+
 smart_objects::SmartObjectSPtr MessageHelper::CreateModuleInfoSO(
     uint32_t function_id, ApplicationManager& app_mngr) {
   return MockMessageHelper::message_helper_mock()->CreateModuleInfoSO(


### PR DESCRIPTION
Fixes #2683

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Automated script : https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2118

### SummarySDL must use the default values in case HMI does not provide values.
in hmi_capabilities.json :

          "lightControlCapabilities": {
                        "moduleName": "light",
                        "supportedLights":[
                              {
                                 "statusAvailable":true,
                                 "densityAvailable":true,
                                 "name":"FRONT_LEFT_HIGH_BEAM",
                                 "rgbColorSpaceAvailable":true
                              },
                              ....
                        ]
         }

**the name for each light must be converted from a string to an enum value** in accordance with HMI_API.xml

### Changelog

Added a conversion for the Light name from string to enum when loading capabilities from the file

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)