### PR TITLE
Fix GetURLS result code in case of unknown service requested

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/get_urls.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/get_urls.cc
@@ -72,7 +72,7 @@ void GetUrls::Run() {
 
   if (endpoints.empty()) {
     LOG4CXX_ERROR(logger_, "No URLs for service " << service_to_check);
-    SendResponseToHMI(Common_Result::DATA_NOT_AVAILABLE);
+    SendResponseToHMI(Common_Result::SUCCESS);
     return;
   }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/get_urls_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/get_urls_test.cc
@@ -134,7 +134,7 @@ TEST_F(GetUrlsTest, RUN_EmptyEndpoints_UNSUCCESS) {
 
   EXPECT_EQ(am::MessageType::kResponse,
             (*command_msg_)[strings::params][strings::message_type].asInt());
-  EXPECT_EQ(Common_Result::DATA_NOT_AVAILABLE,
+  EXPECT_EQ(Common_Result::SUCCESS,
             (*command_msg_)[strings::params][am::hmi_response::code].asInt());
 }
 


### PR DESCRIPTION
Fixes #1401

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF test was provided in [PR](https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2096)

### Summary
The source link to requirment:
https://github.com/smartdevicelink/sdl_hmi_integration_guidelines/blob/master/docs/SDL/GetURLS/assets/GetURLS_in_Proprietary_PTU_flow.png

As was clarified by BA:
> Tetiana Yasyniuk (Inactive) added a comment - 10/Jul/15 16:32 - edited
> Igor,
> 
> In case SDL receives GetURLs (<service>) request from HMI AND <service> is not defined in "endpoint" table SDL must repond with SUCCESS result code but without "urls" param

SDL should send `Common_Result::Success` and without "urls" param. The code was sending before fix was `Common_Result::DATA_NOT_AVAILABLE`.
Result code for this case was changed to `Common_Result::SUCCESS`  in both - source SDL code and related Unit Test code.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)