### PR TITLE
Prevent creation of SSL context during certificate updating

### DIFF
--- a/src/components/security_manager/include/security_manager/crypto_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/crypto_manager_impl.h
@@ -206,6 +206,7 @@ class CryptoManagerImpl : public CryptoManager {
   SSL_CTX* context_;
   static uint32_t instance_count_;
   static sync_primitives::Lock instance_lock_;
+  sync_primitives::Lock crypto_manager_lock_;
   DISALLOW_COPY_AND_ASSIGN(CryptoManagerImpl);
 };
 }  // namespace security_manager

--- a/src/components/security_manager/src/crypto_manager_impl.cc
+++ b/src/components/security_manager/src/crypto_manager_impl.cc
@@ -283,6 +283,9 @@ bool CryptoManagerImpl::Init() {
 
 bool CryptoManagerImpl::OnCertificateUpdated(const std::string& data) {
   LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock lock(crypto_manager_lock_);
+  LOG4CXX_DEBUG(logger_,
+                "CryptoManager is locked. Start of sertificate update");
   if (!context_) {
     LOG4CXX_WARN(logger_, "Not initialized");
     return false;
@@ -307,6 +310,10 @@ bool CryptoManagerImpl::OnCertificateUpdated(const std::string& data) {
 }
 
 SSLContext* CryptoManagerImpl::CreateSSLContext() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock lock(crypto_manager_lock_);
+  LOG4CXX_DEBUG(logger_,
+                "CryptoManager is locked. Start of SSLContext creation");
   if (NULL == context_) {
     return NULL;
   }


### PR DESCRIPTION
Fixes #[2693](https://github.com/SmartDeviceLink/sdl_core/issues/2693)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes

### Summary
Added sync primitive into CryptoManagerImpl as member of class
and added lock into OnCertificateUpdated, CreateSSLContext
methods for preventing race conditions

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)