### PR TITLE
Fixed vrSynonyms and ttsName content in SystemRequest(QUERY_APPS)

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1957,6 +1957,11 @@ void ApplicationManagerImpl::PullLanguagesInfo(const SmartObject& app_data,
     LOG4CXX_DEBUG(logger_, "Get ttsName from " << cur_vr_lang << " language");
     ttsName =
         app_data[json::languages][specific_idx][cur_vr_lang][json::ttsName];
+  } else if (app_data[json::languages][default_idx][json::default_].keyExists(
+                 json::ttsName)) {
+    LOG4CXX_DEBUG(logger_, "Get ttsName from default language");
+    ttsName =
+        app_data[json::languages][default_idx][json::default_][json::ttsName];
   } else {
     LOG4CXX_DEBUG(logger_,
                   "No data for ttsName for " << cur_vr_lang << " language");
@@ -1968,6 +1973,11 @@ void ApplicationManagerImpl::PullLanguagesInfo(const SmartObject& app_data,
                   "Get vrSynonyms from " << cur_vr_lang << " language");
     vrSynonym =
         app_data[json::languages][specific_idx][cur_vr_lang][json::vrSynonyms];
+  } else if (app_data[json::languages][default_idx][json::default_].keyExists(
+                 json::vrSynonyms)) {
+    LOG4CXX_DEBUG(logger_, "Get vrSynonyms from default language");
+    vrSynonym = app_data[json::languages][default_idx][json::default_]
+                        [json::vrSynonyms];
   } else {
     LOG4CXX_DEBUG(logger_,
                   "No data for vrSynonyms for " << cur_vr_lang << " language");


### PR DESCRIPTION


Fixes #977 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF script.

### Summary
There was an issue SDL sends in BC.UpdateAppList in vrSynonyms and ttsName values taken from applications name. Was added logic to apply vrSynonyms and ttsName values from the json file in case when only default language settings are present.


### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)