### PR TITLE
GPS shift support

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1825,6 +1825,13 @@
    <param name="speed" type="Float" minvalue="0" maxvalue="500" mandatory="false">
        <description>The speed in KPH</description>
    </param>
+   <param name="shifted" type="Boolean" mandatory="false" since="5.0">
+       <description>
+           True, if GPS lat/long, time, and altitude have been purposefully shifted (requires a proprietary algorithm to unshift).
+           False, if the GPS data is raw and un-shifted.
+           If not provided, then value is assumed False.
+       </description>
+   </param>
  </struct>
 
  <struct name="SisData">

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1825,7 +1825,7 @@
    <param name="speed" type="Float" minvalue="0" maxvalue="500" mandatory="false">
        <description>The speed in KPH</description>
    </param>
-   <param name="shifted" type="Boolean" mandatory="false" since="5.0">
+   <param name="shifted" type="Boolean" mandatory="false">
        <description>
            True, if GPS lat/long, time, and altitude have been purposefully shifted (requires a proprietary algorithm to unshift).
            False, if the GPS data is raw and un-shifted.

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -1977,6 +1977,13 @@
                 <param name="speed" type="Float" minvalue="0" maxvalue="500" mandatory="true" since="2.0" until="5.0"/>
             </history>
         </param>
+        <param name="shifted" type="Boolean" mandatory="false" since="5.0">
+            <description>
+                True, if GPS lat/long, time, and altitude have been purposefully shifted (requires a proprietary algorithm to unshift).
+                False, if the GPS data is raw and un-shifted.
+                If not provided, then value is assumed False.
+            </description>
+        </param>
     </struct>
     
     <struct name="VehicleDataResult" since="2.0">


### PR DESCRIPTION
Fixes #2639

This PR is **ready** for review.

### Risk
This PR makes **major** API changes.

### Testing Plan
Unit testing.

### Summary
Current commit contains changes for MOBILE_API and HMI_API.
For the China region, GPS data have to be corrected in order to
bridge the gap between different standards used.

### Changelog
##### Breaking Changes
* API changes introduce "shifted" flag for GPS data which defines whether the GPS data
(latitude, longitude, attitude, timestamp) raw or already adjusted.

### Tasks Remaining:
- [ ] Unit tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)