### PR TITLE
Feature/gps shift support

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h
@@ -145,6 +145,14 @@ const char kTP[] = "TP";
 const char kREG[] = "REG";
 // RdsData struct
 
+// SisData struct
+const char kStationShortName[] = "stationShortName";
+const char kStationIDNumber[] = "stationIDNumber";
+const char kStationLongName[] = "stationLongName";
+const char kStationLocation[] = "stationLocation";
+const char kStationMessage[] = "stationMessage";
+// SisData struct
+
 // RadioControlData struct
 const char kFrequencyInteger[] = "frequencyInteger";
 const char kFrequencyFraction[] = "frequencyFraction";

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h
@@ -153,6 +153,28 @@ const char kStationLocation[] = "stationLocation";
 const char kStationMessage[] = "stationMessage";
 // SisData struct
 
+// GPSData struct
+const char kLongitudeDegrees[] = "longitudeDegrees";
+const char kLatitudeDegrees[] = "latitudeDegrees";
+const char kUtcYear[] = "utcYear";
+const char kUtcMonth[] = "utcMonth";
+const char kUtcDay[] = "utcDay";
+const char kUtcHours[] = "utcHours";
+const char kUtcMinutes[] = "utcMinutes";
+const char kUtcSeconds[] = "utcSeconds";
+const char kCompassDirection[] = "compassDirection";
+const char kPdop[] = "pdop";
+const char kHdop[] = "hdop";
+const char kVdop[] = "vdop";
+const char kActual[] = "actual";
+const char kSatellites[] = "satellites";
+const char kDimension[] = "dimension";
+const char kAltitude[] = "altitude";
+const char kHeading[] = "heading";
+const char kSpeed[] = "speed";
+const char kShifted[] = "shifted";
+// GPSData struct
+
 // RadioControlData struct
 const char kFrequencyInteger[] = "frequencyInteger";
 const char kFrequencyFraction[] = "frequencyFraction";

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -245,10 +245,9 @@ TEST_F(
   smart_objects::SmartObject sis_data;
   smart_objects::SmartObject gps_data;
 
-  const char kGpsShifted[] = "shifted";
-  gps_data[application_manager::strings::longitude_degrees] = 1.0;
-  gps_data[application_manager::strings::latitude_degrees] = 1.0;
-  gps_data[kGpsShifted] = true;
+  gps_data[message_params::kLongitudeDegrees] = 1.0;
+  gps_data[message_params::kLatitudeDegrees] = 1.0;
+  gps_data[message_params::kShifted] = true;
 
   sis_data[message_params::kStationShortName] = "dummy_short_name";
   sis_data[message_params::kStationLocation] = gps_data;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -242,7 +242,20 @@ TEST_F(
   (*mobile_message)[application_manager::strings::msg_params]
                    [message_params::kModuleType] = module_type;
   smart_objects::SmartObject radio_data;
+  smart_objects::SmartObject sis_data;
+  smart_objects::SmartObject gps_data;
+
+  const char kGpsShifted[] = "shifted";
+  gps_data[application_manager::strings::longitude_degrees] = 1.0;
+  gps_data[application_manager::strings::latitude_degrees] = 1.0;
+  gps_data[kGpsShifted] = true;
+
+  sis_data[message_params::kStationShortName] = "dummy_short_name";
+  sis_data[message_params::kStationLocation] = gps_data;
+
   radio_data[message_params::kBand] = enums_value::kAM;
+  radio_data[message_params::kSisData] = sis_data;
+
   std::shared_ptr<
       rc_rpc_plugin::commands::GetInteriorVehicleDataRequest> command =
       CreateRCCommand<rc_rpc_plugin::commands::GetInteriorVehicleDataRequest>(

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1825,6 +1825,13 @@
    <param name="speed" type="Float" minvalue="0" maxvalue="500" mandatory="false">
        <description>The speed in KPH</description>
    </param>
+   <param name="shifted" type="Boolean" mandatory="false" since="5.0">
+       <description>
+           True, if GPS lat/long, time, and altitude have been purposefully shifted (requires a proprietary algorithm to unshift).
+           False, if the GPS data is raw and un-shifted.
+           If not provided, then value is assumed False.
+       </description>
+   </param>
  </struct>
 
  <struct name="SisData">

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1825,7 +1825,7 @@
    <param name="speed" type="Float" minvalue="0" maxvalue="500" mandatory="false">
        <description>The speed in KPH</description>
    </param>
-   <param name="shifted" type="Boolean" mandatory="false" since="5.0">
+   <param name="shifted" type="Boolean" mandatory="false">
        <description>
            True, if GPS lat/long, time, and altitude have been purposefully shifted (requires a proprietary algorithm to unshift).
            False, if the GPS data is raw and un-shifted.

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -1977,6 +1977,13 @@
                 <param name="speed" type="Float" minvalue="0" maxvalue="500" mandatory="true" since="2.0" until="5.0"/>
             </history>
         </param>
+        <param name="shifted" type="Boolean" mandatory="false" since="5.0">
+            <description>
+                True, if GPS lat/long, time, and altitude have been purposefully shifted (requires a proprietary algorithm to unshift).
+                False, if the GPS data is raw and un-shifted.
+                If not provided, then value is assumed False.
+            </description>
+        </param>
     </struct>
     
     <struct name="VehicleDataResult" since="2.0">


### PR DESCRIPTION
Fixes #2639

This PR is **ready** for review.

### Risk
This PR makes **major** API changes.

### Testing Plan
Unit testing.

### Summary
Current commit contains changes for MOBILE_API and HMI_API.
For the China region, GPS data have to be corrected in order to
bridge the gap between different standards used.

### Changelog
##### Breaking Changes
* API changes introduce "shifted" flag for GPS data which defines whether the GPS data
(latitude, longitude, attitude, timestamp) raw or already adjusted.

### Tasks Remaining:
- [x] Unit tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)