### PR TITLE
get&set_base_path_to_qdb_sql_implemented

### DIFF
--- a/src/components/utils/include/utils/qdb_wrapper/sql_database.h
+++ b/src/components/utils/include/utils/qdb_wrapper/sql_database.h
@@ -91,6 +91,19 @@ class SQLDatabase {
    */
   bool Backup();
 
+    /**
+   * Sets path to database
+   * If the database is already opened then need reopen it
+   */
+  void set_path(const std::string& path);
+
+  /**
+   * @brief get_path databse location path.
+   *
+   * @return the path to the database location
+   */
+  std::string get_path() const;
+
  protected:
   /**
    * Gets connection to the SQLite database
@@ -108,6 +121,11 @@ class SQLDatabase {
    * Lock for guarding connection to database
    */
   sync_primitives::Lock conn_lock_;
+
+  /**
+   * The file path of database
+   */
+  std::string path_;
 
   /**
    * The database name

--- a/src/components/utils/src/qdb_wrapper/sql_database.cc
+++ b/src/components/utils/src/qdb_wrapper/sql_database.cc
@@ -50,7 +50,7 @@ bool SQLDatabase::Open() {
   sync_primitives::AutoLock auto_lock(conn_lock_);
   if (conn_)
     return true;
-  conn_ = qdb_connect(db_name_.c_str(), 0);
+  conn_ = qdb_connect(get_path().c_str(), 0);
   if (conn_ == NULL) {
     error_ = Error::ERROR;
     return false;
@@ -106,6 +106,14 @@ bool SQLDatabase::Backup() {
   }
   LOG4CXX_INFO(logger_, "Backup was successful.");
   return true;
+}
+
+void SQLDatabase::set_path(const std::string& path) {
+  path_ = path;
+}
+
+std::string SQLDatabase::get_path() const {
+  return path_ + db_name_;
 }
 
 }  // namespace dbms


### PR DESCRIPTION
Fixes #2690 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
ATF test is not needed

### Summary
The reason is:Transfer of implemented features from SYNK4 Ford to Open SDL.
In present time Open SDL uses sql_light database and the issue is implemented in files /src/components/utils/include/utils/**sqlite_wrapper**/sql_database.h and /home/igor/sdl_core/src/components/utils/src/**sqlite_wrapper**/sql_database.cc. But the files which are in use in SYNK4 Ford src/components/utils/include/utils/**qdb_wrapper**/sql_database.h ans /home/igor/sdl_core/src/components/utils/src/utils/**qdb_wrapper**/sql_database.cc also are present but are not compiled (those build the same targetting object file as sqlite_wrapper's files are. But implementing the feature described in the issue it was changed files retated to qdb sqlbase )

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)