### PR TITLE
Fix for OnResetTimeout logic

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -678,6 +678,11 @@ class ApplicationManagerImpl
                             uint32_t mobile_correlation_id,
                             uint32_t new_timeout_value) OVERRIDE;
 
+  bool IsUpdateRequestTimeoutRequired(
+      const uint32_t connection_key,
+      const uint32_t mobile_correlation_id,
+      const uint32_t new_timeout_value) OVERRIDE;
+
   /**
    * @brief AddPolicyObserver allows to subscribe needed component to events
    * from policy.

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -389,7 +389,7 @@ class CommandRequestImpl : public CommandImpl,
    * @param request request to HMI
    */
   void AddRequestToTimeoutHandler(
-      const smart_objects::SmartObject& request) const;
+      const smart_objects::SmartObject& request_to_hmi) const;
 };
 
 }  // namespace commands

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -383,6 +383,8 @@ class CommandRequestImpl : public CommandImpl,
    */
   void AddTimeOutComponentInfoToMessage(
       smart_objects::SmartObject& response) const;
+
+  void AddRequestToTimeoutHandler(smart_objects::SmartObject& request) const;
 };
 
 }  // namespace commands

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -383,8 +383,13 @@ class CommandRequestImpl : public CommandImpl,
    */
   void AddTimeOutComponentInfoToMessage(
       smart_objects::SmartObject& response) const;
-
-  void AddRequestToTimeoutHandler(smart_objects::SmartObject& request) const;
+  /**
+   * @brief AddRequestToTimeoutHandler checks the request and adds it to
+   * reset_timeout_handler map for traking
+   * @param request request to HMI
+   */
+  void AddRequestToTimeoutHandler(
+      const smart_objects::SmartObject& request) const;
 };
 
 }  // namespace commands

--- a/src/components/application_manager/include/application_manager/request_controller.h
+++ b/src/components/application_manager/include/application_manager/request_controller.h
@@ -214,7 +214,7 @@ class RequestController {
    */
   bool IsUpdateRequestTimeoutRequired(const uint32_t app_id,
                                       const uint32_t correlation_id,
-                                      const uint32_t new_timeout);
+                                      const uint32_t new_timeout) const;
   /*
    * @brief Function Should be called when Low Voltage is occured
    */

--- a/src/components/application_manager/include/application_manager/request_controller.h
+++ b/src/components/application_manager/include/application_manager/request_controller.h
@@ -196,7 +196,6 @@ class RequestController {
 
   /**
   * @brief Updates request timeout
-  *
   * @param app_id Connection key of application
   * @param mobile_correlation_id Correlation ID of the mobile request
   * @param new_timeout_value New timeout to be set in milliseconds
@@ -205,6 +204,17 @@ class RequestController {
                             const uint32_t& mobile_correlation_id,
                             const uint32_t& new_timeout);
 
+  /**
+   * @brief IsUpdateRequestTimeoutRequired check is update timeout required.
+   * @param app_id Connection key of application
+   * @param correlation_id Correlation ID of the mobile request
+   * @param new_timeout New timeout to be set in milliseconds
+   * @return true if the new timeout value is greater than the time remaining
+   * from the current timeout, otherwise - false
+   */
+  bool IsUpdateRequestTimeoutRequired(const uint32_t app_id,
+                                      const uint32_t correlation_id,
+                                      const uint32_t new_timeout);
   /*
    * @brief Function Should be called when Low Voltage is occured
    */

--- a/src/components/application_manager/include/application_manager/request_info.h
+++ b/src/components/application_manager/include/application_manager/request_info.h
@@ -194,7 +194,7 @@ class RequestInfoSet {
    * @return founded request or shared_ptr with NULL
    */
   RequestInfoPtr Find(const uint32_t connection_key,
-                      const uint32_t correlation_id);
+                      const uint32_t correlation_id) const;
 
   /*
    * @brief Get request with smalest end_time_
@@ -264,7 +264,7 @@ class RequestInfoSet {
   TimeSortedRequestInfoSet time_sorted_pending_requests_;
   HashSortedRequestInfoSet hash_sorted_pending_requests_;
 
-  sync_primitives::Lock pending_requests_lock_;
+  mutable sync_primitives::Lock pending_requests_lock_;
 };
 
 /**

--- a/src/components/application_manager/include/application_manager/reset_timeout_handler_impl.h
+++ b/src/components/application_manager/include/application_manager/reset_timeout_handler_impl.h
@@ -54,6 +54,10 @@ class ResetTimeoutHandlerImpl : public event_engine::EventObserver,
   void on_event(const event_engine::Event& event) OVERRIDE;
 
  private:
+  bool CheckConditionsForUpdate(Request request,
+                                uint32_t timeout,
+                                hmi_apis::FunctionID::eType method_name);
+
   std::map<uint32_t, Request> requests_;
   ApplicationManager& application_manager_;
   mutable sync_primitives::Lock requests_lock_;

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2154,6 +2154,15 @@ void ApplicationManagerImpl::updateRequestTimeout(
       connection_key, mobile_correlation_id, new_timeout_value);
 }
 
+bool ApplicationManagerImpl::IsUpdateRequestTimeoutRequired(
+    const uint32_t connection_key,
+    const uint32_t mobile_correlation_id,
+    const uint32_t new_timeout_value) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return request_ctrl_.IsUpdateRequestTimeoutRequired(
+      connection_key, mobile_correlation_id, new_timeout_value);
+}
+
 uint32_t ApplicationManagerImpl::application_id(const int32_t correlation_id) {
   // ykazakov: there is no erase for const iterator for QNX
   std::map<const int32_t, const uint32_t>::iterator it =

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -986,16 +986,14 @@ void CommandRequestImpl::AddTimeOutComponentInfoToMessage(
 }
 
 void CommandRequestImpl::AddRequestToTimeoutHandler(
-    const smart_objects::SmartObject& request) const {
-  hmi_apis::FunctionID::eType function_id =
-      static_cast<hmi_apis::FunctionID::eType>(
-          request[strings::params][strings::function_id].asUInt());
+    const smart_objects::SmartObject& request_to_hmi) const {
+  auto function_id = static_cast<hmi_apis::FunctionID::eType>(
+      request_to_hmi[strings::params][strings::function_id].asUInt());
   // SDL must not apply "default timeout for RPCs processing" for
   // BasicCommunication.DialNumber RPC (that is, SDL must always wait for HMI
   // response to BC.DialNumber as long as it takes and not return GENERIC_ERROR
   // to mobile app), so the OnResetTimeout logic is not applicable for
-  // DialNumber
-  // RPC
+  // DialNumber RPC
   if (hmi_apis::FunctionID::BasicCommunication_DialNumber == function_id ||
       hmi_apis::FunctionID::INVALID_ENUM == function_id) {
     return;
@@ -1003,17 +1001,18 @@ void CommandRequestImpl::AddRequestToTimeoutHandler(
   // If soft buttons are present in Alert RPC, SDL will not use timeout tracking
   // for response, so the OnResetTimeout logic is not applicable in this case*/
   if (hmi_apis::FunctionID::UI_Alert == function_id) {
-    if (request.keyExists(strings::msg_params)) {
-      if (request[strings::msg_params].keyExists(strings::soft_buttons)) {
-        LOG4CXX_INFO(logger_,
-                     "Soft buttons are present in Alert RPC, OnResetTimeout "
-                     "logic is not applicable in this case");
+    if (request_to_hmi.keyExists(strings::msg_params)) {
+      if (request_to_hmi[strings::msg_params].keyExists(
+              strings::soft_buttons)) {
+        LOG4CXX_DEBUG(logger_,
+                      "Soft buttons are present in Alert RPC, OnResetTimeout "
+                      "logic is not applicable in this case");
         return;
       }
     }
   }
   application_manager_.GetResetTimeoutHandler().AddRequest(
-      request[strings::params][strings::correlation_id].asUInt(),
+      request_to_hmi[strings::params][strings::correlation_id].asUInt(),
       correlation_id(),
       connection_key(),
       function_id);

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -986,24 +986,28 @@ void CommandRequestImpl::AddTimeOutComponentInfoToMessage(
 }
 
 void CommandRequestImpl::AddRequestToTimeoutHandler(
-    smart_objects::SmartObject& request) const {
-  uint32_t function_id =
-      request[strings::params][strings::function_id].asUInt();
-  /*SDL must not apply "default timeout for RPCs processing" for
-  BasicCommunication.DialNumber RPC (that is, SDL must always wait for HMI
-  response to BC.DialNumber as long as it takes and not return GENERIC_ERROR
-  to mobile app), so the OnResetTimeout logic is not applicable for DialNumber
-  RPC*/
-  if (hmi_apis::FunctionID::BasicCommunication_DialNumber ==
-      static_cast<hmi_apis::FunctionID::eType>(function_id)) {
+    const smart_objects::SmartObject& request) const {
+  hmi_apis::FunctionID::eType function_id =
+      static_cast<hmi_apis::FunctionID::eType>(
+          request[strings::params][strings::function_id].asUInt());
+  // SDL must not apply "default timeout for RPCs processing" for
+  // BasicCommunication.DialNumber RPC (that is, SDL must always wait for HMI
+  // response to BC.DialNumber as long as it takes and not return GENERIC_ERROR
+  // to mobile app), so the OnResetTimeout logic is not applicable for
+  // DialNumber
+  // RPC
+  if (hmi_apis::FunctionID::BasicCommunication_DialNumber == function_id ||
+      hmi_apis::FunctionID::INVALID_ENUM == function_id) {
     return;
   }
-  /*If soft buttons are present in Alert RPC, SDL will not use timeout tracking
-  for response, so the OnResetTimeout logic is not applicable in this case*/
-  if (hmi_apis::FunctionID::UI_Alert ==
-      static_cast<hmi_apis::FunctionID::eType>(function_id)) {
+  // If soft buttons are present in Alert RPC, SDL will not use timeout tracking
+  // for response, so the OnResetTimeout logic is not applicable in this case*/
+  if (hmi_apis::FunctionID::UI_Alert == function_id) {
     if (request.keyExists(strings::msg_params)) {
       if (request[strings::msg_params].keyExists(strings::soft_buttons)) {
+        LOG4CXX_INFO(logger_,
+                     "Soft buttons are present in Alert RPC, OnResetTimeout "
+                     "logic is not applicable in this case");
         return;
       }
     }

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -153,10 +153,9 @@ bool RequestController::CheckPendingRequestsAmount(
 bool RequestController::IsUpdateRequestTimeoutRequired(
     const uint32_t app_id,
     const uint32_t correlation_id,
-    const uint32_t new_timeout) {
+    const uint32_t new_timeout) const {
   LOG4CXX_AUTO_TRACE(logger_);
-  RequestInfoPtr request_info =
-      waiting_for_response_.Find(app_id, correlation_id);
+  auto request_info = waiting_for_response_.Find(app_id, correlation_id);
   if (request_info) {
     date_time::TimeDuration current_time = date_time::getCurrentTime();
     const date_time::TimeDuration end_time = request_info->end_time();

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -150,6 +150,24 @@ bool RequestController::CheckPendingRequestsAmount(
   return true;
 }
 
+bool RequestController::IsUpdateRequestTimeoutRequired(
+    const uint32_t app_id,
+    const uint32_t correlation_id,
+    const uint32_t new_timeout) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  RequestInfoPtr request_info =
+      waiting_for_response_.Find(app_id, correlation_id);
+  if (request_info) {
+    date_time::TimeDuration current_time = date_time::getCurrentTime();
+    const date_time::TimeDuration end_time = request_info->end_time();
+    date_time::AddMilliseconds(current_time, new_timeout);
+    if (date_time::getmSecs(current_time) > date_time::getmSecs(end_time)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 RequestController::TResult RequestController::addMobileRequest(
     const RequestPtr request, const mobile_apis::HMILevel::eType& hmi_level) {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/application_manager/src/request_info.cc
+++ b/src/components/application_manager/src/request_info.cc
@@ -146,7 +146,7 @@ bool RequestInfoSet::Add(RequestInfoPtr request_info) {
 }
 
 RequestInfoPtr RequestInfoSet::Find(const uint32_t connection_key,
-                                    const uint32_t correlation_id) {
+                                    const uint32_t correlation_id) const {
   RequestInfoPtr result;
 
   // Request info for searching in request info set by log_n time

--- a/src/components/application_manager/src/reset_timeout_handler_impl.cc
+++ b/src/components/application_manager/src/reset_timeout_handler_impl.cc
@@ -71,13 +71,7 @@ void ResetTimeoutHandlerImpl::on_event(const event_engine::Event& event) {
     auto method_name = MessageHelper::HMIFunctionIDFromString(
         message[strings::msg_params][strings::method_name].asString());
 
-    /*SDL must not apply "default timeout for RPCs processing" for
-    BasicCommunication.DialNumber RPC (that is, SDL must always wait for HMI
-    response to BC.DialNumber as long as it takes and not return GENERIC_ERROR
-    to mobile app), so the OnResetTimeout logic is not applicable for DialNumber
-    RPC*/
-    if (hmi_apis::FunctionID::BasicCommunication_DialNumber == method_name ||
-        hmi_apis::FunctionID::INVALID_ENUM == method_name) {
+    if (hmi_apis::FunctionID::INVALID_ENUM == method_name) {
       return;
     }
     uint32_t timeout = application_manager_.get_settings().default_timeout();

--- a/src/components/application_manager/src/reset_timeout_handler_impl.cc
+++ b/src/components/application_manager/src/reset_timeout_handler_impl.cc
@@ -63,6 +63,31 @@ void ResetTimeoutHandlerImpl::RemoveRequest(uint32_t hmi_correlation_id) {
   };
 }
 
+bool ResetTimeoutHandlerImpl::CheckConditionsForUpdate(
+    Request request,
+    uint32_t timeout,
+    hmi_apis::FunctionID::eType method_name) {
+  if (static_cast<hmi_apis::FunctionID::eType>(request.hmi_function_id_) ==
+      method_name) {
+    if (application_manager_.IsUpdateRequestTimeoutRequired(
+            request.connection_key_,
+            request.mob_correlation_id_,
+            timeout) ||
+        (0 == timeout)) {  // if timeout = 0 SDL will apply the unlimited
+                           // timeout
+      return true;
+    } else {
+      LOG4CXX_WARN(logger_,
+                   "New timeout value is less than the time remaining from "
+                   "the current timeout. OnResetTimeout will be ignored");
+      return false;
+    }
+  } else {
+    LOG4CXX_WARN(logger_, "Method name does not match the hmi function id");
+    return false;
+  }
+}
+
 void ResetTimeoutHandlerImpl::on_event(const event_engine::Event& event) {
   LOG4CXX_AUTO_TRACE(logger_);
   const auto event_id = event.id();
@@ -72,7 +97,10 @@ void ResetTimeoutHandlerImpl::on_event(const event_engine::Event& event) {
         message[strings::msg_params][strings::method_name].asString());
 
     if (hmi_apis::FunctionID::INVALID_ENUM == method_name) {
-      LOG4CXX_WARN(logger_, "Wrong method name received");
+      LOG4CXX_WARN(
+          logger_,
+          "Wrong method name received: "
+              << message[strings::msg_params][strings::method_name].asString());
       return;
     }
     uint32_t timeout = application_manager_.get_settings().default_timeout();
@@ -84,24 +112,9 @@ void ResetTimeoutHandlerImpl::on_event(const event_engine::Event& event) {
     auto it = requests_.find(hmi_corr_id);
     if (it != requests_.end()) {
       auto request = it->second;
-      if (static_cast<hmi_apis::FunctionID::eType>(request.hmi_function_id_) ==
-          method_name) {
-        if (application_manager_.IsUpdateRequestTimeoutRequired(
-                request.connection_key_,
-                request.mob_correlation_id_,
-                timeout) ||
-            (0 == timeout)) {  // if timeout = 0 SDL will apply the unlimited
-                               // timeout
-          application_manager_.updateRequestTimeout(
-              request.connection_key_, request.mob_correlation_id_, timeout);
-          return;
-        } else {
-          LOG4CXX_WARN(logger_,
-                       "New timeout value is less than the time remaining from "
-                       "the current timeout. OnResetTimeout will be ignored");
-        }
-      } else {
-        LOG4CXX_WARN(logger_, "Method name does not match the hmi function id");
+      if (CheckConditionsForUpdate(request, timeout, method_name)) {
+        application_manager_.updateRequestTimeout(
+            request.connection_key_, request.mob_correlation_id_, timeout);
       }
     } else {
       LOG4CXX_WARN(logger_,

--- a/src/components/application_manager/test/reset_timeout_handler_test.cc
+++ b/src/components/application_manager/test/reset_timeout_handler_test.cc
@@ -56,7 +56,7 @@ using sdl_rpc_plugin::commands::SubscribeWayPointsRequest;
 typedef std::shared_ptr<OnResetTimeoutNotification> NotificationPtr;
 
 const uint32_t kDefaultTimeout = 10000u;
-const uint32_t kTimeout = 3000u;
+const uint32_t kTimeout = 13000u;
 const uint32_t kRequestId = 22;
 const std::string kMethodName = "Navigation.SubscribeWayPoints";
 
@@ -114,6 +114,10 @@ TEST_F(ResetTimeoutHandlerTest, on_event_OnResetTimeout_success) {
   EXPECT_CALL(app_mngr_, GetResetTimeoutHandler())
       .WillOnce(ReturnRef(*reset_timeout_handler_));
   EXPECT_CALL(app_mngr_,
+              IsUpdateRequestTimeoutRequired(
+                  mock_app->app_id(), command->correlation_id(), kTimeout))
+      .WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_,
               updateRequestTimeout(
                   mock_app->app_id(), command->correlation_id(), kTimeout));
 
@@ -150,6 +154,11 @@ TEST_F(ResetTimeoutHandlerTest, on_event_OnResetTimeout_missed_reset_period) {
       .WillOnce(Return(hmi_apis::FunctionID::Navigation_SubscribeWayPoints));
   EXPECT_CALL(app_mngr_, GetResetTimeoutHandler())
       .WillOnce(ReturnRef(*reset_timeout_handler_));
+  EXPECT_CALL(
+      app_mngr_,
+      IsUpdateRequestTimeoutRequired(
+          mock_app->app_id(), command->correlation_id(), kDefaultTimeout))
+      .WillOnce(Return(true));
   EXPECT_CALL(
       app_mngr_,
       updateRequestTimeout(
@@ -189,6 +198,7 @@ TEST_F(ResetTimeoutHandlerTest, on_event_OnResetTimeout_invalid_request_id) {
       .WillOnce(Return(hmi_apis::FunctionID::Navigation_SubscribeWayPoints));
   EXPECT_CALL(app_mngr_, GetResetTimeoutHandler())
       .WillOnce(ReturnRef(*reset_timeout_handler_));
+  EXPECT_CALL(app_mngr_, IsUpdateRequestTimeoutRequired(_, _, _)).Times(0);
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _)).Times(0);
 
   ASSERT_TRUE(command->Init());
@@ -225,6 +235,7 @@ TEST_F(ResetTimeoutHandlerTest, on_event_OnResetTimeout_invalid_method_name) {
       .WillOnce(Return(hmi_apis::FunctionID::INVALID_ENUM));
   EXPECT_CALL(app_mngr_, GetResetTimeoutHandler())
       .WillOnce(ReturnRef(*reset_timeout_handler_));
+  EXPECT_CALL(app_mngr_, IsUpdateRequestTimeoutRequired(_, _, _)).Times(0);
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _)).Times(0);
 
   ASSERT_TRUE(command->Init());

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -551,6 +551,19 @@ class ApplicationManager {
                                     uint32_t mobile_correlation_id,
                                     uint32_t new_timeout_value) = 0;
 
+  /**
+   * @brief IsUpdateRequestTimeoutRequired check is update timeout required.
+   * @param app_id Connection key of application
+   * @param correlation_id Correlation ID of the mobile request
+   * @param new_timeout New timeout to be set in milliseconds
+   * @return true if the new timeout value is greater than the time remaining
+   * from the current timeout, otherwise - false
+   */
+  virtual bool IsUpdateRequestTimeoutRequired(
+      const uint32_t connection_key,
+      const uint32_t mobile_correlation_id,
+      const uint32_t new_timeout_value) = 0;
+
   virtual StateController& state_controller() = 0;
 
   virtual void SetUnregisterAllApplicationsReason(

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -214,6 +214,10 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                void(uint32_t connection_key,
                     uint32_t mobile_correlation_id,
                     uint32_t new_timeout_value));
+  MOCK_METHOD3(IsUpdateRequestTimeoutRequired,
+               bool(uint32_t connection_key,
+                    uint32_t mobile_correlation_id,
+                    uint32_t new_timeout_value));
   MOCK_METHOD0(state_controller, application_manager::StateController&());
   MOCK_METHOD1(SetUnregisterAllApplicationsReason,
                void(mobile_apis::AppInterfaceUnregisteredReason::eType reason));


### PR DESCRIPTION
This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary

-  Fix case for Alert with soft buttons
   In case when mobile send Alert request with soft buttons SDL must not apply OnResetTimeout logic

-  Fix OnResetTimeout logic
    SDL should apply OnResetTimeout only in case when resetPeriod value is greater than the time remaining from the current timeout


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)