### PR TITLE
Add check for missing presetBankCapabilities in Buttons.GetCapabilities

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_response.cc
@@ -68,8 +68,12 @@ void ButtonGetCapabilitiesResponse::Run() {
   hmi_capabilities.set_button_capabilities(
       (*message_)[strings::msg_params][hmi_response::capabilities]);
 
-  hmi_capabilities.set_preset_bank_capabilities(
-      (*message_)[strings::msg_params][hmi_response::preset_bank_capabilities]);
+  if ((*message_)[strings::msg_params].keyExists(
+          hmi_response::preset_bank_capabilities)) {
+    hmi_capabilities.set_preset_bank_capabilities(
+        (*message_)[strings::msg_params]
+                   [hmi_response::preset_bank_capabilities]);
+  }
 }
 
 }  // namespace commands


### PR DESCRIPTION
Fixes #2753 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
1. SDL Core send `Buttons.GetCapabilities` to the HMI
2. HMI responds to `Buttons.GetCapabilities` with `presetBankCapabilities` omitted
3. Register app with Core
4. Verify that `presetBankCapabilities` is valid (omitted or retrieved from `hmi_capabilities.json`)

### Summary
Fix issue where `presetBankCapabilities` was blindly set to NULL in the `Buttons.GetCapabilities response`.

### Changelog
##### Bug Fixes
* Fix issue where `presetBankCapabilities` was blindly set to NULL in the `Buttons.GetCapabilities response`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)