### PR TITLE
Fix: handle network interface removal

### DIFF
--- a/src/components/transport_manager/include/transport_manager/tcp/platform_specific/linux/platform_specific_network_interface_listener_impl.h
+++ b/src/components/transport_manager/include/transport_manager/tcp/platform_specific/linux/platform_specific_network_interface_listener_impl.h
@@ -32,6 +32,9 @@ class InterfaceStatus {
 
   bool IsAvailable() const;
   bool IsLoopback() const;
+  std::string GetName() const {
+    return name_;
+  }
   // only for debugging output
   unsigned int GetFlags() const {
     return flags_;
@@ -40,6 +43,10 @@ class InterfaceStatus {
   bool HasIPAddress() const;
   std::string GetIPv4Address() const;
   std::string GetIPv6Address() const;
+
+  void SetName(std::string name) {
+    name_ = name;
+  }
 
   void SetFlags(unsigned int flags) {
     flags_ = flags;
@@ -50,6 +57,7 @@ class InterfaceStatus {
   void SetIPv6Address(struct in6_addr* addr);
 
  private:
+  std::string name_;
   unsigned int flags_;
   bool has_ipv4_;
   bool has_ipv6_;
@@ -57,7 +65,7 @@ class InterfaceStatus {
   struct in6_addr ipv6_address_;
 };
 
-typedef std::map<std::string, InterfaceStatus> InterfaceStatusTable;
+typedef std::map<unsigned int, InterfaceStatus> InterfaceStatusTable;
 
 /**
  * @brief Listener to detect various events on network interfaces
@@ -126,6 +134,10 @@ class PlatformSpecificNetworkInterfaceListener
   const std::string& GetSelectedInterfaceName() const {
     return selected_interface_;
   }
+
+  void SetDummyNameMap(std::map<unsigned int, std::string> m) {
+    dummy_name_map_ = m;
+  }
 #endif  // BUILD_TESTS
 
  private:
@@ -160,6 +172,7 @@ class PlatformSpecificNetworkInterfaceListener
 
 #ifdef BUILD_TESTS
   bool testing_;
+  std::map<unsigned int, std::string> dummy_name_map_;
 #endif
 
   void Loop();
@@ -175,9 +188,13 @@ class PlatformSpecificNetworkInterfaceListener
   // Select an appropriate network interface that we will get IP addresses. Also
   // update selected_interface_.
   const std::string SelectInterface();
+  // return an entry from status_table_ containing specified interface name
+  InterfaceStatusTable::iterator FindInterfaceStatus(std::string ifname);
   // convert ifaddrmsg to a list of EventParam structs
   std::vector<EventParam> ParseIFAddrMessage(struct ifaddrmsg* message,
                                              unsigned int size);
+  // return network interface name of the specified index
+  const std::string GetInterfaceName(unsigned int if_index) const;
   // for debugging
   void DumpTable() const;
 

--- a/src/components/transport_manager/include/transport_manager/tcp/platform_specific/linux/platform_specific_network_interface_listener_impl.h
+++ b/src/components/transport_manager/include/transport_manager/tcp/platform_specific/linux/platform_specific_network_interface_listener_impl.h
@@ -158,6 +158,17 @@ class PlatformSpecificNetworkInterfaceListener
         : if_index(interface_index), flags(interface_flags), address() {}
   };
 
+  // use with std::find_if() to search for an entry containing specified
+  // interface name
+  struct NamePredicate {
+    NamePredicate(const std::string& name) : name_(name) {}
+    bool operator()(
+        const std::pair<unsigned int, InterfaceStatus>& entry) const {
+      return entry.second.GetName() == name_;
+    }
+    const std::string& name_;
+  };
+
   // parent class which we will notify the events to
   TcpClientListener* tcp_client_listener_;
   // if configured, NetworkInterfaceListener will always look into the IP
@@ -194,8 +205,6 @@ class PlatformSpecificNetworkInterfaceListener
   // Select an appropriate network interface that we will get IP addresses. Also
   // update selected_interface_.
   const std::string SelectInterface();
-  // return an entry from status_table_ containing specified interface name
-  InterfaceStatusTable::iterator FindInterfaceStatus(std::string ifname);
   // convert ifaddrmsg to a list of EventParam structs
   std::vector<EventParam> ParseIFAddrMessage(struct ifaddrmsg* message,
                                              unsigned int size);

--- a/src/components/transport_manager/include/transport_manager/tcp/platform_specific/linux/platform_specific_network_interface_listener_impl.h
+++ b/src/components/transport_manager/include/transport_manager/tcp/platform_specific/linux/platform_specific_network_interface_listener_impl.h
@@ -32,7 +32,7 @@ class InterfaceStatus {
 
   bool IsAvailable() const;
   bool IsLoopback() const;
-  std::string GetName() const {
+  const std::string& GetName() const {
     return name_;
   }
   // only for debugging output
@@ -41,10 +41,10 @@ class InterfaceStatus {
   }
 
   bool HasIPAddress() const;
-  std::string GetIPv4Address() const;
-  std::string GetIPv6Address() const;
+  const std::string GetIPv4Address() const;
+  const std::string GetIPv6Address() const;
 
-  void SetName(std::string name) {
+  void SetName(const std::string& name) {
     name_ = name;
   }
 
@@ -53,8 +53,8 @@ class InterfaceStatus {
   }
 
   // specify NULL to remove existing address
-  void SetIPv4Address(struct in_addr* addr);
-  void SetIPv6Address(struct in6_addr* addr);
+  void SetIPv4Address(const struct in_addr* addr);
+  void SetIPv6Address(const struct in6_addr* addr);
 
  private:
   std::string name_;
@@ -65,6 +65,10 @@ class InterfaceStatus {
   struct in6_addr ipv6_address_;
 };
 
+/**
+ * @brief A map to store various status (IP addresses, status flags, etc.) of
+ *        network interfaces. Keys of the map are index numbers of interfaces.
+ */
 typedef std::map<unsigned int, InterfaceStatus> InterfaceStatusTable;
 
 /**
@@ -135,7 +139,9 @@ class PlatformSpecificNetworkInterfaceListener
     return selected_interface_;
   }
 
-  void SetDummyNameMap(std::map<unsigned int, std::string> m) {
+  // for testing only: overwrites if_indextoname() by registering a dummy
+  // index-to-name mapping table
+  void SetDummyNameMap(const std::map<unsigned int, std::string>& m) {
     dummy_name_map_ = m;
   }
 #endif  // BUILD_TESTS

--- a/src/components/transport_manager/include/transport_manager/tcp/tcp_client_listener.h
+++ b/src/components/transport_manager/include/transport_manager/tcp/tcp_client_listener.h
@@ -150,6 +150,7 @@ class TcpClientListener : public ClientConnectionListener {
   threads::Thread* thread_;
   int socket_;
   bool thread_stop_requested_;
+  bool remove_devices_on_terminate_;
   int pipe_fds_[2];
   NetworkInterfaceListener* interface_listener_;
   const std::string designated_interface_;

--- a/src/components/transport_manager/src/tcp/platform_specific/linux/platform_specific_network_interface_listener.cc
+++ b/src/components/transport_manager/src/tcp/platform_specific/linux/platform_specific_network_interface_listener.cc
@@ -1,7 +1,5 @@
 #include "transport_manager/tcp/platform_specific/linux/platform_specific_network_interface_listener_impl.h"
 
-#include <algorithm>
-
 #include <arpa/inet.h>
 #include <asm/types.h>
 #include <errno.h>

--- a/src/components/transport_manager/src/tcp/platform_specific/linux/platform_specific_network_interface_listener.cc
+++ b/src/components/transport_manager/src/tcp/platform_specific/linux/platform_specific_network_interface_listener.cc
@@ -429,9 +429,9 @@ bool PlatformSpecificNetworkInterfaceListener::UpdateStatus(
         break;
       }
       case RTM_DELLINK:
-        LOG4CXX_DEBUG(logger_,
-                      "netlink event: interface " << status.GetName()
-                                                  << " removed");
+        LOG4CXX_DEBUG(
+            logger_,
+            "netlink event: interface " << status.GetName() << " removed");
         status_table_.erase(it->if_index);
         break;
       case RTM_NEWADDR: {

--- a/src/components/transport_manager/src/tcp/platform_specific/linux/platform_specific_network_interface_listener.cc
+++ b/src/components/transport_manager/src/tcp/platform_specific/linux/platform_specific_network_interface_listener.cc
@@ -38,7 +38,7 @@ bool InterfaceStatus::HasIPAddress() const {
   return has_ipv4_ || has_ipv6_;
 }
 
-std::string InterfaceStatus::GetIPv4Address() const {
+const std::string InterfaceStatus::GetIPv4Address() const {
   char buf[INET_ADDRSTRLEN] = "";
   if (has_ipv4_ && IsAvailable()) {
     inet_ntop(AF_INET, &ipv4_address_, buf, sizeof(buf));
@@ -46,7 +46,7 @@ std::string InterfaceStatus::GetIPv4Address() const {
   return std::string(buf);
 }
 
-std::string InterfaceStatus::GetIPv6Address() const {
+const std::string InterfaceStatus::GetIPv6Address() const {
   char buf[INET6_ADDRSTRLEN] = "";
   if (has_ipv6_ && IsAvailable()) {
     inet_ntop(AF_INET6, &ipv6_address_, buf, sizeof(buf));
@@ -54,7 +54,7 @@ std::string InterfaceStatus::GetIPv6Address() const {
   return std::string(buf);
 }
 
-void InterfaceStatus::SetIPv4Address(struct in_addr* addr) {
+void InterfaceStatus::SetIPv4Address(const struct in_addr* addr) {
   if (addr == NULL) {
     has_ipv4_ = false;
   } else {
@@ -63,7 +63,7 @@ void InterfaceStatus::SetIPv4Address(struct in_addr* addr) {
   }
 }
 
-void InterfaceStatus::SetIPv6Address(struct in6_addr* addr) {
+void InterfaceStatus::SetIPv6Address(const struct in6_addr* addr) {
   if (addr == NULL) {
     has_ipv6_ = false;
   } else {
@@ -420,7 +420,7 @@ bool PlatformSpecificNetworkInterfaceListener::UpdateStatus(
     InterfaceStatus& status = status_table_[it->if_index];
     switch (type) {
       case RTM_NEWLINK: {
-        std::string ifname = GetInterfaceName(it->if_index);
+        const std::string& ifname = GetInterfaceName(it->if_index);
         LOG4CXX_DEBUG(
             logger_,
             "netlink event: interface " << ifname << " created or updated");

--- a/src/components/transport_manager/src/tcp/platform_specific/linux/platform_specific_network_interface_listener.cc
+++ b/src/components/transport_manager/src/tcp/platform_specific/linux/platform_specific_network_interface_listener.cc
@@ -537,7 +537,7 @@ const std::string PlatformSpecificNetworkInterfaceListener::SelectInterface() {
     if (status.IsLoopback()) {
       continue;
     }
-    // if the interface has to be UP and RUNNING, and must have an IP address
+    // the interface has to be UP and RUNNING, and must have an IP address
     if (!(status.IsAvailable() && status.HasIPAddress())) {
       continue;
     }

--- a/src/components/transport_manager/src/tcp/tcp_client_listener.cc
+++ b/src/components/transport_manager/src/tcp/tcp_client_listener.cc
@@ -108,7 +108,7 @@ TransportAdapter::Error TcpClientListener::Init() {
       return TransportAdapter::FAIL;
     }
   } else {
-    // Network interface is specified and we wiill listen only on the interface.
+    // Network interface is specified and we will listen only on the interface.
     // In this case, the server socket will be created once
     // NetworkInterfaceListener notifies the interface's IP address.
     LOG4CXX_INFO(logger_,
@@ -455,8 +455,7 @@ TransportAdapter::Error TcpClientListener::StartListeningThread() {
 
   if (pipe_fds_[0] < 0 || pipe_fds_[1] < 0) {
     // recreate the pipe every time, so that the thread loop will not get
-    // leftover
-    // data inside pipe after it is started
+    // leftover data inside pipe after it is started
     if (pipe(pipe_fds_) != 0) {
       LOG4CXX_ERROR_WITH_ERRNO(logger_, "Failed to create internal pipe");
       return TransportAdapter::FAIL;

--- a/src/components/transport_manager/test/platform_specific/linux/linux_network_interface_listener_test.cc
+++ b/src/components/transport_manager/test/platform_specific/linux/linux_network_interface_listener_test.cc
@@ -32,6 +32,7 @@ class NetworkInterfaceListenerTest : public ::testing::Test {
  protected:
   struct InterfaceEntry {
     const char* name;
+    const unsigned int index;
     const char* ipv4_address;
     const char* ipv6_address;
     unsigned int flags;
@@ -50,6 +51,7 @@ class NetworkInterfaceListenerTest : public ::testing::Test {
 
   void SetDummyInterfaceTable(struct InterfaceEntry* entries) {
     InterfaceStatusTable dummy_table;
+    std::map<unsigned int, std::string> dummy_name_map;
 
     while (entries->name != NULL) {
       InterfaceStatus status;
@@ -63,13 +65,16 @@ class NetworkInterfaceListenerTest : public ::testing::Test {
         ASSERT_EQ(1, inet_pton(AF_INET6, entries->ipv6_address, &addr6));
         status.SetIPv6Address(&addr6);
       }
+      status.SetName(entries->name);
       status.SetFlags(entries->flags);
 
-      dummy_table.insert(std::make_pair(entries->name, status));
+      dummy_table.insert(std::make_pair(entries->index, status));
+      dummy_name_map[entries->index] = std::string(entries->name);
       entries++;
     }
 
     interface_listener_impl_->OverwriteStatusTable(dummy_table);
+    interface_listener_impl_->SetDummyNameMap(dummy_name_map);
   }
 
   void SleepFor(long msec) const {
@@ -108,8 +113,8 @@ TEST_F(NetworkInterfaceListenerTest, Start_success) {
   EXPECT_TRUE(interface_listener_impl_->Init());
 
   struct InterfaceEntry entries[] = {
-      {"dummy_int0", "1.2.3.4", NULL, IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+      {"dummy_int0", 1, "1.2.3.4", NULL, IFF_UP | IFF_RUNNING},
+      {NULL, 0, NULL, NULL, 0}};
   SetDummyInterfaceTable(entries);
 
   // after stated, it is expected that the listener notifies current IP address
@@ -198,11 +203,11 @@ TEST_F(NetworkInterfaceListenerTest, DesignatedInterface_IPAddressChanged) {
   EXPECT_TRUE(interface_listener_impl_->Init());
 
   struct InterfaceEntry entries1[] = {
-      {"dummy_int0", "1.2.3.4", NULL, IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+      {"dummy_int0", 1, "1.2.3.4", NULL, IFF_UP | IFF_RUNNING},
+      {NULL, 0, NULL, NULL, 0}};
   struct InterfaceEntry entries2[] = {
-      {"dummy_int0", "5.6.7.8", NULL, IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+      {"dummy_int0", 1, "5.6.7.8", NULL, IFF_UP | IFF_RUNNING},
+      {NULL, 0, NULL, NULL, 0}};
 
   SetDummyInterfaceTable(entries1);
 
@@ -230,13 +235,13 @@ TEST_F(NetworkInterfaceListenerTest, DesignatedInterface_IPAddressNotChanged) {
   EXPECT_TRUE(interface_listener_impl_->Init());
 
   struct InterfaceEntry entries1[] = {
-      {"dummy_int0", "1.2.3.4", NULL, IFF_UP | IFF_RUNNING},
-      {"dummy_int1", "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+      {"dummy_int0", 1, "1.2.3.4", NULL, IFF_UP | IFF_RUNNING},
+      {"dummy_int1", 2, "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
+      {NULL, 0, NULL, NULL, 0}};
   struct InterfaceEntry entries2[] = {
-      {"dummy_int0", "1.2.3.4", NULL, IFF_UP | IFF_RUNNING},
-      {"dummy_int1", "172.16.23.30", NULL, IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+      {"dummy_int0", 1, "1.2.3.4", NULL, IFF_UP | IFF_RUNNING},
+      {"dummy_int1", 2, "172.16.23.30", NULL, IFF_UP | IFF_RUNNING},
+      {NULL, 0, NULL, NULL, 0}};
 
   SetDummyInterfaceTable(entries1);
 
@@ -261,13 +266,13 @@ TEST_F(NetworkInterfaceListenerTest, DesignatedInterface_GoesUnavailable) {
   EXPECT_TRUE(interface_listener_impl_->Init());
 
   struct InterfaceEntry entries1[] = {
-      {"dummy_int0", "1.2.3.4", "fdc2:12af:327a::1", IFF_UP | IFF_RUNNING},
-      {"dummy_int1", "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+      {"dummy_int0", 1, "1.2.3.4", "fdc2:12af:327a::1", IFF_UP | IFF_RUNNING},
+      {"dummy_int1", 2, "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
+      {NULL, 0, NULL, NULL, 0}};
   struct InterfaceEntry entries2[] = {
-      {"dummy_int0", "1.2.3.4", "fdc2:12af:327a::1", IFF_UP},
-      {"dummy_int1", "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+      {"dummy_int0", 1, "1.2.3.4", "fdc2:12af:327a::1", IFF_UP},
+      {"dummy_int1", 2, "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
+      {NULL, 0, NULL, NULL, 0}};
 
   SetDummyInterfaceTable(entries1);
 
@@ -292,12 +297,12 @@ TEST_F(NetworkInterfaceListenerTest, DesignatedInterface_Removed) {
   EXPECT_TRUE(interface_listener_impl_->Init());
 
   struct InterfaceEntry entries1[] = {
-      {"dummy_int0", "1.2.3.4", "fdc2:12af:327a::1", IFF_UP | IFF_RUNNING},
-      {"dummy_int1", "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+      {"dummy_int0", 1, "1.2.3.4", "fdc2:12af:327a::1", IFF_UP | IFF_RUNNING},
+      {"dummy_int1", 2, "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
+      {NULL, 0, NULL, NULL, 0}};
   struct InterfaceEntry entries2[] = {
-      {"dummy_int1", "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+      {"dummy_int1", 2, "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
+      {NULL, 0, NULL, NULL, 0}};
 
   SetDummyInterfaceTable(entries1);
 
@@ -322,12 +327,12 @@ TEST_F(NetworkInterfaceListenerTest, DesignatedInterface_Added) {
   EXPECT_TRUE(interface_listener_impl_->Init());
 
   struct InterfaceEntry entries1[] = {
-      {"dummy_int1", "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+      {"dummy_int1", 1, "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
+      {NULL, 0, NULL, NULL, 0}};
   struct InterfaceEntry entries2[] = {
-      {"dummy_int1", "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
-      {"dummy_int0", "1.2.3.4", NULL, IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+      {"dummy_int1", 1, "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
+      {"dummy_int0", 2, "1.2.3.4", NULL, IFF_UP | IFF_RUNNING},
+      {NULL, 0, NULL, NULL, 0}};
 
   SetDummyInterfaceTable(entries1);
 
@@ -350,9 +355,13 @@ TEST_F(NetworkInterfaceListenerTest, AutoSelectInterface_SelectInterface) {
   EXPECT_TRUE(interface_listener_impl_->Init());
 
   struct InterfaceEntry entries[] = {
-      {"dummy_int1", "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
-      {"net_dummy2", "192.168.2.3", "fdc2:12af:327a::22", IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+      {"dummy_int1", 1, "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
+      {"net_dummy2",
+       2,
+       "192.168.2.3",
+       "fdc2:12af:327a::22",
+       IFF_UP | IFF_RUNNING},
+      {NULL, 0, NULL, NULL, 0}};
 
   SetDummyInterfaceTable(entries);
 
@@ -384,9 +393,13 @@ TEST_F(NetworkInterfaceListenerTest,
   EXPECT_TRUE(interface_listener_impl_->Init());
 
   struct InterfaceEntry entries[] = {
-      {"dummy_int1", "10.10.10.12", NULL, IFF_UP},
-      {"net_dummy2", "192.168.2.3", "fdc2:12af:327a::22", IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+      {"dummy_int1", 1, "10.10.10.12", NULL, IFF_UP},
+      {"net_dummy2",
+       2,
+       "192.168.2.3",
+       "fdc2:12af:327a::22",
+       IFF_UP | IFF_RUNNING},
+      {NULL, 0, NULL, NULL, 0}};
 
   SetDummyInterfaceTable(entries);
 
@@ -410,9 +423,9 @@ TEST_F(NetworkInterfaceListenerTest, AutoSelectInterface_SkipEmptyInterface) {
   EXPECT_TRUE(interface_listener_impl_->Init());
 
   struct InterfaceEntry entries[] = {
-      {"dummy_int1", "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
-      {"net_dummy2", NULL, NULL, IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+      {"dummy_int1", 1, "10.10.10.12", NULL, IFF_UP | IFF_RUNNING},
+      {"net_dummy2", 2, NULL, NULL, IFF_UP | IFF_RUNNING},
+      {NULL, 0, NULL, NULL, 0}};
 
   SetDummyInterfaceTable(entries);
 
@@ -435,10 +448,17 @@ TEST_F(NetworkInterfaceListenerTest,
   Init("");
   EXPECT_TRUE(interface_listener_impl_->Init());
 
-  struct InterfaceEntry entries[] = {
-      {"dummy_int1", "10.10.10.12", NULL, IFF_UP | IFF_RUNNING | IFF_LOOPBACK},
-      {"net_dummy2", "192.168.2.3", "fdc2:12af:327a::22", IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+  struct InterfaceEntry entries[] = {{"dummy_int1",
+                                      1,
+                                      "10.10.10.12",
+                                      NULL,
+                                      IFF_UP | IFF_RUNNING | IFF_LOOPBACK},
+                                     {"net_dummy2",
+                                      2,
+                                      "192.168.2.3",
+                                      "fdc2:12af:327a::22",
+                                      IFF_UP | IFF_RUNNING},
+                                     {NULL, 0, NULL, NULL, 0}};
 
   // dummy_int1 should not be selected
   struct InterfaceEntry* expected = &entries[1];
@@ -461,9 +481,12 @@ TEST_F(NetworkInterfaceListenerTest, AutoSelectInterface_DisableInterface) {
   Init("");
   EXPECT_TRUE(interface_listener_impl_->Init());
 
-  struct InterfaceEntry entries[] = {
-      {"net_dummy0", "192.168.2.3", "fdc2:12af:327a::22", IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+  struct InterfaceEntry entries[] = {{"net_dummy0",
+                                      1,
+                                      "192.168.2.3",
+                                      "fdc2:12af:327a::22",
+                                      IFF_UP | IFF_RUNNING},
+                                     {NULL, 0, NULL, NULL, 0}};
 
   EXPECT_CALL(mock_tcp_client_listener_, OnIPAddressUpdated(_, _)).Times(1);
   SetDummyInterfaceTable(entries);
@@ -487,9 +510,12 @@ TEST_F(NetworkInterfaceListenerTest, AutoSelectInterface_EnableInterface) {
   Init("");
   EXPECT_TRUE(interface_listener_impl_->Init());
 
-  struct InterfaceEntry entries[] = {
-      {"net_dummy0", "192.168.2.3", "fdc2:12af:327a::22", IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+  struct InterfaceEntry entries[] = {{"net_dummy0",
+                                      1,
+                                      "192.168.2.3",
+                                      "fdc2:12af:327a::22",
+                                      IFF_UP | IFF_RUNNING},
+                                     {NULL, 0, NULL, NULL, 0}};
 
   EXPECT_CALL(mock_tcp_client_listener_, OnIPAddressUpdated(_, _)).Times(1);
   SetDummyInterfaceTable(entries);
@@ -525,13 +551,17 @@ TEST_F(NetworkInterfaceListenerTest, AutoSelectInterface_SwitchInterface) {
   Init("");
   EXPECT_TRUE(interface_listener_impl_->Init());
 
-  struct InterfaceEntry entries[] = {
-      {"dummy_int1",
-       "10.10.10.12",
-       "fd53:ba79:241d:30c1::78",
-       IFF_UP | IFF_RUNNING},
-      {"net_dummy2", "192.168.2.3", "fdc2:12af:327a::22", IFF_UP | IFF_RUNNING},
-      {NULL, NULL, NULL, 0}};
+  struct InterfaceEntry entries[] = {{"dummy_int1",
+                                      1,
+                                      "10.10.10.12",
+                                      "fd53:ba79:241d:30c1::78",
+                                      IFF_UP | IFF_RUNNING},
+                                     {"net_dummy2",
+                                      2,
+                                      "192.168.2.3",
+                                      "fdc2:12af:327a::22",
+                                      IFF_UP | IFF_RUNNING},
+                                     {NULL, 0, NULL, NULL, 0}};
 
   EXPECT_CALL(mock_tcp_client_listener_, OnIPAddressUpdated(_, _)).Times(1);
   SetDummyInterfaceTable(entries);

--- a/src/components/transport_manager/test/platform_specific/linux/linux_network_interface_listener_test.cc
+++ b/src/components/transport_manager/test/platform_specific/linux/linux_network_interface_listener_test.cc
@@ -49,7 +49,7 @@ class NetworkInterfaceListenerTest : public ::testing::Test {
     delete interface_listener_impl_;
   }
 
-  void SetDummyInterfaceTable(struct InterfaceEntry* entries) {
+  void SetDummyInterfaceTable(const struct InterfaceEntry* entries) {
     InterfaceStatusTable dummy_table;
     std::map<unsigned int, std::string> dummy_name_map;
 


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/2758

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
Repeat the repro step mentioned in https://github.com/smartdevicelink/sdl_core/issues/2758 and confirm that IP address is cleared out in the log.

### Summary
- In `PlatformSpecificNetworkInterfaceListener`, internal table `status_table_` is updated to use interface index as the key to handle interface removal.
- After network interface is removed, Transport Adapter's DeviceDisconnected() is triggered to handle device removal.

### Changelog
##### Breaking Changes
* None.

##### Enhancements
* None.

##### Bug Fixes
* IP address isn't notified when network interface is removed
* generate DeviceDisconnected event when network interface is removed 

### Tasks Remaining:
- None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
