### PR TITLE
remove an impossible case from protocol handler impl

### DIFF
--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -177,11 +177,6 @@ void set_hash_id(uint32_t hash_id, protocol_handler::ProtocolPacket& packet) {
   if (HASH_ID_NOT_SUPPORTED == hash_id || HASH_ID_WRONG == hash_id) {
     return;
   }
-  if (packet.protocol_version() < PROTOCOL_VERSION_2) {
-    LOG4CXX_DEBUG(logger_,
-                  "Packet needs no hash data (protocol version less 2)");
-    return;
-  }
   LOG4CXX_DEBUG(logger_,
                 "Set hash_id 0x" << std::hex << hash_id << " to the packet 0x"
                                  << &packet);


### PR DESCRIPTION
Fixes #[2476](https://github.com/SmartDeviceLink/sdl_core/issues/2476)

This PR is [ready] for review.
Risk

This PR makes [no] API changes.

Summary

The case when protocol version less than 2 does not support data hashing. hash_id is not supported too. According it the condition "if (packet.protocol_version() < PROTOCOL_VERSION_2)" following after the condition "if (HASH_ID_NOT_SUPPORTED == hash_id || HASH_ID_WRONG == hash_id)" is an impracticable condition in the function set_hash_id. Therefore this case was deleted.
Copy of https://github.com/smartdevicelink/sdl_core/pull/2660

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)