### PR TITLE
Unhandled SmartType UInteger in SmartObject duplicate function

### DIFF
--- a/src/components/smart_objects/src/smart_object.cc
+++ b/src/components/smart_objects/src/smart_object.cc
@@ -701,6 +701,9 @@ void SmartObject::duplicate(const SmartObject& OtherObject) {
     case SmartType_Integer:
       newData.int_value = OtherObject.m_data.int_value;
       break;
+    case SmartType_UInteger:
+      newData.int_value = OtherObject.m_data.int_value;
+      break;
     case SmartType_Double:
       newData.double_value = OtherObject.m_data.double_value;
       break;


### PR DESCRIPTION

Fixes unhandled case for SmartType UInteger in SmartObject duplicate function. The unhandled case causes a DCHECK error if number assigned to the smart object is larger than `std::numeric_limits<int32_t>::max()`

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)