### PR TITLE
Fix regex command for reading paths post port number

### DIFF
--- a/src/components/transport_manager/src/cloud/cloud_websocket_transport_adapter.cc
+++ b/src/components/transport_manager/src/cloud/cloud_websocket_transport_adapter.cc
@@ -87,7 +87,7 @@ void CloudWebsocketTransportAdapter::CreateDevice(const std::string& uid) {
 
   // Extract host and port from endpoint string
   boost::regex group_pattern(
-      "(wss?:\\/\\/)([A-Z\\d\\.-]{2,}\\.?([A-Z]{2,})?)(:)(\\d{2,4})(\\/)(((([A-Z\\d\\.-]{1,})(\\/)?){1,})?){1,}");
+      "(wss?:\\/\\/)([A-Z\\d\\.-]{2,}\\.?([A-Z]{2,})?)(:)(\\d{2,5})(\\/[A-Z\\d\\.-]+)*\\/?");
   boost::smatch results;
 
   std::string host = "";

--- a/src/components/transport_manager/src/cloud/cloud_websocket_transport_adapter.cc
+++ b/src/components/transport_manager/src/cloud/cloud_websocket_transport_adapter.cc
@@ -87,7 +87,7 @@ void CloudWebsocketTransportAdapter::CreateDevice(const std::string& uid) {
 
   // Extract host and port from endpoint string
   boost::regex group_pattern(
-      "(wss?:\\/\\/)([A-Z\\d\\.-]{2,}\\.?([A-Z]{2,})?)(:)(\\d{2,4})(\\/)");
+      "(wss?:\\/\\/)([A-Z\\d\\.-]{2,}\\.?([A-Z]{2,})?)(:)(\\d{2,4})(\\/)(((([A-Z\\d\\.-]{1,})(\\/)?){1,})?){1,}");
   boost::smatch results;
 
   std::string host = "";

--- a/src/components/transport_manager/src/cloud/cloud_websocket_transport_adapter.cc
+++ b/src/components/transport_manager/src/cloud/cloud_websocket_transport_adapter.cc
@@ -87,7 +87,8 @@ void CloudWebsocketTransportAdapter::CreateDevice(const std::string& uid) {
 
   // Extract host and port from endpoint string
   boost::regex group_pattern(
-      "(wss?:\\/\\/)([A-Z\\d\\.-]{2,}\\.?([A-Z]{2,})?)(:)(\\d{2,5})(\\/[A-Z\\d\\.-]+)*\\/?");
+      "(wss?:\\/\\/)([A-Z\\d\\.-]{2,}\\.?([A-Z]{2,})?)(:)(\\d{2,5})(\\/"
+      "[A-Z\\d\\.-]+)*\\/?");
   boost::smatch results;
 
   std::string host = "";


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Updates the regex command to allow for paths after the port in a ws url.

[REGEX Example](https://regexr.com/48sb2)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)