### PR TITLE
Get Icon URL Request

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -119,11 +119,10 @@ typedef std::map<std::string, hmi_apis::Common_TransportType::eType>
 
 struct AppIconInfo {
   std::string endpoint;
-  bool icon_exists;
   bool pending_request;
   AppIconInfo();
-  AppIconInfo(std::string url, bool exists, bool pending)
-      : endpoint(url), icon_exists(exists), pending_request(pending) {}
+  AppIconInfo(std::string ws_endpoint, bool pending)
+      : endpoint(ws_endpoint), pending_request(pending) {}
 };
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "ApplicationManager")
@@ -390,7 +389,7 @@ class ApplicationManagerImpl
 
   std::string PolicyIDByIconUrl(const std::string url) OVERRIDE;
 
-  void SetIconExists(const std::string policy_id) OVERRIDE;
+  void SetIconFileFromSystemRequest(const std::string policy_id) OVERRIDE;
 
   /**
    * @brief Notifies the applicaiton manager that a cloud connection status has
@@ -522,9 +521,6 @@ class ApplicationManagerImpl
 
   // typedef for Applications list
   typedef std::set<ApplicationSharedPtr, ApplicationsAppIdSorter> ApplictionSet;
-
-  // typedef std::set<ApplicationSharedPtr, ApplicationsPolicyAppIdSorter>
-  //    AppsWaitRegistrationSet;
 
   // typedef for Applications list iterator
   typedef ApplictionSet::iterator ApplictionSetIt;

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -117,6 +117,15 @@ struct CommandParametersPermissions;
 typedef std::map<std::string, hmi_apis::Common_TransportType::eType>
     DeviceTypes;
 
+struct AppIconInfo {
+  std::string endpoint;
+  bool icon_exists;
+  bool pending_request;
+  AppIconInfo();
+  AppIconInfo(std::string url, bool exists, bool pending)
+      : endpoint(url), icon_exists(exists), pending_request(pending) {}
+};
+
 CREATE_LOGGERPTR_GLOBAL(logger_, "ApplicationManager")
 typedef std::shared_ptr<timer::Timer> TimerSPtr;
 
@@ -193,6 +202,9 @@ class ApplicationManagerImpl
       const std::shared_ptr<Application> app) OVERRIDE;
 
   void SendDriverDistractionState(ApplicationSharedPtr application);
+
+  void SendGetIconUrlNotifications(const uint32_t connection_key,
+                                   ApplicationSharedPtr application);
 
   ApplicationSharedPtr application(
       const std::string& device_id,
@@ -370,6 +382,10 @@ class ApplicationManagerImpl
   void SetPendingApplicationState(
       const transport_manager::ConnectionUID connection_id,
       const transport_manager::DeviceInfo& device_info);
+
+  std::string PolicyIDByIconUrl(const std::string url) OVERRIDE;
+
+  void SetIconExists(const std::string policy_id) OVERRIDE;
 
   /**
    * @brief Notifies the applicaiton manager that a cloud connection status has
@@ -1475,6 +1491,9 @@ class ApplicationManagerImpl
   mutable std::shared_ptr<sync_primitives::RecursiveLock>
       pending_device_map_lock_ptr_;
   std::map<std::string, std::string> pending_device_map_;
+
+  sync_primitives::Lock app_icon_map_lock_ptr_;
+  std::map<std::string, AppIconInfo> app_icon_map_;
 
 #ifdef TELEMETRY_MONITOR
   AMTelemetryObserver* metric_observer_;

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -165,6 +165,7 @@ class ApplicationManagerImpl
   bool Stop() OVERRIDE;
 
   DataAccessor<ApplicationSet> applications() const OVERRIDE;
+  DataAccessor<AppsWaitRegistrationSet> pending_applications() const OVERRIDE;
   ApplicationSharedPtr application(uint32_t app_id) const OVERRIDE;
 
   ApplicationSharedPtr active_application() const OVERRIDE;
@@ -172,6 +173,8 @@ class ApplicationManagerImpl
   ApplicationSharedPtr application_by_hmi_app(
       uint32_t hmi_app_id) const OVERRIDE;
   ApplicationSharedPtr application_by_policy_id(
+      const std::string& policy_app_id) const OVERRIDE;
+  ApplicationSharedPtr pending_application_by_policy_id(
       const std::string& policy_app_id) const OVERRIDE;
 
   std::vector<ApplicationSharedPtr> applications_by_button(
@@ -520,8 +523,8 @@ class ApplicationManagerImpl
   // typedef for Applications list
   typedef std::set<ApplicationSharedPtr, ApplicationsAppIdSorter> ApplictionSet;
 
-  typedef std::set<ApplicationSharedPtr, ApplicationsPolicyAppIdSorter>
-      AppsWaitRegistrationSet;
+  //typedef std::set<ApplicationSharedPtr, ApplicationsPolicyAppIdSorter>
+  //    AppsWaitRegistrationSet;
 
   // typedef for Applications list iterator
   typedef ApplictionSet::iterator ApplictionSetIt;

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -523,7 +523,7 @@ class ApplicationManagerImpl
   // typedef for Applications list
   typedef std::set<ApplicationSharedPtr, ApplicationsAppIdSorter> ApplictionSet;
 
-  //typedef std::set<ApplicationSharedPtr, ApplicationsPolicyAppIdSorter>
+  // typedef std::set<ApplicationSharedPtr, ApplicationsPolicyAppIdSorter>
   //    AppsWaitRegistrationSet;
 
   // typedef for Applications list iterator

--- a/src/components/application_manager/include/application_manager/helpers/application_helper.h
+++ b/src/components/application_manager/include/application_manager/helpers/application_helper.h
@@ -58,8 +58,8 @@ ApplicationSharedPtr FindApp(DataAccessor<ApplicationSet> accessor,
 }
 
 template <class UnaryPredicate>
-ApplicationSharedPtr FindPendingApp(DataAccessor<AppsWaitRegistrationSet> accessor,
-                             UnaryPredicate finder) {
+ApplicationSharedPtr FindPendingApp(
+    DataAccessor<AppsWaitRegistrationSet> accessor, UnaryPredicate finder) {
   AppsWaitRegistrationSet::iterator it = std::find_if(
       accessor.GetData().begin(), accessor.GetData().end(), finder);
   if (accessor.GetData().end() == it) {

--- a/src/components/application_manager/include/application_manager/helpers/application_helper.h
+++ b/src/components/application_manager/include/application_manager/helpers/application_helper.h
@@ -57,6 +57,18 @@ ApplicationSharedPtr FindApp(DataAccessor<ApplicationSet> accessor,
   return app;
 }
 
+template <class UnaryPredicate>
+ApplicationSharedPtr FindPendingApp(DataAccessor<AppsWaitRegistrationSet> accessor,
+                             UnaryPredicate finder) {
+  AppsWaitRegistrationSet::iterator it = std::find_if(
+      accessor.GetData().begin(), accessor.GetData().end(), finder);
+  if (accessor.GetData().end() == it) {
+    return ApplicationSharedPtr();
+  }
+  ApplicationSharedPtr app = *it;
+  return app;
+}
+
 /**
  * Helper function for lookup through applications list and returning all
  * applications satisfying predicate logic

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -187,7 +187,8 @@ class PolicyHandler : public PolicyHandlerInterface,
   void GetUpdateUrls(const uint32_t service_type,
                      EndpointUrls& out_end_points) OVERRIDE;
   virtual std::string GetLockScreenIconUrl() const OVERRIDE;
-  virtual std::string GetIconUrl(const std::string& policy_app_id) const OVERRIDE;
+  virtual std::string GetIconUrl(
+      const std::string& policy_app_id) const OVERRIDE;
   uint32_t NextRetryTimeout() OVERRIDE;
 
   /**

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -187,6 +187,7 @@ class PolicyHandler : public PolicyHandlerInterface,
   void GetUpdateUrls(const uint32_t service_type,
                      EndpointUrls& out_end_points) OVERRIDE;
   virtual std::string GetLockScreenIconUrl() const OVERRIDE;
+  virtual std::string GetIconUrl(const std::string& policy_app_id) const OVERRIDE;
   uint32_t NextRetryTimeout() OVERRIDE;
 
   /**

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -447,6 +447,9 @@ void RegisterAppInterfaceRequest::Run() {
       GetLockScreenIconUrlNotification(connection_key(), application);
   rpc_service_.ManageMobileCommand(so, SOURCE_SDL);
   application_manager_.SendDriverDistractionState(application);
+  // Create onSystemRequest to mobile to obtain cloud app icons
+  application_manager_.SendGetIconUrlNotifications(connection_key(),
+                                                   application);
 }
 
 smart_objects::SmartObjectSPtr

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
@@ -511,7 +511,8 @@ void SystemRequest::Run() {
     return;
   }
 
-  if (!file_system::IsFileNameValid(file_name) && mobile_apis::RequestType::ICON_URL != request_type) {
+  if (!file_system::IsFileNameValid(file_name) &&
+      mobile_apis::RequestType::ICON_URL != request_type) {
     const std::string err_msg = "Sync file name contains forbidden symbols.";
     LOG4CXX_ERROR(logger_, err_msg);
     SendResponse(false, mobile_apis::Result::INVALID_DATA, err_msg.c_str());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
@@ -540,6 +540,10 @@ void SystemRequest::Run() {
       // Use the URL file name to identify the policy id.
       // Save the icon file with the policy id as the name.
       file_name = application_manager_.PolicyIDByIconUrl(file_name);
+      if (file_name.empty()) {
+        const std::string err_msg = "Invalid file name";
+        SendResponse(false, mobile_apis::Result::INVALID_DATA, err_msg.c_str());
+      }
       LOG4CXX_DEBUG(logger_, "Got ICON_URL Request. File name: " << file_name);
     } else {
       binary_data_folder =
@@ -592,7 +596,7 @@ void SystemRequest::Run() {
   LOG4CXX_DEBUG(logger_, "Binary data ok.");
 
   if (mobile_apis::RequestType::ICON_URL == request_type) {
-    application_manager_.SetIconExists(file_name);
+    application_manager_.SetIconFileFromSystemRequest(file_name);
     SendResponse(true, mobile_apis::Result::SUCCESS);
     return;
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
@@ -511,7 +511,7 @@ void SystemRequest::Run() {
     return;
   }
 
-  if (!file_system::IsFileNameValid(file_name)) {
+  if (!file_system::IsFileNameValid(file_name) && mobile_apis::RequestType::ICON_URL != request_type) {
     const std::string err_msg = "Sync file name contains forbidden symbols.";
     LOG4CXX_ERROR(logger_, err_msg);
     SendResponse(false, mobile_apis::Result::INVALID_DATA, err_msg.c_str());
@@ -539,6 +539,7 @@ void SystemRequest::Run() {
       // Use the URL file name to identify the policy id.
       // Save the icon file with the policy id as the name.
       file_name = application_manager_.PolicyIDByIconUrl(file_name);
+      LOG4CXX_DEBUG(logger_, "Got ICON_URL Request. File name: " << file_name);
     } else {
       binary_data_folder =
           application_manager_.get_settings().system_files_path();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
@@ -533,8 +533,16 @@ void SystemRequest::Run() {
   std::string binary_data_folder;
   if ((*message_)[strings::params].keyExists(strings::binary_data)) {
     binary_data = (*message_)[strings::params][strings::binary_data].asBinary();
-    binary_data_folder =
-        application_manager_.get_settings().system_files_path();
+    if (mobile_apis::RequestType::ICON_URL == request_type) {
+      binary_data_folder =
+          application_manager_.get_settings().app_icons_folder();
+      // Use the URL file name to identify the policy id.
+      // Save the icon file with the policy id as the name.
+      file_name = application_manager_.PolicyIDByIconUrl(file_name);
+    } else {
+      binary_data_folder =
+          application_manager_.get_settings().system_files_path();
+    }
   } else {
     binary_data_folder =
         application_manager_.get_settings().app_storage_folder();
@@ -580,6 +588,12 @@ void SystemRequest::Run() {
   }
 
   LOG4CXX_DEBUG(logger_, "Binary data ok.");
+
+  if (mobile_apis::RequestType::ICON_URL == request_type) {
+    application_manager_.SetIconExists(file_name);
+    SendResponse(true, mobile_apis::Result::SUCCESS);
+    return;
+  }
 
   if (mobile_apis::RequestType::HTTP == request_type &&
       (*message_)[strings::msg_params].keyExists(strings::file_name)) {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -240,9 +240,10 @@ DataAccessor<ApplicationSet> ApplicationManagerImpl::applications() const {
   return accessor;
 }
 
-DataAccessor<AppsWaitRegistrationSet> ApplicationManagerImpl::pending_applications() const {
-  DataAccessor<AppsWaitRegistrationSet> accessor(apps_to_register_,
-                                        apps_to_register_list_lock_ptr_);
+DataAccessor<AppsWaitRegistrationSet>
+ApplicationManagerImpl::pending_applications() const {
+  DataAccessor<AppsWaitRegistrationSet> accessor(
+      apps_to_register_, apps_to_register_list_lock_ptr_);
   return accessor;
 }
 
@@ -862,7 +863,6 @@ void ApplicationManagerImpl::SetIconExists(const std::string policy_id) {
     file.file_type = mobile_apis::FileType::GRAPHIC_PNG;
     app->AddFile(file);
     app->set_app_icon_path(full_icon_path);
-
   }
   SendUpdateAppList();
 }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -864,7 +864,8 @@ void ApplicationManagerImpl::SetIconFileFromSystemRequest(
     std::string extension = boost::filesystem::extension(icon_url);
     if (extension == "bmp" || extension == "BMP") {
       file.file_type = mobile_apis::FileType::GRAPHIC_BMP;
-    } else if (extension == "JPEG" || extension == "jpeg") {
+    } else if (extension == "JPEG" || extension == "jpeg" ||
+               extension == "JPG" || extension == "jpg") {
       file.file_type = mobile_apis::FileType::GRAPHIC_JPEG;
     } else {
       file.file_type = mobile_apis::FileType::GRAPHIC_PNG;

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1548,7 +1548,6 @@ bool MessageHelper::CreateHMIApplicationStruct(
 
   const std::string icon_path = app->app_icon_path();
 
-  LOG4CXX_DEBUG(logger_, "Get ICON PATH" << icon_path);
   if (file_system::FileExists(app->app_icon_path())) {
     message[strings::icon] = icon_path;
   }

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1547,6 +1547,8 @@ bool MessageHelper::CreateHMIApplicationStruct(
   message[hmi_response::policy_app_id] = policy_app_id;
 
   const std::string icon_path = app->app_icon_path();
+
+  LOG4CXX_DEBUG(logger_, "Get ICON PATH" << icon_path); 
   if (file_system::FileExists(app->app_icon_path())) {
     message[strings::icon] = icon_path;
   }

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1548,7 +1548,7 @@ bool MessageHelper::CreateHMIApplicationStruct(
 
   const std::string icon_path = app->app_icon_path();
 
-  LOG4CXX_DEBUG(logger_, "Get ICON PATH" << icon_path); 
+  LOG4CXX_DEBUG(logger_, "Get ICON PATH" << icon_path);
   if (file_system::FileExists(app->app_icon_path())) {
     message[strings::icon] = icon_path;
   }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -91,7 +91,8 @@ RequestTypeMap TypeToString = {
     {mobile_apis::RequestType::EMERGENCY, "EMERGENCY"},
     {mobile_apis::RequestType::MEDIA, "MEDIA"},
     {mobile_apis::RequestType::FOTA, "FOTA"},
-    {mobile_apis::RequestType::OEM_SPECIFIC, "OEM_SPECIFIC"}};
+    {mobile_apis::RequestType::OEM_SPECIFIC, "OEM_SPECIFIC"},
+    {mobile_apis::RequestType::ICON_URL, "ICON_URL"}};
 
 const std::string RequestTypeToString(mobile_apis::RequestType::eType type) {
   RequestTypeMap::const_iterator it = TypeToString.find(type);
@@ -1574,6 +1575,11 @@ void PolicyHandler::GetUpdateUrls(const uint32_t service_type,
 std::string PolicyHandler::GetLockScreenIconUrl() const {
   POLICY_LIB_CHECK(std::string(""));
   return policy_manager_->GetLockScreenIconUrl();
+}
+
+std::string PolicyHandler::GetIconUrl(const std::string& policy_app_id) const {
+  POLICY_LIB_CHECK(std::string(""));
+  return policy_manager_->GetIconUrl(policy_app_id);
 }
 
 uint32_t PolicyHandler::NextRetryTimeout() {

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -152,7 +152,8 @@ class ApplicationManager {
       connection_handler::ConnectionHandler* handler) = 0;
 
   virtual DataAccessor<ApplicationSet> applications() const = 0;
-  virtual DataAccessor<AppsWaitRegistrationSet> pending_applications() const = 0;
+  virtual DataAccessor<AppsWaitRegistrationSet> pending_applications()
+      const = 0;
 
   virtual ApplicationSharedPtr application(uint32_t app_id) const = 0;
   virtual ApplicationSharedPtr active_application() const = 0;

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -441,7 +441,7 @@ class ApplicationManager {
 
   virtual std::string PolicyIDByIconUrl(const std::string url) = 0;
 
-  virtual void SetIconExists(const std::string policy_id) = 0;
+  virtual void SetIconFileFromSystemRequest(const std::string policy_id) = 0;
 
   /**
    * @brief Retrieve the current connection status of a cloud app

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -152,6 +152,7 @@ class ApplicationManager {
       connection_handler::ConnectionHandler* handler) = 0;
 
   virtual DataAccessor<ApplicationSet> applications() const = 0;
+  virtual DataAccessor<AppsWaitRegistrationSet> pending_applications() const = 0;
 
   virtual ApplicationSharedPtr application(uint32_t app_id) const = 0;
   virtual ApplicationSharedPtr active_application() const = 0;
@@ -165,6 +166,9 @@ class ApplicationManager {
       uint32_t hmi_app_id) const = 0;
 
   virtual ApplicationSharedPtr application_by_policy_id(
+      const std::string& policy_app_id) const = 0;
+
+  virtual ApplicationSharedPtr pending_application_by_policy_id(
       const std::string& policy_app_id) const = 0;
 
   virtual AppSharedPtrs applications_by_button(uint32_t button) = 0;

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -283,6 +283,9 @@ class ApplicationManager {
    */
   virtual void SendDriverDistractionState(ApplicationSharedPtr application) = 0;
 
+  virtual void SendGetIconUrlNotifications(
+      const uint32_t connection_key, ApplicationSharedPtr application) = 0;
+
   /**
    * @brief Checks if Application is subscribed for way points
    * @param Application pointer
@@ -428,6 +431,10 @@ class ApplicationManager {
   virtual void OnHMIStartedCooperation() = 0;
 
   virtual void RefreshCloudAppInformation() = 0;
+
+  virtual std::string PolicyIDByIconUrl(const std::string url) = 0;
+
+  virtual void SetIconExists(const std::string policy_id) = 0;
 
   /**
    * @brief Retrieve the current connection status of a cloud app

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -105,6 +105,7 @@ class PolicyHandlerInterface {
   virtual void GetUpdateUrls(const uint32_t service_type,
                              EndpointUrls& out_end_points) = 0;
   virtual std::string GetLockScreenIconUrl() const = 0;
+  virtual std::string GetIconUrl(const std::string& policy_app_id) const = 0;
   virtual uint32_t NextRetryTimeout() = 0;
 
   /**

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -109,16 +109,16 @@ class PolicyManager : public usage_statistics::StatisticsManager {
 
   /**
    * @brief GetLockScreenIcon allows to obtain lock screen icon url;
-   * @return url which point to the resourse where lock screen icon could be
+   * @return url which point to the resource where lock screen icon could be
    *obtained.
    */
   virtual std::string GetLockScreenIconUrl() const = 0;
 
   /**
-   * @brief Get Icon Url used for showing a cloud apps icon before the intial
+   * @brief Get Icon Url used for showing a cloud apps icon before the initial
    *registration
    *
-   * @return url which point to the resourse where icon could be
+   * @return url which point to the resource where icon could be
    *obtained.
    */
   virtual std::string GetIconUrl(const std::string& policy_app_id) const = 0;

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -115,6 +115,14 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual std::string GetLockScreenIconUrl() const = 0;
 
   /**
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   *
+   * @return url which point to the resourse where icon could be
+   *obtained.
+   */
+  virtual std::string GetIconUrl(const std::string& policy_app_id) const = 0;
+
+  /**
    * @brief PTU is needed, for this PTS has to be formed and sent.
    */
   virtual void RequestPTUpdate() = 0;

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -115,7 +115,8 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual std::string GetLockScreenIconUrl() const = 0;
 
   /**
-   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial
+   *registration
    *
    * @return url which point to the resourse where icon could be
    *obtained.

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -87,16 +87,16 @@ class PolicyManager : public usage_statistics::StatisticsManager {
 
   /**
    * @brief GetLockScreenIcon allows to obtain lock screen icon url;
-   * @return url which point to the resourse where lock screen icon could be
+   * @return url which point to the resource where lock screen icon could be
    *obtained.
    */
   virtual std::string GetLockScreenIconUrl() const = 0;
 
   /**
-   * @brief Get Icon Url used for showing a cloud apps icon before the intial
+   * @brief Get Icon Url used for showing a cloud apps icon before the initial
    *registration
    *
-   * @return url which point to the resourse where icon could be
+   * @return url which point to the resource where icon could be
    *obtained.
    */
   virtual std::string GetIconUrl(const std::string& policy_app_id) const = 0;

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -93,7 +93,8 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual std::string GetLockScreenIconUrl() const = 0;
 
   /**
-   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial
+   *registration
    *
    * @return url which point to the resourse where icon could be
    *obtained.

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -93,6 +93,14 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual std::string GetLockScreenIconUrl() const = 0;
 
   /**
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   *
+   * @return url which point to the resourse where icon could be
+   *obtained.
+   */
+  virtual std::string GetIconUrl(const std::string& policy_app_id) const = 0;
+
+  /**
    * @brief Gets all URLs for sending PTS to from PT itself.
    * @param service_type Service specifies user of URL
    * @param out_end_points output vector of urls

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -124,6 +124,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
       void(const std::shared_ptr<application_manager::Application> app));
   MOCK_METHOD1(SendDriverDistractionState,
                void(application_manager::ApplicationSharedPtr app));
+  MOCK_METHOD2(SendGetIconUrlNotifications,
+               void(const uint32_t connection_key,
+                    application_manager::ApplicationSharedPtr application));
   MOCK_METHOD2(RemoveHMIFakeParameters,
                void(application_manager::commands::MessageSharedPtr& message,
                     const hmi_apis::FunctionID::eType& function_id));
@@ -170,6 +173,8 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD1(GetCloudAppConnectionStatus,
                      hmi_apis::Common_CloudConnectionStatus::eType(
                          application_manager::ApplicationConstSharedPtr app));
+  MOCK_METHOD1(PolicyIDByIconUrl, std::string(const std::string url));
+  MOCK_METHOD1(SetIconExists, void(const std::string policy_id));
   MOCK_CONST_METHOD0(IsHMICooperating, bool());
   MOCK_METHOD2(IviInfoUpdated,
                void(mobile_apis::VehicleDataType::eType vehicle_info,

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -74,6 +74,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                void(connection_handler::ConnectionHandler* handler));
   MOCK_CONST_METHOD0(applications,
                      DataAccessor<application_manager::ApplicationSet>());
+  MOCK_CONST_METHOD0(
+      pending_applications,
+      DataAccessor<application_manager::AppsWaitRegistrationSet>());
   MOCK_CONST_METHOD1(
       application, application_manager::ApplicationSharedPtr(uint32_t app_id));
   MOCK_CONST_METHOD0(active_application,
@@ -95,6 +98,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
       application_by_hmi_app,
       application_manager::ApplicationSharedPtr(uint32_t hmi_app_id));
   MOCK_CONST_METHOD1(application_by_policy_id,
+                     application_manager::ApplicationSharedPtr(
+                         const std::string& policy_app_id));
+  MOCK_CONST_METHOD1(pending_application_by_policy_id,
                      application_manager::ApplicationSharedPtr(
                          const std::string& policy_app_id));
   MOCK_METHOD1(

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -182,7 +182,7 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                      hmi_apis::Common_CloudConnectionStatus::eType(
                          application_manager::ApplicationConstSharedPtr app));
   MOCK_METHOD1(PolicyIDByIconUrl, std::string(const std::string url));
-  MOCK_METHOD1(SetIconExists, void(const std::string policy_id));
+  MOCK_METHOD1(SetIconFileFromSystemRequest, void(const std::string policy_id));
   MOCK_CONST_METHOD0(IsHMICooperating, bool());
   MOCK_METHOD2(IviInfoUpdated,
                void(mobile_apis::VehicleDataType::eType vehicle_info,

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -102,6 +102,7 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                void(const uint32_t service_type,
                     policy::EndpointUrls& end_points));
   MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
+  MOCK_CONST_METHOD1(GetIconUrl, std::string(const std::string& policy_app_id));
   MOCK_METHOD0(ResetRetrySequence, void());
   MOCK_METHOD0(NextRetryTimeout, uint32_t());
   MOCK_CONST_METHOD0(TimeoutExchangeSec, uint32_t());

--- a/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
@@ -119,6 +119,7 @@ class MockCacheManagerInterface : public ::policy::CacheManagerInterface {
   MOCK_METHOD2(GetUpdateUrls,
                void(const uint32_t service_type, EndpointUrls& out_end_points));
   MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
+  MOCK_CONST_METHOD1(GetIconUrl, std::string(const std::string& policy_app_id));
   MOCK_METHOD1(
       GetNotificationsNumber,
       policy_table::NumberOfNotificationsType(const std::string& priority));

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -180,6 +180,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD1(OnAppRegisteredOnMobile,
                void(const std::string& application_id));
   MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
+  MOCK_CONST_METHOD1(GetIconUrl, std::string(const std::string& policy_app_id));
   MOCK_CONST_METHOD1(
       GetAppRequestTypes,
       const std::vector<std::string>(const std::string policy_app_id));

--- a/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
@@ -103,6 +103,7 @@ class MockCacheManagerInterface : public CacheManagerInterface {
   MOCK_METHOD2(GetUpdateUrls,
                void(const uint32_t service_type, EndpointUrls& out_end_points));
   MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
+  MOCK_CONST_METHOD1(GetIconUrl, std::string(const std::string& policy_app_id));
   MOCK_METHOD2(Init,
                bool(const std::string& file_name,
                     const PolicySettings* settings));

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -226,6 +226,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_CONST_METHOD0(get_settings, const PolicySettings&());
   MOCK_METHOD1(set_settings, void(const PolicySettings* get_settings));
   MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
+  MOCK_CONST_METHOD1(GetIconUrl, std::string(const std::string& policy_app_id));
   MOCK_METHOD1(GetNextUpdateUrl, AppIdURL(const EndpointUrls& urls));
   MOCK_CONST_METHOD2(RetrySequenceUrl,
                      AppIdURL(const struct RetrySequenceURL&,

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1268,6 +1268,7 @@
   <element name="MEDIA" />
   <element name="FOTA" />
   <element name="OEM_SPECIFIC"/>
+  <element name="ICON_URL"/>
 </enum>
 
 <enum name="ECallConfirmationStatus">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -2419,6 +2419,7 @@
         <element name="MEDIA" />
         <element name="FOTA" />
         <element name="OEM_SPECIFIC" since="5.0" />
+        <element name ="ICON_URL" />
     </enum>         
  
     <enum name="AppHMIType" since="2.0">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -2419,7 +2419,7 @@
         <element name="MEDIA" />
         <element name="FOTA" />
         <element name="OEM_SPECIFIC" since="5.0" />
-        <element name ="ICON_URL" />
+        <element name="ICON_URL" since="5.1" />
     </enum>         
  
     <enum name="AppHMIType" since="2.0">

--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -262,7 +262,8 @@ class CacheManager : public CacheManagerInterface {
   virtual std::string GetLockScreenIconUrl() const;
 
   /**
-   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial
+   *registration
    *
    * @return url which point to the resourse where icon could be
    *obtained.

--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -262,6 +262,14 @@ class CacheManager : public CacheManagerInterface {
   virtual std::string GetLockScreenIconUrl() const;
 
   /**
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   *
+   * @return url which point to the resourse where icon could be
+   *obtained.
+   */
+  virtual std::string GetIconUrl(const std::string& policy_app_id) const;
+
+  /**
    * @brief Gets list of URL to send PTS to
    * @param service_type If URLs for specific service are preset,
    * return them otherwise default URLs.

--- a/src/components/policy/policy_external/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager_interface.h
@@ -280,7 +280,8 @@ class CacheManagerInterface {
   virtual std::string GetLockScreenIconUrl() const = 0;
 
   /**
-   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial
+   *registration
    *
    * @return url which point to the resourse where icon could be
    *obtained.

--- a/src/components/policy/policy_external/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager_interface.h
@@ -280,6 +280,14 @@ class CacheManagerInterface {
   virtual std::string GetLockScreenIconUrl() const = 0;
 
   /**
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   *
+   * @return url which point to the resourse where icon could be
+   *obtained.
+   */
+  virtual std::string GetIconUrl(const std::string& policy_app_id) const = 0;
+
+  /**
    * @brief Get allowed number of notifications
    * depending on application priority.
    * @param priority Priority of application

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -209,6 +209,14 @@ class PolicyManagerImpl : public PolicyManager {
   std::string GetLockScreenIconUrl() const OVERRIDE;
 
   /**
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   *
+   * @return url which point to the resourse where icon could be
+   *obtained.
+   */
+  std::string GetIconUrl(const std::string& policy_app_id) const OVERRIDE;
+
+  /**
    * @brief Handler of PTS sending out
    */
   void OnUpdateStarted() OVERRIDE;

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -209,7 +209,8 @@ class PolicyManagerImpl : public PolicyManager {
   std::string GetLockScreenIconUrl() const OVERRIDE;
 
   /**
-   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial
+   *registration
    *
    * @return url which point to the resourse where icon could be
    *obtained.

--- a/src/components/policy/policy_external/include/policy/policy_table/enums.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/enums.h
@@ -154,6 +154,7 @@ enum RequestType {
   RT_MEDIA,
   RT_FOTA,
   RT_OEM_SPECIFIC,
+  RT_ICON_URL,
   RT_EMPTY  // Added to allow empty Request Types handling
 };
 

--- a/src/components/policy/policy_external/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/types.h
@@ -184,6 +184,7 @@ struct ApplicationParams : PolicyBase {
   Optional<Boolean> enabled;
   Optional<String<0, 65535> > auth_token;
   Optional<String<0, 255> > cloud_transport_type;
+  Optional<String<0, 65535> > icon_url;
 
  public:
   ApplicationParams();

--- a/src/components/policy/policy_external/include/policy/policy_table_interface_ext.xml
+++ b/src/components/policy/policy_external/include/policy/policy_table_interface_ext.xml
@@ -108,6 +108,8 @@
         <param name="cloud_transport_type" type="String" minlength="0" maxlength="255"
             mandatory="false" />
         <param name="hybrid_app_preference" type="HybridAppPreference" mandatory="false" />
+        <param name="icon_url" type="String" minlength="0" maxlength="65535"
+            mandatory="false" />
     </struct>
 
     <typedef name="HmiLevels" type="HmiLevel" array="true"

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1603,6 +1603,20 @@ std::string CacheManager::GetLockScreenIconUrl() const {
   return std::string("");
 }
 
+std::string CacheManager::GetIconUrl(const std::string& policy_app_id) const {
+  std::string url = "";
+  const policy_table::ApplicationPolicies& policies =
+      pt_->policy_table.app_policies_section.apps;
+  policy_table::ApplicationPolicies::const_iterator policy_iter =
+      policies.find(policy_app_id);
+  if (policies.end() != policy_iter) {
+    auto app_policy = (*policy_iter).second;
+    url = app_policy.icon_url.is_initialized() ? *app_policy.icon_url
+                                                        : std::string();
+  }
+  return url;
+}
+
 rpc::policy_table_interface_base::NumberOfNotificationsType
 CacheManager::GetNotificationsNumber(const std::string& priority) {
   CACHE_MANAGER_CHECK(0);

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1612,7 +1612,7 @@ std::string CacheManager::GetIconUrl(const std::string& policy_app_id) const {
   if (policies.end() != policy_iter) {
     auto app_policy = (*policy_iter).second;
     url = app_policy.icon_url.is_initialized() ? *app_policy.icon_url
-                                                        : std::string();
+                                               : std::string();
   }
   return url;
 }

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1604,7 +1604,8 @@ std::string CacheManager::GetLockScreenIconUrl() const {
 }
 
 std::string CacheManager::GetIconUrl(const std::string& policy_app_id) const {
-  std::string url = "";
+  CACHE_MANAGER_CHECK(std::string());
+  std::string url;
   const policy_table::ApplicationPolicies& policies =
       pt_->policy_table.app_policies_section.apps;
   policy_table::ApplicationPolicies::const_iterator policy_iter =

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -271,7 +271,8 @@ std::string PolicyManagerImpl::GetLockScreenIconUrl() const {
   return cache_->GetLockScreenIconUrl();
 }
 
-std::string PolicyManagerImpl::GetIconUrl(const std::string& policy_app_id) const {
+std::string PolicyManagerImpl::GetIconUrl(
+    const std::string& policy_app_id) const {
   return cache_->GetIconUrl(policy_app_id);
 }
 

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -271,6 +271,10 @@ std::string PolicyManagerImpl::GetLockScreenIconUrl() const {
   return cache_->GetLockScreenIconUrl();
 }
 
+std::string PolicyManagerImpl::GetIconUrl(const std::string& policy_app_id) const {
+  return cache_->GetIconUrl(policy_app_id);
+}
+
 /**
  * @brief FilterInvalidFunctions filter functions that are absent in schema
  * @param rpcs list of functions to filter

--- a/src/components/policy/policy_external/src/policy_table/enums.cc
+++ b/src/components/policy/policy_external/src/policy_table/enums.cc
@@ -629,6 +629,8 @@ bool IsValidEnum(RequestType val) {
       return true;
     case RT_OEM_SPECIFIC:
       return true;
+    case RT_ICON_URL:
+      return true;
     case RT_EMPTY:
       return true;
     default:
@@ -680,6 +682,8 @@ const char* EnumToJsonString(RequestType val) {
       return "FOTA";
     case RT_OEM_SPECIFIC:
       return "OEM_SPECIFIC";
+    case RT_ICON_URL:
+      return "ICON_URL";
     case RT_EMPTY:
       return "EMPTY";
     default:
@@ -770,6 +774,10 @@ bool EnumFromJsonString(const std::string& literal, RequestType* result) {
   }
   if ("OEM_SPECIFIC" == literal) {
     *result = RT_OEM_SPECIFIC;
+    return true;
+  }
+  if ("ICON_URL" == literal) {
+    *result = RT_ICON_URL;
     return true;
   }
   if ("EMPTY" == literal) {

--- a/src/components/policy/policy_external/src/policy_table/types.cc
+++ b/src/components/policy/policy_external/src/policy_table/types.cc
@@ -247,9 +247,8 @@ ApplicationParams::ApplicationParams(const Json::Value* value__)
     , endpoint(impl::ValueMember(value__, "endpoint"))
     , enabled(impl::ValueMember(value__, "enabled"))
     , auth_token(impl::ValueMember(value__, "auth_token"))
-    , cloud_transport_type(impl::ValueMember(value__, "cloud_transport_type")) 
-    , icon_url(impl::ValueMember(value__, "icon_url")) {
-}
+    , cloud_transport_type(impl::ValueMember(value__, "cloud_transport_type"))
+    , icon_url(impl::ValueMember(value__, "icon_url")) {}
 
 Json::Value ApplicationParams::ToJsonValue() const {
   Json::Value result__(PolicyBase::ToJsonValue());

--- a/src/components/policy/policy_external/src/policy_table/types.cc
+++ b/src/components/policy/policy_external/src/policy_table/types.cc
@@ -247,7 +247,8 @@ ApplicationParams::ApplicationParams(const Json::Value* value__)
     , endpoint(impl::ValueMember(value__, "endpoint"))
     , enabled(impl::ValueMember(value__, "enabled"))
     , auth_token(impl::ValueMember(value__, "auth_token"))
-    , cloud_transport_type(impl::ValueMember(value__, "cloud_transport_type")) {
+    , cloud_transport_type(impl::ValueMember(value__, "cloud_transport_type")) 
+    , icon_url(impl::ValueMember(value__, "icon_url")) {
 }
 
 Json::Value ApplicationParams::ToJsonValue() const {
@@ -267,6 +268,7 @@ Json::Value ApplicationParams::ToJsonValue() const {
   impl::WriteJsonField("enabled", enabled, &result__);
   impl::WriteJsonField("auth_token", auth_token, &result__);
   impl::WriteJsonField("cloud_transport_type", cloud_transport_type, &result__);
+  impl::WriteJsonField("icon_url", auth_token, &result__);
   return result__;
 }
 
@@ -307,6 +309,9 @@ bool ApplicationParams::is_valid() const {
     return false;
   }
   if (!hybrid_app_preference.is_valid()) {
+    return false;
+  }
+  if (!icon_url.is_valid()) {
     return false;
   }
   return Validate();
@@ -357,6 +362,9 @@ bool ApplicationParams::struct_empty() const {
     return false;
   }
   if (hybrid_app_preference.is_initialized()) {
+    return false;
+  }
+  if (icon_url.is_initialized()) {
     return false;
   }
   return true;
@@ -426,6 +434,9 @@ void ApplicationParams::ReportErrors(rpc::ValidationReport* report__) const {
     moduleType.ReportErrors(
         &report__->ReportSubobject("hybrid_app_preference"));
   }
+  if (!icon_url.is_valid()) {
+    moduleType.ReportErrors(&report__->ReportSubobject("icon_url"));
+  }
 }
 
 void ApplicationParams::SetPolicyTableType(PolicyTableType pt_type) {
@@ -441,6 +452,7 @@ void ApplicationParams::SetPolicyTableType(PolicyTableType pt_type) {
   enabled.SetPolicyTableType(pt_type);
   cloud_transport_type.SetPolicyTableType(pt_type);
   hybrid_app_preference.SetPolicyTableType(pt_type);
+  icon_url.SetPolicyTableType(pt_type);
 }
 
 // RpcParameters methods

--- a/src/components/policy/policy_external/src/sql_pt_ext_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_ext_queries.cc
@@ -207,8 +207,8 @@ const std::string kInsertApplication =
     " `default_hmi`, `priority_value`, `is_revoked`, `memory_kb`, "
     " `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
     " `endpoint`, `enabled`, `auth_token`, "
-    " `cloud_transport_type`) VALUES "
-    "(?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+    " `cloud_transport_type`, `icon_url`) VALUES "
+    "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
 
 const std::string kCollectFriendlyMsg = "SELECT * FROM `message`";
 
@@ -237,7 +237,7 @@ const std::string kSelectAppPolicies =
     "SELECT `id`, `priority_value`, `default_hmi`, `keep_context`, "
     " `steal_focus`, `memory_kb`, `heart_beat_timeout_ms`, `certificate`, "
     " `hybrid_app_preference_value`, `endpoint`, `enabled`, `auth_token` "
-    " `cloud_transport_type` FROM `application`";
+    " `cloud_transport_type`, `icon_url` FROM `application`";
 
 const std::string kSelectFunctionalGroupNames =
     "SELECT `id`, `user_consent_prompt`, `name`"

--- a/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
@@ -771,9 +771,9 @@ bool SQLPTExtRepresentation::SaveSpecificAppPolicy(
   app.second.cloud_transport_type.is_initialized()
       ? app_query.Bind(13, *app.second.cloud_transport_type)
       : app_query.Bind(13);
-   app.second.icon_url.is_initialized()
+  app.second.icon_url.is_initialized()
       ? app_query.Bind(14, *app.second.icon_url)
-      : app_query.Bind(14); 
+      : app_query.Bind(14);
 
   if (!app_query.Exec() || !app_query.Reset()) {
     LOG4CXX_WARN(logger_, "Incorrect insert into application.");

--- a/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
@@ -771,6 +771,9 @@ bool SQLPTExtRepresentation::SaveSpecificAppPolicy(
   app.second.cloud_transport_type.is_initialized()
       ? app_query.Bind(13, *app.second.cloud_transport_type)
       : app_query.Bind(13);
+   app.second.icon_url.is_initialized()
+      ? app_query.Bind(14, *app.second.icon_url)
+      : app_query.Bind(14); 
 
   if (!app_query.Exec() || !app_query.Reset()) {
     LOG4CXX_WARN(logger_, "Incorrect insert into application.");
@@ -908,6 +911,7 @@ bool SQLPTExtRepresentation::GatherApplicationPoliciesSection(
     }
     *params.auth_token = query.GetString(11);
     *params.cloud_transport_type = query.GetString(12);
+    *params.icon_url = query.GetString(13);
 
     const auto& gather_app_id = ((*policies).apps[app_id].is_string())
                                     ? (*policies).apps[app_id].get_string()

--- a/src/components/policy/policy_external/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_queries.cc
@@ -156,6 +156,7 @@ const std::string kCreateSchema =
     "  `enabled` BOOLEAN, "
     "  `auth_token` VARCHAR(65535), "
     "  `cloud_transport_type` VARCHAR(255), "
+    "  `icon_url` VARCHAR(65535), "
     "  `remote_control_denied` BOOLEAN NOT NULL DEFAULT 0, "
     "  CONSTRAINT `fk_application_hmi_level1` "
     "    FOREIGN KEY(`default_hmi`) "
@@ -649,8 +650,8 @@ const std::string kInsertApplication =
     "INSERT OR IGNORE INTO `application` (`id`, `priority_value`, "
     "`is_revoked`, `memory_kb`, `heart_beat_timeout_ms`, `certificate`, "
     "`hybrid_app_preference_value`, `endpoint`, `enabled`, `auth_token`, "
-    "`cloud_transport_type`) VALUES "
-    "(?,?,?,?,?,?,?,?,?,?,?)";
+    "`cloud_transport_type`, `icon_url`) VALUES "
+    "(?,?,?,?,?,?,?,?,?,?,?,?)";
 
 const std::string kInsertAppGroup =
     "INSERT INTO `app_group` (`application_id`, `functional_group_id`)"
@@ -774,7 +775,7 @@ const std::string kSelectUserMsgsVersion =
 const std::string kSelectAppPolicies =
     "SELECT `id`, `priority_value`, `memory_kb`, "
     " `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
-    " `endpoint`, `enabled`, `auth_token`, `cloud_transport_type` FROM "
+    " `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url` FROM "
     " `application`";
 
 const std::string kCollectFriendlyMsg = "SELECT * FROM `message`";
@@ -875,14 +876,14 @@ const std::string kInsertApplicationFull =
     " `default_hmi`, `priority_value`, `is_revoked`, `is_default`, "
     " `is_predata`, `memory_kb`, `heart_beat_timeout_ms`, "
     " `certificate`, `hybrid_app_preference_value`, `endpoint`, `enabled`, "
-    " `auth_token`, `cloud_transport_type`) "
-    "  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    " `auth_token`, `cloud_transport_type`, `icon_url`) "
+    "  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 const std::string kSelectApplicationFull =
     "SELECT `keep_context`, `steal_focus`, `default_hmi`, `priority_value`, "
     "  `is_revoked`, `is_default`, `is_predata`, `memory_kb`,"
     "  `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
-    "  `endpoint`, `enabled`, `auth_token`, `cloud_transport_type` "
+    "  `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url` "
     "FROM `application` "
     "WHERE `id` = ?";
 

--- a/src/components/policy/policy_external/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_queries.cc
@@ -775,7 +775,8 @@ const std::string kSelectUserMsgsVersion =
 const std::string kSelectAppPolicies =
     "SELECT `id`, `priority_value`, `memory_kb`, "
     " `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
-    " `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url` FROM "
+    " `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url` "
+    "FROM "
     " `application`";
 
 const std::string kCollectFriendlyMsg = "SELECT * FROM `message`";

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -777,6 +777,7 @@ bool SQLPTRepresentation::GatherApplicationPoliciesSection(
     }
     *params.auth_token = query.GetString(8);
     *params.cloud_transport_type = query.GetString(9);
+    *params.icon_url = query.GetString(10);
 
     const auto& gather_app_id = ((*policies).apps[app_id].is_string())
                                     ? (*policies).apps[app_id].get_string()
@@ -1069,6 +1070,9 @@ bool SQLPTRepresentation::SaveSpecificAppPolicy(
       : app_query.Bind(9);
   app.second.cloud_transport_type.is_initialized()
       ? app_query.Bind(10, *app.second.cloud_transport_type)
+      : app_query.Bind(10);
+  app.second.icon_url.is_initialized()
+      ? app_query.Bind(10, *app.second.icon_url)
       : app_query.Bind(10);
 
   if (!app_query.Exec() || !app_query.Reset()) {
@@ -2172,6 +2176,8 @@ bool SQLPTRepresentation::CopyApplication(const std::string& source,
                         : query.Bind(14, source_app.GetString(13));
   source_app.IsNull(14) ? query.Bind(15)
                         : query.Bind(15, source_app.GetString(14));
+  source_app.IsNull(15) ? query.Bind(16)
+                        : query.Bind(16, source_app.GetString(15));
 
   if (!query.Exec()) {
     LOG4CXX_WARN(logger_, "Failed inserting into application.");

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -1072,8 +1072,8 @@ bool SQLPTRepresentation::SaveSpecificAppPolicy(
       ? app_query.Bind(10, *app.second.cloud_transport_type)
       : app_query.Bind(10);
   app.second.icon_url.is_initialized()
-      ? app_query.Bind(10, *app.second.icon_url)
-      : app_query.Bind(10);
+      ? app_query.Bind(11, *app.second.icon_url)
+      : app_query.Bind(11);
 
   if (!app_query.Exec() || !app_query.Reset()) {
     LOG4CXX_WARN(logger_, "Incorrect insert into application.");

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -256,7 +256,8 @@ class CacheManager : public CacheManagerInterface {
   virtual std::string GetLockScreenIconUrl() const;
 
   /**
-   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial
+   *registration
    *
    * @return url which point to the resourse where icon could be
    *obtained.

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -256,6 +256,14 @@ class CacheManager : public CacheManagerInterface {
   virtual std::string GetLockScreenIconUrl() const;
 
   /**
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   *
+   * @return url which point to the resourse where icon could be
+   *obtained.
+   */
+  virtual std::string GetIconUrl(const std::string& policy_app_id) const;
+
+  /**
    * @brief Get allowed number of notifications
    * depending on application priority.
    * @param priority Priority of application

--- a/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
@@ -264,6 +264,14 @@ class CacheManagerInterface {
   virtual std::string GetLockScreenIconUrl() const = 0;
 
   /**
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   *
+   * @return url which point to the resourse where icon could be
+   *obtained.
+   */
+  virtual std::string GetIconUrl(const std::string& policy_app_id) const = 0;
+
+  /**
    * @brief Get allowed number of notifications
    * depending on application priority.
    * @param priority Priority of application

--- a/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
@@ -264,7 +264,8 @@ class CacheManagerInterface {
   virtual std::string GetLockScreenIconUrl() const = 0;
 
   /**
-   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial
+   *registration
    *
    * @return url which point to the resourse where icon could be
    *obtained.

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -117,7 +117,8 @@ class PolicyManagerImpl : public PolicyManager {
   std::string GetLockScreenIconUrl() const OVERRIDE;
 
   /**
-   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial
+   *registration
    *
    * @return url which point to the resourse where icon could be
    *obtained.

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -117,6 +117,14 @@ class PolicyManagerImpl : public PolicyManager {
   std::string GetLockScreenIconUrl() const OVERRIDE;
 
   /**
+   * @brief Get Icon Url used for showing a cloud apps icon before the intial registration
+   *
+   * @return url which point to the resourse where icon could be
+   *obtained.
+   */
+  std::string GetIconUrl(const std::string& policy_app_id) const OVERRIDE;
+
+  /**
    * @brief PTU is needed, for this PTS has to be formed and sent.
    */
   bool RequestPTUpdate() OVERRIDE;

--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -150,6 +150,7 @@ struct ApplicationParams : PolicyBase {
   Optional<Boolean> enabled;
   Optional<String<0, 65535> > auth_token;
   Optional<String<0, 255> > cloud_transport_type;
+  Optional<String<0, 65535> > icon_url;
 
  public:
   ApplicationParams();

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -893,7 +893,8 @@ std::string CacheManager::GetLockScreenIconUrl() const {
 }
 
 std::string CacheManager::GetIconUrl(const std::string& policy_app_id) const {
-  std::string url = "";
+  CACHE_MANAGER_CHECK(std::string());
+  std::string url;
   const policy_table::ApplicationPolicies& policies =
       pt_->policy_table.app_policies_section.apps;
   policy_table::ApplicationPolicies::const_iterator policy_iter =

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -892,6 +892,20 @@ std::string CacheManager::GetLockScreenIconUrl() const {
   return std::string("");
 }
 
+std::string CacheManager::GetIconUrl(const std::string& policy_app_id) const {
+  std::string url = "";
+  const policy_table::ApplicationPolicies& policies =
+      pt_->policy_table.app_policies_section.apps;
+  policy_table::ApplicationPolicies::const_iterator policy_iter =
+      policies.find(policy_app_id);
+  if (policies.end() != policy_iter) {
+    auto app_policy = (*policy_iter).second;
+    url = app_policy.icon_url.is_initialized() ? *app_policy.icon_url
+                                                        : std::string();
+  }
+  return url;
+}
+
 rpc::policy_table_interface_base::NumberOfNotificationsType
 CacheManager::GetNotificationsNumber(const std::string& priority) {
   CACHE_MANAGER_CHECK(0);

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -901,7 +901,7 @@ std::string CacheManager::GetIconUrl(const std::string& policy_app_id) const {
   if (policies.end() != policy_iter) {
     auto app_policy = (*policy_iter).second;
     url = app_policy.icon_url.is_initialized() ? *app_policy.icon_url
-                                                        : std::string();
+                                               : std::string();
   }
   return url;
 }

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -443,6 +443,10 @@ std::string PolicyManagerImpl::GetLockScreenIconUrl() const {
   return cache_->GetLockScreenIconUrl();
 }
 
+std::string PolicyManagerImpl::GetIconUrl(const std::string& policy_app_id) const {
+  return cache_->GetIconUrl(policy_app_id);
+}
+
 void PolicyManagerImpl::StartPTExchange() {
   LOG4CXX_AUTO_TRACE(logger_);
 

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -443,7 +443,8 @@ std::string PolicyManagerImpl::GetLockScreenIconUrl() const {
   return cache_->GetLockScreenIconUrl();
 }
 
-std::string PolicyManagerImpl::GetIconUrl(const std::string& policy_app_id) const {
+std::string PolicyManagerImpl::GetIconUrl(
+    const std::string& policy_app_id) const {
   return cache_->GetIconUrl(policy_app_id);
 }
 

--- a/src/components/policy/policy_regular/src/policy_table/types.cc
+++ b/src/components/policy/policy_regular/src/policy_table/types.cc
@@ -174,8 +174,7 @@ ApplicationParams::ApplicationParams(const Json::Value* value__)
     , enabled(impl::ValueMember(value__, "enabled"))
     , auth_token(impl::ValueMember(value__, "auth_token"))
     , cloud_transport_type(impl::ValueMember(value__, "cloud_transport_type"))
-    , icon_url(impl::ValueMember(value__, "icon_url")) {
-}
+    , icon_url(impl::ValueMember(value__, "icon_url")) {}
 
 Json::Value ApplicationParams::ToJsonValue() const {
   Json::Value result__(PolicyBase::ToJsonValue());

--- a/src/components/policy/policy_regular/src/policy_table/types.cc
+++ b/src/components/policy/policy_regular/src/policy_table/types.cc
@@ -173,7 +173,8 @@ ApplicationParams::ApplicationParams(const Json::Value* value__)
     , endpoint(impl::ValueMember(value__, "endpoint"))
     , enabled(impl::ValueMember(value__, "enabled"))
     , auth_token(impl::ValueMember(value__, "auth_token"))
-    , cloud_transport_type(impl::ValueMember(value__, "cloud_transport_type")) {
+    , cloud_transport_type(impl::ValueMember(value__, "cloud_transport_type"))
+    , icon_url(impl::ValueMember(value__, "icon_url")) {
 }
 
 Json::Value ApplicationParams::ToJsonValue() const {
@@ -194,6 +195,7 @@ Json::Value ApplicationParams::ToJsonValue() const {
   impl::WriteJsonField("enabled", enabled, &result__);
   impl::WriteJsonField("auth_token", auth_token, &result__);
   impl::WriteJsonField("cloud_transport_type", cloud_transport_type, &result__);
+  impl::WriteJsonField("icon_url", auth_token, &result__);
   return result__;
 }
 
@@ -238,6 +240,9 @@ bool ApplicationParams::is_valid() const {
     return false;
   }
   if (!hybrid_app_preference.is_valid()) {
+    return false;
+  }
+  if (!icon_url.is_valid()) {
     return false;
   }
   return Validate();
@@ -291,6 +296,9 @@ bool ApplicationParams::struct_empty() const {
     return false;
   }
   if (hybrid_app_preference.is_initialized()) {
+    return false;
+  }
+  if (icon_url.is_initialized()) {
     return false;
   }
   return true;
@@ -347,6 +355,9 @@ void ApplicationParams::ReportErrors(rpc::ValidationReport* report__) const {
     moduleType.ReportErrors(
         &report__->ReportSubobject("hybrid_app_preference"));
   }
+  if (!icon_url.is_valid()) {
+    moduleType.ReportErrors(&report__->ReportSubobject("icon_url"));
+  }
 }
 
 void ApplicationParams::SetPolicyTableType(PolicyTableType pt_type) {
@@ -363,6 +374,7 @@ void ApplicationParams::SetPolicyTableType(PolicyTableType pt_type) {
   enabled.SetPolicyTableType(pt_type);
   cloud_transport_type.SetPolicyTableType(pt_type);
   hybrid_app_preference.SetPolicyTableType(pt_type);
+  icon_url.SetPolicyTableType(pt_type);
 }
 
 // RpcParameters methods

--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -710,7 +710,8 @@ const std::string kSelectUserMsgsVersion =
 const std::string kSelectAppPolicies =
     "SELECT `id`, `priority_value`, `memory_kb`, "
     " `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
-    " `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url` FROM "
+    " `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url` "
+    "FROM "
     " `application`";
 
 const std::string kCollectFriendlyMsg = "SELECT * FROM `message`";

--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -142,6 +142,7 @@ const std::string kCreateSchema =
     "  `enabled` BOOLEAN, "
     "  `auth_token` VARCHAR(65535), "
     "  `cloud_transport_type` VARCHAR(255), "
+    "  `icon_url` VARCHAR(65535), "
     "  `remote_control_denied` BOOLEAN NOT NULL DEFAULT 0, "
     "  CONSTRAINT `fk_application_hmi_level1` "
     "    FOREIGN KEY(`default_hmi`) "
@@ -598,8 +599,8 @@ const std::string kInsertApplication =
     "INSERT OR IGNORE INTO `application` (`id`, `priority_value`, "
     "`is_revoked`, `memory_kb`, `heart_beat_timeout_ms`, `certificate`, "
     "`hybrid_app_preference_value`, `endpoint`, `enabled`, `auth_token`, "
-    "`cloud_transport_type`) VALUES "
-    "(?,?,?,?,?,?,?,?,?,?,?)";
+    "`cloud_transport_type`, `icon_url`) VALUES "
+    "(?,?,?,?,?,?,?,?,?,?,?,?)";
 
 const std::string kInsertAppGroup =
     "INSERT INTO `app_group` (`application_id`, `functional_group_id`)"
@@ -709,7 +710,7 @@ const std::string kSelectUserMsgsVersion =
 const std::string kSelectAppPolicies =
     "SELECT `id`, `priority_value`, `memory_kb`, "
     " `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
-    " `endpoint`, `enabled`, `auth_token`, `cloud_transport_type` FROM "
+    " `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url` FROM "
     " `application`";
 
 const std::string kCollectFriendlyMsg = "SELECT * FROM `message`";
@@ -810,14 +811,14 @@ const std::string kInsertApplicationFull =
     " `default_hmi`, `priority_value`, `is_revoked`, `is_default`, "
     " `is_predata`, `memory_kb`, `heart_beat_timeout_ms`, "
     " `certificate`, `hybrid_app_preference_value`, `endpoint`, `enabled`, "
-    " `auth_token`, `cloud_transport_type`) "
-    "  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    " `auth_token`, `cloud_transport_type`, `icon_url`) "
+    "  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 const std::string kSelectApplicationFull =
     "SELECT `keep_context`, `steal_focus`, `default_hmi`, `priority_value`, "
     "  `is_revoked`, `is_default`, `is_predata`, `memory_kb`,"
     "  `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
-    "  `endpoint`, `enabled`, `auth_token`, `cloud_transport_type` "
+    "  `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url` "
     "FROM `application` "
     "WHERE `id` = "
     "?";

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -733,7 +733,7 @@ bool SQLPTRepresentation::GatherApplicationPoliciesSection(
     }
     *params.auth_token = query.GetString(8);
     *params.cloud_transport_type = query.GetString(9);
-    *params.icon_url = query.GetString(9);
+    *params.icon_url = query.GetString(10);
 
     const auto& gather_app_id = ((*policies).apps[app_id].is_string())
                                     ? (*policies).apps[app_id].get_string()

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -733,6 +733,7 @@ bool SQLPTRepresentation::GatherApplicationPoliciesSection(
     }
     *params.auth_token = query.GetString(8);
     *params.cloud_transport_type = query.GetString(9);
+    *params.icon_url = query.GetString(9);
 
     const auto& gather_app_id = ((*policies).apps[app_id].is_string())
                                     ? (*policies).apps[app_id].get_string()
@@ -1011,6 +1012,9 @@ bool SQLPTRepresentation::SaveSpecificAppPolicy(
   app.second.cloud_transport_type.is_initialized()
       ? app_query.Bind(10, *app.second.cloud_transport_type)
       : app_query.Bind(10);
+  app.second.icon_url.is_initialized()
+      ? app_query.Bind(11, *app.second.icon_url)
+      : app_query.Bind(11);
 
   if (!app_query.Exec() || !app_query.Reset()) {
     LOG4CXX_WARN(logger_, "Incorrect insert into application.");
@@ -2122,6 +2126,8 @@ bool SQLPTRepresentation::CopyApplication(const std::string& source,
                         : query.Bind(14, source_app.GetString(13));
   source_app.IsNull(14) ? query.Bind(15)
                         : query.Bind(15, source_app.GetString(14));
+  source_app.IsNull(15) ? query.Bind(16)
+                        : query.Bind(16, source_app.GetString(15));
 
   if (!query.Exec()) {
     LOG4CXX_WARN(logger_, "Failed inserting into application.");

--- a/src/components/transport_manager/src/cloud/cloud_websocket_transport_adapter.cc
+++ b/src/components/transport_manager/src/cloud/cloud_websocket_transport_adapter.cc
@@ -87,7 +87,7 @@ void CloudWebsocketTransportAdapter::CreateDevice(const std::string& uid) {
 
   // Extract host and port from endpoint string
   boost::regex group_pattern(
-      "(wss?:\\/\\/)([A-Z\\d\\.-]{2,}\\.?([A-Z]{2,})?)(:)(\\d{2,4})(\\/)");
+      "(wss?:\\/\\/)([A-Z\\d\\.-]{2,}\\.?([A-Z]{2,})?)(:)(\\d{2,4})(\\/)(((([A-Z\\d\\.-]{1,})(\\/)?){1,})?){1,}");
   boost::smatch results;
 
   std::string host = "";

--- a/src/components/transport_manager/src/cloud/cloud_websocket_transport_adapter.cc
+++ b/src/components/transport_manager/src/cloud/cloud_websocket_transport_adapter.cc
@@ -87,7 +87,8 @@ void CloudWebsocketTransportAdapter::CreateDevice(const std::string& uid) {
 
   // Extract host and port from endpoint string
   boost::regex group_pattern(
-      "(wss?:\\/\\/)([A-Z\\d\\.-]{2,}\\.?([A-Z]{2,})?)(:)(\\d{2,4})(\\/)(((([A-Z\\d\\.-]{1,})(\\/)?){1,})?){1,}");
+      "(wss?:\\/\\/)([A-Z\\d\\.-]{2,}\\.?([A-Z]{2,})?)(:)(\\d{2,4})(\\/"
+      ")(((([A-Z\\d\\.-]{1,})(\\/)?){1,})?){1,}");
   boost::smatch results;
 
   std::string host = "";


### PR DESCRIPTION
### Risk
This PR makes **minor** API changes.

### Testing Plan
Add icon_url to policy table app_policies.
Register app. 
Verify onSystemRequest sent to mobile, and SystemRequest received from mobile.
AppIcons for cloud app should appear in the storage folder.

### Summary
Add new RequestType to be used by onSystemRequest and SystemRequest.
After the first app registers, for each cloud app with an icon_url in the policy table that do not have an app icon yet, core will send an onSystemRequest to mobile. 

Mobile will retrieve the icon from the url and send the binary data back to core via a SystemRequest. The fileName will be the image url used in the onSystemRequest. Core will save this icon in the app icon folder under the name of the cloud apps policy id.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)