### PR TITLE
Close Cloud Connection

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -360,6 +360,8 @@ class ApplicationManagerImpl
   void ConnectToDevice(const std::string& device_mac) OVERRIDE;
   void OnHMIStartedCooperation() OVERRIDE;
 
+  void DisconnectCloudApp(ApplicationSharedPtr app) OVERRIDE;
+
   void RefreshCloudAppInformation() OVERRIDE;
 
   void CreatePendingApplication(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_exit_application_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_exit_application_notification.cc
@@ -106,6 +106,10 @@ void OnExitApplicationNotification::Run() {
       application_manager_.UnregisterApplication(app_id, Result::SUCCESS);
       return;
     }
+    case Common_ApplicationExitReason::CLOSE_CLOUD_CONNECTION: {
+      application_manager_.DisconnectCloudApp(app_impl);
+      break;
+    }
     default: {
       LOG4CXX_WARN(logger_, "Unhandled reason");
       return;

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -815,7 +815,8 @@ void ApplicationManagerImpl::DisconnectCloudApp(ApplicationSharedPtr app) {
   std::string cloud_transport_type;
   std::string hybrid_app_preference;
   bool enabled = true;
-  GetPolicyHandler().GetCloudAppParameters(app->policy_app_id(),
+  std::string policy_app_id = app->policy_app_id();
+  GetPolicyHandler().GetCloudAppParameters(policy_app_id,
                                            enabled,
                                            endpoint,
                                            certificate,
@@ -837,7 +838,8 @@ void ApplicationManagerImpl::DisconnectCloudApp(ApplicationSharedPtr app) {
 
   // Create device in pending state
   LOG4CXX_DEBUG(logger_, "Re-adding the cloud app device");
-  connection_handler().AddCloudAppDevice(endpoint, cloud_transport_type);
+  connection_handler().AddCloudAppDevice(
+      policy_app_id, endpoint, cloud_transport_type);
 }
 
 void ApplicationManagerImpl::RefreshCloudAppInformation() {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -809,11 +809,11 @@ void ApplicationManagerImpl::OnHMIStartedCooperation() {
 }
 
 void ApplicationManagerImpl::DisconnectCloudApp(ApplicationSharedPtr app) {
-  std::string endpoint = "";
-  std::string certificate = "";
-  std::string auth_token = "";
-  std::string cloud_transport_type = "";
-  std::string hybrid_app_preference = "";
+  std::string endpoint;
+  std::string certificate;
+  std::string auth_token;
+  std::string cloud_transport_type;
+  std::string hybrid_app_preference;
   bool enabled = true;
   GetPolicyHandler().GetCloudAppParameters(app->policy_app_id(),
                                            enabled,

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -808,6 +808,38 @@ void ApplicationManagerImpl::OnHMIStartedCooperation() {
   RefreshCloudAppInformation();
 }
 
+void ApplicationManagerImpl::DisconnectCloudApp(ApplicationSharedPtr app) {
+  std::string endpoint = "";
+  std::string certificate = "";
+  std::string auth_token = "";
+  std::string cloud_transport_type = "";
+  std::string hybrid_app_preference = "";
+  bool enabled = true;
+  GetPolicyHandler().GetCloudAppParameters(app->policy_app_id(),
+                                           enabled,
+                                           endpoint,
+                                           certificate,
+                                           auth_token,
+                                           cloud_transport_type,
+                                           hybrid_app_preference);
+  if (app->IsRegistered() && app->is_cloud_app()) {
+    LOG4CXX_DEBUG(logger_, "Disabled app is registered, unregistering now");
+    GetRPCService().ManageMobileCommand(
+        MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
+            app->app_id(),
+            mobile_api::AppInterfaceUnregisteredReason::APP_UNAUTHORIZED),
+        commands::Command::SOURCE_SDL);
+
+    OnAppUnauthorized(app->app_id());
+  }
+  // Delete the cloud device
+  connection_handler().RemoveCloudAppDevice(app->device());
+
+  // Create device in pending state
+  LOG4CXX_DEBUG(logger_, "Re-adding the cloud app device");
+  connection_handler().AddCloudAppDevice(endpoint, cloud_transport_type);
+}
+
 void ApplicationManagerImpl::RefreshCloudAppInformation() {
   LOG4CXX_AUTO_TRACE(logger_);
   std::vector<std::string> enabled_apps;

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -427,6 +427,8 @@ class ApplicationManager {
 
   virtual void OnHMIStartedCooperation() = 0;
 
+  virtual void DisconnectCloudApp(ApplicationSharedPtr app) = 0;
+
   virtual void RefreshCloudAppInformation() = 0;
 
   /**

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -166,6 +166,8 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD1(EndAudioPassThru, bool(uint32_t app_id));
   MOCK_METHOD1(ConnectToDevice, void(const std::string& device_mac));
   MOCK_METHOD0(OnHMIStartedCooperation, void());
+  MOCK_METHOD1(DisconnectCloudApp,
+               void(application_manager::ApplicationSharedPtr app));
   MOCK_METHOD0(RefreshCloudAppInformation, void());
   MOCK_CONST_METHOD1(GetCloudAppConnectionStatus,
                      hmi_apis::Common_CloudConnectionStatus::eType(

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -487,6 +487,9 @@
   <element name="UNSUPPORTED_HMI_RESOURCE">
     <description>By getting this value, SDL unregisters the named application</description>
   </element>
+  <element name="CLOSE_CLOUD_CONNECTION">
+    <description>By getting this value, SDL puts the named app to NONE HMILevel. Used by the HMI to close a cloud app connection.</description>
+  </element>
 </enum>
 
 <enum name="TextFieldName">

--- a/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
+++ b/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
@@ -1147,7 +1147,7 @@ TransportAdapter::Error TransportAdapterImpl::ConnectDevice(DeviceSptr device) {
                                            << app_handle
                                            << " failed with error " << error);
         errors_occurred = true;
-        LOG4CXX_DEBUG(logger_, "switch (error), default case error: " << error);
+        LOG4CXX_DEBUG(logger_, "switch (error), default case");
         break;
     }
   }


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
[Describe how you plan to unit test the changes in this PR]
Connect cloud app
Send BasicCommunication.OnExitApplication reason: CLOSE_CLOUD_CONNECTION from HMI

### Summary
Disconnect a cloud app after receiving cloud_cloud_connection from the hmi. A new cloud app instance is recreated and put into the pending state so the user can reactivate/reregister the app.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)