### PR TITLE
Add logic for `HMIOriginID` and `EmbeddedServices` ini params

### DIFF
--- a/src/components/application_manager/include/application_manager/app_service_manager.h
+++ b/src/components/application_manager/include/application_manager/app_service_manager.h
@@ -58,6 +58,8 @@ class ApplicationManager;
  */
 class AppServiceManager {
  public:
+  const std::string kEmbeddedService = "EMBEDDED_SERVICE";
+
   /**
    * @brief Class constructor
    * @param app_manager
@@ -152,9 +154,6 @@ class AppServiceManager {
   std::string DefaultServiceByType(std::string service_type);
 
  private:
-  void GetProviderFromService(const AppService& service,
-                              ApplicationSharedPtr& app,
-                              bool& hmi_service);
   ApplicationManager& app_manager_;
   resumption::LastState& last_state_;
   std::map<std::string, AppService> published_services_;
@@ -164,6 +163,12 @@ class AppServiceManager {
       const smart_objects::SmartObject& service_record,
       const mobile_apis::ServiceUpdateReason::eType update_reason,
       smart_objects::SmartObject& msg_params);
+  void GetProviderFromService(const AppService& service,
+                              ApplicationSharedPtr& app,
+                              bool& hmi_service);
+  std::pair<std::string, AppService> FindServiceByAppID(std::string name,
+                                                        std::string type);
+  std::string GetServiceAppID(AppService service);
 };
 
 }  //  namespace application_manager

--- a/src/components/application_manager/include/application_manager/app_service_manager.h
+++ b/src/components/application_manager/include/application_manager/app_service_manager.h
@@ -166,9 +166,9 @@ class AppServiceManager {
   void GetProviderFromService(const AppService& service,
                               ApplicationSharedPtr& app,
                               bool& hmi_service);
-  std::pair<std::string, AppService> FindServiceByAppID(std::string name,
-                                                        std::string type);
-  std::string GetServiceAppID(AppService service);
+  std::pair<std::string, AppService> FindServiceByPolicyAppID(
+      std::string policy_app_id, std::string type);
+  std::string GetPolicyAppID(AppService service);
 };
 
 }  //  namespace application_manager

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -326,6 +326,7 @@ extern const char* updated_app_service_record;
 extern const char* service_records;
 extern const char* activate;
 extern const char* set_as_default;
+extern const char* origin_app;
 
 // resuming
 extern const char* application_commands;

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_perform_app_service_interaction_request_from_hmi.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_perform_app_service_interaction_request_from_hmi.cc
@@ -57,6 +57,25 @@ void ASPerformAppServiceInteractionRequestFromHMI::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   smart_objects::SmartObject& msg_params = (*message_)[strings::msg_params];
+  std::string hmi_origin_id =
+      application_manager_.get_settings().hmi_origin_id();
+  if (!msg_params.keyExists(strings::origin_app)) {
+    if (hmi_origin_id.empty()) {
+      smart_objects::SmartObject response_params;
+      response_params[strings::info] =
+          "No HMI origin ID to use for interaction passthrough";
+      SendResponse(
+          false,
+          correlation_id(),
+          hmi_apis::FunctionID::AppService_PerformAppServiceInteraction,
+          hmi_apis::Common_Result::INVALID_DATA,
+          &response_params,
+          application_manager::commands::Command::SOURCE_SDL_TO_HMI);
+      return;
+    }
+    msg_params[strings::origin_app] = hmi_origin_id;
+  }
+
   std::string service_id = msg_params[strings::service_id].asString();
   auto service =
       application_manager_.GetAppServiceManager().FindServiceByID(service_id);

--- a/src/components/application_manager/src/app_service_manager.cc
+++ b/src/components/application_manager/src/app_service_manager.cc
@@ -102,7 +102,7 @@ smart_objects::SmartObject AppServiceManager::PublishAppService(
       }
     }
   }
-  app_service.default_service = GetServiceAppID(app_service) == default_app_id;
+  app_service.default_service = GetPolicyAppID(app_service) == default_app_id;
 
   published_services_.insert(
       std::pair<std::string, AppService>(service_id, app_service));
@@ -247,7 +247,8 @@ bool AppServiceManager::SetDefaultService(const std::string service_id) {
           .asString();
   std::string default_app_id = DefaultServiceByType(service_type);
   if (!default_app_id.empty()) {
-    auto default_service = FindServiceByAppID(default_app_id, service_type);
+    auto default_service =
+        FindServiceByPolicyAppID(default_app_id, service_type);
     if (!default_service.first.empty()) {
       default_service.second.default_service = false;
     }
@@ -256,7 +257,7 @@ bool AppServiceManager::SetDefaultService(const std::string service_id) {
 
   Json::Value& dictionary = last_state_.get_dictionary();
   dictionary[kAppServiceSection][kDefaults][service_type] =
-      GetServiceAppID(service);
+      GetPolicyAppID(service);
   return true;
 }
 
@@ -396,8 +397,8 @@ std::pair<std::string, AppService> AppServiceManager::FindServiceByName(
   return std::make_pair(std::string(), empty);
 }
 
-std::pair<std::string, AppService> AppServiceManager::FindServiceByAppID(
-    std::string name, std::string type) {
+std::pair<std::string, AppService> AppServiceManager::FindServiceByPolicyAppID(
+    std::string policy_app_id, std::string type) {
   LOG4CXX_AUTO_TRACE(logger_);
   for (auto it = published_services_.begin(); it != published_services_.end();
        ++it) {
@@ -406,7 +407,7 @@ std::pair<std::string, AppService> AppServiceManager::FindServiceByAppID(
       continue;
     }
 
-    if (name == GetServiceAppID(it->second)) {
+    if (policy_app_id == GetPolicyAppID(it->second)) {
       return *it;
     }
   }
@@ -448,7 +449,7 @@ void AppServiceManager::SetServicePublished(const std::string service_id,
   it->second.record[strings::service_published] = service_published;
 }
 
-std::string AppServiceManager::GetServiceAppID(AppService service) {
+std::string AppServiceManager::GetPolicyAppID(AppService service) {
   if (service.mobile_service) {
     auto app = app_manager_.application(service.connection_key);
     return app ? app->policy_app_id() : std::string();

--- a/src/components/application_manager/src/app_service_manager.cc
+++ b/src/components/application_manager/src/app_service_manager.cc
@@ -88,10 +88,21 @@ smart_objects::SmartObject AppServiceManager::PublishAppService(
   app_service.record = service_record;
 
   std::string service_type = manifest[strings::service_type].asString();
-  Json::Value& dictionary = last_state_.get_dictionary();
-  app_service.default_service =
-      (dictionary[kAppServiceSection][kDefaults][service_type].asString() ==
-       manifest[strings::service_name].asString());
+
+  std::string default_app_id = DefaultServiceByType(service_type);
+  if (default_app_id.empty() && !mobile_service) {
+    auto embedded_services = app_manager_.get_settings().embedded_services();
+    for (auto it = embedded_services.begin(); it != embedded_services.end();
+         ++it) {
+      if (*it == service_type) {
+        Json::Value& dictionary = last_state_.get_dictionary();
+        dictionary[kAppServiceSection][kDefaults][service_type] =
+            kEmbeddedService;
+        default_app_id = kEmbeddedService;
+      }
+    }
+  }
+  app_service.default_service = GetServiceAppID(app_service) == default_app_id;
 
   published_services_.insert(
       std::pair<std::string, AppService>(service_id, app_service));
@@ -234,9 +245,9 @@ bool AppServiceManager::SetDefaultService(const std::string service_id) {
   std::string service_type =
       service.record[strings::service_manifest][strings::service_type]
           .asString();
-  std::string default_service_name = DefaultServiceByType(service_type);
-  if (!default_service_name.empty()) {
-    auto default_service = FindServiceByName(default_service_name);
+  std::string default_app_id = DefaultServiceByType(service_type);
+  if (!default_app_id.empty()) {
+    auto default_service = FindServiceByAppID(default_app_id, service_type);
     if (!default_service.first.empty()) {
       default_service.second.default_service = false;
     }
@@ -245,8 +256,7 @@ bool AppServiceManager::SetDefaultService(const std::string service_id) {
 
   Json::Value& dictionary = last_state_.get_dictionary();
   dictionary[kAppServiceSection][kDefaults][service_type] =
-      service.record[strings::service_manifest][strings::service_name]
-          .asString();
+      GetServiceAppID(service);
   return true;
 }
 
@@ -386,6 +396,24 @@ std::pair<std::string, AppService> AppServiceManager::FindServiceByName(
   return std::make_pair(std::string(), empty);
 }
 
+std::pair<std::string, AppService> AppServiceManager::FindServiceByAppID(
+    std::string name, std::string type) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  for (auto it = published_services_.begin(); it != published_services_.end();
+       ++it) {
+    if (it->second.record[strings::service_manifest][strings::service_type]
+            .asString() != type) {
+      continue;
+    }
+
+    if (name == GetServiceAppID(it->second)) {
+      return *it;
+    }
+  }
+  AppService empty;
+  return std::make_pair(std::string(), empty);
+}
+
 std::pair<std::string, AppService> AppServiceManager::FindServiceByID(
     std::string service_id) {
   LOG4CXX_AUTO_TRACE(logger_);
@@ -418,6 +446,14 @@ void AppServiceManager::SetServicePublished(const std::string service_id,
     return;
   }
   it->second.record[strings::service_published] = service_published;
+}
+
+std::string AppServiceManager::GetServiceAppID(AppService service) {
+  if (service.mobile_service) {
+    auto app = app_manager_.application(service.connection_key);
+    return app ? app->policy_app_id() : std::string();
+  }
+  return kEmbeddedService;
 }
 
 void AppServiceManager::BroadcastAppServiceUpdate(

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -293,6 +293,7 @@ const char* updated_app_service_record = "updatedAppServiceRecord";
 const char* service_records = "serviceRecords";
 const char* activate = "activate";
 const char* set_as_default = "setAsDefault";
+const char* origin_app = "originApp";
 
 // resuming
 const char* application_commands = "applicationCommands";


### PR DESCRIPTION

Partially implements #2343 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
TBD

### Summary
Adds logic to handle the `HMIOriginID` and `EmbeddedServices` ini params

### Changelog
##### Enhancements
* Handle setting embedded services to default
* Use policy app id to store default service for a given type
* Pass `HMIOriginID` in `originApp` field when the HMI sends a PerformAppServiceInteraction

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)