### PR TITLE
Add lock for `published_services_` map

### DIFF
--- a/src/components/application_manager/include/application_manager/app_service_manager.h
+++ b/src/components/application_manager/include/application_manager/app_service_manager.h
@@ -133,15 +133,13 @@ class AppServiceManager {
                        ApplicationSharedPtr& app,
                        bool& hmi_service);
 
-  std::pair<std::string, AppService> ActiveServiceByType(
-      std::string service_type);
+  AppService* ActiveServiceByType(std::string service_type);
 
-  std::pair<std::string, AppService> EmbeddedServiceForType(
-      std::string service_type);
+  AppService* EmbeddedServiceForType(std::string service_type);
 
-  std::pair<std::string, AppService> FindServiceByName(std::string name);
+  AppService* FindServiceByName(std::string name);
 
-  std::pair<std::string, AppService> FindServiceByID(std::string service_id);
+  AppService* FindServiceByID(std::string service_id);
 
   std::string DefaultServiceByType(std::string service_type);
 
@@ -162,6 +160,8 @@ class AppServiceManager {
  private:
   ApplicationManager& app_manager_;
   resumption::LastState& last_state_;
+
+  sync_primitives::RecursiveLock published_services_lock_;
   std::map<std::string, AppService> published_services_;
 
   void AppServiceUpdated(
@@ -171,8 +171,8 @@ class AppServiceManager {
   void GetProviderFromService(const AppService& service,
                               ApplicationSharedPtr& app,
                               bool& hmi_service);
-  std::pair<std::string, AppService> FindServiceByPolicyAppID(
-      std::string policy_app_id, std::string type);
+  AppService* FindServiceByPolicyAppID(std::string policy_app_id,
+                                       std::string type);
   std::string GetPolicyAppID(AppService service);
 };
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_perform_app_service_interaction_request_from_hmi.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_perform_app_service_interaction_request_from_hmi.cc
@@ -79,7 +79,7 @@ void ASPerformAppServiceInteractionRequestFromHMI::Run() {
   std::string service_id = msg_params[strings::service_id].asString();
   auto service =
       application_manager_.GetAppServiceManager().FindServiceByID(service_id);
-  if (service.first.empty()) {
+  if (!service) {
     smart_objects::SmartObject response_params;
     response_params[strings::info] = "The requested service ID does not exist";
     SendResponse(false,
@@ -99,9 +99,8 @@ void ASPerformAppServiceInteractionRequestFromHMI::Run() {
   }
 
   // Only activate service if it is not already active
-  bool activate_service =
-      request_service_active &&
-      !service.second.record[strings::service_active].asBool();
+  bool activate_service = request_service_active &&
+                          !service->record[strings::service_active].asBool();
   if (activate_service) {
     application_manager_.GetAppServiceManager().ActivateAppService(service_id);
   }

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/perform_app_service_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/perform_app_service_interaction_request.cc
@@ -66,7 +66,7 @@ void PerformAppServiceInteractionRequest::Run() {
   std::string service_id = msg_params[strings::service_id].asString();
   auto service =
       application_manager_.GetAppServiceManager().FindServiceByID(service_id);
-  if (service.first.empty()) {
+  if (!service) {
     SendResponse(false,
                  mobile_apis::Result::INVALID_ID,
                  "The requested service ID does not exist");
@@ -81,9 +81,8 @@ void PerformAppServiceInteractionRequest::Run() {
   }
 
   // Only activate service if it is not already active
-  bool activate_service =
-      request_service_active &&
-      !service.second.record[strings::service_active].asBool();
+  bool activate_service = request_service_active &&
+                          !service->record[strings::service_active].asBool();
   if (activate_service) {
     if (app->is_foreground()) {
       // App is in foreground, we can just activate the service


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Add Lock protection for `published_services_` map in the app service manager

### Changelog
##### Enhancements
* Update `FindServiceBy...` functions to return pointer instead of map pair

##### Bug Fixes
* Add Lock protection for `published_services_` map in the app service manager

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)