### PR TITLE
Handle hybrid app preference

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -404,7 +404,6 @@ class ApplicationManagerImpl
    * @param app A cloud application
    * @return The current CloudConnectionStatus of app
    */
-
   hmi_apis::Common_CloudConnectionStatus::eType GetCloudAppConnectionStatus(
       ApplicationConstSharedPtr app) const;
 

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -173,6 +173,8 @@ class ApplicationManagerImpl
       uint32_t hmi_app_id) const OVERRIDE;
   ApplicationSharedPtr application_by_policy_id(
       const std::string& policy_app_id) const OVERRIDE;
+  ApplicationSharedPtr application_by_name(
+      const std::string& app_name) const OVERRIDE;
   ApplicationSharedPtr pending_application_by_policy_id(
       const std::string& policy_app_id) const OVERRIDE;
 
@@ -999,6 +1001,14 @@ class ApplicationManagerImpl
     GrammarIdPredicate(uint32_t grammar_id) : grammar_id_(grammar_id) {}
     bool operator()(const ApplicationSharedPtr app) const {
       return app ? grammar_id_ == app->get_grammar_id() : false;
+    }
+  };
+
+  struct AppNamePredicate {
+    std::string app_name_;
+    AppNamePredicate(const std::string& app_name) : app_name_(app_name) {}
+    bool operator()(const ApplicationSharedPtr app) const {
+      return app ? app->name() == app_name_ : false;
     }
   };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -144,12 +144,14 @@ class RegisterAppInterfaceRequest
   /*
    * @brief Check new application parameters (name, tts, vr) for
    * coincidence with already known parameters of registered applications
+   * @param out_duplicate_apps In the case other apps was found with duplicate
+   * names, this field will be filled with a list of said apps
    *
    * return SUCCESS if there is no coincidence of app.name/TTS/VR synonyms,
    * otherwise appropriate error code returns
-  */
+   */
   mobile_apis::Result::eType CheckCoincidence(
-      app_mngr::ApplicationSharedPtr& app);
+      std::vector<app_mngr::ApplicationSharedPtr>& out_duplicate_apps);
 
   /*
   * @brief Predicate for using with CheckCoincidence method to compare with VR

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -148,7 +148,8 @@ class RegisterAppInterfaceRequest
    * return SUCCESS if there is no coincidence of app.name/TTS/VR synonyms,
    * otherwise appropriate error code returns
   */
-  mobile_apis::Result::eType CheckCoincidence();
+  mobile_apis::Result::eType CheckCoincidence(
+      app_mngr::ApplicationSharedPtr& app);
 
   /*
   * @brief Predicate for using with CheckCoincidence method to compare with VR

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -1185,8 +1185,7 @@ const std::string& ApplicationImpl::cloud_app_certificate() const {
 }
 
 bool ApplicationImpl::is_cloud_app() const {
-  return !endpoint_.empty() &&
-         hybrid_app_preference_ != mobile_apis::HybridAppPreference::MOBILE;
+  return !endpoint_.empty();
 }
 
 void ApplicationImpl::set_cloud_app_endpoint(const std::string& endpoint) {

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -169,6 +169,9 @@ class ApplicationManager {
   virtual ApplicationSharedPtr application_by_policy_id(
       const std::string& policy_app_id) const = 0;
 
+  virtual ApplicationSharedPtr application_by_name(
+      const std::string& app_name) const = 0;
+
   virtual ApplicationSharedPtr pending_application_by_policy_id(
       const std::string& policy_app_id) const = 0;
 

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -100,6 +100,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD1(application_by_policy_id,
                      application_manager::ApplicationSharedPtr(
                          const std::string& policy_app_id));
+  MOCK_CONST_METHOD1(
+      application_by_name,
+      application_manager::ApplicationSharedPtr(const std::string& app_name));
   MOCK_CONST_METHOD1(pending_application_by_policy_id,
                      application_manager::ApplicationSharedPtr(
                          const std::string& policy_app_id));


### PR DESCRIPTION
Partially implements #2215 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
TBD

### Summary
Add handling for the `hybrid_app_preference` property of cloud apps

### Changelog

##### Enhancements
* If both a cloud app and mobile app attempt to register with the same name, the hybrid app preference of the cloud app is used to determine which app should be registered
    * `CLOUD` - Mobile app is unregistered (or not allowed to register)
    * `MOBILE` - HMI app is unregistered (or not allowed to register)
    * `BOTH` - The first app that attempts to register is registered, the second is not allowed to register

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)