### PR TITLE
Allow for unknown enum values for App Service RPCs

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1149,7 +1149,7 @@ class ApplicationManagerImpl
 
   bool ConvertSOtoMessage(const smart_objects::SmartObject& message,
                           Message& output,
-                          const bool remove_unknown_parameters = true);
+                          const bool allow_unknown_parameters = false);
 
   template <typename ApplicationList>
   void PrepareApplicationListSO(ApplicationList app_list,

--- a/src/components/application_manager/include/application_manager/rpc_handler_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_handler_impl.h
@@ -154,7 +154,7 @@ class RPCHandlerImpl : public RPCHandler,
       ns_smart_device_link::ns_smart_objects::SmartObject& output,
       utils::SemanticVersion& message_version);
 
-  bool ValidateRpcSO(smart_objects::SmartObject* message,
+  bool ValidateRpcSO(smart_objects::SmartObject& message,
                      utils::SemanticVersion& msg_version,
                      rpc::ValidationReport& report_out,
                      bool allow_unknown_parameters) OVERRIDE;

--- a/src/components/application_manager/include/application_manager/rpc_handler_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_handler_impl.h
@@ -157,14 +157,14 @@ class RPCHandlerImpl : public RPCHandler,
   bool ValidateRpcSO(smart_objects::SmartObject* message,
                      utils::SemanticVersion& msg_version,
                      rpc::ValidationReport& report_out,
-                     bool remove_unknown_params) OVERRIDE;
+                     bool allow_unknown_parameters) OVERRIDE;
 
  private:
   void ProcessMessageFromMobile(const std::shared_ptr<Message> message);
   void ProcessMessageFromHMI(const std::shared_ptr<Message> message);
   bool ConvertMessageToSO(const Message& message,
                           smart_objects::SmartObject& output,
-                          const bool remove_unknown_parameters = true,
+                          const bool allow_unknown_parameters = false,
                           const bool validate_params = true);
   std::shared_ptr<Message> ConvertRawMsgToMessage(
       const ::protocol_handler::RawMessagePtr message);

--- a/src/components/application_manager/include/application_manager/rpc_service_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_service_impl.h
@@ -132,7 +132,7 @@ class RPCServiceImpl : public RPCService,
  private:
   bool ConvertSOtoMessage(const smart_objects::SmartObject& message,
                           Message& output,
-                          const bool remove_unknown_parameters = true);
+                          const bool allow_unknown_parameters = false);
   hmi_apis::HMI_API& hmi_so_factory();
   mobile_apis::MOBILE_API& mobile_so_factory();
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2294,7 +2294,7 @@ bool ApplicationManagerImpl::ConvertSOtoMessage(
     case 0: {
       if (protocol_version == 1) {
         if (!formatters::CFormatterJsonSDLRPCv1::toString(
-                message, output_string, remove_unknown_parameters)) {
+                message, output_string, !allow_unknown_parameters)) {
           LOG4CXX_WARN(logger_, "Failed to serialize smart object");
           return false;
         }
@@ -2302,7 +2302,7 @@ bool ApplicationManagerImpl::ConvertSOtoMessage(
             protocol_handler::MajorProtocolVersion::PROTOCOL_VERSION_1);
       } else {
         if (!formatters::CFormatterJsonSDLRPCv2::toString(
-                message, output_string, remove_unknown_parameters)) {
+                message, output_string, !allow_unknown_parameters)) {
           LOG4CXX_WARN(logger_, "Failed to serialize smart object");
           return false;
         }
@@ -2315,7 +2315,7 @@ bool ApplicationManagerImpl::ConvertSOtoMessage(
     }
     case 1: {
       if (!formatters::FormatterJsonRpc::ToString(
-              message, output_string, remove_unknown_parameters)) {
+              message, output_string, !allow_unknown_parameters)) {
         LOG4CXX_WARN(logger_, "Failed to serialize smart object");
         return false;
       }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2268,7 +2268,7 @@ bool ApplicationManagerImpl::Stop() {
 bool ApplicationManagerImpl::ConvertSOtoMessage(
     const smart_objects::SmartObject& message,
     Message& output,
-    const bool remove_unknown_parameters) {
+    const bool allow_unknown_parameters) {
   LOG4CXX_AUTO_TRACE(logger_);
 
   if (smart_objects::SmartType_Null == message.getType() ||

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -319,9 +319,8 @@ bool RPCHandlerImpl::ConvertMessageToSO(
       if (!conversion_result ||
           !mobile_so_factory().attachSchema(
               output, remove_unknown_parameters, msg_version) ||
-          ((output.validate(&report, msg_version) !=
-                smart_objects::errors::OK &&
-            remove_unknown_parameters))) {
+          output.validate(&report, msg_version, !remove_unknown_parameters) !=
+              smart_objects::errors::OK) {
         LOG4CXX_WARN(logger_,
                      "Failed to parse string to smart object with API version "
                          << msg_version.toString() << " : "
@@ -387,10 +386,11 @@ bool RPCHandlerImpl::ConvertMessageToSO(
       }
 
       rpc::ValidationReport report("RPC");
-
-      if (output.validate(&report) != smart_objects::errors::OK) {
+      utils::SemanticVersion empty_version;
+      if (output.validate(&report, empty_version, !remove_unknown_parameters) !=
+          smart_objects::errors::OK) {
         LOG4CXX_ERROR(logger_,
-                      "Incorrect parameter from HMI"
+                      "Incorrect parameter from HMI - "
                           << rpc::PrettyFormat(report));
 
         output.erase(strings::msg_params);

--- a/src/components/application_manager/src/rpc_passing_handler.cc
+++ b/src/components/application_manager/src/rpc_passing_handler.cc
@@ -246,7 +246,7 @@ void RPCPassingHandler::ForwardRequestToCore(uint32_t correlation_id) {
   }
 
   if (!app_manager_.GetRPCHandler().ValidateRpcSO(
-          &message, msg_version, report, false)) {
+          message, msg_version, report, false)) {
     std::shared_ptr<smart_objects::SmartObject> response(
         MessageHelper::CreateNegativeResponse(
             connection_key,

--- a/src/components/application_manager/src/rpc_passing_handler.cc
+++ b/src/components/application_manager/src/rpc_passing_handler.cc
@@ -246,7 +246,7 @@ void RPCPassingHandler::ForwardRequestToCore(uint32_t correlation_id) {
   }
 
   if (!app_manager_.GetRPCHandler().ValidateRpcSO(
-          &message, msg_version, report, true)) {
+          &message, msg_version, report, false)) {
     std::shared_ptr<smart_objects::SmartObject> response(
         MessageHelper::CreateNegativeResponse(
             connection_key,

--- a/src/components/include/application_manager/rpc_handler.h
+++ b/src/components/include/application_manager/rpc_handler.h
@@ -52,7 +52,7 @@ class RPCHandler
 #endif  // TELEMETRY_MONITOR
       {
  public:
-  virtual bool ValidateRpcSO(smart_objects::SmartObject* message,
+  virtual bool ValidateRpcSO(smart_objects::SmartObject& message,
                              utils::SemanticVersion& msg_version,
                              rpc::ValidationReport& report_out,
                              bool allow_unknown_parameters) = 0;

--- a/src/components/include/application_manager/rpc_handler.h
+++ b/src/components/include/application_manager/rpc_handler.h
@@ -55,7 +55,7 @@ class RPCHandler
   virtual bool ValidateRpcSO(smart_objects::SmartObject* message,
                              utils::SemanticVersion& msg_version,
                              rpc::ValidationReport& report_out,
-                             bool remove_unknown_params) = 0;
+                             bool allow_unknown_parameters) = 0;
 
   virtual ~RPCHandler() {}
 };

--- a/src/components/smart_objects/include/smart_objects/always_false_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/always_false_schema_item.h
@@ -53,6 +53,10 @@ class CAlwaysFalseSchemaItem : public ISchemaItem {
    * @param Object Object to validate.
    * @param report__ object for reporting errors during validation
    * @param MessageVersion to check mobile RPC version against RPC Spec History
+   * @param allow_unknown_enums
+   *   false - unknown enum values (left as string values after applySchema)
+   *   will be considered invalid.
+   *   true - such values will be considered valid.
    * @return ns_smart_objects::errors::eType
    **/
   errors::eType validate(

--- a/src/components/smart_objects/include/smart_objects/always_false_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/always_false_schema_item.h
@@ -55,10 +55,11 @@ class CAlwaysFalseSchemaItem : public ISchemaItem {
    * @param MessageVersion to check mobile RPC version against RPC Spec History
    * @return ns_smart_objects::errors::eType
    **/
-  errors::eType validate(const SmartObject& Object,
-                         rpc::ValidationReport* report__,
-                         const utils::SemanticVersion& MessageVersion =
-                             utils::SemanticVersion()) OVERRIDE;
+  errors::eType validate(
+      const SmartObject& Object,
+      rpc::ValidationReport* report__,
+      const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
+      const bool allow_unknown_parameters = false) OVERRIDE;
 
  private:
   CAlwaysFalseSchemaItem();

--- a/src/components/smart_objects/include/smart_objects/always_false_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/always_false_schema_item.h
@@ -59,7 +59,7 @@ class CAlwaysFalseSchemaItem : public ISchemaItem {
       const SmartObject& Object,
       rpc::ValidationReport* report__,
       const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
-      const bool allow_unknown_parameters = false) OVERRIDE;
+      const bool allow_unknown_enums = false) OVERRIDE;
 
  private:
   CAlwaysFalseSchemaItem();

--- a/src/components/smart_objects/include/smart_objects/always_true_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/always_true_schema_item.h
@@ -55,10 +55,11 @@ class CAlwaysTrueSchemaItem : public ISchemaItem {
    * @param MessageVersion to check mobile RPC version against RPC Spec History
    * @return ns_smart_objects::errors::eType
    **/
-  errors::eType validate(const SmartObject& Object,
-                         rpc::ValidationReport* report__,
-                         const utils::SemanticVersion& MessageVersion =
-                             utils::SemanticVersion()) OVERRIDE;
+  errors::eType validate(
+      const SmartObject& Object,
+      rpc::ValidationReport* report__,
+      const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
+      const bool allow_unknown_parameters = false) OVERRIDE;
 
  private:
   CAlwaysTrueSchemaItem();

--- a/src/components/smart_objects/include/smart_objects/always_true_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/always_true_schema_item.h
@@ -59,7 +59,7 @@ class CAlwaysTrueSchemaItem : public ISchemaItem {
       const SmartObject& Object,
       rpc::ValidationReport* report__,
       const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
-      const bool allow_unknown_parameters = false) OVERRIDE;
+      const bool allow_unknown_enums = false) OVERRIDE;
 
  private:
   CAlwaysTrueSchemaItem();

--- a/src/components/smart_objects/include/smart_objects/always_true_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/always_true_schema_item.h
@@ -53,6 +53,10 @@ class CAlwaysTrueSchemaItem : public ISchemaItem {
    * @param Object Object to validate.
    * @param report__ object for reporting errors during validation
    * @param MessageVersion to check mobile RPC version against RPC Spec History
+   * @param allow_unknown_enums
+   *   false - unknown enum values (left as string values after applySchema)
+   *   will be considered invalid.
+   *   true - such values will be considered valid.
    * @return ns_smart_objects::errors::eType
    **/
   errors::eType validate(

--- a/src/components/smart_objects/include/smart_objects/array_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/array_schema_item.h
@@ -70,10 +70,11 @@ class CArraySchemaItem : public ISchemaItem {
    * @param MessageVersion to check mobile RPC version against RPC Spec History
    * @return ns_smart_objects::errors::eType
    **/
-  errors::eType validate(const SmartObject& Object,
-                         rpc::ValidationReport* report__,
-                         const utils::SemanticVersion& MessageVersion =
-                             utils::SemanticVersion()) OVERRIDE;
+  errors::eType validate(
+      const SmartObject& Object,
+      rpc::ValidationReport* report__,
+      const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
+      const bool allow_unknown_parameters = false) OVERRIDE;
 
   /**
    * @brief Apply schema.

--- a/src/components/smart_objects/include/smart_objects/array_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/array_schema_item.h
@@ -68,6 +68,10 @@ class CArraySchemaItem : public ISchemaItem {
    * @param Object Object to validate.
    * @param report__ object for reporting errors during validation
    * @param MessageVersion to check mobile RPC version against RPC Spec History
+   * @param allow_unknown_enums
+   *   false - unknown enum values (left as string values after applySchema)
+   *   will be considered invalid.
+   *   true - such values will be considered valid.
    * @return ns_smart_objects::errors::eType
    **/
   errors::eType validate(

--- a/src/components/smart_objects/include/smart_objects/array_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/array_schema_item.h
@@ -74,7 +74,7 @@ class CArraySchemaItem : public ISchemaItem {
       const SmartObject& Object,
       rpc::ValidationReport* report__,
       const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
-      const bool allow_unknown_parameters = false) OVERRIDE;
+      const bool allow_unknown_enums = false) OVERRIDE;
 
   /**
    * @brief Apply schema.

--- a/src/components/smart_objects/include/smart_objects/default_shema_item.h
+++ b/src/components/smart_objects/include/smart_objects/default_shema_item.h
@@ -55,10 +55,11 @@ class CDefaultSchemaItem : public ISchemaItem {
    * @param MessageVersion to check mobile RPC version against RPC Spec History
    * @return ns_smart_objects::errors::eType
    **/
-  errors::eType validate(const SmartObject& Object,
-                         rpc::ValidationReport* report__,
-                         const utils::SemanticVersion& MessageVersion =
-                             utils::SemanticVersion()) OVERRIDE;
+  errors::eType validate(
+      const SmartObject& Object,
+      rpc::ValidationReport* report__,
+      const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
+      const bool allow_unknown_parameters = false) OVERRIDE;
 
   /**
    * @brief Set default value to an object.
@@ -105,7 +106,8 @@ template <typename Type>
 errors::eType CDefaultSchemaItem<Type>::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report__,
-    const utils::SemanticVersion& MessageVersion) {
+    const utils::SemanticVersion& MessageVersion,
+    const bool allow_unknown_parameters) {
   if (getSmartType() != Object.getType()) {
     std::string validation_info = "Incorrect type, expected: " +
                                   SmartObject::typeToString(getSmartType()) +

--- a/src/components/smart_objects/include/smart_objects/default_shema_item.h
+++ b/src/components/smart_objects/include/smart_objects/default_shema_item.h
@@ -59,7 +59,7 @@ class CDefaultSchemaItem : public ISchemaItem {
       const SmartObject& Object,
       rpc::ValidationReport* report__,
       const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
-      const bool allow_unknown_parameters = false) OVERRIDE;
+      const bool allow_unknown_enums = false) OVERRIDE;
 
   /**
    * @brief Set default value to an object.
@@ -107,7 +107,7 @@ errors::eType CDefaultSchemaItem<Type>::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report__,
     const utils::SemanticVersion& MessageVersion,
-    const bool allow_unknown_parameters) {
+    const bool allow_unknown_enums) {
   if (getSmartType() != Object.getType()) {
     std::string validation_info = "Incorrect type, expected: " +
                                   SmartObject::typeToString(getSmartType()) +

--- a/src/components/smart_objects/include/smart_objects/default_shema_item.h
+++ b/src/components/smart_objects/include/smart_objects/default_shema_item.h
@@ -53,6 +53,10 @@ class CDefaultSchemaItem : public ISchemaItem {
    * @param Object Object to validate.
    * @param report__ object for reporting errors during validation
    * @param MessageVersion to check mobile RPC version against RPC Spec History
+   * @param allow_unknown_enums
+   *   false - unknown enum values (left as string values after applySchema)
+   *   will be considered invalid.
+   *   true - such values will be considered valid.
    * @return ns_smart_objects::errors::eType
    **/
   errors::eType validate(

--- a/src/components/smart_objects/include/smart_objects/enum_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/enum_schema_item.h
@@ -108,6 +108,10 @@ class TEnumSchemaItem : public CDefaultSchemaItem<EnumType> {
    * @param Object Object to validate.
    * @param report__ object for reporting errors during validation
    * @param MessageVersion to check mobile RPC version against RPC Spec History
+   * @param allow_unknown_enums
+   *   false - unknown enum values (left as string values after applySchema)
+   *   will be considered invalid.
+   *   true - such values will be considered valid.
    * @return ns_smart_objects::errors::eType
    **/
   errors::eType validate(

--- a/src/components/smart_objects/include/smart_objects/enum_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/enum_schema_item.h
@@ -110,10 +110,11 @@ class TEnumSchemaItem : public CDefaultSchemaItem<EnumType> {
    * @param MessageVersion to check mobile RPC version against RPC Spec History
    * @return ns_smart_objects::errors::eType
    **/
-  errors::eType validate(const SmartObject& Object,
-                         rpc::ValidationReport* report__,
-                         const utils::SemanticVersion& MessageVersion =
-                             utils::SemanticVersion()) OVERRIDE;
+  errors::eType validate(
+      const SmartObject& Object,
+      rpc::ValidationReport* report__,
+      const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
+      const bool allow_unknown_parameters = false) OVERRIDE;
   /**
    * @brief Return the correct history signature based on message version.
    * @param signatures Vector reference of enums history items.
@@ -310,10 +311,14 @@ template <typename EnumType>
 errors::eType TEnumSchemaItem<EnumType>::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report__,
-    const utils::SemanticVersion& MessageVersion) {
+    const utils::SemanticVersion& MessageVersion,
+    const bool allow_unknown_parameters) {
   if (SmartType_Integer != Object.getType()) {
     std::string validation_info;
     if (SmartType_String == Object.getType()) {
+      if (allow_unknown_parameters) {
+        return errors::OK;
+      }
       validation_info = "Invalid enum value: " + Object.asString();
     } else {
       validation_info = "Incorrect type, expected: " +

--- a/src/components/smart_objects/include/smart_objects/enum_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/enum_schema_item.h
@@ -114,7 +114,7 @@ class TEnumSchemaItem : public CDefaultSchemaItem<EnumType> {
       const SmartObject& Object,
       rpc::ValidationReport* report__,
       const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
-      const bool allow_unknown_parameters = false) OVERRIDE;
+      const bool allow_unknown_enums = false) OVERRIDE;
   /**
    * @brief Return the correct history signature based on message version.
    * @param signatures Vector reference of enums history items.
@@ -312,11 +312,11 @@ errors::eType TEnumSchemaItem<EnumType>::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report__,
     const utils::SemanticVersion& MessageVersion,
-    const bool allow_unknown_parameters) {
+    const bool allow_unknown_enums) {
   if (SmartType_Integer != Object.getType()) {
     std::string validation_info;
     if (SmartType_String == Object.getType()) {
-      if (allow_unknown_parameters) {
+      if (allow_unknown_enums) {
         return errors::OK;
       }
       validation_info = "Invalid enum value: " + Object.asString();

--- a/src/components/smart_objects/include/smart_objects/number_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/number_schema_item.h
@@ -72,10 +72,11 @@ class TNumberSchemaItem : public CDefaultSchemaItem<NumberType> {
    * @param MessageVersion to check mobile RPC version against RPC Spec History
    * @return ns_smart_objects::errors::eType
    **/
-  errors::eType validate(const SmartObject& Object,
-                         rpc::ValidationReport* report__,
-                         const utils::SemanticVersion& MessageVersion =
-                             utils::SemanticVersion()) OVERRIDE;
+  errors::eType validate(
+      const SmartObject& Object,
+      rpc::ValidationReport* report__,
+      const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
+      const bool allow_unknown_parameters = false) OVERRIDE;
 
  private:
   /**
@@ -137,7 +138,8 @@ template <typename NumberType>
 errors::eType TNumberSchemaItem<NumberType>::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report__,
-    const utils::SemanticVersion& MessageVersion) {
+    const utils::SemanticVersion& MessageVersion,
+    const bool allow_unknown_parameters) {
   if (!isValidNumberType(Object.getType())) {
     SmartType expectedType = (typeid(double) == typeid(Object.getType()))
                                  ? SmartType_Double

--- a/src/components/smart_objects/include/smart_objects/number_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/number_schema_item.h
@@ -70,6 +70,10 @@ class TNumberSchemaItem : public CDefaultSchemaItem<NumberType> {
    * @param Object Object to validate.
    * @param report__ object for reporting errors during validation
    * @param MessageVersion to check mobile RPC version against RPC Spec History
+   * @param allow_unknown_enums
+   *   false - unknown enum values (left as string values after applySchema)
+   *   will be considered invalid.
+   *   true - such values will be considered valid.
    * @return ns_smart_objects::errors::eType
    **/
   errors::eType validate(

--- a/src/components/smart_objects/include/smart_objects/number_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/number_schema_item.h
@@ -76,7 +76,7 @@ class TNumberSchemaItem : public CDefaultSchemaItem<NumberType> {
       const SmartObject& Object,
       rpc::ValidationReport* report__,
       const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
-      const bool allow_unknown_parameters = false) OVERRIDE;
+      const bool allow_unknown_enums = false) OVERRIDE;
 
  private:
   /**
@@ -139,7 +139,7 @@ errors::eType TNumberSchemaItem<NumberType>::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report__,
     const utils::SemanticVersion& MessageVersion,
-    const bool allow_unknown_parameters) {
+    const bool allow_unknown_enums) {
   if (!isValidNumberType(Object.getType())) {
     SmartType expectedType = (typeid(double) == typeid(Object.getType()))
                                  ? SmartType_Double

--- a/src/components/smart_objects/include/smart_objects/object_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/object_schema_item.h
@@ -109,6 +109,10 @@ class CObjectSchemaItem : public ISchemaItem {
    * @param Object Object to validate.
    * @param report__ object for reporting errors during validation
    * @param MessageVersion to check mobile RPC version against RPC Spec History
+   * @param allow_unknown_enums
+   *   false - unknown enum values (left as string values after applySchema)
+   *   will be considered invalid.
+   *   true - such values will be considered valid.
    * @return ns_smart_objects::errors::eType
    **/
   errors::eType validate(

--- a/src/components/smart_objects/include/smart_objects/object_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/object_schema_item.h
@@ -115,7 +115,7 @@ class CObjectSchemaItem : public ISchemaItem {
       const SmartObject& Object,
       rpc::ValidationReport* report__,
       const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
-      const bool allow_unknown_parameters = false) OVERRIDE;
+      const bool allow_unknown_enums = false) OVERRIDE;
   /**
    * @brief Apply schema.
    * @param Object Object to apply schema.

--- a/src/components/smart_objects/include/smart_objects/object_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/object_schema_item.h
@@ -111,10 +111,11 @@ class CObjectSchemaItem : public ISchemaItem {
    * @param MessageVersion to check mobile RPC version against RPC Spec History
    * @return ns_smart_objects::errors::eType
    **/
-  errors::eType validate(const SmartObject& Object,
-                         rpc::ValidationReport* report__,
-                         const utils::SemanticVersion& MessageVersion =
-                             utils::SemanticVersion()) OVERRIDE;
+  errors::eType validate(
+      const SmartObject& Object,
+      rpc::ValidationReport* report__,
+      const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
+      const bool allow_unknown_parameters = false) OVERRIDE;
   /**
    * @brief Apply schema.
    * @param Object Object to apply schema.

--- a/src/components/smart_objects/include/smart_objects/schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/schema_item.h
@@ -64,7 +64,8 @@ class ISchemaItem {
   virtual errors::eType validate(
       const SmartObject& Object,
       rpc::ValidationReport* report__,
-      const utils::SemanticVersion& MessageVersion = utils::SemanticVersion());
+      const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
+      const bool allow_unknown_parameters = false);
 
   /**
    * @brief Set default value to an object.

--- a/src/components/smart_objects/include/smart_objects/schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/schema_item.h
@@ -65,7 +65,7 @@ class ISchemaItem {
       const SmartObject& Object,
       rpc::ValidationReport* report__,
       const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
-      const bool allow_unknown_parameters = false);
+      const bool allow_unknown_enums = false);
 
   /**
    * @brief Set default value to an object.

--- a/src/components/smart_objects/include/smart_objects/schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/schema_item.h
@@ -58,7 +58,11 @@ class ISchemaItem {
    * @param Object Object to validate.
    * @param report__ object for reporting errors during validation
    * message if an error occurs
-   * @param MessageVersion to check mobile RPC version against RPC Spec Histor
+   * @param MessageVersion to check mobile RPC version against RPC Spec History
+   * @param allow_unknown_enums
+   *   false - unknown enum values (left as string values after applySchema)
+   *   will be considered invalid.
+   *   true - such values will be considered valid.
    * @return ns_smart_objects::errors::eType
    **/
   virtual errors::eType validate(

--- a/src/components/smart_objects/include/smart_objects/smart_object.h
+++ b/src/components/smart_objects/include/smart_objects/smart_object.h
@@ -676,6 +676,10 @@ class SmartObject FINAL {
    *
    * @param report__ object for reporting errors during validation
    * @param messageVersion of the mobile app to check against RPC Spec Schema
+   * @param allow_unknown_enums
+   *   false - unknown enum values (left as string values after applySchema)
+   *   will be considered invalid.
+   *   true - such values will be considered valid.
    * @return Result of validation.
    */
   errors::eType validate(

--- a/src/components/smart_objects/include/smart_objects/smart_object.h
+++ b/src/components/smart_objects/include/smart_objects/smart_object.h
@@ -680,7 +680,8 @@ class SmartObject FINAL {
    */
   errors::eType validate(
       rpc::ValidationReport* report__,
-      const utils::SemanticVersion& MessageVersion = utils::SemanticVersion());
+      const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
+      const bool allow_unknown_parameters = false);
 
   /**
    * @brief Sets new schema

--- a/src/components/smart_objects/include/smart_objects/smart_object.h
+++ b/src/components/smart_objects/include/smart_objects/smart_object.h
@@ -681,7 +681,7 @@ class SmartObject FINAL {
   errors::eType validate(
       rpc::ValidationReport* report__,
       const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
-      const bool allow_unknown_parameters = false);
+      const bool allow_unknown_enums = false);
 
   /**
    * @brief Sets new schema

--- a/src/components/smart_objects/include/smart_objects/smart_schema.h
+++ b/src/components/smart_objects/include/smart_objects/smart_schema.h
@@ -68,10 +68,11 @@ class CSmartSchema FINAL {
    * @param MessageVersion to check mobile RPC version against RPC Spec History
    * @return ns_smart_objects::errors::eType
    **/
-  errors::eType validate(const SmartObject& Object,
-                         rpc::ValidationReport* report__,
-                         const utils::SemanticVersion& messageVersion =
-                             utils::SemanticVersion()) const;
+  errors::eType validate(
+      const SmartObject& Object,
+      rpc::ValidationReport* report__,
+      const utils::SemanticVersion& messageVersion = utils::SemanticVersion(),
+      const bool allow_unknown_parameters = false) const;
 
   /**
    * @brief Set new root schema item.

--- a/src/components/smart_objects/include/smart_objects/smart_schema.h
+++ b/src/components/smart_objects/include/smart_objects/smart_schema.h
@@ -66,6 +66,10 @@ class CSmartSchema FINAL {
    * @param Object Object to validate.
    * @param report__ object for reporting errors during validation
    * @param MessageVersion to check mobile RPC version against RPC Spec History
+   * @param allow_unknown_enums
+   *   false - unknown enum values (left as string values after applySchema)
+   *   will be considered invalid.
+   *   true - such values will be considered valid.
    * @return ns_smart_objects::errors::eType
    **/
   errors::eType validate(

--- a/src/components/smart_objects/include/smart_objects/smart_schema.h
+++ b/src/components/smart_objects/include/smart_objects/smart_schema.h
@@ -72,7 +72,7 @@ class CSmartSchema FINAL {
       const SmartObject& Object,
       rpc::ValidationReport* report__,
       const utils::SemanticVersion& messageVersion = utils::SemanticVersion(),
-      const bool allow_unknown_parameters = false) const;
+      const bool allow_unknown_enums = false) const;
 
   /**
    * @brief Set new root schema item.

--- a/src/components/smart_objects/include/smart_objects/string_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/string_schema_item.h
@@ -67,10 +67,11 @@ class CStringSchemaItem : public CDefaultSchemaItem<std::string> {
    * @param MessageVersion to check mobile RPC version against RPC Spec History
    * @return ns_smart_objects::errors::eType
    **/
-  errors::eType validate(const SmartObject& Object,
-                         rpc::ValidationReport* report__,
-                         const utils::SemanticVersion& MessageVersion =
-                             utils::SemanticVersion()) OVERRIDE;
+  errors::eType validate(
+      const SmartObject& Object,
+      rpc::ValidationReport* report__,
+      const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
+      const bool allow_unknown_parameters = false) OVERRIDE;
 
  private:
   /**

--- a/src/components/smart_objects/include/smart_objects/string_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/string_schema_item.h
@@ -71,7 +71,7 @@ class CStringSchemaItem : public CDefaultSchemaItem<std::string> {
       const SmartObject& Object,
       rpc::ValidationReport* report__,
       const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
-      const bool allow_unknown_parameters = false) OVERRIDE;
+      const bool allow_unknown_enums = false) OVERRIDE;
 
  private:
   /**

--- a/src/components/smart_objects/include/smart_objects/string_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/string_schema_item.h
@@ -65,6 +65,10 @@ class CStringSchemaItem : public CDefaultSchemaItem<std::string> {
    * @param Object Object to validate.
    * @param report__ object for reporting errors during validation
    * @param MessageVersion to check mobile RPC version against RPC Spec History
+   * @param allow_unknown_enums
+   *   false - unknown enum values (left as string values after applySchema)
+   *   will be considered invalid.
+   *   true - such values will be considered valid.
    * @return ns_smart_objects::errors::eType
    **/
   errors::eType validate(

--- a/src/components/smart_objects/src/always_false_schema_item.cc
+++ b/src/components/smart_objects/src/always_false_schema_item.cc
@@ -44,7 +44,8 @@ std::shared_ptr<CAlwaysFalseSchemaItem> CAlwaysFalseSchemaItem::create() {
 errors::eType CAlwaysFalseSchemaItem::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report__,
-    const utils::SemanticVersion& MessageVersion) {
+    const utils::SemanticVersion& MessageVersion,
+    const bool allow_unknown_parameters) {
   report__->set_validation_info("Generic error");
   return errors::ERROR;
 }

--- a/src/components/smart_objects/src/always_false_schema_item.cc
+++ b/src/components/smart_objects/src/always_false_schema_item.cc
@@ -45,7 +45,7 @@ errors::eType CAlwaysFalseSchemaItem::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report__,
     const utils::SemanticVersion& MessageVersion,
-    const bool allow_unknown_parameters) {
+    const bool allow_unknown_enums) {
   report__->set_validation_info("Generic error");
   return errors::ERROR;
 }

--- a/src/components/smart_objects/src/always_true_schema_item.cc
+++ b/src/components/smart_objects/src/always_true_schema_item.cc
@@ -43,7 +43,7 @@ errors::eType CAlwaysTrueSchemaItem::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report__,
     const utils::SemanticVersion& MessageVersion,
-    const bool allow_unknown_parameters) {
+    const bool allow_unknown_enums) {
   return errors::OK;
 }
 

--- a/src/components/smart_objects/src/always_true_schema_item.cc
+++ b/src/components/smart_objects/src/always_true_schema_item.cc
@@ -42,7 +42,8 @@ std::shared_ptr<CAlwaysTrueSchemaItem> CAlwaysTrueSchemaItem::create() {
 errors::eType CAlwaysTrueSchemaItem::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report__,
-    const utils::SemanticVersion& MessageVersion) {
+    const utils::SemanticVersion& MessageVersion,
+    const bool allow_unknown_parameters) {
   return errors::OK;
 }
 

--- a/src/components/smart_objects/src/array_schema_item.cc
+++ b/src/components/smart_objects/src/array_schema_item.cc
@@ -46,7 +46,7 @@ errors::eType CArraySchemaItem::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report__,
     const utils::SemanticVersion& MessageVersion,
-    const bool allow_unknown_parameters) {
+    const bool allow_unknown_enums) {
   if (SmartType_Array != Object.getType()) {
     std::string validation_info = "Incorrect type, expected: " +
                                   SmartObject::typeToString(SmartType_Array) +
@@ -82,7 +82,7 @@ errors::eType CArraySchemaItem::validate(
         mElementSchemaItem->validate(Object.getElement(i),
                                      &report__->ReportSubobject(strVal.str()),
                                      MessageVersion,
-                                     allow_unknown_parameters);
+                                     allow_unknown_enums);
     if (errors::OK != result) {
       return result;
     }

--- a/src/components/smart_objects/src/array_schema_item.cc
+++ b/src/components/smart_objects/src/array_schema_item.cc
@@ -45,7 +45,8 @@ std::shared_ptr<CArraySchemaItem> CArraySchemaItem::create(
 errors::eType CArraySchemaItem::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report__,
-    const utils::SemanticVersion& MessageVersion) {
+    const utils::SemanticVersion& MessageVersion,
+    const bool allow_unknown_parameters) {
   if (SmartType_Array != Object.getType()) {
     std::string validation_info = "Incorrect type, expected: " +
                                   SmartObject::typeToString(SmartType_Array) +
@@ -80,7 +81,8 @@ errors::eType CArraySchemaItem::validate(
     const errors::eType result =
         mElementSchemaItem->validate(Object.getElement(i),
                                      &report__->ReportSubobject(strVal.str()),
-                                     MessageVersion);
+                                     MessageVersion,
+                                     allow_unknown_parameters);
     if (errors::OK != result) {
       return result;
     }

--- a/src/components/smart_objects/src/object_schema_item.cc
+++ b/src/components/smart_objects/src/object_schema_item.cc
@@ -111,7 +111,7 @@ errors::eType CObjectSchemaItem::validate(
     const SmartObject& object,
     rpc::ValidationReport* report__,
     const utils::SemanticVersion& MessageVersion,
-    const bool allow_unknown_parameters) {
+    const bool allow_unknown_enums) {
   if (SmartType_Map != object.getType()) {
     std::string validation_info = "Incorrect type, expected: " +
                                   SmartObject::typeToString(SmartType_Map) +
@@ -147,7 +147,7 @@ errors::eType CObjectSchemaItem::validate(
         correct_member.mSchemaItem->validate(field,
                                              &report__->ReportSubobject(key),
                                              MessageVersion,
-                                             allow_unknown_parameters);
+                                             allow_unknown_enums);
     if (errors::OK != result) {
       return result;
     }

--- a/src/components/smart_objects/src/object_schema_item.cc
+++ b/src/components/smart_objects/src/object_schema_item.cc
@@ -110,7 +110,8 @@ std::shared_ptr<CObjectSchemaItem> CObjectSchemaItem::create(
 errors::eType CObjectSchemaItem::validate(
     const SmartObject& object,
     rpc::ValidationReport* report__,
-    const utils::SemanticVersion& MessageVersion) {
+    const utils::SemanticVersion& MessageVersion,
+    const bool allow_unknown_parameters) {
   if (SmartType_Map != object.getType()) {
     std::string validation_info = "Incorrect type, expected: " +
                                   SmartObject::typeToString(SmartType_Map) +
@@ -142,8 +143,11 @@ errors::eType CObjectSchemaItem::validate(
 
     errors::eType result = errors::OK;
     // Check if MessageVersion matches schema version
-    result = correct_member.mSchemaItem->validate(
-        field, &report__->ReportSubobject(key), MessageVersion);
+    result =
+        correct_member.mSchemaItem->validate(field,
+                                             &report__->ReportSubobject(key),
+                                             MessageVersion,
+                                             allow_unknown_parameters);
     if (errors::OK != result) {
       return result;
     }

--- a/src/components/smart_objects/src/schema_item.cc
+++ b/src/components/smart_objects/src/schema_item.cc
@@ -38,7 +38,8 @@ namespace ns_smart_objects {
 errors::eType ISchemaItem::validate(
     const SmartObject& object,
     rpc::ValidationReport* report__,
-    const utils::SemanticVersion& MessageVersion) {
+    const utils::SemanticVersion& MessageVersion,
+    const bool allow_unknown_parameters) {
   return errors::ERROR;
 }
 

--- a/src/components/smart_objects/src/schema_item.cc
+++ b/src/components/smart_objects/src/schema_item.cc
@@ -39,7 +39,7 @@ errors::eType ISchemaItem::validate(
     const SmartObject& object,
     rpc::ValidationReport* report__,
     const utils::SemanticVersion& MessageVersion,
-    const bool allow_unknown_parameters) {
+    const bool allow_unknown_enums) {
   return errors::ERROR;
 }
 

--- a/src/components/smart_objects/src/smart_object.cc
+++ b/src/components/smart_objects/src/smart_object.cc
@@ -878,8 +878,10 @@ bool SmartObject::isValid() const {
 
 errors::eType SmartObject::validate(
     rpc::ValidationReport* report__,
-    const utils::SemanticVersion& MessageVersion) {
-  return m_schema.validate(*this, report__, MessageVersion);
+    const utils::SemanticVersion& MessageVersion,
+    const bool allow_unknown_parameters) {
+  return m_schema.validate(
+      *this, report__, MessageVersion, allow_unknown_parameters);
 }
 
 void SmartObject::setSchema(const CSmartSchema& schema) {

--- a/src/components/smart_objects/src/smart_object.cc
+++ b/src/components/smart_objects/src/smart_object.cc
@@ -879,9 +879,9 @@ bool SmartObject::isValid() const {
 errors::eType SmartObject::validate(
     rpc::ValidationReport* report__,
     const utils::SemanticVersion& MessageVersion,
-    const bool allow_unknown_parameters) {
+    const bool allow_unknown_enums) {
   return m_schema.validate(
-      *this, report__, MessageVersion, allow_unknown_parameters);
+      *this, report__, MessageVersion, allow_unknown_enums);
 }
 
 void SmartObject::setSchema(const CSmartSchema& schema) {

--- a/src/components/smart_objects/src/smart_schema.cc
+++ b/src/components/smart_objects/src/smart_schema.cc
@@ -43,8 +43,10 @@ CSmartSchema::CSmartSchema(const ISchemaItemPtr SchemaItem)
 errors::eType CSmartSchema::validate(
     const SmartObject& object,
     rpc::ValidationReport* report__,
-    const utils::SemanticVersion& MessageVersion) const {
-  return mSchemaItem->validate(object, report__, MessageVersion);
+    const utils::SemanticVersion& MessageVersion,
+    const bool allow_unknown_parameters) const {
+  return mSchemaItem->validate(
+      object, report__, MessageVersion, allow_unknown_parameters);
 }
 
 void CSmartSchema::setSchemaItem(const ISchemaItemPtr schemaItem) {

--- a/src/components/smart_objects/src/smart_schema.cc
+++ b/src/components/smart_objects/src/smart_schema.cc
@@ -44,9 +44,9 @@ errors::eType CSmartSchema::validate(
     const SmartObject& object,
     rpc::ValidationReport* report__,
     const utils::SemanticVersion& MessageVersion,
-    const bool allow_unknown_parameters) const {
+    const bool allow_unknown_enums) const {
   return mSchemaItem->validate(
-      object, report__, MessageVersion, allow_unknown_parameters);
+      object, report__, MessageVersion, allow_unknown_enums);
 }
 
 void CSmartSchema::setSchemaItem(const ISchemaItemPtr schemaItem) {

--- a/src/components/smart_objects/src/string_schema_item.cc
+++ b/src/components/smart_objects/src/string_schema_item.cc
@@ -49,7 +49,8 @@ std::shared_ptr<CStringSchemaItem> CStringSchemaItem::create(
 errors::eType CStringSchemaItem::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report__,
-    const utils::SemanticVersion& MessageVersion) {
+    const utils::SemanticVersion& MessageVersion,
+    const bool allow_unknown_parameters) {
   if (SmartType_String != Object.getType()) {
     std::string validation_info = "Incorrect type, expected: " +
                                   SmartObject::typeToString(SmartType_String) +

--- a/src/components/smart_objects/src/string_schema_item.cc
+++ b/src/components/smart_objects/src/string_schema_item.cc
@@ -50,7 +50,7 @@ errors::eType CStringSchemaItem::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report__,
     const utils::SemanticVersion& MessageVersion,
-    const bool allow_unknown_parameters) {
+    const bool allow_unknown_enums) {
   if (SmartType_String != Object.getType()) {
     std::string validation_info = "Incorrect type, expected: " +
                                   SmartObject::typeToString(SmartType_String) +


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Manual test of GetAppServiceData

### Summary
Add functionality to allow for unknown enum values for App Service RPCs

### Changelog
##### Bug Fixes
* Allow unknown enum values for App Service RPCs

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)