### PR TITLE
Validating forwarded and App Service RPC requests

### DIFF
--- a/src/components/application_manager/include/application_manager/rpc_handler_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_handler_impl.h
@@ -155,10 +155,8 @@ class RPCHandlerImpl : public RPCHandler,
       utils::SemanticVersion& message_version);
 
   bool ValidateRpcSO(smart_objects::SmartObject* message,
-                     uint32_t connection_key,
-                     uint32_t correlation_id,
-                     int32_t function_id,
                      utils::SemanticVersion& msg_version,
+                     rpc::ValidationReport& report_out,
                      bool remove_unknown_params) OVERRIDE;
 
  private:
@@ -167,7 +165,7 @@ class RPCHandlerImpl : public RPCHandler,
   bool ConvertMessageToSO(const Message& message,
                           smart_objects::SmartObject& output,
                           const bool remove_unknown_parameters = true,
-                          const bool validate_existing_params = true);
+                          const bool validate_params = true);
   std::shared_ptr<Message> ConvertRawMsgToMessage(
       const ::protocol_handler::RawMessagePtr message);
   hmi_apis::HMI_API& hmi_so_factory();

--- a/src/components/application_manager/include/application_manager/rpc_handler_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_handler_impl.h
@@ -154,12 +154,20 @@ class RPCHandlerImpl : public RPCHandler,
       ns_smart_device_link::ns_smart_objects::SmartObject& output,
       utils::SemanticVersion& message_version);
 
+  bool ValidateRPCSO(smart_objects::SmartObject* message,
+                     uint32_t connection_key,
+                     uint32_t correlation_id,
+                     int32_t function_id,
+                     utils::SemanticVersion& msg_version,
+                     bool remove_unknown_params);
+
  private:
   void ProcessMessageFromMobile(const std::shared_ptr<Message> message);
   void ProcessMessageFromHMI(const std::shared_ptr<Message> message);
   bool ConvertMessageToSO(const Message& message,
                           smart_objects::SmartObject& output,
-                          const bool remove_unknown_parameters = true);
+                          const bool remove_unknown_parameters = true,
+                          const bool validate_existing_params = true);
   std::shared_ptr<Message> ConvertRawMsgToMessage(
       const ::protocol_handler::RawMessagePtr message);
   hmi_apis::HMI_API& hmi_so_factory();

--- a/src/components/application_manager/include/application_manager/rpc_handler_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_handler_impl.h
@@ -154,7 +154,7 @@ class RPCHandlerImpl : public RPCHandler,
       ns_smart_device_link::ns_smart_objects::SmartObject& output,
       utils::SemanticVersion& message_version);
 
-  bool ValidateRPCSO(smart_objects::SmartObject* message,
+  bool ValidateRpcSO(smart_objects::SmartObject* message,
                      uint32_t connection_key,
                      uint32_t correlation_id,
                      int32_t function_id,

--- a/src/components/application_manager/include/application_manager/rpc_handler_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_handler_impl.h
@@ -159,7 +159,7 @@ class RPCHandlerImpl : public RPCHandler,
                      uint32_t correlation_id,
                      int32_t function_id,
                      utils::SemanticVersion& msg_version,
-                     bool remove_unknown_params);
+                     bool remove_unknown_params) OVERRIDE;
 
  private:
   void ProcessMessageFromMobile(const std::shared_ptr<Message> message);

--- a/src/components/application_manager/src/rpc_passing_handler.cc
+++ b/src/components/application_manager/src/rpc_passing_handler.cc
@@ -234,7 +234,7 @@ void RPCPassingHandler::ForwardRequestToCore(uint32_t correlation_id) {
   rpc_request_queue.erase(correlation_id);
   rpc_request_queue_lock_.Release();
 
-  // Revalidate rpc message before forwarding to core
+  // Validate rpc message before forwarding to core
   uint32_t connection_key =
       message[strings::params][strings::connection_key].asUInt();
   int32_t function_id = message[strings::params][strings::function_id].asInt();
@@ -245,7 +245,7 @@ void RPCPassingHandler::ForwardRequestToCore(uint32_t correlation_id) {
     msg_version = app_ptr->msg_version();
   }
 
-  app_manager_.GetRPCHandler().ValidateRPCSO(
+  app_manager_.GetRPCHandler().ValidateRpcSO(
       &message, connection_key, correlation_id, function_id, msg_version, true);
   app_manager_.GetRPCService().ManageMobileCommand(
       result, commands::Command::SOURCE_MOBILE);

--- a/src/components/application_manager/src/rpc_passing_handler.cc
+++ b/src/components/application_manager/src/rpc_passing_handler.cc
@@ -38,7 +38,7 @@
 #include "application_manager/application.h"
 #include "application_manager/application_manager.h"
 #include "application_manager/rpc_passing_handler.h"
-#include "application_manager/rpc_handler_impl.h"
+#include "application_manager/rpc_handler.h"
 #include "application_manager/commands/command_impl.h"
 #include "application_manager/message_helper.h"
 #include "application_manager/smart_object_keys.h"
@@ -244,9 +244,8 @@ void RPCPassingHandler::ForwardRequestToCore(uint32_t correlation_id) {
   if (app_ptr) {
     msg_version = app_ptr->msg_version();
   }
-  auto rpc_handler_impl =
-      dynamic_cast<rpc_handler::RPCHandlerImpl*>(&app_manager_.GetRPCHandler());
-  rpc_handler_impl->ValidateRPCSO(
+
+  app_manager_.GetRPCHandler().ValidateRPCSO(
       &message, connection_key, correlation_id, function_id, msg_version, true);
   app_manager_.GetRPCService().ManageMobileCommand(
       result, commands::Command::SOURCE_MOBILE);

--- a/src/components/include/application_manager/rpc_handler.h
+++ b/src/components/include/application_manager/rpc_handler.h
@@ -52,6 +52,13 @@ class RPCHandler
 #endif  // TELEMETRY_MONITOR
       {
  public:
+  virtual bool ValidateRPCSO(smart_objects::SmartObject* message,
+                             uint32_t connection_key,
+                             uint32_t correlation_id,
+                             int32_t function_id,
+                             utils::SemanticVersion& msg_version,
+                             bool remove_unknown_params) = 0;
+
   virtual ~RPCHandler() {}
 };
 

--- a/src/components/include/application_manager/rpc_handler.h
+++ b/src/components/include/application_manager/rpc_handler.h
@@ -52,7 +52,7 @@ class RPCHandler
 #endif  // TELEMETRY_MONITOR
       {
  public:
-  virtual bool ValidateRPCSO(smart_objects::SmartObject* message,
+  virtual bool ValidateRpcSO(smart_objects::SmartObject* message,
                              uint32_t connection_key,
                              uint32_t correlation_id,
                              int32_t function_id,

--- a/src/components/include/application_manager/rpc_handler.h
+++ b/src/components/include/application_manager/rpc_handler.h
@@ -53,10 +53,8 @@ class RPCHandler
       {
  public:
   virtual bool ValidateRpcSO(smart_objects::SmartObject* message,
-                             uint32_t connection_key,
-                             uint32_t correlation_id,
-                             int32_t function_id,
                              utils::SemanticVersion& msg_version,
+                             rpc::ValidationReport& report_out,
                              bool remove_unknown_params) = 0;
 
   virtual ~RPCHandler() {}


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manual testing with changing existing params and sending new params in RPC requests to core.

### Summary
The current implementation allows RPC passing requests and App Service RPC requests to be used without validation. The requests forwarded to core (after PassThrough requests to App Services) are also not validated.

The changes in this PR add a validate param which is used to validate existing parameters for App Service RPCs. For RPC Passing, the RPC request forwarded to core(when no app services can handle the request) is revalidated.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)