### PR TITLE
App service mobile and hmi command creation unit tests

### DIFF
--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/CMakeLists.txt
@@ -80,5 +80,5 @@ install(TARGETS app_service_rpc_plugin
 )
 
 if(BUILD_TESTS)
-  # add_subdirectory(test)
+  add_subdirectory(test)
 endif()

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/CMakeLists.txt
@@ -1,0 +1,37 @@
+include(${CMAKE_SOURCE_DIR}/tools/cmake/helpers/sources.cmake)
+
+include_directories(
+  ${GMOCK_INCLUDE_DIRECTORY}
+  ${COMPONENTS_DIR}/application_manager/rpc_plugins/app_service_rpc_plugin/include
+  ${COMPONENTS_DIR}/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/
+  ${COMPONENTS_DIR}/application_manager/test/include/
+  ${POLICY_MOCK_INCLUDE_PATH}/
+  ${CMAKE_SOURCE_DIR}/src
+)  
+
+
+set(COMMANDS_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR}/commands)
+
+file(GLOB SOURCES
+  ${COMPONENTS_DIR}/application_manager/test/mock_message_helper.cc
+  ${COMPONENTS_DIR}/application_manager/test/mock_application_helper.cc
+  ${COMPONENTS_DIR}/application_manager/src/smart_object_keys.cc
+  ${COMMANDS_TEST_DIR}/hmi/*
+  ${COMMANDS_TEST_DIR}/mobile/*
+  ${COMPONENTS_DIR}/application_manager/src/message.cc
+  ${COMPONENTS_DIR}/application_manager/src/event_engine/*
+)
+
+set(LIBRARIES
+  gmock
+  Utils
+  SmartObjects
+  HMI_API
+  MOBILE_API
+  connectionHandler
+  app_service_rpc_plugin
+  jsoncpp
+  Policy
+)
+
+create_cotired_test("app_services_commands_test" "${SOURCES}" "${LIBRARIES}" )

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/commands/hmi/dummy_hmi_commands_test.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/commands/hmi/dummy_hmi_commands_test.cc
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2018, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/commands/command_request_test.h"
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+
+#include "hmi/as_app_service_activation_request.h"
+#include "hmi/as_app_service_activation_response.h"
+#include "hmi/as_get_active_service_consent_request.h"
+#include "hmi/as_get_active_service_consent_response.h"
+#include "hmi/as_get_app_service_data_request_from_hmi.h"
+#include "hmi/as_get_app_service_data_request_to_hmi.h"
+#include "hmi/as_get_app_service_data_response_from_hmi.h"
+#include "hmi/as_get_app_service_data_response_to_hmi.h"
+#include "hmi/as_get_app_service_records_request.h"
+#include "hmi/as_get_app_service_records_response.h"
+#include "hmi/as_perform_app_service_interaction_request_from_hmi.h"
+#include "hmi/as_perform_app_service_interaction_request_to_hmi.h"
+#include "hmi/as_perform_app_service_interaction_response_from_hmi.h"
+#include "hmi/as_perform_app_service_interaction_response_to_hmi.h"
+#include "hmi/as_publish_app_service_request.h"
+#include "hmi/as_publish_app_service_response.h"
+#include "hmi/on_as_app_service_data_notification.h"
+#include "hmi/on_as_app_service_data_notification_from_hmi.h"
+
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_application_manager_settings.h"
+#include "application_manager/mock_event_dispatcher.h"
+
+namespace am = application_manager;
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+namespace dummy_hmi_commands_test {
+
+namespace commands = app_service_rpc_plugin::commands;
+
+using ::testing::_;
+using ::testing::NotNull;
+using ::testing::Types;
+using application_manager::commands::MessageSharedPtr;
+using ::test::components::event_engine_test::MockEventDispatcher;
+using ::test::components::application_manager_test::MockApplicationManager;
+using ::test::components::application_manager_test::
+    MockApplicationManagerSettings;
+using ::application_manager::ApplicationSharedPtr;
+using ::test::components::application_manager_test::MockApplication;
+
+template <class Command>
+class HMICommandsTest : public components::commands_test::CommandRequestTest<
+                            CommandsTestMocks::kIsNice> {
+ public:
+  typedef Command CommandType;
+
+  void InitCommand(const uint32_t& timeout) OVERRIDE {
+    stream_retry_.first = 0;
+    stream_retry_.second = 0;
+    EXPECT_CALL(app_mngr_settings_, default_timeout())
+        .WillOnce(ReturnRef(timeout));
+    ON_CALL(app_mngr_, event_dispatcher())
+        .WillByDefault(ReturnRef(event_dispatcher_));
+    ON_CALL(app_mngr_, get_settings())
+        .WillByDefault(ReturnRef(app_mngr_settings_));
+    ON_CALL(app_mngr_settings_, start_stream_retry_amount())
+        .WillByDefault(ReturnRef(stream_retry_));
+  }
+
+ protected:
+  std::pair<uint32_t, int32_t> stream_retry_;
+};
+
+template <class Command>
+class HMICommandsTestFirst : public HMICommandsTest<Command> {
+ public:
+  using typename HMICommandsTest<Command>::CommandType;
+};
+
+/* macro TYPED_TEST_CASE takes max 50 args. That is why there are few
+ * TYPED_TEST_CASE for HMI and mobile commands
+ */
+
+typedef Types<commands::ASAppServiceActivationRequest,
+              commands::ASAppServiceActivationResponse,
+              commands::ASGetActiveServiceConsentRequest,
+              commands::ASGetActiveServiceConsentResponse,
+              commands::ASPerformAppServiceInteractionRequestFromHMI,
+              commands::ASGetAppServiceDataRequestToHMI,
+              commands::ASGetAppServiceDataResponseFromHMI,
+              commands::ASGetAppServiceDataResponseToHMI,
+              commands::ASGetAppServiceRecordsRequest,
+              commands::ASGetAppServiceRecordsResponse,
+              commands::ASPerformAppServiceInteractionRequestFromHMI,
+              commands::ASPerformAppServiceInteractionRequestToHMI,
+              commands::ASPerformAppServiceInteractionResponseFromHMI,
+              commands::ASPerformAppServiceInteractionResponseToHMI,
+              commands::ASPublishAppServiceRequest,
+              commands::ASPublishAppServiceResponse,
+              commands::OnASAppServiceDataNotification,
+              commands::OnASAppServiceDataNotificationFromHMI>
+    HMICommandsListFirst;
+
+TYPED_TEST_CASE(HMICommandsTestFirst, HMICommandsListFirst);
+
+TYPED_TEST(HMICommandsTestFirst, CtorAndDtorCall) {
+  std::shared_ptr<typename TestFixture::CommandType> command =
+      this->template CreateCommand<typename TestFixture::CommandType>();
+  UNUSED(command);
+}
+
+}  // namespace dummy_hmi_commands_test
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/commands/hmi/dummy_hmi_commands_test.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/commands/hmi/dummy_hmi_commands_test.cc
@@ -141,7 +141,7 @@ TYPED_TEST_CASE(HMICommandsTestFirst, HMICommandsListFirst);
 TYPED_TEST(HMICommandsTestFirst, CtorAndDtorCall) {
   std::shared_ptr<typename TestFixture::CommandType> command =
       this->template CreateCommand<typename TestFixture::CommandType>();
-  UNUSED(command);
+  EXPECT_NE(command.use_count(), 0);
 }
 
 }  // namespace dummy_hmi_commands_test

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/commands/mobile/dummy_mobile_commands_test.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/commands/mobile/dummy_mobile_commands_test.cc
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2018, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/commands/command_request_test.h"
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+
+#include "mobile/get_app_service_data_request.h"
+#include "mobile/get_app_service_data_request_to_mobile.h"
+#include "mobile/get_app_service_data_response.h"
+#include "mobile/get_app_service_data_response_from_mobile.h"
+#include "mobile/on_app_service_data_notification.h"
+#include "mobile/on_app_service_data_notification_from_mobile.h"
+#include "mobile/perform_app_service_interaction_request.h"
+#include "mobile/perform_app_service_interaction_request_to_mobile.h"
+#include "mobile/perform_app_service_interaction_response.h"
+#include "mobile/perform_app_service_interaction_response_from_mobile.h"
+#include "mobile/publish_app_service_request.h"
+#include "mobile/publish_app_service_response.h"
+
+#include "application_manager/mock_application.h"
+#include "application_manager/mock_application_manager.h"
+#include "test/application_manager/mock_application_manager_settings.h"
+#include "application_manager/mock_event_dispatcher.h"
+
+namespace am = application_manager;
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+namespace dummy_mobile_commands_test {
+
+namespace commands = app_service_rpc_plugin::commands;
+using ::testing::_;
+using ::testing::NotNull;
+using ::testing::Types;
+using am::commands::MessageSharedPtr;
+using ::test::components::event_engine_test::MockEventDispatcher;
+using ::test::components::application_manager_test::MockApplicationManager;
+using ::test::components::application_manager_test::
+    MockApplicationManagerSettings;
+using ::application_manager::ApplicationSharedPtr;
+using ::test::components::application_manager_test::MockApplication;
+
+namespace {
+const std::string kEmptyString_ = "";
+}  // namespace
+
+template <class Command>
+class MobileCommandsTest : public components::commands_test::CommandRequestTest<
+                               CommandsTestMocks::kIsNice> {
+ public:
+  typedef Command CommandType;
+
+  void InitCommand(const uint32_t& timeout) OVERRIDE {
+    EXPECT_CALL(app_mngr_settings_, default_timeout())
+        .WillOnce(ReturnRef(timeout));
+    ON_CALL(app_mngr_, event_dispatcher())
+        .WillByDefault(ReturnRef(event_dispatcher_));
+    ON_CALL(app_mngr_, get_settings())
+        .WillByDefault(ReturnRef(app_mngr_settings_));
+    ON_CALL(app_mngr_settings_, app_icons_folder())
+        .WillByDefault(ReturnRef(kEmptyString_));
+  }
+};
+
+template <class Command>
+class MobileCommandsTestFirst : public MobileCommandsTest<Command> {
+ public:
+  using typename MobileCommandsTest<Command>::CommandType;
+};
+
+/* macro TYPED_TEST_CASE takes max 50 args. That is why there are few
+ * TYPED_TEST_CASE for HMI and mobile commands
+ */
+
+typedef Types<commands::GetAppServiceDataRequest,
+              commands::GetAppServiceDataRequestToMobile,
+              commands::GetAppServiceDataResponse,
+              commands::GetAppServiceDataResponseFromMobile,
+              commands::OnAppServiceDataNotification,
+              commands::OnAppServiceDataNotificationFromMobile,
+              commands::PerformAppServiceInteractionRequest,
+              commands::PerformAppServiceInteractionRequestToMobile,
+              commands::PerformAppServiceInteractionResponse,
+              commands::PerformAppServiceInteractionResponseFromMobile,
+              commands::PublishAppServiceRequest,
+              commands::PublishAppServiceResponse> MobileCommandsListFirst;
+
+TYPED_TEST_CASE(MobileCommandsTestFirst, MobileCommandsListFirst);
+
+TYPED_TEST(MobileCommandsTestFirst, CtorAndDtorCall) {
+  std::shared_ptr<typename TestFixture::CommandType> command =
+      this->template CreateCommand<typename TestFixture::CommandType>();
+  UNUSED(command);
+}
+
+}  // namespace dummy_mobile_commands_test
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/commands/mobile/dummy_mobile_commands_test.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/commands/mobile/dummy_mobile_commands_test.cc
@@ -125,7 +125,7 @@ TYPED_TEST_CASE(MobileCommandsTestFirst, MobileCommandsListFirst);
 TYPED_TEST(MobileCommandsTestFirst, CtorAndDtorCall) {
   std::shared_ptr<typename TestFixture::CommandType> command =
       this->template CreateCommand<typename TestFixture::CommandType>();
-  UNUSED(command);
+  EXPECT_NE(command.use_count(), 0);
 }
 
 }  // namespace dummy_mobile_commands_test

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/dummy_hmi_commands_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/dummy_hmi_commands_test.cc
@@ -223,6 +223,8 @@
 #include "hmi/on_tts_reset_timeout_notification.h"
 #include "hmi/dial_number_request.h"
 #include "hmi/dial_number_response.h"
+#include "hmi/bc_get_file_path_request.h"
+#include "hmi/bc_get_file_path_response.h"
 
 #include "application_manager/commands/commands_test.h"
 #include "application_manager/mock_application.h"
@@ -496,7 +498,9 @@ typedef Types<commands::hmi::OnButtonEventNotification,
 typedef Types<commands::AllowAllAppsRequest,
               commands::AllowAllAppsResponse,
               commands::AllowAppRequest,
-              commands::AllowAppResponse> HMICommandsListFifth;
+              commands::AllowAppResponse,
+              commands::BCGetFilePathRequest,
+              commands::BCGetFilePathResponse> HMICommandsListFifth;
 
 TYPED_TEST_CASE(HMICommandsTestFirst, HMICommandsListFirst);
 TYPED_TEST_CASE(HMICommandsTestSecond, HMICommandsListSecond);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/dummy_hmi_commands_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/dummy_hmi_commands_test.cc
@@ -511,30 +511,30 @@ TYPED_TEST_CASE(HMICommandsTestFifth, HMICommandsListFifth);
 TYPED_TEST(HMICommandsTestFirst, CtorAndDtorCall) {
   std::shared_ptr<typename TestFixture::CommandType> command =
       this->template CreateCommand<typename TestFixture::CommandType>();
-  UNUSED(command);
+  EXPECT_NE(command.use_count(), 0);
 }
 
 TYPED_TEST(HMICommandsTestSecond, CtorAndDtorCall) {
   std::shared_ptr<typename TestFixture::CommandType> command =
       this->template CreateCommand<typename TestFixture::CommandType>();
-  UNUSED(command);
+  EXPECT_NE(command.use_count(), 0);
 }
 TYPED_TEST(HMICommandsTestThird, CtorAndDtorCall) {
   std::shared_ptr<typename TestFixture::CommandType> command =
       this->template CreateCommand<typename TestFixture::CommandType>();
-  UNUSED(command);
+  EXPECT_NE(command.use_count(), 0);
 }
 
 TYPED_TEST(HMICommandsTestFourth, CtorAndDtorCall) {
   std::shared_ptr<typename TestFixture::CommandType> command =
       this->template CreateCommand<typename TestFixture::CommandType>();
-  UNUSED(command);
+  EXPECT_NE(command.use_count(), 0);
 }
 
 TYPED_TEST(HMICommandsTestFifth, CtorAndDtorCall) {
   std::shared_ptr<typename TestFixture::CommandType> command =
       this->template CreateCommand<typename TestFixture::CommandType>();
-  UNUSED(command);
+  EXPECT_NE(command.use_count(), 0);
 }
 
 }  // namespace dummy_hmi_commands_test

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/dummy_mobile_commands_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/dummy_mobile_commands_test.cc
@@ -62,6 +62,8 @@
 #include "mobile/end_audio_pass_thru_request.h"
 #include "mobile/end_audio_pass_thru_response.h"
 #include "mobile/generic_response.h"
+#include "mobile/get_file_request.h"
+#include "mobile/get_file_response.h"
 #include "mobile/get_way_points_request.h"
 #include "mobile/get_way_points_response.h"
 #include "mobile/list_files_request.h"
@@ -78,6 +80,7 @@
 #include "mobile/on_keyboard_input_notification.h"
 #include "mobile/on_language_change_notification.h"
 #include "mobile/on_permissions_change_notification.h"
+#include "mobile/on_system_capability_updated_notification.h"
 #include "mobile/on_system_request_notification.h"
 #include "mobile/on_tbt_client_state_notification.h"
 #include "mobile/on_touch_event_notification.h"
@@ -220,6 +223,8 @@ typedef Types<commands::AddCommandRequest,
               commands::EndAudioPassThruRequest,
               commands::EndAudioPassThruResponse,
               commands::GenericResponse,
+              commands::GetFileRequest,
+              commands::GetFileResponse,
               commands::GetWayPointsRequest,
               commands::GetWayPointsResponse,
               commands::ListFilesRequest,
@@ -236,12 +241,13 @@ typedef Types<commands::AddCommandRequest,
               commands::mobile::OnKeyBoardInputNotification,
               commands::OnLanguageChangeNotification,
               commands::OnPermissionsChangeNotification,
-              commands::mobile::OnSystemRequestNotification,
-              commands::OnTBTClientStateNotification,
-              commands::mobile::OnTouchEventNotification>
+              commands::mobile::OnSystemCapabilityUpdatedNotification>
     MobileCommandsListFirst;
 
-typedef Types<commands::OnWayPointChangeNotification,
+typedef Types<commands::mobile::OnSystemRequestNotification,
+              commands::OnTBTClientStateNotification,
+              commands::mobile::OnTouchEventNotification,
+              commands::OnWayPointChangeNotification,
               commands::PerformAudioPassThruRequest,
               commands::PerformAudioPassThruResponse,
               commands::PerformInteractionRequest,
@@ -277,12 +283,12 @@ typedef Types<commands::OnWayPointChangeNotification,
               commands::SubscribeWayPointsRequest,
               commands::SubscribeWayPointsResponse,
               commands::SystemResponse,
-              commands::UnregisterAppInterfaceRequest,
-              commands::UnregisterAppInterfaceResponse,
-              commands::UnsubscribeButtonRequest,
-              commands::UnsubscribeButtonResponse> MobileCommandsListSecond;
+              commands::UnregisterAppInterfaceRequest> MobileCommandsListSecond;
 
-typedef Types<commands::UnsubscribeWayPointsRequest,
+typedef Types<commands::UnregisterAppInterfaceResponse,
+              commands::UnsubscribeButtonRequest,
+              commands::UnsubscribeButtonResponse,
+              commands::UnsubscribeWayPointsRequest,
               commands::UnsubscribeWayPointsResponse,
               commands::UpdateTurnListRequest,
               commands::UpdateTurnListResponse> MobileCommandsListThird;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/dummy_mobile_commands_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/dummy_mobile_commands_test.cc
@@ -300,18 +300,18 @@ TYPED_TEST_CASE(MobileCommandsTestThird, MobileCommandsListThird);
 TYPED_TEST(MobileCommandsTestFirst, CtorAndDtorCall) {
   std::shared_ptr<typename TestFixture::CommandType> command =
       this->template CreateCommand<typename TestFixture::CommandType>();
-  UNUSED(command);
+  EXPECT_NE(command.use_count(), 0);
 }
 
 TYPED_TEST(MobileCommandsTestSecond, CtorAndDtorCall) {
   std::shared_ptr<typename TestFixture::CommandType> command =
       this->template CreateCommand<typename TestFixture::CommandType>();
-  UNUSED(command);
+  EXPECT_NE(command.use_count(), 0);
 }
 TYPED_TEST(MobileCommandsTestThird, CtorAndDtorCall) {
   std::shared_ptr<typename TestFixture::CommandType> command =
       this->template CreateCommand<typename TestFixture::CommandType>();
-  UNUSED(command);
+  EXPECT_NE(command.use_count(), 0);
 }
 
 }  // namespace dummy_mobile_commands_test


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Created command tests for `app_service_rpc_plugin` and added other App Service related RPCs(`GetFile`, `OnSystemCapabilityUpdated`) to existing command tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)