### PR TITLE
Fix Cloud App Memory Leak

### DIFF
--- a/src/components/transport_manager/src/cloud/websocket_client_connection.cc
+++ b/src/components/transport_manager/src/cloud/websocket_client_connection.cc
@@ -267,6 +267,7 @@ void WebsocketClientConnection::Shutdown() {
     thread_delegate_->SetShutdown();
     write_thread_->join();
     delete thread_delegate_;
+    threads::DeleteThread(write_thread_);
   }
   if (buffer_.size()) {
     buffer_.consume(buffer_.size());

--- a/src/components/transport_manager/src/cloud/websocket_client_connection.cc
+++ b/src/components/transport_manager/src/cloud/websocket_client_connection.cc
@@ -267,7 +267,9 @@ void WebsocketClientConnection::Shutdown() {
     thread_delegate_->SetShutdown();
     write_thread_->join();
     delete thread_delegate_;
+    thread_delegate_ = NULL;
     threads::DeleteThread(write_thread_);
+    write_thread_ = NULL;
   }
   if (buffer_.size()) {
     buffer_.consume(buffer_.size());


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run Core with valgrind
```
valgrind --leak-check=yes --track-origins=yes --log-file="valgrind.txt" ./smartDeviceLinkCore
```
Connect cloud app. Disconnect Cloud App. Shutdown Core.
Check output for not cloud app transport related memory leaks.

### Summary
Add DeleteThread() call to web socket transport destructor. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)