### PR TITLE
Remove pending cloud apps at shutdown

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -933,6 +933,9 @@ void ApplicationManagerImpl::DisconnectCloudApp(ApplicationSharedPtr app) {
 
 void ApplicationManagerImpl::RefreshCloudAppInformation() {
   LOG4CXX_AUTO_TRACE(logger_);
+  if (is_stopping()) {
+    return;
+  }
   std::vector<std::string> enabled_apps;
   GetPolicyHandler().GetEnabledCloudApps(enabled_apps);
   std::vector<std::string>::iterator enabled_it = enabled_apps.begin();
@@ -2824,6 +2827,21 @@ void ApplicationManagerImpl::UnregisterAllApplications() {
       it = accessor.GetData().begin();
     }
   }
+
+  bool send_pending_update_app_list = false;
+  {
+    sync_primitives::AutoLock auto_lock(apps_to_register_list_lock_ptr_);
+    if (!apps_to_register_.empty()) {
+      send_pending_update_app_list = true;
+      apps_to_register_.clear();
+    }
+  }
+
+  // Only send update app list if pending apps were removed.
+  if (send_pending_update_app_list) {
+    SendUpdateAppList();
+  }
+
   if (is_ignition_off) {
     resume_controller().OnIgnitionOff();
   }


### PR DESCRIPTION
This PR is **Ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Add cloud app to preloaded policy table.
- Start Core
- Shutdown core
- Verify UpdateAppList sent to hmi with empty applications array

### Summary
Stops core from refreshing cloud apps during shutdown after unregistering cloud applications. Also removes pending cloud apps from apps_to_register_ and triggers an update app list if pending apps were present. This ensures the HMI is not left with applications in its app list after shutdown.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)