### PR TITLE
Send Invalid ID on duplicate correlation_id

### DIFF
--- a/src/components/application_manager/include/application_manager/rpc_passing_handler.h
+++ b/src/components/application_manager/include/application_manager/rpc_passing_handler.h
@@ -82,7 +82,7 @@ class RPCPassingHandler {
    * @brief Function to handle sending and receiving RPC Passing
    * requests/responses
    * @param rpc_message RPC message SmartObject
-   * @return true if the request was forwarded, false otherwise
+   * @return true if the request was handled, false otherwise
    */
   bool RPCPassThrough(smart_objects::SmartObject rpc_message);
 


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Send a duplicate message with same correlation id for RPC that is meant to be an app service pass through.

ie Send 2 ButtonPress requests in a row. 

### Summary
Changes the return value meaning for RPCPassThrough. If true, that means the RPC was handled even if it was an invalid message. The case is handled where a duplicate correlation id is detected. Core will respond with INVALID_ID in this case.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)