### PR TITLE
Change is_foreground() usages to IsFullscreen()

### DIFF
--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/perform_app_service_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/perform_app_service_interaction_request.cc
@@ -95,7 +95,7 @@ void PerformAppServiceInteractionRequest::Run() {
   bool activate_service = request_service_active &&
                           !service->record[strings::service_active].asBool();
   if (activate_service) {
-    if (app->is_foreground()) {
+    if (app->IsFullscreen()) {
       // App is in foreground, we can just activate the service
       application_manager_.GetAppServiceManager().ActivateAppService(
           service_id);

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/publish_app_service_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/publish_app_service_request.cc
@@ -111,7 +111,7 @@ void PublishAppServiceRequest::Run() {
   smart_objects::SmartObject service_record =
       application_manager_.GetAppServiceManager().PublishAppService(
           manifest, true, connection_key());
-  if (app->is_foreground()) {
+  if (app->IsFullscreen()) {
     // Service should be activated if app is in the foreground
     application_manager_.GetAppServiceManager().ActivateAppService(
         service_record[strings::service_id].asString());


### PR DESCRIPTION

Fixes issue in #2806 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
`app.is_foreground()` was used several places to check if an application was active, but this function does not appear to work as intended, so this PR changes these calls to `app.IsFullscreen()`

### Changelog
##### Bug Fixes
* Changed improper usages of `is_foreground()`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)