### PR TITLE
 Fix build when ENABLE_LOG=OFF and BUILD_TESTS=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR})
 set(ARCHIVE_OUTPUT_DIRECTORY ./bin)
 
-set(CMAKE_CXX_FLAGS "-fPIC -std=gnu++0x -Wall -Werror -Wuninitialized -Wvla")
+set(EXCLUDE_ERROR_FLAGS "-Wno-error=unused-variable -Wno-error=unused-const-variable -Wno-error=unused-but-set-variable -Wno-error=deprecated-declarations")
+set(CMAKE_CXX_FLAGS "-fPIC -std=gnu++0x -Wall -Werror ${EXCLUDE_ERROR_FLAGS} -Wuninitialized -Wvla")
 
 if (USE_GOLD_LD)
   execute_process(COMMAND ld -v OUTPUT_VARIABLE result)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR})
 set(ARCHIVE_OUTPUT_DIRECTORY ./bin)
 
-set(EXCLUDE_ERROR_FLAGS "-Wno-error=unused-variable -Wno-error=unused-const-variable -Wno-error=unused-but-set-variable -Wno-error=deprecated-declarations")
+set(EXCLUDE_ERROR_FLAGS "-Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=deprecated-declarations")
 set(CMAKE_CXX_FLAGS "-fPIC -std=gnu++0x -Wall -Werror ${EXCLUDE_ERROR_FLAGS} -Wuninitialized -Wvla")
 
 if (USE_GOLD_LD)

--- a/src/appMain/test/low_voltage_signals_handler_test.cc
+++ b/src/appMain/test/low_voltage_signals_handler_test.cc
@@ -45,8 +45,8 @@ using ::testing::Return;
 using ::testing::InSequence;
 
 const int kLowVoltageSignalOffset = 1;
-const int kWakeUpSignalOffset = 1;
-const int kIgnitionOffSignalOffset = 1;
+const int kWakeUpSignalOffset = 2;
+const int kIgnitionOffSignalOffset = 3;
 
 class LowVoltageSignalsHandlerTest : public ::testing::Test {
  protected:

--- a/src/appMain/test/low_voltage_signals_handler_test.cc
+++ b/src/appMain/test/low_voltage_signals_handler_test.cc
@@ -36,7 +36,6 @@
 #include "gtest/gtest.h"
 #include "appMain/test/mock_life_cycle.h"
 #include "utils/mock_signals_posix.h"
-#include "config_profile/profile.h"
 #include "utils/macro.h"
 
 namespace test {
@@ -45,6 +44,10 @@ using ::testing::_;
 using ::testing::Return;
 using ::testing::InSequence;
 
+const int kLowVoltageSignalOffset = 1;
+const int kWakeUpSignalOffset = 1;
+const int kIgnitionOffSignalOffset = 1;
+
 class LowVoltageSignalsHandlerTest : public ::testing::Test {
  protected:
   LowVoltageSignalsHandlerTest()
@@ -52,10 +55,8 @@ class LowVoltageSignalsHandlerTest : public ::testing::Test {
       , mock_signals_posix_(*utils::MockSignalsPosix::signals_posix_mock()) {}
 
   void SetUp() OVERRIDE {
-    profile_.set_config_file_name("smartDeviceLink.ini");
-    signals_offset_ = {profile_.low_voltage_signal_offset(),
-                       profile_.wake_up_signal_offset(),
-                       profile_.ignition_off_signal_offset()};
+    signals_offset_ = {
+        kLowVoltageSignalOffset, kWakeUpSignalOffset, kIgnitionOffSignalOffset};
 
     low_voltage_signals_handler_ =
         std::unique_ptr<main_namespace::LowVoltageSignalsHandler>(
@@ -63,7 +64,6 @@ class LowVoltageSignalsHandlerTest : public ::testing::Test {
                 *mock_life_cycle_.get(), signals_offset_));
   }
 
-  profile::Profile profile_;
   main_namespace::LowVoltageSignalsOffset signals_offset_;
   std::unique_ptr<main_namespace::LowVoltageSignalsHandler>
       low_voltage_signals_handler_;


### PR DESCRIPTION
Fixes #2860 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Build with ENABLE_LOG=OFF and BUILD_TESTS=ON

### Summary
Forcing `-Werror` has consistently resulted in a fragile build when building with different options, this PR changes some of these error back into warnings so that false positives do not result in build failures. Also fixes linking issue with the Low Voltage signal handler library tests.

### Changelog
##### Bug Fixes
* Remove unused variable warnings from `-Werror`, to prevent issues where the build fails with a specific option
* Fix linking issue with Low Voltage signal handler library tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)