### PR TITLE
HMI.UnsubscribeWayPoints logic fix

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_way_points_request.cc
@@ -71,9 +71,20 @@ void UnsubscribeWayPointsRequest::Run() {
     return;
   }
 
-  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
-  SendHMIRequest(
-      hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints, NULL, true);
+  std::set<uint32_t> subscribed_apps =
+      application_manager_.GetAppsSubscribedForWayPoints();
+
+  if (subscribed_apps.size() > 1) {
+    // More than 1 subscribed app, don't send HMI unsubscribe request
+    application_manager_.UnsubscribeAppFromWayPoints(app);
+    SendResponse(true, mobile_apis::Result::SUCCESS, NULL);
+    return;
+  } else {
+    // Only subscribed app, send HMI unsubscribe request
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
+    SendHMIRequest(
+        hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints, NULL, true);
+  }
 }
 
 void UnsubscribeWayPointsRequest::on_event(const event_engine::Event& event) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/unsubscribe_way_points_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/unsubscribe_way_points_request_test.cc
@@ -122,6 +122,11 @@ TEST_F(UnsubscribeWayPointsRequestTest, Run_AppSubscribedForWayPoints_SUCCESS) {
                   ::testing::Matcher<am::ApplicationSharedPtr>(mock_app)))
       .WillOnce(Return(true));
 
+  const std::set<uint32_t> subscribed_apps{kConnectionKey};
+
+  EXPECT_CALL(app_mngr_, GetAppsSubscribedForWayPoints())
+      .WillOnce(Return(subscribed_apps));
+
   EXPECT_CALL(mock_rpc_service_,
               ManageHMICommand(
                   HMIResultCodeIs(


### PR DESCRIPTION
Fixes #2862 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Connect two apps and subscribe way points.
- Unsubscribe app1 from waypoints. Expect mobile success. No message sent to HMI
- Unsubscribe app2 from waypoints. Expect mobile success. Expect Unsubscribe sent to HMI

### Summary
Only send HMI UnsubscribeWayPoints if the app unsubscribing is the only app left with a way points subscription.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)