### PR TITLE
Add timeout logic for HMI App Service Consumer RPCs

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/request_from_hmi.h
+++ b/src/components/application_manager/include/application_manager/commands/request_from_hmi.h
@@ -61,6 +61,8 @@ class RequestFromHMI : public CommandImpl, public event_engine::EventObserver {
    * @param correlation_id the correlation id for the rfesponse.
    * @param function_id the function id for which response will be sent
    * @param result_code the result code.
+   * @param response_params extra response params.
+   * @param source command source.
    */
   void SendResponse(
       const bool success,
@@ -76,11 +78,14 @@ class RequestFromHMI : public CommandImpl, public event_engine::EventObserver {
    * @param function_id the function id for which response will be sent
    * @param result_code the result code.
    * @param error_message info message for error.
+   * @param source command source.
    */
-  void SendErrorResponse(const uint32_t correlation_id,
-                         const hmi_apis::FunctionID::eType function_id,
-                         const hmi_apis::Common_Result::eType result_code,
-                         const std::string error_message);
+  void SendErrorResponse(
+      const uint32_t correlation_id,
+      const hmi_apis::FunctionID::eType function_id,
+      const hmi_apis::Common_Result::eType result_code,
+      const std::string error_message,
+      commands::Command::CommandSource source = commands::Command::SOURCE_HMI);
 
   void SendProviderRequest(
       const mobile_apis::FunctionID::eType& mobile_function_id,

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_get_app_service_data_request_from_hmi.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_get_app_service_data_request_from_hmi.h
@@ -69,6 +69,11 @@ class ASGetAppServiceDataRequestFromHMI
   virtual void Run();
 
   /**
+   * @brief onTimeOut from request controller
+   */
+  virtual void onTimeOut();
+
+  /**
    * @brief on_event allows to handle events
    *
    * @param event event type that current request subscribed on.

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_perform_app_service_interaction_request_from_hmi.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_perform_app_service_interaction_request_from_hmi.h
@@ -83,6 +83,11 @@ class ASPerformAppServiceInteractionRequestFromHMI
    */
   void on_event(const app_mngr::event_engine::MobileEvent& event) OVERRIDE;
 
+  /**
+   * @brief onTimeOut from request controller
+   */
+  virtual void onTimeOut();
+
  private:
   DISALLOW_COPY_AND_ASSIGN(ASPerformAppServiceInteractionRequestFromHMI);
 };

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_get_app_service_data_request_from_hmi.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_get_app_service_data_request_from_hmi.cc
@@ -110,5 +110,17 @@ void ASGetAppServiceDataRequestFromHMI::on_event(
                application_manager::commands::Command::SOURCE_SDL_TO_HMI);
 }
 
+void ASGetAppServiceDataRequestFromHMI::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  smart_objects::SmartObject response_params;
+  response_params[strings::info] =
+      "The provider did not respond to the request";
+  SendErrorResponse(correlation_id(),
+                    hmi_apis::FunctionID::AppService_GetAppServiceData,
+                    hmi_apis::Common_Result::GENERIC_ERROR,
+                    "The provider did not respond to the request",
+                    application_manager::commands::Command::SOURCE_SDL_TO_HMI);
+}
+
 }  // namespace commands
 }  // namespace app_service_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_perform_app_service_interaction_request_from_hmi.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_perform_app_service_interaction_request_from_hmi.cc
@@ -153,5 +153,18 @@ void ASPerformAppServiceInteractionRequestFromHMI::on_event(
                application_manager::commands::Command::SOURCE_SDL_TO_HMI);
 }
 
+void ASPerformAppServiceInteractionRequestFromHMI::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  smart_objects::SmartObject response_params;
+  response_params[strings::info] =
+      "The provider did not respond to the request";
+  SendErrorResponse(
+      correlation_id(),
+      hmi_apis::FunctionID::AppService_PerformAppServiceInteraction,
+      hmi_apis::Common_Result::GENERIC_ERROR,
+      "The provider did not respond to the request",
+      application_manager::commands::Command::SOURCE_SDL_TO_HMI);
+}
+
 }  // namespace commands
 }  // namespace app_service_rpc_plugin

--- a/src/components/application_manager/src/commands/request_from_hmi.cc
+++ b/src/components/application_manager/src/commands/request_from_hmi.cc
@@ -89,7 +89,7 @@ void RequestFromHMI::SendResponse(
           smart_objects::SmartType_Map);
   FillCommonParametersOfSO(*message, correlation_id, function_id);
   (*message)[strings::params][strings::message_type] = MessageType::kResponse;
-  (*message)[strings::params][hmi_response::code] = 0;
+  (*message)[strings::params][hmi_response::code] = result_code;
   (*message)[strings::msg_params][strings::success] = success;
   (*message)[strings::msg_params][strings::result_code] = result_code;
 
@@ -104,7 +104,8 @@ void RequestFromHMI::SendErrorResponse(
     const uint32_t correlation_id,
     const hmi_apis::FunctionID::eType function_id,
     const hmi_apis::Common_Result::eType result_code,
-    const std::string error_message) {
+    const std::string error_message,
+    commands::Command::CommandSource source) {
   smart_objects::SmartObjectSPtr message =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
@@ -114,7 +115,7 @@ void RequestFromHMI::SendErrorResponse(
   (*message)[strings::params][hmi_response::code] = result_code;
   (*message)[strings::params][strings::error_msg] = error_message;
 
-  rpc_service_.ManageHMICommand(message);
+  rpc_service_.ManageHMICommand(message, source);
 }
 
 void RequestFromHMI::FillCommonParametersOfSO(


### PR DESCRIPTION
Fixes #2866 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Run [013_H2M_GENERIC_ERROR.lua](https://github.com/smartdevicelink/sdl_core/files/3031216/013_H2M_GENERIC_ERROR.txt)

### Summary
Add missing timeout response for `GetAppServiceData` and `PerformAppServiceInteraction` HMI requests

### Changelog
##### Bug Fixes
* Add missing timeout response for `GetAppServiceData` and `PerformAppServiceInteraction` HMI requests
* Fix issue where `code` was incorrectly set in `RequestFromHMI::SendResponse`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)