### PR TITLE
Fix Icon Url Corner Cases

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
@@ -543,6 +543,7 @@ void SystemRequest::Run() {
       if (file_name.empty()) {
         const std::string err_msg = "Invalid file name";
         SendResponse(false, mobile_apis::Result::INVALID_DATA, err_msg.c_str());
+        return;
       }
       LOG4CXX_DEBUG(logger_, "Got ICON_URL Request. File name: " << file_name);
     } else {

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -74,6 +74,23 @@ void RPCHandlerImpl::ProcessMessageFromMobile(
     return;
   }
 
+  if (message->type() == application_manager::MessageType::kRequest &&
+      message->correlation_id() < 0) {
+    LOG4CXX_ERROR(logger_, "Request correlation id < 0. Returning INVALID_ID");
+    std::shared_ptr<smart_objects::SmartObject> response(
+        MessageHelper::CreateNegativeResponse(message->connection_key(),
+                                              message->function_id(),
+                                              message->correlation_id(),
+                                              mobile_apis::Result::INVALID_ID));
+    (*response)[strings::params][strings::correlation_id] =
+        message->correlation_id();
+    (*response)[strings::msg_params][strings::info] =
+        "Invalid Correlation ID for RPC Request";
+    app_manager_.GetRPCService().ManageMobileCommand(
+        response, commands::Command::SOURCE_SDL);
+    return;
+  }
+
   bool rpc_passing = app_manager_.GetAppServiceManager()
                          .GetRPCPassingHandler()
                          .CanHandleFunctionID(message->function_id());

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -80,8 +80,12 @@ void RPCHandlerImpl::ProcessMessageFromMobile(
     std::shared_ptr<smart_objects::SmartObject> response(
         MessageHelper::CreateNegativeResponse(message->connection_key(),
                                               message->function_id(),
-                                              message->correlation_id(),
+                                              0,
                                               mobile_apis::Result::INVALID_ID));
+    // CreateNegativeResponse() takes a uint32_t for correlation_id, therefore a
+    // negative number cannot be passed to that function or else it will be
+    // improperly cast. correlation_id is reassigned below to its original
+    // value.
     (*response)[strings::params][strings::correlation_id] =
         message->correlation_id();
     (*response)[strings::msg_params][strings::info] =


### PR DESCRIPTION
Fixes #2873 and #2874 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Send invalid icon file name. Only observe INVALID DATA response and no GENERIC_ERROR.
Send correlation ID -1 and observe INVALID_ID response.

### Summary
- Add missing return value after sending invalid data. 
- Checks if correlation id is valid. Otherwise sends INVALID_ID.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)