### PR TITLE
Error Response for AppService.GetAppServiceData with unknown service type/service id

### DIFF
--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_perform_app_service_interaction_request_from_hmi.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_perform_app_service_interaction_request_from_hmi.cc
@@ -63,15 +63,11 @@ void ASPerformAppServiceInteractionRequestFromHMI::Run() {
       application_manager_.get_settings().hmi_origin_id();
   if (!msg_params.keyExists(strings::origin_app)) {
     if (hmi_origin_id.empty()) {
-      smart_objects::SmartObject response_params;
-      response_params[strings::info] =
-          "No HMI origin ID to use for interaction passthrough";
-      SendResponse(
-          false,
+      SendErrorResponse(
           correlation_id(),
           hmi_apis::FunctionID::AppService_PerformAppServiceInteraction,
           hmi_apis::Common_Result::INVALID_DATA,
-          &response_params,
+          "No HMI origin ID to use for interaction passthrough",
           application_manager::commands::Command::SOURCE_SDL_TO_HMI);
       return;
     }
@@ -82,14 +78,12 @@ void ASPerformAppServiceInteractionRequestFromHMI::Run() {
   auto service =
       application_manager_.GetAppServiceManager().FindServiceByID(service_id);
   if (!service) {
-    smart_objects::SmartObject response_params;
-    response_params[strings::info] = "The requested service ID does not exist";
-    SendResponse(false,
-                 correlation_id(),
-                 hmi_apis::FunctionID::AppService_PerformAppServiceInteraction,
-                 hmi_apis::Common_Result::INVALID_ID,
-                 &response_params,
-                 application_manager::commands::Command::SOURCE_SDL_TO_HMI);
+    SendErrorResponse(
+        correlation_id(),
+        hmi_apis::FunctionID::AppService_PerformAppServiceInteraction,
+        hmi_apis::Common_Result::INVALID_ID,
+        "The requested service ID does not exist",
+        application_manager::commands::Command::SOURCE_SDL_TO_HMI);
     return;
   }
 

--- a/src/components/application_manager/src/commands/request_from_hmi.cc
+++ b/src/components/application_manager/src/commands/request_from_hmi.cc
@@ -173,16 +173,22 @@ void RequestFromHMI::SendProviderRequest(
   LOG4CXX_AUTO_TRACE(logger_);
   bool hmi_destination = false;
   ApplicationSharedPtr app;
+  std::string error_msg = "No app service provider available";
+
   if ((*msg)[strings::msg_params].keyExists(strings::service_type)) {
     std::string service_type =
         (*msg)[strings::msg_params][strings::service_type].asString();
     application_manager_.GetAppServiceManager().GetProviderByType(
         service_type, false, app, hmi_destination);
+    error_msg = "No app service provider with serviceType: " + service_type +
+                " is available";
   } else if ((*msg)[strings::msg_params].keyExists(strings::service_id)) {
     std::string service_id =
         (*msg)[strings::msg_params][strings::service_id].asString();
     application_manager_.GetAppServiceManager().GetProviderByID(
         service_id, false, app, hmi_destination);
+    error_msg = "No app service provider with serviceId: " + service_id +
+                " is available";
   }
 
   if (hmi_destination) {
@@ -196,6 +202,11 @@ void RequestFromHMI::SendProviderRequest(
 
   if (!app) {
     LOG4CXX_DEBUG(logger_, "Invalid App Provider pointer");
+    SendErrorResponse(correlation_id(),
+                      static_cast<hmi_apis::FunctionID::eType>(function_id()),
+                      hmi_apis::Common_Result::DATA_NOT_AVAILABLE,
+                      error_msg,
+                      commands::Command::CommandSource::SOURCE_SDL_TO_HMI);
     return;
   }
 

--- a/src/components/application_manager/src/commands/request_from_hmi.cc
+++ b/src/components/application_manager/src/commands/request_from_hmi.cc
@@ -173,7 +173,10 @@ void RequestFromHMI::SendProviderRequest(
   LOG4CXX_AUTO_TRACE(logger_);
   bool hmi_destination = false;
   ApplicationSharedPtr app;
+  // Default error code and error message
   std::string error_msg = "No app service provider available";
+  hmi_apis::Common_Result::eType error_code =
+      hmi_apis::Common_Result::DATA_NOT_AVAILABLE;
 
   if ((*msg)[strings::msg_params].keyExists(strings::service_type)) {
     std::string service_type =
@@ -182,6 +185,7 @@ void RequestFromHMI::SendProviderRequest(
         service_type, false, app, hmi_destination);
     error_msg = "No app service provider with serviceType: " + service_type +
                 " is available";
+    error_code = hmi_apis::Common_Result::DATA_NOT_AVAILABLE;
   } else if ((*msg)[strings::msg_params].keyExists(strings::service_id)) {
     std::string service_id =
         (*msg)[strings::msg_params][strings::service_id].asString();
@@ -189,6 +193,7 @@ void RequestFromHMI::SendProviderRequest(
         service_id, false, app, hmi_destination);
     error_msg = "No app service provider with serviceId: " + service_id +
                 " is available";
+    error_code = hmi_apis::Common_Result::INVALID_ID;
   }
 
   if (hmi_destination) {
@@ -204,7 +209,7 @@ void RequestFromHMI::SendProviderRequest(
     LOG4CXX_DEBUG(logger_, "Invalid App Provider pointer");
     SendErrorResponse(correlation_id(),
                       static_cast<hmi_apis::FunctionID::eType>(function_id()),
-                      hmi_apis::Common_Result::DATA_NOT_AVAILABLE,
+                      error_code,
                       error_msg,
                       commands::Command::CommandSource::SOURCE_SDL_TO_HMI);
     return;


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Create ATF test with HMI sending GetAppServiceData with unknown service type/service id

### Summary
At the moment, if the HMI sends a `AppService.GetAppServiceData` request with an unknown service type/service id core does not respond and the request times out. This fix adds an error response for this case

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)