### PR TITLE
App Services Allow Unknown RPC Passthrough

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -474,6 +474,14 @@ class PolicyHandler : public PolicyHandlerInterface,
       const std::string& requested_service_type,
       smart_objects::SmartArray* requested_handled_rpcs) const OVERRIDE;
 
+  /**
+   * @brief Check if an app can send unknown rpc requests to an app service
+   * provider
+   * @param policy_app_id Unique application id
+  */
+  bool UnknownRPCPassThroughAllowed(
+      const std::string& policy_app_id) const OVERRIDE;
+
   virtual void OnUpdateHMIAppType(
       std::map<std::string, StringArray> app_hmi_types) OVERRIDE;
 

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -479,7 +479,7 @@ class PolicyHandler : public PolicyHandlerInterface,
    * provider
    * @param policy_app_id Unique application id
   */
-  bool UnknownRPCPassThroughAllowed(
+  bool UnknownRPCPassthroughAllowed(
       const std::string& policy_app_id) const OVERRIDE;
 
   virtual void OnUpdateHMIAppType(

--- a/src/components/application_manager/include/application_manager/rpc_passing_handler.h
+++ b/src/components/application_manager/include/application_manager/rpc_passing_handler.h
@@ -104,6 +104,9 @@ class RPCPassingHandler {
   void ForwardResponseToMobile(uint32_t correlation_id,
                                smart_objects::SmartObject response_message);
   void PopulateRPCRequestQueue(smart_objects::SmartObject request_message);
+  bool ExtractRPCParams(const smart_objects::SmartObject& s_map,
+                        const ApplicationSharedPtr app,
+                        const std::string& function_id_str);
 
   AppServiceManager& app_service_manager_;
   ApplicationManager& app_manager_;

--- a/src/components/application_manager/include/application_manager/rpc_passing_handler.h
+++ b/src/components/application_manager/include/application_manager/rpc_passing_handler.h
@@ -83,7 +83,7 @@ class RPCPassingHandler {
    * @return true if the request is allowed to be passed through, false
    * otherwise
    */
-  bool IsPassThroughAllowed(smart_objects::SmartObject rpc_message);
+  bool IsPassthroughAllowed(smart_objects::SmartObject rpc_message);
 
   /**
    * @brief Function to handle sending and receiving RPC Passing

--- a/src/components/application_manager/include/application_manager/rpc_passing_handler.h
+++ b/src/components/application_manager/include/application_manager/rpc_passing_handler.h
@@ -77,6 +77,13 @@ class RPCPassingHandler {
   bool IsPassThroughMessage(uint32_t correlation_id,
                             commands::Command::CommandSource source,
                             int32_t message_type);
+  /**
+   * @brief Check if passthrough is allowed by policies for a given message
+   * @param rpc_message RPC message SmartObject
+   * @return true if the request is allowed to be passed through, false
+   * otherwise
+   */
+  bool IsPassThroughAllowed(smart_objects::SmartObject rpc_message);
 
   /**
    * @brief Function to handle sending and receiving RPC Passing

--- a/src/components/application_manager/include/application_manager/rpc_service_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_service_impl.h
@@ -135,6 +135,9 @@ class RPCServiceImpl : public RPCService,
                           const bool allow_unknown_parameters = false);
   hmi_apis::HMI_API& hmi_so_factory();
   mobile_apis::MOBILE_API& mobile_so_factory();
+  void CheckSourceForUnsupportedRequest(
+      const commands::MessageSharedPtr message,
+      commands::Command::CommandSource source);
 
   ApplicationManager& app_manager_;
   request_controller::RequestController& request_ctrl_;

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -2055,11 +2055,11 @@ bool PolicyHandler::CheckAppServiceParameters(
   return true;
 }
 
-bool PolicyHandler::UnknownRPCPassThroughAllowed(
+bool PolicyHandler::UnknownRPCPassthroughAllowed(
     const std::string& policy_app_id) const {
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK(false);
-  return policy_manager_->UnknownRPCPassThroughAllowed(policy_app_id);
+  return policy_manager_->UnknownRPCPassthroughAllowed(policy_app_id);
 }
 
 uint32_t PolicyHandler::HeartBeatTimeout(const std::string& app_id) const {

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -2055,6 +2055,13 @@ bool PolicyHandler::CheckAppServiceParameters(
   return true;
 }
 
+bool PolicyHandler::UnknownRPCPassThroughAllowed(
+    const std::string& policy_app_id) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  POLICY_LIB_CHECK(false);
+  return policy_manager_->UnknownRPCPassThroughAllowed(policy_app_id);
+}
+
 uint32_t PolicyHandler::HeartBeatTimeout(const std::string& app_id) const {
   POLICY_LIB_CHECK(0);
   return policy_manager_->HeartBeatTimeout(app_id);

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -122,7 +122,7 @@ void RPCHandlerImpl::ProcessMessageFromMobile(
         app_manager_.GetAppServiceManager().GetRPCPassingHandler();
     // Check permissions for requests, otherwise attempt passthrough
     if ((application_manager::MessageType::kRequest != message_type ||
-         handler.IsPassThroughAllowed(*so_from_mobile)) &&
+         handler.IsPassthroughAllowed(*so_from_mobile)) &&
         handler.RPCPassThrough(*so_from_mobile)) {
       // RPC was forwarded. Skip handling by Core
       return;

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -118,16 +118,17 @@ void RPCHandlerImpl::ProcessMessageFromMobile(
         (*so_from_mobile)[strings::params][strings::correlation_id].asUInt();
     int32_t message_type =
         (*so_from_mobile)[strings::params][strings::message_type].asInt();
-    if (app_manager_.GetAppServiceManager()
-            .GetRPCPassingHandler()
-            .RPCPassThrough(*so_from_mobile)) {
+    RPCPassingHandler& handler =
+        app_manager_.GetAppServiceManager().GetRPCPassingHandler();
+    // Check permissions for requests, otherwise attempt passthrough
+    if ((application_manager::MessageType::kRequest != message_type ||
+         handler.IsPassThroughAllowed(*so_from_mobile)) &&
+        handler.RPCPassThrough(*so_from_mobile)) {
       // RPC was forwarded. Skip handling by Core
       return;
-    } else if (!app_manager_.GetAppServiceManager()
-                    .GetRPCPassingHandler()
-                    .IsPassThroughMessage(correlation_id,
-                                          commands::Command::SOURCE_MOBILE,
-                                          message_type)) {
+    } else if (!handler.IsPassThroughMessage(correlation_id,
+                                             commands::Command::SOURCE_MOBILE,
+                                             message_type)) {
       // Since PassThrough failed, refiltering the message
       if (!ConvertMessageToSO(*message, *so_from_mobile)) {
         LOG4CXX_ERROR(logger_, "Cannot create smart object from message");

--- a/src/components/application_manager/src/rpc_passing_handler.cc
+++ b/src/components/application_manager/src/rpc_passing_handler.cc
@@ -93,7 +93,7 @@ bool RPCPassingHandler::CanHandleFunctionID(int32_t function_id) {
   return false;
 }
 
-bool RPCPassingHandler::IsPassThroughAllowed(
+bool RPCPassingHandler::IsPassthroughAllowed(
     smart_objects::SmartObject rpc_message) {
   LOG4CXX_AUTO_TRACE(logger_);
   mobile_api::FunctionID::eType function_id =
@@ -136,7 +136,7 @@ bool RPCPassingHandler::IsPassThroughAllowed(
   mobile_apis::Result::eType check_result = app_manager_.CheckPolicyPermissions(
       app, function_id_str, params, &parameters_permissions);
 
-  // Check, if RPC is allowed by policy (since we are allowing unknown params,
+  // Check if RPC is allowed by policy (since we are allowing unknown params,
   // check should pass if only undefined parameters exist)
   if (mobile_apis::Result::DISALLOWED == check_result &&
       !parameters_permissions.undefined_params.empty() &&

--- a/src/components/application_manager/src/rpc_passing_handler.cc
+++ b/src/components/application_manager/src/rpc_passing_handler.cc
@@ -101,10 +101,7 @@ bool RPCPassingHandler::ExtractRPCParams(
   RPCParams params;
 
   if (smart_objects::SmartType_Map == s_map.getType()) {
-    smart_objects::SmartMap::const_iterator iter = s_map.map_begin();
-    smart_objects::SmartMap::const_iterator iter_end = s_map.map_end();
-
-    for (; iter != iter_end; ++iter) {
+    for (auto iter = s_map.map_begin(); iter != s_map.map_end(); ++iter) {
       LOG4CXX_DEBUG(logger_, "Request's param: " << iter->first);
       params.insert(iter->first);
     }

--- a/src/components/application_manager/src/rpc_passing_handler.cc
+++ b/src/components/application_manager/src/rpc_passing_handler.cc
@@ -93,6 +93,63 @@ bool RPCPassingHandler::CanHandleFunctionID(int32_t function_id) {
   return false;
 }
 
+bool RPCPassingHandler::IsPassThroughAllowed(
+    smart_objects::SmartObject rpc_message) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  mobile_api::FunctionID::eType function_id =
+      static_cast<mobile_api::FunctionID::eType>(
+          rpc_message[strings::params][strings::function_id].asInt());
+  uint32_t connection_key =
+      rpc_message[strings::params][strings::connection_key].asUInt();
+  std::string function_id_str =
+      MessageHelper::StringifiedFunctionID(function_id);
+  ApplicationSharedPtr app = app_manager_.application(connection_key);
+  PolicyHandlerInterface& policy_handler = app_manager_.GetPolicyHandler();
+  if (!app) {
+    return false;
+  } else if (function_id_str.empty()) {
+    // Unknown RPC, just do basic revoked and user consent checks
+    std::string device_mac;
+    app_manager_.connection_handler().get_session_observer().GetDataOnDeviceID(
+        app->device(), NULL, NULL, &device_mac, NULL);
+    return policy_handler.UnknownRPCPassthroughAllowed(app->policy_app_id()) &&
+           !policy_handler.IsApplicationRevoked(app->policy_app_id()) &&
+           policy::kDeviceAllowed ==
+               app_manager_.GetUserConsentForDevice(device_mac);
+  }
+
+  RPCParams params;
+
+  const smart_objects::SmartObject& s_map = rpc_message[strings::msg_params];
+  if (smart_objects::SmartType_Map == s_map.getType()) {
+    smart_objects::SmartMap::const_iterator iter = s_map.map_begin();
+    smart_objects::SmartMap::const_iterator iter_end = s_map.map_end();
+
+    for (; iter != iter_end; ++iter) {
+      LOG4CXX_DEBUG(logger_, "Request's param: " << iter->first);
+      params.insert(iter->first);
+    }
+  }
+
+  CommandParametersPermissions parameters_permissions;
+
+  mobile_apis::Result::eType check_result = app_manager_.CheckPolicyPermissions(
+      app, function_id_str, params, &parameters_permissions);
+
+  // Check, if RPC is allowed by policy (since we are allowing unknown params,
+  // check should pass if only undefined parameters exist)
+  if (mobile_apis::Result::DISALLOWED == check_result &&
+      !parameters_permissions.undefined_params.empty() &&
+      parameters_permissions.disallowed_params.empty() &&
+      parameters_permissions.allowed_params.empty()) {
+    return true;
+  } else if (mobile_apis::Result::SUCCESS != check_result) {
+    return false;
+  }
+
+  return true;
+}
+
 bool RPCPassingHandler::RPCPassThrough(smart_objects::SmartObject rpc_message) {
   LOG4CXX_AUTO_TRACE(logger_);
 
@@ -121,7 +178,7 @@ bool RPCPassingHandler::RPCPassThrough(smart_objects::SmartObject rpc_message) {
         LOG4CXX_DEBUG(logger_, "Correlation id DOES exist in map. Returning");
         std::shared_ptr<smart_objects::SmartObject> response(
             MessageHelper::CreateNegativeResponse(
-                rpc_message[strings::params][strings::connection_key].asInt(),
+                rpc_message[strings::params][strings::connection_key].asUInt(),
                 rpc_message[strings::params][strings::function_id].asInt(),
                 correlation_id,
                 mobile_apis::Result::INVALID_ID));

--- a/src/components/application_manager/src/rpc_service_impl.cc
+++ b/src/components/application_manager/src/rpc_service_impl.cc
@@ -126,13 +126,13 @@ bool RPCServiceImpl::ManageMobileCommand(
   auto plugin =
       app_manager_.GetPluginManager().FindPluginToProcess(function_id, source);
   if (!plugin) {
+    LOG4CXX_WARN(logger_, "Failed to find plugin : " << plugin.error());
     int32_t message_type =
         (*(message.get()))[strings::params][strings::message_type].asInt();
     if ((source == commands::Command::CommandSource::SOURCE_MOBILE &&
          kRequest == message_type) ||
         (source == commands::Command::CommandSource::SOURCE_SDL &&
          kResponse == message_type)) {
-      LOG4CXX_WARN(logger_, "Failed to find plugin : " << plugin.error());
       smart_objects::SmartObjectSPtr response =
           MessageHelper::CreateNegativeResponse(
               connection_key,

--- a/src/components/application_manager/src/rpc_service_impl.cc
+++ b/src/components/application_manager/src/rpc_service_impl.cc
@@ -138,9 +138,17 @@ bool RPCServiceImpl::ManageMobileCommand(
               connection_key,
               static_cast<int32_t>(function_id),
               correlation_id,
-              static_cast<int32_t>(mobile_apis::Result::UNSUPPORTED_REQUEST));
+              0);
+
+      // Since we are dealing with an unknown RPC, there is no schema attached
+      // to the message, so we have to convert the result to string directly
+      std::string result_code;
+      smart_objects::EnumConversionHelper<mobile_apis::Result::eType>::
+          EnumToString(mobile_apis::Result::UNSUPPORTED_REQUEST, &result_code);
+      (*response)[strings::msg_params][strings::result_code] = result_code;
       (*response)[strings::msg_params][strings::info] =
           "Module does not recognize this function id";
+
       SendMessageToMobile(response);
     }
     return false;

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -520,7 +520,7 @@ class PolicyHandlerInterface {
    * provider
    * @param policy_app_id Unique application id
   */
-  virtual bool UnknownRPCPassThroughAllowed(
+  virtual bool UnknownRPCPassthroughAllowed(
       const std::string& policy_app_id) const = 0;
 
 #ifdef EXTERNAL_PROPRIETARY_MODE

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -515,6 +515,14 @@ class PolicyHandlerInterface {
       const std::string& requested_service_type,
       smart_objects::SmartArray* requested_handled_rpcs) const = 0;
 
+  /**
+   * @brief Check if an app can send unknown rpc requests to an app service
+   * provider
+   * @param policy_app_id Unique application id
+  */
+  virtual bool UnknownRPCPassThroughAllowed(
+      const std::string& policy_app_id) const = 0;
+
 #ifdef EXTERNAL_PROPRIETARY_MODE
   /**
    * @brief Gets meta information

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -630,7 +630,7 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * provider
    * @param policy_app_id Unique application id
   */
-  virtual bool UnknownRPCPassThroughAllowed(
+  virtual bool UnknownRPCPassthroughAllowed(
       const std::string& policy_app_id) const = 0;
 
   /**

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -626,6 +626,14 @@ class PolicyManager : public usage_statistics::StatisticsManager {
       policy_table::AppServiceParameters* app_service_parameters) const = 0;
 
   /**
+   * @brief Check if an app can send unknown rpc requests to an app service
+   * provider
+   * @param policy_app_id Unique application id
+  */
+  virtual bool UnknownRPCPassThroughAllowed(
+      const std::string& policy_app_id) const = 0;
+
+  /**
    * @brief Gets meta information
    * @return meta information
    */

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -607,6 +607,14 @@ class PolicyManager : public usage_statistics::StatisticsManager {
       policy_table::AppServiceParameters* app_service_parameters) const = 0;
 
   /**
+   * @brief Check if an app can send unknown rpc requests to an app service
+   * provider
+   * @param policy_app_id Unique application id
+  */
+  virtual bool UnknownRPCPassThroughAllowed(
+      const std::string& policy_app_id) const = 0;
+
+  /**
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
    * It will send OnAppPermissionSend notification and will try to start PTU. *

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -611,7 +611,7 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * provider
    * @param policy_app_id Unique application id
   */
-  virtual bool UnknownRPCPassThroughAllowed(
+  virtual bool UnknownRPCPassthroughAllowed(
       const std::string& policy_app_id) const = 0;
 
   /**

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -237,6 +237,8 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                           const std::string& requested_service_name,
                           const std::string& requested_service_type,
                           smart_objects::SmartArray* requested_handled_rpcs));
+  MOCK_CONST_METHOD1(UnknownRPCPassThroughAllowed,
+                     bool(const std::string& policy_app_id));
 
 #ifdef EXTERNAL_PROPRIETARY_MODE
   MOCK_CONST_METHOD0(GetMetaInfo, const policy::MetaInfo());

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -237,7 +237,7 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                           const std::string& requested_service_name,
                           const std::string& requested_service_type,
                           smart_objects::SmartArray* requested_handled_rpcs));
-  MOCK_CONST_METHOD1(UnknownRPCPassThroughAllowed,
+  MOCK_CONST_METHOD1(UnknownRPCPassthroughAllowed,
                      bool(const std::string& policy_app_id));
 
 #ifdef EXTERNAL_PROPRIETARY_MODE

--- a/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
@@ -108,7 +108,7 @@ class MockCacheManagerInterface : public ::policy::CacheManagerInterface {
       GetAppServiceParameters,
       void(const std::string& policy_app_id,
            policy_table::AppServiceParameters* app_service_parameters));
-  MOCK_CONST_METHOD1(UnknownRPCPassThroughAllowed,
+  MOCK_CONST_METHOD1(UnknownRPCPassthroughAllowed,
                      bool(const std::string& policy_app_id));
   MOCK_CONST_METHOD1(GetDeviceConsent,
                      DeviceConsent(const std::string& device_id));

--- a/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
@@ -108,6 +108,8 @@ class MockCacheManagerInterface : public ::policy::CacheManagerInterface {
       GetAppServiceParameters,
       void(const std::string& policy_app_id,
            policy_table::AppServiceParameters* app_service_parameters));
+  MOCK_CONST_METHOD1(UnknownRPCPassThroughAllowed,
+                     bool(const std::string& policy_app_id));
   MOCK_CONST_METHOD1(GetDeviceConsent,
                      DeviceConsent(const std::string& device_id));
   MOCK_METHOD2(SetDeviceConsent,

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -217,6 +217,8 @@ class MockPolicyManager : public PolicyManager {
       GetAppServiceParameters,
       void(const std::string& policy_app_id,
            policy_table::AppServiceParameters* app_service_parameters));
+  MOCK_CONST_METHOD1(UnknownRPCPassThroughAllowed,
+                     bool(const std::string& policy_app_id));
   MOCK_CONST_METHOD0(GetMetaInfo, const policy::MetaInfo());
   MOCK_CONST_METHOD0(RetrieveCertificate, std::string());
   MOCK_CONST_METHOD0(HasCertificate, bool());

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -217,7 +217,7 @@ class MockPolicyManager : public PolicyManager {
       GetAppServiceParameters,
       void(const std::string& policy_app_id,
            policy_table::AppServiceParameters* app_service_parameters));
-  MOCK_CONST_METHOD1(UnknownRPCPassThroughAllowed,
+  MOCK_CONST_METHOD1(UnknownRPCPassthroughAllowed,
                      bool(const std::string& policy_app_id));
   MOCK_CONST_METHOD0(GetMetaInfo, const policy::MetaInfo());
   MOCK_CONST_METHOD0(RetrieveCertificate, std::string());

--- a/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
@@ -100,7 +100,7 @@ class MockCacheManagerInterface : public CacheManagerInterface {
       GetAppServiceParameters,
       void(const std::string& policy_app_id,
            policy_table::AppServiceParameters* app_service_parameters));
-  MOCK_CONST_METHOD1(UnknownRPCPassThroughAllowed,
+  MOCK_CONST_METHOD1(UnknownRPCPassthroughAllowed,
                      bool(const std::string& policy_app_id));
   MOCK_METHOD1(
       GetNotificationsNumber,

--- a/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
@@ -100,7 +100,8 @@ class MockCacheManagerInterface : public CacheManagerInterface {
       GetAppServiceParameters,
       void(const std::string& policy_app_id,
            policy_table::AppServiceParameters* app_service_parameters));
-
+  MOCK_CONST_METHOD1(UnknownRPCPassThroughAllowed,
+                     bool(const std::string& policy_app_id));
   MOCK_METHOD1(
       GetNotificationsNumber,
       policy_table::NumberOfNotificationsType(const std::string& priority));

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -213,6 +213,8 @@ class MockPolicyManager : public PolicyManager {
       GetAppServiceParameters,
       void(const std::string& policy_app_id,
            policy_table::AppServiceParameters* app_service_parameters));
+  MOCK_CONST_METHOD1(UnknownRPCPassThroughAllowed,
+                     bool(const std::string& policy_app_id));
   MOCK_CONST_METHOD0(GetMetaInfo, const policy::MetaInfo());
   MOCK_CONST_METHOD0(RetrieveCertificate, std::string());
   MOCK_CONST_METHOD0(HasCertificate, bool());

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -213,7 +213,7 @@ class MockPolicyManager : public PolicyManager {
       GetAppServiceParameters,
       void(const std::string& policy_app_id,
            policy_table::AppServiceParameters* app_service_parameters));
-  MOCK_CONST_METHOD1(UnknownRPCPassThroughAllowed,
+  MOCK_CONST_METHOD1(UnknownRPCPassthroughAllowed,
                      bool(const std::string& policy_app_id));
   MOCK_CONST_METHOD0(GetMetaInfo, const policy::MetaInfo());
   MOCK_CONST_METHOD0(RetrieveCertificate, std::string());

--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -253,6 +253,14 @@ class CacheManager : public CacheManagerInterface {
       policy_table::AppServiceParameters* app_service_parameters) const;
 
   /**
+   * @brief Check if an app can send unknown rpc requests to an app service
+   * provider
+   * @param policy_app_id Unique application id
+  */
+  virtual bool UnknownRPCPassThroughAllowed(
+      const std::string& policy_app_id) const;
+
+  /**
    * @brief Allows to update 'vin' field in module_meta table.
    *
    * @param new 'vin' value.

--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -257,7 +257,7 @@ class CacheManager : public CacheManagerInterface {
    * provider
    * @param policy_app_id Unique application id
   */
-  virtual bool UnknownRPCPassThroughAllowed(
+  virtual bool UnknownRPCPassthroughAllowed(
       const std::string& policy_app_id) const;
 
   /**

--- a/src/components/policy/policy_external/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager_interface.h
@@ -266,7 +266,7 @@ class CacheManagerInterface {
    * provider
    * @param policy_app_id Unique application id
   */
-  virtual bool UnknownRPCPassThroughAllowed(
+  virtual bool UnknownRPCPassthroughAllowed(
       const std::string& policy_app_id) const = 0;
 
   /**

--- a/src/components/policy/policy_external/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager_interface.h
@@ -262,6 +262,14 @@ class CacheManagerInterface {
       policy_table::AppServiceParameters* app_service_parameters) const = 0;
 
   /**
+   * @brief Check if an app can send unknown rpc requests to an app service
+   * provider
+   * @param policy_app_id Unique application id
+  */
+  virtual bool UnknownRPCPassThroughAllowed(
+      const std::string& policy_app_id) const = 0;
+
+  /**
    * @brief Allows to update 'vin' field in module_meta table.
    *
    * @param new 'vin' value.

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -678,7 +678,7 @@ class PolicyManagerImpl : public PolicyManager {
    * @param policy_app_id Unique application id
    * @return bool true if allowed
   */
-  bool UnknownRPCPassThroughAllowed(
+  bool UnknownRPCPassthroughAllowed(
       const std::string& policy_app_id) const OVERRIDE;
 
   /**

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -673,6 +673,15 @@ class PolicyManagerImpl : public PolicyManager {
                                    app_service_parameters) const OVERRIDE;
 
   /**
+   * @brief Check if an app can send unknown rpc requests to an app service
+   * provider
+   * @param policy_app_id Unique application id
+   * @return bool true if allowed
+  */
+  bool UnknownRPCPassThroughAllowed(
+      const std::string& policy_app_id) const OVERRIDE;
+
+  /**
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
    * It will send OnAppPermissionSend notification and will try to start PTU. *

--- a/src/components/policy/policy_external/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/types.h
@@ -236,6 +236,7 @@ struct ApplicationParams : PolicyBase {
 
   // App Service Params
   Optional<AppServiceParameters> app_service_parameters;
+  Optional<Boolean> allow_unknown_rpc_pass_through;
 
  public:
   ApplicationParams();

--- a/src/components/policy/policy_external/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/types.h
@@ -236,7 +236,7 @@ struct ApplicationParams : PolicyBase {
 
   // App Service Params
   Optional<AppServiceParameters> app_service_parameters;
-  Optional<Boolean> allow_unknown_rpc_pass_through;
+  Optional<Boolean> allow_unknown_rpc_passthrough;
 
  public:
   ApplicationParams();

--- a/src/components/policy/policy_external/include/policy/policy_table_interface_ext.xml
+++ b/src/components/policy/policy_external/include/policy/policy_table_interface_ext.xml
@@ -113,6 +113,7 @@
         <param name="service_name" type="String" mandatory="false" />
         <param name="service_type" type="String" mandatory="false" />
         <param name="handled_rpcs" array="true"  mandatory="false" />
+        <param name="allow_unknown_rpc_pass_through" type="Boolean" mandatory="false" />
     </struct>
 
     <typedef name="HmiLevels" type="HmiLevel" array="true"

--- a/src/components/policy/policy_external/include/policy/policy_table_interface_ext.xml
+++ b/src/components/policy/policy_external/include/policy/policy_table_interface_ext.xml
@@ -113,7 +113,7 @@
         <param name="service_name" type="String" mandatory="false" />
         <param name="service_type" type="String" mandatory="false" />
         <param name="handled_rpcs" array="true"  mandatory="false" />
-        <param name="allow_unknown_rpc_pass_through" type="Boolean" mandatory="false" />
+        <param name="allow_unknown_rpc_passthrough" type="Boolean" mandatory="false" />
     </struct>
 
     <typedef name="HmiLevels" type="HmiLevel" array="true"

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1541,6 +1541,21 @@ void CacheManager::GetAppServiceParameters(
   }
 }
 
+bool CacheManager::UnknownRPCPassThroughAllowed(
+    const std::string& policy_app_id) const {
+  const policy_table::ApplicationPolicies& policies =
+      pt_->policy_table.app_policies_section.apps;
+  policy_table::ApplicationPolicies::const_iterator policy_iter =
+      policies.find(policy_app_id);
+  if (policies.end() != policy_iter) {
+    auto app_policy = (*policy_iter).second;
+    if (app_policy.allow_unknown_rpc_pass_through.is_initialized()) {
+      return *(app_policy.allow_unknown_rpc_pass_through);
+    }
+  }
+  return false;
+}
+
 std::vector<UserFriendlyMessage> CacheManager::GetUserFriendlyMsg(
     const std::vector<std::string>& msg_codes,
     const std::string& language,

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1548,7 +1548,7 @@ bool CacheManager::UnknownRPCPassthroughAllowed(
   policy_table::ApplicationPolicies::const_iterator policy_iter =
       policies.find(policy_app_id);
   if (policies.end() != policy_iter) {
-    auto app_policy = (*policy_iter).second;
+    const auto app_policy = (*policy_iter).second;
     if (app_policy.allow_unknown_rpc_passthrough.is_initialized()) {
       return *(app_policy.allow_unknown_rpc_passthrough);
     }

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1541,7 +1541,7 @@ void CacheManager::GetAppServiceParameters(
   }
 }
 
-bool CacheManager::UnknownRPCPassThroughAllowed(
+bool CacheManager::UnknownRPCPassthroughAllowed(
     const std::string& policy_app_id) const {
   const policy_table::ApplicationPolicies& policies =
       pt_->policy_table.app_policies_section.apps;
@@ -1549,8 +1549,8 @@ bool CacheManager::UnknownRPCPassThroughAllowed(
       policies.find(policy_app_id);
   if (policies.end() != policy_iter) {
     auto app_policy = (*policy_iter).second;
-    if (app_policy.allow_unknown_rpc_pass_through.is_initialized()) {
-      return *(app_policy.allow_unknown_rpc_pass_through);
+    if (app_policy.allow_unknown_rpc_passthrough.is_initialized()) {
+      return *(app_policy.allow_unknown_rpc_passthrough);
     }
   }
   return false;

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -799,10 +799,10 @@ void PolicyManagerImpl::GetAppServiceParameters(
   cache_->GetAppServiceParameters(policy_app_id, app_service_parameters);
 }
 
-bool PolicyManagerImpl::UnknownRPCPassThroughAllowed(
+bool PolicyManagerImpl::UnknownRPCPassthroughAllowed(
     const std::string& policy_app_id) const {
   LOG4CXX_AUTO_TRACE(logger_);
-  return cache_->UnknownRPCPassThroughAllowed(policy_app_id);
+  return cache_->UnknownRPCPassthroughAllowed(policy_app_id);
 }
 
 void PolicyManagerImpl::CheckPermissions(const PTString& app_id,

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -799,6 +799,12 @@ void PolicyManagerImpl::GetAppServiceParameters(
   cache_->GetAppServiceParameters(policy_app_id, app_service_parameters);
 }
 
+bool PolicyManagerImpl::UnknownRPCPassThroughAllowed(
+    const std::string& policy_app_id) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return cache_->UnknownRPCPassThroughAllowed(policy_app_id);
+}
+
 void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
                                          const PTString& hmi_level,
                                          const PTString& rpc,

--- a/src/components/policy/policy_external/src/policy_table/types.cc
+++ b/src/components/policy/policy_external/src/policy_table/types.cc
@@ -353,7 +353,9 @@ ApplicationParams::ApplicationParams(const Json::Value* value__)
     , auth_token(impl::ValueMember(value__, "auth_token"))
     , cloud_transport_type(impl::ValueMember(value__, "cloud_transport_type"))
     , icon_url(impl::ValueMember(value__, "icon_url"))
-    , app_service_parameters(impl::ValueMember(value__, "app_services")) {}
+    , app_service_parameters(impl::ValueMember(value__, "app_services"))
+    , allow_unknown_rpc_pass_through(
+          impl::ValueMember(value__, "allow_unknown_rpc_pass_through")) {}
 
 Json::Value ApplicationParams::ToJsonValue() const {
   Json::Value result__(PolicyBase::ToJsonValue());
@@ -374,6 +376,9 @@ Json::Value ApplicationParams::ToJsonValue() const {
   impl::WriteJsonField("cloud_transport_type", cloud_transport_type, &result__);
   impl::WriteJsonField("icon_url", auth_token, &result__);
   impl::WriteJsonField("app_services", app_service_parameters, &result__);
+  impl::WriteJsonField("allow_unknown_rpc_pass_through",
+                       allow_unknown_rpc_pass_through,
+                       &result__);
   return result__;
 }
 
@@ -420,6 +425,9 @@ bool ApplicationParams::is_valid() const {
     return false;
   }
   if (!app_service_parameters.is_valid()) {
+    return false;
+  }
+  if (!allow_unknown_rpc_pass_through.is_valid()) {
     return false;
   }
   return Validate();
@@ -476,6 +484,9 @@ bool ApplicationParams::struct_empty() const {
     return false;
   }
   if (app_service_parameters.is_initialized()) {
+    return false;
+  }
+  if (allow_unknown_rpc_pass_through.is_initialized()) {
     return false;
   }
   return true;
@@ -552,6 +563,10 @@ void ApplicationParams::ReportErrors(rpc::ValidationReport* report__) const {
     app_service_parameters.ReportErrors(
         &report__->ReportSubobject("app_services"));
   }
+  if (!allow_unknown_rpc_pass_through.is_valid()) {
+    allow_unknown_rpc_pass_through.ReportErrors(
+        &report__->ReportSubobject("allow_unknown_rpc_pass_through"));
+  }
 }
 
 void ApplicationParams::SetPolicyTableType(PolicyTableType pt_type) {
@@ -569,6 +584,7 @@ void ApplicationParams::SetPolicyTableType(PolicyTableType pt_type) {
   hybrid_app_preference.SetPolicyTableType(pt_type);
   icon_url.SetPolicyTableType(pt_type);
   app_service_parameters.SetPolicyTableType(pt_type);
+  allow_unknown_rpc_pass_through.SetPolicyTableType(pt_type);
 }
 
 // RpcParameters methods

--- a/src/components/policy/policy_external/src/policy_table/types.cc
+++ b/src/components/policy/policy_external/src/policy_table/types.cc
@@ -354,8 +354,8 @@ ApplicationParams::ApplicationParams(const Json::Value* value__)
     , cloud_transport_type(impl::ValueMember(value__, "cloud_transport_type"))
     , icon_url(impl::ValueMember(value__, "icon_url"))
     , app_service_parameters(impl::ValueMember(value__, "app_services"))
-    , allow_unknown_rpc_pass_through(
-          impl::ValueMember(value__, "allow_unknown_rpc_pass_through")) {}
+    , allow_unknown_rpc_passthrough(
+          impl::ValueMember(value__, "allow_unknown_rpc_passthrough")) {}
 
 Json::Value ApplicationParams::ToJsonValue() const {
   Json::Value result__(PolicyBase::ToJsonValue());
@@ -376,8 +376,8 @@ Json::Value ApplicationParams::ToJsonValue() const {
   impl::WriteJsonField("cloud_transport_type", cloud_transport_type, &result__);
   impl::WriteJsonField("icon_url", auth_token, &result__);
   impl::WriteJsonField("app_services", app_service_parameters, &result__);
-  impl::WriteJsonField("allow_unknown_rpc_pass_through",
-                       allow_unknown_rpc_pass_through,
+  impl::WriteJsonField("allow_unknown_rpc_passthrough",
+                       allow_unknown_rpc_passthrough,
                        &result__);
   return result__;
 }
@@ -427,7 +427,7 @@ bool ApplicationParams::is_valid() const {
   if (!app_service_parameters.is_valid()) {
     return false;
   }
-  if (!allow_unknown_rpc_pass_through.is_valid()) {
+  if (!allow_unknown_rpc_passthrough.is_valid()) {
     return false;
   }
   return Validate();
@@ -486,7 +486,7 @@ bool ApplicationParams::struct_empty() const {
   if (app_service_parameters.is_initialized()) {
     return false;
   }
-  if (allow_unknown_rpc_pass_through.is_initialized()) {
+  if (allow_unknown_rpc_passthrough.is_initialized()) {
     return false;
   }
   return true;
@@ -563,9 +563,9 @@ void ApplicationParams::ReportErrors(rpc::ValidationReport* report__) const {
     app_service_parameters.ReportErrors(
         &report__->ReportSubobject("app_services"));
   }
-  if (!allow_unknown_rpc_pass_through.is_valid()) {
-    allow_unknown_rpc_pass_through.ReportErrors(
-        &report__->ReportSubobject("allow_unknown_rpc_pass_through"));
+  if (!allow_unknown_rpc_passthrough.is_valid()) {
+    allow_unknown_rpc_passthrough.ReportErrors(
+        &report__->ReportSubobject("allow_unknown_rpc_passthrough"));
   }
 }
 
@@ -584,7 +584,7 @@ void ApplicationParams::SetPolicyTableType(PolicyTableType pt_type) {
   hybrid_app_preference.SetPolicyTableType(pt_type);
   icon_url.SetPolicyTableType(pt_type);
   app_service_parameters.SetPolicyTableType(pt_type);
-  allow_unknown_rpc_pass_through.SetPolicyTableType(pt_type);
+  allow_unknown_rpc_passthrough.SetPolicyTableType(pt_type);
 }
 
 // RpcParameters methods

--- a/src/components/policy/policy_external/src/sql_pt_ext_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_ext_queries.cc
@@ -237,7 +237,7 @@ const std::string kSelectPreconsentedGroupsId =
 const std::string kSelectAppPolicies =
     "SELECT `id`, `priority_value`, `default_hmi`, `keep_context`, "
     " `steal_focus`, `memory_kb`, `heart_beat_timeout_ms`, `certificate`, "
-    " `hybrid_app_preference_value`, `endpoint`, `enabled`, `auth_token` "
+    " `hybrid_app_preference_value`, `endpoint`, `enabled`, `auth_token`, "
     " `cloud_transport_type`, `icon_url`, `allow_unknown_rpc_passthrough` "
     "FROM `application`";
 

--- a/src/components/policy/policy_external/src/sql_pt_ext_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_ext_queries.cc
@@ -207,8 +207,9 @@ const std::string kInsertApplication =
     " `default_hmi`, `priority_value`, `is_revoked`, `memory_kb`, "
     " `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
     " `endpoint`, `enabled`, `auth_token`, "
-    " `cloud_transport_type`, `icon_url`) VALUES "
-    "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+    " `cloud_transport_type`, `icon_url`, `allow_unknown_rpc_pass_through`) "
+    "VALUES "
+    "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
 
 const std::string kCollectFriendlyMsg = "SELECT * FROM `message`";
 
@@ -237,7 +238,8 @@ const std::string kSelectAppPolicies =
     "SELECT `id`, `priority_value`, `default_hmi`, `keep_context`, "
     " `steal_focus`, `memory_kb`, `heart_beat_timeout_ms`, `certificate`, "
     " `hybrid_app_preference_value`, `endpoint`, `enabled`, `auth_token` "
-    " `cloud_transport_type`, `icon_url` FROM `application`";
+    " `cloud_transport_type`, `icon_url`, `allow_unknown_rpc_pass_through` "
+    "FROM `application`";
 
 const std::string kSelectFunctionalGroupNames =
     "SELECT `id`, `user_consent_prompt`, `name`"

--- a/src/components/policy/policy_external/src/sql_pt_ext_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_ext_queries.cc
@@ -207,7 +207,7 @@ const std::string kInsertApplication =
     " `default_hmi`, `priority_value`, `is_revoked`, `memory_kb`, "
     " `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
     " `endpoint`, `enabled`, `auth_token`, "
-    " `cloud_transport_type`, `icon_url`, `allow_unknown_rpc_pass_through`) "
+    " `cloud_transport_type`, `icon_url`, `allow_unknown_rpc_passthrough`) "
     "VALUES "
     "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
 
@@ -238,7 +238,7 @@ const std::string kSelectAppPolicies =
     "SELECT `id`, `priority_value`, `default_hmi`, `keep_context`, "
     " `steal_focus`, `memory_kb`, `heart_beat_timeout_ms`, `certificate`, "
     " `hybrid_app_preference_value`, `endpoint`, `enabled`, `auth_token` "
-    " `cloud_transport_type`, `icon_url`, `allow_unknown_rpc_pass_through` "
+    " `cloud_transport_type`, `icon_url`, `allow_unknown_rpc_passthrough` "
     "FROM `application`";
 
 const std::string kSelectFunctionalGroupNames =

--- a/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
@@ -793,8 +793,8 @@ bool SQLPTExtRepresentation::SaveSpecificAppPolicy(
   app.second.icon_url.is_initialized()
       ? app_query.Bind(14, *app.second.icon_url)
       : app_query.Bind(14);
-  app.second.allow_unknown_rpc_pass_through.is_initialized()
-      ? app_query.Bind(15, *app.second.allow_unknown_rpc_pass_through)
+  app.second.allow_unknown_rpc_passthrough.is_initialized()
+      ? app_query.Bind(15, *app.second.allow_unknown_rpc_passthrough)
       : app_query.Bind(15);
 
   if (!app_query.Exec() || !app_query.Reset()) {
@@ -939,7 +939,7 @@ bool SQLPTExtRepresentation::GatherApplicationPoliciesSection(
     *params.auth_token = query.GetString(11);
     *params.cloud_transport_type = query.GetString(12);
     *params.icon_url = query.GetString(13);
-    *params.allow_unknown_rpc_pass_through = query.GetBoolean(14);
+    *params.allow_unknown_rpc_passthrough = query.GetBoolean(14);
     const auto& gather_app_id = ((*policies).apps[app_id].is_string())
                                     ? (*policies).apps[app_id].get_string()
                                     : app_id;

--- a/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
@@ -793,6 +793,9 @@ bool SQLPTExtRepresentation::SaveSpecificAppPolicy(
   app.second.icon_url.is_initialized()
       ? app_query.Bind(14, *app.second.icon_url)
       : app_query.Bind(14);
+  app.second.allow_unknown_rpc_pass_through.is_initialized()
+      ? app_query.Bind(15, *app.second.allow_unknown_rpc_pass_through)
+      : app_query.Bind(15);
 
   if (!app_query.Exec() || !app_query.Reset()) {
     LOG4CXX_WARN(logger_, "Incorrect insert into application.");
@@ -936,7 +939,7 @@ bool SQLPTExtRepresentation::GatherApplicationPoliciesSection(
     *params.auth_token = query.GetString(11);
     *params.cloud_transport_type = query.GetString(12);
     *params.icon_url = query.GetString(13);
-
+    *params.allow_unknown_rpc_pass_through = query.GetBoolean(14);
     const auto& gather_app_id = ((*policies).apps[app_id].is_string())
                                     ? (*policies).apps[app_id].get_string()
                                     : app_id;

--- a/src/components/policy/policy_external/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_queries.cc
@@ -157,6 +157,7 @@ const std::string kCreateSchema =
     "  `auth_token` VARCHAR(65535), "
     "  `cloud_transport_type` VARCHAR(255), "
     "  `icon_url` VARCHAR(65535), "
+    "  `allow_unknown_rpc_pass_through` BOOLEAN, "
     "  `remote_control_denied` BOOLEAN NOT NULL DEFAULT 0, "
     "  CONSTRAINT `fk_application_hmi_level1` "
     "    FOREIGN KEY(`default_hmi`) "
@@ -677,8 +678,9 @@ const std::string kInsertApplication =
     "INSERT OR IGNORE INTO `application` (`id`, `priority_value`, "
     "`is_revoked`, `memory_kb`, `heart_beat_timeout_ms`, `certificate`, "
     "`hybrid_app_preference_value`, `endpoint`, `enabled`, `auth_token`, "
-    "`cloud_transport_type`, `icon_url`) VALUES "
-    "(?,?,?,?,?,?,?,?,?,?,?,?)";
+    "`cloud_transport_type`, `icon_url`, `allow_unknown_rpc_pass_through`) "
+    "VALUES "
+    "(?,?,?,?,?,?,?,?,?,?,?,?,?)";
 
 const std::string kInsertAppGroup =
     "INSERT INTO `app_group` (`application_id`, `functional_group_id`)"
@@ -817,7 +819,8 @@ const std::string kSelectUserMsgsVersion =
 const std::string kSelectAppPolicies =
     "SELECT `id`, `priority_value`, `memory_kb`, "
     " `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
-    " `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url` "
+    " `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url`, "
+    " `allow_unknown_rpc_pass_through` "
     "FROM "
     " `application`";
 
@@ -941,14 +944,17 @@ const std::string kInsertApplicationFull =
     " `default_hmi`, `priority_value`, `is_revoked`, `is_default`, "
     " `is_predata`, `memory_kb`, `heart_beat_timeout_ms`, "
     " `certificate`, `hybrid_app_preference_value`, `endpoint`, `enabled`, "
-    " `auth_token`, `cloud_transport_type`, `icon_url`) "
-    "  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    " `auth_token`, `cloud_transport_type`, `icon_url`, "
+    "`allow_unknown_rpc_pass_through`) "
+    "  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 const std::string kSelectApplicationFull =
     "SELECT `keep_context`, `steal_focus`, `default_hmi`, `priority_value`, "
     "  `is_revoked`, `is_default`, `is_predata`, `memory_kb`,"
     "  `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
-    "  `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url` "
+    "  `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, "
+    "`icon_url`, "
+    "  `allow_unknown_rpc_pass_through` "
     "FROM `application` "
     "WHERE `id` = ?";
 

--- a/src/components/policy/policy_external/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_queries.cc
@@ -157,7 +157,7 @@ const std::string kCreateSchema =
     "  `auth_token` VARCHAR(65535), "
     "  `cloud_transport_type` VARCHAR(255), "
     "  `icon_url` VARCHAR(65535), "
-    "  `allow_unknown_rpc_pass_through` BOOLEAN, "
+    "  `allow_unknown_rpc_passthrough` BOOLEAN, "
     "  `remote_control_denied` BOOLEAN NOT NULL DEFAULT 0, "
     "  CONSTRAINT `fk_application_hmi_level1` "
     "    FOREIGN KEY(`default_hmi`) "
@@ -678,7 +678,7 @@ const std::string kInsertApplication =
     "INSERT OR IGNORE INTO `application` (`id`, `priority_value`, "
     "`is_revoked`, `memory_kb`, `heart_beat_timeout_ms`, `certificate`, "
     "`hybrid_app_preference_value`, `endpoint`, `enabled`, `auth_token`, "
-    "`cloud_transport_type`, `icon_url`, `allow_unknown_rpc_pass_through`) "
+    "`cloud_transport_type`, `icon_url`, `allow_unknown_rpc_passthrough`) "
     "VALUES "
     "(?,?,?,?,?,?,?,?,?,?,?,?,?)";
 
@@ -820,7 +820,7 @@ const std::string kSelectAppPolicies =
     "SELECT `id`, `priority_value`, `memory_kb`, "
     " `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
     " `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url`, "
-    " `allow_unknown_rpc_pass_through` "
+    " `allow_unknown_rpc_passthrough` "
     "FROM "
     " `application`";
 
@@ -945,7 +945,7 @@ const std::string kInsertApplicationFull =
     " `is_predata`, `memory_kb`, `heart_beat_timeout_ms`, "
     " `certificate`, `hybrid_app_preference_value`, `endpoint`, `enabled`, "
     " `auth_token`, `cloud_transport_type`, `icon_url`, "
-    "`allow_unknown_rpc_pass_through`) "
+    "`allow_unknown_rpc_passthrough`) "
     "  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 const std::string kSelectApplicationFull =
@@ -954,7 +954,7 @@ const std::string kSelectApplicationFull =
     "  `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
     "  `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, "
     "`icon_url`, "
-    "  `allow_unknown_rpc_pass_through` "
+    "  `allow_unknown_rpc_passthrough` "
     "FROM `application` "
     "WHERE `id` = ?";
 

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -778,7 +778,7 @@ bool SQLPTRepresentation::GatherApplicationPoliciesSection(
     *params.auth_token = query.GetString(8);
     *params.cloud_transport_type = query.GetString(9);
     *params.icon_url = query.GetString(10);
-    *params.allow_unknown_rpc_pass_through = query.GetBoolean(11);
+    *params.allow_unknown_rpc_passthrough = query.GetBoolean(11);
     const auto& gather_app_id = ((*policies).apps[app_id].is_string())
                                     ? (*policies).apps[app_id].get_string()
                                     : app_id;
@@ -1093,8 +1093,8 @@ bool SQLPTRepresentation::SaveSpecificAppPolicy(
   app.second.icon_url.is_initialized()
       ? app_query.Bind(11, *app.second.icon_url)
       : app_query.Bind(11);
-  app.second.allow_unknown_rpc_pass_through.is_initialized()
-      ? app_query.Bind(12, *app.second.allow_unknown_rpc_pass_through)
+  app.second.allow_unknown_rpc_passthrough.is_initialized()
+      ? app_query.Bind(12, *app.second.allow_unknown_rpc_passthrough)
       : app_query.Bind(12);
 
   if (!app_query.Exec() || !app_query.Reset()) {

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -778,7 +778,7 @@ bool SQLPTRepresentation::GatherApplicationPoliciesSection(
     *params.auth_token = query.GetString(8);
     *params.cloud_transport_type = query.GetString(9);
     *params.icon_url = query.GetString(10);
-
+    *params.allow_unknown_rpc_pass_through = query.GetBoolean(11);
     const auto& gather_app_id = ((*policies).apps[app_id].is_string())
                                     ? (*policies).apps[app_id].get_string()
                                     : app_id;
@@ -1093,6 +1093,9 @@ bool SQLPTRepresentation::SaveSpecificAppPolicy(
   app.second.icon_url.is_initialized()
       ? app_query.Bind(11, *app.second.icon_url)
       : app_query.Bind(11);
+  app.second.allow_unknown_rpc_pass_through.is_initialized()
+      ? app_query.Bind(12, *app.second.allow_unknown_rpc_pass_through)
+      : app_query.Bind(12);
 
   if (!app_query.Exec() || !app_query.Reset()) {
     LOG4CXX_WARN(logger_, "Incorrect insert into application.");
@@ -2343,6 +2346,8 @@ bool SQLPTRepresentation::CopyApplication(const std::string& source,
                         : query.Bind(15, source_app.GetString(14));
   source_app.IsNull(15) ? query.Bind(16)
                         : query.Bind(16, source_app.GetString(15));
+  source_app.IsNull(16) ? query.Bind(17)
+                        : query.Bind(17, source_app.GetBoolean(16));
 
   if (!query.Exec()) {
     LOG4CXX_WARN(logger_, "Failed inserting into application.");

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -245,7 +245,7 @@ class CacheManager : public CacheManagerInterface {
    * provider
    * @param policy_app_id Unique application id
   */
-  virtual bool UnknownRPCPassThroughAllowed(
+  virtual bool UnknownRPCPassthroughAllowed(
       const std::string& policy_app_id) const;
 
   /**

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -241,6 +241,14 @@ class CacheManager : public CacheManagerInterface {
       policy_table::AppServiceParameters* app_service_parameters) const;
 
   /**
+   * @brief Check if an app can send unknown rpc requests to an app service
+   * provider
+   * @param policy_app_id Unique application id
+  */
+  virtual bool UnknownRPCPassThroughAllowed(
+      const std::string& policy_app_id) const;
+
+  /**
    * @brief Allows to update 'vin' field in module_meta table.
    *
    * @param new 'vin' value.

--- a/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
@@ -247,6 +247,14 @@ class CacheManagerInterface {
       policy_table::AppServiceParameters* app_service_parameters) const = 0;
 
   /**
+   * @brief Check if an app can send unknown rpc requests to an app service
+   * provider
+   * @param policy_app_id Unique application id
+  */
+  virtual bool UnknownRPCPassThroughAllowed(
+      const std::string& policy_app_id) const = 0;
+
+  /**
    * @brief Allows to update 'vin' field in module_meta table.
    *
    * @param new 'vin' value.

--- a/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
@@ -251,7 +251,7 @@ class CacheManagerInterface {
    * provider
    * @param policy_app_id Unique application id
   */
-  virtual bool UnknownRPCPassThroughAllowed(
+  virtual bool UnknownRPCPassthroughAllowed(
       const std::string& policy_app_id) const = 0;
 
   /**

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -673,7 +673,7 @@ class PolicyManagerImpl : public PolicyManager {
    * @param policy_app_id Unique application id
    * @return bool true if allowed
   */
-  bool UnknownRPCPassThroughAllowed(
+  bool UnknownRPCPassthroughAllowed(
       const std::string& policy_app_id) const OVERRIDE;
 
   /**

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -668,6 +668,15 @@ class PolicyManagerImpl : public PolicyManager {
                                    app_service_parameters) const OVERRIDE;
 
   /**
+   * @brief Check if an app can send unknown rpc requests to an app service
+   * provider
+   * @param policy_app_id Unique application id
+   * @return bool true if allowed
+  */
+  bool UnknownRPCPassThroughAllowed(
+      const std::string& policy_app_id) const OVERRIDE;
+
+  /**
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
    * It will send OnAppPermissionSend notification and will try to start PTU. *

--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -202,6 +202,7 @@ struct ApplicationParams : PolicyBase {
 
   // App Service Params
   Optional<AppServiceParameters> app_service_parameters;
+  Optional<Boolean> allow_unknown_rpc_pass_through;
 
  public:
   ApplicationParams();

--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -202,7 +202,7 @@ struct ApplicationParams : PolicyBase {
 
   // App Service Params
   Optional<AppServiceParameters> app_service_parameters;
-  Optional<Boolean> allow_unknown_rpc_pass_through;
+  Optional<Boolean> allow_unknown_rpc_passthrough;
 
  public:
   ApplicationParams();

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -836,6 +836,21 @@ void CacheManager::GetAppServiceParameters(
   }
 }
 
+bool CacheManager::UnknownRPCPassThroughAllowed(
+    const std::string& policy_app_id) const {
+  const policy_table::ApplicationPolicies& policies =
+      pt_->policy_table.app_policies_section.apps;
+  policy_table::ApplicationPolicies::const_iterator policy_iter =
+      policies.find(policy_app_id);
+  if (policies.end() != policy_iter) {
+    auto app_policy = (*policy_iter).second;
+    if (app_policy.allow_unknown_rpc_pass_through.is_initialized()) {
+      return *(app_policy.allow_unknown_rpc_pass_through);
+    }
+  }
+  return false;
+}
+
 std::vector<UserFriendlyMessage> CacheManager::GetUserFriendlyMsg(
     const std::vector<std::string>& msg_codes, const std::string& language) {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -836,7 +836,7 @@ void CacheManager::GetAppServiceParameters(
   }
 }
 
-bool CacheManager::UnknownRPCPassThroughAllowed(
+bool CacheManager::UnknownRPCPassthroughAllowed(
     const std::string& policy_app_id) const {
   const policy_table::ApplicationPolicies& policies =
       pt_->policy_table.app_policies_section.apps;
@@ -844,8 +844,8 @@ bool CacheManager::UnknownRPCPassThroughAllowed(
       policies.find(policy_app_id);
   if (policies.end() != policy_iter) {
     auto app_policy = (*policy_iter).second;
-    if (app_policy.allow_unknown_rpc_pass_through.is_initialized()) {
-      return *(app_policy.allow_unknown_rpc_pass_through);
+    if (app_policy.allow_unknown_rpc_passthrough.is_initialized()) {
+      return *(app_policy.allow_unknown_rpc_passthrough);
     }
   }
   return false;

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -843,7 +843,7 @@ bool CacheManager::UnknownRPCPassthroughAllowed(
   policy_table::ApplicationPolicies::const_iterator policy_iter =
       policies.find(policy_app_id);
   if (policies.end() != policy_iter) {
-    auto app_policy = (*policy_iter).second;
+    const auto app_policy = (*policy_iter).second;
     if (app_policy.allow_unknown_rpc_passthrough.is_initialized()) {
       return *(app_policy.allow_unknown_rpc_passthrough);
     }

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -618,10 +618,10 @@ void PolicyManagerImpl::GetAppServiceParameters(
   cache_->GetAppServiceParameters(policy_app_id, app_service_parameters);
 }
 
-bool PolicyManagerImpl::UnknownRPCPassThroughAllowed(
+bool PolicyManagerImpl::UnknownRPCPassthroughAllowed(
     const std::string& policy_app_id) const {
   LOG4CXX_AUTO_TRACE(logger_);
-  return cache_->UnknownRPCPassThroughAllowed(policy_app_id);
+  return cache_->UnknownRPCPassthroughAllowed(policy_app_id);
 }
 
 void PolicyManagerImpl::CheckPermissions(const PTString& device_id,

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -618,6 +618,12 @@ void PolicyManagerImpl::GetAppServiceParameters(
   cache_->GetAppServiceParameters(policy_app_id, app_service_parameters);
 }
 
+bool PolicyManagerImpl::UnknownRPCPassThroughAllowed(
+    const std::string& policy_app_id) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return cache_->UnknownRPCPassThroughAllowed(policy_app_id);
+}
+
 void PolicyManagerImpl::CheckPermissions(const PTString& device_id,
                                          const PTString& app_id,
                                          const PTString& hmi_level,

--- a/src/components/policy/policy_regular/src/policy_table/types.cc
+++ b/src/components/policy/policy_regular/src/policy_table/types.cc
@@ -279,8 +279,8 @@ ApplicationParams::ApplicationParams(const Json::Value* value__)
     , cloud_transport_type(impl::ValueMember(value__, "cloud_transport_type"))
     , icon_url(impl::ValueMember(value__, "icon_url"))
     , app_service_parameters(impl::ValueMember(value__, "app_services"))
-    , allow_unknown_rpc_pass_through(
-          impl::ValueMember(value__, "allow_unknown_rpc_pass_through")) {}
+    , allow_unknown_rpc_passthrough(
+          impl::ValueMember(value__, "allow_unknown_rpc_passthrough")) {}
 
 Json::Value ApplicationParams::ToJsonValue() const {
   Json::Value result__(PolicyBase::ToJsonValue());
@@ -302,8 +302,8 @@ Json::Value ApplicationParams::ToJsonValue() const {
   impl::WriteJsonField("cloud_transport_type", cloud_transport_type, &result__);
   impl::WriteJsonField("icon_url", auth_token, &result__);
   impl::WriteJsonField("app_services", app_service_parameters, &result__);
-  impl::WriteJsonField("allow_unknown_rpc_pass_through",
-                       allow_unknown_rpc_pass_through,
+  impl::WriteJsonField("allow_unknown_rpc_passthrough",
+                       allow_unknown_rpc_passthrough,
                        &result__);
   return result__;
 }
@@ -357,7 +357,7 @@ bool ApplicationParams::is_valid() const {
   if (!app_service_parameters.is_valid()) {
     return false;
   }
-  if (!allow_unknown_rpc_pass_through.is_valid()) {
+  if (!allow_unknown_rpc_passthrough.is_valid()) {
     return false;
   }
   return Validate();
@@ -419,7 +419,7 @@ bool ApplicationParams::struct_empty() const {
   if (app_service_parameters.is_initialized()) {
     return false;
   }
-  if (allow_unknown_rpc_pass_through.is_initialized()) {
+  if (allow_unknown_rpc_passthrough.is_initialized()) {
     return false;
   }
   return true;
@@ -483,9 +483,9 @@ void ApplicationParams::ReportErrors(rpc::ValidationReport* report__) const {
     app_service_parameters.ReportErrors(
         &report__->ReportSubobject("app_services"));
   }
-  if (!allow_unknown_rpc_pass_through.is_valid()) {
-    allow_unknown_rpc_pass_through.ReportErrors(
-        &report__->ReportSubobject("allow_unknown_rpc_pass_through"));
+  if (!allow_unknown_rpc_passthrough.is_valid()) {
+    allow_unknown_rpc_passthrough.ReportErrors(
+        &report__->ReportSubobject("allow_unknown_rpc_passthrough"));
   }
 }
 
@@ -505,7 +505,7 @@ void ApplicationParams::SetPolicyTableType(PolicyTableType pt_type) {
   hybrid_app_preference.SetPolicyTableType(pt_type);
   icon_url.SetPolicyTableType(pt_type);
   app_service_parameters.SetPolicyTableType(pt_type);
-  allow_unknown_rpc_pass_through.SetPolicyTableType(pt_type);
+  allow_unknown_rpc_passthrough.SetPolicyTableType(pt_type);
 }
 
 // RpcParameters methods

--- a/src/components/policy/policy_regular/src/policy_table/types.cc
+++ b/src/components/policy/policy_regular/src/policy_table/types.cc
@@ -278,7 +278,9 @@ ApplicationParams::ApplicationParams(const Json::Value* value__)
     , auth_token(impl::ValueMember(value__, "auth_token"))
     , cloud_transport_type(impl::ValueMember(value__, "cloud_transport_type"))
     , icon_url(impl::ValueMember(value__, "icon_url"))
-    , app_service_parameters(impl::ValueMember(value__, "app_services")) {}
+    , app_service_parameters(impl::ValueMember(value__, "app_services"))
+    , allow_unknown_rpc_pass_through(
+          impl::ValueMember(value__, "allow_unknown_rpc_pass_through")) {}
 
 Json::Value ApplicationParams::ToJsonValue() const {
   Json::Value result__(PolicyBase::ToJsonValue());
@@ -300,6 +302,9 @@ Json::Value ApplicationParams::ToJsonValue() const {
   impl::WriteJsonField("cloud_transport_type", cloud_transport_type, &result__);
   impl::WriteJsonField("icon_url", auth_token, &result__);
   impl::WriteJsonField("app_services", app_service_parameters, &result__);
+  impl::WriteJsonField("allow_unknown_rpc_pass_through",
+                       allow_unknown_rpc_pass_through,
+                       &result__);
   return result__;
 }
 
@@ -350,6 +355,9 @@ bool ApplicationParams::is_valid() const {
     return false;
   }
   if (!app_service_parameters.is_valid()) {
+    return false;
+  }
+  if (!allow_unknown_rpc_pass_through.is_valid()) {
     return false;
   }
   return Validate();
@@ -409,6 +417,9 @@ bool ApplicationParams::struct_empty() const {
     return false;
   }
   if (app_service_parameters.is_initialized()) {
+    return false;
+  }
+  if (allow_unknown_rpc_pass_through.is_initialized()) {
     return false;
   }
   return true;
@@ -472,6 +483,10 @@ void ApplicationParams::ReportErrors(rpc::ValidationReport* report__) const {
     app_service_parameters.ReportErrors(
         &report__->ReportSubobject("app_services"));
   }
+  if (!allow_unknown_rpc_pass_through.is_valid()) {
+    allow_unknown_rpc_pass_through.ReportErrors(
+        &report__->ReportSubobject("allow_unknown_rpc_pass_through"));
+  }
 }
 
 void ApplicationParams::SetPolicyTableType(PolicyTableType pt_type) {
@@ -490,6 +505,7 @@ void ApplicationParams::SetPolicyTableType(PolicyTableType pt_type) {
   hybrid_app_preference.SetPolicyTableType(pt_type);
   icon_url.SetPolicyTableType(pt_type);
   app_service_parameters.SetPolicyTableType(pt_type);
+  allow_unknown_rpc_pass_through.SetPolicyTableType(pt_type);
 }
 
 // RpcParameters methods

--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -143,7 +143,7 @@ const std::string kCreateSchema =
     "  `auth_token` VARCHAR(65535), "
     "  `cloud_transport_type` VARCHAR(255), "
     "  `icon_url` VARCHAR(65535), "
-    "  `allow_unknown_rpc_pass_through` BOOLEAN, "
+    "  `allow_unknown_rpc_passthrough` BOOLEAN, "
     "  `remote_control_denied` BOOLEAN NOT NULL DEFAULT 0, "
     "  CONSTRAINT `fk_application_hmi_level1` "
     "    FOREIGN KEY(`default_hmi`) "
@@ -627,7 +627,7 @@ const std::string kInsertApplication =
     "INSERT OR IGNORE INTO `application` (`id`, `priority_value`, "
     "`is_revoked`, `memory_kb`, `heart_beat_timeout_ms`, `certificate`, "
     "`hybrid_app_preference_value`, `endpoint`, `enabled`, `auth_token`, "
-    "`cloud_transport_type`, `icon_url`, `allow_unknown_rpc_pass_through`) "
+    "`cloud_transport_type`, `icon_url`, `allow_unknown_rpc_passthrough`) "
     "VALUES "
     "(?,?,?,?,?,?,?,?,?,?,?,?,?)";
 
@@ -755,7 +755,7 @@ const std::string kSelectAppPolicies =
     "SELECT `id`, `priority_value`, `memory_kb`, "
     " `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
     " `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url`, "
-    " `allow_unknown_rpc_pass_through` "
+    " `allow_unknown_rpc_passthrough` "
     "FROM "
     " `application`";
 
@@ -880,7 +880,7 @@ const std::string kInsertApplicationFull =
     " `is_predata`, `memory_kb`, `heart_beat_timeout_ms`, "
     " `certificate`, `hybrid_app_preference_value`, `endpoint`, `enabled`, "
     " `auth_token`, `cloud_transport_type`, `icon_url`, "
-    "`allow_unknown_rpc_pass_through`) "
+    "`allow_unknown_rpc_passthrough`) "
     "  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 const std::string kSelectApplicationFull =
@@ -889,7 +889,7 @@ const std::string kSelectApplicationFull =
     "  `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
     "  `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, "
     "`icon_url`, "
-    "  `allow_unknown_rpc_pass_through` "
+    "  `allow_unknown_rpc_passthrough` "
     "FROM `application` "
     "WHERE `id` = "
     "?";

--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -143,6 +143,7 @@ const std::string kCreateSchema =
     "  `auth_token` VARCHAR(65535), "
     "  `cloud_transport_type` VARCHAR(255), "
     "  `icon_url` VARCHAR(65535), "
+    "  `allow_unknown_rpc_pass_through` BOOLEAN, "
     "  `remote_control_denied` BOOLEAN NOT NULL DEFAULT 0, "
     "  CONSTRAINT `fk_application_hmi_level1` "
     "    FOREIGN KEY(`default_hmi`) "
@@ -626,8 +627,9 @@ const std::string kInsertApplication =
     "INSERT OR IGNORE INTO `application` (`id`, `priority_value`, "
     "`is_revoked`, `memory_kb`, `heart_beat_timeout_ms`, `certificate`, "
     "`hybrid_app_preference_value`, `endpoint`, `enabled`, `auth_token`, "
-    "`cloud_transport_type`, `icon_url`) VALUES "
-    "(?,?,?,?,?,?,?,?,?,?,?,?)";
+    "`cloud_transport_type`, `icon_url`, `allow_unknown_rpc_pass_through`) "
+    "VALUES "
+    "(?,?,?,?,?,?,?,?,?,?,?,?,?)";
 
 const std::string kInsertAppGroup =
     "INSERT INTO `app_group` (`application_id`, `functional_group_id`)"
@@ -752,7 +754,8 @@ const std::string kSelectUserMsgsVersion =
 const std::string kSelectAppPolicies =
     "SELECT `id`, `priority_value`, `memory_kb`, "
     " `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
-    " `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url` "
+    " `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url`, "
+    " `allow_unknown_rpc_pass_through` "
     "FROM "
     " `application`";
 
@@ -876,14 +879,17 @@ const std::string kInsertApplicationFull =
     " `default_hmi`, `priority_value`, `is_revoked`, `is_default`, "
     " `is_predata`, `memory_kb`, `heart_beat_timeout_ms`, "
     " `certificate`, `hybrid_app_preference_value`, `endpoint`, `enabled`, "
-    " `auth_token`, `cloud_transport_type`, `icon_url`) "
-    "  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    " `auth_token`, `cloud_transport_type`, `icon_url`, "
+    "`allow_unknown_rpc_pass_through`) "
+    "  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 const std::string kSelectApplicationFull =
     "SELECT `keep_context`, `steal_focus`, `default_hmi`, `priority_value`, "
     "  `is_revoked`, `is_default`, `is_predata`, `memory_kb`,"
     "  `heart_beat_timeout_ms`, `certificate`, `hybrid_app_preference_value`, "
-    "  `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, `icon_url` "
+    "  `endpoint`, `enabled`, `auth_token`, `cloud_transport_type`, "
+    "`icon_url`, "
+    "  `allow_unknown_rpc_pass_through` "
     "FROM `application` "
     "WHERE `id` = "
     "?";

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -734,6 +734,7 @@ bool SQLPTRepresentation::GatherApplicationPoliciesSection(
     *params.auth_token = query.GetString(8);
     *params.cloud_transport_type = query.GetString(9);
     *params.icon_url = query.GetString(10);
+    *params.allow_unknown_rpc_pass_through = query.GetBoolean(11);
 
     const auto& gather_app_id = ((*policies).apps[app_id].is_string())
                                     ? (*policies).apps[app_id].get_string()
@@ -1035,6 +1036,9 @@ bool SQLPTRepresentation::SaveSpecificAppPolicy(
   app.second.icon_url.is_initialized()
       ? app_query.Bind(11, *app.second.icon_url)
       : app_query.Bind(11);
+  app.second.allow_unknown_rpc_pass_through.is_initialized()
+      ? app_query.Bind(12, *app.second.allow_unknown_rpc_pass_through)
+      : app_query.Bind(12);
 
   if (!app_query.Exec() || !app_query.Reset()) {
     LOG4CXX_WARN(logger_, "Incorrect insert into application.");
@@ -2296,6 +2300,8 @@ bool SQLPTRepresentation::CopyApplication(const std::string& source,
                         : query.Bind(15, source_app.GetString(14));
   source_app.IsNull(15) ? query.Bind(16)
                         : query.Bind(16, source_app.GetString(15));
+  source_app.IsNull(16) ? query.Bind(17)
+                        : query.Bind(17, source_app.GetBoolean(16));
 
   if (!query.Exec()) {
     LOG4CXX_WARN(logger_, "Failed inserting into application.");

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -734,7 +734,7 @@ bool SQLPTRepresentation::GatherApplicationPoliciesSection(
     *params.auth_token = query.GetString(8);
     *params.cloud_transport_type = query.GetString(9);
     *params.icon_url = query.GetString(10);
-    *params.allow_unknown_rpc_pass_through = query.GetBoolean(11);
+    *params.allow_unknown_rpc_passthrough = query.GetBoolean(11);
 
     const auto& gather_app_id = ((*policies).apps[app_id].is_string())
                                     ? (*policies).apps[app_id].get_string()
@@ -1036,8 +1036,8 @@ bool SQLPTRepresentation::SaveSpecificAppPolicy(
   app.second.icon_url.is_initialized()
       ? app_query.Bind(11, *app.second.icon_url)
       : app_query.Bind(11);
-  app.second.allow_unknown_rpc_pass_through.is_initialized()
-      ? app_query.Bind(12, *app.second.allow_unknown_rpc_pass_through)
+  app.second.allow_unknown_rpc_passthrough.is_initialized()
+      ? app_query.Bind(12, *app.second.allow_unknown_rpc_passthrough)
       : app_query.Bind(12);
 
   if (!app_query.Exec() || !app_query.Reset()) {


### PR DESCRIPTION
Fixes #2877 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Add new field to application policies in sdl_preloaded_pt.json
 > "allow_unknown_rpc_passthrough" : true

### Summary
Adds new field to policies. Field will allow/disallow an app consumer from performing an unknown rpc request that is passed through to another app service.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)