### PR TITLE
Building with option BUILD_CLOUD_APP_SUPPORT=OFF

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_exit_application_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_exit_application_notification.cc
@@ -106,10 +106,13 @@ void OnExitApplicationNotification::Run() {
       application_manager_.UnregisterApplication(app_id, Result::SUCCESS);
       return;
     }
+#if defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
     case Common_ApplicationExitReason::CLOSE_CLOUD_CONNECTION: {
       application_manager_.DisconnectCloudApp(app_impl);
       break;
     }
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
+
     default: {
       LOG4CXX_WARN(logger_, "Unhandled reason");
       return;

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -1185,6 +1185,9 @@ const std::string& ApplicationImpl::cloud_app_certificate() const {
 }
 
 bool ApplicationImpl::is_cloud_app() const {
+#if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
+  return false;
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
   return !endpoint_.empty();
 }
 

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -1187,8 +1187,9 @@ const std::string& ApplicationImpl::cloud_app_certificate() const {
 bool ApplicationImpl::is_cloud_app() const {
 #if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
   return false;
-#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
+#else
   return !endpoint_.empty();
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
 }
 
 void ApplicationImpl::set_cloud_app_endpoint(const std::string& endpoint) {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -892,6 +892,10 @@ void ApplicationManagerImpl::SetIconFileFromSystemRequest(
 }
 
 void ApplicationManagerImpl::DisconnectCloudApp(ApplicationSharedPtr app) {
+#if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
+  LOG4CXX_TRACE(logger_, "Cloud app support is disabled. Exiting function");
+  return;
+#else
   std::string endpoint;
   std::string certificate;
   std::string auth_token;
@@ -929,9 +933,14 @@ void ApplicationManagerImpl::DisconnectCloudApp(ApplicationSharedPtr app) {
   // Create device in pending state
   LOG4CXX_DEBUG(logger_, "Re-adding the cloud app device");
   connection_handler().AddCloudAppDevice(policy_app_id, properties);
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
 }
 
 void ApplicationManagerImpl::RefreshCloudAppInformation() {
+#if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
+  LOG4CXX_TRACE(logger_, "Cloud app support is disabled. Exiting function");
+  return;
+#else
   LOG4CXX_AUTO_TRACE(logger_);
   if (is_stopping()) {
     return;
@@ -1082,6 +1091,7 @@ void ApplicationManagerImpl::RefreshCloudAppInformation() {
     LOG4CXX_DEBUG(logger_, "Removed " << removed_app_count << " disabled apps");
     SendUpdateAppList();
   }
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
 }
 
 void ApplicationManagerImpl::CreatePendingApplication(
@@ -1216,6 +1226,9 @@ void ApplicationManagerImpl::OnConnectionStatusUpdated() {
 hmi_apis::Common_CloudConnectionStatus::eType
 ApplicationManagerImpl::GetCloudAppConnectionStatus(
     ApplicationConstSharedPtr app) const {
+#if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
+  return hmi_apis::Common_CloudConnectionStatus::INVALID_ENUM;
+#else
   transport_manager::ConnectionStatus status =
       connection_handler().GetConnectionStatus(app->device());
   switch (status) {
@@ -1229,6 +1242,7 @@ ApplicationManagerImpl::GetCloudAppConnectionStatus(
     default:
       return hmi_apis::Common_CloudConnectionStatus::INVALID_ENUM;
   }
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
 }
 
 uint32_t ApplicationManagerImpl::GetNextMobileCorrelationID() {

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -103,6 +103,7 @@ const std::string kAppId = "someID";
 const uint32_t kConnectionKey = 1232u;
 const std::string kAppName = "appName";
 
+#if defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
 // Cloud application params
 const std::string kEndpoint = "endpoint";
 const std::string kEndpoint2 = "https://fakesdlcloudapptesting.com:8080";
@@ -113,6 +114,7 @@ const mobile_api::HybridAppPreference::eType kHybridAppPreference =
     mobile_api::HybridAppPreference::CLOUD;
 const std::string kHybridAppPreferenceStr = "CLOUD";
 const bool kEnabled = true;
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
 }  // namespace
 
 class ApplicationManagerImplTest : public ::testing::Test {
@@ -224,8 +226,9 @@ class ApplicationManagerImplTest : public ::testing::Test {
       connection_handler::DeviceHandle secondary_device_handle,
       std::string secondary_transport_device_string);
 
+#if defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
   void AddCloudAppToPendingDeviceMap();
-
+#endif
   uint32_t app_id_;
   NiceMock<policy_test::MockPolicySettings> mock_policy_settings_;
   std::shared_ptr<NiceMock<resumption_test::MockResumptionData> > mock_storage_;
@@ -1447,6 +1450,7 @@ TEST_F(ApplicationManagerImplTest,
   EXPECT_TRUE(file_system::RemoveDirectory(kDirectoryName, true));
 }
 
+#if defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
 void ApplicationManagerImplTest::AddCloudAppToPendingDeviceMap() {
   app_manager_impl_->SetMockPolicyHandler(mock_policy_handler_);
   std::vector<std::string> enabled_apps{"1234"};
@@ -1659,7 +1663,7 @@ TEST_F(ApplicationManagerImplTest,
       app_manager_impl_->RegisterApplication(request_for_registration_ptr);
   EXPECT_EQ(0, application.use_count());
 }
-
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
 }  // namespace application_manager_test
 }  // namespace components
 }  // namespace test

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1394,7 +1394,7 @@ void CacheManager::GetEnabledCloudApps(
 #if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
   enabled_apps.clear();
   return;
-#endif
+#else
   const policy_table::ApplicationPolicies& policies =
       pt_->policy_table.app_policies_section.apps;
   for (policy_table::ApplicationPolicies::const_iterator it = policies.begin();
@@ -1405,6 +1405,7 @@ void CacheManager::GetEnabledCloudApps(
       enabled_apps.push_back((*it).first);
     }
   }
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
 }
 
 bool CacheManager::GetCloudAppParameters(

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1391,6 +1391,10 @@ const policy::VehicleInfo CacheManager::GetVehicleInfo() const {
 
 void CacheManager::GetEnabledCloudApps(
     std::vector<std::string>& enabled_apps) const {
+#if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
+  enabled_apps.clear();
+  return;
+#endif
   const policy_table::ApplicationPolicies& policies =
       pt_->policy_table.app_policies_section.apps;
   for (policy_table::ApplicationPolicies::const_iterator it = policies.begin();

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -684,6 +684,10 @@ const policy::VehicleInfo CacheManager::GetVehicleInfo() const {
 
 void CacheManager::GetEnabledCloudApps(
     std::vector<std::string>& enabled_apps) const {
+#if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
+  enabled_apps.clear();
+  return;
+#endif
   const policy_table::ApplicationPolicies& policies =
       pt_->policy_table.app_policies_section.apps;
   for (policy_table::ApplicationPolicies::const_iterator it = policies.begin();

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -687,7 +687,7 @@ void CacheManager::GetEnabledCloudApps(
 #if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
   enabled_apps.clear();
   return;
-#endif
+#else
   const policy_table::ApplicationPolicies& policies =
       pt_->policy_table.app_policies_section.apps;
   for (policy_table::ApplicationPolicies::const_iterator it = policies.begin();
@@ -698,6 +698,7 @@ void CacheManager::GetEnabledCloudApps(
       enabled_apps.push_back((*it).first);
     }
   }
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
 }
 
 bool CacheManager::GetCloudAppParameters(

--- a/src/components/transport_manager/CMakeLists.txt
+++ b/src/components/transport_manager/CMakeLists.txt
@@ -76,17 +76,22 @@ endif()
 if(BUILD_CLOUD_APP_SUPPORT)
   GET_PROPERTY(BOOST_LIBS_DIRECTORY GLOBAL PROPERTY GLOBAL_BOOST_LIBS)
   list(APPEND LIBRARIES boost_system boost_regex -L${BOOST_LIBS_DIRECTORY})
+else()
+  list(APPEND EXCLUDE_PATHS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/transport_manager/cloud
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/cloud
+  )
 endif()
 
 if(BUILD_USB_SUPPORT)
   if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(EXCLUDE_PATHS
+    list(APPEND EXCLUDE_PATHS
       ${COMPONENTS_DIR}/transport_manager/include/transport_manager/usb/qnx
       ${COMPONENTS_DIR}/transport_manager/src/usb/qnx
     )
 
   elseif(CMAKE_SYSTEM_NAME STREQUAL "QNX")
-    set(EXCLUDE_PATHS
+    list(APPEND EXCLUDE_PATHS
       ${COMPONENTS_DIR}/transport_manager/include/transport_manager/usb/libusb
       ${COMPONENTS_DIR}/transport_manager/src/usb/libusb
     )

--- a/src/components/transport_manager/src/transport_manager_default.cc
+++ b/src/components/transport_manager/src/transport_manager_default.cc
@@ -46,7 +46,7 @@
 
 #if defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
 #include "transport_manager/cloud/cloud_websocket_transport_adapter.h"
-#endif
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
 
 #if defined(BUILD_TESTS)
 #include "transport_manager/iap2_emulation/iap2_transport_adapter.h"
@@ -105,7 +105,7 @@ int TransportManagerDefault::Init(resumption::LastState& last_state) {
   ta_usb = NULL;
 #endif  // USB_SUPPORT
 
-#if defined CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
+#if defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
   transport_adapter::TransportAdapterImpl* ta_cloud =
       new transport_adapter::CloudWebsocketTransportAdapter(last_state,
                                                             get_settings());
@@ -116,7 +116,7 @@ int TransportManagerDefault::Init(resumption::LastState& last_state) {
 #endif  // TELEMETRY_MONITOR
   AddTransportAdapter(ta_cloud);
   ta_cloud = NULL;
-#endif
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
 
 #if defined BUILD_TESTS
   const uint16_t iap2_bt_emu_port = 23456;

--- a/src/components/transport_manager/src/transport_manager_impl.cc
+++ b/src/components/transport_manager/src/transport_manager_impl.cc
@@ -136,7 +136,7 @@ void TransportManagerImpl::AddCloudDevice(
     const transport_manager::transport_adapter::CloudAppProperties&
         cloud_properties) {
 #if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
-  LOG4CXX_TRACE(logger_,"Cloud app support is disabled. Exiting function");
+  LOG4CXX_TRACE(logger_, "Cloud app support is disabled. Exiting function");
 #else
   transport_adapter::DeviceType type = transport_adapter::DeviceType::UNKNOWN;
   if (cloud_properties.cloud_transport_type == "WS") {
@@ -167,7 +167,7 @@ void TransportManagerImpl::AddCloudDevice(
 
 void TransportManagerImpl::RemoveCloudDevice(const DeviceHandle device_handle) {
 #if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
-  LOG4CXX_TRACE(logger_,"Cloud app support is disabled. Exiting function");
+  LOG4CXX_TRACE(logger_, "Cloud app support is disabled. Exiting function");
   return;
 #endif
   DisconnectDevice(device_handle);

--- a/src/components/transport_manager/src/transport_manager_impl.cc
+++ b/src/components/transport_manager/src/transport_manager_impl.cc
@@ -50,7 +50,9 @@
 #include "transport_manager/transport_manager_listener.h"
 #include "transport_manager/transport_manager_listener_empty.h"
 #include "transport_manager/transport_adapter/transport_adapter.h"
+#if defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
 #include "transport_manager/cloud/cloud_websocket_transport_adapter.h"
+#endif
 #include "transport_manager/transport_adapter/transport_adapter_event.h"
 #include "config_profile/profile.h"
 
@@ -135,8 +137,7 @@ void TransportManagerImpl::AddCloudDevice(
         cloud_properties) {
 #if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
   LOG4CXX_TRACE(logger_,"Cloud app support is disabled. Exiting function");
-  return;
-#endif
+#else
   transport_adapter::DeviceType type = transport_adapter::DeviceType::UNKNOWN;
   if (cloud_properties.cloud_transport_type == "WS") {
     type = transport_adapter::DeviceType::CLOUD_WEBSOCKET;
@@ -160,7 +161,7 @@ void TransportManagerImpl::AddCloudDevice(
                                       cloud_properties);
     }
   }
-
+#endif
   return;
 }
 

--- a/src/components/transport_manager/src/transport_manager_impl.cc
+++ b/src/components/transport_manager/src/transport_manager_impl.cc
@@ -133,6 +133,9 @@ void TransportManagerImpl::ReconnectionTimeout() {
 void TransportManagerImpl::AddCloudDevice(
     const transport_manager::transport_adapter::CloudAppProperties&
         cloud_properties) {
+#if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
+  return;
+#endif
   transport_adapter::DeviceType type = transport_adapter::DeviceType::UNKNOWN;
   if (cloud_properties.cloud_transport_type == "WS") {
     type = transport_adapter::DeviceType::CLOUD_WEBSOCKET;

--- a/src/components/transport_manager/src/transport_manager_impl.cc
+++ b/src/components/transport_manager/src/transport_manager_impl.cc
@@ -161,7 +161,7 @@ void TransportManagerImpl::AddCloudDevice(
                                       cloud_properties);
     }
   }
-#endif
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
   return;
 }
 
@@ -169,8 +169,9 @@ void TransportManagerImpl::RemoveCloudDevice(const DeviceHandle device_handle) {
 #if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
   LOG4CXX_TRACE(logger_, "Cloud app support is disabled. Exiting function");
   return;
-#endif
+#else
   DisconnectDevice(device_handle);
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
 }
 
 int TransportManagerImpl::ConnectDevice(const DeviceHandle device_handle) {

--- a/src/components/transport_manager/src/transport_manager_impl.cc
+++ b/src/components/transport_manager/src/transport_manager_impl.cc
@@ -134,6 +134,7 @@ void TransportManagerImpl::AddCloudDevice(
     const transport_manager::transport_adapter::CloudAppProperties&
         cloud_properties) {
 #if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
+  LOG4CXX_TRACE(logger_,"Cloud app support is disabled. Exiting function");
   return;
 #endif
   transport_adapter::DeviceType type = transport_adapter::DeviceType::UNKNOWN;
@@ -164,6 +165,10 @@ void TransportManagerImpl::AddCloudDevice(
 }
 
 void TransportManagerImpl::RemoveCloudDevice(const DeviceHandle device_handle) {
+#if !defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
+  LOG4CXX_TRACE(logger_,"Cloud app support is disabled. Exiting function");
+  return;
+#endif
   DisconnectDevice(device_handle);
 }
 

--- a/src/components/transport_manager/test/transport_adapter_test.cc
+++ b/src/components/transport_manager/test/transport_adapter_test.cc
@@ -478,6 +478,7 @@ TEST_F(TransportAdapterTest, Disconnect_ConnectDoneSuccess) {
   EXPECT_CALL(*serverMock, Terminate());
 }
 
+#if defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
 TEST_F(TransportAdapterTest, FindPending) {
   MockServerConnectionFactory* serverMock = new MockServerConnectionFactory();
   MockTransportAdapterImpl transport_adapter(
@@ -608,6 +609,7 @@ TEST_F(TransportAdapterTest,
 
   EXPECT_CALL(*serverMock, Terminate());
 }
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
 
 TEST_F(TransportAdapterTest, DisconnectDevice_DeviceAddedConnectionCreated) {
   MockServerConnectionFactory* serverMock = new MockServerConnectionFactory();

--- a/src/components/transport_manager/test/transport_manager_impl_test.cc
+++ b/src/components/transport_manager/test/transport_manager_impl_test.cc
@@ -190,6 +190,7 @@ class TransportManagerImplTest : public ::testing::Test {
     tm_.TestHandle(test_event);
   }
 
+#if defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
   void HandlePending() {
     TransportAdapterEvent test_event(EventTypeEnum::ON_CONNECT_PENDING,
                                      mock_adapter_,
@@ -207,6 +208,7 @@ class TransportManagerImplTest : public ::testing::Test {
 
     tm_.TestHandle(test_event);
   }
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
 
   void HandleConnectionFailed() {
     TransportAdapterEvent test_event(EventTypeEnum::ON_CONNECT_FAIL,
@@ -423,6 +425,7 @@ TEST_F(TransportManagerImplTest, DisconnectDevice_DeviceNotConnected) {
   EXPECT_EQ(E_INVALID_HANDLE, tm_.DisconnectDevice(device_handle_));
 }
 
+#if defined(CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT)
 TEST_F(TransportManagerImplTest, Pending) {
   // Calling HandlePending twice verifies the connection_id stays the same if
   // the connection exists.
@@ -448,6 +451,7 @@ TEST_F(TransportManagerImplTest, Pending) {
 
   tm_.TestHandle(test_event);
 }
+#endif  // CLOUD_APP_WEBSOCKET_TRANSPORT_SUPPORT
 
 TEST_F(TransportManagerImplTest, Disconnect) {
   // Arrange


### PR DESCRIPTION
Fixes #2895 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Building with option `BUILD_CLOUD_APP_SUPPORT=OFF` and checking for errors

### Summary
Excluded cloud app transport files when `BUILD_CLOUD_APP_SUPPORT=OFF` and added default returns for cloud app functions in other files

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
