### PR TITLE
Add check for missing option parameter `menu_icon`

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_sub_menu_request.cc
@@ -114,10 +114,12 @@ void AddSubMenuRequest::Run() {
     msg_params[strings::menu_params][strings::position] =
         received_msg_params[strings::position];
   }
+  if (received_msg_params.keyExists(strings::menu_icon)) {
+    msg_params[strings::menu_icon] = received_msg_params[strings::menu_icon];
+  }
   msg_params[strings::menu_params][strings::menu_name] =
       received_msg_params[strings::menu_name];
   msg_params[strings::app_id] = app->app_id();
-  msg_params[strings::menu_icon] = received_msg_params[strings::menu_icon];
 
   StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   SendHMIRequest(hmi_apis::FunctionID::UI_AddSubMenu, &msg_params, true);


### PR DESCRIPTION

Fixes #2744 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Send AddSubMenu without `menu_icon`, verify that `menu_icon` is not sent to the HMI in `UI.AdSubMenu`.

### Summary
Adds check for optional parameter `menu_icon` so that a `null` value is not sent to the HMI

### Changelog
##### Bug Fixes
* Prevent sending `null` value to HMI for `menu_icon`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
