### PR TITLE
Feature/Remote Control - Radio and Climate Parameter Update

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -428,6 +428,7 @@
                         "acMaxEnableAvailable": true,
                         "autoModeEnableAvailable": true,
                         "circulateAirEnableAvailable": true,
+                        "climateEnableAvailable": true,
                         "currentTemperatureAvailable": true,
                         "defrostZone": [
                             "FRONT",
@@ -455,7 +456,7 @@
                 ],
                 "radioControlCapabilities": [
                     {
-                        "availableHDsAvailable": true,
+                        "availableHdChannelsAvailable": true,
                         "hdChannelAvailable": true,
                         "moduleName": "radio",
                         "radioBandAvailable": true,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h
@@ -151,6 +151,7 @@ const char kFrequencyFraction[] = "frequencyFraction";
 const char kBand[] = "band";
 const char kRdsData[] = "rdsData";
 const char kHdRadioEnable[] = "hdRadioEnable";
+const char kAvailableHDs[] = "availableHDs";
 const char kAvailableHdChannels[] = "availableHdChannels";
 const char kHdChannel[] = "hdChannel";
 const char kSignalStrength[] = "signalStrength";

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h
@@ -151,7 +151,7 @@ const char kFrequencyFraction[] = "frequencyFraction";
 const char kBand[] = "band";
 const char kRdsData[] = "rdsData";
 const char kHdRadioEnable[] = "hdRadioEnable";
-const char kAvailableHDs[] = "availableHDs";
+const char kAvailableHdChannels[] = "availableHdChannels";
 const char kHdChannel[] = "hdChannel";
 const char kSignalStrength[] = "signalStrength";
 const char kSignalChangeThreshold[] = "signalChangeThreshold";
@@ -176,6 +176,8 @@ const char kHeatedSteeringWheelEnable[] = "heatedSteeringWheelEnable";
 const char kHeatedWindshieldEnable[] = "heatedWindshieldEnable";
 const char kHeatedRearWindowEnable[] = "heatedRearWindowEnable";
 const char kHeatedMirrorsEnable[] = "heatedMirrorsEnable";
+const char kClimateEnable[] = "climateEnable";
+const char kClimateEnableAvailable[] = "climateEnableAvailable";
 // ClimateControlData struct
 
 // LightControlData

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -108,7 +108,7 @@ void GetInteriorVehicleDataRequest::FilterDisabledModuleData(
   if (module_data.keyExists(message_params::kHdRadioEnable) &&
       module_data[message_params::kHdRadioEnable].asBool() == false) {
     module_data.erase(message_params::kHdChannel);
-    module_data.erase(message_params::kAvailableHDs);
+    module_data.erase(message_params::kAvailableHdChannels);
     module_data.erase(message_params::kSisData);
   }
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -108,6 +108,7 @@ void GetInteriorVehicleDataRequest::FilterDisabledModuleData(
   if (module_data.keyExists(message_params::kHdRadioEnable) &&
       module_data[message_params::kHdRadioEnable].asBool() == false) {
     module_data.erase(message_params::kHdChannel);
+    module_data.erase(message_params::kAvailableHDs);
     module_data.erase(message_params::kAvailableHdChannels);
     module_data.erase(message_params::kSisData);
   }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
@@ -54,6 +54,7 @@ std::vector<std::string> GetModuleReadOnlyParams(
     module_ro_params.push_back(kCurrentTemperature);
   } else if (enums_value::kRadio == module_type) {
     module_ro_params.push_back(kRdsData);
+    module_ro_params.push_back(kAvailableHDs);
     module_ro_params.push_back(kAvailableHdChannels);
     module_ro_params.push_back(kSignalStrength);
     module_ro_params.push_back(kSignalChangeThreshold);
@@ -100,6 +101,7 @@ const std::map<std::string, std::string> GetModuleDataToCapabilitiesMapping() {
   mapping["frequencyInteger"] = "radioFrequencyAvailable";
   mapping["frequencyFraction"] = "radioFrequencyAvailable";
   mapping["rdsData"] = "rdsDataAvailable";
+  mapping["availableHDs"] = "availableHDsAvailable";
   mapping["availableHdChannels"] = "availableHdChannelsAvailable";
   mapping["hdChannel"] = "availableHdChannelsAvailable";
   mapping["hdRadioEnable"] = "hdRadioEnableAvailable";

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
@@ -54,7 +54,7 @@ std::vector<std::string> GetModuleReadOnlyParams(
     module_ro_params.push_back(kCurrentTemperature);
   } else if (enums_value::kRadio == module_type) {
     module_ro_params.push_back(kRdsData);
-    module_ro_params.push_back(kAvailableHDs);
+    module_ro_params.push_back(kAvailableHdChannels);
     module_ro_params.push_back(kSignalStrength);
     module_ro_params.push_back(kSignalChangeThreshold);
     module_ro_params.push_back(kState);
@@ -92,14 +92,16 @@ const std::map<std::string, std::string> GetModuleDataToCapabilitiesMapping() {
   mapping["heatedWindshieldEnable"] = "heatedWindshieldAvailable";
   mapping["heatedMirrorsEnable"] = "heatedMirrorsAvailable";
   mapping["heatedRearWindowEnable"] = "heatedRearWindowAvailable";
+  mapping["climateEnable"] = "climateEnable";
+  mapping["climateEnableAvailable"] = "climateEnableAvailable";
 
   // radio
   mapping["band"] = "radioBandAvailable";
   mapping["frequencyInteger"] = "radioFrequencyAvailable";
   mapping["frequencyFraction"] = "radioFrequencyAvailable";
   mapping["rdsData"] = "rdsDataAvailable";
-  mapping["availableHDs"] = "availableHDsAvailable";
-  mapping["hdChannel"] = "availableHDsAvailable";
+  mapping["availableHdChannels"] = "availableHdChannelsAvailable";
+  mapping["hdChannel"] = "availableHdChannelsAvailable";
   mapping["hdRadioEnable"] = "hdRadioEnableAvailable";
   mapping["signalStrength"] = "signalStrengthAvailable";
   mapping["signalChangeThreshold"] = "signalChangeThresholdAvailable";

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
@@ -92,7 +92,7 @@ const std::map<std::string, std::string> GetModuleDataToCapabilitiesMapping() {
   mapping["heatedWindshieldEnable"] = "heatedWindshieldAvailable";
   mapping["heatedMirrorsEnable"] = "heatedMirrorsAvailable";
   mapping["heatedRearWindowEnable"] = "heatedRearWindowAvailable";
-  mapping["climateEnable"] = "climateEnable";
+  mapping["climateEnable"] = "climateEnableAvailable";
   mapping["climateEnableAvailable"] = "climateEnableAvailable";
 
   // radio

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
@@ -718,21 +718,6 @@ void SetInteriorVehicleDataRequest::CutOffReadOnlyParams(
   const smart_objects::SmartObject& module_type_params =
       ControlData(module_data);
   const std::string module_type = ModuleType();
-  std::vector<std::string> ro_params = GetModuleReadOnlyParams(module_type);
-
-  for (auto& it : ro_params) {
-    if (module_type_params.keyExists(it)) {
-      if (enums_value::kClimate == module_type) {
-        module_data[message_params::kClimateControlData].erase(it);
-      } else if (enums_value::kRadio == module_type) {
-        module_data[message_params::kRadioControlData].erase(it);
-      } else {
-        continue;
-      }
-
-      LOG4CXX_DEBUG(logger_, "Cutting-off READ ONLY parameter: " << it);
-    }
-  }
 
   if (enums_value::kAudio == module_type) {
     auto& equalizer_settings = module_data[message_params::kAudioControlData]
@@ -745,6 +730,15 @@ void SetInteriorVehicleDataRequest::CutOffReadOnlyParams(
                       "Cutting-off READ ONLY parameter: "
                           << message_params::kChannelName);
       }
+    }
+  }
+
+  std::vector<std::string> ro_params = GetModuleReadOnlyParams(module_type);
+  const auto& data_mapping = RCHelpers::GetModuleTypeToDataMapping();
+  for (const auto& param : ro_params) {
+    if (module_type_params.keyExists(param)) {
+      module_data[data_mapping(module_type)].erase(param);
+      LOG4CXX_DEBUG(logger_, "Cutting-off READ ONLY parameter: " << param);
     }
   }
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -44,6 +44,7 @@
 #include "rc_rpc_plugin/rc_module_constants.h"
 #include "rc_rpc_plugin/rc_rpc_plugin.h"
 
+#include <stdint.h>
 #include <chrono>
 #include <thread>
 
@@ -205,6 +206,8 @@ TEST_F(GetInteriorVehicleDataRequestTest,
           HMIResultCodeIs(hmi_apis::FunctionID::RC_GetInteriorVehicleData), _))
       .WillOnce(Return(true));
   // Act
+
+  command->Init();
   command->Run();
 }
 
@@ -232,6 +235,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
           HMIResultCodeIs(hmi_apis::FunctionID::RC_GetInteriorVehicleData), _))
       .WillOnce(Return(true));
   // Act
+  command->Init();
   command->Run();
 }
 
@@ -263,6 +267,7 @@ TEST_F(
       .WillOnce(DoAll(SaveArg<0>(&command_result), Return(true)));
 
   // Act
+  command->Init();
   command->Run();
 
   // Assert
@@ -314,6 +319,7 @@ TEST_F(
       command = CreateRCCommand<
           rc_rpc_plugin::commands::GetInteriorVehicleDataRequest>(
           mobile_message);
+  command->Init();
   command->Run();
   application_manager::event_engine::Event event(
       hmi_apis::FunctionID::RC_GetInteriorVehicleData);
@@ -358,6 +364,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
       .WillOnce(DoAll(SaveArg<0>(&command_result), Return(true)));
 
   // Act
+  command->Init();
   command->Run();
 
   // Assert
@@ -393,6 +400,7 @@ TEST_F(
           MobileResultCodeIs(mobile_apis::Result::UNSUPPORTED_RESOURCE), _))
       .WillOnce((Return(true)));
   // Act
+  command->Init();
   command->Run();
 }
 
@@ -418,6 +426,7 @@ TEST_F(
       .WillOnce((Return(true)));
 
   // Act
+  command->Init();
   command->Run();
 }
 
@@ -458,6 +467,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
   application_manager::event_engine::Event event(
       hmi_apis::FunctionID::RC_GetInteriorVehicleData);
   event.set_smart_object(*hmi_response_message);
+  command->Init();
   command->Run();
   command->on_event(event);
 }
@@ -498,6 +508,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
       hmi_apis::FunctionID::RC_GetInteriorVehicleData);
   event.set_smart_object(*hmi_message);
   auto command = CreateRCCommand<GetInteriorVehicleDataRequest>(mobile_message);
+  command->Init();
   command->Run();
   command->on_event(event);
 }
@@ -542,6 +553,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
       command = CreateRCCommand<
           rc_rpc_plugin::commands::GetInteriorVehicleDataRequest>(
           mobile_message);
+  command->Init();
   command->Run();
   application_manager::event_engine::Event event(
       hmi_apis::FunctionID::RC_GetInteriorVehicleData);
@@ -583,6 +595,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
             _))
         .WillRepeatedly(Return(true));
     // Act
+    command->Init();
     command->Run();
   }
 
@@ -597,6 +610,130 @@ TEST_F(GetInteriorVehicleDataRequestTest,
   EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(0);
 
   // Act
+  command->Init();
   command->Run();
 }
+
+TEST_F(GetInteriorVehicleDataRequestTest,
+       OnEvent_ValidHmiResponse_AvailableHDChanelsIsArrayWithHDChanels) {
+  using rc_rpc_plugin::commands::GetInteriorVehicleDataRequest;
+  namespace hmi_response = application_manager::hmi_response;
+  namespace strings = application_manager::strings;
+
+  const uint32_t chanel1_index = 1u;
+  const uint32_t chanel2_index = 2u;
+  const uint32_t chanel3_index = 3u;
+
+  const uint32_t expected_array_length = 3u;
+
+  // Arrange
+  MessageSharedPtr mobile_message = CreateBasicMessage();
+
+  MessageSharedPtr hmi_response_message = CreateBasicMessage();
+  auto& hmi_response_params = (*hmi_response_message)[strings::msg_params];
+  hmi_response_params[hmi_response::code] = hmi_apis::Common_Result::SUCCESS;
+  hmi_response_params[strings::connection_key] = kAppId;
+
+  auto& msg_params = (*hmi_response_message)[strings::msg_params];
+  msg_params[message_params::kModuleType] = module_type;
+
+  auto available_hd_chanels =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  available_hd_chanels[0] = chanel1_index;
+  available_hd_chanels[1] = chanel2_index;
+  available_hd_chanels[2] = chanel3_index;
+
+  msg_params[message_params::kModuleData][message_params::kRadioControlData]
+            [message_params::kAvailableHdChannels] = available_hd_chanels;
+
+  ON_CALL(mock_interior_data_cache_, Contains(_)).WillByDefault(Return(false));
+  ON_CALL(mock_interior_data_manager_, CheckRequestsToHMIFrequency(_))
+      .WillByDefault(Return(true));
+
+  MessageSharedPtr message_to_mob = CreateBasicMessage();
+
+  // Expectations
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).WillOnce(Return(true));
+  EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&message_to_mob), Return(true)));
+
+  // Act
+  auto command = CreateRCCommand<GetInteriorVehicleDataRequest>(mobile_message);
+  application_manager::event_engine::Event event(
+      hmi_apis::FunctionID::RC_GetInteriorVehicleData);
+
+  command->Init();
+  command->Run();
+
+  event.set_smart_object(*hmi_response_message);
+  command->on_event(event);
+
+  auto& hd_chanels =
+      (*message_to_mob)[strings::msg_params][message_params::kModuleData]
+                       [message_params::kRadioControlData]
+                       [message_params::kAvailableHdChannels];
+  const size_t array_length = hd_chanels.length();
+
+  EXPECT_EQ(expected_array_length, array_length);
+
+  EXPECT_EQ(chanel1_index, hd_chanels[0].asUInt());
+  EXPECT_EQ(chanel2_index, hd_chanels[1].asUInt());
+  EXPECT_EQ(chanel3_index, hd_chanels[2].asUInt());
+}
+
+TEST_F(GetInteriorVehicleDataRequestTest,
+       OnEvent_ValidHmiResponse_ClimateEnableAvailable) {
+  using rc_rpc_plugin::commands::GetInteriorVehicleDataRequest;
+  namespace hmi_response = application_manager::hmi_response;
+  namespace strings = application_manager::strings;
+
+  // Arrange
+  MessageSharedPtr mobile_message = CreateBasicMessage();
+
+  MessageSharedPtr hmi_response_message = CreateBasicMessage();
+  auto& hmi_response_params = (*hmi_response_message)[strings::msg_params];
+  hmi_response_params[hmi_response::code] = hmi_apis::Common_Result::SUCCESS;
+  hmi_response_params[strings::connection_key] = kAppId;
+
+  auto& msg_params = (*hmi_response_message)[strings::msg_params];
+
+  auto climate_control_data =
+      smart_objects::SmartObject(smart_objects::SmartType_Boolean);
+  climate_control_data = true;
+
+  msg_params[message_params::kModuleData][message_params::kClimateControlData]
+            [message_params::kClimateEnableAvailable] = climate_control_data;
+
+  ON_CALL(mock_interior_data_cache_, Contains(_)).WillByDefault(Return(false));
+  ON_CALL(mock_interior_data_manager_, CheckRequestsToHMIFrequency(_))
+      .WillByDefault(Return(true));
+
+  auto message_to_mob = CreateBasicMessage();
+
+  // Expectations
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).WillOnce(Return(true));
+  EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&message_to_mob), Return(true)));
+
+  // Act
+  auto command = CreateRCCommand<GetInteriorVehicleDataRequest>(mobile_message);
+  application_manager::event_engine::Event event(
+      hmi_apis::FunctionID::RC_GetInteriorVehicleData);
+
+  command->Init();
+  command->Run();
+
+  event.set_smart_object(*hmi_response_message);
+  command->on_event(event);
+
+  const bool climate_enable_available =
+      (*message_to_mob)[strings::msg_params][message_params::kModuleData]
+                       [message_params::kClimateControlData]
+                       [message_params::kClimateEnableAvailable]
+                           .asBool();
+
+  EXPECT_TRUE(climate_enable_available);
+}
+
 }  // namespace rc_rpc_plugin_test

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -654,7 +654,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
   MessageSharedPtr message_to_mob = CreateBasicMessage();
 
   // Expectations
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).WillOnce(Return(true));
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).WillOnce(Return(true));
   EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _))
       .WillOnce(DoAll(SaveArg<0>(&message_to_mob), Return(true)));
 
@@ -712,7 +712,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
   auto message_to_mob = CreateBasicMessage();
 
   // Expectations
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).WillOnce(Return(true));
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).WillOnce(Return(true));
   EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _))
       .WillOnce(DoAll(SaveArg<0>(&message_to_mob), Return(true)));
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -207,7 +207,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
       .WillOnce(Return(true));
   // Act
 
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
 }
 
@@ -235,7 +235,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
           HMIResultCodeIs(hmi_apis::FunctionID::RC_GetInteriorVehicleData), _))
       .WillOnce(Return(true));
   // Act
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
 }
 
@@ -267,7 +267,7 @@ TEST_F(
       .WillOnce(DoAll(SaveArg<0>(&command_result), Return(true)));
 
   // Act
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
 
   // Assert
@@ -319,7 +319,7 @@ TEST_F(
       command = CreateRCCommand<
           rc_rpc_plugin::commands::GetInteriorVehicleDataRequest>(
           mobile_message);
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
   application_manager::event_engine::Event event(
       hmi_apis::FunctionID::RC_GetInteriorVehicleData);
@@ -364,7 +364,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
       .WillOnce(DoAll(SaveArg<0>(&command_result), Return(true)));
 
   // Act
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
 
   // Assert
@@ -400,7 +400,7 @@ TEST_F(
           MobileResultCodeIs(mobile_apis::Result::UNSUPPORTED_RESOURCE), _))
       .WillOnce((Return(true)));
   // Act
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
 }
 
@@ -426,7 +426,7 @@ TEST_F(
       .WillOnce((Return(true)));
 
   // Act
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
 }
 
@@ -467,7 +467,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
   application_manager::event_engine::Event event(
       hmi_apis::FunctionID::RC_GetInteriorVehicleData);
   event.set_smart_object(*hmi_response_message);
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
   command->on_event(event);
 }
@@ -508,7 +508,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
       hmi_apis::FunctionID::RC_GetInteriorVehicleData);
   event.set_smart_object(*hmi_message);
   auto command = CreateRCCommand<GetInteriorVehicleDataRequest>(mobile_message);
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
   command->on_event(event);
 }
@@ -553,7 +553,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
       command = CreateRCCommand<
           rc_rpc_plugin::commands::GetInteriorVehicleDataRequest>(
           mobile_message);
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
   application_manager::event_engine::Event event(
       hmi_apis::FunctionID::RC_GetInteriorVehicleData);
@@ -595,7 +595,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
             _))
         .WillRepeatedly(Return(true));
     // Act
-    command->Init();
+    ASSERT_TRUE(command->Init());
     command->Run();
   }
 
@@ -610,7 +610,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
   EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(0);
 
   // Act
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
 }
 
@@ -663,7 +663,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
   application_manager::event_engine::Event event(
       hmi_apis::FunctionID::RC_GetInteriorVehicleData);
 
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
 
   event.set_smart_object(*hmi_response_message);
@@ -721,7 +721,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
   application_manager::event_engine::Event event(
       hmi_apis::FunctionID::RC_GetInteriorVehicleData);
 
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
 
   event.set_smart_object(*hmi_response_message);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
@@ -265,7 +265,7 @@ TEST_F(SetInteriorVehicleDataRequestTest,
 
   MessageSharedPtr message_from_mobile = CreateBasicMessage();
 
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_))
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _))
       .WillOnce(DoAll(SaveArg<0>(&message_from_mobile), Return(true)));
 
   std::shared_ptr<rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>
@@ -311,7 +311,7 @@ TEST_F(SetInteriorVehicleDataRequestTest,
 
   auto message_from_mobile = CreateBasicMessage();
 
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_))
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _))
       .WillOnce(DoAll(SaveArg<0>(&message_from_mobile), Return(true)));
 
   std::shared_ptr<rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
@@ -34,13 +34,15 @@
 #include "application_manager/application.h"
 #include "application_manager/commands/command_request_test.h"
 #include "application_manager/mock_application.h"
-#include "gtest/gtest.h"
 #include "interfaces/MOBILE_API.h"
 #include "rc_rpc_plugin/mock/mock_interior_data_cache.h"
 #include "rc_rpc_plugin/mock/mock_interior_data_manager.h"
 #include "rc_rpc_plugin/mock/mock_resource_allocation_manager.h"
 #include "rc_rpc_plugin/rc_module_constants.h"
 #include "rc_rpc_plugin/rc_rpc_plugin.h"
+
+#include <stdint.h>
+#include "gtest/gtest.h"
 
 using application_manager::ApplicationSet;
 using application_manager::commands::MessageSharedPtr;
@@ -51,6 +53,7 @@ using test::components::commands_test::CommandsTestMocks;
 using ::testing::_;
 using ::testing::NiceMock;
 using ::testing::Return;
+using ::testing::SaveArg;
 
 namespace {
 const uint32_t kAppId = 0u;
@@ -159,6 +162,7 @@ TEST_F(SetInteriorVehicleDataRequestTest,
       command = CreateRCCommand<
           rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>(
           mobile_message);
+  command->Init();
   command->Run();
 }
 
@@ -198,6 +202,7 @@ TEST_F(
       command = CreateRCCommand<
           rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>(
           mobile_message);
+  command->Init();
   command->Run();
 }
 
@@ -229,7 +234,99 @@ TEST_F(
       command = CreateRCCommand<
           rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>(
           mobile_message);
+  command->Init();
   command->Run();
 }
 
+TEST_F(SetInteriorVehicleDataRequestTest,
+       Execute_ValidWithSettableParams_SUCCESSSendToHMI) {
+  MessageSharedPtr mobile_message = CreateBasicMessage();
+  auto& msg_params =
+      (*mobile_message)[application_manager::strings::msg_params];
+  msg_params[message_params::kModuleData][message_params::kModuleType] =
+      mobile_apis::ModuleType::CLIMATE;
+
+  msg_params[message_params::kModuleData][message_params::kClimateControlData] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  msg_params[message_params::kModuleData][message_params::kClimateControlData]
+            [message_params::kClimateEnable] = true;
+
+  // Expectations
+  EXPECT_CALL(mock_policy_handler_, CheckModule(kPolicyAppId, _))
+      .WillOnce(Return(rc_rpc_plugin::TypeAccess::kAllowed));
+
+  EXPECT_CALL(mock_hmi_capabilities_, rc_capability())
+      .WillOnce(Return(nullptr));
+
+  MessageSharedPtr message_from_mobile = CreateBasicMessage();
+
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&message_from_mobile), Return(true)));
+
+  std::shared_ptr<rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>
+      command = CreateRCCommand<
+          rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>(
+          mobile_message);
+
+  command->Init();
+  command->Run();
+
+  auto& msg_params_from_mobile =
+      (*message_from_mobile)[application_manager::strings::msg_params];
+
+  const bool climate_enable =
+      msg_params_from_mobile[message_params::kModuleData]
+                            [message_params::kClimateControlData]
+                            [message_params::kClimateEnable]
+                                .asBool();
+  EXPECT_TRUE(climate_enable);
+}
+
+TEST_F(SetInteriorVehicleDataRequestTest,
+       Execute_ValidWithSettableParams_SUCCESSSendToHMI_HDChannel) {
+  MessageSharedPtr mobile_message = CreateBasicMessage();
+  auto& msg_params =
+      (*mobile_message)[application_manager::strings::msg_params];
+  msg_params[message_params::kModuleData][message_params::kModuleType] =
+      mobile_apis::ModuleType::RADIO;
+
+  msg_params[message_params::kModuleData][message_params::kRadioControlData] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  const std::uint32_t hd_channel = 2u;
+  msg_params[message_params::kModuleData][message_params::kRadioControlData]
+            [message_params::kHdChannel] = hd_channel;
+
+  // Expectations
+  EXPECT_CALL(mock_policy_handler_, CheckModule(kPolicyAppId, _))
+      .WillOnce(Return(rc_rpc_plugin::TypeAccess::kAllowed));
+
+  EXPECT_CALL(mock_hmi_capabilities_, rc_capability())
+      .WillOnce(Return(nullptr));
+
+  auto message_from_mobile = CreateBasicMessage();
+
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_))
+      .WillOnce(DoAll(SaveArg<0>(&message_from_mobile), Return(true)));
+
+  std::shared_ptr<rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>
+      command = CreateRCCommand<
+          rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>(
+          mobile_message);
+
+  command->Init();
+  command->Run();
+
+  auto& msg_params_from_mobile =
+      (*message_from_mobile)[application_manager::strings::msg_params];
+
+  const uint64_t hd_channel_from_hmi =
+      msg_params_from_mobile[message_params::kModuleData]
+                            [message_params::kRadioControlData]
+                            [message_params::kHdChannel]
+                                .asUInt();
+
+  EXPECT_EQ(hd_channel, hd_channel_from_hmi);
+}
 }  // namespace rc_rpc_plugin_test

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
@@ -50,6 +50,7 @@ using test::components::application_manager_test::MockApplication;
 using test::components::application_manager_test::MockApplicationManager;
 using test::components::commands_test::CommandRequestTest;
 using test::components::commands_test::CommandsTestMocks;
+using test::components::commands_test::HMIResultCodeIs;
 using ::testing::_;
 using ::testing::NiceMock;
 using ::testing::Return;
@@ -143,8 +144,11 @@ TEST_F(SetInteriorVehicleDataRequestTest,
       (*mobile_message)[application_manager::strings::msg_params];
   msg_params[message_params::kModuleData][message_params::kModuleType] =
       mobile_apis::ModuleType::CLIMATE;
+  smart_objects::SmartObject climate_control_data(smart_objects::SmartType_Map);
+  climate_control_data[message_params::kFanSpeed] = 10;
+
   msg_params[message_params::kModuleData][message_params::kClimateControlData] =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
+      climate_control_data;
   // Expectations
   EXPECT_CALL(mock_policy_handler_, CheckModule(kPolicyAppId, _))
       .WillOnce(Return(rc_rpc_plugin::TypeAccess::kAllowed));
@@ -154,15 +158,15 @@ TEST_F(SetInteriorVehicleDataRequestTest,
 
   EXPECT_CALL(
       mock_rpc_service_,
-      ManageMobileCommand(test::components::commands_test::MobileResultCodeIs(
-                              mobile_apis::Result::READ_ONLY),
-                          application_manager::commands::Command::SOURCE_SDL));
+      ManageHMICommand(
+          HMIResultCodeIs(hmi_apis::FunctionID::RC_SetInteriorVehicleData), _))
+      .WillOnce(Return(true));
   // Act
   std::shared_ptr<rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>
       command = CreateRCCommand<
           rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>(
           mobile_message);
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
 }
 
@@ -193,16 +197,16 @@ TEST_F(
 
   EXPECT_CALL(
       mock_rpc_service_,
-      ManageMobileCommand(test::components::commands_test::MobileResultCodeIs(
-                              mobile_apis::Result::OUT_OF_MEMORY),
-                          application_manager::commands::Command::SOURCE_SDL));
+      ManageHMICommand(
+          HMIResultCodeIs(hmi_apis::FunctionID::RC_SetInteriorVehicleData), _))
+      .WillOnce(Return(true));
 
   // Act
   std::shared_ptr<rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>
       command = CreateRCCommand<
           rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>(
           mobile_message);
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
 }
 
@@ -234,7 +238,7 @@ TEST_F(
       command = CreateRCCommand<
           rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>(
           mobile_message);
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
 }
 
@@ -269,7 +273,7 @@ TEST_F(SetInteriorVehicleDataRequestTest,
           rc_rpc_plugin::commands::SetInteriorVehicleDataRequest>(
           mobile_message);
 
-  command->Init();
+  ASSERT_TRUE(command->Init());
   command->Run();
 
   auto& msg_params_from_mobile =

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_get_capabilities_response_test.cc
@@ -138,7 +138,7 @@ TEST_F(RCGetCapabilitiesResponseTest, RUN_SUCCESSS) {
   radio_control_capability["radioFrequencyAvailable"] = true;
   radio_control_capability["hdChannelAvailable"] = true;
   radio_control_capability["rdsDataAvailable"] = true;
-  radio_control_capability["availableHDsAvailable"] = true;
+  radio_control_capability["availableHdChannelsAvailable"] = true;
   radio_control_capability["stateAvailable"] = true;
   radio_control_capability["signalStrengthAvailable"] = true;
   radio_control_capability["signalChangeThresholdAvailable"] = true;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_get_capabilities_response_test.cc
@@ -138,6 +138,7 @@ TEST_F(RCGetCapabilitiesResponseTest, RUN_SUCCESSS) {
   radio_control_capability["radioFrequencyAvailable"] = true;
   radio_control_capability["hdChannelAvailable"] = true;
   radio_control_capability["rdsDataAvailable"] = true;
+  radio_control_capability["availableHDsAvailable"] = true;
   radio_control_capability["availableHdChannelsAvailable"] = true;
   radio_control_capability["stateAvailable"] = true;
   radio_control_capability["signalStrengthAvailable"] = true;

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -2040,7 +2040,7 @@
    <param name="heatedMirrorsEnable" type="Boolean" mandatory="false">
        <description>value false means disabled, value true means enabled.</description>
    </param>
-   <param name="climateEnable" type="Boolean" mandatory="false" since="5.1">
+   <param name="climateEnable" type="Boolean" mandatory="false">
    </param>
  </struct>
 

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1888,7 +1888,7 @@
    <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false">
      <description>The list of available hd sub-channel indexes. Empty list means no Hd channel is available. Read-only.</description>
    </param>
-   <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false">
+   <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false">
      <description>Current HD sub-channel if available</description>
    </param>
    <param name="signalStrength" type="Integer" minvalue="0" maxvalue="100" mandatory="false">

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1879,10 +1879,16 @@
    <param name="hdRadioEnable" type="Boolean" mandatory="false">
      <description> True if the hd radio is on, false is the radio is off</description>
    </param>
+   <param name="availableHDs" type="Integer" minvalue="1" maxvalue="7" mandatory="false">
+    <description>
+       Number of HD sub-channels if available.
+       Note that this parameter is deprecated in MOBILE API.
+    </description>
+   </param>
    <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false">
      <description>The list of available hd sub-channel indexes. Empty list means no Hd channel is available. Read-only.</description>
    </param>
-   <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false">
+   <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false">
      <description>Current HD sub-channel if available</description>
    </param>
    <param name="signalStrength" type="Integer" minvalue="0" maxvalue="100" mandatory="false">
@@ -1935,6 +1941,14 @@
        True: Available, False: Not Available, Not present: Not Available.
      </description>
    </param>
+   <param name="availableHDsAvailable" type="Boolean" mandatory="false" >
+   <description>
+       Availability of the getting the number of available HD channels.
+       True: Available, False: Not Available, Not present: Not Available.
+       Note that this parameter is deprecated in MOBILE API
+     </description>
+   </param>
+
    <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false">
      <description>
        Availability of the list of available HD sub-channel indexes.

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1882,7 +1882,7 @@
    <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false">
      <description>The list of available hd sub-channel indexes. Empty list means no Hd channel is available. Read-only.</description>
    </param>
-   <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false">
+   <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false">
      <description>Current HD sub-channel if available</description>
    </param>
    <param name="signalStrength" type="Integer" minvalue="0" maxvalue="100" mandatory="false">

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1879,8 +1879,8 @@
    <param name="hdRadioEnable" type="Boolean" mandatory="false">
      <description> True if the hd radio is on, false is the radio is off</description>
    </param>
-   <param name="availableHDs" type="Integer" minvalue="1" maxvalue="7" mandatory="false">
-     <description>number of HD sub-channels if available</description>
+   <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false">
+     <description>The list of available hd sub-channel indexes. Empty list means no Hd channel is available. Read-only.</description>
    </param>
    <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false">
      <description>Current HD sub-channel if available</description>
@@ -1935,9 +1935,9 @@
        True: Available, False: Not Available, Not present: Not Available.
      </description>
    </param>
-   <param name="availableHDsAvailable" type="Boolean" mandatory="false" >
+   <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false">
      <description>
-       Availability of the getting the number of available HD channels.
+       Availability of the list of available HD sub-channel indexes.
        True: Available, False: Not Available, Not present: Not Available.
      </description>
    </param>
@@ -2040,6 +2040,8 @@
    <param name="heatedMirrorsEnable" type="Boolean" mandatory="false">
        <description>value false means disabled, value true means enabled.</description>
    </param>
+   <param name="climateEnable" type="Boolean" mandatory="false" since="5.1">
+   </param>
  </struct>
 
    <struct name="ClimateControlCapabilities">
@@ -2138,6 +2140,12 @@
    <param name="heatedMirrorsAvailable" type="Boolean" mandatory="false">
        <description>
          Availability of the control (enable/disable) of heated Mirrors.
+         True: Available, False: Not Available, Not present: Not Available.
+       </description>
+   </param>
+   <param name="climateEnableAvailable" type="Boolean" mandatory="false">
+       <description>
+         Availability of the control of enable/disable climate control.
          True: Available, False: Not Available, Not present: Not Available.
        </description>
    </param>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -3100,21 +3100,21 @@
         <param name="hdRadioEnable" type="Boolean" mandatory="false"  since="5.0">
             <description> True if the hd radio is on, false if the radio is off</description>
         </param>
-        <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" deprecated="true" since="5.1">
+        <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" deprecated="true" since="5.2">
             <description>Number of HD sub-channels if available</description>
             <history>
                 <param name="availableHDs" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
-                <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.0" until="5.1"/>
+                <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.0" until="5.2"/>
             </history>
         </param>
-        <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="5.0">
+        <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="5.2">
             <description>The list of available HD sub-channel indexes. Empty list means no Hd channel is available. Read-only. </description>
         </param>
-        <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.0">
+        <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.2">
             <description>Current HD sub-channel if available</description>
             <history>
                 <param name="hdChannel" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
-                <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0" until="5.1"/>
+                <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0" until="5.2"/>
             </history>
         </param>
         <param name="signalStrength" type="Integer" minvalue="0" maxvalue="100" mandatory="false">
@@ -3165,7 +3165,7 @@
         <param name="heatedMirrorsEnable" type="Boolean" mandatory="false" since="5.0">
             <description>value false means disabled, value true means enabled.</description>
         </param>
-        <param name="climateEnable" type="Boolean" mandatory="false" since="5.1">
+        <param name="climateEnable" type="Boolean" mandatory="false" since="5.2">
         </param>
     </struct>
 
@@ -3208,16 +3208,16 @@
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
         </param>
-        <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="5.0">
+        <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="5.2">
             <description>
                 Availability of the getting the number of available HD channels.
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
             <history>
-                <param name="availableHDsAvailable" type="Boolean" mandatory="false" since="1.0" until="5.1"/>
+                <param name="availableHDsAvailable" type="Boolean" mandatory="false" since="1.0" until="5.2"/>
             </history>
         </param>
-        <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.0">
+        <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.2">
             <description>
                 Availability of the list of available HD sub-channel indexes.
                 True: Available, False: Not Available, Not present: Not Available.
@@ -3362,7 +3362,7 @@
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
         </param>
-        <param name="climateEnableAvailable" type="Boolean" mandatory="false" since="5.1">
+        <param name="climateEnableAvailable" type="Boolean" mandatory="false" since="5.2">
             <description>
                 Availability of the control of enable/disable climate control.
                 True: Available, False: Not Available, Not present: Not Available.

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -3107,10 +3107,10 @@
                 <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.0" until="5.1"/>
             </history>
         </param>
-        <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="5.1">
+        <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="5.0">
             <description>The list of available HD sub-channel indexes. Empty list means no Hd channel is available. Read-only. </description>
         </param>
-        <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.1">
+        <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.0">
             <description>Current HD sub-channel if available</description>
             <history>
                 <param name="hdChannel" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
@@ -3208,7 +3208,7 @@
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
         </param>
-        <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="5.1">
+        <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="5.0">
             <description>
                 Availability of the getting the number of available HD channels.
                 True: Available, False: Not Available, Not present: Not Available.
@@ -3217,7 +3217,7 @@
                 <param name="availableHDsAvailable" type="Boolean" mandatory="false" since="1.0" until="5.1"/>
             </history>
         </param>
-        <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.1">
+        <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.0">
             <description>
                 Availability of the list of available HD sub-channel indexes.
                 True: Available, False: Not Available, Not present: Not Available.

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -3100,21 +3100,21 @@
         <param name="hdRadioEnable" type="Boolean" mandatory="false"  since="5.0">
             <description> True if the hd radio is on, false if the radio is off</description>
         </param>
-        <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" deprecated="true" since="5.2">
+        <param name="availableHDs" type="Integer" minvalue="1" maxvalue="7" mandatory="false" deprecated="true" since="5.2">
             <description>Number of HD sub-channels if available</description>
             <history>
                 <param name="availableHDs" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
-                <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.0" until="5.2"/>
+                <param name="availableHDs" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0" until="5.1"/>
             </history>
         </param>
         <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="5.2">
             <description>The list of available HD sub-channel indexes. Empty list means no Hd channel is available. Read-only. </description>
         </param>
-        <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.2">
+        <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="6.0">
             <description>Current HD sub-channel if available</description>
             <history>
                 <param name="hdChannel" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
-                <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0" until="5.2"/>
+                <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0" until="6.0"/>
             </history>
         </param>
         <param name="signalStrength" type="Integer" minvalue="0" maxvalue="100" mandatory="false">
@@ -3214,7 +3214,7 @@
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
             <history>
-                <param name="availableHDsAvailable" type="Boolean" mandatory="false" since="1.0" until="5.2"/>
+                <param name="availableHDsAvailable" type="Boolean" mandatory="false" since="4.5" until="5.2"/>
             </history>
         </param>
         <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.2">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <?xml-stylesheet type="text/xml" href="protocol2html.xsl"?>
 
-<interface name="SmartDeviceLink RAPI" version="5.1.0" minVersion="1.0" date="2019-03-19">
+<interface name="SmartDeviceLink RAPI" version="6.0.0" minVersion="1.0" date="2019-03-19">
     <enum name="Result" internal_scope="base" since="1.0">
         <element name="SUCCESS">
             <description>The request succeeded</description>
@@ -3100,14 +3100,14 @@
         <param name="hdRadioEnable" type="Boolean" mandatory="false"  since="5.0">
             <description> True if the hd radio is on, false if the radio is off</description>
         </param>
-        <param name="availableHDs" type="Integer" minvalue="1" maxvalue="7" mandatory="false" deprecated="true" since="5.2">
+        <param name="availableHDs" type="Integer" minvalue="1" maxvalue="7" mandatory="false" deprecated="true" since="6.0">
             <description>Number of HD sub-channels if available</description>
             <history>
                 <param name="availableHDs" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
-                <param name="availableHDs" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0" until="5.1"/>
+                <param name="availableHDs" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0" until="6.0"/>
             </history>
         </param>
-        <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="5.2">
+        <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="6.0">
             <description>The list of available HD sub-channel indexes. Empty list means no Hd channel is available. Read-only. </description>
         </param>
         <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="6.0">
@@ -3165,7 +3165,7 @@
         <param name="heatedMirrorsEnable" type="Boolean" mandatory="false" since="5.0">
             <description>value false means disabled, value true means enabled.</description>
         </param>
-        <param name="climateEnable" type="Boolean" mandatory="false" since="5.2">
+        <param name="climateEnable" type="Boolean" mandatory="false" since="6.0">
         </param>
     </struct>
 
@@ -3208,16 +3208,16 @@
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
         </param>
-        <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="5.2">
+        <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="6.0">
             <description>
                 Availability of the getting the number of available HD channels.
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
             <history>
-                <param name="availableHDsAvailable" type="Boolean" mandatory="false" since="4.5" until="5.2"/>
+                <param name="availableHDsAvailable" type="Boolean" mandatory="false" since="4.5" until="6.0"/>
             </history>
         </param>
-        <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.2">
+        <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="6.0">
             <description>
                 Availability of the list of available HD sub-channel indexes.
                 True: Available, False: Not Available, Not present: Not Available.
@@ -3362,7 +3362,7 @@
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
         </param>
-        <param name="climateEnableAvailable" type="Boolean" mandatory="false" since="5.2">
+        <param name="climateEnableAvailable" type="Boolean" mandatory="false" since="6.0">
             <description>
                 Availability of the control of enable/disable climate control.
                 True: Available, False: Not Available, Not present: Not Available.

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -3100,16 +3100,21 @@
         <param name="hdRadioEnable" type="Boolean" mandatory="false"  since="5.0">
             <description> True if the hd radio is on, false if the radio is off</description>
         </param>
-        <param name="availableHDs" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0">
-            <description>number of HD sub-channels if available</description>
+        <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" deprecated="true" since="5.1">
+            <description>Number of HD sub-channels if available</description>
             <history>
                 <param name="availableHDs" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
+                <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.0" until="5.1"/>
             </history>
         </param>
-        <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0">
+        <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="5.1">
+            <description>The list of available HD sub-channel indexes. Empty list means no Hd channel is available. Read-only. </description>
+        </param>
+        <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.1">
             <description>Current HD sub-channel if available</description>
             <history>
                 <param name="hdChannel" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
+                <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0" until="5.1"/>
             </history>
         </param>
         <param name="signalStrength" type="Integer" minvalue="0" maxvalue="100" mandatory="false">
@@ -3160,6 +3165,8 @@
         <param name="heatedMirrorsEnable" type="Boolean" mandatory="false" since="5.0">
             <description>value false means disabled, value true means enabled.</description>
         </param>
+        <param name="climateEnable" type="Boolean" mandatory="false" since="5.1">
+        </param>
     </struct>
 
     <struct name="RadioControlCapabilities" since="4.5">
@@ -3201,9 +3208,18 @@
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
         </param>
-        <param name="availableHDsAvailable" type="Boolean" mandatory="false">
+        <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="5.1">
             <description>
                 Availability of the getting the number of available HD channels.
+                True: Available, False: Not Available, Not present: Not Available.
+            </description>
+            <history>
+                <param name="availableHDsAvailable" type="Boolean" mandatory="false" since="1.0" until="5.1"/>
+            </history>
+        </param>
+        <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.1">
+            <description>
+                Availability of the list of available HD sub-channel indexes.
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
         </param>
@@ -3343,6 +3359,12 @@
         <param name="heatedMirrorsAvailable" type="Boolean" mandatory="false" since="5.0">
             <description>
                 Availability of the control (enable/disable) of heated Mirrors.
+                True: Available, False: Not Available, Not present: Not Available.
+            </description>
+        </param>
+        <param name="climateEnableAvailable" type="Boolean" mandatory="false" since="5.1">
+            <description>
+                Availability of the control of enable/disable climate control.
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
         </param>


### PR DESCRIPTION
Fixes #2793

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2191
### Summary
This proposal changes the minimum index of HD radio sub-channels from 1 to 0.
In addition, we propose to add a new parameter climateEnable to ClimateControlData which will allow an application to power climate control on or off.

##### Enhancements
 * Refactor CutOffReadOnlyParams() method for better readable.
 * Update SetInteriorData Unit tests because of incorrect behavior.

### Other parts of delivery:
* HMI Integration guidelines: https://github.com/smartdevicelink/sdl_hmi_integration_guidelines/pull/153
* SDL requirements: https://github.com/smartdevicelink/sdl_requirements/pull/121
* ATF scripts: https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2191
* HMI: https://github.com/smartdevicelink/sdl_hmi/pull/183

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
