### PR TITLE
Fix shutdown crash static var colission

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,7 @@ set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR})
 set(ARCHIVE_OUTPUT_DIRECTORY ./bin)
 
 set(EXCLUDE_ERROR_FLAGS "-Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=deprecated-declarations")
-set(CMAKE_CXX_FLAGS "-fPIC -std=gnu++0x -Wall -Werror ${EXCLUDE_ERROR_FLAGS} -Wuninitialized -Wvla")
+set(CMAKE_CXX_FLAGS "-fPIC -std=gnu++0x -Wall -fvisibility=hidden -Werror ${EXCLUDE_ERROR_FLAGS} -Wuninitialized -Wvla")
 
 if (USE_GOLD_LD)
   execute_process(COMMAND ld -v OUTPUT_VARIABLE result)

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1452,8 +1452,8 @@ class ApplicationManagerImpl
   connection_handler::ConnectionHandler* connection_handler_;
   std::unique_ptr<policy::PolicyHandlerInterface> policy_handler_;
   protocol_handler::ProtocolHandler* protocol_handler_;
-  request_controller::RequestController request_ctrl_;
   std::unique_ptr<plugin_manager::RPCPluginManager> plugin_manager_;
+  request_controller::RequestController request_ctrl_;
   std::unique_ptr<application_manager::AppServiceManager> app_service_manager_;
 
   /**

--- a/src/components/application_manager/include/application_manager/plugin_manager/rpc_plugin.h
+++ b/src/components/application_manager/include/application_manager/plugin_manager/rpc_plugin.h
@@ -117,7 +117,6 @@ class RPCPlugin {
       ApplicationEvent event,
       application_manager::ApplicationSharedPtr application) = 0;
 };
-typedef std::unique_ptr<RPCPlugin> RPCPluginPtr;
 
 }  // namespace plugin_manager
 }  // namespace application_manager

--- a/src/components/application_manager/include/application_manager/plugin_manager/rpc_plugin_manager.h
+++ b/src/components/application_manager/include/application_manager/plugin_manager/rpc_plugin_manager.h
@@ -44,6 +44,10 @@ namespace application_manager {
 namespace plugin_manager {
 
 class RPCPluginManager {
+ protected:
+  typedef std::unique_ptr<RPCPlugin, std::function<void(RPCPlugin*)> >
+      RPCPluginPtr;
+
  public:
   virtual ~RPCPluginManager() {}
   /**
@@ -59,6 +63,7 @@ class RPCPluginManager {
    * @brief GetPlugins get list of plugins
    * @return list of loaded plugins
    */
+  DEPRECATED
   virtual std::vector<RPCPluginPtr>& GetPlugins() = 0;
 
   /**

--- a/src/components/application_manager/include/application_manager/plugin_manager/rpc_plugin_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/plugin_manager/rpc_plugin_manager_impl.h
@@ -58,12 +58,17 @@ class RPCPluginManagerImpl : public RPCPluginManager {
                        policy::PolicyHandlerInterface& policy_handler);
 
   uint32_t LoadPlugins(const std::string& plugins_path) OVERRIDE;
+
+  DEPRECATED
   std::vector<RPCPluginPtr>& GetPlugins() OVERRIDE;
+
   utils::Optional<RPCPlugin> FindPluginToProcess(
       const int32_t function_id,
       const commands::Command::CommandSource message_source) OVERRIDE;
 
  private:
+  RPCPluginPtr LoadPlugin(const std::string& full_plugin_path) const;
+
   std::vector<RPCPluginPtr> loaded_plugins_;
   ApplicationManager& app_manager_;
   rpc_service::RPCService& rpc_service_;

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/CMakeLists.txt
@@ -59,18 +59,19 @@ set(LIBRARIES
   v4_protocol_v1_2_no_extra
   SmartObjects
   Utils
-  sdl_rpc_plugin
+  sdl_rpc_plugin_static
 )
 
 if(ENABLE_LOG)
   list(APPEND LIBRARIES log4cxx -L${LOG4CXX_LIBS_DIRECTORY})
 endif()
 
-add_library("app_service_rpc_plugin" SHARED ${PLUGIN_SOURCES} ${MOBILE_COMMANDS} ${HMI_COMMANDS} ${COMMANDS_SOURCES})
-target_link_libraries("app_service_rpc_plugin" ${LIBRARIES})
+add_library("app_service_rpc_plugin_static" ${PLUGIN_SOURCES} ${MOBILE_COMMANDS} ${HMI_COMMANDS})
+target_link_libraries("app_service_rpc_plugin_static" ${LIBRARIES})
 
-add_library("AppServiceRpcPluginStaticLib" ${PLUGIN_SOURCES} ${MOBILE_COMMANDS} ${HMI_COMMANDS})
-target_link_libraries("AppServiceRpcPluginStaticLib" ${LIBRARIES})
+add_library("app_service_rpc_plugin" SHARED "src/app_service_rpc_plugin.cc")
+target_link_libraries("app_service_rpc_plugin" app_service_rpc_plugin_static)
+
 
 set(INSTALL_DESTINATION bin)
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/CMakeLists.txt
@@ -53,7 +53,9 @@ collect_sources(COMMANDS_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/commands")
 set(LIBRARIES
   HMI_API
   MOBILE_API
+  MessageHelper
   ApplicationManager
+  Resumption
   v4_protocol_v1_2_no_extra
   SmartObjects
   Utils

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/app_service_rpc_plugin.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/app_service_rpc_plugin.h
@@ -69,5 +69,6 @@ class AppServiceRpcPlugin : public plugins::RPCPlugin {
 }  // namespace app_service_rpc_plugin
 
 extern "C" application_manager::plugin_manager::RPCPlugin* Create();
+extern "C" void Delete(application_manager::plugin_manager::RPCPlugin* data);
 
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_PLUGIN_INCLUDE_APP_SERVICE_PLUGIN_APP_SERVICE_PLUGIN_H

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_rpc_plugin.cc
@@ -93,10 +93,13 @@ void AppServiceRpcPlugin::DeleteSubscriptions(
 
 }  // namespace app_service_rpc_plugin
 
-extern "C" application_manager::plugin_manager::RPCPlugin* Create() {
+extern "C" __attribute__((visibility("default")))
+application_manager::plugin_manager::RPCPlugin*
+Create() {
   return new app_service_rpc_plugin::AppServiceRpcPlugin();
 }
 
-void Delete(application_manager::plugin_manager::RPCPlugin* data) {
+extern "C" __attribute__((visibility("default"))) void Delete(
+    application_manager::plugin_manager::RPCPlugin* data) {
   delete data;
 }

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_rpc_plugin.cc
@@ -96,3 +96,7 @@ void AppServiceRpcPlugin::DeleteSubscriptions(
 extern "C" application_manager::plugin_manager::RPCPlugin* Create() {
   return new app_service_rpc_plugin::AppServiceRpcPlugin();
 }
+
+void Delete(application_manager::plugin_manager::RPCPlugin* data) {
+  delete data;
+}

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/CMakeLists.txt
@@ -25,16 +25,8 @@ file(GLOB SOURCES
 
 set(LIBRARIES
   gmock
-  Utils
-  SmartObjects
-  HMI_API
-  MOBILE_API
-  connectionHandler
-  app_service_rpc_plugin
-  sdl_rpc_plugin
-  jsoncpp
-  Policy
-  Resumption
+  sdl_rpc_plugin_static
+  app_service_rpc_plugin_static
 )
 
 create_cotired_test("app_services_commands_test" "${SOURCES}" "${LIBRARIES}" )

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/CMakeLists.txt
@@ -63,11 +63,12 @@ if(ENABLE_LOG)
   list(APPEND LIBRARIES log4cxx -L${LOG4CXX_LIBS_DIRECTORY})
 endif()
 
-add_library("rc_rpc_plugin" SHARED ${PLUGIN_SOURCES} ${MOBILE_COMMANDS} ${HMI_COMMANDS} ${COMMANDS_SOURCES})
-target_link_libraries("rc_rpc_plugin" ${LIBRARIES})
+add_library("rc_rpc_plugin_static" ${PLUGIN_SOURCES} ${MOBILE_COMMANDS} ${HMI_COMMANDS})
+target_link_libraries("rc_rpc_plugin_static" ${LIBRARIES})
 
-add_library("RCRpcPluginStaticLib" ${PLUGIN_SOURCES} ${MOBILE_COMMANDS} ${HMI_COMMANDS})
-target_link_libraries("RCRpcPluginStaticLib" ${LIBRARIES})
+add_library("rc_rpc_plugin" SHARED "src/rc_rpc_plugin.cc")
+target_link_libraries("rc_rpc_plugin" rc_rpc_plugin_static)
+
 
 set(INSTALL_DESTINATION bin)
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/CMakeLists.txt
@@ -50,7 +50,10 @@ collect_sources(COMMANDS_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/commands")
 set(LIBRARIES
   HMI_API
   MOBILE_API
+  MessageHelper
   ApplicationManager
+  ProtocolHandler
+  connectionHandler
   v4_protocol_v1_2_no_extra
   SmartObjects
   Utils

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_rpc_plugin.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_rpc_plugin.h
@@ -109,5 +109,6 @@ class RCRPCPlugin : public plugins::RPCPlugin {
 }  // namespace rc_rpc_plugin
 
 extern "C" application_manager::plugin_manager::RPCPlugin* Create();
+extern "C" void Delete(application_manager::plugin_manager::RPCPlugin* data);
 
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_RC_RPC_PLUGIN_H_

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -136,10 +136,13 @@ RCRPCPlugin::Apps RCRPCPlugin::GetRCApplications(
 
 }  // namespace rc_rpc_plugin
 
-extern "C" application_manager::plugin_manager::RPCPlugin* Create() {
+extern "C" __attribute__((visibility("default")))
+application_manager::plugin_manager::RPCPlugin*
+Create() {
   return new rc_rpc_plugin::RCRPCPlugin();
 }  // namespace rc_rpc_plugin
 
-void Delete(application_manager::plugin_manager::RPCPlugin* data) {
+extern "C" __attribute__((visibility("default"))) void Delete(
+    application_manager::plugin_manager::RPCPlugin* data) {
   delete data;
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -139,3 +139,7 @@ RCRPCPlugin::Apps RCRPCPlugin::GetRCApplications(
 extern "C" application_manager::plugin_manager::RPCPlugin* Create() {
   return new rc_rpc_plugin::RCRPCPlugin();
 }  // namespace rc_rpc_plugin
+
+void Delete(application_manager::plugin_manager::RPCPlugin* data) {
+  delete data;
+}

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/CMakeLists.txt
@@ -52,17 +52,8 @@ file(GLOB SOURCES
 )
 
 set(LIBRARIES
-  RCRpcPluginStaticLib
-  ApplicationManager
-  connectionHandler
-  SmartObjects
-  ProtocolHandler
-  MessageHelper
-  connectionHandler
-  Utils
-  jsoncpp
+  rc_rpc_plugin_static
   gmock_main
-  dl
 )
 
 if(ENABLE_LOG)

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/CMakeLists.txt
@@ -67,8 +67,11 @@ if(ENABLE_LOG)
   list(APPEND LIBRARIES log4cxx -L${LOG4CXX_LIBS_DIRECTORY})
 endif()
 
-add_library("sdl_rpc_plugin" SHARED ${MOBILE_COMMANDS} ${HMI_COMMANDS} ${RPC_PLUGIN_SOURCES} ${APP_EXTENSIONS})
-target_link_libraries("sdl_rpc_plugin" ${LIBRARIES})
+add_library("sdl_rpc_plugin_static" ${MOBILE_COMMANDS} ${HMI_COMMANDS} ${RPC_PLUGIN_SOURCES} ${APP_EXTENSIONS})
+target_link_libraries("sdl_rpc_plugin_static" ${LIBRARIES})
+
+add_library("sdl_rpc_plugin" SHARED "src/sdl_rpc_plugin.cc")
+target_link_libraries("sdl_rpc_plugin" sdl_rpc_plugin_static)
 
 set(INSTALL_DESTINATION bin)
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/CMakeLists.txt
@@ -51,13 +51,16 @@ collect_sources(APP_EXTENSIONS "${EXTENSIONS_SOURCE_DIR}")
 collect_sources(RPC_PLUGIN_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
 set(LIBRARIES
+  ApplicationManager
   HMI_API
   MOBILE_API
-  ApplicationManager
+  MessageHelper
+  connectionHandler
   v4_protocol_v1_2_no_extra
   SmartObjects
   Utils
-  Policy
+  PolicyStatic
+  jsoncpp
 )
 
 if(ENABLE_LOG)

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_rpc_plugin.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_rpc_plugin.h
@@ -67,5 +67,5 @@ class SDLRPCPlugin : public plugins::RPCPlugin {
 }  // namespace sdl_rpc_plugin
 
 extern "C" application_manager::plugin_manager::RPCPlugin* Create();
-
+extern "C" void Delete(application_manager::plugin_manager::RPCPlugin* data);
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_SDL_RPC_PLUGIN_H

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
@@ -87,3 +87,7 @@ void SDLRPCPlugin::ClearSubscriptions(app_mngr::ApplicationSharedPtr app) {
 extern "C" application_manager::plugin_manager::RPCPlugin* Create() {
   return new sdl_rpc_plugin::SDLRPCPlugin();
 }
+
+void Delete(application_manager::plugin_manager::RPCPlugin* data) {
+  delete data;
+}

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
@@ -84,10 +84,13 @@ void SDLRPCPlugin::ClearSubscriptions(app_mngr::ApplicationSharedPtr app) {
 
 }  // namespace sdl_rpc_plugin
 
-extern "C" application_manager::plugin_manager::RPCPlugin* Create() {
+extern "C" __attribute__((visibility("default")))
+application_manager::plugin_manager::RPCPlugin*
+Create() {
   return new sdl_rpc_plugin::SDLRPCPlugin();
 }
 
-void Delete(application_manager::plugin_manager::RPCPlugin* data) {
+extern "C" __attribute__((visibility("default"))) void Delete(
+    application_manager::plugin_manager::RPCPlugin* data) {
   delete data;
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/CMakeLists.txt
@@ -23,15 +23,8 @@ file(GLOB SOURCES
 )
 
 set(LIBRARIES
+  sdl_rpc_plugin_static
   gmock
-  Utils
-  SmartObjects
-  HMI_API
-  MOBILE_API
-  connectionHandler
-  sdl_rpc_plugin
-  jsoncpp
-  Policy
 )
 
 create_cotired_test("sdl_commands_test" "${SOURCES}" "${LIBRARIES}" )

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/CMakeLists.txt
@@ -45,10 +45,13 @@ collect_sources(VEHICLE_INFO_PLUGIN_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src")
 set(LIBRARIES
   HMI_API
   MOBILE_API
+  MessageHelper
   ApplicationManager
   v4_protocol_v1_2_no_extra
   SmartObjects
   Utils
+  jsoncpp
+  connectionHandler
 )
 
 if(ENABLE_LOG)

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/CMakeLists.txt
@@ -58,8 +58,12 @@ if(ENABLE_LOG)
   list(APPEND LIBRARIES log4cxx -L${LOG4CXX_LIBS_DIRECTORY})
 endif()
 
-add_library("vehicle_info_plugin" SHARED ${MOBILE_COMMANDS} ${HMI_COMMANDS} ${VEHICLE_INFO_PLUGIN_SOURCES})
-target_link_libraries("vehicle_info_plugin" ${LIBRARIES})
+add_library("vehicle_info_plugin_static"  ${MOBILE_COMMANDS} ${HMI_COMMANDS} ${VEHICLE_INFO_PLUGIN_SOURCES})
+target_link_libraries("vehicle_info_plugin_static" ${LIBRARIES})
+
+add_library(vehicle_info_plugin SHARED "src/vehicle_info_plugin.cc" )
+target_link_libraries(vehicle_info_plugin vehicle_info_plugin_static)
+
 
 set(INSTALL_DESTINATION bin)
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
@@ -78,5 +78,5 @@ class VehicleInfoPlugin : public plugins::RPCPlugin {
 }  // namespace vehicle_info_plugin
 
 extern "C" application_manager::plugin_manager::RPCPlugin* Create();
-
+extern "C" void Delete(application_manager::plugin_manager::RPCPlugin* data);
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_VEHICLE_INFO_PLUGIN_INCLUDE_VEHICLE_INFO_PLUGIN_VEHICLE_INFO_PLUGIN_H

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -163,10 +163,13 @@ void VehicleInfoPlugin::DeleteSubscriptions(
 }
 }  // namespace vehicle_info_plugin
 
-extern "C" application_manager::plugin_manager::RPCPlugin* Create() {
+extern "C" __attribute__((visibility("default")))
+application_manager::plugin_manager::RPCPlugin*
+Create() {
   return new vehicle_info_plugin::VehicleInfoPlugin();
 }
 
-void Delete(application_manager::plugin_manager::RPCPlugin* data) {
+extern "C" __attribute__((visibility("default"))) void Delete(
+    application_manager::plugin_manager::RPCPlugin* data) {
   delete data;
 }

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -166,3 +166,7 @@ void VehicleInfoPlugin::DeleteSubscriptions(
 extern "C" application_manager::plugin_manager::RPCPlugin* Create() {
   return new vehicle_info_plugin::VehicleInfoPlugin();
 }
+
+void Delete(application_manager::plugin_manager::RPCPlugin* data) {
+  delete data;
+}

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/CMakeLists.txt
@@ -51,14 +51,8 @@ file(GLOB SOURCES
 )
 
 set(LIBRARIES
-  gmock
-  Utils
-  SmartObjects
-  HMI_API
-  MOBILE_API
-  connectionHandler
-  vehicle_info_plugin
-  jsoncpp
+  gmock  
+  vehicle_info_plugin_static
 )
 
 create_cotired_test("vi_commands_test" "${SOURCES}" "${LIBRARIES}" )

--- a/src/components/application_manager/test/CMakeLists.txt
+++ b/src/components/application_manager/test/CMakeLists.txt
@@ -88,7 +88,7 @@ set (RequestController_SOURCES
 set(LIBRARIES
   Utils
   ApplicationManager
-  sdl_rpc_plugin
+  sdl_rpc_plugin_static
   jsoncpp
   Policy
   connectionHandler

--- a/src/components/application_manager/test/commands/CMakeLists.txt
+++ b/src/components/application_manager/test/commands/CMakeLists.txt
@@ -58,7 +58,7 @@ set(LIBRARIES
   connectionHandler
   ApplicationManager
   jsoncpp
-  Policy
+  PolicyStatic
   Resumption
 )
 

--- a/src/components/application_manager/test/message_helper/CMakeLists.txt
+++ b/src/components/application_manager/test/message_helper/CMakeLists.txt
@@ -40,7 +40,7 @@ set(LIBRARIES
     ApplicationManager
     MessageHelper
     jsoncpp
-    Policy
+    PolicyStatic
     connectionHandler
     MediaManager
     Resumption

--- a/src/components/media_manager/test/CMakeLists.txt
+++ b/src/components/media_manager/test/CMakeLists.txt
@@ -58,7 +58,7 @@ set(LIBRARIES
     connectionHandler
     encryption
     Resumption
-    Policy
+    PolicyStatic
     ${SecurityManagerLibrary}
 )
 

--- a/src/components/policy/policy_external/CMakeLists.txt
+++ b/src/components/policy/policy_external/CMakeLists.txt
@@ -29,10 +29,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # --- Policy
-set(target Policy)
 set(install_destination bin)
 set(copy_destination ${CMAKE_BINARY_DIR}/src/appMain)
-set(library_name ${CMAKE_SHARED_LIBRARY_PREFIX}${target}${CMAKE_SHARED_LIBRARY_SUFFIX})
+set(library_name ${CMAKE_SHARED_LIBRARY_PREFIX}Policy${CMAKE_SHARED_LIBRARY_SUFFIX})
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
@@ -75,21 +74,25 @@ else ()
   list(APPEND LIBRARIES sqlite3)
 endif ()
 
-add_library(${target} SHARED ${SOURCES})
-target_link_libraries(${target} ${LIBRARIES} )
+add_library(PolicyStatic ${SOURCES})
+target_link_libraries(PolicyStatic ${LIBRARIES})
+
+
+add_library(Policy SHARED "src/policy_manager_impl.cc")
+target_link_libraries(Policy PolicyStatic)
 
 if (ENABLE_LOG)
-  target_link_libraries(${target} log4cxx -L${LOG4CXX_LIBS_DIRECTORY})
+  target_link_libraries(Policy log4cxx -L${LOG4CXX_LIBS_DIRECTORY})
 endif()
 
-add_custom_target(copy_library_${target} ALL
+add_custom_target(copy_library_Policy ALL
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
     ${CMAKE_CURRENT_BINARY_DIR}/${library_name}
     ${copy_destination}
-    DEPENDS ${target}
+    DEPENDS Policy
     COMMENT "Copying library ${library_name}")
 
-install(TARGETS ${target}
+install(TARGETS Policy
   DESTINATION ${install_destination}
   PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
     GROUP_READ GROUP_EXECUTE

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -53,10 +53,12 @@
 #include "policy/access_remote.h"
 #include "policy/access_remote_impl.h"
 
-policy::PolicyManager* CreateManager() {
+__attribute__((visibility("default"))) policy::PolicyManager* CreateManager() {
   return new policy::PolicyManagerImpl();
 }
-void DeleteManager(policy::PolicyManager* pm) {
+
+__attribute__((visibility("default"))) void DeleteManager(
+    policy::PolicyManager* pm) {
   delete pm;
 }
 namespace {

--- a/src/components/policy/policy_external/test/CMakeLists.txt
+++ b/src/components/policy/policy_external/test/CMakeLists.txt
@@ -42,7 +42,7 @@ include_directories(
 set(testLibraries
   gmock
   Utils
-  Policy
+  PolicyStatic
   UsageStatistics
   ConfigProfile
 )

--- a/src/components/policy/policy_regular/CMakeLists.txt
+++ b/src/components/policy/policy_regular/CMakeLists.txt
@@ -87,8 +87,13 @@ else ()
   list(APPEND LIBRARIES sqlite3)
 endif ()
 
-add_library(Policy SHARED ${SOURCES})
-target_link_libraries(Policy ${LIBRARIES})
+
+add_library(PolicyStatic ${SOURCES})
+target_link_libraries(PolicyStatic ${LIBRARIES})
+
+
+add_library(Policy SHARED "src/policy_manager_impl.cc")
+target_link_libraries(Policy PolicyStatic)
 
 if(ENABLE_LOG)
   target_link_libraries(Policy log4cxx -L${LOG4CXX_LIBS_DIRECTORY})

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -53,10 +53,12 @@
 #include "policy/access_remote.h"
 #include "policy/access_remote_impl.h"
 
-policy::PolicyManager* CreateManager() {
+__attribute__((visibility("default"))) policy::PolicyManager* CreateManager() {
   return new policy::PolicyManagerImpl();
 }
-void DeleteManager(policy::PolicyManager* pm) {
+
+__attribute__((visibility("default"))) void DeleteManager(
+    policy::PolicyManager* pm) {
   delete pm;
 }
 

--- a/src/components/policy/policy_regular/test/CMakeLists.txt
+++ b/src/components/policy/policy_regular/test/CMakeLists.txt
@@ -49,7 +49,7 @@ collect_sources(SOURCES "${CMAKE_CURRENT_SOURCE_DIR}")
 set(LIBRARIES
   gmock
   Utils
-  Policy
+  PolicyStatic
   UsageStatistics
 )
 

--- a/src/components/telemetry_monitor/CMakeLists.txt
+++ b/src/components/telemetry_monitor/CMakeLists.txt
@@ -63,7 +63,7 @@ set(LIBRARIES
   HMI_API
   MOBILE_API
   Utils
-  Policy
+  PolicyStatic
 )
 
 add_library("TelemetryMonitor" ${SOURCES})

--- a/src/components/transport_manager/src/usb/libusb/usb_handler.cc
+++ b/src/components/transport_manager/src/usb/libusb/usb_handler.cc
@@ -90,20 +90,20 @@ UsbHandler::UsbHandler()
 
 UsbHandler::~UsbHandler() {
   shutdown_requested_ = true;
-  if (libusb_context_ != 0) {
+  thread_->stop();
+  LOG4CXX_INFO(logger_, "UsbHandler thread finished");
+  if (libusb_context_ != 0) {  // This wakes up libusb_handle_events()
     libusb_hotplug_deregister_callback(libusb_context_,
                                        arrived_callback_handle_);
     libusb_hotplug_deregister_callback(libusb_context_, left_callback_handle_);
   }
-  thread_->stop();
-  LOG4CXX_INFO(logger_, "UsbHandler thread finished");
+  thread_->join();
+  delete thread_->delegate();
+  threads::DeleteThread(thread_);
   if (libusb_context_) {
     libusb_exit(libusb_context_);
     libusb_context_ = 0;
   }
-  thread_->join();
-  delete thread_->delegate();
-  threads::DeleteThread(thread_);
 }
 
 void UsbHandler::DeviceArrived(libusb_device* device_libusb) {

--- a/src/components/utils/CMakeLists.txt
+++ b/src/components/utils/CMakeLists.txt
@@ -58,7 +58,10 @@ set(EXCLUDE_PATHS
   ${DBMS_PATHS}
 )
 
-set(LIBRARIES)
+set(LIBRARIES
+  encryption
+  jsoncpp
+)
 
 if(NOT BUILD_BACKTRACE_SUPPORT)
   list(APPEND EXCLUDE_PATHS

--- a/src/components/utils/src/push_log.cc
+++ b/src/components/utils/src/push_log.cc
@@ -36,7 +36,11 @@
 
 namespace logger {
 
-static bool logs_enabled_ = false;
+struct __attribute__((visibility("default"))) LogsEnabled {
+  static bool logs_enabled_;
+};
+
+bool LogsEnabled::logs_enabled_ = false;
 static LogMessageLoopThread* log_message_loop_thread = NULL;
 
 bool push_log(log4cxx::LoggerPtr logger,
@@ -73,11 +77,11 @@ bool push_log(log4cxx::LoggerPtr logger,
 }
 
 bool logs_enabled() {
-  return logs_enabled_;
+  return LogsEnabled::logs_enabled_;
 }
 
 void set_logs_enabled(bool state) {
-  logs_enabled_ = state;
+  LogsEnabled::logs_enabled_ = state;
 }
 
 void create_log_message_loop_thread() {

--- a/src/components/utils/src/push_log.cc
+++ b/src/components/utils/src/push_log.cc
@@ -37,11 +37,11 @@
 namespace logger {
 
 struct __attribute__((visibility("default"))) LogsEnabled {
-  static bool logs_enabled_;
+  static std::atomic_bool logs_enabled_;
 };
 
-bool LogsEnabled::logs_enabled_ = false;
-static LogMessageLoopThread* log_message_loop_thread = NULL;
+std::atomic_bool LogsEnabled::logs_enabled_(false);
+static std::unique_ptr<LogMessageLoopThread> log_message_loop_thread;
 
 bool push_log(log4cxx::LoggerPtr logger,
               log4cxx::LevelPtr level,
@@ -86,13 +86,13 @@ void set_logs_enabled(bool state) {
 
 void create_log_message_loop_thread() {
   if (!log_message_loop_thread) {
-    log_message_loop_thread = new LogMessageLoopThread();
+    log_message_loop_thread =
+        std::unique_ptr<LogMessageLoopThread>(new LogMessageLoopThread);
   }
 }
 
 void delete_log_message_loop_thread() {
-  delete log_message_loop_thread;
-  log_message_loop_thread = NULL;
+  log_message_loop_thread.reset();
 }
 
 void flush_logger() {

--- a/src/components/utils/test/CMakeLists.txt
+++ b/src/components/utils/test/CMakeLists.txt
@@ -87,7 +87,7 @@ collect_sources(SOURCES "${CMAKE_CURRENT_SOURCE_DIR}" "${EXCLUDE_PATHS}")
 set(LIBRARIES
   gmock
   Utils
-  Policy
+  PolicyStatic
   ConfigProfile
 )
 


### PR DESCRIPTION
Fixes #2936

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
The problem in double destruction static variables allocated for dynamically linked libraries, shared libraries and binary.

 - Add -fvisibility=hidden to avoid collision of static variables. Remove from ABI all shared objects members except one that certanly needed. Mostly is a specific for gcc compiler

 - Add appropriate destruction of plugins
 - Add Delete exported function to each rpc plugin library. Delete funciton will destroy Plugin instance.
 - Move type definition of PluginPtr to Plugin manager, because other components should use olugins only by reference.
 - Add custom destructor for PluginPtr. Custom destructor will call `Delete` function from shared library for plugin instance and unload plugin dl_handle.
 - Deprecate GetPlugins method because it not used (and actually shouldn't) by other components.
 - Refactored LoadPlugin function, make it more readable, make this function as private RPCPluginManagerImpl private method.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
