### PR TITLE
Expand OnPutFile beyond system files

### DIFF
--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -216,6 +216,7 @@ extern const char* is_template;
 extern const char* image;
 extern const char* type;
 extern const char* system_file;
+extern const char* is_system_file;
 extern const char* offset;
 extern const char* length;
 extern const char* secondary_image;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/put_file_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/put_file_request.h
@@ -76,7 +76,7 @@ class PutFileRequest : public app_mngr::commands::CommandRequestImpl {
   mobile_apis::FileType::eType file_type_;
   bool is_persistent_file_;
 
-  void SendOnPutFileNotification();
+  void SendOnPutFileNotification(bool is_system_file);
   DISALLOW_COPY_AND_ASSIGN(PutFileRequest);
 };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/put_file_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/put_file_request.cc
@@ -284,9 +284,7 @@ void PutFileRequest::Run() {
       }
 
       SendResponse(true, save_result, "File was downloaded", &response_params);
-      if (is_system_file) {
-        SendOnPutFileNotification();
-      }
+      SendOnPutFileNotification(is_system_file);
       break;
     }
     default:
@@ -297,7 +295,7 @@ void PutFileRequest::Run() {
   }
 }
 
-void PutFileRequest::SendOnPutFileNotification() {
+void PutFileRequest::SendOnPutFileNotification(bool is_system_file) {
   LOG4CXX_INFO(logger_, "SendOnPutFileNotification");
   smart_objects::SmartObjectSPtr notification =
       std::make_shared<smart_objects::SmartObject>(
@@ -316,6 +314,7 @@ void PutFileRequest::SendOnPutFileNotification() {
   message[strings::msg_params][strings::length] = length_;
   message[strings::msg_params][strings::persistent_file] = is_persistent_file_;
   message[strings::msg_params][strings::file_type] = file_type_;
+  message[strings::msg_params][strings::is_system_file] = is_system_file;
   rpc_service_.ManageHMICommand(notification);
 }
 

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -183,6 +183,7 @@ const char* is_template = "isTemplate";
 const char* image = "image";
 const char* type = "type";
 const char* system_file = "systemFile";
+const char* is_system_file = "isSystemFile";
 const char* offset = "offset";
 const char* length = "length";
 const char* secondary_image = "secondaryImage";

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -4154,45 +4154,54 @@
     </function>
 
     <function name="OnPutFile" messagetype="notification" >
-    <description>
-      Notification, that comes to HMI when mobile sents file with systemFile flag
-    </description>
-
-    <param name="offset" type="Integer" minvalue="0" maxvalue="100000000000" mandatory="false">
-      <description>Optional offset in bytes for resuming partial data chunks</description>
-    </param>
-    <param name="length" type="Integer" minvalue="0" maxvalue="100000000000" mandatory="false">
-      <description>Optional length in bytes for resuming partial data chunks</description>
-    </param>
-
-    <param name="fileSize" type="Integer" minvalue="0" maxvalue="100000000000" mandatory="false">
-      <description>Full Size of file. sends in first OnPutFile notification if file is splited
-                   into many PutFiles
-      </description>
-    </param>
-
-    <param name="FileName" type="String" maxlength="255" mandatory="true">
-      <description>File reference name.</description>
-    </param>
-
-    <param name="syncFileName" type="String" maxlength="255" mandatory="true">
-      <description>File reference name.</description>
-    </param>
-
-    <param name="fileType" type="Common.FileType" mandatory="true">
-        <description>Selected file type.</description>
-    </param>
-
-    <param name="persistentFile" type="Boolean" defvalue="false" mandatory="false">
       <description>
-        Indicates if the file is meant to persist between sessions / ignition cycles.
-        If set to TRUE, then the system will aim to persist this file through session / cycles.
-        While files with this designation will have priority over others, they are subject to deletion by the system at any time.
-        In the event of automatic deletion by the system, the app will receive a rejection and have to resend the file.
-        If omitted, the value will be set to false.
+        Notification that is sent to HMI when a mobile application uploads a file
       </description>
-    </param>
-  </function>
+
+      <param name="offset" type="Integer" minvalue="0" maxvalue="100000000000" mandatory="false">
+        <description>Optional offset in bytes for resuming partial data chunks</description>
+      </param>
+      <param name="length" type="Integer" minvalue="0" maxvalue="100000000000" mandatory="false">
+        <description>Optional length in bytes for resuming partial data chunks</description>
+      </param>
+
+      <param name="fileSize" type="Integer" minvalue="0" maxvalue="100000000000" mandatory="false">
+        <description>Full Size of file. sends in first OnPutFile notification if file is splited
+                    into many PutFiles
+        </description>
+      </param>
+
+      <param name="FileName" type="String" maxlength="255" mandatory="true">
+        <description>File reference name.</description>
+      </param>
+
+      <param name="syncFileName" type="String" maxlength="255" mandatory="true">
+        <description>File reference name.</description>
+      </param>
+
+      <param name="fileType" type="Common.FileType" mandatory="true">
+          <description>Selected file type.</description>
+      </param>
+
+      <param name="persistentFile" type="Boolean" defvalue="false" mandatory="false">
+        <description>
+          Indicates if the file is meant to persist between sessions / ignition cycles.
+          If set to TRUE, then the system will aim to persist this file through session / cycles.
+          While files with this designation will have priority over others, they are subject to deletion by the system at any time.
+          In the event of automatic deletion by the system, the app will receive a rejection and have to resend the file.
+          If omitted, the value will be set to false.
+        </description>
+      </param>
+      <param name="isSystemFile" type="Boolean" defvalue="false" mandatory="false">
+        <description>
+          Indicates if the file is meant to be passed thru core to elsewhere on the system.
+          If true the system will pass the data thru as it arrives to a predetermined area outside of core.
+        </description>
+      </param>
+      <param name="appID" type="Integer" mandatory="false">
+        <description> ID of application that uploaded this file. </description>
+      </param>
+    </function>
 
   <function name="GetFilePath" messagetype="request">
     <description>This request is sent to retrieve a file path from the HMI.</description>


### PR DESCRIPTION

Fixes #2799 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Test against HMI PRs which utilize the `BC.OnPutFile` message

### Summary
Expanded the `BC.OnPutFile` message to be sent to the HMI for all files uploaded, rather than just system files.
 
### Changelog
##### Enhancements
* Expanded the `BC.OnPutFile` message to be sent to the HMI for all files uploaded

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
