### PR TITLE
Update and delete published app services

### DIFF
--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -599,6 +599,14 @@
                             "NONE"
                         ]
                     },
+                    "UnpublishAppService": {
+                      "hmi_levels": [
+                          "FULL",
+                          "LIMITED",
+                          "BACKGROUND",
+                          "NONE"
+                      ]
+                    },
                     "GetAppServiceData": {
                         "hmi_levels": [
                             "FULL",

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_unpublish_app_service_request.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_unpublish_app_service_request.h
@@ -1,0 +1,78 @@
+/*
+ Copyright (c) 2019, Ford Motor Company, Livio
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the the copyright holders nor the names of their
+ contributors may be used to endorse or promote products derived from this
+ software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_HMI_AS_UNPUBLISH_APP_SERVICE_REQUEST_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_HMI_AS_UNPUBLISH_APP_SERVICE_REQUEST_H_
+
+#include "application_manager/commands/request_from_hmi.h"
+
+namespace app_service_rpc_plugin {
+namespace app_mngr = application_manager;
+
+namespace commands {
+
+/**
+ * @brief ASUnpublishAppServiceRequest command class
+ **/
+class ASUnpublishAppServiceRequest : public app_mngr::commands::RequestFromHMI {
+ public:
+  /**
+   * @brief ASUnpublishAppServiceRequest class constructor
+   *
+   * @param message Incoming SmartObject message
+   **/
+  ASUnpublishAppServiceRequest(
+      const app_mngr::commands::MessageSharedPtr& message,
+      app_mngr::ApplicationManager& application_manager,
+      app_mngr::rpc_service::RPCService& rpc_service,
+      app_mngr::HMICapabilities& hmi_capabilities,
+      policy::PolicyHandlerInterface& policy_handle);
+
+  /**
+   * @brief ASUnpublishAppServiceRequest class destructor
+   **/
+  virtual ~ASUnpublishAppServiceRequest();
+
+  /**
+   * @brief Execute command
+   **/
+  virtual void Run();
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(ASUnpublishAppServiceRequest);
+};
+
+}  // namespace commands
+
+}  // namespace app_service_rpc_plugin
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_HMI_AS_UNPUBLISH_APP_SERVICE_REQUEST_H_

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_unpublish_app_service_response.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_unpublish_app_service_response.h
@@ -1,0 +1,78 @@
+/*
+ Copyright (c) 2019, Ford Motor Company, Livio
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the the copyright holders nor the names of their
+ contributors may be used to endorse or promote products derived from this
+ software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_HMI_AS_UNPUBLISH_APP_SERVICE_RESPONSE_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_HMI_AS_UNPUBLISH_APP_SERVICE_RESPONSE_H_
+
+#include "application_manager/commands/response_to_hmi.h"
+
+namespace app_service_rpc_plugin {
+namespace app_mngr = application_manager;
+
+namespace commands {
+
+/**
+ * @brief ASUnpublishAppServiceResponse command class
+ **/
+class ASUnpublishAppServiceResponse : public app_mngr::commands::ResponseToHMI {
+ public:
+  /**
+   * @brief ASUnpublishAppServiceResponse class constructor
+   *
+   * @param message Incoming SmartObject message
+   **/
+  ASUnpublishAppServiceResponse(
+      const app_mngr::commands::MessageSharedPtr& message,
+      app_mngr::ApplicationManager& application_manager,
+      app_mngr::rpc_service::RPCService& rpc_service,
+      app_mngr::HMICapabilities& hmi_capabilities,
+      policy::PolicyHandlerInterface& policy_handle);
+
+  /**
+   * @brief ASUnpublishAppServiceResponse class destructor
+   **/
+  virtual ~ASUnpublishAppServiceResponse();
+
+  /**
+   * @brief Execute command
+   **/
+  virtual void Run();
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(ASUnpublishAppServiceResponse);
+};
+
+}  // namespace commands
+
+}  // namespace app_service_rpc_plugin
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_HMI_AS_UNPUBLISH_APP_SERVICE_RESPONSE_H_

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/unpublish_app_service_request.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/unpublish_app_service_request.h
@@ -1,0 +1,78 @@
+/*
+ Copyright (c) 2019, Ford Motor Company, Livio
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the the copyright holders nor the names of their
+ contributors may be used to endorse or promote products derived from this
+ software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_MOBILE_UNPUBLISH_APP_SERVICE_REQUEST_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_MOBILE_UNPUBLISH_APP_SERVICE_REQUEST_H_
+
+#include "application_manager/commands/command_request_impl.h"
+
+namespace app_service_rpc_plugin {
+namespace app_mngr = application_manager;
+
+namespace commands {
+
+/**
+ * @brief UnpublishAppServiceRequest command class
+ **/
+class UnpublishAppServiceRequest : public app_mngr::commands::CommandRequestImpl {
+ public:
+  /**
+   * @brief UnpublishAppServiceRequest class constructor
+   *
+   * @param message Incoming SmartObject message
+   **/
+  UnpublishAppServiceRequest(
+      const app_mngr::commands::MessageSharedPtr& message,
+      app_mngr::ApplicationManager& application_manager,
+      app_mngr::rpc_service::RPCService& rpc_service,
+      app_mngr::HMICapabilities& hmi_capabilities,
+      policy::PolicyHandlerInterface& policy_handle);
+
+  /**
+   * @brief UnpublishAppServiceRequest class destructor
+   **/
+  virtual ~UnpublishAppServiceRequest();
+
+  /**
+   * @brief Execute command
+   **/
+  virtual void Run();
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(UnpublishAppServiceRequest);
+};
+
+}  // namespace commands
+
+}  // namespace app_service_rpc_plugin
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_MOBILE_UNPUBLISH_APP_SERVICE_REQUEST_H_

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/unpublish_app_service_request.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/unpublish_app_service_request.h
@@ -43,7 +43,8 @@ namespace commands {
 /**
  * @brief UnpublishAppServiceRequest command class
  **/
-class UnpublishAppServiceRequest : public app_mngr::commands::CommandRequestImpl {
+class UnpublishAppServiceRequest
+    : public app_mngr::commands::CommandRequestImpl {
  public:
   /**
    * @brief UnpublishAppServiceRequest class constructor

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/unpublish_app_service_response.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/unpublish_app_service_response.h
@@ -43,7 +43,8 @@ namespace commands {
 /**
  * @brief UnpublishAppServiceResponse command class
  **/
-class UnpublishAppServiceResponse : public app_mngr::commands::CommandResponseImpl {
+class UnpublishAppServiceResponse
+    : public app_mngr::commands::CommandResponseImpl {
  public:
   /**
    * @brief UnpublishAppServiceResponse class constructor

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/unpublish_app_service_response.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/unpublish_app_service_response.h
@@ -1,0 +1,78 @@
+/*
+ Copyright (c) 2019, Ford Motor Company, Livio
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the the copyright holders nor the names of their
+ contributors may be used to endorse or promote products derived from this
+ software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_MOBILE_UNPUBLISH_APP_SERVICE_RESPONSE_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_MOBILE_UNPUBLISH_APP_SERVICE_RESPONSE_H_
+
+#include "application_manager/commands/command_response_impl.h"
+
+namespace app_service_rpc_plugin {
+namespace app_mngr = application_manager;
+
+namespace commands {
+
+/**
+ * @brief UnpublishAppServiceResponse command class
+ **/
+class UnpublishAppServiceResponse : public app_mngr::commands::CommandResponseImpl {
+ public:
+  /**
+   * @brief UnpublishAppServiceResponse class constructor
+   *
+   * @param message Incoming SmartObject message
+   **/
+  UnpublishAppServiceResponse(
+      const app_mngr::commands::MessageSharedPtr& message,
+      app_mngr::ApplicationManager& application_manager,
+      app_mngr::rpc_service::RPCService& rpc_service,
+      app_mngr::HMICapabilities& hmi_capabilities,
+      policy::PolicyHandlerInterface& policy_handle);
+
+  /**
+   * @brief UnpublishAppServiceResponse class destructor
+   **/
+  virtual ~UnpublishAppServiceResponse();
+
+  /**
+   * @brief Execute command
+   **/
+  virtual void Run();
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(UnpublishAppServiceResponse);
+};
+
+}  // namespace commands
+
+}  // namespace app_service_rpc_plugin
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_MOBILE_UNPUBLISH_APP_SERVICE_RESPONSE_H_

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_hmi_command_factory.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_hmi_command_factory.cc
@@ -131,7 +131,8 @@ app_mngr::CommandCreator& AppServiceHmiCommandFactory::buildCommandCreator(
     case hmi_apis::FunctionID::AppService_UnpublishAppService:
       return hmi_apis::messageType::request == message_type
                  ? factory.GetCreator<commands::ASUnpublishAppServiceRequest>()
-                 : factory.GetCreator<commands::ASUnpublishAppServiceResponse>();
+                 : factory
+                       .GetCreator<commands::ASUnpublishAppServiceResponse>();
     case hmi_apis::FunctionID::AppService_OnAppServiceData:
       return app_mngr::commands::Command::CommandSource::SOURCE_HMI == source
                  ? factory.GetCreator<

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_hmi_command_factory.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_hmi_command_factory.cc
@@ -50,6 +50,8 @@
 #include "app_service_rpc_plugin/commands/hmi/as_perform_app_service_interaction_response_to_hmi.h"
 #include "app_service_rpc_plugin/commands/hmi/as_publish_app_service_request.h"
 #include "app_service_rpc_plugin/commands/hmi/as_publish_app_service_response.h"
+#include "app_service_rpc_plugin/commands/hmi/as_unpublish_app_service_request.h"
+#include "app_service_rpc_plugin/commands/hmi/as_unpublish_app_service_response.h"
 #include "app_service_rpc_plugin/commands/hmi/on_as_app_service_data_notification.h"
 #include "app_service_rpc_plugin/commands/hmi/on_as_app_service_data_notification_from_hmi.h"
 
@@ -126,6 +128,10 @@ app_mngr::CommandCreator& AppServiceHmiCommandFactory::buildCommandCreator(
       return hmi_apis::messageType::request == message_type
                  ? factory.GetCreator<commands::ASPublishAppServiceRequest>()
                  : factory.GetCreator<commands::ASPublishAppServiceResponse>();
+    case hmi_apis::FunctionID::AppService_UnpublishAppService:
+      return hmi_apis::messageType::request == message_type
+                 ? factory.GetCreator<commands::ASUnpublishAppServiceRequest>()
+                 : factory.GetCreator<commands::ASUnpublishAppServiceResponse>();
     case hmi_apis::FunctionID::AppService_OnAppServiceData:
       return app_mngr::commands::Command::CommandSource::SOURCE_HMI == source
                  ? factory.GetCreator<

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_mobile_command_factory.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_mobile_command_factory.cc
@@ -47,6 +47,8 @@
 #include "app_service_rpc_plugin/commands/mobile/perform_app_service_interaction_response_from_mobile.h"
 #include "app_service_rpc_plugin/commands/mobile/publish_app_service_request.h"
 #include "app_service_rpc_plugin/commands/mobile/publish_app_service_response.h"
+#include "app_service_rpc_plugin/commands/mobile/unpublish_app_service_request.h"
+#include "app_service_rpc_plugin/commands/mobile/unpublish_app_service_response.h"
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "AppServiceRpcPlugin")
 
@@ -118,6 +120,16 @@ app_mngr::CommandCreator& AppServiceMobileCommandFactory::buildCommandCreator(
                      source &&
                  mobile_apis::messageType::request != message_type) {
         return factory.GetCreator<commands::PublishAppServiceResponse>();
+      }
+      break;
+    case mobile_apis::FunctionID::UnpublishAppServiceID:
+      if (app_mngr::commands::Command::CommandSource::SOURCE_MOBILE == source &&
+          mobile_apis::messageType::response != message_type) {
+        return factory.GetCreator<commands::UnpublishAppServiceRequest>();
+      } else if (app_mngr::commands::Command::CommandSource::SOURCE_SDL ==
+                     source &&
+                 mobile_apis::messageType::request != message_type) {
+        return factory.GetCreator<commands::UnpublishAppServiceResponse>();
       }
       break;
     case mobile_apis::FunctionID::OnAppServiceDataID:

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_unpublish_app_service_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_unpublish_app_service_request.cc
@@ -1,0 +1,83 @@
+/*
+ Copyright (c) 2019, Ford Motor Company, Livio
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the the copyright holders nor the names of their
+ contributors may be used to endorse or promote products derived from this
+ software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "app_service_rpc_plugin/commands/hmi/as_unpublish_app_service_request.h"
+#include "application_manager/application_impl.h"
+#include "application_manager/rpc_service.h"
+#include "interfaces/MOBILE_API.h"
+#include "application_manager/app_service_manager.h"
+
+namespace app_service_rpc_plugin {
+using namespace application_manager;
+namespace commands {
+
+ASUnpublishAppServiceRequest::ASUnpublishAppServiceRequest(
+    const application_manager::commands::MessageSharedPtr& message,
+    ApplicationManager& application_manager,
+    app_mngr::rpc_service::RPCService& rpc_service,
+    app_mngr::HMICapabilities& hmi_capabilities,
+    policy::PolicyHandlerInterface& policy_handler)
+    : RequestFromHMI(message,
+                         application_manager,
+                         rpc_service,
+                         hmi_capabilities,
+                         policy_handler) {}
+
+ASUnpublishAppServiceRequest::~ASUnpublishAppServiceRequest() {}
+
+void ASUnpublishAppServiceRequest::Run() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  std::string service_id = (*message_)[strings::msg_params][strings::service_id].asString();
+
+  bool ret = application_manager_.GetAppServiceManager().UnpublishAppService(service_id);
+  
+  if (!ret) {
+    SendErrorResponse(
+        (*message_)[strings::params][strings::correlation_id].asUInt(),
+        hmi_apis::FunctionID::AppService_UnpublishAppService,
+        hmi_apis::Common_Result::REJECTED,
+        "The app service with that requested service ID does not exist",
+        application_manager::commands::Command::SOURCE_SDL_TO_HMI);
+    return;
+  }
+
+  SendResponse(true,
+              (*message_)[strings::params][strings::correlation_id].asUInt(),
+              hmi_apis::FunctionID::AppService_UnpublishAppService,
+              hmi_apis::Common_Result::SUCCESS,
+              NULL,
+              application_manager::commands::Command::SOURCE_SDL_TO_HMI);
+}
+
+}  // namespace commands
+}  // namespace app_service_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_unpublish_app_service_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_unpublish_app_service_request.cc
@@ -60,6 +60,18 @@ void ASUnpublishAppServiceRequest::Run() {
   std::string service_id =
       (*message_)[strings::msg_params][strings::service_id].asString();
 
+  auto service =
+      application_manager_.GetAppServiceManager().FindServiceByID(service_id);
+  if (service->mobile_service) {
+    SendErrorResponse(
+        (*message_)[strings::params][strings::correlation_id].asUInt(),
+        hmi_apis::FunctionID::AppService_UnpublishAppService,
+        hmi_apis::Common_Result::REJECTED,
+        "Invalid Service ID",
+        application_manager::commands::Command::SOURCE_SDL_TO_HMI);
+    return;
+  }
+
   bool ret = application_manager_.GetAppServiceManager().UnpublishAppService(
       service_id);
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_unpublish_app_service_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_unpublish_app_service_request.cc
@@ -31,10 +31,10 @@
  */
 
 #include "app_service_rpc_plugin/commands/hmi/as_unpublish_app_service_request.h"
+#include "application_manager/app_service_manager.h"
 #include "application_manager/application_impl.h"
 #include "application_manager/rpc_service.h"
 #include "interfaces/MOBILE_API.h"
-#include "application_manager/app_service_manager.h"
 
 namespace app_service_rpc_plugin {
 using namespace application_manager;
@@ -47,20 +47,22 @@ ASUnpublishAppServiceRequest::ASUnpublishAppServiceRequest(
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
     : RequestFromHMI(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+                     application_manager,
+                     rpc_service,
+                     hmi_capabilities,
+                     policy_handler) {}
 
 ASUnpublishAppServiceRequest::~ASUnpublishAppServiceRequest() {}
 
 void ASUnpublishAppServiceRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  std::string service_id = (*message_)[strings::msg_params][strings::service_id].asString();
+  std::string service_id =
+      (*message_)[strings::msg_params][strings::service_id].asString();
 
-  bool ret = application_manager_.GetAppServiceManager().UnpublishAppService(service_id);
-  
+  bool ret = application_manager_.GetAppServiceManager().UnpublishAppService(
+      service_id);
+
   if (!ret) {
     SendErrorResponse(
         (*message_)[strings::params][strings::correlation_id].asUInt(),
@@ -72,11 +74,11 @@ void ASUnpublishAppServiceRequest::Run() {
   }
 
   SendResponse(true,
-              (*message_)[strings::params][strings::correlation_id].asUInt(),
-              hmi_apis::FunctionID::AppService_UnpublishAppService,
-              hmi_apis::Common_Result::SUCCESS,
-              NULL,
-              application_manager::commands::Command::SOURCE_SDL_TO_HMI);
+               (*message_)[strings::params][strings::correlation_id].asUInt(),
+               hmi_apis::FunctionID::AppService_UnpublishAppService,
+               hmi_apis::Common_Result::SUCCESS,
+               NULL,
+               application_manager::commands::Command::SOURCE_SDL_TO_HMI);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_unpublish_app_service_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_unpublish_app_service_request.cc
@@ -62,11 +62,11 @@ void ASUnpublishAppServiceRequest::Run() {
 
   auto service =
       application_manager_.GetAppServiceManager().FindServiceByID(service_id);
-  if (service->mobile_service) {
+  if (!service || service->mobile_service) {
     SendErrorResponse(
         (*message_)[strings::params][strings::correlation_id].asUInt(),
         hmi_apis::FunctionID::AppService_UnpublishAppService,
-        hmi_apis::Common_Result::REJECTED,
+        hmi_apis::Common_Result::INVALID_ID,
         "Invalid Service ID",
         application_manager::commands::Command::SOURCE_SDL_TO_HMI);
     return;

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_unpublish_app_service_response.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_unpublish_app_service_response.cc
@@ -1,0 +1,61 @@
+/*
+ Copyright (c) 2019, Ford Motor Company, Livio
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the the copyright holders nor the names of their
+ contributors may be used to endorse or promote products derived from this
+ software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "app_service_rpc_plugin/commands/hmi/as_unpublish_app_service_response.h"
+#include "application_manager/application_impl.h"
+#include "application_manager/rpc_service.h"
+#include "interfaces/MOBILE_API.h"
+
+namespace app_service_rpc_plugin {
+using namespace application_manager;
+namespace commands {
+
+ASUnpublishAppServiceResponse::ASUnpublishAppServiceResponse(
+    const application_manager::commands::MessageSharedPtr& message,
+    ApplicationManager& application_manager,
+    app_mngr::rpc_service::RPCService& rpc_service,
+    app_mngr::HMICapabilities& hmi_capabilities,
+    policy::PolicyHandlerInterface& policy_handler)
+    : ResponseToHMI(message,
+                         application_manager,
+                         rpc_service,
+                         hmi_capabilities,
+                         policy_handler) {}
+
+ASUnpublishAppServiceResponse::~ASUnpublishAppServiceResponse() {}
+
+void ASUnpublishAppServiceResponse::Run() {
+  LOG4CXX_AUTO_TRACE(logger_);
+}
+
+}  // namespace commands
+}  // namespace app_service_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_unpublish_app_service_response.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_unpublish_app_service_response.cc
@@ -46,15 +46,16 @@ ASUnpublishAppServiceResponse::ASUnpublishAppServiceResponse(
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
     : ResponseToHMI(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+                    application_manager,
+                    rpc_service,
+                    hmi_capabilities,
+                    policy_handler) {}
 
 ASUnpublishAppServiceResponse::~ASUnpublishAppServiceResponse() {}
 
 void ASUnpublishAppServiceResponse::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
+  rpc_service_.SendMessageToHMI(message_);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/publish_app_service_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/publish_app_service_request.cc
@@ -120,12 +120,6 @@ void PublishAppServiceRequest::Run() {
     return;
   }
 
-  if (app->IsFullscreen()) {
-    // Service should be activated if app is in the foreground
-    application_manager_.GetAppServiceManager().ActivateAppService(
-        service_record[strings::service_id].asString());
-  }
-
   response_params[strings::app_service_record] = service_record;
 
   SendResponse(true, mobile_apis::Result::SUCCESS, NULL, &response_params);

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_request.cc
@@ -58,19 +58,21 @@ UnpublishAppServiceRequest::~UnpublishAppServiceRequest() {}
 void UnpublishAppServiceRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  std::string service_id = (*message_)[strings::msg_params][strings::service_id].asString();
+  std::string service_id =
+      (*message_)[strings::msg_params][strings::service_id].asString();
 
-  bool ret = application_manager_.GetAppServiceManager().UnpublishAppService(service_id);
+  bool ret = application_manager_.GetAppServiceManager().UnpublishAppService(
+      service_id);
 
   if (!ret) {
-    SendResponse(false,
-              mobile_apis::Result::INVALID_ID,
-              "The app service with that requested service ID does not exist");
+    SendResponse(
+        false,
+        mobile_apis::Result::INVALID_ID,
+        "The app service with that requested service ID does not exist");
     return;
   }
 
   SendResponse(true, mobile_apis::Result::SUCCESS, NULL, NULL);
-
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_request.cc
@@ -1,0 +1,77 @@
+/*
+ Copyright (c) 2019, Ford Motor Company, Livio
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the the copyright holders nor the names of their
+ contributors may be used to endorse or promote products derived from this
+ software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "app_service_rpc_plugin/commands/mobile/unpublish_app_service_request.h"
+
+#include "application_manager/app_service_manager.h"
+#include "application_manager/application_impl.h"
+#include "application_manager/rpc_service.h"
+#include "interfaces/MOBILE_API.h"
+
+namespace app_service_rpc_plugin {
+using namespace application_manager;
+namespace commands {
+
+UnpublishAppServiceRequest::UnpublishAppServiceRequest(
+    const application_manager::commands::MessageSharedPtr& message,
+    ApplicationManager& application_manager,
+    app_mngr::rpc_service::RPCService& rpc_service,
+    app_mngr::HMICapabilities& hmi_capabilities,
+    policy::PolicyHandlerInterface& policy_handler)
+    : CommandRequestImpl(message,
+                         application_manager,
+                         rpc_service,
+                         hmi_capabilities,
+                         policy_handler) {}
+
+UnpublishAppServiceRequest::~UnpublishAppServiceRequest() {}
+
+void UnpublishAppServiceRequest::Run() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  std::string service_id = (*message_)[strings::msg_params][strings::service_id].asString();
+
+  bool ret = application_manager_.GetAppServiceManager().UnpublishAppService(service_id);
+
+  if (!ret) {
+    SendResponse(false,
+              mobile_apis::Result::INVALID_ID,
+              "The app service with that requested service ID does not exist");
+    return;
+  }
+
+  SendResponse(true, mobile_apis::Result::SUCCESS, NULL, NULL);
+
+}
+
+}  // namespace commands
+}  // namespace app_service_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_request.cc
@@ -68,7 +68,7 @@ void UnpublishAppServiceRequest::Run() {
     SendResponse(
         false,
         mobile_apis::Result::INVALID_ID,
-        "The app service with that requested service ID does not exist");
+        "No app service with the requested service ID was published by this application");
     return;
   }
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_request.cc
@@ -61,6 +61,17 @@ void UnpublishAppServiceRequest::Run() {
   std::string service_id =
       (*message_)[strings::msg_params][strings::service_id].asString();
 
+  auto service =
+      application_manager_.GetAppServiceManager().FindServiceByID(service_id);
+
+  if (service->connection_key != connection_key()) {
+    SendResponse(
+        false,
+        mobile_apis::Result::INVALID_ID,
+        "The app service with that requested service ID does not exist");
+    return;
+  }
+
   bool ret = application_manager_.GetAppServiceManager().UnpublishAppService(
       service_id);
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_request.cc
@@ -65,10 +65,10 @@ void UnpublishAppServiceRequest::Run() {
       application_manager_.GetAppServiceManager().FindServiceByID(service_id);
 
   if (!service || service->connection_key != connection_key()) {
-    SendResponse(
-        false,
-        mobile_apis::Result::INVALID_ID,
-        "No app service with the requested service ID was published by this application");
+    SendResponse(false,
+                 mobile_apis::Result::INVALID_ID,
+                 "No app service with the requested service ID was published "
+                 "by this application");
     return;
   }
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_request.cc
@@ -64,7 +64,7 @@ void UnpublishAppServiceRequest::Run() {
   auto service =
       application_manager_.GetAppServiceManager().FindServiceByID(service_id);
 
-  if (service->connection_key != connection_key()) {
+  if (!service || service->connection_key != connection_key()) {
     SendResponse(
         false,
         mobile_apis::Result::INVALID_ID,

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_response.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_response.cc
@@ -46,10 +46,10 @@ UnpublishAppServiceResponse::UnpublishAppServiceResponse(
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
     : CommandResponseImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+                          application_manager,
+                          rpc_service,
+                          hmi_capabilities,
+                          policy_handler) {}
 
 UnpublishAppServiceResponse::~UnpublishAppServiceResponse() {}
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_response.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_response.cc
@@ -1,0 +1,62 @@
+/*
+ Copyright (c) 2019, Ford Motor Company, Livio
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the the copyright holders nor the names of their
+ contributors may be used to endorse or promote products derived from this
+ software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "app_service_rpc_plugin/commands/mobile/unpublish_app_service_response.h"
+#include "application_manager/application_impl.h"
+#include "application_manager/rpc_service.h"
+#include "interfaces/MOBILE_API.h"
+
+namespace app_service_rpc_plugin {
+using namespace application_manager;
+namespace commands {
+
+UnpublishAppServiceResponse::UnpublishAppServiceResponse(
+    const application_manager::commands::MessageSharedPtr& message,
+    ApplicationManager& application_manager,
+    app_mngr::rpc_service::RPCService& rpc_service,
+    app_mngr::HMICapabilities& hmi_capabilities,
+    policy::PolicyHandlerInterface& policy_handler)
+    : CommandResponseImpl(message,
+                         application_manager,
+                         rpc_service,
+                         hmi_capabilities,
+                         policy_handler) {}
+
+UnpublishAppServiceResponse::~UnpublishAppServiceResponse() {}
+
+void UnpublishAppServiceResponse::Run() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  rpc_service_.SendMessageToMobile(message_);
+}
+
+}  // namespace commands
+}  // namespace app_service_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/commands/hmi/dummy_hmi_commands_test.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/commands/hmi/dummy_hmi_commands_test.cc
@@ -53,6 +53,8 @@
 #include "hmi/as_perform_app_service_interaction_response_to_hmi.h"
 #include "hmi/as_publish_app_service_request.h"
 #include "hmi/as_publish_app_service_response.h"
+#include "hmi/as_unpublish_app_service_request.h"
+#include "hmi/as_unpublish_app_service_response.h"
 #include "hmi/on_as_app_service_data_notification.h"
 #include "hmi/on_as_app_service_data_notification_from_hmi.h"
 
@@ -132,6 +134,8 @@ typedef Types<commands::ASAppServiceActivationRequest,
               commands::ASPerformAppServiceInteractionResponseToHMI,
               commands::ASPublishAppServiceRequest,
               commands::ASPublishAppServiceResponse,
+              commands::ASUnpublishAppServiceRequest,
+              commands::ASUnpublishAppServiceResponse,
               commands::OnASAppServiceDataNotification,
               commands::OnASAppServiceDataNotificationFromHMI>
     HMICommandsListFirst;

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/commands/mobile/dummy_mobile_commands_test.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/commands/mobile/dummy_mobile_commands_test.cc
@@ -49,6 +49,8 @@
 #include "mobile/perform_app_service_interaction_response_from_mobile.h"
 #include "mobile/publish_app_service_request.h"
 #include "mobile/publish_app_service_response.h"
+#include "mobile/unpublish_app_service_request.h"
+#include "mobile/unpublish_app_service_response.h"
 
 #include "application_manager/mock_application.h"
 #include "application_manager/mock_application_manager.h"
@@ -118,7 +120,9 @@ typedef Types<commands::GetAppServiceDataRequest,
               commands::PerformAppServiceInteractionResponse,
               commands::PerformAppServiceInteractionResponseFromMobile,
               commands::PublishAppServiceRequest,
-              commands::PublishAppServiceResponse>
+              commands::PublishAppServiceResponse,
+              commands::UnpublishAppServiceRequest,
+              commands::UnpublishAppServiceResponse>
     MobileCommandsListFirst;
 
 TYPED_TEST_CASE(MobileCommandsTestFirst, MobileCommandsListFirst);

--- a/src/components/application_manager/src/app_service_manager.cc
+++ b/src/components/application_manager/src/app_service_manager.cc
@@ -72,10 +72,10 @@ smart_objects::SmartObject AppServiceManager::PublishAppService(
 
   std::string service_type = manifest[strings::service_type].asString();
 
-  AppService* found_service = FindServiceByProvider(connection_key, service_type);
+  AppService* found_service =
+      FindServiceByProvider(connection_key, service_type);
   if (found_service) {
-    LOG4CXX_WARN(logger_,
-                 "Service already exists for this provider, updating");
+    LOG4CXX_WARN(logger_, "Service already exists for this provider, updating");
 
     published_services_lock_.Acquire();
     found_service->record[strings::service_manifest] = manifest;
@@ -85,13 +85,14 @@ smart_objects::SmartObject AppServiceManager::PublishAppService(
 
     smart_objects::SmartObject msg_params;
     msg_params[strings::system_capability][strings::system_capability_type] =
-      mobile_apis::SystemCapabilityType::APP_SERVICES;
+        mobile_apis::SystemCapabilityType::APP_SERVICES;
 
-    AppServiceUpdated(
-      updated_service_record, mobile_apis::ServiceUpdateReason::MANIFEST_UPDATE, msg_params);
+    AppServiceUpdated(updated_service_record,
+                      mobile_apis::ServiceUpdateReason::MANIFEST_UPDATE,
+                      msg_params);
 
     MessageHelper::BroadcastCapabilityUpdate(msg_params, app_manager_);
-    
+
     return updated_service_record;
   }
 
@@ -151,12 +152,13 @@ smart_objects::SmartObject AppServiceManager::PublishAppService(
   // Activate the new service if it is the default for its service type, if
   // no service is active of its service type, or it is a mobile app in full.
   AppService* active_service = ActiveServiceForType(service_type);
-  ApplicationSharedPtr app = NULL; 
+  ApplicationSharedPtr app = NULL;
   if (mobile_service && connection_key) {
     app = app_manager_.application(connection_key);
   }
-  
-  if (!active_service || app_service.default_service || (mobile_service && app && app->IsFullscreen())) {
+
+  if (!active_service || app_service.default_service ||
+      (mobile_service && app && app->IsFullscreen())) {
     ActivateAppService(service_id);
   }
 
@@ -185,7 +187,9 @@ bool AppServiceManager::UnpublishAppService(const std::string service_id) {
     // Activate embedded service, if available
     auto embedded_service = EmbeddedServiceForType(
         record[strings::service_manifest][strings::service_type].asString());
-    if (embedded_service) {
+    if (embedded_service &&
+        (embedded_service->record[strings::service_id].asString().compare(
+             service_id) > 0)) {
       embedded_service->record[strings::service_active] = true;
       AppServiceUpdated(embedded_service->record,
                         mobile_apis::ServiceUpdateReason::ACTIVATED,

--- a/src/components/application_manager/src/app_service_manager.cc
+++ b/src/components/application_manager/src/app_service_manager.cc
@@ -80,14 +80,16 @@ smart_objects::SmartObject AppServiceManager::PublishAppService(
     if (manifest.keyExists(strings::service_name)) {
       auto service_by_name =
           FindServiceByName(manifest[strings::service_name].asString());
-      auto service_by_name_id =
-          service_by_name->record[strings::service_id].asString();
-      auto found_service_id =
-          found_service->record[strings::service_id].asString();
-      if (service_by_name_id != found_service_id) {
-        LOG4CXX_WARN(logger_,
-                     "A service already exists with this name, rejecting");
-        return smart_objects::SmartObject();
+      if (service_by_name) {
+        auto service_by_name_id =
+            service_by_name->record[strings::service_id].asString();
+        auto found_service_id =
+            found_service->record[strings::service_id].asString();
+        if (service_by_name_id != found_service_id) {
+          LOG4CXX_WARN(logger_,
+                       "A service already exists with this name, rejecting");
+          return smart_objects::SmartObject();
+        }
       }
     }
     LOG4CXX_WARN(logger_, "Service already exists for this provider, updating");

--- a/src/components/application_manager/src/app_service_manager.cc
+++ b/src/components/application_manager/src/app_service_manager.cc
@@ -83,7 +83,7 @@ smart_objects::SmartObject AppServiceManager::PublishAppService(
       auto service_by_name_id =
           service_by_name->record[strings::service_id].asString();
       auto found_service_id =
-          service_by_name->record[strings::service_id].asString();
+          found_service->record[strings::service_id].asString();
       if (service_by_name_id != found_service_id) {
         LOG4CXX_WARN(logger_,
                      "A service already exists with this name, rejecting");

--- a/src/components/application_manager/src/hmi_interfaces_impl.cc
+++ b/src/components/application_manager/src/hmi_interfaces_impl.cc
@@ -231,6 +231,8 @@ generate_function_to_interface_convert_map() {
   convert_map[RC_OnRemoteControlSettings] = HmiInterfaces::HMI_INTERFACE_RC;
   convert_map[AppService_PublishAppService] =
       HmiInterfaces::HMI_INTERFACE_AppService;
+  convert_map[AppService_UnpublishAppService] =
+      HmiInterfaces::HMI_INTERFACE_AppService;
   convert_map[AppService_GetAppServiceData] =
       HmiInterfaces::HMI_INTERFACE_AppService;
   convert_map[AppService_PerformAppServiceInteraction] =

--- a/src/components/application_manager/test/app_service_manager_test.cc
+++ b/src/components/application_manager/test/app_service_manager_test.cc
@@ -60,6 +60,7 @@ const std::string kServiceType = "MEDIA";
 const std::string kServiceName = "service_name";
 const std::string kServiceId = "service_id";
 const std::string kPolicyAppId = "p_app_id";
+const std::string kPolicyAppId2 = "p_app_id2";
 const uint32_t kConnectionKey = 43629;
 const uint32_t kHMIConnectionKey = 0;
 
@@ -83,6 +84,7 @@ class AppServiceManagerTest : public testing::Test {
  public:
   AppServiceManagerTest()
       : mock_app_ptr_(new MockApplication)
+      , mock_app_ptr2_(new MockApplication)
       , app_service_manager_(mock_app_manager_, mock_last_state_)
       , mock_message_helper_(
             application_manager::MockMessageHelper::message_helper_mock()) {
@@ -101,10 +103,15 @@ class AppServiceManagerTest : public testing::Test {
         .WillByDefault(ReturnRef(mock_settings_));
     ON_CALL(*mock_app_ptr_, policy_app_id())
         .WillByDefault(Return(kPolicyAppId));
+    ON_CALL(*mock_app_ptr2_, policy_app_id())
+        .WillByDefault(Return(kPolicyAppId2));
     ON_CALL(mock_last_state_, get_dictionary()).WillByDefault(ReturnRef(dict_));
     auto app_ptr = std::static_pointer_cast<am::Application>(mock_app_ptr_);
+    auto app_ptr2 = std::static_pointer_cast<am::Application>(mock_app_ptr2_);
     ON_CALL(mock_app_manager_, application(kConnectionKey))
         .WillByDefault(Return(app_ptr));
+    ON_CALL(mock_app_manager_, application(kConnectionKey + 1))
+        .WillByDefault(Return(app_ptr2));
   }
 
  protected:
@@ -192,6 +199,7 @@ class AppServiceManagerTest : public testing::Test {
   Json::Value dict_;
   std::vector<std::string> embedded_services_;
   std::shared_ptr<MockApplication> mock_app_ptr_;
+  std::shared_ptr<MockApplication> mock_app_ptr2_;
   MockApplicationManager mock_app_manager_;
   resumption_test::MockLastState mock_last_state_;
   MockApplicationManagerSettings mock_settings_;

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -6342,7 +6342,7 @@
     </function>
 
     <function name="UnpublishAppService" messagetype="request">
-        <description>Unpublish an existing service published by this application.</description>
+        <description>Unpublish an existing service published by the HMI.</description>
 
         <param name="serviceID" type="String" mandatory="true">
             <description> The ID of the service to be unpublished. </description>

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -6372,7 +6372,10 @@
 <interface name="AppService" version="1.0.0" date="2019-03-18">
     <description>Interface used for interacting with app services as a producer or consumer</description>
     <function name="PublishAppService" messagetype="request">
-        <description>Registers a service offered by this app on the module</description>
+        <description>
+          Registers a service offered by this app on the module.
+          Subsequent calls with the same service type will update the manifest for that service.
+        </description>
 
         <param name="appServiceManifest" type="Common.AppServiceManifest" mandatory="true">
             <description> The manifest of the service that wishes to be published.</description>

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -6333,6 +6333,18 @@
         </param>
     </function>
 
+    <function name="UnpublishAppService" messagetype="request">
+        <description>Unpublish an existing service published by this application.</description>
+
+        <param name="serviceID" type="String" mandatory="true">
+            <description> The ID of the service to be unpublished. </description>
+        </param>
+    </function>
+
+    <function name="UnpublishAppService" messagetype="response">
+        <description>The response to UnpublishAppService</description>
+    </function>
+
     <function name="OnAppServiceData" messagetype="notification">
         <description>This notification includes the data that is updated from the specific service. HMI->SDL if the HMI is a producer, SDL->HMI if the HMI is a consumer</description>
 

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <?xml-stylesheet type="text/xml" href="protocol2html.xsl"?>
 
-<interface name="SmartDeviceLink RAPI" version="5.1.0" minVersion="1.0" date="2019-03-19">
+<interface name="SmartDeviceLink RAPI" version="5.2.0" minVersion="1.0" date="2019-03-19">
     <enum name="Result" internal_scope="base" since="1.0">
         <element name="SUCCESS">
             <description>The request succeeded</description>
@@ -2645,6 +2645,7 @@
         <element name="GetAppServiceDataID" value="53" hexvalue="35" since="5.1" />
         <element name="GetFileID" value="54" hexvalue="36" since="5.1" />
         <element name="PerformAppServiceInteractionID" value="55" hexvalue="37" since="5.1" />
+        <element name="UnpublishAppServiceID" value="56" hexvalue="38" since="5.2" />
         
         <!--
          Base Notifications
@@ -7194,10 +7195,16 @@
     </function>
 
     <function name="PublishAppService" functionID="PublishAppServiceID" messagetype="request" since="5.1">
-        <description>Registers a service offered by this app on the module</description>
+        <description>
+            Registers a service offered by this app on the module.
+            Subsequent calls with the same service type will update the manifest for that service.
+        </description>
 
         <param name="appServiceManifest" type="AppServiceManifest" mandatory="true">
-            <description> The manifest of the service that wishes to be published.</description>
+            <description>
+                The manifest of the service that wishes to be published. 
+                If already published, the updated manifest for this service.
+            </description>
         </param>
     </function>
 
@@ -7226,6 +7233,38 @@
 
         <param name="appServiceRecord" type="AppServiceRecord" mandatory="false">
             <description> If the request was successful, this object will be the current status of the service record for the published service. This will include the Core supplied service ID.</description>
+        </param>
+    </function>
+
+    <function name="UnpublishAppService" functionID="UnpublishAppServiceID" messagetype="request" since="5.2">
+        <description> Unpublish an existing service published by this application. </description>
+
+        <param name="serviceID" type="String" mandatory="true">
+            <description> The ID of the service to be unpublished. </description>
+        </param>
+    </function>
+    
+    <function name="UnpublishAppService" functionID="UnpublishAppServiceID" messagetype="response" since="5.2">
+        <description> The response to UnpublishAppService </description>
+        <param name="success" type="Boolean" platform="documentation" mandatory="true">
+            <description> true, if successful; false, if failed </description>
+        </param>
+       
+        <param name="resultCode" type="Result" platform="documentation" mandatory="true">
+            <description>See Result</description>
+            <element name="SUCCESS"/>
+            <element name="REJECTED"/>
+            <element name="DISALLOWED"/>
+            <element name="INVALID_DATA"/>
+            <element name="INVALID_ID"/>
+            <element name="OUT_OF_MEMORY"/>
+            <element name="TOO_MANY_PENDING_REQUESTS"/>
+            <element name="APPLICATION_NOT_REGISTERED"/>
+            <element name="GENERIC_ERROR"/>
+        </param>
+
+        <param name="info" type="String" maxlength="1000" mandatory="false" platform="documentation">
+            <description>Provides additional human readable info regarding the result.</description>
         </param>
     </function>
 

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -2645,7 +2645,7 @@
         <element name="GetAppServiceDataID" value="53" hexvalue="35" since="5.1" />
         <element name="GetFileID" value="54" hexvalue="36" since="5.1" />
         <element name="PerformAppServiceInteractionID" value="55" hexvalue="37" since="5.1" />
-        <element name="UnpublishAppServiceID" value="56" hexvalue="38" since="5.2" />
+        <element name="UnpublishAppServiceID" value="56" hexvalue="38" since="6.0" />
         
         <!--
          Base Notifications
@@ -7243,7 +7243,7 @@
         </param>
     </function>
 
-    <function name="UnpublishAppService" functionID="UnpublishAppServiceID" messagetype="request" since="5.2">
+    <function name="UnpublishAppService" functionID="UnpublishAppServiceID" messagetype="request" since="6.0">
         <description> Unpublish an existing service published by this application. </description>
 
         <param name="serviceID" type="String" mandatory="true">
@@ -7251,7 +7251,7 @@
         </param>
     </function>
     
-    <function name="UnpublishAppService" functionID="UnpublishAppServiceID" messagetype="response" since="5.2">
+    <function name="UnpublishAppService" functionID="UnpublishAppServiceID" messagetype="response" since="6.0">
         <description> The response to UnpublishAppService </description>
         <param name="success" type="Boolean" platform="documentation" mandatory="true">
             <description> true, if successful; false, if failed </description>

--- a/src/components/policy/policy_external/include/policy/policy_table/enums.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/enums.h
@@ -472,6 +472,11 @@ enum FunctionID {
   PerformAppServiceInteractionID = 55,
 
   /**
+   * @brief UnpublishAppServiceID.
+   */
+  UnpublishAppServiceID = 56,
+
+  /**
    * @brief OnHMIStatusID.
    */
   OnHMIStatusID = 32768,

--- a/src/components/policy/policy_external/src/policy_table/enums.cc
+++ b/src/components/policy/policy_external/src/policy_table/enums.cc
@@ -1159,6 +1159,11 @@ bool EnumFromJsonString(const std::string& literal, FunctionID* result) {
     return true;
   }
 
+  if ("UnpublishAppService" == literal) {
+    *result = PublishAppServiceID;
+    return true;
+  }
+
   if ("OnHMIStatus" == literal) {
     *result = OnHMIStatusID;
     return true;

--- a/src/components/policy/policy_external/src/policy_table/enums.cc
+++ b/src/components/policy/policy_external/src/policy_table/enums.cc
@@ -1160,7 +1160,7 @@ bool EnumFromJsonString(const std::string& literal, FunctionID* result) {
   }
 
   if ("UnpublishAppService" == literal) {
-    *result = PublishAppServiceID;
+    *result = UnpublishAppServiceID;
     return true;
   }
 

--- a/src/components/policy/policy_regular/include/policy/policy_table/enums.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/enums.h
@@ -457,6 +457,11 @@ enum FunctionID {
   PerformAppServiceInteractionID = 55,
 
   /**
+   * @brief UnpublishAppServiceID.
+   */
+  UnpublishAppServiceID = 56,
+
+  /**
    * @brief OnHMIStatusID.
    */
   OnHMIStatusID = 32768,

--- a/src/components/policy/policy_regular/src/policy_table/enums.cc
+++ b/src/components/policy/policy_regular/src/policy_table/enums.cc
@@ -859,6 +859,8 @@ bool IsValidEnum(FunctionID val) {
       return true;
     case PerformAppServiceInteractionID:
       return true;
+    case UnpublishAppServiceID:
+      return true;
     case OnHMIStatusID:
       return true;
     case OnAppInterfaceUnregisteredID:
@@ -1022,6 +1024,8 @@ const char* EnumToJsonString(FunctionID val) {
       return "GetAppServiceData";
     case PerformAppServiceInteractionID:
       return "PerformAppServiceInteraction";
+    case UnpublishAppServiceID:
+      return "UnpublishAppService";
     case OnHMIStatusID:
       return "OnHMIStatus";
     case OnAppInterfaceUnregisteredID:
@@ -1343,6 +1347,11 @@ bool EnumFromJsonString(const std::string& literal, FunctionID* result) {
 
   if ("PerformAppServiceInteraction" == literal) {
     *result = PerformAppServiceInteractionID;
+    return true;
+  }
+
+  if ("UnpublishAppService" == literal) {
+    *result = UnpublishAppServiceID;
     return true;
   }
 


### PR DESCRIPTION
Fixes #2911 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- Connect an app and publish an app service.
- Send a second publish app service with an updated manifest
- Send an UnpublishAppService request. 

### Summary
Allows app service providers to update their manifests via multiple publish app service requests. Providers are given the ability to delete their app service now as well via the UnpublishAppService rpc.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
