### PR TITLE
Add Nav Subscription Buttons

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_button_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_button_request.cc
@@ -126,6 +126,26 @@ bool SubscribeButtonRequest::IsSubscriptionAllowed(
        (mobile_apis::ButtonName::TUNEDOWN == btn_id))) {
     return false;
   }
+
+  if (!app->is_navi() &&
+      ((mobile_apis::ButtonName::NAV_CENTER_LOCATION == btn_id) ||
+       (mobile_apis::ButtonName::NAV_ZOOM_IN == btn_id) ||
+       (mobile_apis::ButtonName::NAV_ZOOM_OUT == btn_id) ||
+       (mobile_apis::ButtonName::NAV_PAN_UP == btn_id) ||
+       (mobile_apis::ButtonName::NAV_PAN_UP_RIGHT == btn_id) ||
+       (mobile_apis::ButtonName::NAV_PAN_RIGHT == btn_id) ||
+       (mobile_apis::ButtonName::NAV_PAN_DOWN_RIGHT == btn_id) ||
+       (mobile_apis::ButtonName::NAV_PAN_DOWN == btn_id) ||
+       (mobile_apis::ButtonName::NAV_PAN_DOWN_LEFT == btn_id) ||
+       (mobile_apis::ButtonName::NAV_PAN_LEFT == btn_id) ||
+       (mobile_apis::ButtonName::NAV_PAN_UP_LEFT == btn_id) ||
+       (mobile_apis::ButtonName::NAV_TILT_TOGGLE == btn_id) ||
+       (mobile_apis::ButtonName::NAV_ROTATE_CLOCKWISE == btn_id) ||
+       (mobile_apis::ButtonName::NAV_ROTATE_COUNTERCLOCKWISE == btn_id) ||
+       (mobile_apis::ButtonName::NAV_HEADING_TOGGLE == btn_id))) {
+    return false;
+  }
+
   return true;
 }
 

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -135,6 +135,46 @@ void InitCapabilities() {
                      hmi_apis::Common_ButtonName::CUSTOM_BUTTON));
   button_enum_name.insert(std::make_pair(std::string("SEARCH"),
                                          hmi_apis::Common_ButtonName::SEARCH));
+  button_enum_name.insert(
+      std::make_pair(std::string("NAV_CENTER_LOCATION"),
+                     hmi_apis::Common_ButtonName::NAV_CENTER_LOCATION));
+  button_enum_name.insert(std::make_pair(
+      std::string("NAV_ZOOM_IN"), hmi_apis::Common_ButtonName::NAV_ZOOM_IN));
+  button_enum_name.insert(std::make_pair(
+      std::string("NAV_ZOOM_OUT"), hmi_apis::Common_ButtonName::NAV_ZOOM_OUT));
+  button_enum_name.insert(std::make_pair(
+      std::string("NAV_PAN_UP"), hmi_apis::Common_ButtonName::NAV_PAN_UP));
+  button_enum_name.insert(
+      std::make_pair(std::string("NAV_PAN_UP_RIGHT"),
+                     hmi_apis::Common_ButtonName::NAV_PAN_UP_RIGHT));
+  button_enum_name.insert(
+      std::make_pair(std::string("NAV_PAN_RIGHT"),
+                     hmi_apis::Common_ButtonName::NAV_PAN_RIGHT));
+  button_enum_name.insert(
+      std::make_pair(std::string("NAV_PAN_DOWN_RIGHT"),
+                     hmi_apis::Common_ButtonName::NAV_PAN_DOWN_RIGHT));
+  button_enum_name.insert(std::make_pair(
+      std::string("NAV_PAN_DOWN"), hmi_apis::Common_ButtonName::NAV_PAN_DOWN));
+  button_enum_name.insert(
+      std::make_pair(std::string("NAV_PAN_DOWN_LEFT"),
+                     hmi_apis::Common_ButtonName::NAV_PAN_DOWN_LEFT));
+  button_enum_name.insert(std::make_pair(
+      std::string("NAV_PAN_LEFT"), hmi_apis::Common_ButtonName::NAV_PAN_LEFT));
+  button_enum_name.insert(
+      std::make_pair(std::string("NAV_PAN_UP_LEFT"),
+                     hmi_apis::Common_ButtonName::NAV_PAN_UP_LEFT));
+  button_enum_name.insert(
+      std::make_pair(std::string("NAV_TILT_TOGGLE"),
+                     hmi_apis::Common_ButtonName::NAV_TILT_TOGGLE));
+  button_enum_name.insert(
+      std::make_pair(std::string("NAV_ROTATE_CLOCKWISE"),
+                     hmi_apis::Common_ButtonName::NAV_ROTATE_CLOCKWISE));
+  button_enum_name.insert(
+      std::make_pair(std::string("NAV_ROTATE_COUNTERCLOCKWISE"),
+                     hmi_apis::Common_ButtonName::NAV_ROTATE_COUNTERCLOCKWISE));
+  button_enum_name.insert(
+      std::make_pair(std::string("NAV_HEADING_TOGGLE"),
+                     hmi_apis::Common_ButtonName::NAV_HEADING_TOGGLE));
 
   text_fields_enum_name.insert(std::make_pair(
       std::string("mainField1"), hmi_apis::Common_TextFieldName::mainField1));

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -116,6 +116,27 @@
     <element name="SOURCE" />
     <element name="SHUFFLE" />
     <element name="REPEAT" />
+
+    <!-- Navigation Subscription Buttons -->
+    <element name="NAV_CENTER_LOCATION" />
+    <element name="NAV_ZOOM_IN" />
+    <element name="NAV_ZOOM_OUT" />
+    <element name="NAV_PAN_UP" />
+    <element name="NAV_PAN_UP_RIGHT" />
+    <element name="NAV_PAN_RIGHT" />
+    <element name="NAV_PAN_DOWN_RIGHT" />
+    <element name="NAV_PAN_DOWN" />
+    <element name="NAV_PAN_DOWN_LEFT" />
+    <element name="NAV_PAN_LEFT" />
+    <element name="NAV_PAN_UP_LEFT" />
+    <element name="NAV_TILT_TOGGLE">
+        <description>If supported, this toggles between a top-down view and an angled/3D view. If your app supports different, but substantially similar options, then you may implement those. If you don't implement these or similar options, do not subscribe to this button.</description>
+    </element>
+    <element name="NAV_ROTATE_CLOCKWISE" />
+    <element name="NAV_ROTATE_COUNTERCLOCKWISE" />
+    <element name="NAV_HEADING_TOGGLE">
+        <description>If supported, this toggles between locking the orientation to north or to the vehicle's heading. If your app supports different, but substantially similar options, then you may implement those. If you don't implement these or similar options, do not subscribe to this button.</description>
+    </element>
 </enum>
 
 <enum name="ButtonEventMode">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -623,6 +623,25 @@
         <element name="SOURCE" since="4.5" />
         <element name="SHUFFLE" since="4.5" />
         <element name="REPEAT" since="4.5" />
+        <element name="NAV_CENTER_LOCATION" since="5.2" />
+        <element name="NAV_ZOOM_IN" since="5.2" />
+        <element name="NAV_ZOOM_OUT" since="5.2" />
+        <element name="NAV_PAN_UP" since="5.2" />
+        <element name="NAV_PAN_UP_RIGHT" since="5.2" />
+        <element name="NAV_PAN_RIGHT" since="5.2" />
+        <element name="NAV_PAN_DOWN_RIGHT" since="5.2" />
+        <element name="NAV_PAN_DOWN" since="5.2" />
+        <element name="NAV_PAN_DOWN_LEFT" since="5.2" />
+        <element name="NAV_PAN_LEFT" since="5.2" />
+        <element name="NAV_PAN_UP_LEFT" since="5.2" />
+        <element name="NAV_TILT_TOGGLE" since="5.2" >
+            <description>If supported, this toggles between a top-down view and an angled/3D view. If your app supports different, but substantially similar options, then you may implement those. If you don't implement these or similar options, do not subscribe to this button.</description>
+        </element>
+        <element name="NAV_ROTATE_CLOCKWISE" since="5.2" />
+        <element name="NAV_ROTATE_COUNTERCLOCKWISE" since="5.2" />
+        <element name="NAV_HEADING_TOGGLE" since="5.2" >
+            <description>If supported, this toggles between locking the orientation to north or to the vehicle's heading. If your app supports different, but substantially similar options, then you may implement those. If you don't implement these or similar options, do not subscribe to this button.</description>
+        </element>
     </enum>
     
     <enum name="MediaClockFormat" since="1.0">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -624,23 +624,23 @@
         <element name="SHUFFLE" since="4.5" />
         <element name="REPEAT" since="4.5" />
         <!-- Navigation Buttons -->
-        <element name="NAV_CENTER_LOCATION" since="5.2" />
-        <element name="NAV_ZOOM_IN" since="5.2" />
-        <element name="NAV_ZOOM_OUT" since="5.2" />
-        <element name="NAV_PAN_UP" since="5.2" />
-        <element name="NAV_PAN_UP_RIGHT" since="5.2" />
-        <element name="NAV_PAN_RIGHT" since="5.2" />
-        <element name="NAV_PAN_DOWN_RIGHT" since="5.2" />
-        <element name="NAV_PAN_DOWN" since="5.2" />
-        <element name="NAV_PAN_DOWN_LEFT" since="5.2" />
-        <element name="NAV_PAN_LEFT" since="5.2" />
-        <element name="NAV_PAN_UP_LEFT" since="5.2" />
-        <element name="NAV_TILT_TOGGLE" since="5.2" >
+        <element name="NAV_CENTER_LOCATION" since="6.0" />
+        <element name="NAV_ZOOM_IN" since="6.0" />
+        <element name="NAV_ZOOM_OUT" since="6.0" />
+        <element name="NAV_PAN_UP" since="6.0" />
+        <element name="NAV_PAN_UP_RIGHT" since="6.0" />
+        <element name="NAV_PAN_RIGHT" since="6.0" />
+        <element name="NAV_PAN_DOWN_RIGHT" since="6.0" />
+        <element name="NAV_PAN_DOWN" since="6.0" />
+        <element name="NAV_PAN_DOWN_LEFT" since="6.0" />
+        <element name="NAV_PAN_LEFT" since="6.0" />
+        <element name="NAV_PAN_UP_LEFT" since="6.0" />
+        <element name="NAV_TILT_TOGGLE" since="6.0" >
             <description>If supported, this toggles between a top-down view and an angled/3D view. If your app supports different, but substantially similar options, then you may implement those. If you don't implement these or similar options, do not subscribe to this button.</description>
         </element>
-        <element name="NAV_ROTATE_CLOCKWISE" since="5.2" />
-        <element name="NAV_ROTATE_COUNTERCLOCKWISE" since="5.2" />
-        <element name="NAV_HEADING_TOGGLE" since="5.2" >
+        <element name="NAV_ROTATE_CLOCKWISE" since="6.0" />
+        <element name="NAV_ROTATE_COUNTERCLOCKWISE" since="6.0" />
+        <element name="NAV_HEADING_TOGGLE" since="6.0" >
             <description>If supported, this toggles between locking the orientation to north or to the vehicle's heading. If your app supports different, but substantially similar options, then you may implement those. If you don't implement these or similar options, do not subscribe to this button.</description>
         </element>
     </enum>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -623,6 +623,7 @@
         <element name="SOURCE" since="4.5" />
         <element name="SHUFFLE" since="4.5" />
         <element name="REPEAT" since="4.5" />
+        <!-- Navigation Buttons -->
         <element name="NAV_CENTER_LOCATION" since="5.2" />
         <element name="NAV_ZOOM_IN" since="5.2" />
         <element name="NAV_ZOOM_OUT" since="5.2" />


### PR DESCRIPTION
Fixes #2917 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Connect nav application and send a subscribeButtonRequest for any of the new nav subscription buttons.

### Summary
Implements proposal to include navigation subscription buttons similar to media's subscription buttons (seek left, play_pause, presets, etc).

New nav buttons will also be returned in buttonCapabilities param for the RegisterAppInterface response and the SetDisplayLayoutResponse. 

Note: These navigation buttons are not a part of the module remote control feature. They can however be used in a button press rpc pass through to a mobile app navigation service if the button press rpc is supported in the apps manifest. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)