### PR TITLE
Fix double declaration of nav_capability

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_system_capability_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_system_capability_request.cc
@@ -89,7 +89,7 @@ void GetSystemCapabilityRequest::Run() {
       bool has_nav_capability = false;
       if (hmi_capabilities.navigation_capability()) {
         has_nav_capability = true;
-        auto nav_capability = *hmi_capabilities.navigation_capability();
+        nav_capability = *hmi_capabilities.navigation_capability();
       }
 
       has_nav_capability = application_manager_.GetAppServiceManager()


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Connect app, send getSystemCapabilityRequest with type NAVIGATION. Verify there is a valid response.

### Summary
Remove auto declaration of an already declared variable.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
