### PR TITLE
Support running the same app from multiple devices at the same time

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1036,17 +1036,6 @@ class ApplicationManagerImpl
       const connection_handler::DeviceHandle handle) const OVERRIDE;
 
   /**
-   * DEPRECATED
-   * @brief IsAppInReconnectMode check if application belongs to session
-   * affected by transport switching at the moment by checking internal
-   * waiting list prepared on switching start
-   * @param policy_app_id Application id
-   * @return True if application is in the waiting list, otherwise - false
-   */
-  DEPRECATED bool IsAppInReconnectMode(
-      const std::string& policy_app_id) const FINAL;
-
-  /**
    * @brief IsAppInReconnectMode check if application belongs to session
    * affected by transport switching at the moment by checking internal
    * waiting list prepared on switching start

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -517,32 +517,6 @@ class ApplicationManagerImpl
   bool IsApplicationForbidden(uint32_t connection_key,
                               const std::string& mobile_app_id);
 
-  struct ApplicationsAppIdSorter {
-    bool operator()(const ApplicationSharedPtr lhs,
-                    const ApplicationSharedPtr rhs) {
-      return lhs->app_id() < rhs->app_id();
-    }
-  };
-
-  struct ApplicationsMobileAppIdSorter {
-    bool operator()(const ApplicationSharedPtr lhs,
-                    const ApplicationSharedPtr rhs) {
-      if (lhs->policy_app_id() == rhs->policy_app_id()) {
-        return lhs->device() < rhs->device();
-      }
-      return lhs->policy_app_id() < rhs->policy_app_id();
-    }
-  };
-
-  // typedef for Applications list
-  typedef std::set<ApplicationSharedPtr, ApplicationsAppIdSorter> ApplictionSet;
-
-  // typedef for Applications list iterator
-  typedef ApplictionSet::iterator ApplictionSetIt;
-
-  // typedef for Applications list const iterator
-  typedef ApplictionSet::const_iterator ApplictionSetConstIt;
-
   /**
    * @brief Notification from PolicyHandler about PTU.
    * Compares AppHMIType between saved in app and received from PTU. If they are
@@ -1062,13 +1036,26 @@ class ApplicationManagerImpl
       const connection_handler::DeviceHandle handle) const OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief IsAppInReconnectMode check if application belongs to session
    * affected by transport switching at the moment by checking internal
    * waiting list prepared on switching start
    * @param policy_app_id Application id
    * @return True if application is in the waiting list, otherwise - false
    */
-  bool IsAppInReconnectMode(const std::string& policy_app_id) const FINAL;
+  DEPRECATED bool IsAppInReconnectMode(
+      const std::string& policy_app_id) const FINAL;
+
+  /**
+   * @brief IsAppInReconnectMode check if application belongs to session
+   * affected by transport switching at the moment by checking internal
+   * waiting list prepared on switching start
+   * @param device_id device identifier
+   * @param policy_app_id Application id
+   * @return True if application is in the waiting list, otherwise - false
+   */
+  bool IsAppInReconnectMode(const connection_handler::DeviceHandle& device_id,
+                            const std::string& policy_app_id) const FINAL;
 
   bool IsStopping() const OVERRIDE {
     return is_stopping_;

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -117,11 +117,23 @@ class PolicyHandler : public PolicyHandlerInterface,
       const std::string& device_id) const OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief Sets HMI default type for specified application
    * @param application_id ID application
    * @param app_types list of HMI types
    */
-  void SetDefaultHmiTypes(const std::string& application_id,
+  DEPRECATED void SetDefaultHmiTypes(
+      const std::string& application_id,
+      const smart_objects::SmartObject* app_types) OVERRIDE;
+
+  /**
+   * @brief Sets HMI default type for specified application
+   * @param device_handle device identifier
+   * @param application_id ID application
+   * @param app_types list of HMI types
+   */
+  void SetDefaultHmiTypes(const transport_manager::DeviceHandle& device_handle,
+                          const std::string& application_id,
                           const smart_objects::SmartObject* app_types) OVERRIDE;
 
   /**
@@ -180,7 +192,10 @@ class PolicyHandler : public PolicyHandlerInterface,
   bool GetModuleTypes(const std::string& policy_app_id,
                       std::vector<std::string>* modules) const OVERRIDE;
 
-  bool GetDefaultHmi(const std::string& policy_app_id,
+  DEPRECATED bool GetDefaultHmi(const std::string& policy_app_id,
+                                std::string* default_hmi) const OVERRIDE;
+  bool GetDefaultHmi(const std::string& device_id,
+                     const std::string& policy_app_id,
                      std::string* default_hmi) const OVERRIDE;
   bool GetInitialAppData(const std::string& application_id,
                          StringArray* nicknames = NULL,
@@ -253,7 +268,8 @@ class PolicyHandler : public PolicyHandlerInterface,
    */
   void OnIgnitionCycleOver() OVERRIDE;
 
-  void OnPendingPermissionChange(const std::string& policy_app_id) OVERRIDE;
+  void OnPendingPermissionChange(const std::string& device_id,
+                                 const std::string& policy_app_id) OVERRIDE;
 
   /**
    * Initializes PT exchange at user request
@@ -340,9 +356,11 @@ class PolicyHandler : public PolicyHandlerInterface,
   /**
    * @brief Update currently used device id in policies manager for given
    * application
+   * @param device_handle device identifier
    * @param policy_app_id Application id
    */
   std::string OnCurrentDeviceIdUpdateRequired(
+      const transport_manager::DeviceHandle& device_handle,
       const std::string& policy_app_id) OVERRIDE;
 
   /**
@@ -506,6 +524,7 @@ class PolicyHandler : public PolicyHandlerInterface,
 
   virtual void SendOnAppPermissionsChanged(
       const AppPermissions& permissions,
+      const std::string& device_id,
       const std::string& policy_app_id) const OVERRIDE;
 
   virtual void OnPTExchangeNeeded() OVERRIDE;
@@ -513,13 +532,27 @@ class PolicyHandler : public PolicyHandlerInterface,
   virtual void GetAvailableApps(std::queue<std::string>& apps) OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief Allows to add new or update existed application during
    * registration process
    * @param application_id The policy aplication id.
    * @param hmi_types list of hmi types
    * @return function that will notify update manager about new application
    */
+  DEPRECATED StatusNotifier AddApplication(
+      const std::string& application_id,
+      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) OVERRIDE;
+
+  /**
+   * @brief Allows to add new or update existed application during
+   * registration process
+   * @param device_id device identifier
+   * @param application_id The policy aplication id.
+   * @param hmi_types list of hmi types
+   * @return function that will notify update manager about new application
+   */
   StatusNotifier AddApplication(
+      const std::string& device_id,
       const std::string& application_id,
       const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) OVERRIDE;
 
@@ -581,12 +614,25 @@ class PolicyHandler : public PolicyHandlerInterface,
                                const std::string& application_id) OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief Checks if certain request type is allowed for application
    * @param policy_app_id Unique applicaion id
    * @param type Request type
    * @return true, if allowed, otherwise - false
    */
+  DEPRECATED bool IsRequestTypeAllowed(
+      const std::string& policy_app_id,
+      mobile_apis::RequestType::eType type) const OVERRIDE;
+
+  /**
+   * @brief Checks if certain request type is allowed for application
+   * @param device_handle device identifier
+   * @param policy_app_id Unique applicaion id
+   * @param type Request type
+   * @return true, if allowed, otherwise - false
+   */
   bool IsRequestTypeAllowed(
+      const transport_manager::DeviceHandle& device_handle,
       const std::string& policy_app_id,
       mobile_apis::RequestType::eType type) const OVERRIDE;
 
@@ -617,11 +663,22 @@ class PolicyHandler : public PolicyHandlerInterface,
       const std::string& policy_app_id) const OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief Gets application request types
    * @param policy_app_id Unique application id
    * @return request types
    */
+  DEPRECATED const std::vector<std::string> GetAppRequestTypes(
+      const std::string& policy_app_id) const OVERRIDE;
+
+  /**
+   * @brief Gets application request types
+   * @param device_id device identifier
+   * @param policy_app_id Unique application id
+   * @return request types
+   */
   const std::vector<std::string> GetAppRequestTypes(
+      const transport_manager::DeviceHandle& device_id,
       const std::string& policy_app_id) const OVERRIDE;
 
   /**
@@ -689,6 +746,21 @@ class PolicyHandler : public PolicyHandlerInterface,
   void StartNextRetry();
 
  private:
+  /**
+   * DEPRECATED
+   * @brief Update currently used device id in policies manager for given
+   * application
+   * @param policy_app_id Application id
+   */
+  std::string OnCurrentDeviceIdUpdateRequired(
+      const std::string& policy_app_id) OVERRIDE;
+
+  void OnPendingPermissionChange(const std::string& policy_app_id) OVERRIDE;
+
+  void SendOnAppPermissionsChanged(
+      const AppPermissions& permissions,
+      const std::string& policy_app_id) const OVERRIDE;
+
   void OnPermissionsUpdated(const std::string& policy_app_id,
                             const Permissions& permissions,
                             const HMILevel& default_hmi) OVERRIDE;
@@ -748,7 +820,7 @@ class PolicyHandler : public PolicyHandlerInterface,
   void UpdateHMILevel(application_manager::ApplicationSharedPtr app,
                       mobile_apis::HMILevel::eType level);
   std::vector<std::string> GetDevicesIds(
-      const std::string& policy_app_id) OVERRIDE;
+      const std::string& policy_app_id) const OVERRIDE;
 
   /**
    * @brief Sets days after epoch on successful policy update

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -117,16 +117,6 @@ class PolicyHandler : public PolicyHandlerInterface,
       const std::string& device_id) const OVERRIDE;
 
   /**
-   * DEPRECATED
-   * @brief Sets HMI default type for specified application
-   * @param application_id ID application
-   * @param app_types list of HMI types
-   */
-  DEPRECATED void SetDefaultHmiTypes(
-      const std::string& application_id,
-      const smart_objects::SmartObject* app_types) OVERRIDE;
-
-  /**
    * @brief Sets HMI default type for specified application
    * @param device_handle device identifier
    * @param application_id ID application
@@ -192,8 +182,6 @@ class PolicyHandler : public PolicyHandlerInterface,
   bool GetModuleTypes(const std::string& policy_app_id,
                       std::vector<std::string>* modules) const OVERRIDE;
 
-  DEPRECATED bool GetDefaultHmi(const std::string& policy_app_id,
-                                std::string* default_hmi) const OVERRIDE;
   bool GetDefaultHmi(const std::string& device_id,
                      const std::string& policy_app_id,
                      std::string* default_hmi) const OVERRIDE;
@@ -532,18 +520,6 @@ class PolicyHandler : public PolicyHandlerInterface,
   virtual void GetAvailableApps(std::queue<std::string>& apps) OVERRIDE;
 
   /**
-   * DEPRECATED
-   * @brief Allows to add new or update existed application during
-   * registration process
-   * @param application_id The policy aplication id.
-   * @param hmi_types list of hmi types
-   * @return function that will notify update manager about new application
-   */
-  DEPRECATED StatusNotifier AddApplication(
-      const std::string& application_id,
-      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) OVERRIDE;
-
-  /**
    * @brief Allows to add new or update existed application during
    * registration process
    * @param device_id device identifier
@@ -592,17 +568,6 @@ class PolicyHandler : public PolicyHandlerInterface,
   void OnAppsSearchCompleted(const bool trigger_ptu) OVERRIDE;
 
   /**
-   * DEPRECATED
-   * @brief OnAppRegisteredOnMobile allows to handle event when application were
-   * succesfully registered on mobile device.
-   * It will send OnAppPermissionSend notification and will try to start PTU.
-   *
-   * @param application_id registered application.
-   */
-  DEPRECATED void OnAppRegisteredOnMobile(
-      const std::string& application_id) OVERRIDE;
-
-  /**
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
    * It will send OnAppPermissionSend notification and will try to start PTU.
@@ -612,17 +577,6 @@ class PolicyHandler : public PolicyHandlerInterface,
    */
   void OnAppRegisteredOnMobile(const std::string& device_id,
                                const std::string& application_id) OVERRIDE;
-
-  /**
-   * DEPRECATED
-   * @brief Checks if certain request type is allowed for application
-   * @param policy_app_id Unique applicaion id
-   * @param type Request type
-   * @return true, if allowed, otherwise - false
-   */
-  DEPRECATED bool IsRequestTypeAllowed(
-      const std::string& policy_app_id,
-      mobile_apis::RequestType::eType type) const OVERRIDE;
 
   /**
    * @brief Checks if certain request type is allowed for application
@@ -660,15 +614,6 @@ class PolicyHandler : public PolicyHandlerInterface,
    * @return request subtypes state
    */
   RequestSubType::State GetAppRequestSubTypeState(
-      const std::string& policy_app_id) const OVERRIDE;
-
-  /**
-   * DEPRECATED
-   * @brief Gets application request types
-   * @param policy_app_id Unique application id
-   * @return request types
-   */
-  DEPRECATED const std::vector<std::string> GetAppRequestTypes(
       const std::string& policy_app_id) const OVERRIDE;
 
   /**
@@ -746,28 +691,6 @@ class PolicyHandler : public PolicyHandlerInterface,
   void StartNextRetry();
 
  private:
-  /**
-   * DEPRECATED
-   * @brief Update currently used device id in policies manager for given
-   * application
-   * @param policy_app_id Application id
-   */
-  std::string OnCurrentDeviceIdUpdateRequired(
-      const std::string& policy_app_id) OVERRIDE;
-
-  void OnPendingPermissionChange(const std::string& policy_app_id) OVERRIDE;
-
-  void SendOnAppPermissionsChanged(
-      const AppPermissions& permissions,
-      const std::string& policy_app_id) const OVERRIDE;
-
-  void OnPermissionsUpdated(const std::string& policy_app_id,
-                            const Permissions& permissions,
-                            const HMILevel& default_hmi) OVERRIDE;
-
-  void OnPermissionsUpdated(const std::string& policy_app_id,
-                            const Permissions& permissions) OVERRIDE;
-
   /**
    * Checks system action of application for permission of keep context
    * @param system_action system action (see mobile api)

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -87,11 +87,14 @@ class PolicyHandler : public PolicyHandlerInterface,
   bool ReceiveMessageFromSDK(const std::string& file,
                              const BinaryMessage& pt_string) OVERRIDE;
   bool UnloadPolicyLibrary() OVERRIDE;
-  virtual void OnPermissionsUpdated(const std::string& policy_app_id,
+
+  virtual void OnPermissionsUpdated(const std::string& device_id,
+                                    const std::string& policy_app_id,
                                     const Permissions& permissions,
                                     const HMILevel& default_hmi) OVERRIDE;
 
-  virtual void OnPermissionsUpdated(const std::string& policy_app_id,
+  virtual void OnPermissionsUpdated(const std::string& device_id,
+                                    const std::string& policy_app_id,
                                     const Permissions& permissions) OVERRIDE;
 
 #ifdef EXTERNAL_PROPRIETARY_MODE
@@ -556,13 +559,26 @@ class PolicyHandler : public PolicyHandlerInterface,
   void OnAppsSearchCompleted(const bool trigger_ptu) OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
    * It will send OnAppPermissionSend notification and will try to start PTU.
    *
    * @param application_id registered application.
    */
-  void OnAppRegisteredOnMobile(const std::string& application_id) OVERRIDE;
+  DEPRECATED void OnAppRegisteredOnMobile(
+      const std::string& application_id) OVERRIDE;
+
+  /**
+   * @brief OnAppRegisteredOnMobile allows to handle event when application were
+   * succesfully registered on mobile device.
+   * It will send OnAppPermissionSend notification and will try to start PTU.
+   *
+   * @param device_id device identifier
+   * @param application_id registered application.
+   */
+  void OnAppRegisteredOnMobile(const std::string& device_id,
+                               const std::string& application_id) OVERRIDE;
 
   /**
    * @brief Checks if certain request type is allowed for application
@@ -673,6 +689,13 @@ class PolicyHandler : public PolicyHandlerInterface,
   void StartNextRetry();
 
  private:
+  void OnPermissionsUpdated(const std::string& policy_app_id,
+                            const Permissions& permissions,
+                            const HMILevel& default_hmi) OVERRIDE;
+
+  void OnPermissionsUpdated(const std::string& policy_app_id,
+                            const Permissions& permissions) OVERRIDE;
+
   /**
    * Checks system action of application for permission of keep context
    * @param system_action system action (see mobile api)

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/change_registration_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/change_registration_request.h
@@ -123,11 +123,12 @@ class ChangeRegistrationRequest
   /**
    * @brief Check parameters (name, vr) for
    * coincidence with already known parameters of registered applications
-   *
+   * @param device_id device identifier
    * @return SUCCESS if there is no coincidence of app.name/VR synonyms,
    * otherwise appropriate error code returns
    */
-  mobile_apis::Result::eType CheckCoincidence();
+  mobile_apis::Result::eType CheckCoincidence(
+      const connection_handler::DeviceHandle& device_id);
 
   /**
    * @brief Checks if requested name is allowed by policy

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -215,9 +215,23 @@ class RegisterAppInterfaceRequest
    */
   bool IsApplicationSwitched();
 
+  /**
+   * @brief Information about given Connection Key.
+   * @param key Unique key used by other components as session identifier
+   * @param device_id device identifier.
+   * @param mac_address uniq address
+   * @return false in case of error or true in case of success
+   */
+  bool GetDataOnSessionKey(
+      const uint32_t key,
+      connection_handler::DeviceHandle* device_id = nullptr,
+      std::string* mac_address = nullptr) const;
+
  private:
   std::string response_info_;
   mobile_apis::Result::eType result_code_;
+  connection_handler::DeviceHandle device_handle_;
+  std::string device_id_;
 
   policy::PolicyHandlerInterface& GetPolicyHandler();
   DISALLOW_COPY_AND_ASSIGN(RegisterAppInterfaceRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/cancel_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/cancel_interaction_request.cc
@@ -61,12 +61,13 @@ void CancelInteractionRequest::Run() {
   auto function_id = static_cast<mobile_apis::FunctionID::eType>(
       (*message_)[strings::msg_params][strings::func_id].asInt());
 
-  if (helpers::Compare<mobile_apis::FunctionID::eType, helpers::NEQ, helpers::ALL>(
-          function_id,
-          mobile_apis::FunctionID::PerformInteractionID,
-          mobile_apis::FunctionID::AlertID,
-          mobile_apis::FunctionID::ScrollableMessageID,
-          mobile_apis::FunctionID::SliderID)) {
+  if (helpers::
+          Compare<mobile_apis::FunctionID::eType, helpers::NEQ, helpers::ALL>(
+              function_id,
+              mobile_apis::FunctionID::PerformInteractionID,
+              mobile_apis::FunctionID::AlertID,
+              mobile_apis::FunctionID::ScrollableMessageID,
+              mobile_apis::FunctionID::SliderID)) {
     LOG4CXX_ERROR(logger_, "Bad function ID" << function_id);
     SendResponse(false, mobile_apis::Result::INVALID_ID);
     return;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/change_registration_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/change_registration_request.cc
@@ -49,7 +49,7 @@ struct IsSameNickname {
   }
 
  private:
-  const custom_str::CustomString& app_id_;
+  const custom_str::CustomString app_id_;
 };
 }  // namespace
 
@@ -160,7 +160,7 @@ void ChangeRegistrationRequest::Run() {
     return;
   }
 
-  if (mobile_apis::Result::SUCCESS != CheckCoincidence()) {
+  if (mobile_apis::Result::SUCCESS != CheckCoincidence(app->device())) {
     SendResponse(false, mobile_apis::Result::DUPLICATE_NAME);
     return;
   }
@@ -578,36 +578,46 @@ bool ChangeRegistrationRequest::IsWhiteSpaceExist() {
   return false;
 }
 
-mobile_apis::Result::eType ChangeRegistrationRequest::CheckCoincidence() {
+mobile_apis::Result::eType ChangeRegistrationRequest::CheckCoincidence(
+    const connection_handler::DeviceHandle& device_id) {
   LOG4CXX_AUTO_TRACE(logger_);
 
   const smart_objects::SmartObject& msg_params =
       (*message_)[strings::msg_params];
 
-  ApplicationSet accessor = application_manager_.applications().GetData();
+  auto compare_tts_name = [](const smart_objects::SmartObject& obj_1,
+                             const smart_objects::SmartObject& obj_2) {
+    return obj_1[application_manager::strings::text]
+        .asCustomString()
+        .CompareIgnoreCase(
+            obj_2[application_manager::strings::text].asCustomString());
+  };
+
+  const auto& accessor = application_manager_.applications().GetData();
   custom_str::CustomString app_name;
-  uint32_t app_id = connection_key();
+  const uint32_t app_id = connection_key();
   if (msg_params.keyExists(strings::app_name)) {
     app_name = msg_params[strings::app_name].asCustomString();
   }
 
-  ApplicationSetConstIt it = accessor.begin();
-  for (; accessor.end() != it; ++it) {
-    if (app_id == (*it)->app_id()) {
+  for (const auto& app : accessor) {
+    if (app->device() != device_id) {
       continue;
     }
 
-    const custom_str::CustomString& cur_name = (*it)->name();
+    if (app->app_id() == app_id) {
+      continue;
+    }
+
+    const auto& cur_name = app->name();
     if (msg_params.keyExists(strings::app_name)) {
       if (app_name.CompareIgnoreCase(cur_name)) {
         LOG4CXX_ERROR(logger_, "Application name is known already.");
         return mobile_apis::Result::DUPLICATE_NAME;
       }
-
-      const smart_objects::SmartObject* vr = (*it)->vr_synonyms();
-      const std::vector<smart_objects::SmartObject>* curr_vr = NULL;
-      if (NULL != vr) {
-        curr_vr = vr->asArray();
+      const auto vr = app->vr_synonyms();
+      if (vr) {
+        const auto curr_vr = vr->asArray();
         CoincidencePredicateVR v(app_name);
 
         if (0 != std::count_if(curr_vr->begin(), curr_vr->end(), v)) {
@@ -617,18 +627,37 @@ mobile_apis::Result::eType ChangeRegistrationRequest::CheckCoincidence() {
       }
     }
 
-    // vr check
+    // VR check
     if (msg_params.keyExists(strings::vr_synonyms)) {
-      const std::vector<smart_objects::SmartObject>* new_vr =
-          msg_params[strings::vr_synonyms].asArray();
+      const auto new_vr = msg_params[strings::vr_synonyms].asArray();
 
       CoincidencePredicateVR v(cur_name);
       if (0 != std::count_if(new_vr->begin(), new_vr->end(), v)) {
         LOG4CXX_ERROR(logger_, "vr_synonyms duplicated with app_name .");
         return mobile_apis::Result::DUPLICATE_NAME;
       }
-    }  // end vr check
-  }    // application for end
+    }  // End vr check
+
+    // TTS check
+    if (msg_params.keyExists(strings::tts_name) && app->tts_name()) {
+      const auto tts_array = msg_params[strings::tts_name].asArray();
+      const auto tts_curr = app->tts_name()->asArray();
+      const auto& it_tts = std::find_first_of(tts_array->begin(),
+                                              tts_array->end(),
+                                              tts_curr->begin(),
+                                              tts_curr->end(),
+                                              compare_tts_name);
+      if (it_tts != tts_array->end()) {
+        LOG4CXX_ERROR(
+            logger_,
+            "TTS name: "
+                << (*it_tts)[strings::text].asCustomString().AsMBString()
+                << " is known already");
+        return mobile_apis::Result::DUPLICATE_NAME;
+      }
+    }  // End tts check
+
+  }  // Application for end
   return mobile_apis::Result::SUCCESS;
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_request_notification.cc
@@ -86,8 +86,8 @@ void OnSystemRequestNotification::Run() {
           static_cast<rpc::policy_table_interface_base::RequestType>(
               request_type));
 
-  if (!policy_handler.IsRequestTypeAllowed(app->policy_app_id(),
-                                           request_type)) {
+  if (!policy_handler.IsRequestTypeAllowed(
+          app->device(), app->policy_app_id(), request_type)) {
     LOG4CXX_WARN(logger_,
                  "Request type " << stringified_request_type
                                  << " is not allowed by policies");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -1339,7 +1339,7 @@ bool RegisterAppInterfaceRequest::IsApplicationSwitched() {
         logger_,
         "Policy id " << policy_app_id << " is not found in reconnection list.");
     SendResponse(false, mobile_apis::Result::APPLICATION_REGISTERED_ALREADY);
-    return false;
+    return true;
   }
 
   LOG4CXX_DEBUG(logger_, "Application is found in reconnection list.");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -841,14 +841,15 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
     }
   }
   policy::StatusNotifier notify_upd_manager = GetPolicyHandler().AddApplication(
-      application->policy_app_id(), hmi_types);
+      application->mac_address(), application->policy_app_id(), hmi_types);
 
   response_params[strings::icon_resumed] =
       file_system::FileExists(application->app_icon_path());
 
   SendResponse(true, result_code, add_info.c_str(), &response_params);
   if (msg_params.keyExists(strings::app_hmi_type)) {
-    GetPolicyHandler().SetDefaultHmiTypes(application->policy_app_id(),
+    GetPolicyHandler().SetDefaultHmiTypes(application->device(),
+                                          application->policy_app_id(),
                                           &(msg_params[strings::app_hmi_type]));
   }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -1425,7 +1425,7 @@ bool RegisterAppInterfaceRequest::GetDataOnSessionKey(
   if (result) {
     LOG4CXX_DEBUG(
         logger_,
-        "Failed get device info for connection key: " << connection_key());
+        "Failed to get device info for connection key: " << connection_key());
     return false;
   }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
@@ -470,8 +470,8 @@ void SystemRequest::Run() {
           static_cast<rpc::policy_table_interface_base::RequestType>(
               request_type));
 
-  if (!policy_handler.IsRequestTypeAllowed(application->policy_app_id(),
-                                           request_type)) {
+  if (!policy_handler.IsRequestTypeAllowed(
+          application->device(), application->policy_app_id(), request_type)) {
     LOG4CXX_ERROR(logger_,
                   "RequestType " << stringified_request_type
                                  << " is DISALLOWED by policies");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_system_request_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_system_request_notification_test.cc
@@ -174,7 +174,7 @@ TEST_F(OnSystemRequestNotificationTest, Run_InvalidApp_NoNotification) {
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(MockAppPtr()));
   EXPECT_CALL(*mock_app_, policy_app_id()).Times(0);
-  EXPECT_CALL(mock_policy_handler_, IsRequestTypeAllowed(_, _)).Times(0);
+  EXPECT_CALL(mock_policy_handler_, IsRequestTypeAllowed(_, _, _)).Times(0);
 
   EXPECT_CALL(mock_message_helper_, PrintSmartObject(_)).Times(0);
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_system_request_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_system_request_notification_test.cc
@@ -62,6 +62,7 @@ using testing::SaveArg;
 namespace {
 const uint32_t kConnectionKey = 1u;
 const std::string kPolicyAppId = "fake-app-id";
+const connection_handler::DeviceHandle kDeviceId = 1u;
 }  // namespace
 
 class OnSystemRequestNotificationTest
@@ -73,6 +74,7 @@ class OnSystemRequestNotificationTest
     ON_CALL(app_mngr_, application(kConnectionKey))
         .WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, policy_app_id()).WillByDefault(Return(kPolicyAppId));
+    ON_CALL(*mock_app_, device()).WillByDefault(Return(kDeviceId));
   }
 
  protected:
@@ -90,12 +92,14 @@ TEST_F(OnSystemRequestNotificationTest, Run_ProprietaryType_SUCCESS) {
   std::shared_ptr<OnSystemRequestNotification> command =
       CreateCommand<OnSystemRequestNotification>(msg);
 
+  PreConditions();
+
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillRepeatedly(Return(mock_app_));
 
   EXPECT_CALL(*mock_app_, policy_app_id()).WillOnce(Return(kPolicyAppId));
   EXPECT_CALL(mock_policy_handler_,
-              IsRequestTypeAllowed(kPolicyAppId, request_type))
+              IsRequestTypeAllowed(kDeviceId, kPolicyAppId, request_type))
       .WillRepeatedly(Return(true));
 
 #ifdef PROPRIETARY_MODE
@@ -130,10 +134,13 @@ TEST_F(OnSystemRequestNotificationTest, Run_HTTPType_SUCCESS) {
   std::shared_ptr<OnSystemRequestNotification> command =
       CreateCommand<OnSystemRequestNotification>(msg);
 
+  PreConditions();
+
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_app_, policy_app_id()).WillOnce(Return(kPolicyAppId));
-  EXPECT_CALL(mock_policy_handler_, IsRequestTypeAllowed(_, _))
+  EXPECT_CALL(mock_policy_handler_,
+              IsRequestTypeAllowed(kDeviceId, kPolicyAppId, request_type))
       .WillOnce(Return(true));
 
   EXPECT_CALL(mock_message_helper_, PrintSmartObject(_))
@@ -187,10 +194,13 @@ TEST_F(OnSystemRequestNotificationTest, Run_RequestNotAllowed_NoNotification) {
   std::shared_ptr<OnSystemRequestNotification> command =
       CreateCommand<OnSystemRequestNotification>(msg);
 
+  PreConditions();
+
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_app_, policy_app_id()).WillOnce(Return(kPolicyAppId));
-  EXPECT_CALL(mock_policy_handler_, IsRequestTypeAllowed(_, _))
+  EXPECT_CALL(mock_policy_handler_,
+              IsRequestTypeAllowed(kDeviceId, kPolicyAppId, request_type))
       .WillOnce(Return(false));
 
   EXPECT_CALL(mock_message_helper_, PrintSmartObject(_)).Times(0);
@@ -214,7 +224,7 @@ TEST_F(
   PreConditions();
 
   EXPECT_CALL(mock_policy_handler_,
-              IsRequestTypeAllowed(kPolicyAppId, request_type))
+              IsRequestTypeAllowed(kDeviceId, kPolicyAppId, request_type))
       .WillOnce(Return(true));
   EXPECT_CALL(mock_policy_handler_,
               IsRequestSubTypeAllowed(kPolicyAppId, request_subtype))
@@ -241,7 +251,7 @@ TEST_F(OnSystemRequestNotificationTest,
   PreConditions();
 
   EXPECT_CALL(mock_policy_handler_,
-              IsRequestTypeAllowed(kPolicyAppId, request_type))
+              IsRequestTypeAllowed(kDeviceId, kPolicyAppId, request_type))
       .WillOnce(Return(true));
   EXPECT_CALL(mock_policy_handler_,
               IsRequestSubTypeAllowed(kPolicyAppId, request_subtype))

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/system_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/system_request_test.cc
@@ -74,6 +74,7 @@ const std::string kAppStorageFolder = "fake-storage";
 const std::string kSystemFilesPath = "/fake/system/files";
 const std::string kFileName = "Filename";
 const uint32_t kHmiAppId = 3u;
+const connection_handler::DeviceHandle kDeviceId = 1u;
 }  // namespace
 
 class SystemRequestTest
@@ -99,13 +100,15 @@ class SystemRequestTest
     ON_CALL(*mock_app_, policy_app_id()).WillByDefault(Return(kAppPolicyId));
     ON_CALL(*mock_app_, folder_name()).WillByDefault(Return(kAppFolderName));
     ON_CALL(*mock_app_, hmi_app_id()).WillByDefault(Return(kHmiAppId));
+    ON_CALL(*mock_app_, device()).WillByDefault(Return(kDeviceId));
 
     ON_CALL(app_mngr_settings_, system_files_path())
         .WillByDefault(ReturnRef(kSystemFilesPath));
     ON_CALL(app_mngr_settings_, app_storage_folder())
         .WillByDefault(ReturnRef(kAppStorageFolder));
 
-    ON_CALL(mock_policy_handler_, IsRequestTypeAllowed(kAppPolicyId, _))
+    ON_CALL(mock_policy_handler_,
+            IsRequestTypeAllowed(kDeviceId, kAppPolicyId, _))
         .WillByDefault(Return(true));
   }
 
@@ -146,9 +149,10 @@ TEST_F(SystemRequestTest,
 
   PreConditions();
 
-  EXPECT_CALL(mock_policy_handler_,
-              IsRequestTypeAllowed(kAppPolicyId,
-                                   mobile_apis::RequestType::OEM_SPECIFIC))
+  EXPECT_CALL(
+      mock_policy_handler_,
+      IsRequestTypeAllowed(
+          kDeviceId, kAppPolicyId, mobile_apis::RequestType::OEM_SPECIFIC))
       .WillOnce(Return(true));
 
   EXPECT_CALL(mock_policy_handler_,
@@ -191,9 +195,10 @@ TEST_F(
 
   PreConditions();
 
-  EXPECT_CALL(mock_policy_handler_,
-              IsRequestTypeAllowed(kAppPolicyId,
-                                   mobile_apis::RequestType::OEM_SPECIFIC))
+  EXPECT_CALL(
+      mock_policy_handler_,
+      IsRequestTypeAllowed(
+          kDeviceId, kAppPolicyId, mobile_apis::RequestType::OEM_SPECIFIC))
       .WillOnce(Return(true));
 
   EXPECT_CALL(mock_policy_handler_,
@@ -216,9 +221,10 @@ TEST_F(SystemRequestTest, Run_RequestTypeDisallowed_SendDisallowedResponse) {
 
   PreConditions();
 
-  EXPECT_CALL(mock_policy_handler_,
-              IsRequestTypeAllowed(kAppPolicyId,
-                                   mobile_apis::RequestType::OEM_SPECIFIC))
+  EXPECT_CALL(
+      mock_policy_handler_,
+      IsRequestTypeAllowed(
+          kDeviceId, kAppPolicyId, mobile_apis::RequestType::OEM_SPECIFIC))
       .WillOnce(Return(false));
 
   ExpectManageMobileCommandWithResultCode(mobile_apis::Result::DISALLOWED);
@@ -241,9 +247,9 @@ TEST_F(SystemRequestTest, Run_RequestType_IconURL_Success) {
   const std::vector<uint8_t> binary_data = {1u, 2u};
   (*msg)[am::strings::params][am::strings::binary_data] = binary_data;
 
-  EXPECT_CALL(
-      mock_policy_handler_,
-      IsRequestTypeAllowed(kAppPolicyId, mobile_apis::RequestType::ICON_URL))
+  EXPECT_CALL(mock_policy_handler_,
+              IsRequestTypeAllowed(
+                  kDeviceId, kAppPolicyId, mobile_apis::RequestType::ICON_URL))
       .WillOnce(Return(true));
   EXPECT_CALL(app_mngr_settings_, app_icons_folder())
       .WillOnce(ReturnRef(kAppStorageFolder));

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -121,20 +121,6 @@ bool device_id_comparator(const std::string& device_id,
 }
 
 /**
- * DEPRECATED
- * @brief policy_app_id_comparator is predicate to compare policy application
- * ids
- * @param policy_app_id Policy id of application
- * @param app Application pointer
- * @return True if policy id of application matches to policy id passed
- */
-bool policy_app_id_comparator(const std::string& policy_app_id,
-                              ApplicationSharedPtr app) {
-  DCHECK_OR_RETURN(app, false);
-  return app->policy_app_id() == policy_app_id;
-}
-
-/**
  * @brief PolicyAppIdComparator is struct predicate to compare policy
  * application ids & device
  * @param device_handle of application
@@ -3538,17 +3524,6 @@ bool ApplicationManagerImpl::IsApplicationForbidden(
     uint32_t connection_key, const std::string& mobile_app_id) const {
   const std::string name = GetHashedAppID(connection_key, mobile_app_id);
   return forbidden_applications.find(name) != forbidden_applications.end();
-}
-
-bool ApplicationManagerImpl::IsAppInReconnectMode(
-    const std::string& policy_app_id) const {
-  LOG4CXX_AUTO_TRACE(logger_);
-  sync_primitives::AutoLock lock(reregister_wait_list_lock_);
-  return reregister_wait_list_.end() !=
-         std::find_if(reregister_wait_list_.begin(),
-                      reregister_wait_list_.end(),
-                      std::bind1st(std::ptr_fun(&policy_app_id_comparator),
-                                   policy_app_id));
 }
 
 bool ApplicationManagerImpl::IsAppInReconnectMode(

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1648,7 +1648,8 @@ bool MessageHelper::CreateHMIApplicationStruct(
   const policy::RequestType::State app_request_types_state =
       policy_handler.GetAppRequestTypeState(policy_app_id);
   if (policy::RequestType::State::AVAILABLE == app_request_types_state) {
-    const auto request_types = policy_handler.GetAppRequestTypes(policy_app_id);
+    const auto request_types =
+        policy_handler.GetAppRequestTypes(app->device(), policy_app_id);
     message[strings::request_type] =
         SmartObject(smart_objects::SmartType_Array);
     smart_objects::SmartObject& request_types_array =

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -2214,7 +2214,11 @@ bool PolicyHandler::IsRequestTypeAllowed(
     case RequestType::State::AVAILABLE: {
       // If any of request types is available for current application - get them
       const auto request_types =
+#ifdef EXTERNAL_PROPRIETARY_MODE
+          policy_manager_->GetAppRequestTypes(device_id, policy_app_id);
+#else
           policy_manager_->GetAppRequestTypes(policy_app_id);
+#endif
       return helpers::in_range(request_types, stringified_type);
     }
     default:
@@ -2262,7 +2266,11 @@ bool PolicyHandler::IsRequestSubTypeAllowed(
 const std::vector<std::string> PolicyHandler::GetAppRequestTypes(
     const std::string& policy_app_id) const {
   POLICY_LIB_CHECK(std::vector<std::string>());
+#ifdef EXTERNAL_PROPRIETARY_MODE
+  return policy_manager_->GetAppRequestTypes(device_handle, policy_app_id);
+#else
   return policy_manager_->GetAppRequestTypes(policy_app_id);
+#endif
 }
 
 const std::vector<std::string> PolicyHandler::GetAppRequestSubTypes(

--- a/src/components/application_manager/src/rpc_service_impl.cc
+++ b/src/components/application_manager/src/rpc_service_impl.cc
@@ -82,7 +82,8 @@ bool RPCServiceImpl::ManageMobileCommand(
       (*message)[strings::params][strings::connection_key].asUInt());
 
   auto app_ptr = app_manager_.application(connection_key);
-  if (app_ptr && app_manager_.IsAppInReconnectMode(app_ptr->policy_app_id())) {
+  if (app_ptr && app_manager_.IsAppInReconnectMode(app_ptr->device(),
+                                                   app_ptr->policy_app_id())) {
     commands_holder_.Suspend(
         app_ptr, CommandHolder::CommandType::kMobileCommand, message);
     return true;
@@ -296,7 +297,8 @@ bool RPCServiceImpl::ManageHMICommand(const commands::MessageSharedPtr message,
         (*message)[strings::msg_params][strings::app_id].asUInt();
 
     auto app = app_manager_.application(static_cast<uint32_t>(connection_key));
-    if (app && app_manager_.IsAppInReconnectMode(app->policy_app_id())) {
+    if (app && app_manager_.IsAppInReconnectMode(app->device(),
+                                                 app->policy_app_id())) {
       commands_holder_.Suspend(
           app, CommandHolder::CommandType::kHmiCommand, message);
       return true;

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -233,7 +233,7 @@ class PolicyHandlerTest : public ::testing::Test {
 
   void TestOnPermissionsUpdated(const std::string& default_hmi_level,
                                 const mobile_apis::HMILevel::eType hmi_level) {
-    EXPECT_CALL(app_manager_, application_by_policy_id(kPolicyAppId_))
+    EXPECT_CALL(app_manager_, application(kDeviceId, kPolicyAppId_))
         .WillRepeatedly(Return(mock_app_));
     EXPECT_CALL(*mock_app_, app_id()).WillRepeatedly(Return(kAppId1_));
     EXPECT_CALL(*mock_app_, hmi_level())
@@ -247,7 +247,7 @@ class PolicyHandlerTest : public ::testing::Test {
 
     Permissions permissions;
     policy_handler_.OnPermissionsUpdated(
-        kPolicyAppId_, permissions, default_hmi_level);
+        kDeviceId, kPolicyAppId_, permissions, default_hmi_level);
   }
 
   void CreateFunctionalGroupPermission(
@@ -494,31 +494,31 @@ TEST_F(PolicyHandlerTest, UnloadPolicyLibrary_method_ExpectLibraryUnloaded) {
 
 TEST_F(PolicyHandlerTest, OnPermissionsUpdated_method_With2Parameters) {
   // Check expectations
-  EXPECT_CALL(app_manager_, application_by_policy_id(kPolicyAppId_))
+  EXPECT_CALL(app_manager_, application(kDeviceId, kPolicyAppId_))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppId1_));
   EXPECT_CALL(mock_message_helper_,
               SendOnPermissionsChangeNotification(kAppId1_, _, _));
   // Act
   Permissions perms;
-  policy_handler_.OnPermissionsUpdated(kPolicyAppId_, perms);
+  policy_handler_.OnPermissionsUpdated(kDeviceId, kPolicyAppId_, perms);
 }
 
 TEST_F(PolicyHandlerTest, OnPermissionsUpdated_TwoParams_InvalidApp_UNSUCCESS) {
   std::shared_ptr<application_manager_test::MockApplication> invalid_app;
-  EXPECT_CALL(app_manager_, application_by_policy_id(kPolicyAppId_))
+  EXPECT_CALL(app_manager_, application(kDeviceId, kPolicyAppId_))
       .WillOnce(Return(invalid_app));
   EXPECT_CALL(mock_message_helper_,
               SendOnPermissionsChangeNotification(_, _, _))
       .Times(0);
 
   Permissions permissions;
-  policy_handler_.OnPermissionsUpdated(kPolicyAppId_, permissions);
+  policy_handler_.OnPermissionsUpdated(kDeviceId, kPolicyAppId_, permissions);
 }
 
 TEST_F(PolicyHandlerTest, OnPermissionsUpdated_InvalidApp_UNSUCCESS) {
   std::shared_ptr<application_manager_test::MockApplication> invalid_app;
-  EXPECT_CALL(app_manager_, application_by_policy_id(kPolicyAppId_))
+  EXPECT_CALL(app_manager_, application(kDeviceId, kPolicyAppId_))
       .WillOnce(Return(mock_app_))
       .WillOnce(Return(invalid_app));
   EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppId1_));
@@ -526,7 +526,8 @@ TEST_F(PolicyHandlerTest, OnPermissionsUpdated_InvalidApp_UNSUCCESS) {
               SendOnPermissionsChangeNotification(kAppId1_, _, _));
 
   Permissions permissions;
-  policy_handler_.OnPermissionsUpdated(kPolicyAppId_, permissions, "HMI_FULL");
+  policy_handler_.OnPermissionsUpdated(
+      kDeviceId, kPolicyAppId_, permissions, "HMI_FULL");
 }
 
 TEST_F(PolicyHandlerTest, OnPermissionsUpdated_HmiLevelInvalidEnum_UNSUCCESS) {
@@ -544,7 +545,7 @@ TEST_F(PolicyHandlerTest,
   const std::string new_kHmiLevel_string = "HMI_FULL";
   mobile_apis::HMILevel::eType new_hmi_level = mobile_apis::HMILevel::HMI_FULL;
   // Check expectations
-  EXPECT_CALL(app_manager_, application_by_policy_id(kPolicyAppId_))
+  EXPECT_CALL(app_manager_, application(kDeviceId, kPolicyAppId_))
       .Times(2)
       .WillRepeatedly(Return(mock_app_));
   EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppId1_));
@@ -562,7 +563,7 @@ TEST_F(PolicyHandlerTest,
   // Act
   Permissions perms;
   policy_handler_.OnPermissionsUpdated(
-      kPolicyAppId_, perms, new_kHmiLevel_string);
+      kDeviceId, kPolicyAppId_, perms, new_kHmiLevel_string);
 }
 
 TEST_F(PolicyHandlerTest,
@@ -572,7 +573,7 @@ TEST_F(PolicyHandlerTest,
   mobile_apis::HMILevel::eType new_hmi_level =
       mobile_apis::HMILevel::HMI_LIMITED;
   // Check expectations
-  EXPECT_CALL(app_manager_, application_by_policy_id(kPolicyAppId_))
+  EXPECT_CALL(app_manager_, application(kDeviceId, kPolicyAppId_))
       .Times(2)
       .WillRepeatedly(Return(mock_app_));
   EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppId1_));
@@ -590,7 +591,7 @@ TEST_F(PolicyHandlerTest,
   // Act
   Permissions perms;
   policy_handler_.OnPermissionsUpdated(
-      kPolicyAppId_, perms, new_kHmiLevel_string);
+      kDeviceId, kPolicyAppId_, perms, new_kHmiLevel_string);
 }
 
 TEST_F(PolicyHandlerTest,
@@ -599,7 +600,7 @@ TEST_F(PolicyHandlerTest,
   std::string new_kHmiLevel_string = "HMI_FULL";
   mobile_apis::HMILevel::eType new_hmi_level = mobile_apis::HMILevel::HMI_FULL;
   // Check expectations
-  EXPECT_CALL(app_manager_, application_by_policy_id(kPolicyAppId_))
+  EXPECT_CALL(app_manager_, application(kDeviceId, kPolicyAppId_))
       .Times(2)
       .WillRepeatedly(Return(mock_app_));
   EXPECT_CALL(*mock_app_, app_id()).WillOnce(Return(kAppId1_));
@@ -615,7 +616,7 @@ TEST_F(PolicyHandlerTest,
   // Act
   Permissions perms;
   policy_handler_.OnPermissionsUpdated(
-      kPolicyAppId_, perms, new_kHmiLevel_string);
+      kDeviceId, kPolicyAppId_, perms, new_kHmiLevel_string);
 }
 
 TEST_F(PolicyHandlerTest, GetPriority) {
@@ -639,16 +640,9 @@ TEST_F(PolicyHandlerTest, CheckPermissions) {
   EXPECT_CALL(*mock_app_, hmi_level()).WillOnce(Return(hmi_level));
   EXPECT_CALL(*mock_app_, device()).WillOnce(Return(device));
   EXPECT_CALL(*mock_app_, policy_app_id()).WillOnce(Return(kPolicyAppId_));
-#ifdef EXTERNAL_PROPRIETARY_MODE
-  EXPECT_CALL(
-      *mock_policy_manager_,
-      CheckPermissions(kPolicyAppId_, kHmiLevel_, kRpc_, kRpc_params, _));
-
-#else   // EXTERNAL_PROPRIETARY_MODE
   EXPECT_CALL(*mock_policy_manager_,
               CheckPermissions(
                   kDeviceId, kPolicyAppId_, kHmiLevel_, kRpc_, kRpc_params, _));
-#endif  // EXTERNAL_PROPRIETARY_MODE
   EXPECT_CALL(mock_message_helper_, StringifiedHMILevel(hmi_level))
       .WillOnce(Return(kHmiLevel_));
   EXPECT_CALL(mock_message_helper_, GetDeviceMacAddressForHandle(device, _))
@@ -681,9 +675,9 @@ TEST_F(PolicyHandlerTest, GetDefaultHmi) {
   EnablePolicyAndPolicyManagerMock();
   // Check expectations
   EXPECT_CALL(*mock_policy_manager_,
-              GetDefaultHmi(kPolicyAppId_, &default_hmi_));
+              GetDefaultHmi(kDeviceId_, kPolicyAppId_, &default_hmi_));
   // Act
-  policy_handler_.GetDefaultHmi(kPolicyAppId_, &default_hmi_);
+  policy_handler_.GetDefaultHmi(kDeviceId_, kPolicyAppId_, &default_hmi_);
 }
 
 TEST_F(PolicyHandlerTest, GetInitialAppData) {
@@ -882,12 +876,14 @@ void PolicyHandlerTest::TestActivateApp(const uint32_t connection_key,
 #endif  // EXTERNAL_PROPRIETARY_MODE
 
   EXPECT_CALL(*application1, policy_app_id()).WillOnce(Return(kPolicyAppId_));
-  EXPECT_CALL(*mock_policy_manager_, GetAppPermissionsChanges(_))
+  EXPECT_CALL(*mock_policy_manager_,
+              GetAppPermissionsChanges(kMacAddr_, kPolicyAppId_))
       .WillOnce(Return(permissions));
   ON_CALL(*mock_policy_manager_, Increment(_, _)).WillByDefault(Return());
   EXPECT_CALL(*mock_policy_manager_, RemovePendingPermissionChanges(_));
   EXPECT_CALL(mock_message_helper_, SendSDLActivateAppResponse(_, _, _));
   ON_CALL(*application1, app_id()).WillByDefault(Return(kAppId1_));
+  ON_CALL(*application1, mac_address()).WillByDefault(ReturnRef(kMacAddr_));
   // Act
   policy_handler_.OnActivateApp(connection_key, correlation_id);
 }
@@ -936,12 +932,14 @@ TEST_F(PolicyHandlerTest, OnActivateApp_AppIsRevoked_AppNotActivated) {
 
   // Check expectations
   EXPECT_CALL(*mock_app_, policy_app_id()).WillOnce(Return(kPolicyAppId_));
-  EXPECT_CALL(*mock_policy_manager_, GetAppPermissionsChanges(_))
+  EXPECT_CALL(*mock_policy_manager_,
+              GetAppPermissionsChanges(kDefaultId, kPolicyAppId_))
       .WillOnce(Return(permissions));
   ON_CALL(*mock_policy_manager_, Increment(_, _)).WillByDefault(Return());
   EXPECT_CALL(*mock_policy_manager_, RemovePendingPermissionChanges(_));
   EXPECT_CALL(mock_message_helper_, SendSDLActivateAppResponse(_, _, _));
   ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId1_));
+  ON_CALL(*mock_app_, mac_address()).WillByDefault(ReturnRef(kDefaultId));
   // Act
   policy_handler_.OnActivateApp(kConnectionKey_, kCorrelationKey_);
 }
@@ -963,8 +961,7 @@ void PolicyHandlerTest::OnPendingPermissionChangePrecondition(
   std::shared_ptr<application_manager_test::MockApplication> application =
       std::make_shared<application_manager_test::MockApplication>();
 
-  EXPECT_CALL(app_manager_, application_by_policy_id(kPolicyAppId_))
-      .WillOnce(Return(application));
+  EXPECT_CALL(app_manager_, application(_, _)).WillOnce(Return(application));
   EXPECT_CALL(*application, app_id()).WillRepeatedly(Return(kAppId1_));
   EXPECT_CALL(*application, hmi_level()).WillRepeatedly(Return(hmi_level));
 }
@@ -980,13 +977,13 @@ TEST_F(PolicyHandlerTest,
   EXPECT_CALL(mock_message_helper_,
               SendOnAppPermissionsChangedNotification(kAppId1_, _, _))
       .Times(0);
-
-  EXPECT_CALL(*mock_policy_manager_, GetAppPermissionsChanges(_))
+  EXPECT_CALL(*mock_policy_manager_,
+              GetAppPermissionsChanges(kDeviceId_, kPolicyAppId_))
       .WillOnce(Return(permissions));
   EXPECT_CALL(*mock_policy_manager_,
               RemovePendingPermissionChanges(kPolicyAppId_));
   // Act
-  policy_handler_.OnPendingPermissionChange(kPolicyAppId_);
+  policy_handler_.OnPendingPermissionChange(kDeviceId_, kPolicyAppId_);
 }
 
 TEST_F(PolicyHandlerTest, OnPendingPermissionChange_AppInLimitedConsentNeeded) {
@@ -998,12 +995,13 @@ TEST_F(PolicyHandlerTest, OnPendingPermissionChange_AppInLimitedConsentNeeded) {
   // Check expectations
   EXPECT_CALL(mock_message_helper_,
               SendOnAppPermissionsChangedNotification(kAppId1_, _, _));
-  EXPECT_CALL(*mock_policy_manager_, GetAppPermissionsChanges(_))
+  EXPECT_CALL(*mock_policy_manager_,
+              GetAppPermissionsChanges(kDeviceId_, kPolicyAppId_))
       .WillOnce(Return(permissions));
   EXPECT_CALL(*mock_policy_manager_,
               RemovePendingPermissionChanges(kPolicyAppId_));
   // Act
-  policy_handler_.OnPendingPermissionChange(kPolicyAppId_);
+  policy_handler_.OnPendingPermissionChange(kDeviceId_, kPolicyAppId_);
 }
 
 TEST_F(PolicyHandlerTest, OnPendingPermissionChange_AppLimitedAndRevoked) {
@@ -1025,12 +1023,13 @@ TEST_F(PolicyHandlerTest, OnPendingPermissionChange_AppLimitedAndRevoked) {
                               mobile_apis::VideoStreamingState::NOT_STREAMABLE,
                               true));
 
-  EXPECT_CALL(*mock_policy_manager_, GetAppPermissionsChanges(_))
+  EXPECT_CALL(*mock_policy_manager_,
+              GetAppPermissionsChanges(kDeviceId_, kPolicyAppId_))
       .WillOnce(Return(permissions));
   EXPECT_CALL(*mock_policy_manager_,
               RemovePendingPermissionChanges(kPolicyAppId_));
   // Act
-  policy_handler_.OnPendingPermissionChange(kPolicyAppId_);
+  policy_handler_.OnPendingPermissionChange(kDeviceId_, kPolicyAppId_);
 }
 
 TEST_F(PolicyHandlerTest, OnPendingPermissionChange_AppInBackgroundAndRevoked) {
@@ -1044,12 +1043,13 @@ TEST_F(PolicyHandlerTest, OnPendingPermissionChange_AppInBackgroundAndRevoked) {
   EXPECT_CALL(mock_message_helper_,
               SendOnAppPermissionsChangedNotification(kAppId1_, _, _));
 
-  EXPECT_CALL(*mock_policy_manager_, GetAppPermissionsChanges(_))
+  EXPECT_CALL(*mock_policy_manager_,
+              GetAppPermissionsChanges(kDeviceId_, kPolicyAppId_))
       .WillOnce(Return(permissions));
   EXPECT_CALL(*mock_policy_manager_,
               RemovePendingPermissionChanges(kPolicyAppId_));
   // Act
-  policy_handler_.OnPendingPermissionChange(kPolicyAppId_);
+  policy_handler_.OnPendingPermissionChange(kDeviceId_, kPolicyAppId_);
 }
 
 TEST_F(PolicyHandlerTest,
@@ -1066,7 +1066,8 @@ TEST_F(PolicyHandlerTest,
   EXPECT_CALL(mock_message_helper_,
               SendOnAppPermissionsChangedNotification(kAppId1_, _, _));
 
-  EXPECT_CALL(*mock_policy_manager_, GetAppPermissionsChanges(_))
+  EXPECT_CALL(*mock_policy_manager_,
+              GetAppPermissionsChanges(kDeviceId_, kPolicyAppId_))
       .WillOnce(Return(permissions));
 
   EXPECT_CALL(mock_message_helper_,
@@ -1083,7 +1084,7 @@ TEST_F(PolicyHandlerTest,
               RemovePendingPermissionChanges(kPolicyAppId_));
 
   // Act
-  policy_handler_.OnPendingPermissionChange(kPolicyAppId_);
+  policy_handler_.OnPendingPermissionChange(kDeviceId_, kPolicyAppId_);
 }
 
 TEST_F(PolicyHandlerTest,
@@ -1096,13 +1097,14 @@ TEST_F(PolicyHandlerTest,
   EXPECT_CALL(mock_message_helper_,
               SendOnAppPermissionsChangedNotification(kAppId1_, _, _));
 
-  EXPECT_CALL(*mock_policy_manager_, GetAppPermissionsChanges(_))
+  EXPECT_CALL(*mock_policy_manager_,
+              GetAppPermissionsChanges(kDeviceId_, kPolicyAppId_))
       .WillOnce(Return(permissions));
 
   EXPECT_CALL(*mock_policy_manager_,
               RemovePendingPermissionChanges(kPolicyAppId_));
 
-  policy_handler_.OnPendingPermissionChange(kPolicyAppId_);
+  policy_handler_.OnPendingPermissionChange(kDeviceId_, kPolicyAppId_);
 }
 
 TEST_F(PolicyHandlerTest,
@@ -1121,7 +1123,8 @@ TEST_F(PolicyHandlerTest,
               SendOnAppPermissionsChangedNotification(kAppId1_, _, _))
       .Times(0);
 
-  EXPECT_CALL(*mock_policy_manager_, GetAppPermissionsChanges(_))
+  EXPECT_CALL(*mock_policy_manager_,
+              GetAppPermissionsChanges(kDeviceId_, kPolicyAppId_))
       .WillOnce(Return(permissions));
 
   EXPECT_CALL(mock_message_helper_,
@@ -1138,7 +1141,7 @@ TEST_F(PolicyHandlerTest,
               RemovePendingPermissionChanges(kPolicyAppId_));
 
   // Act
-  policy_handler_.OnPendingPermissionChange(kPolicyAppId_);
+  policy_handler_.OnPendingPermissionChange(kDeviceId_, kPolicyAppId_);
 }
 
 TEST_F(PolicyHandlerTest, PTExchangeAtUserRequest) {
@@ -1234,7 +1237,7 @@ TEST_F(PolicyHandlerTest, OnCurrentDeviceIdUpdateRequired) {
   // Check expectations
   std::shared_ptr<application_manager_test::MockApplication> application =
       std::make_shared<application_manager_test::MockApplication>();
-  EXPECT_CALL(app_manager_, application_by_policy_id(kPolicyAppId_))
+  EXPECT_CALL(app_manager_, application(kDeviceId_, kPolicyAppId_))
       .WillOnce(Return(application));
   EXPECT_CALL(app_manager_, connection_handler())
       .WillOnce(ReturnRef(conn_handler));
@@ -1251,10 +1254,11 @@ TEST_F(PolicyHandlerTest, OnCurrentDeviceIdUpdateRequired) {
                   _,
                   _,
                   _,
-                  _));
+                  _))
+      .WillOnce(DoAll(SetArgPointee<3>(kDeviceId_), Return(0)));
 
   // Act
-  policy_handler_.OnCurrentDeviceIdUpdateRequired(kPolicyAppId_);
+  policy_handler_.OnCurrentDeviceIdUpdateRequired(handle, kPolicyAppId_);
 }
 
 TEST_F(PolicyHandlerTest, OnSystemInfoChanged) {
@@ -1303,11 +1307,17 @@ TEST_F(PolicyHandlerTest, GetAppRequestTypes) {
   // Arrange
   EnablePolicy();
   ChangePolicyManagerToMock();
-  // Check expectations
+  const transport_manager::DeviceHandle handle = 0u;
+// Check expectations
+#ifdef EXTERNAL_PROPRIETARY_MODE
+  EXPECT_CALL(*mock_policy_manager_, GetAppRequestTypes(handle, kPolicyAppId_))
+      .WillOnce(Return(std::vector<std::string>()));
+#else
   EXPECT_CALL(*mock_policy_manager_, GetAppRequestTypes(kPolicyAppId_))
       .WillOnce(Return(std::vector<std::string>()));
+#endif
   // Act
-  policy_handler_.GetAppRequestTypes(kPolicyAppId_);
+  policy_handler_.GetAppRequestTypes(handle, kPolicyAppId_);
 }
 
 TEST_F(PolicyHandlerTest, OnVIIsReady) {
@@ -1376,13 +1386,14 @@ TEST_F(PolicyHandlerTest, SendOnAppPermissionsChanged) {
   std::shared_ptr<application_manager_test::MockApplication> application =
       std::make_shared<application_manager_test::MockApplication>();
   // Check expectations
-  EXPECT_CALL(app_manager_, application_by_policy_id(kPolicyAppId_))
+  EXPECT_CALL(app_manager_, application(kDeviceId_, kPolicyAppId_))
       .WillOnce(Return(application));
   EXPECT_CALL(mock_message_helper_,
               SendOnAppPermissionsChangedNotification(_, _, _));
   AppPermissions permissions(kPolicyAppId_);
   // Act
-  policy_handler_.SendOnAppPermissionsChanged(permissions, kPolicyAppId_);
+  policy_handler_.SendOnAppPermissionsChanged(
+      permissions, kDeviceId_, kPolicyAppId_);
 }
 
 TEST_F(PolicyHandlerTest, OnPTExchangeNeeded) {
@@ -1400,11 +1411,12 @@ TEST_F(PolicyHandlerTest, AddApplication) {
   // Check expectations
   EXPECT_CALL(
       *mock_policy_manager_,
-      AddApplication(kPolicyAppId_, HmiTypes(policy_table::AHT_DEFAULT)))
+      AddApplication(
+          kMacAddr_, kPolicyAppId_, HmiTypes(policy_table::AHT_DEFAULT)))
       .WillOnce(Return(std::make_shared<utils::CallNothing>()));
   // Act
-  policy_handler_.AddApplication(kPolicyAppId_,
-                                 HmiTypes(policy_table::AHT_DEFAULT));
+  policy_handler_.AddApplication(
+      kMacAddr_, kPolicyAppId_, HmiTypes(policy_table::AHT_DEFAULT));
 }
 
 TEST_F(PolicyHandlerTest, HeartBeatTimeout) {
@@ -1439,9 +1451,10 @@ TEST_F(PolicyHandlerTest, OnAppRegisteredOnMobile) {
   EnablePolicyAndPolicyManagerMock();
   // Check expectations
 
-  EXPECT_CALL(*mock_policy_manager_, OnAppRegisteredOnMobile(kPolicyAppId_));
+  EXPECT_CALL(*mock_policy_manager_,
+              OnAppRegisteredOnMobile(kDeviceId, kPolicyAppId_));
   // Act
-  policy_handler_.OnAppRegisteredOnMobile(kPolicyAppId_);
+  policy_handler_.OnAppRegisteredOnMobile(kDeviceId, kPolicyAppId_);
 }
 
 TEST_F(PolicyHandlerTest, IsRequestTypeAllowed) {
@@ -1452,13 +1465,20 @@ TEST_F(PolicyHandlerTest, IsRequestTypeAllowed) {
   mobile_apis::RequestType::eType type =
       mobile_apis::RequestType::eType::EMERGENCY;
 
+  const transport_manager::DeviceHandle handle = 0u;
+
   EXPECT_CALL(*mock_policy_manager_, GetAppRequestTypesState(kPolicyAppId_))
       .WillOnce(Return(policy::RequestType::State::AVAILABLE));
-
+#ifdef EXTERNAL_PROPRIETARY_MODE
+  EXPECT_CALL(*mock_policy_manager_, GetAppRequestTypes(handle, kPolicyAppId_))
+      .WillOnce(Return(std::vector<std::string>({"HTTP"})));
+#else
   EXPECT_CALL(*mock_policy_manager_, GetAppRequestTypes(kPolicyAppId_))
       .WillOnce(Return(std::vector<std::string>({"HTTP"})));
+#endif
   // Act
-  EXPECT_FALSE(policy_handler_.IsRequestTypeAllowed(kPolicyAppId_, type));
+  EXPECT_FALSE(
+      policy_handler_.IsRequestTypeAllowed(handle, kPolicyAppId_, type));
 }
 
 TEST_F(PolicyHandlerTest, IsRequestSubTypeAllowed) {
@@ -1848,8 +1868,9 @@ TEST_F(PolicyHandlerTest, OnDeviceConsentChanged_ConsentAllowed) {
   connection_handler::DeviceHandle test_device_id = 100u;
   EXPECT_CALL(app_manager_, connection_handler())
       .WillOnce(ReturnRef(conn_handler));
+  EXPECT_CALL(app_manager_, applications()).WillRepeatedly(Return(app_set));
 
-  EXPECT_CALL(conn_handler, GetDeviceID(kPolicyAppId_, _))
+  EXPECT_CALL(conn_handler, GetDeviceID(kDeviceId, _))
       .WillOnce(DoAll(SetArgPointee<1>(test_device_id), Return(true)));
 
   test_app.insert(mock_app_);
@@ -1859,12 +1880,13 @@ TEST_F(PolicyHandlerTest, OnDeviceConsentChanged_ConsentAllowed) {
   EXPECT_CALL(*mock_policy_manager_, IsPredataPolicy(kPolicyAppId_))
       .WillOnce(Return(true));
 
+  EXPECT_CALL(
+      *mock_policy_manager_,
+      ReactOnUserDevConsentForApp(test_device_id, kPolicyAppId_, is_allowed));
   EXPECT_CALL(*mock_policy_manager_,
-              ReactOnUserDevConsentForApp(kPolicyAppId_, is_allowed));
-  EXPECT_CALL(*mock_policy_manager_,
-              SendNotificationOnPermissionsUpdated(kPolicyAppId_));
+              SendNotificationOnPermissionsUpdated(kDeviceId, kPolicyAppId_));
 
-  policy_handler_.OnDeviceConsentChanged(kPolicyAppId_, is_allowed);
+  policy_handler_.OnDeviceConsentChanged(kDeviceId, is_allowed);
 }
 
 TEST_F(PolicyHandlerTest, OnDeviceConsentChanged_ConsentNotAllowed) {
@@ -1872,27 +1894,29 @@ TEST_F(PolicyHandlerTest, OnDeviceConsentChanged_ConsentNotAllowed) {
   // Arrange
   EnablePolicyAndPolicyManagerMock();
 
-  connection_handler::DeviceHandle test_device_id = 100u;
+  connection_handler::DeviceHandle handle = 100u;
   EXPECT_CALL(app_manager_, connection_handler())
       .WillOnce(ReturnRef(conn_handler));
 
   // Check expectations
-  EXPECT_CALL(conn_handler, GetDeviceID(kPolicyAppId_, _))
-      .WillOnce(DoAll(SetArgPointee<1>(test_device_id), Return(true)));
+  EXPECT_CALL(conn_handler, GetDeviceID(kMacAddr_, _))
+      .WillOnce(DoAll(SetArgPointee<1>(handle), Return(true)));
   test_app.insert(mock_app_);
 
-  EXPECT_CALL(*mock_app_, device()).WillOnce(Return(test_device_id));
+  EXPECT_CALL(*mock_app_, device()).WillOnce(Return(handle));
   EXPECT_CALL(*mock_app_, policy_app_id()).WillOnce(Return(kPolicyAppId_));
 
   EXPECT_CALL(*mock_policy_manager_, IsPredataPolicy(kPolicyAppId_))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*mock_policy_manager_, ReactOnUserDevConsentForApp(_, _))
+  EXPECT_CALL(*mock_policy_manager_,
+              ReactOnUserDevConsentForApp(handle, kPolicyAppId_, is_allowed))
       .Times(0);
-  EXPECT_CALL(*mock_policy_manager_, SendNotificationOnPermissionsUpdated(_))
+  EXPECT_CALL(*mock_policy_manager_,
+              SendNotificationOnPermissionsUpdated(kMacAddr_, kPolicyAppId_))
       .Times(0);
 
-  policy_handler_.OnDeviceConsentChanged(kPolicyAppId_, is_allowed);
+  policy_handler_.OnDeviceConsentChanged(kMacAddr_, is_allowed);
 }
 
 TEST_F(PolicyHandlerTest, OnDeviceConsentChanged_PredatePolicyNotAllowed) {
@@ -1903,8 +1927,9 @@ TEST_F(PolicyHandlerTest, OnDeviceConsentChanged_PredatePolicyNotAllowed) {
   connection_handler::DeviceHandle test_device_id = 100u;
   EXPECT_CALL(app_manager_, connection_handler())
       .WillOnce(ReturnRef(conn_handler));
+  EXPECT_CALL(app_manager_, applications()).WillRepeatedly(Return(app_set));
 
-  EXPECT_CALL(conn_handler, GetDeviceID(kPolicyAppId_, _))
+  EXPECT_CALL(conn_handler, GetDeviceID(kMacAddr_, _))
       .WillOnce(DoAll(SetArgPointee<1>(test_device_id), Return(true)));
 
   test_app.insert(mock_app_);
@@ -1916,12 +1941,13 @@ TEST_F(PolicyHandlerTest, OnDeviceConsentChanged_PredatePolicyNotAllowed) {
   EXPECT_CALL(*mock_policy_manager_, IsPredataPolicy(kPolicyAppId_))
       .WillOnce(Return(false));
 
+  EXPECT_CALL(
+      *mock_policy_manager_,
+      ReactOnUserDevConsentForApp(test_device_id, kPolicyAppId_, is_allowed));
   EXPECT_CALL(*mock_policy_manager_,
-              ReactOnUserDevConsentForApp(kPolicyAppId_, is_allowed));
-  EXPECT_CALL(*mock_policy_manager_,
-              SendNotificationOnPermissionsUpdated(kPolicyAppId_));
+              SendNotificationOnPermissionsUpdated(kMacAddr_, kPolicyAppId_));
 
-  policy_handler_.OnDeviceConsentChanged(kPolicyAppId_, is_allowed);
+  policy_handler_.OnDeviceConsentChanged(kMacAddr_, is_allowed);
 }
 #ifdef ENABLE_SECURITY
 #ifdef EXTERNAL_PROPRIETARY_MODE

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -94,12 +94,6 @@ class StateControllerImpl;
 struct CommandParametersPermissions;
 using policy::RPCParams;
 typedef std::vector<ApplicationSharedPtr> AppSharedPtrs;
-struct DEPRECATED ApplicationsAppIdSorter {
-  bool operator()(const ApplicationSharedPtr lhs,
-                  const ApplicationSharedPtr rhs) const {
-    return lhs->app_id() < rhs->app_id();
-  }
-};
 struct ApplicationsSorter {
   bool operator()(const ApplicationSharedPtr lhs,
                   const ApplicationSharedPtr rhs) const {
@@ -640,17 +634,6 @@ class ApplicationManager {
    */
   virtual bool IsApplicationForbidden(
       uint32_t connection_key, const std::string& policy_app_id) const = 0;
-
-  /**
-   * DEPRECATED
-   * @brief IsAppInReconnectMode check if application belongs to session
-   * affected by transport switching at the moment
-   * @param policy_app_id Application id
-   * @return True if application is registered within session being switched,
-   * otherwise - false
-   */
-  DEPRECATED virtual bool IsAppInReconnectMode(
-      const std::string& policy_app_id) const = 0;
 
   /**
    * @brief IsAppInReconnectMode check if application belongs to session

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -94,9 +94,18 @@ class StateControllerImpl;
 struct CommandParametersPermissions;
 using policy::RPCParams;
 typedef std::vector<ApplicationSharedPtr> AppSharedPtrs;
-struct ApplicationsAppIdSorter {
+struct DEPRECATED ApplicationsAppIdSorter {
   bool operator()(const ApplicationSharedPtr lhs,
                   const ApplicationSharedPtr rhs) const {
+    return lhs->app_id() < rhs->app_id();
+  }
+};
+struct ApplicationsSorter {
+  bool operator()(const ApplicationSharedPtr lhs,
+                  const ApplicationSharedPtr rhs) const {
+    if (lhs->app_id() == rhs->app_id()) {
+      return lhs->device() < rhs->device();
+    }
     return lhs->app_id() < rhs->app_id();
   }
 };
@@ -110,7 +119,7 @@ struct ApplicationsPolicyAppIdSorter {
   }
 };
 
-typedef std::set<ApplicationSharedPtr, ApplicationsAppIdSorter> ApplicationSet;
+typedef std::set<ApplicationSharedPtr, ApplicationsSorter> ApplicationSet;
 
 typedef std::set<ApplicationSharedPtr, ApplicationsPolicyAppIdSorter>
     AppsWaitRegistrationSet;
@@ -633,13 +642,27 @@ class ApplicationManager {
       uint32_t connection_key, const std::string& policy_app_id) const = 0;
 
   /**
+   * DEPRECATED
    * @brief IsAppInReconnectMode check if application belongs to session
    * affected by transport switching at the moment
    * @param policy_app_id Application id
    * @return True if application is registered within session being switched,
    * otherwise - false
    */
-  virtual bool IsAppInReconnectMode(const std::string& policy_app_id) const = 0;
+  DEPRECATED virtual bool IsAppInReconnectMode(
+      const std::string& policy_app_id) const = 0;
+
+  /**
+   * @brief IsAppInReconnectMode check if application belongs to session
+   * affected by transport switching at the moment
+   * @param device_id device indentifier
+   * @param policy_app_id Application id
+   * @return True if application is registered within session being switched,
+   * otherwise - false
+   */
+  virtual bool IsAppInReconnectMode(
+      const connection_handler::DeviceHandle& device_id,
+      const std::string& policy_app_id) const = 0;
 
   virtual resumption::ResumeCtrl& resume_controller() = 0;
 

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -71,15 +71,10 @@ class PolicyHandlerInterface {
   virtual bool ReceiveMessageFromSDK(const std::string& file,
                                      const BinaryMessage& pt_string) = 0;
   virtual bool UnloadPolicyLibrary() = 0;
-  DEPRECATED virtual void OnPermissionsUpdated(const std::string& policy_app_id,
-                                               const Permissions& permissions,
-                                               const HMILevel& default_hmi) = 0;
   virtual void OnPermissionsUpdated(const std::string& device_id,
                                     const std::string& policy_app_id,
                                     const Permissions& permissions,
                                     const HMILevel& default_hmi) = 0;
-  DEPRECATED virtual void OnPermissionsUpdated(
-      const std::string& policy_app_id, const Permissions& permissions) = 0;
   virtual void OnPermissionsUpdated(const std::string& device_id,
                                     const std::string& policy_app_id,
                                     const Permissions& permissions) = 0;
@@ -104,8 +99,6 @@ class PolicyHandlerInterface {
       const std::string& priority) const = 0;
   virtual DeviceConsent GetUserConsentForDevice(
       const std::string& device_id) const = 0;
-  DEPRECATED virtual bool GetDefaultHmi(const std::string& policy_app_id,
-                                        std::string* default_hmi) const = 0;
   virtual bool GetDefaultHmi(const std::string& device_id,
                              const std::string& policy_app_id,
                              std::string* default_hmi) const = 0;
@@ -143,10 +136,6 @@ class PolicyHandlerInterface {
 
   virtual std::shared_ptr<usage_statistics::StatisticsManager>
   GetStatisticManager() const = 0;
-
-  DEPRECATED virtual void SendOnAppPermissionsChanged(
-      const AppPermissions& permissions,
-      const std::string& policy_app_id) const = 0;
 
   virtual void SendOnAppPermissionsChanged(
       const AppPermissions& permissions,
@@ -189,9 +178,6 @@ class PolicyHandlerInterface {
    * @brief Increment counter for ignition cycles
    */
   virtual void OnIgnitionCycleOver() = 0;
-
-  DEPRECATED virtual void OnPendingPermissionChange(
-      const std::string& policy_app_id) = 0;
 
   virtual void OnPendingPermissionChange(const std::string& device_id,
                                          const std::string& policy_app_id) = 0;
@@ -269,15 +255,6 @@ class PolicyHandlerInterface {
    * @param status Current policy update state
    */
   virtual void OnUpdateStatusChanged(const std::string& status) = 0;
-
-  /**
-   * DEPRECATED
-   * @brief Update currently used device id in policies manager for given
-   * application
-   * @param policy_app_id Application id
-   */
-  DEPRECATED virtual std::string OnCurrentDeviceIdUpdateRequired(
-      const std::string& policy_app_id) = 0;
 
   /**
    * @brief Update currently used device id in policies manager for given
@@ -369,17 +346,6 @@ class PolicyHandlerInterface {
   virtual void GetAvailableApps(std::queue<std::string>& apps) = 0;
 
   /**
-   * DEPRECATED
-   * @brief Allows to add new or update existed application during
-   * registration process
-   * @param application_id The policy aplication id.
-   * @return function that will notify update manager about new application
-   */
-  DEPRECATED virtual StatusNotifier AddApplication(
-      const std::string& application_id,
-      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) = 0;
-
-  /**
    * @brief Allows to add new or update existed application during
    * registration process
    * @param device_id device identifier
@@ -422,17 +388,6 @@ class PolicyHandlerInterface {
   virtual void OnAppsSearchCompleted(const bool trigger_ptu) = 0;
 
   /**
-   * DEPRECATED
-   * @brief OnAppRegisteredOnMobile allows to handle event when application were
-   * succesfully registered on mobile device.
-   * It will send OnAppPermissionSend notification and will try to start PTU.
-   *
-   * @param application_id registered application.
-   */
-  DEPRECATED virtual void OnAppRegisteredOnMobile(
-      const std::string& application_id) = 0;
-
-  /**
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
    * It will send OnAppPermissionSend notification and will try to start PTU.
@@ -442,17 +397,6 @@ class PolicyHandlerInterface {
    */
   virtual void OnAppRegisteredOnMobile(const std::string& device_id,
                                        const std::string& application_id) = 0;
-
-  /**
-   * DEPRECATED
-   * @brief Checks if certain request type is allowed for application
-   * @param policy_app_id Unique applicaion id
-   * @param type Request type
-   * @return true, if allowed, otherwise - false
-   */
-  DEPRECATED virtual bool IsRequestTypeAllowed(
-      const std::string& policy_app_id,
-      mobile_apis::RequestType::eType type) const = 0;
 
   /**
    * @brief Checks if certain request type is allowed for application
@@ -490,15 +434,6 @@ class PolicyHandlerInterface {
    * @return request subtypes state
    */
   virtual RequestSubType::State GetAppRequestSubTypeState(
-      const std::string& policy_app_id) const = 0;
-
-  /**
-   * DEPRECATED
-   * @brief Gets application request types
-   * @param policy_app_id Unique application id
-   * @return request types
-   */
-  DEPRECATED virtual const std::vector<std::string> GetAppRequestTypes(
       const std::string& policy_app_id) const = 0;
 
   /**
@@ -641,16 +576,6 @@ class PolicyHandlerInterface {
    */
   virtual void OnDeviceSwitching(const std::string& device_id_from,
                                  const std::string& device_id_to) = 0;
-
-  /**
-   * DEPERECATED
-   * @brief Sets HMI default type for specified application
-   * @param application_id ID application
-   * @param app_types list of HMI types
-   */
-  DEPRECATED virtual void SetDefaultHmiTypes(
-      const std::string& application_id,
-      const smart_objects::SmartObject* app_types) = 0;
 
   /**
    * @brief Sets HMI default type for specified application

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -104,7 +104,10 @@ class PolicyHandlerInterface {
       const std::string& priority) const = 0;
   virtual DeviceConsent GetUserConsentForDevice(
       const std::string& device_id) const = 0;
-  virtual bool GetDefaultHmi(const std::string& policy_app_id,
+  DEPRECATED virtual bool GetDefaultHmi(const std::string& policy_app_id,
+                                        std::string* default_hmi) const = 0;
+  virtual bool GetDefaultHmi(const std::string& device_id,
+                             const std::string& policy_app_id,
                              std::string* default_hmi) const = 0;
   virtual bool GetInitialAppData(const std::string& application_id,
                                  StringArray* nicknames = NULL,
@@ -141,8 +144,13 @@ class PolicyHandlerInterface {
   virtual std::shared_ptr<usage_statistics::StatisticsManager>
   GetStatisticManager() const = 0;
 
+  DEPRECATED virtual void SendOnAppPermissionsChanged(
+      const AppPermissions& permissions,
+      const std::string& policy_app_id) const = 0;
+
   virtual void SendOnAppPermissionsChanged(
       const AppPermissions& permissions,
+      const std::string& device_id,
       const std::string& policy_app_id) const = 0;
 
   /**
@@ -182,7 +190,11 @@ class PolicyHandlerInterface {
    */
   virtual void OnIgnitionCycleOver() = 0;
 
-  virtual void OnPendingPermissionChange(const std::string& policy_app_id) = 0;
+  DEPRECATED virtual void OnPendingPermissionChange(
+      const std::string& policy_app_id) = 0;
+
+  virtual void OnPendingPermissionChange(const std::string& device_id,
+                                         const std::string& policy_app_id) = 0;
 
   /**
    * Initializes PT exchange at user request
@@ -259,11 +271,22 @@ class PolicyHandlerInterface {
   virtual void OnUpdateStatusChanged(const std::string& status) = 0;
 
   /**
+   * DEPRECATED
    * @brief Update currently used device id in policies manager for given
    * application
    * @param policy_app_id Application id
    */
+  DEPRECATED virtual std::string OnCurrentDeviceIdUpdateRequired(
+      const std::string& policy_app_id) = 0;
+
+  /**
+   * @brief Update currently used device id in policies manager for given
+   * application
+   * @param device_handle device identifier
+   * @param policy_app_id Application id
+   */
   virtual std::string OnCurrentDeviceIdUpdateRequired(
+      const transport_manager::DeviceHandle& device_handle,
       const std::string& policy_app_id) = 0;
 
   /**
@@ -346,12 +369,25 @@ class PolicyHandlerInterface {
   virtual void GetAvailableApps(std::queue<std::string>& apps) = 0;
 
   /**
+   * DEPRECATED
    * @brief Allows to add new or update existed application during
    * registration process
    * @param application_id The policy aplication id.
    * @return function that will notify update manager about new application
    */
+  DEPRECATED virtual StatusNotifier AddApplication(
+      const std::string& application_id,
+      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) = 0;
+
+  /**
+   * @brief Allows to add new or update existed application during
+   * registration process
+   * @param device_id device identifier
+   * @param application_id The policy aplication id.
+   * @return function that will notify update manager about new application
+   */
   virtual StatusNotifier AddApplication(
+      const std::string& device_id,
       const std::string& application_id,
       const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) = 0;
 
@@ -408,12 +444,25 @@ class PolicyHandlerInterface {
                                        const std::string& application_id) = 0;
 
   /**
+   * DEPRECATED
    * @brief Checks if certain request type is allowed for application
    * @param policy_app_id Unique applicaion id
    * @param type Request type
    * @return true, if allowed, otherwise - false
    */
+  DEPRECATED virtual bool IsRequestTypeAllowed(
+      const std::string& policy_app_id,
+      mobile_apis::RequestType::eType type) const = 0;
+
+  /**
+   * @brief Checks if certain request type is allowed for application
+   * @param device_handle device identifier
+   * @param policy_app_id Unique applicaion id
+   * @param type Request type
+   * @return true, if allowed, otherwise - false
+   */
   virtual bool IsRequestTypeAllowed(
+      const transport_manager::DeviceHandle& device_handle,
       const std::string& policy_app_id,
       mobile_apis::RequestType::eType type) const = 0;
 
@@ -444,11 +493,22 @@ class PolicyHandlerInterface {
       const std::string& policy_app_id) const = 0;
 
   /**
+   * DEPRECATED
    * @brief Gets application request types
    * @param policy_app_id Unique application id
    * @return request types
    */
+  DEPRECATED virtual const std::vector<std::string> GetAppRequestTypes(
+      const std::string& policy_app_id) const = 0;
+
+  /**
+   * @brief Gets application request types
+   * @param device_handle device identifier
+   * @param policy_app_id Unique application id
+   * @return request types
+   */
   virtual const std::vector<std::string> GetAppRequestTypes(
+      const transport_manager::DeviceHandle& device_handle,
       const std::string& policy_app_id) const = 0;
 
   /**
@@ -583,11 +643,23 @@ class PolicyHandlerInterface {
                                  const std::string& device_id_to) = 0;
 
   /**
+   * DEPERECATED
    * @brief Sets HMI default type for specified application
    * @param application_id ID application
    * @param app_types list of HMI types
    */
+  DEPRECATED virtual void SetDefaultHmiTypes(
+      const std::string& application_id,
+      const smart_objects::SmartObject* app_types) = 0;
+
+  /**
+   * @brief Sets HMI default type for specified application
+   * @param device_handle device identifier
+   * @param application_id ID application
+   * @param app_types list of HMI types
+   */
   virtual void SetDefaultHmiTypes(
+      const transport_manager::DeviceHandle& device_handle,
       const std::string& application_id,
       const smart_objects::SmartObject* app_types) = 0;
 

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -71,11 +71,17 @@ class PolicyHandlerInterface {
   virtual bool ReceiveMessageFromSDK(const std::string& file,
                                      const BinaryMessage& pt_string) = 0;
   virtual bool UnloadPolicyLibrary() = 0;
-  virtual void OnPermissionsUpdated(const std::string& policy_app_id,
+  DEPRECATED virtual void OnPermissionsUpdated(const std::string& policy_app_id,
+                                               const Permissions& permissions,
+                                               const HMILevel& default_hmi) = 0;
+  virtual void OnPermissionsUpdated(const std::string& device_id,
+                                    const std::string& policy_app_id,
                                     const Permissions& permissions,
                                     const HMILevel& default_hmi) = 0;
-
-  virtual void OnPermissionsUpdated(const std::string& policy_app_id,
+  DEPRECATED virtual void OnPermissionsUpdated(
+      const std::string& policy_app_id, const Permissions& permissions) = 0;
+  virtual void OnPermissionsUpdated(const std::string& device_id,
+                                    const std::string& policy_app_id,
                                     const Permissions& permissions) = 0;
 
 #ifdef EXTERNAL_PROPRIETARY_MODE
@@ -380,13 +386,26 @@ class PolicyHandlerInterface {
   virtual void OnAppsSearchCompleted(const bool trigger_ptu) = 0;
 
   /**
+   * DEPRECATED
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
    * It will send OnAppPermissionSend notification and will try to start PTU.
    *
    * @param application_id registered application.
    */
-  virtual void OnAppRegisteredOnMobile(const std::string& application_id) = 0;
+  DEPRECATED virtual void OnAppRegisteredOnMobile(
+      const std::string& application_id) = 0;
+
+  /**
+   * @brief OnAppRegisteredOnMobile allows to handle event when application were
+   * succesfully registered on mobile device.
+   * It will send OnAppPermissionSend notification and will try to start PTU.
+   *
+   * @param device_id device identifier
+   * @param application_id registered application.
+   */
+  virtual void OnAppRegisteredOnMobile(const std::string& device_id,
+                                       const std::string& application_id) = 0;
 
   /**
    * @brief Checks if certain request type is allowed for application

--- a/src/components/include/policy/policy_external/policy/policy_listener.h
+++ b/src/components/include/policy/policy_external/policy/policy_listener.h
@@ -45,10 +45,18 @@ namespace custom_str = utils::custom_string;
 class PolicyListener {
  public:
   virtual ~PolicyListener() {}
-  virtual void OnPermissionsUpdated(const std::string& policy_app_id,
+  DEPRECATED virtual void OnPermissionsUpdated(
+      const std::string& policy_app_id,
+      const Permissions& permissions,
+      const policy::HMILevel& default_hmi) = 0;
+  virtual void OnPermissionsUpdated(const std::string& device_id,
+                                    const std::string& policy_app_id,
                                     const Permissions& permissions,
                                     const policy::HMILevel& default_hmi) = 0;
-  virtual void OnPermissionsUpdated(const std::string& policy_app_id,
+  DEPRECATED virtual void OnPermissionsUpdated(
+      const std::string& policy_app_id, const Permissions& permissions) = 0;
+  virtual void OnPermissionsUpdated(const std::string& device_id,
+                                    const std::string& policy_app_id,
                                     const Permissions& permissions) = 0;
   virtual void OnPendingPermissionChange(const std::string& policy_app_id) = 0;
   virtual void OnUpdateStatusChanged(const std::string&) = 0;

--- a/src/components/include/policy/policy_external/policy/policy_listener.h
+++ b/src/components/include/policy/policy_external/policy/policy_listener.h
@@ -58,9 +58,15 @@ class PolicyListener {
   virtual void OnPermissionsUpdated(const std::string& device_id,
                                     const std::string& policy_app_id,
                                     const Permissions& permissions) = 0;
-  virtual void OnPendingPermissionChange(const std::string& policy_app_id) = 0;
+  DEPRECATED virtual void OnPendingPermissionChange(
+      const std::string& policy_app_id) = 0;
+  virtual void OnPendingPermissionChange(const std::string& device_id,
+                                         const std::string& policy_app_id) = 0;
   virtual void OnUpdateStatusChanged(const std::string&) = 0;
+  DEPRECATED virtual std::string OnCurrentDeviceIdUpdateRequired(
+      const std::string& policy_app_id) = 0;
   virtual std::string OnCurrentDeviceIdUpdateRequired(
+      const transport_manager::DeviceHandle& device_handle,
       const std::string& policy_app_id) = 0;
   virtual void OnSystemInfoUpdateRequired() = 0;
   virtual custom_str::CustomString GetAppName(
@@ -101,12 +107,24 @@ class PolicyListener {
                                       bool is_allowed) = 0;
 
   /**
+   * DEPRECATED
    * @brief Sends OnAppPermissionsChanged notification to HMI
    * @param permissions contains parameter for OnAppPermisionChanged
    * @param policy_app_id contains policy application id
    */
+  DEPRECATED virtual void SendOnAppPermissionsChanged(
+      const AppPermissions& permissions,
+      const std::string& policy_app_id) const = 0;
+
+  /**
+   * @brief Sends OnAppPermissionsChanged notification to HMI
+   * @param permissions contains parameter for OnAppPermisionChanged
+   * @param device_id device identifier
+   * @param policy_app_id contains policy application id
+   */
   virtual void SendOnAppPermissionsChanged(
       const AppPermissions& permissions,
+      const std::string& device_id,
       const std::string& policy_app_id) const = 0;
 
   /**
@@ -154,7 +172,7 @@ class PolicyListener {
    * @return list devices ids
    */
   virtual std::vector<std::string> GetDevicesIds(
-      const std::string& policy_app_id) = 0;
+      const std::string& policy_app_id) const = 0;
 
   /**
    * Notifies about changing HMI level

--- a/src/components/include/policy/policy_external/policy/policy_listener.h
+++ b/src/components/include/policy/policy_external/policy/policy_listener.h
@@ -45,26 +45,16 @@ namespace custom_str = utils::custom_string;
 class PolicyListener {
  public:
   virtual ~PolicyListener() {}
-  DEPRECATED virtual void OnPermissionsUpdated(
-      const std::string& policy_app_id,
-      const Permissions& permissions,
-      const policy::HMILevel& default_hmi) = 0;
   virtual void OnPermissionsUpdated(const std::string& device_id,
                                     const std::string& policy_app_id,
                                     const Permissions& permissions,
                                     const policy::HMILevel& default_hmi) = 0;
-  DEPRECATED virtual void OnPermissionsUpdated(
-      const std::string& policy_app_id, const Permissions& permissions) = 0;
   virtual void OnPermissionsUpdated(const std::string& device_id,
                                     const std::string& policy_app_id,
                                     const Permissions& permissions) = 0;
-  DEPRECATED virtual void OnPendingPermissionChange(
-      const std::string& policy_app_id) = 0;
   virtual void OnPendingPermissionChange(const std::string& device_id,
                                          const std::string& policy_app_id) = 0;
   virtual void OnUpdateStatusChanged(const std::string&) = 0;
-  DEPRECATED virtual std::string OnCurrentDeviceIdUpdateRequired(
-      const std::string& policy_app_id) = 0;
   virtual std::string OnCurrentDeviceIdUpdateRequired(
       const transport_manager::DeviceHandle& device_handle,
       const std::string& policy_app_id) = 0;
@@ -105,16 +95,6 @@ class PolicyListener {
    */
   virtual void OnDeviceConsentChanged(const std::string& device_id,
                                       bool is_allowed) = 0;
-
-  /**
-   * DEPRECATED
-   * @brief Sends OnAppPermissionsChanged notification to HMI
-   * @param permissions contains parameter for OnAppPermisionChanged
-   * @param policy_app_id contains policy application id
-   */
-  DEPRECATED virtual void SendOnAppPermissionsChanged(
-      const AppPermissions& permissions,
-      const std::string& policy_app_id) const = 0;
 
   /**
    * @brief Sends OnAppPermissionsChanged notification to HMI

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -130,24 +130,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void RequestPTUpdate() = 0;
 
   /**
-   * DEPRECATED
-   * @brief Check if specified RPC for specified application
-   * has permission to be executed in specified HMI Level
-   * and also its permitted params.
-   * @param app_id Id of application provided during registration
-   * @param hmi_level Current HMI Level of application
-   * @param rpc Name of RPC
-   * @param rpc_params List of RPC params
-   * @param CheckPermissionResult containing flag if HMI Level is allowed
-   * and list of allowed params.
-   */
-  DEPRECATED virtual void CheckPermissions(const PTString& app_id,
-                                           const PTString& hmi_level,
-                                           const PTString& rpc,
-                                           const RPCParams& rpc_params,
-                                           CheckPermissionResult& result) = 0;
-
-  /**
    * @brief Check if specified RPC for specified application
    * has permission to be executed in specified HMI Level
    * and also its permitted params.
@@ -283,17 +265,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
                                        const bool is_allowed) = 0;
 
   /**
-   * DEPRECATED
-   * @brief Update Application Policies as reaction
-   * on User allowing/disallowing device this app is running on.
-   * @param app_id Unique application id
-   * @param is_device_allowed true if user allowing device otherwise false
-   * @return true if operation was successful
-   */
-  DEPRECATED virtual bool ReactOnUserDevConsentForApp(
-      const std::string& app_id, const bool is_device_allowed) = 0;
-
-  /**
    * @brief Update Application Policies as reaction
    * on User allowing/disallowing device this app is running on.
    * @param device_handle device identifier
@@ -351,17 +322,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
                                     const NotificationMode mode) = 0;
 
   /**
-   * DEPRECATED
-   * @brief Get default HMI level for application
-   * @param policy_app_id Unique application id
-   * @param default_hmi Default HMI level for application or empty, if value
-   * was not set
-   * @return true, if succedeed, otherwise - false
-   */
-  DEPRECATED virtual bool GetDefaultHmi(const std::string& policy_app_id,
-                                        std::string* default_hmi) const = 0;
-
-  /**
    * @brief Get default HMI level for application
    * @param device_id device identifier
    * @param policy_app_id Unique application id
@@ -414,16 +374,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
       std::vector<FunctionalGroupPermission>& permissions) = 0;
 
   /**
-   * DEPRECATED
-   * @brief Gets specific application permissions changes since last policy
-   * table update
-   * @param policy_app_id Unique application id
-   * @return Permissions changes
-   */
-  DEPRECATED virtual AppPermissions GetAppPermissionsChanges(
-      const std::string& policy_app_id) = 0;
-
-  /**
    * @brief Gets specific application permissions changes since last policy
    * table update
    * @param device_id device identifier
@@ -438,14 +388,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * @param app_id Unique application id
    */
   virtual void RemovePendingPermissionChanges(const std::string& app_id) = 0;
-
-  /**
-   * DEPRECATED
-   * @brief Return device id, which hosts specific application
-   * @param policy_app_id Application id, which is required to update device id
-   */
-  DEPRECATED virtual std::string& GetCurrentDeviceId(
-      const std::string& policy_app_id) const = 0;
 
   /**
    * @brief Return device id, which hosts specific application
@@ -473,14 +415,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
                              const std::string& language) = 0;
 
   /**
-   * DEPRECATED
-   * @brief Send OnPermissionsUpdated for choosen application
-   * @param application_id Unique application id
-   */
-  DEPRECATED virtual void SendNotificationOnPermissionsUpdated(
-      const std::string& application_id) = 0;
-
-  /**
    * @brief Send OnPermissionsUpdated for choosen application
    * @param device_id device identifier
    * @param application_id Unique application id
@@ -493,18 +427,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * @param device_id id device
    */
   virtual void MarkUnpairedDevice(const std::string& device_id) = 0;
-
-  /**
-   * DEPRECATED
-   * @brief Adds, application to the db or update existed one
-   * run PTU if policy update is necessary for application.
-   * @param application_id Unique application id
-   * @param hmi_types application HMI types
-   * @return function that will notify update manager about new application
-   */
-  DEPRECATED virtual StatusNotifier AddApplication(
-      const std::string& application_id,
-      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) = 0;
 
   /**
    * @brief Adds, application to the db or update existed one
@@ -593,17 +515,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void OnAppsSearchCompleted(const bool trigger_ptu) = 0;
 
   /**
-   * DEPRECATED
-   * @brief OnAppRegisteredOnMobile allows to handle event when application were
-   * succesfully registered on mobile device.
-   * It will send OnAppPermissionSend notification and will try to start PTU.
-   *
-   * @param application_id registered application.
-   */
-  DEPRECATED virtual void OnAppRegisteredOnMobile(
-      const std::string& application_id) = 0;
-
-  /**
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
    * It will send OnAppPermissionSend notification and will try to start PTU.
@@ -632,15 +543,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    */
   virtual RequestSubType::State GetAppRequestSubTypesState(
       const std::string& policy_app_id) const = 0;
-
-  /**
-   * DEPRECATED
-   * @brief Gets request types for application
-   * @param policy_app_id Unique application id
-   * @return request types of application
-   */
-  DEPRECATED virtual const std::vector<std::string> GetAppRequestTypes(
-      const std::string policy_app_id) const = 0;
 
   /**
    * @brief Gets request types for application
@@ -807,15 +709,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * urls vector
    */
   virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) = 0;
-
-  /**
-   * DEPRECATED
-   * @brief Assigns new HMI types for specified application
-   * @param application_id Unique application id
-   * @param hmi_types new HMI types list
-   */
-  DEPRECATED virtual void SetDefaultHmiTypes(
-      const std::string& application_id, const std::vector<int>& hmi_types) = 0;
 
   /**
    * @brief Assigns new HMI types for specified application

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -130,6 +130,7 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void RequestPTUpdate() = 0;
 
   /**
+   * DEPRECATED
    * @brief Check if specified RPC for specified application
    * has permission to be executed in specified HMI Level
    * and also its permitted params.
@@ -140,7 +141,26 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * @param CheckPermissionResult containing flag if HMI Level is allowed
    * and list of allowed params.
    */
-  virtual void CheckPermissions(const PTString& app_id,
+  DEPRECATED virtual void CheckPermissions(const PTString& app_id,
+                                           const PTString& hmi_level,
+                                           const PTString& rpc,
+                                           const RPCParams& rpc_params,
+                                           CheckPermissionResult& result) = 0;
+
+  /**
+   * @brief Check if specified RPC for specified application
+   * has permission to be executed in specified HMI Level
+   * and also its permitted params.
+   * @param device_id device identifier
+   * @param app_id Id of application provided during registration
+   * @param hmi_level Current HMI Level of application
+   * @param rpc Name of RPC
+   * @param rpc_params List of RPC params
+   * @param CheckPermissionResult containing flag if HMI Level is allowed
+   * and list of allowed params.
+   */
+  virtual void CheckPermissions(const PTString& device_id,
+                                const PTString& app_id,
                                 const PTString& hmi_level,
                                 const PTString& rpc,
                                 const RPCParams& rpc_params,
@@ -263,14 +283,28 @@ class PolicyManager : public usage_statistics::StatisticsManager {
                                        const bool is_allowed) = 0;
 
   /**
+   * DEPRECATED
    * @brief Update Application Policies as reaction
    * on User allowing/disallowing device this app is running on.
    * @param app_id Unique application id
    * @param is_device_allowed true if user allowing device otherwise false
    * @return true if operation was successful
    */
-  virtual bool ReactOnUserDevConsentForApp(const std::string& app_id,
-                                           const bool is_device_allowed) = 0;
+  DEPRECATED virtual bool ReactOnUserDevConsentForApp(
+      const std::string& app_id, const bool is_device_allowed) = 0;
+
+  /**
+   * @brief Update Application Policies as reaction
+   * on User allowing/disallowing device this app is running on.
+   * @param device_handle device identifier
+   * @param app_id Unique application id
+   * @param is_device_allowed true if user allowing device otherwise false
+   * @return true if operation was successful
+   */
+  virtual bool ReactOnUserDevConsentForApp(
+      const transport_manager::DeviceHandle& device_handle,
+      const std::string& app_id,
+      const bool is_device_allowed) = 0;
 
   /**
    * @brief Sets counter value that passed for receiving PT UPdate.
@@ -317,13 +351,26 @@ class PolicyManager : public usage_statistics::StatisticsManager {
                                     const NotificationMode mode) = 0;
 
   /**
+   * DEPRECATED
    * @brief Get default HMI level for application
    * @param policy_app_id Unique application id
    * @param default_hmi Default HMI level for application or empty, if value
    * was not set
    * @return true, if succedeed, otherwise - false
    */
-  virtual bool GetDefaultHmi(const std::string& policy_app_id,
+  DEPRECATED virtual bool GetDefaultHmi(const std::string& policy_app_id,
+                                        std::string* default_hmi) const = 0;
+
+  /**
+   * @brief Get default HMI level for application
+   * @param device_id device identifier
+   * @param policy_app_id Unique application id
+   * @param default_hmi Default HMI level for application or empty, if value
+   * was not set
+   * @return true, if succedeed, otherwise - false
+   */
+  virtual bool GetDefaultHmi(const std::string& device_id,
+                             const std::string& policy_app_id,
                              std::string* default_hmi) const = 0;
 
   /**
@@ -367,13 +414,24 @@ class PolicyManager : public usage_statistics::StatisticsManager {
       std::vector<FunctionalGroupPermission>& permissions) = 0;
 
   /**
+   * DEPRECATED
    * @brief Gets specific application permissions changes since last policy
    * table update
    * @param policy_app_id Unique application id
    * @return Permissions changes
    */
-  virtual AppPermissions GetAppPermissionsChanges(
+  DEPRECATED virtual AppPermissions GetAppPermissionsChanges(
       const std::string& policy_app_id) = 0;
+
+  /**
+   * @brief Gets specific application permissions changes since last policy
+   * table update
+   * @param device_id device identifier
+   * @param policy_app_id Unique application id
+   * @return Permissions changes
+   */
+  virtual AppPermissions GetAppPermissionsChanges(
+      const std::string& device_id, const std::string& policy_app_id) = 0;
 
   /**
    * @brief Removes specific application permissions changes
@@ -382,10 +440,20 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void RemovePendingPermissionChanges(const std::string& app_id) = 0;
 
   /**
+   * DEPRECATED
    * @brief Return device id, which hosts specific application
    * @param policy_app_id Application id, which is required to update device id
    */
+  DEPRECATED virtual std::string& GetCurrentDeviceId(
+      const std::string& policy_app_id) const = 0;
+
+  /**
+   * @brief Return device id, which hosts specific application
+   * @param device_handle device identifier
+   * @param policy_app_id Application id, which is required to update device id
+   */
   virtual std::string& GetCurrentDeviceId(
+      const transport_manager::DeviceHandle& device_handle,
       const std::string& policy_app_id) const = 0;
 
   /**
@@ -427,13 +495,27 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void MarkUnpairedDevice(const std::string& device_id) = 0;
 
   /**
+   * DEPRECATED
    * @brief Adds, application to the db or update existed one
    * run PTU if policy update is necessary for application.
    * @param application_id Unique application id
    * @param hmi_types application HMI types
    * @return function that will notify update manager about new application
    */
+  DEPRECATED virtual StatusNotifier AddApplication(
+      const std::string& application_id,
+      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) = 0;
+
+  /**
+   * @brief Adds, application to the db or update existed one
+   * run PTU if policy update is necessary for application.
+   * @param device_id device identifier
+   * @param application_id Unique application id
+   * @param hmi_types application HMI types
+   * @return function that will notify update manager about new application
+   */
   virtual StatusNotifier AddApplication(
+      const std::string& device_id,
       const std::string& application_id,
       const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) = 0;
 
@@ -552,11 +634,22 @@ class PolicyManager : public usage_statistics::StatisticsManager {
       const std::string& policy_app_id) const = 0;
 
   /**
+   * DEPRECATED
    * @brief Gets request types for application
    * @param policy_app_id Unique application id
    * @return request types of application
    */
+  DEPRECATED virtual const std::vector<std::string> GetAppRequestTypes(
+      const std::string policy_app_id) const = 0;
+
+  /**
+   * @brief Gets request types for application
+   * @param device_handle device identifier
+   * @param policy_app_id Unique application id
+   * @return request types of application
+   */
   virtual const std::vector<std::string> GetAppRequestTypes(
+      const transport_manager::DeviceHandle& device_handle,
       const std::string policy_app_id) const = 0;
 
   /**
@@ -716,12 +809,24 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) = 0;
 
   /**
+   * DEPRECATED
    * @brief Assigns new HMI types for specified application
    * @param application_id Unique application id
    * @param hmi_types new HMI types list
    */
-  virtual void SetDefaultHmiTypes(const std::string& application_id,
-                                  const std::vector<int>& hmi_types) = 0;
+  DEPRECATED virtual void SetDefaultHmiTypes(
+      const std::string& application_id, const std::vector<int>& hmi_types) = 0;
+
+  /**
+   * @brief Assigns new HMI types for specified application
+   * @param device_handle device identifier
+   * @param application_id Unique application id
+   * @param hmi_types new HMI types list
+   */
+  virtual void SetDefaultHmiTypes(
+      const transport_manager::DeviceHandle& device_handle,
+      const std::string& application_id,
+      const std::vector<int>& hmi_types) = 0;
   /**
    * @brief Gets HMI types
    * @param application_id ID application

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -405,11 +405,20 @@ class PolicyManager : public usage_statistics::StatisticsManager {
                              const std::string& language) = 0;
 
   /**
+   * DEPRECATED
    * @brief Send OnPermissionsUpdated for choosen application
    * @param application_id Unique application id
    */
-  virtual void SendNotificationOnPermissionsUpdated(
+  DEPRECATED virtual void SendNotificationOnPermissionsUpdated(
       const std::string& application_id) = 0;
+
+  /**
+   * @brief Send OnPermissionsUpdated for choosen application
+   * @param device_id device identifier
+   * @param application_id Unique application id
+   */
+  virtual void SendNotificationOnPermissionsUpdated(
+      const std::string& device_id, const std::string& application_id) = 0;
 
   /**
    * @brief Marks device as upaired
@@ -502,12 +511,26 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void OnAppsSearchCompleted(const bool trigger_ptu) = 0;
 
   /**
+   * DEPRECATED
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
-   * It will send OnAppPermissionSend notification and will try to start PTU. *
+   * It will send OnAppPermissionSend notification and will try to start PTU.
+   *
    * @param application_id registered application.
    */
-  virtual void OnAppRegisteredOnMobile(const std::string& application_id) = 0;
+  DEPRECATED virtual void OnAppRegisteredOnMobile(
+      const std::string& application_id) = 0;
+
+  /**
+   * @brief OnAppRegisteredOnMobile allows to handle event when application were
+   * succesfully registered on mobile device.
+   * It will send OnAppPermissionSend notification and will try to start PTU.
+   *
+   * @param device_id device identifier
+   * @param application_id registered application.
+   */
+  virtual void OnAppRegisteredOnMobile(const std::string& device_id,
+                                       const std::string& application_id) = 0;
 
   virtual void OnDeviceSwitching(const std::string& device_id_from,
                                  const std::string& device_id_to) = 0;

--- a/src/components/include/policy/policy_regular/policy/policy_listener.h
+++ b/src/components/include/policy/policy_regular/policy/policy_listener.h
@@ -58,9 +58,15 @@ class PolicyListener {
   virtual void OnPermissionsUpdated(const std::string& device_id,
                                     const std::string& policy_app_id,
                                     const Permissions& permissions) = 0;
-  virtual void OnPendingPermissionChange(const std::string& policy_app_id) = 0;
+  DEPRECATED virtual void OnPendingPermissionChange(
+      const std::string& policy_app_id) = 0;
+  virtual void OnPendingPermissionChange(const std::string& device_id,
+                                         const std::string& policy_app_id) = 0;
   virtual void OnUpdateStatusChanged(const std::string&) = 0;
+  DEPRECATED virtual std::string OnCurrentDeviceIdUpdateRequired(
+      const std::string& policy_app_id) = 0;
   virtual std::string OnCurrentDeviceIdUpdateRequired(
+      const transport_manager::DeviceHandle& device_handle,
       const std::string& policy_app_id) = 0;
   virtual void OnSystemInfoUpdateRequired() = 0;
   virtual custom_str::CustomString GetAppName(
@@ -99,12 +105,24 @@ class PolicyListener {
                                       bool is_allowed) = 0;
 
   /**
+   * DEPRECATED
    * @brief Sends OnAppPermissionsChanged notification to HMI
    * @param permissions contains parameter for OnAppPermisionChanged
    * @param policy_app_id contains policy application id
    */
+  DEPRECATED virtual void SendOnAppPermissionsChanged(
+      const AppPermissions& permissions,
+      const std::string& policy_app_id) const = 0;
+
+  /**
+   * @brief Sends OnAppPermissionsChanged notification to HMI
+   * @param permissions contains parameter for OnAppPermisionChanged
+   * @param device_id device identifier
+   * @param policy_app_id contains policy application id
+   */
   virtual void SendOnAppPermissionsChanged(
       const AppPermissions& permissions,
+      const std::string& device_id,
       const std::string& policy_app_id) const = 0;
 
   /**
@@ -136,7 +154,7 @@ class PolicyListener {
    * @return list devices ids
    */
   virtual std::vector<std::string> GetDevicesIds(
-      const std::string& policy_app_id) = 0;
+      const std::string& policy_app_id) const = 0;
 
   /**
    * Notifies about changing HMI level

--- a/src/components/include/policy/policy_regular/policy/policy_listener.h
+++ b/src/components/include/policy/policy_regular/policy/policy_listener.h
@@ -45,26 +45,16 @@ namespace custom_str = utils::custom_string;
 class PolicyListener {
  public:
   virtual ~PolicyListener() {}
-  DEPRECATED virtual void OnPermissionsUpdated(
-      const std::string& policy_app_id,
-      const Permissions& permissions,
-      const policy::HMILevel& default_hmi) = 0;
   virtual void OnPermissionsUpdated(const std::string& device_id,
                                     const std::string& policy_app_id,
                                     const Permissions& permissions,
                                     const policy::HMILevel& default_hmi) = 0;
-  DEPRECATED virtual void OnPermissionsUpdated(
-      const std::string& policy_app_id, const Permissions& permissions) = 0;
   virtual void OnPermissionsUpdated(const std::string& device_id,
                                     const std::string& policy_app_id,
                                     const Permissions& permissions) = 0;
-  DEPRECATED virtual void OnPendingPermissionChange(
-      const std::string& policy_app_id) = 0;
   virtual void OnPendingPermissionChange(const std::string& device_id,
                                          const std::string& policy_app_id) = 0;
   virtual void OnUpdateStatusChanged(const std::string&) = 0;
-  DEPRECATED virtual std::string OnCurrentDeviceIdUpdateRequired(
-      const std::string& policy_app_id) = 0;
   virtual std::string OnCurrentDeviceIdUpdateRequired(
       const transport_manager::DeviceHandle& device_handle,
       const std::string& policy_app_id) = 0;
@@ -103,16 +93,6 @@ class PolicyListener {
    */
   virtual void OnDeviceConsentChanged(const std::string& device_id,
                                       bool is_allowed) = 0;
-
-  /**
-   * DEPRECATED
-   * @brief Sends OnAppPermissionsChanged notification to HMI
-   * @param permissions contains parameter for OnAppPermisionChanged
-   * @param policy_app_id contains policy application id
-   */
-  DEPRECATED virtual void SendOnAppPermissionsChanged(
-      const AppPermissions& permissions,
-      const std::string& policy_app_id) const = 0;
 
   /**
    * @brief Sends OnAppPermissionsChanged notification to HMI

--- a/src/components/include/policy/policy_regular/policy/policy_listener.h
+++ b/src/components/include/policy/policy_regular/policy/policy_listener.h
@@ -45,10 +45,18 @@ namespace custom_str = utils::custom_string;
 class PolicyListener {
  public:
   virtual ~PolicyListener() {}
-  virtual void OnPermissionsUpdated(const std::string& policy_app_id,
+  DEPRECATED virtual void OnPermissionsUpdated(
+      const std::string& policy_app_id,
+      const Permissions& permissions,
+      const policy::HMILevel& default_hmi) = 0;
+  virtual void OnPermissionsUpdated(const std::string& device_id,
+                                    const std::string& policy_app_id,
                                     const Permissions& permissions,
                                     const policy::HMILevel& default_hmi) = 0;
-  virtual void OnPermissionsUpdated(const std::string& policy_app_id,
+  DEPRECATED virtual void OnPermissionsUpdated(
+      const std::string& policy_app_id, const Permissions& permissions) = 0;
+  virtual void OnPermissionsUpdated(const std::string& device_id,
+                                    const std::string& policy_app_id,
                                     const Permissions& permissions) = 0;
   virtual void OnPendingPermissionChange(const std::string& policy_app_id) = 0;
   virtual void OnUpdateStatusChanged(const std::string&) = 0;

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -258,17 +258,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
                                        bool is_allowed) = 0;
 
   /**
-   * DEPRECATED
-   * @brief Update Application Policies as reaction
-   * on User allowing/disallowing device this app is running on.
-   * @param app_id Unique application id
-   * @param is_device_allowed true if user allowing device otherwise false
-   * @return true if operation was successful
-   */
-  DEPRECATED virtual bool ReactOnUserDevConsentForApp(
-      const std::string app_id, bool is_device_allowed) = 0;
-
-  /**
    * @brief Update Application Policies as reaction
    * on User allowing/disallowing device this app is running on.
    * @param device_handle device identifier
@@ -324,17 +313,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void SetUserConsentForApp(const PermissionConsent& permissions) = 0;
 
   /**
-   * DEPRECATED
-   * @brief Get default HMI level for application
-   * @param policy_app_id Unique application id
-   * @param default_hmi Default HMI level for application or empty, if value
-   * was not set
-   * @return true, if succedeed, otherwise - false
-   */
-  DEPRECATED virtual bool GetDefaultHmi(const std::string& policy_app_id,
-                                        std::string* default_hmi) const = 0;
-
-  /**
    * @brief Get default HMI level for application
    * @param device_id device identifier
    * @param policy_app_id Unique application id
@@ -385,16 +363,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
       std::vector<FunctionalGroupPermission>& permissions) = 0;
 
   /**
-   * DEPRECATED
-   * @brief Gets specific application permissions changes since last policy
-   * table update
-   * @param policy_app_id Unique application id
-   * @return Permissions changes
-   */
-  DEPRECATED virtual AppPermissions GetAppPermissionsChanges(
-      const std::string& policy_app_id) = 0;
-
-  /**
    * @brief Gets specific application permissions changes since last policy
    * table update
    * @param device_id device identifier
@@ -409,14 +377,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * @param app_id Unique application id
    */
   virtual void RemovePendingPermissionChanges(const std::string& app_id) = 0;
-
-  /**
-   * DEPRECATED
-   * @brief Return device id, which hosts specific application
-   * @param policy_app_id Application id, which is required to update device id
-   */
-  DEPRECATED virtual std::string& GetCurrentDeviceId(
-      const std::string& policy_app_id) const = 0;
 
   /**
    * @brief Return device id, which hosts specific application
@@ -444,14 +404,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
                              const std::string& language) = 0;
 
   /**
-   * DEPRECATED
-   * @brief Send OnPermissionsUpdated for choosen application
-   * @param application_id Unique application id
-   */
-  DEPRECATED virtual void SendNotificationOnPermissionsUpdated(
-      const std::string& application_id) = 0;
-
-  /**
    * @brief Send OnPermissionsUpdated for choosen application
    * @param device_id device identifier
    * @param application_id Unique application id
@@ -464,18 +416,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * @param device_id id device
    */
   virtual void MarkUnpairedDevice(const std::string& device_id) = 0;
-
-  /**
-   * DEPRECATED
-   * @brief Adds, application to the db or update existed one
-   * run PTU if policy update is necessary for application.
-   * @param application_id Unique application id
-   * @param hmi_types application HMI types
-   * @return function that will notify update manager about new application
-   */
-  DEPRECATED virtual StatusNotifier AddApplication(
-      const std::string& application_id,
-      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) = 0;
 
   /**
    * @brief Adds, application to the db or update existed one
@@ -705,17 +645,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
       const std::string& policy_app_id) const = 0;
 
   /**
-   * DEPRECATED
-   * @brief OnAppRegisteredOnMobile allows to handle event when application were
-   * succesfully registered on mobile device.
-   * It will send OnAppPermissionSend notification and will try to start PTU.
-   *
-   * @param application_id registered application.
-   */
-  DEPRECATED virtual void OnAppRegisteredOnMobile(
-      const std::string& application_id) = 0;
-
-  /**
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
    * It will send OnAppPermissionSend notification and will try to start PTU.
@@ -756,15 +685,6 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * urls vector
    */
   virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) = 0;
-
-  /**
-   * DEPRECATED
-   * @brief Assigns new HMI types for specified application
-   * @param application_id Unique application id
-   * @param hmi_types new HMI types list
-   */
-  DEPRECATED virtual void SetDefaultHmiTypes(
-      const std::string& application_id, const std::vector<int>& hmi_types) = 0;
 
   /**
    * @brief Assigns new HMI types for specified application

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -396,11 +396,20 @@ class PolicyManager : public usage_statistics::StatisticsManager {
                              const std::string& language) = 0;
 
   /**
+   * DEPRECATED
    * @brief Send OnPermissionsUpdated for choosen application
    * @param application_id Unique application id
    */
-  virtual void SendNotificationOnPermissionsUpdated(
+  DEPRECATED virtual void SendNotificationOnPermissionsUpdated(
       const std::string& application_id) = 0;
+
+  /**
+   * @brief Send OnPermissionsUpdated for choosen application
+   * @param device_id device identifier
+   * @param application_id Unique application id
+   */
+  virtual void SendNotificationOnPermissionsUpdated(
+      const std::string& device_id, const std::string& application_id) = 0;
 
   /**
    * @brief Marks device as upaired
@@ -634,12 +643,26 @@ class PolicyManager : public usage_statistics::StatisticsManager {
       const std::string& policy_app_id) const = 0;
 
   /**
+   * DEPRECATED
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
-   * It will send OnAppPermissionSend notification and will try to start PTU. *
+   * It will send OnAppPermissionSend notification and will try to start PTU.
+   *
    * @param application_id registered application.
    */
-  virtual void OnAppRegisteredOnMobile(const std::string& application_id) = 0;
+  DEPRECATED virtual void OnAppRegisteredOnMobile(
+      const std::string& application_id) = 0;
+
+  /**
+   * @brief OnAppRegisteredOnMobile allows to handle event when application were
+   * succesfully registered on mobile device.
+   * It will send OnAppPermissionSend notification and will try to start PTU.
+   *
+   * @param device_id device identifier
+   * @param application_id registered application.
+   */
+  virtual void OnAppRegisteredOnMobile(const std::string& device_id,
+                                       const std::string& application_id) = 0;
 
   virtual void OnDeviceSwitching(const std::string& device_id_from,
                                  const std::string& device_id_to) = 0;

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -258,14 +258,28 @@ class PolicyManager : public usage_statistics::StatisticsManager {
                                        bool is_allowed) = 0;
 
   /**
+   * DEPRECATED
    * @brief Update Application Policies as reaction
    * on User allowing/disallowing device this app is running on.
    * @param app_id Unique application id
    * @param is_device_allowed true if user allowing device otherwise false
    * @return true if operation was successful
    */
-  virtual bool ReactOnUserDevConsentForApp(const std::string app_id,
-                                           bool is_device_allowed) = 0;
+  DEPRECATED virtual bool ReactOnUserDevConsentForApp(
+      const std::string app_id, bool is_device_allowed) = 0;
+
+  /**
+   * @brief Update Application Policies as reaction
+   * on User allowing/disallowing device this app is running on.
+   * @param device_handle device identifier
+   * @param app_id Unique application id
+   * @param is_device_allowed true if user allowing device otherwise false
+   * @return true if operation was successful
+   */
+  virtual bool ReactOnUserDevConsentForApp(
+      const transport_manager::DeviceHandle& device_handle,
+      const std::string app_id,
+      bool is_device_allowed) = 0;
 
   /**
    * @brief Sets counter value that passed for receiving PT UPdate.
@@ -310,13 +324,26 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void SetUserConsentForApp(const PermissionConsent& permissions) = 0;
 
   /**
+   * DEPRECATED
    * @brief Get default HMI level for application
    * @param policy_app_id Unique application id
    * @param default_hmi Default HMI level for application or empty, if value
    * was not set
    * @return true, if succedeed, otherwise - false
    */
-  virtual bool GetDefaultHmi(const std::string& policy_app_id,
+  DEPRECATED virtual bool GetDefaultHmi(const std::string& policy_app_id,
+                                        std::string* default_hmi) const = 0;
+
+  /**
+   * @brief Get default HMI level for application
+   * @param device_id device identifier
+   * @param policy_app_id Unique application id
+   * @param default_hmi Default HMI level for application or empty, if value
+   * was not set
+   * @return true, if succedeed, otherwise - false
+   */
+  virtual bool GetDefaultHmi(const std::string& device_id,
+                             const std::string& policy_app_id,
                              std::string* default_hmi) const = 0;
 
   /**
@@ -358,13 +385,24 @@ class PolicyManager : public usage_statistics::StatisticsManager {
       std::vector<FunctionalGroupPermission>& permissions) = 0;
 
   /**
+   * DEPRECATED
    * @brief Gets specific application permissions changes since last policy
    * table update
    * @param policy_app_id Unique application id
    * @return Permissions changes
    */
-  virtual AppPermissions GetAppPermissionsChanges(
+  DEPRECATED virtual AppPermissions GetAppPermissionsChanges(
       const std::string& policy_app_id) = 0;
+
+  /**
+   * @brief Gets specific application permissions changes since last policy
+   * table update
+   * @param device_id device identifier
+   * @param policy_app_id Unique application id
+   * @return Permissions changes
+   */
+  virtual AppPermissions GetAppPermissionsChanges(
+      const std::string& device_id, const std::string& policy_app_id) = 0;
 
   /**
    * @brief Removes specific application permissions changes
@@ -373,10 +411,20 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void RemovePendingPermissionChanges(const std::string& app_id) = 0;
 
   /**
+   * DEPRECATED
    * @brief Return device id, which hosts specific application
    * @param policy_app_id Application id, which is required to update device id
    */
+  DEPRECATED virtual std::string& GetCurrentDeviceId(
+      const std::string& policy_app_id) const = 0;
+
+  /**
+   * @brief Return device id, which hosts specific application
+   * @param device_handle device identifier
+   * @param policy_app_id Application id, which is required to update device id
+   */
   virtual std::string& GetCurrentDeviceId(
+      const transport_manager::DeviceHandle& device_handle,
       const std::string& policy_app_id) const = 0;
 
   /**
@@ -418,13 +466,27 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual void MarkUnpairedDevice(const std::string& device_id) = 0;
 
   /**
+   * DEPRECATED
    * @brief Adds, application to the db or update existed one
    * run PTU if policy update is necessary for application.
    * @param application_id Unique application id
    * @param hmi_types application HMI types
    * @return function that will notify update manager about new application
    */
+  DEPRECATED virtual StatusNotifier AddApplication(
+      const std::string& application_id,
+      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) = 0;
+
+  /**
+   * @brief Adds, application to the db or update existed one
+   * run PTU if policy update is necessary for application.
+   * @param device_id device identifier
+   * @param application_id Unique application id
+   * @param hmi_types application HMI types
+   * @return function that will notify update manager about new application
+   */
   virtual StatusNotifier AddApplication(
+      const std::string& device_id,
       const std::string& application_id,
       const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) = 0;
 
@@ -696,12 +758,24 @@ class PolicyManager : public usage_statistics::StatisticsManager {
   virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) = 0;
 
   /**
+   * DEPRECATED
    * @brief Assigns new HMI types for specified application
    * @param application_id Unique application id
    * @param hmi_types new HMI types list
    */
-  virtual void SetDefaultHmiTypes(const std::string& application_id,
-                                  const std::vector<int>& hmi_types) = 0;
+  DEPRECATED virtual void SetDefaultHmiTypes(
+      const std::string& application_id, const std::vector<int>& hmi_types) = 0;
+
+  /**
+   * @brief Assigns new HMI types for specified application
+   * @param device_handle device identifier
+   * @param application_id Unique application id
+   * @param hmi_types new HMI types list
+   */
+  virtual void SetDefaultHmiTypes(
+      const transport_manager::DeviceHandle& device_handle,
+      const std::string& application_id,
+      const std::vector<int>& hmi_types) = 0;
 
   /**
    * @brief Gets HMI types

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -337,6 +337,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                     const uint32_t connection_key));
   MOCK_CONST_METHOD1(IsAppInReconnectMode,
                      bool(const std::string& policy_app_id));
+  MOCK_CONST_METHOD2(IsAppInReconnectMode,
+                     bool(const connection_handler::DeviceHandle& device_id,
+                          const std::string& policy_app_id));
   MOCK_CONST_METHOD0(GetCommandFactory, application_manager::CommandFactory&());
   MOCK_CONST_METHOD0(get_current_audio_source, uint32_t());
   MOCK_METHOD1(set_current_audio_source, void(const uint32_t));

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -335,8 +335,6 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD2(ProcessReconnection,
                void(application_manager::ApplicationSharedPtr application,
                     const uint32_t connection_key));
-  MOCK_CONST_METHOD1(IsAppInReconnectMode,
-                     bool(const std::string& policy_app_id));
   MOCK_CONST_METHOD2(IsAppInReconnectMode,
                      bool(const connection_handler::DeviceHandle& device_id,
                           const std::string& policy_app_id));

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -57,12 +57,21 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                bool(const std::string& file,
                     const policy::BinaryMessage& pt_string));
   MOCK_METHOD0(UnloadPolicyLibrary, bool());
+  MOCK_METHOD2(OnPermissionsUpdated,
+               void(const std::string& policy_app_id,
+                    const policy::Permissions& permissions));
   MOCK_METHOD3(OnPermissionsUpdated,
                void(const std::string& policy_app_id,
                     const policy::Permissions& permissions,
                     const policy::HMILevel& default_hmi));
-  MOCK_METHOD2(OnPermissionsUpdated,
-               void(const std::string& policy_app_id,
+  MOCK_METHOD4(OnPermissionsUpdated,
+               void(const std::string& device_id,
+                    const std::string& policy_app_id,
+                    const policy::Permissions& permissions,
+                    const policy::HMILevel& default_hmi));
+  MOCK_METHOD3(OnPermissionsUpdated,
+               void(const std::string& device_id,
+                    const std::string& policy_app_id,
                     const policy::Permissions& permissions));
 
 #ifdef EXTERNAL_PROPRIETARY_MODE
@@ -88,6 +97,10 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                      policy::DeviceConsent(const std::string& device_id));
   MOCK_CONST_METHOD2(GetDefaultHmi,
                      bool(const std::string& policy_app_id,
+                          std::string* default_hmi));
+  MOCK_CONST_METHOD3(GetDefaultHmi,
+                     bool(const std::string& device_id,
+                          const std::string& policy_app_id,
                           std::string* default_hmi));
 
   MOCK_METHOD3(GetInitialAppData,
@@ -129,6 +142,9 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD0(OnIgnitionCycleOver, void());
   MOCK_METHOD1(OnPendingPermissionChange,
                void(const std::string& policy_app_id));
+  MOCK_METHOD2(OnPendingPermissionChange,
+               void(const std::string& device_id,
+                    const std::string& policy_app_id));
   MOCK_METHOD1(PTExchangeAtUserRequest, void(uint32_t correlation_id));
   MOCK_METHOD2(AddDevice,
                void(const std::string& device_id,
@@ -158,6 +174,9 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD1(OnUpdateStatusChanged, void(const std::string& status));
   MOCK_METHOD1(OnCurrentDeviceIdUpdateRequired,
                std::string(const std::string& policy_app_id));
+  MOCK_METHOD2(OnCurrentDeviceIdUpdateRequired,
+               std::string(const transport_manager::DeviceHandle& device_handle,
+                           const std::string& policy_app_id));
   MOCK_METHOD1(OnSystemInfoChanged, void(const std::string& language));
   MOCK_METHOD3(OnGetSystemInfo,
                void(const std::string& ccpu_version,
@@ -185,11 +204,21 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_CONST_METHOD2(SendOnAppPermissionsChanged,
                      void(const policy::AppPermissions& permissions,
                           const std::string& policy_app_id));
+  MOCK_CONST_METHOD3(SendOnAppPermissionsChanged,
+                     void(const policy::AppPermissions& permissions,
+                          const std::string& device_id,
+                          const std::string& policy_app_id));
   MOCK_METHOD0(OnPTExchangeNeeded, void());
   MOCK_METHOD1(GetAvailableApps, void(std::queue<std::string>& apps));
   MOCK_METHOD2(
       AddApplication,
       policy::StatusNotifier(
+          const std::string& application_id,
+          const rpc::policy_table_interface_base::AppHmiTypes& hmi_types));
+  MOCK_METHOD3(
+      AddApplication,
+      policy::StatusNotifier(
+          const std::string& device_id,
           const std::string& application_id,
           const rpc::policy_table_interface_base::AppHmiTypes& hmi_types));
   MOCK_METHOD1(IsApplicationRevoked, bool(const std::string& app_id));
@@ -199,8 +228,15 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD1(OnAppsSearchCompleted, void(const bool trigger_ptu));
   MOCK_METHOD1(OnAppRegisteredOnMobile,
                void(const std::string& application_id));
+  MOCK_METHOD2(OnAppRegisteredOnMobile,
+               void(const std::string& device_id,
+                    const std::string& application_id));
   MOCK_CONST_METHOD2(IsRequestTypeAllowed,
                      bool(const std::string& policy_app_id,
+                          mobile_apis::RequestType::eType type));
+  MOCK_CONST_METHOD3(IsRequestTypeAllowed,
+                     bool(const transport_manager::DeviceHandle& device_handle,
+                          const std::string& policy_app_id,
                           mobile_apis::RequestType::eType type));
   MOCK_CONST_METHOD2(IsRequestSubTypeAllowed,
                      bool(const std::string& policy_app_id,
@@ -217,6 +253,10 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_CONST_METHOD1(
       GetAppRequestTypes,
       const std::vector<std::string>(const std::string& policy_app_id));
+  MOCK_CONST_METHOD2(GetAppRequestTypes,
+                     const std::vector<std::string>(
+                         const transport_manager::DeviceHandle& device_handle,
+                         const std::string& policy_app_id));
   MOCK_CONST_METHOD0(GetVehicleInfo, const policy::VehicleInfo());
   MOCK_CONST_METHOD1(GetEnabledCloudApps,
                      void(std::vector<std::string>& enabled_apps));
@@ -295,6 +335,10 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                           std::vector<std::string>* modules));
   MOCK_METHOD2(SetDefaultHmiTypes,
                void(const std::string& application_id,
+                    const smart_objects::SmartObject* app_types));
+  MOCK_METHOD3(SetDefaultHmiTypes,
+               void(const transport_manager::DeviceHandle& device_handle,
+                    const std::string& application_id,
                     const smart_objects::SmartObject* app_types));
   MOCK_METHOD2(OnDeviceSwitching,
                void(const std::string& device_id_from,

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -57,13 +57,6 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                bool(const std::string& file,
                     const policy::BinaryMessage& pt_string));
   MOCK_METHOD0(UnloadPolicyLibrary, bool());
-  MOCK_METHOD2(OnPermissionsUpdated,
-               void(const std::string& policy_app_id,
-                    const policy::Permissions& permissions));
-  MOCK_METHOD3(OnPermissionsUpdated,
-               void(const std::string& policy_app_id,
-                    const policy::Permissions& permissions,
-                    const policy::HMILevel& default_hmi));
   MOCK_METHOD4(OnPermissionsUpdated,
                void(const std::string& device_id,
                     const std::string& policy_app_id,
@@ -95,9 +88,6 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                      uint32_t(const std::string& priority));
   MOCK_CONST_METHOD1(GetUserConsentForDevice,
                      policy::DeviceConsent(const std::string& device_id));
-  MOCK_CONST_METHOD2(GetDefaultHmi,
-                     bool(const std::string& policy_app_id,
-                          std::string* default_hmi));
   MOCK_CONST_METHOD3(GetDefaultHmi,
                      bool(const std::string& device_id,
                           const std::string& policy_app_id,
@@ -140,8 +130,6 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD2(OnAllowSDLFunctionalityNotification,
                void(bool is_allowed, const std::string& device_id));
   MOCK_METHOD0(OnIgnitionCycleOver, void());
-  MOCK_METHOD1(OnPendingPermissionChange,
-               void(const std::string& policy_app_id));
   MOCK_METHOD2(OnPendingPermissionChange,
                void(const std::string& device_id,
                     const std::string& policy_app_id));
@@ -172,8 +160,6 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                     const uint32_t correlation_id));
   MOCK_METHOD1(OnGetStatusUpdate, void(const uint32_t correlation_id));
   MOCK_METHOD1(OnUpdateStatusChanged, void(const std::string& status));
-  MOCK_METHOD1(OnCurrentDeviceIdUpdateRequired,
-               std::string(const std::string& policy_app_id));
   MOCK_METHOD2(OnCurrentDeviceIdUpdateRequired,
                std::string(const transport_manager::DeviceHandle& device_handle,
                            const std::string& policy_app_id));
@@ -201,20 +187,12 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD0(CanUpdate, bool());
   MOCK_METHOD2(OnDeviceConsentChanged,
                void(const std::string& device_id, bool is_allowed));
-  MOCK_CONST_METHOD2(SendOnAppPermissionsChanged,
-                     void(const policy::AppPermissions& permissions,
-                          const std::string& policy_app_id));
   MOCK_CONST_METHOD3(SendOnAppPermissionsChanged,
                      void(const policy::AppPermissions& permissions,
                           const std::string& device_id,
                           const std::string& policy_app_id));
   MOCK_METHOD0(OnPTExchangeNeeded, void());
   MOCK_METHOD1(GetAvailableApps, void(std::queue<std::string>& apps));
-  MOCK_METHOD2(
-      AddApplication,
-      policy::StatusNotifier(
-          const std::string& application_id,
-          const rpc::policy_table_interface_base::AppHmiTypes& hmi_types));
   MOCK_METHOD3(
       AddApplication,
       policy::StatusNotifier(
@@ -226,14 +204,9 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_CONST_METHOD1(HeartBeatTimeout, uint32_t(const std::string& app_id));
   MOCK_METHOD0(OnAppsSearchStarted, void());
   MOCK_METHOD1(OnAppsSearchCompleted, void(const bool trigger_ptu));
-  MOCK_METHOD1(OnAppRegisteredOnMobile,
-               void(const std::string& application_id));
   MOCK_METHOD2(OnAppRegisteredOnMobile,
                void(const std::string& device_id,
                     const std::string& application_id));
-  MOCK_CONST_METHOD2(IsRequestTypeAllowed,
-                     bool(const std::string& policy_app_id,
-                          mobile_apis::RequestType::eType type));
   MOCK_CONST_METHOD3(IsRequestTypeAllowed,
                      bool(const transport_manager::DeviceHandle& device_handle,
                           const std::string& policy_app_id,
@@ -249,9 +222,6 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
       policy::RequestSubType::State(const std::string& policy_app_id));
   MOCK_CONST_METHOD1(
       GetAppRequestSubTypes,
-      const std::vector<std::string>(const std::string& policy_app_id));
-  MOCK_CONST_METHOD1(
-      GetAppRequestTypes,
       const std::vector<std::string>(const std::string& policy_app_id));
   MOCK_CONST_METHOD2(GetAppRequestTypes,
                      const std::vector<std::string>(
@@ -333,9 +303,6 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_CONST_METHOD2(GetModuleTypes,
                      bool(const std::string& policy_app_id,
                           std::vector<std::string>* modules));
-  MOCK_METHOD2(SetDefaultHmiTypes,
-               void(const std::string& application_id,
-                    const smart_objects::SmartObject* app_types));
   MOCK_METHOD3(SetDefaultHmiTypes,
                void(const transport_manager::DeviceHandle& device_handle,
                     const std::string& application_id,

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_listener.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_listener.h
@@ -55,30 +55,19 @@ namespace custom_str = utils::custom_string;
 
 class MockPolicyListener : public ::policy::PolicyListener {
  public:
-  MOCK_METHOD3(OnPermissionsUpdated,
-               void(const std::string& policy_app_id,
-                    const policy::Permissions& permissions,
-                    const policy::HMILevel& default_hmi));
   MOCK_METHOD4(OnPermissionsUpdated,
                void(const std::string& device_id,
                     const std::string& policy_app_id,
                     const policy::Permissions& permissions,
                     const policy::HMILevel& default_hmi));
-  MOCK_METHOD2(OnPermissionsUpdated,
-               void(const std::string& policy_app_id,
-                    const policy::Permissions& permissions));
   MOCK_METHOD3(OnPermissionsUpdated,
                void(const std::string& device_id,
                     const std::string& policy_app_id,
                     const policy::Permissions& permissions));
-  MOCK_METHOD1(OnPendingPermissionChange,
-               void(const std::string& policy_app_id));
   MOCK_METHOD2(OnPendingPermissionChange,
                void(const std::string& device_id,
                     const std::string& policy_app_id));
   MOCK_METHOD1(OnUpdateStatusChanged, void(const std::string& status));
-  MOCK_METHOD1(OnCurrentDeviceIdUpdateRequired,
-               std::string(const std::string& policy_app_id));
   MOCK_METHOD2(OnCurrentDeviceIdUpdateRequired,
                std::string(const transport_manager::DeviceHandle& device_handle,
                            const std::string& policy_app_id));
@@ -101,8 +90,6 @@ class MockPolicyListener : public ::policy::PolicyListener {
                void(const std::string& policy_app_id,
                     const std::string& auth_token));
   MOCK_METHOD1(OnPTUFinished, void(const bool ptu_result));
-  MOCK_CONST_METHOD2(SendOnAppPermissionsChanged,
-                     void(const policy::AppPermissions&, const std::string&));
   MOCK_CONST_METHOD3(SendOnAppPermissionsChanged,
                      void(const policy::AppPermissions& permissions,
                           const std::string& device_id,

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_listener.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_listener.h
@@ -38,6 +38,7 @@
 #include <vector>
 
 #include "gmock/gmock.h"
+#include "utils/macro.h"
 
 #include "policy/policy_listener.h"
 #include "policy/policy_table/types.h"
@@ -58,14 +59,29 @@ class MockPolicyListener : public ::policy::PolicyListener {
                void(const std::string& policy_app_id,
                     const policy::Permissions& permissions,
                     const policy::HMILevel& default_hmi));
+  MOCK_METHOD4(OnPermissionsUpdated,
+               void(const std::string& device_id,
+                    const std::string& policy_app_id,
+                    const policy::Permissions& permissions,
+                    const policy::HMILevel& default_hmi));
   MOCK_METHOD2(OnPermissionsUpdated,
                void(const std::string& policy_app_id,
                     const policy::Permissions& permissions));
+  MOCK_METHOD3(OnPermissionsUpdated,
+               void(const std::string& device_id,
+                    const std::string& policy_app_id,
+                    const policy::Permissions& permissions));
   MOCK_METHOD1(OnPendingPermissionChange,
                void(const std::string& policy_app_id));
+  MOCK_METHOD2(OnPendingPermissionChange,
+               void(const std::string& device_id,
+                    const std::string& policy_app_id));
   MOCK_METHOD1(OnUpdateStatusChanged, void(const std::string& status));
   MOCK_METHOD1(OnCurrentDeviceIdUpdateRequired,
                std::string(const std::string& policy_app_id));
+  MOCK_METHOD2(OnCurrentDeviceIdUpdateRequired,
+               std::string(const transport_manager::DeviceHandle& device_handle,
+                           const std::string& policy_app_id));
   MOCK_METHOD0(OnSystemInfoUpdateRequired, void());
   MOCK_METHOD1(GetAppName,
                custom_str::CustomString(const std::string& policy_app_id));
@@ -87,8 +103,13 @@ class MockPolicyListener : public ::policy::PolicyListener {
   MOCK_METHOD1(OnPTUFinished, void(const bool ptu_result));
   MOCK_CONST_METHOD2(SendOnAppPermissionsChanged,
                      void(const policy::AppPermissions&, const std::string&));
-  MOCK_METHOD1(GetDevicesIds,
-               std::vector<std::string>(const std::string& policy_app_id));
+  MOCK_CONST_METHOD3(SendOnAppPermissionsChanged,
+                     void(const policy::AppPermissions& permissions,
+                          const std::string& device_id,
+                          const std::string& policy_app_id));
+  MOCK_CONST_METHOD1(
+      GetDevicesIds,
+      std::vector<std::string>(const std::string& policy_app_id));
   MOCK_METHOD3(OnUpdateHMILevel,
                void(const std::string& device_id,
                     const std::string& policy_app_id,

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -74,6 +74,13 @@ class MockPolicyManager : public PolicyManager {
                     const PTString& rpc,
                     const RPCParams& rpc_params,
                     CheckPermissionResult& result));
+  MOCK_METHOD6(CheckPermissions,
+               void(const PTString& device_id,
+                    const PTString& app_id,
+                    const PTString& hmi_level,
+                    const PTString& rpc,
+                    const RPCParams& rpc_params,
+                    CheckPermissionResult& result));
   MOCK_METHOD0(ResetUserConsent, bool());
   MOCK_CONST_METHOD0(GetPolicyTableStatus, std::string());
   MOCK_METHOD1(KmsChanged, void(int kilometers));
@@ -101,6 +108,10 @@ class MockPolicyManager : public PolicyManager {
                void(const std::string& device_id, const bool is_allowed));
   MOCK_METHOD2(ReactOnUserDevConsentForApp,
                bool(const std::string& app_id, bool is_device_allowed));
+  MOCK_METHOD3(ReactOnUserDevConsentForApp,
+               bool(const transport_manager::DeviceHandle& device_handle,
+                    const std::string& app_id,
+                    bool is_device_allowed));
   MOCK_METHOD2(PTUpdatedAt, void(policy::Counters counter, int value));
 
   MOCK_METHOD3(GetInitialAppData,
@@ -120,6 +131,10 @@ class MockPolicyManager : public PolicyManager {
   MOCK_CONST_METHOD2(GetDefaultHmi,
                      bool(const std::string& policy_app_id,
                           std::string* default_hmi));
+  MOCK_CONST_METHOD3(GetDefaultHmi,
+                     bool(const std::string& device_id,
+                          const std::string& policy_app_id,
+                          std::string* default_hmi));
   MOCK_CONST_METHOD2(GetPriority,
                      bool(const std::string& policy_app_id,
                           std::string* priority));
@@ -136,9 +151,16 @@ class MockPolicyManager : public PolicyManager {
            std::vector<policy::FunctionalGroupPermission>& permissions));
   MOCK_METHOD1(GetAppPermissionsChanges,
                policy::AppPermissions(const std::string& policy_app_id));
+  MOCK_METHOD2(GetAppPermissionsChanges,
+               policy::AppPermissions(const std::string& device_id,
+                                      const std::string& policy_app_id));
   MOCK_METHOD1(RemovePendingPermissionChanges, void(const std::string& app_id));
   MOCK_CONST_METHOD1(GetCurrentDeviceId,
                      std::string&(const std::string& policy_app_id));
+  MOCK_CONST_METHOD2(
+      GetCurrentDeviceId,
+      std::string&(const transport_manager::DeviceHandle& device_handle,
+                   const std::string& policy_app_id));
   MOCK_METHOD1(SetSystemLanguage, void(const std::string& language));
   MOCK_METHOD3(SetSystemInfo,
                void(const std::string& ccpu_version,
@@ -146,14 +168,27 @@ class MockPolicyManager : public PolicyManager {
                     const std::string& language));
   MOCK_METHOD1(SendNotificationOnPermissionsUpdated,
                void(const std::string& application_id));
+  MOCK_METHOD2(SendNotificationOnPermissionsUpdated,
+               void(const std::string& device_id,
+                    const std::string& application_id));
   MOCK_METHOD1(MarkUnpairedDevice, void(const std::string& device_id));
   MOCK_METHOD2(
       AddApplication,
       StatusNotifier(
           const std::string& application_id,
           const rpc::policy_table_interface_base::AppHmiTypes& hmi_types));
+  MOCK_METHOD3(
+      AddApplication,
+      StatusNotifier(
+          const std::string& device_id,
+          const std::string& application_id,
+          const rpc::policy_table_interface_base::AppHmiTypes& hmi_types));
   MOCK_METHOD2(SetDefaultHmiTypes,
                void(const std::string& application_id,
+                    const std::vector<int>& hmi_types));
+  MOCK_METHOD3(SetDefaultHmiTypes,
+               void(const transport_manager::DeviceHandle& device_handle,
+                    const std::string& application_id,
                     const std::vector<int>& hmi_types));
   MOCK_METHOD2(GetHMITypes,
                bool(const std::string& application_id,
@@ -183,11 +218,18 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD1(OnAppsSearchCompleted, void(const bool trigger_ptu));
   MOCK_METHOD1(OnAppRegisteredOnMobile,
                void(const std::string& application_id));
+  MOCK_METHOD2(OnAppRegisteredOnMobile,
+               void(const std::string& device_id,
+                    const std::string& application_id));
   MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
   MOCK_CONST_METHOD1(GetIconUrl, std::string(const std::string& policy_app_id));
   MOCK_CONST_METHOD1(
       GetAppRequestTypes,
       const std::vector<std::string>(const std::string policy_app_id));
+  MOCK_CONST_METHOD2(GetAppRequestTypes,
+                     const std::vector<std::string>(
+                         const transport_manager::DeviceHandle& device_handle,
+                         const std::string policy_app_id));
   MOCK_CONST_METHOD0(GetVehicleInfo, const policy::VehicleInfo());
   MOCK_CONST_METHOD1(GetEnabledCloudApps,
                      void(std::vector<std::string>& enabled_apps));

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -68,12 +68,6 @@ class MockPolicyManager : public PolicyManager {
                void(const std::string& service_type,
                     EndpointUrls& out_end_points));
   MOCK_METHOD0(RequestPTUpdate, void());
-  MOCK_METHOD5(CheckPermissions,
-               void(const PTString& app_id,
-                    const PTString& hmi_level,
-                    const PTString& rpc,
-                    const RPCParams& rpc_params,
-                    CheckPermissionResult& result));
   MOCK_METHOD6(CheckPermissions,
                void(const PTString& device_id,
                     const PTString& app_id,
@@ -106,8 +100,6 @@ class MockPolicyManager : public PolicyManager {
            std::vector<policy::FunctionalGroupPermission>& permissions));
   MOCK_METHOD2(SetUserConsentForDevice,
                void(const std::string& device_id, const bool is_allowed));
-  MOCK_METHOD2(ReactOnUserDevConsentForApp,
-               bool(const std::string& app_id, bool is_device_allowed));
   MOCK_METHOD3(ReactOnUserDevConsentForApp,
                bool(const transport_manager::DeviceHandle& device_handle,
                     const std::string& app_id,
@@ -128,9 +120,6 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD2(SetUserConsentForApp,
                void(const policy::PermissionConsent& permissions,
                     const policy::PolicyManager::NotificationMode mode));
-  MOCK_CONST_METHOD2(GetDefaultHmi,
-                     bool(const std::string& policy_app_id,
-                          std::string* default_hmi));
   MOCK_CONST_METHOD3(GetDefaultHmi,
                      bool(const std::string& device_id,
                           const std::string& policy_app_id,
@@ -149,14 +138,10 @@ class MockPolicyManager : public PolicyManager {
       void(const std::string& device_id,
            const std::string& policy_app_id,
            std::vector<policy::FunctionalGroupPermission>& permissions));
-  MOCK_METHOD1(GetAppPermissionsChanges,
-               policy::AppPermissions(const std::string& policy_app_id));
   MOCK_METHOD2(GetAppPermissionsChanges,
                policy::AppPermissions(const std::string& device_id,
                                       const std::string& policy_app_id));
   MOCK_METHOD1(RemovePendingPermissionChanges, void(const std::string& app_id));
-  MOCK_CONST_METHOD1(GetCurrentDeviceId,
-                     std::string&(const std::string& policy_app_id));
   MOCK_CONST_METHOD2(
       GetCurrentDeviceId,
       std::string&(const transport_manager::DeviceHandle& device_handle,
@@ -166,26 +151,16 @@ class MockPolicyManager : public PolicyManager {
                void(const std::string& ccpu_version,
                     const std::string& wers_country_code,
                     const std::string& language));
-  MOCK_METHOD1(SendNotificationOnPermissionsUpdated,
-               void(const std::string& application_id));
   MOCK_METHOD2(SendNotificationOnPermissionsUpdated,
                void(const std::string& device_id,
                     const std::string& application_id));
   MOCK_METHOD1(MarkUnpairedDevice, void(const std::string& device_id));
-  MOCK_METHOD2(
-      AddApplication,
-      StatusNotifier(
-          const std::string& application_id,
-          const rpc::policy_table_interface_base::AppHmiTypes& hmi_types));
   MOCK_METHOD3(
       AddApplication,
       StatusNotifier(
           const std::string& device_id,
           const std::string& application_id,
           const rpc::policy_table_interface_base::AppHmiTypes& hmi_types));
-  MOCK_METHOD2(SetDefaultHmiTypes,
-               void(const std::string& application_id,
-                    const std::vector<int>& hmi_types));
   MOCK_METHOD3(SetDefaultHmiTypes,
                void(const transport_manager::DeviceHandle& device_handle,
                     const std::string& application_id,
@@ -216,16 +191,11 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD1(SaveUpdateStatusRequired, void(bool is_update_needed));
   MOCK_METHOD0(OnAppsSearchStarted, void());
   MOCK_METHOD1(OnAppsSearchCompleted, void(const bool trigger_ptu));
-  MOCK_METHOD1(OnAppRegisteredOnMobile,
-               void(const std::string& application_id));
   MOCK_METHOD2(OnAppRegisteredOnMobile,
                void(const std::string& device_id,
                     const std::string& application_id));
   MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
   MOCK_CONST_METHOD1(GetIconUrl, std::string(const std::string& policy_app_id));
-  MOCK_CONST_METHOD1(
-      GetAppRequestTypes,
-      const std::vector<std::string>(const std::string policy_app_id));
   MOCK_CONST_METHOD2(GetAppRequestTypes,
                      const std::vector<std::string>(
                          const transport_manager::DeviceHandle& device_handle,

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_listener.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_listener.h
@@ -35,6 +35,7 @@
 #include <string>
 
 #include "gmock/gmock.h"
+#include "utils/macro.h"
 
 #include "policy/policy_listener.h"
 #include "policy/policy_table/types.h"
@@ -51,18 +52,33 @@ namespace custom_str = utils::custom_string;
 
 class MockPolicyListener : public ::policy::PolicyListener {
  public:
+  MOCK_METHOD2(OnPermissionsUpdated,
+               void(const std::string& policy_app_id,
+                    const policy::Permissions& permissions));
   MOCK_METHOD3(OnPermissionsUpdated,
                void(const std::string& policy_app_id,
                     const policy::Permissions& permissions,
                     const policy::HMILevel& default_hmi));
-  MOCK_METHOD2(OnPermissionsUpdated,
-               void(const std::string& policy_app_id,
+  MOCK_METHOD3(OnPermissionsUpdated,
+               void(const std::string& device_id,
+                    const std::string& policy_app_id,
                     const policy::Permissions& permissions));
+  MOCK_METHOD4(OnPermissionsUpdated,
+               void(const std::string& device_id,
+                    const std::string& policy_app_id,
+                    const policy::Permissions& permissions,
+                    const policy::HMILevel& default_hmi));
   MOCK_METHOD1(OnPendingPermissionChange,
                void(const std::string& policy_app_id));
+  MOCK_METHOD2(OnPendingPermissionChange,
+               void(const std::string& device_id,
+                    const std::string& policy_app_id));
   MOCK_METHOD1(OnUpdateStatusChanged, void(const std::string& status));
   MOCK_METHOD1(OnCurrentDeviceIdUpdateRequired,
                std::string(const std::string& policy_app_id));
+  MOCK_METHOD2(OnCurrentDeviceIdUpdateRequired,
+               std::string(const transport_manager::DeviceHandle& device_handle,
+                           const std::string& policy_app_id));
   MOCK_METHOD0(OnSystemInfoUpdateRequired, void());
   MOCK_METHOD1(GetAppName,
                custom_str::CustomString(const std::string& policy_app_id));
@@ -80,12 +96,17 @@ class MockPolicyListener : public ::policy::PolicyListener {
                     const std::string& auth_token));
   MOCK_CONST_METHOD2(SendOnAppPermissionsChanged,
                      void(const policy::AppPermissions&, const std::string&));
+  MOCK_CONST_METHOD3(SendOnAppPermissionsChanged,
+                     void(const policy::AppPermissions& permissions,
+                          const std::string& device_id,
+                          const std::string& policy_app_id));
   MOCK_METHOD3(OnUpdateHMILevel,
                void(const std::string& device_id,
                     const std::string& policy_app_id,
                     const std::string& hmi_level));
-  MOCK_METHOD1(GetDevicesIds,
-               std::vector<std::string>(const std::string& policy_app_id));
+  MOCK_CONST_METHOD1(
+      GetDevicesIds,
+      std::vector<std::string>(const std::string& policy_app_id));
   MOCK_CONST_METHOD1(GetRegisteredLinks,
                      void(std::map<std::string, std::string>&));
   MOCK_METHOD1(OnRemoteAllowedChanged, void(bool new_consent));

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_listener.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_listener.h
@@ -52,13 +52,6 @@ namespace custom_str = utils::custom_string;
 
 class MockPolicyListener : public ::policy::PolicyListener {
  public:
-  MOCK_METHOD2(OnPermissionsUpdated,
-               void(const std::string& policy_app_id,
-                    const policy::Permissions& permissions));
-  MOCK_METHOD3(OnPermissionsUpdated,
-               void(const std::string& policy_app_id,
-                    const policy::Permissions& permissions,
-                    const policy::HMILevel& default_hmi));
   MOCK_METHOD3(OnPermissionsUpdated,
                void(const std::string& device_id,
                     const std::string& policy_app_id,
@@ -68,14 +61,10 @@ class MockPolicyListener : public ::policy::PolicyListener {
                     const std::string& policy_app_id,
                     const policy::Permissions& permissions,
                     const policy::HMILevel& default_hmi));
-  MOCK_METHOD1(OnPendingPermissionChange,
-               void(const std::string& policy_app_id));
   MOCK_METHOD2(OnPendingPermissionChange,
                void(const std::string& device_id,
                     const std::string& policy_app_id));
   MOCK_METHOD1(OnUpdateStatusChanged, void(const std::string& status));
-  MOCK_METHOD1(OnCurrentDeviceIdUpdateRequired,
-               std::string(const std::string& policy_app_id));
   MOCK_METHOD2(OnCurrentDeviceIdUpdateRequired,
                std::string(const transport_manager::DeviceHandle& device_handle,
                            const std::string& policy_app_id));
@@ -94,8 +83,6 @@ class MockPolicyListener : public ::policy::PolicyListener {
   MOCK_METHOD2(OnAuthTokenUpdated,
                void(const std::string& policy_app_id,
                     const std::string& auth_token));
-  MOCK_CONST_METHOD2(SendOnAppPermissionsChanged,
-                     void(const policy::AppPermissions&, const std::string&));
   MOCK_CONST_METHOD3(SendOnAppPermissionsChanged,
                      void(const policy::AppPermissions& permissions,
                           const std::string& device_id,

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -102,6 +102,10 @@ class MockPolicyManager : public PolicyManager {
                void(const std::string& device_id, const bool is_allowed));
   MOCK_METHOD2(ReactOnUserDevConsentForApp,
                bool(const std::string app_id, bool is_device_allowed));
+  MOCK_METHOD3(ReactOnUserDevConsentForApp,
+               bool(const transport_manager::DeviceHandle& device_handle,
+                    const std::string app_id,
+                    bool is_device_allowed));
   MOCK_METHOD2(PTUpdatedAt, void(policy::Counters counter, int value));
 
   MOCK_METHOD3(GetInitialAppData,
@@ -120,6 +124,10 @@ class MockPolicyManager : public PolicyManager {
   MOCK_CONST_METHOD2(GetDefaultHmi,
                      bool(const std::string& policy_app_id,
                           std::string* default_hmi));
+  MOCK_CONST_METHOD3(GetDefaultHmi,
+                     bool(const std::string& device_id,
+                          const std::string& policy_app_id,
+                          std::string* default_hmi));
   MOCK_CONST_METHOD2(GetPriority,
                      bool(const std::string& policy_app_id,
                           std::string* priority));
@@ -135,9 +143,16 @@ class MockPolicyManager : public PolicyManager {
            std::vector<policy::FunctionalGroupPermission>& permissions));
   MOCK_METHOD1(GetAppPermissionsChanges,
                policy::AppPermissions(const std::string& policy_app_id));
+  MOCK_METHOD2(GetAppPermissionsChanges,
+               policy::AppPermissions(const std::string& device_id,
+                                      const std::string& policy_app_id));
   MOCK_METHOD1(RemovePendingPermissionChanges, void(const std::string& app_id));
   MOCK_CONST_METHOD1(GetCurrentDeviceId,
                      std::string&(const std::string& policy_app_id));
+  MOCK_CONST_METHOD2(
+      GetCurrentDeviceId,
+      std::string&(const transport_manager::DeviceHandle& device_handle,
+                   const std::string& policy_app_id));
   MOCK_METHOD1(SetSystemLanguage, void(const std::string& language));
   MOCK_METHOD3(SetSystemInfo,
                void(const std::string& ccpu_version,
@@ -145,14 +160,27 @@ class MockPolicyManager : public PolicyManager {
                     const std::string& language));
   MOCK_METHOD1(SendNotificationOnPermissionsUpdated,
                void(const std::string& application_id));
+  MOCK_METHOD2(SendNotificationOnPermissionsUpdated,
+               void(const std::string& device_id,
+                    const std::string& application_id));
   MOCK_METHOD1(MarkUnpairedDevice, void(const std::string& device_id));
   MOCK_METHOD2(
       AddApplication,
       StatusNotifier(
           const std::string& application_id,
           const rpc::policy_table_interface_base::AppHmiTypes& hmi_types));
+  MOCK_METHOD3(
+      AddApplication,
+      StatusNotifier(
+          const std::string& device_id,
+          const std::string& application_id,
+          const rpc::policy_table_interface_base::AppHmiTypes& hmi_types));
   MOCK_METHOD2(SetDefaultHmiTypes,
                void(const std::string& application_id,
+                    const std::vector<int>& hmi_types));
+  MOCK_METHOD3(SetDefaultHmiTypes,
+               void(const transport_manager::DeviceHandle& device_handle,
+                    const std::string& application_id,
                     const std::vector<int>& hmi_types));
   MOCK_METHOD2(GetHMITypes,
                bool(const std::string& application_id,
@@ -181,6 +209,9 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD1(OnAppsSearchCompleted, void(const bool trigger_ptu));
   MOCK_METHOD1(OnAppRegisteredOnMobile,
                void(const std::string& application_id));
+  MOCK_METHOD2(OnAppRegisteredOnMobile,
+               void(const std::string& device_id,
+                    const std::string& application_id));
   MOCK_CONST_METHOD1(
       GetAppRequestTypes,
       const std::vector<std::string>(const std::string policy_app_id));

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -100,8 +100,6 @@ class MockPolicyManager : public PolicyManager {
            std::vector<policy::FunctionalGroupPermission>& permissions));
   MOCK_METHOD2(SetUserConsentForDevice,
                void(const std::string& device_id, const bool is_allowed));
-  MOCK_METHOD2(ReactOnUserDevConsentForApp,
-               bool(const std::string app_id, bool is_device_allowed));
   MOCK_METHOD3(ReactOnUserDevConsentForApp,
                bool(const transport_manager::DeviceHandle& device_handle,
                     const std::string app_id,
@@ -121,9 +119,6 @@ class MockPolicyManager : public PolicyManager {
                     const policy::DeviceInfo& device_info));
   MOCK_METHOD1(SetUserConsentForApp,
                void(const policy::PermissionConsent& permissions));
-  MOCK_CONST_METHOD2(GetDefaultHmi,
-                     bool(const std::string& policy_app_id,
-                          std::string* default_hmi));
   MOCK_CONST_METHOD3(GetDefaultHmi,
                      bool(const std::string& device_id,
                           const std::string& policy_app_id,
@@ -141,14 +136,10 @@ class MockPolicyManager : public PolicyManager {
       void(const std::string& device_id,
            const std::string& policy_app_id,
            std::vector<policy::FunctionalGroupPermission>& permissions));
-  MOCK_METHOD1(GetAppPermissionsChanges,
-               policy::AppPermissions(const std::string& policy_app_id));
   MOCK_METHOD2(GetAppPermissionsChanges,
                policy::AppPermissions(const std::string& device_id,
                                       const std::string& policy_app_id));
   MOCK_METHOD1(RemovePendingPermissionChanges, void(const std::string& app_id));
-  MOCK_CONST_METHOD1(GetCurrentDeviceId,
-                     std::string&(const std::string& policy_app_id));
   MOCK_CONST_METHOD2(
       GetCurrentDeviceId,
       std::string&(const transport_manager::DeviceHandle& device_handle,
@@ -158,26 +149,16 @@ class MockPolicyManager : public PolicyManager {
                void(const std::string& ccpu_version,
                     const std::string& wers_country_code,
                     const std::string& language));
-  MOCK_METHOD1(SendNotificationOnPermissionsUpdated,
-               void(const std::string& application_id));
   MOCK_METHOD2(SendNotificationOnPermissionsUpdated,
                void(const std::string& device_id,
                     const std::string& application_id));
   MOCK_METHOD1(MarkUnpairedDevice, void(const std::string& device_id));
-  MOCK_METHOD2(
-      AddApplication,
-      StatusNotifier(
-          const std::string& application_id,
-          const rpc::policy_table_interface_base::AppHmiTypes& hmi_types));
   MOCK_METHOD3(
       AddApplication,
       StatusNotifier(
           const std::string& device_id,
           const std::string& application_id,
           const rpc::policy_table_interface_base::AppHmiTypes& hmi_types));
-  MOCK_METHOD2(SetDefaultHmiTypes,
-               void(const std::string& application_id,
-                    const std::vector<int>& hmi_types));
   MOCK_METHOD3(SetDefaultHmiTypes,
                void(const transport_manager::DeviceHandle& device_handle,
                     const std::string& application_id,
@@ -207,8 +188,6 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD1(SaveUpdateStatusRequired, void(bool is_update_needed));
   MOCK_METHOD0(OnAppsSearchStarted, void());
   MOCK_METHOD1(OnAppsSearchCompleted, void(const bool trigger_ptu));
-  MOCK_METHOD1(OnAppRegisteredOnMobile,
-               void(const std::string& application_id));
   MOCK_METHOD2(OnAppRegisteredOnMobile,
                void(const std::string& device_id,
                     const std::string& application_id));

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -4077,7 +4077,7 @@
       <param name="vrSynonyms" type="String" maxlength="40" minsize="1" maxsize="100" array="true" mandatory="false">
         <description>
           Defines an additional voice recognition command.
-          Must not interfere with any name of previously registered applications(SDL makes check).
+          Must not interfere with any name of previously registered applications from the same device.
         </description>
       </param>
       <param name="resumeVrGrammars" type="Boolean" mandatory="false">
@@ -4462,7 +4462,7 @@
       <description>
         Request new VR synonyms registration
         Defines an additional voice recognition command.
-        Must not interfere with any name of previously registered applications(SDL makes check).
+        Must not interfere with any name of previously registered applications from the same device.
       </description>
     </param>
     <param name="language" type="Common.Language" mandatory="true">

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -2665,7 +2665,7 @@
     <param name="vrSynonyms" type="String" maxlength="40" minsize="1" maxsize="100" array="true" mandatory="false">
       <description>
         Defines an additional voice recognition command.
-        Must not interfere with any name of previously registered applications(SDL makes check).
+        Must not interfere with any name of previously registered applications from the same device.
       </description>
     </param>
     <param name="appID" type="Integer" mandatory="true">
@@ -4932,10 +4932,10 @@
     <param name="appName" type="String" maxlength="100" mandatory="false">
       <description>
         Request new app name registration
-        Needs to be unique over all applications.
+        Needs to be unique over all applications from the same device.
         May not be empty. May not start with a new line character.
-        May not interfere with any name or synonym of any registered applications.
-        Applications with the same name will be rejected. (SDL makes all the checks)
+        May not interfere with any name or synonym of any registered applications from the same device.
+        Additional applications with the same name from the same device will be rejected.
       </description>
     </param>
     <param name="ngnMediaScreenAppName" type="String" maxlength="100" mandatory="false">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -4235,11 +4235,11 @@
         <param name="appName" type="String" maxlength="100" mandatory="true" since="1.0">
             <description>
                 The mobile application name, e.g. "Ford Drive Green".
-                Needs to be unique over all applications.
+                Needs to be unique over all applications from the same device.
                 May not be empty.
                 May not start with a new line character.
-                May not interfere with any name or synonym of previously registered applications and any predefined blacklist of words (global commands)
-                Needs to be unique over all applications. Applications with the same name will be rejected.
+                May not interfere with any name or synonym of previously registered applications from the same device and any predefined blacklist of words (global commands)
+                Additional applications with the same name from the same device will be rejected.
                 Only characters from char set [@TODO: Create char set (character/hex value) for each ACM and refer to] are supported.
             </description>
         </param>
@@ -4248,7 +4248,7 @@
             <description>
                 TTS string for VR recognition of the mobile application name, e.g. "Ford Drive Green".
                 Meant to overcome any failing on speech engine in properly pronouncing / understanding app name.
-                Needs to be unique over all applications.
+                Needs to be unique over all applications from the same device.
                 May not be empty.
                 May not start with a new line character.
                 Only characters from char set [@TODO: Create char set (character/hex value) for each ACM and refer to] are supported.
@@ -4266,7 +4266,7 @@
         <param name="vrSynonyms" type="String" maxlength="40" minsize="1" maxsize="100" array="true" mandatory="false" since="1.0">
             <description>
                 Defines an additional voice recognition command.
-                May not interfere with any app name of previously registered applications and any predefined blacklist of words (global commands)
+                May not interfere with any app name of previously registered applications from the same device and any predefined blacklist of words (global commands)
                 Only characters from char set [@TODO: Create char set (character/hex value) for each ACM and refer to] are supported.
             </description>
         </param>

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -423,10 +423,11 @@ class PolicyManagerImpl : public PolicyManager {
 
   /**
    * @brief Send OnPermissionsUpdated for choosen application
+   * @param device_id device identifier
    * @param application_id Unique application id
    */
   void SendNotificationOnPermissionsUpdated(
-      const std::string& application_id) OVERRIDE;
+      const std::string& device_id, const std::string& application_id) OVERRIDE;
 
   /**
    * @brief Removes unpaired device records and related records from DB
@@ -687,12 +688,26 @@ class PolicyManagerImpl : public PolicyManager {
       const std::string& policy_app_id) const OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
-   * It will send OnAppPermissionSend notification and will try to start PTU. *
+   * It will send OnAppPermissionSend notification and will try to start PTU.
+   *
    * @param application_id registered application.
    */
-  void OnAppRegisteredOnMobile(const std::string& application_id) OVERRIDE;
+  DEPRECATED void OnAppRegisteredOnMobile(
+      const std::string& application_id) OVERRIDE;
+
+  /**
+   * @brief OnAppRegisteredOnMobile allows to handle event when application were
+   * succesfully registered on mobile device.
+   * It will send OnAppPermissionSend notification and will try to start PTU.
+   *
+   * @param device_id device identifier
+   * @param application_id registered application.
+   */
+  void OnAppRegisteredOnMobile(const std::string& device_id,
+                               const std::string& application_id) OVERRIDE;
 
   void OnDeviceSwitching(const std::string& device_id_from,
                          const std::string& device_id_to) OVERRIDE;
@@ -837,6 +852,14 @@ class PolicyManagerImpl : public PolicyManager {
       const BinaryMessage& pt_content);
 
  private:
+  /**
+   * DEPRECATED
+   * @brief Send OnPermissionsUpdated for choosen application
+   * @param application_id Unique application id
+   */
+  void SendNotificationOnPermissionsUpdated(
+      const std::string& application_id) OVERRIDE;
+
   /**
    * @brief Checks if PT update should be started and schedules it if needed
    */
@@ -1036,11 +1059,13 @@ class PolicyManagerImpl : public PolicyManager {
   /**
    * @brief Notify application about its permissions changes by preparing and
    * sending OnPermissionsChanged notification
+   * @param device_id device identifier
    * @param policy_app_id Application id to send notification to
    * @param app_group_permissons Current permissions for groups assigned to
    * application
    */
   void NotifyPermissionsChanges(
+      const std::string& device_id,
       const std::string& policy_app_id,
       const std::vector<FunctionalGroupPermission>& app_group_permissions);
 

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -119,24 +119,6 @@ class PolicyManagerImpl : public PolicyManager {
   void RequestPTUpdate() OVERRIDE;
 
   /**
-   * DEPRECATED
-   * @brief Check if specified RPC for specified application
-   * has permission to be executed in specified HMI Level
-   * and also its permitted params.
-   * @param app_id Id of application provided during registration
-   * @param hmi_level Current HMI Level of application
-   * @param rpc Name of RPC
-   * @param rpc_params List of RPC params
-   * @param result containing flag if HMI Level is allowed
-   * and list of allowed params.
-   */
-  DEPRECATED void CheckPermissions(const PTString& app_id,
-                                   const PTString& hmi_level,
-                                   const PTString& rpc,
-                                   const RPCParams& rpc_params,
-                                   CheckPermissionResult& result) OVERRIDE;
-
-  /**
    * @brief Check if specified RPC for specified application
    * has permission to be executed in specified HMI Level
    * and also its permitted params.
@@ -285,17 +267,6 @@ class PolicyManagerImpl : public PolicyManager {
                                const bool is_allowed) OVERRIDE;
 
   /**
-   * DEPRECATED
-   * @brief Update Application Policies as reaction
-   * on User allowing/disallowing device this app is running on.
-   * @param app_id Unique application id
-   * @param is_device_allowed true if user allowing device otherwise false
-   * @return true if operation was successful
-   */
-  DEPRECATED bool ReactOnUserDevConsentForApp(
-      const std::string& app_id, const bool is_device_allowed) OVERRIDE;
-
-  /**
    * @brief Update Application Policies as reaction
    * on User allowing/disallowing device this app is running on.
    * @param device_handle device identifier
@@ -346,17 +317,6 @@ class PolicyManagerImpl : public PolicyManager {
    */
   void SetUserConsentForApp(const PermissionConsent& permissions,
                             const NotificationMode mode) OVERRIDE;
-
-  /**
-   * DEPRECATED
-   * @brief Get default HMI level for application
-   * @param policy_app_id Unique application id
-   * @param default_hmi Default HMI level for application or empty, if value
-   * was not set
-   * @return true, if succedeed, otherwise - false
-   */
-  DEPRECATED bool GetDefaultHmi(const std::string& policy_app_id,
-                                std::string* default_hmi) const OVERRIDE;
 
   /**
    * @brief Get default HMI level for application
@@ -456,16 +416,6 @@ class PolicyManagerImpl : public PolicyManager {
   void SetVINValue(const std::string& value) OVERRIDE;
 
   /**
-   * DEPRECATED
-   * @brief Gets specific application permissions changes since last policy
-   * table update
-   * @param policy_app_id Unique application id
-   * @return Permissions changes
-   */
-  DEPRECATED AppPermissions
-  GetAppPermissionsChanges(const std::string& policy_app_id) OVERRIDE;
-
-  /**
    * @brief Gets specific application permissions changes since last policy
    * table update
    * @param device_id device identifier
@@ -516,18 +466,6 @@ class PolicyManagerImpl : public PolicyManager {
   void MarkUnpairedDevice(const std::string& device_id) OVERRIDE;
 
   /**
-   * DEPRECATED
-   * @brief Adds, application to the db or update existed one
-   * run PTU if policy update is necessary for application.
-   * @param application_id Unique application id
-   * @param hmi_types application HMI types
-   * @return function that will notify update manager about new application
-   */
-  DEPRECATED StatusNotifier AddApplication(
-      const std::string& application_id,
-      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) OVERRIDE;
-
-  /**
    * @brief Adds, application to the db or update existed one
    * run PTU if policy update is necessary for application.
    * @param device_id device identifier
@@ -539,16 +477,6 @@ class PolicyManagerImpl : public PolicyManager {
       const std::string& device_id,
       const std::string& application_id,
       const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) OVERRIDE;
-
-  /**
-   * DEPRECATED
-   * @brief Assigns new HMI types for specified application
-   * @param application_id Unique application id
-   * @param hmi_types new HMI types list
-   */
-  DEPRECATED void SetDefaultHmiTypes(
-      const std::string& application_id,
-      const std::vector<int>& hmi_types) OVERRIDE;
 
   /**
    * @brief Assigns new HMI types for specified application
@@ -776,17 +704,6 @@ class PolicyManagerImpl : public PolicyManager {
       const std::string& policy_app_id) const OVERRIDE;
 
   /**
-   * DEPRECATED
-   * @brief OnAppRegisteredOnMobile allows to handle event when application were
-   * succesfully registered on mobile device.
-   * It will send OnAppPermissionSend notification and will try to start PTU.
-   *
-   * @param application_id registered application.
-   */
-  DEPRECATED void OnAppRegisteredOnMobile(
-      const std::string& application_id) OVERRIDE;
-
-  /**
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
    * It will send OnAppPermissionSend notification and will try to start PTU.
@@ -940,31 +857,6 @@ class PolicyManagerImpl : public PolicyManager {
       const BinaryMessage& pt_content);
 
  private:
-  /**
-   * DEPRECATED
-   * @brief Gets request types for application
-   * @param policy_app_id Unique application id
-   * @return request types of application
-   */
-  const std::vector<std::string> GetAppRequestTypes(
-      const std::string policy_app_id) const OVERRIDE;
-
-  /**
-   * DEPRECATED
-   * @brief Return device id, which hosts specific application
-   * @param policy_app_id Application id, which is required to update device id
-   */
-  std::string& GetCurrentDeviceId(
-      const std::string& policy_app_id) const OVERRIDE;
-
-  /**
-   * DEPRECATED
-   * @brief Send OnPermissionsUpdated for choosen application
-   * @param application_id Unique application id
-   */
-  void SendNotificationOnPermissionsUpdated(
-      const std::string& application_id) OVERRIDE;
-
   /**
    * @brief Checks if PT update should be started and schedules it if needed
    */

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -119,6 +119,7 @@ class PolicyManagerImpl : public PolicyManager {
   void RequestPTUpdate() OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief Check if specified RPC for specified application
    * has permission to be executed in specified HMI Level
    * and also its permitted params.
@@ -129,7 +130,26 @@ class PolicyManagerImpl : public PolicyManager {
    * @param result containing flag if HMI Level is allowed
    * and list of allowed params.
    */
-  void CheckPermissions(const PTString& app_id,
+  DEPRECATED void CheckPermissions(const PTString& app_id,
+                                   const PTString& hmi_level,
+                                   const PTString& rpc,
+                                   const RPCParams& rpc_params,
+                                   CheckPermissionResult& result) OVERRIDE;
+
+  /**
+   * @brief Check if specified RPC for specified application
+   * has permission to be executed in specified HMI Level
+   * and also its permitted params.
+   * @param device_id device identifier
+   * @param app_id Id of application provided during registration
+   * @param hmi_level Current HMI Level of application
+   * @param rpc Name of RPC
+   * @param rpc_params List of RPC params
+   * @param result containing flag if HMI Level is allowed
+   * and list of allowed params.
+   */
+  void CheckPermissions(const PTString& device_id,
+                        const PTString& app_id,
                         const PTString& hmi_level,
                         const PTString& rpc,
                         const RPCParams& rpc_params,
@@ -265,14 +285,28 @@ class PolicyManagerImpl : public PolicyManager {
                                const bool is_allowed) OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief Update Application Policies as reaction
    * on User allowing/disallowing device this app is running on.
    * @param app_id Unique application id
    * @param is_device_allowed true if user allowing device otherwise false
    * @return true if operation was successful
    */
-  bool ReactOnUserDevConsentForApp(const std::string& app_id,
-                                   const bool is_device_allowed) OVERRIDE;
+  DEPRECATED bool ReactOnUserDevConsentForApp(
+      const std::string& app_id, const bool is_device_allowed) OVERRIDE;
+
+  /**
+   * @brief Update Application Policies as reaction
+   * on User allowing/disallowing device this app is running on.
+   * @param device_handle device identifier
+   * @param app_id Unique application id
+   * @param is_device_allowed true if user allowing device otherwise false
+   * @return true if operation was successful
+   */
+  bool ReactOnUserDevConsentForApp(
+      const transport_manager::DeviceHandle& device_handle,
+      const std::string& app_id,
+      const bool is_device_allowed) OVERRIDE;
 
   /**
    * @brief Retrieves data from app_policies about app on its registration:
@@ -314,13 +348,26 @@ class PolicyManagerImpl : public PolicyManager {
                             const NotificationMode mode) OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief Get default HMI level for application
    * @param policy_app_id Unique application id
    * @param default_hmi Default HMI level for application or empty, if value
    * was not set
    * @return true, if succedeed, otherwise - false
    */
-  bool GetDefaultHmi(const std::string& policy_app_id,
+  DEPRECATED bool GetDefaultHmi(const std::string& policy_app_id,
+                                std::string* default_hmi) const OVERRIDE;
+
+  /**
+   * @brief Get default HMI level for application
+   * @param device_id device identifier
+   * @param policy_app_id Unique application id
+   * @param default_hmi Default HMI level for application or empty, if value
+   * was not set
+   * @return true, if succedeed, otherwise - false
+   */
+  bool GetDefaultHmi(const std::string& device_id,
+                     const std::string& policy_app_id,
                      std::string* default_hmi) const OVERRIDE;
 
   /**
@@ -365,9 +412,11 @@ class PolicyManagerImpl : public PolicyManager {
 
   /**
    * @brief Return device id, which hosts specific application
+   * @param device_id device identifier
    * @param policy_app_id Application id, which is required to update device id
    */
   std::string& GetCurrentDeviceId(
+      const transport_manager::DeviceHandle& device_id,
       const std::string& policy_app_id) const OVERRIDE;
 
   /**
@@ -407,13 +456,24 @@ class PolicyManagerImpl : public PolicyManager {
   void SetVINValue(const std::string& value) OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief Gets specific application permissions changes since last policy
    * table update
    * @param policy_app_id Unique application id
    * @return Permissions changes
    */
+  DEPRECATED AppPermissions
+  GetAppPermissionsChanges(const std::string& policy_app_id) OVERRIDE;
+
+  /**
+   * @brief Gets specific application permissions changes since last policy
+   * table update
+   * @param device_id device identifier
+   * @param policy_app_id Unique application id
+   * @return Permissions changes
+   */
   AppPermissions GetAppPermissionsChanges(
-      const std::string& policy_app_id) OVERRIDE;
+      const std::string& device_id, const std::string& policy_app_id) OVERRIDE;
 
   /**
    * @brief Removes specific application permissions changes
@@ -456,22 +516,48 @@ class PolicyManagerImpl : public PolicyManager {
   void MarkUnpairedDevice(const std::string& device_id) OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief Adds, application to the db or update existed one
    * run PTU if policy update is necessary for application.
    * @param application_id Unique application id
    * @param hmi_types application HMI types
    * @return function that will notify update manager about new application
    */
-  StatusNotifier AddApplication(
+  DEPRECATED StatusNotifier AddApplication(
       const std::string& application_id,
       const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) OVERRIDE;
 
   /**
+   * @brief Adds, application to the db or update existed one
+   * run PTU if policy update is necessary for application.
+   * @param device_id device identifier
+   * @param application_id Unique application id
+   * @param hmi_types application HMI types
+   * @return function that will notify update manager about new application
+   */
+  StatusNotifier AddApplication(
+      const std::string& device_id,
+      const std::string& application_id,
+      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) OVERRIDE;
+
+  /**
+   * DEPRECATED
    * @brief Assigns new HMI types for specified application
    * @param application_id Unique application id
    * @param hmi_types new HMI types list
    */
-  void SetDefaultHmiTypes(const std::string& application_id,
+  DEPRECATED void SetDefaultHmiTypes(
+      const std::string& application_id,
+      const std::vector<int>& hmi_types) OVERRIDE;
+
+  /**
+   * @brief Assigns new HMI types for specified application
+   * @param device_handle device identifier
+   * @param application_id Unique application id
+   * @param hmi_types new HMI types list
+   */
+  void SetDefaultHmiTypes(const transport_manager::DeviceHandle& device_handle,
+                          const std::string& application_id,
                           const std::vector<int>& hmi_types) OVERRIDE;
 
   /**
@@ -565,10 +651,12 @@ class PolicyManagerImpl : public PolicyManager {
 
   /**
    * @brief Gets request types for application
+   * @param device_handle device identifier
    * @param policy_app_id Unique application id
    * @return request types of application
    */
   const std::vector<std::string> GetAppRequestTypes(
+      const transport_manager::DeviceHandle& device_handle,
       const std::string policy_app_id) const OVERRIDE;
 
   /**
@@ -854,6 +942,23 @@ class PolicyManagerImpl : public PolicyManager {
  private:
   /**
    * DEPRECATED
+   * @brief Gets request types for application
+   * @param policy_app_id Unique application id
+   * @return request types of application
+   */
+  const std::vector<std::string> GetAppRequestTypes(
+      const std::string policy_app_id) const OVERRIDE;
+
+  /**
+   * DEPRECATED
+   * @brief Return device id, which hosts specific application
+   * @param policy_app_id Application id, which is required to update device id
+   */
+  std::string& GetCurrentDeviceId(
+      const std::string& policy_app_id) const OVERRIDE;
+
+  /**
+   * DEPRECATED
    * @brief Send OnPermissionsUpdated for choosen application
    * @param application_id Unique application id
    */
@@ -941,19 +1046,23 @@ class PolicyManagerImpl : public PolicyManager {
   /**
    * @brief Allows to process case when added application is not present in
    * policy db.
+   * @param device_id device identifier
    * @param policy application id.
    * @param cuuren consent for application's device.
    */
-  void AddNewApplication(const std::string& application_id,
+  void AddNewApplication(const std::string& device_id,
+                         const std::string& application_id,
                          DeviceConsent device_consent);
 
   /**
    * @brief Allows to process case when added application is already
    * in policy db.
+   * @param device_id device identifier
    * @param policy application id.
    * @param cuuren consent for application's device.
    */
-  void PromoteExistedApplication(const std::string& application_id,
+  void PromoteExistedApplication(const std::string& device_id,
+                                 const std::string& application_id,
                                  DeviceConsent device_consent);
 
   /**
@@ -971,9 +1080,12 @@ class PolicyManagerImpl : public PolicyManager {
 
   /**
    * @brief Checks whether need ask the permission of users
+   * @param device_id device identifier
+   * @param appid policy application id
    * @return true if user consent is needed
    */
-  virtual bool IsConsentNeeded(const std::string& app_id);
+  virtual bool IsConsentNeeded(const std::string& device_id,
+                               const std::string& app_id);
 
   /**
    * @brief Changes isConsentNeeded for app pending permissions, in case
@@ -1090,11 +1202,13 @@ class PolicyManagerImpl : public PolicyManager {
    * user consents (if any) and ExternalConsent consents (if any) will be
    * updated
    * appropiately to current ExternalConsent status stored by policy table
+   * @param device_id device identifier
    * @param application_id Application id
    * @param processing_policy Defines whether consents timestamps must be
    * considered or external consents take over
    */
   void ProcessExternalConsentStatusForApp(
+      const std::string& device_id,
       const std::string& application_id,
       const ConsentProcessingPolicy processing_policy);
   /**
@@ -1122,16 +1236,20 @@ class PolicyManagerImpl : public PolicyManager {
 
   /**
    * @brief Notifies system by sending OnAppPermissionChanged notification
+   * @param device_id device identifier
    * @param app_policy Reference to application policy
    */
-  void NotifySystem(const AppPoliciesValueType& app_policy) const;
+  void NotifySystem(const std::string& device_id,
+                    const AppPoliciesValueType& app_policy) const;
 
   /**
    * @brief Sends OnPermissionChange notification to application if its
    * currently registered
+   * @param device_id device identifier
    * @param app_policy Reference to application policy
    */
-  void SendPermissionsToApp(const AppPoliciesValueType& app_policy);
+  void SendPermissionsToApp(const std::string& device_id,
+                            const AppPoliciesValueType& app_policy);
 
   /**
    * @brief Gets groups names from collection of groups permissions

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -341,8 +341,10 @@ TEST_F(PolicyManagerImplTest, MarkUnpairedDevice) {
 
 TEST_F(PolicyManagerImplTest2, GetCurrentDeviceId) {
   // Arrange
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_)).Times(1);
-  EXPECT_EQ("", policy_manager_->GetCurrentDeviceId(app_id_2_));
+  const transport_manager::DeviceHandle handle = 1;
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(handle, app_id_2_))
+      .Times(1);
+  EXPECT_EQ("", policy_manager_->GetCurrentDeviceId(handle, app_id_2_));
 }
 
 TEST_F(PolicyManagerImplTest2, UpdateApplication_AppServices) {
@@ -424,7 +426,7 @@ TEST_F(
   status.insert(ExternalConsentStatusItem(type_2_, id_2_, kStatusOn));
   status.insert(ExternalConsentStatusItem(type_3_, id_3_, kStatusOn));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _));
+  EXPECT_CALL(listener_, OnPermissionsUpdated(device_id_1_, app_id_1_, _));
 
   EXPECT_TRUE(policy_manager_->SetExternalConsentStatus(status));
 
@@ -473,7 +475,7 @@ TEST_F(
   status.insert(ExternalConsentStatusItem(type_2_, id_2_, kStatusOn));
   status.insert(ExternalConsentStatusItem(type_3_, id_3_, kStatusOn));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _));
+  EXPECT_CALL(listener_, OnPermissionsUpdated(device_id_1_, app_id_1_, _));
 
   EXPECT_TRUE(policy_manager_->SetExternalConsentStatus(status));
 
@@ -529,12 +531,12 @@ TEST_F(
 
   EXPECT_FALSE(pt->policy_table.device_data->end() != updated_device_data);
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _));
+  EXPECT_CALL(listener_, OnPermissionsUpdated(device_id_1_, app_id_1_, _));
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
       .WillRepeatedly(Return(device_id_1_));
 
-  policy_manager_->AddApplication(app_id_1_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_1_, HmiTypes(policy_table::AHT_DEFAULT));
 
   // Check ExternalConsent consents for application
   updated_device_data = pt->policy_table.device_data->find(device_id_1_);
@@ -597,12 +599,12 @@ TEST_F(
 
   EXPECT_FALSE(pt->policy_table.device_data->end() != updated_device_data);
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _));
+  EXPECT_CALL(listener_, OnPermissionsUpdated(device_id_1_, app_id_1_, _));
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
       .WillRepeatedly(Return(device_id_1_));
 
-  policy_manager_->AddApplication(app_id_1_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_1_, HmiTypes(policy_table::AHT_DEFAULT));
 
   // Checking ExternalConsent consents after setting new ExternalConsent status
   ApplicationPolicies::const_iterator app_parameters =
@@ -652,15 +654,12 @@ TEST_F(
 
   EXPECT_TRUE(policy_manager_->GetCache()->ApplyUpdate(t));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _));
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
-      .WillOnce(Return(device_id_1_))         // registered
-      .WillOnce(Return(""))                   // not registered
-      .WillRepeatedly(Return(device_id_1_));  // again registered
-
+  EXPECT_CALL(listener_, OnPermissionsUpdated(device_id_1_, app_id_1_, _));
+  EXPECT_CALL(listener_, GetDevicesIds(app_id_1_))
+      .WillRepeatedly(Return(transport_manager::DeviceList()));
   // First register w/o app having groups to consent
-  policy_manager_->AddApplication(app_id_1_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_1_, HmiTypes(policy_table::AHT_DEFAULT));
 
   // Act
   std::shared_ptr<policy_table::Table> pt =
@@ -691,8 +690,8 @@ TEST_F(
   EXPECT_TRUE(policy_manager_->GetCache()->ApplyUpdate(t));
 
   // Second time register w/ app having groups to consent
-  policy_manager_->AddApplication(app_id_1_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_1_, HmiTypes(policy_table::AHT_DEFAULT));
 
   // Checking ExternalConsent consents after setting new ExternalConsent status
   ApplicationPolicies::const_iterator app_parameters =
@@ -742,15 +741,11 @@ TEST_F(
 
   EXPECT_TRUE(policy_manager_->GetCache()->ApplyUpdate(t));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _));
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
-      .WillOnce(Return(device_id_1_))         // registered
-      .WillOnce(Return(""))                   // not registered
-      .WillRepeatedly(Return(device_id_1_));  // registered again
+  EXPECT_CALL(listener_, OnPermissionsUpdated(device_id_1_, app_id_1_, _));
 
   // First register w/o app having groups to consent
-  policy_manager_->AddApplication(app_id_1_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_1_, HmiTypes(policy_table::AHT_DEFAULT));
 
   // Act
   std::shared_ptr<policy_table::Table> pt =
@@ -781,8 +776,8 @@ TEST_F(
   EXPECT_TRUE(policy_manager_->GetCache()->ApplyUpdate(t));
 
   // Second time register w/ app having groups to consent
-  policy_manager_->AddApplication(app_id_1_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_1_, HmiTypes(policy_table::AHT_DEFAULT));
 
   // Check ExternalConsent consents for application
   updated_device_data = pt->policy_table.device_data->find(device_id_1_);
@@ -840,12 +835,11 @@ TEST_F(PolicyManagerImplTest_ExternalConsent,
 
   EXPECT_TRUE(policy_manager_->SetExternalConsentStatus(status));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _));
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
-      .WillRepeatedly(Return(device_id_1_));
-
-  policy_manager_->AddApplication(app_id_1_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  EXPECT_CALL(listener_, OnPermissionsUpdated(device_id_1_, app_id_1_, _));
+  EXPECT_CALL(listener_, GetDevicesIds(app_id_1_))
+      .WillRepeatedly(Return(transport_manager::DeviceList()));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_1_, HmiTypes(policy_table::AHT_DEFAULT));
 
   std::shared_ptr<policy_table::Table> pt =
       policy_manager_->GetCache()->GetPT();
@@ -965,12 +959,11 @@ TEST_F(PolicyManagerImplTest_ExternalConsent,
 
   EXPECT_TRUE(policy_manager_->SetExternalConsentStatus(status));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _));
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
-      .WillRepeatedly(Return(device_id_1_));
-
-  policy_manager_->AddApplication(app_id_1_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  EXPECT_CALL(listener_, OnPermissionsUpdated(device_id_1_, app_id_1_, _));
+  EXPECT_CALL(listener_, GetDevicesIds(app_id_1_))
+      .WillRepeatedly(Return(transport_manager::DeviceList()));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_1_, HmiTypes(policy_table::AHT_DEFAULT));
 
   std::shared_ptr<policy_table::Table> pt =
       policy_manager_->GetCache()->GetPT();
@@ -1099,7 +1092,7 @@ TEST_F(
   status_on.insert(ExternalConsentStatusItem(type_2_, id_2_, kStatusOn));
   status_on.insert(ExternalConsentStatusItem(type_3_, id_3_, kStatusOn));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _));
+  EXPECT_CALL(listener_, OnPermissionsUpdated(device_id_1_, app_id_1_, _));
 
   EXPECT_TRUE(policy_manager_->SetExternalConsentStatus(status_on));
 
@@ -1135,7 +1128,8 @@ TEST_F(
   status_off.insert(ExternalConsentStatusItem(type_2_, id_2_, kStatusOff));
   status_off.insert(ExternalConsentStatusItem(type_3_, id_3_, kStatusOff));
 
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_1_, _)).Times(1);
+  EXPECT_CALL(listener_, OnPermissionsUpdated(device_id_1_, app_id_1_, _))
+      .Times(1);
 
   EXPECT_TRUE(policy_manager_->SetExternalConsentStatus(status_off));
 

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -532,7 +532,7 @@ TEST_F(
   EXPECT_FALSE(pt->policy_table.device_data->end() != updated_device_data);
 
   EXPECT_CALL(listener_, OnPermissionsUpdated(device_id_1_, app_id_1_, _));
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(_, app_id_1_))
       .WillRepeatedly(Return(device_id_1_));
 
   policy_manager_->AddApplication(
@@ -600,7 +600,7 @@ TEST_F(
   EXPECT_FALSE(pt->policy_table.device_data->end() != updated_device_data);
 
   EXPECT_CALL(listener_, OnPermissionsUpdated(device_id_1_, app_id_1_, _));
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(_, app_id_1_))
       .WillRepeatedly(Return(device_id_1_));
 
   policy_manager_->AddApplication(

--- a/src/components/policy/policy_external/test/policy_manager_impl_test_base.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test_base.cc
@@ -342,7 +342,7 @@ void PolicyManagerImplTest2::AddRTtoAppSectionPT(
   // section
   pt_request_types_ = policy_manager_->GetAppRequestTypes(handle, section_name);
   EXPECT_EQ(rt_number, pt_request_types_.size());
-  EXPECT_CALL(listener_, OnPendingPermissionChange(section_name)).Times(1);
+  EXPECT_CALL(listener_, OnPendingPermissionChange(_, section_name)).Times(1);
   Json::Value root = GetPTU(update_file_name);
 
   // Get App Request Types from PTU

--- a/src/components/policy/policy_external/test/policy_manager_impl_test_base.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test_base.cc
@@ -307,7 +307,10 @@ void PolicyManagerImplTest2::AddRTtoPT(const std::string& update_file_name,
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
   // Get RequestTypes from section of preloaded_pt app_policies
-  pt_request_types_ = policy_manager_->GetAppRequestTypes(section_name);
+  const transport_manager::DeviceHandle handle = 1;
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(handle, section_name))
+      .WillRepeatedly(Return(device_id_1_));
+  pt_request_types_ = policy_manager_->GetAppRequestTypes(handle, section_name);
   EXPECT_EQ(rt_number, pt_request_types_.size());
   Json::Value root = GetPTU(update_file_name);
   // Get Request Types from JSON (PTU)
@@ -316,7 +319,7 @@ void PolicyManagerImplTest2::AddRTtoPT(const std::string& update_file_name,
   ptu_request_types_size_ = ptu_request_types_.size();
   pt_request_types_.clear();
   // Get RequestTypes from section of PT app policies after update
-  pt_request_types_ = policy_manager_->GetAppRequestTypes(section_name);
+  pt_request_types_ = policy_manager_->GetAppRequestTypes(handle, section_name);
   // Check number of RT in PTU and PT now are equal
   ASSERT_EQ(ptu_request_types_size_ - invalid_rt_number,
             pt_request_types_.size());
@@ -329,12 +332,15 @@ void PolicyManagerImplTest2::AddRTtoAppSectionPT(
     const uint32_t invalid_rt_number) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
+  const transport_manager::DeviceHandle handle = 1;
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(handle, section_name))
+      .WillRepeatedly(Return(device_id_1_));
   // Add app
-  policy_manager_->AddApplication(section_name,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, section_name, HmiTypes(policy_table::AHT_DEFAULT));
   // Check app gets RequestTypes from pre_DataConsent of app_policies
   // section
-  pt_request_types_ = policy_manager_->GetAppRequestTypes(section_name);
+  pt_request_types_ = policy_manager_->GetAppRequestTypes(handle, section_name);
   EXPECT_EQ(rt_number, pt_request_types_.size());
   EXPECT_CALL(listener_, OnPendingPermissionChange(section_name)).Times(1);
   Json::Value root = GetPTU(update_file_name);
@@ -346,13 +352,13 @@ void PolicyManagerImplTest2::AddRTtoAppSectionPT(
 
   pt_request_types_.clear();
   // Get RequestTypes from <app_id> section of app policies after PT update
-  pt_request_types_ = policy_manager_->GetAppRequestTypes(section_name);
+  pt_request_types_ = policy_manager_->GetAppRequestTypes(handle, section_name);
   // Check sizes of Request types of PT and PTU
   ASSERT_EQ(ptu_request_types_size_ - invalid_rt_number,
             pt_request_types_.size());
 
   ::policy::AppPermissions permissions =
-      policy_manager_->GetAppPermissionsChanges(section_name);
+      policy_manager_->GetAppPermissionsChanges(device_id_1_, section_name);
   EXPECT_TRUE(permissions.requestTypeChanged);
 }
 
@@ -449,9 +455,13 @@ void PolicyManagerImplTest2::
                                    2,
                                    "Bluetooth"));
 
+  EXPECT_CALL(listener_, GetDevicesIds(application_id_))
+      .WillRepeatedly(Return(transport_manager::DeviceList()));
+
   // Add app from consented device. App will be assigned with default policies
-  policy_manager_->AddApplication(application_id_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->SetUserConsentForDevice(device_id_1_, true);
+  policy_manager_->AddApplication(
+      device_id_1_, application_id_, HmiTypes(policy_table::AHT_DEFAULT));
 
   // Expect all parameters are allowed
   std::ifstream ifile(update_file);
@@ -467,19 +477,18 @@ void PolicyManagerImplTest2::
   EXPECT_TRUE(policy_manager_->LoadPT(kFilePtUpdateJson, msg));
   EXPECT_FALSE(cache->IsPTPreloaded());
 
-  // Will be called each time permissions are checked
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(application_id_))
-      .Times(4)
-      .WillRepeatedly(Return(device_id_1_));
-
   // Check RPC in each level
   ::policy::RPCParams input_params;
   InsertRpcParametersInList(input_params);
 
   ::policy::CheckPermissionResult output;
   // Rpc in FULL level
-  policy_manager_->CheckPermissions(
-      application_id_, kHmiLevelFull, "SendLocation", input_params, output);
+  policy_manager_->CheckPermissions(device_id_1_,
+                                    application_id_,
+                                    kHmiLevelFull,
+                                    "SendLocation",
+                                    input_params,
+                                    output);
   // Check RPC is allowed
   EXPECT_EQ(::policy::kRpcAllowed, output.hmi_level_permitted);
   // Check list of allowed parameters is not empty
@@ -489,8 +498,12 @@ void PolicyManagerImplTest2::
   ResetOutputList(output);
 
   // Rpc in LIMITED level
-  policy_manager_->CheckPermissions(
-      application_id_, kHmiLevelLimited, "SendLocation", input_params, output);
+  policy_manager_->CheckPermissions(device_id_1_,
+                                    application_id_,
+                                    kHmiLevelLimited,
+                                    "SendLocation",
+                                    input_params,
+                                    output);
   // Check RPC is allowed
   EXPECT_EQ(::policy::kRpcAllowed, output.hmi_level_permitted);
   // Check list of allowed parameters is not empty
@@ -500,7 +513,8 @@ void PolicyManagerImplTest2::
   ResetOutputList(output);
 
   // Rpc in BACKGROUND level
-  policy_manager_->CheckPermissions(application_id_,
+  policy_manager_->CheckPermissions(device_id_1_,
+                                    application_id_,
                                     kHmiLevelBackground,
                                     "SendLocation",
                                     input_params,
@@ -515,8 +529,12 @@ void PolicyManagerImplTest2::
   ResetOutputList(output);
 
   // Rpc in NONE level
-  policy_manager_->CheckPermissions(
-      application_id_, kHmiLevelNone, "SendLocation", input_params, output);
+  policy_manager_->CheckPermissions(device_id_1_,
+                                    application_id_,
+                                    kHmiLevelNone,
+                                    "SendLocation",
+                                    input_params,
+                                    output);
   // Check RPC is disallowed
   EXPECT_EQ(::policy::kRpcDisallowed, output.hmi_level_permitted);
   // Check lists of parameters are  empty
@@ -529,8 +547,12 @@ void PolicyManagerImplTest2::CheckRpcPermissions(
     const std::string& rpc_name, const PermitResult& expected_permission) {
   ::policy::RPCParams input_params;
   ::policy::CheckPermissionResult output;
-  policy_manager_->CheckPermissions(
-      application_id_, kHmiLevelFull, rpc_name, input_params, output);
+  policy_manager_->CheckPermissions(device_id_1_,
+                                    application_id_,
+                                    kHmiLevelFull,
+                                    rpc_name,
+                                    input_params,
+                                    output);
   EXPECT_EQ(expected_permission, output.hmi_level_permitted);
 }
 
@@ -541,7 +563,7 @@ void PolicyManagerImplTest2::CheckRpcPermissions(
   ::policy::RPCParams input_params;
   ::policy::CheckPermissionResult output;
   policy_manager_->CheckPermissions(
-      app_id, kHmiLevelFull, rpc_name, input_params, output);
+      device_id_1_, app_id, kHmiLevelFull, rpc_name, input_params, output);
   EXPECT_EQ(out_expected_permission, output.hmi_level_permitted);
 }
 
@@ -576,8 +598,9 @@ void PolicyManagerImplTest2::AddSetDeviceData() {
                                   "Bluetooth"));
 
   // Add app from consented device. App will be assigned with default policies
-  policy_manager_->AddApplication(application_id_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->SetUserConsentForDevice(device_id_1_, true);
+  policy_manager_->AddApplication(
+      device_id_1_, application_id_, HmiTypes(policy_table::AHT_DEFAULT));
   (policy_manager_->GetCache())->AddDevice(device_id_1_, "Bluetooth");
 }
 

--- a/src/components/policy/policy_external/test/policy_manager_impl_user_consent_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_user_consent_test.cc
@@ -34,6 +34,7 @@
 
 #include "policy/policy_manager_impl_test_base.h"
 #include "utils/date_time.h"
+#include "utils/macro.h"
 
 namespace test {
 namespace components {
@@ -54,8 +55,8 @@ TEST_F(
 
   policy_manager_->SetUserConsentForDevice(device_id_1_, true);
 
-  policy_manager_->AddApplication(app_id_1_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_1_, HmiTypes(policy_table::AHT_DEFAULT));
 
   EXPECT_EQ("UPDATE_NEEDED", policy_manager_->GetPolicyTableStatus());
 }
@@ -76,13 +77,14 @@ TEST_F(
   policy_manager_->PTUpdatedAt(DAYS_AFTER_EPOCH, days_after_epoch);
   policy_manager_->PTUpdatedAt(KILOMETERS, 1000);
 
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
+  const transport_manager::DeviceHandle handle = 1;
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(handle, app_id_1_))
       .WillRepeatedly(Return(device_id_1_));
 
   policy_manager_->SetUserConsentForDevice(device_id_1_, false);
 
-  policy_manager_->AddApplication(app_id_1_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_1_, HmiTypes(policy_table::AHT_DEFAULT));
 
   EXPECT_EQ("UP_TO_DATE", policy_manager_->GetPolicyTableStatus());
 }
@@ -92,10 +94,13 @@ TEST_F(
     ReactOnUserDevConsentForApp_AddNewApplicationFromDeviceWithoutConsent_ExpectPreDataConsent) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
-  policy_manager_->AddApplication(app_id_1_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  const transport_manager::DeviceHandle handle = 1;
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(handle, app_id_1_))
+      .WillRepeatedly(Return(device_id_1_));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_1_, HmiTypes(policy_table::AHT_DEFAULT));
   ASSERT_TRUE(policy_manager_->IsPredataPolicy(app_id_1_));
-  policy_manager_->ReactOnUserDevConsentForApp(app_id_1_, false);
+  policy_manager_->ReactOnUserDevConsentForApp(handle, app_id_1_, false);
   EXPECT_TRUE(policy_manager_->IsPredataPolicy(app_id_1_));
 }
 
@@ -106,8 +111,8 @@ TEST_F(PolicyManagerImplTest2,
   CreateLocalPT(kSdlPreloadedPtJson2);
   ASSERT_TRUE(
       (policy_manager_->GetCache())->AddDevice(device_id_2_, "Bluetooth"));
-  policy_manager_->AddApplication(application_id_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_2_, application_id_, HmiTypes(policy_table::AHT_DEFAULT));
 
   // Expect RPCs from pre_dataConsent group are allowed
   // Next checks are equal to BaseBeforeDataConsent_APIs.xml checks from task
@@ -155,11 +160,11 @@ TEST_F(PolicyManagerImplTest2,
 TEST_F(PolicyManagerImplTest2, CheckPreDataConsent_GetDefaultHmiLevel_NONE) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   std::string default_hmi;
   // Default HMI level is NONE
-  policy_manager_->GetDefaultHmi(app_id_2_, &default_hmi);
+  policy_manager_->GetDefaultHmi(device_id_1_, app_id_2_, &default_hmi);
   EXPECT_EQ("NONE", default_hmi);
 
   // Default priority level is NONE
@@ -173,11 +178,11 @@ TEST_F(PolicyManagerImplTest2,
        CheckPreDataConsent_GetDefaultHmiLevel_BACKGROUNG) {
   // Arrange
   CreateLocalPT(kSdlPreloadedPtJson2);
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   std::string default_hmi;
   // Default HMI level is BACKGROUND
-  policy_manager_->GetDefaultHmi(app_id_2_, &default_hmi);
+  policy_manager_->GetDefaultHmi(device_id_1_, app_id_2_, &default_hmi);
   EXPECT_EQ("BACKGROUND", default_hmi);
   // Default priority level is EMERGENCY
   std::string priority1;
@@ -191,10 +196,13 @@ TEST_F(
   // Arrange
   // RequestTypes for default & preDataConsent are different
   CreateLocalPT("json/ptu_requestType.json");
-  policy_manager_->AddApplication(app_id_1_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  const transport_manager::DeviceHandle handle = 1;
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(handle, app_id_1_))
+      .WillRepeatedly(Return(device_id_1_));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_1_, HmiTypes(policy_table::AHT_DEFAULT));
   ASSERT_TRUE(policy_manager_->IsPredataPolicy(app_id_1_));
-  policy_manager_->ReactOnUserDevConsentForApp(app_id_1_, true);
+  policy_manager_->ReactOnUserDevConsentForApp(handle, app_id_1_, true);
   EXPECT_FALSE(policy_manager_->IsPredataPolicy(app_id_1_));
   // Expect app_id_1_ has default policy
   EXPECT_TRUE((policy_manager_->GetCache())->IsDefaultPolicy(app_id_1_));
@@ -206,11 +214,14 @@ TEST_F(
   // Arrange
   // RequestTypes for default & preDataConsent are the same
   CreateLocalPT(kPtu2RequestTypeJson);
-  policy_manager_->AddApplication(app_id_1_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  const transport_manager::DeviceHandle handle = 1;
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(handle, app_id_1_))
+      .WillRepeatedly(Return(device_id_1_));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_1_, HmiTypes(policy_table::AHT_DEFAULT));
   ASSERT_TRUE(policy_manager_->IsPredataPolicy(app_id_1_));
   EXPECT_CALL(listener_, OnPendingPermissionChange(app_id_1_)).Times(0);
-  policy_manager_->ReactOnUserDevConsentForApp(app_id_1_, true);
+  policy_manager_->ReactOnUserDevConsentForApp(handle, app_id_1_, true);
   EXPECT_FALSE(policy_manager_->IsPredataPolicy(app_id_1_));
   EXPECT_TRUE((policy_manager_->GetCache())->IsDefaultPolicy(app_id_1_));
 }
@@ -299,10 +310,10 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(::policy::DeviceConsent::kDeviceDisallowed, consent);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_2_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   std::string default_hmi;
-  policy_manager_->GetDefaultHmi(app_id_2_, &default_hmi);
+  policy_manager_->GetDefaultHmi(device_id_2_, app_id_2_, &default_hmi);
   EXPECT_EQ("NONE", default_hmi);
 }
 
@@ -310,12 +321,12 @@ TEST_F(PolicyManagerImplTest2,
        GetDefaultHmi_SetDeviceAllowed_ExpectReceivedHmiCorrect) {
   // Arrange
   CreateLocalPT(kPtu2RequestTypeJson);
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_TRUE(policy_manager_->IsPredataPolicy(app_id_2_));
   std::string default_hmi1;
-  policy_manager_->GetDefaultHmi(app_id_2_, &default_hmi1);
+  policy_manager_->GetDefaultHmi(device_id_1_, app_id_2_, &default_hmi1);
   EXPECT_EQ("NONE", default_hmi1);
   ASSERT_TRUE(
       (policy_manager_->GetCache())->AddDevice(device_id_2_, "Bluetooth"));
@@ -335,11 +346,11 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_2_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_TRUE((policy_manager_->GetCache())->IsDefaultPolicy(app_id_2_));
   std::string default_hmi2;
-  policy_manager_->GetDefaultHmi(app_id_2_, &default_hmi2);
+  policy_manager_->GetDefaultHmi(device_id_2_, app_id_2_, &default_hmi2);
   EXPECT_EQ("LIMITED", default_hmi2);
 }
 
@@ -347,8 +358,8 @@ TEST_F(PolicyManagerImplTest2,
        GetDefaultPriority_SetDeviceAllowed_ExpectReceivedPriorityCorrect) {
   // Arrange
   CreateLocalPT(kPtu2RequestTypeJson);
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_TRUE(policy_manager_->IsPredataPolicy(app_id_2_));
   std::string priority1;
@@ -372,8 +383,8 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_2_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_TRUE((policy_manager_->GetCache())->IsDefaultPolicy(app_id_2_));
   std::string priority2;
   EXPECT_TRUE(policy_manager_->GetPriority(app_id_2_, &priority2));
@@ -490,8 +501,10 @@ TEST_F(PolicyManagerImplTest2, SetDeviceInfo_ExpectDevInfoAddedToPT) {
 TEST_F(PolicyManagerImplTest2, GetInitialAppData_ExpectReceivedConsentCorrect) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  EXPECT_CALL(listener_, GetDevicesIds(app_id_2_))
+      .WillRepeatedly(Return(transport_manager::DeviceList()));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   ::policy::StringArray app_nicknames;
   ::policy::StringArray app_hmi_types;
   policy_manager_->GetInitialAppData(app_id_2_, &app_nicknames, &app_hmi_types);
@@ -534,8 +547,8 @@ TEST_F(
     CanAppKeepContext_AddAppFromUnconsentedDevice_ExpectAppCannotKeepContext) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_TRUE(policy_manager_->IsPredataPolicy(app_id_2_));
   // Check keep context in preData policy
@@ -548,8 +561,8 @@ TEST_F(PolicyManagerImplTest2,
   CreateLocalPT(preloaded_pt_filename_);
   ASSERT_TRUE(
       (policy_manager_->GetCache())->AddDevice(device_id_2_, "Bluetooth"));
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   ASSERT_TRUE((policy_manager_->GetCache())
                   ->SetDeviceData(device_id_2_,
                                   "hardware IPX",
@@ -565,8 +578,8 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_2_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_TRUE((policy_manager_->GetCache())->IsDefaultPolicy(app_id_2_));
   // Check keep context in default policy
   EXPECT_FALSE(policy_manager_->CanAppKeepContext(app_id_2_));
@@ -576,8 +589,8 @@ TEST_F(PolicyManagerImplTest2,
        CanAppStealFocus_AddAppFromUnconsentedDevice_ExpectAppCannotStealFocus) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_TRUE(policy_manager_->IsPredataPolicy(app_id_2_));
   // Check keep context in preData policy
@@ -590,8 +603,8 @@ TEST_F(PolicyManagerImplTest2,
   CreateLocalPT(preloaded_pt_filename_);
   ASSERT_TRUE(
       (policy_manager_->GetCache())->AddDevice(device_id_2_, "Bluetooth"));
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   ASSERT_TRUE((policy_manager_->GetCache())
                   ->SetDeviceData(device_id_2_,
                                   "hardware IPX",
@@ -607,8 +620,8 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
   EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_2_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_TRUE((policy_manager_->GetCache())->IsDefaultPolicy(app_id_2_));
   // Check keep context in default policy
   EXPECT_FALSE(policy_manager_->CanAppStealFocus(app_id_2_));
@@ -618,8 +631,8 @@ TEST_F(PolicyManagerImplTest2,
        IsPredataPolicy_SetAppWIthPredataPolicy_ExpectPredataPolicy) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_TRUE(policy_manager_->IsPredataPolicy(app_id_2_));
 }
@@ -629,18 +642,18 @@ TEST_F(
     SendNotificationOnPermissionsUpdated_SetDeviceAllowed_ExpectNotificationSent) {
   // Arrange
   CreateLocalPT(kPtu2RequestTypeJson);
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  EXPECT_CALL(listener_, GetDevicesIds(app_id_2_)).Times(0);
+  policy_manager_->AddApplication(
+      device_id_1_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   // Check if app has preData policy
   EXPECT_TRUE(policy_manager_->IsPredataPolicy(app_id_2_));
   std::string default_hmi1;
-  policy_manager_->GetDefaultHmi(app_id_2_, &default_hmi1);
+  policy_manager_->GetDefaultHmi(device_id_1_, app_id_2_, &default_hmi1);
   EXPECT_EQ("NONE", default_hmi1);
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
-      .WillOnce(Return(""));
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_2_, _, default_hmi1))
+  EXPECT_CALL(listener_, OnPermissionsUpdated(device_id_1_, app_id_2_, _))
       .Times(0);
-  policy_manager_->SendNotificationOnPermissionsUpdated(app_id_2_);
+  policy_manager_->SendNotificationOnPermissionsUpdated(device_id_1_,
+                                                        app_id_2_);
 
   ASSERT_TRUE(
       (policy_manager_->GetCache())->AddDevice(device_id_2_, "Bluetooth"));
@@ -658,16 +671,17 @@ TEST_F(
       policy_manager_->GetUserConsentForDevice(device_id_2_);
   // Check
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
-      .WillRepeatedly(Return(device_id_2_));
-  policy_manager_->AddApplication(app_id_2_,
-                                  HmiTypes(policy_table::AHT_DEFAULT));
+  EXPECT_CALL(listener_, GetDevicesIds(app_id_2_)).Times(0);
+  policy_manager_->AddApplication(
+      device_id_2_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_TRUE((policy_manager_->GetCache())->IsDefaultPolicy(app_id_2_));
   std::string default_hmi2;
-  policy_manager_->GetDefaultHmi(app_id_2_, &default_hmi2);
+  policy_manager_->GetDefaultHmi(device_id_2_, app_id_2_, &default_hmi2);
   EXPECT_EQ("LIMITED", default_hmi2);
-  EXPECT_CALL(listener_, OnPermissionsUpdated(app_id_2_, _, default_hmi2));
-  policy_manager_->SendNotificationOnPermissionsUpdated(app_id_2_);
+  EXPECT_CALL(listener_,
+              OnPermissionsUpdated(device_id_2_, app_id_2_, _, default_hmi2));
+  policy_manager_->SendNotificationOnPermissionsUpdated(device_id_2_,
+                                                        app_id_2_);
 }
 
 }  // namespace policy_test

--- a/src/components/policy/policy_external/test/policy_manager_impl_user_consent_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_user_consent_test.cc
@@ -50,7 +50,7 @@ TEST_F(
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);
 
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_1_))
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(_, app_id_1_))
       .WillRepeatedly(Return(device_id_1_));
 
   policy_manager_->SetUserConsentForDevice(device_id_1_, true);
@@ -220,7 +220,7 @@ TEST_F(
   policy_manager_->AddApplication(
       device_id_1_, app_id_1_, HmiTypes(policy_table::AHT_DEFAULT));
   ASSERT_TRUE(policy_manager_->IsPredataPolicy(app_id_1_));
-  EXPECT_CALL(listener_, OnPendingPermissionChange(app_id_1_)).Times(0);
+  EXPECT_CALL(listener_, OnPendingPermissionChange(_, app_id_1_)).Times(0);
   policy_manager_->ReactOnUserDevConsentForApp(handle, app_id_1_, true);
   EXPECT_FALSE(policy_manager_->IsPredataPolicy(app_id_1_));
   EXPECT_TRUE((policy_manager_->GetCache())->IsDefaultPolicy(app_id_1_));
@@ -308,7 +308,7 @@ TEST_F(PolicyManagerImplTest2,
       policy_manager_->GetUserConsentForDevice(device_id_2_);
   // Check
   EXPECT_EQ(::policy::DeviceConsent::kDeviceDisallowed, consent);
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(_, app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
   policy_manager_->AddApplication(
       device_id_2_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
@@ -344,7 +344,7 @@ TEST_F(PolicyManagerImplTest2,
       policy_manager_->GetUserConsentForDevice(device_id_2_);
   // Check
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(_, app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
   policy_manager_->AddApplication(
       device_id_2_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
@@ -381,7 +381,7 @@ TEST_F(PolicyManagerImplTest2,
       policy_manager_->GetUserConsentForDevice(device_id_2_);
   // Check
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(_, app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
   policy_manager_->AddApplication(
       device_id_2_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
@@ -576,7 +576,7 @@ TEST_F(PolicyManagerImplTest2,
   ::policy::DeviceConsent consent =
       policy_manager_->GetUserConsentForDevice(device_id_2_);
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(_, app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
   policy_manager_->AddApplication(
       device_id_2_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));
@@ -618,7 +618,7 @@ TEST_F(PolicyManagerImplTest2,
   ::policy::DeviceConsent consent =
       policy_manager_->GetUserConsentForDevice(device_id_2_);
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
-  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(app_id_2_))
+  EXPECT_CALL(listener_, OnCurrentDeviceIdUpdateRequired(_, app_id_2_))
       .WillRepeatedly(Return(device_id_2_));
   policy_manager_->AddApplication(
       device_id_2_, app_id_2_, HmiTypes(policy_table::AHT_DEFAULT));

--- a/src/components/policy/policy_regular/CMakeLists.txt
+++ b/src/components/policy/policy_regular/CMakeLists.txt
@@ -38,6 +38,8 @@ include_directories (
   ${JSONCPP_INCLUDE_DIRECTORY}
   ${COMPONENTS_DIR}/utils/include/
   ${COMPONENTS_DIR}/config_profile/include
+  ${COMPONENTS_DIR}/connection_handler/include/
+  ${COMPONENTS_DIR}/protocol_handler/include/
   ${LOG4CXX_INCLUDE_DIRECTORY}
   ${BOOST_INCLUDE_DIR}
 )

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -263,14 +263,28 @@ class PolicyManagerImpl : public PolicyManager {
                                const bool is_allowed) OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief Update Application Policies as reaction
    * on User allowing/disallowing device this app is running on.
    * @param app_id Unique application id
    * @param is_device_allowed true if user allowing device otherwise false
    * @return true if operation was successful
    */
-  bool ReactOnUserDevConsentForApp(const std::string app_id,
-                                   const bool is_device_allowed) OVERRIDE;
+  DEPRECATED bool ReactOnUserDevConsentForApp(
+      const std::string app_id, const bool is_device_allowed) OVERRIDE;
+
+  /**
+   * @brief Update Application Policies as reaction
+   * on User allowing/disallowing device this app is running on.
+   * @param device_handle device identifier
+   * @param app_id Unique application id
+   * @param is_device_allowed true if user allowing device otherwise false
+   * @return true if operation was successful
+   */
+  bool ReactOnUserDevConsentForApp(
+      const transport_manager::DeviceHandle& device_handle,
+      const std::string app_id,
+      const bool is_device_allowed) OVERRIDE;
 
   /**
    * @brief Retrieves data from app_policies about app on its registration:
@@ -310,13 +324,26 @@ class PolicyManagerImpl : public PolicyManager {
   void SetUserConsentForApp(const PermissionConsent& permissions) OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief Get default HMI level for application
    * @param policy_app_id Unique application id
    * @param default_hmi Default HMI level for application or empty, if value
    * was not set
    * @return true, if succedeed, otherwise - false
    */
-  bool GetDefaultHmi(const std::string& policy_app_id,
+  DEPRECATED bool GetDefaultHmi(const std::string& policy_app_id,
+                                std::string* default_hmi) const OVERRIDE;
+
+  /**
+   * @brief Get default HMI level for application
+   * @param device_id device identifier
+   * @param policy_app_id Unique application id
+   * @param default_hmi Default HMI level for application or empty, if value
+   * was not set
+   * @return true, if succedeed, otherwise - false
+   */
+  bool GetDefaultHmi(const std::string& device_id,
+                     const std::string& policy_app_id,
                      std::string* default_hmi) const OVERRIDE;
 
   /**
@@ -359,9 +386,11 @@ class PolicyManagerImpl : public PolicyManager {
 
   /**
    * @brief Return device id, which hosts specific application
+   * @param device_handle device identifier
    * @param policy_app_id Application id, which is required to update device id
    */
   std::string& GetCurrentDeviceId(
+      const transport_manager::DeviceHandle& device_handle,
       const std::string& policy_app_id) const OVERRIDE;
 
   /**
@@ -401,13 +430,24 @@ class PolicyManagerImpl : public PolicyManager {
   void SetVINValue(const std::string& value) OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief Gets specific application permissions changes since last policy
    * table update
    * @param policy_app_id Unique application id
    * @return Permissions changes
    */
+  DEPRECATED AppPermissions
+  GetAppPermissionsChanges(const std::string& policy_app_id) OVERRIDE;
+
+  /**
+   * @brief Gets specific application permissions changes since last policy
+   * table update
+   * @param device_id device identifier
+   * @param policy_app_id Unique application id
+   * @return Permissions changes
+   */
   AppPermissions GetAppPermissionsChanges(
-      const std::string& policy_app_id) OVERRIDE;
+      const std::string& device_id, const std::string& policy_app_id) OVERRIDE;
 
   /**
    * @brief Removes specific application permissions changes
@@ -450,22 +490,48 @@ class PolicyManagerImpl : public PolicyManager {
   void MarkUnpairedDevice(const std::string& device_id) OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief Adds, application to the db or update existed one
    * run PTU if policy update is necessary for application.
    * @param application_id Unique application id
    * @param hmi_types application HMI types
    * @return function that will notify update manager about new application
    */
-  StatusNotifier AddApplication(
+  DEPRECATED StatusNotifier AddApplication(
       const std::string& application_id,
       const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) OVERRIDE;
 
   /**
+   * @brief Adds, application to the db or update existed one
+   * run PTU if policy update is necessary for application.
+   * @param device_id device identifier
+   * @param application_id Unique application id
+   * @param hmi_types application HMI types
+   * @return function that will notify update manager about new application
+   */
+  StatusNotifier AddApplication(
+      const std::string& device_id,
+      const std::string& application_id,
+      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) OVERRIDE;
+
+  /**
+   * DEPRECATED
    * @brief Assigns new HMI types for specified application
    * @param application_id Unique application id
    * @param hmi_types new HMI types list
    */
-  void SetDefaultHmiTypes(const std::string& application_id,
+  DEPRECATED void SetDefaultHmiTypes(
+      const std::string& application_id,
+      const std::vector<int>& hmi_types) OVERRIDE;
+
+  /**
+   * @brief Assigns new HMI types for specified application
+   * @param device_handle device identifier
+   * @param application_id Unique application id
+   * @param hmi_types new HMI types list
+   */
+  void SetDefaultHmiTypes(const transport_manager::DeviceHandle& device_handle,
+                          const std::string& application_id,
                           const std::vector<int>& hmi_types) OVERRIDE;
 
   /**
@@ -823,6 +889,14 @@ class PolicyManagerImpl : public PolicyManager {
  private:
   /**
    * DEPRECATED
+   * @brief Return device id, which hosts specific application
+   * @param policy_app_id Application id, which is required to update device id
+   */
+  std::string& GetCurrentDeviceId(
+      const std::string& policy_app_id) const OVERRIDE;
+
+  /**
+   * DEPRECATED
    * @brief Send OnPermissionsUpdated for choosen application
    * @param application_id Unique application id
    */
@@ -913,10 +987,21 @@ class PolicyManagerImpl : public PolicyManager {
   bool CheckAppStorageFolder() const;
 
   /**
+   * DEPRECATED
    * @brief Checks whether need ask the permission of users
+   * @param app_id policy application id
    * @return true if user consent is needed
    */
   virtual bool IsConsentNeeded(const std::string& app_id);
+
+  /**
+   * @brief Checks whether need ask the permission of users
+   * @param device_id device identifier
+   * @param app_id policy application id
+   * @return true if user consent is needed
+   */
+  virtual bool IsConsentNeeded(const std::string& device_id,
+                               const std::string& app_id);
 
   /**
    * @brief Changes isConsentNeeded for app pending permissions, in case

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -263,17 +263,6 @@ class PolicyManagerImpl : public PolicyManager {
                                const bool is_allowed) OVERRIDE;
 
   /**
-   * DEPRECATED
-   * @brief Update Application Policies as reaction
-   * on User allowing/disallowing device this app is running on.
-   * @param app_id Unique application id
-   * @param is_device_allowed true if user allowing device otherwise false
-   * @return true if operation was successful
-   */
-  DEPRECATED bool ReactOnUserDevConsentForApp(
-      const std::string app_id, const bool is_device_allowed) OVERRIDE;
-
-  /**
    * @brief Update Application Policies as reaction
    * on User allowing/disallowing device this app is running on.
    * @param device_handle device identifier
@@ -322,17 +311,6 @@ class PolicyManagerImpl : public PolicyManager {
    * from this structure.
    */
   void SetUserConsentForApp(const PermissionConsent& permissions) OVERRIDE;
-
-  /**
-   * DEPRECATED
-   * @brief Get default HMI level for application
-   * @param policy_app_id Unique application id
-   * @param default_hmi Default HMI level for application or empty, if value
-   * was not set
-   * @return true, if succedeed, otherwise - false
-   */
-  DEPRECATED bool GetDefaultHmi(const std::string& policy_app_id,
-                                std::string* default_hmi) const OVERRIDE;
 
   /**
    * @brief Get default HMI level for application
@@ -430,16 +408,6 @@ class PolicyManagerImpl : public PolicyManager {
   void SetVINValue(const std::string& value) OVERRIDE;
 
   /**
-   * DEPRECATED
-   * @brief Gets specific application permissions changes since last policy
-   * table update
-   * @param policy_app_id Unique application id
-   * @return Permissions changes
-   */
-  DEPRECATED AppPermissions
-  GetAppPermissionsChanges(const std::string& policy_app_id) OVERRIDE;
-
-  /**
    * @brief Gets specific application permissions changes since last policy
    * table update
    * @param device_id device identifier
@@ -490,18 +458,6 @@ class PolicyManagerImpl : public PolicyManager {
   void MarkUnpairedDevice(const std::string& device_id) OVERRIDE;
 
   /**
-   * DEPRECATED
-   * @brief Adds, application to the db or update existed one
-   * run PTU if policy update is necessary for application.
-   * @param application_id Unique application id
-   * @param hmi_types application HMI types
-   * @return function that will notify update manager about new application
-   */
-  DEPRECATED StatusNotifier AddApplication(
-      const std::string& application_id,
-      const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) OVERRIDE;
-
-  /**
    * @brief Adds, application to the db or update existed one
    * run PTU if policy update is necessary for application.
    * @param device_id device identifier
@@ -513,16 +469,6 @@ class PolicyManagerImpl : public PolicyManager {
       const std::string& device_id,
       const std::string& application_id,
       const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) OVERRIDE;
-
-  /**
-   * DEPRECATED
-   * @brief Assigns new HMI types for specified application
-   * @param application_id Unique application id
-   * @param hmi_types new HMI types list
-   */
-  DEPRECATED void SetDefaultHmiTypes(
-      const std::string& application_id,
-      const std::vector<int>& hmi_types) OVERRIDE;
 
   /**
    * @brief Assigns new HMI types for specified application
@@ -749,17 +695,6 @@ class PolicyManagerImpl : public PolicyManager {
       const std::string& policy_app_id) const OVERRIDE;
 
   /**
-   * DEPRECATED
-   * @brief OnAppRegisteredOnMobile allows to handle event when application were
-   * succesfully registered on mobile device.
-   * It will send OnAppPermissionSend notification and will try to start PTU.
-   *
-   * @param application_id registered application.
-   */
-  DEPRECATED void OnAppRegisteredOnMobile(
-      const std::string& application_id) OVERRIDE;
-
-  /**
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
    * It will send OnAppPermissionSend notification and will try to start PTU.
@@ -888,22 +823,6 @@ class PolicyManagerImpl : public PolicyManager {
 
  private:
   /**
-   * DEPRECATED
-   * @brief Return device id, which hosts specific application
-   * @param policy_app_id Application id, which is required to update device id
-   */
-  std::string& GetCurrentDeviceId(
-      const std::string& policy_app_id) const OVERRIDE;
-
-  /**
-   * DEPRECATED
-   * @brief Send OnPermissionsUpdated for choosen application
-   * @param application_id Unique application id
-   */
-  void SendNotificationOnPermissionsUpdated(
-      const std::string& application_id) OVERRIDE;
-
-  /**
    * @brief Checks if PT update should be started and schedules it if needed
    */
   void CheckTriggers();
@@ -985,14 +904,6 @@ class PolicyManagerImpl : public PolicyManager {
    * @return true if AppStorageFolder exists and has permissions read/write
    */
   bool CheckAppStorageFolder() const;
-
-  /**
-   * DEPRECATED
-   * @brief Checks whether need ask the permission of users
-   * @param app_id policy application id
-   * @return true if user consent is needed
-   */
-  virtual bool IsConsentNeeded(const std::string& app_id);
 
   /**
    * @brief Checks whether need ask the permission of users

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -417,10 +417,11 @@ class PolicyManagerImpl : public PolicyManager {
 
   /**
    * @brief Send OnPermissionsUpdated for choosen application
+   * @param device_id device identifier
    * @param application_id Unique application id
    */
   void SendNotificationOnPermissionsUpdated(
-      const std::string& application_id) OVERRIDE;
+      const std::string& device_id, const std::string& application_id) OVERRIDE;
 
   /**
    * @brief Removes unpaired device records and related records from DB
@@ -682,12 +683,26 @@ class PolicyManagerImpl : public PolicyManager {
       const std::string& policy_app_id) const OVERRIDE;
 
   /**
+   * DEPRECATED
    * @brief OnAppRegisteredOnMobile allows to handle event when application were
    * succesfully registered on mobile device.
-   * It will send OnAppPermissionSend notification and will try to start PTU. *
+   * It will send OnAppPermissionSend notification and will try to start PTU.
+   *
    * @param application_id registered application.
    */
-  void OnAppRegisteredOnMobile(const std::string& application_id) OVERRIDE;
+  DEPRECATED void OnAppRegisteredOnMobile(
+      const std::string& application_id) OVERRIDE;
+
+  /**
+   * @brief OnAppRegisteredOnMobile allows to handle event when application were
+   * succesfully registered on mobile device.
+   * It will send OnAppPermissionSend notification and will try to start PTU.
+   *
+   * @param device_id device identifier
+   * @param application_id registered application.
+   */
+  void OnAppRegisteredOnMobile(const std::string& device_id,
+                               const std::string& application_id) OVERRIDE;
 
   void OnDeviceSwitching(const std::string& device_id_from,
                          const std::string& device_id_to) OVERRIDE;
@@ -806,6 +821,14 @@ class PolicyManagerImpl : public PolicyManager {
   const PolicySettings& get_settings() const OVERRIDE;
 
  private:
+  /**
+   * DEPRECATED
+   * @brief Send OnPermissionsUpdated for choosen application
+   * @param application_id Unique application id
+   */
+  void SendNotificationOnPermissionsUpdated(
+      const std::string& application_id) OVERRIDE;
+
   /**
    * @brief Checks if PT update should be started and schedules it if needed
    */

--- a/src/components/policy/policy_regular/src/policy_helper.cc
+++ b/src/components/policy/policy_regular/src/policy_helper.cc
@@ -286,7 +286,8 @@ void CheckAppPolicy::SendPermissionsToApp(
   LOG4CXX_INFO(logger_, "Send notification for application_id: " << app_id);
   // Default_hmi is Ford-specific and should not be used with basic policy
   const std::string default_hmi;
-  pm_->listener()->OnPermissionsUpdated(app_id, notification_data, default_hmi);
+  pm_->listener()->OnPermissionsUpdated(
+      device_id, app_id, notification_data, default_hmi);
 }
 
 bool CheckAppPolicy::IsAppRevoked(

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -282,7 +282,7 @@ class PolicyManagerImplTest2 : public ::testing::Test {
     // section
     PT_request_types = manager->GetAppRequestTypes(section_name);
     EXPECT_EQ(rt_number, PT_request_types.size());
-    EXPECT_CALL(listener, OnPendingPermissionChange(section_name)).Times(1);
+    EXPECT_CALL(listener, OnPendingPermissionChange(_, section_name)).Times(1);
     Json::Value root = GetPTU(update_file_name);
 
     // Get App Request Types from PTU
@@ -543,7 +543,7 @@ TEST_F(PolicyManagerImplTest2,
                       "Life",
                       2,
                       "Bluetooth");
-  EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(app_id1))
+  EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(_, app_id1))
       .WillRepeatedly(Return(dev_id1));
   manager->SetUserConsentForDevice(dev_id1, true);
   // Add app from consented device. App will be assigned with default policies
@@ -603,7 +603,7 @@ TEST_F(PolicyManagerImplTest2,
                                   "Life",
                                   2,
                                   "Bluetooth"));
-  EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired("1234"))
+  EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(_, "1234"))
       .WillRepeatedly(Return(dev_id1));
   manager->SetUserConsentForDevice(dev_id1, true);
   // Add app from consented device. App will be assigned with default policies
@@ -824,7 +824,7 @@ TEST_F(
   manager->AddApplication(
       dev_id1, app_id1, HmiTypes(policy_table::AHT_DEFAULT));
   EXPECT_FALSE(manager->IsPredataPolicy(app_id1));
-  EXPECT_CALL(listener, OnPendingPermissionChange(app_id1)).Times(0);
+  EXPECT_CALL(listener, OnPendingPermissionChange(_, app_id1)).Times(0);
   manager->ReactOnUserDevConsentForApp(dev_handle1, app_id1, true);
   EXPECT_FALSE(manager->IsPredataPolicy(app_id1));
   EXPECT_TRUE((manager->GetCache())->IsDefaultPolicy(app_id1));
@@ -1121,7 +1121,7 @@ TEST_F(PolicyManagerImplTest2,
   ::policy::DeviceConsent consent = manager->GetUserConsentForDevice(dev_id2);
   // Check
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
-  EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(app_id2))
+  EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(_, app_id2))
       .WillRepeatedly(Return(dev_id2));
   manager->AddApplication(
       dev_id2, app_id2, HmiTypes(policy_table::AHT_DEFAULT));
@@ -1156,7 +1156,7 @@ TEST_F(PolicyManagerImplTest2,
   ::policy::DeviceConsent consent = manager->GetUserConsentForDevice(dev_id2);
   // Check
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
-  EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(app_id2))
+  EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(_, app_id2))
       .WillRepeatedly(Return(dev_id2));
   manager->AddApplication(
       dev_id2, app_id2, HmiTypes(policy_table::AHT_DEFAULT));
@@ -1241,7 +1241,7 @@ TEST_F(PolicyManagerImplTest2,
   manager->SetUserConsentForDevice(dev_id2, true);
   ::policy::DeviceConsent consent = manager->GetUserConsentForDevice(dev_id2);
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
-  EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(app_id2))
+  EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(_, app_id2))
       .WillRepeatedly(Return(dev_id2));
   manager->AddApplication(
       dev_id2, app_id2, HmiTypes(policy_table::AHT_DEFAULT));
@@ -1282,7 +1282,7 @@ TEST_F(PolicyManagerImplTest2,
   manager->SetUserConsentForDevice(dev_id2, true);
   ::policy::DeviceConsent consent = manager->GetUserConsentForDevice(dev_id2);
   EXPECT_EQ(::policy::DeviceConsent::kDeviceAllowed, consent);
-  EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(app_id2))
+  EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(_, app_id2))
       .WillRepeatedly(Return(dev_id2));
   manager->AddApplication(
       dev_id2, app_id2, HmiTypes(policy_table::AHT_DEFAULT));
@@ -1354,7 +1354,7 @@ TEST_F(
       ->SetUserPermissionsForDevice(
           dev_id2, consented_groups, disallowed_groups);
   manager->SetUserConsentForDevice(dev_id2, true);
-  EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(app_id2))
+  EXPECT_CALL(listener, OnCurrentDeviceIdUpdateRequired(_, app_id2))
       .WillRepeatedly(Return(dev_id2));
   manager->AddApplication(
       dev_id2, app_id2, HmiTypes(policy_table::AHT_DEFAULT));

--- a/src/components/rpc_base/include/rpc_base/rpc_base_inl.h
+++ b/src/components/rpc_base/include/rpc_base/rpc_base_inl.h
@@ -185,12 +185,14 @@ Integer<T, minval, maxval>& Integer<T, minval, maxval>::operator=(
 template <typename T, T minval, T maxval>
 Integer<T, minval, maxval>& Integer<T, minval, maxval>::operator++() {
   ++value_;
+  value_state_ = range_.Includes(value_) ? kValid : kInvalid;
   return *this;
 }
 
 template <typename T, T minval, T maxval>
 Integer<T, minval, maxval>& Integer<T, minval, maxval>::operator+=(int value) {
   value_ += value;
+  value_state_ = range_.Includes(value_) ? kValid : kInvalid;
   return *this;
 }
 


### PR DESCRIPTION
Fixes #2763 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes. Just updates for some descriptions

### Testing Plan
* Unit tests were updated/extended
* ATF scripts 

### Summary
Added possibility for registration and usage of the same application from multiple devices.

### Changelog
* Updated interfaces.
* Extended registration flow
* Added usage of device id for both policy modes: proprietary/external proprietary
* Unit tests were fixed according to the code changes


##### Bug Fixes
* Fixed sending a secondary message APPLICATION_REGISTERED_ALREADY
* Update functionality of user permissions for all applications.
* Fixed putting counters into Policy Table Snapshot during Policy table update sequence.

### Other parts of delivery:

- HMI integration guidelines: https://github.com/smartdevicelink/sdl_hmi_integration_guidelines/pull/161

- ATF Scripts: https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2202

- WebHMI: https://github.com/smartdevicelink/sdl_hmi/pull/191

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)