### PR TITLE
implement alert icon parameter to alert rpc

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -245,6 +245,9 @@
                 },
                 {
                     "name": "alertIcon",
+                    "imageTypeSupported": [
+                        "GRAPHIC_PNG"
+                    ],
                     "imageResolution": {
                         "resolutionWidth": 225,
                         "resolutionHeight": 225

--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -272,6 +272,10 @@
             "imageCapabilities": [
                 "DYNAMIC",
                 "STATIC"
+            ],
+            "menuLayoutsAvailable": [
+                "LIST",
+                "TILES"
             ]
         },
         "audioPassThruCapabilities": {

--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -242,6 +242,13 @@
                         "resolutionWidth": 35,
                         "resolutionHeight": 35
                     }
+                },
+                {
+                    "name": "alertIcon",
+                    "imageResolution": {
+                        "resolutionWidth": 225,
+                        "resolutionHeight": 225
+                    }
                 }
 
             ],
@@ -272,10 +279,6 @@
             "imageCapabilities": [
                 "DYNAMIC",
                 "STATIC"
-            ],
-            "menuLayoutsAvailable": [
-                "LIST",
-                "TILES"
             ]
         },
         "audioPassThruCapabilities": {

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -130,6 +130,7 @@ extern const char* initial_text;
 extern const char* duration;
 extern const char* progress_indicator;
 extern const char* alert_type;
+extern const char* alert_icon;
 extern const char* play_tone;
 extern const char* soft_buttons;
 extern const char* soft_button_id;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_request.cc
@@ -350,6 +350,23 @@ void AlertRequest::SendAlertRequest(int32_t app_id) {
     MessageHelper::SubscribeApplicationToSoftButton(
         (*message_)[strings::msg_params], app, function_id());
   }
+
+  if ((*message_)[strings::msg_params].keyExists(strings::alert_icon)) {
+    auto verification_result = MessageHelper::VerifyImage(
+        (*message_)[strings::msg_params][strings::alert_icon],
+        app,
+        application_manager_);
+
+    if (mobile_apis::Result::INVALID_DATA == verification_result) {
+      LOG4CXX_ERROR(logger_, "Image verification failed.");
+      SendResponse(false, verification_result);
+      return;
+    }
+
+    msg_params[strings::alert_icon] =
+        (*message_)[strings::msg_params][strings::alert_icon];
+  }
+
   // app_id
   msg_params[strings::app_id] = app_id;
   msg_params[strings::duration] = default_timeout_;

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -97,6 +97,7 @@ const char* initial_text = "initialText";
 const char* duration = "duration";
 const char* progress_indicator = "progressIndicator";
 const char* alert_type = "alertType";
+const char* alert_icon = "alertIcon";
 const char* play_tone = "playTone";
 const char* soft_buttons = "softButtons";
 const char* soft_button_id = "softButtonID";

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -667,6 +667,9 @@
   <element name="locationImage">
     <description>The optional image of a destination / location</description>
   </element>
+  <element name="alertIcon">
+    <description>The image field for Alert</description>
+  </element>
 </enum>
 
 <enum name="TextAlignment">
@@ -4607,6 +4610,12 @@
     </param>
     <param name="appID" type="Integer" mandatory="true">
       <description>ID of application requested this RPC.</description>
+    </param>
+    <param name="alertIcon" type="Common.Image" mandatory="false" >
+      <description>
+        Image to be displayed for the corresponding alert. See Image. 
+        If omitted, no (or the default if applicable) icon should be displayed.
+      </description>
     </param>
   </function>
   <function name="Alert" messagetype="response">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -871,7 +871,11 @@
         <element name="locationImage" since="4.0">
             <description>The optional image of a destination / location</description>
         </element>
-        
+
+        <element name="alertIcon" since="6.0">
+            <description>The image field for Alert</description>>
+        </element>
+
     </enum>
     
     <enum name="CharacterSet" since="1.0">
@@ -4929,6 +4933,13 @@
             <description>
                 App defined SoftButtons.
                 If omitted on supported displays, the displayed alert shall not have any SoftButtons.
+            </description>
+        </param>
+
+        <param name="alertIcon" type="Image" mandatory="false" since="6.0">
+            <description>
+                Image struct determining whether static or dynamic icon.
+                If omitted on supported displays, no (or the default if applicable) icon should be displayed.
             </description>
         </param>
         


### PR DESCRIPTION
Fixes #2287

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
ATF Test Suite

### Summary
Adds another optional parameter to the Alert RPC that allows for custom icons on an alert.

### Changelog
##### Enhancements
* Adds an optional parameter to Alert RPC that can be used to specify the icon for an alert.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
