### PR TITLE
Add AOA filtering parameters to .ini configuration

### DIFF
--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -205,6 +205,15 @@ TCPAdapterNetworkInterface =
 ; 128 bit uuid for bluetooth device discovery. Please format as 16 seperate bytes.
 ;BluetoothUUID = 0x93, 0x6D, 0xA0, 0x1F, 0x9A, 0xBD, 0x4D, 0x9D, 0x80, 0xC7, 0x02, 0xAF, 0x85, 0xC8, 0x22, 0xA8
 
+; AOA USB Transport Configuration
+; USBAccessory Filter Parameters
+AOAFilterManufacturer = SDL
+AOAFilterModelName = Core
+AOAFilterDescription = SmartDeviceLink Core Component USB
+AOAFilterVersion = 1.0
+AOAFilterURI = http://www.smartdevicelink.org
+AOAFilterSerialNumber = N000000
+
 [CloudAppConnections]
 ; Value in milliseconds for time between retry attempts on a failed websocket connection
 CloudAppRetryTimeout = 1000 

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -425,6 +425,13 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
 
   const uint8_t* bluetooth_uuid() const OVERRIDE;
 
+  const std::string& aoa_filter_manufacturer() const OVERRIDE;
+  const std::string& aoa_filter_model_name() const OVERRIDE;
+  const std::string& aoa_filter_description() const OVERRIDE;
+  const std::string& aoa_filter_version() const OVERRIDE;
+  const std::string& aoa_filter_uri() const OVERRIDE;
+  const std::string& aoa_filter_serial_number() const OVERRIDE;
+
   // TransportManageMMESettings interface
 
   const std::string& event_mq_name() const OVERRIDE;
@@ -982,6 +989,12 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   uint32_t cloud_app_retry_timeout_;
   uint16_t cloud_app_max_retry_attempts_;
   std::vector<uint8_t> bluetooth_uuid_;
+  std::string aoa_filter_manufacturer_;
+  std::string aoa_filter_model_name_;
+  std::string aoa_filter_description_;
+  std::string aoa_filter_version_;
+  std::string aoa_filter_uri_;
+  std::string aoa_filter_serial_number_;
   std::string tts_delimiter_;
   uint32_t audio_data_stopped_timeout_;
   uint32_t video_data_stopped_timeout_;

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -185,6 +185,12 @@ const char* kPendingRequestsAmoundKey = "PendingRequestsAmount";
 const char* kSupportedDiagModesKey = "SupportedDiagModes";
 const char* kTransportManagerDisconnectTimeoutKey = "DisconnectTimeout";
 const char* kBluetoothUUIDKey = "BluetoothUUID";
+const char* kAOAFilterManufacturerKey = "AOAFilterManufacturer";
+const char* kAOAFilterModelNameKey = "AOAFilterModelName";
+const char* kAOAFilterDescriptionKey = "AOAFilterDescription";
+const char* kAOAFilterVersionKey = "AOAFilterVersion";
+const char* kAOAFilterURIKey = "AOAFilterURI";
+const char* kAOAFilterSerialNumber = "AOAFilterSerialNumber";
 const char* kTTSDelimiterKey = "TTSDelimiter";
 const char* kRecordingFileNameKey = "RecordingFileName";
 const char* kRecordingFileSourceKey = "RecordingFileSource";
@@ -414,6 +420,12 @@ const std::vector<uint8_t> kDefaultBluetoothUUID = {0x93,
                                                     0xC8,
                                                     0x22,
                                                     0xA8};
+const char* kDefaultAOAFilterManufacturer = "SDL";
+const char* kDefaultAOAFilterModelName = "Core";
+const char* kDefaultAOAFilterDescription = "SmartDeviceLink Core Component USB";
+const char* kDefaultAOAFilterVersion = "1.0";
+const char* kDefaultAOAFilterURI = "http://www.smartdevicelink.org";
+const char* kDefaultAOAFilterSerialNumber = "N000000";
 }  // namespace
 
 namespace profile {
@@ -825,6 +837,30 @@ uint16_t Profile::cloud_app_max_retry_attempts() const {
 
 const uint8_t* Profile::bluetooth_uuid() const {
   return bluetooth_uuid_.data();
+}
+
+const std::string& Profile::aoa_filter_manufacturer() const {
+  return aoa_filter_manufacturer_;
+}
+
+const std::string& Profile::aoa_filter_model_name() const {
+  return aoa_filter_model_name_;
+}
+
+const std::string& Profile::aoa_filter_description() const {
+  return aoa_filter_description_;
+}
+
+const std::string& Profile::aoa_filter_version() const {
+  return aoa_filter_version_;
+}
+
+const std::string& Profile::aoa_filter_uri() const {
+  return aoa_filter_uri_;
+}
+
+const std::string& Profile::aoa_filter_serial_number() const {
+  return aoa_filter_serial_number_;
 }
 
 const std::string& Profile::tts_delimiter() const {
@@ -1848,6 +1884,57 @@ void Profile::UpdateValues() {
   if (!read_result || bluetooth_uuid_.size() != 16) {
     bluetooth_uuid_ = kDefaultBluetoothUUID;
   }
+
+  ReadStringValue(&aoa_filter_manufacturer_,
+                  kDefaultAOAFilterManufacturer,
+                  kTransportManagerSection,
+                  kAOAFilterManufacturerKey);
+
+  LOG_UPDATED_VALUE(aoa_filter_manufacturer_,
+                    kAOAFilterManufacturerKey,
+                    kTransportManagerSection);
+
+  ReadStringValue(&aoa_filter_model_name_,
+                  kDefaultAOAFilterModelName,
+                  kTransportManagerSection,
+                  kAOAFilterModelNameKey);
+
+  LOG_UPDATED_VALUE(
+      aoa_filter_model_name_, kAOAFilterModelNameKey, kTransportManagerSection);
+
+  ReadStringValue(&aoa_filter_description_,
+                  kDefaultAOAFilterDescription,
+                  kTransportManagerSection,
+                  kAOAFilterDescriptionKey);
+
+  LOG_UPDATED_VALUE(aoa_filter_description_,
+                    kAOAFilterDescriptionKey,
+                    kTransportManagerSection);
+
+  ReadStringValue(&aoa_filter_version_,
+                  kDefaultAOAFilterVersion,
+                  kTransportManagerSection,
+                  kAOAFilterVersionKey);
+
+  LOG_UPDATED_VALUE(
+      aoa_filter_version_, kAOAFilterVersionKey, kTransportManagerSection);
+
+  ReadStringValue(&aoa_filter_uri_,
+                  kDefaultAOAFilterURI,
+                  kTransportManagerSection,
+                  kAOAFilterURIKey);
+
+  LOG_UPDATED_VALUE(
+      aoa_filter_uri_, kAOAFilterURIKey, kTransportManagerSection);
+
+  ReadStringValue(&aoa_filter_serial_number_,
+                  kDefaultAOAFilterSerialNumber,
+                  kTransportManagerSection,
+                  kAOAFilterSerialNumber);
+
+  LOG_UPDATED_VALUE(aoa_filter_serial_number_,
+                    kAOAFilterSerialNumber,
+                    kTransportManagerSection);
 
   // Event MQ
   ReadStringValue(

--- a/src/components/include/test/transport_manager/mock_transport_manager_settings.h
+++ b/src/components/include/test/transport_manager/mock_transport_manager_settings.h
@@ -66,6 +66,12 @@ class MockTransportManagerSettings
   MOCK_CONST_METHOD0(cloud_app_retry_timeout, uint32_t());
   MOCK_CONST_METHOD0(cloud_app_max_retry_attempts, uint16_t());
   MOCK_CONST_METHOD0(bluetooth_uuid, const uint8_t*());
+  MOCK_CONST_METHOD0(aoa_filter_manufacturer, const std::string&());
+  MOCK_CONST_METHOD0(aoa_filter_model_name, const std::string&());
+  MOCK_CONST_METHOD0(aoa_filter_description, const std::string&());
+  MOCK_CONST_METHOD0(aoa_filter_version, const std::string&());
+  MOCK_CONST_METHOD0(aoa_filter_uri, const std::string&());
+  MOCK_CONST_METHOD0(aoa_filter_serial_number, const std::string&());
 };
 
 }  // namespace transport_manager_test

--- a/src/components/include/transport_manager/transport_manager_settings.h
+++ b/src/components/include/transport_manager/transport_manager_settings.h
@@ -81,6 +81,13 @@ class TransportManagerSettings : public TransportManagerMMESettings {
   virtual uint16_t cloud_app_max_retry_attempts() const = 0;
 
   virtual const uint8_t* bluetooth_uuid() const = 0;
+
+  virtual const std::string& aoa_filter_manufacturer() const = 0;
+  virtual const std::string& aoa_filter_model_name() const = 0;
+  virtual const std::string& aoa_filter_description() const = 0;
+  virtual const std::string& aoa_filter_version() const = 0;
+  virtual const std::string& aoa_filter_uri() const = 0;
+  virtual const std::string& aoa_filter_serial_number() const = 0;
 };
 }  // namespace transport_manager
 #endif  // SRC_COMPONENTS_INCLUDE_TRANSPORT_MANAGER_TRANSPORT_MANAGER_SETTINGS_H_

--- a/src/components/transport_manager/include/transport_manager/usb/usb_device_scanner.h
+++ b/src/components/transport_manager/include/transport_manager/usb/usb_device_scanner.h
@@ -48,7 +48,8 @@ namespace transport_adapter {
 
 class UsbDeviceScanner : public DeviceScanner, public UsbDeviceListener {
  public:
-  UsbDeviceScanner(class TransportAdapterController* controller);
+  UsbDeviceScanner(class TransportAdapterController* controller,
+                   const TransportManagerSettings& settings);
   virtual ~UsbDeviceScanner();
 
  protected:
@@ -65,6 +66,7 @@ class UsbDeviceScanner : public DeviceScanner, public UsbDeviceListener {
   void SupportedDeviceFound(PlatformUsbDevice* device);
 
   TransportAdapterController* controller_;
+  const TransportManagerSettings& settings_;
 
   typedef std::list<PlatformUsbDevice*> Devices;
   Devices devices_;

--- a/src/components/transport_manager/src/usb/usb_aoa_adapter.cc
+++ b/src/components/transport_manager/src/usb/usb_aoa_adapter.cc
@@ -45,7 +45,7 @@ namespace transport_adapter {
 CREATE_LOGGERPTR_GLOBAL(logger_, "TransportManager")
 UsbAoaAdapter::UsbAoaAdapter(resumption::LastState& last_state,
                              const TransportManagerSettings& settings)
-    : TransportAdapterImpl(new UsbDeviceScanner(this),
+    : TransportAdapterImpl(new UsbDeviceScanner(this, settings),
                            new UsbConnectionFactory(this),
                            NULL,
                            last_state,


### PR DESCRIPTION
Fixes #2971 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Connect android device using USB.

### Summary
Moved location of aoa filter parameters to be set in the .ini configuration.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
