### PR TITLE
[SDL 0173] Add customDataTYpe parameter and add  VEHICLEDATA_OEM_CUSTOM_DATA enum value

### DIFF
--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -312,7 +312,7 @@ extern const char* sdl_version;
 extern const char* system_software_version;
 extern const char* priority;
 extern const char* engine_oil_life;
-extern const char* oem_specific;
+extern const char* oem_custom_data_type;
 
 // app services
 extern const char* app_service_manifest;

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/subscribe_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/subscribe_vehicle_data_request.h
@@ -155,6 +155,13 @@ class SubscribeVehicleDataRequest
   const std::string& ConvertRequestToResponseName(const std::string& name);
 
   /**
+   * @brief Appends data types for vehicle data in response to mobile
+   * @param msg_params 'message_parameters' response section reference
+   */
+  void AppendDataTypesToMobileResponse(
+      smart_objects::SmartObject& msg_params) const;
+
+  /**
    * @brief VI parameters which had been already subscribed by another apps
    * befor particular app subscribed for these parameters
    */

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/unsubscribe_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/unsubscribe_vehicle_data_request.h
@@ -146,6 +146,13 @@ class UnsubscribeVehicleDataRequest
    */
   const std::string& ConvertResponseToRequestName(const std::string& name);
 
+  /**
+   * @brief Appends data types for vehicle data in response to mobile
+   * @param msg_params 'message_parameters' response section reference
+   */
+  void AppendDataTypesToMobileResponse(
+      smart_objects::SmartObject& msg_params) const;
+
   bool CheckSubscriptionStatus(std::string key,
                                const smart_objects::SmartObject& msg_params);
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/custom_vehicle_data_manager.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/custom_vehicle_data_manager.h
@@ -27,6 +27,14 @@ class CustomVehicleDataManager {
       const std::set<std::string>& item_names) = 0;
 
   /**
+   * @brief Gets data type of vehicle data item
+   * @param vehicle_data_item_name name of vehicle data
+   * @return data type of vehicle_data if one found, item name otherwise
+   */
+  virtual std::string GetVehicleDataItemType(
+      const std::string& vehicle_data_item_name) const = 0;
+
+  /**
    * @brief Creates message params (nested if needed) to be sent to Mobile
    * according to vehicle data item schema
    * @param input_params message params received from hmi

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/custom_vehicle_data_manager_impl.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/custom_vehicle_data_manager_impl.h
@@ -32,6 +32,9 @@ class CustomVehicleDataManagerImpl : public CustomVehicleDataManager {
   virtual smart_objects::SmartObject CreateHMIMessageParams(
       const std::set<std::string>& item_names) OVERRIDE;
 
+  std::string GetVehicleDataItemType(
+      const std::string& vehicle_data_item_name) const OVERRIDE;
+
   virtual void CreateMobileMessageParams(
       smart_objects::SmartObject& msg_params) OVERRIDE;
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -73,6 +73,7 @@ void SubscribeVehicleDataRequest::Run() {
       app, info, result_code, response_params, msg_params, result);
 
   if (mobile_apis::Result::INVALID_ENUM != result_code) {
+    AppendDataTypesToMobileResponse(response_params);
     SendResponse(result,
                  result_code,
                  info.empty() ? NULL : info.c_str(),
@@ -131,7 +132,7 @@ void SubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
       const auto& converted_name = ConvertResponseToRequestName(param);
       if (vi_waiting_for_subscribe_.end() ==
           vi_waiting_for_subscribe_.find(converted_name)) {
-        LOG4CXX_DEBUG(logger_, "eraze " << converted_name);
+        LOG4CXX_DEBUG(logger_, "erase " << converted_name);
         converted_msg_params.erase(param);
       }
     }
@@ -148,10 +149,33 @@ void SubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
       !vi_already_subscribed_by_this_app_.empty()) {
     AddAlreadySubscribedVI(converted_msg_params);
   }
+  AppendDataTypesToMobileResponse(converted_msg_params);
+
   SendResponse(is_succeeded,
                result_code,
                response_info.empty() ? NULL : response_info.c_str(),
                &converted_msg_params);
+}
+
+void SubscribeVehicleDataRequest::AppendDataTypesToMobileResponse(
+    smart_objects::SmartObject& msg_params) const {
+  using namespace smart_objects;
+
+  std::string oem_vehicle_data_type_str;
+  EnumConversionHelper<VehicleDataType>::EnumToString(
+      VehicleDataType::VEHICLEDATA_OEM_CUSTOM_DATA, &oem_vehicle_data_type_str);
+
+  const auto& rpc_spec_vehicle_data = MessageHelper::vehicle_data();
+  for (const auto& item : msg_params.enumerate()) {
+    const auto& rpc_spec_vehicle_data_item = rpc_spec_vehicle_data.find(item);
+    if (rpc_spec_vehicle_data.end() == rpc_spec_vehicle_data_item) {
+      msg_params[item][strings::data_type] = oem_vehicle_data_type_str;
+      msg_params[item][strings::oem_custom_data_type] =
+          custom_vehicle_data_manager_.GetVehicleDataItemType(item);
+    } else {
+      msg_params[item][strings::data_type] = rpc_spec_vehicle_data_item->second;
+    }
+  }
 }
 
 bool SubscribeVehicleDataRequest::CheckSubscriptionStatus(
@@ -204,25 +228,14 @@ void SubscribeVehicleDataRequest::AddAlreadySubscribedVI(
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace mobile_apis;
 
-  const auto& rpc_spec_vehicle_data = MessageHelper::vehicle_data();
   for (const auto& item : vi_already_subscribed_by_this_app_) {
-    const auto& data_type =
-        rpc_spec_vehicle_data.end() == rpc_spec_vehicle_data.find(item)
-            ? strings::oem_specific
-            : item;
     msg_params[item][strings::result_code] =
         VehicleDataResultCode::VDRC_DATA_ALREADY_SUBSCRIBED;
-    msg_params[item][strings::data_type] = data_type;
   }
 
   for (const auto& item : vi_already_subscribed_by_another_apps_) {
-    const auto& data_type =
-        rpc_spec_vehicle_data.end() == rpc_spec_vehicle_data.find(item)
-            ? strings::oem_specific
-            : item;
     msg_params[item][strings::result_code] =
         VehicleDataResultCode::VDRC_SUCCESS;
-    msg_params[item][strings::data_type] = data_type;
   }
 }
 
@@ -335,9 +348,10 @@ void SubscribeVehicleDataRequest::CheckVISubscriptions(
       }
 
       auto vehicle_data = rpc_spec_vehicle_data.find(name);
-      auto vehicle_data_type = (vehicle_data == rpc_spec_vehicle_data.end())
-                                   ? VehicleDataType::OEM_SPECIFIC
-                                   : vehicle_data->second;
+      auto vehicle_data_type =
+          (vehicle_data == rpc_spec_vehicle_data.end())
+              ? VehicleDataType::VEHICLEDATA_OEM_CUSTOM_DATA
+              : vehicle_data->second;
       if (ext.isSubscribedToVehicleInfo(name)) {
         app_already_subscribed(name, vehicle_data_type);
       } else if (IsSomeoneSubscribedFor(name)) {

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -39,6 +39,7 @@
 #include "application_manager/smart_object_keys.h"
 #include "interfaces/HMI_API.h"
 #include "interfaces/MOBILE_API.h"
+#include "smart_objects/enum_schema_item.h"
 #include "utils/helpers.h"
 #include "vehicle_info_plugin/vehicle_info_app_extension.h"
 
@@ -80,32 +81,25 @@ void UnsubscribeVehicleDataRequest::Run() {
   auto rpc_spec_vehicle_data = MessageHelper::vehicle_data();
   std::set<std::string> custom_vehicle_data;
 
-  auto app_not_subscribed_response =
-      [this](const std::string& key_name,
-             const mobile_apis::VehicleDataType::eType vd_type) {
-        LOG4CXX_DEBUG(
-            logger_,
-            "App with connection key "
-                << connection_key()
-                << " is not subscribed for VehicleData: " << key_name);
-        vi_already_unsubscribed_by_this_app_.insert(key_name);
-        response_params_[key_name][strings::data_type] = vd_type;
-        response_params_[key_name][strings::result_code] =
-            mobile_apis::VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED;
-      };
+  auto app_not_subscribed_response = [this](const std::string& key_name) {
+    LOG4CXX_DEBUG(logger_,
+                  "App with connection key "
+                      << connection_key()
+                      << " is not subscribed for VehicleData: " << key_name);
+    vi_already_unsubscribed_by_this_app_.insert(key_name);
+    response_params_[key_name][strings::result_code] =
+        mobile_apis::VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED;
+  };
 
-  auto other_app_subscribed_response =
-      [this](const std::string& key_name,
-             const mobile_apis::VehicleDataType::eType vd_type) {
-        LOG4CXX_DEBUG(logger_,
-                      "There are apps still subscribed for "
-                      "VehicleDataType: "
-                          << key_name);
-        vi_still_subscribed_by_another_apps_.insert(key_name);
-        response_params_[key_name][strings::data_type] = vd_type;
-        response_params_[key_name][strings::result_code] =
-            mobile_apis::VehicleDataResultCode::VDRC_SUCCESS;
-      };
+  auto other_app_subscribed_response = [this](const std::string& key_name) {
+    LOG4CXX_DEBUG(logger_,
+                  "There are apps still subscribed for "
+                  "VehicleDataType: "
+                      << key_name);
+    vi_still_subscribed_by_another_apps_.insert(key_name);
+    response_params_[key_name][strings::result_code] =
+        mobile_apis::VehicleDataResultCode::VDRC_SUCCESS;
+  };
 
   auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
 
@@ -123,13 +117,8 @@ void UnsubscribeVehicleDataRequest::Run() {
 
     ++items_to_unsubscribe;
 
-    auto vehicle_data = rpc_spec_vehicle_data.find(name);
-    auto vehicle_data_type = vehicle_data == rpc_spec_vehicle_data.end()
-                                 ? VehicleDataType::OEM_SPECIFIC
-                                 : vehicle_data->second;
-
     if (!(ext.isSubscribedToVehicleInfo(name))) {
-      app_not_subscribed_response(name, vehicle_data_type);
+      app_not_subscribed_response(name);
       continue;
     }
 
@@ -140,7 +129,7 @@ void UnsubscribeVehicleDataRequest::Run() {
     ++unsubscribed_items;
 
     if (IsSomeoneSubscribedFor(name)) {
-      other_app_subscribed_response(name, vehicle_data_type);
+      other_app_subscribed_response(name);
       ext.unsubscribeFromVehicleInfo(name);
       continue;
     }
@@ -162,6 +151,7 @@ void UnsubscribeVehicleDataRequest::Run() {
     }
     return true;
   };
+  AppendDataTypesToMobileResponse(response_params_);
 
   if (0 == items_to_unsubscribe) {
     if (HasDisallowedParams() && undefined_params_valid()) {
@@ -263,6 +253,7 @@ void UnsubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
     }
   }
 
+  AppendDataTypesToMobileResponse(hmi_response_msg_params);
   for (const auto& key : hmi_response_msg_params.enumerate()) {
     response_params_[key] = hmi_response_msg_params[key];
   }
@@ -309,24 +300,13 @@ void UnsubscribeVehicleDataRequest::AddAlreadyUnsubscribedVI(
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace mobile_apis;
 
-  const auto& rpc_spec_vehicle_data = MessageHelper::vehicle_data();
   for (const auto& item : vi_already_unsubscribed_by_this_app_) {
-    const auto& data_type =
-        rpc_spec_vehicle_data.end() == rpc_spec_vehicle_data.find(item)
-            ? strings::oem_specific
-            : item;
     response[item][strings::result_code] =
         VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED;
-    response[item][strings::data_type] = data_type;
   }
 
   for (const auto& item : vi_still_subscribed_by_another_apps_) {
-    const auto& data_type =
-        rpc_spec_vehicle_data.end() == rpc_spec_vehicle_data.find(item)
-            ? strings::oem_specific
-            : item;
     response[item][strings::result_code] = VehicleDataResultCode::VDRC_SUCCESS;
-    response[item][strings::data_type] = data_type;
   }
 }
 
@@ -385,6 +365,27 @@ const std::string& UnsubscribeVehicleDataRequest::ConvertResponseToRequestName(
   return parameter_name_converion_map.end() == converted_it
              ? name
              : converted_it->second;
+}
+
+void UnsubscribeVehicleDataRequest::AppendDataTypesToMobileResponse(
+    smart_objects::SmartObject& msg_params) const {
+  using namespace smart_objects;
+
+  std::string oem_vehicle_data_type_str;
+  EnumConversionHelper<VehicleDataType>::EnumToString(
+      VehicleDataType::VEHICLEDATA_OEM_CUSTOM_DATA, &oem_vehicle_data_type_str);
+
+  const auto& rpc_spec_vehicle_data = MessageHelper::vehicle_data();
+  for (const auto& item : msg_params.enumerate()) {
+    const auto& rpc_spec_vehicle_data_item = rpc_spec_vehicle_data.find(item);
+    if (rpc_spec_vehicle_data.end() == rpc_spec_vehicle_data_item) {
+      msg_params[item][strings::data_type] = oem_vehicle_data_type_str;
+      msg_params[item][strings::oem_custom_data_type] =
+          custom_vehicle_data_manager_.GetVehicleDataItemType(item);
+    } else {
+      msg_params[item][strings::data_type] = rpc_spec_vehicle_data_item->second;
+    }
+  }
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/custom_vehicle_data_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/custom_vehicle_data_manager_impl.cc
@@ -79,6 +79,15 @@ bool CustomVehicleDataManagerImpl::ValidateVehicleDataItems(
   return true;
 }
 
+std::string CustomVehicleDataManagerImpl::GetVehicleDataItemType(
+    const std::string& vehicle_data_item_name) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const auto& schema = FindSchemaByNameNonRecursive(vehicle_data_item_name);
+
+  return schema.is_initialized() ? std::string(schema->type)
+                                 : vehicle_data_item_name;
+}
+
 void CustomVehicleDataManagerImpl::CreateMobileMessageParams(
     smart_objects::SmartObject& msg_params) {
   using namespace application_manager;
@@ -92,8 +101,7 @@ void CustomVehicleDataManagerImpl::CreateMobileMessageParams(
   MobileMsgConstructor fill_mobile_msg =
       [this, &fill_mobile_msg](
           const smart_objects::SmartObject& input_params,
-          SearchMethod search_method =
-              SearchMethod::NON_RECURSIVE) -> smart_objects::SmartObject {
+          SearchMethod search_method) -> smart_objects::SmartObject {
     smart_objects::SmartObject out_params;
 
     const auto& items = input_params.enumerate();

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_get_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_get_vehicle_data_request_test.cc
@@ -34,6 +34,7 @@
 
 #include "gtest/gtest.h"
 
+#include "smart_objects/enum_schema_item.h"
 #include "smart_objects/smart_object.h"
 #include "vehicle_info_plugin/commands/vi_command_request_test.h"
 
@@ -79,9 +80,14 @@ TEST_F(VIGetVehicleDataRequestTest, Run_Success) {
   ON_CALL(mock_message_helper_, vehicle_data())
       .WillByDefault(ReturnRef(vehicle_data));
 
+  std::string oem_vehicle_data_type_str;
+  smart_objects::EnumConversionHelper<mobile_apis::VehicleDataType::eType>::
+      EnumToString(mobile_apis::VehicleDataType::VEHICLEDATA_OEM_CUSTOM_DATA,
+                   &oem_vehicle_data_type_str);
+
   smart_objects::SmartObject hmi_params;
   hmi_params[kHMIParam] = smart_objects::SmartType_Map;
-  hmi_params[kHMIParam][strings::data_type] = strings::oem_specific;
+  hmi_params[kHMIParam][strings::data_type] = oem_vehicle_data_type_str;
   ON_CALL(mock_custom_vehicle_data_manager_, CreateHMIMessageParams(_))
       .WillByDefault(Return(hmi_params));
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_subscribe_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_subscribe_vehicle_data_request_test.cc
@@ -34,6 +34,7 @@
 
 #include "gtest/gtest.h"
 
+#include "smart_objects/enum_schema_item.h"
 #include "smart_objects/smart_object.h"
 #include "vehicle_info_plugin/commands/vi_command_request_test.h"
 
@@ -79,9 +80,14 @@ TEST_F(VISubscribeVehicleDataRequestTest, Run_Success) {
   ON_CALL(mock_message_helper_, vehicle_data())
       .WillByDefault(ReturnRef(vehicle_data));
 
+  std::string oem_vehicle_data_type_str;
+  smart_objects::EnumConversionHelper<mobile_apis::VehicleDataType::eType>::
+      EnumToString(mobile_apis::VehicleDataType::VEHICLEDATA_OEM_CUSTOM_DATA,
+                   &oem_vehicle_data_type_str);
+
   smart_objects::SmartObject hmi_params;
   hmi_params[kHMIParam] = smart_objects::SmartType_Map;
-  hmi_params[kHMIParam][strings::data_type] = strings::oem_specific;
+  hmi_params[kHMIParam][strings::data_type] = oem_vehicle_data_type_str;
   ON_CALL(mock_custom_vehicle_data_manager_, CreateHMIMessageParams(_))
       .WillByDefault(Return(hmi_params));
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_unsubscribe_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_unsubscribe_vehicle_data_request_test.cc
@@ -34,6 +34,7 @@
 
 #include "gtest/gtest.h"
 
+#include "smart_objects/enum_schema_item.h"
 #include "smart_objects/smart_object.h"
 #include "vehicle_info_plugin/commands/vi_command_request_test.h"
 
@@ -79,9 +80,14 @@ TEST_F(VIUnsubscribeVehicleDataRequestTest, Run_Success) {
   ON_CALL(mock_message_helper_, vehicle_data())
       .WillByDefault(ReturnRef(vehicle_data));
 
+  std::string oem_vehicle_data_type_str;
+  smart_objects::EnumConversionHelper<mobile_apis::VehicleDataType::eType>::
+      EnumToString(mobile_apis::VehicleDataType::VEHICLEDATA_OEM_CUSTOM_DATA,
+                   &oem_vehicle_data_type_str);
+
   smart_objects::SmartObject hmi_params;
   hmi_params[kHMIParam] = smart_objects::SmartType_Map;
-  hmi_params[kHMIParam][strings::data_type] = strings::oem_specific;
+  hmi_params[kHMIParam][strings::data_type] = oem_vehicle_data_type_str;
   ON_CALL(mock_custom_vehicle_data_manager_, CreateHMIMessageParams(_))
       .WillByDefault(Return(hmi_params));
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/mobile/unsubscribe_vehicle_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/mobile/unsubscribe_vehicle_request_test.cc
@@ -122,7 +122,8 @@ TEST_F(UnsubscribeVehicleRequestTest,
       kVehicleTypeStr;
 
   am::VehicleData data;
-  EXPECT_CALL(mock_message_helper_, vehicle_data()).WillOnce(ReturnRef(data));
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
+      .WillRepeatedly(ReturnRef(data));
 
   smart_objects::SmartObject empty_hmi_custom_params;
   ON_CALL(mock_custom_vehicle_data_manager_, CreateHMIMessageParams(_))
@@ -185,7 +186,7 @@ TEST_F(UnsubscribeVehicleRequestTest,
        Run_EmptyVehicleData_INVALID_DATA_SentToMobile) {
   am::VehicleData vehicle_data;
   EXPECT_CALL(mock_message_helper_, vehicle_data())
-      .WillOnce(ReturnRef(vehicle_data));
+      .WillRepeatedly(ReturnRef(vehicle_data));
 
   smart_objects::SmartObject empty_hmi_custom_params;
   ON_CALL(mock_custom_vehicle_data_manager_, CreateHMIMessageParams(_))
@@ -218,7 +219,7 @@ TEST_F(UnsubscribeVehicleRequestTest,
   am::VehicleData vehicle_data;
   vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
   EXPECT_CALL(mock_message_helper_, vehicle_data())
-      .WillOnce(ReturnRef(vehicle_data));
+      .WillRepeatedly(ReturnRef(vehicle_data));
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
 
@@ -252,7 +253,7 @@ TEST_F(UnsubscribeVehicleRequestTest, Run_UnsubscribeDataDisabled_UNSUCCESS) {
   am::VehicleData vehicle_data;
   vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
   EXPECT_CALL(mock_message_helper_, vehicle_data())
-      .WillOnce(ReturnRef(vehicle_data));
+      .WillRepeatedly(ReturnRef(vehicle_data));
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(mock_app_));
 
@@ -326,6 +327,11 @@ TEST_F(UnsubscribeVehicleRequestTest, OnEvent_DataUnsubscribed_SUCCESS) {
   message[am::strings::params][am::hmi_response::code] = hmi_result;
   message[am::strings::msg_params][kMsgParamKey] = true;
   test_event.set_smart_object(message);
+
+  am::VehicleData vehicle_data;
+  vehicle_data.insert(am::VehicleData::value_type(kMsgParamKey, kVehicleType));
+  EXPECT_CALL(mock_message_helper_, vehicle_data())
+      .WillRepeatedly(ReturnRef(vehicle_data));
 
   EXPECT_CALL(
       mock_rpc_service_,

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/include/vehicle_info_plugin/mock_custom_vehicle_data_manager.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/include/vehicle_info_plugin/mock_custom_vehicle_data_manager.h
@@ -15,6 +15,8 @@ class MockCustomVehicleDataManager : public CustomVehicleDataManager {
       smart_objects::SmartObject(const std::set<std::string>& msg_params));
   MOCK_METHOD1(CreateMobileMessageParams,
                void(smart_objects::SmartObject& msg_params));
+  MOCK_CONST_METHOD1(GetVehicleDataItemType,
+                     std::string(const std::string& vehicle_data_item_name));
   MOCK_METHOD1(IsVehicleDataName, bool(const std::string& name));
   MOCK_METHOD1(IsVehicleDataKey, bool(const std::string& key));
 };

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -150,9 +150,10 @@ struct DisallowedParamsInserter {
 
     auto rpc_spec_vehicle_data = MessageHelper::vehicle_data();
     auto vehicle_data = rpc_spec_vehicle_data.find(param);
-    auto vehicle_data_type = vehicle_data == rpc_spec_vehicle_data.end()
-                                 ? mobile_apis::VehicleDataType::OEM_SPECIFIC
-                                 : vehicle_data->second;
+    auto vehicle_data_type =
+        vehicle_data == rpc_spec_vehicle_data.end()
+            ? mobile_apis::VehicleDataType::VEHICLEDATA_OEM_CUSTOM_DATA
+            : vehicle_data->second;
 
     (*disallowed_param)[strings::data_type] = vehicle_data_type;
     (*disallowed_param)[strings::result_code] = code_;

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -279,7 +279,7 @@ const char* sdl_version = "sdlVersion";
 const char* system_software_version = "systemSoftwareVersion";
 const char* priority = "priority";
 const char* engine_oil_life = "engineOilLife";
-const char* oem_specific = "OEM_SPECIFIC";
+const char* oem_custom_data_type = "oemCustomDataType";
 
 // app services
 const char* app_service_manifest = "appServiceManifest";

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1138,6 +1138,7 @@
   <element name="VEHICLEDATA_ENGINEOILLIFE" />
   <element name="VEHICLEDATA_ELECTRONICPARKBRAKESTATUS" />
   <element name="VEHICLEDATA_CLOUDAPPVEHICLEID" />
+  <element name="VEHICLEDATA_OEM_CUSTOM_DATA" />
 </enum>
 
 <enum name="WiperStatus">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -543,6 +543,7 @@
         <element name="VEHICLEDATA_ENGINEOILLIFE" since="5.0" />
         <element name="VEHICLEDATA_ELECTRONICPARKBRAKESTATUS" since="5.0" />
         <element name="VEHICLEDATA_CLOUDAPPVEHICLEID" since="5.1"/>
+        <element name="VEHICLEDATA_OEM_CUSTOM_DATA" since="6.0"/>
     </enum>
 
     <enum name="HybridAppPreference" since="5.1">
@@ -2058,6 +2059,9 @@
         </param>
         <param name="resultCode" type="VehicleDataResultCode" mandatory="true">
             <description>Published data result code.</description>
+        </param>
+        <param name="oemCustomDataType" type="String" mandatory="false" since="6.0">
+            <description>Type of requested oem specific parameter </description>
         </param>
     </struct>
     

--- a/tools/InterfaceGenerator/generator/parsers/JSONRPC.py
+++ b/tools/InterfaceGenerator/generator/parsers/JSONRPC.py
@@ -52,9 +52,7 @@ class Parser(RPCBase.Parser):
 
         """
 
-        if enum.name == "Common_VehicleDataType":
-            item = Model.EnumElement("OEM_SPECIFIC")
-            enum.elements["OEM_SPECIFIC"] = item
+        pass
 
     def _check_function(self, struct):
         custom_vdi_subs = [

--- a/tools/InterfaceGenerator/generator/parsers/SDLRPCV2.py
+++ b/tools/InterfaceGenerator/generator/parsers/SDLRPCV2.py
@@ -33,9 +33,7 @@ class Parser(RPCBase.Parser):
 
         """
 
-        if enum.name == "VehicleDataType":
-            item = Model.EnumElement("OEM_SPECIFIC")
-            enum.elements["OEM_SPECIFIC"] = item
+        pass
 
 
     def _check_function(self, struct):


### PR DESCRIPTION
This PR is **ready** for review.

Related to https://github.com/smartdevicelink/sdl_evolution/pull/802 
### Summary
Current PR implements custom data type in response to mobile for Subscribe/Unsubscribe VehicleData

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)