### PR TITLE
Avoid converting to Json non object values

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_get_policy_configuration_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_get_policy_configuration_data_request.cc
@@ -135,19 +135,27 @@ smart_objects::SmartObject SDLGetPolicyConfigurationDataRequest::GetValueParam(
     const Json::Value& policy_property) const {
   LOG4CXX_AUTO_TRACE(logger_);
   smart_objects::SmartObject value(smart_objects::SmartType_Array);
-  Json::FastWriter writer;
+
+  auto put_element_in_value_array = [&value](const Json::Value& element,
+                                             const int32_t index) {
+    Json::FastWriter writer;
+    std::string str;
+    if (element.type() == Json::objectValue) {
+      str = writer.write(element);
+      clear_new_line_symbol(str);
+    } else {
+      str = element.asString();
+    }
+    value[index] = str;
+  };
 
   if (policy_property.type() == Json::arrayValue) {
     for (Json::ArrayIndex i = 0; i < policy_property.size(); i++) {
-      std::string element = writer.write(policy_property[i]);
-      clear_new_line_symbol(element);
-      value[i] = element;
+      put_element_in_value_array(policy_property[i], i);
     }
     return value;
   }
-  std::string object_str = writer.write(policy_property);
-  clear_new_line_symbol(object_str);
-  value[0] = object_str;
+  put_element_in_value_array(policy_property, 0);
   return value;
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_get_policy_configuration_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_get_policy_configuration_data_request_test.cc
@@ -52,7 +52,9 @@ namespace hmi_response = ::app_mngr::hmi_response;
 class SDLGetPolicyConfigurationDataRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {};
 
-MATCHER_P(GetPolicyConfigurationDataMatchesJson, json_value, "") {
+MATCHER_P(GetPolicyConfigurationDataFirstElementMatches,
+          string_first_element_value,
+          "") {
   auto message = static_cast<smart_objects::SmartObject>(*arg);
   if (!message.keyExists(strings::msg_params) ||
       !message[strings::msg_params].keyExists(strings::value)) {
@@ -67,17 +69,9 @@ MATCHER_P(GetPolicyConfigurationDataMatchesJson, json_value, "") {
 
   Json::Reader reader;
   Json::Value msg_json_value(Json::ValueType::arrayValue);
-  auto msg_value_array = message[strings::msg_params][strings::value].asArray();
-  auto msg_value_array_it = msg_value_array->begin();
-  auto msg_value_array_end = msg_value_array->end();
-  for (; msg_value_array_it != msg_value_array_end; ++msg_value_array_it) {
-    Json::Value item(Json::objectValue);
-    auto msg_value_item = msg_value_array_it->asString();
-    reader.parse(msg_value_item, item);
-    msg_json_value.append(item);
-  }
 
-  return msg_json_value == json_value;
+  auto msg_value_first = message[strings::msg_params][strings::value][0];
+  return msg_value_first.asString() == string_first_element_value;
 }
 
 MATCHER_P(HMIResultCodeIs, result_code, "") {
@@ -108,6 +102,14 @@ TEST_F(SDLGetPolicyConfigurationDataRequestTest, Run_Fail_DataNotAvailable) {
   command->Run();
 }
 
+void clear_new_line_symbol(std::string& str_to_clear) {
+  str_to_clear.erase(
+      std::remove_if(str_to_clear.begin(),
+                     str_to_clear.end(),
+                     [](char character) { return '\n' == character; }),
+      str_to_clear.end());
+}
+
 TEST_F(SDLGetPolicyConfigurationDataRequestTest, Run_Success) {
   MessageSharedPtr msg = CreateMessage();
   (*msg)[strings::msg_params][strings::policy_type] = "module_config";
@@ -126,19 +128,44 @@ TEST_F(SDLGetPolicyConfigurationDataRequestTest, Run_Success) {
   endpoint_url_list["default"] = urls;
   module_config_with_endpoints.endpoints["0x9"] = endpoint_url_list;
 
-  pt.module_config = module_config_with_endpoints;
-  Json::Value value_json(Json::ValueType::arrayValue);
-  Json::Value endpoints_json =
-      module_config_with_endpoints.endpoints.ToJsonValue();
-  value_json.append(endpoints_json);
+  ON_CALL(mock_policy_handler_, GetPolicyTableData())
+      .WillByDefault(Return(pt.ToJsonValue()));
+
+  auto json_val = endpoint_url_list.ToJsonValue();
+  Json::FastWriter writer;
+  std::string expected_string = writer.write(json_val);
+  clear_new_line_symbol(expected_string);
+
+  EXPECT_CALL(mock_rpc_service_,
+              ManageHMICommand(GetPolicyConfigurationDataFirstElementMatches(
+                                   expected_string),
+                               Command::SOURCE_SDL_TO_HMI));
+  command->Run();
+}
+
+TEST_F(SDLGetPolicyConfigurationDataRequestTest,
+       Run_RetriveStringValueFromPolicy) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::msg_params][strings::policy_type] =
+      "consumer_friendly_messages";
+  (*msg)[strings::msg_params][strings::property] = "version";
+
+  auto command = CreateCommand<SDLGetPolicyConfigurationDataRequest>(msg);
+
+  const std::string version_test_value("version string");
+  PolicyTable pt;
+  pt.mark_initialized();
+  pt.consumer_friendly_messages->mark_initialized();
+  pt.consumer_friendly_messages->version =
+      rpc::String<1, 100>(version_test_value);
 
   ON_CALL(mock_policy_handler_, GetPolicyTableData())
       .WillByDefault(Return(pt.ToJsonValue()));
 
-  EXPECT_CALL(
-      mock_rpc_service_,
-      ManageHMICommand(GetPolicyConfigurationDataMatchesJson(value_json),
-                       Command::SOURCE_SDL_TO_HMI));
+  EXPECT_CALL(mock_rpc_service_,
+              ManageHMICommand(GetPolicyConfigurationDataFirstElementMatches(
+                                   version_test_value),
+                               Command::SOURCE_SDL_TO_HMI));
 
   command->Run();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_get_policy_configuration_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_get_policy_configuration_data_request_test.cc
@@ -118,8 +118,6 @@ TEST_F(SDLGetPolicyConfigurationDataRequestTest, Run_Success) {
   std::shared_ptr<SDLGetPolicyConfigurationDataRequest> command(
       CreateCommand<SDLGetPolicyConfigurationDataRequest>(msg));
 
-  PolicyTable pt;
-
   policy_table::ModuleConfig module_config_with_endpoints;
   policy_table::URLList endpoint_url_list;
   policy_table::URL urls;
@@ -128,10 +126,15 @@ TEST_F(SDLGetPolicyConfigurationDataRequestTest, Run_Success) {
   endpoint_url_list["default"] = urls;
   module_config_with_endpoints.endpoints["0x9"] = endpoint_url_list;
 
+  PolicyTable pt;
+  pt.mark_initialized();
+  pt.module_config.mark_initialized();
+  pt.module_config = module_config_with_endpoints;
+
   ON_CALL(mock_policy_handler_, GetPolicyTableData())
       .WillByDefault(Return(pt.ToJsonValue()));
 
-  auto json_val = endpoint_url_list.ToJsonValue();
+  auto json_val = module_config_with_endpoints.endpoints.ToJsonValue();
   Json::FastWriter writer;
   std::string expected_string = writer.write(json_val);
   clear_new_line_symbol(expected_string);


### PR DESCRIPTION
Json::write adds additional `"` to string type as json value.
But string parameters should not contain additional `"` 