### PR TITLE
Fix messages conversion to json

### DIFF
--- a/src/components/policy/policy_external/src/policy_table/types.cc
+++ b/src/components/policy/policy_external/src/policy_table/types.cc
@@ -1313,8 +1313,7 @@ ConsumerFriendlyMessages::ConsumerFriendlyMessages(const Json::Value* value__)
 Json::Value ConsumerFriendlyMessages::ToJsonValue() const {
   Json::Value result__(Json::objectValue);
   impl::WriteJsonField("version", version, &result__);
-  // According to requirements, it is not necessary to provide this to PTS
-  // impl::WriteJsonField("messages", messages, &result__);
+  impl::WriteJsonField("messages", messages, &result__);
   return result__;
 }
 


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
The conversion of messages to JSON was commented in external policy flow due to some reason.
So the data persists in the policy table, but not in JSON view of the same table.
Current PR brings back messages to the JSON representation of PT.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
