### PR TITLE
Fix/reject register too many requests

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -236,8 +236,9 @@ void RegisterAppInterfaceRequest::Run() {
   }
 
   if (!GetDataOnSessionKey(connection_key(), &device_handle_, &device_id_)) {
-    SendResponse(false, mobile_apis::Result::GENERIC_ERROR, 
-              "Could not find a session for your connection key!");
+    SendResponse(false,
+                 mobile_apis::Result::GENERIC_ERROR,
+                 "Could not find a session for your connection key!");
     return;
   }
 


### PR DESCRIPTION
Fixes #2991 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF Test from Issue

### Summary
Always initialize a RegisterAppInterface request and reply appropriately to them in the Run function.

### Changelog
##### Bug Fixes
* Apps which were forbidden for TOO_MANY_REQUESTS will be denied registration with reason TOO_MANY_PENDING_REQUESTS.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
