### PR TITLE
Add MinValue to PixelPerInch and DiagonalScreenSize

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -3368,10 +3368,10 @@
     <param name="hapticSpatialDataSupported" type="Boolean" mandatory="false">
       <description>True if the system can utilize the haptic spatial data from the source being streamed. </description>
     </param>
-    <param name="diagonalScreenSize" type="Float" mandatory="false">
+    <param name="diagonalScreenSize" type="Float" minvalue="0" mandatory="false">
       <description>The diagonal screen size in inches.</description>
     </param>
-    <param name="pixelPerInch" type="Float" mandatory="false">
+    <param name="pixelPerInch" type="Float" minvalue="0" mandatory="false">
       <description>PPI is the diagonal resolution in pixels divided by the diagonal screen size in inches.</description>
     </param>
     <param name="scale" type="Float" minvalue="1" maxvalue="10" mandatory="false">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -2928,10 +2928,10 @@
         <param name="hapticSpatialDataSupported" type="Boolean" mandatory="false">
             <description>True if the system can utilize the haptic spatial data from the source being streamed. If not included, it can be assumed the module doesn't support haptic spatial data'. </description>
         </param>
-        <param name="diagonalScreenSize" type="Float" mandatory="false" since="6.0">
+        <param name="diagonalScreenSize" type="Float" minvalue="0" mandatory="false" since="6.0">
           <description>The diagonal screen size in inches.</description>
         </param>
-        <param name="pixelPerInch" type="Float" mandatory="false" since="6.0">
+        <param name="pixelPerInch" type="Float" minvalue="0" mandatory="false" since="6.0">
           <description>PPI is the diagonal resolution in pixels divided by the diagonal screen size in inches.</description>
         </param>
         <param name="scale" type="Float" minvalue="1" maxvalue="10" mandatory="false" since="6.0">


### PR DESCRIPTION
Fixes #2319

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Changelog
##### Enhancements
* add `minvalue="0"` to `pixelPerInch`
* add `minvalue="0"` to `diagonalScreenSize`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
