### PR TITLE
Add check for already stored vehicle data item params

### DIFF
--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -2660,9 +2660,16 @@ bool SQLPTRepresentation::InsertVehicleDataItem(
   }
 
   if (vehicle_data_item.params->is_initialized()) {
+    std::map<std::string, std::string> stored_vehicle_data_item_params;
     for (const auto& param : *(vehicle_data_item.params)) {
       if (!InsertVehicleDataItem(param)) {
         return false;
+      }
+
+      if (stored_vehicle_data_item_params.end() !=
+          stored_vehicle_data_item_params.find(param.name)) {
+        LOG4CXX_DEBUG(logger_, "Parameter already stored.");
+        continue;
       }
 
       if (!query.Prepare(sql_pt::kInsertVehicleDataItemParams)) {
@@ -2685,6 +2692,7 @@ bool SQLPTRepresentation::InsertVehicleDataItem(
                 << ". Error: " << query.LastError().text());
         return false;
       }
+      stored_vehicle_data_item_params[param.name] = param.key;
     }
   }
 

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -2687,10 +2687,17 @@ bool SQLPTRepresentation::InsertVehicleDataItem(
   }
 
   if (vehicle_data_item.params->is_initialized()) {
+    std::map<std::string, std::string> stored_vehicle_data_item_params;
     for (const auto& param : *(vehicle_data_item.params)) {
       if (!InsertVehicleDataItem(param)) {
         return false;
       }
+
+      if (stored_vehicle_data_item_params.end() !=
+          stored_vehicle_data_item_params.find(param.name)) {
+        LOG4CXX_DEBUG(logger_, "Parameter already stored.");
+        continue;
+      };
 
       if (!query.Prepare(sql_pt::kInsertVehicleDataItemParams)) {
         LOG4CXX_ERROR(logger_,
@@ -2712,6 +2719,7 @@ bool SQLPTRepresentation::InsertVehicleDataItem(
                 << ". Error: " << query.LastError().text());
         return false;
       }
+      stored_vehicle_data_item_params[param.name] = param.key;
     }
   }
 


### PR DESCRIPTION
Fixes #3003

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
During vehicle data item parameter storage to DB, the new (and the same) row will be inserted to parent-parameter relation table for each one's version. As a result, during the retrieve of a composite vehicle data item, such parameter could be retrieved several times. And after several cycles, parameter array will exceed max boundary and therefore will be invalid, so the storage process fails and some data (including meta as `exchange_after_x_ignition_cycles`) will not be stored.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
