### PR TITLE
Fix failing build with enable_security=off

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -584,7 +584,9 @@ class ApplicationManagerImpl
       utils::Optional<hmi_apis::Common_ServiceStatusUpdateReason::eType>
           service_update_reason) FINAL;
 
+#ifdef ENABLE_SECURITY
   bool OnPTUFailed() FINAL;
+#endif  // ENABLE_SECURITY
   /*
    * @brief Starts audio pass thru thread
    *

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2163,11 +2163,12 @@ bool ApplicationManagerImpl::OnHandshakeDone(
   }
   return false;
 }
-
+#ifdef ENABLE_SECURITY
 bool ApplicationManagerImpl::OnPTUFailed() {
   LOG4CXX_AUTO_TRACE(logger_);
   return false;
 }
+#endif  // ENABLE_SECURITY
 
 bool ApplicationManagerImpl::OnGetSystemTimeFailed() {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/application_manager/src/rpc_service_impl.cc
+++ b/src/components/application_manager/src/rpc_service_impl.cc
@@ -164,6 +164,7 @@ bool RPCServiceImpl::ManageMobileCommand(
       SendMessageToMobile(response);
       return false;
     }
+#ifdef ENABLE_SECURITY
     if (EncryptionFlagCheckResult::kError_EncryptionNeeded ==
         IsEncryptionRequired(
             *message,
@@ -177,6 +178,7 @@ bool RPCServiceImpl::ManageMobileCommand(
       SendMessageToMobile(response);
       return false;
     }
+#endif  // ENABLE_SECURITY
 
     // Message for "CheckPermission" must be with attached schema
     mobile_so_factory().attachSchema(*message, false);

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -746,12 +746,11 @@ TEST_F(ProtocolHandlerImplTest,
   const uint8_t session_id1 = 1u;
   const ::transport_manager::ConnectionUID connection_id2 = 0xBu;
   const uint8_t session_id2 = 2u;
+  EXPECT_CALL(session_observer_mock, KeyFromPair(connection_id2, session_id2))
+      .WillRepeatedly(Return(connection_key));
 
 #ifdef ENABLE_SECURITY
   AddSecurityManager();
-
-  EXPECT_CALL(session_observer_mock, KeyFromPair(connection_id2, session_id2))
-      .WillRepeatedly(Return(connection_key));
 
   EXPECT_CALL(session_observer_mock,
               GetSSLContext(connection_key, start_service))

--- a/src/components/transport_manager/test/websocket_connection_test.cc
+++ b/src/components/transport_manager/test/websocket_connection_test.cc
@@ -425,6 +425,7 @@ TEST_F(WebsocketConnectionTest, WSSConnection_SUCCESS_ValidTarget) {
   t1.join();
 }
 
+#ifdef ENABLE_SECURITY
 TEST_F(WebsocketConnectionTest, WSSConnection_FAILURE_InvalidTarget) {
   transport_manager::transport_adapter::CloudAppProperties properties{
       .endpoint = "wss://" + kHost + ":" + std::to_string(kPort),
@@ -486,6 +487,7 @@ TEST_F(WebsocketConnectionTest, WSSConnection_FAILURE_IncorrectCert) {
   wss_session->Stop();
   t1.join();
 }
+#endif  // ENABLE_SECURITY
 }  // namespace transport_manager_test
 }  // namespace components
 }  // namespace test


### PR DESCRIPTION
Fixes #3000 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
Security-related code is enabled with `ENABLED_SECURITY` macro. There were some chunks that were missing this macro.

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
