### PR TITLE
Fix redundant OnPermissionChanged notification

### DIFF
--- a/src/components/policy/policy_regular/include/policy/policy_helper.h
+++ b/src/components/policy/policy_regular/include/policy/policy_helper.h
@@ -106,8 +106,6 @@ struct CheckAppPolicy {
       const std::vector<FunctionalGroupPermission>& revoked_groups) const;
   bool IsKnownAppication(const std::string& application_id) const;
   void NotifySystem(const AppPoliciesValueType& app_policy) const;
-  void SendPermissionsToApp(const std::string& app_id,
-                            const policy_table::Strings& groups) const;
   bool IsAppRevoked(const AppPoliciesValueType& app_policy) const;
   bool NicknamesMatch(const AppPoliciesValueType& app_policy) const;
 

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -136,16 +136,20 @@ class PolicyManagerImpl : public PolicyManager {
 
   /**
    * @brief Notifies system by sending OnAppPermissionChanged notification
+   * @param device_id device identifier
    * @param app_policy Reference to application policy
    */
-  void NotifySystem(const AppPoliciesValueType& app_policy) const;
+  void NotifySystem(const std::string& device_id,
+                    const AppPoliciesValueType& app_policy) const;
 
   /**
    * @brief Sends OnPermissionChange notification to application if its
    * currently registered
+   * @param device_id device identifier
    * @param app_policy Reference to application policy
    */
-  void SendPermissionsToApp(const AppPoliciesValueType& app_policy);
+  void SendPermissionsToApp(const std::string& device_id,
+                            const AppPoliciesValueType& app_policy);
 
   /**
    * @brief Resets Policy Table

--- a/src/components/policy/policy_regular/src/policy_helper.cc
+++ b/src/components/policy/policy_regular/src/policy_helper.cc
@@ -350,33 +350,6 @@ void policy::CheckAppPolicy::NotifySystem(
   }
 }
 
-void CheckAppPolicy::SendPermissionsToApp(
-    const std::string& app_id, const policy_table::Strings& groups) const {
-  const auto devices_ids = pm_->listener()->GetDevicesIds(app_id);
-  if (devices_ids.empty()) {
-    LOG4CXX_WARN(logger_,
-                 "Couldn't find device info for application id: " << app_id);
-    return;
-  }
-
-  for (const auto& device_id : devices_ids) {
-    std::vector<FunctionalGroupPermission> group_permissons;
-    pm_->GetPermissionsForApp(device_id, app_id, group_permissons);
-
-    Permissions notification_data;
-    pm_->PrepareNotificationData(update_->policy_table.functional_groupings,
-                                 groups,
-                                 group_permissons,
-                                 notification_data);
-
-    LOG4CXX_INFO(logger_, "Send notification for application_id: " << app_id);
-    // Default_hmi is Ford-specific and should not be used with basic policy
-    const std::string default_hmi;
-    pm_->listener()->OnPermissionsUpdated(
-        device_id, app_id, notification_data, default_hmi);
-  }
-}
-
 bool CheckAppPolicy::IsAppRevoked(
     const AppPoliciesValueType& app_policy) const {
   LOG4CXX_AUTO_TRACE(logger_);
@@ -485,7 +458,6 @@ bool CheckAppPolicy::operator()(const AppPoliciesValueType& app_policy) {
     AddResult(app_id, RESULT_CONSENT_NEEDED);
   }
 
-  SendPermissionsToApp(app_policy.first, app_policy.second.groups);
   return true;
 }
 
@@ -545,16 +517,16 @@ void policy::CheckAppPolicy::SetPendingPermissions(
 
 policy::PermissionsCheckResult policy::CheckAppPolicy::CheckPermissionsChanges(
     const policy::AppPoliciesValueType& app_policy) const {
-  bool has_revoked_groups = HasRevokedGroups(app_policy);
+  const bool has_revoked_groups = HasRevokedGroups(app_policy);
 
-  bool has_consent_needed_groups = HasConsentNeededGroups(app_policy);
+  const bool has_consent_needed_groups = HasConsentNeededGroups(app_policy);
 
-  bool has_new_groups = HasNewGroups(app_policy);
+  const bool has_new_groups = HasNewGroups(app_policy);
+
+  const bool has_updated_groups = HasUpdatedGroups(app_policy);
 
   const bool encryption_required_flag_changed =
       IsEncryptionRequiredFlagChanged(app_policy);
-
-  bool has_updated_groups = HasUpdatedGroups(app_policy);
 
   if (has_revoked_groups && has_consent_needed_groups) {
     return RESULT_PERMISSIONS_REVOKED_AND_CONSENT_NEEDED;

--- a/src/components/policy/policy_regular/src/policy_helper.cc
+++ b/src/components/policy/policy_regular/src/policy_helper.cc
@@ -453,11 +453,13 @@ bool CheckAppPolicy::operator()(const AppPoliciesValueType& app_policy) {
     return true;
   }
 
+  SetPendingPermissions(app_policy, result);
   if (RESULT_CONSENT_NOT_REQUIRED != result) {
-    SetPendingPermissions(app_policy, result);
     AddResult(app_id, RESULT_CONSENT_NEEDED);
+    return true;
   }
 
+  AddResult(app_id, result);
   return true;
 }
 

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -381,9 +381,13 @@ bool PolicyManagerImpl::LoadPT(const std::string& file,
       return false;
     }
 
-    // Replace predefined policies with its actual setting, e.g. "123":"default"
-    // to actual values of default section
-    UnwrapAppPolicies(pt_update->policy_table.app_policies_section.apps);
+    // Checking of difference between PTU and current policy state
+    // Must to be done before PTU applying since it is possible, that functional
+    // groups, which had been present before are absent in PTU and will be
+    // removed after update. So in case of revoked groups system has to know
+    // names and ids of revoked groups before they will be removed.
+    const auto results =
+        CheckPermissionsChanges(pt_update, policy_table_snapshot);
 
     // Replace current data with updated
     if (!cache_->ApplyUpdate(*pt_update)) {
@@ -394,14 +398,6 @@ bool PolicyManagerImpl::LoadPT(const std::string& file,
       return false;
     }
     CheckPermissionsChangesAfterUpdate(*pt_update, *policy_table_snapshot);
-
-    // Checking of difference between PTU and current policy state
-    // Must to be done before PTU applying since it is possible, that functional
-    // groups, which had been present before are absent in PTU and will be
-    // removed after update. So in case of revoked groups system has to know
-    // names and ids of revoked groups before they will be removed.
-    const auto results =
-        CheckPermissionsChanges(pt_update, policy_table_snapshot);
 
     ProcessAppPolicyCheckResults(
         results, pt_update->policy_table.app_policies_section.apps);

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -1013,7 +1013,8 @@ TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_removeRPC_SendUpdate) {
   // Assert
   EXPECT_CALL(*cache_manager, GetVehicleDataItems())
       .WillOnce(Return(std::vector<policy_table::VehicleDataItem>()));
-  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(snapshot));
+  EXPECT_CALL(*cache_manager, GenerateSnapshot())
+      .WillRepeatedly(Return(snapshot));
   EXPECT_CALL(*cache_manager, ApplyUpdate(_)).WillOnce(Return(true));
   ExpectOnPermissionsUpdated();
 
@@ -1045,7 +1046,8 @@ TEST_F(PolicyManagerImplTest,
   ::policy::BinaryMessage msg(json.begin(), json.end());
 
   // Assert
-  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(snapshot));
+  EXPECT_CALL(*cache_manager, GenerateSnapshot())
+      .WillRepeatedly(Return(snapshot));
   EXPECT_CALL(*cache_manager, GetVehicleDataItems())
       .WillOnce(Return(std::vector<policy_table::VehicleDataItem>()));
   EXPECT_CALL(*cache_manager, ApplyUpdate(_)).WillOnce(Return(true));
@@ -1079,7 +1081,8 @@ TEST_F(PolicyManagerImplTest,
   ::policy::BinaryMessage msg(json.begin(), json.end());
 
   // Assert
-  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(snapshot));
+  EXPECT_CALL(*cache_manager, GenerateSnapshot())
+      .WillRepeatedly(Return(snapshot));
   EXPECT_CALL(*cache_manager, GetVehicleDataItems())
       .WillOnce(Return(std::vector<policy_table::VehicleDataItem>()));
   EXPECT_CALL(*cache_manager, ApplyUpdate(_)).WillOnce(Return(true));
@@ -1114,7 +1117,8 @@ TEST_F(PolicyManagerImplTest,
   ::policy::BinaryMessage msg(json.begin(), json.end());
 
   // Assert
-  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(snapshot));
+  EXPECT_CALL(*cache_manager, GenerateSnapshot())
+      .WillRepeatedly(Return(snapshot));
   EXPECT_CALL(*cache_manager, GetVehicleDataItems())
       .WillOnce(Return(std::vector<policy_table::VehicleDataItem>()));
   EXPECT_CALL(*cache_manager, ApplyUpdate(_)).WillOnce(Return(true));
@@ -1148,7 +1152,8 @@ TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_addRPCParams_SendUpdate) {
   ::policy::BinaryMessage msg(json.begin(), json.end());
 
   // Assert
-  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(snapshot));
+  EXPECT_CALL(*cache_manager, GenerateSnapshot())
+      .WillRepeatedly(Return(snapshot));
   EXPECT_CALL(*cache_manager, GetVehicleDataItems())
       .WillOnce(Return(std::vector<policy_table::VehicleDataItem>()));
   EXPECT_CALL(*cache_manager, ApplyUpdate(_)).WillOnce(Return(true));
@@ -1175,7 +1180,8 @@ TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_NoUpdate_DONT_SendUpdate) {
   ::policy::BinaryMessage msg(json.begin(), json.end());
 
   // Assert
-  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(snapshot));
+  EXPECT_CALL(*cache_manager, GenerateSnapshot())
+      .WillRepeatedly(Return(snapshot));
   EXPECT_CALL(*cache_manager, GetVehicleDataItems())
       .WillOnce(Return(std::vector<policy_table::VehicleDataItem>()));
   EXPECT_CALL(*cache_manager, ApplyUpdate(_)).WillOnce(Return(true));


### PR DESCRIPTION
Fixes #3004

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
OnPermissionChange used to be sent from CheckAppPolicy. But now it is sent from PolicyManager. And the duplication of this notification was left in CheckAppPolicy for proprietary flow.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
