### PR TITLE
Fix build with disabled logger.

### DIFF
--- a/src/components/protocol_handler/CMakeLists.txt
+++ b/src/components/protocol_handler/CMakeLists.txt
@@ -38,6 +38,7 @@ include_directories(
   ${CMAKE_BINARY_DIR}/src/components/
   ${LOG4CXX_INCLUDE_DIRECTORY}
   ${BSON_INCLUDE_DIRECTORY}
+  ${BOOST_INCLUDE_DIR}
 )
 
 set(PATHS

--- a/src/components/utils/include/utils/stl_utils.h
+++ b/src/components/utils/include/utils/stl_utils.h
@@ -32,6 +32,7 @@
 #ifndef SRC_COMPONENTS_UTILS_INCLUDE_UTILS_STL_UTILS_H_
 #define SRC_COMPONENTS_UTILS_INCLUDE_UTILS_STL_UTILS_H_
 
+#include <cstddef>
 #include "utils/macro.h"
 
 namespace utils {

--- a/tools/policy_table_validator/CMakeLists.txt
+++ b/tools/policy_table_validator/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/src/components/utils/include/
   ${COMPONENTS_DIR}/smart_objects/include/
   ${JSONCPP_INCLUDE_DIRECTORY}
+  ${BOOST_INCLUDE_DIR}
 )
 
 message(STATUS "Using ${EXTENDED_POLICY} policy mode")


### PR DESCRIPTION
Fixes #3002

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Since boost and logger include are mostly located in the same directory, there is no issue building with the logger.
In `stl_utils.h` NULL is not defined while building `stl_utils_test`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
