### PR TITLE
Fix SDL's core crash during retry sequence

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -685,6 +685,8 @@ class PolicyHandler : public PolicyHandlerInterface,
 
   virtual void OnPTInited() OVERRIDE;
 
+  void ForceRetrySequenceStop() OVERRIDE;
+
   /**
    * @brief OnDeviceSwitching Notifies policy manager on device switch event so
    * policy permissions should be processed accordingly

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3092,6 +3092,7 @@ void ApplicationManagerImpl::UnregisterApplication(
   MessageHelper::SendOnAppUnregNotificationToHMI(
       app_to_remove, is_unexpected_disconnect, *this);
   request_ctrl_.terminateAppRequests(app_id);
+  policy_handler_->ForceRetrySequenceStop();
   return;
 }
 

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -391,6 +391,12 @@ void PolicyHandler::OnPTInited() {
                 std::mem_fun(&PolicyHandlerObserver::OnPTInited));
 }
 
+void PolicyHandler::ForceRetrySequenceStop() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  policy_manager_->ForceRetrySequenceStop();
+}
+
 bool PolicyHandler::ResetPolicyTable() {
   LOG4CXX_TRACE(logger_, "Reset policy table.");
   POLICY_LIB_CHECK(false);
@@ -441,6 +447,11 @@ uint32_t PolicyHandler::GetAppIdForSending() const {
   LOG4CXX_DEBUG(
       logger_,
       "Number of apps with NONE level: " << apps_with_none_level.size());
+
+  if (apps_with_none_level.empty() && apps_without_none_level.empty()) {
+    LOG4CXX_WARN(logger_, "There is no registered application");
+    return 0;
+  }
 
   return ChooseRandomAppForPolicyUpdate(apps_with_none_level);
 }
@@ -1522,8 +1533,13 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string,
   }
 
   if (PTUIterationType::RetryIteration == iteration_type) {
-    MessageHelper::SendPolicySnapshotNotification(
-        GetAppIdForSending(), pt_string, std::string(""), application_manager_);
+    uint32_t app_id_for_sending = GetAppIdForSending();
+
+    if (0 != app_id_for_sending) {
+      MessageHelper::SendPolicySnapshotNotification(
+          app_id_for_sending, pt_string, std::string(""), application_manager_);
+    }
+
   } else {
     MessageHelper::SendPolicyUpdate(
         policy_snapshot_full_path,

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -351,6 +351,11 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
 
   virtual void OnPTInited() = 0;
 
+  /**
+   * @brief Force stops retry sequence timer and resets retry sequence
+   */
+  virtual void ForceRetrySequenceStop() = 0;
+
 #ifdef EXTERNAL_PROPRIETARY_MODE
   virtual void OnCertificateDecrypted(bool is_succeeded) = 0;
 #endif  // EXTERNAL_PROPRIETARY_MODE

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -202,6 +202,11 @@ class PolicyManager : public usage_statistics::StatisticsManager,
   virtual std::string ForcePTExchangeAtUserRequest() = 0;
 
   /**
+   * @brief Force stops retry sequence timer and resets retry sequence
+   */
+  virtual void ForceRetrySequenceStop() = 0;
+
+  /**
    * @brief Resets retry sequence
    * @param send_event - if true corresponding event is sent to
    * UpdateStatusManager

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -194,6 +194,7 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD1(OnCertificateUpdated, void(const std::string& certificate_data));
   MOCK_METHOD1(OnPTUFinished, void(const bool ptu_result));
   MOCK_METHOD0(OnPTInited, void());
+  MOCK_METHOD0(ForceRetrySequenceStop, void());
   MOCK_METHOD1(OnCertificateDecrypted, void(bool is_succeeded));
   MOCK_METHOD0(CanUpdate, bool());
   MOCK_METHOD2(OnDeviceConsentChanged,

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -103,6 +103,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(IncrementIgnitionCycles, void());
   MOCK_METHOD0(ForcePTExchange, std::string());
   MOCK_METHOD0(ForcePTExchangeAtUserRequest, std::string());
+  MOCK_METHOD0(ForceRetrySequenceStop, void());
   MOCK_METHOD1(ResetRetrySequence,
                void(const policy::ResetRetryCountType send_event));
   MOCK_METHOD0(NextRetryTimeout, uint32_t());

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -237,6 +237,8 @@ class PolicyManagerImpl : public PolicyManager {
    */
   std::string ForcePTExchange() OVERRIDE;
 
+  void ForceRetrySequenceStop() OVERRIDE;
+
   /**
    * @brief Exchange by user request
    * @return Current status of policy table

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1229,6 +1229,16 @@ std::string PolicyManagerImpl::ForcePTExchange() {
   return update_status_manager_.StringifiedUpdateStatus();
 }
 
+void PolicyManagerImpl::ForceRetrySequenceStop() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (timer_retry_sequence_.is_running()) {
+    timer_retry_sequence_.Stop();
+  }
+
+  ResetRetrySequence(ResetRetryCountType::kResetWithStatusUpdate);
+}
+
 std::string PolicyManagerImpl::ForcePTExchangeAtUserRequest() {
   update_status_manager_.ScheduleManualUpdate();
   StartPTExchange();


### PR DESCRIPTION
Fixes [#3019](https://github.com/smartdevicelink/sdl_core/issues/3019)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
In case, when lust application is unregistered, SDL has to stop retry sequence, because doesn't exist any mobile connection and these actions are redundant. 
Also, SDL should check if exist registered applications before sending PolicySnapshotNotification.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
