### PR TITLE
Fix crash on secure rpc service

### DIFF
--- a/src/components/security_manager/src/ssl_context_impl.cc
+++ b/src/components/security_manager/src/ssl_context_impl.cc
@@ -529,13 +529,18 @@ bool CryptoManagerImpl::SSLContextImpl::Decrypt(const uint8_t* const in_data,
 }
 
 size_t CryptoManagerImpl::SSLContextImpl::get_max_block_size(size_t mtu) const {
+  LOG4CXX_AUTO_TRACE(logger_);
   if (!max_block_size_) {
     // FIXME(EZamakhov): add correct logics for TLS1/1.2/SSL3
     // For SSL3.0 set temporary value 90, old TLS1.2 value is 29
     assert(mtu > 90);
     return mtu - 90;
   }
-  return max_block_size_(mtu);
+
+  const auto max_allowed_block_size =
+      mtu > SSL3_RT_MAX_PLAIN_LENGTH ? SSL3_RT_MAX_PLAIN_LENGTH : mtu;
+
+  return max_block_size_(max_allowed_block_size);
 }
 
 bool CryptoManagerImpl::SSLContextImpl::IsHandshakePending() const {


### PR DESCRIPTION
Fixes #2922 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
ATF scripts

### Summary
When maximum allowed block size was calculated, maximum DTLS MTU was not taken into account, hence `BIO_read` resulted in error, which in turn lead to  failing `DCHECK` .

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
