### PR TITLE
Make usage logger stabilization

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -864,7 +864,6 @@ class PolicyHandler : public PolicyHandlerInterface,
 
   mutable sync_primitives::RWLock policy_manager_lock_;
   std::shared_ptr<PolicyManager> policy_manager_;
-  void* dl_handle_;
   std::shared_ptr<PolicyEventObserver> event_observer_;
   uint32_t last_activated_app_id_;
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_rpc_plugin.cc
@@ -104,4 +104,5 @@ Create() {
 extern "C" __attribute__((visibility("default"))) void Delete(
     application_manager::plugin_manager::RPCPlugin* data) {
   delete data;
+  DELETE_THREAD_LOGGER(app_service_rpc_plugin::logger_);
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -170,4 +170,5 @@ Create() {
 extern "C" __attribute__((visibility("default"))) void Delete(
     application_manager::plugin_manager::RPCPlugin* data) {
   delete data;
+  DELETE_THREAD_LOGGER(rc_rpc_plugin::logger_);
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
@@ -101,4 +101,5 @@ Create() {
 extern "C" __attribute__((visibility("default"))) void Delete(
     application_manager::plugin_manager::RPCPlugin* data) {
   delete data;
+  DELETE_THREAD_LOGGER(sdl_rpc_plugin::logger_);
 }

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -182,4 +182,5 @@ Create() {
 extern "C" __attribute__((visibility("default"))) void Delete(
     application_manager::plugin_manager::RPCPlugin* data) {
   delete data;
+  DELETE_THREAD_LOGGER(vehicle_info_plugin::logger_);
 }

--- a/src/components/include/utils/logger.h
+++ b/src/components/include/utils/logger.h
@@ -65,6 +65,11 @@
 void deinit_logger();
 #define DEINIT_LOGGER() deinit_logger()
 
+// Logger thread deinitilization macro that need to stop the thread of handling
+// messages for the log4cxx
+#define DELETE_THREAD_LOGGER(logger_var) \
+  logger::delete_log_message_loop_thread(logger_var)
+
 // special macros to dump logs from queue
 // it's need, for example, when crash happend
 #define FLUSH_LOGGER() logger::flush_logger()
@@ -140,6 +145,8 @@ log4cxx_time_t time_now();
 #define INIT_LOGGER(file_name, logs_enabled)
 
 #define DEINIT_LOGGER()
+
+#define DELETE_THREAD_LOGGER(logger_var)
 
 #define FLUSH_LOGGER()
 

--- a/src/components/include/utils/push_log.h
+++ b/src/components/include/utils/push_log.h
@@ -51,7 +51,7 @@ bool logs_enabled();
 void set_logs_enabled(bool state);
 
 void create_log_message_loop_thread();
-void delete_log_message_loop_thread();
+void delete_log_message_loop_thread(log4cxx::LoggerPtr& logger);
 }  // namespace logger
 
 #endif  // SRC_COMPONENTS_INCLUDE_UTILS_PUSH_LOG_H_

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -54,14 +54,6 @@
 #include "policy/access_remote_impl.h"
 #include "utils/timer_task_impl.h"
 
-__attribute__((visibility("default"))) policy::PolicyManager* CreateManager() {
-  return new policy::PolicyManagerImpl();
-}
-
-__attribute__((visibility("default"))) void DeleteManager(
-    policy::PolicyManager* pm) {
-  delete pm;
-}
 namespace {
 
 /**
@@ -2522,3 +2514,13 @@ const std::vector<std::string> PolicyManagerImpl::GetRPCsForFunctionGroup(
 }
 
 }  //  namespace policy
+
+__attribute__((visibility("default"))) policy::PolicyManager* CreateManager() {
+  return new policy::PolicyManagerImpl();
+}
+
+__attribute__((visibility("default"))) void DeleteManager(
+    policy::PolicyManager* pm) {
+  delete pm;
+  DELETE_THREAD_LOGGER(policy::logger_);
+}

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -53,15 +53,6 @@
 #include "policy/access_remote.h"
 #include "policy/access_remote_impl.h"
 
-__attribute__((visibility("default"))) policy::PolicyManager* CreateManager() {
-  return new policy::PolicyManagerImpl();
-}
-
-__attribute__((visibility("default"))) void DeleteManager(
-    policy::PolicyManager* pm) {
-  delete pm;
-}
-
 namespace {
 const uint32_t kDefaultRetryTimeoutInMSec =
     60u * date_time::MILLISECONDS_IN_SECOND;
@@ -1813,3 +1804,13 @@ const std::vector<std::string> PolicyManagerImpl::GetRPCsForFunctionGroup(
 }
 
 }  //  namespace policy
+
+__attribute__((visibility("default"))) policy::PolicyManager* CreateManager() {
+  return new policy::PolicyManagerImpl();
+}
+
+__attribute__((visibility("default"))) void DeleteManager(
+    policy::PolicyManager* pm) {
+  delete pm;
+  DELETE_THREAD_LOGGER(policy::logger_);
+}

--- a/src/components/utils/src/logger.cc
+++ b/src/components/utils/src/logger.cc
@@ -39,11 +39,8 @@ void deinit_logger() {
   CREATE_LOGGERPTR_LOCAL(logger_, "Utils")
   LOG4CXX_DEBUG(logger_, "Logger deinitialization");
   logger::set_logs_enabled(false);
-  if (logger::logger_status == logger::LoggerThreadCreated) {
-    logger::flush_logger();
-  }
-  logger::delete_log_message_loop_thread();
   log4cxx::LoggerPtr rootLogger = log4cxx::Logger::getRootLogger();
+  logger::delete_log_message_loop_thread(rootLogger);
   log4cxx::spi::LoggerRepositoryPtr repository =
       rootLogger->getLoggerRepository();
   log4cxx::LoggerList loggers = repository->getCurrentLoggers();


### PR DESCRIPTION
Fixes #2976

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF script:
https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/develop/test_scripts/Smoke/ShutDown/001_ShutDown_IGNITION_OFF.lua

### Summary
Added custom deleter for logger
Added flush logger during each handle deleting
Added deleting logger thread during destroy each plugin
This changes are necessary to avoid deadlock during work with log4cxx.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)