### PR TITLE
Fix missing minlength attribute for templateTitle parameter

### DIFF
--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -5503,7 +5503,7 @@
                 If any text field contains no tags or the none tag, the metadata tag for that textfield should be removed.</description>
         </param>
 
-        <param name="templateTitle" type="String" maxlength="100" mandatory="false" since="6.0">
+        <param name="templateTitle" type="String" minlength="0" maxlength="100" mandatory="false" since="6.0">
             <description>
                 The title of the new template that will be displayed.
                 How this will be displayed is dependent on the OEM design and implementation of the template.


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
The `minlength` attribute for the `templateTitle` parameter was added in https://github.com/smartdevicelink/sdl_core/pull/2964/files#diff-cfd2a12866985b9fdcfdbc6ee134baf1R5074 to allow clearing the `templateTitle`. 

It was removed by https://github.com/smartdevicelink/sdl_core/commit/3fa26cf5a0011a241ccb91da1c8a02dcfd75a75f#diff-cfd2a12866985b9fdcfdbc6ee134baf1L5177 and https://github.com/smartdevicelink/sdl_core/commit/6c1a61d911e18e2f191052cab95412f98bd3b954#diff-cfd2a12866985b9fdcfdbc6ee134baf1R5400.

This PR restores the `minlength` attribute for the `templateTitle` parameter

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
