### PR TITLE
Fix SDL behavior during low voltage

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3185,10 +3185,10 @@ bool ApplicationManagerImpl::IsLowVoltage() const {
 
 void ApplicationManagerImpl::OnWakeUp() {
   LOG4CXX_AUTO_TRACE(logger_);
-  is_low_voltage_ = false;
   resume_ctrl_->SaveWakeUpTime();
   resume_ctrl_->StartSavePersistentDataTimer();
   request_ctrl_.OnWakeUp();
+  is_low_voltage_ = false;
 }
 
 std::string ApplicationManagerImpl::GetHashedAppID(

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -126,6 +126,12 @@ RequestController::TResult RequestController::CheckPosibilitytoAdd(
     return RequestController::TOO_MANY_REQUESTS;
   }
 
+  if (IsLowVoltage()) {
+    LOG4CXX_ERROR(logger_,
+                  "Impossible to add request due to Low Voltage is active");
+    return RequestController::INVALID_DATA;
+  }
+
   return SUCCESS;
 }
 
@@ -192,6 +198,13 @@ RequestController::TResult RequestController::addHMIRequest(
                   "Default timeout was set to 0."
                   "RequestController will not track timeout of this request.");
   }
+
+  if (IsLowVoltage()) {
+    LOG4CXX_ERROR(logger_,
+                  "Impossible to add request due to Low Voltage is active");
+    return RequestController::INVALID_DATA;
+  }
+
   waiting_for_response_.Add(request_info_ptr);
   LOG4CXX_DEBUG(logger_,
                 "Waiting for response count:" << waiting_for_response_.Size());
@@ -202,6 +215,11 @@ RequestController::TResult RequestController::addHMIRequest(
 
 void RequestController::addNotification(const RequestPtr ptr) {
   LOG4CXX_AUTO_TRACE(logger_);
+  if (IsLowVoltage()) {
+    LOG4CXX_ERROR(
+        logger_, "Impossible to add notification due to Low Voltage is active");
+    return;
+  }
   notification_list_.push_back(ptr);
 }
 

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -208,6 +208,10 @@ void RPCHandlerImpl::Handle(const impl::MessageFromMobile message) {
     LOG4CXX_INFO(logger_, "Application manager is stopping");
     return;
   }
+  if (app_manager_.IsLowVoltage()) {
+    LOG4CXX_ERROR(logger_, "Low Voltage is active.");
+    return;
+  }
 
   ProcessMessageFromMobile(message);
 }
@@ -219,12 +223,22 @@ void RPCHandlerImpl::Handle(const impl::MessageFromHmi message) {
     LOG4CXX_ERROR(logger_, "Null-pointer message received.");
     return;
   }
+  if (app_manager_.IsLowVoltage()) {
+    LOG4CXX_ERROR(logger_, "Low Voltage is active.");
+    return;
+  }
+
   ProcessMessageFromHMI(message);
 }
 
 void RPCHandlerImpl::OnMessageReceived(
     const protocol_handler::RawMessagePtr message) {
   LOG4CXX_AUTO_TRACE(logger_);
+
+  if (app_manager_.IsLowVoltage()) {
+    LOG4CXX_ERROR(logger_, "Low Voltage is active.");
+    return;
+  }
 
   if (!message) {
     LOG4CXX_ERROR(logger_, "Null-pointer message received.");

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -1368,7 +1368,8 @@ void ConnectionHandlerImpl::RemoveCloudAppDevice(const DeviceHandle device_id) {
 
 void ConnectionHandlerImpl::StartTransportManager() {
   LOG4CXX_AUTO_TRACE(logger_);
-  transport_manager_.Visibility(true);
+  transport_manager_.PerformActionOnClients(
+      transport_manager::TransportAction::kVisibilityOn);
 }
 
 void ConnectionHandlerImpl::CloseRevokedConnection(uint32_t connection_key) {

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -787,7 +787,9 @@ TEST_F(ConnectionHandlerTest, StartTransportManager) {
   AddTestDeviceConnection();
   AddTestSession();
 
-  EXPECT_CALL(mock_transport_manager_, Visibility(true));
+  EXPECT_CALL(mock_transport_manager_,
+              PerformActionOnClients(
+                  transport_manager::TransportAction::kVisibilityOn));
   connection_handler_->StartTransportManager();
 }
 

--- a/src/components/include/test/transport_manager/mock_transport_manager.h
+++ b/src/components/include/test/transport_manager/mock_transport_manager.h
@@ -58,6 +58,9 @@ class MockTransportManager : public ::transport_manager::TransportManager,
  public:
   MOCK_METHOD1(Init, int(resumption::LastState& last_state));
   MOCK_METHOD0(Reinit, int());
+  MOCK_METHOD0(Deinit, void());
+  MOCK_METHOD0(StopEventsProcessing, void());
+  MOCK_METHOD0(StartEventsProcessing, void());
   MOCK_METHOD0(SearchDevices, int());
   MOCK_METHOD1(
       AddCloudDevice,
@@ -78,7 +81,9 @@ class MockTransportManager : public ::transport_manager::TransportManager,
   MOCK_METHOD1(AddEventListener, int(TransportManagerListener* listener));
   MOCK_METHOD0(Stop, int());
   MOCK_METHOD1(RemoveDevice, int(const DeviceHandle));
-  MOCK_CONST_METHOD1(Visibility, int(const bool&));
+  MOCK_CONST_METHOD1(PerformActionOnClients,
+                     int(transport_manager::TransportAction required_action));
+
   MOCK_METHOD1(SetTelemetryObserver,
                void(transport_manager::TMTelemetryObserver* observer));
 };

--- a/src/components/include/test/transport_manager/transport_adapter/mock_transport_adapter.h
+++ b/src/components/include/test/transport_manager/transport_adapter/mock_transport_adapter.h
@@ -72,12 +72,9 @@ class MockTransportAdapter
                          const ::transport_manager::DeviceUID& device_handle));
   MOCK_METHOD2(RunAppOnDevice, void(const std::string&, const std::string&));
   MOCK_CONST_METHOD0(IsClientOriginatedConnectSupported, bool());
-  MOCK_METHOD0(
-      StartClientListening,
-      ::transport_manager::transport_adapter::TransportAdapter::Error());
-  MOCK_METHOD0(
-      StopClientListening,
-      ::transport_manager::transport_adapter::TransportAdapter::Error());
+  MOCK_METHOD1(ChangeClientListening,
+               ::transport_manager::transport_adapter::TransportAdapter::Error(
+                   ::transport_manager::TransportAction required_change));
   MOCK_METHOD2(RemoveFinalizedConnection,
                void(const ::transport_manager::DeviceUID& device_handle,
                     const ::transport_manager::ApplicationHandle& app_handle));

--- a/src/components/include/transport_manager/common.h
+++ b/src/components/include/transport_manager/common.h
@@ -43,6 +43,17 @@
 namespace transport_manager {
 
 /**
+ * @enum Actions that could
+ * be performed on connected clients.
+ */
+enum class TransportAction {
+  kVisibilityOn,
+  kVisibilityOff,
+  kListeningOn,
+  kListeningOff
+};
+
+/**
  * @enum Transport manager states.
  */
 enum {

--- a/src/components/include/transport_manager/transport_adapter/transport_adapter.h
+++ b/src/components/include/transport_manager/transport_adapter/transport_adapter.h
@@ -111,7 +111,15 @@ class TransportAdapter {
   /**
    * @enum Available types of errors.
    */
-  enum Error { OK, FAIL, NOT_SUPPORTED, ALREADY_EXISTS, BAD_STATE, BAD_PARAM };
+  enum Error {
+    UNKNOWN = -1,
+    OK,
+    FAIL,
+    NOT_SUPPORTED,
+    ALREADY_EXISTS,
+    BAD_STATE,
+    BAD_PARAM
+  };
 
  public:
   /**
@@ -236,18 +244,10 @@ class TransportAdapter {
   virtual bool IsClientOriginatedConnectSupported() const = 0;
 
   /**
-   * @brief Start client listener.
-   *
+   * @brief Changes client listening state of current adapter
    * @return Error information about possible reason of failure.
    */
-  virtual Error StartClientListening() = 0;
-
-  /**
-   * @brief Stop client listener.
-   *
-   * @return Error information about possible reason of failure.
-   */
-  virtual Error StopClientListening() = 0;
+  virtual Error ChangeClientListening(TransportAction required_change) = 0;
 
   /**
    * @brief Remove marked as FINALISING connection from accounting.

--- a/src/components/include/transport_manager/transport_manager.h
+++ b/src/components/include/transport_manager/transport_manager.h
@@ -69,6 +69,21 @@ class TransportManager {
   virtual int Reinit() = 0;
 
   /**
+   * @brief Deinitializes all transport adapters and device instances
+   */
+  virtual void Deinit() = 0;
+
+  /**
+   * @brief Stops transport events processing handler threads
+   */
+  virtual void StopEventsProcessing() = 0;
+
+  /**
+   * @brief Resumes transport events processing handler threads
+   */
+  virtual void StartEventsProcessing() = 0;
+
+  /**
    * @brief Start scanning for new devices.
    *
    * @return Code error.
@@ -193,13 +208,13 @@ class TransportManager {
   virtual int RemoveDevice(const DeviceHandle device_handle) = 0;
 
   /**
-   * @brief Turns on or off visibility of SDL to mobile devices
-   * when visibility is ON (on_off = true) mobile devices are able to connect
-   * otherwise ((on_off = false)) SDL is not visible from outside
-   *
-   * @return Code error.
+   * @brief Performs specified action on connected clients
+   * @param required_action is the action which should be performed for the
+   * connected clients
+   * @return error code
    */
-  virtual int Visibility(const bool& on_off) const = 0;
+  virtual int PerformActionOnClients(
+      const TransportAction required_action) const = 0;
 };
 }  // namespace transport_manager
 #endif  // SRC_COMPONENTS_INCLUDE_TRANSPORT_MANAGER_TRANSPORT_MANAGER_H_

--- a/src/components/transport_manager/include/transport_manager/tcp/tcp_client_listener.h
+++ b/src/components/transport_manager/include/transport_manager/tcp/tcp_client_listener.h
@@ -108,6 +108,10 @@ class TcpClientListener : public ClientConnectionListener {
    */
   virtual TransportAdapter::Error StopListening();
 
+  TransportAdapter::Error SuspendListening() OVERRIDE;
+
+  TransportAdapter::Error ResumeListening() OVERRIDE;
+
   /**
    * @brief Called from NetworkInterfaceListener when IP address of the network
    *        interface is changed.

--- a/src/components/transport_manager/include/transport_manager/transport_adapter/client_connection_listener.h
+++ b/src/components/transport_manager/include/transport_manager/transport_adapter/client_connection_listener.h
@@ -76,6 +76,18 @@ class ClientConnectionListener {
   virtual TransportAdapter::Error StopListening() = 0;
 
   /**
+   * @brief Suspends current listening thread
+   * @return Error information about possible reason of failure.
+   */
+  virtual TransportAdapter::Error SuspendListening() = 0;
+
+  /**
+   * @brief Resumes current listening thread
+   * @return Error information about possible reason of failure.
+   */
+  virtual TransportAdapter::Error ResumeListening() = 0;
+
+  /**
    * @brief Destructor.
    */
   virtual ~ClientConnectionListener() {}

--- a/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
+++ b/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
@@ -202,19 +202,8 @@ class TransportAdapterImpl : public TransportAdapter,
       const ApplicationHandle& app_handle,
       const ::protocol_handler::RawMessagePtr data) OVERRIDE;
 
-  /**
-   * @brief Start client listener.
-   *
-   * @return Error information about possible reason of failure.
-   */
-  TransportAdapter::Error StartClientListening() OVERRIDE;
-
-  /**
-   * @brief Stop client listener.
-   *
-   * @return Error information about possible reason of failure.
-   */
-  TransportAdapter::Error StopClientListening() OVERRIDE;
+  TransportAdapter::Error ChangeClientListening(
+      TransportAction required_change) OVERRIDE;
 
   /**
    * @brief Notify that device scanner is available.

--- a/src/components/transport_manager/include/transport_manager/transport_manager_impl.h
+++ b/src/components/transport_manager/include/transport_manager/transport_manager_impl.h
@@ -132,6 +132,12 @@ class TransportManagerImpl
    */
   virtual int Reinit() OVERRIDE;
 
+  virtual void Deinit() OVERRIDE;
+
+  void StopEventsProcessing() OVERRIDE;
+
+  void StartEventsProcessing() OVERRIDE;
+
   /**
    * @brief Start scanning for new devices.
    *
@@ -250,14 +256,8 @@ class TransportManagerImpl
    **/
   int RemoveDevice(const DeviceHandle device) OVERRIDE;
 
-  /**
-   * @brief Turns on or off visibility of SDL to mobile devices
-   * when visibility is ON (on_off = true) mobile devices are able to connect
-   * otherwise ((on_off = false)) SDL is not visible from outside
-   *
-   * @return Code error.
-   */
-  int Visibility(const bool& on_off) const OVERRIDE;
+  int PerformActionOnClients(
+      const TransportAction required_action) const OVERRIDE;
 
   /**
    * @brief OnDeviceListUpdated updates device list and sends appropriate
@@ -413,6 +413,10 @@ class TransportManagerImpl
   timer::Timer device_switch_timer_;
   sync_primitives::Lock device_lock_;
   DeviceUID device_to_reconnect_;
+
+  std::atomic_bool events_processing_is_active_;
+  sync_primitives::Lock events_processing_lock_;
+  sync_primitives::ConditionalVariable events_processing_cond_var_;
 
   /**
    * @brief Adds new incoming connection to connections list

--- a/src/components/transport_manager/src/tcp/platform_specific/linux/platform_specific_network_interface_listener.cc
+++ b/src/components/transport_manager/src/tcp/platform_specific/linux/platform_specific_network_interface_listener.cc
@@ -105,7 +105,7 @@ PlatformSpecificNetworkInterfaceListener::
 
 bool PlatformSpecificNetworkInterfaceListener::Init() {
   LOG4CXX_AUTO_TRACE(logger_);
-
+  LOG4CXX_DEBUG(logger_, "Init socket: " << socket_);
   if (socket_ >= 0) {
     LOG4CXX_WARN(logger_, "Network interface listener is already initialized");
     return false;
@@ -151,7 +151,7 @@ bool PlatformSpecificNetworkInterfaceListener::Init() {
 
 void PlatformSpecificNetworkInterfaceListener::Deinit() {
   LOG4CXX_AUTO_TRACE(logger_);
-
+  LOG4CXX_DEBUG(logger_, "Deinit socket: " << socket_);
   if (socket_ >= 0) {
     close(socket_);
     socket_ = -1;

--- a/src/components/transport_manager/test/include/transport_manager/transport_adapter/mock_client_connection_listener.h
+++ b/src/components/transport_manager/test/include/transport_manager/transport_adapter/mock_client_connection_listener.h
@@ -51,6 +51,12 @@ class MockClientConnectionListener
       StartListening,
       ::transport_manager::transport_adapter::TransportAdapter::Error());
   MOCK_METHOD0(
+      SuspendListening,
+      ::transport_manager::transport_adapter::TransportAdapter::Error());
+  MOCK_METHOD0(
+      ResumeListening,
+      ::transport_manager::transport_adapter::TransportAdapter::Error());
+  MOCK_METHOD0(
       StopListening,
       ::transport_manager::transport_adapter::TransportAdapter::Error());
 };

--- a/src/components/transport_manager/test/transport_adapter_test.cc
+++ b/src/components/transport_manager/test/transport_adapter_test.cc
@@ -1035,7 +1035,8 @@ TEST_F(TransportAdapterTest, StartClientListening_ClientNotInitialized) {
   EXPECT_CALL(*clientMock, IsInitialised()).WillOnce(Return(false));
   EXPECT_CALL(*clientMock, StartListening()).Times(0);
 
-  TransportAdapter::Error res = transport_adapter.StartClientListening();
+  TransportAdapter::Error res = transport_adapter.ChangeClientListening(
+      transport_manager::TransportAction::kVisibilityOn);
   EXPECT_EQ(TransportAdapter::BAD_STATE, res);
 
   EXPECT_CALL(*dev_mock, Terminate());
@@ -1058,7 +1059,8 @@ TEST_F(TransportAdapterTest, StartClientListening) {
   EXPECT_CALL(*clientMock, StartListening())
       .WillOnce(Return(TransportAdapter::OK));
 
-  TransportAdapter::Error res = transport_adapter.StartClientListening();
+  TransportAdapter::Error res = transport_adapter.ChangeClientListening(
+      transport_manager::TransportAction::kVisibilityOn);
   EXPECT_EQ(TransportAdapter::OK, res);
 
   EXPECT_CALL(*dev_mock, Terminate());
@@ -1092,7 +1094,8 @@ TEST_F(TransportAdapterTest, StopClientListening_Success) {
   EXPECT_CALL(*clientMock, StopListening())
       .WillOnce(Return(TransportAdapter::OK));
 
-  res = transport_adapter.StopClientListening();
+  res = transport_adapter.ChangeClientListening(
+      transport_manager::TransportAction::kVisibilityOff);
   EXPECT_EQ(TransportAdapter::OK, res);
 
   EXPECT_CALL(*dev_mock, Terminate());

--- a/src/components/transport_manager/test/transport_manager_default_test.cc
+++ b/src/components/transport_manager/test/transport_manager_default_test.cc
@@ -97,6 +97,19 @@ TEST(TestTransportManagerDefault, Init_LastStateNotUsed) {
   EXPECT_CALL(transport_manager_settings, bluetooth_uuid())
       .WillRepeatedly(Return(kBTUUID.data()));
 
+  std::string dummy_parameter;
+  EXPECT_CALL(transport_manager_settings, aoa_filter_manufacturer())
+      .WillRepeatedly(ReturnRef(dummy_parameter));
+  EXPECT_CALL(transport_manager_settings, aoa_filter_model_name())
+      .WillRepeatedly(ReturnRef(dummy_parameter));
+  EXPECT_CALL(transport_manager_settings, aoa_filter_description())
+      .WillRepeatedly(ReturnRef(dummy_parameter));
+  EXPECT_CALL(transport_manager_settings, aoa_filter_version())
+      .WillRepeatedly(ReturnRef(dummy_parameter));
+  EXPECT_CALL(transport_manager_settings, aoa_filter_uri())
+      .WillRepeatedly(ReturnRef(dummy_parameter));
+  EXPECT_CALL(transport_manager_settings, aoa_filter_serial_number())
+      .WillRepeatedly(ReturnRef(dummy_parameter));
   transport_manager.Init(mock_last_state);
   transport_manager.Stop();
 }

--- a/src/components/transport_manager/test/transport_manager_impl_test.cc
+++ b/src/components/transport_manager/test/transport_manager_impl_test.cc
@@ -664,15 +664,23 @@ TEST_F(TransportManagerImplTest, RemoveDevice_DeviceWasAdded) {
 }
 
 TEST_F(TransportManagerImplTest, SetVisibilityOn_StartClientListening) {
-  EXPECT_CALL(*mock_adapter_, StartClientListening())
+  EXPECT_CALL(
+      *mock_adapter_,
+      ChangeClientListening(transport_manager::TransportAction::kVisibilityOn))
       .WillOnce(Return(TransportAdapter::OK));
-  EXPECT_EQ(::transport_manager::E_SUCCESS, tm_.Visibility(true));
+  EXPECT_EQ(::transport_manager::E_SUCCESS,
+            tm_.PerformActionOnClients(
+                transport_manager::TransportAction::kVisibilityOn));
 }
 
 TEST_F(TransportManagerImplTest, SetVisibilityOff_StopClientListening) {
-  EXPECT_CALL(*mock_adapter_, StopClientListening())
+  EXPECT_CALL(
+      *mock_adapter_,
+      ChangeClientListening(transport_manager::TransportAction::kVisibilityOff))
       .WillOnce(Return(TransportAdapter::OK));
-  EXPECT_EQ(::transport_manager::E_SUCCESS, tm_.Visibility(false));
+  EXPECT_EQ(::transport_manager::E_SUCCESS,
+            tm_.PerformActionOnClients(
+                transport_manager::TransportAction::kVisibilityOff));
 }
 
 TEST_F(TransportManagerImplTest, StopTransportManager) {
@@ -691,12 +699,14 @@ TEST_F(TransportManagerImplTest, StopTransportManager) {
 TEST_F(TransportManagerImplTest, Reinit) {
   EXPECT_CALL(*mock_adapter_, Terminate());
   EXPECT_CALL(*mock_adapter_, Init()).WillOnce(Return(TransportAdapter::OK));
+  tm_.Deinit();
   EXPECT_EQ(E_SUCCESS, tm_.Reinit());
 }
 
 TEST_F(TransportManagerImplTest, Reinit_InitAdapterFailed) {
   EXPECT_CALL(*mock_adapter_, Terminate());
   EXPECT_CALL(*mock_adapter_, Init()).WillOnce(Return(TransportAdapter::FAIL));
+  tm_.Deinit();
   EXPECT_EQ(E_ADAPTERS_FAIL, tm_.Reinit());
 }
 
@@ -940,12 +950,16 @@ TEST_F(TransportManagerImplTest, RemoveDevice_TMIsNotInitialized) {
 
 TEST_F(TransportManagerImplTest, Visibility_TMIsNotInitialized) {
   // Arrange
-  const bool visible = true;
+  const transport_manager::TransportAction action =
+      transport_manager::TransportAction::kVisibilityOn;
   // Check before Act
   UninitializeTM();
   // Act and Assert
-  EXPECT_CALL(*mock_adapter_, StartClientListening()).Times(0);
-  EXPECT_EQ(E_TM_IS_NOT_INITIALIZED, tm_.Visibility(visible));
+  EXPECT_CALL(
+      *mock_adapter_,
+      ChangeClientListening(transport_manager::TransportAction::kVisibilityOn))
+      .Times(0);
+  EXPECT_EQ(E_TM_IS_NOT_INITIALIZED, tm_.PerformActionOnClients(action));
 }
 
 TEST_F(TransportManagerImplTest, HandleMessage_ConnectionNotExist) {
@@ -971,16 +985,24 @@ TEST_F(TransportManagerImplTest, SearchDevices_TMIsNotInitialized) {
 }
 
 TEST_F(TransportManagerImplTest, SetVisibilityOn_TransportAdapterNotSupported) {
-  EXPECT_CALL(*mock_adapter_, StartClientListening())
+  EXPECT_CALL(
+      *mock_adapter_,
+      ChangeClientListening(transport_manager::TransportAction::kVisibilityOn))
       .WillOnce(Return(TransportAdapter::NOT_SUPPORTED));
-  EXPECT_EQ(E_SUCCESS, tm_.Visibility(true));
+  EXPECT_EQ(E_SUCCESS,
+            tm_.PerformActionOnClients(
+                transport_manager::TransportAction::kVisibilityOn));
 }
 
 TEST_F(TransportManagerImplTest,
        SetVisibilityOff_TransportAdapterNotSupported) {
-  EXPECT_CALL(*mock_adapter_, StopClientListening())
+  EXPECT_CALL(
+      *mock_adapter_,
+      ChangeClientListening(transport_manager::TransportAction::kVisibilityOff))
       .WillOnce(Return(TransportAdapter::NOT_SUPPORTED));
-  EXPECT_EQ(E_SUCCESS, tm_.Visibility(false));
+  EXPECT_EQ(E_SUCCESS,
+            tm_.PerformActionOnClients(
+                transport_manager::TransportAction::kVisibilityOff));
 }
 
 TEST_F(TransportManagerImplTest,

--- a/src/components/utils/src/signals_posix.cc
+++ b/src/components/utils/src/signals_posix.cc
@@ -83,7 +83,7 @@ pid_t Signals::Fork() {
 }
 
 void Signals::ExitProcess(const int status) {
-  exit(status);
+  _Exit(status);
 }
 
 void Signals::WaitPid(pid_t cpid, int* status, int options) {


### PR DESCRIPTION
Fixes #2996 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test scripts

### Summary
There were found a several problems during SDL testing with ATF scripts:
1. SDL ignores messages from mobile/HMI during low voltage but as they are still delivered to the independent external container (e.g. socket) during Low Voltage - when SDL wakes up - it is not aware what data was in the container and starts processing them. 
2. Sometimes SDL ignores messages on wake up due to timings
3. SDL low voltage process is not stopping properly by exit() function
4. SDL does not send OnAppUnregistered after wake up to HMI

To solve mentioned problems, the following changes were done:
1.  `exit()` was replaced with `_Exit()` which allow to force close the child process which has fully done its job.
2. Suspend transport events processing threads during low voltage, such as unexpected disconnect etc. These events should be processed when SDL wakes up completely.
3. Suspend all client listening threads and shut down sockets for a TCP connections to prevent any possibility to receive message during low voltage. These threads will be resumed on wake up.
4.  Set `low_voltage` flag to false in the end of `wakeup()` function to prevent any timing issues.
5. Don't add pending requests/notifications into request controller if low voltage event has happened, as it may happen at any moment
6. Don't handle received pending messages from mobile/HMI  in RPC handler if low voltage event has happened as it may happen at any moment

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
