### PR TITLE
Fix/unexpected ptu after app reconnect

### DIFF
--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1880,7 +1880,7 @@ std::string PolicyManagerImpl::ForcePTExchange() {
 void policy::PolicyManagerImpl::StopRetrySequence() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  ResetRetrySequence(ResetRetryCountType::kResetWithStatusUpdate);
+  ResetRetrySequence(ResetRetryCountType::kResetInternally);
 }
 
 std::string PolicyManagerImpl::ForcePTExchangeAtUserRequest() {

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1232,11 +1232,14 @@ std::string PolicyManagerImpl::ForcePTExchange() {
 void PolicyManagerImpl::StopRetrySequence() {
   LOG4CXX_AUTO_TRACE(logger_);
 
+  auto reset_type = ResetRetryCountType::kResetInternally;
+
   if (timer_retry_sequence_.is_running()) {
+    reset_type = ResetRetryCountType::kResetWithStatusUpdate;
     timer_retry_sequence_.Stop();
   }
 
-  ResetRetrySequence(ResetRetryCountType::kResetWithStatusUpdate);
+  ResetRetrySequence(reset_type);
 }
 
 std::string PolicyManagerImpl::ForcePTExchangeAtUserRequest() {


### PR DESCRIPTION
Fixes #3026 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
ATF tests

### Summary
After `StopRetrySequence` routine was introduced, it performed a `ResetRetryCount` with sending `UPDATE_NEEDED` notification. However, it is only needed when current retry status is `UPDATING`. Parameter check was added  to fix that.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
