### PR TITLE
Add condition check for policy ResetRetrySequence

### DIFF
--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1879,8 +1879,9 @@ std::string PolicyManagerImpl::ForcePTExchange() {
 
 void policy::PolicyManagerImpl::StopRetrySequence() {
   LOG4CXX_AUTO_TRACE(logger_);
-
-  ResetRetrySequence(ResetRetryCountType::kResetWithStatusUpdate);
+  if (update_status_manager_.IsUpdateRequired()) {
+    ResetRetrySequence(ResetRetryCountType::kResetWithStatusUpdate);
+  }
 }
 
 std::string PolicyManagerImpl::ForcePTExchangeAtUserRequest() {

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1236,7 +1236,9 @@ void PolicyManagerImpl::StopRetrySequence() {
     timer_retry_sequence_.Stop();
   }
 
-  ResetRetrySequence(ResetRetryCountType::kResetWithStatusUpdate);
+  if (update_status_manager_.IsUpdateRequired()) {
+    ResetRetrySequence(ResetRetryCountType::kResetWithStatusUpdate);
+  }
 }
 
 std::string PolicyManagerImpl::ForcePTExchangeAtUserRequest() {


### PR DESCRIPTION
Fixes #3026 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manual testing described in #3026 

### Summary
Fixes an issue with #3020 which made it so `UPDATE_NEEDED` was sent whenever all apps were disconnected, this fix changes the behavior of `StopRetrySequence` to only reset the sequence if it is currently in progress.

### Changelog
##### Bug Fixes
* Changes the behavior of `StopRetrySequence` to only reset the sequence if it is currently in progress.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
