### PR TITLE
Add reregister wait list accessor and fix IsApplicationSwitched in RAI

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -170,6 +170,7 @@ class ApplicationManagerImpl
 
   DataAccessor<ApplicationSet> applications() const OVERRIDE;
   DataAccessor<AppsWaitRegistrationSet> pending_applications() const OVERRIDE;
+  DataAccessor<ReregisterWaitList> reregister_applications() const OVERRIDE;
   ApplicationSharedPtr application(uint32_t app_id) const OVERRIDE;
 
   ApplicationSharedPtr active_application() const OVERRIDE;
@@ -181,6 +182,8 @@ class ApplicationManagerImpl
   ApplicationSharedPtr application_by_name(
       const std::string& app_name) const OVERRIDE;
   ApplicationSharedPtr pending_application_by_policy_id(
+      const std::string& policy_app_id) const OVERRIDE;
+  ApplicationSharedPtr reregister_application_by_policy_id(
       const std::string& policy_app_id) const OVERRIDE;
 
   std::vector<ApplicationSharedPtr> applications_by_button(
@@ -1436,12 +1439,14 @@ class ApplicationManagerImpl
   ApplicationSet applications_;
   AppsWaitRegistrationSet apps_to_register_;
   ForbiddenApps forbidden_applications;
+  ReregisterWaitList reregister_wait_list_;
 
   // Lock for applications list
   mutable std::shared_ptr<sync_primitives::RecursiveLock>
       applications_list_lock_ptr_;
   mutable std::shared_ptr<sync_primitives::Lock>
       apps_to_register_list_lock_ptr_;
+  mutable std::shared_ptr<sync_primitives::Lock> reregister_wait_list_lock_ptr_;
   mutable sync_primitives::Lock subscribed_way_points_apps_lock_;
 
   /**
@@ -1532,15 +1537,6 @@ class ApplicationManagerImpl
   StateControllerImpl state_ctrl_;
   std::unique_ptr<app_launch::AppLaunchData> app_launch_dto_;
   std::unique_ptr<app_launch::AppLaunchCtrl> app_launch_ctrl_;
-
-  /**
-   * @brief ReregisterWaitList is list of applications expected to be
-   * re-registered after transport switching is complete
-   */
-  typedef std::vector<ApplicationSharedPtr> ReregisterWaitList;
-  ReregisterWaitList reregister_wait_list_;
-
-  mutable sync_primitives::Lock reregister_wait_list_lock_;
 
   // This is a cache to remember DeviceHandle of secondary transports. Only used
   // during RegisterApplication().

--- a/src/components/application_manager/include/application_manager/helpers/application_helper.h
+++ b/src/components/application_manager/include/application_manager/helpers/application_helper.h
@@ -69,6 +69,19 @@ ApplicationSharedPtr FindPendingApp(
   return app;
 }
 
+template <class UnaryPredicate>
+ApplicationSharedPtr FindReregisterApp(
+    DataAccessor<ReregisterWaitList> accessor, UnaryPredicate finder) {
+  ReregisterWaitList::const_iterator begin = accessor.GetData().begin();
+  ReregisterWaitList::const_iterator end = accessor.GetData().end();
+  ReregisterWaitList::const_iterator it = std::find_if(begin, end, finder);
+  if (accessor.GetData().end() == it) {
+    return ApplicationSharedPtr();
+  }
+  ApplicationSharedPtr app = *it;
+  return app;
+}
+
 /**
  * Helper function for lookup through applications list and returning all
  * applications satisfying predicate logic

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -1380,8 +1380,8 @@ bool RegisterAppInterfaceRequest::IsApplicationSwitched() {
       application_manager_.GetCorrectMobileIDFromMessage(message_);
 
   LOG4CXX_DEBUG(logger_, "Looking for application id " << policy_app_id);
-
-  auto app = application_manager_.application(device_id_, policy_app_id);
+  auto app =
+      application_manager_.reregister_application_by_policy_id(policy_app_id);
 
   if (!app) {
     LOG4CXX_DEBUG(
@@ -1392,11 +1392,12 @@ bool RegisterAppInterfaceRequest::IsApplicationSwitched() {
 
   LOG4CXX_DEBUG(logger_,
                 "Application with policy id " << policy_app_id << " is found.");
-  if (!application_manager_.IsAppInReconnectMode(device_handle_,
-                                                 policy_app_id)) {
-    LOG4CXX_DEBUG(
-        logger_,
-        "Policy id " << policy_app_id << " is not found in reconnection list.");
+
+  const auto app_device_handle = app->device();
+  if (app_device_handle == device_handle_) {
+    LOG4CXX_DEBUG(logger_,
+                  "Application " << policy_app_id
+                                 << " is already registered from this device.");
     SendResponse(false, mobile_apis::Result::APPLICATION_REGISTERED_ALREADY);
     return true;
   }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -159,6 +159,7 @@ ApplicationManagerImpl::ApplicationManagerImpl(
     , applications_list_lock_ptr_(
           std::make_shared<sync_primitives::RecursiveLock>())
     , apps_to_register_list_lock_ptr_(std::make_shared<sync_primitives::Lock>())
+    , reregister_wait_list_lock_ptr_(std::make_shared<sync_primitives::Lock>())
     , audio_pass_thru_active_(false)
     , audio_pass_thru_app_id_(0)
     , driver_distraction_state_(hmi_apis::Common_DriverDistractionState::DD_OFF)
@@ -266,6 +267,13 @@ ApplicationManagerImpl::pending_applications() const {
   return accessor;
 }
 
+DataAccessor<ReregisterWaitList>
+ApplicationManagerImpl::reregister_applications() const {
+  DataAccessor<ReregisterWaitList> accessor(reregister_wait_list_,
+                                            reregister_wait_list_lock_ptr_);
+  return accessor;
+}
+
 ApplicationSharedPtr ApplicationManagerImpl::application(
     uint32_t app_id) const {
   AppIdPredicate finder(app_id);
@@ -299,6 +307,14 @@ ApplicationSharedPtr ApplicationManagerImpl::pending_application_by_policy_id(
   PolicyAppIdPredicate finder(policy_app_id);
   DataAccessor<AppsWaitRegistrationSet> accessor = pending_applications();
   return FindPendingApp(accessor, finder);
+}
+
+ApplicationSharedPtr
+ApplicationManagerImpl::reregister_application_by_policy_id(
+    const std::string& policy_app_id) const {
+  PolicyAppIdPredicate finder(policy_app_id);
+  DataAccessor<ReregisterWaitList> accessor = reregister_applications();
+  return FindReregisterApp(accessor, finder);
 }
 
 bool ActiveAppPredicate(const ApplicationSharedPtr app) {
@@ -1554,7 +1570,7 @@ void ApplicationManagerImpl::OnDeviceSwitchingStart(
   {
     // During sending of UpdateDeviceList this lock is acquired also so making
     // it scoped
-    sync_primitives::AutoLock lock(reregister_wait_list_lock_);
+    sync_primitives::AutoLock lock(reregister_wait_list_lock_ptr_);
     for (auto i = reregister_wait_list_.begin();
          reregister_wait_list_.end() != i;
          ++i) {
@@ -1594,7 +1610,7 @@ void ApplicationManagerImpl::OnDeviceSwitchingFinish(
     const std::string& device_uid) {
   LOG4CXX_AUTO_TRACE(logger_);
   UNUSED(device_uid);
-  sync_primitives::AutoLock lock(reregister_wait_list_lock_);
+  sync_primitives::AutoLock lock(reregister_wait_list_lock_ptr_);
 
   const bool unexpected_disonnect = true;
   const bool is_resuming = true;
@@ -3569,7 +3585,7 @@ bool ApplicationManagerImpl::IsAppInReconnectMode(
     const connection_handler::DeviceHandle& device_id,
     const std::string& policy_app_id) const {
   LOG4CXX_AUTO_TRACE(logger_);
-  sync_primitives::AutoLock lock(reregister_wait_list_lock_);
+  sync_primitives::AutoLock lock(reregister_wait_list_lock_ptr_);
   return reregister_wait_list_.end() !=
          std::find_if(reregister_wait_list_.begin(),
                       reregister_wait_list_.end(),
@@ -3902,7 +3918,7 @@ void ApplicationManagerImpl::EraseAppFromReconnectionList(
   }
 
   const auto policy_app_id = app->policy_app_id();
-  sync_primitives::AutoLock lock(reregister_wait_list_lock_);
+  sync_primitives::AutoLock lock(reregister_wait_list_lock_ptr_);
   auto app_it =
       std::find_if(reregister_wait_list_.begin(),
                    reregister_wait_list_.end(),

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -120,6 +120,12 @@ typedef std::set<ApplicationSharedPtr, ApplicationsSorter> ApplicationSet;
 typedef std::set<ApplicationSharedPtr, ApplicationsPolicyAppIdSorter>
     AppsWaitRegistrationSet;
 
+/**
+ * @brief ReregisterWaitList is list of applications expected to be
+ * re-registered after transport switching is complete
+ */
+typedef std::vector<ApplicationSharedPtr> ReregisterWaitList;
+
 // typedef for Applications list iterator
 typedef ApplicationSet::iterator ApplicationSetIt;
 
@@ -160,6 +166,7 @@ class ApplicationManager {
   virtual DataAccessor<ApplicationSet> applications() const = 0;
   virtual DataAccessor<AppsWaitRegistrationSet> pending_applications()
       const = 0;
+  virtual DataAccessor<ReregisterWaitList> reregister_applications() const = 0;
 
   virtual ApplicationSharedPtr application(uint32_t app_id) const = 0;
   virtual ApplicationSharedPtr active_application() const = 0;
@@ -179,6 +186,9 @@ class ApplicationManager {
       const std::string& app_name) const = 0;
 
   virtual ApplicationSharedPtr pending_application_by_policy_id(
+      const std::string& policy_app_id) const = 0;
+
+  virtual ApplicationSharedPtr reregister_application_by_policy_id(
       const std::string& policy_app_id) const = 0;
 
   virtual AppSharedPtrs applications_by_button(uint32_t button) = 0;

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -80,6 +80,8 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD0(
       pending_applications,
       DataAccessor<application_manager::AppsWaitRegistrationSet>());
+  MOCK_CONST_METHOD0(reregister_applications,
+                     DataAccessor<application_manager::ReregisterWaitList>());
   MOCK_CONST_METHOD1(
       application, application_manager::ApplicationSharedPtr(uint32_t app_id));
   MOCK_CONST_METHOD0(active_application,
@@ -109,6 +111,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
       application_by_name,
       application_manager::ApplicationSharedPtr(const std::string& app_name));
   MOCK_CONST_METHOD1(pending_application_by_policy_id,
+                     application_manager::ApplicationSharedPtr(
+                         const std::string& policy_app_id));
+  MOCK_CONST_METHOD1(reregister_application_by_policy_id,
                      application_manager::ApplicationSharedPtr(
                          const std::string& policy_app_id));
   MOCK_METHOD1(


### PR DESCRIPTION
Fixes #2262

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run IAP switching ATF Tests

### Summary
Add a data accessor for the reregister wait list apps that are undergoing a transport switch. This method can be used by the RAI request body to find apps that are being switched.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
