### PR TITLE
move MenuLayoutsAvailable to WindowCapability

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -268,6 +268,12 @@ class DynamicApplicationData {
   virtual void remove_window_capability(const WindowID window_id) = 0;
 
   /**
+   * @brief checks whether a specific menu layout is supported
+   * @param menu layout to check
+   */
+  virtual bool menu_layout_supported(const mobile_apis::MenuLayout::eType layout) = 0;
+
+  /**
    * @brief Sets layout for application's specific window
    * @param window_id window id for which layout should be set
    * @param layout - layout to be set

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -271,7 +271,8 @@ class DynamicApplicationData {
    * @brief checks whether a specific menu layout is supported
    * @param menu layout to check
    */
-  virtual bool menu_layout_supported(const mobile_apis::MenuLayout::eType layout) = 0;
+  virtual bool menu_layout_supported(
+      const mobile_apis::MenuLayout::eType layout) const = 0;
 
   /**
    * @brief Sets layout for application's specific window

--- a/src/components/application_manager/include/application_manager/application_data_impl.h
+++ b/src/components/application_manager/include/application_manager/application_data_impl.h
@@ -152,7 +152,8 @@ class DynamicApplicationDataImpl : public virtual Application {
    * @brief checks whether a specific menu layout is supported
    * @param menu layout to check
    */
-  bool menu_layout_supported(const mobile_apis::MenuLayout::eType layout) OVERRIDE;
+  bool menu_layout_supported(
+      const mobile_apis::MenuLayout::eType layout) const OVERRIDE;
 
   /*
    * @brief Adds a command to the in application menu

--- a/src/components/application_manager/include/application_manager/application_data_impl.h
+++ b/src/components/application_manager/include/application_manager/application_data_impl.h
@@ -147,6 +147,13 @@ class DynamicApplicationDataImpl : public virtual Application {
   void set_display_capabilities(
       const smart_objects::SmartObject& display_capabilities) OVERRIDE;
   void remove_window_capability(const WindowID window_id) OVERRIDE;
+
+  /**
+   * @brief checks whether a specific menu layout is supported
+   * @param menu layout to check
+   */
+  bool menu_layout_supported(const mobile_apis::MenuLayout::eType layout) OVERRIDE;
+
   /*
    * @brief Adds a command to the in application menu
    */

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -453,14 +453,6 @@ class HMICapabilitiesImpl : public HMICapabilities {
   bool rc_supported() const OVERRIDE;
 
   /*
-   * @brief Retrieves whether HMI supports passed Menu Layout
-   *
-   * @return TRUE if it supported, otherwise FALSE
-   */
-  bool menu_layout_supported(
-      mobile_apis::MenuLayout::eType layout) const OVERRIDE;
-
-  /*
    * @brief Interface used to store information regarding
    * the navigation "System Capability"
    *

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_sub_menu_request.cc
@@ -112,8 +112,7 @@ void AddSubMenuRequest::Run() {
   if (received_msg_params.keyExists(strings::menu_layout)) {
     auto menu_layout = static_cast<mobile_apis::MenuLayout::eType>(
         received_msg_params[strings::menu_layout].asUInt());
-    if (application_manager_.hmi_capabilities().menu_layout_supported(
-            menu_layout)) {
+    if (app->menu_layout_supported(menu_layout)) {
       msg_params[strings::menu_layout] =
           received_msg_params[strings::menu_layout];
     } else {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -591,13 +591,6 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
     }
 
     if (hmi_capabilities.display_capabilities()->keyExists(
-            strings::menu_layouts_available)) {
-      display_caps[strings::menu_layouts_available] =
-          hmi_capabilities.display_capabilities()->getElement(
-              strings::menu_layouts_available);
-    }
-
-    if (hmi_capabilities.display_capabilities()->keyExists(
             hmi_response::media_clock_formats)) {
       display_caps[hmi_response::media_clock_formats] =
           hmi_capabilities.display_capabilities()->getElement(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_global_properties_request.cc
@@ -174,8 +174,7 @@ void SetGlobalPropertiesRequest::Run() {
   if (msg_params.keyExists(strings::menu_layout)) {
     auto menu_layout = static_cast<mobile_apis::MenuLayout::eType>(
         msg_params[strings::menu_layout].asUInt());
-    if (application_manager_.hmi_capabilities().menu_layout_supported(
-            menu_layout)) {
+    if (app->menu_layout_supported(menu_layout)) {
       params[strings::menu_layout] = msg_params[strings::menu_layout];
     } else {
       is_menu_layout_available_ = false;

--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -604,19 +604,26 @@ void DynamicApplicationDataImpl::remove_window_capability(
       "No window id " << window_id << " found in display capabilities");
 }
 
-bool DynamicApplicationDataImpl::menu_layout_supported(const mobile_apis::MenuLayout::eType layout) {
+bool DynamicApplicationDataImpl::menu_layout_supported(
+    const mobile_apis::MenuLayout::eType layout) const {
   if (!display_capabilities_)
     return false;
 
-  const auto tmp_window_capabilities_arr = (*display_capabilities_)[0][strings::window_capabilities].asArray();
+  const auto tmp_window_capabilities_arr =
+      (*display_capabilities_)[0][strings::window_capabilities].asArray();
 
   if (!tmp_window_capabilities_arr)
     return false;
 
   for (auto element : *tmp_window_capabilities_arr) {
-    if (!element.keyExists(strings::window_id) && element.keyExists(strings::menu_layouts_available)) {
-      for (uint32_t i = 0; i < element[strings::menu_layouts_available].length(); ++i) {
-        if (layout == static_cast<mobile_apis::MenuLayout::eType>(element[strings::menu_layouts_available][i].asUInt())) {
+    if (!element.keyExists(strings::window_id) &&
+        element.keyExists(strings::menu_layouts_available)) {
+      for (uint32_t i = 0;
+           i < element[strings::menu_layouts_available].length();
+           ++i) {
+        if (layout ==
+            static_cast<mobile_apis::MenuLayout::eType>(
+                element[strings::menu_layouts_available][i].asUInt())) {
           return true;
         }
       }

--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -616,7 +616,8 @@ bool DynamicApplicationDataImpl::menu_layout_supported(
     return false;
 
   for (auto element : *tmp_window_capabilities_arr) {
-    if (!element.keyExists(strings::window_id) &&
+    if ((!element.keyExists(strings::window_id) ||
+         element[strings::window_id].asInt() == 0) &&
         element.keyExists(strings::menu_layouts_available)) {
       for (uint32_t i = 0;
            i < element[strings::menu_layouts_available].length();

--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -621,9 +621,9 @@ bool DynamicApplicationDataImpl::menu_layout_supported(
       for (uint32_t i = 0;
            i < element[strings::menu_layouts_available].length();
            ++i) {
-        if (layout ==
-            static_cast<mobile_apis::MenuLayout::eType>(
-                element[strings::menu_layouts_available][i].asUInt())) {
+        if (static_cast<mobile_apis::MenuLayout::eType>(
+                element[strings::menu_layouts_available][i].asUInt()) ==
+            layout) {
           return true;
         }
       }

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -58,7 +58,6 @@ std::map<std::string, hmi_apis::Common_TextFieldName::eType>
     text_fields_enum_name;
 std::map<std::string, hmi_apis::Common_MediaClockFormat::eType>
     media_clock_enum_name;
-std::map<std::string, hmi_apis::Common_MenuLayout::eType> menu_layout_enum;
 std::map<std::string, hmi_apis::Common_ImageType::eType> image_type_enum;
 std::map<std::string, hmi_apis::Common_SamplingRate::eType> sampling_rate_enum;
 std::map<std::string, hmi_apis::Common_BitsPerSample::eType>
@@ -279,11 +278,6 @@ void InitCapabilities() {
   media_clock_enum_name.insert(
       std::make_pair(std::string("CLOCKTEXT4"),
                      hmi_apis::Common_MediaClockFormat::CLOCKTEXT4));
-
-  menu_layout_enum.insert(
-      std::make_pair(std::string("LIST"), hmi_apis::Common_MenuLayout::LIST));
-  menu_layout_enum.insert(
-      std::make_pair(std::string("TILES"), hmi_apis::Common_MenuLayout::TILES));
 
   image_type_enum.insert(std::make_pair(std::string("STATIC"),
                                         hmi_apis::Common_ImageType::STATIC));
@@ -895,26 +889,6 @@ bool HMICapabilitiesImpl::rc_supported() const {
   return is_rc_supported_;
 }
 
-bool HMICapabilitiesImpl::menu_layout_supported(
-    mobile_apis::MenuLayout::eType layout) const {
-  if (!display_capabilities_ ||
-      !display_capabilities_->keyExists(strings::menu_layouts_available))
-    return false;
-
-  auto menu_layouts =
-      display_capabilities_->getElement(strings::menu_layouts_available);
-  if (menu_layouts.getType() == smart_objects::SmartType_Array) {
-    for (uint32_t i = 0; i < menu_layouts.length(); ++i) {
-      if (layout == static_cast<mobile_apis::MenuLayout::eType>(
-                        menu_layouts.getElement(i).asUInt())) {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
-
 const smart_objects::SmartObject* HMICapabilitiesImpl::navigation_capability()
     const {
   return navigation_capability_;
@@ -1096,25 +1070,6 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
         }
 
         if (display_capabilities_so.keyExists(
-                strings::menu_layouts_available)) {
-          smart_objects::SmartObject menu_layouts_available_enum(
-              smart_objects::SmartType_Array);
-          auto menu_layouts_available_array =
-              display_capabilities_so[strings::menu_layouts_available];
-          for (uint32_t i = 0, j = 0; i < menu_layouts_available_array.length();
-               ++i) {
-            auto it = menu_layout_enum.find(
-                menu_layouts_available_array[i].asString());
-            if (it != menu_layout_enum.end()) {
-              menu_layouts_available_enum[j++] = it->second;
-            }
-          }
-          display_capabilities_so.erase(strings::menu_layouts_available);
-          display_capabilities_so[strings::menu_layouts_available] =
-              menu_layouts_available_enum;
-        }
-
-        if (display_capabilities_so.keyExists(
                 hmi_response::image_capabilities)) {
           smart_objects::SmartObject& image_capabilities_array =
               display_capabilities_so[hmi_response::image_capabilities];
@@ -1178,6 +1133,7 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
             soft_button_capabilities, soft_button_capabilities_so);
         set_soft_button_capabilities(soft_button_capabilities_so);
       }
+
       if (check_existing_json_member(ui, "systemCapabilities")) {
         Json::Value system_capabilities = ui.get("systemCapabilities", "");
         if (check_existing_json_member(system_capabilities,

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -425,7 +425,7 @@ class MockApplication : public ::application_manager::Application {
                application_manager::WindowID(const uint32_t button_id));
   MOCK_METHOD1(remove_window_capability,
                void(const application_manager::WindowID window_id));
-  MOCK_METHOD1(menu_layout_supported,
+  MOCK_CONST_METHOD1(menu_layout_supported,
                bool(const mobile_apis::MenuLayout::eType layout));
   MOCK_METHOD1(set_user_location,
                void(const smart_objects::SmartObject& user_location));

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -426,7 +426,7 @@ class MockApplication : public ::application_manager::Application {
   MOCK_METHOD1(remove_window_capability,
                void(const application_manager::WindowID window_id));
   MOCK_CONST_METHOD1(menu_layout_supported,
-               bool(const mobile_apis::MenuLayout::eType layout));
+                     bool(const mobile_apis::MenuLayout::eType layout));
   MOCK_METHOD1(set_user_location,
                void(const smart_objects::SmartObject& user_location));
   MOCK_CONST_METHOD0(get_user_location, const smart_objects::SmartObject&());

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -425,6 +425,8 @@ class MockApplication : public ::application_manager::Application {
                application_manager::WindowID(const uint32_t button_id));
   MOCK_METHOD1(remove_window_capability,
                void(const application_manager::WindowID window_id));
+  MOCK_METHOD1(menu_layout_supported,
+               bool(const mobile_apis::MenuLayout::eType layout));
   MOCK_METHOD1(set_user_location,
                void(const smart_objects::SmartObject& user_location));
   MOCK_CONST_METHOD0(get_user_location, const smart_objects::SmartObject&());

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -168,9 +168,6 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
   MOCK_CONST_METHOD0(rc_supported, bool());
   MOCK_METHOD1(set_rc_supported, void(const bool supported));
 
-  MOCK_CONST_METHOD1(menu_layout_supported,
-                     bool(mobile_apis::MenuLayout::eType layout));
-
   MOCK_CONST_METHOD0(navigation_capability,
                      const smart_objects::SmartObject*());
   MOCK_METHOD1(set_navigation_capability,

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -455,14 +455,6 @@ class HMICapabilities {
   virtual bool rc_supported() const = 0;
 
   /*
-   * @brief Retrieves whether HMI supports passed Menu Layout
-   *
-   * @return TRUE if it supported, otherwise FALSE
-   */
-  virtual bool menu_layout_supported(
-      mobile_apis::MenuLayout::eType layout) const = 0;
-
-  /*
    * @brief Interface used to store information regarding
    * the navigation "System Capability"
    *

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -2976,9 +2976,6 @@
   <param name="numCustomPresetsAvailable" type="Integer" minvalue="1" maxvalue="100" mandatory="false">
     <description>The number of on-screen custom presets available (if any); otherwise omitted.</description>
   </param>
-  <param name="menuLayoutsAvailable" type="Common.MenuLayout" array="true" minsize="1" maxsize="1000" mandatory="false">
-    <description>An array of available menu layouts. If this parameter is not provided, only the `LIST` layout is assumed to be available</description>
-  </param>
 </struct>
 
 <struct name="SoftButtonCapabilities">
@@ -3525,6 +3522,9 @@
     </param>
     <param name="softButtonCapabilities" type="SoftButtonCapabilities" minsize="1" maxsize="100" array="true" mandatory="false">
       <description>The number of soft buttons available on-window and the capabilities for each button.</description>
+    </param>
+    <param name="menuLayoutsAvailable" type="Common.MenuLayout" array="true" minsize="1" maxsize="1000" mandatory="false">
+      <description>An array of available menu layouts. If this parameter is not provided, only the `LIST` layout is assumed to be available</description>
     </param>
   </struct>
 

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -2283,9 +2283,6 @@
         <param name="numCustomPresetsAvailable" type="Integer" minvalue="1" maxvalue="100" mandatory="false" since="3.0">
             <description>The number of on-screen custom presets available (if any); otherwise omitted.</description>
         </param>
-        <param name="menuLayoutsAvailable" type="MenuLayout" array="true" minsize="1" maxsize="1000" mandatory="false" since="6.0">
-            <description>An array of available menu layouts. If this parameter is not provided, only the `LIST` layout is assumed to be available</description>
-        </param>
         <!-- TODO:  Add pixel density? -->
     </struct>
     
@@ -2416,6 +2413,9 @@
         </param>
         <param name="softButtonCapabilities" type="SoftButtonCapabilities" minsize="1" maxsize="100" array="true" mandatory="false">
             <description>The number of soft buttons available on-window and the capabilities for each button.</description>
+        </param>
+        <param name="menuLayoutsAvailable" type="MenuLayout" array="true" minsize="1" maxsize="1000" mandatory="false" since="6.0">
+            <description>An array of available menu layouts. If this parameter is not provided, only the `LIST` layout is assumed to be available</description>
         </param>
     </struct>
 


### PR DESCRIPTION
Fixes #2925 

#2925 was closed with the expectation that this change would be made as part of the fix for #2918 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Manually, [ATF #2268](https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2268)

### Summary
Remove MenuLayoutsAvailable from HMI Capabilities
Add MenuLayoutsAvailable to WindowCapabilities

### Changelog
##### Breaking Changes
* menuLayoutsAvailable now has a new location in the hmi_capabilities.json

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
