### PR TITLE
Fix/crash on ign off

### DIFF
--- a/src/components/application_manager/include/application_manager/rpc_service_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_service_impl.h
@@ -118,6 +118,8 @@ class RPCServiceImpl : public RPCService,
                  mobile_apis::MOBILE_API& mobile_so_factory_);
   ~RPCServiceImpl();
 
+  void Stop() OVERRIDE;
+
   bool ManageMobileCommand(const commands::MessageSharedPtr message,
                            commands::Command::CommandSource source) OVERRIDE;
   bool ManageHMICommand(const commands::MessageSharedPtr message,

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2351,6 +2351,8 @@ bool ApplicationManagerImpl::Stop() {
   LOG4CXX_DEBUG(logger_, "Unloading policy library.");
   GetPolicyHandler().UnloadPolicyLibrary();
 
+  rpc_service_->Stop();
+
   return true;
 }
 

--- a/src/components/application_manager/src/rpc_protection_manager_impl.cc
+++ b/src/components/application_manager/src/rpc_protection_manager_impl.cc
@@ -61,6 +61,10 @@ bool RPCProtectionManagerImpl::CheckPolicyEncryptionFlag(
   LOG4CXX_AUTO_TRACE(logger_);
   const auto& policy_encryption_flag_getter =
       policy_handler_.PolicyEncryptionFlagGetter();
+  if (!policy_encryption_flag_getter) {
+    LOG4CXX_ERROR(logger_, "Policy Encryption Flag getter is not inited");
+    return false;
+  }
   const std::string function_name =
       policy_encryption_flag_getter->GetPolicyFunctionName(function_id);
   LOG4CXX_DEBUG(logger_, "Function for check is " << function_name);

--- a/src/components/application_manager/src/rpc_service_impl.cc
+++ b/src/components/application_manager/src/rpc_service_impl.cc
@@ -68,6 +68,13 @@ RPCServiceImpl::RPCServiceImpl(
 
 RPCServiceImpl::~RPCServiceImpl() {}
 
+void RPCServiceImpl::Stop() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  messages_to_mobile_.Shutdown();
+  messages_to_hmi_.Shutdown();
+}
+
 EncryptionFlagCheckResult RPCServiceImpl::IsEncryptionRequired(
     const smart_objects::SmartObject& message,
     std::shared_ptr<Application> app,

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -1128,6 +1128,15 @@ TEST_F(ApplicationManagerImplTest, StartStopAudioPassThru) {
   }
 }
 
+TEST_F(ApplicationManagerImplTest,
+       StopApplicationManager_ExpectStopRPCService) {
+  EXPECT_CALL(*mock_policy_handler_, UnloadPolicyLibrary());
+
+  EXPECT_CALL(*mock_rpc_service_, Stop());
+
+  app_manager_impl_->Stop();
+}
+
 TEST_F(ApplicationManagerImplTest, UnregisterAnotherAppDuringAudioPassThru) {
   std::string dummy_file_name;
   ON_CALL(mock_application_manager_settings_, recording_file_name())

--- a/src/components/include/application_manager/rpc_service.h
+++ b/src/components/include/application_manager/rpc_service.h
@@ -102,6 +102,11 @@ class RPCService {
       const std::map<std::string, SMember>& members) = 0;
 
   /**
+   * @brief Stop RPC service by shutting down hmi and mobile message queues
+   */
+  virtual void Stop() = 0;
+
+  /**
    * @brief set_protocol_handler
    * @param handler
    * set protocol handler

--- a/src/components/include/test/application_manager/mock_rpc_service.h
+++ b/src/components/include/test/application_manager/mock_rpc_service.h
@@ -43,6 +43,8 @@ class MockRPCService : public application_manager::rpc_service::RPCService {
                void(const hmi_apis::FunctionID::eType& function_id,
                     const hmi_apis::messageType::eType& message_type,
                     const std::map<std::string, SMember>& members));
+
+  MOCK_METHOD0(Stop, void());
 };
 }  // namespace application_manager_test
 }  // namespace components


### PR DESCRIPTION
Fixes #3031 
This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
ATF tests

### Summary
`RPCServiceImpl` has two message queues, that were not stopped during SDL shutdown procedure. This resulted in one the queues trying to handle a message when other components had been already deleted. To fix that, a `Stop` procedure was introduced to `RPCServiceImpl`. 

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
