### PR TITLE
Fix PTU notifications order

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_start_stream_request.cc
@@ -64,8 +64,9 @@ NaviStartStreamRequest::NaviStartStreamRequest(
 }
 
 NaviStartStreamRequest::~NaviStartStreamRequest() {
-  // unsubscribe_from_all_hmi_events() in EventObserver's destructor isn't enough;
-  // we must unsubscribe before this NaviStartStreamRequest instance is removed
+  // unsubscribe_from_all_hmi_events() in EventObserver's destructor isn't
+  // enough; we must unsubscribe before this NaviStartStreamRequest instance is
+  // removed
   unsubscribe_from_event(hmi_apis::FunctionID::Navigation_StartStream);
 }
 

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -401,7 +401,10 @@ TEST_F(PolicyHandlerTest, AppServiceUpdate_CheckAppService) {
   ifile.close();
   BinaryMessage msg(json.begin(), json.end());
   // Checks
-  EXPECT_CALL(*mock_policy_manager_, LoadPT("", msg)).WillOnce(Return(true));
+  EXPECT_CALL(*mock_policy_manager_, LoadPT("", msg))
+      .WillOnce(Return(PolicyManager::PtProcessingResult::kSuccess));
+  EXPECT_CALL(*mock_policy_manager_,
+              OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess));
   policy_handler_.ReceiveMessageFromSDK("", msg);
 
   policy_table::AppServiceParameters app_service_params =
@@ -468,7 +471,10 @@ TEST_F(PolicyHandlerTest, ReceiveMessageFromSDK) {
   EXPECT_CALL(app_manager_, GetNextHMICorrelationID());
   EXPECT_CALL(mock_message_helper_, CreateGetVehicleDataRequest(_, _, _));
   EXPECT_CALL(*mock_policy_manager_, PTUpdatedAt(_, _));
-  EXPECT_CALL(*mock_policy_manager_, LoadPT("", msg)).WillOnce(Return(true));
+  EXPECT_CALL(*mock_policy_manager_, LoadPT("", msg))
+      .WillOnce(Return(PolicyManager::PtProcessingResult::kSuccess));
+  EXPECT_CALL(*mock_policy_manager_,
+              OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess));
   EXPECT_CALL(*mock_policy_manager_, CleanupUnpairedDevices());
   policy_handler_.ReceiveMessageFromSDK("", msg);
 }
@@ -479,7 +485,11 @@ TEST_F(PolicyHandlerTest, ReceiveMessageFromSDK_PTNotLoaded) {
   BinaryMessage msg;
   // Checks
 
-  EXPECT_CALL(*mock_policy_manager_, LoadPT("", msg)).WillOnce(Return(false));
+  EXPECT_CALL(*mock_policy_manager_, LoadPT("", msg))
+      .WillOnce(Return(PolicyManager::PtProcessingResult::kWrongPtReceived));
+  EXPECT_CALL(
+      *mock_policy_manager_,
+      OnPTUFinished(PolicyManager::PtProcessingResult::kWrongPtReceived));
   EXPECT_CALL(app_manager_, GetNextHMICorrelationID()).Times(0);
   EXPECT_CALL(mock_message_helper_, CreateGetVehicleDataRequest(_, _, _))
       .Times(0);

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -60,6 +60,9 @@ class PolicyManager : public usage_statistics::StatisticsManager,
    * notified about changes done (e.g. after consents were changed) or not
    */
   enum NotificationMode { kSilentMode, kNotifyApplicationMode };
+
+  enum PtProcessingResult { kSuccess, kWrongPtReceived, kNewPtRequired };
+
   virtual ~PolicyManager() {}
 
   /**
@@ -83,10 +86,16 @@ class PolicyManager : public usage_statistics::StatisticsManager,
    * sent in snapshot and received Policy Table.
    * @param file name of file with update policy table
    * @param pt_content PTU as binary string
-   * @return true if successfully
+   * @return result of PT processing
    */
-  virtual bool LoadPT(const std::string& file,
-                      const BinaryMessage& pt_content) = 0;
+  virtual PtProcessingResult LoadPT(const std::string& file,
+                                    const BinaryMessage& pt_content) = 0;
+
+  /**
+   * @brief Performs finalizing actions after PT update was processed
+   * @param ptu_result result of last PT processing
+   */
+  virtual void OnPTUFinished(const PtProcessingResult ptu_result) = 0;
 
   /**
    * @brief Resets Policy Table

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -53,6 +53,8 @@ typedef std::shared_ptr<utils::Callable> StatusNotifier;
 class PolicyManager : public usage_statistics::StatisticsManager,
                       public PolicyEncryptionFlagGetterInterface {
  public:
+  enum PtProcessingResult { kSuccess, kWrongPtReceived, kNewPtRequired };
+
   virtual ~PolicyManager() {}
 
   /**
@@ -76,10 +78,16 @@ class PolicyManager : public usage_statistics::StatisticsManager,
    * sent in snapshot and received Policy Table.
    * @param file name of file with update policy table
    * @param pt_content PTU as binary string
-   * @return true if successfully
+   * @return result of PT processing
    */
-  virtual bool LoadPT(const std::string& file,
-                      const BinaryMessage& pt_content) = 0;
+  virtual PtProcessingResult LoadPT(const std::string& file,
+                                    const BinaryMessage& pt_content) = 0;
+
+  /**
+   * @brief Performs finalizing actions after PT update was processed
+   * @param ptu_result result of last PT processing
+   */
+  virtual void OnPTUFinished(const PtProcessingResult ptu_result) = 0;
 
   /**
    * @brief Resets Policy Table

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -76,7 +76,9 @@ class MockPolicyManager : public PolicyManager {
                bool(const std::string& file_name,
                     const PolicySettings* settings));
   MOCK_METHOD2(LoadPT,
-               bool(const std::string& file, const BinaryMessage& pt_content));
+               PtProcessingResult(const std::string& file,
+                                  const BinaryMessage& pt_content));
+  MOCK_METHOD1(OnPTUFinished, void(const PtProcessingResult ptu_result));
   MOCK_METHOD1(ResetPT, bool(const std::string& file_name));
   MOCK_METHOD1(GetUpdateUrl, std::string(int service_type));
   MOCK_METHOD2(GetUpdateUrls,

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -77,7 +77,9 @@ class MockPolicyManager : public PolicyManager {
                bool(const std::string& file_name,
                     const PolicySettings* settings));
   MOCK_METHOD2(LoadPT,
-               bool(const std::string& file, const BinaryMessage& pt_content));
+               PtProcessingResult(const std::string& file,
+                                  const BinaryMessage& pt_content));
+  MOCK_METHOD1(OnPTUFinished, void(const PtProcessingResult ptu_result));
   MOCK_METHOD1(ResetPT, bool(const std::string& file_name));
 
   MOCK_METHOD2(GetUpdateUrls,

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -855,12 +855,10 @@ class PolicyManagerImpl : public PolicyManager {
   }
 
   /**
-   * @brief Setter for send_on_update_sent_out and wrong_ptu_update_received
+   * @brief Setter for send_on_update_sent_out
    * @param send_on_update_sent_out new value of this flag
-   * @param wrong_ptu_update_received new value of this flag
    */
-  inline void SetSendOnUpdateFlags(const bool send_on_update_sent_out,
-                                   const bool wrong_ptu_update_received) {
+  inline void SetSendOnUpdateFlags(const bool send_on_update_sent_out) {
     send_on_update_sent_out_ = send_on_update_sent_out;
   }
 #endif  // BUILD_TESTS

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -127,8 +127,10 @@ class PolicyManagerImpl : public PolicyManager {
    * @param pt_content PTU as binary string
    * @return true if successfully
    */
-  bool LoadPT(const std::string& file,
-              const BinaryMessage& pt_content) OVERRIDE;
+  PtProcessingResult LoadPT(const std::string& file,
+                            const BinaryMessage& pt_content) OVERRIDE;
+
+  void OnPTUFinished(const PtProcessingResult ptu_result) OVERRIDE;
 
   /**
    * @brief Resets Policy Table
@@ -860,7 +862,6 @@ class PolicyManagerImpl : public PolicyManager {
   inline void SetSendOnUpdateFlags(const bool send_on_update_sent_out,
                                    const bool wrong_ptu_update_received) {
     send_on_update_sent_out_ = send_on_update_sent_out;
-    wrong_ptu_update_received_ = wrong_ptu_update_received;
   }
 #endif  // BUILD_TESTS
 
@@ -1221,6 +1222,12 @@ class PolicyManagerImpl : public PolicyManager {
                             const AppPoliciesValueType& app_policy);
 
   /**
+   * @brief Resumes all policy actions for all apps, suspended during
+   * PTU applying
+   */
+  void ResumePendingAppPolicyActions();
+
+  /**
    * @brief Gets groups names from collection of groups permissions
    * @param app_group_permissions Collection of groups permissions
    * @return Collection of group names
@@ -1327,11 +1334,6 @@ class PolicyManagerImpl : public PolicyManager {
   friend struct ProccessAppGroups;
 
   /**
-   * @brief Flag for notifying that invalid PTU was received
-   */
-  bool wrong_ptu_update_received_;
-
-  /**
    * @brief Flag for notifying that PTU was started
    */
   bool send_on_update_sent_out_;
@@ -1346,6 +1348,21 @@ class PolicyManagerImpl : public PolicyManager {
    * progress
    */
   bool is_ptu_in_progress_;
+
+  typedef std::list<std::pair<std::string, AppPoliciesValueType> >
+      PendingAppPolicyActionsList;
+
+  /**
+   * @brief List containing device_id and pending permissions structure pairs
+   * which can be processed later on demand
+   */
+  PendingAppPolicyActionsList notify_system_list_;
+
+  /**
+   * @brief List containing device_id and pending permissions structure pairs
+   * which can be processed later on demand
+   */
+  PendingAppPolicyActionsList send_permissions_list_;
 };
 
 }  // namespace policy

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1904,10 +1904,9 @@ std::string PolicyManagerImpl::ForcePTExchange() {
 void policy::PolicyManagerImpl::StopRetrySequence() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  const ResetRetryCountType reset_type =
-      cache_->UpdateRequired() ? ResetRetryCountType::kResetWithStatusUpdate
-                               : ResetRetryCountType::kResetInternally;
-  ResetRetrySequence(reset_type);
+  if (cache_->UpdateRequired()) {
+    ResetRetrySequence(ResetRetryCountType::kResetWithStatusUpdate);
+  }
 }
 
 std::string PolicyManagerImpl::ForcePTExchangeAtUserRequest() {

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -107,7 +107,7 @@ TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
   EXPECT_CALL(*cache_manager_, DaysBeforeExchange(_))
       .WillOnce(Return(kNonZero));
   policy_manager_->ForcePTExchange();
-  policy_manager_->SetSendOnUpdateFlags(true, false);
+  policy_manager_->SetSendOnUpdateFlags(true);
   policy_manager_->OnUpdateStarted();
   Json::Value table = createPTforLoad();
 
@@ -186,7 +186,7 @@ TEST_F(PolicyManagerImplTest2, ResetRetrySequence) {
   policy_manager_->ResetRetrySequence(
       policy::ResetRetryCountType::kResetWithStatusUpdate);
   EXPECT_EQ("UPDATE_NEEDED", policy_manager_->GetPolicyTableStatus());
-  policy_manager_->SetSendOnUpdateFlags(false, false);
+  policy_manager_->SetSendOnUpdateFlags(false);
   policy_manager_->OnUpdateStarted();
   EXPECT_EQ("UPDATING", policy_manager_->GetPolicyTableStatus());
 }

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -131,16 +131,20 @@ TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
   EXPECT_CALL(*cache_manager_, ApplyUpdate(_)).WillOnce(Return(true));
   EXPECT_CALL(listener_, GetDevicesIds("1234"))
       .WillRepeatedly(Return(transport_manager::DeviceList()));
-  EXPECT_CALL(listener_, OnUpdateStatusChanged(_));
   EXPECT_CALL(*cache_manager_, SaveUpdateRequired(false));
-  EXPECT_CALL(*cache_manager_, TimeoutResponse());
-  EXPECT_CALL(*cache_manager_, SecondsBetweenRetries(_));
 
   EXPECT_CALL(*cache_manager_, GetVehicleDataItems())
       .WillOnce(Return(std::vector<policy_table::VehicleDataItem>()));
-  EXPECT_TRUE(policy_manager_->LoadPT(kFilePtUpdateJson, msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            policy_manager_->LoadPT(kFilePtUpdateJson, msg));
+
   EXPECT_CALL(*cache_manager_, IsPTPreloaded());
   EXPECT_FALSE(policy_manager_->GetCache()->IsPTPreloaded());
+
+  EXPECT_CALL(*cache_manager_, TimeoutResponse());
+  EXPECT_CALL(*cache_manager_, SecondsBetweenRetries(_));
+  EXPECT_CALL(listener_, OnUpdateStatusChanged(_));
+  policy_manager_->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 }
 
 TEST_F(PolicyManagerImplTest2,
@@ -863,7 +867,9 @@ TEST_F(PolicyManagerImplTest_ExternalConsent,
 
   EXPECT_CALL(listener_, OnCertificateUpdated(_));
 
-  EXPECT_TRUE(policy_manager_->LoadPT("DummyFileName", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            policy_manager_->LoadPT("DummyFileName", msg));
+  policy_manager_->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 
   pt = policy_manager_->GetCache()->GetPT();
 
@@ -982,7 +988,9 @@ TEST_F(PolicyManagerImplTest_ExternalConsent,
 
   EXPECT_CALL(listener_, OnCertificateUpdated(_));
 
-  EXPECT_TRUE(policy_manager_->LoadPT("DummyFileName", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            policy_manager_->LoadPT("DummyFileName", msg));
+  policy_manager_->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 
   pt = policy_manager_->GetCache()->GetPT();
 

--- a/src/components/policy/policy_external/test/policy_manager_impl_test_base.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test_base.cc
@@ -291,7 +291,9 @@ const Json::Value PolicyManagerImplTest2::GetPTU(const std::string& file_name) {
   ifile.close();
   ::policy::BinaryMessage msg(json.begin(), json.end());
   // Load Json to cache
-  EXPECT_TRUE(policy_manager_->LoadPT(kFilePtUpdateJson, msg));
+  EXPECT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            policy_manager_->LoadPT(kFilePtUpdateJson, msg));
+  policy_manager_->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
   EXPECT_FALSE(policy_manager_->GetCache()->IsPTPreloaded());
   return root;
 }
@@ -478,7 +480,10 @@ void PolicyManagerImplTest2::
   json = root.toStyledString();
   ifile.close();
   ::policy::BinaryMessage msg(json.begin(), json.end());
-  EXPECT_TRUE(policy_manager_->LoadPT(kFilePtUpdateJson, msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            policy_manager_->LoadPT(kFilePtUpdateJson, msg));
+  policy_manager_->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
+
   EXPECT_FALSE(cache->IsPTPreloaded());
 
   // Check RPC in each level
@@ -584,7 +589,9 @@ void PolicyManagerImplTest2::EmulatePTAppRevoked(const std::string& ptu_name) {
   ifile.close();
 
   ::policy::BinaryMessage msg(json.begin(), json.end());
-  ASSERT_TRUE(policy_manager_->LoadPT(kDummyUpdateFileName, msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            policy_manager_->LoadPT(kDummyUpdateFileName, msg));
+  policy_manager_->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 }
 
 // To avoid duplicate arrange of test
@@ -622,7 +629,10 @@ void PolicyManagerImplTest2::LoadPTUFromJsonFile(
   json = root.toStyledString();
   ifile.close();
   ::policy::BinaryMessage msg(json.begin(), json.end());
-  EXPECT_TRUE(policy_manager_->LoadPT(kFilePtUpdateJson, msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            policy_manager_->LoadPT(kFilePtUpdateJson, msg));
+  policy_manager_->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
+
   EXPECT_FALSE(policy_manager_->GetCache()->IsPTPreloaded());
 }
 
@@ -683,7 +693,11 @@ const Json::Value PolicyManagerImplTest_RequestTypes::GetPTU(
   ifile.close();
   ::policy::BinaryMessage msg(json.begin(), json.end());
   // Load Json to cache
-  EXPECT_TRUE(policy_manager_impl_sptr_->LoadPT(kFilePtUpdateJson, msg));
+  EXPECT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            policy_manager_impl_sptr_->LoadPT(kFilePtUpdateJson, msg));
+  policy_manager_impl_sptr_->OnPTUFinished(
+      PolicyManager::PtProcessingResult::kSuccess);
+
   EXPECT_FALSE(policy_manager_impl_sptr_->GetCache()->IsPTPreloaded());
   return root;
 }

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -129,8 +129,10 @@ class PolicyManagerImpl : public PolicyManager {
    * @param pt_content PTU as binary string
    * @return true if successfully
    */
-  bool LoadPT(const std::string& file,
-              const BinaryMessage& pt_content) OVERRIDE;
+  PtProcessingResult LoadPT(const std::string& file,
+                            const BinaryMessage& pt_content) OVERRIDE;
+
+  void OnPTUFinished(const PtProcessingResult ptu_result) OVERRIDE;
 
   typedef policy_table::ApplicationPolicies::value_type AppPoliciesValueType;
 
@@ -150,6 +152,12 @@ class PolicyManagerImpl : public PolicyManager {
    */
   void SendPermissionsToApp(const std::string& device_id,
                             const AppPoliciesValueType& app_policy);
+
+  /**
+   * @brief Resumes all policy actions for all apps, suspended during
+   * PTU applying
+   */
+  void ResumePendingAppPolicyActions();
 
   /**
    * @brief Resets Policy Table
@@ -1167,11 +1175,6 @@ class PolicyManagerImpl : public PolicyManager {
   RetrySequenceURL retry_sequence_url_;
 
   /**
-   * @brief Flag for notifying that invalid PTU was received
-   */
-  bool wrong_ptu_update_received_;
-
-  /**
    * @brief Flag for notifying that PTU was started
    */
   bool send_on_update_sent_out_;
@@ -1180,6 +1183,21 @@ class PolicyManagerImpl : public PolicyManager {
    * @brief Flag for notifying that invalid PTU should be triggered
    */
   bool trigger_ptu_;
+
+  typedef std::list<std::pair<std::string, AppPoliciesValueType> >
+      PendingAppPolicyActionsList;
+
+  /**
+   * @brief List containing device_id and pending permissions structure pairs
+   * which can be processed later on demand
+   */
+  PendingAppPolicyActionsList notify_system_list_;
+
+  /**
+   * @brief List containing device_id and pending permissions structure pairs
+   * which can be processed later on demand
+   */
+  PendingAppPolicyActionsList send_permissions_list_;
 };
 
 }  // namespace policy

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1261,10 +1261,9 @@ void PolicyManagerImpl::StopRetrySequence() {
     timer_retry_sequence_.Stop();
   }
 
-  const ResetRetryCountType reset_type =
-      cache_->UpdateRequired() ? ResetRetryCountType::kResetWithStatusUpdate
-                               : ResetRetryCountType::kResetInternally;
-  ResetRetrySequence(reset_type);
+  if (cache_->UpdateRequired()) {
+    ResetRetrySequence(ResetRetryCountType::kResetWithStatusUpdate);
+  }
 }
 
 std::string PolicyManagerImpl::ForcePTExchangeAtUserRequest() {

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -76,7 +76,6 @@ PolicyManagerImpl::PolicyManagerImpl()
               this, &PolicyManagerImpl::OnPTUIterationTimeout))
     , ignition_check(true)
     , retry_sequence_url_(0, 0, "")
-    , wrong_ptu_update_received_(false)
     , send_on_update_sent_out_(false)
     , trigger_ptu_(false) {}
 
@@ -315,8 +314,8 @@ void FilterPolicyTable(
   }
 }
 
-bool PolicyManagerImpl::LoadPT(const std::string& file,
-                               const BinaryMessage& pt_content) {
+PolicyManager::PtProcessingResult PolicyManagerImpl::LoadPT(
+    const std::string& file, const BinaryMessage& pt_content) {
   LOG4CXX_INFO(logger_, "LoadPT of size " << pt_content.size());
   LOG4CXX_DEBUG(
       logger_,
@@ -333,9 +332,9 @@ bool PolicyManagerImpl::LoadPT(const std::string& file,
   std::shared_ptr<policy_table::Table> pt_update = ParseArray(pt_content);
 #endif
   if (!pt_update) {
-    LOG4CXX_WARN(logger_, "Parsed table pointer is 0.");
-    update_status_manager_.OnWrongUpdateReceived();
-    return false;
+    LOG4CXX_WARN(logger_, "Parsed table pointer is NULL.");
+    ;
+    return PtProcessingResult::kWrongPtReceived;
   }
 
   file_system::DeleteFile(file);
@@ -344,13 +343,9 @@ bool PolicyManagerImpl::LoadPT(const std::string& file,
 
   FilterPolicyTable(pt_update->policy_table, current_vd_items);
   if (!IsPTValid(pt_update, policy_table::PT_UPDATE)) {
-    wrong_ptu_update_received_ = true;
-    update_status_manager_.OnWrongUpdateReceived();
-    return false;
+    LOG4CXX_WARN(logger_, "Received policy table update is not valid");
+    return PtProcessingResult::kWrongPtReceived;
   }
-
-  update_status_manager_.OnValidUpdateReceived();
-  cache_->SaveUpdateRequired(false);
 
   // Update finished, no need retry
   if (timer_retry_sequence_.is_running()) {
@@ -358,69 +353,89 @@ bool PolicyManagerImpl::LoadPT(const std::string& file,
     timer_retry_sequence_.Stop();
   }
 
-  {
-    sync_primitives::AutoLock lock(apps_registration_lock_);
+  cache_->SaveUpdateRequired(false);
 
-    // Get current DB data, since it could be updated during awaiting of PTU
-    std::shared_ptr<policy_table::Table> policy_table_snapshot =
-        cache_->GenerateSnapshot();
-    if (!policy_table_snapshot) {
-      LOG4CXX_ERROR(
-          logger_,
-          "Failed to create snapshot of policy table, trying another exchange");
-      ForcePTExchange();
-      return false;
-    }
+  sync_primitives::AutoLock lock(apps_registration_lock_);
 
-    // Checking of difference between PTU and current policy state
-    // Must to be done before PTU applying since it is possible, that functional
-    // groups, which had been present before are absent in PTU and will be
-    // removed after update. So in case of revoked groups system has to know
-    // names and ids of revoked groups before they will be removed.
-    const auto results =
-        CheckPermissionsChanges(pt_update, policy_table_snapshot);
-
-    // Replace current data with updated
-    if (!cache_->ApplyUpdate(*pt_update)) {
-      LOG4CXX_WARN(
-          logger_,
-          "Unsuccessful save of updated policy table, trying another exchange");
-      ForcePTExchange();
-      return false;
-    }
-    CheckPermissionsChangesAfterUpdate(*pt_update, *policy_table_snapshot);
-
-    ProcessAppPolicyCheckResults(
-        results, pt_update->policy_table.app_policies_section.apps);
-
-    listener_->OnCertificateUpdated(
-        *(pt_update->policy_table.module_config.certificate));
-
-    std::map<std::string, StringArray> app_hmi_types;
-    cache_->GetHMIAppTypeAfterUpdate(app_hmi_types);
-    if (!app_hmi_types.empty()) {
-      LOG4CXX_INFO(logger_, "app_hmi_types is full calling OnUpdateHMIAppType");
-      listener_->OnUpdateHMIAppType(app_hmi_types);
-    } else {
-      LOG4CXX_INFO(logger_, "app_hmi_types empty" << pt_content.size());
-    }
-
-    std::vector<std::string> enabled_apps;
-    cache_->GetEnabledCloudApps(enabled_apps);
-    for (auto it = enabled_apps.begin(); it != enabled_apps.end(); ++it) {
-      SendAuthTokenUpdated(*it);
-    }
+  // Get current DB data, since it could be updated during awaiting of PTU
+  auto policy_table_snapshot = cache_->GenerateSnapshot();
+  if (!policy_table_snapshot) {
+    LOG4CXX_ERROR(
+        logger_,
+        "Failed to create snapshot of policy table, trying another exchange");
+    return PtProcessingResult::kNewPtRequired;
   }
+
+  // Checking of difference between PTU and current policy state
+  // Must to be done before PTU applying since it is possible, that functional
+  // groups, which had been present before are absent in PTU and will be
+  // removed after update. So in case of revoked groups system has to know
+  // names and ids of revoked groups before they will be removed.
+  const auto results =
+      CheckPermissionsChanges(pt_update, policy_table_snapshot);
+
+  // Replace current data with updated
+  if (!cache_->ApplyUpdate(*pt_update)) {
+    LOG4CXX_WARN(
+        logger_,
+        "Unsuccessful save of updated policy table, trying another exchange");
+    return PtProcessingResult::kNewPtRequired;
+  }
+  CheckPermissionsChangesAfterUpdate(*pt_update, *policy_table_snapshot);
+
+  ProcessAppPolicyCheckResults(
+      results, pt_update->policy_table.app_policies_section.apps);
+
+  listener_->OnCertificateUpdated(
+      *(pt_update->policy_table.module_config.certificate));
+
+  std::map<std::string, StringArray> app_hmi_types;
+  cache_->GetHMIAppTypeAfterUpdate(app_hmi_types);
+  if (!app_hmi_types.empty()) {
+    LOG4CXX_INFO(logger_, "app_hmi_types is full calling OnUpdateHMIAppType");
+    listener_->OnUpdateHMIAppType(app_hmi_types);
+  } else {
+    LOG4CXX_INFO(logger_, "app_hmi_types empty" << pt_content.size());
+  }
+
+  std::vector<std::string> enabled_apps;
+  cache_->GetEnabledCloudApps(enabled_apps);
+  for (auto it = enabled_apps.begin(); it != enabled_apps.end(); ++it) {
+    SendAuthTokenUpdated(*it);
+  }
+
+  return PtProcessingResult::kSuccess;
+}
+
+void PolicyManagerImpl::OnPTUFinished(const PtProcessingResult ptu_result) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (PtProcessingResult::kWrongPtReceived == ptu_result) {
+    LOG4CXX_DEBUG(logger_, "Wrong PT was received");
+    update_status_manager_.OnWrongUpdateReceived();
+    return;
+  }
+
+  update_status_manager_.OnValidUpdateReceived();
+
+  if (PtProcessingResult::kNewPtRequired == ptu_result) {
+    LOG4CXX_DEBUG(logger_, "New PTU interation is required");
+    ForcePTExchange();
+    return;
+  }
+
+  ResumePendingAppPolicyActions();
 
   // If there was a user request for policy table update, it should be started
   // right after current update is finished
   if (update_status_manager_.IsUpdateRequired()) {
+    LOG4CXX_DEBUG(logger_,
+                  "PTU was successful and new PTU iteration was scheduled");
     StartPTExchange();
-    return true;
+    return;
   }
 
   RefreshRetrySequence();
-  return true;
 }
 
 void PolicyManagerImpl::ProcessAppPolicyCheckResults(
@@ -439,6 +454,9 @@ void PolicyManagerImpl::ProcessAppPolicyCheckResults(
 void PolicyManagerImpl::ProcessActionsForAppPolicies(
     const ApplicationsPoliciesActions& actions,
     const policy_table::ApplicationPolicies& app_policies) {
+  notify_system_list_.clear();
+  send_permissions_list_.clear();
+
   ApplicationsPoliciesActions::const_iterator it_actions = actions.begin();
   for (; it_actions != actions.end(); ++it_actions) {
     auto app_policy = app_policies.find(it_actions->first);
@@ -463,13 +481,29 @@ void PolicyManagerImpl::ProcessActionsForAppPolicies(
         }
       }
       if (it_actions->second.is_notify_system) {
-        NotifySystem(device_id, *app_policy);
+        notify_system_list_.push_back(std::make_pair(device_id, *app_policy));
       }
       if (it_actions->second.is_send_permissions_to_app) {
-        SendPermissionsToApp(device_id, *app_policy);
+        send_permissions_list_.push_back(
+            std::make_pair(device_id, *app_policy));
       }
     }
   }
+}
+
+void PolicyManagerImpl::ResumePendingAppPolicyActions() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  for (auto& notify_system_params : notify_system_list_) {
+    NotifySystem(notify_system_params.first, notify_system_params.second);
+  }
+  notify_system_list_.clear();
+
+  for (auto& send_permissions_params : send_permissions_list_) {
+    SendPermissionsToApp(send_permissions_params.first,
+                         send_permissions_params.second);
+  }
+  send_permissions_list_.clear();
 }
 
 void PolicyManagerImpl::NotifySystem(
@@ -1227,9 +1261,10 @@ void PolicyManagerImpl::StopRetrySequence() {
     timer_retry_sequence_.Stop();
   }
 
-  if (update_status_manager_.IsUpdateRequired()) {
-    ResetRetrySequence(ResetRetryCountType::kResetWithStatusUpdate);
-  }
+  const ResetRetryCountType reset_type =
+      cache_->UpdateRequired() ? ResetRetryCountType::kResetWithStatusUpdate
+                               : ResetRetryCountType::kResetInternally;
+  ResetRetrySequence(reset_type);
 }
 
 std::string PolicyManagerImpl::ForcePTExchangeAtUserRequest() {

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -314,7 +314,9 @@ class PolicyManagerImplTest2 : public ::testing::Test {
     ifile.close();
     ::policy::BinaryMessage msg(json.begin(), json.end());
     // Load Json to cache
-    EXPECT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+    EXPECT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+              manager->LoadPT("file_pt_update.json", msg));
+    manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
     return root;
   }
 
@@ -609,8 +611,11 @@ TEST_F(PolicyManagerImplTest2, GetNotificationsNumberAfterPTUpdate) {
   // Act
   const std::string json = table.toStyledString();
   ::policy::BinaryMessage msg(json.begin(), json.end());
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+
   EXPECT_CALL(listener, OnUpdateStatusChanged(_));
-  EXPECT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 
   std::string priority = "EMERGENCY";
   uint32_t notif_number = manager->GetNotificationsNumber(priority);
@@ -651,7 +656,10 @@ TEST_F(PolicyManagerImplTest2, IsAppRevoked_SetRevokedAppID_ExpectAppRevoked) {
   ifile.close();
 
   ::policy::BinaryMessage msg(json.begin(), json.end());
-  ASSERT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
+
   EXPECT_TRUE(manager->IsApplicationRevoked(app_id1));
 }
 
@@ -705,7 +713,9 @@ TEST_F(PolicyManagerImplTest2,
   ifile.close();
 
   ::policy::BinaryMessage msg(json.begin(), json.end());
-  ASSERT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 
   manager->CheckPermissions(
       dev_id1, app_id1, std::string("FULL"), "Alert", input_params, output);
@@ -746,7 +756,9 @@ TEST_F(
       AddWidgetSupportToFunctionalGroups(&root, rpc_name, hmi_level);
 
   ::policy::BinaryMessage msg(json.begin(), json.end());
-  ASSERT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 
   ::policy::RPCParams input_params;
   ::policy::CheckPermissionResult output;
@@ -760,7 +772,9 @@ TEST_F(
   // Act
   json = AddWidgetSupportToPt(&root, app_id1, group_number);
   msg = BinaryMessage(json.begin(), json.end());
-  ASSERT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 
   output.hmi_level_permitted = ::policy::kRpcDisallowed;
   manager->CheckPermissions(
@@ -802,7 +816,9 @@ TEST_F(
       AddWidgetSupportToFunctionalGroups(&root, rpc_name, hmi_level);
 
   ::policy::BinaryMessage msg(json.begin(), json.end());
-  ASSERT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 
   ::policy::RPCParams input_params;
   ::policy::CheckPermissionResult output;
@@ -821,7 +837,9 @@ TEST_F(
       Json::Value("Base-4");
   json = root.toStyledString();
   msg = BinaryMessage(json.begin(), json.end());
-  ASSERT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 
   manager->CheckPermissions(
       dev_id1, app_id1, hmi_level, rpc_name, input_params, output);
@@ -886,7 +904,9 @@ TEST_F(PolicyManagerImplTest2,
 
   ::policy::BinaryMessage msg(json.begin(), json.end());
   // Load Json to cache
-  EXPECT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 
   policy_table::RpcParameters rpc_parameters;
   rpc_parameters.hmi_levels.push_back(policy_table::HL_FULL);
@@ -984,9 +1004,13 @@ TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
   EXPECT_CALL(listener, GetDevicesIds("1234"))
       .WillRepeatedly(Return(transport_manager::DeviceList()));
   EXPECT_CALL(*cache_manager, SaveUpdateRequired(false));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+
   EXPECT_CALL(*cache_manager, TimeoutResponse());
   EXPECT_CALL(*cache_manager, SecondsBetweenRetries(_));
-  EXPECT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  EXPECT_CALL(listener, OnUpdateStatusChanged(_));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 }
 
 TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_removeRPC_SendUpdate) {
@@ -1018,7 +1042,9 @@ TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_removeRPC_SendUpdate) {
   EXPECT_CALL(*cache_manager, ApplyUpdate(_)).WillOnce(Return(true));
   ExpectOnPermissionsUpdated();
 
-  EXPECT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 }
 
 TEST_F(PolicyManagerImplTest,
@@ -1053,7 +1079,9 @@ TEST_F(PolicyManagerImplTest,
   EXPECT_CALL(*cache_manager, ApplyUpdate(_)).WillOnce(Return(true));
   ExpectOnPermissionsUpdated();
 
-  EXPECT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 }
 
 TEST_F(PolicyManagerImplTest,
@@ -1088,7 +1116,9 @@ TEST_F(PolicyManagerImplTest,
   EXPECT_CALL(*cache_manager, ApplyUpdate(_)).WillOnce(Return(true));
   ExpectOnPermissionsUpdated();
 
-  EXPECT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 }
 
 TEST_F(PolicyManagerImplTest,
@@ -1124,7 +1154,9 @@ TEST_F(PolicyManagerImplTest,
   EXPECT_CALL(*cache_manager, ApplyUpdate(_)).WillOnce(Return(true));
   ExpectOnPermissionsUpdated();
 
-  EXPECT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 }
 
 TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_addRPCParams_SendUpdate) {
@@ -1159,7 +1191,9 @@ TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_addRPCParams_SendUpdate) {
   EXPECT_CALL(*cache_manager, ApplyUpdate(_)).WillOnce(Return(true));
   ExpectOnPermissionsUpdated();
 
-  EXPECT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 }
 
 TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_NoUpdate_DONT_SendUpdate) {
@@ -1186,7 +1220,9 @@ TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_NoUpdate_DONT_SendUpdate) {
       .WillOnce(Return(std::vector<policy_table::VehicleDataItem>()));
   EXPECT_CALL(*cache_manager, ApplyUpdate(_)).WillOnce(Return(true));
 
-  EXPECT_TRUE(manager->LoadPT("file_pt_update.json", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kSuccess,
+            manager->LoadPT("file_pt_update.json", msg));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kSuccess);
 }
 
 TEST_F(PolicyManagerImplTest, LoadPT_SetInvalidUpdatePT_PTIsNotLoaded) {
@@ -1214,11 +1250,14 @@ TEST_F(PolicyManagerImplTest, LoadPT_SetInvalidUpdatePT_PTIsNotLoaded) {
   // Assert
   EXPECT_CALL(*cache_manager, ApplyUpdate(_)).Times(0);
   EXPECT_CALL(listener, GetAppName(_)).Times(0);
-  EXPECT_CALL(listener, OnUpdateStatusChanged(_)).Times(1);
   EXPECT_CALL(*cache_manager, SaveUpdateRequired(false)).Times(0);
   EXPECT_CALL(*cache_manager, TimeoutResponse()).Times(0);
   EXPECT_CALL(*cache_manager, SecondsBetweenRetries(_)).Times(0);
-  EXPECT_FALSE(manager->LoadPT("file_pt_update.json", msg));
+  ASSERT_EQ(PolicyManager::PtProcessingResult::kWrongPtReceived,
+            manager->LoadPT("file_pt_update.json", msg));
+
+  EXPECT_CALL(listener, OnUpdateStatusChanged(_));
+  manager->OnPTUFinished(PolicyManager::PtProcessingResult::kWrongPtReceived);
 }
 
 TEST_F(PolicyManagerImplTest2,


### PR DESCRIPTION
Fixes #3042 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test scripts

### Summary
The existing order of actions were changed to make it more obvious for external systems like
HMI and mobile apps. The main concern was that SDL is sending `OnStatusUpdate(UP_TO_DATE)` when policy table update was not actually done. The order of actions done during PTU was updated
to perform sending of `UP_TO_DATE` only when all policy actions were actually done.

### Tasks Remaining:
- [x] [Fix failed unit tests]
- [x] [Perform full regression testing]

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
