### PR TITLE
Fix/Set mandatory=false for optional response params

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_helpers.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_helpers.cc
@@ -257,6 +257,9 @@ void RCHelpers::RemoveRedundantGPSDataFromIVDataMsg(
   using namespace application_manager::strings;
 
   LOG4CXX_AUTO_TRACE(logger_);
+  if (!msg_params.keyExists(kModuleData)) {
+    return;
+  }
   auto& module_data = msg_params[kModuleData];
   if (!module_data.keyExists(kRadioControlData) ||
       !module_data[kRadioControlData].keyExists(kSisData) ||

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -6529,7 +6529,7 @@
             <description>Provides additional human readable info regarding the result.</description>
         </param>
         
-        <param name="ecuHeader" type="Integer" minvalue="0" maxvalue="65535" mandatory="true">
+        <param name="ecuHeader" type="Integer" minvalue="0" maxvalue="65535" mandatory="false">
             <description>2 byte ECU Header for DTC response (as defined in VHR_Layout_Specification_DTCs.pdf)</description>
         </param>
         
@@ -6584,7 +6584,7 @@
             <description>Provides additional human readable info regarding the result.</description>
         </param>
         
-        <param name="messageDataResult" type="Integer" minvalue="0" maxvalue="255" minsize="1" maxsize="65535" array="true" mandatory="true">
+        <param name="messageDataResult" type="Integer" minvalue="0" maxvalue="255" minsize="1" maxsize="65535" array="true" mandatory="false">
             <description>
                 Array of bytes comprising CAN message result.
             </description>
@@ -7438,7 +7438,7 @@
     </function>
     
     <function name="GetInteriorVehicleData" functionID="GetInteriorVehicleDataID" messagetype="response" since="4.5">
-        <param name="moduleData" type="ModuleData" mandatory="true">
+        <param name="moduleData" type="ModuleData" mandatory="false">
         </param>
         <param name="resultCode" type="Result" platform="documentation" mandatory="true">
             <description>See Result</description>
@@ -7540,7 +7540,7 @@
     
     <function name="SetInteriorVehicleData" functionID="SetInteriorVehicleDataID" messagetype="response" since="4.5">
         <description>Used to set the values of one remote control module </description>
-        <param name="moduleData" type="ModuleData" mandatory="true">
+        <param name="moduleData" type="ModuleData" mandatory="false">
         </param>
         <param name="resultCode" type="Result" platform="documentation" mandatory="true">
             <description>See Result</description>
@@ -7656,7 +7656,7 @@
     </function>
     
     <function name="GetSystemCapability" functionID="GetSystemCapabilityID" messagetype="response" since="4.5">
-        <param name="systemCapability" type="SystemCapability" mandatory="true">
+        <param name="systemCapability" type="SystemCapability" mandatory="false">
         </param>
         <param name="resultCode" type="Result" platform="documentation" mandatory="true">
             <description>See Result</description>


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
ATF tests

### Summary
This PR changes the `mandatory` attribute for parameters(other than `success` and `resultCode`) in RPC responses(in the MOBILE_API) from `mandatory=true` to `mandatory=false`.

Currently, core is only guaranteed to return `resultCode` and `success` for **all** RPC responses to mobile. In the case of an error, core may not return other parameters. If those other parameters have `mandatory=true` in the API spec that could cause issues on the mobile side.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
