### PR TITLE
Add appServices param to HMICapabilities

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -642,6 +642,7 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
       hmi_capabilities.video_streaming_supported();
   response_params[strings::hmi_capabilities][strings::remote_control] =
       hmi_capabilities.rc_supported();
+  response_params[strings::hmi_capabilities][strings::app_services] = true;
 }
 
 void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -2457,6 +2457,9 @@
         <param name="remoteControl" type="Boolean" mandatory="false" since="4.5">
             <description>Availability of remote control feature. True: Available, False: Not Available</description>
         </param>
+        <param name="appServices" type="Boolean" mandatory="false" since="6.0">
+            <description>Availability of App Services functionality. True: Available, False: Not Available</description>
+        </param>
     </struct>
 
     <struct name="MenuParams" since="1.0">


### PR DESCRIPTION
Fixes #2998 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Connect app and verify appService = true in the hmiCapabilities RAI response.

### Summary
Adds HMICapabilities param appServices to the RAI response.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
