### PR TITLE
Fix SDL crash on app service unpublishing

### DIFF
--- a/src/components/application_manager/src/app_service_manager.cc
+++ b/src/components/application_manager/src/app_service_manager.cc
@@ -223,12 +223,20 @@ bool AppServiceManager::UnpublishAppService(const std::string service_id) {
 void AppServiceManager::UnpublishServices(const uint32_t connection_key) {
   LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_DEBUG(logger_, "Unpublishing all app services: " << connection_key);
-  sync_primitives::AutoLock lock(published_services_lock_);
-  for (auto it = published_services_.begin(); it != published_services_.end();
-       ++it) {
-    if (it->second.connection_key == connection_key) {
-      UnpublishAppService(it->first);
+
+  std::list<std::string> app_published_services;
+  {
+    sync_primitives::AutoLock lock(published_services_lock_);
+    for (auto it = published_services_.begin(); it != published_services_.end();
+         ++it) {
+      if (it->second.connection_key == connection_key) {
+        app_published_services.push_back(it->first);
+      }
     }
+  }
+
+  for (auto& service_id : app_published_services) {
+    UnpublishAppService(service_id);
   }
 }
 


### PR DESCRIPTION
Fixes #3053 

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test script

### Summary
There was found an unsafe work with STL map in `AppServiceManager` - during service unpublishing there might be a possibility when component iterates over `published_services_` and another function indirectly erases the same element from the same map what may cause an undefined behavior during iteration over the map.
To make this safer - iteration over the map and erasure of element in the map were splitted onto two separate atomic actions.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
