### PR TITLE
[WIP] initial fix of socket streaming by guessing playback time

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -656,6 +656,7 @@ class Application : public virtual InitialApplicationData,
   /**
    * @brief Wakes up streaming process for application
    * @param service_type Type of streaming service
+   * @param timer_len The amount of time in ms the timer will wait
    */
   virtual void WakeUpStreaming(protocol_handler::ServiceType service_type,
                                uint32_t timer_len = 0) = 0;

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -657,7 +657,8 @@ class Application : public virtual InitialApplicationData,
    * @brief Wakes up streaming process for application
    * @param service_type Type of streaming service
    */
-  virtual void WakeUpStreaming(protocol_handler::ServiceType service_type) = 0;
+  virtual void WakeUpStreaming(protocol_handler::ServiceType service_type,
+                               uint32_t timer_len = 0) = 0;
 
   virtual bool is_voice_communication_supported() const = 0;
   virtual void set_voice_communication_supported(

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -139,7 +139,8 @@ class ApplicationImpl : public virtual Application,
   void StopStreamingForce(protocol_handler::ServiceType service_type);
   void StopStreaming(protocol_handler::ServiceType service_type);
   void SuspendStreaming(protocol_handler::ServiceType service_type);
-  void WakeUpStreaming(protocol_handler::ServiceType service_type);
+  void WakeUpStreaming(protocol_handler::ServiceType service_type,
+                       uint32_t timer_len = 0);
 
   virtual bool is_voice_communication_supported() const;
   virtual void set_voice_communication_supported(

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -634,7 +634,7 @@ void ApplicationImpl::SuspendStreaming(
 }
 
 void ApplicationImpl::WakeUpStreaming(
-    protocol_handler::ServiceType service_type) {
+    protocol_handler::ServiceType service_type, uint32_t timer_len) {
   using namespace protocol_handler;
   LOG4CXX_AUTO_TRACE(logger_);
 
@@ -650,8 +650,9 @@ void ApplicationImpl::WakeUpStreaming(
           ServiceType::kMobileNav, true, application_manager_);
       video_streaming_suspended_ = false;
     }
-    video_stream_suspend_timer_.Start(video_stream_suspend_timeout_,
-                                      timer::kPeriodic);
+    video_stream_suspend_timer_.Start(
+        timer_len == 0 ? video_stream_suspend_timeout_ : timer_len,
+        timer::kPeriodic);
   } else if (ServiceType::kAudio == service_type) {
     sync_primitives::AutoLock lock(audio_streaming_suspended_lock_);
     if (audio_streaming_suspended_) {
@@ -660,8 +661,9 @@ void ApplicationImpl::WakeUpStreaming(
           ServiceType::kAudio, true, application_manager_);
       audio_streaming_suspended_ = false;
     }
-    audio_stream_suspend_timer_.Start(audio_stream_suspend_timeout_,
-                                      timer::kPeriodic);
+    audio_stream_suspend_timer_.Start(
+        timer_len == 0 ? audio_stream_suspend_timeout_ : timer_len,
+        timer::kPeriodic);
   }
 }
 

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -86,8 +86,9 @@ class MockApplication : public ::application_manager::Application {
                void(protocol_handler::ServiceType service_type));
   MOCK_METHOD1(SuspendStreaming,
                void(protocol_handler::ServiceType service_type));
-  MOCK_METHOD1(WakeUpStreaming,
-               void(protocol_handler::ServiceType service_type));
+  MOCK_METHOD2(WakeUpStreaming,
+               void(protocol_handler::ServiceType service_type,
+                    uint32_t timer_len));
   MOCK_CONST_METHOD0(is_voice_communication_supported, bool());
   MOCK_METHOD1(set_voice_communication_supported,
                void(bool is_voice_communication_supported));

--- a/src/components/include/media_manager/media_manager.h
+++ b/src/components/include/media_manager/media_manager.h
@@ -60,6 +60,12 @@ class MediaManager {
    */
   virtual const MediaManagerSettings& settings() const = 0;
 
+  /**
+   * \brief Convert an amount of audio bytes to an estimated time in ms
+   * \param data_size number of bytes to be played
+   * \return milliseconds required to play <data_size> many bytes with
+   *          the current pcm stream capabilities
+   */
   virtual uint32_t DataSizeToMilliseconds(uint64_t data_size) const = 0;
 
   virtual ~MediaManager() {}

--- a/src/components/include/media_manager/media_manager.h
+++ b/src/components/include/media_manager/media_manager.h
@@ -60,6 +60,8 @@ class MediaManager {
    */
   virtual const MediaManagerSettings& settings() const = 0;
 
+  virtual uint32_t DataSizeToMilliseconds(uint64_t data_size) const = 0;
+
   virtual ~MediaManager() {}
 };
 

--- a/src/components/include/test/media_manager/mock_media_manager.h
+++ b/src/components/include/test/media_manager/mock_media_manager.h
@@ -57,6 +57,7 @@ class MockMediaManager : public media_manager::MediaManager {
   MOCK_METHOD2(FramesProcessed,
                void(int32_t application_key, int32_t frame_number));
   MOCK_CONST_METHOD0(settings, const media_manager::MediaManagerSettings&());
+  MOCK_METHOD1(DataSizeToMilliseconds, uint32_t(uint64_t data_size));
 };
 
 }  // namespace media_manager_test

--- a/src/components/include/test/media_manager/mock_media_manager.h
+++ b/src/components/include/test/media_manager/mock_media_manager.h
@@ -57,7 +57,7 @@ class MockMediaManager : public media_manager::MediaManager {
   MOCK_METHOD2(FramesProcessed,
                void(int32_t application_key, int32_t frame_number));
   MOCK_CONST_METHOD0(settings, const media_manager::MediaManagerSettings&());
-  MOCK_METHOD1(DataSizeToMilliseconds, uint32_t(uint64_t data_size));
+  MOCK_CONST_METHOD1(DataSizeToMilliseconds, uint32_t(uint64_t data_size));
 };
 
 }  // namespace media_manager_test

--- a/src/components/media_manager/include/media_manager/media_manager_impl.h
+++ b/src/components/media_manager/include/media_manager/media_manager_impl.h
@@ -112,7 +112,8 @@ class MediaManagerImpl : public MediaManager,
   uint32_t bits_per_sample_;
   uint32_t sampling_rate_;
   uint64_t stream_data_size_;
-  std::chrono::time_point<std::chrono::system_clock> stream_start_time_;
+  std::chrono::time_point<std::chrono::system_clock>
+      socket_audio_stream_start_time_;
 
   application_manager::ApplicationManager& application_manager_;
 

--- a/src/components/media_manager/include/media_manager/media_manager_impl.h
+++ b/src/components/media_manager/include/media_manager/media_manager_impl.h
@@ -34,6 +34,7 @@
 #define SRC_COMPONENTS_MEDIA_MANAGER_INCLUDE_MEDIA_MANAGER_MEDIA_MANAGER_IMPL_H_
 
 #include <map>
+#include <chrono>
 #include <string>
 #include "media_manager/media_adapter_impl.h"
 #include "media_manager/media_adapter_listener.h"
@@ -81,6 +82,8 @@ class MediaManagerImpl : public MediaManager,
 
   virtual const MediaManagerSettings& settings() const OVERRIDE;
 
+  virtual uint32_t DataSizeToMilliseconds(uint64_t data_size) const OVERRIDE;
+
 #ifdef BUILD_TESTS
   void set_mock_a2dp_player(MediaAdapter* media_adapter);
   void set_mock_mic_listener(MediaListenerPtr media_listener);
@@ -105,6 +108,11 @@ class MediaManagerImpl : public MediaManager,
 
   std::map<protocol_handler::ServiceType, MediaAdapterImplPtr> streamer_;
   std::map<protocol_handler::ServiceType, MediaListenerPtr> streamer_listener_;
+
+  uint32_t bits_per_sample_;
+  uint32_t sampling_rate_;
+  uint64_t stream_data_size_;
+  std::chrono::time_point<std::chrono::system_clock> stream_start_time_;
 
   application_manager::ApplicationManager& application_manager_;
 

--- a/src/components/media_manager/include/media_manager/media_manager_impl.h
+++ b/src/components/media_manager/include/media_manager/media_manager_impl.h
@@ -33,8 +33,8 @@
 #ifndef SRC_COMPONENTS_MEDIA_MANAGER_INCLUDE_MEDIA_MANAGER_MEDIA_MANAGER_IMPL_H_
 #define SRC_COMPONENTS_MEDIA_MANAGER_INCLUDE_MEDIA_MANAGER_MEDIA_MANAGER_IMPL_H_
 
-#include <map>
 #include <chrono>
+#include <map>
 #include <string>
 #include "media_manager/media_adapter_impl.h"
 #include "media_manager/media_adapter_listener.h"

--- a/src/components/media_manager/src/media_manager_impl.cc
+++ b/src/components/media_manager/src/media_manager_impl.cc
@@ -321,7 +321,7 @@ void MediaManagerImpl::OnMessageReceived(
   ApplicationSharedPtr app = application_manager_.application(streaming_app_id);
   if (app) {
     if (ServiceType::kAudio == service_type &&
-        "socket" == settings().video_server_type()) {
+        "socket" == settings().audio_server_type()) {
       stream_data_size_ += message->data_size();
       uint32_t ms_for_all_data = DataSizeToMilliseconds(stream_data_size_);
       uint32_t ms_since_stream_start =
@@ -347,10 +347,6 @@ void MediaManagerImpl::FramesProcessed(int32_t application_key,
     protocol_handler_->SendFramesNumber(application_key, frame_number);
   }
 
-  if ("pipe" != settings().audio_server_type()) {
-    return;
-  }
-
   application_manager::ApplicationSharedPtr app =
       application_manager_.application(application_key);
 
@@ -360,7 +356,7 @@ void MediaManagerImpl::FramesProcessed(int32_t application_key,
     auto video_stream = std::dynamic_pointer_cast<StreamerAdapter>(
         streamer_[protocol_handler::ServiceType::kMobileNav]);
 
-    if (audio_stream.use_count() != 0) {
+    if (audio_stream.use_count() != 0 && "pipe" == settings().audio_server_type()) {
       size_t audio_queue_size = audio_stream->GetMsgQueueSize();
       LOG4CXX_DEBUG(logger_,
                     "# Messages in audio queue = " << audio_queue_size);
@@ -369,7 +365,7 @@ void MediaManagerImpl::FramesProcessed(int32_t application_key,
       }
     }
 
-    if (video_stream.use_count() != 0) {
+    if (video_stream.use_count() != 0 && "pipe" == settings().video_server_type()) {
       size_t video_queue_size = video_stream->GetMsgQueueSize();
       LOG4CXX_DEBUG(logger_,
                     "# Messages in video queue = " << video_queue_size);

--- a/src/components/media_manager/src/media_manager_impl.cc
+++ b/src/components/media_manager/src/media_manager_impl.cc
@@ -320,15 +320,20 @@ void MediaManagerImpl::OnMessageReceived(
 
   ApplicationSharedPtr app = application_manager_.application(streaming_app_id);
   if (app) {
-    stream_data_size_ += message->data_size();
-    uint32_t ms_for_all_data = DataSizeToMilliseconds(stream_data_size_);
-    uint32_t ms_since_stream_start =
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::system_clock::now() - stream_start_time_)
-            .count();
-    uint32_t ms_stream_remaining = ms_for_all_data - ms_since_stream_start;
+    if (ServiceType::kAudio == service_type &&
+        "socket" == settings().video_server_type()) {
+      stream_data_size_ += message->data_size();
+      uint32_t ms_for_all_data = DataSizeToMilliseconds(stream_data_size_);
+      uint32_t ms_since_stream_start =
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::system_clock::now() - stream_start_time_)
+              .count();
+      uint32_t ms_stream_remaining = ms_for_all_data - ms_since_stream_start;
 
-    app->WakeUpStreaming(service_type, ms_stream_remaining);
+      app->WakeUpStreaming(service_type, ms_stream_remaining);
+    } else {
+      app->WakeUpStreaming(service_type);
+    }
     streamer_[service_type]->SendData(streaming_app_id, message);
   }
 }

--- a/src/components/media_manager/src/media_manager_impl.cc
+++ b/src/components/media_manager/src/media_manager_impl.cc
@@ -385,7 +385,9 @@ const MediaManagerSettings& MediaManagerImpl::settings() const {
 }
 
 uint32_t MediaManagerImpl::DataSizeToMilliseconds(uint64_t data_size) const {
-  return 1000 * data_size / (sampling_rate_ * bits_per_sample_ / 8);
+  constexpr uint16_t latency_compensation = 500;
+  return 1000 * data_size / (sampling_rate_ * bits_per_sample_ / 8) +
+         latency_compensation;
 }
 
 }  //  namespace media_manager

--- a/src/components/media_manager/src/media_manager_impl.cc
+++ b/src/components/media_manager/src/media_manager_impl.cc
@@ -275,7 +275,7 @@ void MediaManagerImpl::StartStreaming(
     int32_t application_key, protocol_handler::ServiceType service_type) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  if (ServiceType::kAudio == service_type &&
+  if (protocol_handler::ServiceType::kAudio == service_type &&
       "socket" == settings().audio_server_type()) {
     socket_audio_stream_start_time_ = std::chrono::system_clock::now();
   }

--- a/src/components/media_manager/test/media_manager_impl_test.cc
+++ b/src/components/media_manager/test/media_manager_impl_test.cc
@@ -405,9 +405,6 @@ TEST_F(MediaManagerImplTest,
       .WillByDefault(ReturnRef(kDefaultValue));
   ON_CALL(mock_media_manager_settings_, audio_server_type())
       .WillByDefault(ReturnRef(kDefaultValue));
-  const std::string audio_server_type_pipe = "pipe";
-  EXPECT_CALL(mock_media_manager_settings_, audio_server_type())
-      .WillOnce(ReturnRef(audio_server_type_pipe));
   protocol_handler_test::MockProtocolHandler mock_protocol_handler;
   media_manager_impl_->SetProtocolHandler(&mock_protocol_handler);
   const int32_t frame_number = 10;

--- a/src/components/media_manager/test/media_manager_impl_test.cc
+++ b/src/components/media_manager/test/media_manager_impl_test.cc
@@ -35,6 +35,7 @@
 #include "application_manager/message.h"
 #include "application_manager/mock_application.h"
 #include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_hmi_capabilities.h"
 #include "application_manager/resumption/resume_ctrl.h"
 #include "application_manager/state_controller.h"
 #include "gmock/gmock.h"
@@ -109,6 +110,10 @@ class MediaManagerImplTest : public ::testing::Test {
         .WillByDefault(ReturnRef(kDefaultValue));
     ON_CALL(mock_media_manager_settings_, audio_server_type())
         .WillByDefault(ReturnRef(kDefaultValue));
+    ON_CALL(mock_hmi_capabilities_, pcm_stream_capabilities())
+        .WillByDefault(Return(nullptr));
+    ON_CALL(app_mngr_, hmi_capabilities())
+        .WillByDefault(ReturnRef(mock_hmi_capabilities_));
     mock_app_ = std::make_shared<MockApp>();
     media_manager_impl_.reset(
         new MediaManagerImpl(app_mngr_, mock_media_manager_settings_));
@@ -176,7 +181,7 @@ class MediaManagerImplTest : public ::testing::Test {
         .WillOnce(Return(true));
     EXPECT_CALL(app_mngr_, application(kConnectionKey))
         .WillOnce(Return(mock_app_));
-    EXPECT_CALL(*mock_app_, WakeUpStreaming(service_type));
+    EXPECT_CALL(*mock_app_, WakeUpStreaming(service_type, 0ull));
     MockMediaAdapterImplPtr mock_media_streamer =
         std::make_shared<MockMediaAdapterImpl>();
     media_manager_impl_->set_mock_streamer(service_type, mock_media_streamer);
@@ -206,6 +211,7 @@ class MediaManagerImplTest : public ::testing::Test {
   const ::testing::NiceMock<MockMediaManagerSettings>
       mock_media_manager_settings_;
   std::shared_ptr<MediaManagerImpl> media_manager_impl_;
+  application_manager_test::MockHMICapabilities mock_hmi_capabilities_;
 };
 
 TEST_F(MediaManagerImplTest,
@@ -399,6 +405,9 @@ TEST_F(MediaManagerImplTest,
       .WillByDefault(ReturnRef(kDefaultValue));
   ON_CALL(mock_media_manager_settings_, audio_server_type())
       .WillByDefault(ReturnRef(kDefaultValue));
+  const std::string audio_server_type_pipe = "pipe";
+  EXPECT_CALL(mock_media_manager_settings_, audio_server_type())
+      .WillOnce(ReturnRef(audio_server_type_pipe));
   protocol_handler_test::MockProtocolHandler mock_protocol_handler;
   media_manager_impl_->SetProtocolHandler(&mock_protocol_handler);
   const int32_t frame_number = 10;


### PR DESCRIPTION
Partially Fixes #2945 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF, Manually

### Summary
Add logic for Core to guess how long an audio stream will take based on PCM capabilities.

### Changelog

##### Enhancements
* Socket streaming somewhat works

### Tasks Remaining:
- [x] Decide how much latency compensation should be added in DataSizeToMilliseconds
- [x] Restrict logic in this PR to only applicable scenarios (streaming is socket, maybe just for audio)
- [x] Test a lot more!
- [x] Make sure it builds with tests, add mock functions!

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
