### PR TITLE
Add HMICapabilities Params

### DIFF
--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -222,6 +222,8 @@ extern const char* endpoint;
 extern const char* display_capabilities;
 extern const char* policy_type;
 extern const char* property;
+extern const char* displays;
+extern const char* seat_location;
 
 // PutFile
 extern const char* sync_file_name;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -642,6 +642,7 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
       hmi_capabilities.video_streaming_supported();
   response_params[strings::hmi_capabilities][strings::remote_control] =
       hmi_capabilities.rc_supported();
+  response_params[strings::hmi_capabilities][strings::app_services] = true;
 }
 
 void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -643,6 +643,10 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
   response_params[strings::hmi_capabilities][strings::remote_control] =
       hmi_capabilities.rc_supported();
   response_params[strings::hmi_capabilities][strings::app_services] = true;
+  // Apps are automatically subscribed to the SystemCapability: DISPLAYS
+  response_params[strings::hmi_capabilities][strings::displays] = true;
+  response_params[strings::hmi_capabilities][strings::seat_location] =
+      hmi_capabilities.seat_location_capability() ? true : false;
 }
 
 void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -189,6 +189,8 @@ const char* endpoint = "endpoint";
 const char* display_capabilities = "displayCapabilities";
 const char* policy_type = "policyType";
 const char* property = "property";
+const char* displays = "displays";
+const char* seat_location = "seatLocation";
 
 // PutFile
 const char* sync_file_name = "syncFileName";

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -2457,6 +2457,9 @@
         <param name="remoteControl" type="Boolean" mandatory="false" since="4.5">
             <description>Availability of remote control feature. True: Available, False: Not Available</description>
         </param>
+        <param name="appServices" type="Boolean" mandatory="false" since="6.0">
+            <description>Availability of App Services functionality. True: Available, False: Not Available</description>
+        </param>
     </struct>
 
     <struct name="MenuParams" since="1.0">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -2460,6 +2460,12 @@
         <param name="appServices" type="Boolean" mandatory="false" since="6.0">
             <description>Availability of App Services functionality. True: Available, False: Not Available</description>
         </param>
+        <param name="displays" type="Boolean" mandatory="false" since="6.0">
+            <description>Availability of displays capability. True: Available, False: Not Available</description>
+        </param>
+        <param name="seatLocation" type="Boolean" mandatory="false" since="6.0">
+            <description>Availability of seat location feature. True: Available, False: Not Available</description>
+        </param>
     </struct>
 
     <struct name="MenuParams" since="1.0">


### PR DESCRIPTION
Fixes #2998 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Connect app and verify appService, seatLocation, and displays all equal true in the hmiCapabilities RAI response.

### Summary
Adds HMICapabilities param appServices, seatLocation, and displays to the RAI response.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)