### PR TITLE
Fix hmi level only resumption

### DIFF
--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -637,6 +637,9 @@ bool ResumeCtrlImpl::StartAppHmiStateResumption(
       return false;
     }
     RemoveApplicationFromSaved(application);
+    if (!application->is_app_data_resumption_allowed()) {
+      application->set_is_resuming(false);
+    }
     return hmi_state_restore_result;
   } else {
     LOG4CXX_INFO(


### PR DESCRIPTION
Fixes #1902 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
ATF Scripts

### Summary
During hmi level only resumption, SDL has no way of setting  application's `is_resuming` flag to false, which resulted in extra `OnResumeAudioSource`notification being sent during second app resumption. To fix this, `RestoreAppHMIState` method was extended with a check whether app's data resumption is allowed. In case it is not, app is marked as not resuming.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
