### PR TITLE
Fix SSL handshake for a secondary connection

### DIFF
--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -620,6 +620,15 @@ class ConnectionHandlerImpl
   const uint8_t GetSessionIdFromSecondaryTransport(
       transport_manager::ConnectionUID secondary_transport_id) const;
 
+  /**
+   * @brief Get pointer to the primary connection by connection handle
+   * @param connection_handle handle of the current connection
+   * @return pointer to the primary connection if current one is secondary
+   * otherwise returns pointer to the same connection
+   */
+  Connection* GetPrimaryConnection(
+      const ConnectionHandle connection_handle) const;
+
   const ConnectionHandlerSettings& settings_;
   /**
    * \brief Pointer to observer

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -1703,7 +1703,7 @@ bool ConnectionHandlerImpl::IsHeartBeatSupported(
     uint8_t session_id) const {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoReadLock lock(connection_list_lock_);
-  uint32_t connection_id = static_cast<uint32_t>(connection_handle);
+  const uint32_t connection_id = static_cast<uint32_t>(connection_handle);
   auto connection = GetPrimaryConnection(connection_id);
 
   if (!connection) {

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -1251,7 +1251,6 @@ int ConnectionHandlerImpl::SetSSLContext(
   sync_primitives::AutoReadLock lock(connection_list_lock_);
   auto connection = GetPrimaryConnection(connection_handle);
   if (!connection) {
-    LOG4CXX_ERROR(logger_, "Unknown connection!");
     return security_manager::SecurityManager::ERROR_INTERNAL;
   }
 
@@ -1268,7 +1267,6 @@ security_manager::SSLContext* ConnectionHandlerImpl::GetSSLContext(
   sync_primitives::AutoReadLock lock(connection_list_lock_);
   auto connection = GetPrimaryConnection(connection_handle);
   if (!connection) {
-    LOG4CXX_ERROR(logger_, "Unknown connection!");
     return nullptr;
   }
 
@@ -1285,7 +1283,6 @@ void ConnectionHandlerImpl::SetProtectionFlag(
   sync_primitives::AutoReadLock lock(connection_list_lock_);
   auto connection = GetPrimaryConnection(connection_handle);
   if (!connection) {
-    LOG4CXX_ERROR(logger_, "Unknown connection!");
     return;
   }
 
@@ -1301,7 +1298,6 @@ ConnectionHandlerImpl::GetHandshakeContext(uint32_t key) const {
   sync_primitives::AutoReadLock lock(connection_list_lock_);
   auto connection = GetPrimaryConnection(connection_handle);
   if (!connection) {
-    LOG4CXX_ERROR(logger_, "Unknown connection!");
     return security_manager::SSLContext::HandshakeContext();
   }
 
@@ -1711,7 +1707,6 @@ bool ConnectionHandlerImpl::IsHeartBeatSupported(
   auto connection = GetPrimaryConnection(connection_id);
 
   if (!connection) {
-    LOG4CXX_WARN(logger_, "Connection not found !");
     return false;
   }
 
@@ -1733,7 +1728,6 @@ bool ConnectionHandlerImpl::ProtocolVersionUsed(
                  connection_id) {
     return ending_connection_->ProtocolVersion(session_id, protocol_version);
   }
-  LOG4CXX_WARN(logger_, "Connection not found !");
   return false;
 }
 

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -1124,6 +1124,26 @@ const uint8_t ConnectionHandlerImpl::GetSessionIdFromSecondaryTransport(
   return 0;
 }
 
+Connection* ConnectionHandlerImpl::GetPrimaryConnection(
+    const ConnectionHandle connection_handle) const {
+  LOG4CXX_DEBUG(logger_,
+                "Getting primary connection for ID " << connection_handle);
+  ConnectionList::const_iterator it = connection_list_.find(connection_handle);
+  if (connection_list_.end() == it) {
+    LOG4CXX_ERROR(
+        logger_,
+        "Connection with ID " << connection_handle << " was not found");
+    return nullptr;
+  }
+
+  auto connection_ptr = it->second;
+  if (connection_ptr->primary_connection_handle() != 0) {
+    return GetPrimaryConnection(connection_ptr->primary_connection_handle());
+  }
+
+  return connection_ptr;
+}
+
 std::string ConnectionHandlerImpl::GetCloudAppID(
     const transport_manager::ConnectionUID connection_id) const {
   sync_primitives::AutoLock auto_lock(cloud_app_id_map_lock_);
@@ -1229,13 +1249,13 @@ int ConnectionHandlerImpl::SetSSLContext(
   PairFromKey(key, &connection_handle, &session_id);
 
   sync_primitives::AutoReadLock lock(connection_list_lock_);
-  ConnectionList::iterator it = connection_list_.find(connection_handle);
-  if (connection_list_.end() == it) {
+  auto connection = GetPrimaryConnection(connection_handle);
+  if (!connection) {
     LOG4CXX_ERROR(logger_, "Unknown connection!");
     return security_manager::SecurityManager::ERROR_INTERNAL;
   }
-  Connection& connection = *it->second;
-  return connection.SetSSLContext(session_id, context);
+
+  return connection->SetSSLContext(session_id, context);
 }
 
 security_manager::SSLContext* ConnectionHandlerImpl::GetSSLContext(
@@ -1246,13 +1266,13 @@ security_manager::SSLContext* ConnectionHandlerImpl::GetSSLContext(
   PairFromKey(key, &connection_handle, &session_id);
 
   sync_primitives::AutoReadLock lock(connection_list_lock_);
-  ConnectionList::iterator it = connection_list_.find(connection_handle);
-  if (connection_list_.end() == it) {
+  auto connection = GetPrimaryConnection(connection_handle);
+  if (!connection) {
     LOG4CXX_ERROR(logger_, "Unknown connection!");
-    return NULL;
+    return nullptr;
   }
-  Connection& connection = *it->second;
-  return connection.GetSSLContext(session_id, service_type);
+
+  return connection->GetSSLContext(session_id, service_type);
 }
 
 void ConnectionHandlerImpl::SetProtectionFlag(
@@ -1263,18 +1283,30 @@ void ConnectionHandlerImpl::SetProtectionFlag(
   PairFromKey(key, &connection_handle, &session_id);
 
   sync_primitives::AutoReadLock lock(connection_list_lock_);
-  ConnectionList::iterator it = connection_list_.find(connection_handle);
-  if (connection_list_.end() == it) {
+  auto connection = GetPrimaryConnection(connection_handle);
+  if (!connection) {
     LOG4CXX_ERROR(logger_, "Unknown connection!");
     return;
   }
-  Connection& connection = *it->second;
-  connection.SetProtectionFlag(session_id, service_type);
+
+  connection->SetProtectionFlag(session_id, service_type);
 }
 
 security_manager::SSLContext::HandshakeContext
 ConnectionHandlerImpl::GetHandshakeContext(uint32_t key) const {
-  return connection_handler_observer_->GetHandshakeContext(key);
+  transport_manager::ConnectionUID connection_handle = 0;
+  uint8_t session_id = 0;
+  PairFromKey(key, &connection_handle, &session_id);
+
+  sync_primitives::AutoReadLock lock(connection_list_lock_);
+  auto connection = GetPrimaryConnection(connection_handle);
+  if (!connection) {
+    LOG4CXX_ERROR(logger_, "Unknown connection!");
+    return security_manager::SSLContext::HandshakeContext();
+  }
+
+  auto primary_key = KeyFromPair(connection->connection_handle(), session_id);
+  return connection_handler_observer_->GetHandshakeContext(primary_key);
 }
 
 #endif  // ENABLE_SECURITY
@@ -1664,9 +1696,9 @@ void ConnectionHandlerImpl::BindProtocolVersionWithSession(
   PairFromKey(connection_key, &connection_handle, &session_id);
 
   sync_primitives::AutoReadLock lock(connection_list_lock_);
-  ConnectionList::iterator it = connection_list_.find(connection_handle);
-  if (connection_list_.end() != it) {
-    it->second->UpdateProtocolVersionSession(session_id, protocol_version);
+  auto connection = GetPrimaryConnection(connection_handle);
+  if (connection) {
+    connection->UpdateProtocolVersionSession(session_id, protocol_version);
   }
 }
 
@@ -1675,13 +1707,15 @@ bool ConnectionHandlerImpl::IsHeartBeatSupported(
     uint8_t session_id) const {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoReadLock lock(connection_list_lock_);
-  uint32_t connection = static_cast<uint32_t>(connection_handle);
-  ConnectionList::const_iterator it = connection_list_.find(connection);
-  if (connection_list_.end() == it) {
+  uint32_t connection_id = static_cast<uint32_t>(connection_handle);
+  auto connection = GetPrimaryConnection(connection_id);
+
+  if (!connection) {
     LOG4CXX_WARN(logger_, "Connection not found !");
     return false;
   }
-  return it->second->SupportHeartBeat(session_id);
+
+  return connection->SupportHeartBeat(session_id);
 }
 
 bool ConnectionHandlerImpl::ProtocolVersionUsed(
@@ -1690,9 +1724,10 @@ bool ConnectionHandlerImpl::ProtocolVersionUsed(
     uint8_t& protocol_version) const {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoReadLock lock(connection_list_lock_);
-  ConnectionList::const_iterator it = connection_list_.find(connection_id);
-  if (connection_list_.end() != it) {
-    return it->second->ProtocolVersion(session_id, protocol_version);
+  auto connection = GetPrimaryConnection(connection_id);
+
+  if (connection) {
+    return connection->ProtocolVersion(session_id, protocol_version);
   } else if (ending_connection_ &&
              static_cast<uint32_t>(ending_connection_->connection_handle()) ==
                  connection_id) {

--- a/src/components/protocol_handler/include/protocol_handler/handshake_handler.h
+++ b/src/components/protocol_handler/include/protocol_handler/handshake_handler.h
@@ -111,6 +111,12 @@ class HandshakeHandler : public security_manager::SecurityManagerListener {
    */
   uint32_t connection_key() const;
 
+  /**
+   * @brief Get primary connection key of this handler
+   * @return primary connection key
+   */
+  uint32_t primary_connection_key() const;
+
  private:
   /**
    * @brief Performs related actions if handshake was successfully finished

--- a/src/components/protocol_handler/src/handshake_handler.cc
+++ b/src/components/protocol_handler/src/handshake_handler.cc
@@ -69,6 +69,11 @@ uint32_t HandshakeHandler::connection_key() const {
                                        context_.new_session_id_);
 }
 
+uint32_t HandshakeHandler::primary_connection_key() const {
+  return session_observer_.KeyFromPair(context_.primary_connection_id_,
+                                       context_.new_session_id_);
+}
+
 bool HandshakeHandler::GetPolicyCertificateData(std::string& data) const {
   return false;
 }
@@ -120,11 +125,11 @@ bool HandshakeHandler::OnHandshakeDone(
   LOG4CXX_DEBUG(logger_,
                 "OnHandshakeDone for service : " << context_.service_type_);
 
-  if (connection_key != this->connection_key()) {
+  if (connection_key != this->primary_connection_key()) {
     LOG4CXX_DEBUG(logger_,
                   "Listener " << this
                               << " expects notification for connection id: "
-                              << this->connection_key()
+                              << this->primary_connection_key()
                               << ". Received notification for connection id "
                               << connection_key << " will be ignored");
     return false;
@@ -161,7 +166,7 @@ bool HandshakeHandler::CanBeProtected() const {
 }
 
 bool HandshakeHandler::IsAlreadyProtected() const {
-  return (session_observer_.GetSSLContext(this->connection_key(),
+  return (session_observer_.GetSSLContext(this->primary_connection_key(),
                                           context_.service_type_) != NULL);
 }
 


### PR DESCRIPTION
Fixes #3059 

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tested manually

### Summary
There was found a several places in SDL code where SSL handshake was working wrong when secured service was started from a secondary connection like WIFI. All these places were updated to consider primary connection as a source for an SSL context and other attributes for case when the current connection is secondary.
Looks like this is a part which was not considered during initial implementation of the secondary transport feature.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)