### PR TITLE
Add history tag to SetDisplayLayout

### DIFF
--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -7186,6 +7186,9 @@
     </function>
     
     <function name="SetDisplayLayout" functionID="SetDisplayLayoutID" messagetype="request" deprecated="true" since="6.0">
+        <history>
+            <function name="SetDisplayLayout" functionID="SetDisplayLayoutID" messagetype="request" since="3.0" until="6.0"/>
+        </history>
         <description>This RPC is deprecated. Use Show RPC to change layout.</description>
         <param name="displayLayout" type="String" maxlength="500" mandatory="true">
             <description>
@@ -7200,6 +7203,9 @@
     </function>
     
     <function name="SetDisplayLayout" functionID="SetDisplayLayoutID" messagetype="response" deprecated="true" since="6.0">
+        <history>
+            <function name="SetDisplayLayout" functionID="SetDisplayLayoutID" messagetype="response" since="3.0" until="6.0"/>
+        </history>
         <description>This RPC is deprecated. Use Show RPC to change layout.</description>
         <param name="success" type="Boolean" platform="documentation" mandatory="true">
             <description> true, if successful; false, if failed </description>

--- a/tools/InterfaceGenerator/generator/parsers/RPCBase.py
+++ b/tools/InterfaceGenerator/generator/parsers/RPCBase.py
@@ -904,7 +904,7 @@ class Parser(object):
             elif subelement.tag == "param" and parent.tag == "param":
                 items.append(self._parse_function_param(subelement, prefix))
             elif subelement.tag == "function" and parent.tag == "function":
-                items.append(self.__parse_function(subelement, prefix))
+                items.append(self._parse_function(subelement, prefix))
             else: 
                 raise ParseError("A history tag must be nested within the element it notes the history for. Fix item: '" +
                  parent.attrib["name"] + "'")


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF test scripts:

- ./test_scripts/WidgetSupport/Versioning/002_SetDisplayLayout_new_app.lua
- ./test_scripts/WidgetSupport/Versioning/004_SetDisplayLayout_old_app.lua

### Summary
Add history tag to set display layout request and response. Also fixed a typo error that was exposed by adding a history tag to a RPC.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
