### PR TITLE
Replace DCHECK in Create Window Request

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_window_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_window_request.cc
@@ -307,7 +307,10 @@ bool CreateWindowRequest::DoesExceedMaxAllowedWindows(
   const auto window_type = static_cast<mobile_apis::WindowType::eType>(
       (*message_)[strings::msg_params][strings::window_type].asInt());
 
-  const auto display_capabilities = app->display_capabilities();
+  auto display_capabilities = hmi_capabilities_.system_display_capabilities();
+  if (app->display_capabilities()) {
+    display_capabilities = app->display_capabilities();
+  }
 
   if (!display_capabilities) {
     LOG4CXX_WARN(logger_, "Application has no capabilities");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_window_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_window_request.cc
@@ -333,7 +333,10 @@ bool CreateWindowRequest::DoesExceedMaxAllowedWindows(
         return false;
       });
 
-  DCHECK(find_res != windowTypeSupported->end());
+  if (find_res == windowTypeSupported->end()) {
+    LOG4CXX_WARN(logger_, "Requested Window Type is not supported by the HMI");
+    return false;
+  }
 
   if (get_current_number_of_windows(window_type) + 1 >
       (*find_res)[strings::maximum_number_of_windows].asUInt()) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_window_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_window_request.cc
@@ -335,7 +335,7 @@ bool CreateWindowRequest::DoesExceedMaxAllowedWindows(
 
   if (find_res == windowTypeSupported->end()) {
     LOG4CXX_WARN(logger_, "Requested Window Type is not supported by the HMI");
-    return false;
+    return true;
   }
 
   if (get_current_number_of_windows(window_type) + 1 >

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/create_window_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/create_window_request_test.cc
@@ -164,6 +164,9 @@ class CreateWindowRequestTest
     ON_CALL(*mock_app_, display_capabilities())
         .WillByDefault(Return(display_capabilities_));
 
+    ON_CALL(mock_hmi_capabilities_, system_display_capabilities())
+        .WillByDefault(Return(display_capabilities_));
+
     window_params_map_lock_ptr_ = std::make_shared<sync_primitives::Lock>();
 
     DataAccessor<am::WindowParamsMap> window_params_map(


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [Use HMI that does not include the widget type in its capabilities. Base widgets branch.](https://github.com/smartdevicelink/generic_hmi/tree/feature/base_widgets_rpc_support)
- Connect app and send a CreateWindow Request.

### Summary
Replace a DCHECK that was crashing core with an if condition checking against the find results instead.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
