### PR TITLE
Fix  resource allocation manager unit tests are not included in /resource_allocation_manager_tests testing binary .

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_rc_helpers.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_rc_helpers.h
@@ -84,8 +84,10 @@ class MockRCHelpers {
                std::vector<bool>(const smart_objects::SmartObject& consents));
   MOCK_METHOD1(RemoveRedundantGPSDataFromIVDataMsg,
                void(smart_objects::SmartObject& msg_params));
-    MOCK_METHOD2(MergeModuleData, smart_objects::SmartObject(const smart_objects::SmartObject& data1,
-      const smart_objects::SmartObject& data2));
+  MOCK_METHOD2(
+      MergeModuleData,
+      smart_objects::SmartObject(const smart_objects::SmartObject& data1,
+                                 const smart_objects::SmartObject& data2));
 
   static MockRCHelpers* rc_helpers_mock();
 };

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_rc_helpers.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_rc_helpers.h
@@ -84,6 +84,8 @@ class MockRCHelpers {
                std::vector<bool>(const smart_objects::SmartObject& consents));
   MOCK_METHOD1(RemoveRedundantGPSDataFromIVDataMsg,
                void(smart_objects::SmartObject& msg_params));
+    MOCK_METHOD2(MergeModuleData, smart_objects::SmartObject(const smart_objects::SmartObject& data1,
+      const smart_objects::SmartObject& data2));
 
   static MockRCHelpers* rc_helpers_mock();
 };

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/mock_rc_helpers.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/mock_rc_helpers.cc
@@ -34,6 +34,11 @@
 
 namespace rc_rpc_plugin {
 
+smart_objects::SmartObject RCHelpers::MergeModuleData(const smart_objects::SmartObject& data1,
+      const smart_objects::SmartObject& data2) {
+  return MockRCHelpers::rc_helpers_mock()->MergeModuleData(data1, data2);
+}
+
 const std::function<std::string(const std::string&)>
 rc_rpc_plugin::RCHelpers::GetModuleTypeToDataMapping() {
   return MockRCHelpers::rc_helpers_mock()->GetModuleTypeToDataMapping();

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/mock_rc_helpers.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/mock_rc_helpers.cc
@@ -34,8 +34,9 @@
 
 namespace rc_rpc_plugin {
 
-smart_objects::SmartObject RCHelpers::MergeModuleData(const smart_objects::SmartObject& data1,
-      const smart_objects::SmartObject& data2) {
+smart_objects::SmartObject RCHelpers::MergeModuleData(
+    const smart_objects::SmartObject& data1,
+    const smart_objects::SmartObject& data2) {
   return MockRCHelpers::rc_helpers_mock()->MergeModuleData(data1, data2);
 }
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/resource_allocation_manager/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/resource_allocation_manager/CMakeLists.txt
@@ -54,7 +54,7 @@ ${CMAKE_CURRENT_SOURCE_DIR}/resource_allocation_manager_impl_test.cc
 
 set(RC_COMMANDS_TEST_SOURCE_DIR ${COMPONENTS_DIR}/application_manager/rpc_plugins/rc_rpc_plugin/test/commands)
 set(RC_COMMANDS_SOURCE_DIR ${COMPONENTS_DIR}/application_manager/rpc_plugins/rc_rpc_plugin/src/commands)
-collect_sources(COMMANDS_SOURCES "${RC_COMMANDS_TEST_DIR}" "${RC_COMMANDS_TEST_SOURCE_DIR}")
+collect_sources(COMMANDS_SOURCES "${RC_COMMANDS_SOURCE_DIR}" "${RC_COMMANDS_TEST_SOURCE_DIR}")
 
 set(LIBRARIES
   ApplicationManager
@@ -77,5 +77,7 @@ if(ENABLE_LOG)
   list(APPEND LIBRARIES expat -L${EXPAT_LIBS_DIRECTORY})
 endif()
 
-create_test("resource_allocation_manager_test" "${COMMANDS_SOURCES}" "${LIBRARIES}" "${RESOURCE_ALLOC_MANAGER_TEST_SOURCES}")
+list(APPEND COMMANDS_SOURCES ${RESOURCE_ALLOC_MANAGER_TEST_SOURCES})
+
+create_test("resource_allocation_manager_test" "${COMMANDS_SOURCES}" "${LIBRARIES}")
 


### PR DESCRIPTION
Fixes #3069

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
There is the Unit tests' issue when resource allocation manager unit tests are not included in /resource_allocation_manager_tests testing binary. As a result, the Google Test framework isn't able to run the Unit tests for testing ResourceAllocationManage component.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
