### PR TITLE
move mismatched textfields to bottom of enum

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -611,12 +611,6 @@
   <element name="menuTitle">
     <description> Optional text to label an app menu button (for certain touchscreen platforms).</description>
   </element>
-  <element name="navigationText">
-    <description>Navigation text for UpdateTurnList.</description>
-  </element>
-  <element name="notificationText">
-    <description>Text of notification to be displayed on screen.</description>
-  </element>
   <element name="locationName">
     <description> Optional name / title of intended location for SendLocation.</description>
   </element>
@@ -632,6 +626,12 @@
   <element name="timeToDestination"/>
     <!-- TO DO to be removed -->
   <element name="turnText"/>
+  <element name="navigationText">
+    <description>Navigation text for UpdateTurnList.</description>
+  </element>
+  <element name="notificationText">
+    <description>Text of notification to be displayed on screen.</description>
+  </element>
 </enum>
 
 <enum name="MetadataType">


### PR DESCRIPTION
This PR fixes https://github.com/smartdevicelink/sdl_core/issues/1392

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Manually

### Summary
This PR adjusts an enum in the HMI_API that does not match the enum's definition in the MOBILE_API.
There are two more elements in the HMI_API version of `textFields`: `navigationText` and `notificationText`. When core forwards these `textFields` to mobile as a capability update and in the RAI response it is using the values pulled from the HMI_API. This caused any element after the mismatched elements in the HMI_API to be sent to mobile with the wrong value.

### Changelog
##### Bug Fixes
* Move `navigationText` and `notificationText` to the end of the enum so that all other textFields have the same value in both the MOBILE and HMI apis.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
