### PR TITLE
Fix VD items subscriptions after PTU

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/custom_vehicle_data_provider.h
+++ b/src/components/application_manager/include/application_manager/policies/custom_vehicle_data_provider.h
@@ -24,7 +24,7 @@ class VehicleDataItemProvider {
    * @brief Gets vehicle data items removed by policies
    * @return Structure with vehicle data items
    */
-  virtual const std::vector<rpc::policy_table_interface_base::VehicleDataItem>
+  virtual std::vector<rpc::policy_table_interface_base::VehicleDataItem>
   GetRemovedVehicleDataItems() const = 0;
 };
 }  // namespace policy

--- a/src/components/application_manager/include/application_manager/policies/custom_vehicle_data_provider.h
+++ b/src/components/application_manager/include/application_manager/policies/custom_vehicle_data_provider.h
@@ -19,6 +19,13 @@ class VehicleDataItemProvider {
    */
   virtual const std::vector<rpc::policy_table_interface_base::VehicleDataItem>
   GetVehicleDataItems() const = 0;
+
+  /**
+   * @brief Gets vehicle data items removed by policies
+   * @return Structure with vehicle data items
+   */
+  virtual const std::vector<rpc::policy_table_interface_base::VehicleDataItem>
+  GetRemovedVehicleDataItems() const = 0;
 };
 }  // namespace policy
 

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -704,6 +704,9 @@ class PolicyHandler : public PolicyHandlerInterface,
   const std::vector<rpc::policy_table_interface_base::VehicleDataItem>
   GetVehicleDataItems() const OVERRIDE;
 
+  const std::vector<rpc::policy_table_interface_base::VehicleDataItem>
+  GetRemovedVehicleDataItems() const OVERRIDE;
+
   void OnLockScreenDismissalStateChanged() FINAL;
 
  protected:

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -704,7 +704,7 @@ class PolicyHandler : public PolicyHandlerInterface,
   const std::vector<rpc::policy_table_interface_base::VehicleDataItem>
   GetVehicleDataItems() const OVERRIDE;
 
-  const std::vector<rpc::policy_table_interface_base::VehicleDataItem>
+  std::vector<rpc::policy_table_interface_base::VehicleDataItem>
   GetRemovedVehicleDataItems() const OVERRIDE;
 
   void OnLockScreenDismissalStateChanged() FINAL;

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/custom_vehicle_data_manager.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/custom_vehicle_data_manager.h
@@ -41,6 +41,15 @@ class CustomVehicleDataManager {
   virtual void OnPolicyEvent(plugin_manager::PolicyEvent policy_event) = 0;
 
   virtual bool IsValidCustomVehicleDataName(const std::string& name) const = 0;
+
+  /**
+   * @brief Checks whether custom vehicle data name was removed after the last
+   * PTU or not
+   * @param name vehicle item name to check
+   * @return true if vehicle data with this name was removed after the last PTU
+   */
+  virtual bool IsRemovedCustomVehicleDataName(
+      const std::string& name) const = 0;
 };
 }  // namespace vehicle_info_plugin
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_VEHICLE_INFO_PLUGIN_INCLUDE_VEHICLE_INFO_PLUGIN_CUSTOM_VEHICLE_DATA_MANAGER_H_

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/custom_vehicle_data_manager_impl.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/custom_vehicle_data_manager_impl.h
@@ -42,6 +42,8 @@ class CustomVehicleDataManagerImpl : public CustomVehicleDataManager {
 
   bool IsValidCustomVehicleDataName(const std::string& name) const OVERRIDE;
 
+  bool IsRemovedCustomVehicleDataName(const std::string& name) const OVERRIDE;
+
  private:
   class RPCParams {
    public:
@@ -82,6 +84,8 @@ class CustomVehicleDataManagerImpl : public CustomVehicleDataManager {
   void UpdateVehicleDataItems();
 
   const OptionalDataItem FindSchemaByNameNonRecursive(
+      const std::string& name) const;
+  const OptionalDataItem FindRemovedSchemaByNameNonRecursive(
       const std::string& name) const;
   const OptionalDataItem FindSchemaByKeyNonRecursive(
       const std::string& key) const;

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
@@ -72,6 +72,7 @@ class VehicleInfoPlugin : public plugins::RPCPlugin {
                                      VehicleInfoAppExtension& ext);
 
  private:
+  void UnsubscribeFromNonExistingVDItems();
   smart_objects::SmartObjectSPtr GetUnsubscribeIVIRequest(
       const std::vector<std::string>& ivi_names);
   void DeleteSubscriptions(app_mngr::ApplicationSharedPtr app);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
@@ -72,7 +72,7 @@ class VehicleInfoPlugin : public plugins::RPCPlugin {
                                      VehicleInfoAppExtension& ext);
 
  private:
-  void UnsubscribeFromNonExistingVDItems();
+  void UnsubscribeFromRemovedVDItems();
   smart_objects::SmartObjectSPtr GetUnsubscribeIVIRequest(
       const std::vector<std::string>& ivi_names);
   void DeleteSubscriptions(app_mngr::ApplicationSharedPtr app);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/custom_vehicle_data_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/custom_vehicle_data_manager_impl.cc
@@ -514,7 +514,8 @@ CustomVehicleDataManagerImpl::FindRemovedSchemaByNameNonRecursive(
     const std::string& name) const {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  auto& removed_oem_items = vehicle_data_provider_.GetRemovedVehicleDataItems();
+  const auto& removed_oem_items =
+      vehicle_data_provider_.GetRemovedVehicleDataItems();
   auto compare_by_name = [&name](const policy_table::VehicleDataItem& item) {
     return (name == std::string(item.name));
   };

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/custom_vehicle_data_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/custom_vehicle_data_manager_impl.cc
@@ -77,6 +77,12 @@ bool CustomVehicleDataManagerImpl::IsValidCustomVehicleDataName(
   return schema.is_initialized();
 }
 
+bool CustomVehicleDataManagerImpl::IsRemovedCustomVehicleDataName(
+    const std::string& name) const {
+  const auto& schema = FindRemovedSchemaByNameNonRecursive(name);
+  return schema.is_initialized();
+}
+
 void CustomVehicleDataManagerImpl::CreateMobileMessageParams(
     smart_objects::SmartObject& msg_params) {
   using namespace application_manager;
@@ -174,6 +180,12 @@ smart_objects::SmartObject CustomVehicleDataManagerImpl::CreateHMIMessageParams(
     auto schema = FindSchemaByNameNonRecursive(name);
     if (schema.is_initialized()) {
       fill_param(fill_hmi_params, *schema, &out_params);
+      continue;
+    }
+
+    auto removed_schema = FindRemovedSchemaByNameNonRecursive(name);
+    if (removed_schema.is_initialized()) {
+      fill_param(fill_hmi_params, *removed_schema, &out_params);
     }
   }
 
@@ -495,6 +507,20 @@ CustomVehicleDataManagerImpl::FindSchemaByNameNonRecursive(
   };
 
   return FindSchema(oem_items, SearchMethod::NON_RECURSIVE, compare_by_name);
+}
+
+const OptionalDataItem
+CustomVehicleDataManagerImpl::FindRemovedSchemaByNameNonRecursive(
+    const std::string& name) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  auto& removed_oem_items = vehicle_data_provider_.GetRemovedVehicleDataItems();
+  auto compare_by_name = [&name](const policy_table::VehicleDataItem& item) {
+    return (name == std::string(item.name));
+  };
+
+  return FindSchema(
+      removed_oem_items, SearchMethod::NON_RECURSIVE, compare_by_name);
 }
 
 const OptionalDataItem CustomVehicleDataManagerImpl::FindSchemaByNameRecursive(

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -141,9 +141,15 @@ void VehicleInfoPlugin::ProcessResumptionSubscription(
       smart_objects::SmartObject(smart_objects::SmartType_Map);
   msg_params[strings::app_id] = app.app_id();
   const auto& subscriptions = ext.Subscriptions();
+  if (subscriptions.empty()) {
+    LOG4CXX_DEBUG(logger_, "No vehicle data to subscribe. Exiting");
+    return;
+  }
+
   for (const auto& item : subscriptions) {
     msg_params[item] = true;
   }
+
   smart_objects::SmartObjectSPtr request =
       application_manager::MessageHelper::CreateModuleInfoSO(
           hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData,

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -100,7 +100,8 @@ void VehicleInfoPlugin::OnApplicationEvent(
 void VehicleInfoPlugin::UnsubscribeFromNonExistingVDItems() {
   typedef std::vector<std::string> StringsVector;
 
-  auto get_items_to_unsubscribe = [this](StringsVector& out_items) {
+  auto get_items_to_unsubscribe = [this]() -> StringsVector {
+    StringsVector output_items_list;
     auto applications = application_manager_->applications();
     for (auto& app : applications.GetData()) {
       auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
@@ -109,20 +110,20 @@ void VehicleInfoPlugin::UnsubscribeFromNonExistingVDItems() {
         if (custom_vehicle_data_manager_->IsRemovedCustomVehicleDataName(
                 subscription_name)) {
           ext.unsubscribeFromVehicleInfo(subscription_name);
-          if (!helpers::in_range(out_items, subscription_name)) {
+          if (!helpers::in_range(output_items_list, subscription_name)) {
             LOG4CXX_DEBUG(logger_,
                           "Vehicle data item "
                               << subscription_name
                               << " has been removed by policy");
-            out_items.push_back(subscription_name);
+            output_items_list.push_back(subscription_name);
           }
         }
       }
     }
+    return output_items_list;
   };
 
-  StringsVector items_to_unsubscribe;
-  get_items_to_unsubscribe(items_to_unsubscribe);
+  const StringsVector items_to_unsubscribe = get_items_to_unsubscribe();
 
   if (items_to_unsubscribe.empty()) {
     LOG4CXX_DEBUG(logger_, "There is no data to unsubscribe");

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -81,7 +81,7 @@ app_mngr::CommandFactory& VehicleInfoPlugin::GetCommandFactory() {
 }
 
 void VehicleInfoPlugin::OnPolicyEvent(plugins::PolicyEvent event) {
-  UnsubscribeFromNonExistingVDItems();
+  UnsubscribeFromRemovedVDItems();
   custom_vehicle_data_manager_->OnPolicyEvent(event);
 }
 
@@ -97,7 +97,7 @@ void VehicleInfoPlugin::OnApplicationEvent(
   }
 }
 
-void VehicleInfoPlugin::UnsubscribeFromNonExistingVDItems() {
+void VehicleInfoPlugin::UnsubscribeFromRemovedVDItems() {
   typedef std::vector<std::string> StringsVector;
 
   auto get_items_to_unsubscribe = [this]() -> StringsVector {

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/custom_vehicle_data_manager_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/custom_vehicle_data_manager_test.cc
@@ -60,6 +60,8 @@ class CustomVehicleDataManagerTest : public ::testing::Test {
 
     ON_CALL(mock_custom_vehicle_data_provider_, GetVehicleDataItems())
         .WillByDefault(Return(items));
+    ON_CALL(mock_custom_vehicle_data_provider_, GetRemovedVehicleDataItems())
+        .WillByDefault(Return(policy_table::VehicleDataItems()));
     custom_vd_manager_.reset(new CustomVehicleDataManagerImpl(
         mock_custom_vehicle_data_provider_, mock_rpc_service_));
   }

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/include/vehicle_info_plugin/mock_custom_vehicle_data_manager.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/include/vehicle_info_plugin/mock_custom_vehicle_data_manager.h
@@ -18,6 +18,8 @@ class MockCustomVehicleDataManager : public CustomVehicleDataManager {
   MOCK_METHOD1(OnPolicyEvent, void(plugin_manager::PolicyEvent policy_event));
   MOCK_CONST_METHOD1(IsValidCustomVehicleDataName,
                      bool(const std::string& name));
+  MOCK_CONST_METHOD1(IsRemovedCustomVehicleDataName,
+                     bool(const std::string& name));
 };
 
 }  // namespace vehicle_info_plugin

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -2325,7 +2325,7 @@ policy::PolicyHandler::GetVehicleDataItems() const {
   return policy_manager_->GetVehicleDataItems();
 }
 
-const std::vector<rpc::policy_table_interface_base::VehicleDataItem>
+std::vector<rpc::policy_table_interface_base::VehicleDataItem>
 policy::PolicyHandler::GetRemovedVehicleDataItems() const {
   return policy_manager_->GetRemovedVehicleDataItems();
 }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -2325,6 +2325,11 @@ policy::PolicyHandler::GetVehicleDataItems() const {
   return policy_manager_->GetVehicleDataItems();
 }
 
+const std::vector<rpc::policy_table_interface_base::VehicleDataItem>
+policy::PolicyHandler::GetRemovedVehicleDataItems() const {
+  return policy_manager_->GetRemovedVehicleDataItems();
+}
+
 #ifdef EXTERNAL_PROPRIETARY_MODE
 const MetaInfo PolicyHandler::GetMetaInfo() const {
   POLICY_LIB_CHECK(MetaInfo());

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -589,6 +589,13 @@ class PolicyManager : public usage_statistics::StatisticsManager,
       const = 0;
 
   /**
+   * @brief Gets vehicle data items removed by policies
+   * @return Structure with vehicle data items
+   */
+  virtual std::vector<rpc::policy_table_interface_base::VehicleDataItem>
+  GetRemovedVehicleDataItems() const = 0;
+
+  /**
    * @brief Gets copy of current policy table data
    * @return policy_table as json object
    */

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -567,7 +567,7 @@ class PolicyManager : public usage_statistics::StatisticsManager,
    * @brief Gets removed vehicle data items
    * @return Structure with vehicle data items
    */
-  virtual const std::vector<policy_table::VehicleDataItem>
+  virtual std::vector<policy_table::VehicleDataItem>
   GetRemovedVehicleDataItems() const = 0;
 
   /**

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -564,6 +564,13 @@ class PolicyManager : public usage_statistics::StatisticsManager,
       const = 0;
 
   /**
+   * @brief Gets removed vehicle data items
+   * @return Structure with vehicle data items
+   */
+  virtual const std::vector<policy_table::VehicleDataItem>
+  GetRemovedVehicleDataItems() const = 0;
+
+  /**
    * @brief Gets copy of current policy table data
    * @return policy_table as json object
    */

--- a/src/components/include/test/application_manager/policies/mock_custom_vehicle_data_provider.h
+++ b/src/components/include/test/application_manager/policies/mock_custom_vehicle_data_provider.h
@@ -15,7 +15,7 @@ class MockCustomVehicleDataProvider : public policy::VehicleDataItemProvider {
       const std::vector<rpc::policy_table_interface_base::VehicleDataItem>());
   MOCK_CONST_METHOD0(
       GetRemovedVehicleDataItems,
-      const std::vector<rpc::policy_table_interface_base::VehicleDataItem>());
+      std::vector<rpc::policy_table_interface_base::VehicleDataItem>());
 };
 
 }  // namespace policy_test

--- a/src/components/include/test/application_manager/policies/mock_custom_vehicle_data_provider.h
+++ b/src/components/include/test/application_manager/policies/mock_custom_vehicle_data_provider.h
@@ -13,6 +13,9 @@ class MockCustomVehicleDataProvider : public policy::VehicleDataItemProvider {
   MOCK_CONST_METHOD0(
       GetVehicleDataItems,
       const std::vector<rpc::policy_table_interface_base::VehicleDataItem>());
+  MOCK_CONST_METHOD0(
+      GetRemovedVehicleDataItems,
+      const std::vector<rpc::policy_table_interface_base::VehicleDataItem>());
 };
 
 }  // namespace policy_test

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -75,7 +75,7 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
       const std::vector<rpc::policy_table_interface_base::VehicleDataItem>());
   MOCK_CONST_METHOD0(
       GetRemovedVehicleDataItems,
-      const std::vector<rpc::policy_table_interface_base::VehicleDataItem>());
+      std::vector<rpc::policy_table_interface_base::VehicleDataItem>());
 
 #ifdef EXTERNAL_PROPRIETARY_MODE
   MOCK_METHOD3(OnSnapshotCreated,

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -73,6 +73,9 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_CONST_METHOD0(
       GetVehicleDataItems,
       const std::vector<rpc::policy_table_interface_base::VehicleDataItem>());
+  MOCK_CONST_METHOD0(
+      GetRemovedVehicleDataItems,
+      const std::vector<rpc::policy_table_interface_base::VehicleDataItem>());
 
 #ifdef EXTERNAL_PROPRIETARY_MODE
   MOCK_METHOD3(OnSnapshotCreated,

--- a/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
@@ -79,6 +79,8 @@ class MockCacheManagerInterface : public ::policy::CacheManagerInterface {
   MOCK_CONST_METHOD0(GetPolicyTableData, Json::Value());
   MOCK_CONST_METHOD0(GetVehicleDataItems,
                      const std::vector<policy_table::VehicleDataItem>());
+  MOCK_CONST_METHOD0(GetRemovedVehicleDataItems,
+                     std::vector<policy_table::VehicleDataItem>());
   MOCK_CONST_METHOD1(GetEnabledCloudApps,
                      void(std::vector<std::string>& enabled_apps));
   MOCK_CONST_METHOD7(GetCloudAppParameters,

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -224,6 +224,8 @@ class MockPolicyManager : public PolicyManager {
   MOCK_CONST_METHOD0(GetPolicyTableData, Json::Value());
   MOCK_CONST_METHOD0(GetVehicleDataItems,
                      const std::vector<policy_table::VehicleDataItem>());
+  MOCK_CONST_METHOD0(GetRemovedVehicleDataItems,
+                     std::vector<policy_table::VehicleDataItem>());
   MOCK_CONST_METHOD1(GetEnabledCloudApps,
                      void(std::vector<std::string>& enabled_apps));
   MOCK_CONST_METHOD7(GetCloudAppParameters,

--- a/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
@@ -65,6 +65,8 @@ class MockCacheManagerInterface : public CacheManagerInterface {
   MOCK_CONST_METHOD0(GetPolicyTableData, Json::Value());
   MOCK_CONST_METHOD0(GetVehicleDataItems,
                      const std::vector<policy_table::VehicleDataItem>());
+  MOCK_CONST_METHOD0(GetRemovedVehicleDataItems,
+                     const std::vector<policy_table::VehicleDataItem>());
   MOCK_CONST_METHOD1(GetEnabledCloudApps,
                      void(std::vector<std::string>& enabled_apps));
   MOCK_CONST_METHOD7(GetCloudAppParameters,

--- a/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
@@ -66,7 +66,7 @@ class MockCacheManagerInterface : public CacheManagerInterface {
   MOCK_CONST_METHOD0(GetVehicleDataItems,
                      const std::vector<policy_table::VehicleDataItem>());
   MOCK_CONST_METHOD0(GetRemovedVehicleDataItems,
-                     const std::vector<policy_table::VehicleDataItem>());
+                     std::vector<policy_table::VehicleDataItem>());
   MOCK_CONST_METHOD1(GetEnabledCloudApps,
                      void(std::vector<std::string>& enabled_apps));
   MOCK_CONST_METHOD7(GetCloudAppParameters,

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -219,6 +219,8 @@ class MockPolicyManager : public PolicyManager {
   MOCK_CONST_METHOD0(GetPolicyTableData, Json::Value());
   MOCK_CONST_METHOD0(GetVehicleDataItems,
                      const std::vector<policy_table::VehicleDataItem>());
+  MOCK_CONST_METHOD0(GetRemovedVehicleDataItems,
+                     const std::vector<policy_table::VehicleDataItem>());
   MOCK_CONST_METHOD1(GetEnabledCloudApps,
                      void(std::vector<std::string>& enabled_apps));
   MOCK_CONST_METHOD7(GetCloudAppParameters,

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -220,7 +220,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_CONST_METHOD0(GetVehicleDataItems,
                      const std::vector<policy_table::VehicleDataItem>());
   MOCK_CONST_METHOD0(GetRemovedVehicleDataItems,
-                     const std::vector<policy_table::VehicleDataItem>());
+                     std::vector<policy_table::VehicleDataItem>());
   MOCK_CONST_METHOD1(GetEnabledCloudApps,
                      void(std::vector<std::string>& enabled_apps));
   MOCK_CONST_METHOD7(GetCloudAppParameters,

--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -166,6 +166,9 @@ class CacheManager : public CacheManagerInterface {
   virtual const std::vector<policy_table::VehicleDataItem> GetVehicleDataItems()
       const OVERRIDE;
 
+  std::vector<policy_table::VehicleDataItem> GetRemovedVehicleDataItems()
+      const OVERRIDE;
+
   /**
    * @brief Gets copy of current policy table data
    * @return policy_table as json object
@@ -893,6 +896,24 @@ class CacheManager : public CacheManagerInterface {
    */
   void CheckSnapshotInitialization();
 
+  /**
+   * @brief Calculates difference between two provided custom vehicle data items
+   * @param items_before list of vehicle data items before PTU was applied
+   * @param items_after list of vehicle data items after PTU was applied
+   * @return list with calculated difference or empty list if two input lists
+   * are equal
+   */
+  policy_table::VehicleDataItems CalculateCustomVdItemsDiff(
+      const policy_table::VehicleDataItems& items_before,
+      const policy_table::VehicleDataItems& items_after) const;
+
+  /**
+   * @brief Sets the custom vehicle data items
+   * @param removed_items list of vehicle data items to set
+   */
+  void SetRemovedCustomVdItems(
+      const policy_table::VehicleDataItems& removed_items);
+
   void PersistData();
 
   /**
@@ -938,6 +959,7 @@ class CacheManager : public CacheManagerInterface {
   bool update_required;
   typedef std::set<std::string> UnpairedDevices;
   UnpairedDevices is_unpaired_;
+  policy_table::VehicleDataItems removed_custom_vd_items_;
 
   mutable sync_primitives::RecursiveLock cache_lock_;
   sync_primitives::Lock unpaired_lock_;

--- a/src/components/policy/policy_external/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager_interface.h
@@ -175,6 +175,13 @@ class CacheManagerInterface {
       const = 0;
 
   /**
+   * @brief Gets vehicle data items removed after the last PTU
+   * @return List of removed vehicle data items
+   */
+  virtual std::vector<policy_table::VehicleDataItem>
+  GetRemovedVehicleDataItems() const = 0;
+
+  /**
    * @brief Get a list of enabled cloud applications
    * @param enabled_apps List filled with the policy app id of each enabled
    * cloud application

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -655,6 +655,9 @@ class PolicyManagerImpl : public PolicyManager {
   const std::vector<policy_table::VehicleDataItem> GetVehicleDataItems()
       const OVERRIDE;
 
+  std::vector<policy_table::VehicleDataItem> GetRemovedVehicleDataItems()
+      const OVERRIDE;
+
   /**
    * @brief Get a list of enabled cloud applications
    * @param enabled_apps List filled with the policy app id of each enabled

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1971,7 +1971,7 @@ policy_table::VehicleDataItems CacheManager::CalculateCustomVdItemsDiff(
   }
 
   LOG4CXX_DEBUG(logger_,
-                "Was found " << removed_items.size() << " removed VD items");
+                "Found " << removed_items.size() << " removed VD items");
   return removed_items;
 }
 

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -269,7 +269,8 @@ CacheManager::CacheManager()
     : CacheManagerInterface()
     , pt_(new policy_table::Table)
     , backup_(new SQLPTExtRepresentation())
-    , update_required(false) {
+    , update_required(false)
+    , removed_custom_vd_items_() {
   InitBackupThread();
 }
 
@@ -758,6 +759,12 @@ bool CacheManager::ApplyUpdate(const policy_table::Table& update_pt) {
 
   // Apply update for vehicle data
   if (update_pt.policy_table.vehicle_data.is_initialized()) {
+    policy_table::VehicleDataItems custom_items_before_apply;
+    if (pt_->policy_table.vehicle_data->schema_items.is_initialized()) {
+      custom_items_before_apply =
+          CollectCustomVDItems(*pt_->policy_table.vehicle_data->schema_items);
+    }
+
     if (!update_pt.policy_table.vehicle_data->schema_items.is_initialized() ||
         update_pt.policy_table.vehicle_data->schema_items->empty()) {
       pt_->policy_table.vehicle_data->schema_items =
@@ -771,6 +778,12 @@ bool CacheManager::ApplyUpdate(const policy_table::Table& update_pt) {
       pt_->policy_table.vehicle_data->schema_items =
           rpc::Optional<policy_table::VehicleDataItems>(custom_items);
     }
+
+    policy_table::VehicleDataItems custom_items_after_apply =
+        *pt_->policy_table.vehicle_data->schema_items;
+    const auto& items_diff = CalculateCustomVdItemsDiff(
+        custom_items_before_apply, custom_items_after_apply);
+    SetRemovedCustomVdItems(items_diff);
   }
 
   ResetCalculatedPermissions();
@@ -1430,6 +1443,12 @@ CacheManager::GetVehicleDataItems() const {
   return std::vector<policy_table::VehicleDataItem>();
 }
 
+std::vector<policy_table::VehicleDataItem>
+CacheManager::GetRemovedVehicleDataItems() const {
+  CACHE_MANAGER_CHECK(std::vector<policy_table::VehicleDataItem>());
+  return removed_custom_vd_items_;
+}
+
 Json::Value CacheManager::GetPolicyTableData() const {
   return pt_->policy_table.ToJsonValue();
 }
@@ -1920,6 +1939,46 @@ void CacheManager::CheckSnapshotInitialization() {
       }
     }
   }
+}
+
+policy_table::VehicleDataItems CacheManager::CalculateCustomVdItemsDiff(
+    const policy_table::VehicleDataItems& items_before,
+    const policy_table::VehicleDataItems& items_after) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (items_before.empty()) {
+    LOG4CXX_DEBUG(logger_, "No custom VD items found in policy");
+    return policy_table::VehicleDataItems();
+  }
+
+  if (items_after.empty()) {
+    LOG4CXX_DEBUG(logger_,
+                  "All custom VD items were removed after policy update");
+    return items_before;
+  }
+
+  policy_table::VehicleDataItems removed_items;
+  for (auto& item_to_search : items_before) {
+    auto item_predicate =
+        [&item_to_search](const policy_table::VehicleDataItem& item_to_check) {
+          return item_to_search.name == item_to_check.name;
+        };
+
+    auto it =
+        std::find_if(items_after.begin(), items_after.end(), item_predicate);
+    if (items_after.end() == it) {
+      removed_items.push_back(item_to_search);
+    }
+  }
+
+  LOG4CXX_DEBUG(logger_,
+                "Was found " << removed_items.size() << " removed VD items");
+  return removed_items;
+}
+
+void CacheManager::SetRemovedCustomVdItems(
+    const policy_table::VehicleDataItems& removed_items) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  removed_custom_vd_items_ = removed_items;
 }
 
 void CacheManager::PersistData() {

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -804,6 +804,11 @@ PolicyManagerImpl::GetVehicleDataItems() const {
   return cache_->GetVehicleDataItems();
 }
 
+std::vector<policy_table::VehicleDataItem>
+PolicyManagerImpl::GetRemovedVehicleDataItems() const {
+  return cache_->GetRemovedVehicleDataItems();
+}
+
 Json::Value PolicyManagerImpl::GetPolicyTableData() const {
   return cache_->GetPolicyTableData();
 }

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -154,7 +154,7 @@ class CacheManager : public CacheManagerInterface {
   virtual const std::vector<policy_table::VehicleDataItem> GetVehicleDataItems()
       const;
 
-  const std::vector<policy_table::VehicleDataItem> GetRemovedVehicleDataItems()
+  std::vector<policy_table::VehicleDataItem> GetRemovedVehicleDataItems()
       const OVERRIDE;
 
   const boost::optional<bool> LockScreenDismissalEnabledState() const OVERRIDE;
@@ -923,14 +923,22 @@ class CacheManager : public CacheManagerInterface {
   void CheckSnapshotInitialization();
 
   /**
-   * @brief Checks for custom vehicle data items removed after PTU and stores
-   * the difference
+   * @brief Calculates difference between two provided custom vehicle data items
    * @param items_before list of vehicle data items before PTU was applied
    * @param items_after list of vehicle data items after PTU was applied
+   * @return list with calculated difference or empty list if two input lists
+   * are equal
+   */
+  policy_table::VehicleDataItems CalculateCustomVdItemsDiff(
+      const policy_table::VehicleDataItems& items_before,
+      const policy_table::VehicleDataItems& items_after) const;
+
+  /**
+   * @brief Sets the custom vehicle data items
+   * @param removed_items list of vehicle data items to set
    */
   void SetRemovedCustomVdItems(
-      const policy_table::VehicleDataItems& items_before,
-      const policy_table::VehicleDataItems& items_after);
+      const policy_table::VehicleDataItems& removed_items);
 
   void PersistData();
 

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -154,6 +154,9 @@ class CacheManager : public CacheManagerInterface {
   virtual const std::vector<policy_table::VehicleDataItem> GetVehicleDataItems()
       const;
 
+  const std::vector<policy_table::VehicleDataItem> GetRemovedVehicleDataItems()
+      const OVERRIDE;
+
   const boost::optional<bool> LockScreenDismissalEnabledState() const OVERRIDE;
 
   const boost::optional<std::string> LockScreenDismissalWarningMessage(
@@ -919,6 +922,16 @@ class CacheManager : public CacheManagerInterface {
    */
   void CheckSnapshotInitialization();
 
+  /**
+   * @brief Checks for custom vehicle data items removed after PTU and stores
+   * the difference
+   * @param items_before list of vehicle data items before PTU was applied
+   * @param items_after list of vehicle data items after PTU was applied
+   */
+  void SetRemovedCustomVdItems(
+      const policy_table::VehicleDataItems& items_before,
+      const policy_table::VehicleDataItems& items_after);
+
   void PersistData();
 
   /**
@@ -945,6 +958,7 @@ class CacheManager : public CacheManagerInterface {
   bool update_required;
   typedef std::set<std::string> UnpairedDevices;
   UnpairedDevices is_unpaired_;
+  policy_table::VehicleDataItems removed_custom_vd_items_;
 
   mutable sync_primitives::RecursiveLock cache_lock_;
   sync_primitives::Lock unpaired_lock_;

--- a/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
@@ -162,6 +162,13 @@ class CacheManagerInterface {
       const = 0;
 
   /**
+   * @brief Gets vehicle data items removed after the last PTU
+   * @return List of removed vehicle data items
+   */
+  virtual const std::vector<policy_table::VehicleDataItem>
+  GetRemovedVehicleDataItems() const = 0;
+
+  /**
    * @brief Get a list of enabled cloud applications
    * @param enabled_apps List filled with the policy app id of each enabled
    * cloud application

--- a/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
@@ -165,7 +165,7 @@ class CacheManagerInterface {
    * @brief Gets vehicle data items removed after the last PTU
    * @return List of removed vehicle data items
    */
-  virtual const std::vector<policy_table::VehicleDataItem>
+  virtual std::vector<policy_table::VehicleDataItem>
   GetRemovedVehicleDataItems() const = 0;
 
   /**

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -663,7 +663,7 @@ class PolicyManagerImpl : public PolicyManager {
   const std::vector<policy_table::VehicleDataItem> GetVehicleDataItems()
       const OVERRIDE;
 
-  const std::vector<policy_table::VehicleDataItem> GetRemovedVehicleDataItems()
+  std::vector<policy_table::VehicleDataItem> GetRemovedVehicleDataItems()
       const OVERRIDE;
 
   /**

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -663,6 +663,9 @@ class PolicyManagerImpl : public PolicyManager {
   const std::vector<policy_table::VehicleDataItem> GetVehicleDataItems()
       const OVERRIDE;
 
+  const std::vector<policy_table::VehicleDataItem> GetRemovedVehicleDataItems()
+      const OVERRIDE;
+
   /**
    * @brief Gets copy of current policy table data
    * @return policy_table as json object

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -1272,7 +1272,7 @@ policy_table::VehicleDataItems CacheManager::CalculateCustomVdItemsDiff(
   }
 
   LOG4CXX_DEBUG(logger_,
-                "Was found " << removed_items.size() << " removed VD items");
+                "Found " << removed_items.size() << " removed VD items");
   return removed_items;
 }
 

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -107,6 +107,7 @@ CacheManager::CacheManager()
     , pt_(new policy_table::Table)
     , backup_(new SQLPTRepresentation())
     , update_required(false)
+    , removed_custom_vd_items_()
     , settings_(nullptr) {
   LOG4CXX_AUTO_TRACE(logger_);
   backuper_ = new BackgroundBackuper(this);
@@ -304,6 +305,12 @@ bool CacheManager::ApplyUpdate(const policy_table::Table& update_pt) {
 
   // Apply update for vehicle data
   if (update_pt.policy_table.vehicle_data.is_initialized()) {
+    policy_table::VehicleDataItems custom_items_before_apply;
+    if (pt_->policy_table.vehicle_data->schema_items.is_initialized()) {
+      custom_items_before_apply =
+          CollectCustomVDItems(*pt_->policy_table.vehicle_data->schema_items);
+    }
+
     if (!update_pt.policy_table.vehicle_data->schema_items.is_initialized() ||
         update_pt.policy_table.vehicle_data->schema_items->empty()) {
       pt_->policy_table.vehicle_data->schema_items =
@@ -317,9 +324,11 @@ bool CacheManager::ApplyUpdate(const policy_table::Table& update_pt) {
       pt_->policy_table.vehicle_data->schema_items =
           rpc::Optional<policy_table::VehicleDataItems>(custom_items);
     }
-    if (update_pt.policy_table.vehicle_data->schema_version.is_initialized() &&
-        update_pt.policy_table.vehicle_data->schema_items.is_initialized()) {
-    }
+
+    policy_table::VehicleDataItems custom_items_after_apply =
+        *pt_->policy_table.vehicle_data->schema_items;
+    SetRemovedCustomVdItems(custom_items_before_apply,
+                            custom_items_after_apply);
   }
 
   ResetCalculatedPermissions();
@@ -725,6 +734,12 @@ CacheManager::GetVehicleDataItems() const {
   }
 
   return std::vector<policy_table::VehicleDataItem>();
+}
+
+const std::vector<policy_table::VehicleDataItem>
+CacheManager::GetRemovedVehicleDataItems() const {
+  CACHE_MANAGER_CHECK(std::vector<policy_table::VehicleDataItem>());
+  return removed_custom_vd_items_;
 }
 
 Json::Value CacheManager::GetPolicyTableData() const {
@@ -1224,6 +1239,41 @@ void CacheManager::CheckSnapshotInitialization() {
   } else {
     LOG4CXX_WARN(logger_, "app_level is not initialized");
   }
+}
+
+void CacheManager::SetRemovedCustomVdItems(
+    const policy_table::VehicleDataItems& items_before,
+    const policy_table::VehicleDataItems& items_after) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (items_before.empty()) {
+    LOG4CXX_DEBUG(logger_, "No custom VD items found in policy");
+    return;
+  }
+
+  if (items_after.empty()) {
+    LOG4CXX_DEBUG(logger_,
+                  "All custom VD items were removed after policy update");
+    removed_custom_vd_items_ = items_before;
+    return;
+  }
+
+  policy_table::VehicleDataItems removed_items;
+  for (auto& item_to_search : items_before) {
+    auto item_predicate =
+        [&item_to_search](const policy_table::VehicleDataItem& item_to_check) {
+          return item_to_search.name == item_to_check.name;
+        };
+
+    auto it =
+        std::find_if(items_after.begin(), items_after.end(), item_predicate);
+    if (items_after.end() == it) {
+      removed_items.push_back(item_to_search);
+    }
+  }
+
+  LOG4CXX_DEBUG(logger_,
+                "Was found " << removed_items.size() << " removed VD items");
+  removed_custom_vd_items_.swap(removed_items);
 }
 
 void CacheManager::PersistData() {

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -721,6 +721,11 @@ PolicyManagerImpl::GetVehicleDataItems() const {
   return cache_->GetVehicleDataItems();
 }
 
+const std::vector<policy_table::VehicleDataItem>
+PolicyManagerImpl::GetRemovedVehicleDataItems() const {
+  return cache_->GetRemovedVehicleDataItems();
+}
+
 Json::Value PolicyManagerImpl::GetPolicyTableData() const {
   return cache_->GetPolicyTableData();
 }

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -721,7 +721,7 @@ PolicyManagerImpl::GetVehicleDataItems() const {
   return cache_->GetVehicleDataItems();
 }
 
-const std::vector<policy_table::VehicleDataItem>
+std::vector<policy_table::VehicleDataItem>
 PolicyManagerImpl::GetRemovedVehicleDataItems() const {
   return cache_->GetRemovedVehicleDataItems();
 }


### PR DESCRIPTION
Fixes #3079  and #3080 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered with ATF scripts

### Summary
There was found an issue that SDL still kept subscriptions for custom vehicle data items even
for case when they were removed during PTU. By that reason, SDL was crashing with DCHECK on
attempt to unsubscribe from non existing custom data.

There was added missing logic of internal unsubscribe in case  some custom vehicle data was removed by policies.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
