### PR TITLE
Fix SDL does not set the app to NONE HMI level after a rejecting of StartService

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1138,11 +1138,11 @@ class ApplicationManagerImpl
 
  private:
   /**
-   * @brief Stop services that failed to start
-   * @param app Application whose service should be stopped
-   * @param Service type that should be stopped
+   * @brief Removes service status record for service that failed to start
+   * @param app Application whose service status record should be removed
+   * @param Service type which status record should be removed
    */
-  bool StopServicesForApp(
+  bool HandleRejectedServiceStatus(
       ApplicationSharedPtr app,
       const hmi_apis::Common_ServiceType::eType service_type);
   /**

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1138,6 +1138,14 @@ class ApplicationManagerImpl
 
  private:
   /**
+   * @brief Stop services that failed to start
+   * @param app Application whose service should be stopped
+   * @param Service type that should be stopped
+   */
+  bool StopServicesForApp(
+      ApplicationSharedPtr app,
+      const hmi_apis::Common_ServiceType::eType service_type);
+  /**
    * @brief PullLanguagesInfo allows to pull information about languages.
    *
    * @param app_data entry to parse

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2070,7 +2070,7 @@ void ApplicationManagerImpl::ProcessServiceStatusUpdate(
   rpc_service_->ManageHMICommand(notification);
 
   if (hmi_apis::Common_ServiceEvent::REQUEST_REJECTED == service_event &&
-      StopServicesForApp(app, service_type)) {
+      HandleRejectedServiceStatus(app, service_type)) {
     state_ctrl_.SetRegularState(app,
                                 mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
                                 mobile_apis::HMILevel::HMI_NONE,
@@ -2078,7 +2078,7 @@ void ApplicationManagerImpl::ProcessServiceStatusUpdate(
   }
 }
 
-bool ApplicationManagerImpl::StopServicesForApp(
+bool ApplicationManagerImpl::HandleRejectedServiceStatus(
     ApplicationSharedPtr app,
     const hmi_apis::Common_ServiceType::eType service_type) {
   LOG4CXX_AUTO_TRACE(logger_);


### PR DESCRIPTION
Fixes #3073

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
There is the issue when SDL tries to start streaming service (VIDEO or AUDIO) and receives a rejected request from HMI (e.g. GetSystemTime(INVALID_TIME)). In this case, SDL should send to mobile device OnHMIStatus("NONE") notification and send CloseApplication request to HMI.
In the current implementation in the case when SDL receives a rejected request, it sends just OnServiceUpdate notification to HMI with reject reason.
This PR provides changes for ApplicationManagerImpl, In that case SDL removes records about service status and sends to mobile device OnHMIStatus("NONE") notification and sends CloseApplication request to HMI.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
