### PR TITLE
Set alert duration to 0 if softbuttons exist

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_request.cc
@@ -352,6 +352,10 @@ void AlertRequest::SendAlertRequest(int32_t app_id) {
         (*message_)[strings::msg_params][strings::soft_buttons];
     MessageHelper::SubscribeApplicationToSoftButton(
         (*message_)[strings::msg_params], app, function_id());
+    msg_params[strings::duration] = 0;
+  } else {
+    msg_params[strings::duration] =
+        (*message_)[strings::msg_params][strings::duration].asUInt();
   }
 
   if ((*message_)[strings::msg_params].keyExists(strings::alert_icon)) {
@@ -372,8 +376,6 @@ void AlertRequest::SendAlertRequest(int32_t app_id) {
 
   // app_id
   msg_params[strings::app_id] = app_id;
-  msg_params[strings::duration] =
-      (*message_)[strings::msg_params][strings::duration].asUInt();
 
   // NAVI platform progressIndicator
   if ((*message_)[strings::msg_params].keyExists(strings::progress_indicator)) {


### PR DESCRIPTION
Fixes #3088 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Send alert with softbuttons. Ensure that the HMI receives an alert request with a duration field of 0.

### Summary
In the alert request body, duration should be set to 0 if softbuttons exist before sending the message to the HMI.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
