### PR TITLE
Fix sending of OnServiceUpdate on service NACK

### DIFF
--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1816,8 +1816,15 @@ void ProtocolHandlerImpl::NotifySessionStarted(
     LOG4CXX_WARN(logger_,
                  "Refused by session_observer to create service "
                      << static_cast<int32_t>(service_type) << " type.");
+    const auto session_id = packet->session_id();
+    const auto connection_key =
+        session_observer_.KeyFromPair(context.connection_id_, session_id);
+    service_status_update_handler_->OnServiceUpdate(
+        connection_key,
+        context.service_type_,
+        ServiceStatus::SERVICE_START_FAILED);
     SendStartSessionNAck(context.connection_id_,
-                         packet->session_id(),
+                         session_id,
                          protocol_version,
                          packet->service_type(),
                          rejected_params);


### PR DESCRIPTION
Fixes #3093 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test scripts

### Summary
There was found one corner case when SDL does not change the internal status when service
start was refused due to current HMI level of application. Was added missing check to set status properly and send expected notification.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
