### PR TITLE
Fix app service extension resumption data processing

### DIFF
--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/get_app_service_data_request.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/get_app_service_data_request.h
@@ -67,6 +67,11 @@ class GetAppServiceDataRequest : public app_mngr::commands::CommandRequestImpl {
    **/
   virtual void Run();
 
+  /*
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() FINAL;
+
   /**
    * @brief Interface method that is called whenever new event received
    *

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/get_app_service_data_request.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/get_app_service_data_request.h
@@ -67,9 +67,9 @@ class GetAppServiceDataRequest : public app_mngr::commands::CommandRequestImpl {
    **/
   virtual void Run();
 
-  /*
+  /**
    * @brief Init sets hash update mode for request
-   */
+   **/
   bool Init() FINAL;
 
   /**

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_app_extension.cc
@@ -103,7 +103,8 @@ void AppServiceAppExtension::ProcessResumption(
     const smart_objects::SmartObject& subscriptions_app_services =
         resumption_data[app_service_info];
     for (size_t i = 0; i < subscriptions_app_services.length(); ++i) {
-      std::string service_type = resumption_data[i].asString();
+      std::string service_type =
+          resumption_data[app_service_info][i].asString();
       SubscribeToAppService(service_type);
     }
   }

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_app_extension.cc
@@ -103,8 +103,7 @@ void AppServiceAppExtension::ProcessResumption(
     const smart_objects::SmartObject& subscriptions_app_services =
         resumption_data[app_service_info];
     for (size_t i = 0; i < subscriptions_app_services.length(); ++i) {
-      std::string service_type =
-          resumption_data[app_service_info][i].asString();
+      std::string service_type = subscriptions_app_services[i].asString();
       SubscribeToAppService(service_type);
     }
   }

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/get_app_service_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/get_app_service_data_request.cc
@@ -65,6 +65,11 @@ void GetAppServiceDataRequest::Run() {
                       true);
 }
 
+bool GetAppServiceDataRequest::Init() {
+  hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
+  return true;
+}
+
 void GetAppServiceDataRequest::HandleSubscribe() {
   std::string service_type =
       (*message_)[strings::msg_params][strings::service_type].asString();

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/CMakeLists.txt
@@ -30,3 +30,5 @@ set(LIBRARIES
 )
 
 create_cotired_test("app_services_commands_test" "${SOURCES}" "${LIBRARIES}" )
+
+add_subdirectory("app_service_plugin")

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/CMakeLists.txt
@@ -1,0 +1,25 @@
+include(${CMAKE_SOURCE_DIR}/tools/cmake/helpers/sources.cmake)
+
+
+set(APP_SERVICE_DIR "${COMPONENTS_DIR}/application_manager/rpc_plugins/app_service_rpc_plugin")
+set(APP_SERVICE_SRC_DIR "${APP_SERVICE_DIR}/src")
+set(APP_SERVICE_INCLUDE_DIR "${APP_SERVICE_DIR}/include/app_service_rpc_plugin")
+set(APP_SERVICE_TEST_DIR "${APP_SERVICE_DIR}/test")
+
+include_directories(
+  ${GMOCK_INCLUDE_DIRECTORY}
+  ${APP_SERVICE_INCLUDE_DIR}
+) 
+
+set(SOURCES ${APP_SERVICE_TEST_DIR}/app_service_plugin/app_service_app_extension_test.cc
+            ${APP_SERVICE_SRC_DIR}/app_service_rpc_plugin.cc
+            ${COMPONENTS_DIR}/application_manager/test/mock_message_helper.cc
+)
+
+set(LIBRARIES
+  gmock
+  sdl_rpc_plugin_static
+  app_service_rpc_plugin_static
+)
+
+create_test("app_service_plugin_test" "${SOURCES}" "${LIBRARIES}" )

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/CMakeLists.txt
@@ -42,7 +42,6 @@ include_directories(
 ) 
 
 set(SOURCES ${APP_SERVICE_TEST_DIR}/app_service_plugin/app_service_app_extension_test.cc
-            ${APP_SERVICE_SRC_DIR}/app_service_rpc_plugin.cc
             ${COMPONENTS_DIR}/application_manager/test/mock_message_helper.cc
 )
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/CMakeLists.txt
@@ -1,3 +1,33 @@
+# Copyright (c) 2019, Ford Motor Company, Livio
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the
+# distribution.
+#
+# Neither the name of the copyright holders nor the names of their contributors
+# may be used to endorse or promote products derived from this software
+# without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 include(${CMAKE_SOURCE_DIR}/tools/cmake/helpers/sources.cmake)
 
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/app_service_app_extension_test.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/app_service_app_extension_test.cc
@@ -146,7 +146,9 @@ TEST_F(AppServiceAppExtensionTest,
 
 TEST_F(AppServiceAppExtensionTest,
        UnsubscribeFromAppService_UnsubscribeAll_SUCCESS) {
-  for (const auto& app_service_type : {kAppServiceType1, kAppServiceType2}) {
+  auto app_service_types = {kAppServiceType1, kAppServiceType2};
+
+  for (const auto& app_service_type : app_service_types) {
     ASSERT_TRUE(
         app_service_app_extension_->SubscribeToAppService(app_service_type));
     ASSERT_TRUE(
@@ -156,7 +158,7 @@ TEST_F(AppServiceAppExtensionTest,
 
   app_service_app_extension_->UnsubscribeFromAppService();
 
-  for (const auto& app_service_type : {kAppServiceType1, kAppServiceType2}) {
+  for (const auto& app_service_type : app_service_types) {
     EXPECT_FALSE(
         app_service_app_extension_->IsSubscribedToAppService(app_service_type));
   }
@@ -185,13 +187,15 @@ TEST_F(AppServiceAppExtensionTest, ProcessResumption_SUCCESS) {
   app_service_app_extension_->UnsubscribeFromAppService();
   ASSERT_EQ(0u, app_service_app_extension_->Subscriptions().size());
 
-  smart_objects::SmartObject resumption_data;
-  resumption_data[kAppServiceInfoKey] =
+  smart_objects::SmartObject app_service_data =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
-  resumption_data[kAppServiceInfoKey].asArray()->push_back(
+  app_service_data.asArray()->push_back(
       smart_objects::SmartObject(kAppServiceType1));
-  resumption_data[kAppServiceInfoKey].asArray()->push_back(
+  app_service_data.asArray()->push_back(
       smart_objects::SmartObject(kAppServiceType2));
+
+  smart_objects::SmartObject resumption_data;
+  resumption_data[kAppServiceInfoKey] = app_service_data;
 
   app_service_app_extension_->ProcessResumption(resumption_data);
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/app_service_app_extension_test.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/app_service_app_extension_test.cc
@@ -64,12 +64,12 @@ class AppServiceAppExtensionTest : public ::testing::Test {
  public:
   AppServiceAppExtensionTest() : mock_app_(new NiceMock<MockApplication>()) {}
 
-  void SetUp() {
+  void SetUp() OVERRIDE {
     app_service_app_extension_.reset(
         new AppServiceAppExtension(app_service_plugin_, *mock_app_));
   }
 
-  void TearDown() {
+  void TearDown() OVERRIDE {
     app_service_app_extension_.reset();
   }
 
@@ -204,8 +204,6 @@ TEST_F(AppServiceAppExtensionTest, ProcessResumption_SUCCESS) {
         app_service_app_extension_->IsSubscribedToAppService(app_service_type));
   }
   EXPECT_EQ(2u, app_service_app_extension_->Subscriptions().size());
-  EXPECT_EQ(kAppServiceType1,
-            *app_service_app_extension_->Subscriptions().begin());
 }
 
 }  // namespace app_service_plugin_test

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/app_service_app_extension_test.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/app_service_app_extension_test.cc
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2019, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "app_service_rpc_plugin/app_service_app_extension.h"
+#include <memory>
+#include "app_service_rpc_plugin/app_service_rpc_plugin.h"
+#include "application_manager/mock_application.h"
+#include "gtest/gtest.h"
+
+namespace {
+const std::string kAppServiceType1 = "AppServiceType1";
+const std::string kAppServiceType2 = "AppServiceType2";
+const std::string kResumptionDataKey = "kResumptionDataKey";
+const std::string kAppServiceInfoKey = "appService";
+}  // namespace
+
+namespace app_service_plugin_test {
+
+using test::components::application_manager_test::MockApplication;
+using ::testing::_;
+using ::testing::Mock;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::ReturnNull;
+using ::testing::ReturnRef;
+using ::testing::SaveArg;
+
+using namespace app_service_rpc_plugin;
+namespace strings = application_manager::strings;
+namespace plugins = application_manager::plugin_manager;
+
+class AppServiceAppExtensionTest : public ::testing::Test {
+ public:
+  AppServiceAppExtensionTest()
+      : mock_app_(std::make_shared<NiceMock<MockApplication> >())
+      , app_service_app_extension_(
+            std::make_shared<app_service_rpc_plugin::AppServiceAppExtension>(
+                app_service_plugin_, *mock_app_)) {
+    ON_CALL(*mock_app_, AddExtension(_)).WillByDefault(Return(true));
+    ON_CALL(*mock_app_, QueryInterface(_))
+        .WillByDefault(Return(app_service_app_extension_));
+  }
+
+ protected:
+  app_service_rpc_plugin::AppServiceRpcPlugin app_service_plugin_;
+  std::shared_ptr<MockApplication> mock_app_;
+  std::shared_ptr<AppServiceAppExtension> app_service_app_extension_;
+};
+
+TEST_F(AppServiceAppExtensionTest, SubscribeToAppService_SUCCESS) {
+  auto app_service_app_extension =
+      std::make_shared<AppServiceAppExtension>(app_service_plugin_, *mock_app_);
+  EXPECT_TRUE(
+      app_service_app_extension->SubscribeToAppService(kAppServiceType1));
+  const auto& subs = app_service_app_extension->Subscriptions();
+  EXPECT_EQ(1u, subs.size());
+  EXPECT_TRUE(
+      app_service_app_extension->IsSubscribedToAppService(kAppServiceType1));
+}
+
+TEST_F(AppServiceAppExtensionTest,
+       SubscribeToAppService_SubscribeOneAppServiceType_Twice_FAIL) {
+  auto app_service_app_extension =
+      std::make_shared<AppServiceAppExtension>(app_service_plugin_, *mock_app_);
+  ASSERT_TRUE(
+      app_service_app_extension->SubscribeToAppService(kAppServiceType1));
+  ASSERT_TRUE(
+      app_service_app_extension->IsSubscribedToAppService(kAppServiceType1));
+
+  EXPECT_FALSE(
+      app_service_app_extension->SubscribeToAppService(kAppServiceType1));
+  EXPECT_TRUE(
+      app_service_app_extension->IsSubscribedToAppService(kAppServiceType1));
+  const auto& subs = app_service_app_extension->Subscriptions();
+  EXPECT_EQ(1u, subs.size());
+}
+
+TEST_F(
+    AppServiceAppExtensionTest,
+    UnsubscribeFromAppService_AppServiceType1Unsubscribed_AppServiceType2Remains_SUCCESS) {
+  auto app_service_app_extension =
+      std::make_shared<AppServiceAppExtension>(app_service_plugin_, *mock_app_);
+  // Subscribe
+  ASSERT_TRUE(
+      app_service_app_extension->SubscribeToAppService(kAppServiceType1));
+  ASSERT_TRUE(
+      app_service_app_extension->SubscribeToAppService(kAppServiceType2));
+  auto subs = app_service_app_extension->Subscriptions();
+  ASSERT_EQ(2u, subs.size());
+  ASSERT_TRUE(
+      app_service_app_extension->IsSubscribedToAppService(kAppServiceType1));
+  ASSERT_TRUE(
+      app_service_app_extension->IsSubscribedToAppService(kAppServiceType2));
+
+  // Unsubscribe
+  EXPECT_TRUE(
+      app_service_app_extension->UnsubscribeFromAppService(kAppServiceType1));
+  EXPECT_FALSE(
+      app_service_app_extension->IsSubscribedToAppService(kAppServiceType1));
+  EXPECT_TRUE(
+      app_service_app_extension->IsSubscribedToAppService(kAppServiceType2));
+  subs = app_service_app_extension->Subscriptions();
+  EXPECT_EQ(1u, subs.size());
+}
+
+TEST_F(AppServiceAppExtensionTest,
+       UnsubscribeFromAppService_UnsubscribeNotSubscribedAppServiceType_FAIL) {
+  auto app_service_app_extension =
+      std::make_shared<AppServiceAppExtension>(app_service_plugin_, *mock_app_);
+
+  ASSERT_TRUE(
+      app_service_app_extension->SubscribeToAppService(kAppServiceType1));
+  ASSERT_EQ(1u, app_service_app_extension->Subscriptions().size());
+  ASSERT_TRUE(
+      app_service_app_extension->IsSubscribedToAppService(kAppServiceType1));
+
+  EXPECT_FALSE(
+      app_service_app_extension->UnsubscribeFromAppService(kAppServiceType2));
+  EXPECT_TRUE(
+      app_service_app_extension->IsSubscribedToAppService(kAppServiceType1));
+  EXPECT_EQ(1u, app_service_app_extension->Subscriptions().size());
+}
+
+TEST_F(AppServiceAppExtensionTest,
+       UnsubscribeFromAppService_UnsubscribeAll_SUCCESS) {
+  auto app_service_app_extension =
+      std::make_shared<AppServiceAppExtension>(app_service_plugin_, *mock_app_);
+
+  for (const auto& app_service_type : {kAppServiceType1, kAppServiceType2}) {
+    ASSERT_TRUE(
+        app_service_app_extension->SubscribeToAppService(app_service_type));
+    ASSERT_TRUE(
+        app_service_app_extension->IsSubscribedToAppService(app_service_type));
+  }
+  ASSERT_EQ(2u, app_service_app_extension->Subscriptions().size());
+
+  app_service_app_extension->UnsubscribeFromAppService();
+
+  for (const auto& app_service_type : {kAppServiceType1, kAppServiceType2}) {
+    EXPECT_FALSE(
+        app_service_app_extension->IsSubscribedToAppService(app_service_type));
+  }
+  EXPECT_EQ(0u, app_service_app_extension->Subscriptions().size());
+}
+
+TEST_F(AppServiceAppExtensionTest, SaveResumptionData_SUCCESS) {
+  auto app_service_app_extension =
+      std::make_shared<AppServiceAppExtension>(app_service_plugin_, *mock_app_);
+
+  ASSERT_TRUE(
+      app_service_app_extension->SubscribeToAppService(kAppServiceType1));
+  ASSERT_EQ(1u, app_service_app_extension->Subscriptions().size());
+  ASSERT_TRUE(
+      app_service_app_extension->IsSubscribedToAppService(kAppServiceType1));
+
+  smart_objects::SmartObject resumption_data;
+  resumption_data[kResumptionDataKey] = "some resumption data";
+
+  app_service_app_extension->SaveResumptionData(resumption_data);
+
+  EXPECT_TRUE(resumption_data.keyExists(kResumptionDataKey));
+  EXPECT_TRUE(resumption_data.keyExists(kAppServiceInfoKey));
+  EXPECT_EQ(kAppServiceType1,
+            resumption_data[kAppServiceInfoKey][0].asString());
+}
+
+TEST_F(AppServiceAppExtensionTest, ProcessResumption_SUCCESS) {
+  auto app_service_app_extension =
+      std::make_shared<AppServiceAppExtension>(app_service_plugin_, *mock_app_);
+  app_service_app_extension->UnsubscribeFromAppService();
+  ASSERT_EQ(0u, app_service_app_extension->Subscriptions().size());
+
+  smart_objects::SmartObject resumption_data;
+  resumption_data[kAppServiceInfoKey] =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+  resumption_data[kAppServiceInfoKey].asArray()->push_back(
+      smart_objects::SmartObject(kAppServiceType1));
+  resumption_data[kAppServiceInfoKey].asArray()->push_back(
+      smart_objects::SmartObject(kAppServiceType2));
+
+  app_service_app_extension->ProcessResumption(resumption_data);
+
+  for (const auto& app_service_type : {kAppServiceType1, kAppServiceType2}) {
+    EXPECT_TRUE(
+        app_service_app_extension->IsSubscribedToAppService(app_service_type));
+  }
+  EXPECT_EQ(2u, app_service_app_extension->Subscriptions().size());
+  EXPECT_EQ(kAppServiceType1,
+            *app_service_app_extension->Subscriptions().begin());
+}
+}  // namespace app_service_plugin_test

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/app_service_app_extension_test.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/app_service_app_extension_test.cc
@@ -64,6 +64,7 @@ class AppServiceAppExtensionTest : public ::testing::Test {
  public:
   AppServiceAppExtensionTest() : mock_app_(new NiceMock<MockApplication>()) {}
 
+ protected:
   void SetUp() OVERRIDE {
     app_service_app_extension_.reset(
         new AppServiceAppExtension(app_service_plugin_, *mock_app_));
@@ -73,7 +74,6 @@ class AppServiceAppExtensionTest : public ::testing::Test {
     app_service_app_extension_.reset();
   }
 
- protected:
   app_service_rpc_plugin::AppServiceRpcPlugin app_service_plugin_;
   std::unique_ptr<MockApplication> mock_app_;
   std::unique_ptr<AppServiceAppExtension> app_service_app_extension_;


### PR DESCRIPTION
Fixes #3096 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF Regression testing + UT

### Summary
In case of resumption app services subscription data for particular application lost every time due to incorrect behaviour of AppServiceAppExtension::ProcessResumption method logic.
With fix resumption data is treated correctly.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
