### PR TITLE
Fix custom VD key translation for struct arrays

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/custom_vehicle_data_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/custom_vehicle_data_manager_impl.cc
@@ -112,7 +112,8 @@ void CustomVehicleDataManagerImpl::CreateMobileMessageParams(
       const auto& item_name = schema->name;
       if (policy_table::VehicleDataItem::kStruct == std::string(schema->type)) {
         auto& input_param = input_params[key];
-        if (*schema->array) {
+        if (*schema->array &&
+            input_param.getType() == smart_objects::SmartType_Array) {
           for (size_t i = 0; i < input_param.length(); i++) {
             const auto param =
                 fill_mobile_msg(input_param[i], SearchMethod::RECURSIVE);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/custom_vehicle_data_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/custom_vehicle_data_manager_impl.cc
@@ -111,11 +111,21 @@ void CustomVehicleDataManagerImpl::CreateMobileMessageParams(
 
       const auto& item_name = schema->name;
       if (policy_table::VehicleDataItem::kStruct == std::string(schema->type)) {
-        const auto param =
-            fill_mobile_msg(input_params[key], SearchMethod::RECURSIVE);
-        if (!param.empty()) {
-          out_params[item_name] = param;
+        auto& input_param = input_params[key];
+        if (*schema->array) {
+          for (size_t i = 0; i < input_param.length(); i++) {
+            const auto param =
+                fill_mobile_msg(input_param[i], SearchMethod::RECURSIVE);
+            out_params[item_name][i] = param;
+          }
           continue;
+        } else {
+          const auto param =
+              fill_mobile_msg(input_param, SearchMethod::RECURSIVE);
+          if (!param.empty()) {
+            out_params[item_name] = param;
+            continue;
+          }
         }
       }
 


### PR DESCRIPTION

Fixes issue with #2840 
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run Generic Network Network Signal data ATF tests

### Summary
Custom VD items were not translated properly if they were defined as an array of structs, this PR fixes that.

### Changelog
##### Bug Fixes
* Properly handle struct arrays in custom vehicle data manager

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
