### PR TITLE
Fix SDL crash during application registration

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1136,7 +1136,18 @@ class ApplicationManagerImpl
    */
   protocol_handler::MajorProtocolVersion SupportedSDLVersion() const OVERRIDE;
 
+  void ApplyFunctorForEachPlugin(
+      std::function<void(plugin_manager::RPCPlugin&)> functor) OVERRIDE;
+
  private:
+  /**
+   * @brief Adds application to registered applications list and marks it as
+   * registered
+   * @param application Application that should be added to registered
+   * applications list.
+   */
+  void AddAppToRegisteredAppList(const ApplicationSharedPtr application);
+
   /**
    * @brief Removes service status record for service that failed to start
    * @param app Application whose service status record should be removed

--- a/src/components/application_manager/include/application_manager/plugin_manager/rpc_plugin.h
+++ b/src/components/application_manager/include/application_manager/plugin_manager/rpc_plugin.h
@@ -65,7 +65,8 @@ enum ApplicationEvent {
   kApplicationRegistered,
   kApplicationUnregistered,
   kDeleteApplicationData,
-  kGlobalPropertiesUpdated
+  kGlobalPropertiesUpdated,
+  kRCStatusChanged
 };
 
 class RPCPlugin {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_helpers.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_helpers.cc
@@ -175,6 +175,7 @@ const std::vector<std::string> RCHelpers::GetModuleTypesList() {
 
 RCAppExtensionPtr RCHelpers::GetRCExtension(
     application_manager::Application& app) {
+  LOG4CXX_AUTO_TRACE(logger_);
   auto extension_interface = app.QueryInterface(RCRPCPlugin::kRCPluginID);
   auto extension =
       std::static_pointer_cast<RCAppExtension>(extension_interface);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -107,7 +107,12 @@ void RCRPCPlugin::OnPolicyEvent(
 void RCRPCPlugin::OnApplicationEvent(
     application_manager::plugin_manager::ApplicationEvent event,
     application_manager::ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
   if (!application->is_remote_control_supported()) {
+    LOG4CXX_DEBUG(
+        logger_,
+        "Remote control is not supported for application with app_id: "
+            << application->app_id());
     return;
   }
   switch (event) {
@@ -119,8 +124,6 @@ void RCRPCPlugin::OnApplicationEvent(
           rc_capabilities_manager_
               ->GetDriverLocationFromSeatLocationCapability();
       extension->SetUserLocation(driver_location);
-      resource_allocation_manager_->SendOnRCStatusNotifications(
-          NotificationTrigger::APP_REGISTRATION, application);
       break;
     }
     case plugins::kApplicationExit: {
@@ -137,6 +140,11 @@ void RCRPCPlugin::OnApplicationEvent(
       const auto user_location = application->get_user_location();
       auto extension = RCHelpers::GetRCExtension(*application);
       extension->SetUserLocation(user_location);
+      break;
+    }
+    case plugins::kRCStatusChanged: {
+      resource_allocation_manager_->SendOnRCStatusNotifications(
+          NotificationTrigger::APP_REGISTRATION, application);
       break;
     }
     default:

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
@@ -156,6 +156,7 @@ bool ResourceAllocationManagerImpl::IsUserLocationValid(
     ModuleUid& module, application_manager::ApplicationSharedPtr app) {
   LOG4CXX_AUTO_TRACE(logger_);
   const auto extension = RCHelpers::GetRCExtension(*app);
+  DCHECK_OR_RETURN(extension, false);
   const auto user_location = extension->GetUserLocation();
   const auto module_service_area =
       rc_capabilities_manager_.GetModuleServiceArea(module);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -98,6 +98,7 @@ void VehicleInfoPlugin::OnApplicationEvent(
 }
 
 void VehicleInfoPlugin::UnsubscribeFromRemovedVDItems() {
+  LOG4CXX_AUTO_TRACE(logger_);
   typedef std::vector<std::string> StringsVector;
 
   auto get_items_to_unsubscribe = [this]() -> StringsVector {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -434,12 +434,6 @@ void ApplicationManagerImpl::OnApplicationRegistered(ApplicationSharedPtr app) {
   sync_primitives::AutoLock lock(applications_list_lock_ptr_);
   const mobile_apis::HMILevel::eType default_level = GetDefaultHmiLevel(app);
   state_ctrl_.OnApplicationRegistered(app, default_level);
-
-  std::function<void(plugin_manager::RPCPlugin&)> on_app_registered =
-      [app](plugin_manager::RPCPlugin& plugin) {
-        plugin.OnApplicationEvent(plugin_manager::kApplicationRegistered, app);
-      };
-  plugin_manager_->ForEachPlugin(on_app_registered);
 }
 
 void ApplicationManagerImpl::OnApplicationSwitched(ApplicationSharedPtr app) {
@@ -729,14 +723,7 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
   // Timer will be started after hmi level resumption.
   resume_controller().OnAppRegistrationStart(policy_app_id, device_mac);
 
-  // Add application to registered app list and set appropriate mark.
-  // Lock has to be released before adding app to policy DB to avoid possible
-  // deadlock with simultaneous PTU processing
-  applications_list_lock_ptr_->Acquire();
-  application->MarkRegistered();
-  applications_.insert(application);
-  apps_size_ = applications_.size();
-  applications_list_lock_ptr_->Release();
+  AddAppToRegisteredAppList(application);
 
   // Update cloud app information, in case any pending apps are unable to be
   // registered due to a mobile app taking precedence
@@ -4174,6 +4161,28 @@ ApplicationManagerImpl::SupportedSDLVersion() const {
   LOG4CXX_AUTO_TRACE(logger_);
   return static_cast<protocol_handler::MajorProtocolVersion>(
       get_settings().max_supported_protocol_version());
+}
+
+void ApplicationManagerImpl::AddAppToRegisteredAppList(
+    const ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  DCHECK_OR_RETURN_VOID(application);
+  sync_primitives::AutoLock lock(applications_list_lock_ptr_);
+
+  // Add application to registered app list and set appropriate mark.
+  application->MarkRegistered();
+  applications_.insert(application);
+  LOG4CXX_DEBUG(
+      logger_,
+      "App with app_id: " << application->app_id()
+                          << " has been added to registered applications list");
+  apps_size_ = static_cast<uint32_t>(applications_.size());
+}
+
+void ApplicationManagerImpl::ApplyFunctorForEachPlugin(
+    std::function<void(plugin_manager::RPCPlugin&)> functor) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  plugin_manager_->ForEachPlugin(functor);
 }
 
 event_engine::EventDispatcher& ApplicationManagerImpl::event_dispatcher() {

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -90,6 +90,7 @@ using ::testing::SaveArg;
 using ::testing::SetArgPointee;
 using ::testing::SetArgReferee;
 
+using application_manager::plugin_manager::MockRPCPluginManager;
 using test::components::application_manager_test::MockStateController;
 using test::components::policy_test::MockPolicyHandlerInterface;
 
@@ -1607,6 +1608,9 @@ TEST_F(ApplicationManagerImplTest,
   smart_objects::SmartObjectSPtr request_for_registration_ptr =
       std::make_shared<smart_objects::SmartObject>(request_for_registration);
 
+  std::unique_ptr<plugin_manager::RPCPluginManager> rpc_plugin_manager(
+      new MockRPCPluginManager());
+  app_manager_impl_->SetPluginManager(rpc_plugin_manager);
   ApplicationSharedPtr application =
       app_manager_impl_->RegisterApplication(request_for_registration_ptr);
   EXPECT_STREQ(kAppName.c_str(), application->name().c_str());
@@ -1774,6 +1778,9 @@ TEST_F(ApplicationManagerImplTest,
   smart_objects::SmartObjectSPtr request_for_registration_ptr =
       std::make_shared<smart_objects::SmartObject>(request_for_registration);
 
+  std::unique_ptr<plugin_manager::RPCPluginManager> rpc_plugin_manager(
+      new MockRPCPluginManager());
+  app_manager_impl_->SetPluginManager(rpc_plugin_manager);
   ApplicationSharedPtr application =
       app_manager_impl_->RegisterApplication(request_for_registration_ptr);
 

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -664,6 +664,13 @@ class ApplicationManager {
   virtual protocol_handler::MajorProtocolVersion SupportedSDLVersion()
       const = 0;
 
+  /**
+   * @brief Applies functor for each plugin
+   * @param functor Functor that will be applied to each plugin
+   */
+  virtual void ApplyFunctorForEachPlugin(
+      std::function<void(plugin_manager::RPCPlugin&)> functor) = 0;
+
   /*
    * @brief Converts connection string transport type representation
    * to HMI Common_TransportType

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -269,6 +269,10 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD0(SupportedSDLVersion,
                      protocol_handler::MajorProtocolVersion());
   MOCK_METHOD1(
+      ApplyFunctorForEachPlugin,
+      void(std::function<void(application_manager::plugin_manager::RPCPlugin&)>
+               functor));
+  MOCK_METHOD1(
       GetDeviceTransportType,
       hmi_apis::Common_TransportType::eType(const std::string& transport_type));
   MOCK_METHOD1(AddAppToTTSGlobalPropertiesList, void(const uint32_t app_id));


### PR DESCRIPTION
Fixes #3108 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
There is an issue when SDL crashes during registration second application in the time when already exists a registered other one application.

In the current implementation ApplicationManager during application registering by the `ApplicationManager::RegisterApplication` method creates a new instance of the application and adds it to the collection of all registered applications. This method calls in the  RegisterAppInterfaceRequest, but all needed extensions will be added only by the `ApplicationManager::OnApplicationRegistered` method during sending RegisterAppInterface Response to the mobile.

According to the described behavior could appear case when a first application is registered successfully and all needed application extensions are successfully added too. The second application starts the registration process in someone thread, but in the other one thread, SDL receives `PolicyEvent::kApplicationPolicyUpdated` event and tries to unsubscribe all applications from removed in policy table Vehicle Data Items. All actions go on in the next sequence:

**Precondition:**
The first application is successfully registered and all needed extensions are added.

**The first thread:**
1. The Mobile device sends RegisterAppInterfaceRequest RPC to the SDL for registration of the second application.
2. SDL receives the RegisterAppInterfaceRequest and calls method Run.
3. Within method RegisterAppInterfaceRequest::Run ApplicationManager runs the method `RegisterApplication`.

**The second thread:**
4. The SDL receives the `PolicyEvent::kApplicationPolicyUpdated` event and forwards the event to each plugin for processing it.
5. `VehicleInfoPlugin` tries to unsubscribe all registered applications from removed in policy table Vehicle Data Items. 
- The plugin finds the first application and unsubscribes it from all removed Vehicle Data Items. 
- The plugin finds the second application and doesn't find any extensions for the application and crashes on the DCHECK with an uninitialized pointer to the extension.

### Changelog
**RPC plugin:**
- Add the new Application event  (`ApplicationEvent::kRCStatusChanged`). The event uses to inform `RcRPCPlugin` that `OnRcStatus` notification should be sent.

**RC RPC plugin:**
- Split adding `RCExtension` to an application and sending `OnRCStatus` notification to the separate actions.

**ApplicatioManager:**
- Split adding all extensions to an application and sending OnRCStatus notification to separate actions (via applying to each plugin the new application event;
- Add the new method for applying someone functor to each plugin. The new method uses for applying the `ApplicationEvent::kRCStatusChanged` event to RCRPCPlugin

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
