### PR TITLE
Fix undefined behavior after changing HMICapabilities smart object field

### DIFF
--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -219,7 +219,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return Currently supported display capabilities
    */
-  const smart_objects::SmartObject* display_capabilities() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr display_capabilities() const OVERRIDE;
 
   /*
    * @brief Sets supported display capabilities
@@ -248,7 +248,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return Currently supported HMI zone capabilities
    */
-  const smart_objects::SmartObject* hmi_zone_capabilities() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr hmi_zone_capabilities() const OVERRIDE;
 
   /*
    * @brief Sets supported HMI zone capabilities
@@ -263,7 +263,8 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return Currently supported SoftButton's capabilities
    */
-  const smart_objects::SmartObject* soft_button_capabilities() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr soft_button_capabilities()
+      const OVERRIDE;
 
   /*
    * @brief Sets supported SoftButton's capabilities
@@ -278,7 +279,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return Currently supported Button's capabilities
    */
-  const smart_objects::SmartObject* button_capabilities() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr button_capabilities() const OVERRIDE;
 
   /*
    * @brief Sets supported Button's capabilities
@@ -301,7 +302,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return Currently supported speech capabilities
    */
-  const smart_objects::SmartObject* speech_capabilities() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr speech_capabilities() const OVERRIDE;
 
   /*
    * @brief Sets supported VR capabilities
@@ -316,7 +317,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return Currently supported VR capabilities
    */
-  const smart_objects::SmartObject* vr_capabilities() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr vr_capabilities() const OVERRIDE;
 
   /*
    * @brief Sets supported audio_pass_thru capabilities
@@ -331,7 +332,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return Currently supported audio_pass_thru capabilities
    */
-  const smart_objects::SmartObject* audio_pass_thru_capabilities()
+  const smart_objects::SmartObjectSPtr audio_pass_thru_capabilities()
       const OVERRIDE;
 
   /*
@@ -347,14 +348,15 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return Currently supported pcm_streaming capabilities
    */
-  const smart_objects::SmartObject* pcm_stream_capabilities() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr pcm_stream_capabilities() const OVERRIDE;
 
   /*
    * @brief Retrieves information about the preset bank capabilities
    *
    * @return Currently supported preset bank capabilities
    */
-  const smart_objects::SmartObject* preset_bank_capabilities() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr preset_bank_capabilities()
+      const OVERRIDE;
 
   /*
    * @brief Sets supported preset bank capabilities
@@ -377,14 +379,14 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @param vehicle_type Cuurent vehicle information
    */
-  const smart_objects::SmartObject* vehicle_type() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr vehicle_type() const OVERRIDE;
 
   /*
    * @brief Retrieves information about the prerecorded speech
    *
    * @return Currently supported prerecorded speech
    */
-  const smart_objects::SmartObject* prerecorded_speech() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr prerecorded_speech() const OVERRIDE;
 
   /*
    * @brief Sets supported prerecorded speech
@@ -585,7 +587,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
   hmi_apis::Common_Language::eType ui_language_;
   hmi_apis::Common_Language::eType vr_language_;
   hmi_apis::Common_Language::eType tts_language_;
-  smart_objects::SmartObject* vehicle_type_;
+  smart_objects::SmartObjectSPtr vehicle_type_;
   smart_objects::SmartObject* ui_supported_languages_;
   smart_objects::SmartObject* tts_supported_languages_;
   smart_objects::SmartObject* vr_supported_languages_;
@@ -594,17 +596,17 @@ class HMICapabilitiesImpl : public HMICapabilities {
    * system_display_capabilities_. For backward compatibility
    * display_capabilities_ is not removed.
    */
-  smart_objects::SmartObject* display_capabilities_;
+  smart_objects::SmartObjectSPtr display_capabilities_;
   smart_objects::SmartObjectSPtr system_display_capabilities_;
-  smart_objects::SmartObject* hmi_zone_capabilities_;
-  smart_objects::SmartObject* soft_buttons_capabilities_;
-  smart_objects::SmartObject* button_capabilities_;
-  smart_objects::SmartObject* preset_bank_capabilities_;
-  smart_objects::SmartObject* vr_capabilities_;
-  smart_objects::SmartObject* speech_capabilities_;
-  smart_objects::SmartObject* audio_pass_thru_capabilities_;
-  smart_objects::SmartObject* pcm_stream_capabilities_;
-  smart_objects::SmartObject* prerecorded_speech_;
+  smart_objects::SmartObjectSPtr hmi_zone_capabilities_;
+  smart_objects::SmartObjectSPtr soft_buttons_capabilities_;
+  smart_objects::SmartObjectSPtr button_capabilities_;
+  smart_objects::SmartObjectSPtr preset_bank_capabilities_;
+  smart_objects::SmartObjectSPtr vr_capabilities_;
+  smart_objects::SmartObjectSPtr speech_capabilities_;
+  smart_objects::SmartObjectSPtr audio_pass_thru_capabilities_;
+  smart_objects::SmartObjectSPtr pcm_stream_capabilities_;
+  smart_objects::SmartObjectSPtr prerecorded_speech_;
   bool is_navigation_supported_;
   bool is_phone_call_supported_;
   bool is_video_streaming_supported_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -524,30 +524,30 @@ RegisterAppInterfaceRequest::GetLockScreenIconUrlNotification(
 void FillVRRelatedFields(smart_objects::SmartObject& response_params,
                          const HMICapabilities& hmi_capabilities) {
   response_params[strings::language] = hmi_capabilities.active_vr_language();
-  if (hmi_capabilities.vr_capabilities()) {
-    response_params[strings::vr_capabilities] =
-        *hmi_capabilities.vr_capabilities();
+  auto vr_capabilities = hmi_capabilities.vr_capabilities();
+  if (vr_capabilities) {
+    response_params[strings::vr_capabilities] = *vr_capabilities;
   }
 }
 
 void FillVIRelatedFields(smart_objects::SmartObject& response_params,
                          const HMICapabilities& hmi_capabilities) {
-  if (hmi_capabilities.vehicle_type()) {
-    response_params[hmi_response::vehicle_type] =
-        *hmi_capabilities.vehicle_type();
+  auto vehicle_type = hmi_capabilities.vehicle_type();
+  if (vehicle_type) {
+    response_params[hmi_response::vehicle_type] = *vehicle_type;
   }
 }
 
 void FillTTSRelatedFields(smart_objects::SmartObject& response_params,
                           const HMICapabilities& hmi_capabilities) {
   response_params[strings::language] = hmi_capabilities.active_tts_language();
-  if (hmi_capabilities.speech_capabilities()) {
-    response_params[strings::speech_capabilities] =
-        *hmi_capabilities.speech_capabilities();
+  auto speech_capabilities = hmi_capabilities.speech_capabilities();
+  if (speech_capabilities) {
+    response_params[strings::speech_capabilities] = *speech_capabilities;
   }
-  if (hmi_capabilities.prerecorded_speech()) {
-    response_params[strings::prerecorded_speech] =
-        *(hmi_capabilities.prerecorded_speech());
+  auto prerecorded_speech = hmi_capabilities.prerecorded_speech();
+  if (prerecorded_speech) {
+    response_params[strings::prerecorded_speech] = *prerecorded_speech;
   }
 }
 
@@ -555,82 +555,70 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
                          const HMICapabilities& hmi_capabilities) {
   response_params[strings::hmi_display_language] =
       hmi_capabilities.active_ui_language();
-  if (hmi_capabilities.display_capabilities()) {
+
+  auto display_capabilities = hmi_capabilities.display_capabilities();
+  if (display_capabilities) {
     response_params[hmi_response::display_capabilities] =
         smart_objects::SmartObject(smart_objects::SmartType_Map);
 
     smart_objects::SmartObject& display_caps =
         response_params[hmi_response::display_capabilities];
 
-    if (hmi_capabilities.display_capabilities()->keyExists(
-            hmi_response::display_type)) {
+    if (display_capabilities->keyExists(hmi_response::display_type)) {
       display_caps[hmi_response::display_type] =
-          hmi_capabilities.display_capabilities()->getElement(
-              hmi_response::display_type);
+          display_capabilities->getElement(hmi_response::display_type);
     }
 
-    if (hmi_capabilities.display_capabilities()->keyExists(
-            hmi_response::display_name)) {
+    if (display_capabilities->keyExists(hmi_response::display_name)) {
       display_caps[hmi_response::display_name] =
-          hmi_capabilities.display_capabilities()->getElement(
-              hmi_response::display_name);
+          display_capabilities->getElement(hmi_response::display_name);
     }
 
-    if (hmi_capabilities.display_capabilities()->keyExists(
-            hmi_response::text_fields)) {
+    if (display_capabilities->keyExists(hmi_response::text_fields)) {
       display_caps[hmi_response::text_fields] =
-          hmi_capabilities.display_capabilities()->getElement(
-              hmi_response::text_fields);
+          display_capabilities->getElement(hmi_response::text_fields);
     }
 
-    if (hmi_capabilities.display_capabilities()->keyExists(
-            hmi_response::image_fields)) {
+    if (display_capabilities->keyExists(hmi_response::image_fields)) {
       display_caps[hmi_response::image_fields] =
-          hmi_capabilities.display_capabilities()->getElement(
-              hmi_response::image_fields);
+          display_capabilities->getElement(hmi_response::image_fields);
     }
 
-    if (hmi_capabilities.display_capabilities()->keyExists(
-            hmi_response::media_clock_formats)) {
+    if (display_capabilities->keyExists(hmi_response::media_clock_formats)) {
       display_caps[hmi_response::media_clock_formats] =
-          hmi_capabilities.display_capabilities()->getElement(
-              hmi_response::media_clock_formats);
+          display_capabilities->getElement(hmi_response::media_clock_formats);
     }
 
-    if (hmi_capabilities.display_capabilities()->keyExists(
-            hmi_response::templates_available)) {
+    if (display_capabilities->keyExists(hmi_response::templates_available)) {
       display_caps[hmi_response::templates_available] =
-          hmi_capabilities.display_capabilities()->getElement(
-              hmi_response::templates_available);
+          display_capabilities->getElement(hmi_response::templates_available);
     }
 
-    if (hmi_capabilities.display_capabilities()->keyExists(
-            hmi_response::screen_params)) {
+    if (display_capabilities->keyExists(hmi_response::screen_params)) {
       display_caps[hmi_response::screen_params] =
-          hmi_capabilities.display_capabilities()->getElement(
-              hmi_response::screen_params);
+          display_capabilities->getElement(hmi_response::screen_params);
     }
 
-    if (hmi_capabilities.display_capabilities()->keyExists(
+    if (display_capabilities->keyExists(
             hmi_response::num_custom_presets_available)) {
       display_caps[hmi_response::num_custom_presets_available] =
-          hmi_capabilities.display_capabilities()->getElement(
+          display_capabilities->getElement(
               hmi_response::num_custom_presets_available);
     }
 
-    if (hmi_capabilities.display_capabilities()->keyExists(
-            hmi_response::image_capabilities)) {
+    if (display_capabilities->keyExists(hmi_response::image_capabilities)) {
       display_caps[hmi_response::graphic_supported] =
-          (hmi_capabilities.display_capabilities()
-               ->getElement(hmi_response::image_capabilities)
+          (display_capabilities->getElement(hmi_response::image_capabilities)
                .length() > 0);
     }
   }
 
-  if (hmi_capabilities.audio_pass_thru_capabilities()) {
+  auto audio_pass_thru_capabilities =
+      hmi_capabilities.audio_pass_thru_capabilities();
+  if (audio_pass_thru_capabilities) {
     // hmi_capabilities json contains array and HMI response object
     response_params[strings::audio_pass_thru_capabilities] =
-        *hmi_capabilities.audio_pass_thru_capabilities();
+        *audio_pass_thru_capabilities;
   }
   response_params[strings::hmi_capabilities] =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
@@ -728,36 +716,39 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
     FillVIRelatedFields(response_params, hmi_capabilities);
   }
 
-  if (hmi_capabilities.button_capabilities()) {
-    response_params[hmi_response::button_capabilities] =
-        *hmi_capabilities.button_capabilities();
+  auto button_capabilities = hmi_capabilities.button_capabilities();
+  if (button_capabilities) {
+    response_params[hmi_response::button_capabilities] = *button_capabilities;
   }
 
-  if (hmi_capabilities.soft_button_capabilities()) {
+  auto soft_button_capabilities = hmi_capabilities.soft_button_capabilities();
+  if (soft_button_capabilities) {
     response_params[hmi_response::soft_button_capabilities] =
-        *hmi_capabilities.soft_button_capabilities();
+        *soft_button_capabilities;
   }
 
-  if (hmi_capabilities.preset_bank_capabilities()) {
+  auto preset_bank_capabilities = hmi_capabilities.preset_bank_capabilities();
+  if (preset_bank_capabilities) {
     response_params[hmi_response::preset_bank_capabilities] =
-        *hmi_capabilities.preset_bank_capabilities();
+        *preset_bank_capabilities;
   }
 
-  if (hmi_capabilities.hmi_zone_capabilities()) {
-    if (smart_objects::SmartType_Array ==
-        hmi_capabilities.hmi_zone_capabilities()->getType()) {
+  auto hmi_zone_capabilities = hmi_capabilities.hmi_zone_capabilities();
+  if (hmi_zone_capabilities) {
+    if (smart_objects::SmartType_Array == hmi_zone_capabilities->getType()) {
       // hmi_capabilities json contains array and HMI response object
       response_params[hmi_response::hmi_zone_capabilities] =
-          *hmi_capabilities.hmi_zone_capabilities();
+          *hmi_zone_capabilities;
     } else {
       response_params[hmi_response::hmi_zone_capabilities][0] =
-          *hmi_capabilities.hmi_zone_capabilities();
+          *hmi_zone_capabilities;
     }
   }
 
-  if (hmi_capabilities.pcm_stream_capabilities()) {
+  auto pcm_stream_capabilities = hmi_capabilities.pcm_stream_capabilities();
+  if (pcm_stream_capabilities) {
     response_params[strings::pcm_stream_capabilities] =
-        *hmi_capabilities.pcm_stream_capabilities();
+        *pcm_stream_capabilities;
   }
 
   const std::vector<uint32_t>& diag_modes =

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/send_location_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/send_location_request.cc
@@ -254,10 +254,10 @@ bool SendLocationRequest::CheckHMICapabilities(
     return false;
   }
 
-  if (hmi_capabilities.display_capabilities()) {
-    const SmartObject disp_cap = (*hmi_capabilities.display_capabilities());
+  auto display_capabilities = hmi_capabilities.display_capabilities();
+  if (display_capabilities) {
     const SmartObject& text_fields =
-        disp_cap.getElement(hmi_response::text_fields);
+        display_capabilities->getElement(hmi_response::text_fields);
     const size_t len = text_fields.length();
     for (size_t i = 0; i < len; ++i) {
       const SmartObject& text_field = text_fields[i];

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_display_layout_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_display_layout_request.cc
@@ -154,10 +154,13 @@ void SetDisplayLayoutRequest::on_event(const event_engine::Event& event) {
           if (0 == msg_params[hmi_response::display_capabilities]
                              [hmi_response::templates_available]
                                  .length()) {
-            msg_params[hmi_response::display_capabilities]
-                      [hmi_response::templates_available] =
-                          hmi_capabilities.display_capabilities()->getElement(
-                              hmi_response::templates_available);
+            auto display_capabilities = hmi_capabilities.display_capabilities();
+            if (display_capabilities) {
+              msg_params[hmi_response::display_capabilities]
+                        [hmi_response::templates_available] =
+                            display_capabilities->getElement(
+                                hmi_response::templates_available);
+            }
           }
         }
         const Version& app_version = app->version();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
@@ -173,6 +173,28 @@ class RegisterAppInterfaceRequestTest
         .WillByDefault(ReturnRef(kDummyString));
     ON_CALL(mock_hmi_capabilities_, ccpu_version())
         .WillByDefault(ReturnRef(kDummyString));
+    ON_CALL(mock_hmi_capabilities_, speech_capabilities())
+        .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
+    ON_CALL(mock_hmi_capabilities_, prerecorded_speech())
+        .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
+    ON_CALL(mock_hmi_capabilities_, vr_capabilities())
+        .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
+    ON_CALL(mock_hmi_capabilities_, display_capabilities())
+        .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
+    ON_CALL(mock_hmi_capabilities_, audio_pass_thru_capabilities())
+        .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
+    ON_CALL(mock_hmi_capabilities_, vehicle_type())
+        .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
+    ON_CALL(mock_hmi_capabilities_, button_capabilities())
+        .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
+    ON_CALL(mock_hmi_capabilities_, soft_button_capabilities())
+        .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
+    ON_CALL(mock_hmi_capabilities_, preset_bank_capabilities())
+        .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
+    ON_CALL(mock_hmi_capabilities_, hmi_zone_capabilities())
+        .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
+    ON_CALL(mock_hmi_capabilities_, pcm_stream_capabilities())
+        .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
     ON_CALL(app_mngr_settings_, supported_diag_modes())
         .WillByDefault(ReturnRef(kDummyDiagModes));
     ON_CALL(mock_policy_handler_, GetAppRequestTypes(_, _))
@@ -419,15 +441,20 @@ TEST_F(RegisterAppInterfaceRequestTest,
       "test_templates_available";
   display_capabilities[am::hmi_response::screen_params] = "test_screen_params";
 
+  auto vehicle_type_ptr = std::make_shared<smart_objects::SmartObject>(
+      (*expected_message)[am::hmi_response::vehicle_type]);
   ON_CALL(mock_hmi_capabilities_, vehicle_type())
-      .WillByDefault(
-          Return(&(*expected_message)[am::hmi_response::vehicle_type]));
+      .WillByDefault(Return(vehicle_type_ptr));
+
+  auto vr_capabilities_ptr = std::make_shared<smart_objects::SmartObject>(
+      (*expected_message)[am::strings::vr_capabilities]);
   ON_CALL(mock_hmi_capabilities_, vr_capabilities())
-      .WillByDefault(
-          Return(&(*expected_message)[am::strings::vr_capabilities]));
+      .WillByDefault(Return(vr_capabilities_ptr));
+
+  auto display_capabilities_ptr = std::make_shared<smart_objects::SmartObject>(
+      (*expected_message)[am::hmi_response::display_capabilities]);
   ON_CALL(mock_hmi_capabilities_, display_capabilities())
-      .WillByDefault(
-          Return(&(*expected_message)[am::hmi_response::display_capabilities]));
+      .WillByDefault(Return(display_capabilities_ptr));
 
   ON_CALL(app_mngr_, applications())
       .WillByDefault(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/send_location_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/send_location_request_test.cc
@@ -110,6 +110,8 @@ class SendLocationRequestTest
     (*message_)[strings::msg_params] =
         SmartObject(smart_objects::SmartType_Map);
     (*message_)[strings::msg_params][strings::address] = kCorrectAddress;
+    ON_CALL(mock_hmi_capabilities_, display_capabilities())
+        .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
     EXPECT_CALL(app_mngr_, application(kConnectionKey))
         .WillOnce(Return(mock_app_));
 
@@ -130,8 +132,7 @@ class SendLocationRequestTest
         SmartObject(smart_objects::SmartType_Map);
     (*disp_cap_)[hmi_response::text_fields][0][strings::name] = field_name;
     EXPECT_CALL(mock_hmi_capabilities_, display_capabilities())
-        .Times(2)
-        .WillRepeatedly(Return(disp_cap_.get()));
+        .WillOnce(Return(disp_cap_));
   }
 
   void FinishSetup() {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/set_display_layout_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/set_display_layout_test.cc
@@ -240,7 +240,7 @@ TEST_F(SetDisplayLayoutRequestTest, OnEvent_AppVersion_v6_WARNING) {
       "templates_available";
 
   EXPECT_CALL(mock_hmi_capabilities_, display_capabilities())
-      .WillOnce(Return(dispaly_capabilities_msg.get()));
+      .WillOnce(Return(dispaly_capabilities_msg));
   EXPECT_CALL(
       mock_rpc_service_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::WARNINGS),
@@ -274,7 +274,7 @@ TEST_F(SetDisplayLayoutRequestTest, OnEvent_AppVersion_v5_SUCCESS) {
       "templates_available";
 
   EXPECT_CALL(mock_hmi_capabilities_, display_capabilities())
-      .WillOnce(Return(dispaly_capabilities_msg.get()));
+      .WillOnce(Return(dispaly_capabilities_msg));
   EXPECT_CALL(
       mock_rpc_service_,
       ManageMobileCommand(MobileResultCodeIs(mobile_result::SUCCESS),

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/subscribe_button_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/subscribe_button_request_test.cc
@@ -162,7 +162,7 @@ TEST_F(SubscribeButtonRequestTest, Run_IsSubscribedToButton_UNSUCCESS) {
   (*button_caps_ptr)[0][am::hmi_response::button_name] = kButtonName;
 
   ON_CALL(mock_hmi_capabilities_, button_capabilities())
-      .WillByDefault(Return(button_caps_ptr.get()));
+      .WillByDefault(Return(button_caps_ptr));
 
   ON_CALL(*app, IsSubscribedToButton(_)).WillByDefault(Return(true));
 
@@ -193,7 +193,7 @@ TEST_F(SubscribeButtonRequestTest, Run_SUCCESS) {
   (*button_caps_ptr)[0][am::hmi_response::button_name] = kButtonName;
 
   ON_CALL(mock_hmi_capabilities_, button_capabilities())
-      .WillByDefault(Return(button_caps_ptr.get()));
+      .WillByDefault(Return(button_caps_ptr));
 
   ON_CALL(*app, IsSubscribedToButton(_)).WillByDefault(Return(false));
 
@@ -240,7 +240,7 @@ TEST_F(SubscribeButtonRequestTest, Run_NAV_SUCCESS) {
   (*button_caps_ptr)[0][am::hmi_response::button_name] = kButtonName;
 
   ON_CALL(mock_hmi_capabilities_, button_capabilities())
-      .WillByDefault(Return(button_caps_ptr.get()));
+      .WillByDefault(Return(button_caps_ptr));
 
   ON_CALL(*app, IsSubscribedToButton(_)).WillByDefault(Return(false));
 
@@ -289,7 +289,7 @@ TEST_F(SubscribeButtonRequestTest, Run_SUCCESS_App_Base_RPC_Version) {
       mobile_apis::ButtonName::PLAY_PAUSE;
 
   ON_CALL(mock_hmi_capabilities_, button_capabilities())
-      .WillByDefault(Return(button_caps_ptr.get()));
+      .WillByDefault(Return(button_caps_ptr));
 
   ON_CALL(*app, IsSubscribedToButton(_)).WillByDefault(Return(false));
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/unsubscribe_button_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/unsubscribe_button_request_test.cc
@@ -70,7 +70,7 @@ TEST_F(UnsubscribeButtonRequestTest,
   MessageSharedPtr button_caps_ptr(CreateMessage(smart_objects::SmartType_Map));
   (*button_caps_ptr)[0][am::hmi_response::button_name] = kButtonId;
   EXPECT_CALL(mock_hmi_capabilities_, button_capabilities())
-      .WillOnce(Return(button_caps_ptr.get()));
+      .WillOnce(Return(button_caps_ptr));
 
   MockAppPtr mock_app(CreateMockApp());
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
@@ -106,7 +106,7 @@ TEST_F(UnsubscribeButtonRequestTest,
 
   MessageSharedPtr button_caps_ptr(CreateMessage(smart_objects::SmartType_Map));
   EXPECT_CALL(mock_hmi_capabilities_, button_capabilities())
-      .WillOnce(Return(button_caps_ptr.get()));
+      .WillOnce(Return(button_caps_ptr));
 
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(
@@ -129,7 +129,7 @@ TEST_F(UnsubscribeButtonRequestTest, Run_SUCCESS) {
   MessageSharedPtr button_caps_ptr(CreateMessage(smart_objects::SmartType_Map));
   (*button_caps_ptr)[0][am::hmi_response::button_name] = kButtonId;
   EXPECT_CALL(mock_hmi_capabilities_, button_capabilities())
-      .WillOnce(Return(button_caps_ptr.get()));
+      .WillOnce(Return(button_caps_ptr));
 
   MockAppPtr mock_app(CreateMockApp());
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
@@ -172,7 +172,7 @@ TEST_F(UnsubscribeButtonRequestTest, Run_SUCCESS_Base_RPC_Version) {
       mobile_apis::ButtonName::PLAY_PAUSE;
 
   EXPECT_CALL(mock_hmi_capabilities_, button_capabilities())
-      .WillRepeatedly(Return(button_caps_ptr.get()));
+      .WillRepeatedly(Return(button_caps_ptr));
 
   MockAppPtr mock_app(CreateMockApp());
   EXPECT_CALL(app_mngr_, application(kConnectionKey))

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -772,16 +772,14 @@ bool CommandRequestImpl::CheckHMICapabilities(
     return false;
   }
 
-  const SmartObject* button_capabilities_so =
-      hmi_capabilities_.button_capabilities();
-  if (!button_capabilities_so) {
+  auto button_capabilities = hmi_capabilities_.button_capabilities();
+  if (!button_capabilities) {
     LOG4CXX_ERROR(logger_, "Invalid button capabilities object");
     return false;
   }
 
-  const SmartObject& button_capabilities = *button_capabilities_so;
-  for (size_t i = 0; i < button_capabilities.length(); ++i) {
-    const SmartObject& capabilities = button_capabilities[i];
+  for (size_t i = 0; i < button_capabilities->length(); ++i) {
+    const SmartObject& capabilities = (*button_capabilities)[i];
     const ButtonName::eType current_button = static_cast<ButtonName::eType>(
         capabilities.getElement(hmi_response::button_name).asInt());
     if (current_button == button) {

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -462,20 +462,9 @@ HMICapabilitiesImpl::HMICapabilitiesImpl(ApplicationManager& app_mngr)
 }
 
 HMICapabilitiesImpl::~HMICapabilitiesImpl() {
-  delete vehicle_type_;
   delete ui_supported_languages_;
   delete tts_supported_languages_;
   delete vr_supported_languages_;
-  delete display_capabilities_;
-  delete hmi_zone_capabilities_;
-  delete soft_buttons_capabilities_;
-  delete button_capabilities_;
-  delete preset_bank_capabilities_;
-  delete vr_capabilities_;
-  delete speech_capabilities_;
-  delete audio_pass_thru_capabilities_;
-  delete pcm_stream_capabilities_;
-  delete prerecorded_speech_;
   delete navigation_capability_;
   delete phone_capability_;
   delete video_streaming_capability_;
@@ -483,13 +472,14 @@ HMICapabilitiesImpl::~HMICapabilitiesImpl() {
 }
 
 bool HMICapabilitiesImpl::VerifyImageType(const int32_t image_type) const {
-  if (!display_capabilities_) {
+  auto capabilities = display_capabilities();
+  if (!capabilities) {
     return false;
   }
 
-  if (display_capabilities_->keyExists(hmi_response::image_capabilities)) {
+  if (capabilities->keyExists(hmi_response::image_capabilities)) {
     const smart_objects::SmartObject& image_caps =
-        display_capabilities_->getElement(hmi_response::image_capabilities);
+        capabilities->getElement(hmi_response::image_capabilities);
     for (uint32_t i = 0; i < image_caps.length(); ++i) {
       if (image_caps.getElement(i).asInt() == image_type) {
         return true;
@@ -603,11 +593,9 @@ void HMICapabilitiesImpl::set_display_capabilities(
   if (app_mngr_.IsSOStructValid(
           hmi_apis::StructIdentifiers::Common_DisplayCapabilities,
           display_capabilities)) {
-    if (display_capabilities_) {
-      delete display_capabilities_;
-    }
-    display_capabilities_ =
-        new smart_objects::SmartObject(display_capabilities);
+    smart_objects::SmartObjectSPtr new_value =
+        std::make_shared<smart_objects::SmartObject>(display_capabilities);
+    display_capabilities_.swap(new_value);
   }
 }
 
@@ -619,88 +607,73 @@ void HMICapabilitiesImpl::set_system_display_capabilities(
 
 void HMICapabilitiesImpl::set_hmi_zone_capabilities(
     const smart_objects::SmartObject& hmi_zone_capabilities) {
-  if (hmi_zone_capabilities_) {
-    delete hmi_zone_capabilities_;
-  }
-  hmi_zone_capabilities_ =
-      new smart_objects::SmartObject(hmi_zone_capabilities);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(hmi_zone_capabilities);
+  hmi_zone_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_soft_button_capabilities(
     const smart_objects::SmartObject& soft_button_capabilities) {
-  if (soft_buttons_capabilities_) {
-    delete soft_buttons_capabilities_;
-  }
-  soft_buttons_capabilities_ =
-      new smart_objects::SmartObject(soft_button_capabilities);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(soft_button_capabilities);
+  soft_buttons_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_button_capabilities(
     const smart_objects::SmartObject& button_capabilities) {
-  if (button_capabilities_) {
-    delete button_capabilities_;
-  }
-  button_capabilities_ = new smart_objects::SmartObject(button_capabilities);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(button_capabilities);
+  button_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_vr_capabilities(
     const smart_objects::SmartObject& vr_capabilities) {
-  if (vr_capabilities_) {
-    delete vr_capabilities_;
-  }
-  vr_capabilities_ = new smart_objects::SmartObject(vr_capabilities);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(vr_capabilities);
+  vr_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_speech_capabilities(
     const smart_objects::SmartObject& speech_capabilities) {
-  if (speech_capabilities_) {
-    delete speech_capabilities_;
-  }
-  speech_capabilities_ = new smart_objects::SmartObject(speech_capabilities);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(speech_capabilities);
+  speech_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_audio_pass_thru_capabilities(
     const smart_objects::SmartObject& audio_pass_thru_capabilities) {
-  if (audio_pass_thru_capabilities_) {
-    delete audio_pass_thru_capabilities_;
-  }
-  audio_pass_thru_capabilities_ =
-      new smart_objects::SmartObject(audio_pass_thru_capabilities);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(
+          audio_pass_thru_capabilities);
+  audio_pass_thru_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_pcm_stream_capabilities(
     const smart_objects::SmartObject& pcm_stream_capabilities) {
-  if (pcm_stream_capabilities_) {
-    delete pcm_stream_capabilities_;
-  }
-  pcm_stream_capabilities_ =
-      new smart_objects::SmartObject(pcm_stream_capabilities);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(pcm_stream_capabilities);
+  pcm_stream_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_preset_bank_capabilities(
     const smart_objects::SmartObject& preset_bank_capabilities) {
-  if (preset_bank_capabilities_) {
-    delete preset_bank_capabilities_;
-  }
-  preset_bank_capabilities_ =
-      new smart_objects::SmartObject(preset_bank_capabilities);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(preset_bank_capabilities);
+  preset_bank_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_vehicle_type(
     const smart_objects::SmartObject& vehicle_type) {
-  if (vehicle_type_) {
-    delete vehicle_type_;
-  }
-  vehicle_type_ = new smart_objects::SmartObject(vehicle_type);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(vehicle_type);
+  vehicle_type_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_prerecorded_speech(
     const smart_objects::SmartObject& prerecorded_speech) {
-  if (prerecorded_speech_) {
-    delete prerecorded_speech_;
-    prerecorded_speech_ = NULL;
-  }
-  prerecorded_speech_ = new smart_objects::SmartObject(prerecorded_speech);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(prerecorded_speech);
+  prerecorded_speech_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_navigation_supported(const bool supported) {
@@ -811,7 +784,7 @@ const smart_objects::SmartObject* HMICapabilitiesImpl::tts_supported_languages()
   return tts_supported_languages_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::display_capabilities()
+const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::display_capabilities()
     const {
   return display_capabilities_;
 }
@@ -821,41 +794,42 @@ HMICapabilitiesImpl::system_display_capabilities() const {
   return system_display_capabilities_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::hmi_zone_capabilities()
-    const {
+const smart_objects::SmartObjectSPtr
+HMICapabilitiesImpl::hmi_zone_capabilities() const {
   return hmi_zone_capabilities_;
 }
 
-const smart_objects::SmartObject*
+const smart_objects::SmartObjectSPtr
 HMICapabilitiesImpl::soft_button_capabilities() const {
   return soft_buttons_capabilities_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::button_capabilities()
+const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::button_capabilities()
     const {
   return button_capabilities_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::speech_capabilities()
+const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::speech_capabilities()
     const {
   return speech_capabilities_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::vr_capabilities() const {
+const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::vr_capabilities()
+    const {
   return vr_capabilities_;
 }
 
-const smart_objects::SmartObject*
+const smart_objects::SmartObjectSPtr
 HMICapabilitiesImpl::audio_pass_thru_capabilities() const {
   return audio_pass_thru_capabilities_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::pcm_stream_capabilities()
-    const {
+const smart_objects::SmartObjectSPtr
+HMICapabilitiesImpl::pcm_stream_capabilities() const {
   return pcm_stream_capabilities_;
 }
 
-const smart_objects::SmartObject*
+const smart_objects::SmartObjectSPtr
 HMICapabilitiesImpl::preset_bank_capabilities() const {
   return preset_bank_capabilities_;
 }
@@ -864,11 +838,11 @@ bool HMICapabilitiesImpl::attenuated_supported() const {
   return attenuated_supported_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::vehicle_type() const {
+const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::vehicle_type() const {
   return vehicle_type_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::prerecorded_speech()
+const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::prerecorded_speech()
     const {
   return prerecorded_speech_;
 }

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -604,23 +604,25 @@ TEST_F(HMICapabilitiesTest,
 
   // with old audio pass thru format, the object is an array containing a single
   // object
-  smart_objects::SmartObject audio_pass_thru_capabilities_so =
-      *(hmi_capabilities->audio_pass_thru_capabilities());
+  smart_objects::SmartObjectSPtr audio_pass_thru_capabilities_so =
+      hmi_capabilities->audio_pass_thru_capabilities();
   EXPECT_EQ(smart_objects::SmartType_Array,
-            audio_pass_thru_capabilities_so.getType());
-  EXPECT_EQ(1u, audio_pass_thru_capabilities_so.length());
-  EXPECT_TRUE(audio_pass_thru_capabilities_so[0].keyExists("samplingRate"));
+            audio_pass_thru_capabilities_so->getType());
+  EXPECT_EQ(1u, audio_pass_thru_capabilities_so->length());
+  smart_objects::SmartObject& first_element =
+      (*audio_pass_thru_capabilities_so)[0];
+  EXPECT_TRUE(first_element.keyExists("samplingRate"));
   EXPECT_EQ(hmi_apis::Common_SamplingRate::RATE_22KHZ,
             static_cast<hmi_apis::Common_SamplingRate::eType>(
-                audio_pass_thru_capabilities_so[0]["samplingRate"].asInt()));
-  EXPECT_TRUE(audio_pass_thru_capabilities_so[0].keyExists("bitsPerSample"));
+                first_element["samplingRate"].asInt()));
+  EXPECT_TRUE(first_element.keyExists("bitsPerSample"));
   EXPECT_EQ(hmi_apis::Common_BitsPerSample::RATE_16_BIT,
             static_cast<hmi_apis::Common_BitsPerSample::eType>(
-                audio_pass_thru_capabilities_so[0]["bitsPerSample"].asInt()));
-  EXPECT_TRUE(audio_pass_thru_capabilities_so[0].keyExists("audioType"));
+                first_element["bitsPerSample"].asInt()));
+  EXPECT_TRUE(first_element.keyExists("audioType"));
   EXPECT_EQ(hmi_apis::Common_AudioType::PCM,
             static_cast<hmi_apis::Common_AudioType::eType>(
-                audio_pass_thru_capabilities_so[0]["audioType"].asInt()));
+                first_element["audioType"].asInt()));
 }
 
 TEST_F(HMICapabilitiesTest, VerifyImageType) {

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -99,7 +99,8 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
   MOCK_METHOD1(set_tts_supported_languages,
                void(const smart_objects::SmartObject& supported_languages));
 
-  MOCK_CONST_METHOD0(display_capabilities, const smart_objects::SmartObject*());
+  MOCK_CONST_METHOD0(display_capabilities,
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(set_display_capabilities,
                void(const smart_objects::SmartObject& display_capabilities));
 
@@ -109,50 +110,53 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
                void(const smart_objects::SmartObject& display_capabilities));
 
   MOCK_CONST_METHOD0(hmi_zone_capabilities,
-                     const smart_objects::SmartObject*());
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(set_hmi_zone_capabilities,
                void(const smart_objects::SmartObject& hmi_zone_capabilities));
 
   MOCK_CONST_METHOD0(soft_button_capabilities,
-                     const smart_objects::SmartObject*());
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(
       set_soft_button_capabilities,
       void(const smart_objects::SmartObject& soft_button_capabilities));
 
-  MOCK_CONST_METHOD0(button_capabilities, const smart_objects::SmartObject*());
+  MOCK_CONST_METHOD0(button_capabilities,
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(set_button_capabilities,
                void(const smart_objects::SmartObject& button_capabilities));
 
-  MOCK_CONST_METHOD0(speech_capabilities, const smart_objects::SmartObject*());
+  MOCK_CONST_METHOD0(speech_capabilities,
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(set_speech_capabilities,
                void(const smart_objects::SmartObject& speech_capabilities));
 
-  MOCK_CONST_METHOD0(vr_capabilities, const smart_objects::SmartObject*());
+  MOCK_CONST_METHOD0(vr_capabilities, const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(set_vr_capabilities,
                void(const smart_objects::SmartObject& vr_capabilities));
 
   MOCK_CONST_METHOD0(audio_pass_thru_capabilities,
-                     const smart_objects::SmartObject*());
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(
       set_audio_pass_thru_capabilities,
       void(const smart_objects::SmartObject& audio_pass_thru_capabilities));
 
   MOCK_CONST_METHOD0(pcm_stream_capabilities,
-                     const smart_objects::SmartObject*());
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(set_pcm_stream_capabilities,
                void(const smart_objects::SmartObject& pcm_stream_capabilities));
 
   MOCK_CONST_METHOD0(preset_bank_capabilities,
-                     const smart_objects::SmartObject*());
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(
       set_preset_bank_capabilities,
       void(const smart_objects::SmartObject& preset_bank_capabilities));
 
-  MOCK_CONST_METHOD0(vehicle_type, const smart_objects::SmartObject*());
+  MOCK_CONST_METHOD0(vehicle_type, const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(set_vehicle_type,
                void(const smart_objects::SmartObject& vehicle_type));
 
-  MOCK_CONST_METHOD0(prerecorded_speech, const smart_objects::SmartObject*());
+  MOCK_CONST_METHOD0(prerecorded_speech,
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(set_prerecorded_speech,
                void(const smart_objects::SmartObject& prerecorded_speech));
 

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -219,7 +219,7 @@ class HMICapabilities {
    *
    * @return Currently supported display capabilities
    */
-  virtual const smart_objects::SmartObject* display_capabilities() const = 0;
+  virtual const smart_objects::SmartObjectSPtr display_capabilities() const = 0;
 
   /*
    * @brief Sets supported display capabilities
@@ -248,7 +248,8 @@ class HMICapabilities {
    *
    * @return Currently supported HMI zone capabilities
    */
-  virtual const smart_objects::SmartObject* hmi_zone_capabilities() const = 0;
+  virtual const smart_objects::SmartObjectSPtr hmi_zone_capabilities()
+      const = 0;
 
   /*
    * @brief Sets supported HMI zone capabilities
@@ -263,7 +264,7 @@ class HMICapabilities {
    *
    * @return Currently supported SoftButton's capabilities
    */
-  virtual const smart_objects::SmartObject* soft_button_capabilities()
+  virtual const smart_objects::SmartObjectSPtr soft_button_capabilities()
       const = 0;
 
   /*
@@ -279,7 +280,7 @@ class HMICapabilities {
    *
    * @return Currently supported Button's capabilities
    */
-  virtual const smart_objects::SmartObject* button_capabilities() const = 0;
+  virtual const smart_objects::SmartObjectSPtr button_capabilities() const = 0;
 
   /*
    * @brief Sets supported Button's capabilities
@@ -302,7 +303,7 @@ class HMICapabilities {
    *
    * @return Currently supported speech capabilities
    */
-  virtual const smart_objects::SmartObject* speech_capabilities() const = 0;
+  virtual const smart_objects::SmartObjectSPtr speech_capabilities() const = 0;
 
   /*
    * @brief Sets supported VR capabilities
@@ -317,7 +318,7 @@ class HMICapabilities {
    *
    * @return Currently supported VR capabilities
    */
-  virtual const smart_objects::SmartObject* vr_capabilities() const = 0;
+  virtual const smart_objects::SmartObjectSPtr vr_capabilities() const = 0;
 
   /*
    * @brief Sets supported audio_pass_thru capabilities
@@ -332,7 +333,7 @@ class HMICapabilities {
    *
    * @return Currently supported audio_pass_thru capabilities
    */
-  virtual const smart_objects::SmartObject* audio_pass_thru_capabilities()
+  virtual const smart_objects::SmartObjectSPtr audio_pass_thru_capabilities()
       const = 0;
 
   /*
@@ -348,14 +349,15 @@ class HMICapabilities {
    *
    * @return Currently supported pcm_streaming capabilities
    */
-  virtual const smart_objects::SmartObject* pcm_stream_capabilities() const = 0;
+  virtual const smart_objects::SmartObjectSPtr pcm_stream_capabilities()
+      const = 0;
 
   /*
    * @brief Retrieves information about the preset bank capabilities
    *
    * @return Currently supported preset bank capabilities
    */
-  virtual const smart_objects::SmartObject* preset_bank_capabilities()
+  virtual const smart_objects::SmartObjectSPtr preset_bank_capabilities()
       const = 0;
 
   /*
@@ -379,14 +381,14 @@ class HMICapabilities {
    *
    * @param vehicle_type Cuurent vehicle information
    */
-  virtual const smart_objects::SmartObject* vehicle_type() const = 0;
+  virtual const smart_objects::SmartObjectSPtr vehicle_type() const = 0;
 
   /*
    * @brief Retrieves information about the prerecorded speech
    *
    * @return Currently supported prerecorded speech
    */
-  virtual const smart_objects::SmartObject* prerecorded_speech() const = 0;
+  virtual const smart_objects::SmartObjectSPtr prerecorded_speech() const = 0;
 
   /*
    * @brief Sets supported prerecorded speech

--- a/src/components/smart_objects/src/smart_object.cc
+++ b/src/components/smart_objects/src/smart_object.cc
@@ -734,16 +734,32 @@ void SmartObject::duplicate(const SmartObject& OtherObject) {
 void SmartObject::cleanup_data() {
   switch (m_type) {
     case SmartType_String:
-      delete m_data.str_value;
+      if (m_data.str_value) {
+        delete m_data.str_value;
+        m_data.str_value = nullptr;
+        m_type = SmartType_Null;
+      }
       break;
     case SmartType_Map:
-      delete m_data.map_value;
+      if (m_data.map_value) {
+        delete m_data.map_value;
+        m_data.map_value = nullptr;
+        m_type = SmartType_Null;
+      }
       break;
     case SmartType_Array:
-      delete m_data.array_value;
+      if (m_data.array_value) {
+        delete m_data.array_value;
+        m_data.array_value = nullptr;
+        m_type = SmartType_Null;
+      }
       break;
     case SmartType_Binary:
-      delete m_data.binary_value;
+      if (m_data.binary_value) {
+        delete m_data.binary_value;
+        m_data.array_value = nullptr;
+        m_type = SmartType_Null;
+      }
       break;
     default:
       break;

--- a/src/components/smart_objects/src/smart_object.cc
+++ b/src/components/smart_objects/src/smart_object.cc
@@ -757,7 +757,7 @@ void SmartObject::cleanup_data() {
     case SmartType_Binary:
       if (m_data.binary_value) {
         delete m_data.binary_value;
-        m_data.array_value = nullptr;
+        m_data.binary_value = nullptr;
         m_type = SmartType_Null;
       }
       break;


### PR DESCRIPTION
Fixes #3109 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF tests

### Summary
After `cleanup_data()` call, delete is used to deallocate memory by pointer, however pointer still hold a value of address of deallocated memory. By that reason SO still have an ability to access that data what might cause UB including core crash in the random places.

This function has been updated to set pointers to NULL as well as smart object type to prevent accident access to deallocated memory.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
