### PR TITLE
Check for conflicting app resumption level

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -175,6 +175,8 @@ class ApplicationManagerImpl
 
   ApplicationSharedPtr active_application() const OVERRIDE;
 
+  ApplicationSharedPtr get_full_or_limited_application() const OVERRIDE;
+
   ApplicationSharedPtr application_by_hmi_app(
       uint32_t hmi_app_id) const OVERRIDE;
   ApplicationSharedPtr application_by_policy_id(

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -113,7 +113,7 @@ class ResumeCtrl {
    * @brief RestoreAppWidgets add widgets for the application
    * @param application application which will be resumed
    * @param saved_app application specific section from backup file
-   * @return true if widgets resumed successfully otherwise - false
+   * @return the number of widget windows to be resumed
    */
   virtual size_t RestoreAppWidgets(
       application_manager::ApplicationSharedPtr application,

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -115,7 +115,7 @@ class ResumeCtrl {
    * @param saved_app application specific section from backup file
    * @return true if widgets resumed successfully otherwise - false
    */
-  virtual void RestoreAppWidgets(
+  virtual size_t RestoreAppWidgets(
       application_manager::ApplicationSharedPtr application,
       const smart_objects::SmartObject& saved_app) = 0;
 

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -89,12 +89,6 @@ class ResumeCtrlImpl : public ResumeCtrl,
   void SaveApplication(app_mngr::ApplicationSharedPtr application) OVERRIDE;
 
   /**
-   * @brief Helper function to identify if an app exists in full or limited
-   * @return true if an app exists in full or limited, otherwise return false
-   */
-  bool AppExistsInFullOrLimited();
-
-  /**
    * @brief Set application HMI Level and ausio_state as saved
    * @param application is application witch HMI Level is need to restore
    * @return true if success, otherwise return false

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -124,8 +124,9 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @param application application which will be resumed
    * @param saved_app application specific section from backup file
    */
-  void RestoreAppWidgets(application_manager::ApplicationSharedPtr application,
-                         const smart_objects::SmartObject& saved_app) OVERRIDE;
+  size_t RestoreAppWidgets(
+      application_manager::ApplicationSharedPtr application,
+      const smart_objects::SmartObject& saved_app) OVERRIDE;
 
   /**
    * @brief Remove application from list of saved applications

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -89,6 +89,12 @@ class ResumeCtrlImpl : public ResumeCtrl,
   void SaveApplication(app_mngr::ApplicationSharedPtr application) OVERRIDE;
 
   /**
+   * @brief Helper function to identify if an app exists in full or limited
+   * @return true if an app exists in full or limited, otherwise return false
+   */
+  bool AppExistsInFullOrLimited();
+
+  /**
    * @brief Set application HMI Level and ausio_state as saved
    * @param application is application witch HMI Level is need to restore
    * @return true if success, otherwise return false

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -774,8 +774,6 @@ protocol_handler::MajorProtocolVersion ApplicationImpl::protocol_version()
 }
 
 void ApplicationImpl::set_is_resuming(bool is_resuming) {
-  LOG4CXX_DEBUG(logger_, "ApplicationImpl::set_is_resuming id : " << policy_app_id());
-  LOG4CXX_DEBUG(logger_, "ApplicationImpl::set_is_resuming is resuming: " << is_resuming);
   is_resuming_ = is_resuming;
 }
 

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -774,6 +774,8 @@ protocol_handler::MajorProtocolVersion ApplicationImpl::protocol_version()
 }
 
 void ApplicationImpl::set_is_resuming(bool is_resuming) {
+  LOG4CXX_DEBUG(logger_, "ApplicationImpl::set_is_resuming id : " << policy_app_id());
+  LOG4CXX_DEBUG(logger_, "ApplicationImpl::set_is_resuming is resuming: " << is_resuming);
   is_resuming_ = is_resuming;
 }
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -327,6 +327,20 @@ ApplicationSharedPtr ApplicationManagerImpl::active_application() const {
   return FindApp(accessor, ActiveAppPredicate);
 }
 
+bool FullOrLimitedAppPredicate(const ApplicationSharedPtr app) {
+  return app ? app->IsFullscreen() ||
+                   app->hmi_level(
+                       mobile_api::PredefinedWindows::DEFAULT_WINDOW) ==
+                       mobile_api::HMILevel::HMI_LIMITED
+             : false;
+}
+
+ApplicationSharedPtr ApplicationManagerImpl::get_full_or_limited_application()
+    const {
+  DataAccessor<ApplicationSet> accessor = applications();
+  return FindApp(accessor, FullOrLimitedAppPredicate);
+}
+
 bool LimitedAppPredicate(const ApplicationSharedPtr app) {
   return app ? app->hmi_level(mobile_api::PredefinedWindows::DEFAULT_WINDOW) ==
                    mobile_api::HMILevel::HMI_LIMITED

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -169,6 +169,27 @@ void ResumeCtrlImpl::on_event(const event_engine::Event& event) {
   }
 }
 
+// Helper method
+bool ResumeCtrlImpl::AppExistsInFullOrLimited() {
+  if (application_manager_.active_application().use_count() != 0) {
+    return true;
+  } else if (application_manager_.get_limited_media_application().use_count() !=
+             0) {
+    return true;
+  } else if (application_manager_.get_limited_navi_application().use_count() !=
+             0) {
+    return true;
+  } else if (application_manager_.get_limited_voice_application().use_count() !=
+             0) {
+    return true;
+  } else if (application_manager_.get_limited_mobile_projection_application()
+                 .use_count() != 0) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
   using namespace mobile_apis;
   LOG4CXX_AUTO_TRACE(logger_);
@@ -214,6 +235,7 @@ bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
             "High-bandwidth transport not available, app will resume into : "
                 << saved_hmi_level);
       }
+      const bool app_exists_in_full_or_limited = AppExistsInFullOrLimited();
       const bool app_hmi_state_is_set =
           SetAppHMIState(application, saved_hmi_level, true);
       size_t restored_widgets = 0;
@@ -221,9 +243,7 @@ bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
           application->is_app_data_resumption_allowed()) {
         restored_widgets = RestoreAppWidgets(application, saved_app);
       }
-      const bool active_app_exists =
-          (application_manager_.active_application().use_count() != 0);
-      if (0 == restored_widgets && active_app_exists) {
+      if (0 == restored_widgets && app_exists_in_full_or_limited) {
         LOG4CXX_DEBUG(logger_, "App exists in full or limited. Do not resume");
         return false;
       }

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -216,13 +216,14 @@ bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
       }
       const bool app_hmi_state_is_set =
           SetAppHMIState(application, saved_hmi_level, true);
+      size_t restored_widgets = 0;
       if (app_hmi_state_is_set &&
           application->is_app_data_resumption_allowed()) {
-        RestoreAppWidgets(application, saved_app);
+        restored_widgets = RestoreAppWidgets(application, saved_app);
       }
       const bool does_app_with_same_level_exist =
           application_manager_.IsAppTypeExistsInFullOrLimited(application);
-      if (does_app_with_same_level_exist) {
+      if (does_app_with_same_level_exist && restored_widgets == 0) {
         LOG4CXX_DEBUG(
             logger_,
             "App of same type exists in full or limited. Do no resume");
@@ -406,7 +407,7 @@ bool ResumeCtrlImpl::SetAppHMIState(
   return true;
 }
 
-void ResumeCtrlImpl::RestoreAppWidgets(
+size_t ResumeCtrlImpl::RestoreAppWidgets(
     application_manager::ApplicationSharedPtr application,
     const smart_objects::SmartObject& saved_app) {
   using namespace mobile_apis;
@@ -414,7 +415,7 @@ void ResumeCtrlImpl::RestoreAppWidgets(
   DCHECK(application);
   if (!saved_app.keyExists(strings::windows_info)) {
     LOG4CXX_ERROR(logger_, "windows_info section does not exist");
-    return;
+    return 0;
   }
   const auto& windows_info = saved_app[strings::windows_info];
   auto request_list = MessageHelper::CreateUICreateWindowRequestsToHMI(
@@ -426,6 +427,7 @@ void ResumeCtrlImpl::RestoreAppWidgets(
         (*request)[strings::params][strings::correlation_id].asInt(), request));
   }
   ProcessHMIRequests(request_list);
+  return request_list.size();
 }
 
 bool ResumeCtrlImpl::IsHMIApplicationIdExist(uint32_t hmi_app_id) {

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -222,7 +222,7 @@ bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
         restored_widgets = RestoreAppWidgets(application, saved_app);
       }
       const bool active_app_exists = (application_manager_.active_application().use_count() != 0);
-      if (0 == restored_widgets && is_active_app_exists) {
+      if (0 == restored_widgets && active_app_exists) {
         LOG4CXX_DEBUG(
             logger_,
             "App exists in full or limited. Do not resume");

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -221,12 +221,11 @@ bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
           application->is_app_data_resumption_allowed()) {
         restored_widgets = RestoreAppWidgets(application, saved_app);
       }
-      const bool does_app_with_same_level_exist =
-          application_manager_.IsAppTypeExistsInFullOrLimited(application);
-      if (0 == restored_widgets && does_app_with_same_level_exist) {
+      const bool active_app_exists = (application_manager_.active_application().use_count() != 0);
+      if (0 == restored_widgets && is_active_app_exists) {
         LOG4CXX_DEBUG(
             logger_,
-            "App of same type exists in full or limited. Do not resume");
+            "App exists in full or limited. Do not resume");
         return false;
       }
     } else {

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -223,10 +223,10 @@ bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
       }
       const bool does_app_with_same_level_exist =
           application_manager_.IsAppTypeExistsInFullOrLimited(application);
-      if (does_app_with_same_level_exist && restored_widgets == 0) {
+      if (0 == restored_widgets && does_app_with_same_level_exist) {
         LOG4CXX_DEBUG(
             logger_,
-            "App of same type exists in full or limited. Do no resume");
+            "App of same type exists in full or limited. Do not resume");
         return false;
       }
     } else {
@@ -365,6 +365,7 @@ void ResumeCtrlImpl::ApplicationResumptiOnTimer() {
 }
 
 void ResumeCtrlImpl::OnAppActivated(ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
   if (is_resumption_active_) {
     RemoveFromResumption(application->app_id());
     application->set_is_resuming(false);

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -169,27 +169,6 @@ void ResumeCtrlImpl::on_event(const event_engine::Event& event) {
   }
 }
 
-// Helper method
-bool ResumeCtrlImpl::AppExistsInFullOrLimited() {
-  if (application_manager_.active_application().use_count() != 0) {
-    return true;
-  } else if (application_manager_.get_limited_media_application().use_count() !=
-             0) {
-    return true;
-  } else if (application_manager_.get_limited_navi_application().use_count() !=
-             0) {
-    return true;
-  } else if (application_manager_.get_limited_voice_application().use_count() !=
-             0) {
-    return true;
-  } else if (application_manager_.get_limited_mobile_projection_application()
-                 .use_count() != 0) {
-    return true;
-  } else {
-    return false;
-  }
-}
-
 bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
   using namespace mobile_apis;
   LOG4CXX_AUTO_TRACE(logger_);
@@ -235,7 +214,9 @@ bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
             "High-bandwidth transport not available, app will resume into : "
                 << saved_hmi_level);
       }
-      const bool app_exists_in_full_or_limited = AppExistsInFullOrLimited();
+      const bool app_exists_in_full_or_limited =
+          application_manager_.get_full_or_limited_application().use_count() !=
+          0;
       const bool app_hmi_state_is_set =
           SetAppHMIState(application, saved_hmi_level, true);
       size_t restored_widgets = 0;
@@ -383,7 +364,6 @@ void ResumeCtrlImpl::ApplicationResumptiOnTimer() {
 }
 
 void ResumeCtrlImpl::OnAppActivated(ApplicationSharedPtr application) {
-  LOG4CXX_AUTO_TRACE(logger_);
   if (is_resumption_active_) {
     RemoveFromResumption(application->app_id());
     application->set_is_resuming(false);

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -214,7 +214,14 @@ bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
             "High-bandwidth transport not available, app will resume into : "
                 << saved_hmi_level);
       }
-
+      const bool does_app_with_same_type_exist =
+          application_manager_.IsAppTypeExistsInFullOrLimited(application);
+      if (does_app_with_same_type_exist) {
+        LOG4CXX_DEBUG(
+            logger_,
+            "App of same type exists in full or limited. Do no resume");
+        return false;
+      }
       const bool app_hmi_state_is_set =
           SetAppHMIState(application, saved_hmi_level, true);
       if (app_hmi_state_is_set &&

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -214,6 +214,12 @@ bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
             "High-bandwidth transport not available, app will resume into : "
                 << saved_hmi_level);
       }
+      const bool app_hmi_state_is_set =
+          SetAppHMIState(application, saved_hmi_level, true);
+      if (app_hmi_state_is_set &&
+          application->is_app_data_resumption_allowed()) {
+        RestoreAppWidgets(application, saved_app);
+      }
       const bool does_app_with_same_level_exist =
           application_manager_.IsAppTypeExistsInFullOrLimited(application);
       if (does_app_with_same_level_exist) {
@@ -221,12 +227,6 @@ bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
             logger_,
             "App of same type exists in full or limited. Do no resume");
         return false;
-      }
-      const bool app_hmi_state_is_set =
-          SetAppHMIState(application, saved_hmi_level, true);
-      if (app_hmi_state_is_set &&
-          application->is_app_data_resumption_allowed()) {
-        RestoreAppWidgets(application, saved_app);
       }
     } else {
       result = false;

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -214,9 +214,9 @@ bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
             "High-bandwidth transport not available, app will resume into : "
                 << saved_hmi_level);
       }
-      const bool does_app_with_same_type_exist =
+      const bool does_app_with_same_level_exist =
           application_manager_.IsAppTypeExistsInFullOrLimited(application);
-      if (does_app_with_same_type_exist) {
+      if (does_app_with_same_level_exist) {
         LOG4CXX_DEBUG(
             logger_,
             "App of same type exists in full or limited. Do no resume");

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -221,11 +221,10 @@ bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
           application->is_app_data_resumption_allowed()) {
         restored_widgets = RestoreAppWidgets(application, saved_app);
       }
-      const bool active_app_exists = (application_manager_.active_application().use_count() != 0);
+      const bool active_app_exists =
+          (application_manager_.active_application().use_count() != 0);
       if (0 == restored_widgets && active_app_exists) {
-        LOG4CXX_DEBUG(
-            logger_,
-            "App exists in full or limited. Do not resume");
+        LOG4CXX_DEBUG(logger_, "App exists in full or limited. Do not resume");
         return false;
       }
     } else {

--- a/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
@@ -102,8 +102,8 @@ class MockResumeCtrl : public resumption::ResumeCtrl {
   MOCK_CONST_METHOD0(LaunchTime, time_t());
 
   MOCK_METHOD2(RestoreAppWidgets,
-               void(app_mngr::ApplicationSharedPtr application,
-                    const smart_objects::SmartObject& saved_app));
+               size_t(app_mngr::ApplicationSharedPtr application,
+                      const smart_objects::SmartObject& saved_app));
 
   MOCK_METHOD1(RestoreWidgetsHMIState,
                void(const smart_objects::SmartObject& response_message));

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -128,6 +128,8 @@ class ResumeCtrlTest : public ::testing::Test {
     EXPECT_CALL(mock_app_mngr_, CheckResumptionRequiredTransportAvailable(_))
         .Times(AtLeast(0))
         .WillRepeatedly(Return(true));
+    ON_CALL(mock_app_mngr_, get_full_or_limited_application())
+        .WillByDefault(Return(ApplicationSharedPtr()));
 
     ON_CALL(mock_application_manager_settings_, use_db_for_resumption())
         .WillByDefault(Return(false));

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -171,6 +171,8 @@ class ApplicationManager {
   virtual ApplicationSharedPtr application(uint32_t app_id) const = 0;
   virtual ApplicationSharedPtr active_application() const = 0;
 
+  virtual ApplicationSharedPtr get_full_or_limited_application() const = 0;
+
   /**
    * Function used only by HMI request/response/notification base classes
    * to change HMI app id to Mobile app id and vice versa.

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -86,6 +86,8 @@ class MockApplicationManager : public application_manager::ApplicationManager {
       application, application_manager::ApplicationSharedPtr(uint32_t app_id));
   MOCK_CONST_METHOD0(active_application,
                      application_manager::ApplicationSharedPtr());
+  MOCK_CONST_METHOD0(get_full_or_limited_application,
+                     application_manager::ApplicationSharedPtr());
   MOCK_CONST_METHOD2(application,
                      application_manager::ApplicationSharedPtr(
                          const std::string& device_id,


### PR DESCRIPTION
Fixes #3111 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Use ATF script GH-3111.lua supplied in issue.

### Summary
When the resume controllers timer fires to resume an app, there is no check to see if the saved hmi level conflicts with an app that is already in a limited or full state. This fix looks for that case and returns false for RestoreAppHMIState. This will mark the resumption as failed and set the app is_resuming state to false. This allows an app to later be activated via SDL.ActivateApp.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
