### PR TITLE
Rework usb handler delegate completion

### DIFF
--- a/src/components/transport_manager/include/transport_manager/usb/libusb/usb_handler.h
+++ b/src/components/transport_manager/include/transport_manager/usb/libusb/usb_handler.h
@@ -76,6 +76,7 @@ class UsbHandler {
    public:
     explicit UsbHandlerDelegate(UsbHandler* handler);
     void threadMain() OVERRIDE;
+    void exitThreadMain() OVERRIDE;
 
    private:
     UsbHandler* handler_;

--- a/src/components/transport_manager/src/usb/libusb/usb_handler.cc
+++ b/src/components/transport_manager/src/usb/libusb/usb_handler.cc
@@ -77,12 +77,12 @@ class UsbHandler::ControlTransferSequenceState {
 
 UsbHandler::UsbHandler()
     : shutdown_requested_(false)
-    , thread_(NULL)
+    , thread_(nullptr)
     , usb_device_listeners_()
     , devices_()
     , transfer_sequences_()
     , device_handles_to_close_()
-    , libusb_context_(NULL)
+    , libusb_context_(nullptr)
     , arrived_callback_handle_()
     , left_callback_handle_() {
   thread_ = threads::CreateThread("UsbHandler", new UsbHandlerDelegate(this));
@@ -90,19 +90,23 @@ UsbHandler::UsbHandler()
 
 UsbHandler::~UsbHandler() {
   shutdown_requested_ = true;
-  thread_->stop();
   LOG4CXX_INFO(logger_, "UsbHandler thread finished");
-  if (libusb_context_ != 0) {  // This wakes up libusb_handle_events()
+
+  if (libusb_context_) {
+    // The libusb_hotplug_deregister_callback() wakes up blocking call of
+    // libusb_handle_events_completed() in the Thread() method of delegate
     libusb_hotplug_deregister_callback(libusb_context_,
                                        arrived_callback_handle_);
     libusb_hotplug_deregister_callback(libusb_context_, left_callback_handle_);
   }
+
   thread_->join();
   delete thread_->delegate();
   threads::DeleteThread(thread_);
+
   if (libusb_context_) {
     libusb_exit(libusb_context_);
-    libusb_context_ = 0;
+    libusb_context_ = nullptr;
   }
 }
 
@@ -516,6 +520,12 @@ void UsbHandler::UsbHandlerDelegate::threadMain() {
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK(handler_);
   handler_->Thread();
+}
+
+void UsbHandler::UsbHandlerDelegate::exitThreadMain() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  // Empty method required in order to avoid force delegate thread
+  // finishing by exitThreadMain() of the base class
 }
 
 }  // namespace transport_adapter


### PR DESCRIPTION
Fixes #3110

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tested by existing unit tests


### Summary
The problem was in the Thread() function of USB handler delegate. It used blocking call `libusb_handle_events_completed()`. So when USB handler dtor was called - delegate was destroyed in force way without free of allocated resources. Therefore it leads to file descriptors leak and as a result core crash when the number of available file descriptors exceeded OS maximum per user.



### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
