### PR TITLE
Fix processing of VR only Perform Interaction response

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_interaction_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_interaction_request.h
@@ -288,6 +288,7 @@ class PerformInteractionRequest
   hmi_apis::Common_Result::eType ui_result_code_;
   std::string ui_info_;
   std::string vr_info_;
+  smart_objects::SmartObject response_msg_params;
 
   DISALLOW_COPY_AND_ASSIGN(PerformInteractionRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_interaction_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_interaction_request.h
@@ -93,6 +93,33 @@ class PerformInteractionRequest
    */
   virtual void onTimeOut();
 
+ protected:
+  /**
+   * @brief Prepare result code for sending to mobile application
+   * @param ui_response contains result_code from HMI response and
+   * interface that returns response
+   * @param vr_response contains result_code from HMI response and
+   * interface that returns response.
+   * @return resulting code for sending to mobile application.
+   */
+  mobile_apis::Result::eType PrepareResultCodeForResponse(
+      const app_mngr::commands::ResponseInfo& ui_response,
+      const app_mngr::commands::ResponseInfo& vr_response);
+
+  /**
+   * @brief Checks result code from HMI for splitted RPC
+   * and returns parameter for sending to mobile app.
+   * @param ui_response contains result_code from HMI response and
+   * interface that returns response
+   * @param vr_response contains result_code from HMI response and
+   * interface that returns response
+   * @return true if result code complies successful result code
+   * otherwise returns false
+   */
+  bool PrepareResultForMobileResponse(
+      app_mngr::commands::ResponseInfo& out_first,
+      app_mngr::commands::ResponseInfo& out_second) const;
+
  private:
   /**
    * @brief Function will be called when VR_OnCommand event
@@ -194,7 +221,7 @@ class PerformInteractionRequest
    * otherwise returns FALSE.
    */
   bool CheckChoiceIDFromResponse(app_mngr::ApplicationSharedPtr app,
-                                 int32_t choice_id);
+                                 const int32_t choice_id);
 
   /**
    * @brief Checks for a match of choice ID, in
@@ -232,7 +259,27 @@ class PerformInteractionRequest
    */
   void SendBothModeResponse(const smart_objects::SmartObject& msg_param);
 
+  /**
+   * @brief Sends UiClosePopUp request to HMI
+   */
+  void SendClosePopupRequestToHMI();
+
+  /**
+   * @brief Sets the choice according to the current interaction mode and first
+   * received choice id (UI or VR).
+   *
+   * @param msg_param Message parameters which will be included in the response
+   * to mobile device.
+   * @return Returns false, if choice_id received from UI and VR are valid and
+   * not equal. Otherwise returns true.
+   */
+  bool SetChoiceIdToResponseMsgParams(
+      smart_objects::SmartObject& msg_param) const;
+
   mobile_apis::InteractionMode::eType interaction_mode_;
+  std::int32_t ui_choice_id_received_;
+  std::int32_t vr_choice_id_received_;
+
   bool ui_response_received_;
   bool vr_response_received_;
   bool app_pi_was_active_before_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
@@ -1116,20 +1116,12 @@ PerformInteractionRequest::PrepareResultCodeForResponse(
   auto mobile_ui_result_code =
       MessageHelper::HMIToMobileResult(ui_result_code_);
 
-  {
-    bool vr_success =
-        mobile_apis::Result::eType::SUCCESS == mobile_vr_result_code;
-    bool vr_warnings =
-        mobile_apis::Result::eType::WARNINGS == mobile_vr_result_code;
-    bool ui_success =
-        mobile_apis::Result::eType::SUCCESS == mobile_ui_result_code;
-    bool ui_warnings =
-        mobile_apis::Result::eType::WARNINGS == mobile_ui_result_code;
-
-    bool is_vr_success_and_ui_warnings = vr_success && ui_warnings;
-    bool is_ui_success_and_vr_warnings = ui_success && vr_warnings;
-
-    if (is_vr_success_and_ui_warnings || is_ui_success_and_vr_warnings) {
+  if (mobile_apis::Result::eType::WARNINGS == mobile_vr_result_code) {
+    if (mobile_apis::Result::eType::SUCCESS == mobile_ui_result_code) {
+      return mobile_apis::Result::eType::WARNINGS;
+    }
+  } else if (mobile_apis::Result::eType::WARNINGS == mobile_ui_result_code) {
+    if (mobile_apis::Result::eType::SUCCESS == mobile_vr_result_code) {
       return mobile_apis::Result::eType::WARNINGS;
     }
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
@@ -32,6 +32,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/mobile/perform_interaction_request.h"
+
 #include <string.h>
 #include <numeric>
 #include <string>
@@ -45,6 +46,10 @@
 #include "utils/file_system.h"
 #include "utils/gen_hash.h"
 #include "utils/helpers.h"
+
+namespace {
+const std::int32_t INVALID_CHOICE_ID = -1;
+}
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -67,6 +72,8 @@ PerformInteractionRequest::PerformInteractionRequest(
                          hmi_capabilities,
                          policy_handler)
     , interaction_mode_(mobile_apis::InteractionMode::INVALID_ENUM)
+    , ui_choice_id_received_(INVALID_CHOICE_ID)
+    , vr_choice_id_received_(INVALID_CHOICE_ID)
     , ui_response_received_(false)
     , vr_response_received_(false)
     , app_pi_was_active_before_(false)
@@ -241,6 +248,7 @@ void PerformInteractionRequest::on_event(const event_engine::Event& event) {
       LOG4CXX_DEBUG(logger_, "Received UI_PerformInteraction event");
       EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
       ui_response_received_ = true;
+
       unsubscribe_from_event(hmi_apis::FunctionID::UI_PerformInteraction);
       ui_result_code_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asUInt());
@@ -252,6 +260,7 @@ void PerformInteractionRequest::on_event(const event_engine::Event& event) {
       LOG4CXX_DEBUG(logger_, "Received VR_PerformInteraction");
       EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
       vr_response_received_ = true;
+
       unsubscribe_from_event(hmi_apis::FunctionID::VR_PerformInteraction);
       vr_result_code_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asUInt());
@@ -268,8 +277,17 @@ void PerformInteractionRequest::on_event(const event_engine::Event& event) {
   }
 
   if (!HasHMIResponsesToWait()) {
-    LOG4CXX_DEBUG(logger_, "Send response in BOTH iteraction mode");
-    SendBothModeResponse(msg_param);
+    LOG4CXX_DEBUG(logger_,
+                  "Send response in interaction mode "
+                      << static_cast<int32_t>(interaction_mode_));
+    if (SetChoiceIdToResponseMsgParams(msg_param)) {
+      SendBothModeResponse(msg_param);
+    } else {
+      DisablePerformInteraction();
+      SendResponse(false,
+                   mobile_apis::Result::GENERIC_ERROR,
+                   "Received two different choice IDs");
+    }
   }
 }
 
@@ -346,6 +364,11 @@ bool PerformInteractionRequest::ProcessVRResponse(
     return false;
   }
 
+  if (!ui_response_received_ &&
+      InteractionMode::MANUAL_ONLY != interaction_mode_) {
+    SendClosePopupRequestToHMI();
+  }
+
   const SmartObject& hmi_msg_params = message[strings::msg_params];
   if (hmi_msg_params.keyExists(strings::choice_id)) {
     const int choice_id = hmi_msg_params[strings::choice_id].asInt();
@@ -356,7 +379,7 @@ bool PerformInteractionRequest::ProcessVRResponse(
           false, Result::GENERIC_ERROR, "Wrong choiceID was received from HMI");
       return true;
     }
-    msg_params[strings::choice_id] = choice_id;
+    vr_choice_id_received_ = choice_id;
   }
 
   if (mobile_apis::InteractionMode::BOTH == interaction_mode_ ||
@@ -397,8 +420,8 @@ void PerformInteractionRequest::ProcessUIResponse(
   HmiInterfaces::InterfaceState ui_interface_state =
       application_manager_.hmi_interfaces().GetInterfaceState(
           HmiInterfaces::HMI_INTERFACE_UI);
-  bool result = false;
-  result = Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+
+  bool result = Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
       ui_result_code_,
       hmi_apis::Common_Result::SUCCESS,
       hmi_apis::Common_Result::WARNINGS);
@@ -430,11 +453,14 @@ void PerformInteractionRequest::ProcessUIResponse(
 
     // result code must be GENERIC_ERROR in case wrong choice_id
     if (msg_params.keyExists(strings::choice_id)) {
-      if (!CheckChoiceIDFromResponse(app,
-                                     msg_params[strings::choice_id].asInt())) {
+      const std::int32_t ui_choice_id =
+          static_cast<std::int32_t>(msg_params[strings::choice_id].asInt());
+
+      if (!CheckChoiceIDFromResponse(app, ui_choice_id)) {
         ui_result_code_ = hmi_apis::Common_Result::GENERIC_ERROR;
         ui_info_ = "Wrong choiceID was received from HMI";
       } else {
+        ui_choice_id_received_ = ui_choice_id;
         msg_params[strings::trigger_source] =
             mobile_apis::TriggerSource::TS_MENU;
       }
@@ -931,15 +957,19 @@ bool PerformInteractionRequest::IsWhiteSpaceExist() {
 void PerformInteractionRequest::TerminatePerformInteraction() {
   LOG4CXX_AUTO_TRACE(logger_);
 
+  SendClosePopupRequestToHMI();
+  DisablePerformInteraction();
+}
+
+void PerformInteractionRequest::SendClosePopupRequestToHMI() {
   smart_objects::SmartObject msg_params =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
   msg_params[hmi_request::method_name] = "UI.PerformInteraction";
   SendHMIRequest(hmi_apis::FunctionID::UI_ClosePopUp, &msg_params);
-  DisablePerformInteraction();
 }
 
 bool PerformInteractionRequest::CheckChoiceIDFromResponse(
-    ApplicationSharedPtr app, int32_t choice_id) {
+    ApplicationSharedPtr app, const int32_t choice_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   const DataAccessor<PerformChoiceSetMap> accessor =
       app->performinteraction_choice_set_map();
@@ -951,12 +981,14 @@ bool PerformInteractionRequest::CheckChoiceIDFromResponse(
     const PerformChoice& choice = choice_set_map_it->second;
     PerformChoice::const_iterator it = choice.begin();
     for (; choice.end() != it; ++it) {
-      const smart_objects::SmartObject& choice_set =
-          (*it->second).getElement(strings::choice_set);
-      for (size_t j = 0; j < choice_set.length(); ++j) {
-        if (choice_id ==
-            choice_set.getElement(j).getElement(strings::choice_id).asInt()) {
-          return true;
+      if ((*it->second).keyExists(strings::choice_set)) {
+        const smart_objects::SmartObject& choice_set =
+            (*it->second).getElement(strings::choice_set);
+        for (size_t j = 0; j < choice_set.length(); ++j) {
+          if (choice_id ==
+              choice_set.getElement(j).getElement(strings::choice_id).asInt()) {
+            return true;
+          }
         }
       }
     }
@@ -1063,13 +1095,79 @@ void PerformInteractionRequest::SendBothModeResponse(
       msg_param.empty() ? NULL : &msg_param;
   std::string info = app_mngr::commands::MergeInfos(
       ui_perform_info, ui_info_, vr_perform_info, vr_info_);
+
   DisablePerformInteraction();
+
   SendResponse(result,
                perform_interaction_result_code,
                info.empty() ? NULL : info.c_str(),
                response_params);
 }
 
-}  // namespace commands
+mobile_apis::Result::eType
+PerformInteractionRequest::PrepareResultCodeForResponse(
+    const app_mngr::commands::ResponseInfo& ui_response,
+    const app_mngr::commands::ResponseInfo& vr_response) {
+  LOG4CXX_DEBUG(
+      logger_, "InteractionMode = " << static_cast<int32_t>(interaction_mode_));
 
+  if (mobile_apis::InteractionMode::VR_ONLY == interaction_mode_) {
+    return MessageHelper::HMIToMobileResult(vr_result_code_);
+  }
+  if (mobile_apis::InteractionMode::MANUAL_ONLY == interaction_mode_) {
+    return MessageHelper::HMIToMobileResult(ui_result_code_);
+  }
+
+  if (INVALID_CHOICE_ID != vr_choice_id_received_) {
+    return MessageHelper::HMIToMobileResult(vr_result_code_);
+  }
+  if (INVALID_CHOICE_ID != ui_choice_id_received_) {
+    return MessageHelper::HMIToMobileResult(ui_result_code_);
+  }
+
+  return CommandRequestImpl::PrepareResultCodeForResponse(ui_response,
+                                                          vr_response);
+}
+
+bool PerformInteractionRequest::PrepareResultForMobileResponse(
+    app_mngr::commands::ResponseInfo& ui_response,
+    app_mngr::commands::ResponseInfo& vr_response) const {
+  if (mobile_apis::InteractionMode::VR_ONLY == interaction_mode_) {
+    return vr_response.is_ok;
+  }
+  if (mobile_apis::InteractionMode::MANUAL_ONLY == interaction_mode_) {
+    return ui_response.is_ok;
+  }
+
+  return (vr_response.is_ok || ui_response.is_ok);
+}
+
+bool PerformInteractionRequest::SetChoiceIdToResponseMsgParams(
+    ns_smart_device_link::ns_smart_objects::SmartObject& msg_param) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const bool ui_choice_id_valid = INVALID_CHOICE_ID != ui_choice_id_received_;
+  const bool vr_choice_id_valid = INVALID_CHOICE_ID != vr_choice_id_received_;
+
+  if (ui_choice_id_valid && vr_choice_id_valid &&
+      ui_choice_id_received_ != vr_choice_id_received_) {
+    return false;
+  }
+
+  if (mobile_apis::InteractionMode::eType::MANUAL_ONLY == interaction_mode_) {
+    msg_param[strings::choice_id] = ui_choice_id_received_;
+    return true;
+  }
+
+  if (mobile_apis::InteractionMode::eType::VR_ONLY == interaction_mode_) {
+    msg_param[strings::choice_id] = vr_choice_id_received_;
+    return true;
+  }
+
+  msg_param[strings::choice_id] =
+      ui_choice_id_valid ? ui_choice_id_received_ : vr_choice_id_received_;
+  return true;
+}
+
+}  // namespace commands
 }  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/perform_interaction_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/perform_interaction_test.cc
@@ -70,37 +70,107 @@ namespace strings = ::application_manager::strings;
 namespace hmi_response = ::application_manager::hmi_response;
 
 namespace {
+const int32_t kCorrelationId = 1u;
 const int32_t kCommandId = 1;
 const uint32_t kCmdId = 1u;
 const uint32_t kConnectionKey = 2u;
+const int32_t kUiChoiceID = 1u;
+const int32_t kVrChoiceID = 2u;
+const int32_t kInvalidChoiceId = -1;
 }  // namespace
 
 class PerformInteractionRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  PerformInteractionRequestTest() : mock_app_(CreateMockApp()) {}
+  PerformInteractionRequestTest()
+      : mock_app_(CreateMockApp())
+      , performinteraction_choice_set_lock_ptr_(
+            std::make_shared<sync_primitives::RecursiveLock>()) {}
 
   void SetUp() OVERRIDE {
+    smart_objects::SmartObject choice_set1(
+        smart_objects::SmartType::SmartType_Map);
+    smart_objects::SmartObject choice_set2(
+        smart_objects::SmartType::SmartType_Map);
+
+    choice_set1[strings::choice_set] =
+        smart_objects::SmartType::SmartType_Array;
+    choice_set2[strings::choice_set] =
+        smart_objects::SmartType::SmartType_Array;
+
+    choice_set1[strings::choice_set][0][strings::choice_id] = kUiChoiceID;
+    choice_set2[strings::choice_set][0][strings::choice_id] = kVrChoiceID;
+
+    choice_set_map_[kCorrelationId].insert(std::make_pair(
+        kUiChoiceID, new smart_objects::SmartObject(choice_set1)));
+    choice_set_map_[kCorrelationId].insert(std::make_pair(
+        kVrChoiceID, new smart_objects::SmartObject(choice_set2)));
+
     ON_CALL(app_mngr_, application(kConnectionKey))
         .WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
+    ON_CALL(*mock_app_, performinteraction_choice_set_map())
+        .WillByDefault(Return(DataAccessor<app_mngr::PerformChoiceSetMap>(
+            choice_set_map_, performinteraction_choice_set_lock_ptr_)));
   }
 
   void ResultCommandExpectations(MessageSharedPtr msg,
-                                  bool success,
-                                  hmi_apis::Common_Result::eType result_code,
+                                 bool success,
+                                 hmi_apis::Common_Result::eType result_code,
                                  const std::string& info) {
-    EXPECT_EQ((*msg)[am::strings::msg_params][am::strings::success].asBool(),
-              success);
+    EXPECT_EQ((*msg)[strings::msg_params][strings::success].asBool(), success);
+    EXPECT_EQ((*msg)[strings::msg_params][strings::result_code].asInt(),
+              static_cast<int32_t>(result_code));
+    EXPECT_EQ((*msg)[strings::msg_params][strings::info].asString(), info);
+  }
+
+  void HMIRequestExpectations(MessageSharedPtr msg,
+                              hmi_apis::FunctionID::eType function_id,
+                              const std::string& method_name) {
+    EXPECT_EQ((*msg)[strings::params][strings::function_id].asInt(),
+              static_cast<int32_t>(function_id));
     EXPECT_EQ(
-        (*msg)[am::strings::msg_params][am::strings::result_code].asInt(),
-        static_cast<int32_t>(result_code));
-    EXPECT_EQ((*msg)[am::strings::msg_params][am::strings::info].asString(),
-              info);
+        (*msg)[strings::msg_params][am::hmi_request::method_name].asString(),
+        method_name);
+  }
+
+  MessageSharedPtr CreateRequestMessage(
+      const mobile_apis::InteractionMode::eType& interaction_mode) {
+    MessageSharedPtr request_msg = CreateMessage(smart_objects::SmartType_Map);
+    (*request_msg)[strings::params][strings::connection_key] = kConnectionKey;
+    (*request_msg)[strings::params][strings::correlation_id] = kCorrelationId;
+    (*request_msg)[strings::msg_params][strings::interaction_mode] =
+        interaction_mode;
+    return request_msg;
+  }
+
+  MessageSharedPtr CreateHMIResponseMessage(
+      const hmi_apis::Common_Result::eType& response_code,
+      const std::string& message_info,
+      const int32_t command_id = kCommandId) {
+    MessageSharedPtr response_msg = CreateMessage(smart_objects::SmartType_Map);
+    (*response_msg)[strings::params][hmi_response::code] = response_code;
+    (*response_msg)[strings::msg_params][strings::cmd_id] = command_id;
+    (*response_msg)[strings::msg_params][strings::info] = message_info;
+    return response_msg;
+  }
+
+  MessageSharedPtr CreateHMIResponseMessageWithChoiceID(
+      const hmi_apis::Common_Result::eType& response_code,
+      const std::string& message_info,
+      const int32_t choice_id,
+      const int32_t command_id = kCommandId) {
+    MessageSharedPtr response_msg =
+        CreateHMIResponseMessage(response_code, message_info, kCommandId);
+    (*response_msg)[strings::msg_params][strings::choice_id] = choice_id;
+    return response_msg;
   }
 
   sync_primitives::Lock lock_;
   MockAppPtr mock_app_;
+  app_mngr::PerformChoiceSetMap choice_set_map_;
+  mutable std::shared_ptr<sync_primitives::RecursiveLock>
+      performinteraction_choice_set_lock_ptr_;
 };
 
 TEST_F(PerformInteractionRequestTest, OnTimeout_VR_GENERIC_ERROR) {
@@ -149,36 +219,101 @@ TEST_F(PerformInteractionRequestTest, OnTimeout_VR_GENERIC_ERROR) {
 }
 
 TEST_F(PerformInteractionRequestTest,
-       OnEvent_VRHmiSendSuccess_UNSUPPORTED_RESOURCE) {
+       OnEvent_BOTHMode_UIChoiceIdReceivedFirst) {
   MessageSharedPtr msg_from_mobile =
-      CreateMessage(smart_objects::SmartType_Map);
-  (*msg_from_mobile)[strings::params][strings::connection_key] = kConnectionKey;
-  (*msg_from_mobile)[strings::msg_params][strings::interaction_mode] =
-      mobile_apis::InteractionMode::VR_ONLY;
+      CreateRequestMessage(mobile_apis::InteractionMode::BOTH);
   std::shared_ptr<PerformInteractionRequest> command =
       CreateCommand<PerformInteractionRequest>(msg_from_mobile);
-  
+
+  ASSERT_TRUE(command->Init());
+
+  MessageSharedPtr response_msg_vr = CreateHMIResponseMessage(
+      hmi_apis::Common_Result::SUCCESS, "", kInvalidChoiceId);
+  am::event_engine::Event event_vr(hmi_apis::FunctionID::VR_PerformInteraction);
+  event_vr.set_smart_object(*response_msg_vr);
+
+  MessageSharedPtr response_msg_ui = CreateHMIResponseMessageWithChoiceID(
+      hmi_apis::Common_Result::SUCCESS, "", kUiChoiceID);
+  am::event_engine::Event event_ui(hmi_apis::FunctionID::UI_PerformInteraction);
+  event_ui.set_smart_object(*response_msg_ui);
+
+  MessageSharedPtr response_to_mobile;
+
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&response_to_mobile), Return(true)));
+
+  command->on_event(event_ui);
+  command->on_event(event_vr);
+
+  EXPECT_EQ(
+      kUiChoiceID,
+      (*response_to_mobile)[strings::msg_params][strings::choice_id].asInt());
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_BOTHMode_VRChoiceIdReceivedFirst) {
+  MessageSharedPtr msg_from_mobile =
+      CreateRequestMessage(mobile_apis::InteractionMode::BOTH);
+  std::shared_ptr<PerformInteractionRequest> command =
+      CreateCommand<PerformInteractionRequest>(msg_from_mobile);
+
+  ASSERT_TRUE(command->Init());
+
+  MessageSharedPtr response_msg_vr = CreateHMIResponseMessageWithChoiceID(
+      hmi_apis::Common_Result::SUCCESS, "", kVrChoiceID);
+  MessageSharedPtr response_msg_ui = CreateHMIResponseMessageWithChoiceID(
+      hmi_apis::Common_Result::SUCCESS, "", kInvalidChoiceId);
+
+  am::event_engine::Event event_vr(hmi_apis::FunctionID::VR_PerformInteraction);
+  event_vr.set_smart_object(*response_msg_vr);
+
+  am::event_engine::Event event_ui(hmi_apis::FunctionID::UI_PerformInteraction);
+  event_ui.set_smart_object(*response_msg_ui);
+
+  MessageSharedPtr request_to_hmi;
+  EXPECT_CALL(mock_rpc_service_,
+              ManageHMICommand(
+                  _, am::commands::Command::CommandSource::SOURCE_SDL_TO_HMI))
+      .WillOnce(DoAll(SaveArg<0>(&request_to_hmi), Return(true)));
+
+  command->on_event(event_vr);
+  EXPECT_EQ(hmi_apis::FunctionID::UI_ClosePopUp,
+            (*request_to_hmi)[strings::params][strings::function_id].asInt());
+
+  MessageSharedPtr response_to_mobile;
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&response_to_mobile), Return(true)));
+  command->on_event(event_ui);
+
+  EXPECT_EQ(
+      kVrChoiceID,
+      (*response_to_mobile)[strings::msg_params][strings::choice_id].asInt());
+}
+
+TEST_F(PerformInteractionRequestTest,
+       OnEvent_VRHmiSendSuccess_UNSUPPORTED_RESOURCE) {
+  MessageSharedPtr msg_from_mobile =
+      CreateRequestMessage(mobile_apis::InteractionMode::VR_ONLY);
+  std::shared_ptr<PerformInteractionRequest> command =
+      CreateCommand<PerformInteractionRequest>(msg_from_mobile);
+
   ASSERT_TRUE(command->Init());
 
   MockAppPtr mock_app;
   EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(mock_app));
 
   MessageSharedPtr response_msg_vr =
-      CreateMessage(smart_objects::SmartType_Map);
-  (*response_msg_vr)[strings::params][hmi_response::code] =
-      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE;
-  (*response_msg_vr)[strings::msg_params][strings::cmd_id] = kCommandId;
-  (*response_msg_vr)[am::strings::msg_params][am::strings::info] =
-      "VR is not supported by system";
-
+      CreateHMIResponseMessage(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
+                               "VR is not supported by system");
   am::event_engine::Event event_vr(hmi_apis::FunctionID::VR_PerformInteraction);
   event_vr.set_smart_object(*response_msg_vr);
 
   MessageSharedPtr response_msg_ui =
-      CreateMessage(smart_objects::SmartType_Map);
-  (*response_msg_ui)[strings::params][hmi_response::code] =
-      hmi_apis::Common_Result::SUCCESS;
-
+      CreateHMIResponseMessage(hmi_apis::Common_Result::SUCCESS, "");
   am::event_engine::Event event_ui(hmi_apis::FunctionID::UI_PerformInteraction);
   event_ui.set_smart_object(*response_msg_ui);
 
@@ -199,42 +334,32 @@ TEST_F(PerformInteractionRequestTest,
   command->on_event(event_vr);
   command->on_event(event_ui);
 
-  ResultCommandExpectations(response_to_mobile, 
-                            false, 
-                            hmi_apis::Common_Result::UNSUPPORTED_RESOURCE, 
+  ResultCommandExpectations(response_to_mobile,
+                            false,
+                            hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
                             "VR is not supported by system");
 }
 
 TEST_F(PerformInteractionRequestTest,
        OnEvent_UIHmiSendSuccess_UNSUPPORTED_RESOURCE) {
   MessageSharedPtr msg_from_mobile =
-      CreateMessage(smart_objects::SmartType_Map);
-  (*msg_from_mobile)[strings::params][strings::connection_key] = kConnectionKey;
-  (*msg_from_mobile)[strings::msg_params][strings::interaction_mode] =
-      mobile_apis::InteractionMode::VR_ONLY;
+      CreateRequestMessage(mobile_apis::InteractionMode::VR_ONLY);
   std::shared_ptr<PerformInteractionRequest> command =
       CreateCommand<PerformInteractionRequest>(msg_from_mobile);
-  
+
   ASSERT_TRUE(command->Init());
 
   MockAppPtr mock_app;
   EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(mock_app));
 
   MessageSharedPtr response_msg_vr =
-      CreateMessage(smart_objects::SmartType_Map);
-  (*response_msg_vr)[strings::params][hmi_response::code] =
-      hmi_apis::Common_Result::SUCCESS;
+      CreateHMIResponseMessage(hmi_apis::Common_Result::SUCCESS, "");
   am::event_engine::Event event_vr(hmi_apis::FunctionID::VR_PerformInteraction);
   event_vr.set_smart_object(*response_msg_vr);
 
   MessageSharedPtr response_msg_ui =
-      CreateMessage(smart_objects::SmartType_Map);
-  (*response_msg_ui)[strings::params][hmi_response::code] =
-      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE;
-  (*response_msg_ui)[strings::msg_params][strings::cmd_id] = kCommandId;
-  (*response_msg_ui)[am::strings::msg_params][am::strings::info] =
-      "UI is not supported by system";
-
+      CreateHMIResponseMessage(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
+                               "UI is not supported by system");
   am::event_engine::Event event_ui(hmi_apis::FunctionID::UI_PerformInteraction);
   event_ui.set_smart_object(*response_msg_ui);
 
@@ -244,7 +369,7 @@ TEST_F(PerformInteractionRequestTest,
       mock_rpc_service_,
       ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
       .WillOnce(DoAll(SaveArg<0>(&response_to_mobile), Return(true)));
-  
+
   command->on_event(event_vr);
   command->on_event(event_ui);
 
@@ -252,6 +377,145 @@ TEST_F(PerformInteractionRequestTest,
                             true,
                             hmi_apis::Common_Result::SUCCESS,
                             "UI is not supported by system");
+}
+
+TEST_F(
+    PerformInteractionRequestTest,
+    PrepareResultCodeAndResponseForMobile_GetVRResultCodeOnly_InVR_OnlyMode_SUCCESS) {
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  MessageSharedPtr msg_from_mobile =
+      CreateRequestMessage(mobile_apis::InteractionMode::VR_ONLY);
+  std::shared_ptr<PerformInteractionRequest> command =
+      CreateCommand<PerformInteractionRequest>(msg_from_mobile);
+
+  ASSERT_TRUE(command->Init());
+
+  MockAppPtr mock_app;
+  EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(mock_app));
+
+  MessageSharedPtr response_msg_vr =
+      CreateHMIResponseMessage(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
+                               "VR is not supported by system");
+  am::event_engine::Event event_vr(hmi_apis::FunctionID::VR_PerformInteraction);
+  event_vr.set_smart_object(*response_msg_vr);
+
+  MessageSharedPtr response_msg_ui =
+      CreateHMIResponseMessage(hmi_apis::Common_Result::SUCCESS, "");
+  am::event_engine::Event event_ui(hmi_apis::FunctionID::UI_PerformInteraction);
+  event_ui.set_smart_object(*response_msg_ui);
+
+  MessageSharedPtr response_to_mobile;
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&response_to_mobile), Return(true)));
+
+  command->on_event(event_vr);
+  command->on_event(event_ui);
+
+  ResultCommandExpectations(response_to_mobile,
+                            false,
+                            hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
+                            "VR is not supported by system");
+}
+
+TEST_F(
+    PerformInteractionRequestTest,
+    PrepareResultCodeAndResponseForMobile_GetVR_ErrorInfoAndCode_InBOTH_Mode_With_UI_success_result_code) {
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  auto msg_from_mobile =
+      CreateRequestMessage(mobile_apis::InteractionMode::BOTH);
+  std::shared_ptr<PerformInteractionRequest> command =
+      CreateCommand<PerformInteractionRequest>(msg_from_mobile);
+
+  ASSERT_TRUE(command->Init());
+
+  MessageSharedPtr response_msg_vr =
+      CreateHMIResponseMessage(hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
+                               "VR is not supported by system");
+  am::event_engine::Event event_vr(hmi_apis::FunctionID::VR_PerformInteraction);
+  event_vr.set_smart_object(*response_msg_vr);
+
+  MessageSharedPtr response_msg_ui =
+      CreateHMIResponseMessage(hmi_apis::Common_Result::SUCCESS, "");
+  am::event_engine::Event event_ui(hmi_apis::FunctionID::UI_PerformInteraction);
+  event_ui.set_smart_object(*response_msg_ui);
+
+  MessageSharedPtr response_to_mobile;
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&response_to_mobile), Return(true)));
+
+  MessageSharedPtr request_to_hmi;
+  EXPECT_CALL(mock_rpc_service_,
+              ManageHMICommand(
+                  _, am::commands::Command::CommandSource::SOURCE_SDL_TO_HMI))
+      .WillOnce(DoAll(SaveArg<0>(&request_to_hmi), Return(true)));
+
+  command->on_event(event_vr);
+  command->on_event(event_ui);
+
+  HMIRequestExpectations(request_to_hmi,
+                         hmi_apis::FunctionID::UI_ClosePopUp,
+                         "UI.PerformInteraction");
+
+  ResultCommandExpectations(response_to_mobile,
+                            true,
+                            hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
+                            "VR is not supported by system");
+}
+
+TEST_F(
+    PerformInteractionRequestTest,
+    PrepareResultCodeAndResponseForMobile_Send_GENERIC_ERROR_To_Mobile_When_different_valid_choice_ids_received_in_BOTH_mode_SUCCESS) {
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  MessageSharedPtr msg_from_mobile =
+      CreateRequestMessage(mobile_apis::InteractionMode::BOTH);
+  std::shared_ptr<PerformInteractionRequest> command =
+      CreateCommand<PerformInteractionRequest>(msg_from_mobile);
+
+  ASSERT_TRUE(command->Init());
+
+  MessageSharedPtr response_msg_vr = CreateHMIResponseMessageWithChoiceID(
+      hmi_apis::Common_Result::SUCCESS, "", kVrChoiceID);
+  MessageSharedPtr response_msg_ui = CreateHMIResponseMessageWithChoiceID(
+      hmi_apis::Common_Result::SUCCESS, "", kUiChoiceID);
+
+  am::event_engine::Event event_vr(hmi_apis::FunctionID::VR_PerformInteraction);
+  event_vr.set_smart_object(*response_msg_vr);
+  am::event_engine::Event event_ui(hmi_apis::FunctionID::UI_PerformInteraction);
+  event_ui.set_smart_object(*response_msg_ui);
+
+  MessageSharedPtr response_to_mobile;
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&response_to_mobile), Return(true)));
+
+  MessageSharedPtr request_to_hmi;
+  EXPECT_CALL(mock_rpc_service_,
+              ManageHMICommand(
+                  _, am::commands::Command::CommandSource::SOURCE_SDL_TO_HMI))
+      .WillOnce(DoAll(SaveArg<0>(&request_to_hmi), Return(true)));
+
+  command->on_event(event_vr);
+  command->on_event(event_ui);
+
+  HMIRequestExpectations(request_to_hmi,
+                         hmi_apis::FunctionID::UI_ClosePopUp,
+                         "UI.PerformInteraction");
+
+  ResultCommandExpectations(response_to_mobile,
+                            false,
+                            hmi_apis::Common_Result::GENERIC_ERROR,
+                            "Received two different choice IDs");
 }
 
 }  // namespace perform_interaction_request

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/perform_interaction_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/perform_interaction_test.cc
@@ -518,6 +518,150 @@ TEST_F(
                             "Received two different choice IDs");
 }
 
+TEST_F(
+    PerformInteractionRequestTest,
+    VR_response_WARNINGS_UI_response_SUCCESS_MobileResponseContains_true_WARNINGS_warnings_info) {
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  auto msg_from_mobile =
+      CreateRequestMessage(mobile_apis::InteractionMode::VR_ONLY);
+  std::shared_ptr<PerformInteractionRequest> command =
+      CreateCommand<PerformInteractionRequest>(msg_from_mobile);
+
+  ASSERT_TRUE(command->Init());
+
+  MessageSharedPtr response_msg_vr = CreateHMIResponseMessage(
+      hmi_apis::Common_Result::WARNINGS, "WARNING MESSAGE");
+  am::event_engine::Event event_vr(hmi_apis::FunctionID::VR_PerformInteraction);
+  event_vr.set_smart_object(*response_msg_vr);
+
+  MessageSharedPtr response_msg_ui =
+      CreateHMIResponseMessage(hmi_apis::Common_Result::SUCCESS, "");
+  am::event_engine::Event event_ui(hmi_apis::FunctionID::UI_PerformInteraction);
+  event_ui.set_smart_object(*response_msg_ui);
+
+  MessageSharedPtr response_to_mobile;
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&response_to_mobile), Return(true)));
+
+  MessageSharedPtr request_to_hmi;
+  EXPECT_CALL(mock_rpc_service_,
+              ManageHMICommand(
+                  _, am::commands::Command::CommandSource::SOURCE_SDL_TO_HMI))
+      .WillOnce(DoAll(SaveArg<0>(&request_to_hmi), Return(true)));
+
+  command->on_event(event_vr);
+  command->on_event(event_ui);
+
+  HMIRequestExpectations(request_to_hmi,
+                         hmi_apis::FunctionID::UI_ClosePopUp,
+                         "UI.PerformInteraction");
+
+  ResultCommandExpectations(response_to_mobile,
+                            true,
+                            hmi_apis::Common_Result::WARNINGS,
+                            "WARNING MESSAGE");
+}
+
+TEST_F(
+    PerformInteractionRequestTest,
+    VR_response_SUCCESS_UI_response_WARNINGS_MobileResponseContains_true_WARNINGS_warnings_info) {
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  auto msg_from_mobile =
+      CreateRequestMessage(mobile_apis::InteractionMode::BOTH);
+  std::shared_ptr<PerformInteractionRequest> command =
+      CreateCommand<PerformInteractionRequest>(msg_from_mobile);
+
+  ASSERT_TRUE(command->Init());
+
+  MessageSharedPtr response_msg_vr =
+      CreateHMIResponseMessage(hmi_apis::Common_Result::SUCCESS, "");
+  am::event_engine::Event event_vr(hmi_apis::FunctionID::VR_PerformInteraction);
+  event_vr.set_smart_object(*response_msg_vr);
+
+  MessageSharedPtr response_msg_ui = CreateHMIResponseMessage(
+      hmi_apis::Common_Result::WARNINGS, "WARNING MESSAGE");
+  am::event_engine::Event event_ui(hmi_apis::FunctionID::UI_PerformInteraction);
+  event_ui.set_smart_object(*response_msg_ui);
+
+  MessageSharedPtr response_to_mobile;
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&response_to_mobile), Return(true)));
+
+  MessageSharedPtr request_to_hmi;
+  EXPECT_CALL(mock_rpc_service_,
+              ManageHMICommand(
+                  _, am::commands::Command::CommandSource::SOURCE_SDL_TO_HMI))
+      .WillOnce(DoAll(SaveArg<0>(&request_to_hmi), Return(true)));
+
+  command->on_event(event_vr);
+  command->on_event(event_ui);
+
+  HMIRequestExpectations(request_to_hmi,
+                         hmi_apis::FunctionID::UI_ClosePopUp,
+                         "UI.PerformInteraction");
+
+  ResultCommandExpectations(response_to_mobile,
+                            true,
+                            hmi_apis::Common_Result::WARNINGS,
+                            "WARNING MESSAGE");
+}
+
+TEST_F(
+    PerformInteractionRequestTest,
+    VR_response_UNSUPPORTED_RESOURCE_UI_response_WARNINGS_MobileResponseContains_false_UNSUPPORTED_RESOURSE_error_info) {
+  ON_CALL(mock_hmi_interfaces_, GetInterfaceState(_))
+      .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
+
+  auto msg_from_mobile =
+      CreateRequestMessage(mobile_apis::InteractionMode::BOTH);
+  std::shared_ptr<PerformInteractionRequest> command =
+      CreateCommand<PerformInteractionRequest>(msg_from_mobile);
+
+  ASSERT_TRUE(command->Init());
+
+  MessageSharedPtr response_msg_vr = CreateHMIResponseMessage(
+      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE, "VR error message");
+  am::event_engine::Event event_vr(hmi_apis::FunctionID::VR_PerformInteraction);
+  event_vr.set_smart_object(*response_msg_vr);
+
+  MessageSharedPtr response_msg_ui =
+      CreateHMIResponseMessage(hmi_apis::Common_Result::WARNINGS, "");
+  am::event_engine::Event event_ui(hmi_apis::FunctionID::UI_PerformInteraction);
+  event_ui.set_smart_object(*response_msg_ui);
+
+  MessageSharedPtr response_to_mobile;
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&response_to_mobile), Return(true)));
+
+  MessageSharedPtr request_to_hmi;
+  EXPECT_CALL(mock_rpc_service_,
+              ManageHMICommand(
+                  _, am::commands::Command::CommandSource::SOURCE_SDL_TO_HMI))
+      .WillOnce(DoAll(SaveArg<0>(&request_to_hmi), Return(true)));
+
+  command->on_event(event_vr);
+  command->on_event(event_ui);
+
+  HMIRequestExpectations(request_to_hmi,
+                         hmi_apis::FunctionID::UI_ClosePopUp,
+                         "UI.PerformInteraction");
+
+  ResultCommandExpectations(response_to_mobile,
+                            true,
+                            hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
+                            "VR error message");
+}
+
 }  // namespace perform_interaction_request
 }  // namespace mobile_commands_test
 }  // namespace commands_test

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/perform_interaction_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/perform_interaction_test.cc
@@ -632,8 +632,8 @@ TEST_F(
   am::event_engine::Event event_vr(hmi_apis::FunctionID::VR_PerformInteraction);
   event_vr.set_smart_object(*response_msg_vr);
 
-  MessageSharedPtr response_msg_ui =
-      CreateHMIResponseMessage(hmi_apis::Common_Result::WARNINGS, "");
+  MessageSharedPtr response_msg_ui = CreateHMIResponseMessage(
+      hmi_apis::Common_Result::WARNINGS, "UI warning message");
   am::event_engine::Event event_ui(hmi_apis::FunctionID::UI_PerformInteraction);
   event_ui.set_smart_object(*response_msg_ui);
 
@@ -659,7 +659,7 @@ TEST_F(
   ResultCommandExpectations(response_to_mobile,
                             true,
                             hmi_apis::Common_Result::UNSUPPORTED_RESOURCE,
-                            "VR error message");
+                            "UI warning message, VR error message");
 }
 
 }  // namespace perform_interaction_request


### PR DESCRIPTION
Fixes #2830 #3112 #2990 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF test script attached to https://github.com/smartdevicelink/sdl_core/issues/2830

### Summary
In case of successful VR.PerformInteraction response from HMI with choiceID present in response
SDL doesn't send UI_ClosePopUp request to HMI if VR.PerformInteraction response came before UI.PerformInteraction response. More than that, SDL doesn't send successful response to mobile with choiceID.
Another problem is next: in case of `InteractionMode::BOTH` mobile app doesn't receive successful response from SDL in case HMI responsed SUCCESS to UI or VR PerformInteraction. More over, SDL doesn't provide info message of unsuccessful (UI or VR PerformInteraction) response.

Next changes were added in this PR:
1. Added sending of UI_ClosePopUp request to HMI after VR.PerformInteraction response.
2. Added sending response with choiceID to mobile in case of successful VR.PerformInteraction response.
3. Added info message from unsuccessful (UI or VR PerformInteraction) response in `InteractionMode::BOTH` to response from SDL to MobileApp.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
