### PR TITLE
Fix the SDL incorrect validates display_capabilities.

### DIFF
--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -339,6 +339,8 @@ void InitCapabilities() {
   image_field_name_enum.insert(
       std::make_pair(std::string("locationImage"),
                      hmi_apis::Common_ImageFieldName::locationImage));
+  image_field_name_enum.insert(std::make_pair(
+      std::string("alertIcon"), hmi_apis::Common_ImageFieldName::alertIcon));
 
   file_type_enum.insert(std::make_pair(std::string("GRAPHIC_BMP"),
                                        hmi_apis::Common_FileType::GRAPHIC_BMP));


### PR DESCRIPTION
Fixes #3113 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
There is the issue when SDL incorrect validates display capabilities as a Smart Object. The route cause of the issue is the missed `"alertIcon"` parameter in  the `<string value, hmi_apis::Common_ImageFieldName::eType>` mapping. During validation, a Smart Object SDL can't find mandatory parameter and fail validation. As a result, SDL doesn't set display capabilities into the HMI capabilities entity.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
