### PR TITLE
Test for double data cleanup

### DIFF
--- a/src/components/smart_objects/test/CMakeLists.txt
+++ b/src/components/smart_objects/test/CMakeLists.txt
@@ -53,5 +53,11 @@ set(EXCLUDE_PATHS
   SmartObjectConvertionTime_test.cc
 )
 
+# Enable detect Double-free, invalid free
+# AddressSanitizer is a fast memory error detector. 
+# It consists of a compiler instrumentation module and a run-time library.
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+
 collect_sources(SOURCES "${CMAKE_CURRENT_SOURCE_DIR}" "${EXCLUDE_PATHS}")
 create_test(smart_object_test "${SOURCES}" "${LIBRARIES}")

--- a/src/components/smart_objects/test/SmartObjectUnit_test.cc
+++ b/src/components/smart_objects/test/SmartObjectUnit_test.cc
@@ -31,6 +31,7 @@
  */
 
 #include "gmock/gmock.h"
+#define final  // Disable error: cannot derive from ‘final’ base
 #include "smart_objects/smart_object.h"
 
 namespace test {
@@ -584,6 +585,29 @@ TEST(MapEraseTest, SmartObjectTest) {
   ASSERT_FALSE(srcObj.erase("one"));
 }
 // TODO: Add a test to check accessing an array at strange indexes.
+
+TEST(DoubleCleanupDataTest, SmartObjectTest) {
+  class DerivedSmartObject : public SmartObject {
+   public:
+    DerivedSmartObject(SmartType Type) : SmartObject(Type) {}
+    using SmartObject::operator=;
+    void cleanup_data() {
+      SmartObject::cleanup_data();
+    }
+  };
+
+  DerivedSmartObject obj(SmartType_String);
+  ASSERT_EQ(SmartType_String, obj.getType());
+
+  obj = "test string_value";
+  ASSERT_EQ(std::string("test string_value"), obj.asString());
+
+  obj.cleanup_data();
+  ASSERT_EQ(std::string(""), obj.asCharArray());
+
+  obj.cleanup_data();
+  ASSERT_EQ(std::string(""), obj.asCharArray());
+}
 
 }  // namespace smart_object_test
 }  // namespace components


### PR DESCRIPTION
Fixes #3135

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Stability test

### Summary
After `cleanup_data()` call, `delete` is used to deallocate memory by pointer, however pointer is still holding a value of address of the already deallocated memory. By that reason SO still have an ability to access that data what might cause UB including core crashes in the random places.

This issue is often observed during cable unplug while audio/video streaming is active. To avoid such problem, NULL pointer is assigned explicitly to avoid unwanted memory access. Also this fixes possible "double free memory" issues.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)