### PR TITLE
Fix SDL app stream processing with non-streamable state.

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1285,7 +1285,7 @@ class ApplicationManagerImpl
    * @brief Starts EndStream timer for a specified application
    * @param app_id Application to process
    */
-  void StartEndStreamTimer(uint32_t app_id);
+  void StartEndStreamTimer(const uint32_t app_id);
 
   /**
    * @brief Allows to send appropriate message to mobile device.

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -787,12 +787,13 @@ class ApplicationManagerImpl
   void RemovePolicyObserver(PolicyHandlerObserver* listener);
 
   /**
-   * @brief Checks HMI level and returns true if streaming is allowed
+   * @brief Checks application HMI state and returns true if streaming is
+   * allowed
    * @param app_id Application id
    * @param service_type Service type to check
    * @return True if streaming is allowed, false in other case
    */
-  bool HMILevelAllowsStreaming(
+  bool HMIStateAllowsStreaming(
       uint32_t app_id,
       protocol_handler::ServiceType service_type) const OVERRIDE;
 

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -210,9 +210,9 @@ class ApplicationManagerImpl
 
   void set_current_audio_source(const uint32_t source) OVERRIDE;
 
-  void OnHMILevelChanged(uint32_t app_id,
-                         mobile_apis::HMILevel::eType from,
-                         mobile_apis::HMILevel::eType to) OVERRIDE;
+  void OnHMIStateChanged(const uint32_t app_id,
+                         const HmiStatePtr from,
+                         const HmiStatePtr to) OVERRIDE;
 
   void SendDriverDistractionState(ApplicationSharedPtr application);
 
@@ -1278,8 +1278,14 @@ class ApplicationManagerImpl
    * @param to the new HMILevel for the certain app.
    */
   void ProcessApp(const uint32_t app_id,
-                  const mobile_apis::HMILevel::eType from,
-                  const mobile_apis::HMILevel::eType to);
+                  const HmiStatePtr from,
+                  const HmiStatePtr to);
+
+  /**
+   * @brief Starts EndStream timer for a specified application
+   * @param app_id Application to process
+   */
+  void StartEndStreamTimer(uint32_t app_id);
 
   /**
    * @brief Allows to send appropriate message to mobile device.

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_audio_start_stream_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_audio_start_stream_request.cc
@@ -113,7 +113,7 @@ void AudioStartStreamRequest::on_event(const event_engine::Event& event) {
 
       if (hmi_apis::Common_Result::SUCCESS == code) {
         LOG4CXX_INFO(logger_, "StartAudioStream response SUCCESS");
-        if (application_manager_.HMILevelAllowsStreaming(app->app_id(),
+        if (application_manager_.HMIStateAllowsStreaming(app->app_id(),
                                                          ServiceType::kAudio)) {
           app->set_audio_streaming_approved(true);
         } else {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_start_stream_request.cc
@@ -115,7 +115,7 @@ void NaviStartStreamRequest::on_event(const event_engine::Event& event) {
 
       if (hmi_apis::Common_Result::SUCCESS == code) {
         LOG4CXX_INFO(logger_, "NaviStartStreamResponse SUCCESS");
-        if (application_manager_.HMILevelAllowsStreaming(
+        if (application_manager_.HMIStateAllowsStreaming(
                 app->app_id(), ServiceType::kMobileNav)) {
           app->set_video_streaming_approved(true);
         } else {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3283,6 +3283,8 @@ bool ApplicationManagerImpl::HMILevelAllowsStreaming(
     uint32_t app_id, protocol_handler::ServiceType service_type) const {
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace mobile_apis::HMILevel;
+  using namespace mobile_apis::PredefinedWindows;
+  using namespace mobile_apis::VideoStreamingState;
   using namespace helpers;
 
   ApplicationSharedPtr app = application(app_id);
@@ -3290,10 +3292,14 @@ bool ApplicationManagerImpl::HMILevelAllowsStreaming(
     LOG4CXX_WARN(logger_, "An application is not registered.");
     return false;
   }
-  return Compare<eType, EQ, ONE>(
-      app->hmi_level(mobile_api::PredefinedWindows::DEFAULT_WINDOW),
-      HMI_FULL,
-      HMI_LIMITED);
+
+  const auto hmi_state = app->CurrentHmiState(DEFAULT_WINDOW);
+  const bool allow_streaming =
+      Compare<mobile_apis::HMILevel::eType, EQ, ONE>(
+          hmi_state->hmi_level(), HMI_FULL, HMI_LIMITED) &&
+      hmi_state->video_streaming_state() == STREAMABLE;
+
+  return allow_streaming;
 }
 
 bool ApplicationManagerImpl::CanAppStream(
@@ -3439,10 +3445,9 @@ void ApplicationManagerImpl::EndNaviServices(uint32_t app_id) {
   }
 }
 
-void ApplicationManagerImpl::OnHMILevelChanged(
-    uint32_t app_id,
-    mobile_apis::HMILevel::eType from,
-    mobile_apis::HMILevel::eType to) {
+void ApplicationManagerImpl::OnHMIStateChanged(const uint32_t app_id,
+                                               const HmiStatePtr from,
+                                               const HmiStatePtr to) {
   LOG4CXX_AUTO_TRACE(logger_);
   ProcessPostponedMessages(app_id);
   ProcessApp(app_id, from, to);
@@ -3478,15 +3483,11 @@ void ApplicationManagerImpl::ProcessPostponedMessages(const uint32_t app_id) {
 }
 
 void ApplicationManagerImpl::ProcessApp(const uint32_t app_id,
-                                        const mobile_apis::HMILevel::eType from,
-                                        const mobile_apis::HMILevel::eType to) {
+                                        const HmiStatePtr from,
+                                        const HmiStatePtr to) {
   using namespace mobile_apis::HMILevel;
+  using namespace mobile_apis::VideoStreamingState;
   using namespace helpers;
-
-  if (from == to) {
-    LOG4CXX_TRACE(logger_, "HMILevel from = to");
-    return;
-  }
 
   ApplicationSharedPtr app = application(app_id);
   if (!app || (!app->is_navi() && !app->mobile_projection_enabled())) {
@@ -3494,32 +3495,77 @@ void ApplicationManagerImpl::ProcessApp(const uint32_t app_id,
     return;
   }
 
-  if (to == HMI_FULL || to == HMI_LIMITED) {
-    LOG4CXX_TRACE(logger_, "HMILevel to FULL or LIMITED");
-    if (from == HMI_BACKGROUND) {
-      LOG4CXX_TRACE(logger_, "HMILevel from BACKGROUND");
-      AllowStreaming(app_id);
-    }
-  } else if (to == HMI_BACKGROUND) {
-    LOG4CXX_TRACE(logger_, "HMILevel to BACKGROUND");
-    if (from == HMI_FULL || from == HMI_LIMITED) {
-      LOG4CXX_TRACE(logger_, "HMILevel from FULL or LIMITED");
-      navi_app_to_end_stream_.push_back(app_id);
-      TimerSPtr end_stream_timer(std::make_shared<timer::Timer>(
-          "AppShouldFinishStreaming",
-          new TimerTaskImpl<ApplicationManagerImpl>(
-              this, &ApplicationManagerImpl::EndNaviStreaming)));
-      end_stream_timer->Start(navi_end_stream_timeout_, timer::kPeriodic);
+  const auto hmi_level_from = from->hmi_level();
+  const auto hmi_level_to = to->hmi_level();
+  const auto streaming_state_from = from->video_streaming_state();
+  const auto streaming_state_to = to->video_streaming_state();
 
-      sync_primitives::AutoLock lock(timer_pool_lock_);
-      timer_pool_.push_back(end_stream_timer);
-    }
-  } else if (to == HMI_NONE) {
-    LOG4CXX_TRACE(logger_, "HMILevel to NONE");
-    if (from == HMI_FULL || from == HMI_LIMITED || from == HMI_BACKGROUND) {
-      EndNaviServices(app_id);
-    }
+  if (hmi_level_from == hmi_level_to &&
+      streaming_state_from == streaming_state_to) {
+    LOG4CXX_TRACE(logger_, "HMILevel && streaming state was not changed");
+    return;
   }
+
+  auto full_or_limited_hmi_level = [](mobile_apis::HMILevel::eType hmi_level) {
+    return Compare<mobile_apis::HMILevel::eType, EQ, ONE>(
+        hmi_level, HMI_FULL, HMI_LIMITED);
+  };
+
+  const bool allow_streaming_by_streaming_state =
+      NOT_STREAMABLE == streaming_state_from &&
+      STREAMABLE == streaming_state_to;
+  const bool allow_streaming_by_hmi_level =
+      HMI_BACKGROUND == hmi_level_from &&
+      full_or_limited_hmi_level(hmi_level_to) &&
+      STREAMABLE == streaming_state_to;
+  if (allow_streaming_by_streaming_state || allow_streaming_by_hmi_level) {
+    LOG4CXX_TRACE(logger_,
+                  "Allow streaming by streaming state: "
+                      << std::boolalpha << allow_streaming_by_streaming_state
+                      << "; by hmi level: " << std::boolalpha
+                      << allow_streaming_by_hmi_level);
+    AllowStreaming(app_id);
+    return;
+  }
+
+  const bool end_streaming_by_streaming_state =
+      STREAMABLE == streaming_state_from &&
+      NOT_STREAMABLE == streaming_state_to &&
+      full_or_limited_hmi_level(hmi_level_to);
+  const bool start_timer_by_hmi_level =
+      full_or_limited_hmi_level(hmi_level_from) &&
+      HMI_BACKGROUND == hmi_level_to;
+  if (end_streaming_by_streaming_state || start_timer_by_hmi_level) {
+    LOG4CXX_TRACE(logger_,
+                  "Start EndStream timer by streaming state: "
+                      << std::boolalpha << end_streaming_by_streaming_state
+                      << "; by hmi level: " << std::boolalpha
+                      << start_timer_by_hmi_level);
+    StartEndStreamTimer(app_id);
+    return;
+  }
+
+  const bool end_streaming_by_hmi_level =
+      full_or_limited_hmi_level(hmi_level_from) && HMI_NONE == hmi_level_to;
+  if (end_streaming_by_hmi_level) {
+    LOG4CXX_TRACE(logger_,
+                  "End streaming services by hmi level: "
+                      << std::boolalpha << end_streaming_by_hmi_level);
+    EndNaviServices(app_id);
+  }
+}
+
+void ApplicationManagerImpl::StartEndStreamTimer(uint32_t app_id) {
+  LOG4CXX_DEBUG(logger_, "Start end stream timer for app " << app_id);
+  navi_app_to_end_stream_.push_back(app_id);
+  TimerSPtr end_stream_timer(std::make_shared<timer::Timer>(
+      "AppShouldFinishStreaming",
+      new TimerTaskImpl<ApplicationManagerImpl>(
+          this, &ApplicationManagerImpl::EndNaviStreaming)));
+  end_stream_timer->Start(navi_end_stream_timeout_, timer::kPeriodic);
+
+  sync_primitives::AutoLock lock(timer_pool_lock_);
+  timer_pool_.push_back(end_stream_timer);
 }
 
 void ApplicationManagerImpl::ClearTimerPool() {
@@ -4508,11 +4554,19 @@ void ApplicationManagerImpl::ChangeAppsHMILevel(
     LOG4CXX_ERROR(logger_, "There is no app with id: " << app_id);
     return;
   }
-  const mobile_apis::HMILevel::eType old_level =
-      app->hmi_level(mobile_api::PredefinedWindows::DEFAULT_WINDOW);
-  if (old_level != level) {
+
+  const auto old_hmi_state =
+      app->CurrentHmiState(mobile_apis::PredefinedWindows::DEFAULT_WINDOW);
+  if (old_hmi_state->hmi_level() != level) {
     app->set_hmi_level(mobile_apis::PredefinedWindows::DEFAULT_WINDOW, level);
-    OnHMILevelChanged(app_id, old_level, level);
+    const auto new_hmi_state =
+        CreateRegularState(app,
+                           mobile_apis::WindowType::MAIN,
+                           level,
+                           old_hmi_state->audio_streaming_state(),
+                           old_hmi_state->video_streaming_state(),
+                           old_hmi_state->system_context());
+    OnHMIStateChanged(app_id, old_hmi_state, new_hmi_state);
   } else {
     LOG4CXX_WARN(logger_, "Redundant changing HMI level: " << level);
   }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3553,7 +3553,9 @@ void ApplicationManagerImpl::ProcessApp(const uint32_t app_id,
                   "End streaming services by hmi level: "
                       << std::boolalpha << end_streaming_by_hmi_level);
     EndNaviServices(app_id);
+    return;
   }
+
   LOG4CXX_TRACE(logger_, "No actions required for app " << app_id);
 }
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1805,7 +1805,7 @@ bool ApplicationManagerImpl::StartNaviService(
   using namespace protocol_handler;
   LOG4CXX_AUTO_TRACE(logger_);
 
-  if (HMILevelAllowsStreaming(app_id, service_type)) {
+  if (HMIStateAllowsStreaming(app_id, service_type)) {
     {
       sync_primitives::AutoLock lock(navi_service_status_lock_);
 
@@ -3279,7 +3279,7 @@ std::string ApplicationManagerImpl::GetHashedAppID(
   return mobile_app_id + device_name;
 }
 
-bool ApplicationManagerImpl::HMILevelAllowsStreaming(
+bool ApplicationManagerImpl::HMIStateAllowsStreaming(
     uint32_t app_id, protocol_handler::ServiceType service_type) const {
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace mobile_apis::HMILevel;
@@ -3323,7 +3323,7 @@ bool ApplicationManagerImpl::CanAppStream(
     LOG4CXX_WARN(logger_, "Unsupported service_type " << service_type);
   }
 
-  return HMILevelAllowsStreaming(app_id, service_type) && is_allowed;
+  return HMIStateAllowsStreaming(app_id, service_type) && is_allowed;
 }
 
 void ApplicationManagerImpl::ForbidStreaming(uint32_t app_id) {

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -2411,13 +2411,13 @@ void PolicyHandler::UpdateHMILevel(ApplicationSharedPtr app,
       LOG4CXX_INFO(logger_,
                    "Changing hmi level of application "
                        << app->app_id() << " to default hmi level " << level);
-      // Set application hmi level
-      application_manager_.ChangeAppsHMILevel(app->app_id(), level);
       // If hmi Level is full, it will be seted after ActivateApp response
       MessageHelper::SendHMIStatusNotification(
           app,
           mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
           application_manager_);
+      // Set application hmi level
+      application_manager_.ChangeAppsHMILevel(app->app_id(), level);
     }
   }
 }
@@ -2458,12 +2458,12 @@ void PolicyHandler::OnUpdateHMIStatus(const std::string& device_id,
   LOG4CXX_INFO(logger_,
                "Changing hmi level of application "
                    << app->app_id() << " to default hmi level " << level);
-  // Set application hmi level
-  application_manager_.ChangeAppsHMILevel(app->app_id(), level);
   MessageHelper::SendHMIStatusNotification(
       app,
       mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
       application_manager_);
+  // Set application hmi level
+  application_manager_.ChangeAppsHMILevel(app->app_id(), level);
 }
 
 bool PolicyHandler::GetModuleTypes(const std::string& policy_app_id,

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -2411,13 +2411,13 @@ void PolicyHandler::UpdateHMILevel(ApplicationSharedPtr app,
       LOG4CXX_INFO(logger_,
                    "Changing hmi level of application "
                        << app->app_id() << " to default hmi level " << level);
+      // Set application hmi level
+      application_manager_.ChangeAppsHMILevel(app->app_id(), level);
       // If hmi Level is full, it will be seted after ActivateApp response
       MessageHelper::SendHMIStatusNotification(
           app,
           mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
           application_manager_);
-      // Set application hmi level
-      application_manager_.ChangeAppsHMILevel(app->app_id(), level);
     }
   }
 }
@@ -2458,12 +2458,12 @@ void PolicyHandler::OnUpdateHMIStatus(const std::string& device_id,
   LOG4CXX_INFO(logger_,
                "Changing hmi level of application "
                    << app->app_id() << " to default hmi level " << level);
+  // Set application hmi level
+  application_manager_.ChangeAppsHMILevel(app->app_id(), level);
   MessageHelper::SendHMIStatusNotification(
       app,
       mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
       application_manager_);
-  // Set application hmi level
-  application_manager_.ChangeAppsHMILevel(app->app_id(), level);
 }
 
 bool PolicyHandler::GetModuleTypes(const std::string& policy_app_id,

--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -881,8 +881,7 @@ void StateControllerImpl::OnStateChanged(ApplicationSharedPtr app,
     app->ResetDataInNone();
   }
 
-  app_mngr_.OnHMILevelChanged(
-      app->app_id(), old_state->hmi_level(), new_state->hmi_level());
+  app_mngr_.OnHMIStateChanged(app->app_id(), old_state, new_state);
   app->usage_report().RecordHmiStateChanged(new_state->hmi_level());
 }
 

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -531,10 +531,16 @@ TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_VideoServiceStart) {
   const protocol_handler::ServiceType service_type =
       protocol_handler::ServiceType::kMobileNav;
   const int32_t session_key = 123;
+  HmiStatePtr hmi_state(std::make_shared<HmiState>(
+      mock_app_ptr_, mock_app_mngr_, HmiState::STATE_ID_REGULAR));
+  hmi_state->set_video_streaming_state(
+      mobile_apis::VideoStreamingState::eType::STREAMABLE);
+  hmi_state->set_hmi_level(mobile_apis::HMILevel::HMI_FULL);
+
+  EXPECT_CALL(*mock_app_ptr_, CurrentHmiState(_))
+      .WillRepeatedly(Return(hmi_state));
   EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
   EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(true));
-  EXPECT_CALL(*mock_app_ptr_, hmi_level(kDefaultWindowId))
-      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
 
   bool result = false;
   std::vector<std::string> rejected_params;
@@ -595,8 +601,14 @@ TEST_F(ApplicationManagerImplTest,
   EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
   EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(true));
   // HMI level is not FULL nor LIMITED
-  EXPECT_CALL(*mock_app_ptr_, hmi_level(kDefaultWindowId))
-      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_BACKGROUND));
+  HmiStatePtr hmi_state(std::make_shared<HmiState>(
+      mock_app_ptr_, mock_app_mngr_, HmiState::STATE_ID_REGULAR));
+  hmi_state->set_video_streaming_state(
+      mobile_apis::VideoStreamingState::eType::STREAMABLE);
+  hmi_state->set_hmi_level(mobile_apis::HMILevel::HMI_BACKGROUND);
+
+  EXPECT_CALL(*mock_app_ptr_, CurrentHmiState(_))
+      .WillRepeatedly(Return(hmi_state));
 
   bool result = false;
   std::vector<std::string> rejected_params;
@@ -625,8 +637,14 @@ TEST_F(ApplicationManagerImplTest,
   const int32_t session_key = 123;
   EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
   EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(true));
-  EXPECT_CALL(*mock_app_ptr_, hmi_level(kDefaultWindowId))
-      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_LIMITED));
+  HmiStatePtr hmi_state(std::make_shared<HmiState>(
+      mock_app_ptr_, mock_app_mngr_, HmiState::STATE_ID_REGULAR));
+  hmi_state->set_video_streaming_state(
+      mobile_apis::VideoStreamingState::eType::STREAMABLE);
+  hmi_state->set_hmi_level(mobile_apis::HMILevel::HMI_LIMITED);
+
+  EXPECT_CALL(*mock_app_ptr_, CurrentHmiState(_))
+      .WillRepeatedly(Return(hmi_state));
 
   bool result = false;
   std::vector<std::string> rejected_params;
@@ -709,8 +727,13 @@ TEST_F(ApplicationManagerImplTest,
   const int32_t session_key = 123;
   EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
   EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(true));
-  EXPECT_CALL(*mock_app_ptr_, hmi_level(kDefaultWindowId))
-      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
+  HmiStatePtr hmi_state(std::make_shared<HmiState>(
+      mock_app_ptr_, mock_app_mngr_, HmiState::STATE_ID_REGULAR));
+  hmi_state->set_video_streaming_state(
+      mobile_apis::VideoStreamingState::eType::STREAMABLE);
+  hmi_state->set_hmi_level(mobile_apis::HMILevel::HMI_FULL);
+  EXPECT_CALL(*mock_app_ptr_, CurrentHmiState(_))
+      .WillRepeatedly(Return(hmi_state));
 
   bool result = false;
   std::vector<std::string> rejected_params;
@@ -783,8 +806,13 @@ TEST_F(ApplicationManagerImplTest,
   const int32_t session_key = 123;
   EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
   EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(true));
-  EXPECT_CALL(*mock_app_ptr_, hmi_level(kDefaultWindowId))
-      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
+  HmiStatePtr hmi_state(std::make_shared<HmiState>(
+      mock_app_ptr_, mock_app_mngr_, HmiState::STATE_ID_REGULAR));
+  hmi_state->set_video_streaming_state(
+      mobile_apis::VideoStreamingState::eType::STREAMABLE);
+  hmi_state->set_hmi_level(mobile_apis::HMILevel::HMI_FULL);
+  EXPECT_CALL(*mock_app_ptr_, CurrentHmiState(_))
+      .WillRepeatedly(Return(hmi_state));
 
   bool result = false;
   std::vector<std::string> rejected_params;
@@ -818,8 +846,13 @@ TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_AudioServiceStart) {
   const int32_t session_key = 123;
   EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
   EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(true));
-  EXPECT_CALL(*mock_app_ptr_, hmi_level(kDefaultWindowId))
-      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
+  HmiStatePtr hmi_state(std::make_shared<HmiState>(
+      mock_app_ptr_, mock_app_mngr_, HmiState::STATE_ID_REGULAR));
+  hmi_state->set_video_streaming_state(
+      mobile_apis::VideoStreamingState::eType::STREAMABLE);
+  hmi_state->set_hmi_level(mobile_apis::HMILevel::HMI_FULL);
+  EXPECT_CALL(*mock_app_ptr_, CurrentHmiState(_))
+      .WillRepeatedly(Return(hmi_state));
 
   bool result = false;
   std::vector<std::string> rejected_params;
@@ -848,8 +881,13 @@ TEST_F(ApplicationManagerImplTest,
   const int32_t session_key = 123;
   EXPECT_CALL(*mock_app_ptr_, app_id()).WillRepeatedly(Return(session_key));
   EXPECT_CALL(*mock_app_ptr_, is_navi()).WillRepeatedly(Return(true));
-  EXPECT_CALL(*mock_app_ptr_, hmi_level(kDefaultWindowId))
-      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
+  HmiStatePtr hmi_state(std::make_shared<HmiState>(
+      mock_app_ptr_, mock_app_mngr_, HmiState::STATE_ID_REGULAR));
+  hmi_state->set_video_streaming_state(
+      mobile_apis::VideoStreamingState::eType::STREAMABLE);
+  hmi_state->set_hmi_level(mobile_apis::HMILevel::HMI_FULL);
+  EXPECT_CALL(*mock_app_ptr_, CurrentHmiState(_))
+      .WillRepeatedly(Return(hmi_state));
 
   bool result = false;
   std::vector<std::string> rejected_params;

--- a/src/components/application_manager/test/state_controller/state_controller_test.cc
+++ b/src/components/application_manager/test/state_controller/state_controller_test.cc
@@ -1451,7 +1451,9 @@ TEST_F(StateControllerImplTest, MoveSimpleAppToValidStates) {
     EXPECT_CALL(message_helper_mock_,
                 SendHMIStatusNotification(simple_app_, kDefaultWindowId, _));
     EXPECT_CALL(app_manager_mock_,
-                OnHMIStateChanged(simple_app_id_, _, state_to_setup));
+                OnHMIStateChanged(simple_app_id_,
+                                  Truly(HmiStatesComparator(initial_state)),
+                                  state_to_setup));
 
     EXPECT_CALL(*simple_app_ptr_,
                 SetRegularState(kDefaultWindowId,

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -604,12 +604,13 @@ class ApplicationManager {
       mobile_api::AppInterfaceUnregisteredReason::eType reason) = 0;
 
   /**
-   * @brief Checks HMI level and returns true if streaming is allowed
+   * @brief Checks application HMI state and returns true if streaming is
+   * allowed
    * @param app_id Application id
    * @param service_type Service type to check
    * @return True if streaming is allowed, false in other case
    */
-  virtual bool HMILevelAllowsStreaming(
+  virtual bool HMIStateAllowsStreaming(
       uint32_t app_id, protocol_handler::ServiceType service_type) const = 0;
 
   /**

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -284,17 +284,17 @@ class ApplicationManager {
   virtual void set_current_audio_source(const uint32_t source) = 0;
 
   /**
-   * @brief OnHMILevelChanged the callback that allows SDL to react when
+   * @brief OnHMIStateChanged the callback that allows SDL to react when
    * application's HMI level has been changed.
    *
-   * @param app_id application identifier for which HMILevel has been chaned.
+   * @param app_id application identifier for which HMIState has been chaned.
    *
-   * @param from previous HMILevel.
-   * @param to current HMILevel.
+   * @param from previous HMIState.
+   * @param to current HMIState.
    */
-  virtual void OnHMILevelChanged(uint32_t app_id,
-                                 mobile_apis::HMILevel::eType from,
-                                 mobile_apis::HMILevel::eType to) = 0;
+  virtual void OnHMIStateChanged(const uint32_t app_id,
+                                 const HmiStatePtr from,
+                                 const HmiStatePtr to) = 0;
 
   /**
    * @brief Checks if driver distraction state is valid, creates message

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -254,7 +254,7 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                void(mobile_apis::AppInterfaceUnregisteredReason::eType reason));
   MOCK_METHOD1(HeadUnitReset,
                void(mobile_apis::AppInterfaceUnregisteredReason::eType reason));
-  MOCK_CONST_METHOD2(HMILevelAllowsStreaming,
+  MOCK_CONST_METHOD2(HMIStateAllowsStreaming,
                      bool(uint32_t app_id,
                           protocol_handler::ServiceType service_type));
   MOCK_METHOD5(CheckPolicyPermissions,

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -139,10 +139,10 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD1(application_id, uint32_t(const int32_t correlation_id));
   MOCK_METHOD2(set_application_id,
                void(const int32_t correlation_id, const uint32_t app_id));
-  MOCK_METHOD3(OnHMILevelChanged,
-               void(uint32_t app_id,
-                    mobile_apis::HMILevel::eType from,
-                    mobile_apis::HMILevel::eType to));
+  MOCK_METHOD3(OnHMIStateChanged,
+               void(const uint32_t app_id,
+                    const HmiStatePtr from,
+                    const HmiStatePtr to));
   MOCK_METHOD1(
       SendHMIStatusNotification,
       void(const std::shared_ptr<application_manager::Application> app));

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -141,8 +141,8 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                void(const int32_t correlation_id, const uint32_t app_id));
   MOCK_METHOD3(OnHMIStateChanged,
                void(const uint32_t app_id,
-                    const HmiStatePtr from,
-                    const HmiStatePtr to));
+                    const application_manager::HmiStatePtr from,
+                    const application_manager::HmiStatePtr to));
   MOCK_METHOD1(
       SendHMIStatusNotification,
       void(const std::shared_ptr<application_manager::Application> app));


### PR DESCRIPTION
Fixes #3139

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
For determining whether an application is allowed to stream,
SDL considered only HMI_Level.
Now streaming state is also taken into account.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
