### PR TITLE
Fix misplaced OnDataVideoStreaming

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -220,7 +220,7 @@ class ApplicationManagerImpl
   void ProcessOnDataStreamingNotification(
       const protocol_handler::ServiceType service_type,
       const uint32_t app_id,
-      const bool status) FINAL;
+      const bool streaming_data_available) FINAL;
 
   void SendDriverDistractionState(ApplicationSharedPtr application);
 

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -117,6 +117,9 @@ class ApplicationManagerImpl;
 
 enum VRTTSSessionChanging { kVRSessionChanging = 0, kTTSSessionChanging };
 
+typedef std::map<protocol_handler::ServiceType, std::set<uint32_t> >
+    ServiceStreamingStatusMap;
+
 struct CommandParametersPermissions;
 typedef std::map<std::string, hmi_apis::Common_TransportType::eType>
     DeviceTypes;
@@ -213,6 +216,11 @@ class ApplicationManagerImpl
   void OnHMILevelChanged(uint32_t app_id,
                          mobile_apis::HMILevel::eType from,
                          mobile_apis::HMILevel::eType to) OVERRIDE;
+
+  void ProcessOnDataStreamingNotification(
+      const protocol_handler::ServiceType service_type,
+      const uint32_t app_id,
+      const bool status) FINAL;
 
   void SendDriverDistractionState(ApplicationSharedPtr application);
 
@@ -1592,6 +1600,9 @@ class ApplicationManagerImpl
 
   std::unique_ptr<rpc_service::RPCService> rpc_service_;
   std::unique_ptr<rpc_handler::RPCHandler> rpc_handler_;
+
+  ServiceStreamingStatusMap streaming_application_services_;
+  sync_primitives::Lock streaming_services_lock_;
 
 #ifdef BUILD_TESTS
  public:

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -649,7 +649,7 @@ void ApplicationImpl::WakeUpStreaming(
     if (video_streaming_suspended_) {
       application_manager_.OnAppStreaming(app_id(), service_type, true);
       application_manager_.ProcessOnDataStreamingNotification(
-          ServiceType::kMobileNav, app_id(), true);
+          service_type, app_id(), true);
       video_streaming_suspended_ = false;
     }
     video_stream_suspend_timer_.Start(
@@ -660,7 +660,7 @@ void ApplicationImpl::WakeUpStreaming(
     if (audio_streaming_suspended_) {
       application_manager_.OnAppStreaming(app_id(), service_type, true);
       application_manager_.ProcessOnDataStreamingNotification(
-          ServiceType::kAudio, app_id(), true);
+          service_type, app_id(), true);
       audio_streaming_suspended_ = false;
     }
     audio_stream_suspend_timer_.Start(

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -631,7 +631,8 @@ void ApplicationImpl::SuspendStreaming(
     sync_primitives::AutoLock lock(audio_streaming_suspended_lock_);
     audio_streaming_suspended_ = true;
   }
-  MessageHelper::SendOnDataStreaming(service_type, false, application_manager_);
+  application_manager_.ProcessOnDataStreamingNotification(
+      service_type, app_id(), false);
 }
 
 void ApplicationImpl::WakeUpStreaming(
@@ -647,8 +648,8 @@ void ApplicationImpl::WakeUpStreaming(
     sync_primitives::AutoLock lock(video_streaming_suspended_lock_);
     if (video_streaming_suspended_) {
       application_manager_.OnAppStreaming(app_id(), service_type, true);
-      MessageHelper::SendOnDataStreaming(
-          ServiceType::kMobileNav, true, application_manager_);
+      application_manager_.ProcessOnDataStreamingNotification(
+          ServiceType::kMobileNav, app_id(), true);
       video_streaming_suspended_ = false;
     }
     video_stream_suspend_timer_.Start(
@@ -658,8 +659,8 @@ void ApplicationImpl::WakeUpStreaming(
     sync_primitives::AutoLock lock(audio_streaming_suspended_lock_);
     if (audio_streaming_suspended_) {
       application_manager_.OnAppStreaming(app_id(), service_type, true);
-      MessageHelper::SendOnDataStreaming(
-          ServiceType::kAudio, true, application_manager_);
+      application_manager_.ProcessOnDataStreamingNotification(
+          ServiceType::kAudio, app_id(), true);
       audio_streaming_suspended_ = false;
     }
     audio_stream_suspend_timer_.Start(

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3499,6 +3499,9 @@ void ApplicationManagerImpl::ProcessOnDataStreamingNotification(
                         << active_services.size());
     } else {
       active_services.erase(app_id);
+      should_send_notification =
+          !should_send_notification && active_services.empty();
+
       LOG4CXX_DEBUG(logger_,
                     "Streaming session with id "
                         << app_id << " for service "

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3480,7 +3480,7 @@ void ApplicationManagerImpl::ProcessPostponedMessages(const uint32_t app_id) {
 void ApplicationManagerImpl::ProcessOnDataStreamingNotification(
     const protocol_handler::ServiceType service_type,
     const uint32_t app_id,
-    const bool status) {
+    const bool streaming_data_available) {
   LOG4CXX_AUTO_TRACE(logger_);
 
   bool should_send_notification = false;
@@ -3489,7 +3489,7 @@ void ApplicationManagerImpl::ProcessOnDataStreamingNotification(
     sync_primitives::AutoLock lock(streaming_services_lock_);
     auto& active_services = streaming_application_services_[service_type];
     should_send_notification = active_services.empty();
-    if (status) {
+    if (streaming_data_available) {
       active_services.insert(app_id);
       LOG4CXX_DEBUG(logger_,
                     "Streaming session with id "
@@ -3512,7 +3512,8 @@ void ApplicationManagerImpl::ProcessOnDataStreamingNotification(
   }
 
   if (should_send_notification) {
-    MessageHelper::SendOnDataStreaming(service_type, status, *this);
+    MessageHelper::SendOnDataStreaming(
+        service_type, streaming_data_available, *this);
   }
 }
 

--- a/src/components/application_manager/test/application_impl_test.cc
+++ b/src/components/application_manager/test/application_impl_test.cc
@@ -764,16 +764,16 @@ TEST_F(ApplicationImplTest, SuspendNaviStreaming) {
   protocol_handler::ServiceType type =
       protocol_handler::ServiceType::kMobileNav;
   EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
-  EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
-              SendOnDataStreaming(type, false, _));
+  EXPECT_CALL(mock_application_manager_,
+              ProcessOnDataStreamingNotification(type, app_id, false));
   app_impl->SuspendStreaming(type);
 }
 
 TEST_F(ApplicationImplTest, SuspendAudioStreaming) {
   protocol_handler::ServiceType type = protocol_handler::ServiceType::kAudio;
   EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
-  EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
-              SendOnDataStreaming(type, false, _));
+  EXPECT_CALL(mock_application_manager_,
+              ProcessOnDataStreamingNotification(type, app_id, false));
   app_impl->SuspendStreaming(type);
 }
 
@@ -812,8 +812,8 @@ TEST_F(ApplicationImplTest, StopStreaming_StreamingApproved) {
   app_impl->set_video_streaming_approved(true);
 
   EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
-  EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
-              SendOnDataStreaming(type, false, _));
+  EXPECT_CALL(mock_application_manager_,
+              ProcessOnDataStreamingNotification(type, app_id, false));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendNaviStopStream(app_id, _));
 
@@ -824,8 +824,8 @@ TEST_F(ApplicationImplTest, StopStreaming_StreamingApproved) {
   app_impl->set_audio_streaming_approved(true);
   type = protocol_handler::ServiceType::kAudio;
   EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
-  EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
-              SendOnDataStreaming(type, false, _));
+  EXPECT_CALL(mock_application_manager_,
+              ProcessOnDataStreamingNotification(type, app_id, false));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendAudioStopStream(app_id, _));
 

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -301,12 +301,13 @@ class ApplicationManager {
    * HMI via notification if required
    * @param service_type Id of service which status should be updated
    * @param app_id Id of session which status should be updated
-   * @param status New streming status for specified session
+   * @param streaming_data_available Availability of streaming data for
+   * specified session
    */
   virtual void ProcessOnDataStreamingNotification(
       const protocol_handler::ServiceType service_type,
       const uint32_t app_id,
-      const bool status) = 0;
+      const bool streaming_data_available) = 0;
 
   /**
    * @brief Checks if driver distraction state is valid, creates message

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -297,6 +297,18 @@ class ApplicationManager {
                                  mobile_apis::HMILevel::eType to) = 0;
 
   /**
+   * @brief Updates streaming service status for specified session and notifies
+   * HMI via notification if required
+   * @param service_type Id of service which status should be updated
+   * @param app_id Id of session which status should be updated
+   * @param status New streming status for specified session
+   */
+  virtual void ProcessOnDataStreamingNotification(
+      const protocol_handler::ServiceType service_type,
+      const uint32_t app_id,
+      const bool status) = 0;
+
+  /**
    * @brief Checks if driver distraction state is valid, creates message
    * which is sent to the application if allowed, otherwise it is added
    * to a list of postponed messages.

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -143,6 +143,10 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                void(uint32_t app_id,
                     mobile_apis::HMILevel::eType from,
                     mobile_apis::HMILevel::eType to));
+  MOCK_METHOD3(ProcessOnDataStreamingNotification,
+               void(const protocol_handler::ServiceType service_type,
+                    const uint32_t app_id,
+                    const bool status));
   MOCK_METHOD1(
       SendHMIStatusNotification,
       void(const std::shared_ptr<application_manager::Application> app));

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -146,7 +146,7 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD3(ProcessOnDataStreamingNotification,
                void(const protocol_handler::ServiceType service_type,
                     const uint32_t app_id,
-                    const bool status));
+                    const bool streaming_data_available));
   MOCK_METHOD1(
       SendHMIStatusNotification,
       void(const std::shared_ptr<application_manager::Application> app));


### PR DESCRIPTION
Fixes #3142

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Fix misplaces sending of OnDataVideoStreaming notification.

SDL used to send OnDataVideoStreaming from the application instance independently. Not it will be sent from application_manager, taking into account common service status, not status of certain app.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
