### PR TITLE
Fix crash in WebsocketSession on start.

### DIFF
--- a/src/components/hmi_message_handler/src/websocket_session.cc
+++ b/src/components/hmi_message_handler/src/websocket_session.cc
@@ -304,12 +304,14 @@ void WebsocketSession::LoopThreadDelegate::exitThreadMain() {
 }
 
 void WebsocketSession::LoopThreadDelegate::DrainQueue() {
-  while (!message_queue_.empty()) {
-    Message message_ptr;
-    message_queue_.pop(message_ptr);
-    if (!shutdown_) {
-      handler_.ws_.write(boost::asio::buffer(*message_ptr));
-    };
+  Message message_ptr;
+  while (!shutdown_ && message_queue_.pop(message_ptr)) {
+    boost::system::error_code ec;
+    handler_.ws_.write(boost::asio::buffer(*message_ptr), ec);
+    if (ec) {
+      LOG4CXX_ERROR(ws_logger_,
+                    "A system error has occurred: " << ec.message());
+    }
   }
 }
 


### PR DESCRIPTION
Fixes [#3150](https://github.com/smartdevicelink/sdl_core/issues/3150)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
A crash occurs because we use an overload of
`boost::beast::websocket::stream::write` without `error_code`.
After the error occurs we add an error message to the logger
and continue working.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)