### PR TITLE
Fix core crash on accesing the application pointer.

### DIFF
--- a/src/components/application_manager/include/application_manager/state_controller_impl.h
+++ b/src/components/application_manager/include/application_manager/state_controller_impl.h
@@ -158,12 +158,8 @@ class StateControllerImpl : public event_engine::EventObserver,
       applications = accessor.GetData();
     }
 
-    ApplicationSet::iterator it = applications.begin();
-    for (; it != applications.end(); ++it) {
-      auto app = *it;
-      if (app) {
-        func(app);
-      }
+    for (const auto& app : applications) {
+      func(app);
     }
   }
 

--- a/src/components/application_manager/include/application_manager/state_controller_impl.h
+++ b/src/components/application_manager/include/application_manager/state_controller_impl.h
@@ -152,12 +152,17 @@ class StateControllerImpl : public event_engine::EventObserver,
 
   template <typename UnaryFunction>
   void ForEachApplication(UnaryFunction func) const {
-    DataAccessor<ApplicationSet> accessor = app_mngr_.applications();
-    ApplicationSet::iterator it = accessor.GetData().begin();
-    for (; it != accessor.GetData().end(); ++it) {
-      ApplicationConstSharedPtr const_app = *it;
-      if (const_app) {
-        func(app_mngr_.application(const_app->app_id()));
+    ApplicationSet applications;
+    {
+      DataAccessor<ApplicationSet> accessor = app_mngr_.applications();
+      applications = accessor.GetData();
+    }
+
+    ApplicationSet::iterator it = applications.begin();
+    for (; it != applications.end(); ++it) {
+      auto app = *it;
+      if (app) {
+        func(app);
       }
     }
   }

--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -977,6 +977,7 @@ int64_t StateControllerImpl::RequestHMIStateChange(
 
 void StateControllerImpl::ApplyPostponedStateForApp(ApplicationSharedPtr app) {
   LOG4CXX_AUTO_TRACE(logger_);
+  DCHECK_OR_RETURN_VOID(app);
   const WindowIds window_ids = app->GetWindowIds();
 
   for (const auto& window_id : window_ids) {


### PR DESCRIPTION
Fixes #3156

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
The issue will occur when the state controller gets an application collection from the application manager and tries to apply a functor to each application.
One of the application's pointers could be uninitialized and the state controller should check if pointer is valid.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
