### PR TITLE
Stop app unregister timer after streaming session restarted

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1554,8 +1554,11 @@ class ApplicationManagerImpl
   uint32_t navi_close_app_timeout_;
   uint32_t navi_end_stream_timeout_;
 
-  std::vector<TimerSPtr> timer_pool_;
-  sync_primitives::Lock timer_pool_lock_;
+  std::vector<TimerSPtr> close_app_timer_pool_;
+  std::vector<TimerSPtr> end_stream_timer_pool_;
+  sync_primitives::Lock close_app_timer_pool_lock_;
+  sync_primitives::Lock end_stream_timer_pool_lock_;
+
   mutable sync_primitives::RecursiveLock stopping_application_mng_lock_;
   StateControllerImpl state_ctrl_;
   std::unique_ptr<app_launch::AppLaunchData> app_launch_dto_;
@@ -1581,6 +1584,8 @@ class ApplicationManagerImpl
   Timer application_list_update_timer_;
 
   Timer tts_global_properties_timer_;
+
+  Timer clear_pool_timer_;
 
   bool is_low_voltage_;
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3898,7 +3898,7 @@ void ApplicationManagerImpl::AddAppToTTSGlobalPropertiesList(
     LOG4CXX_INFO(logger_, "Start tts_global_properties_timer_");
     tts_global_properties_app_list_lock_.Release();
     const uint32_t timeout_ms = 1000;
-    tts_global_properties_timer_.Start(timeout_ms, timer::kPeriodic);
+    tts_global_properties_timer_.Start(timeout_ms, timer::kSingleShot);
     return;
   }
   tts_global_properties_app_list_lock_.Release();

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -205,7 +205,7 @@ ApplicationManagerImpl::ApplicationManagerImpl(
                              {TYPE_ICONS, "Icons"}};
 
   const uint32_t timeout_ms = 10000u;
-  clear_pool_timer_.Start(timeout_ms, timer::kSingleShot);
+  clear_pool_timer_.Start(timeout_ms, timer::kPeriodic);
 
   rpc_handler_.reset(new rpc_handler::RPCHandlerImpl(
       *this, hmi_so_factory(), mobile_so_factory()));
@@ -3898,7 +3898,7 @@ void ApplicationManagerImpl::AddAppToTTSGlobalPropertiesList(
     LOG4CXX_INFO(logger_, "Start tts_global_properties_timer_");
     tts_global_properties_app_list_lock_.Release();
     const uint32_t timeout_ms = 1000;
-    tts_global_properties_timer_.Start(timeout_ms, timer::kSingleShot);
+    tts_global_properties_timer_.Start(timeout_ms, timer::kPeriodic);
     return;
   }
   tts_global_properties_app_list_lock_.Release();

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -191,6 +191,9 @@ ApplicationManagerImpl::ApplicationManagerImpl(
           "AM TTSGLPRTimer",
           new TimerTaskImpl<ApplicationManagerImpl>(
               this, &ApplicationManagerImpl::OnTimerSendTTSGlobalProperties))
+    , clear_pool_timer_("ClearPoolTimer",
+                        new TimerTaskImpl<ApplicationManagerImpl>(
+                            this, &ApplicationManagerImpl::ClearTimerPool))
     , is_low_voltage_(false)
     , apps_size_(0)
     , is_stopping_(false) {
@@ -201,14 +204,9 @@ ApplicationManagerImpl::ApplicationManagerImpl(
                              {TYPE_SYSTEM, "System"},
                              {TYPE_ICONS, "Icons"}};
 
-  sync_primitives::AutoLock lock(timer_pool_lock_);
-  TimerSPtr clearing_timer(std::make_shared<timer::Timer>(
-      "ClearTimerPoolTimer",
-      new TimerTaskImpl<ApplicationManagerImpl>(
-          this, &ApplicationManagerImpl::ClearTimerPool)));
   const uint32_t timeout_ms = 10000u;
-  clearing_timer->Start(timeout_ms, timer::kSingleShot);
-  timer_pool_.push_back(clearing_timer);
+  clear_pool_timer_.Start(timeout_ms, timer::kSingleShot);
+
   rpc_handler_.reset(new rpc_handler::RPCHandlerImpl(
       *this, hmi_so_factory(), mobile_so_factory()));
   commands_holder_.reset(new CommandHolderImpl(*this));
@@ -245,8 +243,15 @@ ApplicationManagerImpl::~ApplicationManagerImpl() {
   LOG4CXX_DEBUG(logger_, "Destroying Policy Handler");
   RemovePolicyObserver(this);
 
-  sync_primitives::AutoLock lock(timer_pool_lock_);
-  timer_pool_.clear();
+  {
+    sync_primitives::AutoLock lock(close_app_timer_pool_lock_);
+    close_app_timer_pool_.clear();
+  }
+
+  {
+    sync_primitives::AutoLock lock(end_stream_timer_pool_lock_);
+    end_stream_timer_pool_.clear();
+  }
 
   navi_app_to_stop_.clear();
   navi_app_to_end_stream_.clear();
@@ -1893,6 +1898,18 @@ void ApplicationManagerImpl::OnStreamingConfigured(
       // started audio service
       service_type == ServiceType::kMobileNav ? it->second.first = true
                                               : it->second.second = true;
+
+      for (size_t i = 0; i < navi_app_to_stop_.size(); ++i) {
+        if (app_id == navi_app_to_stop_[i]) {
+          {
+            sync_primitives::AutoLock lock(close_app_timer_pool_lock_);
+            close_app_timer_pool_[i]->Stop();
+            close_app_timer_pool_.erase(close_app_timer_pool_.begin() + i);
+            navi_app_to_stop_.erase(navi_app_to_stop_.begin() + i);
+          }
+          break;
+        }
+      }
     }
 
     application(app_id)->StartStreaming(service_type);
@@ -3434,8 +3451,8 @@ void ApplicationManagerImpl::EndNaviServices(uint32_t app_id) {
             this, &ApplicationManagerImpl::CloseNaviApp)));
     close_timer->Start(navi_close_app_timeout_, timer::kSingleShot);
 
-    sync_primitives::AutoLock lock(timer_pool_lock_);
-    timer_pool_.push_back(close_timer);
+    sync_primitives::AutoLock lock(close_app_timer_pool_lock_);
+    close_app_timer_pool_.push_back(close_timer);
   }
 }
 
@@ -3511,8 +3528,8 @@ void ApplicationManagerImpl::ProcessApp(const uint32_t app_id,
               this, &ApplicationManagerImpl::EndNaviStreaming)));
       end_stream_timer->Start(navi_end_stream_timeout_, timer::kPeriodic);
 
-      sync_primitives::AutoLock lock(timer_pool_lock_);
-      timer_pool_.push_back(end_stream_timer);
+      sync_primitives::AutoLock lock(end_stream_timer_pool_lock_);
+      end_stream_timer_pool_.push_back(end_stream_timer);
     }
   } else if (to == HMI_NONE) {
     LOG4CXX_TRACE(logger_, "HMILevel to NONE");
@@ -3525,19 +3542,25 @@ void ApplicationManagerImpl::ProcessApp(const uint32_t app_id,
 void ApplicationManagerImpl::ClearTimerPool() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  std::vector<TimerSPtr> new_timer_pool;
-
-  sync_primitives::AutoLock lock(timer_pool_lock_);
-  new_timer_pool.push_back(timer_pool_[0]);
-
-  for (size_t i = 1; i < timer_pool_.size(); ++i) {
-    if (timer_pool_[i]->is_running()) {
-      new_timer_pool.push_back(timer_pool_[i]);
+  auto clear_timer_pool = [](std::vector<TimerSPtr> vector_to_clear) {
+    std::vector<TimerSPtr> new_timer_pool;
+    for (size_t i = 0; i < vector_to_clear.size(); ++i) {
+      if (vector_to_clear[i]->is_running()) {
+        new_timer_pool.push_back(vector_to_clear[i]);
+      }
     }
+    vector_to_clear.swap(new_timer_pool);
+  };
+
+  {
+    sync_primitives::AutoLock lock(close_app_timer_pool_lock_);
+    clear_timer_pool(close_app_timer_pool_);
   }
 
-  timer_pool_.swap(new_timer_pool);
-  new_timer_pool.clear();
+  {
+    sync_primitives::AutoLock lock(end_stream_timer_pool_lock_);
+    clear_timer_pool(end_stream_timer_pool_);
+  }
 }
 
 void ApplicationManagerImpl::CloseNaviApp() {


### PR DESCRIPTION
Fixes #3140

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
SDL starts a timer for an app to be unregistered if it continues streaming. And when timeout expired and Application already stopped service - nothing would happen. But if the application restarts streaming service, SDL would not know that it is a new session. And so, in this case, after timer expiration, SDL will unregister an application, despite the fact it is a brand new streaming session. Current PR implements the cleaning up of timers on service start.

**UPD:** 11.01.2020

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
