### PR TITLE
Fix BC.PolicyUpdate double sending

### DIFF
--- a/src/components/policy/policy_external/include/policy/status.h
+++ b/src/components/policy/policy_external/include/policy/status.h
@@ -163,7 +163,8 @@ class UpdateNeededStatus : public Status {
 };
 
 /**
- * @brief The UpdatePendingStatus class represents 'update pending' status
+ * @brief The UpdatePendingStatus class represents cases when SDL knows that an
+ * update is required and but before the snapshot is sent to the HMI
  */
 class UpdatePendingStatus : public Status {
  public:

--- a/src/components/policy/policy_external/include/policy/status.h
+++ b/src/components/policy/policy_external/include/policy/status.h
@@ -52,6 +52,7 @@ enum UpdateEvent {
   kOnResetPolicyTableRequireUpdate,
   kOnResetPolicyTableNoUpdate,
   kScheduleUpdate,
+  kPendingUpdate,
   kScheduleManualUpdate,
   kOnResetRetrySequence,
   kNoEvent
@@ -159,6 +160,37 @@ class UpdateNeededStatus : public Status {
    * @return True if update is required, otherwise - false
    */
   bool IsUpdateRequired() const OVERRIDE;
+};
+
+/**
+ * @brief The UpdatePendingStatus class represents 'update pending' status
+ */
+class UpdatePendingStatus : public Status {
+ public:
+  /**
+   * @brief Constructor
+   */
+  UpdatePendingStatus();
+
+  /**
+   * @brief Process event by setting next status in case event can affect
+   * current status or ignores the event
+   * @param manager Status manager pointer
+   * @param event Event which needs to be processed
+   */
+  void ProcessEvent(UpdateStatusManager* manager, UpdateEvent event) OVERRIDE;
+
+  /**
+   * @brief Check whether update is required in terms of status
+   * @return True if update is required, otherwise - false
+   */
+  bool IsUpdateRequired() const OVERRIDE;
+
+  /**
+   * @brief Check whether update is pending in terms of status
+   * @return True if update is pending, otherwise - false
+   */
+  bool IsUpdatePending() const OVERRIDE;
 };
 
 /**

--- a/src/components/policy/policy_external/include/policy/update_status_manager.h
+++ b/src/components/policy/policy_external/include/policy/update_status_manager.h
@@ -149,6 +149,10 @@ class UpdateStatusManager {
    */
   void ScheduleUpdate();
 
+  /**
+   * @brief PendingUpdate will change state from Update_Needed
+   * to Update_Pending
+   */
   void PendingUpdate();
 
   /**

--- a/src/components/policy/policy_external/include/policy/update_status_manager.h
+++ b/src/components/policy/policy_external/include/policy/update_status_manager.h
@@ -149,6 +149,8 @@ class UpdateStatusManager {
    */
   void ScheduleUpdate();
 
+  void PendingUpdate();
+
   /**
    * @brief ScheduleUpdate allows to schedule next update.
    * It will change state to Update_Needed, that's is

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -745,6 +745,7 @@ void PolicyManagerImpl::StartPTExchange() {
   if (listener_ && listener_->CanUpdate()) {
     LOG4CXX_INFO(logger_, "Listener CanUpdate");
     if (update_status_manager_.IsUpdateRequired()) {
+      update_status_manager_.PendingUpdate();
       LOG4CXX_INFO(logger_, "IsUpdateRequired");
       RequestPTUpdate();
     }
@@ -1975,7 +1976,8 @@ void PolicyManagerImpl::OnUpdateStarted() {
   uint32_t update_timeout = TimeoutExchangeMSec();
   LOG4CXX_DEBUG(logger_,
                 "Update timeout will be set to (milisec): " << update_timeout);
-  send_on_update_sent_out_ = !update_status_manager_.IsUpdatePending();
+  send_on_update_sent_out_ =
+      policy::kUpdating != update_status_manager_.StringifiedUpdateStatus();
 
   if (send_on_update_sent_out_) {
     update_status_manager_.OnUpdateSentOut(update_timeout);

--- a/src/components/policy/policy_external/src/status.cc
+++ b/src/components/policy/policy_external/src/status.cc
@@ -67,12 +67,44 @@ void policy::UpdateNeededStatus::ProcessEvent(
     case kOnResetPolicyTableNoUpdate:
       manager->SetNextStatus(std::make_shared<UpToDateStatus>());
       break;
+    case kPendingUpdate:
+      manager->SetNextStatus(std::make_shared<UpdatePendingStatus>());
+      break;
     default:
       break;
   }
 }
 
 bool policy::UpdateNeededStatus::IsUpdateRequired() const {
+  return true;
+}
+
+policy::UpdatePendingStatus::UpdatePendingStatus()
+    : Status(kUpdateNeeded, policy::PolicyTableStatus::StatusUpdatePending) {}
+
+void policy::UpdatePendingStatus::ProcessEvent(
+    policy::UpdateStatusManager* manager, policy::UpdateEvent event) {
+  switch (event) {
+    case kOnUpdateSentOut:
+      manager->SetNextStatus(std::make_shared<UpdatingStatus>());
+      break;
+    case kOnResetPolicyTableRequireUpdate:
+      manager->SetNextStatus(std::make_shared<UpToDateStatus>());
+      manager->SetPostponedStatus(std::make_shared<UpdateNeededStatus>());
+      break;
+    case kOnResetPolicyTableNoUpdate:
+      manager->SetNextStatus(std::make_shared<UpToDateStatus>());
+      break;
+    default:
+      break;
+  }
+}
+
+bool policy::UpdatePendingStatus::IsUpdatePending() const {
+  return true;
+}
+
+bool policy::UpdatePendingStatus::IsUpdateRequired() const {
   return true;
 }
 

--- a/src/components/policy/policy_external/src/update_status_manager.cc
+++ b/src/components/policy/policy_external/src/update_status_manager.cc
@@ -175,6 +175,7 @@ void UpdateStatusManager::PendingUpdate() {
 }
 
 void UpdateStatusManager::ScheduleManualUpdate() {
+  LOG4CXX_AUTO_TRACE(logger_);
   ProcessEvent(kScheduleManualUpdate);
 }
 


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3138

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
http://172.26.147.12/view/Issue_3138/

### Summary
Sometimes SDL sends BasicCommunication.PolicyUpdate twice.
I believe that the main problem is that when SDL receives the second PTU trigger, in the PolicyManagerImpl::StartPTExchange() ->  update_status_manager_.IsUpdatePending() returned **false** because the state is still "UPDATE_NEEDED". 

On the latest release - SDL should change the status to "UPDATING" right after sending the BasicCommunication.PolicyUpdate to the HMI. But in some cases, SDL can process the second PTU trigger before changing the status to the "UPDATING".

Taking into account all the above I have created another one internal status "UPDATE_PENDING" and use this status for cases when SDL knows that update is required and until the snapshot will be sent to the HMI. 
So SDL will change the status to "UPDATE_PENDING" before calling RequestPTUpdate(); in PolicyManagerImpl::StartPTExchange(); -> IsUpdatePending() for "UPDATE_PENDING" will return **true**; ->  After sending the first BC.PolicyUpdate the status will be changed to "UPDATING" -> SDL won't request a PolicyUpdate twice
