### PR TITLE
Fix for No mechanism for managing the switching sequence(Start/StopSt…

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1830,22 +1830,17 @@ bool ApplicationManagerImpl::StartNaviService(
        later than App2's Startcallback(). Cause streaming issue on HMI.
       */
       sync_primitives::AutoLock lock(applications_list_lock_ptr_);
-      auto it_app = applications_.begin();
-      while (applications_.end() != it_app) {
-        ApplicationSharedPtr app = application((*it_app)->app_id());
+      for (auto app : applications_) {
         if (!app || (!app->is_navi() && !app->mobile_projection_enabled())) {
           LOG4CXX_DEBUG(logger_,
-                        "Continue, Not Navi App Id: " << (*it_app)->app_id());
-          ++it_app;
+                        "Continue, Not Navi App Id: " << app->app_id());
           continue;
-        } else {
-          LOG4CXX_DEBUG(logger_,
-                        "Abort Stream Service of other NaviAppId: "
-                            << (*it_app)->app_id()
-                            << " Service_type: " << service_type);
-          StopNaviService((*it_app)->app_id(), service_type);
-          ++it_app;
         }
+        LOG4CXX_DEBUG(logger_,
+                      "Abort Stream Service of other NaviAppId: "
+                          << app->app_id()
+                          << " Service_type: " << service_type);
+        StopNaviService(app->app_id(), service_type);
       }
     }
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1826,21 +1826,23 @@ bool ApplicationManagerImpl::StartNaviService(
     }
 
     {
-      /*
-        * Fix: For NaviApp1 Switch to NaviApp2, App1's Endcallback() arrives later than
-        * App2's Startcallback(). Cause streaming issue on HMI.
+      /* Fix: For NaviApp1 Switch to NaviApp2, App1's Endcallback() arrives 
+       later than App2's Startcallback(). Cause streaming issue on HMI.
       */
       sync_primitives::AutoLock lock(applications_list_lock_ptr_);
       auto it_app = applications_.begin();
       while (applications_.end() != it_app) {
         ApplicationSharedPtr app = application((*it_app)->app_id());
         if (!app || (!app->is_navi() && !app->mobile_projection_enabled())) {
-          LOG4CXX_DEBUG(logger_, "Continue, Not Navi App Id: "<< (*it_app)->app_id());
+          LOG4CXX_DEBUG(logger_,
+                        "Continue, Not Navi App Id: "<< (*it_app)->app_id());
           ++it_app;
           continue;
         } else {
-          LOG4CXX_DEBUG(logger_, "Abort Stream Service of other NaviAppId: " << (*it_app)->app_id()
-           << " Service_type: " << service_type);
+          LOG4CXX_DEBUG(logger_,
+                        "Abort Stream Service of other NaviAppId: "
+                            << (*it_app)->app_id()
+                            << " Service_type: " << service_type);
           StopNaviService((*it_app)->app_id(), service_type);
           ++it_app;
         }
@@ -1945,7 +1947,8 @@ void ApplicationManagerImpl::StopNaviService(
       return;
     } else {
       // Fix: Repeated tests are not executed after they have stopped for Navi
-      if (false == it->second.first && service_type == ServiceType::kMobileNav) {
+      if (false == it->second.first &&
+          service_type == ServiceType::kMobileNav) {
         LOG4CXX_DEBUG(logger_, "appId: " << app_id << "Navi had stopped");
         return;
       }
@@ -1958,7 +1961,9 @@ void ApplicationManagerImpl::StopNaviService(
       // Fill NaviServices map. Set false to first value of pair if
       // we've stopped video service or to second value if we've
       // stopped audio service
-      LOG4CXX_DEBUG(logger_, "appId: " << app_id << " service_type: "<< service_type << " to stopped");
+      LOG4CXX_DEBUG(logger_,
+                    "appId: " << app_id << " service_type: "<< service_type
+                              << " to stopped");
       service_type == ServiceType::kMobileNav ? it->second.first = false
                                               : it->second.second = false;
     }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1948,7 +1948,7 @@ void ApplicationManagerImpl::StopNaviService(
     } else {
       // Fix: Repeated tests are not executed after they have stopped for Navi
       if (false == it->second.first &&
-          service_type == ServiceType::kMobileNav) {
+          ServiceType::kMobileNav == service_type) {
         LOG4CXX_DEBUG(logger_, "appId: " << app_id << "Navi had stopped");
         return;
       }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1826,7 +1826,7 @@ bool ApplicationManagerImpl::StartNaviService(
     }
 
     {
-      /* Fix: For NaviApp1 Switch to NaviApp2, App1's Endcallback() arrives 
+      /* Fix: For NaviApp1 Switch to NaviApp2, App1's Endcallback() arrives
        later than App2's Startcallback(). Cause streaming issue on HMI.
       */
       sync_primitives::AutoLock lock(applications_list_lock_ptr_);
@@ -1835,7 +1835,7 @@ bool ApplicationManagerImpl::StartNaviService(
         ApplicationSharedPtr app = application((*it_app)->app_id());
         if (!app || (!app->is_navi() && !app->mobile_projection_enabled())) {
           LOG4CXX_DEBUG(logger_,
-                        "Continue, Not Navi App Id: "<< (*it_app)->app_id());
+                        "Continue, Not Navi App Id: " << (*it_app)->app_id());
           ++it_app;
           continue;
         } else {
@@ -1962,7 +1962,7 @@ void ApplicationManagerImpl::StopNaviService(
       // we've stopped video service or to second value if we've
       // stopped audio service
       LOG4CXX_DEBUG(logger_,
-                    "appId: " << app_id << " service_type: "<< service_type
+                    "appId: " << app_id << " service_type: " << service_type
                               << " to stopped");
       service_type == ServiceType::kMobileNav ? it->second.first = false
                                               : it->second.second = false;

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1954,7 +1954,7 @@ void ApplicationManagerImpl::StopNaviService(
       }
 
       // Fix: Repeated tests are not executed after they have stopped for Audio
-      if (false == it->second.second && service_type == ServiceType::kAudio) {
+      if (false == it->second.second && ServiceType::kAudio == service_type) {
         LOG4CXX_DEBUG(logger_, "appId: " << app_id << "Audio had stopped");
         return;
       }


### PR DESCRIPTION
Fixes #3123

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by Unit tests.

### Summary
**Reason**
1. Because switch between NaviApps. Only one app can be active at a time. Asynchronous notifications between apps may have timing issues.									
eg: App1.EndServiceCallback(11) arrives later than App2.StartServiceCallback(11)									
2. SDLCore does not effectively cover this case. Duplicate notifications affect the activated App.

**Solution**
1. When NaviApp2 activated and NaviApp1 hadn't stopNaviService, force stop NaviApp1 VPM as a failsafe process.
2. Double-check in StopNaviService to prevent NaviApp2 duplicate notifications

**Sequence**
![image](https://user-images.githubusercontent.com/35795928/72868085-560c8700-3d24-11ea-855d-4b7293fe62e4.png)


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)