### PR TITLE
Fix build with external proprietary after update new jsoncpp lib

### DIFF
--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -41,7 +41,6 @@
 #include <utility>
 #include <vector>
 
-#include "json/features.h"
 #include "json/writer.h"
 #include "policy/policy_helper.h"
 #include "policy/policy_table/enums.h"

--- a/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
@@ -806,7 +806,7 @@ TEST_F(PolicyManagerImplTest2,
   std::string json;
   Json::Value root(Json::objectValue);
   if (ifile.is_open()) {
-    Json::parseFromStream(reader_builder, ifile, &root, nullptr)
+    Json::parseFromStream(reader_builder, ifile, &root, nullptr);
   }
   json = root.toStyledString();
   ifile.close();
@@ -908,7 +908,7 @@ TEST_F(PolicyManagerImplTest2,
   std::string json;
   Json::Value root(Json::objectValue);
   if (ifile.is_open()) {
-    Json::parseFromStream(reader_builder, ifile, &root, nullptr)
+    Json::parseFromStream(reader_builder, ifile, &root, nullptr);
   }
   json = root.toStyledString();
   ifile.close();

--- a/src/components/policy/policy_external/test/policy_manager_impl_test_base.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test_base.cc
@@ -476,7 +476,7 @@ void PolicyManagerImplTest2::
   std::string json;
   Json::Value root(Json::objectValue);
   if (ifile.is_open()) {
-    Json::parseFromStream(reader_builder, ifile, &root, nullptr)
+    Json::parseFromStream(reader_builder, ifile, &root, nullptr);
   }
   json = root.toStyledString();
   ifile.close();
@@ -626,7 +626,7 @@ void PolicyManagerImplTest2::LoadPTUFromJsonFile(
   std::string json;
   Json::Value root(Json::objectValue);
   if (ifile.is_open()) {
-    Json::parseFromStream(reader_builder, ifile, &root, nullptr)
+    Json::parseFromStream(reader_builder, ifile, &root, nullptr);
   }
   json = root.toStyledString();
   ifile.close();


### PR DESCRIPTION
Fix #3225 
This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
Fix build with external proprietary after update new jsoncpp lib.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
