### PR TITLE
Fix ApplicationSet reference variables are not lock-protected

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -426,7 +426,8 @@ bool PolicyHandler::ClearUserConsent() {
 uint32_t PolicyHandler::GetAppIdForSending() const {
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK(0);
-  const ApplicationSet& accessor =
+  // fix ApplicationSet access crash
+  const ApplicationSet accessor =
       application_manager_.applications().GetData();
 
   HMILevelPredicate has_none_level(mobile_api::HMILevel::HMI_NONE);

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -427,8 +427,7 @@ uint32_t PolicyHandler::GetAppIdForSending() const {
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK(0);
   // fix ApplicationSet access crash
-  const ApplicationSet accessor =
-      application_manager_.applications().GetData();
+  const ApplicationSet accessor = application_manager_.applications().GetData();
 
   HMILevelPredicate has_none_level(mobile_api::HMILevel::HMI_NONE);
   Applications apps_without_none_level;


### PR DESCRIPTION
Fixes #3149 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by Unit tests.

### Summary
**Reason**
When App registered and another App unregistered, multiple threads access the same variable: application.
`AM FromMobile` thread free `applicationPtr`, and `AM Pool` thread uses the same `applicationPtr` which had freed by `AM FromMobile` thread.

**Solution**
`ApplicationSet` reference variables are not lock-protected, change it to a local variable.

**Sequence**
![image](https://user-images.githubusercontent.com/35795928/73700004-aa523680-4728-11ea-9ee3-d109bf05f9e9.png)


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
