### PR TITLE
fix warning in compiling core

### DIFF
--- a/src/components/policy/policy_external/test/policy_manager_impl_snapshot_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_snapshot_test.cc
@@ -71,9 +71,8 @@ TEST_F(PolicyManagerImplTest2, UpdatedPreloadedPT_ExpectLPT_IsUpdated) {
   }
   ifile.close();
 
-  Json::StyledStreamWriter writer;
   std::ofstream ofile(preloaded_pt_filename_);
-  writer.write(ofile, root);
+  ofile << root;
   ofile.flush();
   ofile.close();
 


### PR DESCRIPTION
Fixes #3235

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This can be tested by building core and then running the affected unit test to ensure it is still passing

### Summary
remove reference to deprecated StyledStreamWriter

### Changelog
##### Enhancements
* Remove warning while building core

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
