### PR TITLE
Add function UnwrapAppPolicies to CacheManager::Init() method

### DIFF
--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -2629,10 +2629,7 @@ bool CacheManager::Init(const std::string& file_name,
       LOG4CXX_DEBUG(logger_,
                     "Check if snapshot valid: " << std::boolalpha << result);
 
-      bool unwrap_result =
-          UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps);
-      result &= unwrap_result;
-      if (!unwrap_result) {
+      if (!UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps)) {
         LOG4CXX_ERROR(logger_, "Cannot unwrap application policies");
       }
       if (result) {

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -2629,6 +2629,12 @@ bool CacheManager::Init(const std::string& file_name,
       LOG4CXX_DEBUG(logger_,
                     "Check if snapshot valid: " << std::boolalpha << result);
 
+      result &= UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps);
+      if (!result) {
+        LOG4CXX_ERROR(logger_, "Cannot unwrap application policies");
+        return result;
+      }
+
       if (result) {
         backup_->UpdateDBVersion();
         Backup();

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -2629,10 +2629,11 @@ bool CacheManager::Init(const std::string& file_name,
       LOG4CXX_DEBUG(logger_,
                     "Check if snapshot valid: " << std::boolalpha << result);
 
-      if (!UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps)) {
+      bool unwrap_result = UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps);
+      result &= unwrap_result;
+      if (!unwrap_result){
         LOG4CXX_ERROR(logger_, "Cannot unwrap application policies");
       }
-
       if (result) {
         backup_->UpdateDBVersion();
         Backup();

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -2632,7 +2632,6 @@ bool CacheManager::Init(const std::string& file_name,
       result &= UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps);
       if (!result) {
         LOG4CXX_ERROR(logger_, "Cannot unwrap application policies");
-        return result;
       }
 
       if (result) {

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -2629,8 +2629,7 @@ bool CacheManager::Init(const std::string& file_name,
       LOG4CXX_DEBUG(logger_,
                     "Check if snapshot valid: " << std::boolalpha << result);
 
-      result &= UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps);
-      if (!result) {
+      if (!UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps)) {
         LOG4CXX_ERROR(logger_, "Cannot unwrap application policies");
       }
 

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -2629,9 +2629,10 @@ bool CacheManager::Init(const std::string& file_name,
       LOG4CXX_DEBUG(logger_,
                     "Check if snapshot valid: " << std::boolalpha << result);
 
-      bool unwrap_result = UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps);
+      bool unwrap_result =
+          UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps);
       result &= unwrap_result;
-      if (!unwrap_result){
+      if (!unwrap_result) {
         LOG4CXX_ERROR(logger_, "Cannot unwrap application policies");
       }
       if (result) {

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -2632,6 +2632,7 @@ bool CacheManager::Init(const std::string& file_name,
       if (!UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps)) {
         LOG4CXX_ERROR(logger_, "Cannot unwrap application policies");
       }
+
       if (result) {
         backup_->UpdateDBVersion();
         Backup();

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -1800,7 +1800,6 @@ bool CacheManager::Init(const std::string& file_name,
       result &= UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps);
       if (!result) {
         LOG4CXX_ERROR(logger_, "Cannot unwrap application policies");
-        return result;
       }
 
       backup_->UpdateDBVersion();

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -53,6 +53,7 @@
 #include "utils/threads/thread.h"
 #include "utils/threads/thread_delegate.h"
 
+#include "policy/policy_helper.h"
 #include "policy/sql_pt_representation.h"
 
 namespace policy_table = rpc::policy_table_interface_base;
@@ -1793,6 +1794,12 @@ bool CacheManager::Init(const std::string& file_name,
         snapshot->ReportErrors(&report);
         LOG4CXX_DEBUG(logger_,
                       "Validation report: " << rpc::PrettyFormat(report));
+        return result;
+      }
+
+      result &= UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps);
+      if (!result) {
+        LOG4CXX_ERROR(logger_, "Cannot unwrap application policies");
         return result;
       }
 

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -1797,8 +1797,7 @@ bool CacheManager::Init(const std::string& file_name,
         return result;
       }
 
-      result &= UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps);
-      if (!result) {
+      if (!UnwrapAppPolicies(pt_->policy_table.app_policies_section.apps)) {
         LOG4CXX_ERROR(logger_, "Cannot unwrap application policies");
       }
 


### PR DESCRIPTION
Fixes #2966

This PR is **[ready]** for review.

### Risk
This PR makes [no] API changes.

### Testing Plan
Covered within existing unit tests and ATF tests.

### Summary
This Pull Request is intended to fix issue with default permissions for applications, which have already presented in PT preloaded file. Main cause of this issue is absence of function UnwrapAppPolicies in CacheManager::Init() method, as result of which section with permissions for existed app wasn't mapped with default parameters (if PTU didn't happen, because earlier function UnwrapAppPolicies was used only during PTU).

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
