### PR TITLE
Added missing until param for enumeration elements

### DIFF
--- a/src/components/interfaces/MOBILE_API.xsd
+++ b/src/components/interfaces/MOBILE_API.xsd
@@ -32,6 +32,7 @@
         </xs:sequence>
         <xs:attribute type="xs:string" name="name" use="optional"/>
         <xs:attribute type="xs:float" name="since" use="optional"/>
+        <xs:attribute type="xs:float" name="until" use="optional"/>
         <xs:attribute type="xs:string" name="internal_name" use="optional"/>
         <xs:attribute type="xs:int" name="value" use="optional"/>
         <xs:attribute type="xs:string" name="rootscreen" use="optional"/>


### PR DESCRIPTION
Fixes #3246

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Summary
Added missing attribute "until" for support it in any enum element in Mobile_API.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
