### PR TITLE
Impl/persisting hmi capabilities

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -929,7 +929,7 @@
         }
     },
     "VR": {
-        "capabilities": ["TEXT"],
+        "vrCapabilities": ["TEXT"],
         "language": "EN-US",
         "languages": [
             "EN-US", "ES-MX", "FR-CA", "DE-DE", "ES-ES", "EN-GB", "RU-RU", "TR-TR", "PL-PL", "FR-FR", "IT-IT", "SV-SE", "PT-PT", "NL-NL", "ZH-TW",
@@ -937,7 +937,8 @@
         ]
     },
     "TTS": {
-        "capabilities": ["TEXT"],
+        "speechCapabilities": ["TEXT"],
+        "prerecordedSpeechCapabilities": ["HELP_JINGLE"],
         "language": "EN-US",
         "languages": [
             "EN-US", "ES-MX", "FR-CA", "DE-DE", "ES-ES", "EN-GB", "RU-RU", "TR-TR", "PL-PL", "FR-FR", "IT-IT", "SV-SE", "PT-PT", "NL-NL", "ZH-TW",
@@ -1047,10 +1048,12 @@
         }
     },
     "VehicleInfo": {
-        "make": "SDL",
-        "model": "Generic",
-        "modelYear": "2019",
-        "trim": "SE"
+        "vehicleType": {
+            "make": "SDL",
+            "model": "Generic",
+            "modelYear": "2019",
+            "trim": "SE"
+        }
     },
     "SyncMessageVersion": {
         "majorVersion": 3,

--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -51,6 +51,8 @@ ThreadStackSize = 20480
 MixingAudioSupported = true
 ; In case HMI doesn’t send some capabilities to SDL, the values from the file are used by SDL
 HMICapabilities = hmi_capabilities.json
+; Path to file containing cached response for UI.GetCapabilities/GetSupportedLanguages
+HMICapabilitiesCacheFile = hmi_capabilities_cache.json
 ; Maximum cmdId of VR command which may be registered on SDL
 ; Bigger value used for system VR commands processing by SDL
 MaxCmdID = 2000000000

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -531,6 +531,12 @@ class HMICapabilitiesImpl : public HMICapabilities {
   void set_handle_response_for(
       const smart_objects::SmartObject& request) OVERRIDE;
 
+  bool SaveCachedCapabilitiesToFile(
+      const std::vector<std::string> sections_to_update,
+      const smart_objects::CSmartSchema& schema) OVERRIDE;
+
+  void DeleteCachedCapabilitiesFile() const OVERRIDE;
+
  protected:
   /*
    * @brief Loads capabilities from local file in case SDL was launched

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -236,7 +236,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
       const std::vector<std::string>& sections_to_update,
       const smart_objects::CSmartSchema& schema) OVERRIDE;
 
-  void DeleteCachedCapabilitiesFile() const OVERRIDE;
+  bool DeleteCachedCapabilitiesFile() const OVERRIDE;
 
   std::set<hmi_apis::FunctionID::eType> GetInterfacesFromDefault()
       const OVERRIDE;

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -240,6 +240,9 @@ class HMICapabilitiesImpl : public HMICapabilities {
 
   void DeleteCachedCapabilitiesFile() const OVERRIDE;
 
+  std::vector<hmi_apis::FunctionID::eType> GetInterfacesToUpdate()
+      const OVERRIDE;
+
  protected:
   /**
    * @brief Loads capabilities from local file in case SDL was launched
@@ -462,6 +465,8 @@ class HMICapabilitiesImpl : public HMICapabilities {
 
   ApplicationManager& app_mngr_;
   HMILanguageHandler hmi_language_handler_;
+
+  std::vector<hmi_apis::FunctionID::eType> interfaces_to_update_;
 
   DISALLOW_COPY_AND_ASSIGN(HMICapabilitiesImpl);
 };

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -238,7 +238,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
 
   bool DeleteCachedCapabilitiesFile() const OVERRIDE;
 
-  std::set<hmi_apis::FunctionID::eType> GetInterfacesFromDefault()
+  std::set<hmi_apis::FunctionID::eType> GetDefaultInitializedCapabilities()
       const OVERRIDE;
 
  protected:
@@ -432,7 +432,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
   ApplicationManager& app_mngr_;
   HMILanguageHandler hmi_language_handler_;
 
-  std::set<hmi_apis::FunctionID::eType> interfaces_from_default_;
+  std::set<hmi_apis::FunctionID::eType> default_initialized_capabilities_;
 
   DISALLOW_COPY_AND_ASSIGN(HMICapabilitiesImpl);
 };

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -282,7 +282,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    * otherwise returns false
    */
   bool AllFieldsSaved(const Json::Value& root_node,
-                      const char* interface_name,
+                      const std::string& interface_name,
                       const std::vector<std::string>& sections_to_check) const;
 
   /**
@@ -292,7 +292,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    */
   hmi_apis::Common_Language::eType GetActiveLanguageForInterface(
-      const char* interface_name) const;
+      const std::string& interface_name) const;
 
   /**
    * @brief Prepares specified JSON structure according to sections which

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -38,6 +38,7 @@
 #include "interfaces/HMI_API.h"
 #include "interfaces/MOBILE_API.h"
 #include "json/json.h"
+#include "smart_objects/enum_schema_item.h"
 #include "smart_objects/smart_object.h"
 #include "utils/macro.h"
 
@@ -233,7 +234,8 @@ class HMICapabilitiesImpl : public HMICapabilities {
       const smart_objects::SmartObject& request) OVERRIDE;
 
   bool SaveCachedCapabilitiesToFile(
-      const std::vector<std::string> sections_to_update,
+      const std::string& interface_name,
+      const std::vector<std::string>& sections_to_update,
       const smart_objects::CSmartSchema& schema) OVERRIDE;
 
   void DeleteCachedCapabilitiesFile() const OVERRIDE;
@@ -247,43 +249,175 @@ class HMICapabilitiesImpl : public HMICapabilities {
    */
   bool load_capabilities_from_file();
 
-  /*
-   * @brief function checks if json member exists
-   *
-   * @param json_member from file hmi_capabilities.json
-   * @param name_of_member name which we should check
-   *     hmi_capabilities.json
-   *
-   * @returns TRUE if member exists and returns FALSE if
-   * member does not exist.
-   */
-  bool check_existing_json_member(const Json::Value& json_member,
-                                  const char* name_of_member) const OVERRIDE;
-
-  /*
+  /**
    * @brief function converts json object "languages" to smart object
-   *
    * @param json_languages from file hmi_capabilities.json
    * @param languages - the converted object
    *
    */
   void convert_json_languages_to_obj(
       const Json::Value& json_languages,
-      smart_objects::SmartObject& languages) const OVERRIDE;
+      smart_objects::SmartObject& languages) const;
 
-  /*
+  /**
    * @brief function that converts a single entry of audio pass thru capability
    *        to smart object
-   *
    * @param capability json object that represents a single entry of audio pass
    *        thru capability
    * @param output_so the converted object
    */
   void convert_audio_capability_to_obj(
       const Json::Value& capability,
-      smart_objects::SmartObject& output_so) const OVERRIDE;
+      smart_objects::SmartObject& output_so) const;
+
+  /**
+   * @brief Converts specified string to appropriate enum value
+   * according to schema
+   * @return converted enum value
+   */
+  template <typename EnumType>
+  EnumType ConvertStringToEnum(const std::string& str) {
+    using ns_smart_device_link::ns_smart_objects::EnumConversionHelper;
+    EnumType value;
+    if (EnumConversionHelper<EnumType>::StringToEnum(str, &value)) {
+      return value;
+    }
+
+    return EnumType::INVALID_ENUM;
+  }
+
+  /**
+   * @brief Converts the JSON array of string type into the SmartArray of enums
+   * @param json_array JSON value containing array
+   * @param out_so_array output SmartArray
+   */
+  template <typename EnumType>
+  void ConvertJsonArrayToSoArray(const Json::Value& json_array,
+                                 smart_objects::SmartObject& out_so_array) {
+    out_so_array =
+        smart_objects::SmartObject(smart_objects::SmartType::SmartType_Array);
+    for (uint32_t i = 0; i < json_array.size(); ++i) {
+      out_so_array[i] = ConvertStringToEnum<EnumType>(json_array[i].asString());
+    }
+  }
 
  private:
+  /**
+   * @brief Checks are all updating fields are currently saved in the JSON
+   * structure
+   * @param root_node reference to root node of JSON structure
+   * @param interface_name name of interface to check
+   * @param sections_to_check reference to list of fields to check
+   * @return true if all fields from the list are saved in the JSON structure,
+   * otherwise returns false
+   */
+  bool AreAllFieldsSaved(
+      const Json::Value& root_node,
+      const char* interface_name,
+      const std::vector<std::string>& sections_to_check) const;
+
+  /**
+   * @brief Gets the currently active language depending on interface
+   * @param interface_name name of interface of currently active language
+   * @return active language for specified interface
+   *
+   */
+  hmi_apis::Common_Language::eType GetActiveLanguageForInterface(
+      const char* interface_name) const;
+
+  /**
+   * @brief Prepares specified JSON structure according to sections which
+   * should be updated
+   * @param interface_name name of interface to prepare
+   * @param sections_to_update reference to list of fields to update
+   * @param schema reference to schema which should be unapplied before field
+   * updating
+   * @param out_root_node reference to JSON structure to update
+   */
+  void PrepareJsonValueForSaving(
+      const char* interface_name,
+      const std::vector<std::string>& sections_to_update,
+      const smart_objects::CSmartSchema& schema,
+      Json::Value& out_root_node) const;
+
+  /**
+   * @brief Prepares specified JSON structure for UI interface according to
+   * sections which should be updated
+   * @param sections_to_update reference to list of fields to update
+   * @param schema reference to schema which should be unapplied before field
+   * updating
+   * @param out_node reference to JSON structure to update
+   */
+  void PrepareUiJsonValueForSaving(
+      const std::vector<std::string>& sections_to_update,
+      const smart_objects::CSmartSchema& schema,
+      Json::Value& out_node) const;
+
+  /**
+   * @brief Prepares specified JSON structure for VR interface according to
+   * sections which should be updated
+   * @param sections_to_update reference to list of fields to update
+   * @param schema reference to schema which should be unapplied before field
+   * updating
+   * @param out_node reference to JSON structure to update
+   */
+  void PrepareVrJsonValueForSaving(
+      const std::vector<std::string>& sections_to_update,
+      const smart_objects::CSmartSchema& schema,
+      Json::Value& out_node) const;
+
+  /**
+   * @brief Prepares specified JSON structure for TTS interface according to
+   * sections which should be updated
+   * @param sections_to_update reference to list of fields to update
+   * @param schema reference to schema which should be unapplied before field
+   * updating
+   * @param out_node reference to JSON structure to update
+   */
+  void PrepareTtsJsonValueForSaving(
+      const std::vector<std::string>& sections_to_update,
+      const smart_objects::CSmartSchema& schema,
+      Json::Value& out_node) const;
+
+  /**
+   * @brief Prepares specified JSON structure for Buttons interface according to
+   * sections which should be updated
+   * @param sections_to_update reference to list of fields to update
+   * @param schema reference to schema which should be unapplied before field
+   * updating
+   * @param out_node reference to JSON structure to update
+   */
+  void PrepareButtonsJsonValueForSaving(
+      const std::vector<std::string>& sections_to_update,
+      const smart_objects::CSmartSchema& schema,
+      Json::Value& out_node) const;
+
+  /**
+   * @brief Prepares specified JSON structure for VehicleInfo interface
+   * according to sections which should be updated
+   * @param sections_to_update reference to list of fields to update
+   * @param schema reference to schema which should be unapplied before field
+   * updating
+   * @param out_node reference to JSON structure to update
+   */
+  void PrepareVehicleInfoJsonValueForSaving(
+      const std::vector<std::string>& sections_to_update,
+      const smart_objects::CSmartSchema& schema,
+      Json::Value& out_node) const;
+
+  /**
+   * @brief Prepares specified JSON structure for RC interface according to
+   * sections which should be updated
+   * @param sections_to_update reference to list of fields to update
+   * @param schema reference to schema which should be unapplied before field
+   * updating
+   * @param out_node reference to JSON structure to update
+   */
+  void PrepareRCJsonValueForSaving(
+      const std::vector<std::string>& sections_to_update,
+      const smart_objects::CSmartSchema& schema,
+      Json::Value& out_node) const;
+
   bool is_vr_cooperating_;
   bool is_tts_cooperating_;
   bool is_ui_cooperating_;

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -38,8 +38,6 @@
 #include "interfaces/HMI_API.h"
 #include "interfaces/MOBILE_API.h"
 #include "json/json.h"
-#include "smart_objects/enum_schema_item.h"
-#include "smart_objects/smart_object.h"
 #include "utils/macro.h"
 
 namespace application_manager {
@@ -250,7 +248,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return TRUE if capabilities loaded successfully, otherwise FALSE.
    */
-  bool load_capabilities_from_file();
+  bool LoadCapabilitiesFromFile();
 
   /**
    * @brief function converts json object "languages" to smart object
@@ -273,37 +271,6 @@ class HMICapabilitiesImpl : public HMICapabilities {
       const Json::Value& capability,
       smart_objects::SmartObject& output_so) const;
 
-  /**
-   * @brief Converts specified string to appropriate enum value
-   * according to schema
-   * @return converted enum value
-   */
-  template <typename EnumType>
-  EnumType ConvertStringToEnum(const std::string& str) {
-    using ns_smart_device_link::ns_smart_objects::EnumConversionHelper;
-    EnumType value;
-    if (EnumConversionHelper<EnumType>::StringToEnum(str, &value)) {
-      return value;
-    }
-
-    return EnumType::INVALID_ENUM;
-  }
-
-  /**
-   * @brief Converts the JSON array of string type into the SmartArray of enums
-   * @param json_array JSON value containing array
-   * @param out_so_array output SmartArray
-   */
-  template <typename EnumType>
-  void ConvertJsonArrayToSoArray(const Json::Value& json_array,
-                                 smart_objects::SmartObject& out_so_array) {
-    out_so_array =
-        smart_objects::SmartObject(smart_objects::SmartType::SmartType_Array);
-    for (uint32_t i = 0; i < json_array.size(); ++i) {
-      out_so_array[i] = ConvertStringToEnum<EnumType>(json_array[i].asString());
-    }
-  }
-
  private:
   /**
    * @brief Checks are all updating fields are currently saved in the JSON
@@ -314,10 +281,9 @@ class HMICapabilitiesImpl : public HMICapabilities {
    * @return true if all fields from the list are saved in the JSON structure,
    * otherwise returns false
    */
-  bool AreAllFieldsSaved(
-      const Json::Value& root_node,
-      const char* interface_name,
-      const std::vector<std::string>& sections_to_check) const;
+  bool AllFieldsSaved(const Json::Value& root_node,
+                      const char* interface_name,
+                      const std::vector<std::string>& sections_to_check) const;
 
   /**
    * @brief Gets the currently active language depending on interface

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -46,32 +46,19 @@ class ApplicationManager;
 
 class HMICapabilitiesImpl : public HMICapabilities {
  public:
-  /*
+  /**
    * @ Class constructor
-   *
    * @param app_mngr Application manager pointer
    */
   explicit HMICapabilitiesImpl(ApplicationManager& app_mngr);
 
-  /*
+  /**
    * @brief Class destructor
-   *
    */
   virtual ~HMICapabilitiesImpl();
 
-  /*
-   * @brief Checks is image type(Static/Dynamic) requested by
-   * Mobile Device is supported on current HMI.
-   * @param image_type recieved type of image from Enum.
-   * @return Bool true if supported
-   */
   bool VerifyImageType(const int32_t image_type) const OVERRIDE;
 
-  /**
-   * @brief Checks if all HMI capabilities received
-   *
-   * @return TRUE if all information received, otherwise FALSE
-   */
   bool is_vr_cooperating() const OVERRIDE;
   void set_is_vr_cooperating(const bool value) OVERRIDE;
 
@@ -90,414 +77,137 @@ class HMICapabilitiesImpl : public HMICapabilities {
   bool is_rc_cooperating() const OVERRIDE;
   void set_is_rc_cooperating(const bool value) OVERRIDE;
 
-  /*
-   * @brief Interface used to store information about software version of the
-   *target
-   *
-   * @param ccpu_version Received system/hmi software version
-   */
   void set_ccpu_version(const std::string& ccpu_version) OVERRIDE;
 
-  /*
-   * @brief Returns software version of the target
-   *
-   * @return TRUE if it supported, otherwise FALSE
-   */
   const std::string& ccpu_version() const OVERRIDE;
 
-  /*
-   * @brief Retrieves if mixing audio is supported by HMI
-   * (ie recording TTS command and playing audio)
-   *
-   * @return Current state of the mixing audio flag
-   */
   bool attenuated_supported() const OVERRIDE;
 
-  /*
-   * @brief Sets state for mixing audio
-   *
-   * @param state New state to be set
-   */
   void set_attenuated_supported(const bool state) OVERRIDE;
 
-  /*
-   * @brief Retrieves currently active UI language
-   *
-   * @return Currently active UI language
-   */
   const hmi_apis::Common_Language::eType active_ui_language() const OVERRIDE;
 
-  /*
-   * @brief Sets currently active UI language
-   *
-   * @param language Currently active UI language
-   */
   void set_active_ui_language(
       const hmi_apis::Common_Language::eType language) OVERRIDE;
 
-  /*
-   * @brief Retrieves UI supported languages
-   *
-   * @return Currently supported UI languages
-   */
   const smart_objects::SmartObjectSPtr ui_supported_languages() const OVERRIDE;
 
-  /*
-   * @brief Sets supported UI languages
-   *
-   * @param supported_languages Supported UI languages
-   */
   void set_ui_supported_languages(
       const smart_objects::SmartObject& supported_languages) OVERRIDE;
 
-  /*
-   * @brief Retrieves currently active VR language
-   *
-   * @return Currently active VR language
-   */
   const hmi_apis::Common_Language::eType active_vr_language() const OVERRIDE;
 
-  /*
-   * @brief Sets currently active VR language
-   *
-   * @param language Currently active VR language
-   */
   void set_active_vr_language(
       const hmi_apis::Common_Language::eType language) OVERRIDE;
 
-  /*
-   * @brief Retrieves VR supported languages
-   *
-   * @return Currently supported VR languages
-   */
   const smart_objects::SmartObjectSPtr vr_supported_languages() const OVERRIDE;
 
-  /*
-   * @brief Sets supported VR languages
-   *
-   * @param supported_languages Supported VR languages
-   */
   void set_vr_supported_languages(
       const smart_objects::SmartObject& supported_languages) OVERRIDE;
 
-  /*
-   * @brief Retrieves currently active TTS language
-   *
-   * @return Currently active TTS language
-   */
   const hmi_apis::Common_Language::eType active_tts_language() const OVERRIDE;
 
-  /*
-   * @brief Sets currently active TTS language
-   *
-   * @param language Currently active TTS language
-   */
   void set_active_tts_language(
       const hmi_apis::Common_Language::eType language) OVERRIDE;
 
-  /*
-   * @brief Retrieves TTS  supported languages
-   *
-   * @return Currently supported TTS languages
-   */
   const smart_objects::SmartObjectSPtr tts_supported_languages() const OVERRIDE;
 
-  /*
-   * @brief Sets supported TTS languages
-   *
-   * @param supported_languages Supported TTS languages
-   */
   void set_tts_supported_languages(
       const smart_objects::SmartObject& supported_languages) OVERRIDE;
 
-  /*
-   * @brief Retrieves information about the display capabilities
-   *
-   * @return Currently supported display capabilities
-   */
   const smart_objects::SmartObjectSPtr display_capabilities() const OVERRIDE;
 
-  /*
-   * @brief Sets supported display capabilities
-   *
-   * @param display_capabilities supported display capabilities
-   */
   void set_display_capabilities(
       const smart_objects::SmartObject& display_capabilities) OVERRIDE;
 
-  /*
-   * @brief Retrieves information about the display capability
-   * @return Currently supported display capability
-   */
   const smart_objects::SmartObjectSPtr system_display_capabilities()
       const OVERRIDE;
 
-  /*
-   * @brief Sets supported display capability
-   * @param display_capabilities supported display capability
-   */
   void set_system_display_capabilities(
       const smart_objects::SmartObject& display_capabilities);
 
-  /*
-   * @brief Retrieves information about the HMI zone capabilities
-   *
-   * @return Currently supported HMI zone capabilities
-   */
   const smart_objects::SmartObjectSPtr hmi_zone_capabilities() const OVERRIDE;
 
-  /*
-   * @brief Sets supported HMI zone capabilities
-   *
-   * @param hmi_zone_capabilities supported HMI zone capabilities
-   */
   void set_hmi_zone_capabilities(
       const smart_objects::SmartObject& hmi_zone_capabilities) OVERRIDE;
 
-  /*
-   * @brief Retrieves information about the SoftButton's capabilities
-   *
-   * @return Currently supported SoftButton's capabilities
-   */
   const smart_objects::SmartObjectSPtr soft_button_capabilities()
       const OVERRIDE;
 
-  /*
-   * @brief Sets supported SoftButton's capabilities
-   *
-   * @param soft_button_capabilities supported SoftButton's capabilities
-   */
   void set_soft_button_capabilities(
       const smart_objects::SmartObject& soft_button_capabilities) OVERRIDE;
 
-  /*
-   * @brief Retrieves information about the Button's capabilities
-   *
-   * @return Currently supported Button's capabilities
-   */
   const smart_objects::SmartObjectSPtr button_capabilities() const OVERRIDE;
 
-  /*
-   * @brief Sets supported Button's capabilities
-   *
-   * @param soft_button_capabilities supported Button's capabilities
-   */
   void set_button_capabilities(
       const smart_objects::SmartObject& button_capabilities) OVERRIDE;
 
-  /*
-   * @brief Sets supported speech capabilities
-   *
-   * @param speech_capabilities supported speech capabilities
-   */
   void set_speech_capabilities(
       const smart_objects::SmartObject& speech_capabilities) OVERRIDE;
 
-  /*
-   * @brief Retrieves information about the speech capabilities
-   *
-   * @return Currently supported speech capabilities
-   */
   const smart_objects::SmartObjectSPtr speech_capabilities() const OVERRIDE;
 
-  /*
-   * @brief Sets supported VR capabilities
-   *
-   * @param vr_capabilities supported VR capabilities
-   */
   void set_vr_capabilities(
       const smart_objects::SmartObject& vr_capabilities) OVERRIDE;
 
-  /*
-   * @brief Retrieves information about the VR capabilities
-   *
-   * @return Currently supported VR capabilities
-   */
   const smart_objects::SmartObjectSPtr vr_capabilities() const OVERRIDE;
 
-  /*
-   * @brief Sets supported audio_pass_thru capabilities
-   *
-   * @param vr_capabilities supported audio_pass_thru capabilities
-   */
   void set_audio_pass_thru_capabilities(
       const smart_objects::SmartObject& audio_pass_thru_capabilities) OVERRIDE;
 
-  /*
-   * @brief Retrieves information about the audio_pass_thru capabilities
-   *
-   * @return Currently supported audio_pass_thru capabilities
-   */
   const smart_objects::SmartObjectSPtr audio_pass_thru_capabilities()
       const OVERRIDE;
 
-  /*
-   * @brief Sets supported pcm_stream capabilities
-   *
-   * @param supported pcm_stream capabilities
-   */
   void set_pcm_stream_capabilities(
       const smart_objects::SmartObject& pcm_stream_capabilities) OVERRIDE;
 
-  /*
-   * @brief Retrieves information about the pcm_stream capabilities
-   *
-   * @return Currently supported pcm_streaming capabilities
-   */
   const smart_objects::SmartObjectSPtr pcm_stream_capabilities() const OVERRIDE;
 
-  /*
-   * @brief Retrieves information about the preset bank capabilities
-   *
-   * @return Currently supported preset bank capabilities
-   */
   const smart_objects::SmartObjectSPtr preset_bank_capabilities()
       const OVERRIDE;
 
-  /*
-   * @brief Sets supported preset bank capabilities
-   *
-   * @param soft_button_capabilities supported preset bank capabilities
-   */
   void set_preset_bank_capabilities(
       const smart_objects::SmartObject& preset_bank_capabilities) OVERRIDE;
 
-  /*
-   * @brief Sets vehicle information(make, model, modelYear)
-   *
-   * @param vehicle_type Cuurent vehicle information
-   */
   void set_vehicle_type(
       const smart_objects::SmartObject& vehicle_type) OVERRIDE;
 
-  /*
-   * @brief Retrieves vehicle information(make, model, modelYear)
-   *
-   * @param vehicle_type Cuurent vehicle information
-   */
   const smart_objects::SmartObjectSPtr vehicle_type() const OVERRIDE;
 
-  /*
-   * @brief Retrieves information about the prerecorded speech
-   *
-   * @return Currently supported prerecorded speech
-   */
   const smart_objects::SmartObjectSPtr prerecorded_speech() const OVERRIDE;
 
-  /*
-   * @brief Sets supported prerecorded speech
-   *
-   * @param prerecorded_speech supported prerecorded speech
-   */
   void set_prerecorded_speech(
       const smart_objects::SmartObject& prerecorded_speech) OVERRIDE;
 
-  /*
-   * @brief Interface used to store information if navigation
-   * supported by the system
-   *
-   * @param supported Indicates if navigation supported by the system
-   */
   void set_navigation_supported(const bool supported) OVERRIDE;
 
-  /*
-   * @brief Retrieves information if navi supported by the system
-   *
-   * @return TRUE if it supported, otherwise FALSE
-   */
   bool navigation_supported() const OVERRIDE;
 
-  /*
-   * @brief Interface used to store information if phone call
-   * supported by the system
-   *
-   * @param supported Indicates if navigation supported by the sustem
-   */
   void set_phone_call_supported(const bool supported) OVERRIDE;
 
-  /*
-   * @brief Retrieves information if phone call supported by the system
-   *
-   * @return TRUE if it supported, otherwise FALSE
-   */
   bool phone_call_supported() const OVERRIDE;
 
-  /*
-   * @brief Interface to store whether HMI supports video streaming
-   *
-   * @param supported Indicates whether video streaming is supported by HMI
-   */
   void set_video_streaming_supported(const bool supported) OVERRIDE;
 
-  /*
-   * @brief Retrieves whether HMI supports video streaming
-   *
-   * @return TRUE if it supported, otherwise FALSE
-   */
   bool video_streaming_supported() const OVERRIDE;
 
-  /*
-   * @brief Interface to store whether HMI supports remote control
-   *
-   * @param supported Indicates whether video streaming is supported by HMI
-   */
   void set_rc_supported(const bool supported) OVERRIDE;
 
-  /*
-   * @brief Retrieves whether HMI supports remote control
-   *
-   * @return TRUE if it supported, otherwise FALSE
-   */
   bool rc_supported() const OVERRIDE;
 
-  /*
-   * @brief Interface used to store information regarding
-   * the navigation "System Capability"
-   *
-   * @param navigation_capability contains information related
-   * to the navigation system capability.
-   */
   void set_navigation_capability(
       const smart_objects::SmartObject& navigation_capability) OVERRIDE;
 
-  /*
-   * @brief Retrieves information regarding the navigation system capability
-   *
-   * @return NAVIGATION system capability
-   */
   const smart_objects::SmartObjectSPtr navigation_capability() const OVERRIDE;
 
-  /*
-   * @brief Interface used to store information regarding
-   * the phone "System Capability"
-   *
-   * @param phone_capability contains information related
-   * to the phone system capability.
-   */
   void set_phone_capability(
       const smart_objects::SmartObject& phone_capability) OVERRIDE;
 
-  /*
-   * @brief Retrieves information regarding the phone call system capability
-   *
-   * @return PHONE_CALL system capability
-   */
-
   const smart_objects::SmartObjectSPtr phone_capability() const OVERRIDE;
 
-  /*
-   * @brief Sets HMI's video streaming related capability information
-   *
-   * @param video_streaming_capability the video streaming related capabilities
-   */
   void set_video_streaming_capability(
       const smart_objects::SmartObject& video_streaming_capability) OVERRIDE;
 
-  /*
-   * @brief Retrieves HMI's video streaming related capabilities
-   *
-   * @return HMI's video streaming related capability information
-   */
   const smart_objects::SmartObjectSPtr video_streaming_capability()
       const OVERRIDE;
 
@@ -517,17 +227,8 @@ class HMICapabilitiesImpl : public HMICapabilities {
   DEPRECATED
   void Init(resumption::LastState* last_state) OVERRIDE;
 
-  /*
-   * @brief return component which follows for correctness of
-   * languages
-   * @return HMI language handler
-   */
   HMILanguageHandler& get_hmi_language_handler() OVERRIDE;
 
-  /**
-   * @brief Trigger waiting for response
-   * @param request Request object
-   */
   void set_handle_response_for(
       const smart_objects::SmartObject& request) OVERRIDE;
 
@@ -538,7 +239,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
   void DeleteCachedCapabilitiesFile() const OVERRIDE;
 
  protected:
-  /*
+  /**
    * @brief Loads capabilities from local file in case SDL was launched
    * without HMI
    *

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -140,7 +140,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return Currently supported UI languages
    */
-  const smart_objects::SmartObject* ui_supported_languages() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr ui_supported_languages() const OVERRIDE;
 
   /*
    * @brief Sets supported UI languages
@@ -170,7 +170,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return Currently supported VR languages
    */
-  const smart_objects::SmartObject* vr_supported_languages() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr vr_supported_languages() const OVERRIDE;
 
   /*
    * @brief Sets supported VR languages
@@ -200,7 +200,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return Currently supported TTS languages
    */
-  const smart_objects::SmartObject* tts_supported_languages() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr tts_supported_languages() const OVERRIDE;
 
   /*
    * @brief Sets supported TTS languages
@@ -465,7 +465,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return NAVIGATION system capability
    */
-  const smart_objects::SmartObject* navigation_capability() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr navigation_capability() const OVERRIDE;
 
   /*
    * @brief Interface used to store information regarding
@@ -483,7 +483,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    * @return PHONE_CALL system capability
    */
 
-  const smart_objects::SmartObject* phone_capability() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr phone_capability() const OVERRIDE;
 
   /*
    * @brief Sets HMI's video streaming related capability information
@@ -498,17 +498,19 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return HMI's video streaming related capability information
    */
-  const smart_objects::SmartObject* video_streaming_capability() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr video_streaming_capability()
+      const OVERRIDE;
 
   void set_rc_capability(
       const smart_objects::SmartObject& rc_capability) OVERRIDE;
 
-  const smart_objects::SmartObject* rc_capability() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr rc_capability() const OVERRIDE;
 
   void set_seat_location_capability(
       const smart_objects::SmartObject& seat_location_capability) OVERRIDE;
 
-  const smart_objects::SmartObject* seat_location_capability() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr seat_location_capability()
+      const OVERRIDE;
 
   void Init(resumption::LastStateWrapperPtr last_state_wrapper) OVERRIDE;
 
@@ -587,9 +589,9 @@ class HMICapabilitiesImpl : public HMICapabilities {
   hmi_apis::Common_Language::eType vr_language_;
   hmi_apis::Common_Language::eType tts_language_;
   smart_objects::SmartObjectSPtr vehicle_type_;
-  smart_objects::SmartObject* ui_supported_languages_;
-  smart_objects::SmartObject* tts_supported_languages_;
-  smart_objects::SmartObject* vr_supported_languages_;
+  smart_objects::SmartObjectSPtr ui_supported_languages_;
+  smart_objects::SmartObjectSPtr tts_supported_languages_;
+  smart_objects::SmartObjectSPtr vr_supported_languages_;
   /*
    * display_capabilities_ is deprecated and replaced by
    * system_display_capabilities_. For backward compatibility
@@ -611,11 +613,11 @@ class HMICapabilitiesImpl : public HMICapabilities {
   bool is_video_streaming_supported_;
   bool is_rc_supported_;
   std::string ccpu_version_;
-  smart_objects::SmartObject* navigation_capability_;
-  smart_objects::SmartObject* phone_capability_;
-  smart_objects::SmartObject* video_streaming_capability_;
-  smart_objects::SmartObject* rc_capability_;
-  smart_objects::SmartObject* seat_location_capability_;
+  smart_objects::SmartObjectSPtr navigation_capability_;
+  smart_objects::SmartObjectSPtr phone_capability_;
+  smart_objects::SmartObjectSPtr video_streaming_capability_;
+  smart_objects::SmartObjectSPtr rc_capability_;
+  smart_objects::SmartObjectSPtr seat_location_capability_;
 
   ApplicationManager& app_mngr_;
   HMILanguageHandler hmi_language_handler_;

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -238,7 +238,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
 
   void DeleteCachedCapabilitiesFile() const OVERRIDE;
 
-  std::vector<hmi_apis::FunctionID::eType> GetInterfacesToUpdate()
+  std::set<hmi_apis::FunctionID::eType> GetInterfacesFromDefault()
       const OVERRIDE;
 
  protected:
@@ -432,7 +432,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
   ApplicationManager& app_mngr_;
   HMILanguageHandler hmi_language_handler_;
 
-  std::vector<hmi_apis::FunctionID::eType> interfaces_to_update_;
+  std::set<hmi_apis::FunctionID::eType> interfaces_from_default_;
 
   DISALLOW_COPY_AND_ASSIGN(HMICapabilitiesImpl);
 };

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -480,6 +480,19 @@ extern const char* const x;
 extern const char* const y;
 }  // namespace strings
 
+namespace hmi_interface {
+extern const char* basic_communication;
+extern const char* buttons;
+extern const char* navigation;
+extern const char* sdl;
+extern const char* tts;
+extern const char* ui;
+extern const char* vr;
+extern const char* rc;
+extern const char* vehicle_info;
+extern const char* app_service;
+}  // namespace hmi_interface
+
 namespace json {
 extern const char* appId;
 extern const char* name;

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -220,6 +220,7 @@ extern const char* is_cloud_application;
 extern const char* cloud_connection_status;
 extern const char* endpoint;
 extern const char* display_capabilities;
+extern const char* system_display_capabilities;
 extern const char* policy_type;
 extern const char* property;
 extern const char* displays;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -54,8 +54,7 @@ GetInteriorVehicleDataRequest::GetInteriorVehicleDataRequest(
 
 bool GetInteriorVehicleDataRequest::ProcessCapabilities() {
   LOG4CXX_AUTO_TRACE(logger_);
-  const smart_objects::SmartObject* rc_capabilities =
-      hmi_capabilities_.rc_capability();
+  const auto rc_capabilities = hmi_capabilities_.rc_capability();
 
   const std::string module_type = ModuleType();
   const std::string module_id = ModuleId();

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -54,12 +54,12 @@ GetInteriorVehicleDataRequest::GetInteriorVehicleDataRequest(
 
 bool GetInteriorVehicleDataRequest::ProcessCapabilities() {
   LOG4CXX_AUTO_TRACE(logger_);
-  const auto rc_capabilities = hmi_capabilities_.rc_capability();
+  const auto rc_capability = hmi_capabilities_.rc_capability();
 
   const std::string module_type = ModuleType();
   const std::string module_id = ModuleId();
   const ModuleUid module(module_type, module_id);
-  if (rc_capabilities &&
+  if (rc_capability &&
       !rc_capabilities_manager_.CheckIfModuleExistsInCapabilities(module)) {
     LOG4CXX_WARN(
         logger_,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/release_interior_vehicle_data_module_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/release_interior_vehicle_data_module_request.cc
@@ -91,12 +91,12 @@ ReleaseInteriorVehicleDataModuleRequest::
 
 bool ReleaseInteriorVehicleDataModuleRequest::ProcessCapabilities() {
   LOG4CXX_AUTO_TRACE(logger_);
-  const auto rc_capabilities = hmi_capabilities_.rc_capability();
+  const auto rc_capability = hmi_capabilities_.rc_capability();
 
   const std::string module_type = ModuleType();
   const std::string module_id = ModuleId();
   const ModuleUid module(module_type, module_id);
-  if (rc_capabilities &&
+  if (rc_capability &&
       !rc_capabilities_manager_.CheckIfModuleExistsInCapabilities(module)) {
     LOG4CXX_WARN(
         logger_,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/release_interior_vehicle_data_module_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/release_interior_vehicle_data_module_request.cc
@@ -91,8 +91,7 @@ ReleaseInteriorVehicleDataModuleRequest::
 
 bool ReleaseInteriorVehicleDataModuleRequest::ProcessCapabilities() {
   LOG4CXX_AUTO_TRACE(logger_);
-  const smart_objects::SmartObject* rc_capabilities =
-      hmi_capabilities_.rc_capability();
+  const auto rc_capabilities = hmi_capabilities_.rc_capability();
 
   const std::string module_type = ModuleType();
   const std::string module_id = ModuleId();

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
@@ -157,8 +157,8 @@ void RCCommandRequest::Run() {
                  "Remote control is disabled by user");
     return;
   }
-  auto rc_capabilities = hmi_capabilities_.rc_capability();
-  if (!rc_capabilities || rc_capabilities->empty()) {
+  auto rc_capability = hmi_capabilities_.rc_capability();
+  if (!rc_capability || rc_capability->empty()) {
     LOG4CXX_WARN(logger_, "Accessing not supported module: " << ModuleType());
     SetResourceState(ModuleType(), ResourceState::FREE);
     SendResponse(false,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
@@ -79,14 +79,15 @@ class ButtonPressRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
   ButtonPressRequestTest()
-      : rc_capabilities_(smart_objects::SmartType_Map)
+      : rc_capabilities_(std::make_shared<smart_objects::SmartObject>(
+            smart_objects::SmartType_Map))
       , mock_app_(std::make_shared<NiceMock<MockApplication> >())
       , rc_app_extention_(
             std::make_shared<rc_rpc_plugin::RCAppExtension>(kModuleId)) {}
 
   void SetUp() OVERRIDE {
     smart_objects::SmartObject control_caps((smart_objects::SmartType_Array));
-    rc_capabilities_[strings::kradioControlCapabilities] = control_caps;
+    (*rc_capabilities_)[strings::kradioControlCapabilities] = control_caps;
     ON_CALL(app_mngr_, application(_)).WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, QueryInterface(RCRPCPlugin::kRCPluginID))
         .WillByDefault(Return(rc_app_extention_));
@@ -95,7 +96,7 @@ class ButtonPressRequestTest
     ON_CALL(app_mngr_, hmi_capabilities())
         .WillByDefault(ReturnRef(mock_hmi_capabilities_));
     ON_CALL(mock_hmi_capabilities_, rc_capability())
-        .WillByDefault(Return(&rc_capabilities_));
+        .WillByDefault(Return(rc_capabilities_));
     ON_CALL(*mock_app_, policy_app_id()).WillByDefault(Return(kPolicyAppId));
     ON_CALL(mock_policy_handler_,
             CheckHMIType(kPolicyAppId,
@@ -140,7 +141,7 @@ class ButtonPressRequestTest
   }
 
  protected:
-  smart_objects::SmartObject rc_capabilities_;
+  smart_objects::SmartObjectSPtr rc_capabilities_;
   std::shared_ptr<MockApplication> mock_app_;
   std::shared_ptr<rc_rpc_plugin::RCAppExtension> rc_app_extention_;
   test::components::policy_test::MockPolicyHandlerInterface

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -96,7 +96,8 @@ class GetInteriorVehicleDataRequestTest
       , rc_app_extention2_(std::make_shared<RCAppExtension>(kModuleId))
       , apps_lock_(std::make_shared<sync_primitives::Lock>())
       , apps_da_(apps_, apps_lock_)
-      , rc_capabilities_(smart_objects::SmartType::SmartType_Array) {
+      , rc_capabilities_(std::make_shared<smart_objects::SmartObject>(
+            smart_objects::SmartType::SmartType_Array)) {
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId));
     ON_CALL(*mock_app2_, app_id()).WillByDefault(Return(kAppId2));
     ON_CALL(*mock_app_, is_remote_control_supported())
@@ -131,7 +132,7 @@ class GetInteriorVehicleDataRequestTest
     frequency.first = max_request_in_time_frame;
     frequency.second = time_frame_of_allowed_requests;
     smart_objects::SmartObject control_caps((smart_objects::SmartType_Array));
-    rc_capabilities_[strings::kradioControlCapabilities] = control_caps;
+    (*rc_capabilities_)[strings::kradioControlCapabilities] = control_caps;
     ON_CALL(app_mngr_, get_settings())
         .WillByDefault(ReturnRef(app_mngr_settings_));
     ON_CALL(app_mngr_settings_, get_interior_vehicle_data_frequency())
@@ -151,7 +152,7 @@ class GetInteriorVehicleDataRequestTest
     ON_CALL(app_mngr_, hmi_capabilities())
         .WillByDefault(ReturnRef(mock_hmi_capabilities_));
     ON_CALL(mock_hmi_capabilities_, rc_capability())
-        .WillByDefault(Return(&rc_capabilities_));
+        .WillByDefault(Return(rc_capabilities_));
     ON_CALL(mock_policy_handler_,
             CheckHMIType(
                 _, mobile_apis::AppHMIType::eType::REMOTE_CONTROL, nullptr))
@@ -195,7 +196,7 @@ class GetInteriorVehicleDataRequestTest
   DataAccessor<application_manager::ApplicationSet> apps_da_;
   testing::NiceMock<rc_rpc_plugin_test::MockRCCapabilitiesManager>
       mock_rc_capabilities_manager_;
-  smart_objects::SmartObject rc_capabilities_;
+  smart_objects::SmartObjectSPtr rc_capabilities_;
   testing::NiceMock<MockRCConsentManager> mock_rc_consent_manger_;
 };
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
@@ -106,7 +106,8 @@ class RCGetInteriorVehicleDataConsentTest
   RCGetInteriorVehicleDataConsentTest()
       : mock_app_(std::make_shared<NiceMock<MockApplication> >())
       , command_holder(app_mngr_)
-      , rc_capabilities_(smart_objects::SmartType::SmartType_Array)
+      , rc_capabilities_(std::make_shared<smart_objects::SmartObject>(
+            smart_objects::SmartType::SmartType_Array))
       , request_controller(mock_request_controler)
       , rpc_protection_manager_(
             std::make_shared<application_manager::MockRPCProtectionManager>())
@@ -124,7 +125,7 @@ class RCGetInteriorVehicleDataConsentTest
       , rpc_plugin(mock_rpc_plugin)
       , optional_mock_rpc_plugin(mock_rpc_plugin) {
     smart_objects::SmartObject control_caps((smart_objects::SmartType_Array));
-    rc_capabilities_[strings::kradioControlCapabilities] = control_caps;
+    (*rc_capabilities_)[strings::kradioControlCapabilities] = control_caps;
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId));
     ON_CALL(app_mngr_, hmi_interfaces())
         .WillByDefault(ReturnRef(mock_hmi_interfaces_));
@@ -143,7 +144,7 @@ class RCGetInteriorVehicleDataConsentTest
     ON_CALL(app_mngr_, hmi_capabilities())
         .WillByDefault(ReturnRef(mock_hmi_capabilities_));
     ON_CALL(mock_hmi_capabilities_, rc_capability())
-        .WillByDefault(Return(&rc_capabilities_));
+        .WillByDefault(Return(rc_capabilities_));
     ON_CALL(mock_policy_handler_,
             CheckHMIType(
                 _, mobile_apis::AppHMIType::eType::REMOTE_CONTROL, nullptr))
@@ -209,7 +210,7 @@ class RCGetInteriorVehicleDataConsentTest
       mock_interior_data_cache_;
   testing::NiceMock<rc_rpc_plugin_test::MockInteriorDataManager>
       mock_interior_data_manager_;
-  smart_objects::SmartObject rc_capabilities_;
+  smart_objects::SmartObjectSPtr rc_capabilities_;
   MockRPCPlugin mock_rpc_plugin;
   MockCommandFactory mock_command_factory;
   am::request_controller::RequestController request_controller;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/release_interior_vehicle_data_module_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/release_interior_vehicle_data_module_request_test.cc
@@ -84,12 +84,19 @@ using namespace rc_rpc_plugin;
 class ReleaseInteriorVehicleDataModuleRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  ReleaseInteriorVehicleDataModuleRequestTest() : mock_app_(CreateMockApp()) {}
+  ReleaseInteriorVehicleDataModuleRequestTest()
+      : mock_app_(CreateMockApp())
+      , rc_capabilities_(std::make_shared<smart_objects::SmartObject>(
+            smart_objects::SmartType::SmartType_Array)) {}
 
   void SetUp() OVERRIDE {
     TestPreCondition();
     ON_CALL(app_mngr_, application(kAppID)).WillByDefault(Return(mock_app_));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppID));
+    ON_CALL(mock_hmi_capabilities_, rc_capability())
+        .WillByDefault(Return(rc_capabilities_));
+    ON_CALL(mock_rc_capabilities_manager_, CheckIfModuleExistsInCapabilities(_))
+        .WillByDefault(Return(true));
     ON_CALL(mock_rc_capabilities_manager_,
             GetDefaultModuleIdFromCapabilities(kModuleType))
         .WillByDefault(Return(kDefaultModuleID));
@@ -143,6 +150,7 @@ class ReleaseInteriorVehicleDataModuleRequestTest
   MockInteriorDataManager mock_interior_data_manager_;
   NiceMock<MockRCCapabilitiesManager> mock_rc_capabilities_manager_;
   MockRCConsentManager mock_rc_consent_manger_;
+  smart_objects::SmartObjectSPtr rc_capabilities_;
 };
 
 TEST_F(ReleaseInteriorVehicleDataModuleRequestTest,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
@@ -74,11 +74,12 @@ class SetInteriorVehicleDataRequestTest
   SetInteriorVehicleDataRequestTest()
       : mock_app_(std::make_shared<NiceMock<MockApplication> >())
       , rc_app_extention_(std::make_shared<RCAppExtension>(kModuleId))
-      , rc_capabilities_(smart_objects::SmartType::SmartType_Array) {}
+      , rc_capabilities_(std::make_shared<smart_objects::SmartObject>(
+            smart_objects::SmartType::SmartType_Array)) {}
 
   void SetUp() OVERRIDE {
     smart_objects::SmartObject control_caps((smart_objects::SmartType_Array));
-    rc_capabilities_[strings::kradioControlCapabilities] = control_caps;
+    (*rc_capabilities_)[strings::kradioControlCapabilities] = control_caps;
     ON_CALL(app_mngr_, hmi_interfaces())
         .WillByDefault(ReturnRef(mock_hmi_interfaces_));
     ON_CALL(
@@ -102,7 +103,7 @@ class SetInteriorVehicleDataRequestTest
                          nullptr))
         .WillByDefault(Return(true));
     ON_CALL(mock_hmi_capabilities_, rc_capability())
-        .WillByDefault(Return(&rc_capabilities_));
+        .WillByDefault(Return(rc_capabilities_));
     ON_CALL(mock_allocation_manager_, is_rc_enabled())
         .WillByDefault(Return(true));
     ON_CALL(mock_rc_capabilities_manager_, CheckIfModuleExistsInCapabilities(_))
@@ -149,7 +150,7 @@ class SetInteriorVehicleDataRequestTest
   std::shared_ptr<RCAppExtension> rc_app_extention_;
   testing::NiceMock<rc_rpc_plugin_test::MockRCCapabilitiesManager>
       mock_rc_capabilities_manager_;
-  smart_objects::SmartObject rc_capabilities_;
+  smart_objects::SmartObjectSPtr rc_capabilities_;
   testing::NiceMock<MockRCConsentManager> mock_rc_consent_manger_;
 };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/rc_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/rc_is_ready_request.h
@@ -79,9 +79,9 @@ class RCIsReadyRequest : public app_mngr::commands::RequestToHMI,
   void onTimeOut() OVERRIDE;
 
   /**
-   * @brief Send request to HMI for fetching of cappabilities
+   * @brief Send request to HMI for fetching of capabilities
    */
-  void SendMessageToHMI();
+  void RequestCapabilities();
 
  private:
   DISALLOW_COPY_AND_ASSIGN(RCIsReadyRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_is_ready_request.h
@@ -80,7 +80,7 @@ class TTSIsReadyRequest : public app_mngr::commands::RequestToHMI,
   /**
    * @brief Send request to HMI for fetching of cappabilities
    */
-  void SendMessageToHMI();
+  void RequestCapabilities();
 
  private:
   DISALLOW_COPY_AND_ASSIGN(TTSIsReadyRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_is_ready_request.h
@@ -80,7 +80,7 @@ class UIIsReadyRequest : public app_mngr::commands::RequestToHMI,
   /**
    * @brief Send request to HMI for fetching of cappabilities
    */
-  void SendMessageToHMI();
+  void RequestCapabilities();
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UIIsReadyRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_is_ready_request.h
@@ -81,7 +81,7 @@ class VRIsReadyRequest : public app_mngr::commands::RequestToHMI,
   /**
    * @brief Send request to HMI for fetching of cappabilities
    */
-  void SendMessageToHMI();
+  void RequestCapabilities();
 
  private:
   DISALLOW_COPY_AND_ASSIGN(VRIsReadyRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_response.cc
@@ -63,16 +63,23 @@ void ButtonGetCapabilitiesResponse::Run() {
     return;
   }
 
-  HMICapabilities& hmi_capabilities = hmi_capabilities_;
-
-  hmi_capabilities.set_button_capabilities(
+  std::vector<std::string> sections_to_update;
+  hmi_capabilities_.set_button_capabilities(
       (*message_)[strings::msg_params][hmi_response::capabilities]);
+  sections_to_update.push_back(hmi_response::button_capabilities);
 
   if ((*message_)[strings::msg_params].keyExists(
           hmi_response::preset_bank_capabilities)) {
-    hmi_capabilities.set_preset_bank_capabilities(
+    sections_to_update.push_back(hmi_response::preset_bank_capabilities);
+    hmi_capabilities_.set_preset_bank_capabilities(
         (*message_)[strings::msg_params]
                    [hmi_response::preset_bank_capabilities]);
+  }
+
+  if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
+          hmi_interface::buttons, sections_to_update, message_->getSchema())) {
+    LOG4CXX_ERROR(logger_,
+                  "Failed to save Buttons.GetCapabilities response to cache");
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_tts_language_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_tts_language_change_notification.cc
@@ -59,20 +59,26 @@ OnTTSLanguageChangeNotification::~OnTTSLanguageChangeNotification() {}
 void OnTTSLanguageChangeNotification::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  HMICapabilities& hmi_capabilities = hmi_capabilities_;
-
-  hmi_capabilities.set_active_tts_language(
+  hmi_capabilities_.set_active_tts_language(
       static_cast<hmi_apis::Common_Language::eType>(
           (*message_)[strings::msg_params][strings::language].asInt()));
 
   /* need to clarify, because unchanged VR
   cause WRONG_LANGUAGE on Register */
-  hmi_capabilities.set_active_vr_language(
+  hmi_capabilities_.set_active_vr_language(
       static_cast<hmi_apis::Common_Language::eType>(
           (*message_)[strings::msg_params][strings::language].asInt()));
 
+  std::vector<std::string> sections_to_update;
+  sections_to_update.push_back(hmi_response::language);
+  if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
+          hmi_interface::tts, sections_to_update, message_->getSchema())) {
+    LOG4CXX_ERROR(logger_,
+                  "Failed to save TTS.OnLanguageChange response to cache");
+  }
+
   (*message_)[strings::msg_params][strings::hmi_display_language] =
-      hmi_capabilities.active_ui_language();
+      hmi_capabilities_.active_ui_language();
 
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_ui_language_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_ui_language_change_notification.cc
@@ -59,17 +59,23 @@ OnUILanguageChangeNotification::~OnUILanguageChangeNotification() {}
 void OnUILanguageChangeNotification::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  HMICapabilities& hmi_capabilities = hmi_capabilities_;
-
-  hmi_capabilities.set_active_ui_language(
+  hmi_capabilities_.set_active_ui_language(
       static_cast<hmi_apis::Common_Language::eType>(
           (*message_)[strings::msg_params][strings::language].asInt()));
+
+  std::vector<std::string> sections_to_update;
+  sections_to_update.push_back(hmi_response::language);
+  if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
+          hmi_interface::ui, sections_to_update, message_->getSchema())) {
+    LOG4CXX_ERROR(logger_,
+                  "Failed to save UI.OnLanguageChange response to cache");
+  }
 
   (*message_)[strings::msg_params][strings::hmi_display_language] =
       (*message_)[strings::msg_params][strings::language];
 
   (*message_)[strings::msg_params][strings::language] =
-      hmi_capabilities.active_vr_language();
+      hmi_capabilities_.active_vr_language();
 
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_vr_language_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_vr_language_change_notification.cc
@@ -60,14 +60,20 @@ OnVRLanguageChangeNotification::~OnVRLanguageChangeNotification() {}
 void OnVRLanguageChangeNotification::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  HMICapabilities& hmi_capabilities = hmi_capabilities_;
-
-  hmi_capabilities.set_active_vr_language(
+  hmi_capabilities_.set_active_vr_language(
       static_cast<hmi_apis::Common_Language::eType>(
           (*message_)[strings::msg_params][strings::language].asInt()));
 
+  std::vector<std::string> sections_to_update;
+  sections_to_update.push_back(hmi_response::language);
+  if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
+          hmi_interface::vr, sections_to_update, message_->getSchema())) {
+    LOG4CXX_ERROR(logger_,
+                  "Failed to save UI.OnLanguageChange response to cache");
+  }
+
   (*message_)[strings::msg_params][strings::hmi_display_language] =
-      hmi_capabilities.active_ui_language();
+      hmi_capabilities_.active_ui_language();
 
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_get_capabilities_response.cc
@@ -53,9 +53,8 @@ RCGetCapabilitiesResponse::~RCGetCapabilitiesResponse() {}
 void RCGetCapabilitiesResponse::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  const hmi_apis::Common_Result::eType result_code =
-      static_cast<hmi_apis::Common_Result::eType>(
-          (*message_)[strings::params][hmi_response::code].asInt());
+  const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
+      (*message_)[strings::params][hmi_response::code].asInt());
 
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     LOG4CXX_DEBUG(logger_,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_request.cc
@@ -82,14 +82,7 @@ void RCIsReadyRequest::on_event(const event_engine::Event& event) {
         return;
       }
 
-      // ilytvynenko ToDo: uncomment code after RC capabilities refactoring is
-      // finish
-      //      if (hmi_capabilities_.GetInterfacesToUpdate().empty()) {
-      //        LOG4CXX_INFO(logger_, "All fiels are present in the cache");
-      //        return;
-      //      }
-
-      SendMessageToHMI();
+      RequestCapabilities();
       break;
     }
     default: {
@@ -101,14 +94,14 @@ void RCIsReadyRequest::on_event(const event_engine::Event& event) {
 
 void RCIsReadyRequest::onTimeOut() {
   // Note(dtrunov): According to new requirment APPLINK-27956
-  SendMessageToHMI();
+  RequestCapabilities();
 }
 
-void RCIsReadyRequest::SendMessageToHMI() {
-  //  const auto interfaces_to_update =
-  //  hmi_capabilities_.GetInterfacesToUpdate();
+void RCIsReadyRequest::RequestCapabilities() {
+  //  const auto interfaces_from_default =
+  //  hmi_capabilities_.GetInterfacesFromDefault();
 
-  //  if (helpers::in_range(interfaces_to_update,
+  //  if (helpers::in_range(interfaces_from_default,
   //                        hmi_apis::FunctionID::RC_GetCapabilities)) {
   std::shared_ptr<smart_objects::SmartObject> get_capabilities(
       MessageHelper::CreateModuleInfoSO(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_request.cc
@@ -81,6 +81,14 @@ void RCIsReadyRequest::on_event(const event_engine::Event& event) {
                      "HmiInterfaces::HMI_INTERFACE_RC isn't available");
         return;
       }
+
+      // ilytvynenko ToDo: uncomment code after RC capabilities refactoring is
+      // finish
+      //      if (hmi_capabilities_.GetInterfacesToUpdate().empty()) {
+      //        LOG4CXX_INFO(logger_, "All fiels are present in the cache");
+      //        return;
+      //      }
+
       SendMessageToHMI();
       break;
     }
@@ -97,10 +105,16 @@ void RCIsReadyRequest::onTimeOut() {
 }
 
 void RCIsReadyRequest::SendMessageToHMI() {
+  //  const auto interfaces_to_update =
+  //  hmi_capabilities_.GetInterfacesToUpdate();
+
+  //  if (helpers::in_range(interfaces_to_update,
+  //                        hmi_apis::FunctionID::RC_GetCapabilities)) {
   std::shared_ptr<smart_objects::SmartObject> get_capabilities(
       MessageHelper::CreateModuleInfoSO(
           hmi_apis::FunctionID::RC_GetCapabilities, application_manager_));
   rpc_service_.ManageHMICommand(get_capabilities);
+  //  }
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_request.cc
@@ -98,10 +98,10 @@ void RCIsReadyRequest::onTimeOut() {
 }
 
 void RCIsReadyRequest::RequestCapabilities() {
-  //  const auto interfaces_from_default =
-  //  hmi_capabilities_.GetInterfacesFromDefault();
+  //  const auto default_initialized_capabilities =
+  //  hmi_capabilities_.GetDefaultInitializedCapabilities();
 
-  //  if (helpers::in_range(interfaces_from_default,
+  //  if (helpers::in_range(default_initialized_capabilities,
   //                        hmi_apis::FunctionID::RC_GetCapabilities)) {
   std::shared_ptr<smart_objects::SmartObject> get_capabilities(
       MessageHelper::CreateModuleInfoSO(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_capabilities_response.cc
@@ -52,9 +52,8 @@ TTSGetCapabilitiesResponse::~TTSGetCapabilitiesResponse() {}
 
 void TTSGetCapabilitiesResponse::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
-  const hmi_apis::Common_Result::eType result_code =
-      static_cast<hmi_apis::Common_Result::eType>(
-          (*message_)[strings::params][hmi_response::code].asInt());
+  const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
+      (*message_)[strings::params][hmi_response::code].asInt());
 
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     LOG4CXX_DEBUG(logger_,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_supported_languages_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_supported_languages_response.cc
@@ -59,11 +59,21 @@ void TTSGetSupportedLanguagesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
-  if (hmi_apis::Common_Result::SUCCESS == code) {
-    HMICapabilities& hmi_capabilities = hmi_capabilities_;
+  if (hmi_apis::Common_Result::SUCCESS != code) {
+    LOG4CXX_DEBUG(logger_,
+                  "Request was not successful. Don't change HMI capabilities");
+    return;
+  }
 
-    hmi_capabilities.set_tts_supported_languages(
-        (*message_)[strings::msg_params][hmi_response::languages]);
+  hmi_capabilities_.set_tts_supported_languages(
+      (*message_)[strings::msg_params][hmi_response::languages]);
+
+  std::vector<std::string> sections_to_update;
+  sections_to_update.push_back(hmi_response::languages);
+  if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
+          hmi_interface::tts, sections_to_update, message_->getSchema())) {
+    LOG4CXX_ERROR(logger_,
+                  "Failed to save TTS.GetSupportedLanguages response to cache");
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_is_ready_request.cc
@@ -78,6 +78,10 @@ void TTSIsReadyRequest::on_event(const event_engine::Event& event) {
                      "HmiInterfaces::HMI_INTERFACE_TTS isn't available");
         return;
       }
+      if (hmi_capabilities_.GetInterfacesToUpdate().empty()) {
+        LOG4CXX_INFO(logger_, "All fiels are present in the cache");
+        return;
+      }
       SendMessageToHMI();
       break;
     }
@@ -94,21 +98,34 @@ void TTSIsReadyRequest::onTimeOut() {
 }
 
 void TTSIsReadyRequest::SendMessageToHMI() {
-  std::shared_ptr<smart_objects::SmartObject> get_language(
-      MessageHelper::CreateModuleInfoSO(hmi_apis::FunctionID::TTS_GetLanguage,
-                                        application_manager_));
-  HMICapabilities& hmi_capabilities = hmi_capabilities_;
-  hmi_capabilities.set_handle_response_for(*get_language);
-  rpc_service_.ManageHMICommand(get_language);
-  std::shared_ptr<smart_objects::SmartObject> get_all_languages(
-      MessageHelper::CreateModuleInfoSO(
-          hmi_apis::FunctionID::TTS_GetSupportedLanguages,
-          application_manager_));
-  rpc_service_.ManageHMICommand(get_all_languages);
-  std::shared_ptr<smart_objects::SmartObject> get_capabilities(
-      MessageHelper::CreateModuleInfoSO(
-          hmi_apis::FunctionID::TTS_GetCapabilities, application_manager_));
-  rpc_service_.ManageHMICommand(get_capabilities);
+  const auto interfaces_to_update = hmi_capabilities_.GetInterfacesToUpdate();
+
+  if (helpers::in_range(interfaces_to_update,
+                        hmi_apis::FunctionID::TTS_GetLanguage)) {
+    std::shared_ptr<smart_objects::SmartObject> get_language(
+        MessageHelper::CreateModuleInfoSO(hmi_apis::FunctionID::TTS_GetLanguage,
+                                          application_manager_));
+    HMICapabilities& hmi_capabilities = hmi_capabilities_;
+    hmi_capabilities.set_handle_response_for(*get_language);
+    rpc_service_.ManageHMICommand(get_language);
+  }
+
+  if (helpers::in_range(interfaces_to_update,
+                        hmi_apis::FunctionID::TTS_GetSupportedLanguages)) {
+    std::shared_ptr<smart_objects::SmartObject> get_all_languages(
+        MessageHelper::CreateModuleInfoSO(
+            hmi_apis::FunctionID::TTS_GetSupportedLanguages,
+            application_manager_));
+    rpc_service_.ManageHMICommand(get_all_languages);
+  }
+
+  if (helpers::in_range(interfaces_to_update,
+                        hmi_apis::FunctionID::TTS_GetCapabilities)) {
+    std::shared_ptr<smart_objects::SmartObject> get_capabilities(
+        MessageHelper::CreateModuleInfoSO(
+            hmi_apis::FunctionID::TTS_GetCapabilities, application_manager_));
+    rpc_service_.ManageHMICommand(get_capabilities);
+  }
 }
 }  // namespace commands
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_is_ready_request.cc
@@ -95,10 +95,10 @@ void TTSIsReadyRequest::onTimeOut() {
 }
 
 void TTSIsReadyRequest::RequestCapabilities() {
-  const auto interfaces_from_default =
-      hmi_capabilities_.GetInterfacesFromDefault();
+  const auto default_initialized_capabilities =
+      hmi_capabilities_.GetDefaultInitializedCapabilities();
 
-  if (helpers::in_range(interfaces_from_default,
+  if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::TTS_GetLanguage)) {
     std::shared_ptr<smart_objects::SmartObject> get_language(
         MessageHelper::CreateModuleInfoSO(hmi_apis::FunctionID::TTS_GetLanguage,
@@ -108,7 +108,7 @@ void TTSIsReadyRequest::RequestCapabilities() {
     rpc_service_.ManageHMICommand(get_language);
   }
 
-  if (helpers::in_range(interfaces_from_default,
+  if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::TTS_GetSupportedLanguages)) {
     std::shared_ptr<smart_objects::SmartObject> get_supported_languages(
         MessageHelper::CreateModuleInfoSO(
@@ -117,7 +117,7 @@ void TTSIsReadyRequest::RequestCapabilities() {
     rpc_service_.ManageHMICommand(get_supported_languages);
   }
 
-  if (helpers::in_range(interfaces_from_default,
+  if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::TTS_GetCapabilities)) {
     std::shared_ptr<smart_objects::SmartObject> get_capabilities(
         MessageHelper::CreateModuleInfoSO(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
@@ -88,7 +88,7 @@ void UIGetCapabilitiesResponse::Run() {
 
   // use newer parameter "audioPassThruCapabilitiesList" when available
   if (msg_params.keyExists(strings::audio_pass_thru_capabilities_list)) {
-    sections_to_update.push_back(strings::audio_pass_thru_capabilities_list);
+    sections_to_update.push_back(strings::audio_pass_thru_capabilities);
     hmi_capabilities_.set_audio_pass_thru_capabilities(
         msg_params[strings::audio_pass_thru_capabilities_list]);
   } else if (msg_params.keyExists(strings::audio_pass_thru_capabilities)) {
@@ -96,7 +96,7 @@ void UIGetCapabilitiesResponse::Run() {
         smart_objects::SmartType_Array);
     audio_pass_thru_capabilities_list[0] =
         msg_params[strings::audio_pass_thru_capabilities];
-    sections_to_update.push_back(strings::audio_pass_thru_capabilities_list);
+    sections_to_update.push_back(strings::audio_pass_thru_capabilities);
     hmi_capabilities_.set_audio_pass_thru_capabilities(
         audio_pass_thru_capabilities_list);
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
@@ -54,27 +54,32 @@ void UIGetCapabilitiesResponse::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   HMICapabilities& hmi_capabilities = hmi_capabilities_;
+  std::vector<std::string> sections_to_update;
 
   const smart_objects::SmartObject& msg_params =
       (*message_)[strings::msg_params];
 
   if (msg_params.keyExists(hmi_response::display_capabilities)) {
+    sections_to_update.push_back(hmi_response::display_capabilities);
     hmi_capabilities.set_display_capabilities(
         msg_params[hmi_response::display_capabilities]);
   }
 
   if (msg_params.keyExists(hmi_response::hmi_zone_capabilities)) {
+    sections_to_update.push_back(hmi_response::hmi_zone_capabilities);
     hmi_capabilities.set_hmi_zone_capabilities(
         msg_params[hmi_response::hmi_zone_capabilities]);
   }
 
   if (msg_params.keyExists(hmi_response::soft_button_capabilities)) {
+    sections_to_update.push_back(hmi_response::soft_button_capabilities);
     hmi_capabilities.set_soft_button_capabilities(
         msg_params[hmi_response::soft_button_capabilities]);
   }
 
   // use newer parameter "audioPassThruCapabilitiesList" when available
   if (msg_params.keyExists(strings::audio_pass_thru_capabilities_list)) {
+    sections_to_update.push_back(strings::audio_pass_thru_capabilities_list);
     hmi_capabilities.set_audio_pass_thru_capabilities(
         msg_params[strings::audio_pass_thru_capabilities_list]);
   } else if (msg_params.keyExists(strings::audio_pass_thru_capabilities)) {
@@ -82,21 +87,25 @@ void UIGetCapabilitiesResponse::Run() {
         smart_objects::SmartType_Array);
     audio_pass_thru_capabilities_list[0] =
         msg_params[strings::audio_pass_thru_capabilities];
+    sections_to_update.push_back(strings::audio_pass_thru_capabilities_list);
     hmi_capabilities.set_audio_pass_thru_capabilities(
         audio_pass_thru_capabilities_list);
   }
 
   if (msg_params.keyExists(strings::hmi_capabilities)) {
     if (msg_params[strings::hmi_capabilities].keyExists(strings::navigation)) {
+      sections_to_update.push_back(strings::navigation);
       hmi_capabilities.set_navigation_supported(
           msg_params[strings::hmi_capabilities][strings::navigation].asBool());
     }
     if (msg_params[strings::hmi_capabilities].keyExists(strings::phone_call)) {
+      sections_to_update.push_back(strings::phone_call);
       hmi_capabilities.set_phone_call_supported(
           msg_params[strings::hmi_capabilities][strings::phone_call].asBool());
     }
     if (msg_params[strings::hmi_capabilities].keyExists(
             strings::video_streaming)) {
+      sections_to_update.push_back(strings::video_streaming);
       hmi_capabilities.set_video_streaming_supported(
           msg_params[strings::hmi_capabilities][strings::video_streaming]
               .asBool());
@@ -106,27 +115,36 @@ void UIGetCapabilitiesResponse::Run() {
   if (msg_params.keyExists(strings::system_capabilities)) {
     if (msg_params[strings::system_capabilities].keyExists(
             strings::navigation_capability)) {
+      sections_to_update.push_back(strings::navigation_capability);
       hmi_capabilities.set_navigation_capability(
           msg_params[strings::system_capabilities]
                     [strings::navigation_capability]);
     }
     if (msg_params[strings::system_capabilities].keyExists(
             strings::phone_capability)) {
+      sections_to_update.push_back(strings::phone_capability);
       hmi_capabilities.set_phone_capability(
           msg_params[strings::system_capabilities][strings::phone_capability]);
     }
     if (msg_params[strings::system_capabilities].keyExists(
             strings::video_streaming_capability)) {
+      sections_to_update.push_back(strings::video_streaming_capability);
       hmi_capabilities.set_video_streaming_capability(
           msg_params[strings::system_capabilities]
                     [strings::video_streaming_capability]);
     }
     if (msg_params[strings::system_capabilities].keyExists(
             strings::display_capabilities)) {
+      sections_to_update.push_back(strings::system_display_capabilities);
       hmi_capabilities.set_system_display_capabilities(
           msg_params[strings::system_capabilities]
                     [strings::display_capabilities]);
     }
+  }
+
+  if (!hmi_capabilities.SaveCachedCapabilitiesToFile(sections_to_update,
+                                                     message_->getSchema())) {
+    LOG4CXX_ERROR(logger_, "Failed to save GetCapabilities response to cache");
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
@@ -53,9 +53,8 @@ UIGetCapabilitiesResponse::~UIGetCapabilitiesResponse() {}
 void UIGetCapabilitiesResponse::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  const hmi_apis::Common_Result::eType result_code =
-      static_cast<hmi_apis::Common_Result::eType>(
-          (*message_)[strings::params][hmi_response::code].asInt());
+  const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
+      (*message_)[strings::params][hmi_response::code].asInt());
 
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     LOG4CXX_DEBUG(logger_,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
@@ -53,7 +53,16 @@ UIGetCapabilitiesResponse::~UIGetCapabilitiesResponse() {}
 void UIGetCapabilitiesResponse::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  HMICapabilities& hmi_capabilities = hmi_capabilities_;
+  const hmi_apis::Common_Result::eType result_code =
+      static_cast<hmi_apis::Common_Result::eType>(
+          (*message_)[strings::params][hmi_response::code].asInt());
+
+  if (hmi_apis::Common_Result::SUCCESS != result_code) {
+    LOG4CXX_DEBUG(logger_,
+                  "Request was not successful. Don't change HMI capabilities");
+    return;
+  }
+
   std::vector<std::string> sections_to_update;
 
   const smart_objects::SmartObject& msg_params =
@@ -61,26 +70,26 @@ void UIGetCapabilitiesResponse::Run() {
 
   if (msg_params.keyExists(hmi_response::display_capabilities)) {
     sections_to_update.push_back(hmi_response::display_capabilities);
-    hmi_capabilities.set_display_capabilities(
+    hmi_capabilities_.set_display_capabilities(
         msg_params[hmi_response::display_capabilities]);
   }
 
   if (msg_params.keyExists(hmi_response::hmi_zone_capabilities)) {
     sections_to_update.push_back(hmi_response::hmi_zone_capabilities);
-    hmi_capabilities.set_hmi_zone_capabilities(
+    hmi_capabilities_.set_hmi_zone_capabilities(
         msg_params[hmi_response::hmi_zone_capabilities]);
   }
 
   if (msg_params.keyExists(hmi_response::soft_button_capabilities)) {
     sections_to_update.push_back(hmi_response::soft_button_capabilities);
-    hmi_capabilities.set_soft_button_capabilities(
+    hmi_capabilities_.set_soft_button_capabilities(
         msg_params[hmi_response::soft_button_capabilities]);
   }
 
   // use newer parameter "audioPassThruCapabilitiesList" when available
   if (msg_params.keyExists(strings::audio_pass_thru_capabilities_list)) {
     sections_to_update.push_back(strings::audio_pass_thru_capabilities_list);
-    hmi_capabilities.set_audio_pass_thru_capabilities(
+    hmi_capabilities_.set_audio_pass_thru_capabilities(
         msg_params[strings::audio_pass_thru_capabilities_list]);
   } else if (msg_params.keyExists(strings::audio_pass_thru_capabilities)) {
     smart_objects::SmartObject audio_pass_thru_capabilities_list(
@@ -88,63 +97,59 @@ void UIGetCapabilitiesResponse::Run() {
     audio_pass_thru_capabilities_list[0] =
         msg_params[strings::audio_pass_thru_capabilities];
     sections_to_update.push_back(strings::audio_pass_thru_capabilities_list);
-    hmi_capabilities.set_audio_pass_thru_capabilities(
+    hmi_capabilities_.set_audio_pass_thru_capabilities(
         audio_pass_thru_capabilities_list);
   }
 
   if (msg_params.keyExists(strings::hmi_capabilities)) {
+    sections_to_update.push_back(strings::hmi_capabilities);
     if (msg_params[strings::hmi_capabilities].keyExists(strings::navigation)) {
-      sections_to_update.push_back(strings::navigation);
-      hmi_capabilities.set_navigation_supported(
+      hmi_capabilities_.set_navigation_supported(
           msg_params[strings::hmi_capabilities][strings::navigation].asBool());
     }
     if (msg_params[strings::hmi_capabilities].keyExists(strings::phone_call)) {
-      sections_to_update.push_back(strings::phone_call);
-      hmi_capabilities.set_phone_call_supported(
+      hmi_capabilities_.set_phone_call_supported(
           msg_params[strings::hmi_capabilities][strings::phone_call].asBool());
     }
     if (msg_params[strings::hmi_capabilities].keyExists(
             strings::video_streaming)) {
-      sections_to_update.push_back(strings::video_streaming);
-      hmi_capabilities.set_video_streaming_supported(
+      hmi_capabilities_.set_video_streaming_supported(
           msg_params[strings::hmi_capabilities][strings::video_streaming]
               .asBool());
     }
   }
 
   if (msg_params.keyExists(strings::system_capabilities)) {
+    sections_to_update.push_back(strings::system_capabilities);
     if (msg_params[strings::system_capabilities].keyExists(
             strings::navigation_capability)) {
-      sections_to_update.push_back(strings::navigation_capability);
-      hmi_capabilities.set_navigation_capability(
+      hmi_capabilities_.set_navigation_capability(
           msg_params[strings::system_capabilities]
                     [strings::navigation_capability]);
     }
     if (msg_params[strings::system_capabilities].keyExists(
             strings::phone_capability)) {
-      sections_to_update.push_back(strings::phone_capability);
-      hmi_capabilities.set_phone_capability(
+      hmi_capabilities_.set_phone_capability(
           msg_params[strings::system_capabilities][strings::phone_capability]);
     }
     if (msg_params[strings::system_capabilities].keyExists(
             strings::video_streaming_capability)) {
-      sections_to_update.push_back(strings::video_streaming_capability);
-      hmi_capabilities.set_video_streaming_capability(
+      hmi_capabilities_.set_video_streaming_capability(
           msg_params[strings::system_capabilities]
                     [strings::video_streaming_capability]);
     }
     if (msg_params[strings::system_capabilities].keyExists(
             strings::display_capabilities)) {
-      sections_to_update.push_back(strings::system_display_capabilities);
-      hmi_capabilities.set_system_display_capabilities(
+      hmi_capabilities_.set_system_display_capabilities(
           msg_params[strings::system_capabilities]
                     [strings::display_capabilities]);
     }
   }
 
-  if (!hmi_capabilities.SaveCachedCapabilitiesToFile(sections_to_update,
-                                                     message_->getSchema())) {
-    LOG4CXX_ERROR(logger_, "Failed to save GetCapabilities response to cache");
+  if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
+          hmi_interface::ui, sections_to_update, message_->getSchema())) {
+    LOG4CXX_ERROR(logger_,
+                  "Failed to save UI.GetCapabilities response to cache");
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_response.cc
@@ -67,6 +67,13 @@ void UIGetLanguageResponse::Run() {
 
   hmi_capabilities_.set_active_ui_language(language);
 
+  std::vector<std::string> sections_to_update;
+  sections_to_update.push_back(hmi_response::language);
+  if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(sections_to_update,
+                                                      message_->getSchema())) {
+    LOG4CXX_ERROR(logger_, "Failed to save GetCapabilities response to cache");
+  }
+
   LOG4CXX_DEBUG(logger_,
                 "Raising event for function_id " << function_id()
                                                  << " and correlation_id "

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_response.cc
@@ -56,6 +56,14 @@ UIGetLanguageResponse::~UIGetLanguageResponse() {}
 void UIGetLanguageResponse::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace hmi_apis;
+  const Common_Result::eType result_code = static_cast<Common_Result::eType>(
+      (*message_)[strings::params][hmi_response::code].asInt());
+
+  if (Common_Result::SUCCESS != result_code) {
+    LOG4CXX_DEBUG(logger_,
+                  "Request was not successful. Don't change HMI capabilities");
+    return;
+  }
 
   Common_Language::eType language = Common_Language::INVALID_ENUM;
 
@@ -69,9 +77,9 @@ void UIGetLanguageResponse::Run() {
 
   std::vector<std::string> sections_to_update;
   sections_to_update.push_back(hmi_response::language);
-  if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(sections_to_update,
-                                                      message_->getSchema())) {
-    LOG4CXX_ERROR(logger_, "Failed to save GetCapabilities response to cache");
+  if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
+          hmi_interface::ui, sections_to_update, message_->getSchema())) {
+    LOG4CXX_ERROR(logger_, "Failed to save UI.GetLanguage response to cache");
   }
 
   LOG4CXX_DEBUG(logger_,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_response.cc
@@ -59,19 +59,21 @@ void UIGetSupportedLanguagesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
-  if (hmi_apis::Common_Result::SUCCESS == code) {
-    HMICapabilities& hmi_capabilities = hmi_capabilities_;
+  if (hmi_apis::Common_Result::SUCCESS != code) {
+    LOG4CXX_DEBUG(logger_,
+                  "Request was not successful. Don't change HMI capabilities");
+    return;
+  }
 
-    hmi_capabilities.set_ui_supported_languages(
-        (*message_)[strings::msg_params][hmi_response::languages]);
+  hmi_capabilities_.set_ui_supported_languages(
+      (*message_)[strings::msg_params][hmi_response::languages]);
 
-    std::vector<std::string> sections_to_update;
-    sections_to_update.push_back(hmi_response::languages);
-    if (!hmi_capabilities.SaveCachedCapabilitiesToFile(sections_to_update,
-                                                       message_->getSchema())) {
-      LOG4CXX_ERROR(logger_,
-                    "Failed to save GetCapabilities response to cache");
-    }
+  std::vector<std::string> sections_to_update;
+  sections_to_update.push_back(hmi_response::languages);
+  if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
+          hmi_interface::ui, sections_to_update, message_->getSchema())) {
+    LOG4CXX_ERROR(logger_,
+                  "Failed to save UI.GetSupportedLanguages response to cache");
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_response.cc
@@ -64,6 +64,14 @@ void UIGetSupportedLanguagesResponse::Run() {
 
     hmi_capabilities.set_ui_supported_languages(
         (*message_)[strings::msg_params][hmi_response::languages]);
+
+    std::vector<std::string> sections_to_update;
+    sections_to_update.push_back(hmi_response::languages);
+    if (!hmi_capabilities.SaveCachedCapabilitiesToFile(sections_to_update,
+                                                       message_->getSchema())) {
+      LOG4CXX_ERROR(logger_,
+                    "Failed to save GetCapabilities response to cache");
+    }
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_is_ready_request.cc
@@ -77,11 +77,8 @@ void UIIsReadyRequest::on_event(const event_engine::Event& event) {
                      "HmiInterfaces::HMI_INTERFACE_UI isn't available");
         return;
       }
-      if (hmi_capabilities_.GetInterfacesToUpdate().empty()) {
-        LOG4CXX_INFO(logger_, "All fiels are present in the cache");
-        return;
-      }
-      SendMessageToHMI();
+
+      RequestCapabilities();
       break;
     }
     default: {
@@ -93,13 +90,14 @@ void UIIsReadyRequest::on_event(const event_engine::Event& event) {
 
 void UIIsReadyRequest::onTimeOut() {
   // Note(dtrunov): According to new requirment APPLINK-27956
-  SendMessageToHMI();
+  RequestCapabilities();
 }
 
-void UIIsReadyRequest::SendMessageToHMI() {
-  const auto interfaces_to_update = hmi_capabilities_.GetInterfacesToUpdate();
+void UIIsReadyRequest::RequestCapabilities() {
+  const auto interfaces_from_default =
+      hmi_capabilities_.GetInterfacesFromDefault();
 
-  if (helpers::in_range(interfaces_to_update,
+  if (helpers::in_range(interfaces_from_default,
                         hmi_apis::FunctionID::UI_GetLanguage)) {
     std::shared_ptr<smart_objects::SmartObject> get_language(
         MessageHelper::CreateModuleInfoSO(hmi_apis::FunctionID::UI_GetLanguage,
@@ -108,16 +106,16 @@ void UIIsReadyRequest::SendMessageToHMI() {
     rpc_service_.ManageHMICommand(get_language);
   }
 
-  if (helpers::in_range(interfaces_to_update,
+  if (helpers::in_range(interfaces_from_default,
                         hmi_apis::FunctionID::UI_GetSupportedLanguages)) {
-    std::shared_ptr<smart_objects::SmartObject> get_all_languages(
+    std::shared_ptr<smart_objects::SmartObject> get_supported_languages(
         MessageHelper::CreateModuleInfoSO(
             hmi_apis::FunctionID::UI_GetSupportedLanguages,
             application_manager_));
-    rpc_service_.ManageHMICommand(get_all_languages);
+    rpc_service_.ManageHMICommand(get_supported_languages);
   }
 
-  if (helpers::in_range(interfaces_to_update,
+  if (helpers::in_range(interfaces_from_default,
                         hmi_apis::FunctionID::UI_GetCapabilities)) {
     std::shared_ptr<smart_objects::SmartObject> get_capabilities(
         MessageHelper::CreateModuleInfoSO(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_is_ready_request.cc
@@ -94,10 +94,10 @@ void UIIsReadyRequest::onTimeOut() {
 }
 
 void UIIsReadyRequest::RequestCapabilities() {
-  const auto interfaces_from_default =
-      hmi_capabilities_.GetInterfacesFromDefault();
+  const auto default_initialized_capabilities =
+      hmi_capabilities_.GetDefaultInitializedCapabilities();
 
-  if (helpers::in_range(interfaces_from_default,
+  if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::UI_GetLanguage)) {
     std::shared_ptr<smart_objects::SmartObject> get_language(
         MessageHelper::CreateModuleInfoSO(hmi_apis::FunctionID::UI_GetLanguage,
@@ -106,7 +106,7 @@ void UIIsReadyRequest::RequestCapabilities() {
     rpc_service_.ManageHMICommand(get_language);
   }
 
-  if (helpers::in_range(interfaces_from_default,
+  if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::UI_GetSupportedLanguages)) {
     std::shared_ptr<smart_objects::SmartObject> get_supported_languages(
         MessageHelper::CreateModuleInfoSO(
@@ -115,7 +115,7 @@ void UIIsReadyRequest::RequestCapabilities() {
     rpc_service_.ManageHMICommand(get_supported_languages);
   }
 
-  if (helpers::in_range(interfaces_from_default,
+  if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::UI_GetCapabilities)) {
     std::shared_ptr<smart_objects::SmartObject> get_capabilities(
         MessageHelper::CreateModuleInfoSO(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_capabilities_response.cc
@@ -52,9 +52,8 @@ VRGetCapabilitiesResponse::~VRGetCapabilitiesResponse() {}
 
 void VRGetCapabilitiesResponse::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
-  const hmi_apis::Common_Result::eType result_code =
-      static_cast<hmi_apis::Common_Result::eType>(
-          (*message_)[strings::params][hmi_response::code].asInt());
+  const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
+      (*message_)[strings::params][hmi_response::code].asInt());
 
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     LOG4CXX_DEBUG(logger_,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_language_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_language_response.cc
@@ -56,6 +56,14 @@ VRGetLanguageResponse::~VRGetLanguageResponse() {}
 void VRGetLanguageResponse::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace hmi_apis;
+  const Common_Result::eType result_code = static_cast<Common_Result::eType>(
+      (*message_)[strings::params][hmi_response::code].asInt());
+
+  if (Common_Result::SUCCESS != result_code) {
+    LOG4CXX_DEBUG(logger_,
+                  "Request was not successful. Don't change HMI capabilities");
+    return;
+  }
 
   Common_Language::eType language = Common_Language::INVALID_ENUM;
 
@@ -66,6 +74,13 @@ void VRGetLanguageResponse::Run() {
   }
 
   hmi_capabilities_.set_active_vr_language(language);
+
+  std::vector<std::string> sections_to_update;
+  sections_to_update.push_back(hmi_response::language);
+  if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
+          hmi_interface::vr, sections_to_update, message_->getSchema())) {
+    LOG4CXX_ERROR(logger_, "Failed to save VR.GetLanguage response to cache");
+  }
 
   LOG4CXX_DEBUG(logger_,
                 "Raising event for function_id " << function_id()

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_supported_languages_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_supported_languages_response.cc
@@ -64,6 +64,15 @@ void VRGetSupportedLanguagesResponse::Run() {
     HMICapabilities& hmi_capabilities = hmi_capabilities_;
     hmi_capabilities.set_vr_supported_languages(
         (*message_)[strings::msg_params][hmi_response::languages]);
+
+    std::vector<std::string> sections_to_update;
+    sections_to_update.push_back(hmi_response::languages);
+    if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
+            hmi_interface::vr, sections_to_update, message_->getSchema())) {
+      LOG4CXX_ERROR(
+          logger_,
+          "Failed to save TTS.GetSupportedLanguages response to cache");
+    }
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_is_ready_request.cc
@@ -94,10 +94,10 @@ void VRIsReadyRequest::onTimeOut() {
 }
 
 void VRIsReadyRequest::RequestCapabilities() {
-  const auto interfaces_from_default =
-      hmi_capabilities_.GetInterfacesFromDefault();
+  const auto default_initialized_capabilities =
+      hmi_capabilities_.GetDefaultInitializedCapabilities();
 
-  if (helpers::in_range(interfaces_from_default,
+  if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::VR_GetLanguage)) {
     std::shared_ptr<smart_objects::SmartObject> get_language(
         MessageHelper::CreateModuleInfoSO(hmi_apis::FunctionID::VR_GetLanguage,
@@ -107,7 +107,7 @@ void VRIsReadyRequest::RequestCapabilities() {
     rpc_service_.ManageHMICommand(get_language);
   }
 
-  if (helpers::in_range(interfaces_from_default,
+  if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::VR_GetSupportedLanguages)) {
     std::shared_ptr<smart_objects::SmartObject> get_supported_languages(
         MessageHelper::CreateModuleInfoSO(
@@ -116,7 +116,7 @@ void VRIsReadyRequest::RequestCapabilities() {
     rpc_service_.ManageHMICommand(get_supported_languages);
   }
 
-  if (helpers::in_range(interfaces_from_default,
+  if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::VR_GetCapabilities)) {
     std::shared_ptr<smart_objects::SmartObject> get_capabilities(
         MessageHelper::CreateModuleInfoSO(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/change_registration_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/change_registration_request.cc
@@ -460,8 +460,7 @@ bool ChangeRegistrationRequest::PrepareResponseParameters(
 bool ChangeRegistrationRequest::IsLanguageSupportedByUI(
     const int32_t& hmi_display_lang) {
   const HMICapabilities& hmi_capabilities = hmi_capabilities_;
-  const smart_objects::SmartObject* ui_languages =
-      hmi_capabilities.ui_supported_languages();
+  const auto ui_languages = hmi_capabilities.ui_supported_languages();
 
   if (!ui_languages) {
     LOG4CXX_ERROR(logger_, "NULL pointer");
@@ -482,8 +481,7 @@ bool ChangeRegistrationRequest::IsLanguageSupportedByUI(
 bool ChangeRegistrationRequest::IsLanguageSupportedByVR(
     const int32_t& hmi_display_lang) {
   const HMICapabilities& hmi_capabilities = hmi_capabilities_;
-  const smart_objects::SmartObject* vr_languages =
-      hmi_capabilities.vr_supported_languages();
+  const auto vr_languages = hmi_capabilities.vr_supported_languages();
 
   if (!vr_languages) {
     LOG4CXX_ERROR(logger_, "NULL pointer");
@@ -504,8 +502,7 @@ bool ChangeRegistrationRequest::IsLanguageSupportedByVR(
 bool ChangeRegistrationRequest::IsLanguageSupportedByTTS(
     const int32_t& hmi_display_lang) {
   const HMICapabilities& hmi_capabilities = hmi_capabilities_;
-  const smart_objects::SmartObject* tts_languages =
-      hmi_capabilities.tts_supported_languages();
+  const auto tts_languages = hmi_capabilities.tts_supported_languages();
 
   if (!tts_languages) {
     LOG4CXX_ERROR(logger_, "NULL pointer");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_capabilities_response_test.cc
@@ -52,16 +52,20 @@ using testing::_;
 
 namespace strings = ::application_manager::strings;
 namespace hmi_response = ::application_manager::hmi_response;
+namespace hmi_interface = ::application_manager::hmi_interface;
 
 namespace {
 const std::string kText = "TEXT";
-}
+const hmi_apis::Common_Result::eType kSuccess =
+    hmi_apis::Common_Result::SUCCESS;
+}  // namespace
 
 class TTSGetCapabilitiesResponseTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {};
 
 TEST_F(TTSGetCapabilitiesResponseTest, Run_BothExist_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][hmi_response::code] = kSuccess;
   (*msg)[strings::msg_params][hmi_response::speech_capabilities] = kText;
   (*msg)[strings::msg_params][hmi_response::prerecorded_speech_capabilities] =
       kText;
@@ -70,6 +74,8 @@ TEST_F(TTSGetCapabilitiesResponseTest, Run_BothExist_SUCCESS) {
               set_speech_capabilities(SmartObject(kText)));
   EXPECT_CALL(mock_hmi_capabilities_,
               set_prerecorded_speech(SmartObject(kText)));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::tts, _, _));
 
   std::shared_ptr<TTSGetCapabilitiesResponse> command(
       CreateCommand<TTSGetCapabilitiesResponse>(msg));
@@ -79,11 +85,14 @@ TEST_F(TTSGetCapabilitiesResponseTest, Run_BothExist_SUCCESS) {
 
 TEST_F(TTSGetCapabilitiesResponseTest, Run_OnlySpeech_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][hmi_response::code] = kSuccess;
   (*msg)[strings::msg_params][hmi_response::speech_capabilities] = kText;
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_speech_capabilities(SmartObject(kText)));
   EXPECT_CALL(mock_hmi_capabilities_, set_prerecorded_speech(_)).Times(0);
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::tts, _, _));
 
   std::shared_ptr<TTSGetCapabilitiesResponse> command(
       CreateCommand<TTSGetCapabilitiesResponse>(msg));
@@ -93,12 +102,15 @@ TEST_F(TTSGetCapabilitiesResponseTest, Run_OnlySpeech_SUCCESS) {
 
 TEST_F(TTSGetCapabilitiesResponseTest, Run_OnlyPrerecorded_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][hmi_response::code] = kSuccess;
   (*msg)[strings::msg_params][hmi_response::prerecorded_speech_capabilities] =
       kText;
 
   EXPECT_CALL(mock_hmi_capabilities_, set_speech_capabilities(_)).Times(0);
   EXPECT_CALL(mock_hmi_capabilities_,
               set_prerecorded_speech(SmartObject(kText)));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::tts, _, _));
 
   std::shared_ptr<TTSGetCapabilitiesResponse> command(
       CreateCommand<TTSGetCapabilitiesResponse>(msg));
@@ -108,9 +120,12 @@ TEST_F(TTSGetCapabilitiesResponseTest, Run_OnlyPrerecorded_SUCCESS) {
 
 TEST_F(TTSGetCapabilitiesResponseTest, Run_Nothing_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][hmi_response::code] = kSuccess;
 
   EXPECT_CALL(mock_hmi_capabilities_, set_speech_capabilities(_)).Times(0);
   EXPECT_CALL(mock_hmi_capabilities_, set_prerecorded_speech(_)).Times(0);
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::tts, _, _));
 
   std::shared_ptr<TTSGetCapabilitiesResponse> command(
       CreateCommand<TTSGetCapabilitiesResponse>(msg));

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_language_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_language_response_test.cc
@@ -51,10 +51,13 @@ using testing::ReturnRef;
 
 namespace strings = application_manager::strings;
 namespace hmi_response = application_manager::hmi_response;
+namespace hmi_interface = application_manager::hmi_interface;
 using namespace hmi_apis;
 
 namespace {
 const Common_Language::eType kLanguage = Common_Language::EN_GB;
+const hmi_apis::Common_Result::eType kSuccess =
+    hmi_apis::Common_Result::SUCCESS;
 }  // namespace
 
 class TTSGetLanguageResponseTest
@@ -63,11 +66,15 @@ class TTSGetLanguageResponseTest
 TEST_F(TTSGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
   (*msg)[strings::msg_params][hmi_response::language] = kLanguage;
+  (*msg)[strings::params][hmi_response::code] = kSuccess;
 
   std::shared_ptr<TTSGetLanguageResponse> command(
       CreateCommand<TTSGetLanguageResponse>(msg));
 
   EXPECT_CALL(mock_hmi_capabilities_, set_active_tts_language(kLanguage));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::tts, _, _));
 
   MockEventDispatcher mock_event_dispatcher;
   EXPECT_CALL(app_mngr_, event_dispatcher())
@@ -79,12 +86,16 @@ TEST_F(TTSGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
 
 TEST_F(TTSGetLanguageResponseTest, Run_LanguageNotSet_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][hmi_response::code] = kSuccess;
 
   std::shared_ptr<TTSGetLanguageResponse> command(
       CreateCommand<TTSGetLanguageResponse>(msg));
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_active_tts_language(Common_Language::INVALID_ENUM));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::tts, _, _));
 
   MockEventDispatcher mock_event_dispatcher;
   EXPECT_CALL(app_mngr_, event_dispatcher())

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_language_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_language_response_test.cc
@@ -52,6 +52,7 @@ using testing::ReturnRef;
 
 namespace strings = application_manager::strings;
 namespace hmi_response = application_manager::hmi_response;
+namespace hmi_interface = application_manager::hmi_interface;
 using namespace hmi_apis;
 
 typedef NiceMock<
@@ -60,6 +61,8 @@ typedef NiceMock<
 
 namespace {
 const hmi_apis::Common_Language::eType kLanguage = Common_Language::EN_GB;
+const hmi_apis::Common_Result::eType kSuccess =
+    hmi_apis::Common_Result::SUCCESS;
 }  // namespace
 
 class UIGetLanguageResponseTest
@@ -68,11 +71,14 @@ class UIGetLanguageResponseTest
 TEST_F(UIGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
   (*msg)[strings::msg_params][hmi_response::language] = kLanguage;
+  (*msg)[strings::params][hmi_response::code] = kSuccess;
 
   std::shared_ptr<UIGetLanguageResponse> command(
       CreateCommand<UIGetLanguageResponse>(msg));
 
   EXPECT_CALL(mock_hmi_capabilities_, set_active_ui_language(kLanguage));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::ui, _, _));
 
   MockEventDispatcher mock_event_dispatcher;
   EXPECT_CALL(app_mngr_, event_dispatcher())
@@ -84,12 +90,15 @@ TEST_F(UIGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
 
 TEST_F(UIGetLanguageResponseTest, Run_LanguageNotSet_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][hmi_response::code] = kSuccess;
 
   std::shared_ptr<UIGetLanguageResponse> command(
       CreateCommand<UIGetLanguageResponse>(msg));
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_active_ui_language(Common_Language::INVALID_ENUM));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::ui, _, _));
 
   MockEventDispatcher mock_event_dispatcher;
   EXPECT_CALL(app_mngr_, event_dispatcher())

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_language_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_language_response_test.cc
@@ -52,6 +52,7 @@ using testing::ReturnRef;
 
 namespace strings = application_manager::strings;
 namespace hmi_response = application_manager::hmi_response;
+namespace hmi_interface = application_manager::hmi_interface;
 using namespace hmi_apis;
 
 typedef NiceMock<
@@ -60,6 +61,8 @@ typedef NiceMock<
 
 namespace {
 const hmi_apis::Common_Language::eType kLanguage = Common_Language::EN_GB;
+const hmi_apis::Common_Result::eType kSuccess =
+    hmi_apis::Common_Result::SUCCESS;
 }  // namespace
 
 class VRGetLanguageResponseTest
@@ -68,11 +71,15 @@ class VRGetLanguageResponseTest
 TEST_F(VRGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
   (*msg)[strings::msg_params][hmi_response::language] = kLanguage;
+  (*msg)[strings::params][hmi_response::code] = kSuccess;
 
   std::shared_ptr<VRGetLanguageResponse> command(
       CreateCommand<VRGetLanguageResponse>(msg));
 
   EXPECT_CALL(mock_hmi_capabilities_, set_active_vr_language(kLanguage));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::vr, _, _));
 
   MockEventDispatcher mock_event_dispatcher;
   EXPECT_CALL(app_mngr_, event_dispatcher())
@@ -84,12 +91,16 @@ TEST_F(VRGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
 
 TEST_F(VRGetLanguageResponseTest, Run_LanguageNotSet_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][hmi_response::code] = kSuccess;
 
   std::shared_ptr<VRGetLanguageResponse> command(
       CreateCommand<VRGetLanguageResponse>(msg));
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_active_vr_language(Common_Language::INVALID_ENUM));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::vr, _, _));
 
   MockEventDispatcher mock_event_dispatcher;
   EXPECT_CALL(app_mngr_, event_dispatcher())

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/change_registration_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/change_registration_test.cc
@@ -103,11 +103,11 @@ class ChangeRegistrationRequestTest
     (*supported_languages_)[0] =
         static_cast<int32_t>(mobile_apis::Language::EN_US);
     EXPECT_CALL(mock_hmi_capabilities_, ui_supported_languages())
-        .WillOnce(Return(supported_languages_.get()));
+        .WillOnce(Return(supported_languages_));
     EXPECT_CALL(mock_hmi_capabilities_, vr_supported_languages())
-        .WillOnce(Return(supported_languages_.get()));
+        .WillOnce(Return(supported_languages_));
     EXPECT_CALL(mock_hmi_capabilities_, tts_supported_languages())
-        .WillOnce(Return(supported_languages_.get()));
+        .WillOnce(Return(supported_languages_));
 
     EXPECT_CALL(app_mngr_, hmi_interfaces())
         .WillRepeatedly(ReturnRef(mock_hmi_interfaces_));
@@ -242,11 +242,11 @@ class ChangeRegistrationRequestTest
   void ExpectationsHmiCapabilities(
       smart_objects::SmartObjectSPtr supported_languages) {
     EXPECT_CALL(mock_hmi_capabilities_, ui_supported_languages())
-        .WillOnce(Return(supported_languages.get()));
+        .WillOnce(Return(supported_languages));
     EXPECT_CALL(mock_hmi_capabilities_, vr_supported_languages())
-        .WillOnce(Return(supported_languages.get()));
+        .WillOnce(Return(supported_languages));
     EXPECT_CALL(mock_hmi_capabilities_, tts_supported_languages())
-        .WillOnce(Return(supported_languages.get()));
+        .WillOnce(Return(supported_languages));
   }
 
   void ResultCommandExpectations(MessageSharedPtr msg,
@@ -381,11 +381,11 @@ TEST_F(ChangeRegistrationRequestTest,
   (*supported_languages_)[0] =
       static_cast<int32_t>(mobile_apis::Language::EN_US);
   EXPECT_CALL(mock_hmi_capabilities_, ui_supported_languages())
-      .WillOnce(Return(supported_languages_.get()));
+      .WillOnce(Return(supported_languages_));
   EXPECT_CALL(mock_hmi_capabilities_, vr_supported_languages())
-      .WillOnce(Return(supported_languages_.get()));
+      .WillOnce(Return(supported_languages_));
   EXPECT_CALL(mock_hmi_capabilities_, tts_supported_languages())
-      .WillOnce(Return(supported_languages_.get()));
+      .WillOnce(Return(supported_languages_));
 
   EXPECT_CALL(app_mngr_, hmi_interfaces())
       .WillRepeatedly(ReturnRef(mock_hmi_interfaces_));

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
@@ -201,6 +201,8 @@ class RegisterAppInterfaceRequestTest
         .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
     ON_CALL(mock_hmi_capabilities_, pcm_stream_capabilities())
         .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
+    ON_CALL(mock_hmi_capabilities_, seat_location_capability())
+        .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
     ON_CALL(app_mngr_settings_, supported_diag_modes())
         .WillByDefault(ReturnRef(kDummyDiagModes));
     ON_CALL(mock_policy_handler_, GetAppRequestTypes(_, _))

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/hmi/vi_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/hmi/vi_is_ready_request.h
@@ -76,9 +76,9 @@ class VIIsReadyRequest : public app_mngr::commands::RequestToHMI,
   void onTimeOut() OVERRIDE;
 
   /**
-   * @brief Send request to HMI for fetching of cappabilities
+   * @brief Send request to HMI for fetching of capabilities
    */
-  void SendMessageToHMI();
+  void RequestCapabilities();
 
  private:
   DISALLOW_COPY_AND_ASSIGN(VIIsReadyRequest);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_response.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_response.cc
@@ -66,7 +66,9 @@ void VIGetVehicleTypeResponse::Run() {
   sections_to_update.push_back(hmi_response::vehicle_type);
 
   if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
-          hmi_interface::vr, sections_to_update, message_->getSchema())) {
+          hmi_interface::vehicle_info,
+          sections_to_update,
+          message_->getSchema())) {
     LOG4CXX_ERROR(
         logger_, "Failed to save VehicleInfo.GetVehicleType response to cache");
   }

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_response.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_response.cc
@@ -50,9 +50,8 @@ VIGetVehicleTypeResponse::~VIGetVehicleTypeResponse() {}
 void VIGetVehicleTypeResponse::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  const hmi_apis::Common_Result::eType result_code =
-      static_cast<hmi_apis::Common_Result::eType>(
-          (*message_)[strings::params][hmi_response::code].asInt());
+  const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
+      (*message_)[strings::params][hmi_response::code].asInt());
 
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     LOG4CXX_DEBUG(logger_,

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_is_ready_request.cc
@@ -98,10 +98,10 @@ void VIIsReadyRequest::onTimeOut() {
 }
 
 void VIIsReadyRequest::RequestCapabilities() {
-  const auto interfaces_from_default =
-      hmi_capabilities_.GetInterfacesFromDefault();
+  const auto default_initialized_capabilities =
+      hmi_capabilities_.GetDefaultInitializedCapabilities();
 
-  if (helpers::in_range(interfaces_from_default,
+  if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::VehicleInfo_GetVehicleType)) {
     std::shared_ptr<smart_objects::SmartObject> get_type(
         MessageHelper::CreateModuleInfoSO(

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_is_ready_request.cc
@@ -81,12 +81,8 @@ void VIIsReadyRequest::on_event(const event_engine::Event& event) {
             "HmiInterfaces::HMI_INTERFACE_VehicleInfo isn't available");
         return;
       }
-      if (hmi_capabilities_.GetInterfacesToUpdate().empty()) {
-        LOG4CXX_INFO(logger_, "All fiels are present in the cache");
-        return;
-      }
 
-      SendMessageToHMI();
+      RequestCapabilities();
       break;
     }
     default: {
@@ -98,13 +94,14 @@ void VIIsReadyRequest::on_event(const event_engine::Event& event) {
 
 void VIIsReadyRequest::onTimeOut() {
   // Note(dtrunov): According to new requirment APPLINK-27956
-  SendMessageToHMI();
+  RequestCapabilities();
 }
 
-void VIIsReadyRequest::SendMessageToHMI() {
-  const auto interfaces_to_update = hmi_capabilities_.GetInterfacesToUpdate();
+void VIIsReadyRequest::RequestCapabilities() {
+  const auto interfaces_from_default =
+      hmi_capabilities_.GetInterfacesFromDefault();
 
-  if (helpers::in_range(interfaces_to_update,
+  if (helpers::in_range(interfaces_from_default,
                         hmi_apis::FunctionID::VehicleInfo_GetVehicleType)) {
     std::shared_ptr<smart_objects::SmartObject> get_type(
         MessageHelper::CreateModuleInfoSO(

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2903,7 +2903,9 @@ void ApplicationManagerImpl::HeadUnitReset(
       GetPolicyHandler().UnloadPolicyLibrary();
 
       resume_controller().StopSavePersistentDataTimer();
-      hmi_capabilities_->DeleteCachedCapabilitiesFile();
+      if (!hmi_capabilities_->DeleteCachedCapabilitiesFile()) {
+        LOG4CXX_ERROR(logger_, "Failed to remove HMI capabilities cache file");
+      }
       const std::string storage_folder = get_settings().app_storage_folder();
       file_system::RemoveDirectory(storage_folder, true);
       ClearAppsPersistentData();
@@ -2914,7 +2916,9 @@ void ApplicationManagerImpl::HeadUnitReset(
       GetPolicyHandler().ClearUserConsent();
 
       resume_controller().StopSavePersistentDataTimer();
-      hmi_capabilities_->DeleteCachedCapabilitiesFile();
+      if (!hmi_capabilities_->DeleteCachedCapabilitiesFile()) {
+        LOG4CXX_ERROR(logger_, "Failed to remove HMI capabilities cache file");
+      }
       ClearAppsPersistentData();
       break;
     }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -872,10 +872,10 @@ void ApplicationManagerImpl::OnHMIStartedCooperation() {
                                         *this));
   rpc_service_->ManageHMICommand(is_rc_ready);
 
-  const auto interfaces_from_default =
-      hmi_capabilities_->GetInterfacesFromDefault();
+  const auto default_initialized_capabilities =
+      hmi_capabilities_->GetDefaultInitializedCapabilities();
 
-  if (helpers::in_range(interfaces_from_default,
+  if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::Buttons_GetCapabilities)) {
     std::shared_ptr<smart_objects::SmartObject> button_capabilities(
         MessageHelper::CreateModuleInfoSO(

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2897,7 +2897,7 @@ void ApplicationManagerImpl::HeadUnitReset(
       GetPolicyHandler().UnloadPolicyLibrary();
 
       resume_controller().StopSavePersistentDataTimer();
-
+      hmi_capabilities_->DeleteCachedCapabilitiesFile();
       const std::string storage_folder = get_settings().app_storage_folder();
       file_system::RemoveDirectory(storage_folder, true);
       ClearAppsPersistentData();
@@ -2908,7 +2908,7 @@ void ApplicationManagerImpl::HeadUnitReset(
       GetPolicyHandler().ClearUserConsent();
 
       resume_controller().StopSavePersistentDataTimer();
-
+      hmi_capabilities_->DeleteCachedCapabilitiesFile();
       ClearAppsPersistentData();
       break;
     }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -872,10 +872,15 @@ void ApplicationManagerImpl::OnHMIStartedCooperation() {
                                         *this));
   rpc_service_->ManageHMICommand(is_rc_ready);
 
-  std::shared_ptr<smart_objects::SmartObject> button_capabilities(
-      MessageHelper::CreateModuleInfoSO(
-          hmi_apis::FunctionID::Buttons_GetCapabilities, *this));
-  rpc_service_->ManageHMICommand(button_capabilities);
+  const auto interfaces_to_update = hmi_capabilities_->GetInterfacesToUpdate();
+
+  if (helpers::in_range(interfaces_to_update,
+                        hmi_apis::FunctionID::Buttons_GetCapabilities)) {
+    std::shared_ptr<smart_objects::SmartObject> button_capabilities(
+        MessageHelper::CreateModuleInfoSO(
+            hmi_apis::FunctionID::Buttons_GetCapabilities, *this));
+    rpc_service_->ManageHMICommand(button_capabilities);
+  }
 
   std::shared_ptr<smart_objects::SmartObject> mixing_audio_supported_request(
       MessageHelper::CreateModuleInfoSO(

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -872,9 +872,10 @@ void ApplicationManagerImpl::OnHMIStartedCooperation() {
                                         *this));
   rpc_service_->ManageHMICommand(is_rc_ready);
 
-  const auto interfaces_to_update = hmi_capabilities_->GetInterfacesToUpdate();
+  const auto interfaces_from_default =
+      hmi_capabilities_->GetInterfacesFromDefault();
 
-  if (helpers::in_range(interfaces_to_update,
+  if (helpers::in_range(interfaces_from_default,
                         hmi_apis::FunctionID::Buttons_GetCapabilities)) {
     std::shared_ptr<smart_objects::SmartObject> button_capabilities(
         MessageHelper::CreateModuleInfoSO(

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -1028,21 +1028,25 @@ std::string GetComponentNameFromInterface(
     const HmiInterfaces::InterfaceID& interface) {
   switch (interface) {
     case HmiInterfaces::HMI_INTERFACE_Buttons:
-      return "Buttons";
+      return hmi_interface::buttons;
     case HmiInterfaces::HMI_INTERFACE_BasicCommunication:
-      return "BasicCommunication";
+      return hmi_interface::basic_communication;
     case HmiInterfaces::HMI_INTERFACE_VR:
-      return "VR";
+      return hmi_interface::vr;
     case HmiInterfaces::HMI_INTERFACE_TTS:
-      return "TTS";
+      return hmi_interface::tts;
     case HmiInterfaces::HMI_INTERFACE_UI:
-      return "UI";
+      return hmi_interface::ui;
     case HmiInterfaces::HMI_INTERFACE_Navigation:
-      return "Navigation";
+      return hmi_interface::navigation;
     case HmiInterfaces::HMI_INTERFACE_VehicleInfo:
-      return "VehicleInfo";
+      return hmi_interface::vehicle_info;
     case HmiInterfaces::HMI_INTERFACE_SDL:
-      return "SDL";
+      return hmi_interface::sdl;
+    case HmiInterfaces::HMI_INTERFACE_RC:
+      return hmi_interface::rc;
+    case HmiInterfaces::HMI_INTERFACE_AppService:
+      return hmi_interface::app_service;
     default:
       return "Unknown type";
   }

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -593,21 +593,21 @@ HMICapabilitiesImpl::active_tts_language() const {
 
 void HMICapabilitiesImpl::set_ui_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(supported_languages);
   ui_supported_languages_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_tts_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(supported_languages);
   tts_supported_languages_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_vr_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(supported_languages);
   vr_supported_languages_.swap(new_value);
 }
@@ -617,7 +617,7 @@ void HMICapabilitiesImpl::set_display_capabilities(
   if (app_mngr_.IsSOStructValid(
           hmi_apis::StructIdentifiers::Common_DisplayCapabilities,
           display_capabilities)) {
-    smart_objects::SmartObjectSPtr new_value =
+    auto new_value =
         std::make_shared<smart_objects::SmartObject>(display_capabilities);
     display_capabilities_.swap(new_value);
   }
@@ -631,71 +631,69 @@ void HMICapabilitiesImpl::set_system_display_capabilities(
 
 void HMICapabilitiesImpl::set_hmi_zone_capabilities(
     const smart_objects::SmartObject& hmi_zone_capabilities) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(hmi_zone_capabilities);
   hmi_zone_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_soft_button_capabilities(
     const smart_objects::SmartObject& soft_button_capabilities) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(soft_button_capabilities);
   soft_buttons_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_button_capabilities(
     const smart_objects::SmartObject& button_capabilities) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(button_capabilities);
   button_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_vr_capabilities(
     const smart_objects::SmartObject& vr_capabilities) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(vr_capabilities);
   vr_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_speech_capabilities(
     const smart_objects::SmartObject& speech_capabilities) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(speech_capabilities);
   speech_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_audio_pass_thru_capabilities(
     const smart_objects::SmartObject& audio_pass_thru_capabilities) {
-  smart_objects::SmartObjectSPtr new_value =
-      std::make_shared<smart_objects::SmartObject>(
-          audio_pass_thru_capabilities);
+  auto new_value = std::make_shared<smart_objects::SmartObject>(
+      audio_pass_thru_capabilities);
   audio_pass_thru_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_pcm_stream_capabilities(
     const smart_objects::SmartObject& pcm_stream_capabilities) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(pcm_stream_capabilities);
   pcm_stream_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_preset_bank_capabilities(
     const smart_objects::SmartObject& preset_bank_capabilities) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(preset_bank_capabilities);
   preset_bank_capabilities_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_vehicle_type(
     const smart_objects::SmartObject& vehicle_type) {
-  smart_objects::SmartObjectSPtr new_value =
-      std::make_shared<smart_objects::SmartObject>(vehicle_type);
+  auto new_value = std::make_shared<smart_objects::SmartObject>(vehicle_type);
   vehicle_type_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_prerecorded_speech(
     const smart_objects::SmartObject& prerecorded_speech) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(prerecorded_speech);
   prerecorded_speech_.swap(new_value);
 }
@@ -717,35 +715,34 @@ void HMICapabilitiesImpl::set_rc_supported(const bool supported) {
 
 void HMICapabilitiesImpl::set_navigation_capability(
     const smart_objects::SmartObject& navigation_capability) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(navigation_capability);
   navigation_capability_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_phone_capability(
     const smart_objects::SmartObject& phone_capability) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(phone_capability);
   phone_capability_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_video_streaming_capability(
     const smart_objects::SmartObject& video_streaming_capability) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(video_streaming_capability);
   video_streaming_capability_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_rc_capability(
     const smart_objects::SmartObject& rc_capability) {
-  smart_objects::SmartObjectSPtr new_value =
-      std::make_shared<smart_objects::SmartObject>(rc_capability);
+  auto new_value = std::make_shared<smart_objects::SmartObject>(rc_capability);
   rc_capability_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_seat_location_capability(
     const smart_objects::SmartObject& seat_location_capability) {
-  smart_objects::SmartObjectSPtr new_value =
+  auto new_value =
       std::make_shared<smart_objects::SmartObject>(seat_location_capability);
   seat_location_capability_.swap(new_value);
 }

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -1599,15 +1599,15 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
 
 hmi_apis::Common_Language::eType
 HMICapabilitiesImpl::GetActiveLanguageForInterface(
-    const char* interface_name) const {
+    const std::string& interface_name) const {
   LOG4CXX_AUTO_TRACE(logger_);
-  if (strcmp(hmi_interface::ui, interface_name) == 0) {
+  if (hmi_interface::ui == interface_name) {
     return active_ui_language();
   }
-  if (strcmp(hmi_interface::vr, interface_name) == 0) {
+  if (hmi_interface::vr == interface_name) {
     return active_vr_language();
   }
-  if (strcmp(hmi_interface::tts, interface_name) == 0) {
+  if (hmi_interface::tts == interface_name) {
     return active_tts_language();
   }
   return hmi_apis::Common_Language::INVALID_ENUM;
@@ -1620,10 +1620,10 @@ HMICapabilitiesImpl::GetInterfacesFromDefault() const {
 
 bool HMICapabilitiesImpl::AllFieldsSaved(
     const Json::Value& root_node,
-    const char* interface_name,
+    const std::string& interface_name,
     const std::vector<std::string>& sections_to_check) const {
   LOG4CXX_AUTO_TRACE(logger_);
-  if (!JsonIsMemberSafe(root_node, interface_name)) {
+  if (!JsonIsMemberSafe(root_node, interface_name.c_str())) {
     LOG4CXX_DEBUG(logger_,
                   interface_name
                       << " interface is not found. All fields should be saved");
@@ -1918,7 +1918,7 @@ bool HMICapabilitiesImpl::SaveCachedCapabilitiesToFile(
       return false;
     }
 
-    if (AllFieldsSaved(root_node, interface_name.c_str(), sections_to_update)) {
+    if (AllFieldsSaved(root_node, interface_name, sections_to_update)) {
       LOG4CXX_DEBUG(
           logger_,
           "All " << interface_name

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -463,15 +463,7 @@ HMICapabilitiesImpl::HMICapabilitiesImpl(ApplicationManager& app_mngr)
   }
 }
 
-HMICapabilitiesImpl::~HMICapabilitiesImpl() {
-  delete ui_supported_languages_;
-  delete tts_supported_languages_;
-  delete vr_supported_languages_;
-  delete navigation_capability_;
-  delete phone_capability_;
-  delete video_streaming_capability_;
-  delete rc_capability_;
-}
+HMICapabilitiesImpl::~HMICapabilitiesImpl() {}
 
 bool HMICapabilitiesImpl::VerifyImageType(const int32_t image_type) const {
   auto capabilities = display_capabilities();
@@ -567,27 +559,23 @@ HMICapabilitiesImpl::active_tts_language() const {
 
 void HMICapabilitiesImpl::set_ui_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
-  if (ui_supported_languages_) {
-    delete ui_supported_languages_;
-  }
-  ui_supported_languages_ = new smart_objects::SmartObject(supported_languages);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(supported_languages);
+  ui_supported_languages_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_tts_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
-  if (tts_supported_languages_) {
-    delete tts_supported_languages_;
-  }
-  tts_supported_languages_ =
-      new smart_objects::SmartObject(supported_languages);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(supported_languages);
+  tts_supported_languages_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_vr_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
-  if (vr_supported_languages_) {
-    delete vr_supported_languages_;
-  }
-  vr_supported_languages_ = new smart_objects::SmartObject(supported_languages);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(supported_languages);
+  vr_supported_languages_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_display_capabilities(
@@ -695,45 +683,37 @@ void HMICapabilitiesImpl::set_rc_supported(const bool supported) {
 
 void HMICapabilitiesImpl::set_navigation_capability(
     const smart_objects::SmartObject& navigation_capability) {
-  if (navigation_capability_) {
-    delete navigation_capability_;
-  }
-  navigation_capability_ =
-      new smart_objects::SmartObject(navigation_capability);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(navigation_capability);
+  navigation_capability_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_phone_capability(
     const smart_objects::SmartObject& phone_capability) {
-  if (phone_capability_) {
-    delete phone_capability_;
-  }
-  phone_capability_ = new smart_objects::SmartObject(phone_capability);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(phone_capability);
+  phone_capability_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_video_streaming_capability(
     const smart_objects::SmartObject& video_streaming_capability) {
-  if (video_streaming_capability_) {
-    delete video_streaming_capability_;
-  }
-  video_streaming_capability_ =
-      new smart_objects::SmartObject(video_streaming_capability);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(video_streaming_capability);
+  video_streaming_capability_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_rc_capability(
     const smart_objects::SmartObject& rc_capability) {
-  if (rc_capability_) {
-    delete rc_capability_;
-  }
-  rc_capability_ = new smart_objects::SmartObject(rc_capability);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(rc_capability);
+  rc_capability_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_seat_location_capability(
     const smart_objects::SmartObject& seat_location_capability) {
-  if (seat_location_capability_) {
-    delete seat_location_capability_;
-  }
-  seat_location_capability_ =
-      new smart_objects::SmartObject(seat_location_capability);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(seat_location_capability);
+  seat_location_capability_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::Init(
@@ -774,18 +754,18 @@ bool HMICapabilitiesImpl::is_rc_cooperating() const {
   return is_rc_cooperating_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::ui_supported_languages()
-    const {
+const smart_objects::SmartObjectSPtr
+HMICapabilitiesImpl::ui_supported_languages() const {
   return ui_supported_languages_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::vr_supported_languages()
-    const {
+const smart_objects::SmartObjectSPtr
+HMICapabilitiesImpl::vr_supported_languages() const {
   return vr_supported_languages_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::tts_supported_languages()
-    const {
+const smart_objects::SmartObjectSPtr
+HMICapabilitiesImpl::tts_supported_languages() const {
   return tts_supported_languages_;
 }
 
@@ -868,26 +848,27 @@ bool HMICapabilitiesImpl::rc_supported() const {
   return is_rc_supported_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::navigation_capability()
-    const {
+const smart_objects::SmartObjectSPtr
+HMICapabilitiesImpl::navigation_capability() const {
   return navigation_capability_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::phone_capability()
+const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::phone_capability()
     const {
   return phone_capability_;
 }
 
-const smart_objects::SmartObject*
+const smart_objects::SmartObjectSPtr
 HMICapabilitiesImpl::video_streaming_capability() const {
   return video_streaming_capability_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::rc_capability() const {
+const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::rc_capability()
+    const {
   return rc_capability_;
 }
 
-const smart_objects::SmartObject*
+const smart_objects::SmartObjectSPtr
 HMICapabilitiesImpl::seat_location_capability() const {
   return seat_location_capability_;
 }

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -36,6 +36,7 @@
 #include "application_manager/application_manager.h"
 #include "application_manager/hmi_capabilities_impl.h"
 #include "application_manager/message_helper.h"
+#include "application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h"
 #include "application_manager/smart_object_keys.h"
 #include "config_profile/profile.h"
 #include "formatters/CFormatterJsonBase.h"
@@ -417,6 +418,37 @@ void InitCapabilities() {
 }
 
 }  // namespace
+
+namespace {
+/**
+ * @brief Saves smart object content into the JSON node
+ * @param field_name name of the field to save
+ * @param schema reference to schema to unapply
+ * @param object_to_save pointer to object to save
+ * @param out_json_node JSON node for the output result
+ */
+void save_hmi_capability_field_to_json(
+    const std::string& field_name,
+    const smart_objects::CSmartSchema& schema,
+    smart_objects::SmartObjectSPtr object_to_save,
+    Json::Value& out_json_node) {
+  if (!object_to_save) {
+    return;
+  }
+
+  namespace Formatters = ns_smart_device_link::ns_json_handler::formatters;
+  smart_objects::SmartObject formatted_object(smart_objects::SmartType_Map);
+  formatted_object[strings::msg_params][field_name] = *object_to_save;
+  formatted_object.setSchema(schema);
+  formatted_object.getSchema().unapplySchema(
+      formatted_object);  // converts enums back to strings
+
+  Json::Value temp_value;
+  Formatters::CFormatterJsonBase::objToJsonValue(formatted_object, temp_value);
+  out_json_node[field_name] = temp_value[strings::msg_params][field_name];
+}
+
+}  //  namespace
 
 HMICapabilitiesImpl::HMICapabilitiesImpl(ApplicationManager& app_mngr)
     : is_vr_cooperating_(false)
@@ -876,30 +908,75 @@ HMICapabilitiesImpl::seat_location_capability() const {
 }
 
 /**
- * @brief Saves smart object content into the JSON node
- * @param field_name name of the field to save
- * @param schema reference to schema to unapply
- * @param object_to_save pointer to object to save
- * @param out_json_node JSON node for the output result
+ * @brief Checks if JSON member exists
+ * @param json_member reference to JSON structure to check
+ * @param name_of_member name which we should be checked
+ * @returns true if member exists, otherwise returns false
  */
-void save_hmi_capability_field_to_json(
-    const std::string& field_name,
-    const smart_objects::CSmartSchema& schema,
-    smart_objects::SmartObjectSPtr object_to_save,
-    Json::Value& out_json_node) {
-  if (!object_to_save) {
-    return;
-  }
-  smart_objects::SmartObject formatted_object(smart_objects::SmartType_Map);
-  formatted_object[strings::msg_params][field_name] = *object_to_save;
-  formatted_object.setSchema(schema);
-  formatted_object.getSchema().unapplySchema(
-      formatted_object);  // converts enums back to strings
-
-  Json::Value temp_value;
-  formatters::CFormatterJsonBase::objToJsonValue(formatted_object, temp_value);
-  out_json_node[field_name] = temp_value[strings::msg_params][field_name];
+bool check_existing_json_member(const Json::Value& json_member,
+                                const char* name_of_member) {
+  return !json_member.isNull() && json_member.isMember(name_of_member);
 }
+
+/**
+ * @brief Helper class for obtaining proper capabilities JSON value considering
+ * case if it were overriden by cache
+ */
+struct JsonCapabilitiesGetter {
+ public:
+  /**
+   * @brief JsonCapabilitiesGetter constructor
+   * @param json_main_node reference to the main JSON capabilities node
+   * @param json_override_node reference to overriden JSON capabilities node
+   */
+  JsonCapabilitiesGetter(Json::Value& json_main_node,
+                         Json::Value& json_override_node)
+      : json_main_node_(json_main_node)
+      , json_override_node_(json_override_node) {}
+
+  /**
+   * @brief GetJsonMember gets JSON value for a specified JSON member from
+   * overriden JSON node if member exists, otherwise main JSON node will be
+   * taken
+   * @param member_name name of the JSON member to get
+   * @return JSON value for specified member or Value::null if not found
+   */
+  Json::Value GetJsonMember(const char* member_name) {
+    if (check_existing_json_member(json_override_node_, member_name)) {
+      return GetOverrideJsonMember(member_name);
+    }
+
+    if (check_existing_json_member(json_main_node_, member_name)) {
+      return GetMainJsonMember(member_name);
+    }
+
+    return Json::Value::null;
+  }
+
+  /**
+   * @brief GetMainJsonMember gets JSON value for a specified JSON member from
+   * the main JSON node
+   * @param member_name name of the JSON member to get
+   * @return JSON value for specified member or Value::null if not found
+   */
+  Json::Value GetMainJsonMember(const char* member_name) {
+    return json_main_node_.get(member_name, Json::Value::null);
+  }
+
+  /**
+   * @brief GetOverrideJsonMember gets JSON value for a specified JSON member
+   * from the overriden JSON node
+   * @param member_name name of the JSON member to get
+   * @return JSON value for specified member or Value::null if not found
+   */
+  Json::Value GetOverrideJsonMember(const char* member_name) {
+    return json_override_node_.get(member_name, Json::Value::null);
+  }
+
+ private:
+  Json::Value& json_main_node_;
+  Json::Value& json_override_node_;
+};
 
 bool HMICapabilitiesImpl::load_capabilities_from_file() {
   std::string json_string;
@@ -962,35 +1039,40 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
       LOG4CXX_DEBUG(logger_, "Json parsing fails: " << err);
       return false;
     }
+
+    JsonCapabilitiesGetter json_root_getter(root_json, root_json_override);
     // UI
-    if (check_existing_json_member(root_json_override, "UI") ||
-        (check_existing_json_member(root_json, "UI"))) {
-      Json::Value ui = root_json_override.get("UI", Json::Value::null);
-      if (ui.isNull()) {
-        ui = root_json.get("UI", Json::Value::null);
-      }
 
-      if (check_existing_json_member(ui, "language")) {
-        const std::string lang = ui.get("language", "EN-US").asString();
+    if (!json_root_getter.GetJsonMember(hmi_interface::ui).isNull()) {
+      auto ui_main_node = json_root_getter.GetMainJsonMember(hmi_interface::ui);
+      auto ui_override_node =
+          json_root_getter.GetOverrideJsonMember(hmi_interface::ui);
+      JsonCapabilitiesGetter json_ui_getter(ui_main_node, ui_override_node);
+
+      auto ui_language_node =
+          json_ui_getter.GetJsonMember(hmi_response::language);
+
+      if (!ui_language_node.isNull()) {
+        const std::string lang = ui_language_node.asString();
         set_active_ui_language(MessageHelper::CommonLanguageFromString(lang));
-      } else {
-        set_active_ui_language(
-            MessageHelper::CommonLanguageFromString("EN-US"));
       }
 
-      if (check_existing_json_member(ui, "languages")) {
+      auto ui_languages_node =
+          json_ui_getter.GetJsonMember(hmi_response::languages);
+      if (!ui_languages_node.isNull()) {
         smart_objects::SmartObject ui_languages_so(
             smart_objects::SmartType_Array);
-        Json::Value languages_ui = ui.get("languages", "");
-        convert_json_languages_to_obj(languages_ui, ui_languages_so);
+        ConvertJsonArrayToSoArray<hmi_apis::Common_Language::eType>(
+            ui_languages_node, ui_languages_so);
         set_ui_supported_languages(ui_languages_so);
       }
 
-      if (check_existing_json_member(ui, "displayCapabilities")) {
+      auto ui_display_capabilities_node =
+          json_ui_getter.GetJsonMember(hmi_response::display_capabilities);
+      if (!ui_display_capabilities_node.isNull()) {
         smart_objects::SmartObject display_capabilities_so;
-        Json::Value display_capabilities = ui.get("displayCapabilities", "");
-        formatters::CFormatterJsonBase::jsonValueToObj(display_capabilities,
-                                                       display_capabilities_so);
+        formatters::CFormatterJsonBase::jsonValueToObj(
+            ui_display_capabilities_node, display_capabilities_so);
 
         if (display_capabilities_so.keyExists(hmi_response::display_type)) {
           std::map<std::string,
@@ -1124,55 +1206,64 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
         set_display_capabilities(display_capabilities_so);
       }
 
-      if (check_existing_json_member(ui, "audioPassThruCapabilities")) {
-        Json::Value audio_capabilities =
-            ui.get("audioPassThruCapabilities", "");
+      auto ui_audio_pass_thru_capabilities_node =
+          json_ui_getter.GetJsonMember(strings::audio_pass_thru_capabilities);
+      if (!ui_audio_pass_thru_capabilities_node.isNull()) {
         smart_objects::SmartObject audio_capabilities_so(
             smart_objects::SmartType_Array);
-        if (audio_capabilities.type() == Json::arrayValue) {
-          for (uint32_t i = 0; i < audio_capabilities.size(); i++) {
-            convert_audio_capability_to_obj(audio_capabilities[i],
-                                            audio_capabilities_so[i]);
+        if (ui_audio_pass_thru_capabilities_node.type() == Json::arrayValue) {
+          for (uint32_t i = 0; i < ui_audio_pass_thru_capabilities_node.size();
+               i++) {
+            convert_audio_capability_to_obj(
+                ui_audio_pass_thru_capabilities_node[i],
+                audio_capabilities_so[i]);
           }
-        } else if (audio_capabilities.type() == Json::objectValue) {
-          convert_audio_capability_to_obj(audio_capabilities,
+        } else if (ui_audio_pass_thru_capabilities_node.type() ==
+                   Json::objectValue) {
+          convert_audio_capability_to_obj(ui_audio_pass_thru_capabilities_node,
                                           audio_capabilities_so[0]);
         }
         set_audio_pass_thru_capabilities(audio_capabilities_so);
       }
 
-      if (check_existing_json_member(ui, "pcmStreamCapabilities")) {
-        Json::Value pcm_capabilities = ui.get("pcmStreamCapabilities", "");
+      auto ui_pcm_stream_capabilities_node =
+          json_ui_getter.GetJsonMember(strings::pcm_stream_capabilities);
+      if (!ui_pcm_stream_capabilities_node.isNull()) {
         smart_objects::SmartObject pcm_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Map);
-        convert_audio_capability_to_obj(pcm_capabilities, pcm_capabilities_so);
+        convert_audio_capability_to_obj(ui_pcm_stream_capabilities_node,
+                                        pcm_capabilities_so);
         set_pcm_stream_capabilities(pcm_capabilities_so);
       }
 
-      if (check_existing_json_member(ui, "hmiZoneCapabilities")) {
+      auto ui_hmi_zone_capabilities_node =
+          json_ui_getter.GetJsonMember(hmi_response::hmi_zone_capabilities);
+      if (!ui_hmi_zone_capabilities_node.isNull()) {
         smart_objects::SmartObject hmi_zone_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
         hmi_zone_capabilities_so =
-            hmi_zone_enum.find(ui.get("hmiZoneCapabilities", "").asString())
+            hmi_zone_enum.find(ui_hmi_zone_capabilities_node.asString())
                 ->second;
         set_hmi_zone_capabilities(hmi_zone_capabilities_so);
       }
 
-      if (check_existing_json_member(ui, "softButtonCapabilities")) {
-        Json::Value soft_button_capabilities =
-            ui.get("softButtonCapabilities", "");
+      auto ui_soft_button_capabilities_node =
+          json_ui_getter.GetJsonMember(hmi_response::soft_button_capabilities);
+      if (!ui_soft_button_capabilities_node.isNull()) {
         smart_objects::SmartObject soft_button_capabilities_so;
         formatters::CFormatterJsonBase::jsonValueToObj(
-            soft_button_capabilities, soft_button_capabilities_so);
+            ui_soft_button_capabilities_node, soft_button_capabilities_so);
         set_soft_button_capabilities(soft_button_capabilities_so);
       }
 
-      if (check_existing_json_member(ui, "systemCapabilities")) {
-        Json::Value system_capabilities = ui.get("systemCapabilities", "");
-        if (check_existing_json_member(system_capabilities,
-                                       "navigationCapability")) {
+      auto ui_system_capabilities_capabilities_node =
+          json_ui_getter.GetJsonMember(strings::system_capabilities);
+      if (!ui_system_capabilities_capabilities_node.isNull()) {
+        if (check_existing_json_member(ui_system_capabilities_capabilities_node,
+                                       strings::navigation_capability)) {
           Json::Value navigation_capability =
-              system_capabilities.get("navigationCapability", "");
+              ui_system_capabilities_capabilities_node.get(
+                  strings::navigation_capability, "");
           smart_objects::SmartObject navigation_capability_so;
           formatters::CFormatterJsonBase::jsonValueToObj(
               navigation_capability, navigation_capability_so);
@@ -1181,10 +1272,11 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
             set_navigation_supported(true);
           }
         }
-        if (check_existing_json_member(system_capabilities,
-                                       "phoneCapability")) {
+        if (check_existing_json_member(ui_system_capabilities_capabilities_node,
+                                       strings::phone_capability)) {
           Json::Value phone_capability =
-              system_capabilities.get("phoneCapability", "");
+              ui_system_capabilities_capabilities_node.get(
+                  strings::phone_capability, "");
           smart_objects::SmartObject phone_capability_so;
           formatters::CFormatterJsonBase::jsonValueToObj(phone_capability,
                                                          phone_capability_so);
@@ -1193,23 +1285,24 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
             set_phone_call_supported(true);
           }
         }
-        if (check_existing_json_member(system_capabilities,
-                                       "videoStreamingCapability")) {
+        if (check_existing_json_member(ui_system_capabilities_capabilities_node,
+                                       strings::video_streaming_capability)) {
           Json::Value vs_capability =
-              system_capabilities.get("videoStreamingCapability", "");
+              ui_system_capabilities_capabilities_node.get(
+                  strings::video_streaming_capability, "");
           smart_objects::SmartObject vs_capability_so;
           formatters::CFormatterJsonBase::jsonValueToObj(vs_capability,
                                                          vs_capability_so);
 
-          if (vs_capability_so.keyExists("supportedFormats")) {
+          if (vs_capability_so.keyExists(strings::supported_formats)) {
             smart_objects::SmartObject& supported_format_array =
-                vs_capability_so["supportedFormats"];
+                vs_capability_so[strings::supported_formats];
             smart_objects::SmartObject converted_array(
                 smart_objects::SmartType_Array);
             for (uint32_t i = 0, j = 0; i < supported_format_array.length();
                  i++) {
-              if (!supported_format_array[i].keyExists("protocol") ||
-                  !supported_format_array[i].keyExists("codec")) {
+              if (!supported_format_array[i].keyExists(strings::protocol) ||
+                  !supported_format_array[i].keyExists(strings::codec)) {
                 continue;
               }
 
@@ -1217,12 +1310,13 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
                        hmi_apis::Common_VideoStreamingProtocol::eType>::
                   const_iterator it_protocol =
                       video_streaming_protocol_enum.find(
-                          supported_format_array[i]["protocol"].asString());
+                          supported_format_array[i][strings::protocol]
+                              .asString());
 
               std::map<std::string,
                        hmi_apis::Common_VideoStreamingCodec::eType>::
                   const_iterator it_codec = video_streaming_codec_enum.find(
-                      supported_format_array[i]["codec"].asString());
+                      supported_format_array[i][strings::codec].asString());
 
               // format is valid only if both protocol and codec are converted
               // to enum values successfully
@@ -1230,34 +1324,39 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
                   it_codec != video_streaming_codec_enum.end()) {
                 smart_objects::SmartObject format_so =
                     smart_objects::SmartObject(smart_objects::SmartType_Map);
-                format_so["protocol"] = it_protocol->second;
-                format_so["codec"] = it_codec->second;
+                format_so[strings::protocol] = it_protocol->second;
+                format_so[strings::codec] = it_codec->second;
                 converted_array[j++] = format_so;
               }
             }
-            vs_capability_so.erase("supportedFormats");
-            vs_capability_so["supportedFormats"] = converted_array;
+            vs_capability_so.erase(strings::supported_formats);
+            vs_capability_so[strings::supported_formats] = converted_array;
           }
           set_video_streaming_capability(vs_capability_so);
           if (!vs_capability_so.empty()) {
             set_video_streaming_supported(true);
           }
         }
-        if (check_existing_json_member(system_capabilities,
-                                       "remoteControlCapability")) {
+        if (check_existing_json_member(ui_system_capabilities_capabilities_node,
+                                       strings::rc_capability)) {
           Json::Value rc_capability =
-              system_capabilities.get("remoteControlCapability", "");
+              ui_system_capabilities_capabilities_node.get(
+                  strings::rc_capability, "");
           smart_objects::SmartObject rc_capability_so;
           formatters::CFormatterJsonBase::jsonValueToObj(rc_capability,
                                                          rc_capability_so);
-          if (rc_capability_so.keyExists("lightControlCapabilities")) {
-            if (rc_capability_so["lightControlCapabilities"].keyExists(
-                    "supportedLights")) {
-              auto& lights = rc_capability_so["lightControlCapabilities"]
-                                             ["supportedLights"];
+          if (rc_capability_so.keyExists(
+                  rc_rpc_plugin::strings::klightControlCapabilities)) {
+            if (rc_capability_so
+                    [rc_rpc_plugin::strings::klightControlCapabilities]
+                        .keyExists(rc_rpc_plugin::strings::kSupportedLights)) {
+              auto& lights = rc_capability_so
+                  [rc_rpc_plugin::strings::klightControlCapabilities]
+                  [rc_rpc_plugin::strings::kSupportedLights];
               auto it = lights.asArray()->begin();
               for (; it != lights.asArray()->end(); ++it) {
-                smart_objects::SmartObject& light_name_so = (*it)["name"];
+                smart_objects::SmartObject& light_name_so =
+                    (*it)[strings::name];
                 auto light_name = MessageHelper::CommonLightNameFromString(
                     light_name_so.asString());
                 light_name_so = light_name;
@@ -1269,10 +1368,11 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
             set_rc_supported(true);
           }
         }
-        if (check_existing_json_member(system_capabilities,
-                                       "seatLocationCapability")) {
+        if (check_existing_json_member(ui_system_capabilities_capabilities_node,
+                                       strings::seat_location_capability)) {
           Json::Value seat_location_capability =
-              system_capabilities.get("seatLocationCapability", "");
+              ui_system_capabilities_capabilities_node.get(
+                  strings::seat_location_capability, "");
           smart_objects::SmartObject seat_location_capability_so;
           formatters::CFormatterJsonBase::jsonValueToObj(
               seat_location_capability, seat_location_capability_so);
@@ -1282,76 +1382,90 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
     }  // UI end
 
     // VR
-    if (check_existing_json_member(root_json, "VR")) {
-      Json::Value vr = root_json.get("VR", "");
-      if (check_existing_json_member(vr, "language")) {
-        const std::string lang = vr.get("language", "EN-US").asString();
+    if (!json_root_getter.GetJsonMember(hmi_interface::vr).isNull()) {
+      auto vr_main_node = json_root_getter.GetMainJsonMember(hmi_interface::vr);
+      auto vr_override_node =
+          json_root_getter.GetOverrideJsonMember(hmi_interface::vr);
+      JsonCapabilitiesGetter json_vr_getter(vr_main_node, vr_override_node);
+
+      auto vr_language_node =
+          json_vr_getter.GetJsonMember(hmi_response::language);
+      if (!vr_language_node.isNull()) {
+        const std::string lang = vr_language_node.asString();
         set_active_vr_language(MessageHelper::CommonLanguageFromString(lang));
-      } else {
-        set_active_vr_language(
-            MessageHelper::CommonLanguageFromString("EN-US"));
       }
 
-      if (check_existing_json_member(vr, "languages")) {
-        Json::Value languages_vr = vr.get("languages", "");
+      auto vr_languages_node =
+          json_vr_getter.GetJsonMember(hmi_response::languages);
+      if (!vr_languages_node.isNull()) {
         smart_objects::SmartObject vr_languages_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
-        convert_json_languages_to_obj(languages_vr, vr_languages_so);
+        ConvertJsonArrayToSoArray<hmi_apis::Common_Language::eType>(
+            vr_languages_node, vr_languages_so);
         set_vr_supported_languages(vr_languages_so);
       }
 
-      if (check_existing_json_member(vr, "capabilities")) {
-        Json::Value capabilities = vr.get("capabilities", "");
+      auto vr_capabilities_node =
+          json_vr_getter.GetJsonMember(hmi_response::capabilities);
+      if (!vr_capabilities_node.isNull()) {
         smart_objects::SmartObject vr_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
-        for (uint32_t i = 0; i < capabilities.size(); ++i) {
-          vr_capabilities_so[i] =
-              vr_enum_capabilities.find(capabilities[i].asString())->second;
-        }
+        ConvertJsonArrayToSoArray<hmi_apis::Common_VrCapabilities::eType>(
+            vr_capabilities_node, vr_capabilities_so);
         set_vr_capabilities(vr_capabilities_so);
       }
     }  // VR end
 
     // TTS
-    if (check_existing_json_member(root_json, "TTS")) {
-      Json::Value tts = root_json.get("TTS", "");
+    if (!json_root_getter.GetJsonMember(hmi_interface::tts).isNull()) {
+      auto tts_main_node =
+          json_root_getter.GetMainJsonMember(hmi_interface::tts);
+      auto tts_override_node =
+          json_root_getter.GetOverrideJsonMember(hmi_interface::tts);
+      JsonCapabilitiesGetter json_tts_getter(tts_main_node, tts_override_node);
 
-      if (check_existing_json_member(tts, "language")) {
-        const std::string lang = tts.get("language", "EN-US").asString();
+      auto tts_language_node =
+          json_tts_getter.GetJsonMember(hmi_response::language);
+      if (!tts_language_node.isNull()) {
+        const std::string lang = tts_language_node.asString();
         set_active_tts_language(MessageHelper::CommonLanguageFromString(lang));
-      } else {
-        set_active_tts_language(
-            MessageHelper::CommonLanguageFromString("EN-US"));
       }
 
-      if (check_existing_json_member(tts, "languages")) {
-        Json::Value languages_tts = tts.get("languages", "");
+      auto tts_languages_node =
+          json_tts_getter.GetJsonMember(hmi_response::languages);
+      if (!tts_languages_node.isNull()) {
         smart_objects::SmartObject tts_languages_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
-        convert_json_languages_to_obj(languages_tts, tts_languages_so);
+        ConvertJsonArrayToSoArray<hmi_apis::Common_Language::eType>(
+            tts_languages_node, tts_languages_so);
         set_tts_supported_languages(tts_languages_so);
       }
 
-      if (check_existing_json_member(tts, "capabilities")) {
-        Json::Value capabilities = tts.get("capabilities", "");
+      auto tts_capabilities_node =
+          json_tts_getter.GetJsonMember(hmi_response::capabilities);
+      if (!tts_capabilities_node.isNull()) {
         smart_objects::SmartObject tts_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
-        for (uint32_t i = 0; i < capabilities.size(); ++i) {
-          tts_capabilities_so[i] =
-              tts_enum_capabilities.find(capabilities[i].asString())->second;
-        }
+        ConvertJsonArrayToSoArray<hmi_apis::Common_SpeechCapabilities::eType>(
+            tts_capabilities_node, tts_capabilities_so);
         set_speech_capabilities(tts_capabilities_so);
       }
     }  // TTS end
 
     // Buttons
-    if (check_existing_json_member(root_json, "Buttons")) {
-      Json::Value buttons = root_json.get("Buttons", "");
-      if (check_existing_json_member(buttons, "capabilities")) {
-        Json::Value bt_capabilities = buttons.get("capabilities", "");
+    if (!json_root_getter.GetJsonMember(hmi_interface::buttons).isNull()) {
+      auto buttons_main_node =
+          json_root_getter.GetMainJsonMember(hmi_interface::buttons);
+      auto buttons_override_node =
+          json_root_getter.GetOverrideJsonMember(hmi_interface::buttons);
+      JsonCapabilitiesGetter json_buttons_getter(buttons_main_node,
+                                                 buttons_override_node);
+      auto buttons_capabilities_node =
+          json_buttons_getter.GetJsonMember(hmi_response::capabilities);
+      if (!buttons_capabilities_node.isNull()) {
         smart_objects::SmartObject buttons_capabilities_so;
-        formatters::CFormatterJsonBase::jsonValueToObj(bt_capabilities,
-                                                       buttons_capabilities_so);
+        formatters::CFormatterJsonBase::jsonValueToObj(
+            buttons_capabilities_node, buttons_capabilities_so);
 
         for (uint32_t i = 0; i < buttons_capabilities_so.length(); ++i) {
           if ((buttons_capabilities_so[i]).keyExists(strings::name)) {
@@ -1367,20 +1481,25 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
         }
         set_button_capabilities(buttons_capabilities_so);
       }
-      if (check_existing_json_member(buttons, "presetBankCapabilities")) {
-        Json::Value presetBank = buttons.get("presetBankCapabilities", "");
+
+      auto buttons_preset_bank_capabilities_node =
+          json_buttons_getter.GetMainJsonMember(
+              hmi_response::preset_bank_capabilities);
+      if (!buttons_preset_bank_capabilities_node.isNull()) {
         smart_objects::SmartObject preset_bank_so;
-        formatters::CFormatterJsonBase::jsonValueToObj(presetBank,
-                                                       preset_bank_so);
+        formatters::CFormatterJsonBase::jsonValueToObj(
+            buttons_preset_bank_capabilities_node, preset_bank_so);
         set_preset_bank_capabilities(preset_bank_so);
       }
     }  // Buttons end
 
     // VehicleType
-    if (check_existing_json_member(root_json, "VehicleInfo")) {
-      Json::Value vehicle_info = root_json.get("VehicleInfo", "");
+
+    if (!json_root_getter.GetJsonMember(hmi_interface::vehicle_info).isNull()) {
+      auto vehicle_info_node =
+          json_root_getter.GetJsonMember(hmi_interface::vehicle_info);
       smart_objects::SmartObject vehicle_type_so;
-      formatters::CFormatterJsonBase::jsonValueToObj(vehicle_info,
+      formatters::CFormatterJsonBase::jsonValueToObj(vehicle_info_node,
                                                      vehicle_type_so);
       set_vehicle_type(vehicle_type_so);
     }  // VehicleType end
@@ -1390,8 +1509,291 @@ bool HMICapabilitiesImpl::load_capabilities_from_file() {
   return true;
 }
 
+hmi_apis::Common_Language::eType
+HMICapabilitiesImpl::GetActiveLanguageForInterface(
+    const char* interface_name) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (strcmp(hmi_interface::ui, interface_name) == 0) {
+    return active_ui_language();
+  }
+  if (strcmp(hmi_interface::vr, interface_name) == 0) {
+    return active_vr_language();
+  }
+  if (strcmp(hmi_interface::tts, interface_name) == 0) {
+    return active_tts_language();
+  }
+  return hmi_apis::Common_Language::INVALID_ENUM;
+}
+
+bool HMICapabilitiesImpl::AreAllFieldsSaved(
+    const Json::Value& root_node,
+    const char* interface_name,
+    const std::vector<std::string>& sections_to_check) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!check_existing_json_member(root_node, interface_name)) {
+    LOG4CXX_DEBUG(logger_,
+                  interface_name
+                      << " interface is not found. All fields should be saved");
+    return false;
+  }
+
+  const auto& interface_node = root_node.get(interface_name, Json::Value::null);
+  for (auto it = sections_to_check.begin(); it != sections_to_check.end();
+       ++it) {
+    const std::string section = (*it).c_str();
+    if (!check_existing_json_member(interface_node, section.c_str())) {
+      LOG4CXX_DEBUG(logger_,
+                    "Field " << *it << " should be saved into the file");
+      return false;
+    }
+
+    if (hmi_response::language == section) {
+      const auto active_language =
+          GetActiveLanguageForInterface(interface_name);
+      const auto json_language = interface_node[hmi_response::language];
+
+      if (active_language !=
+          MessageHelper::CommonLanguageFromString(json_language.asString())) {
+        LOG4CXX_DEBUG(logger_,
+                      "Active " << interface_name
+                                << " language is not the same as the persisted "
+                                   "one. Field should be overwritten");
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+void HMICapabilitiesImpl::PrepareUiJsonValueForSaving(
+    const std::vector<std::string>& sections_to_update,
+    const smart_objects::CSmartSchema& schema,
+    Json::Value& out_node) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (helpers::in_range(sections_to_update,
+                        hmi_response::display_capabilities)) {
+    save_hmi_capability_field_to_json(hmi_response::display_capabilities,
+                                      schema,
+                                      display_capabilities(),
+                                      out_node);
+  }
+
+  if (helpers::in_range(sections_to_update,
+                        hmi_response::hmi_zone_capabilities)) {
+    save_hmi_capability_field_to_json(hmi_response::hmi_zone_capabilities,
+                                      schema,
+                                      hmi_zone_capabilities(),
+                                      out_node);
+  }
+
+  if (helpers::in_range(sections_to_update,
+                        hmi_response::soft_button_capabilities)) {
+    save_hmi_capability_field_to_json(hmi_response::soft_button_capabilities,
+                                      schema,
+                                      soft_button_capabilities(),
+                                      out_node);
+  }
+
+  if (helpers::in_range(sections_to_update,
+                        strings::audio_pass_thru_capabilities)) {
+    save_hmi_capability_field_to_json(strings::audio_pass_thru_capabilities,
+                                      schema,
+                                      audio_pass_thru_capabilities(),
+                                      out_node);
+  }
+
+  if (helpers::in_range(sections_to_update, strings::hmi_capabilities)) {
+    out_node[strings::hmi_capabilities][strings::navigation] =
+        navigation_supported();
+    out_node[strings::hmi_capabilities][strings::phone_call] =
+        phone_call_supported();
+    out_node[strings::hmi_capabilities][strings::video_streaming] =
+        video_streaming_supported();
+  }
+
+  if (helpers::in_range(sections_to_update, strings::system_capabilities)) {
+    save_hmi_capability_field_to_json(strings::navigation_capability,
+                                      schema,
+                                      navigation_capability(),
+                                      out_node[strings::system_capabilities]);
+    save_hmi_capability_field_to_json(strings::phone_capability,
+                                      schema,
+                                      phone_capability(),
+                                      out_node[strings::system_capabilities]);
+    save_hmi_capability_field_to_json(strings::video_streaming_capability,
+                                      schema,
+                                      video_streaming_capability(),
+                                      out_node[strings::system_capabilities]);
+    save_hmi_capability_field_to_json(strings::display_capabilities,
+                                      schema,
+                                      system_display_capabilities(),
+                                      out_node[strings::system_capabilities]);
+  }
+
+  if (helpers::in_range(sections_to_update, hmi_response::language)) {
+    out_node[hmi_response::language] =
+        MessageHelper::CommonLanguageToString(active_ui_language());
+  }
+
+  if (helpers::in_range(sections_to_update, hmi_response::languages)) {
+    save_hmi_capability_field_to_json(
+        hmi_response::languages, schema, ui_supported_languages(), out_node);
+  }
+}
+
+void HMICapabilitiesImpl::PrepareVrJsonValueForSaving(
+    const std::vector<std::string>& sections_to_update,
+    const smart_objects::CSmartSchema& schema,
+    Json::Value& out_node) const {
+  UNUSED(schema);
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (helpers::in_range(sections_to_update, hmi_response::language)) {
+    out_node[hmi_response::language] =
+        MessageHelper::CommonLanguageToString(active_vr_language());
+  }
+
+  if (helpers::in_range(sections_to_update, hmi_response::languages)) {
+    save_hmi_capability_field_to_json(
+        hmi_response::languages, schema, vr_supported_languages(), out_node);
+  }
+
+  if (helpers::in_range(sections_to_update, strings::vr_capabilities)) {
+    save_hmi_capability_field_to_json(
+        strings::vr_capabilities, schema, vr_capabilities(), out_node);
+  }
+}
+
+void HMICapabilitiesImpl::PrepareTtsJsonValueForSaving(
+    const std::vector<std::string>& sections_to_update,
+    const smart_objects::CSmartSchema& schema,
+    Json::Value& out_node) const {
+  UNUSED(schema);
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (helpers::in_range(sections_to_update, hmi_response::language)) {
+    out_node[hmi_response::language] =
+        MessageHelper::CommonLanguageToString(active_tts_language());
+  }
+
+  if (helpers::in_range(sections_to_update, hmi_response::languages)) {
+    save_hmi_capability_field_to_json(
+        hmi_response::languages, schema, tts_supported_languages(), out_node);
+  }
+
+  if (helpers::in_range(sections_to_update,
+                        hmi_response::speech_capabilities)) {
+    save_hmi_capability_field_to_json(hmi_response::speech_capabilities,
+                                      schema,
+                                      speech_capabilities(),
+                                      out_node);
+  }
+  if (helpers::in_range(sections_to_update,
+                        hmi_response::prerecorded_speech_capabilities)) {
+    save_hmi_capability_field_to_json(
+        hmi_response::prerecorded_speech_capabilities,
+        schema,
+        prerecorded_speech(),
+        out_node);
+  }
+}
+
+void HMICapabilitiesImpl::PrepareButtonsJsonValueForSaving(
+    const std::vector<std::string>& sections_to_update,
+    const smart_objects::CSmartSchema& schema,
+    Json::Value& out_node) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (helpers::in_range(sections_to_update,
+                        hmi_response::button_capabilities)) {
+    save_hmi_capability_field_to_json(
+        hmi_response::capabilities, schema, button_capabilities(), out_node);
+  }
+
+  if (helpers::in_range(sections_to_update,
+                        hmi_response::preset_bank_capabilities)) {
+    save_hmi_capability_field_to_json(hmi_response::preset_bank_capabilities,
+                                      schema,
+                                      preset_bank_capabilities(),
+                                      out_node);
+  }
+}
+
+void HMICapabilitiesImpl::PrepareVehicleInfoJsonValueForSaving(
+    const std::vector<std::string>& sections_to_update,
+    const smart_objects::CSmartSchema& schema,
+    Json::Value& out_node) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (helpers::in_range(sections_to_update, hmi_response::vehicle_type)) {
+    save_hmi_capability_field_to_json(
+        hmi_response::vehicle_type, schema, vehicle_type(), out_node);
+  }
+}
+
+void HMICapabilitiesImpl::PrepareRCJsonValueForSaving(
+    const std::vector<std::string>& sections_to_update,
+    const smart_objects::CSmartSchema& schema,
+    Json::Value& out_node) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (helpers::in_range(sections_to_update, strings::rc_capability)) {
+    save_hmi_capability_field_to_json(
+        strings::rc_capability, schema, rc_capability(), out_node);
+  }
+
+  if (helpers::in_range(sections_to_update,
+                        strings::seat_location_capability)) {
+    save_hmi_capability_field_to_json(strings::seat_location_capability,
+                                      schema,
+                                      seat_location_capability(),
+                                      out_node);
+  }
+}
+
+void HMICapabilitiesImpl::PrepareJsonValueForSaving(
+    const char* interface_name,
+    const std::vector<std::string>& sections_to_update,
+    const smart_objects::CSmartSchema& schema,
+    Json::Value& out_root_node) const {
+  LOG4CXX_DEBUG(logger_,
+                "Prepare " << interface_name << " sections for saving");
+
+  if (out_root_node.isNull()) {
+    out_root_node = Json::Value(Json::objectValue);
+  }
+
+  if (!out_root_node.isMember(interface_name)) {
+    out_root_node[interface_name] = Json::Value(Json::objectValue);
+  }
+
+  Json::Value& interface_node = out_root_node[interface_name];
+  if (strcmp(interface_name, hmi_interface::ui) == 0) {
+    PrepareUiJsonValueForSaving(sections_to_update, schema, interface_node);
+  }
+
+  if (strcmp(interface_name, hmi_interface::vr) == 0) {
+    PrepareVrJsonValueForSaving(sections_to_update, schema, interface_node);
+  }
+
+  if (strcmp(interface_name, hmi_interface::tts) == 0) {
+    PrepareTtsJsonValueForSaving(sections_to_update, schema, interface_node);
+  }
+
+  if (strcmp(interface_name, hmi_interface::buttons) == 0) {
+    PrepareButtonsJsonValueForSaving(
+        sections_to_update, schema, interface_node);
+  }
+
+  if (strcmp(interface_name, hmi_interface::vehicle_info) == 0) {
+    PrepareVehicleInfoJsonValueForSaving(
+        sections_to_update, schema, interface_node);
+  }
+
+  if (strcmp(interface_name, hmi_interface::rc) == 0) {
+    PrepareRCJsonValueForSaving(sections_to_update, schema, interface_node);
+  }
+}
+
 bool HMICapabilitiesImpl::SaveCachedCapabilitiesToFile(
-    const std::vector<std::string> sections_to_update,
+    const std::string& interface_name,
+    const std::vector<std::string>& sections_to_update,
     const smart_objects::CSmartSchema& schema) {
   LOG4CXX_AUTO_TRACE(logger_);
 
@@ -1413,129 +1815,30 @@ bool HMICapabilitiesImpl::SaveCachedCapabilitiesToFile(
       return false;
     }
 
-    Json::CharReaderBuilder reader_builder;
-    const std::unique_ptr<Json::CharReader> reader(
-        reader_builder.newCharReader());
-    JSONCPP_STRING err;
-    const size_t json_len = file_content.length();
+    Json::CharReaderBuilder builder;
+    const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
     if (!reader->parse(file_content.c_str(),
-                       file_content.c_str() + json_len,
+                       file_content.c_str() + file_content.length(),
                        &root_node,
-                       &err)) {
-      LOG4CXX_ERROR(logger_, "Can't parse the file." << err << "Skipping");
+                       NULL)) {
+      LOG4CXX_ERROR(logger_, "Can't parse the file. Skipping");
       return false;
     }
 
-    if (check_existing_json_member(root_node, "UI")) {
-      Json::Value ui = root_node.get("UI", Json::Value::null);
-      bool are_all_sections_exist = true;
-      for (auto it = sections_to_update.begin(); it != sections_to_update.end();
-           ++it) {
-        if (!check_existing_json_member(ui, (*it).c_str())) {
-          LOG4CXX_DEBUG(logger_,
-                        "Field " << *it << " should be saved into the file");
-          are_all_sections_exist = false;
-          break;
-        }
-      }
-
-      if (are_all_sections_exist) {
-        LOG4CXX_DEBUG(logger_,
-                      "All fields are present in the file. No need to update");
-        return true;
-      }
+    if (AreAllFieldsSaved(
+            root_node, interface_name.c_str(), sections_to_update)) {
+      LOG4CXX_DEBUG(
+          logger_,
+          "All " << interface_name
+                 << " fields are present in the file. No need to update");
+      return true;
     }
+
+    LOG4CXX_DEBUG(logger_, "Some fields in the cache file should be updated");
   }
 
-  if (root_node.isNull()) {
-    root_node = Json::Value(Json::objectValue);
-  }
-
-  if (!root_node.isMember("UI")) {
-    root_node["UI"] = Json::Value(Json::objectValue);
-  }
-
-  Json::Value& ui_node = root_node["UI"];
-  if (helpers::in_range(sections_to_update,
-                        hmi_response::display_capabilities)) {
-    save_hmi_capability_field_to_json(hmi_response::display_capabilities,
-                                      schema,
-                                      display_capabilities(),
-                                      ui_node);
-  }
-
-  if (helpers::in_range(sections_to_update,
-                        hmi_response::hmi_zone_capabilities)) {
-    save_hmi_capability_field_to_json(hmi_response::hmi_zone_capabilities,
-                                      schema,
-                                      hmi_zone_capabilities(),
-                                      ui_node);
-  }
-
-  if (helpers::in_range(sections_to_update,
-                        hmi_response::soft_button_capabilities)) {
-    save_hmi_capability_field_to_json(hmi_response::soft_button_capabilities,
-                                      schema,
-                                      soft_button_capabilities(),
-                                      ui_node);
-  }
-
-  if (helpers::in_range(sections_to_update,
-                        strings::audio_pass_thru_capabilities)) {
-    save_hmi_capability_field_to_json(strings::audio_pass_thru_capabilities,
-                                      schema,
-                                      audio_pass_thru_capabilities(),
-                                      ui_node);
-  }
-
-  if (helpers::in_range(sections_to_update, strings::navigation)) {
-    ui_node[strings::hmi_capabilities] = navigation_supported();
-  }
-
-  if (helpers::in_range(sections_to_update, strings::phone_call)) {
-    ui_node[strings::hmi_capabilities] = phone_call_supported();
-  }
-
-  if (helpers::in_range(sections_to_update, strings::video_streaming)) {
-    ui_node[strings::hmi_capabilities] = video_streaming_supported();
-  }
-
-  if (helpers::in_range(sections_to_update, strings::navigation_capability)) {
-    save_hmi_capability_field_to_json(strings::navigation_capability,
-                                      schema,
-                                      navigation_capability(),
-                                      ui_node[strings::system_capabilities]);
-  }
-  if (helpers::in_range(sections_to_update, strings::phone_capability)) {
-    save_hmi_capability_field_to_json(strings::phone_capability,
-                                      schema,
-                                      phone_capability(),
-                                      ui_node[strings::system_capabilities]);
-  }
-  if (helpers::in_range(sections_to_update,
-                        strings::video_streaming_capability)) {
-    save_hmi_capability_field_to_json(strings::video_streaming_capability,
-                                      schema,
-                                      video_streaming_capability(),
-                                      ui_node[strings::system_capabilities]);
-  }
-  if (helpers::in_range(sections_to_update,
-                        strings::system_display_capabilities)) {
-    save_hmi_capability_field_to_json(strings::display_capabilities,
-                                      schema,
-                                      system_display_capabilities(),
-                                      ui_node[strings::system_capabilities]);
-  }
-
-  if (helpers::in_range(sections_to_update, hmi_response::language)) {
-    ui_node[hmi_response::language] =
-        MessageHelper::CommonLanguageToString(active_ui_language());
-  }
-
-  if (helpers::in_range(sections_to_update, hmi_response::languages)) {
-    save_hmi_capability_field_to_json(
-        hmi_response::languages, schema, ui_supported_languages(), ui_node);
-  }
+  PrepareJsonValueForSaving(
+      interface_name.c_str(), sections_to_update, schema, root_node);
 
   LOG4CXX_DEBUG(logger_, "Saving cache to file: " << cache_file_name);
   const std::string content_to_save = root_node.toStyledString();
@@ -1571,11 +1874,6 @@ void HMICapabilitiesImpl::set_ccpu_version(const std::string& ccpu_version) {
 
 const std::string& HMICapabilitiesImpl::ccpu_version() const {
   return ccpu_version_;
-}
-
-bool HMICapabilitiesImpl::check_existing_json_member(
-    const Json::Value& json_member, const char* name_of_member) const {
-  return json_member.isMember(name_of_member);
 }
 
 void HMICapabilitiesImpl::convert_json_languages_to_obj(

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -984,13 +984,13 @@ struct JsonCapabilitiesGetter {
   Json::Value GetJsonMember(
       const char* member_name,
       hmi_apis::FunctionID::eType request_id,
-      std::set<hmi_apis::FunctionID::eType>& interfaces_from_default) {
+      std::set<hmi_apis::FunctionID::eType>& default_initialized_capabilities) {
     if (JsonIsMemberSafe(json_cache_node_, member_name)) {
       return GetCachedJsonMember(member_name);
     }
 
     if (JsonIsMemberSafe(json_default_node_, member_name)) {
-      interfaces_from_default.insert(request_id);
+      default_initialized_capabilities.insert(request_id);
       return GetMainJsonMember(member_name);
     }
 
@@ -1082,7 +1082,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_language_node =
           json_ui_getter.GetJsonMember(hmi_response::language,
                                        hmi_apis::FunctionID::UI_GetLanguage,
-                                       interfaces_from_default_);
+                                       default_initialized_capabilities_);
 
       if (!ui_language_node.isNull()) {
         const std::string lang = ui_language_node.asString();
@@ -1092,7 +1092,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_languages_node = json_ui_getter.GetJsonMember(
           hmi_response::languages,
           hmi_apis::FunctionID::UI_GetSupportedLanguages,
-          interfaces_from_default_);
+          default_initialized_capabilities_);
       if (!ui_languages_node.isNull()) {
         smart_objects::SmartObject ui_languages_so(
             smart_objects::SmartType_Array);
@@ -1104,7 +1104,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_display_capabilities_node =
           json_ui_getter.GetJsonMember(hmi_response::display_capabilities,
                                        hmi_apis::FunctionID::UI_GetCapabilities,
-                                       interfaces_from_default_);
+                                       default_initialized_capabilities_);
       if (!ui_display_capabilities_node.isNull()) {
         smart_objects::SmartObject display_capabilities_so;
         formatters::CFormatterJsonBase::jsonValueToObj(
@@ -1245,7 +1245,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_audio_pass_thru_capabilities_node =
           json_ui_getter.GetJsonMember(strings::audio_pass_thru_capabilities,
                                        hmi_apis::FunctionID::UI_GetCapabilities,
-                                       interfaces_from_default_);
+                                       default_initialized_capabilities_);
       if (!ui_audio_pass_thru_capabilities_node.isNull()) {
         smart_objects::SmartObject audio_capabilities_so(
             smart_objects::SmartType_Array);
@@ -1268,7 +1268,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_pcm_stream_capabilities_node =
           json_ui_getter.GetJsonMember(strings::pcm_stream_capabilities,
                                        hmi_apis::FunctionID::INVALID_ENUM,
-                                       interfaces_from_default_);
+                                       default_initialized_capabilities_);
       if (!ui_pcm_stream_capabilities_node.isNull()) {
         smart_objects::SmartObject pcm_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Map);
@@ -1280,7 +1280,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_hmi_zone_capabilities_node =
           json_ui_getter.GetJsonMember(hmi_response::hmi_zone_capabilities,
                                        hmi_apis::FunctionID::UI_GetCapabilities,
-                                       interfaces_from_default_);
+                                       default_initialized_capabilities_);
       if (!ui_hmi_zone_capabilities_node.isNull()) {
         smart_objects::SmartObject hmi_zone_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
@@ -1293,7 +1293,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_soft_button_capabilities_node =
           json_ui_getter.GetJsonMember(hmi_response::soft_button_capabilities,
                                        hmi_apis::FunctionID::UI_GetCapabilities,
-                                       interfaces_from_default_);
+                                       default_initialized_capabilities_);
       if (!ui_soft_button_capabilities_node.isNull()) {
         smart_objects::SmartObject soft_button_capabilities_so;
         formatters::CFormatterJsonBase::jsonValueToObj(
@@ -1304,7 +1304,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_system_capabilities_capabilities_node =
           json_ui_getter.GetJsonMember(strings::system_capabilities,
                                        hmi_apis::FunctionID::UI_GetCapabilities,
-                                       interfaces_from_default_);
+                                       default_initialized_capabilities_);
       if (!ui_system_capabilities_capabilities_node.isNull()) {
         if (JsonIsMemberSafe(ui_system_capabilities_capabilities_node,
                              strings::navigation_capability)) {
@@ -1439,7 +1439,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto vr_language_node =
           json_vr_getter.GetJsonMember(hmi_response::language,
                                        hmi_apis::FunctionID::VR_GetLanguage,
-                                       interfaces_from_default_);
+                                       default_initialized_capabilities_);
       if (!vr_language_node.isNull()) {
         const std::string lang = vr_language_node.asString();
         set_active_vr_language(MessageHelper::CommonLanguageFromString(lang));
@@ -1448,7 +1448,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto vr_languages_node = json_vr_getter.GetJsonMember(
           hmi_response::languages,
           hmi_apis::FunctionID::VR_GetSupportedLanguages,
-          interfaces_from_default_);
+          default_initialized_capabilities_);
       if (!vr_languages_node.isNull()) {
         smart_objects::SmartObject vr_languages_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
@@ -1460,7 +1460,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto vr_capabilities_node =
           json_vr_getter.GetJsonMember(strings::vr_capabilities,
                                        hmi_apis::FunctionID::VR_GetCapabilities,
-                                       interfaces_from_default_);
+                                       default_initialized_capabilities_);
       if (!vr_capabilities_node.isNull()) {
         smart_objects::SmartObject vr_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
@@ -1481,7 +1481,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto tts_language_node =
           json_tts_getter.GetJsonMember(hmi_response::language,
                                         hmi_apis::FunctionID::TTS_GetLanguage,
-                                        interfaces_from_default_);
+                                        default_initialized_capabilities_);
       if (!tts_language_node.isNull()) {
         const std::string lang = tts_language_node.asString();
         set_active_tts_language(MessageHelper::CommonLanguageFromString(lang));
@@ -1490,7 +1490,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto tts_languages_node = json_tts_getter.GetJsonMember(
           hmi_response::languages,
           hmi_apis::FunctionID::TTS_GetSupportedLanguages,
-          interfaces_from_default_);
+          default_initialized_capabilities_);
       if (!tts_languages_node.isNull()) {
         smart_objects::SmartObject tts_languages_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
@@ -1502,7 +1502,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto tts_speech_capabilities_node = json_tts_getter.GetJsonMember(
           hmi_response::speech_capabilities,
           hmi_apis::FunctionID::TTS_GetCapabilities,
-          interfaces_from_default_);
+          default_initialized_capabilities_);
       if (!tts_speech_capabilities_node.isNull()) {
         smart_objects::SmartObject tts_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
@@ -1515,7 +1515,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
           json_tts_getter.GetJsonMember(
               hmi_response::prerecorded_speech_capabilities,
               hmi_apis::FunctionID::TTS_GetCapabilities,
-              interfaces_from_default_);
+              default_initialized_capabilities_);
       if (!tts_prerecorded_speech_capabilities_node.isNull()) {
         smart_objects::SmartObject tts_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
@@ -1538,7 +1538,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto buttons_capabilities_node = json_buttons_getter.GetJsonMember(
           hmi_response::capabilities,
           hmi_apis::FunctionID::Buttons_GetCapabilities,
-          interfaces_from_default_);
+          default_initialized_capabilities_);
       if (!buttons_capabilities_node.isNull()) {
         smart_objects::SmartObject buttons_capabilities_so;
         formatters::CFormatterJsonBase::jsonValueToObj(
@@ -1583,7 +1583,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto vehicle_type_node = json_vehicle_info_getter.GetJsonMember(
           hmi_response::vehicle_type,
           hmi_apis::FunctionID::VehicleInfo_GetVehicleType,
-          interfaces_from_default_);
+          default_initialized_capabilities_);
       if (!vehicle_type_node.isNull()) {
         smart_objects::SmartObject vehicle_type_so;
         formatters::CFormatterJsonBase::jsonValueToObj(vehicle_type_node,
@@ -1614,8 +1614,8 @@ HMICapabilitiesImpl::GetActiveLanguageForInterface(
 }
 
 std::set<hmi_apis::FunctionID::eType>
-HMICapabilitiesImpl::GetInterfacesFromDefault() const {
-  return interfaces_from_default_;
+HMICapabilitiesImpl::GetDefaultInitializedCapabilities() const {
+  return default_initialized_capabilities_;
 }
 
 bool HMICapabilitiesImpl::AllFieldsSaved(

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -158,6 +158,7 @@ const char* pcm_stream_capabilities = "pcmStreamCapabilities";
 const char* audio_pass_thru_icon = "audioPassThruIcon";
 const char* way_points = "wayPoints";
 const char* system_capability = "systemCapability";
+const char* system_display_capabilities = "systemDisplayCapabilities";
 const char* system_capability_type = "systemCapabilityType";
 const char* system_capabilities = "systemCapabilities";
 const char* navigation_capability = "navigationCapability";

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -439,6 +439,19 @@ const char* const x = "x";
 const char* const y = "y";
 }  // namespace strings
 
+namespace hmi_interface {
+const char* basic_communication = "BasicCommunication";
+const char* buttons = "Buttons";
+const char* navigation = "Navigation";
+const char* sdl = "SDL";
+const char* tts = "TTS";
+const char* ui = "UI";
+const char* vr = "VR";
+const char* rc = "RC";
+const char* vehicle_info = "VehicleInfo";
+const char* app_service = "AppService";
+}  // namespace hmi_interface
+
 namespace json {
 const char* appId = "appId";
 const char* name = "name";

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -72,15 +72,18 @@ class HMICapabilitiesTest : public ::testing::Test {
       : last_state_wrapper_(std::make_shared<resumption::LastStateWrapperImpl>(
             std::make_shared<resumption::LastStateImpl>("app_storage_folder",
                                                         "app_info_storage")))
-      , file_name_("hmi_capabilities.json") {}
+      , file_name_("hmi_capabilities.json")
+      , file_cache_name_("hmi_capabilities_cache.json") {}
   virtual void SetUp() OVERRIDE {
     EXPECT_CALL(app_mngr_, event_dispatcher())
         .WillOnce(ReturnRef(mock_event_dispatcher));
     EXPECT_CALL(app_mngr_, get_settings())
         .WillRepeatedly(ReturnRef(mock_application_manager_settings_));
-    EXPECT_CALL(mock_application_manager_settings_,
-                hmi_capabilities_file_name())
-        .WillOnce(ReturnRef(file_name_));
+    ON_CALL(mock_application_manager_settings_, hmi_capabilities_file_name())
+        .WillByDefault(ReturnRef(file_name_));
+    ON_CALL(mock_application_manager_settings_,
+            hmi_capabilities_cache_file_name())
+        .WillByDefault(ReturnRef(file_cache_name_));
     EXPECT_CALL(mock_event_dispatcher, add_observer(_, _, _)).Times(1);
     EXPECT_CALL(mock_event_dispatcher, remove_observer(_)).Times(1);
     EXPECT_CALL(mock_application_manager_settings_, launch_hmi())
@@ -106,6 +109,7 @@ class HMICapabilitiesTest : public ::testing::Test {
   MockApplicationManagerSettings mock_application_manager_settings_;
   std::shared_ptr<HMICapabilitiesForTesting> hmi_capabilities_test;
   const std::string file_name_;
+  const std::string file_cache_name_;
   application_manager_test::MockRPCService mock_rpc_service_;
 };
 
@@ -506,6 +510,9 @@ TEST_F(HMICapabilitiesTest,
       .WillRepeatedly(ReturnRef(mock_application_manager_settings));
   EXPECT_CALL(mock_application_manager_settings, hmi_capabilities_file_name())
       .WillOnce(ReturnRef(hmi_capabilities_file));
+  EXPECT_CALL(mock_application_manager_settings,
+              hmi_capabilities_cache_file_name())
+      .WillOnce(ReturnRef(file_cache_name_));
   EXPECT_CALL(mock_dispatcher, add_observer(_, _, _)).Times(1);
   EXPECT_CALL(mock_dispatcher, remove_observer(_)).Times(1);
   EXPECT_CALL(mock_application_manager_settings, launch_hmi())
@@ -546,6 +553,9 @@ TEST_F(HMICapabilitiesTest,
       .WillRepeatedly(ReturnRef(mock_application_manager_settings));
   EXPECT_CALL(mock_application_manager_settings, hmi_capabilities_file_name())
       .WillOnce(ReturnRef(hmi_capabilities_file));
+  EXPECT_CALL(mock_application_manager_settings,
+              hmi_capabilities_cache_file_name())
+      .WillOnce(ReturnRef(file_cache_name_));
   EXPECT_CALL(mock_dispatcher, add_observer(_, _, _)).Times(1);
   EXPECT_CALL(mock_dispatcher, remove_observer(_)).Times(1);
   EXPECT_CALL(mock_application_manager_settings, launch_hmi())
@@ -589,6 +599,9 @@ TEST_F(HMICapabilitiesTest,
       .WillRepeatedly(ReturnRef(mock_application_manager_settings));
   EXPECT_CALL(mock_application_manager_settings, hmi_capabilities_file_name())
       .WillOnce(ReturnRef(hmi_capabilities_file));
+  EXPECT_CALL(mock_application_manager_settings,
+              hmi_capabilities_cache_file_name())
+      .WillOnce(ReturnRef(file_cache_name_));
   EXPECT_CALL(mock_dispatcher, add_observer(_, _, _)).Times(1);
   EXPECT_CALL(mock_dispatcher, remove_observer(_)).Times(1);
   EXPECT_CALL(mock_application_manager_settings, launch_hmi())

--- a/src/components/application_manager/test/include/application_manager/hmi_capabilities_for_testing.h
+++ b/src/components/application_manager/test/include/application_manager/hmi_capabilities_for_testing.h
@@ -45,7 +45,7 @@ class HMICapabilitiesForTesting
   HMICapabilitiesForTesting(::application_manager::ApplicationManager& app_mngr)
       : HMICapabilitiesImpl(app_mngr) {}
   bool LoadCapabilitiesFromFile() {
-    return load_capabilities_from_file();
+    return LoadCapabilitiesFromFile();
   }
 };
 

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -212,8 +212,8 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
                     const std::vector<std::string>& sections_to_update,
                     const smart_objects::CSmartSchema& schema));
   MOCK_CONST_METHOD0(DeleteCachedCapabilitiesFile, void());
-  MOCK_CONST_METHOD0(GetInterfacesToUpdate,
-                     std::vector<hmi_apis::FunctionID::eType>());
+  MOCK_CONST_METHOD0(GetInterfacesFromDefault,
+                     std::set<hmi_apis::FunctionID::eType>());
 };
 
 }  // namespace application_manager_test

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -207,22 +207,11 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
                application_manager::HMILanguageHandler&());
   MOCK_METHOD1(set_handle_response_for,
                void(const smart_objects::SmartObject& request));
-  MOCK_METHOD2(SaveCachedCapabilitiesToFile,
-               bool(const std::vector<std::string> sections_to_update,
+  MOCK_METHOD3(SaveCachedCapabilitiesToFile,
+               bool(const std::string& interface_name,
+                    const std::vector<std::string>& sections_to_update,
                     const smart_objects::CSmartSchema& schema));
   MOCK_CONST_METHOD0(DeleteCachedCapabilitiesFile, void());
-
- protected:
-  MOCK_CONST_METHOD2(check_existing_json_member,
-                     bool(const Json::Value& json_member,
-                          const char* name_of_member));
-
-  MOCK_CONST_METHOD2(convert_json_languages_to_obj,
-                     void(const Json::Value& json_languages,
-                          smart_objects::SmartObject& languages));
-  MOCK_CONST_METHOD2(convert_audio_capability_to_obj,
-                     void(const Json::Value& capability,
-                          smart_objects::SmartObject& output_so));
 };
 
 }  // namespace application_manager_test

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -207,6 +207,10 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
                application_manager::HMILanguageHandler&());
   MOCK_METHOD1(set_handle_response_for,
                void(const smart_objects::SmartObject& request));
+  MOCK_METHOD2(SaveCachedCapabilitiesToFile,
+               bool(const std::vector<std::string> sections_to_update,
+                    const smart_objects::CSmartSchema& schema));
+  MOCK_CONST_METHOD0(DeleteCachedCapabilitiesFile, void());
 
  protected:
   MOCK_CONST_METHOD2(check_existing_json_member,

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -75,7 +75,7 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
                void(const hmi_apis::Common_Language::eType language));
 
   MOCK_CONST_METHOD0(ui_supported_languages,
-                     const smart_objects::SmartObject*());
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(set_ui_supported_languages,
                void(const smart_objects::SmartObject& supported_languages));
 
@@ -85,7 +85,7 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
                void(const hmi_apis::Common_Language::eType language));
 
   MOCK_CONST_METHOD0(vr_supported_languages,
-                     const smart_objects::SmartObject*());
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(set_vr_supported_languages,
                void(const smart_objects::SmartObject& supported_languages));
 
@@ -95,7 +95,7 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
                void(const hmi_apis::Common_Language::eType language));
 
   MOCK_CONST_METHOD0(tts_supported_languages,
-                     const smart_objects::SmartObject*());
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(set_tts_supported_languages,
                void(const smart_objects::SmartObject& supported_languages));
 
@@ -173,25 +173,25 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
   MOCK_METHOD1(set_rc_supported, void(const bool supported));
 
   MOCK_CONST_METHOD0(navigation_capability,
-                     const smart_objects::SmartObject*());
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(set_navigation_capability,
                void(const smart_objects::SmartObject& navigation_capability));
 
-  MOCK_CONST_METHOD0(phone_capability, const smart_objects::SmartObject*());
+  MOCK_CONST_METHOD0(phone_capability, const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(set_phone_capability,
                void(const smart_objects::SmartObject& phone_capability));
 
   MOCK_CONST_METHOD0(video_streaming_capability,
-                     const smart_objects::SmartObject*());
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(
       set_video_streaming_capability,
       void(const smart_objects::SmartObject& video_streaming_capability));
-  MOCK_CONST_METHOD0(rc_capability, const smart_objects::SmartObject*());
+  MOCK_CONST_METHOD0(rc_capability, const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(set_rc_capability,
                void(const smart_objects::SmartObject& rc_capability));
 
   MOCK_CONST_METHOD0(seat_location_capability,
-                     const smart_objects::SmartObject*());
+                     const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(
       set_seat_location_capability,
       void(const smart_objects::SmartObject& seat_location_capability));

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -212,7 +212,7 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
                     const std::vector<std::string>& sections_to_update,
                     const smart_objects::CSmartSchema& schema));
   MOCK_CONST_METHOD0(DeleteCachedCapabilitiesFile, bool());
-  MOCK_CONST_METHOD0(GetInterfacesFromDefault,
+  MOCK_CONST_METHOD0(GetDefaultInitializedCapabilities,
                      std::set<hmi_apis::FunctionID::eType>());
 };
 

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -211,7 +211,7 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
                bool(const std::string& interface_name,
                     const std::vector<std::string>& sections_to_update,
                     const smart_objects::CSmartSchema& schema));
-  MOCK_CONST_METHOD0(DeleteCachedCapabilitiesFile, void());
+  MOCK_CONST_METHOD0(DeleteCachedCapabilitiesFile, bool());
   MOCK_CONST_METHOD0(GetInterfacesFromDefault,
                      std::set<hmi_apis::FunctionID::eType>());
 };

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -212,6 +212,8 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
                     const std::vector<std::string>& sections_to_update,
                     const smart_objects::CSmartSchema& schema));
   MOCK_CONST_METHOD0(DeleteCachedCapabilitiesFile, void());
+  MOCK_CONST_METHOD0(GetInterfacesToUpdate,
+                     std::vector<hmi_apis::FunctionID::eType>());
 };
 
 }  // namespace application_manager_test

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -212,6 +212,12 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   const std::string& hmi_capabilities_file_name() const;
 
   /**
+   * @brief Returns hmi capabilities cache file name
+   * @return hmi capabilities cache file name
+   */
+  const std::string& hmi_capabilities_cache_file_name() const;
+
+  /**
    * @brief Returns help promt vector
    */
   const std::vector<std::string>& help_prompt() const;
@@ -951,6 +957,7 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   uint32_t stop_streaming_timeout_;
   uint16_t time_testing_port_;
   std::string hmi_capabilities_file_name_;
+  std::string hmi_capabilities_cache_file_name_;
   std::vector<std::string> help_prompt_;
   std::vector<std::string> time_out_promt_;
   std::vector<std::string> vr_commands_;

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -101,6 +101,7 @@ const char* kRCModuleConsentSection = "RCModuleConsent";
 
 const char* kSDLVersionKey = "SDLVersion";
 const char* kHmiCapabilitiesKey = "HMICapabilities";
+const char* kHmiCapabilitiesCacheFileKey = "HMICapabilitiesCacheFile";
 const char* kPathToSnapshotKey = "PathToSnapshot";
 const char* kPreloadedPTKey = "PreloadedPT";
 const char* kAttemptsToOpenPolicyDBKey = "AttemptsToOpenPolicyDB";
@@ -303,6 +304,8 @@ const char* kDefaultLinkToWebHMI = "HMI/index.html";
 #endif  // WEB_HMI
 const char* kDefaultPoliciesSnapshotFileName = "sdl_snapshot.json";
 const char* kDefaultHmiCapabilitiesFileName = "hmi_capabilities.json";
+const char* kDefaultHmiCapabilitiesCacheFileName =
+    "hmi_capabilities_cache.json";
 const char* kDefaultPreloadedPTFileName = "sdl_preloaded_pt.json";
 const char* kDefaultServerAddress = "127.0.0.1";
 const char* kDefaultAppInfoFileName = "app_info.dat";
@@ -461,6 +464,7 @@ Profile::Profile()
     , stop_streaming_timeout_(kDefaultStopStreamingTimeout)
     , time_testing_port_(kDefaultTimeTestingPort)
     , hmi_capabilities_file_name_(kDefaultHmiCapabilitiesFileName)
+    , hmi_capabilities_cache_file_name_(kDefaultHmiCapabilitiesCacheFileName)
     , help_prompt_()
     , time_out_promt_()
     , min_tread_stack_size_(threads::Thread::kMinStackSize)
@@ -633,6 +637,10 @@ size_t Profile::maximum_video_payload_size() const {
 
 const std::string& Profile::hmi_capabilities_file_name() const {
   return hmi_capabilities_file_name_;
+}
+
+const std::string& Profile::hmi_capabilities_cache_file_name() const {
+  return hmi_capabilities_cache_file_name_;
 }
 
 const std::string& Profile::server_address() const {
@@ -1291,6 +1299,19 @@ void Profile::UpdateValues() {
   }
 
   LOG_UPDATED_VALUE(app_storage_folder_, kAppStorageFolderKey, kMainSection);
+
+  // HMI capabilities cache file
+  ReadStringValue(&hmi_capabilities_cache_file_name_,
+                  kDefaultHmiCapabilitiesCacheFileName,
+                  kMainSection,
+                  kHmiCapabilitiesCacheFileKey);
+
+  hmi_capabilities_cache_file_name_ =
+      app_storage_folder_ + "/" + hmi_capabilities_cache_file_name_;
+
+  LOG_UPDATED_VALUE(hmi_capabilities_cache_file_name_,
+                    kHmiCapabilitiesCacheFileKey,
+                    kMainSection);
 
   // Application resourse folder
   ReadStringValue(&app_resource_folder_,

--- a/src/components/include/application_manager/application_manager_settings.h
+++ b/src/components/include/application_manager/application_manager_settings.h
@@ -74,6 +74,7 @@ class ApplicationManagerSettings : public RequestControlerSettings,
   virtual const std::string& sdl_version() const = 0;
   virtual const std::vector<std::string>& time_out_promt() const = 0;
   virtual const std::string& hmi_capabilities_file_name() const = 0;
+  virtual const std::string& hmi_capabilities_cache_file_name() const = 0;
   virtual const std::string& video_server_type() const = 0;
   virtual const std::string& audio_server_type() const = 0;
   virtual const std::string& server_address() const = 0;

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -512,7 +512,7 @@ class HMICapabilities {
   /**
    * @brief Deletes cached HMI capabilities file from a file system
    */
-  virtual void DeleteCachedCapabilitiesFile() const = 0;
+  virtual bool DeleteCachedCapabilitiesFile() const = 0;
 
   virtual std::set<hmi_apis::FunctionID::eType> GetInterfacesFromDefault()
       const = 0;

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -497,6 +497,7 @@ class HMICapabilities {
   /**
    * @brief Writes cached HMI capabilities from internal cache into the file if
    * any of updated sections are not present in the file
+   * @param interface_name name of interface to be updated
    * @param sections_to_update vector of names of sections which were updated in
    * cache
    * @param schema reference to schema which should be unapplied before saving
@@ -504,43 +505,14 @@ class HMICapabilities {
    * @return true if cache was saved successfully, otherwise returns false
    */
   virtual bool SaveCachedCapabilitiesToFile(
-      const std::vector<std::string> sections_to_update,
+      const std::string& interface_name,
+      const std::vector<std::string>& sections_to_update,
       const smart_objects::CSmartSchema& schema) = 0;
 
   /**
    * @brief Deletes cached HMI capabilities file from a file system
    */
   virtual void DeleteCachedCapabilitiesFile() const = 0;
-
- protected:
-  /*
-   * @brief function checks if json member exists
-   *
-   * @param json_member from file hmi_capabilities.json
-   * @param name_of_member name which we should check
-   *     hmi_capabilities.json
-   *
-   * @returns TRUE if member exists and returns FALSE if
-   * member does not exist.
-   */
-  virtual bool check_existing_json_member(const Json::Value& json_member,
-                                          const char* name_of_member) const = 0;
-
-  virtual void convert_json_languages_to_obj(
-      const Json::Value& json_languages,
-      smart_objects::SmartObject& languages) const = 0;
-
-  /*
-   * @brief function that converts a single entry of audio pass thru capability
-   *        to smart object
-   *
-   * @param capability json object that represents a single entry of audio pass
-   *        thru capability
-   * @param output_so the converted object
-   */
-  virtual void convert_audio_capability_to_obj(
-      const Json::Value& capability,
-      smart_objects::SmartObject& output_so) const = 0;
 };
 
 }  //  namespace application_manager

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -514,8 +514,13 @@ class HMICapabilities {
    */
   virtual bool DeleteCachedCapabilitiesFile() const = 0;
 
-  virtual std::set<hmi_apis::FunctionID::eType> GetInterfacesFromDefault()
-      const = 0;
+  /**
+   * @brief Returns collection of requests that should be send to
+   * the HMI to get required HMI capabilities, that was missing in the cache
+   * @return set of function id's
+   */
+  virtual std::set<hmi_apis::FunctionID::eType>
+  GetDefaultInitializedCapabilities() const = 0;
 };
 
 }  //  namespace application_manager

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -544,6 +544,24 @@ class HMICapabilities {
   virtual void set_handle_response_for(
       const smart_objects::SmartObject& request) = 0;
 
+  /**
+   * @brief Writes cached HMI capabilities from internal cache into the file if
+   * any of updated sections are not present in the file
+   * @param sections_to_update vector of names of sections which were updated in
+   * cache
+   * @param schema reference to schema which should be unapplied before saving
+   * stringified JSON data into the file
+   * @return true if cache was saved successfully, otherwise returns false
+   */
+  virtual bool SaveCachedCapabilitiesToFile(
+      const std::vector<std::string> sections_to_update,
+      const smart_objects::CSmartSchema& schema) = 0;
+
+  /**
+   * @brief Deletes cached HMI capabilities file from a file system
+   */
+  virtual void DeleteCachedCapabilitiesFile() const = 0;
+
  protected:
   /*
    * @brief function checks if json member exists

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -140,7 +140,8 @@ class HMICapabilities {
    *
    * @return Currently supported UI languages
    */
-  virtual const smart_objects::SmartObject* ui_supported_languages() const = 0;
+  virtual const smart_objects::SmartObjectSPtr ui_supported_languages()
+      const = 0;
 
   /*
    * @brief Sets supported UI languages
@@ -170,7 +171,8 @@ class HMICapabilities {
    *
    * @return Currently supported VR languages
    */
-  virtual const smart_objects::SmartObject* vr_supported_languages() const = 0;
+  virtual const smart_objects::SmartObjectSPtr vr_supported_languages()
+      const = 0;
 
   /*
    * @brief Sets supported VR languages
@@ -201,7 +203,8 @@ class HMICapabilities {
    *
    * @return Currently supported TTS languages
    */
-  virtual const smart_objects::SmartObject* tts_supported_languages() const = 0;
+  virtual const smart_objects::SmartObjectSPtr tts_supported_languages()
+      const = 0;
 
   /*
    * @brief Sets supported TTS languages
@@ -468,7 +471,8 @@ class HMICapabilities {
    *
    * @return NAVIGATION system capability
    */
-  virtual const smart_objects::SmartObject* navigation_capability() const = 0;
+  virtual const smart_objects::SmartObjectSPtr navigation_capability()
+      const = 0;
 
   /*
    * @brief Interface used to store information regarding
@@ -485,7 +489,7 @@ class HMICapabilities {
    *
    * @return PHONE_CALL system capability
    */
-  virtual const smart_objects::SmartObject* phone_capability() const = 0;
+  virtual const smart_objects::SmartObjectSPtr phone_capability() const = 0;
 
   /*
    * @brief Sets HMI's video streaming related capability information
@@ -500,7 +504,7 @@ class HMICapabilities {
    *
    * @return HMI's video streaming related capability information
    */
-  virtual const smart_objects::SmartObject* video_streaming_capability()
+  virtual const smart_objects::SmartObjectSPtr video_streaming_capability()
       const = 0;
 
   /**
@@ -510,7 +514,7 @@ class HMICapabilities {
   virtual void set_rc_capability(
       const smart_objects::SmartObject& rc_capability) = 0;
 
-  virtual const smart_objects::SmartObject* rc_capability() const = 0;
+  virtual const smart_objects::SmartObjectSPtr rc_capability() const = 0;
 
   /**
    * @brief Sets available SeatLocation capabilities for further usage by
@@ -525,7 +529,7 @@ class HMICapabilities {
    * seat location capability
    * @return smart object of seat location capability
    */
-  virtual const smart_objects::SmartObject* seat_location_capability()
+  virtual const smart_objects::SmartObjectSPtr seat_location_capability()
       const = 0;
 
   DEPRECATED

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -46,9 +46,8 @@ class ApplicationManager;
 
 class HMICapabilities {
  public:
-  /*
+  /**
    * @brief Class destructor
-   *
    */
   virtual ~HMICapabilities() {}
 
@@ -59,7 +58,7 @@ class HMICapabilities {
    */
   virtual HMILanguageHandler& get_hmi_language_handler() = 0;
 
-  /*
+  /**
    * @brief Checks if image type(Static/Dynamic) requested by
    * Mobile Device is supported on current HMI.
    * @param image_type received type of image from Enum.
@@ -69,7 +68,6 @@ class HMICapabilities {
 
   /**
    * @brief Checks if all HMI capabilities received
-   *
    * @return TRUE if all information received, otherwise FALSE
    */
   virtual bool is_vr_cooperating() const = 0;
@@ -90,418 +88,366 @@ class HMICapabilities {
   virtual bool is_rc_cooperating() const = 0;
   virtual void set_is_rc_cooperating(const bool value) = 0;
 
-  /*
+  /**
    * @brief Interface used to store information about software version of the
-   *target
-   *
+   * target
    * @param ccpu_version Received system/hmi software version
    */
   virtual void set_ccpu_version(const std::string& ccpu_version) = 0;
 
-  /*
+  /**
    * @brief Returns software version of the target
-   *
    * @return TRUE if it supported, otherwise FALSE
    */
   virtual const std::string& ccpu_version() const = 0;
 
-  /*
+  /**
    * @brief Retrieves if mixing audio is supported by HMI
    * (ie recording TTS command and playing audio)
-   *
    * @return Current state of the mixing audio flag
    */
   virtual bool attenuated_supported() const = 0;
 
-  /*
+  /**
    * @brief Sets state for mixing audio
-   *
    * @param state New state to be set
    */
   virtual void set_attenuated_supported(const bool state) = 0;
 
-  /*
+  /**
    * @brief Retrieves currently active UI language
-   *
    * @return Currently active UI language
    */
   virtual const hmi_apis::Common_Language::eType active_ui_language() const = 0;
 
-  /*
+  /**
    * @brief Sets currently active UI language
-   *
    * @param language Currently active UI language
    */
   virtual void set_active_ui_language(
       const hmi_apis::Common_Language::eType language) = 0;
 
-  /*
+  /**
    * @brief Retrieves UI supported languages
-   *
    * @return Currently supported UI languages
    */
   virtual const smart_objects::SmartObjectSPtr ui_supported_languages()
       const = 0;
 
-  /*
+  /**
    * @brief Sets supported UI languages
-   *
    * @param supported_languages Supported UI languages
    */
   virtual void set_ui_supported_languages(
       const smart_objects::SmartObject& supported_languages) = 0;
 
-  /*
+  /**
    * @brief Retrieves currently active VR language
-   *
    * @return Currently active VR language
    */
   virtual const hmi_apis::Common_Language::eType active_vr_language() const = 0;
 
-  /*
+  /**
    * @brief Sets currently active VR language
-   *
    * @param language Currently active VR language
    */
   virtual void set_active_vr_language(
       const hmi_apis::Common_Language::eType language) = 0;
 
-  /*
+  /**
    * @brief Retrieves VR supported languages
-   *
    * @return Currently supported VR languages
    */
   virtual const smart_objects::SmartObjectSPtr vr_supported_languages()
       const = 0;
 
-  /*
+  /**
    * @brief Sets supported VR languages
-   *
    * @param supported_languages Supported VR languages
    */
   virtual void set_vr_supported_languages(
       const smart_objects::SmartObject& supported_languages) = 0;
 
-  /*
+  /**
    * @brief Retrieves currently active TTS language
-   *
    * @return Currently active TTS language
    */
   virtual const hmi_apis::Common_Language::eType active_tts_language()
       const = 0;
 
-  /*
+  /**
    * @brief Sets currently active TTS language
-   *
    * @param language Currently active TTS language
    */
   virtual void set_active_tts_language(
       const hmi_apis::Common_Language::eType language) = 0;
 
-  /*
+  /**
    * @brief Retrieves TTS  supported languages
-   *
    * @return Currently supported TTS languages
    */
   virtual const smart_objects::SmartObjectSPtr tts_supported_languages()
       const = 0;
 
-  /*
+  /**
    * @brief Sets supported TTS languages
-   *
    * @param supported_languages Supported TTS languages
    */
   virtual void set_tts_supported_languages(
       const smart_objects::SmartObject& supported_languages) = 0;
 
-  /*
+  /**
    * @brief Retrieves information about the display capabilities
-   *
    * @return Currently supported display capabilities
    */
   virtual const smart_objects::SmartObjectSPtr display_capabilities() const = 0;
 
-  /*
+  /**
    * @brief Sets supported display capabilities
-   *
    * @param display_capabilities supported display capabilities
    */
   virtual void set_display_capabilities(
       const smart_objects::SmartObject& display_capabilities) = 0;
 
-  /*
+  /**
    * @brief Retrieves information about the display capability
    * @return Currently supported display capability
    */
   virtual const smart_objects::SmartObjectSPtr system_display_capabilities()
       const = 0;
 
-  /*
+  /**
    * @brief Sets supported display capability
    * @param display_capabilities supported display capability
    */
   virtual void set_system_display_capabilities(
       const smart_objects::SmartObject& display_capabilities) = 0;
 
-  /*
+  /**
    * @brief Retrieves information about the HMI zone capabilities
-   *
    * @return Currently supported HMI zone capabilities
    */
   virtual const smart_objects::SmartObjectSPtr hmi_zone_capabilities()
       const = 0;
 
-  /*
+  /**
    * @brief Sets supported HMI zone capabilities
-   *
    * @param hmi_zone_capabilities supported HMI zone capabilities
    */
   virtual void set_hmi_zone_capabilities(
       const smart_objects::SmartObject& hmi_zone_capabilities) = 0;
 
-  /*
+  /**
    * @brief Retrieves information about the SoftButton's capabilities
-   *
    * @return Currently supported SoftButton's capabilities
    */
   virtual const smart_objects::SmartObjectSPtr soft_button_capabilities()
       const = 0;
 
-  /*
+  /**
    * @brief Sets supported SoftButton's capabilities
-   *
    * @param soft_button_capabilities supported SoftButton's capabilities
    */
   virtual void set_soft_button_capabilities(
       const smart_objects::SmartObject& soft_button_capabilities) = 0;
 
-  /*
+  /**
    * @brief Retrieves information about the Button's capabilities
-   *
    * @return Currently supported Button's capabilities
    */
   virtual const smart_objects::SmartObjectSPtr button_capabilities() const = 0;
 
-  /*
+  /**
    * @brief Sets supported Button's capabilities
-   *
    * @param soft_button_capabilities supported Button's capabilities
    */
   virtual void set_button_capabilities(
       const smart_objects::SmartObject& button_capabilities) = 0;
 
-  /*
+  /**
    * @brief Sets supported speech capabilities
-   *
    * @param speech_capabilities supported speech capabilities
    */
   virtual void set_speech_capabilities(
       const smart_objects::SmartObject& speech_capabilities) = 0;
 
-  /*
+  /**
    * @brief Retrieves information about the speech capabilities
-   *
    * @return Currently supported speech capabilities
    */
   virtual const smart_objects::SmartObjectSPtr speech_capabilities() const = 0;
 
-  /*
+  /**
    * @brief Sets supported VR capabilities
-   *
    * @param vr_capabilities supported VR capabilities
    */
   virtual void set_vr_capabilities(
       const smart_objects::SmartObject& vr_capabilities) = 0;
 
-  /*
+  /**
    * @brief Retrieves information about the VR capabilities
-   *
    * @return Currently supported VR capabilities
    */
   virtual const smart_objects::SmartObjectSPtr vr_capabilities() const = 0;
 
-  /*
+  /**
    * @brief Sets supported audio_pass_thru capabilities
-   *
    * @param vr_capabilities supported audio_pass_thru capabilities
    */
   virtual void set_audio_pass_thru_capabilities(
       const smart_objects::SmartObject& audio_pass_thru_capabilities) = 0;
 
-  /*
+  /**
    * @brief Retrieves information about the audio_pass_thru capabilities
-   *
    * @return Currently supported audio_pass_thru capabilities
    */
   virtual const smart_objects::SmartObjectSPtr audio_pass_thru_capabilities()
       const = 0;
 
-  /*
+  /**
    * @brief Sets supported pcm_stream capabilities
-   *
    * @param supported pcm_stream capabilities
    */
   virtual void set_pcm_stream_capabilities(
       const smart_objects::SmartObject& pcm_stream_capabilities) = 0;
 
-  /*
+  /**
    * @brief Retrieves information about the pcm_stream capabilities
-   *
    * @return Currently supported pcm_streaming capabilities
    */
   virtual const smart_objects::SmartObjectSPtr pcm_stream_capabilities()
       const = 0;
 
-  /*
+  /**
    * @brief Retrieves information about the preset bank capabilities
-   *
    * @return Currently supported preset bank capabilities
    */
   virtual const smart_objects::SmartObjectSPtr preset_bank_capabilities()
       const = 0;
 
-  /*
+  /**
    * @brief Sets supported preset bank capabilities
-   *
    * @param soft_button_capabilities supported preset bank capabilities
    */
   virtual void set_preset_bank_capabilities(
       const smart_objects::SmartObject& preset_bank_capabilities) = 0;
 
-  /*
+  /**
    * @brief Sets vehicle information(make, model, modelYear)
-   *
-   * @param vehicle_type Cuurent vehicle information
+   * @param vehicle_type vehicle information
    */
   virtual void set_vehicle_type(
       const smart_objects::SmartObject& vehicle_type) = 0;
 
-  /*
+  /**
    * @brief Retrieves vehicle information(make, model, modelYear)
-   *
-   * @param vehicle_type Cuurent vehicle information
+   * @param vehicle_type Current vehicle information
    */
   virtual const smart_objects::SmartObjectSPtr vehicle_type() const = 0;
 
-  /*
+  /**
    * @brief Retrieves information about the prerecorded speech
-   *
    * @return Currently supported prerecorded speech
    */
   virtual const smart_objects::SmartObjectSPtr prerecorded_speech() const = 0;
 
-  /*
+  /**
    * @brief Sets supported prerecorded speech
-   *
    * @param prerecorded_speech supported prerecorded speech
    */
   virtual void set_prerecorded_speech(
       const smart_objects::SmartObject& prerecorded_speech) = 0;
 
-  /*
+  /**
    * @brief Interface used to store information if navigation
    * supported by the system
-   *
    * @param supported Indicates if navigation supported by the system
    */
   virtual void set_navigation_supported(const bool supported) = 0;
 
-  /*
+  /**
    * @brief Retrieves information if navi supported by the system
-   *
    * @return TRUE if it supported, otherwise FALSE
    */
   virtual bool navigation_supported() const = 0;
 
-  /*
+  /**
    * @brief Interface used to store information if phone call
    * supported by the system
-   *
    * @param supported Indicates if navigation supported by the sustem
    */
   virtual void set_phone_call_supported(const bool supported) = 0;
 
-  /*
+  /**
    * @brief Retrieves information if phone call supported by the system
-   *
    * @return TRUE if it supported, otherwise FALSE
    */
   virtual bool phone_call_supported() const = 0;
 
-  /*
+  /**
    * @brief Interface to store whether HMI supports video streaming
-   *
    * @param supported Indicates whether video streaming is supported by HMI
    */
   virtual void set_video_streaming_supported(const bool supported) = 0;
 
-  /*
+  /**
    * @brief Retrieves whether HMI supports video streaming
-   *
    * @return TRUE if it supported, otherwise FALSE
    */
   virtual bool video_streaming_supported() const = 0;
 
-  /*
+  /**
    * @brief Interface to store whether HMI supports remote control
-   *
-   * @param supported Indicates whether remote control is supported by HMI
+   * @param supported Indicates whether video streaming is supported by HMI
    */
   virtual void set_rc_supported(const bool supported) = 0;
 
-  /*
+  /**
    * @brief Retrieves whether HMI supports remote control
-   *
    * @return TRUE if it supported, otherwise FALSE
    */
   virtual bool rc_supported() const = 0;
 
-  /*
+  /**
    * @brief Interface used to store information regarding
    * the navigation "System Capability"
-   *
    * @param navigation_capability contains information related
    * to the navigation system capability.
    */
   virtual void set_navigation_capability(
       const smart_objects::SmartObject& navigation_capability) = 0;
 
-  /*
+  /**
    * @brief Retrieves information regarding the navigation system capability
-   *
    * @return NAVIGATION system capability
    */
   virtual const smart_objects::SmartObjectSPtr navigation_capability()
       const = 0;
 
-  /*
+  /**
    * @brief Interface used to store information regarding
    * the phone "System Capability"
-   *
    * @param phone_capability contains information related
    * to the phone system capability.
    */
   virtual void set_phone_capability(
       const smart_objects::SmartObject& phone_capability) = 0;
 
-  /*
+  /**
    * @brief Retrieves information regarding the phone call system capability
-   *
    * @return PHONE_CALL system capability
    */
   virtual const smart_objects::SmartObjectSPtr phone_capability() const = 0;
 
-  /*
+  /**
    * @brief Sets HMI's video streaming related capability information
-   *
    * @param video_streaming_capability the video streaming related capabilities
    */
   virtual void set_video_streaming_capability(
       const smart_objects::SmartObject& video_streaming_capability) = 0;
 
-  /*
+  /**
    * @brief Retrieves HMI's video streaming related capabilities
-   *
    * @return HMI's video streaming related capability information
    */
   virtual const smart_objects::SmartObjectSPtr video_streaming_capability()
@@ -514,6 +460,10 @@ class HMICapabilities {
   virtual void set_rc_capability(
       const smart_objects::SmartObject& rc_capability) = 0;
 
+  /**
+   * @brief Retrieves information regarding the remote control capabilities
+   * @return RC capabilities
+   */
   virtual const smart_objects::SmartObjectSPtr rc_capability() const = 0;
 
   /**

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -514,7 +514,7 @@ class HMICapabilities {
    */
   virtual void DeleteCachedCapabilitiesFile() const = 0;
 
-  virtual std::vector<hmi_apis::FunctionID::eType> GetInterfacesToUpdate()
+  virtual std::set<hmi_apis::FunctionID::eType> GetInterfacesFromDefault()
       const = 0;
 };
 

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -513,6 +513,9 @@ class HMICapabilities {
    * @brief Deletes cached HMI capabilities file from a file system
    */
   virtual void DeleteCachedCapabilitiesFile() const = 0;
+
+  virtual std::vector<hmi_apis::FunctionID::eType> GetInterfacesToUpdate()
+      const = 0;
 };
 
 }  //  namespace application_manager

--- a/src/components/include/test/application_manager/mock_application_manager_settings.h
+++ b/src/components/include/test/application_manager/mock_application_manager_settings.h
@@ -80,6 +80,7 @@ class MockApplicationManagerSettings
   MOCK_CONST_METHOD0(sdl_version, const std::string&());
   MOCK_CONST_METHOD0(time_out_promt, const std::vector<std::string>&());
   MOCK_CONST_METHOD0(hmi_capabilities_file_name, const std::string&());
+  MOCK_CONST_METHOD0(hmi_capabilities_cache_file_name, const std::string&());
   MOCK_CONST_METHOD0(video_server_type, const std::string&());
   MOCK_CONST_METHOD0(audio_server_type, const std::string&());
   MOCK_CONST_METHOD0(server_address, const std::string&());


### PR DESCRIPTION
This PR is part of https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0249-Persisting-HMI-Capabilities-specific-to-headunit.md proposal implementation

### Risk
This PR makes **[no]** API changes.

### Testing Plan
unit tests

### Summary

Config Changes:

    SDL Core should add a new variable in SmartDeviceLink.ini named HMICapabilitiesCacheFile which stores name of cache file.
        If this variable is null/empty, SDL Core should not persist HMI Capabilities received from headunit.
        Else, SDL Core should persist HMI Capabilities received from headunit as per functional logic below.

 
Functional Changes:

    During boot up, SDL Core should check if HMICapabilitiesCacheFile file is present in AppStorageFolder from smartDeviceLink.ini
        If present, SDL Core loads the contents of the file and uses that as current system HMI capabilities.
            In case any capability is missing, SDL Core should default back to hmi_capabilities.json file for corresponding capability and should send requests to get these capabilities from HMI.
            If not present, SDL Core should create the file and should send requests to get all HMI capabilities from HMI. (see Static section above)
    SDL Core, upon receiving HMI response for any of the UI/VR/TTS/Buttons/VehicleInfo/Navigation/RC capabilities, should check if HMICapabilitiesCacheFile file already has the data set received in HMI response
        If no :
            Write the response data to HMICapabilitiesCacheFile file
            Do not send corresponding request to get HMI capabilities to HMI for subsequent ignition cycles. SDL Core should still follow rest of launch sequence requests/notifications as applicable.
            SDL Core should use this new data set for usages by apps/SDL Core communication until ignition cycle is performed
        If yes :
            Do not overwrite the response to HMICapabilitiesCacheFile file
            Do not send corresponding request to get HMI capabilities to HMI for subsequent ignition cycles. SDL Core should still follow rest of launch sequence.
    SDL Core, upon receiving HMI response for UI.OnLanguageChange, TTS.OnLanguageChange and VR.OnLanguageChange (Dynamic APIs), should override point 2 with following requirements
        Overwrite contents of received responses/notifications in hmi_capabilities_cache.json file.
        Should use this new data set for usages by apps/SDL Core communication until ignition cycle is performed.
    In all cases above, SDL Core should still send IsReady requests to HMI for all applicable interfaces.
    SDL Core should delete the HMICapabilitiesCacheFile file when a master reset is performed.
    SDL Core should regenerate HMICapabilitiesCacheFile file when system SW version changes, as per below flow.



### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
