### PR TITLE
don't send onSystemRequest LOCK_SCREEN_ICON_URL to mobile if url is m…

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_request_notification.cc
@@ -126,9 +126,7 @@ void OnSystemRequestNotification::Run() {
 
   if (mobile_apis::RequestType::OEM_SPECIFIC == request_type) {
     (*message_)[strings::params][strings::binary_data] = binary_data;
-  }
-
-  if (mobile_apis::RequestType::PROPRIETARY == request_type) {
+  } else if (mobile_apis::RequestType::PROPRIETARY == request_type) {
     /* According to requirements:
        "If the requestType = PROPRIETARY, add to mobile API fileType = JSON
         If the requestType = HTTP, add to mobile API fileType = BINARY"
@@ -144,13 +142,18 @@ void OnSystemRequestNotification::Run() {
 #endif  // PROPRIETARY_MODE
 
     (*message_)[strings::msg_params][strings::file_type] = FileType::JSON;
-  }
-
-  if (mobile_apis::RequestType::HTTP == request_type) {
+  } else if (mobile_apis::RequestType::HTTP == request_type) {
     (*message_)[strings::msg_params][strings::file_type] = FileType::BINARY;
     if ((*message_)[strings::msg_params].keyExists(strings::url)) {
       (*message_)[strings::msg_params][strings::timeout] =
           policy_handler.TimeoutExchangeSec();
+    }
+  } else if (mobile_apis::RequestType::LOCK_SCREEN_ICON_URL == request_type) {
+    if (!(*message_)[strings::msg_params].keyExists(strings::url) ||
+        (*message_)[strings::msg_params][strings::url].empty()) {
+      LOG4CXX_ERROR(logger_,
+                    "discarding LOCK_SCREEN_ICON_URL request without URL");
+      return;
     }
   }
 


### PR DESCRIPTION
Fixes #2932

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manually tested by editing preloaded policy table

### Summary
- change mutually exclusive if statements to else ifs
- add case for OnSystemRequest LOCK_SCREEN_ICON_URL
  - dont send notification if url is missing or empty

### Changelog
##### Bug Fixes
* a useless and possibly confusing message will no longer be sent

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
