### PR TITLE
Remove intendation for policy table snapshot

### DIFF
--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -708,6 +708,7 @@ void PolicyManagerImpl::RequestPTUpdate() {
   if (IsPTValid(policy_table_snapshot, policy_table::PT_SNAPSHOT)) {
     Json::Value value = policy_table_snapshot->ToJsonValue();
     Json::StreamWriterBuilder writer_builder;
+    writer_builder["indentation"] = "";
     std::string message_string = Json::writeString(writer_builder, value);
 
     LOG4CXX_DEBUG(logger_, "Snapshot contents is : " << message_string);

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -617,6 +617,7 @@ bool PolicyManagerImpl::RequestPTUpdate(const PTUIterationType iteration_type) {
 
   Json::Value value = policy_table_snapshot->ToJsonValue();
   Json::StreamWriterBuilder writer_builder;
+  writer_builder["indentation"] = "";
   std::string message_string = Json::writeString(writer_builder, value);
 
   LOG4CXX_DEBUG(logger_, "Snapshot contents is : " << message_string);


### PR DESCRIPTION
Fixes #3260 

This PR is **ready** for review.

### Risk
This PR makes *no* API changes.

### Testing Plan
Connect ios app and verify that OnSystemRequest for a PTU is successful. 

### Summary
The new json cpp submodule has a default indentation value of "\t". These characters were being written into the policy table snapshot and were causing the ios json parser to fail. For the ptu json writer i set the indentation to "" which removes any whitespace characters. This new behavior aligns with how the deprecated json writer worked.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
