### PR TITLE
Fix result code generic error while subscribing to vehicle data

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/subscribe_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/subscribe_vehicle_data_request.h
@@ -108,9 +108,8 @@ class SubscribeVehicleDataRequest
    * @param app Pointer to application sent subscribe request
    * @param msg_params 'message_parameters' response section reference
    */
-  bool SubscribePendingVehicleData(
-      app_mngr::ApplicationSharedPtr app,
-      const smart_objects::SmartObject& msg_params);
+  bool SubscribePendingVehicleData(app_mngr::ApplicationSharedPtr app,
+                                   smart_objects::SmartObject& msg_params);
 
   /**
    * @brief Checks if current application and other applications

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -32,7 +32,6 @@
 #include <boost/algorithm/string.hpp>
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
-#include "interfaces/HMI_API.h"
 #include "smart_objects/enum_schema_item.h"
 #include "utils/helpers.h"
 #include "vehicle_info_plugin/vehicle_info_app_extension.h"

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -204,17 +204,19 @@ bool SubscribeVehicleDataRequest::SubscribePendingVehicleData(
     ApplicationSharedPtr app, const smart_objects::SmartObject& msg_params) {
   LOG4CXX_DEBUG(logger_, "Subscribing to all pending VehicleData");
 
-  for (const auto& vi_name : vi_waiting_for_subscribe_) {
+  for (auto vi_name = vi_waiting_for_subscribe_.begin();
+       vi_name != vi_waiting_for_subscribe_.end();) {
     const bool is_subscription_successful = CheckSubscriptionStatus(
-        ConvertRequestToResponseName(vi_name), msg_params);
+        ConvertRequestToResponseName(*vi_name), msg_params);
 
     if (is_subscription_successful) {
       auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
-      ext.subscribeToVehicleInfo(vi_name);
-      vi_waiting_for_subscribe_.erase(vi_name);
+      ext.subscribeToVehicleInfo(*vi_name);
+      vi_name = vi_waiting_for_subscribe_.erase(vi_name);
+    } else {
+      ++vi_name;
     }
   }
-
   return vi_waiting_for_subscribe_.empty();
 }
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -32,9 +32,12 @@
 #include <boost/algorithm/string.hpp>
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
+#include "interfaces/HMI_API.h"
 #include "smart_objects/enum_schema_item.h"
 #include "utils/helpers.h"
 #include "vehicle_info_plugin/vehicle_info_app_extension.h"
+
+namespace VD_ResultCode = hmi_apis::Common_VehicleDataResultCode;
 
 namespace vehicle_info_plugin {
 using namespace application_manager;
@@ -189,9 +192,8 @@ bool SubscribeVehicleDataRequest::CheckSubscriptionStatus(
   }
 
   auto res_code = msg_params[vi_name][strings::result_code].asInt();
-  if (hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS != res_code &&
-      hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_ALREADY_SUBSCRIBED !=
-          res_code) {
+  if (VD_ResultCode::VDRC_SUCCESS != res_code &&
+      VD_ResultCode::VDRC_DATA_ALREADY_SUBSCRIBED != res_code) {
     LOG4CXX_WARN(logger_,
                  "Subscription to " << vi_name << " for " << connection_key()
                                     << " failed.");
@@ -205,13 +207,13 @@ bool SubscribeVehicleDataRequest::SubscribePendingVehicleData(
   LOG4CXX_DEBUG(logger_, "Subscribing to all pending VehicleData");
 
   std::set<hmi_apis::Common_VehicleDataResultCode::eType> skiped_result_codes(
-      {hmi_apis::Common_VehicleDataResultCode::VDRC_TRUNCATED_DATA,
-       hmi_apis::Common_VehicleDataResultCode::VDRC_DISALLOWED,
-       hmi_apis::Common_VehicleDataResultCode::VDRC_USER_DISALLOWED,
-       hmi_apis::Common_VehicleDataResultCode::VDRC_INVALID_ID,
-       hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_AVAILABLE,
-       hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED,
-       hmi_apis::Common_VehicleDataResultCode::VDRC_IGNORED});
+      {VD_ResultCode::VDRC_TRUNCATED_DATA,
+       VD_ResultCode::VDRC_DISALLOWED,
+       VD_ResultCode::VDRC_USER_DISALLOWED,
+       VD_ResultCode::VDRC_INVALID_ID,
+       VD_ResultCode::VDRC_DATA_NOT_AVAILABLE,
+       VD_ResultCode::VDRC_DATA_NOT_SUBSCRIBED,
+       VD_ResultCode::VDRC_IGNORED});
 
   for (auto vi_name = vi_waiting_for_subscribe_.begin();
        vi_name != vi_waiting_for_subscribe_.end();) {


### PR DESCRIPTION
Fixes #3196

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
Covered within existing unit tests and ATF tests.

### Summary
This pull request is intended to fix issue with sending "resultCode: GENERIC_ERROR" from SDL to mobile, if some parameters of VehicleData have valid (existing in API) result codes, which are different from SUCCESS or DATA_ALREADY_SUBSCRIBED. Due to this fix SDL can process all valid result codes without generating generic error, which will be present only in case, if result code of particular parameter is absent in API.

## CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
