### PR TITLE
Add missing attributes for API elements in the schema

### DIFF
--- a/src/components/interfaces/MOBILE_API.xsd
+++ b/src/components/interfaces/MOBILE_API.xsd
@@ -33,6 +33,8 @@
         <xs:attribute type="xs:string" name="name" use="optional"/>
         <xs:attribute type="xs:float" name="since" use="optional"/>
         <xs:attribute type="xs:float" name="until" use="optional"/>
+        <xs:attribute type="xs:string" name="deprecated" use="optional"/>
+        <xs:attribute type="xs:string" name="removed" use="optional"/>
         <xs:attribute type="xs:string" name="internal_name" use="optional"/>
         <xs:attribute type="xs:int" name="value" use="optional"/>
         <xs:attribute type="xs:string" name="rootscreen" use="optional"/>
@@ -68,6 +70,7 @@
         <xs:attribute type="xs:float" name="since" use="optional"/>
         <xs:attribute type="xs:float" name="until" use="optional"/>
         <xs:attribute type="xs:string" name="deprecated" use="optional"/>
+        <xs:attribute type="xs:string" name="removed" use="optional"/>
         <xs:attribute type="xs:string" name="platform" use="optional"/>
     </xs:complexType>
     <xs:complexType name="paramType" mixed="true">
@@ -91,6 +94,7 @@
         <xs:attribute type="xs:float" name="maxvalue" use="optional"/>
         <xs:attribute type="xs:string" name="until" use="optional"/>
         <xs:attribute type="xs:string" name="deprecated" use="optional"/>
+        <xs:attribute type="xs:string" name="removed" use="optional"/>
         <xs:attribute type="xs:string" name="platform" use="optional"/>
     </xs:complexType>
     <xs:complexType name="structType" mixed="true">
@@ -122,6 +126,7 @@
         <xs:attribute type="xs:float" name="since" use="optional"/>
         <xs:attribute type="xs:float" name="until" use="optional"/>
         <xs:attribute type="xs:string" name="deprecated" use="optional"/>
+        <xs:attribute type="xs:string" name="removed" use="optional"/>
         <xs:attribute type="xs:string" name="internal_scope" use="optional"/>
         <xs:attribute type="xs:string" name="platform" use="optional"/>
     </xs:complexType>
@@ -149,6 +154,7 @@
         <xs:attribute type="xs:float" name="since" use="optional"/>
         <xs:attribute type="xs:float" name="until" use="optional"/>
         <xs:attribute type="xs:string" name="deprecated" use="optional"/>
+        <xs:attribute type="xs:string" name="removed" use="optional"/>
     </xs:complexType>
     <xs:complexType name="interfaceType">
         <xs:choice maxOccurs="unbounded" minOccurs="0">


### PR DESCRIPTION
Fixes #3246 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
Added the the missing `deprecated` attribute for elementType and `removed` attribute for all API elements

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
