### PR TITLE
Create implementation for HMI capabilities persistence after SW…

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -400,7 +400,9 @@ class ApplicationManagerImpl
   mobile_api::HMILevel::eType IsHmiLevelFullAllowed(ApplicationSharedPtr app);
 
   void ConnectToDevice(const std::string& device_mac) OVERRIDE;
-  void OnHMIStartedCooperation() OVERRIDE;
+  void OnHMIReady() OVERRIDE;
+
+  void RequestForInterfacesAvailability() OVERRIDE;
 
   void DisconnectCloudApp(ApplicationSharedPtr app) OVERRIDE;
 
@@ -928,6 +930,7 @@ class ApplicationManagerImpl
    */
   bool IsHMICooperating() const OVERRIDE;
 
+  void SetHMICooperating(const bool hmi_cooperating) OVERRIDE;
   /**
    * @brief Method used to send default app tts globalProperties
    * in case they were not provided from mobile side after defined time

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -241,6 +241,13 @@ class HMICapabilitiesImpl : public HMICapabilities {
   std::set<hmi_apis::FunctionID::eType> GetDefaultInitializedCapabilities()
       const OVERRIDE;
 
+  void OnCapabilityInitialized(
+      hmi_apis::FunctionID::eType requested_interface) OVERRIDE;
+
+  bool MatchesCCPUVersion(const std::string& ccpu_version) const OVERRIDE;
+
+  void OnSoftwareVersionReceived(const std::string& ccpu_version) OVERRIDE;
+
  protected:
   /**
    * @brief Loads capabilities from local file in case SDL was launched
@@ -284,6 +291,17 @@ class HMICapabilitiesImpl : public HMICapabilities {
   bool AllFieldsSaved(const Json::Value& root_node,
                       const std::string& interface_name,
                       const std::vector<std::string>& sections_to_check) const;
+
+  /**
+   * @brief Remove received interface from default initialized capabilities
+   * @param requested_interface interface which should be removed
+   */
+  void RemoveFromDefaultInitialized(hmi_apis::FunctionID::eType requested_interface);
+
+  /**
+   * @brief Setting HMICooperating to true for respond all holding RAI requests
+   */
+  void CheckPendingDefaultInitialized() const;
 
   /**
    * @brief Gets the currently active language depending on interface

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -382,6 +382,8 @@ class PolicyHandler : public PolicyHandlerInterface,
                        const std::string& wers_country_code,
                        const std::string& language) OVERRIDE;
 
+  std::string GetCCPUVersionFromPT() const OVERRIDE;
+
   /**
    * @brief Send request to HMI to get update on system parameters
    */

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/button_get_capabilities_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/button_get_capabilities_request.h
@@ -62,10 +62,9 @@ class ButtonGetCapabilitiesRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual ~ButtonGetCapabilitiesRequest();
 
-  /**
-   * @brief Execute command
-   **/
-  virtual void Run();
+  void Run() OVERRIDE;
+
+  void onTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(ButtonGetCapabilitiesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/rc_get_capabilities_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/rc_get_capabilities_request.h
@@ -61,10 +61,9 @@ class RCGetCapabilitiesRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual ~RCGetCapabilitiesRequest();
 
-  /**
-   * @brief Execute command
-   **/
-  virtual void Run();
+  void Run() OVERRIDE;
+
+  void onTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(RCGetCapabilitiesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_get_capabilities_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_get_capabilities_request.h
@@ -61,10 +61,9 @@ class TTSGetCapabilitiesRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual ~TTSGetCapabilitiesRequest();
 
-  /**
-   * @brief Execute command
-   **/
-  virtual void Run();
+  void Run() OVERRIDE;
+
+  void onTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(TTSGetCapabilitiesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_get_language_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_get_language_request.h
@@ -61,10 +61,9 @@ class TTSGetLanguageRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual ~TTSGetLanguageRequest();
 
-  /**
-   * @brief Execute command
-   **/
-  virtual void Run();
+  void Run() OVERRIDE;
+
+  void onTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(TTSGetLanguageRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_get_supported_languages_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_get_supported_languages_request.h
@@ -63,10 +63,9 @@ class TTSGetSupportedLanguagesRequest
    **/
   virtual ~TTSGetSupportedLanguagesRequest();
 
-  /**
-   * @brief Execute command
-   **/
-  virtual void Run();
+  void Run() OVERRIDE;
+
+  void onTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(TTSGetSupportedLanguagesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_get_capabilities_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_get_capabilities_request.h
@@ -61,10 +61,9 @@ class UIGetCapabilitiesRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual ~UIGetCapabilitiesRequest();
 
-  /**
-   * @brief Execute command
-   **/
-  virtual void Run();
+  void Run() OVERRIDE;
+
+  void onTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UIGetCapabilitiesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_get_language_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_get_language_request.h
@@ -61,10 +61,9 @@ class UIGetLanguageRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual ~UIGetLanguageRequest();
 
-  /**
-   * @brief Execute command
-   **/
-  virtual void Run();
+  void Run() OVERRIDE;
+
+  void onTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UIGetLanguageRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_get_supported_languages_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_get_supported_languages_request.h
@@ -62,10 +62,9 @@ class UIGetSupportedLanguagesRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual ~UIGetSupportedLanguagesRequest();
 
-  /**
-   * @brief Execute command
-   **/
-  virtual void Run();
+  void Run() OVERRIDE;
+
+  void onTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UIGetSupportedLanguagesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_get_capabilities_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_get_capabilities_request.h
@@ -61,10 +61,9 @@ class VRGetCapabilitiesRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual ~VRGetCapabilitiesRequest();
 
-  /**
-   * @brief Execute command
-   **/
-  virtual void Run();
+  void Run() OVERRIDE;
+
+  void onTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(VRGetCapabilitiesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_get_language_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_get_language_request.h
@@ -61,10 +61,9 @@ class VRGetLanguageRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual ~VRGetLanguageRequest();
 
-  /**
-   * @brief Execute command
-   **/
-  virtual void Run();
+  void Run() OVERRIDE;
+
+  void onTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(VRGetLanguageRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_get_supported_languages_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_get_supported_languages_request.h
@@ -62,10 +62,9 @@ class VRGetSupportedLanguagesRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual ~VRGetSupportedLanguagesRequest();
 
-  /**
-   * @brief Execute command
-   **/
-  virtual void Run();
+  void Run() OVERRIDE;
+
+  void onTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(VRGetSupportedLanguagesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_request.cc
@@ -58,6 +58,12 @@ void ButtonGetCapabilitiesRequest::Run() {
   SendRequest();
 }
 
+void ButtonGetCapabilitiesRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::Buttons_GetCapabilities);
+}
+
 }  // namespace commands
 
 }  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_response.cc
@@ -58,6 +58,9 @@ void ButtonGetCapabilitiesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::Buttons_GetCapabilities);
+
   if (hmi_apis::Common_Result::SUCCESS != code) {
     LOG4CXX_ERROR(logger_, "Error is returned. Capabilities won't be updated.");
     return;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/get_system_info_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/get_system_info_response.cc
@@ -57,6 +57,7 @@ void GetSystemInfoResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
+  hmi_capabilities_.set_ccpu_version(policy_handler_.GetCCPUVersionFromPT());
   const SystemInfo& info = GetSystemInfo(code);
 
   // We have to set preloaded flag as false in policy table on any response
@@ -84,7 +85,7 @@ const SystemInfo GetSystemInfoResponse::GetSystemInfo(
   info.language = application_manager::MessageHelper::CommonLanguageToString(
       static_cast<hmi_apis::Common_Language::eType>(lang_code));
 
-  hmi_capabilities_.set_ccpu_version(info.ccpu_version);
+  hmi_capabilities_.OnSoftwareVersionReceived(info.ccpu_version);
 
   return info;
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_ready_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_ready_notification.cc
@@ -54,7 +54,7 @@ OnReadyNotification::~OnReadyNotification() {}
 void OnReadyNotification::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  application_manager_.OnHMIStartedCooperation();
+  application_manager_.OnHMIReady();
   event_engine::Event event(hmi_apis::FunctionID::BasicCommunication_OnReady);
   event.set_smart_object(*message_);
   event.raise(application_manager_.event_dispatcher());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_get_capabilities_request.cc
@@ -57,6 +57,12 @@ void RCGetCapabilitiesRequest::Run() {
   SendRequest();
 }
 
+void RCGetCapabilitiesRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::RC_GetCapabilities);
+}
+
 }  // namespace commands
 
 }  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_get_capabilities_response.cc
@@ -56,6 +56,9 @@ void RCGetCapabilitiesResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::RC_GetCapabilities);
+
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     LOG4CXX_DEBUG(logger_,
                   "Request was not successful. Don't change HMI capabilities");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_capabilities_request.cc
@@ -57,6 +57,11 @@ void TTSGetCapabilitiesRequest::Run() {
   SendRequest();
 }
 
+void TTSGetCapabilitiesRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::TTS_GetCapabilities);
+}
 }  // namespace commands
 
 }  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_capabilities_response.cc
@@ -55,6 +55,9 @@ void TTSGetCapabilitiesResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::TTS_GetCapabilities);
+
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     LOG4CXX_DEBUG(logger_,
                   "Request was not successful. Don't change HMI capabilities");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_language_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_language_request.cc
@@ -57,6 +57,11 @@ void TTSGetLanguageRequest::Run() {
   SendRequest();
 }
 
+void TTSGetLanguageRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::TTS_GetLanguage);
+}
 }  // namespace commands
 
 }  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_language_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_language_response.cc
@@ -59,6 +59,9 @@ void TTSGetLanguageResponse::Run() {
   const Common_Result::eType result_code = static_cast<Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::TTS_GetLanguage);
+
   if (Common_Result::SUCCESS != result_code) {
     LOG4CXX_DEBUG(logger_,
                   "Request was not successful. Don't change HMI capabilities");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_supported_languages_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_supported_languages_request.cc
@@ -57,6 +57,11 @@ void TTSGetSupportedLanguagesRequest::Run() {
   SendRequest();
 }
 
+void TTSGetSupportedLanguagesRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::TTS_GetSupportedLanguages);
+}
 }  // namespace commands
 
 }  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_supported_languages_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_supported_languages_response.cc
@@ -59,6 +59,9 @@ void TTSGetSupportedLanguagesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::TTS_GetSupportedLanguages);
+
   if (hmi_apis::Common_Result::SUCCESS != code) {
     LOG4CXX_DEBUG(logger_,
                   "Request was not successful. Don't change HMI capabilities");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_request.cc
@@ -57,6 +57,11 @@ void UIGetCapabilitiesRequest::Run() {
   SendRequest();
 }
 
+void UIGetCapabilitiesRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::UI_GetCapabilities);
+}
 }  // namespace commands
 
 }  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
@@ -56,6 +56,9 @@ void UIGetCapabilitiesResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::UI_GetCapabilities);
+
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     LOG4CXX_DEBUG(logger_,
                   "Request was not successful. Don't change HMI capabilities");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_request.cc
@@ -57,6 +57,11 @@ void UIGetLanguageRequest::Run() {
   SendRequest();
 }
 
+void UIGetLanguageRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::UI_GetLanguage);
+}
 }  // namespace commands
 
 }  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_response.cc
@@ -59,6 +59,9 @@ void UIGetLanguageResponse::Run() {
   const Common_Result::eType result_code = static_cast<Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::UI_GetLanguage);
+
   if (Common_Result::SUCCESS != result_code) {
     LOG4CXX_DEBUG(logger_,
                   "Request was not successful. Don't change HMI capabilities");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_request.cc
@@ -57,6 +57,11 @@ void UIGetSupportedLanguagesRequest::Run() {
   SendRequest();
 }
 
+void UIGetSupportedLanguagesRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::UI_GetSupportedLanguages);
+}
 }  // namespace commands
 
 }  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_response.cc
@@ -59,6 +59,9 @@ void UIGetSupportedLanguagesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::UI_GetSupportedLanguages);
+
   if (hmi_apis::Common_Result::SUCCESS != code) {
     LOG4CXX_DEBUG(logger_,
                   "Request was not successful. Don't change HMI capabilities");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_capabilities_request.cc
@@ -57,6 +57,11 @@ void VRGetCapabilitiesRequest::Run() {
   SendRequest();
 }
 
+void VRGetCapabilitiesRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::VR_GetCapabilities);
+}
 }  // namespace commands
 
 }  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_capabilities_response.cc
@@ -55,6 +55,9 @@ void VRGetCapabilitiesResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::VR_GetCapabilities);
+
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     LOG4CXX_DEBUG(logger_,
                   "Request was not successful. Don't change HMI capabilities");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_language_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_language_request.cc
@@ -57,6 +57,11 @@ void VRGetLanguageRequest::Run() {
   SendRequest();
 }
 
+void VRGetLanguageRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::VR_GetLanguage);
+}
 }  // namespace commands
 
 }  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_language_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_language_response.cc
@@ -59,6 +59,9 @@ void VRGetLanguageResponse::Run() {
   const Common_Result::eType result_code = static_cast<Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::VR_GetLanguage);
+
   if (Common_Result::SUCCESS != result_code) {
     LOG4CXX_DEBUG(logger_,
                   "Request was not successful. Don't change HMI capabilities");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_supported_languages_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_supported_languages_request.cc
@@ -57,6 +57,11 @@ void VRGetSupportedLanguagesRequest::Run() {
   SendRequest();
 }
 
+void VRGetSupportedLanguagesRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::VR_GetSupportedLanguages);
+}
 }  // namespace commands
 
 }  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_supported_languages_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_supported_languages_response.cc
@@ -60,6 +60,9 @@ void VRGetSupportedLanguagesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::VR_GetSupportedLanguages);
+
   if (hmi_apis::Common_Result::SUCCESS == code) {
     HMICapabilities& hmi_capabilities = hmi_capabilities_;
     hmi_capabilities.set_vr_supported_languages(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/button_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/button_get_capabilities_response_test.cc
@@ -86,6 +86,7 @@ TEST_F(ButtonGetCapabilitiesResponseTest, Run_CodeSuccess_SUCCESS) {
   EXPECT_CALL(mock_hmi_capabilities_, set_button_capabilities(capabilities_));
   EXPECT_CALL(mock_hmi_capabilities_,
               set_preset_bank_capabilities(preset_bank_capabilities_));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -102,6 +103,23 @@ TEST_F(ButtonGetCapabilitiesResponseTest, Run_CodeAborted_SUCCESS) {
   EXPECT_CALL(mock_hmi_capabilities_,
               set_preset_bank_capabilities(preset_bank_capabilities_))
       .Times(0);
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
+}
+
+TEST_F(ButtonGetCapabilitiesResponseTest,
+       onTimeOut_Run_ResponseForInterface_ReceivedError) {
+  MessageSharedPtr msg = CreateMsgParams();
+  (*msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::ABORTED;
+
+  ResponsePtr command(CreateCommand<ButtonGetCapabilitiesResponse>(msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              OnCapabilityInitialized(
+                  hmi_apis::FunctionID::Buttons_GetCapabilities));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/get_system_info_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/get_system_info_response_test.cc
@@ -131,6 +131,21 @@ TEST_F(GetSystemInfoResponseTest, GetSystemInfo_UNSUCCESS) {
   command->Run();
 }
 
+TEST_F(GetSystemInfoResponseTest, GetSystemInfo_UpdateCapabilities_Called) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+  (*command_msg)[strings::msg_params][hmi_response::capabilities] =
+      (capabilities_);
+
+  ResponseFromHMIPtr command(CreateCommand<GetSystemInfoResponse>(command_msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_, OnSoftwareVersionReceived(ccpu_version));
+
+  ASSERT_TRUE(command->Init());
+  command->Run();
+}
+
 }  // namespace get_system_info_response
 }  // namespace hmi_commands_test
 }  // namespace commands_test

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/hmi_notifications_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/hmi_notifications_test.cc
@@ -545,7 +545,7 @@ TEST_F(HMICommandsNotificationsTest, OnReadyNotificationEventDispatcher) {
   std::shared_ptr<Command> command =
       CreateCommand<OnReadyNotification>(message);
 
-  EXPECT_CALL(app_mngr_, OnHMIStartedCooperation());
+  EXPECT_CALL(app_mngr_, OnHMIReady());
   EXPECT_CALL(app_mngr_, event_dispatcher());
   EXPECT_CALL(mock_event_dispatcher_, raise_event(_))
       .WillOnce(GetEventId(&event_id));

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_get_capabilities_response_test.cc
@@ -166,6 +166,24 @@ TEST_F(RCGetCapabilitiesResponseTest, RUN_SUCCESSS) {
 
   EXPECT_CALL(mock_hmi_capabilities_, set_rc_capability(rc_capability_so));
   EXPECT_CALL(mock_hmi_capabilities_, set_rc_supported(true));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
+}
+
+TEST_F(RCGetCapabilitiesResponseTest,
+       onTimeOut_Run_ResponseForInterface_ReceivedError) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::ABORTED;
+
+  RCGetCapabilitiesResponsePtr command(
+      CreateCommand<RCGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              OnCapabilityInitialized(
+                  hmi_apis::FunctionID::RC_GetCapabilities));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_capabilities_response_test.cc
@@ -79,6 +79,7 @@ TEST_F(TTSGetCapabilitiesResponseTest, Run_BothExist_SUCCESS) {
 
   std::shared_ptr<TTSGetCapabilitiesResponse> command(
       CreateCommand<TTSGetCapabilitiesResponse>(msg));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -96,6 +97,7 @@ TEST_F(TTSGetCapabilitiesResponseTest, Run_OnlySpeech_SUCCESS) {
 
   std::shared_ptr<TTSGetCapabilitiesResponse> command(
       CreateCommand<TTSGetCapabilitiesResponse>(msg));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -114,6 +116,7 @@ TEST_F(TTSGetCapabilitiesResponseTest, Run_OnlyPrerecorded_SUCCESS) {
 
   std::shared_ptr<TTSGetCapabilitiesResponse> command(
       CreateCommand<TTSGetCapabilitiesResponse>(msg));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -129,6 +132,24 @@ TEST_F(TTSGetCapabilitiesResponseTest, Run_Nothing_SUCCESS) {
 
   std::shared_ptr<TTSGetCapabilitiesResponse> command(
       CreateCommand<TTSGetCapabilitiesResponse>(msg));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
+}
+
+TEST_F(TTSGetCapabilitiesResponseTest,
+       onTimeOut_Run_ResponseForInterface_ReceivedError) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::ABORTED;
+
+  std::shared_ptr<TTSGetCapabilitiesResponse> command(
+      CreateCommand<TTSGetCapabilitiesResponse>(msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              OnCapabilityInitialized(
+                  hmi_apis::FunctionID::TTS_GetCapabilities));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_language_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_language_response_test.cc
@@ -80,6 +80,7 @@ TEST_F(TTSGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
   EXPECT_CALL(app_mngr_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -101,6 +102,24 @@ TEST_F(TTSGetLanguageResponseTest, Run_LanguageNotSet_SUCCESS) {
   EXPECT_CALL(app_mngr_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
+}
+
+TEST_F(TTSGetLanguageResponseTest,
+       onTimeOut_Run_ResponseForInterface_ReceivedError) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::ABORTED;
+
+  std::shared_ptr<TTSGetLanguageResponse> command(
+      CreateCommand<TTSGetLanguageResponse>(msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              OnCapabilityInitialized(
+                  hmi_apis::FunctionID::TTS_GetLanguage));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_supported_languages_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_supported_languages_response_test.cc
@@ -57,6 +57,7 @@ using ::testing::Return;
 namespace am = ::application_manager;
 namespace strings = ::application_manager::strings;
 namespace hmi_response = am::hmi_response;
+namespace hmi_interface = ::application_manager::hmi_interface;
 using am::commands::CommandImpl;
 using application_manager::commands::ResponseFromHMI;
 using sdl_rpc_plugin::commands::TTSGetSupportedLanguagesResponse;
@@ -95,6 +96,9 @@ TEST_F(TTSGetSupportedLanguageResponseTest, RUN_SUCCESS) {
   EXPECT_CALL(mock_hmi_capabilities_,
               set_tts_supported_languages((
                   *command_msg)[strings::msg_params][hmi_response::languages]));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::tts, _, _));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -115,11 +119,29 @@ TEST_F(TTSGetSupportedLanguageResponseTest, RUN_UNSUCCESS) {
   EXPECT_CALL(mock_hmi_capabilities_,
               set_tts_supported_languages(supported_languages))
       .Times(0);
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 
   EXPECT_FALSE((*command_msg)[am::strings::msg_params].keyExists(
       am::hmi_response::languages));
+}
+
+TEST_F(TTSGetSupportedLanguageResponseTest,
+       onTimeOut_Run_ResponseForInterface_ReceivedError) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::ABORTED;
+
+  ResponseFromHMIPtr command(
+      CreateCommand<TTSGetSupportedLanguagesResponse>(command_msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              OnCapabilityInitialized(
+                  hmi_apis::FunctionID::TTS_GetSupportedLanguages));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
 }
 
 }  // namespace tts_get_supported_languages_response

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -51,6 +51,7 @@ using ::testing::NiceMock;
 namespace am = ::application_manager;
 namespace strings = am::strings;
 namespace hmi_response = am::hmi_response;
+namespace hmi_interface = ::application_manager::hmi_interface;
 using am::commands::CommandImpl;
 using application_manager::commands::ResponseFromHMI;
 using sdl_rpc_plugin::commands::UIGetCapabilitiesResponse;
@@ -99,6 +100,7 @@ TEST_F(UIGetCapabilitiesResponseTest, RUN_SetDisplay_SUCCESSS) {
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_display_capabilities(display_capabilities_so));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -119,6 +121,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetSoftButton_SUCCESS) {
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_soft_button_capabilities(soft_button_capabilities_so));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -138,6 +141,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetHmiZone_SUCCESS) {
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_hmi_zone_capabilities(hmi_zone_capabilities_so));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -162,6 +166,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetAudioPassThru_SUCCESS) {
   EXPECT_CALL(
       mock_hmi_capabilities_,
       set_audio_pass_thru_capabilities(audio_pass_thru_capabilities_list_so));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -187,6 +192,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetAudioPassThruList_SUCCESS) {
   EXPECT_CALL(
       mock_hmi_capabilities_,
       set_audio_pass_thru_capabilities(audio_pass_thru_capabilities_list_so));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -206,6 +212,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetNavigation_SUCCESS) {
   EXPECT_CALL(mock_hmi_capabilities_,
               set_navigation_supported(
                   hmi_capabilities_so[strings::navigation].asBool()));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -225,6 +232,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetPhoneCall_SUCCESS) {
   EXPECT_CALL(mock_hmi_capabilities_,
               set_phone_call_supported(
                   hmi_capabilities_so[strings::phone_call].asBool()));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -244,6 +252,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetVideoStreaming_SUCCESS) {
   EXPECT_CALL(mock_hmi_capabilities_,
               set_video_streaming_supported(
                   hmi_capabilities_so[strings::video_streaming].asBool()));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -268,6 +277,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetNavigationCapability_SUCCESS) {
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_navigation_capability(navigation_capability_so));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -289,6 +299,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetPhonenCapability_SUCCESS) {
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_phone_capability(phone_capability_so));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -339,6 +350,7 @@ TEST_F(UIGetCapabilitiesResponseTest, SetVideoStreamingCapability_SUCCESS) {
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_video_streaming_capability(video_streaming_capability));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -359,6 +371,39 @@ TEST_F(UIGetCapabilitiesResponseTest, SetSystemDisplayCapabilities_SUCCESS) {
               set_system_display_capabilities(display_capability_so));
 
   ASSERT_TRUE(command->Init());
+  command->Run();
+}
+
+TEST_F(UIGetCapabilitiesResponseTest,
+       SaveCachedCapabilitiesToFileCall_SUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::msg_params][strings::system_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::ui, _, _));
+
+  ASSERT_TRUE(command->Init());
+  command->Run();
+}
+
+TEST_F(UIGetCapabilitiesResponseTest,
+       onTimeOut_Run_ResponseForInterface_ReceivedError) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::ABORTED;
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              OnCapabilityInitialized(
+                  hmi_apis::FunctionID::UI_GetCapabilities));
+  ASSERT_TRUE(command->Init());
+
   command->Run();
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_language_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_language_response_test.cc
@@ -84,6 +84,7 @@ TEST_F(UIGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
   EXPECT_CALL(app_mngr_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -104,6 +105,24 @@ TEST_F(UIGetLanguageResponseTest, Run_LanguageNotSet_SUCCESS) {
   EXPECT_CALL(app_mngr_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
+}
+
+TEST_F(UIGetLanguageResponseTest,
+       onTimeOut_Run_ResponseForInterface_ReceivedError) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::ABORTED;
+
+  std::shared_ptr<UIGetLanguageResponse> command(
+      CreateCommand<UIGetLanguageResponse>(msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              OnCapabilityInitialized(
+                  hmi_apis::FunctionID::UI_GetLanguage));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_supported_languages_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_supported_languages_response_test.cc
@@ -54,6 +54,7 @@ using ::testing::Return;
 namespace am = ::application_manager;
 namespace strings = ::application_manager::strings;
 namespace hmi_response = am::hmi_response;
+namespace hmi_interface = ::application_manager::hmi_interface;
 using sdl_rpc_plugin::commands::UIGetSupportedLanguagesResponse;
 
 typedef std::shared_ptr<UIGetSupportedLanguagesResponse>
@@ -91,6 +92,9 @@ TEST_F(UIGetSupportedLanguagesResponseTest, RUN_SUCCESS) {
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_ui_supported_languages((supported_languages)));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::ui, _, _));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -109,11 +113,29 @@ TEST_F(UIGetSupportedLanguagesResponseTest, RUN_UNSUCCESS) {
   EXPECT_CALL(mock_hmi_capabilities_,
               set_ui_supported_languages(supported_languages))
       .Times(0);
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 
   EXPECT_FALSE((*command_msg)[am::strings::msg_params].keyExists(
       am::hmi_response::languages));
+}
+
+TEST_F(UIGetSupportedLanguagesResponseTest,
+       onTimeOut_Run_ResponseForInterface_ReceivedError) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::ABORTED;
+
+  UIGetSupportedLanguagesResponsePtr command(
+      CreateCommand<UIGetSupportedLanguagesResponse>(command_msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              OnCapabilityInitialized(
+                  hmi_apis::FunctionID::UI_GetSupportedLanguages));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
 }
 
 }  // namespace ui_get_supported_languages_response

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_capabilities_response_test.cc
@@ -51,6 +51,7 @@ using ::testing::NiceMock;
 namespace am = ::application_manager;
 namespace strings = am::strings;
 namespace hmi_response = am::hmi_response;
+namespace hmi_interface = ::application_manager::hmi_interface;
 using am::commands::CommandImpl;
 using sdl_rpc_plugin::commands::VRGetCapabilitiesResponse;
 
@@ -95,6 +96,26 @@ TEST_F(VRGetCapabilitiesResponseTest, RUN_SUCCESSS) {
       (*command_msg)[strings::msg_params][strings::vr_capabilities];
 
   EXPECT_CALL(mock_hmi_capabilities_, set_vr_capabilities(vr_capabilities_so));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::vr, _, _));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
+}
+
+TEST_F(VRGetCapabilitiesResponseTest,
+       onTimeOut_Run_ResponseForInterface_ReceivedError) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::ABORTED;
+
+  VRGetCapabilitiesResponsePtr command(
+      CreateCommand<VRGetCapabilitiesResponse>(command_msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              OnCapabilityInitialized(
+                  hmi_apis::FunctionID::VR_GetCapabilities));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_language_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_language_response_test.cc
@@ -85,6 +85,7 @@ TEST_F(VRGetLanguageResponseTest, Run_LanguageSet_SUCCESS) {
   EXPECT_CALL(app_mngr_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -106,6 +107,24 @@ TEST_F(VRGetLanguageResponseTest, Run_LanguageNotSet_SUCCESS) {
   EXPECT_CALL(app_mngr_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
+}
+
+TEST_F(VRGetLanguageResponseTest,
+       onTimeOut_Run_ResponseForInterface_ReceivedError) {
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::ABORTED;
+
+  std::shared_ptr<VRGetLanguageResponse> command(
+      CreateCommand<VRGetLanguageResponse>(msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              OnCapabilityInitialized(
+                  hmi_apis::FunctionID::VR_GetLanguage));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_supported_languages_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_supported_languages_response_test.cc
@@ -54,6 +54,7 @@ using ::testing::Return;
 namespace am = ::application_manager;
 namespace strings = ::application_manager::strings;
 namespace hmi_response = am::hmi_response;
+namespace hmi_interface = ::application_manager::hmi_interface;
 using sdl_rpc_plugin::commands::VRGetSupportedLanguagesResponse;
 
 typedef std::shared_ptr<VRGetSupportedLanguagesResponse>
@@ -91,6 +92,9 @@ TEST_F(VRGetSupportedLanguagesResponseTest, RUN_SUCCESS) {
 
   EXPECT_CALL(mock_hmi_capabilities_,
               set_vr_supported_languages((supported_languages)));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::vr, _, _));
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 }
@@ -109,11 +113,29 @@ TEST_F(VRGetSupportedLanguagesResponseTest, RUN_UNSUCCESS) {
   EXPECT_CALL(mock_hmi_capabilities_,
               set_vr_supported_languages(supported_languages))
       .Times(0);
+  ASSERT_TRUE(command->Init());
 
   command->Run();
 
   EXPECT_FALSE((*command_msg)[am::strings::msg_params].keyExists(
       am::hmi_response::languages));
+}
+
+TEST_F(VRGetSupportedLanguagesResponseTest,
+       onTimeOut_Run_ResponseForInterface_ReceivedError) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::ABORTED;
+
+  VRGetSupportedLanguagesResponsePtr command(
+      CreateCommand<VRGetSupportedLanguagesResponse>(command_msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              OnCapabilityInitialized(
+                  hmi_apis::FunctionID::VR_GetSupportedLanguages));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
 }
 
 }  // namespace vr_get_supported_languages_response

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/hmi/vi_get_vehicle_type_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/hmi/vi_get_vehicle_type_request.h
@@ -59,10 +59,9 @@ class VIGetVehicleTypeRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual ~VIGetVehicleTypeRequest();
 
-  /**
-   * @brief Execute command
-   **/
-  virtual void Run();
+  void Run() OVERRIDE;
+
+  void onTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(VIGetVehicleTypeRequest);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_request.cc
@@ -54,6 +54,12 @@ void VIGetVehicleTypeRequest::Run() {
   SendRequest();
 }
 
+void VIGetVehicleTypeRequest::onTimeOut() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::VehicleInfo_GetVehicleType);
+}
+
 }  // namespace commands
 
 }  // namespace vehicle_info_plugin

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_response.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_response.cc
@@ -53,6 +53,9 @@ void VIGetVehicleTypeResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
+  hmi_capabilities_.OnCapabilityInitialized(
+      hmi_apis::FunctionID::VehicleInfo_GetVehicleType);
+
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     LOG4CXX_DEBUG(logger_,
                   "Request was not successful. Don't change HMI capabilities");

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -837,10 +837,31 @@ void ApplicationManagerImpl::ConnectToDevice(const std::string& device_mac) {
   connection_handler().ConnectToDevice(handle);
 }
 
-void ApplicationManagerImpl::OnHMIStartedCooperation() {
+void ApplicationManagerImpl::OnHMIReady() {
   LOG4CXX_AUTO_TRACE(logger_);
-  hmi_cooperating_ = true;
   MessageHelper::SendGetSystemInfoRequest(*this);
+
+  std::shared_ptr<smart_objects::SmartObject> is_navi_ready(
+      MessageHelper::CreateModuleInfoSO(
+          hmi_apis::FunctionID::Navigation_IsReady, *this));
+  rpc_service_->ManageHMICommand(is_navi_ready);
+
+  std::shared_ptr<smart_objects::SmartObject> mixing_audio_supported_request(
+      MessageHelper::CreateModuleInfoSO(
+          hmi_apis::FunctionID::BasicCommunication_MixingAudioSupported,
+          *this));
+  rpc_service_->ManageHMICommand(mixing_audio_supported_request);
+  resume_controller().ResetLaunchTime();
+
+  RefreshCloudAppInformation();
+}
+
+void ApplicationManagerImpl::RequestForInterfacesAvailability() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  std::shared_ptr<smart_objects::SmartObject> is_ivi_ready(
+      MessageHelper::CreateModuleInfoSO(
+          hmi_apis::FunctionID::VehicleInfo_IsReady, *this));
+  rpc_service_->ManageHMICommand(is_ivi_ready);
 
   std::shared_ptr<smart_objects::SmartObject> is_vr_ready(
       MessageHelper::CreateModuleInfoSO(hmi_apis::FunctionID::VR_IsReady,
@@ -857,16 +878,6 @@ void ApplicationManagerImpl::OnHMIStartedCooperation() {
                                         *this));
   rpc_service_->ManageHMICommand(is_ui_ready);
 
-  std::shared_ptr<smart_objects::SmartObject> is_navi_ready(
-      MessageHelper::CreateModuleInfoSO(
-          hmi_apis::FunctionID::Navigation_IsReady, *this));
-  rpc_service_->ManageHMICommand(is_navi_ready);
-
-  std::shared_ptr<smart_objects::SmartObject> is_ivi_ready(
-      MessageHelper::CreateModuleInfoSO(
-          hmi_apis::FunctionID::VehicleInfo_IsReady, *this));
-  rpc_service_->ManageHMICommand(is_ivi_ready);
-
   std::shared_ptr<smart_objects::SmartObject> is_rc_ready(
       MessageHelper::CreateModuleInfoSO(hmi_apis::FunctionID::RC_IsReady,
                                         *this));
@@ -882,15 +893,6 @@ void ApplicationManagerImpl::OnHMIStartedCooperation() {
             hmi_apis::FunctionID::Buttons_GetCapabilities, *this));
     rpc_service_->ManageHMICommand(button_capabilities);
   }
-
-  std::shared_ptr<smart_objects::SmartObject> mixing_audio_supported_request(
-      MessageHelper::CreateModuleInfoSO(
-          hmi_apis::FunctionID::BasicCommunication_MixingAudioSupported,
-          *this));
-  rpc_service_->ManageHMICommand(mixing_audio_supported_request);
-  resume_controller().ResetLaunchTime();
-
-  RefreshCloudAppInformation();
 }
 
 std::string ApplicationManagerImpl::PolicyIDByIconUrl(const std::string url) {
@@ -3017,7 +3019,7 @@ void ApplicationManagerImpl::SendOnSDLClose() {
 void ApplicationManagerImpl::UnregisterAllApplications() {
   LOG4CXX_DEBUG(logger_, "Unregister reason  " << unregister_reason_);
 
-  hmi_cooperating_ = false;
+  SetHMICooperating(false);
   bool is_ignition_off = false;
   using namespace mobile_api::AppInterfaceUnregisteredReason;
   using namespace helpers;
@@ -3879,6 +3881,10 @@ uint32_t ApplicationManagerImpl::GetAvailableSpaceForApp(
 
 bool ApplicationManagerImpl::IsHMICooperating() const {
   return hmi_cooperating_;
+}
+
+void ApplicationManagerImpl::SetHMICooperating(const bool hmi_cooperating) {
+  hmi_cooperating_ = hmi_cooperating;
 }
 
 void ApplicationManagerImpl::OnApplicationListUpdateTimer() {

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -750,7 +750,7 @@ void HMICapabilitiesImpl::set_seat_location_capability(
 void HMICapabilitiesImpl::Init(
     resumption::LastStateWrapperPtr last_state_wrapper) {
   hmi_language_handler_.Init(last_state_wrapper);
-  if (false == LoadCapabilitiesFromFile()) {
+  if (!LoadCapabilitiesFromFile()) {
     LOG4CXX_ERROR(logger_, "file hmi_capabilities.json was not loaded");
   } else {
     LOG4CXX_INFO(logger_, "file hmi_capabilities.json was loaded");
@@ -1618,6 +1618,46 @@ HMICapabilitiesImpl::GetDefaultInitializedCapabilities() const {
   return default_initialized_capabilities_;
 }
 
+void HMICapabilitiesImpl::OnCapabilityInitialized(
+    hmi_apis::FunctionID::eType requested_interface) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (app_mngr_.IsHMICooperating()) {
+    LOG4CXX_DEBUG(logger_,
+                  "Remove from default initialized capabilities skipped, "
+                  "because hmi_cooperating equal true already");
+    return;
+  }
+  RemoveFromDefaultInitialized(requested_interface);
+  CheckPendingDefaultInitialized();
+}
+
+bool HMICapabilitiesImpl::MatchesCCPUVersion(
+    const std::string& ccpu_version) const {
+  return ccpu_version_ == ccpu_version;
+}
+
+void HMICapabilitiesImpl::OnSoftwareVersionReceived(
+    const std::string& ccpu_version) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (MatchesCCPUVersion(ccpu_version)) {
+    LOG4CXX_DEBUG(logger_, "Software version not changed");
+    app_mngr_.SetHMICooperating(true);
+    app_mngr_.RequestForInterfacesAvailability();
+    return;
+  }
+
+  LOG4CXX_DEBUG(logger_, "Software version changed");
+  set_ccpu_version(ccpu_version);
+  DeleteCachedCapabilitiesFile();
+
+  if (!LoadCapabilitiesFromFile()) {
+    LOG4CXX_ERROR(logger_, "file hmi_capabilities.json was not loaded");
+  }
+
+  app_mngr_.RequestForInterfacesAvailability();
+}
+
 bool HMICapabilitiesImpl::AllFieldsSaved(
     const Json::Value& root_node,
     const std::string& interface_name,
@@ -1657,6 +1697,27 @@ bool HMICapabilitiesImpl::AllFieldsSaved(
   }
 
   return true;
+}
+
+void HMICapabilitiesImpl::RemoveFromDefaultInitialized(hmi_apis::FunctionID::eType requested_interface) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  auto it = find(default_initialized_capabilities_.begin(),
+                 default_initialized_capabilities_.end(),
+                 requested_interface);
+  if (it != default_initialized_capabilities_.end()) {
+    default_initialized_capabilities_.erase(it);
+    LOG4CXX_DEBUG(logger_,
+                  "Wait for " << default_initialized_capabilities_.size()
+                              << " responses");
+  }
+}
+
+void HMICapabilitiesImpl::CheckPendingDefaultInitialized() const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (default_initialized_capabilities_.empty()) {
+    app_mngr_.SetHMICooperating(true);
+  }
 }
 
 void HMICapabilitiesImpl::PrepareUiJsonValueForSaving(

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -954,6 +954,11 @@ void PolicyHandler::OnGetSystemInfo(const std::string& ccpu_version,
   policy_manager_->SetSystemInfo(ccpu_version, wers_country_code, language);
 }
 
+std::string PolicyHandler::GetCCPUVersionFromPT() const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return policy_manager_->GetCCPUVersionFromPT();
+}
+
 void PolicyHandler::OnSystemInfoUpdateRequired() {
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK_VOID();

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -522,7 +522,7 @@ TEST_F(HMICapabilitiesTest,
     EXPECT_TRUE(::file_system::DeleteFile("./app_info_data"));
   }
 
-  std::shared_ptr<HMICapabilitiesForTesting> hmi_capabilities =
+  auto hmi_capabilities =
       std::make_shared<HMICapabilitiesForTesting>(mock_app_mngr);
   hmi_capabilities->Init(last_state_wrapper_);
 
@@ -565,7 +565,7 @@ TEST_F(HMICapabilitiesTest,
     EXPECT_TRUE(::file_system::DeleteFile("./app_info_data"));
   }
 
-  std::shared_ptr<HMICapabilitiesForTesting> hmi_capabilities =
+  auto hmi_capabilities =
       std::make_shared<HMICapabilitiesForTesting>(mock_app_mngr);
   hmi_capabilities->Init(last_state_wrapper_);
 
@@ -614,7 +614,7 @@ TEST_F(HMICapabilitiesTest,
     EXPECT_TRUE(::file_system::DeleteFile("./app_info_data"));
   }
 
-  std::shared_ptr<HMICapabilitiesForTesting> hmi_capabilities =
+  auto hmi_capabilities =
       std::make_shared<HMICapabilitiesForTesting>(mock_app_mngr);
   hmi_capabilities->Init(last_state_wrapper_);
 
@@ -681,6 +681,75 @@ TEST_F(HMICapabilitiesTest, SetUICooperating) {
 TEST_F(HMICapabilitiesTest, SetIviCooperating) {
   hmi_capabilities_test->set_is_ivi_cooperating(true);
   EXPECT_EQ(true, hmi_capabilities_test->is_ivi_cooperating());
+}
+
+TEST_F(
+    HMICapabilitiesTest,
+    UpdateCapabilitiesDependingOn_ccpuVersion_FromCacheForOld_RequestForNew) {
+  MockApplicationManager mock_app_mngr;
+  event_engine_test::MockEventDispatcher mock_dispatcher;
+  MockApplicationManagerSettings mock_application_manager_settings;
+  const std::string ccpu_version = "4.1.3.B_EB355B";
+  const std::string ccpu_version_new = "5.1.3.B_EB355B";
+  const std::string hmi_capabilities_invalid_file =
+      "hmi_capabilities_invalid_file.json";
+
+  EXPECT_CALL(mock_application_manager_settings, hmi_capabilities_file_name())
+      .WillOnce(ReturnRef(hmi_capabilities_invalid_file));
+  EXPECT_CALL(mock_app_mngr, event_dispatcher())
+      .WillOnce(ReturnRef(mock_dispatcher));
+  EXPECT_CALL(mock_app_mngr, get_settings())
+      .WillRepeatedly(ReturnRef(mock_application_manager_settings));
+  EXPECT_CALL(mock_application_manager_settings,
+              hmi_capabilities_cache_file_name())
+      .WillOnce(ReturnRef(file_cache_name_));
+
+  auto hmi_capabilities =
+      std::make_shared<HMICapabilitiesForTesting>(mock_app_mngr);
+
+  EXPECT_CALL(mock_app_mngr, SetHMICooperating(true));
+  EXPECT_CALL(mock_app_mngr, RequestForInterfacesAvailability()).Times(2);
+
+  hmi_capabilities->set_ccpu_version(ccpu_version);
+  hmi_capabilities->OnSoftwareVersionReceived(ccpu_version);
+
+  EXPECT_EQ(ccpu_version, hmi_capabilities->ccpu_version());
+
+  hmi_capabilities->OnSoftwareVersionReceived(ccpu_version_new);
+  EXPECT_EQ(ccpu_version_new, hmi_capabilities->ccpu_version());
+}
+
+TEST_F(HMICapabilitiesTest,
+       UpdateCapabilitiesForNew_ccpuVersion_DeleteCacheFile) {
+  MockApplicationManager mock_app_mngr;
+  event_engine_test::MockEventDispatcher mock_dispatcher;
+  MockApplicationManagerSettings mock_application_manager_settings;
+  const std::string ccpu_version = "4.1.3.B_EB355B";
+  const std::string ccpu_version_new = "5.1.3.B_EB355B";
+  const std::string hmi_capabilities_invalid_file =
+      "hmi_capabilities_invalid_file.json";
+
+  file_system::CreateFile(file_cache_name_);
+  EXPECT_TRUE(file_system::FileExists(file_cache_name_));
+
+  EXPECT_CALL(mock_application_manager_settings, hmi_capabilities_file_name())
+      .WillOnce(ReturnRef(hmi_capabilities_invalid_file));
+  EXPECT_CALL(mock_app_mngr, event_dispatcher())
+      .WillOnce(ReturnRef(mock_dispatcher));
+  EXPECT_CALL(mock_app_mngr, get_settings())
+      .WillRepeatedly(ReturnRef(mock_application_manager_settings));
+  EXPECT_CALL(mock_application_manager_settings,
+              hmi_capabilities_cache_file_name())
+      .WillOnce(ReturnRef(file_cache_name_));
+
+  auto hmi_capabilities =
+      std::make_shared<HMICapabilitiesForTesting>(mock_app_mngr);
+
+  hmi_capabilities->set_ccpu_version(ccpu_version);
+  hmi_capabilities->OnSoftwareVersionReceived(ccpu_version_new);
+  EXPECT_EQ(ccpu_version_new, hmi_capabilities->ccpu_version());
+
+  EXPECT_FALSE(file_system::FileExists(file_cache_name_));
 }
 
 }  // namespace application_manager_test

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -203,6 +203,9 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
 
   MOCK_CONST_METHOD0(ccpu_version, const std::string&());
   MOCK_METHOD1(set_ccpu_version, void(const std::string& ccpu_version));
+  MOCK_CONST_METHOD1(MatchesCCPUVersion, bool(const std::string& ccpu_version));
+  MOCK_METHOD1(OnSoftwareVersionReceived,
+               void(const std::string& ccpu_version));
   MOCK_METHOD0(get_hmi_language_handler,
                application_manager::HMILanguageHandler&());
   MOCK_METHOD1(set_handle_response_for,
@@ -214,6 +217,8 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
   MOCK_CONST_METHOD0(DeleteCachedCapabilitiesFile, bool());
   MOCK_CONST_METHOD0(GetDefaultInitializedCapabilities,
                      std::set<hmi_apis::FunctionID::eType>());
+  MOCK_METHOD1(OnCapabilityInitialized,
+               void(hmi_apis::FunctionID::eType requested_interface));
 };
 
 }  // namespace application_manager_test

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -464,7 +464,13 @@ class ApplicationManager {
 
   virtual void ConnectToDevice(const std::string& device_mac) = 0;
 
-  virtual void OnHMIStartedCooperation() = 0;
+  virtual void OnHMIReady() = 0;
+
+  /**
+   * @brief Send GetCapabilities requests for
+   * each interface (VR, TTS, UI etc) to HMI
+   */
+  virtual void RequestForInterfacesAvailability() = 0;
 
   virtual void DisconnectCloudApp(ApplicationSharedPtr app) = 0;
 
@@ -483,6 +489,13 @@ class ApplicationManager {
   GetCloudAppConnectionStatus(ApplicationConstSharedPtr app) const = 0;
 
   virtual bool IsHMICooperating() const = 0;
+
+  /*
+   * @brief Hold or respond to all pending RAI requests
+   * @param hmi_cooperating new state to be set
+   */
+  virtual void SetHMICooperating(const bool hmi_cooperating) = 0;
+
   /**
    * @brief Notifies all components interested in Vehicle Data update
    * i.e. new value of odometer etc and returns list of applications

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -521,6 +521,26 @@ class HMICapabilities {
    */
   virtual std::set<hmi_apis::FunctionID::eType>
   GetDefaultInitializedCapabilities() const = 0;
+
+  /**
+   * @brief Response was received for default initialized capabilities
+   * @param requested_interface interface for which received response
+   */
+  virtual void OnCapabilityInitialized(
+      hmi_apis::FunctionID::eType requested_interface) = 0;
+
+  /**
+   * @brief Interface that checks for compliance new software version of the
+   * target with last received
+   * @param ccpu_version Received system/hmi software version
+   */
+  virtual bool MatchesCCPUVersion(const std::string& ccpu_version) const = 0;
+
+  /**
+   * @brief Interface that update capabilities depending on ccpu_version
+   * @param ccpu_version Received system/hmi software version
+   */
+  virtual void OnSoftwareVersionReceived(const std::string& ccpu_version) = 0;
 };
 
 }  //  namespace application_manager

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -299,6 +299,12 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
                                const std::string& language) = 0;
 
   /**
+   * @brief Get information about last ccpu_version from PT
+   * @return ccpu_version from PT
+   */
+  virtual std::string GetCCPUVersionFromPT() const = 0;
+
+  /**
    * @brief Send request to HMI to get update on system parameters
    */
   virtual void OnSystemInfoUpdateRequired() = 0;

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -434,6 +434,12 @@ class PolicyManager : public usage_statistics::StatisticsManager,
                              const std::string& language) = 0;
 
   /**
+   * @brief Get information about last ccpu_version from PT
+   * @return ccpu_version from PT
+   */
+  virtual std::string GetCCPUVersionFromPT() const = 0;
+
+  /**
    * @brief Send OnPermissionsUpdated for choosen application
    * @param device_id device identifier
    * @param application_id Unique application id

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -425,6 +425,12 @@ class PolicyManager : public usage_statistics::StatisticsManager,
                              const std::string& language) = 0;
 
   /**
+   * @brief Get information about last ccpu_version from PT
+   * @return ccpu_version from PT
+   */
+  virtual std::string GetCCPUVersionFromPT() const = 0;
+
+  /**
    * @brief Send OnPermissionsUpdated for choosen application
    * @param device_id device identifier
    * @param application_id Unique application id

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -201,7 +201,8 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD1(BeginAudioPassThru, bool(uint32_t app_id));
   MOCK_METHOD1(EndAudioPassThru, bool(uint32_t app_id));
   MOCK_METHOD1(ConnectToDevice, void(const std::string& device_mac));
-  MOCK_METHOD0(OnHMIStartedCooperation, void());
+  MOCK_METHOD0(OnHMIReady, void());
+  MOCK_METHOD0(RequestForInterfacesAvailability, void());
   MOCK_METHOD1(DisconnectCloudApp,
                void(application_manager::ApplicationSharedPtr app));
   MOCK_METHOD0(RefreshCloudAppInformation, void());
@@ -211,6 +212,7 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD1(PolicyIDByIconUrl, std::string(const std::string url));
   MOCK_METHOD1(SetIconFileFromSystemRequest, void(const std::string policy_id));
   MOCK_CONST_METHOD0(IsHMICooperating, bool());
+  MOCK_METHOD1(SetHMICooperating, void(const bool hmi_cooperating));
   MOCK_METHOD2(IviInfoUpdated,
                void(const std::string& vehicle_info, int value));
   MOCK_METHOD1(RegisterApplication,

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -181,6 +181,7 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                void(const std::string& ccpu_version,
                     const std::string& wers_country_code,
                     const std::string& language));
+  MOCK_CONST_METHOD0(GetCCPUVersionFromPT, std::string());
   MOCK_METHOD0(OnSystemInfoUpdateRequired, void());
   MOCK_METHOD0(OnVIIsReady, void());
   MOCK_METHOD1(OnVehicleDataUpdated,

--- a/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
@@ -210,6 +210,7 @@ class MockCacheManagerInterface : public ::policy::CacheManagerInterface {
                bool(const std::string& ccpu_version,
                     const std::string& wers_country_code,
                     const std::string& language));
+  MOCK_CONST_METHOD0(GetCCPUVersionFromPT, std::string());
   MOCK_CONST_METHOD0(IsMetaInfoPresent, bool());
   MOCK_METHOD1(SetSystemLanguage, bool(const std::string& language));
   MOCK_METHOD1(Increment, void(usage_statistics::GlobalCounterId type));

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -305,6 +305,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(OnSystemRequestReceived, void());
   MOCK_METHOD0(RetrySequenceFailed, void());
   MOCK_METHOD0(ResetTimeout, void());
+  MOCK_CONST_METHOD0(GetCCPUVersionFromPT, std::string());
 };
 }  // namespace policy_manager_test
 }  // namespace components

--- a/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
@@ -184,6 +184,7 @@ class MockCacheManagerInterface : public CacheManagerInterface {
                bool(const std::string& ccpu_version,
                     const std::string& wers_country_code,
                     const std::string& language));
+  MOCK_CONST_METHOD0(GetCCPUVersionFromPT, std::string());
   MOCK_CONST_METHOD0(IsMetaInfoPresent, bool());
   MOCK_METHOD1(SetSystemLanguage, bool(const std::string& language));
   MOCK_METHOD1(Increment, void(usage_statistics::GlobalCounterId type));

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -307,6 +307,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_CONST_METHOD1(GetAppRequestSubTypesState,
                      RequestSubType::State(const std::string& policy_app_id));
   MOCK_METHOD0(ResetTimeout, void());
+  MOCK_CONST_METHOD0(GetCCPUVersionFromPT, std::string());
 };
 
 }  // namespace policy_manager_test

--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -627,6 +627,12 @@ class CacheManager : public CacheManagerInterface {
                    const std::string& language);
 
   /**
+   * @brief Get information about last ccpu_version from PT
+   * @return ccpu_version from PT
+   */
+  std::string GetCCPUVersionFromPT() const;
+
+  /**
    * @brief Checks, if specific head unit is present in PT
    * @return boot Suceess, if present, otherwise - false
    */

--- a/src/components/policy/policy_external/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager_interface.h
@@ -662,6 +662,12 @@ class CacheManagerInterface {
                            const std::string& language) = 0;
 
   /**
+   * @brief Get information about last ccpu_version from PT
+   * @return ccpu_version from PT
+   */
+  virtual std::string GetCCPUVersionFromPT() const = 0;
+
+  /**
    * @brief Checks, if specific head unit is present in PT
    * @return boot Suceess, if present, otherwise - false
    */

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -442,6 +442,8 @@ class PolicyManagerImpl : public PolicyManager {
                      const std::string& wers_country_code,
                      const std::string& language) OVERRIDE;
 
+  std::string GetCCPUVersionFromPT() const OVERRIDE;
+
   /**
    * @brief Runs necessary operations, which is depends on external system
    * state, e.g. getting system-specific parameters which are need to be

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -2280,6 +2280,13 @@ bool CacheManager::SetMetaInfo(const std::string& ccpu_version,
   return true;
 }
 
+std::string CacheManager::GetCCPUVersionFromPT() const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  rpc::Optional<policy_table::ModuleMeta>& module_meta =
+      pt_->policy_table.module_meta;
+  return *(module_meta->ccpu_version);
+}
+
 bool CacheManager::IsMetaInfoPresent() const {
   CACHE_MANAGER_CHECK(false);
   bool result = true;

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1614,6 +1614,11 @@ void PolicyManagerImpl::SetSystemInfo(const std::string& ccpu_version,
   cache_->SetMetaInfo(ccpu_version, wers_country_code, language);
 }
 
+std::string PolicyManagerImpl::GetCCPUVersionFromPT() const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return cache_->GetCCPUVersionFromPT();
+}
+
 void PolicyManagerImpl::OnSystemReady() {
   // Update policy table for the first time with system information
   if (!cache_->IsMetaInfoPresent()) {

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -572,6 +572,12 @@ class CacheManager : public CacheManagerInterface {
                    const std::string& language);
 
   /**
+   * @brief Get information about last ccpu_version from PT
+   * @return ccpu_version from PT
+   */
+  std::string GetCCPUVersionFromPT() const;
+
+  /**
    * @brief Checks, if specific head unit is present in PT
    * @return boot Suceess, if present, otherwise - false
    */

--- a/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
@@ -603,6 +603,12 @@ class CacheManagerInterface {
                            const std::string& language) = 0;
 
   /**
+   * @brief Get information about last ccpu_version from PT
+   * @return ccpu_version from PT
+   */
+  virtual std::string GetCCPUVersionFromPT() const = 0;
+
+  /**
    * @brief Checks, if specific head unit is present in PT
    * @return boot Suceess, if present, otherwise - false
    */

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -458,6 +458,8 @@ class PolicyManagerImpl : public PolicyManager {
                      const std::string& wers_country_code,
                      const std::string& language) OVERRIDE;
 
+  std::string GetCCPUVersionFromPT() const OVERRIDE;
+
   /**
    * @brief Runs necessary operations, which is depends on external system
    * state, e.g. getting system-specific parameters which are need to be

--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -424,6 +424,9 @@ struct ConsumerFriendlyMessages : CompositeType {
 
 struct ModuleMeta : CompositeType {
  public:
+  Optional<String<0, 250> > ccpu_version;
+  Optional<String<0, 250> > language;
+  Optional<String<0, 250> > wers_country_code;
   Optional<Integer<uint32_t, 0, ODO_MAX> > pt_exchanged_at_odometer_x;
   Optional<Integer<uint16_t, 0, 65535> > pt_exchanged_x_days_after_epoch;
   Optional<Integer<uint16_t, 0, 65535> > ignition_cycles_since_last_exchange;

--- a/src/components/policy/policy_regular/include/policy/pt_representation.h
+++ b/src/components/policy/policy_regular/include/policy/pt_representation.h
@@ -160,6 +160,13 @@ class PTRepresentation {
   virtual std::string GetLockScreenIconUrl() const = 0;
 
   /**
+   * @brief Records information about head unit system to PT
+   * @return bool Success of operation
+   */
+  virtual bool SetMetaInfo(const std::string& ccpu_version,
+                           const std::string& wers_country_code,
+                           const std::string& language) = 0;
+  /**
    * @brief Get allowed number of notifications
    * depending on application priority.
    * @param priority Priority of application

--- a/src/components/policy/policy_regular/include/policy/sql_pt_queries.h
+++ b/src/components/policy/policy_regular/include/policy/sql_pt_queries.h
@@ -143,6 +143,7 @@ extern const std::string kSelectDBVersion;
 extern const std::string kUpdateDBVersion;
 extern const std::string kSaveModuleMeta;
 extern const std::string kSelectModuleMeta;
+extern const std::string kUpdateMetaParams;
 extern const std::string kInsertVehicleDataItem;
 extern const std::string kSelectVehicleDataItem;
 extern const std::string kDeleteVehicleDataItems;

--- a/src/components/policy/policy_regular/include/policy/sql_pt_representation.h
+++ b/src/components/policy/policy_regular/include/policy/sql_pt_representation.h
@@ -90,7 +90,9 @@ class SQLPTRepresentation : public virtual PTRepresentation {
                          StringArray* nicknames = NULL,
                          StringArray* app_hmi_types = NULL);
   bool GetFunctionalGroupings(policy_table::FunctionalGroupings& groups);
-
+  bool SetMetaInfo(const std::string& ccpu_version,
+                   const std::string& wers_country_code,
+                   const std::string& language);
 #ifdef BUILD_TESTS
   uint32_t open_counter() {
     return open_counter_;

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1182,6 +1182,12 @@ void PolicyManagerImpl::SetSystemInfo(const std::string& ccpu_version,
                                       const std::string& wers_country_code,
                                       const std::string& language) {
   LOG4CXX_AUTO_TRACE(logger_);
+  cache_->SetMetaInfo(ccpu_version, wers_country_code, language);
+}
+
+std::string PolicyManagerImpl::GetCCPUVersionFromPT() const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return cache_->GetCCPUVersionFromPT();
 }
 
 void PolicyManagerImpl::OnSystemReady() {

--- a/src/components/policy/policy_regular/src/policy_table/types.cc
+++ b/src/components/policy/policy_regular/src/policy_table/types.cc
@@ -1269,6 +1269,9 @@ ModuleMeta::~ModuleMeta() {}
 
 ModuleMeta::ModuleMeta(const Json::Value* value__)
     : CompositeType(InitHelper(value__, &Json::Value::isObject))
+    , ccpu_version(impl::ValueMember(value__, "ccpu_version"))
+    , language(impl::ValueMember(value__, "language"))
+    , wers_country_code(impl::ValueMember(value__, "wers_country_code"))
     , pt_exchanged_at_odometer_x(
           impl::ValueMember(value__, "pt_exchanged_at_odometer_x"))
     , pt_exchanged_x_days_after_epoch(
@@ -1278,6 +1281,9 @@ ModuleMeta::ModuleMeta(const Json::Value* value__)
 
 Json::Value ModuleMeta::ToJsonValue() const {
   Json::Value result__(Json::objectValue);
+  impl::WriteJsonField("ccpu_version", ccpu_version, &result__);
+  impl::WriteJsonField("language", language, &result__);
+  impl::WriteJsonField("wers_country_code", wers_country_code, &result__);
   impl::WriteJsonField(
       "pt_exchanged_at_odometer_x", pt_exchanged_at_odometer_x, &result__);
   impl::WriteJsonField("pt_exchanged_x_days_after_epoch",
@@ -1292,6 +1298,15 @@ Json::Value ModuleMeta::ToJsonValue() const {
 bool ModuleMeta::is_valid() const {
   if (struct_empty()) {
     return initialization_state__ == kInitialized && Validate();
+  }
+  if (!ccpu_version.is_valid()) {
+    return false;
+  }
+  if (!language.is_valid()) {
+    return false;
+  }
+  if (!wers_country_code.is_valid()) {
+    return false;
   }
   if (!pt_exchanged_at_odometer_x.is_valid()) {
     return false;
@@ -1310,6 +1325,16 @@ bool ModuleMeta::is_initialized() const {
 }
 
 bool ModuleMeta::struct_empty() const {
+  if (ccpu_version.is_initialized()) {
+    return false;
+  }
+  if (language.is_initialized()) {
+    return false;
+  }
+
+  if (wers_country_code.is_initialized()) {
+    return false;
+  }
   if (pt_exchanged_at_odometer_x.is_initialized()) {
     return false;
   }
@@ -1327,6 +1352,16 @@ void ModuleMeta::ReportErrors(rpc::ValidationReport* report__) const {
   if (struct_empty()) {
     rpc::CompositeType::ReportErrors(report__);
   }
+  if (!ccpu_version.is_valid()) {
+    ccpu_version.ReportErrors(&report__->ReportSubobject("ccpu_version"));
+  }
+  if (!language.is_valid()) {
+    language.ReportErrors(&report__->ReportSubobject("language"));
+  }
+  if (!wers_country_code.is_valid()) {
+    wers_country_code.ReportErrors(
+        &report__->ReportSubobject("wers_country_code"));
+  }
   if (!pt_exchanged_at_odometer_x.is_valid()) {
     pt_exchanged_at_odometer_x.ReportErrors(
         &report__->ReportSubobject("pt_exchanged_at_odometer_x"));
@@ -1343,6 +1378,9 @@ void ModuleMeta::ReportErrors(rpc::ValidationReport* report__) const {
 
 void ModuleMeta::SetPolicyTableType(PolicyTableType pt_type) {
   CompositeType::SetPolicyTableType(pt_type);
+  ccpu_version.SetPolicyTableType(pt_type);
+  language.SetPolicyTableType(pt_type);
+  wers_country_code.SetPolicyTableType(pt_type);
   pt_exchanged_at_odometer_x.SetPolicyTableType(pt_type);
   pt_exchanged_x_days_after_epoch.SetPolicyTableType(pt_type);
   ignition_cycles_since_last_exchange.SetPolicyTableType(pt_type);

--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -56,6 +56,9 @@ const std::string kCreateSchema =
     "  `count_of_sync_reboots` INTEGER "
     "); "
     "CREATE TABLE IF NOT EXISTS `module_meta`( "
+    "  `ccpu_version` VARCHAR(45), "
+    "  `language` VARCHAR(45), "
+    "  `wers_country_code` VARCHAR(45), "
     "  `pt_exchanged_at_odometer_x` INTEGER NOT NULL DEFAULT 0, "
     "  `pt_exchanged_x_days_after_epoch` INTEGER NOT NULL DEFAULT 0, "
     "  `ignition_cycles_since_last_exchange` INTEGER NOT NULL DEFAULT 0, "
@@ -1050,5 +1053,9 @@ const std::string kSaveModuleMeta =
     "`ignition_cycles_since_last_exchange` = ? ";
 
 const std::string kSelectModuleMeta = "SELECT* FROM `module_meta`";
+
+const std::string kUpdateMetaParams =
+    "UPDATE `module_meta` SET "
+    "`ccpu_version` = ?, `language` = ?, `wers_country_code` = ? ";
 }  // namespace sql_pt
 }  // namespace policy

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -498,9 +498,12 @@ void SQLPTRepresentation::GatherModuleMeta(
   LOG4CXX_INFO(logger_, "Gather Module Meta Info");
   utils::dbms::SQLQuery query(db());
   if (query.Prepare(sql_pt::kSelectModuleMeta) && query.Next()) {
-    *meta->pt_exchanged_at_odometer_x = query.GetInteger(0);
-    *meta->pt_exchanged_x_days_after_epoch = query.GetInteger(1);
-    *meta->ignition_cycles_since_last_exchange = query.GetInteger(2);
+    *meta->ccpu_version = query.GetString(0);
+    *meta->language = query.GetString(1);
+    *meta->wers_country_code = query.GetString(2);
+    *meta->pt_exchanged_at_odometer_x = query.GetInteger(3);
+    *meta->pt_exchanged_x_days_after_epoch = query.GetInteger(4);
+    *meta->ignition_cycles_since_last_exchange = query.GetInteger(5);
   }
 }
 
@@ -712,6 +715,27 @@ bool SQLPTRepresentation::GatherConsumerFriendlyMessages(
     LOG4CXX_WARN(logger_, "Incorrect statement for select friendly messages.");
   }
 
+  return true;
+}
+
+bool SQLPTRepresentation::SetMetaInfo(const std::string& ccpu_version,
+                                      const std::string& wers_country_code,
+                                      const std::string& language) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  utils::dbms::SQLQuery query(db());
+  if (!query.Prepare(sql_pt::kUpdateMetaParams)) {
+    LOG4CXX_WARN(logger_, "Incorrect statement for insert to module meta.");
+    return false;
+  }
+
+  query.Bind(0, ccpu_version);
+  query.Bind(1, wers_country_code);
+  query.Bind(2, language);
+
+  if (!query.Exec() || !query.Reset()) {
+    LOG4CXX_WARN(logger_, "Incorrect insert to module meta.");
+    return false;
+  }
   return true;
 }
 
@@ -1418,9 +1442,12 @@ bool SQLPTRepresentation::SaveModuleMeta(const policy_table::ModuleMeta& meta) {
   }
   const int64_t odometer = *(meta.pt_exchanged_at_odometer_x);
 
-  query.Bind(0, odometer);
-  query.Bind(1, *(meta.pt_exchanged_x_days_after_epoch));
-  query.Bind(2, *(meta.ignition_cycles_since_last_exchange));
+  query.Bind(0, *(meta.ccpu_version));
+  query.Bind(1, *(meta.language));
+  query.Bind(2, *(meta.wers_country_code));
+  query.Bind(3, odometer);
+  query.Bind(4, *(meta.pt_exchanged_x_days_after_epoch));
+  query.Bind(5, *(meta.ignition_cycles_since_last_exchange));
 
   if (!query.Exec()) {
     LOG4CXX_WARN(logger_, "Incorrect update for module_meta.");


### PR DESCRIPTION
This PR is part of https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0249-Persisting-HMI-Capabilities-specific-to-headunit.md proposal implementation

### Risk
This PR makes **[no]** API changes.

### Testing Plan
unit tests

### Summary
HMI Capabilities Persistence after HMI SW update:

    HMI sends BC.OnReady to SDL Core.
    SDL Core should NOT set IsHMICooperating to true yet (i.e. hold all RAI requests from MOBILE).
    SDL Core should then send a request to HMI to get ccpu_version (`BC.GetSystemInfo).
    Upon receiving ccpu_version from HMI, SDL Core should check if local ccpu_version matches with received ccpu_version.
        If No:
            SDL Core should delete HMICapabilitiesCacheFile and send GetCapabilities requests for each interface (VR, TTS, UI etc) to HMI as defined in Step 1ib above and persist the responses received from HMI to HMICapabilitiesCacheFile as defined in step 2i above.
            When HMI has responded to all the HMI capabilities requests, SDL Core should set IsHMICooperating to true.
            In case HMI does not send response for GetCapabilities requests or if HMI sends error, SDL Core should fall back to default HMI Capabilities and set IsHMICooperating to true. SDL Core should not persist those capabilities in cache.
        If Yes:
            SDL Core should set IsHMICooperating to true.
    SDL Core should respond to all pending RAI requests from MOBILE.


