### PR TITLE
Feature/Align HMI API with MOBILE API for pcmStreamCapabilities

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
@@ -128,6 +128,11 @@ void UIGetCapabilitiesResponse::Run() {
                     [strings::display_capabilities]);
     }
   }
+
+  if (msg_params.keyExists(strings::pcm_stream_capabilities)) {
+    hmi_capabilities.set_pcm_stream_capabilities(
+        msg_params[strings::pcm_stream_capabilities]);
+  }
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -362,6 +362,24 @@ TEST_F(UIGetCapabilitiesResponseTest, SetSystemDisplayCapabilities_SUCCESS) {
   command->Run();
 }
 
+TEST_F(UIGetCapabilitiesResponseTest, SetPCMStreamCapabilities_SUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  (*command_msg)[strings::msg_params][strings::pcm_stream_capabilities] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  ResponseFromHMIPtr command(
+      CreateCommand<UIGetCapabilitiesResponse>(command_msg));
+
+  const auto& pcm_capabilities_so =
+      (*command_msg)[strings::msg_params][strings::pcm_stream_capabilities];
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              set_pcm_stream_capabilities(pcm_capabilities_so));
+
+  ASSERT_TRUE(command->Init());
+  command->Run();
+}
+
 }  // namespace ui_get_capabilities_response
 }  // namespace hmi_commands_test
 }  // namespace commands_test

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -5469,6 +5469,7 @@
     <param name="systemCapabilities" type="Common.SystemCapabilities" mandatory="false">
       <description>Specifies system capabilities. See SystemCapabilities</description>
     </param>
+    <param name="pcmStreamCapabilities" type="Common.AudioPassThruCapabilities" mandatory="false"/>
   </function>
   <function name="ChangeRegistration" messagetype="request">
     <description>Request from SmartDeviceLink to HMI to change language for app.</description>


### PR DESCRIPTION
Fixes [#3078](https://github.com/smartdevicelink/sdl_core/issues/3078)

This PR is **not ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests and ATF scripts.

Use scripts from:
[smartdevicelink/sdl_atf_test_scripts#128](https://github.ford.com/SmartDeviceLinkMirror/sdl_atf_test_scripts/pull/128)

### Summary
PR contains sdl_core implementation of [SDL 0252] Aligning HMI and MOBILE API for pcmStreamCapabilities


### CLA
- [x ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)