### PR TITLE
Change reason to IGNITION_OFF only if reason wasn't defined before

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2571,8 +2571,12 @@ bool ApplicationManagerImpl::Stop() {
   stopping_application_mng_lock_.Release();
   application_list_update_timer_.Stop();
   try {
-    SetUnregisterAllApplicationsReason(
-        mobile_api::AppInterfaceUnregisteredReason::IGNITION_OFF);
+    if (unregister_reason_ ==
+        mobile_api::AppInterfaceUnregisteredReason::INVALID_ENUM) {
+      SetUnregisterAllApplicationsReason(
+          mobile_api::AppInterfaceUnregisteredReason::IGNITION_OFF);
+    }
+
     UnregisterAllApplications();
   } catch (...) {
     LOG4CXX_ERROR(logger_,


### PR DESCRIPTION
Fixes #3204 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
Covered within existing unit tests and ATF tests.
During regression incorrect script was found, this fact was reflected in corresponding issue https://github.com/smartdevicelink/sdl_atf_test_scripts/issues/2355, and this problem is solved in pull request https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2354.

### Summary
This pull request is intended to fix issue with changing reason from FACTORY_DEFAULTS to IGNITION_OFF after unregistration of apps by SDL. Root cause of this issue is incorrect behavior of class ApplicationManagerImpl in method Stop(), where it assigns reason of unregistration to IGNITION_OFF in any case, even if this reason was defined earlier. Now it will change unregister_reason to IGNITION_OFF only for undefined reasons and will leave already known unregister_reason as is.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
