### PR TITLE
Fix/SDL does not send BC.PolicyUpdate to HMI if no apps are registered

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1953,7 +1953,7 @@ void PolicyHandler::OnPTUFinished(const bool ptu_result) {
 }
 
 bool PolicyHandler::CanUpdate() {
-  return 0 != GetAppIdForSending();
+  return true;
 }
 
 void PolicyHandler::RemoveDevice(const std::string& device_id) {

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1953,7 +1953,7 @@ void PolicyHandler::OnPTUFinished(const bool ptu_result) {
 }
 
 bool PolicyHandler::CanUpdate() {
-  return true;
+  return 0 != GetAppIdForSending();
 }
 
 void PolicyHandler::RemoveDevice(const std::string& device_id) {

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -755,7 +755,7 @@ void PolicyManagerImpl::StartPTExchange() {
     return;
   }
   LOG4CXX_INFO(logger_, "Policy want to  call RequestPTUpdate");
-  if (listener_ && listener_->CanUpdate()) {
+  if (listener_) {
     LOG4CXX_INFO(logger_, "Listener CanUpdate");
     if (update_status_manager_.IsUpdateRequired()) {
       update_status_manager_.PendingUpdate();

--- a/src/components/policy/policy_external/test/include/policy/policy_manager_impl_test_base.h
+++ b/src/components/policy/policy_external/test/include/policy/policy_manager_impl_test_base.h
@@ -117,6 +117,7 @@ class PolicyManagerImplTest : public ::testing::Test {
   MockUpdateStatusManager update_manager_;
   NiceMock<MockPolicyListener> listener_;
   NiceMock<MockPTURetryHandler> ptu_retry_handler_;
+  PolicyTableSPtr default_pt_snapshot_;
 
   void SetUp() OVERRIDE;
 

--- a/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_ptu_test.cc
@@ -980,6 +980,8 @@ TEST_F(PolicyManagerImplTest2,
 
 TEST_F(PolicyManagerImplTest, LoadPT_SetInvalidUpdatePT_PTIsNotLoaded) {
   // Arrange
+  EXPECT_CALL(*cache_manager_, GenerateSnapshot())
+      .WillOnce(Return(default_pt_snapshot_));
   policy_manager_->ForcePTExchange();
   policy_manager_->OnUpdateStarted();
   Json::Value table(Json::objectValue);

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -106,6 +106,8 @@ TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
   // Arrange
   EXPECT_CALL(*cache_manager_, DaysBeforeExchange(_))
       .WillOnce(Return(kNonZero));
+  ON_CALL(*cache_manager_, GenerateSnapshot())
+      .WillByDefault(Return(default_pt_snapshot_));
   policy_manager_->ForcePTExchange();
   policy_manager_->SetSendOnUpdateFlags(true);
   policy_manager_->OnUpdateStarted();
@@ -254,6 +256,8 @@ TEST_F(PolicyManagerImplTest2, GetPolicyTableStatus_ExpectUpToDate) {
 TEST_F(PolicyManagerImplTest,
        SetUpdateStarted_GetPolicyTableStatus_Expect_Updating) {
   // Arrange
+  EXPECT_CALL(*cache_manager_, GenerateSnapshot())
+      .WillOnce(Return(default_pt_snapshot_));
   policy_manager_->ForcePTExchange();
   EXPECT_CALL(*cache_manager_, SaveUpdateRequired(true));
   policy_manager_->OnUpdateStarted();
@@ -306,6 +310,8 @@ TEST_F(PolicyManagerImplTest, MarkUnpairedDevice) {
   EXPECT_CALL(*cache_manager_, IgnitionCyclesBeforeExchange());
   EXPECT_CALL(*cache_manager_, DaysBeforeExchange(_));
   // Act
+  EXPECT_CALL(*cache_manager_, GenerateSnapshot())
+      .WillOnce(Return(default_pt_snapshot_));
   policy_manager_->MarkUnpairedDevice(unpaired_device_id_);
 }
 

--- a/src/components/policy/policy_external/test/policy_manager_impl_test_base.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test_base.cc
@@ -220,6 +220,8 @@ void PolicyManagerImplTest::SetUp() {
   ON_CALL(listener_, GetRegisteredLinks(_)).WillByDefault(Return());
   ON_CALL(listener_, ptu_retry_handler())
       .WillByDefault(ReturnRef(ptu_retry_handler_));
+  Json::Value table = createPTforLoad();
+  default_pt_snapshot_ = std::make_shared<policy_table::Table>(&table);
 }
 
 void PolicyManagerImplTest::TearDown() {

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -662,7 +662,7 @@ void PolicyManagerImpl::StartPTExchange() {
     return;
   }
 
-  if (listener_ && listener_->CanUpdate()) {
+  if (listener_) {
     if (ignition_check) {
       CheckTriggers();
       ignition_check = false;

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -77,6 +77,8 @@ namespace custom_str = utils::custom_string;
 typedef std::multimap<std::string, policy_table::Rpcs&>
     UserConsentPromptToRpcsConnections;
 
+typedef std::shared_ptr<policy_table::Table> PolicyTableSPtr;
+
 namespace {
 std::string kSpeed = "speed";
 std::string kRPM = "rpm";
@@ -153,6 +155,7 @@ class PolicyManagerImplTest : public ::testing::Test {
   NiceMock<MockUpdateStatusManager> update_status_manager;
   const std::string device_id;
   std::shared_ptr<access_remote_test::MockAccessRemote> access_remote;
+  PolicyTableSPtr default_pt_snapshot_;
 
   void SetUp() OVERRIDE {
     manager = new PolicyManagerImpl();
@@ -161,6 +164,8 @@ class PolicyManagerImplTest : public ::testing::Test {
     manager->set_cache_manager(cache_manager);
     access_remote = std::make_shared<access_remote_test::MockAccessRemote>();
     manager->set_access_remote(access_remote);
+    // Json::Value table = createPTforLoad();
+    default_pt_snapshot_ = std::make_shared<policy_table::Table>();
   }
 
   void TearDown() OVERRIDE {
@@ -985,6 +990,7 @@ TEST_F(PolicyManagerImplTest, ResetPT) {
 
 TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
   // Arrange
+  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
@@ -1021,6 +1027,7 @@ TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
 
 TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_removeRPC_SendUpdate) {
   // Arrange
+  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
@@ -1056,6 +1063,7 @@ TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_removeRPC_SendUpdate) {
 TEST_F(PolicyManagerImplTest,
        LoadPT_FunctionalGroup_removeRPCParams_SendUpdate) {
   // Arrange
+  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
@@ -1093,6 +1101,7 @@ TEST_F(PolicyManagerImplTest,
 TEST_F(PolicyManagerImplTest,
        LoadPT_FunctionalGroup_removeRPC_HMILevels_SendUpdate) {
   // Arrange
+  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
@@ -1130,6 +1139,7 @@ TEST_F(PolicyManagerImplTest,
 TEST_F(PolicyManagerImplTest,
        LoadPT_FunctionalGroup_addRPC_HMILevels_SendUpdate) {
   // Arrange
+  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
@@ -1168,6 +1178,7 @@ TEST_F(PolicyManagerImplTest,
 TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_addRPCParams_SendUpdate) {
   using namespace application_manager;
   // Arrange
+  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
@@ -1204,6 +1215,7 @@ TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_addRPCParams_SendUpdate) {
 
 TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_NoUpdate_DONT_SendUpdate) {
   // Arrange
+  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
@@ -1234,6 +1246,7 @@ TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_NoUpdate_DONT_SendUpdate) {
 TEST_F(PolicyManagerImplTest, LoadPT_SetInvalidUpdatePT_PTIsNotLoaded) {
   // Arrange
   Json::Value table(Json::objectValue);
+  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
 

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -990,7 +990,8 @@ TEST_F(PolicyManagerImplTest, ResetPT) {
 
 TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
   // Arrange
-  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
+  EXPECT_CALL(*cache_manager, GenerateSnapshot())
+      .WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
@@ -1027,7 +1028,8 @@ TEST_F(PolicyManagerImplTest, LoadPT_SetPT_PTIsLoaded) {
 
 TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_removeRPC_SendUpdate) {
   // Arrange
-  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
+  EXPECT_CALL(*cache_manager, GenerateSnapshot())
+      .WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
@@ -1063,7 +1065,8 @@ TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_removeRPC_SendUpdate) {
 TEST_F(PolicyManagerImplTest,
        LoadPT_FunctionalGroup_removeRPCParams_SendUpdate) {
   // Arrange
-  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
+  EXPECT_CALL(*cache_manager, GenerateSnapshot())
+      .WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
@@ -1101,7 +1104,8 @@ TEST_F(PolicyManagerImplTest,
 TEST_F(PolicyManagerImplTest,
        LoadPT_FunctionalGroup_removeRPC_HMILevels_SendUpdate) {
   // Arrange
-  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
+  EXPECT_CALL(*cache_manager, GenerateSnapshot())
+      .WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
@@ -1139,7 +1143,8 @@ TEST_F(PolicyManagerImplTest,
 TEST_F(PolicyManagerImplTest,
        LoadPT_FunctionalGroup_addRPC_HMILevels_SendUpdate) {
   // Arrange
-  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
+  EXPECT_CALL(*cache_manager, GenerateSnapshot())
+      .WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
@@ -1178,7 +1183,8 @@ TEST_F(PolicyManagerImplTest,
 TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_addRPCParams_SendUpdate) {
   using namespace application_manager;
   // Arrange
-  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
+  EXPECT_CALL(*cache_manager, GenerateSnapshot())
+      .WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
@@ -1215,7 +1221,8 @@ TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_addRPCParams_SendUpdate) {
 
 TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_NoUpdate_DONT_SendUpdate) {
   // Arrange
-  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
+  EXPECT_CALL(*cache_manager, GenerateSnapshot())
+      .WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
   Json::Value table = CreatePTforLoad();
@@ -1246,7 +1253,8 @@ TEST_F(PolicyManagerImplTest, LoadPT_FunctionalGroup_NoUpdate_DONT_SendUpdate) {
 TEST_F(PolicyManagerImplTest, LoadPT_SetInvalidUpdatePT_PTIsNotLoaded) {
   // Arrange
   Json::Value table(Json::objectValue);
-  EXPECT_CALL(*cache_manager, GenerateSnapshot()).WillOnce(Return(default_pt_snapshot_));
+  EXPECT_CALL(*cache_manager, GenerateSnapshot())
+      .WillOnce(Return(default_pt_snapshot_));
   manager->ForcePTExchange();
   manager->OnUpdateStarted();
 


### PR DESCRIPTION


Fixes #3279 

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test Suite app and ATF

### Summary
Temporary fix: Change the `PolicyHandler::CanUpdate` function to return true even when no apps are registered

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
