### PR TITLE
fix/Move AppProperties struct to the Common interface

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -4689,20 +4689,6 @@
   
   <function name="SetAppProperties" messagetype="response">
     <description>The response to SetAppProperties</description>
-    <param name="success" type="Boolean" platform="documentation" mandatory="true">
-      <description>true if successful; false if failed</description>
-    </param>
-    <param name="resultCode" type="Common.Result" platform="documentation" mandatory="true">
-      <description>See Result</description>
-      <element name="SUCCESS"/>
-      <element name="INVALID_DATA"/>
-      <element name="OUT_OF_MEMORY"/>
-      <element name="TOO_MANY_PENDING_REQUESTS"/>
-      <element name="GENERIC_ERROR"/>
-      <element name="DISALLOWED"/>
-      <element name="WARNINGS"/>
-      <element name="DATA_NOT_AVAILABLE"/>
-    </param>
   </function>
   
   <function name="GetAppProperties" messagetype="request">
@@ -4719,20 +4705,6 @@
     <description>The response to GetAppProperties</description>
     <param name="properties" type="Common.AppProperties" array="true" minsize="1" mandatory="false">
       <description>The requested application properties</description>
-    </param>
-    <param name="success" type="Boolean" platform="documentation" mandatory="true">
-      <description>true if successful; false if failed</description>
-    </param>
-    <param name="resultCode" type="Common.Result" platform="documentation" mandatory="true">
-      <description>See Result</description>
-      <element name="SUCCESS"/>
-      <element name="INVALID_DATA"/>
-      <element name="OUT_OF_MEMORY"/>
-      <element name="TOO_MANY_PENDING_REQUESTS"/>
-      <element name="GENERIC_ERROR"/>
-      <element name="DISALLOWED"/>
-      <element name="WARNINGS"/>
-      <element name="DATA_NOT_AVAILABLE"/>
     </param>
   </function>
   

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -4699,7 +4699,7 @@
       <description>
         If specified the response will contain the properties of the specified app ID.
         Otherwise if omitted all app properties will be returned at once.
-      <description>
+      </description>
     </param>
   </function>
   

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -4131,6 +4131,34 @@
         <element name="BOTH"/>
     </enum>
 
+    <struct name="AppProperties">
+      <param name="nicknames" type="String" minlength="0" maxlength="100" array="true" minsize="0" maxsize="100" mandatory="false">
+          <description>An array of app names an app is allowed to register with. If included in a SetAppProperties request, this value will overwrite the existing "nicknames" field in the app policies section of the policy table.</description>
+      </param>
+      <param name="policyAppID" type="String" maxlength="100" minlength="1" mandatory="true" />
+      <param name="enabled" type="Boolean" mandatory="false">
+          <description>If true, the app will be marked as "available" or "installed" and will be included in HMI RPC UpdateAppList.</description>
+      </param>
+      <param name="authToken" type="String" maxlength="65535" mandatory="false">
+          <description>Used to authenticate connection on app activation</description>
+      </param>
+      <param name="transportType" type="String" maxlength="100" mandatory="false">
+          <description>
+            Specifies the connection type Core should use. The Core role (server or client) is dependent of "endpoint" being specified.
+            See "endpoint" for details.
+          </description>
+      </param>
+      <param name="hybridAppPreference" type="Common.HybridAppPreference" mandatory="false">
+          <description>Specifies the user preference to use one specific app type or all available types</description>
+      </param>
+      <param name="endpoint" type="String" maxlength="65535" mandatory="false">
+          <description>
+            If specified, which Core uses a client implementation of the connection type and attempts to connect to the endpoint when this app is selected (activated).
+            If omitted, Core won't attempt to connect as the app selection (activation) is managed outside of Core. Instead it uses a server implementation of the connection type and expects the app to connect.
+          </description>
+      </param>
+    </struct>
+
 </interface>
 
 <interface name="Buttons" version="1.3.0" date="2017-07-18">
@@ -4650,39 +4678,11 @@
     </param>
   </function>
   
-  <struct name="AppProperties">
-    <param name="nicknames" type="String" minlength="0" maxlength="100" array="true" minsize="0" maxsize="100" mandatory="false">
-        <description>An array of app names an app is allowed to register with. If included in a SetAppProperties request, this value will overwrite the existing "nicknames" field in the app policies section of the policy table.</description>
-    </param>
-    <param name="policyAppID" type="String" maxlength="100" minlength="1" mandatory="true" />
-    <param name="enabled" type="Boolean" mandatory="false">
-        <description>If true, the app will be marked as "available" or "installed" and will be included in HMI RPC UpdateAppList.</description>
-    </param>
-    <param name="authToken" type="String" maxlength="65535" mandatory="false">
-        <description>Used to authenticate connection on app activation</description>
-    </param>
-    <param name="transportType" type="String" maxlength="100" mandatory="false">
-        <description>
-          Specifies the connection type Core should use. The Core role (server or client) is dependent of "endpoint" being specified.
-          See "endpoint" for details.
-        </description>
-    </param>
-    <param name="hybridAppPreference" type="Common.HybridAppPreference" mandatory="false">
-        <description>Specifies the user preference to use one specific app type or all available types</description>
-    </param>
-    <param name="endpoint" type="String" maxlength="65535" mandatory="false">
-        <description>
-          If specified, which Core uses a client implementation of the connection type and attempts to connect to the endpoint when this app is selected (activated).
-          If omitted, Core won't attempt to connect as the app selection (activation) is managed outside of Core. Instead it uses a server implementation of the connection type and expects the app to connect.
-        </description>
-    </param>
-  </struct>
-  
   <function name="SetAppProperties" messagetype="request">
     <description>
       HMI >SDL. RPC used to enable/disable an application and set authentication data
     </description>
-    <param name="properties" type="AppProperties" mandatory="true">
+    <param name="properties" type="Common.AppProperties" mandatory="true">
       <description>The new application properties</description>
     </param>
   </function> 
@@ -4717,7 +4717,7 @@
   
   <function name="GetAppProperties" messagetype="response">
     <description>The response to GetAppProperties</description>
-    <param name="properties" type="AppProperties" array="true" minsize="1" mandatory="false">
+    <param name="properties" type="Common.AppProperties" array="true" minsize="1" mandatory="false">
       <description>The requested application properties</description>
     </param>
     <param name="success" type="Boolean" platform="documentation" mandatory="true">
@@ -4740,7 +4740,7 @@
     <description>
       SDL >HMI. RPC used to inform HMI about app properties change (such as auth token).
     </description>
-    <param name="properties" type="AppProperties" mandatory="true">
+    <param name="properties" type="Common.AppProperties" mandatory="true">
       <description>The new application properties</description>
     </param>
   </function>

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -4696,8 +4696,10 @@
       HMI >SDL. RPC used to get the current properties of an application
     </description>
     <param name="policyAppID" type="String" maxlength="100" mandatory="false">
-      If specified the response will contain the properties of the specified app ID.
-      Otherwise if omitted all app properties will be returned at once.
+      <description>
+        If specified the response will contain the properties of the specified app ID.
+        Otherwise if omitted all app properties will be returned at once.
+      <description>
     </param>
   </function>
   


### PR DESCRIPTION
Currently the `AppProperties` struct in the HMI_API is a part of the `BasicCommunication` interface even though all the enums and interfaces are only added in HMI_API to the `Common` interface. This PR  moves the struct into the Common Interface

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Test Suite and ATF

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
