### PR TITLE
Prevent restoring resumption-related data after MASTER_RESET

### DIFF
--- a/src/components/resumption/src/last_state_impl.cc
+++ b/src/components/resumption/src/last_state_impl.cc
@@ -49,7 +49,6 @@ LastStateImpl::LastStateImpl(const std::string& app_storage_folder,
 
 LastStateImpl::~LastStateImpl() {
   LOG4CXX_AUTO_TRACE(logger_);
-  SaveToFileSystem();
 }
 
 void LastStateImpl::SaveStateToFileSystem() {


### PR DESCRIPTION
Fixes #2448 

This PR is **not ready** for review.

**NOTE:** This PR depends on #3274.
### Risk
This PR makes **no** API changes.

### Testing Plan
TBD
### Summary
The issue #2448 root cause is resumption-related data being restored after its cleanup in ApplicationManagerImpl::HeadUnitReset. There are two scenarios:
1. LastStateImpl's destructor restores the data by calling SaveToFileSystem. It is safe to remove this call from the destructor as the resumption data is saved in either ResumeCtrlImpl::OnSuspend, ResumeCtrlImpl::OnIgnitionOff or ResumeCtrlImpl::SaveDataOnTimer.
2. The wrong unregister reason set in ApplicationManagerImpl::Stop results in ResumeCtrlImpl::OnIgnitionOff call. The unregister reason has been fixed in #3274.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
