### PR TITLE
Fix/Perform hash check before copying over mobile api files

### DIFF
--- a/src/components/interfaces/CMakeLists.txt
+++ b/src/components/interfaces/CMakeLists.txt
@@ -30,14 +30,12 @@
 
 # Copy RPC spec submodule files to interfaces directory
 if(EXISTS ${CMAKE_SOURCE_DIR}/tools/rpc_spec/)
-  execute_process(COMMAND  cmp --silent ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xml ${CMAKE_CURRENT_SOURCE_DIR}/MOBILE_API.xml RESULT_VARIABLE ret)
-  if(NOT ret EQUAL "0")
-    execute_process(COMMAND cp ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xml ${CMAKE_CURRENT_SOURCE_DIR}/)
-  endif()
-  execute_process(COMMAND  cmp --silent ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xsd ${CMAKE_CURRENT_SOURCE_DIR}/MOBILE_API.xsd RESULT_VARIABLE ret)
-  if(NOT ret EQUAL "0")
-    execute_process(COMMAND cp ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xsd ${CMAKE_CURRENT_SOURCE_DIR}/)
-  endif()
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different 
+                  ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xml 
+                  ${CMAKE_CURRENT_SOURCE_DIR}/MOBILE_API.xml)
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different 
+                  ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xsd 
+                  ${CMAKE_CURRENT_SOURCE_DIR}/MOBILE_API.xsd)
 else ()
   message( FATAL_ERROR "Missing the RPC Spec submodule" )
   message( FATAL_ERROR "Please run `git submodule update --init` in the SDL Core source directory" )

--- a/src/components/interfaces/CMakeLists.txt
+++ b/src/components/interfaces/CMakeLists.txt
@@ -30,8 +30,14 @@
 
 # Copy RPC spec submodule files to interfaces directory
 if(EXISTS ${CMAKE_SOURCE_DIR}/tools/rpc_spec/)
-  execute_process(COMMAND cp ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xml ${CMAKE_CURRENT_SOURCE_DIR}/)
-  execute_process(COMMAND cp ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xsd ${CMAKE_CURRENT_SOURCE_DIR}/)
+  execute_process(COMMAND  cmp --silent ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xml ${CMAKE_CURRENT_SOURCE_DIR}/MOBILE_API.xml RESULT_VARIABLE ret)
+  if(NOT ret EQUAL "0")
+    execute_process(COMMAND cp ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xml ${CMAKE_CURRENT_SOURCE_DIR}/)
+  endif()
+  execute_process(COMMAND  cmp --silent ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xsd ${CMAKE_CURRENT_SOURCE_DIR}/MOBILE_API.xsd RESULT_VARIABLE ret)
+  if(NOT ret EQUAL "0")
+    execute_process(COMMAND cp ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xsd ${CMAKE_CURRENT_SOURCE_DIR}/)
+  endif()
 else ()
   message( FATAL_ERROR "Missing the RPC Spec submodule" )
   message( FATAL_ERROR "Please run `git submodule update --init` in the SDL Core source directory" )

--- a/src/components/interfaces/CMakeLists.txt
+++ b/src/components/interfaces/CMakeLists.txt
@@ -30,11 +30,11 @@
 
 # Copy RPC spec submodule files to interfaces directory
 if(EXISTS ${CMAKE_SOURCE_DIR}/tools/rpc_spec/)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different 
-                  ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xml 
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                  ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xml
                   ${CMAKE_CURRENT_SOURCE_DIR}/MOBILE_API.xml)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different 
-                  ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xsd 
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                  ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xsd
                   ${CMAKE_CURRENT_SOURCE_DIR}/MOBILE_API.xsd)
 else ()
   message( FATAL_ERROR "Missing the RPC Spec submodule" )


### PR DESCRIPTION
Currently, running the cmake command copies the MOBILE_API xml and xsd files into the interface directory **every time**. When make happens, the build process thinks these files have changed and rebuilds every file linked to the mobile_api.xml

This PR adds a fix which compares the hash of the `interfaces/MOBILE_API.*` files to the `tools/rpc_spec/MOBILE_API.*` files. If the hashes do not match, then copy the file.


This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Re-run cmake and make after building core

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
