### PR TITLE
Fix APTDisplayText is not displayed properly

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -287,20 +287,22 @@ void PerformAudioPassThruRequest::SendPerformAudioPassThruRequest() {
   msg_params[hmi_request::audio_pass_display_texts] =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
 
+  int32_t index = 0;
   if ((*message_)[str::msg_params].keyExists(str::audio_pass_display_text1)) {
-    msg_params[hmi_request::audio_pass_display_texts][0]
+    msg_params[hmi_request::audio_pass_display_texts][index]
               [hmi_request::field_name] = static_cast<int32_t>(
                   hmi_apis::Common_TextFieldName::audioPassThruDisplayText1);
-    msg_params[hmi_request::audio_pass_display_texts][0]
+    msg_params[hmi_request::audio_pass_display_texts][index]
               [hmi_request::field_text] =
                   (*message_)[str::msg_params][str::audio_pass_display_text1];
+    ++index;
   }
 
   if ((*message_)[str::msg_params].keyExists(str::audio_pass_display_text2)) {
-    msg_params[hmi_request::audio_pass_display_texts][1]
+    msg_params[hmi_request::audio_pass_display_texts][index]
               [hmi_request::field_name] = static_cast<int32_t>(
                   hmi_apis::Common_TextFieldName::audioPassThruDisplayText2);
-    msg_params[hmi_request::audio_pass_display_texts][1]
+    msg_params[hmi_request::audio_pass_display_texts][index]
               [hmi_request::field_text] =
                   (*message_)[str::msg_params][str::audio_pass_display_text2];
   }


### PR DESCRIPTION
Fixes #3238 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
**Reason**
SDLCore's rules for `audio_pass_display_text` are inconsistent with the rules for converting into JSON data, resulting in data loss.
![image](https://user-images.githubusercontent.com/35795928/76812977-e0abc700-6839-11ea-84c2-8d2ee3deec20.png)


**Solution**
Just like `show_strings` parameter in show struct converted into JSON format. When `audio_pass_display_text` parameter in `Msg_parans` struct converted to JSON format, 
the rules of JSON format conversion should be followed, that is, set from the first element. 


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)