### PR TITLE
Fix sdl crash when policies disabled

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -141,7 +141,7 @@ struct HMILevelPredicate
 
 }  // namespace
 
-#define POLICY_LIB_CHECK(return_value)                                      \
+#define POLICY_LIB_CHECK_OR_RETURN(return_value)                            \
   {                                                                         \
     sync_primitives::AutoReadLock lock(policy_manager_lock_);               \
     if (!policy_manager_) {                                                 \
@@ -375,7 +375,7 @@ const PolicySettings& PolicyHandler::get_settings() const {
 
 bool PolicyHandler::InitPolicyTable() {
   LOG4CXX_AUTO_TRACE(logger_);
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   // Subscribing to notification for system readiness to be able to get system
   // info necessary for policy table
   event_observer_->subscribe_on_event(
@@ -409,7 +409,7 @@ void PolicyHandler::StopRetrySequence() {
 
 bool PolicyHandler::ResetPolicyTable() {
   LOG4CXX_TRACE(logger_, "Reset policy table.");
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   std::string preloaded_file = get_settings().preloaded_pt_file();
   if (file_system::FileExists(preloaded_file)) {
     return policy_manager_->ResetPT(preloaded_file);
@@ -420,13 +420,13 @@ bool PolicyHandler::ResetPolicyTable() {
 
 bool PolicyHandler::ClearUserConsent() {
   LOG4CXX_AUTO_TRACE(logger_);
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   return policy_manager_->ResetUserConsent();
 }
 
 uint32_t PolicyHandler::GetAppIdForSending() const {
   LOG4CXX_AUTO_TRACE(logger_);
-  POLICY_LIB_CHECK(0);
+  POLICY_LIB_CHECK_OR_RETURN(0);
   // fix ApplicationSet access crash
   const ApplicationSet accessor = application_manager_.applications().GetData();
 
@@ -605,7 +605,7 @@ StatusNotifier PolicyHandler::AddApplication(
     const std::string& device_id,
     const std::string& application_id,
     const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) {
-  POLICY_LIB_CHECK(std::make_shared<utils::CallNothing>());
+  POLICY_LIB_CHECK_OR_RETURN(std::make_shared<utils::CallNothing>());
   return policy_manager_->AddApplication(device_id, application_id, hmi_types);
 }
 
@@ -720,7 +720,7 @@ void policy::PolicyHandler::SetDaysAfterEpoch() {
 
 #ifdef ENABLE_SECURITY
 std::string PolicyHandler::RetrieveCertificate() const {
-  POLICY_LIB_CHECK(std::string(""));
+  POLICY_LIB_CHECK_OR_RETURN(std::string(""));
   return policy_manager_->RetrieveCertificate();
 }
 #endif  // ENABLE_SECURITY
@@ -768,7 +768,7 @@ void PolicyHandler::GetRegisteredLinks(
 std::vector<policy::FunctionalGroupPermission>
 PolicyHandler::CollectRegisteredAppsPermissions() {
   LOG4CXX_AUTO_TRACE(logger_);
-  POLICY_LIB_CHECK(std::vector<policy::FunctionalGroupPermission>());
+  POLICY_LIB_CHECK_OR_RETURN(std::vector<policy::FunctionalGroupPermission>());
   // If no specific app was passed, get permissions for all currently registered
   // applications
   sync_primitives::AutoLock lock(app_to_device_link_lock_);
@@ -1106,7 +1106,7 @@ void PolicyHandler::OnPendingPermissionChange(
 bool PolicyHandler::SendMessageToSDK(const BinaryMessage& pt_string,
                                      const std::string& url) {
   LOG4CXX_AUTO_TRACE(logger_);
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
 
   const uint32_t app_id = GetAppIdForSending();
   ApplicationSharedPtr app = application_manager_.application(app_id);
@@ -1143,7 +1143,7 @@ bool PolicyHandler::SendMessageToSDK(const BinaryMessage& pt_string,
 
 bool PolicyHandler::ReceiveMessageFromSDK(const std::string& file,
                                           const BinaryMessage& pt_string) {
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
 
   const auto load_pt_result = policy_manager_->LoadPT(file, pt_string);
 
@@ -1619,7 +1619,7 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string,
 
 bool PolicyHandler::GetPriority(const std::string& policy_app_id,
                                 std::string* priority) const {
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   return policy_manager_->GetPriority(policy_app_id, priority);
 }
 
@@ -1651,32 +1651,32 @@ void PolicyHandler::CheckPermissions(
 
 uint32_t PolicyHandler::GetNotificationsNumber(
     const std::string& priority) const {
-  POLICY_LIB_CHECK(0);
+  POLICY_LIB_CHECK_OR_RETURN(0);
   return policy_manager_->GetNotificationsNumber(priority);
 }
 
 DeviceConsent PolicyHandler::GetUserConsentForDevice(
     const std::string& device_id) const {
-  POLICY_LIB_CHECK(kDeviceDisallowed);
+  POLICY_LIB_CHECK_OR_RETURN(kDeviceDisallowed);
   return policy_manager_->GetUserConsentForDevice(device_id);
 }
 
 Json::Value PolicyHandler::GetPolicyTableData() const {
-  POLICY_LIB_CHECK(Json::Value());
+  POLICY_LIB_CHECK_OR_RETURN(Json::Value());
   return policy_manager_->GetPolicyTableData();
 }
 
 bool PolicyHandler::GetDefaultHmi(const std::string& device_id,
                                   const std::string& policy_app_id,
                                   std::string* default_hmi) const {
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   return policy_manager_->GetDefaultHmi(device_id, policy_app_id, default_hmi);
 }
 
 bool PolicyHandler::GetInitialAppData(const std::string& application_id,
                                       StringArray* nicknames,
                                       StringArray* app_hmi_types) {
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   return policy_manager_->GetInitialAppData(
       application_id, nicknames, app_hmi_types);
 }
@@ -1694,17 +1694,17 @@ void PolicyHandler::GetUpdateUrls(const uint32_t service_type,
 }
 
 std::string PolicyHandler::GetLockScreenIconUrl() const {
-  POLICY_LIB_CHECK(std::string(""));
+  POLICY_LIB_CHECK_OR_RETURN(std::string(""));
   return policy_manager_->GetLockScreenIconUrl();
 }
 
 std::string PolicyHandler::GetIconUrl(const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK(std::string(""));
+  POLICY_LIB_CHECK_OR_RETURN(std::string(""));
   return policy_manager_->GetIconUrl(policy_app_id);
 }
 
 uint32_t PolicyHandler::NextRetryTimeout() {
-  POLICY_LIB_CHECK(0);
+  POLICY_LIB_CHECK_OR_RETURN(0);
   LOG4CXX_AUTO_TRACE(logger_);
   return policy_manager_->NextRetryTimeout();
 }
@@ -1714,7 +1714,7 @@ uint32_t PolicyHandler::TimeoutExchangeSec() const {
 }
 
 uint32_t PolicyHandler::TimeoutExchangeMSec() const {
-  POLICY_LIB_CHECK(0);
+  POLICY_LIB_CHECK_OR_RETURN(0);
   return policy_manager_->TimeoutExchangeMSec();
 }
 
@@ -1736,14 +1736,14 @@ void PolicyHandler::OnSystemReady() {
 
 const boost::optional<bool> PolicyHandler::LockScreenDismissalEnabledState()
     const {
-  POLICY_LIB_CHECK(boost::optional<bool>());
+  POLICY_LIB_CHECK_OR_RETURN(boost::optional<bool>());
   return policy_manager_->LockScreenDismissalEnabledState();
 }
 
 const boost::optional<std::string>
 PolicyHandler::LockScreenDismissalWarningMessage(
     const std::string& language) const {
-  POLICY_LIB_CHECK(boost::optional<std::string>());
+  POLICY_LIB_CHECK_OR_RETURN(boost::optional<std::string>());
   return policy_manager_->LockScreenDismissalWarningMessage(language);
 }
 
@@ -1978,7 +1978,7 @@ void PolicyHandler::RemoveDevice(const std::string& device_id) {
 
 bool PolicyHandler::IsApplicationRevoked(const std::string& app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
 
   return policy_manager_->IsApplicationRevoked(app_id);
 }
@@ -1990,12 +1990,12 @@ void PolicyHandler::OnUpdateRequestSentToMobile() {
 }
 
 bool PolicyHandler::CheckKeepContext(const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   return policy_manager_->CanAppKeepContext(policy_app_id);
 }
 
 bool PolicyHandler::CheckStealFocus(const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   return policy_manager_->CanAppStealFocus(policy_app_id);
 }
 
@@ -2019,7 +2019,7 @@ bool PolicyHandler::CheckSystemAction(
 }
 
 std::vector<std::string> PolicyHandler::GetApplicationPolicyIDs() const {
-  POLICY_LIB_CHECK(std::vector<std::string>());
+  POLICY_LIB_CHECK_OR_RETURN(std::vector<std::string>());
   const auto all_policy_ids = policy_manager_->GetApplicationPolicyIDs();
   std::vector<std::string> policy_app_ids;
 
@@ -2043,18 +2043,18 @@ void PolicyHandler::GetEnabledCloudApps(
 
 bool PolicyHandler::GetAppProperties(const std::string& policy_app_id,
                                      AppProperties& out_app_properties) const {
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   return policy_manager_->GetAppProperties(policy_app_id, out_app_properties);
 }
 
 std::vector<std::string> PolicyHandler::GetEnabledLocalApps() const {
-  POLICY_LIB_CHECK(std::vector<std::string>());
+  POLICY_LIB_CHECK_OR_RETURN(std::vector<std::string>());
   return policy_manager_->GetEnabledLocalApps();
 }
 
 const bool PolicyHandler::CheckCloudAppEnabled(
     const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   AppProperties out_app_properties;
   policy_manager_->GetAppProperties(policy_app_id, out_app_properties);
   return out_app_properties.enabled;
@@ -2367,18 +2367,18 @@ bool PolicyHandler::CheckAppServiceParameters(
 bool PolicyHandler::UnknownRPCPassthroughAllowed(
     const std::string& policy_app_id) const {
   LOG4CXX_AUTO_TRACE(logger_);
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   return policy_manager_->UnknownRPCPassthroughAllowed(policy_app_id);
 }
 
 uint32_t PolicyHandler::HeartBeatTimeout(const std::string& app_id) const {
-  POLICY_LIB_CHECK(0);
+  POLICY_LIB_CHECK_OR_RETURN(0);
   return policy_manager_->HeartBeatTimeout(app_id);
 }
 
 const std::string PolicyHandler::RemoteAppsUrl() const {
   const std::string default_url;
-  POLICY_LIB_CHECK(default_url);
+  POLICY_LIB_CHECK_OR_RETURN(default_url);
   EndpointUrls endpoints;
   policy_manager_->GetUpdateUrls("queryAppsUrl", endpoints);
   if (endpoints.empty() || endpoints[0].url.empty()) {
@@ -2389,12 +2389,12 @@ const std::string PolicyHandler::RemoteAppsUrl() const {
 }
 
 void PolicyHandler::OnAppsSearchStarted() {
-  POLICY_LIB_CHECK();
+  POLICY_LIB_CHECK_VOID();
   policy_manager_->OnAppsSearchStarted();
 }
 
 void PolicyHandler::OnAppsSearchCompleted(const bool trigger_ptu) {
-  POLICY_LIB_CHECK();
+  POLICY_LIB_CHECK_VOID();
   policy_manager_->OnAppsSearchCompleted(trigger_ptu);
 }
 
@@ -2416,13 +2416,13 @@ void PolicyHandler::OnAppRegisteredOnMobile(const std::string& device_id,
 
 RequestType::State PolicyHandler::GetAppRequestTypeState(
     const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK(RequestType::State::UNAVAILABLE);
+  POLICY_LIB_CHECK_OR_RETURN(RequestType::State::UNAVAILABLE);
   return policy_manager_->GetAppRequestTypesState(policy_app_id);
 }
 
 RequestSubType::State PolicyHandler::GetAppRequestSubTypeState(
     const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK(RequestSubType::State::UNAVAILABLE);
+  POLICY_LIB_CHECK_OR_RETURN(RequestSubType::State::UNAVAILABLE);
   return policy_manager_->GetAppRequestSubTypesState(policy_app_id);
 }
 
@@ -2430,7 +2430,7 @@ bool PolicyHandler::IsRequestTypeAllowed(
     const transport_manager::DeviceHandle& device_id,
     const std::string& policy_app_id,
     mobile_apis::RequestType::eType type) const {
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   using namespace mobile_apis;
 
   const std::string stringified_type = RequestTypeToString(type);
@@ -2471,7 +2471,7 @@ bool PolicyHandler::IsRequestTypeAllowed(
 bool PolicyHandler::IsRequestSubTypeAllowed(
     const std::string& policy_app_id,
     const std::string& request_subtype) const {
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   using namespace mobile_apis;
 
   if (request_subtype.empty()) {
@@ -2508,7 +2508,7 @@ bool PolicyHandler::IsRequestSubTypeAllowed(
 const std::vector<std::string> PolicyHandler::GetAppRequestTypes(
     const transport_manager::DeviceHandle& device_handle,
     const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK(std::vector<std::string>());
+  POLICY_LIB_CHECK_OR_RETURN(std::vector<std::string>());
 #ifdef EXTERNAL_PROPRIETARY_MODE
   return policy_manager_->GetAppRequestTypes(device_handle, policy_app_id);
 #else
@@ -2518,51 +2518,51 @@ const std::vector<std::string> PolicyHandler::GetAppRequestTypes(
 
 const std::vector<std::string> PolicyHandler::GetAppRequestSubTypes(
     const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK(std::vector<std::string>());
+  POLICY_LIB_CHECK_OR_RETURN(std::vector<std::string>());
   return policy_manager_->GetAppRequestSubTypes(policy_app_id);
 }
 
 const std::vector<policy_table::VehicleDataItem>
 policy::PolicyHandler::GetVehicleDataItems() const {
-  POLICY_LIB_CHECK(std::vector<policy_table::VehicleDataItem>());
+  POLICY_LIB_CHECK_OR_RETURN(std::vector<policy_table::VehicleDataItem>());
   return policy_manager_->GetVehicleDataItems();
 }
 
 std::vector<rpc::policy_table_interface_base::VehicleDataItem>
 policy::PolicyHandler::GetRemovedVehicleDataItems() const {
-  POLICY_LIB_CHECK(std::vector<policy_table::VehicleDataItem>());
+  POLICY_LIB_CHECK_OR_RETURN(std::vector<policy_table::VehicleDataItem>());
   return policy_manager_->GetRemovedVehicleDataItems();
 }
 
 #ifdef EXTERNAL_PROPRIETARY_MODE
 const MetaInfo PolicyHandler::GetMetaInfo() const {
-  POLICY_LIB_CHECK(MetaInfo());
+  POLICY_LIB_CHECK_OR_RETURN(MetaInfo());
   return policy_manager_->GetMetaInfo();
 }
 #endif  // EXTERNAL_PROPRIETARY_MODE
 
 void PolicyHandler::Increment(usage_statistics::GlobalCounterId type) {
-  POLICY_LIB_CHECK();
+  POLICY_LIB_CHECK_VOID();
   policy_manager_->Increment(type);
 }
 
 void PolicyHandler::Increment(const std::string& app_id,
                               usage_statistics::AppCounterId type) {
-  POLICY_LIB_CHECK();
+  POLICY_LIB_CHECK_VOID();
   policy_manager_->Increment(app_id, type);
 }
 
 void PolicyHandler::Set(const std::string& app_id,
                         usage_statistics::AppInfoId type,
                         const std::string& value) {
-  POLICY_LIB_CHECK();
+  POLICY_LIB_CHECK_VOID();
   policy_manager_->Set(app_id, type, value);
 }
 
 void PolicyHandler::Add(const std::string& app_id,
                         usage_statistics::AppStopwatchId type,
                         int32_t timespan_seconds) {
-  POLICY_LIB_CHECK();
+  POLICY_LIB_CHECK_VOID();
   policy_manager_->Add(app_id, type, timespan_seconds);
 }
 
@@ -2628,7 +2628,7 @@ void PolicyHandler::UpdateHMILevel(ApplicationSharedPtr app,
 
 bool PolicyHandler::CheckModule(const PTString& app_id,
                                 const PTString& module) {
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   return policy_manager_->CheckModule(app_id, module);
 }
 
@@ -2673,7 +2673,7 @@ void PolicyHandler::OnUpdateHMIStatus(const std::string& device_id,
 bool PolicyHandler::GetModuleTypes(const std::string& policy_app_id,
                                    std::vector<std::string>* modules) const {
   LOG4CXX_AUTO_TRACE(logger_);
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   return policy_manager_->GetModuleTypes(policy_app_id, modules);
 }
 
@@ -2698,7 +2698,7 @@ bool PolicyHandler::CheckHMIType(const std::string& application_id,
                                  mobile_apis::AppHMIType::eType hmi,
                                  const smart_objects::SmartObject* app_types) {
   LOG4CXX_AUTO_TRACE(logger_);
-  POLICY_LIB_CHECK(false);
+  POLICY_LIB_CHECK_OR_RETURN(false);
   std::vector<int> policy_hmi_types;
   bool ret = policy_manager_->GetHMITypes(application_id, &policy_hmi_types);
 

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -478,6 +478,7 @@ void PolicyHandler::PushAppIdToPTUQueue(const uint32_t app_id) {
 
 void PolicyHandler::PopAppIdFromPTUQueue() {
   LOG4CXX_AUTO_TRACE(logger_);
+  POLICY_LIB_CHECK_VOID();
   sync_primitives::AutoLock lock(app_id_queue_lock_);
   if (applications_ptu_queue_.size() > 0) {
     applications_ptu_queue_.erase(applications_ptu_queue_.begin());
@@ -789,9 +790,11 @@ PolicyHandler::CollectRegisteredAppsPermissions() {
 
 std::vector<FunctionalGroupPermission> PolicyHandler::CollectAppPermissions(
     const uint32_t connection_key) {
+  std::vector<FunctionalGroupPermission> group_permissions;
+  POLICY_LIB_CHECK_OR_RETURN(group_permissions);
+
   // Single app only
   ApplicationSharedPtr app = application_manager_.application(connection_key);
-  std::vector<FunctionalGroupPermission> group_permissions;
 
   if (NULL == app.get() || app.use_count() == 0) {
     LOG4CXX_WARN(logger_,
@@ -869,6 +872,7 @@ void PolicyHandler::LinkAppsToDevice() {
 bool PolicyHandler::IsAppSuitableForPolicyUpdate(
     const Applications::value_type value) const {
   LOG4CXX_AUTO_TRACE(logger_);
+  POLICY_LIB_CHECK_OR_RETURN(false);
 
   if (!value->IsRegistered()) {
     LOG4CXX_DEBUG(
@@ -1508,6 +1512,8 @@ void PolicyHandler::OnPermissionsUpdated(const std::string& device_id,
                                          const std::string& policy_app_id,
                                          const Permissions& permissions) {
   LOG4CXX_AUTO_TRACE(logger_);
+  POLICY_LIB_CHECK_VOID();
+
   ApplicationSharedPtr app =
       application_manager_.application(device_id, policy_app_id);
   if (app.use_count() == 0) {
@@ -2064,6 +2070,7 @@ PolicyHandler::AppPropertiesState PolicyHandler::GetAppPropertiesStatus(
     const smart_objects::SmartObject& properties,
     const std::string& app_id) const {
   LOG4CXX_AUTO_TRACE(logger_);
+  POLICY_LIB_CHECK_OR_RETURN(AppPropertiesState::NO_CHANGES);
 
   AppProperties app_properties;
   policy_manager_->GetAppProperties(app_id, app_properties);
@@ -2158,6 +2165,7 @@ PolicyHandler::AppPropertiesState PolicyHandler::GetAppPropertiesStatus(
 }
 
 bool PolicyHandler::IsNewApplication(const std::string& policy_app_id) const {
+  POLICY_LIB_CHECK_OR_RETURN(false);
   return policy_manager_->IsNewApplication(policy_app_id);
 }
 
@@ -2216,6 +2224,7 @@ void PolicyHandler::OnSetAppProperties(
 }
 
 void PolicyHandler::OnLocalAppAdded() {
+  POLICY_LIB_CHECK_VOID();
   policy_manager_->OnLocalAppAdded();
 }
 

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -2530,6 +2530,7 @@ policy::PolicyHandler::GetVehicleDataItems() const {
 
 std::vector<rpc::policy_table_interface_base::VehicleDataItem>
 policy::PolicyHandler::GetRemovedVehicleDataItems() const {
+  POLICY_LIB_CHECK(std::vector<policy_table::VehicleDataItem>());
   return policy_manager_->GetRemovedVehicleDataItems();
 }
 

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -470,7 +470,7 @@ void PolicyHandler::PushAppIdToPTUQueue(const uint32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(app_id_queue_lock_);
   const auto result = applications_ptu_queue_.insert(app_id);
-  if (result.second) {
+  if (result.second && PolicyEnabled()) {
     policy_manager_->UpdatePTUReadyAppsCount(applications_ptu_queue_.size());
   }
 }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -468,10 +468,10 @@ uint32_t PolicyHandler::GetAppIdForSending() const {
 
 void PolicyHandler::PushAppIdToPTUQueue(const uint32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
+  POLICY_LIB_CHECK_VOID();
   sync_primitives::AutoLock lock(app_id_queue_lock_);
   const auto result = applications_ptu_queue_.insert(app_id);
   if (result.second) {
-    POLICY_LIB_CHECK_VOID();
     policy_manager_->UpdatePTUReadyAppsCount(applications_ptu_queue_.size());
   }
 }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -470,7 +470,8 @@ void PolicyHandler::PushAppIdToPTUQueue(const uint32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(app_id_queue_lock_);
   const auto result = applications_ptu_queue_.insert(app_id);
-  if (result.second && PolicyEnabled()) {
+  if (result.second) {
+    POLICY_LIB_CHECK_VOID();
     policy_manager_->UpdatePTUReadyAppsCount(applications_ptu_queue_.size());
   }
 }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -403,7 +403,7 @@ void PolicyHandler::OnPTInited() {
 
 void PolicyHandler::StopRetrySequence() {
   LOG4CXX_AUTO_TRACE(logger_);
-
+  POLICY_LIB_CHECK_VOID();
   policy_manager_->StopRetrySequence();
 }
 
@@ -1662,6 +1662,7 @@ DeviceConsent PolicyHandler::GetUserConsentForDevice(
 }
 
 Json::Value PolicyHandler::GetPolicyTableData() const {
+  POLICY_LIB_CHECK(Json::Value());
   return policy_manager_->GetPolicyTableData();
 }
 

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -3130,6 +3130,7 @@ TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyEnabled_SUCCESS) {
   ChangePolicyManagerToMock();
   EXPECT_CALL(*mock_policy_manager_, UpdatePTUReadyAppsCount(_));
   policy_handler_.PushAppIdToPTUQueue(kAppId1_);
+  EXPECT_EQ(1u, policy_handler_.applications_ptu_queue_.size());
 }
 
 TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyDisabled_FAIL) {
@@ -3140,6 +3141,7 @@ TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyDisabled_FAIL) {
 
   policy_handler_.LoadPolicyLibrary();
   policy_handler_.PushAppIdToPTUQueue(kAppId1_);
+  EXPECT_EQ(0u, policy_handler_.applications_ptu_queue_.size());
 }
 
 }  // namespace policy_handler_test

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -3129,7 +3129,8 @@ TEST_F(PolicyHandlerTest, GetEnabledLocalApps_SUCCESS) {
 TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyEnabled_SUCCESS) {
   ChangePolicyManagerToMock();
   const uint32_t expected_apps_count = 1u;
-  EXPECT_CALL(*mock_policy_manager_, UpdatePTUReadyAppsCount(_));
+  EXPECT_CALL(*mock_policy_manager_,
+              UpdatePTUReadyAppsCount(expected_apps_count));
   policy_handler_.PushAppIdToPTUQueue(kAppId1_);
   EXPECT_EQ(expected_apps_count,
             policy_handler_.applications_ptu_queue_.size());
@@ -3140,7 +3141,9 @@ TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyDisabled_FAIL) {
 
   const uint32_t expected_apps_count = 0u;
   EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
-  EXPECT_CALL(*mock_policy_manager_, UpdatePTUReadyAppsCount(_)).Times(0);
+  EXPECT_CALL(*mock_policy_manager_,
+              UpdatePTUReadyAppsCount(expected_apps_count))
+      .Times(0);
 
   policy_handler_.LoadPolicyLibrary();
   policy_handler_.PushAppIdToPTUQueue(kAppId1_);

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -3185,6 +3185,36 @@ TEST_F(PolicyHandlerTest, GetPolicyTableData_PolicyDisabled_FAIL) {
   EXPECT_EQ(expected_table_data, policy_handler_.GetPolicyTableData());
 }
 
+TEST_F(PolicyHandlerTest, GetRemovedVehicleDataItems_PolicyEnabled_SUCCESS) {
+  using rpc::policy_table_interface_base::VehicleDataItem;
+
+  ChangePolicyManagerToMock();
+
+  std::vector<VehicleDataItem> expected_removed_items;
+  expected_removed_items.push_back(VehicleDataItem());
+
+  EXPECT_CALL(*mock_policy_manager_, GetRemovedVehicleDataItems())
+      .WillOnce(Return(expected_removed_items));
+
+  const auto& actually_removed_items =
+      policy_handler_.GetRemovedVehicleDataItems();
+  ASSERT_EQ(expected_removed_items.size(), actually_removed_items.size());
+  EXPECT_TRUE(expected_removed_items[0] == actually_removed_items[0]);
+}
+
+TEST_F(PolicyHandlerTest, GetRemovedVehicleDataItems_PolicyDisabled_FAIL) {
+  using rpc::policy_table_interface_base::VehicleDataItem;
+
+  ChangePolicyManagerToMock();
+
+  EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
+  EXPECT_CALL(*mock_policy_manager_, GetRemovedVehicleDataItems()).Times(0);
+
+  policy_handler_.LoadPolicyLibrary();
+
+  EXPECT_TRUE(policy_handler_.GetRemovedVehicleDataItems().empty());
+}
+
 }  // namespace policy_handler_test
 }  // namespace components
 }  // namespace test

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -3126,6 +3126,24 @@ TEST_F(PolicyHandlerTest, GetEnabledLocalApps_SUCCESS) {
   EXPECT_EQ(enabled_local_apps, policy_handler_.GetEnabledLocalApps());
 }
 
+TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyEnabled_SUCCESS) {
+  ChangePolicyManagerToMock();
+
+  EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(true));
+  EXPECT_CALL(*mock_policy_manager_, UpdatePTUReadyAppsCount(_));
+
+  policy_handler_.PushAppIdToPTUQueue(kAppId1_);
+}
+
+TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyDisabled_FAIL) {
+  ChangePolicyManagerToMock();
+
+  EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
+  EXPECT_CALL(*mock_policy_manager_, UpdatePTUReadyAppsCount(_)).Times(0);
+
+  policy_handler_.PushAppIdToPTUQueue(kAppId1_);
+}
+
 }  // namespace policy_handler_test
 }  // namespace components
 }  // namespace test

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -3128,20 +3128,24 @@ TEST_F(PolicyHandlerTest, GetEnabledLocalApps_SUCCESS) {
 
 TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyEnabled_SUCCESS) {
   ChangePolicyManagerToMock();
+  const uint32_t expected_apps_count = 1u;
   EXPECT_CALL(*mock_policy_manager_, UpdatePTUReadyAppsCount(_));
   policy_handler_.PushAppIdToPTUQueue(kAppId1_);
-  EXPECT_EQ(1u, policy_handler_.applications_ptu_queue_.size());
+  EXPECT_EQ(expected_apps_count,
+            policy_handler_.applications_ptu_queue_.size());
 }
 
 TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyDisabled_FAIL) {
   ChangePolicyManagerToMock();
 
+  const uint32_t expected_apps_count = 0u;
   EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
   EXPECT_CALL(*mock_policy_manager_, UpdatePTUReadyAppsCount(_)).Times(0);
 
   policy_handler_.LoadPolicyLibrary();
   policy_handler_.PushAppIdToPTUQueue(kAppId1_);
-  EXPECT_EQ(0u, policy_handler_.applications_ptu_queue_.size());
+  EXPECT_EQ(expected_apps_count,
+            policy_handler_.applications_ptu_queue_.size());
 }
 
 }  // namespace policy_handler_test

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -3148,6 +3148,43 @@ TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyDisabled_FAIL) {
             policy_handler_.applications_ptu_queue_.size());
 }
 
+TEST_F(PolicyHandlerTest, StopRetrySequence_PolicyEnabled_SUCCESS) {
+  ChangePolicyManagerToMock();
+  EXPECT_CALL(*mock_policy_manager_, StopRetrySequence());
+  policy_handler_.StopRetrySequence();
+}
+
+TEST_F(PolicyHandlerTest, StopRetrySequence_PolicyDisabled_FAIL) {
+  ChangePolicyManagerToMock();
+
+  EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
+  EXPECT_CALL(*mock_policy_manager_, StopRetrySequence()).Times(0);
+
+  policy_handler_.LoadPolicyLibrary();
+  policy_handler_.StopRetrySequence();
+}
+
+TEST_F(PolicyHandlerTest, GetPolicyTableData_PolicyEnabled_SUCCESS) {
+  ChangePolicyManagerToMock();
+  Json::Value expected_table_data(Json::objectValue);
+  expected_table_data["test_key"] = "test_value";
+  EXPECT_CALL(*mock_policy_manager_, GetPolicyTableData())
+      .WillOnce(Return(expected_table_data));
+  EXPECT_EQ(expected_table_data, policy_handler_.GetPolicyTableData());
+}
+
+TEST_F(PolicyHandlerTest, GetPolicyTableData_PolicyDisabled_FAIL) {
+  ChangePolicyManagerToMock();
+
+  EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
+  EXPECT_CALL(*mock_policy_manager_, GetPolicyTableData()).Times(0);
+
+  policy_handler_.LoadPolicyLibrary();
+
+  Json::Value expected_table_data;
+  EXPECT_EQ(expected_table_data, policy_handler_.GetPolicyTableData());
+}
+
 }  // namespace policy_handler_test
 }  // namespace components
 }  // namespace test

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -3112,6 +3112,23 @@ TEST_F(PolicyHandlerTest, GetAppPropertiesStatus_HybridAppNotChanged_SUCCESS) {
       policy::PolicyHandlerInterface::AppPropertiesState::NO_CHANGES);
 }
 
+TEST_F(PolicyHandlerTest, GetAppPropertiesStatus_PolicyDisabled_FAIL) {
+  ChangePolicyManagerToMock();
+
+  EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
+  policy_handler_.LoadPolicyLibrary();
+
+  smart_objects::SmartObject properties;
+  properties[strings::app_id] = kPolicyAppId_;
+
+  EXPECT_CALL(*mock_policy_manager_, GetAppProperties(_, _)).Times(0);
+  EXPECT_CALL(*mock_policy_manager_, GetInitialAppData(_, _, _)).Times(0);
+  const auto expected_app_properties_state =
+      policy::PolicyHandlerInterface::AppPropertiesState::NO_CHANGES;
+  EXPECT_EQ(expected_app_properties_state,
+            policy_handler_.GetAppPropertiesStatus(properties, kPolicyAppId_));
+}
+
 TEST_F(PolicyHandlerTest, GetEnabledLocalApps_SUCCESS) {
   ChangePolicyManagerToMock();
   std::vector<std::string> enabled_local_apps;
@@ -3216,6 +3233,102 @@ TEST_F(PolicyHandlerTest, GetRemovedVehicleDataItems_PolicyDisabled_FAIL) {
   policy_handler_.LoadPolicyLibrary();
 
   EXPECT_TRUE(policy_handler_.GetRemovedVehicleDataItems().empty());
+}
+
+TEST_F(PolicyHandlerTest, PopAppIdFromPTUQueue_PolicyEnabled_SUCCESS) {
+  ChangePolicyManagerToMock();
+
+  policy_handler_.PushAppIdToPTUQueue(kAppId1_);
+  ASSERT_EQ(1u, policy_handler_.applications_ptu_queue_.size());
+
+  policy_handler_.PopAppIdFromPTUQueue();
+  EXPECT_EQ(0u, policy_handler_.applications_ptu_queue_.size());
+}
+
+TEST_F(PolicyHandlerTest, PopAppIdFromPTUQueue_PolicyDisabled_FAIL) {
+  ChangePolicyManagerToMock();
+
+  const uint32_t expected_apps_count = 0u;
+  EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
+  EXPECT_CALL(*mock_policy_manager_,
+              UpdatePTUReadyAppsCount(expected_apps_count))
+      .Times(0);
+
+  policy_handler_.LoadPolicyLibrary();
+  policy_handler_.PopAppIdFromPTUQueue();
+  EXPECT_EQ(expected_apps_count,
+            policy_handler_.applications_ptu_queue_.size());
+}
+
+TEST_F(PolicyHandlerTest, OnLocalAppAdded_PolicyEnabled_SUCCESS) {
+  ChangePolicyManagerToMock();
+  EXPECT_CALL(*mock_policy_manager_, OnLocalAppAdded());
+  policy_handler_.OnLocalAppAdded();
+}
+
+TEST_F(PolicyHandlerTest, OnLocalAppAdded_PolicyDisabled_FAIL) {
+  ChangePolicyManagerToMock();
+
+  EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
+  EXPECT_CALL(*mock_policy_manager_, OnLocalAppAdded()).Times(0);
+
+  policy_handler_.LoadPolicyLibrary();
+  policy_handler_.OnLocalAppAdded();
+}
+
+TEST_F(PolicyHandlerTest, OnPermissionsUpdated_PolicyEnabled_SUCCESS) {
+  ChangePolicyManagerToMock();
+
+  EXPECT_CALL(app_manager_, application(kDeviceId_, kPolicyAppId_))
+      .WillOnce(Return(mock_app_));
+
+  const rpc::Optional<rpc::Boolean> encryption_requiered;
+  EXPECT_CALL(*mock_policy_manager_, GetAppEncryptionRequired(kPolicyAppId_))
+      .WillOnce(Return(encryption_requiered));
+  EXPECT_CALL(*mock_app_, app_id()).WillRepeatedly(Return(kAppId1_));
+
+  Permissions app_permissions;
+  EXPECT_CALL(mock_message_helper_,
+              SendOnPermissionsChangeNotification(kAppId1_, _, _, _));
+  policy_handler_.OnPermissionsUpdated(
+      kDeviceId_, kPolicyAppId_, app_permissions);
+}
+
+TEST_F(PolicyHandlerTest, OnPermissionsUpdated_PolicyDisabled_FAIL) {
+  ChangePolicyManagerToMock();
+
+  EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
+  policy_handler_.LoadPolicyLibrary();
+
+  EXPECT_CALL(app_manager_, application(kDeviceId_, kPolicyAppId_)).Times(0);
+  EXPECT_CALL(*mock_policy_manager_, GetAppEncryptionRequired(kPolicyAppId_))
+      .Times(0);
+  EXPECT_CALL(*mock_app_, app_id()).Times(0);
+
+  Permissions app_permissions;
+  EXPECT_CALL(mock_message_helper_,
+              SendOnPermissionsChangeNotification(_, _, _, _))
+      .Times(0);
+  policy_handler_.OnPermissionsUpdated(
+      kDeviceId_, kPolicyAppId_, app_permissions);
+}
+
+TEST_F(PolicyHandlerTest, IsNewApplication_PolicyEnabled_SUCCESS) {
+  ChangePolicyManagerToMock();
+
+  EXPECT_CALL(*mock_policy_manager_, IsNewApplication(kPolicyAppId_))
+      .WillOnce(Return(true));
+  EXPECT_TRUE(policy_handler_.IsNewApplication(kPolicyAppId_));
+}
+
+TEST_F(PolicyHandlerTest, IsNewApplication_PolicyDisabled_FAIL) {
+  ChangePolicyManagerToMock();
+
+  EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
+  policy_handler_.LoadPolicyLibrary();
+
+  EXPECT_CALL(*mock_policy_manager_, IsNewApplication(kPolicyAppId_)).Times(0);
+  EXPECT_FALSE(policy_handler_.IsNewApplication(kPolicyAppId_));
 }
 
 }  // namespace policy_handler_test

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -3128,10 +3128,7 @@ TEST_F(PolicyHandlerTest, GetEnabledLocalApps_SUCCESS) {
 
 TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyEnabled_SUCCESS) {
   ChangePolicyManagerToMock();
-
-  EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(true));
   EXPECT_CALL(*mock_policy_manager_, UpdatePTUReadyAppsCount(_));
-
   policy_handler_.PushAppIdToPTUQueue(kAppId1_);
 }
 
@@ -3141,6 +3138,7 @@ TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyDisabled_FAIL) {
   EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
   EXPECT_CALL(*mock_policy_manager_, UpdatePTUReadyAppsCount(_)).Times(0);
 
+  policy_handler_.LoadPolicyLibrary();
   policy_handler_.PushAppIdToPTUQueue(kAppId1_);
 }
 


### PR DESCRIPTION
Fixes #3285 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF and unit testing

### Summary
When `EnablePolicy=false` inside smartdevicelink.ini file pointer to `PolicyManager` inside of `PolicyHandler` class is not set.

This way when `PushAppIdToPTUQueue` method was called there were no check for `PolicyManager` pointer validity, and so core crash happened on `policy_manager_->UpdatePTUReadyAppsCount()` call. So check for enabled policy added.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
