### PR TITLE
Fix/consider timeouts during streaming switching

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -834,6 +834,9 @@ class ApplicationManagerImpl
    */
   void EndNaviServices(uint32_t app_id) OVERRIDE;
 
+  DEPRECATED
+  void ForbidStreaming(uint32_t app_id) OVERRIDE;
+
   void ForbidStreaming(uint32_t app_id,
                        protocol_handler::ServiceType service_type) OVERRIDE;
 

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -834,11 +834,8 @@ class ApplicationManagerImpl
    */
   void EndNaviServices(uint32_t app_id) OVERRIDE;
 
-  /**
-   * @brief ForbidStreaming forbid the stream over the certain application.
-   * @param app_id the application's id which should stop streaming.
-   */
-  void ForbidStreaming(uint32_t app_id) OVERRIDE;
+  void ForbidStreaming(uint32_t app_id,
+                       protocol_handler::ServiceType service_type) OVERRIDE;
 
   /**
    * @brief Called when application completes streaming configuration

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -201,10 +201,11 @@ class PolicyHandler : public PolicyHandlerInterface,
                          StringArray* nicknames = NULL,
                          StringArray* app_hmi_types = NULL) OVERRIDE;
   void GetUpdateUrls(const std::string& service_type,
-                     EndpointUrls& out_end_points) OVERRIDE;
+                     EndpointUrls& out_end_points) const OVERRIDE;
   void GetUpdateUrls(const uint32_t service_type,
-                     EndpointUrls& out_end_points) OVERRIDE;
-  virtual std::string GetLockScreenIconUrl() const OVERRIDE;
+                     EndpointUrls& out_end_points) const OVERRIDE;
+  virtual std::string GetLockScreenIconUrl(
+      const std::string& policy_app_id) const OVERRIDE;
   virtual std::string GetIconUrl(
       const std::string& policy_app_id) const OVERRIDE;
   uint32_t NextRetryTimeout() OVERRIDE;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -551,7 +551,7 @@ RegisterAppInterfaceRequest::GetLockScreenIconUrlNotification(
   (*message)[strings::msg_params][strings::request_type] =
       mobile_apis::RequestType::LOCK_SCREEN_ICON_URL;
   (*message)[strings::msg_params][strings::url] =
-      GetPolicyHandler().GetLockScreenIconUrl();
+      GetPolicyHandler().GetLockScreenIconUrl(app->policy_app_id());
   return message;
 }
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3465,9 +3465,11 @@ bool ApplicationManagerImpl::CanAppStream(
   return HMIStateAllowsStreaming(app_id, service_type) && is_allowed;
 }
 
-void ApplicationManagerImpl::ForbidStreaming(uint32_t app_id) {
+void ApplicationManagerImpl::ForbidStreaming(
+    uint32_t app_id, protocol_handler::ServiceType service_type) {
   using namespace mobile_apis::AppInterfaceUnregisteredReason;
   using namespace mobile_apis::Result;
+  using namespace protocol_handler;
 
   LOG4CXX_AUTO_TRACE(logger_);
 
@@ -3507,6 +3509,18 @@ void ApplicationManagerImpl::ForbidStreaming(uint32_t app_id) {
     UnregisterApplication(app_id, ABORTED);
     return;
   }
+
+  if (ServiceType::kMobileNav == service_type &&
+      app->video_streaming_allowed()) {
+    LOG4CXX_DEBUG(logger_, "Video streaming is still allowed");
+    return;
+  }
+
+  if (ServiceType::kAudio == service_type && app->audio_streaming_allowed()) {
+    LOG4CXX_DEBUG(logger_, "Audio streaming is still allowed");
+    return;
+  }
+
   EndNaviServices(app_id);
 }
 

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -2590,11 +2590,24 @@ TEST_F(PolicyHandlerTest,
 #endif
 }
 
+ACTION_P(SetEndpoint, endpoint) {
+  arg1 = endpoint;
+}
+
 TEST_F(PolicyHandlerTest, GetLockScreenIconUrl_SUCCESS) {
   EnablePolicyAndPolicyManagerMock();
-  EXPECT_CALL(*mock_policy_manager_, GetLockScreenIconUrl());
 
-  policy_handler_.GetLockScreenIconUrl();
+  const std::string url_str = "test_icon_url";
+  EndpointData data(url_str);
+
+  EndpointUrls endpoints;
+  endpoints.push_back(data);
+
+  const std::string service_type = "lock_screen_icon_url";
+  EXPECT_CALL(*mock_policy_manager_, GetUpdateUrls(service_type, _))
+      .WillOnce(SetEndpoint(endpoints));
+
+  EXPECT_EQ(url_str, policy_handler_.GetLockScreenIconUrl(kPolicyAppId_));
 }
 
 TEST_F(PolicyHandlerTest, RemoveListener_SUCCESS) {
@@ -2655,10 +2668,6 @@ TEST_F(PolicyHandlerTest, OnSystemError_SUCCESS) {
   policy_handler_.OnSystemError(
       hmi_apis::Common_SystemError::SYNC_OUT_OF_MEMMORY);
   EXPECT_TRUE(waiter1.Wait(auto_lock));
-}
-
-ACTION_P(SetEndpoint, endpoint) {
-  arg1 = endpoint;
 }
 
 TEST_F(PolicyHandlerTest, RemoteAppsUrl_EndpointsEmpty_UNSUCCESS) {

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -788,8 +788,10 @@ class ApplicationManager {
   /**
    * @brief ForbidStreaming forbid the stream over the certain application.
    * @param app_id the application's id which should stop streaming.
+   * @param service_type Service type to check
    */
-  virtual void ForbidStreaming(uint32_t app_id) = 0;
+  virtual void ForbidStreaming(uint32_t app_id,
+                               protocol_handler::ServiceType service_type) = 0;
 
   /**
    * @brief Called when application completes streaming configuration

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -785,6 +785,9 @@ class ApplicationManager {
   virtual bool CanAppStream(
       uint32_t app_id, protocol_handler::ServiceType service_type) const = 0;
 
+  DEPRECATED
+  virtual void ForbidStreaming(uint32_t app_id) = 0;
+
   /**
    * @brief ForbidStreaming forbid the stream over the certain application.
    * @param app_id the application's id which should stop streaming.

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -121,11 +121,19 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
                                  StringArray* nicknames = NULL,
                                  StringArray* app_hmi_types = NULL) = 0;
   virtual void GetUpdateUrls(const std::string& service_type,
-                             EndpointUrls& out_end_points) = 0;
+                             EndpointUrls& out_end_points) const = 0;
   virtual void GetUpdateUrls(const uint32_t service_type,
-                             EndpointUrls& out_end_points) = 0;
+                             EndpointUrls& out_end_points) const = 0;
   virtual Json::Value GetPolicyTableData() const = 0;
-  virtual std::string GetLockScreenIconUrl() const = 0;
+
+  /**
+   * @brief Gets lock screen icon URL for a requested application
+   * @param policy_app_id policy application id
+   * @return URL for a requested application
+   */
+  virtual std::string GetLockScreenIconUrl(
+      const std::string& policy_app_id) const = 0;
+
   virtual std::string GetIconUrl(const std::string& policy_app_id) const = 0;
   virtual uint32_t NextRetryTimeout() = 0;
 

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -117,16 +117,9 @@ class PolicyManager : public usage_statistics::StatisticsManager,
    * @return vector of urls
    */
   virtual void GetUpdateUrls(const uint32_t service_type,
-                             EndpointUrls& out_end_points) = 0;
+                             EndpointUrls& out_end_points) const = 0;
   virtual void GetUpdateUrls(const std::string& service_type,
-                             EndpointUrls& out_end_points) = 0;
-
-  /**
-   * @brief GetLockScreenIcon allows to obtain lock screen icon url;
-   * @return url which point to the resource where lock screen icon could be
-   *obtained.
-   */
-  virtual std::string GetLockScreenIconUrl() const = 0;
+                             EndpointUrls& out_end_points) const = 0;
 
   /**
    * @brief Get Icon Url used for showing a cloud apps icon before the initial

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -97,13 +97,6 @@ class PolicyManager : public usage_statistics::StatisticsManager,
   virtual bool ResetPT(const std::string& file_name) = 0;
 
   /**
-   * @brief GetLockScreenIcon allows to obtain lock screen icon url;
-   * @return url which point to the resource where lock screen icon could be
-   *obtained.
-   */
-  virtual std::string GetLockScreenIconUrl() const = 0;
-
-  /**
    * @brief Get Icon Url used for showing a cloud apps icon before the initial
    *registration
    *
@@ -118,9 +111,9 @@ class PolicyManager : public usage_statistics::StatisticsManager,
    * @param out_end_points output vector of urls
    */
   virtual void GetUpdateUrls(const std::string& service_type,
-                             EndpointUrls& out_end_points) = 0;
+                             EndpointUrls& out_end_points) const = 0;
   virtual void GetUpdateUrls(const uint32_t service_type,
-                             EndpointUrls& out_end_points) = 0;
+                             EndpointUrls& out_end_points) const = 0;
 
   /**
    * @brief PTU is needed, for this PTS has to be formed and sent.

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -321,6 +321,8 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD2(CanAppStream,
                      bool(uint32_t app_id,
                           protocol_handler::ServiceType service_type));
+  DEPRECATED
+  MOCK_METHOD1(ForbidStreaming, void(uint32_t app_id));
   MOCK_METHOD2(ForbidStreaming,
                void(uint32_t app_id,
                     protocol_handler::ServiceType service_type));

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -321,7 +321,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD2(CanAppStream,
                      bool(uint32_t app_id,
                           protocol_handler::ServiceType service_type));
-  MOCK_METHOD1(ForbidStreaming, void(uint32_t app_id));
+  MOCK_METHOD2(ForbidStreaming,
+               void(uint32_t app_id,
+                    protocol_handler::ServiceType service_type));
   MOCK_CONST_METHOD0(get_settings,
                      const application_manager::ApplicationManagerSettings&());
   MOCK_CONST_METHOD1(

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -114,10 +114,11 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                bool(const std::string& application_id,
                     policy::StringArray* nicknames));
   MOCK_METHOD1(GetInitialAppData, bool(const std::string& application_id));
-  MOCK_METHOD2(GetUpdateUrls,
-               void(const uint32_t service_type,
-                    policy::EndpointUrls& end_points));
-  MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
+  MOCK_CONST_METHOD2(GetUpdateUrls,
+                     void(const uint32_t service_type,
+                          policy::EndpointUrls& end_points));
+  MOCK_CONST_METHOD1(GetLockScreenIconUrl,
+                     std::string(const std::string& policy_app_id));
   MOCK_CONST_METHOD1(GetIconUrl, std::string(const std::string& policy_app_id));
   MOCK_METHOD0(ResetRetrySequence, void());
   MOCK_METHOD0(NextRetryTimeout, uint32_t());
@@ -301,9 +302,9 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
 #endif  // ENABLE_SECURITY
   MOCK_CONST_METHOD0(get_settings, const policy::PolicySettings&());
   MOCK_CONST_METHOD0(RemoteAppsUrl, const std::string());
-  MOCK_METHOD2(GetUpdateUrls,
-               void(const std::string& service_type,
-                    policy::EndpointUrls& end_points));
+  MOCK_CONST_METHOD2(GetUpdateUrls,
+                     void(const std::string& service_type,
+                          policy::EndpointUrls& end_points));
 
   MOCK_METHOD3(OnUpdateHMILevel,
                void(const std::string& device_id,

--- a/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
@@ -130,12 +130,12 @@ class MockCacheManagerInterface : public ::policy::CacheManagerInterface {
                          const std::vector<std::string>& msg_codes,
                          const std::string& language,
                          const std::string& active_hmi_language));
-  MOCK_METHOD2(GetUpdateUrls,
-               void(const std::string& service_type,
-                    EndpointUrls& out_end_points));
-  MOCK_METHOD2(GetUpdateUrls,
-               void(const uint32_t service_type, EndpointUrls& out_end_points));
-  MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
+  MOCK_CONST_METHOD2(GetUpdateUrls,
+                     void(const std::string& service_type,
+                          EndpointUrls& out_end_points));
+  MOCK_CONST_METHOD2(GetUpdateUrls,
+                     void(const uint32_t service_type,
+                          EndpointUrls& out_end_points));
   MOCK_CONST_METHOD1(GetIconUrl, std::string(const std::string& policy_app_id));
   MOCK_METHOD1(
       GetNotificationsNumber,

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -81,11 +81,12 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD1(OnPTUFinished, void(const PtProcessingResult ptu_result));
   MOCK_METHOD1(ResetPT, bool(const std::string& file_name));
   MOCK_METHOD1(GetUpdateUrl, std::string(int service_type));
-  MOCK_METHOD2(GetUpdateUrls,
-               void(const uint32_t service_type, EndpointUrls& out_end_points));
-  MOCK_METHOD2(GetUpdateUrls,
-               void(const std::string& service_type,
-                    EndpointUrls& out_end_points));
+  MOCK_CONST_METHOD2(GetUpdateUrls,
+                     void(const uint32_t service_type,
+                          EndpointUrls& out_end_points));
+  MOCK_CONST_METHOD2(GetUpdateUrls,
+                     void(const std::string& service_type,
+                          EndpointUrls& out_end_points));
   MOCK_METHOD0(RequestPTUpdate, void());
   MOCK_METHOD6(CheckPermissions,
                void(const PTString& device_id,
@@ -218,7 +219,6 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD2(OnAppRegisteredOnMobile,
                void(const std::string& device_id,
                     const std::string& application_id));
-  MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
   MOCK_CONST_METHOD1(GetIconUrl, std::string(const std::string& policy_app_id));
   MOCK_CONST_METHOD2(GetAppRequestTypes,
                      const std::vector<std::string>(

--- a/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
@@ -112,12 +112,12 @@ class MockCacheManagerInterface : public CacheManagerInterface {
   MOCK_CONST_METHOD2(GetPriority,
                      bool(const std::string& policy_app_id,
                           std::string& priority));
-  MOCK_METHOD2(GetUpdateUrls,
-               void(const std::string& service_type,
-                    EndpointUrls& out_end_points));
-  MOCK_METHOD2(GetUpdateUrls,
-               void(const uint32_t service_type, EndpointUrls& out_end_points));
-  MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
+  MOCK_CONST_METHOD2(GetUpdateUrls,
+                     void(const std::string& service_type,
+                          EndpointUrls& out_end_points));
+  MOCK_CONST_METHOD2(GetUpdateUrls,
+                     void(const uint32_t service_type,
+                          EndpointUrls& out_end_points));
   MOCK_CONST_METHOD1(GetIconUrl, std::string(const std::string& policy_app_id));
   MOCK_METHOD2(Init,
                bool(const std::string& file_name,

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -82,11 +82,12 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD1(OnPTUFinished, void(const PtProcessingResult ptu_result));
   MOCK_METHOD1(ResetPT, bool(const std::string& file_name));
 
-  MOCK_METHOD2(GetUpdateUrls,
-               void(const uint32_t service_type, EndpointUrls& out_end_points));
-  MOCK_METHOD2(GetUpdateUrls,
-               void(const std::string& service_type,
-                    EndpointUrls& out_end_points));
+  MOCK_CONST_METHOD2(GetUpdateUrls,
+                     void(const uint32_t service_type,
+                          EndpointUrls& out_end_points));
+  MOCK_CONST_METHOD2(GetUpdateUrls,
+                     void(const std::string& service_type,
+                          EndpointUrls& out_end_points));
   MOCK_METHOD1(RequestPTUpdate,
                bool(const policy::PTUIterationType iteration_type));
   MOCK_METHOD5(CheckPermissions,
@@ -278,7 +279,6 @@ class MockPolicyManager : public PolicyManager {
                     int32_t timespan_seconds));
   MOCK_CONST_METHOD0(get_settings, const PolicySettings&());
   MOCK_METHOD1(set_settings, void(const PolicySettings* get_settings));
-  MOCK_CONST_METHOD0(GetLockScreenIconUrl, std::string());
   MOCK_CONST_METHOD1(GetIconUrl, std::string(const std::string& policy_app_id));
   MOCK_METHOD1(GetNextUpdateUrl, AppIdURL(const EndpointUrls& urls));
   MOCK_CONST_METHOD2(RetrySequenceUrl,

--- a/src/components/media_manager/src/media_manager_impl.cc
+++ b/src/components/media_manager/src/media_manager_impl.cc
@@ -313,9 +313,11 @@ void MediaManagerImpl::OnMessageReceived(
   }
 
   if (!application_manager_.CanAppStream(streaming_app_id, service_type)) {
-    application_manager_.ForbidStreaming(streaming_app_id);
+    application_manager_.ForbidStreaming(streaming_app_id, service_type);
     LOG4CXX_ERROR(logger_,
-                  "The application trying to stream when it should not.");
+                  "The application trying to stream when it should not."
+                  " service type: "
+                      << service_type);
     return;
   }
 

--- a/src/components/media_manager/src/media_manager_impl.cc
+++ b/src/components/media_manager/src/media_manager_impl.cc
@@ -315,7 +315,7 @@ void MediaManagerImpl::OnMessageReceived(
   if (!application_manager_.CanAppStream(streaming_app_id, service_type)) {
     application_manager_.ForbidStreaming(streaming_app_id, service_type);
     LOG4CXX_ERROR(logger_,
-                  "The application trying to stream when it should not."
+                  "The application is trying to stream when it should not."
                   " service type: "
                       << service_type);
     return;

--- a/src/components/media_manager/test/media_manager_impl_test.cc
+++ b/src/components/media_manager/test/media_manager_impl_test.cc
@@ -246,7 +246,7 @@ TEST_F(MediaManagerImplTest,
   const ServiceType audio_type = ServiceType::kAudio;
   EXPECT_CALL(app_mngr_, CanAppStream(kConnectionKey, audio_type))
       .WillOnce(Return(false));
-  EXPECT_CALL(app_mngr_, ForbidStreaming(kConnectionKey));
+  EXPECT_CALL(app_mngr_, ForbidStreaming(kConnectionKey, audio_type));
   EmulateMobileMessage(audio_type);
 }
 
@@ -255,7 +255,7 @@ TEST_F(MediaManagerImplTest,
   const ServiceType video_type = ServiceType::kMobileNav;
   EXPECT_CALL(app_mngr_, CanAppStream(kConnectionKey, video_type))
       .WillOnce(Return(false));
-  EXPECT_CALL(app_mngr_, ForbidStreaming(kConnectionKey));
+  EXPECT_CALL(app_mngr_, ForbidStreaming(kConnectionKey, video_type));
   EmulateMobileMessage(video_type);
 }
 

--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -290,14 +290,6 @@ class CacheManager : public CacheManagerInterface {
       const std::string& active_hmi_language) const;
 
   /**
-   * @brief GetLockScreenIcon allows to obtain lock screen icon url;
-   *
-   * @return url which point to the resourse where lock screen icon could be
-   *obtained.
-   */
-  virtual std::string GetLockScreenIconUrl() const;
-
-  /**
    * @brief Get Icon Url used for showing a cloud apps icon before the intial
    *registration
    *
@@ -311,11 +303,11 @@ class CacheManager : public CacheManagerInterface {
    * @param service_type If URLs for specific service are preset,
    * return them otherwise default URLs.
    */
-  virtual void GetUpdateUrls(const std::string& service_type,
-                             EndpointUrls& out_end_points);
+  void GetUpdateUrls(const std::string& service_type,
+                     EndpointUrls& out_end_points) const OVERRIDE;
 
-  virtual void GetUpdateUrls(const uint32_t service_type,
-                             EndpointUrls& out_end_points);
+  void GetUpdateUrls(const uint32_t service_type,
+                     EndpointUrls& out_end_points) const OVERRIDE;
 
   /**
    * @brief Gets allowed number of notifications

--- a/src/components/policy/policy_external/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager_interface.h
@@ -324,18 +324,10 @@ class CacheManagerInterface {
    * return them otherwise default URLs.
    */
   virtual void GetUpdateUrls(const std::string& service_type,
-                             EndpointUrls& out_end_points) = 0;
+                             EndpointUrls& out_end_points) const = 0;
 
   virtual void GetUpdateUrls(const uint32_t service_type,
-                             EndpointUrls& out_end_points) = 0;
-
-  /**
-   * @brief GetLockScreenIcon allows to obtain lock screen icon url;
-   *
-   * @return url which point to the resourse where lock screen icon could be
-   *obtained.
-   */
-  virtual std::string GetLockScreenIconUrl() const = 0;
+                             EndpointUrls& out_end_points) const = 0;
 
   /**
    * @brief Get Icon Url used for showing a cloud apps icon before the intial

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -152,9 +152,9 @@ class PolicyManagerImpl : public PolicyManager {
    * @param out_end_points output vector of urls
    */
   void GetUpdateUrls(const uint32_t service_type,
-                     EndpointUrls& out_end_points) OVERRIDE;
+                     EndpointUrls& out_end_points) const OVERRIDE;
   void GetUpdateUrls(const std::string& service_type,
-                     EndpointUrls& out_end_points) OVERRIDE;
+                     EndpointUrls& out_end_points) const OVERRIDE;
 
   /**
    * @brief PTU is needed, for this PTS has to be formed and sent.
@@ -254,13 +254,6 @@ class PolicyManagerImpl : public PolicyManager {
    * @brief Handler of exceeding timeout of exchanging policy table
    */
   void OnExceededTimeout() OVERRIDE;
-
-  /**
-   * @brief GetLockScreenIcon allows to obtain lock screen icon url;
-   * @return url which point to the resourse where lock screen icon could be
-   *obtained.
-   */
-  std::string GetLockScreenIconUrl() const OVERRIDE;
 
   /**
    * @brief Get Icon Url used for showing a cloud apps icon before the intial

--- a/src/components/policy/policy_external/include/policy/pt_representation.h
+++ b/src/components/policy/policy_external/include/policy/pt_representation.h
@@ -71,14 +71,6 @@ class PTRepresentation {
   virtual bool IsPTPreloaded() = 0;
 
   /**
-   * @brief GetLockScreenIcon allows to obtain lock screen icon url;
-   *
-   * @return url which point to the resourse where lock screen icon could be
-   *obtained.
-   */
-  virtual std::string GetLockScreenIconUrl() const = 0;
-
-  /**
    * @brief Re-creates schema in DB, drops all data
    * @return true, if succedeed, otherwise - false
    */

--- a/src/components/policy/policy_external/include/policy/sql_pt_queries.h
+++ b/src/components/policy/policy_external/include/policy/sql_pt_queries.h
@@ -49,7 +49,6 @@ extern const std::string kSelectPreloaded;
 extern const std::string kIsFirstRun;
 extern const std::string kSetNotFirstRun;
 extern const std::string kSelectEndpoint;
-extern const std::string kSelectLockScreenIcon;
 extern const std::string kSelectModuleConfig;
 extern const std::string kSelectEndpoints;
 extern const std::string kSelectNotificationsPerMin;

--- a/src/components/policy/policy_external/include/policy/sql_pt_representation.h
+++ b/src/components/policy/policy_external/include/policy/sql_pt_representation.h
@@ -185,7 +185,6 @@ class SQLPTRepresentation : public virtual PTRepresentation {
       const policy_table::AppServiceParameters& app_service_parameters);
 
  public:
-  virtual std::string GetLockScreenIconUrl() const;
   bool UpdateRequired() const;
   void SaveUpdateRequired(bool value);
 

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1737,7 +1737,7 @@ std::vector<UserFriendlyMessage> CacheManager::GetUserFriendlyMsg(
 }
 
 void CacheManager::GetUpdateUrls(const uint32_t service_type,
-                                 EndpointUrls& out_end_points) {
+                                 EndpointUrls& out_end_points) const {
   auto find_hexademical =
       [service_type](policy_table::ServiceEndpoints::value_type end_point) {
         uint32_t decimal;
@@ -1754,7 +1754,7 @@ void CacheManager::GetUpdateUrls(const uint32_t service_type,
 }
 
 void CacheManager::GetUpdateUrls(const std::string& service_type,
-                                 EndpointUrls& out_end_points) {
+                                 EndpointUrls& out_end_points) const {
   LOG4CXX_AUTO_TRACE(logger_);
   CACHE_MANAGER_CHECK_VOID();
 
@@ -1779,13 +1779,6 @@ void CacheManager::GetUpdateUrls(const std::string& service_type,
       out_end_points.push_back(data);
     }
   }
-}
-
-std::string CacheManager::GetLockScreenIconUrl() const {
-  if (backup_) {
-    return backup_->GetLockScreenIconUrl();
-  }
-  return std::string("");
 }
 
 std::string CacheManager::GetIconUrl(const std::string& policy_app_id) const {

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -268,10 +268,6 @@ void PolicyManagerImpl::CheckTriggers() {
   }
 }
 
-std::string PolicyManagerImpl::GetLockScreenIconUrl() const {
-  return cache_->GetLockScreenIconUrl();
-}
-
 std::string PolicyManagerImpl::GetIconUrl(
     const std::string& policy_app_id) const {
   return cache_->GetIconUrl(policy_app_id);
@@ -693,12 +689,12 @@ std::string PolicyManagerImpl::GetUpdateUrl(int service_type) {
 }
 
 void PolicyManagerImpl::GetUpdateUrls(const std::string& service_type,
-                                      EndpointUrls& out_end_points) {
+                                      EndpointUrls& out_end_points) const {
   LOG4CXX_AUTO_TRACE(logger_);
   cache_->GetUpdateUrls(service_type, out_end_points);
 }
 void PolicyManagerImpl::GetUpdateUrls(const uint32_t service_type,
-                                      EndpointUrls& out_end_points) {
+                                      EndpointUrls& out_end_points) const {
   LOG4CXX_AUTO_TRACE(logger_);
   cache_->GetUpdateUrls(service_type, out_end_points);
 }

--- a/src/components/policy/policy_external/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_queries.cc
@@ -781,9 +781,6 @@ const std::string kSetNotFirstRun =
 const std::string kSelectEndpoint =
     "SELECT `url`, `application_id` FROM `endpoint` WHERE `service` = ? ";
 
-const std::string kSelectLockScreenIcon =
-    "SELECT `url` FROM `endpoint` WHERE `service` = ? AND `application_id` = ?";
-
 const std::string kInsertFunctionalGroup =
     "INSERT INTO `functional_group` (`id`, `name`, `user_consent_prompt`, "
     "`encryption_required`) "

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -101,28 +101,6 @@ SQLPTRepresentation::~SQLPTRepresentation() {
   delete db_;
 }
 
-std::string SQLPTRepresentation::GetLockScreenIconUrl() const {
-  utils::dbms::SQLQuery query(db());
-  std::string ret;
-  if (query.Prepare(sql_pt::kSelectLockScreenIcon)) {
-    query.Bind(0, std::string("lock_screen_icon_url"));
-    query.Bind(1, std::string("default"));
-
-    if (!query.Exec()) {
-      LOG4CXX_WARN(logger_, "Incorrect select from notifications by priority.");
-      return ret;
-    }
-
-    if (!query.IsNull(0)) {
-      ret = query.GetString(0);
-    }
-
-  } else {
-    LOG4CXX_WARN(logger_, "Invalid select endpoints statement.");
-  }
-  return ret;
-}
-
 void SQLPTRepresentation::CheckPermissions(const PTString& app_id,
                                            const PTString& hmi_level,
                                            const PTString& rpc,

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -277,18 +277,11 @@ class CacheManager : public CacheManagerInterface {
    * @param service_type If URLs for specific service are preset,
    * return them otherwise default URLs.
    */
-  virtual void GetUpdateUrls(const std::string& service_type,
-                             EndpointUrls& out_end_points);
+  void GetUpdateUrls(const std::string& service_type,
+                     EndpointUrls& out_end_points) const OVERRIDE;
 
-  virtual void GetUpdateUrls(const uint32_t service_type,
-                             EndpointUrls& out_end_points);
-  /**
-   * @brief GetLockScreenIcon allows to obtain lock screen icon url;
-   *
-   * @return url which point to the resourse where lock screen icon could be
-   *obtained.
-   */
-  virtual std::string GetLockScreenIconUrl() const;
+  void GetUpdateUrls(const uint32_t service_type,
+                     EndpointUrls& out_end_points) const OVERRIDE;
 
   /**
    * @brief Get Icon Url used for showing a cloud apps icon before the intial

--- a/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
@@ -308,17 +308,9 @@ class CacheManagerInterface {
    * return them otherwise default URLs.
    */
   virtual void GetUpdateUrls(const std::string& service_type,
-                             EndpointUrls& out_end_points) = 0;
+                             EndpointUrls& out_end_points) const = 0;
   virtual void GetUpdateUrls(const uint32_t service_type,
-                             EndpointUrls& out_end_points) = 0;
-
-  /**
-   * @brief GetLockScreenIcon allows to obtain lock screen icon url;
-   *
-   * @return url which point to the resourse where lock screen icon could be
-   *obtained.
-   */
-  virtual std::string GetLockScreenIconUrl() const = 0;
+                             EndpointUrls& out_end_points) const = 0;
 
   /**
    * @brief Get Icon Url used for showing a cloud apps icon before the intial

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -172,16 +172,9 @@ class PolicyManagerImpl : public PolicyManager {
    * @param out_end_points output vector of urls
    */
   void GetUpdateUrls(const uint32_t service_type,
-                     EndpointUrls& out_end_points) OVERRIDE;
+                     EndpointUrls& out_end_points) const OVERRIDE;
   void GetUpdateUrls(const std::string& service_type,
-                     EndpointUrls& out_end_points) OVERRIDE;
-
-  /**
-   * @brief GetLockScreenIcon allows to obtain lock screen icon url;
-   * @return url which point to the resourse where lock screen icon could be
-   *obtained.
-   */
-  std::string GetLockScreenIconUrl() const OVERRIDE;
+                     EndpointUrls& out_end_points) const OVERRIDE;
 
   /**
    * @brief Get Icon Url used for showing a cloud apps icon before the intial

--- a/src/components/policy/policy_regular/include/policy/pt_representation.h
+++ b/src/components/policy/policy_regular/include/policy/pt_representation.h
@@ -152,14 +152,6 @@ class PTRepresentation {
   virtual EndpointUrls GetUpdateUrls(int service_type) = 0;
 
   /**
-   * @brief GetLockScreenIcon allows to obtain lock screen icon url;
-   *
-   * @return url which point to the resourse where lock screen icon could be
-   *obtained.
-   */
-  virtual std::string GetLockScreenIconUrl() const = 0;
-
-  /**
    * @brief Get allowed number of notifications
    * depending on application priority.
    * @param priority Priority of application

--- a/src/components/policy/policy_regular/include/policy/sql_pt_queries.h
+++ b/src/components/policy/policy_regular/include/policy/sql_pt_queries.h
@@ -49,7 +49,6 @@ extern const std::string kSelectPreloaded;
 extern const std::string kIsFirstRun;
 extern const std::string kSetNotFirstRun;
 extern const std::string kSelectEndpoint;
-extern const std::string kSelectLockScreenIcon;
 extern const std::string kSelectModuleConfig;
 extern const std::string kSelectEndpoints;
 extern const std::string kSelectNotificationsPerMin;

--- a/src/components/policy/policy_regular/include/policy/sql_pt_representation.h
+++ b/src/components/policy/policy_regular/include/policy/sql_pt_representation.h
@@ -75,7 +75,6 @@ class SQLPTRepresentation : public virtual PTRepresentation {
       const std::vector<std::string>& msg_codes, const std::string& language);
 
   virtual EndpointUrls GetUpdateUrls(int service_type);
-  virtual std::string GetLockScreenIconUrl() const;
   virtual int GetNotificationsNumber(const std::string& priority);
   virtual bool GetPriority(const std::string& policy_app_id,
                            std::string* priority);

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -1040,7 +1040,7 @@ std::vector<UserFriendlyMessage> CacheManager::GetUserFriendlyMsg(
 }
 
 void CacheManager::GetUpdateUrls(const uint32_t service_type,
-                                 EndpointUrls& out_end_points) {
+                                 EndpointUrls& out_end_points) const {
   auto find_hexademical =
       [service_type](policy_table::ServiceEndpoints::value_type end_point) {
         uint32_t decimal;
@@ -1057,7 +1057,7 @@ void CacheManager::GetUpdateUrls(const uint32_t service_type,
 }
 
 void CacheManager::GetUpdateUrls(const std::string& service_type,
-                                 EndpointUrls& out_end_points) {
+                                 EndpointUrls& out_end_points) const {
   LOG4CXX_AUTO_TRACE(logger_);
   CACHE_MANAGER_CHECK_VOID();
 
@@ -1082,13 +1082,6 @@ void CacheManager::GetUpdateUrls(const std::string& service_type,
       out_end_points.push_back(data);
     }
   }
-}
-
-std::string CacheManager::GetLockScreenIconUrl() const {
-  if (backup_) {
-    return backup_->GetLockScreenIconUrl();
-  }
-  return std::string("");
 }
 
 std::string CacheManager::GetIconUrl(const std::string& policy_app_id) const {

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -597,12 +597,13 @@ void PolicyManagerImpl::PrepareNotificationData(
 }
 
 void PolicyManagerImpl::GetUpdateUrls(const std::string& service_type,
-                                      EndpointUrls& out_end_points) {
+                                      EndpointUrls& out_end_points) const {
   LOG4CXX_AUTO_TRACE(logger_);
   cache_->GetUpdateUrls(service_type, out_end_points);
 }
+
 void PolicyManagerImpl::GetUpdateUrls(const uint32_t service_type,
-                                      EndpointUrls& out_end_points) {
+                                      EndpointUrls& out_end_points) const {
   LOG4CXX_AUTO_TRACE(logger_);
   cache_->GetUpdateUrls(service_type, out_end_points);
 }
@@ -629,10 +630,6 @@ bool PolicyManagerImpl::RequestPTUpdate(const PTUIterationType iteration_type) {
   ptu_requested_ = true;
   listener_->OnSnapshotCreated(update, iteration_type);
   return true;
-}
-
-std::string PolicyManagerImpl::GetLockScreenIconUrl() const {
-  return cache_->GetLockScreenIconUrl();
 }
 
 std::string PolicyManagerImpl::GetIconUrl(

--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -739,9 +739,6 @@ const std::string kSetNotFirstRun =
 const std::string kSelectEndpoint =
     "SELECT `url`, `application_id` FROM `endpoint` WHERE `service` = ? ";
 
-const std::string kSelectLockScreenIcon =
-    "SELECT `url` FROM `endpoint` WHERE `service` = ? AND `application_id` = ?";
-
 const std::string kInsertFunctionalGroup =
     "INSERT INTO `functional_group` (`id`, `name`, `user_consent_prompt`, "
     "`encryption_required`) "

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -241,28 +241,6 @@ EndpointUrls SQLPTRepresentation::GetUpdateUrls(int service_type) {
   return ret;
 }
 
-std::string SQLPTRepresentation::GetLockScreenIconUrl() const {
-  utils::dbms::SQLQuery query(db());
-  std::string ret;
-  if (query.Prepare(sql_pt::kSelectLockScreenIcon)) {
-    query.Bind(0, std::string("lock_screen_icon_url"));
-    query.Bind(1, std::string("default"));
-
-    if (!query.Exec()) {
-      LOG4CXX_WARN(logger_, "Incorrect select from notifications by priority.");
-      return ret;
-    }
-
-    if (!query.IsNull(0)) {
-      ret = query.GetString(0);
-    }
-
-  } else {
-    LOG4CXX_WARN(logger_, "Invalid select endpoints statement.");
-  }
-  return ret;
-}
-
 int SQLPTRepresentation::GetNotificationsNumber(const std::string& priority) {
   LOG4CXX_AUTO_TRACE(logger_);
   utils::dbms::SQLQuery query(db());


### PR DESCRIPTION
Fixes #3275 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF Script: [3139_02_Stop_streaming_gracefully_2nd_timer](https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/develop/test_scripts/Defects/6_1/3139_02_Stop_streaming_gracefully_2nd_timer.lua)

### Summary
The issue is happening, when SDL receives audio/video streaming data during changes HMI state (e.g. STREAMABLE -> NOT_STREAMABLE) internally. Earlier SDL considered only HMI_Level, but now after fix: [Fix SDL app stream processing with non-streamable](https://github.com/smartdevicelink/sdl_core/pull/3151) streaming state is also taken into account.
Relation to this change SDL need to consider audio/video application state for sends EndService from ForbidStreaming, which changing according to  timeout for mobile to stop streaming.

### Changelog
* Consider video and audio status before send EndService 
* Update UTs 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)