### PR TITLE
maintain signature for GetLockScreenIconUrl

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -205,7 +205,7 @@ class PolicyHandler : public PolicyHandlerInterface,
   void GetUpdateUrls(const uint32_t service_type,
                      EndpointUrls& out_end_points) const OVERRIDE;
   virtual std::string GetLockScreenIconUrl(
-      const std::string& policy_app_id) const OVERRIDE;
+      const std::string& policy_app_id = kDefaultId) const OVERRIDE;
   virtual std::string GetIconUrl(
       const std::string& policy_app_id) const OVERRIDE;
   uint32_t NextRetryTimeout() OVERRIDE;

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -132,7 +132,7 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
    * @return URL for a requested application
    */
   virtual std::string GetLockScreenIconUrl(
-      const std::string& policy_app_id) const = 0;
+      const std::string& policy_app_id = kDefaultId) const = 0;
 
   virtual std::string GetIconUrl(const std::string& policy_app_id) const = 0;
   virtual uint32_t NextRetryTimeout() = 0;


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
PR https://github.com/smartdevicelink/sdl_core/pull/3271 changed the signature of GetLockScreenIconUrl in order to support app specific URLs for getting a lock screen image.

This PR adds a default appID value so that the signature of the method is not required to change for anyone with a custom Core implementation.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
