### PR TITLE
Remove redundant GetSystemInfo sending

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -222,7 +222,6 @@ class PolicyHandler : public PolicyHandlerInterface,
    */
   uint32_t TimeoutExchangeMSec() const OVERRIDE;
   void OnExceededTimeout() OVERRIDE;
-  void OnSystemReady() OVERRIDE;
   const boost::optional<bool> LockScreenDismissalEnabledState() const OVERRIDE;
   const boost::optional<std::string> LockScreenDismissalWarningMessage(
       const std::string& language) const OVERRIDE;
@@ -381,11 +380,6 @@ class PolicyHandler : public PolicyHandlerInterface,
   void OnGetSystemInfo(const std::string& ccpu_version,
                        const std::string& wers_country_code,
                        const std::string& language) OVERRIDE;
-
-  /**
-   * @brief Send request to HMI to get update on system parameters
-   */
-  virtual void OnSystemInfoUpdateRequired() OVERRIDE;
 
   /**
    * @brief Sends GetVehicleData request in case when Vechicle info is ready.

--- a/src/components/application_manager/src/policies/policy_event_observer.cc
+++ b/src/components/application_manager/src/policies/policy_event_observer.cc
@@ -70,11 +70,6 @@ void PolicyEventObserver::on_event(const event_engine::Event& event) {
       unsubscribe_from_event(hmi_apis::FunctionID::VehicleInfo_GetVehicleData);
       break;
     }
-    case hmi_apis::FunctionID::BasicCommunication_OnReady: {
-      policy_handler_->OnSystemReady();
-      unsubscribe_from_event(hmi_apis::FunctionID::BasicCommunication_OnReady);
-      break;
-    }
     default: { break; }
   }
 }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -376,10 +376,6 @@ const PolicySettings& PolicyHandler::get_settings() const {
 bool PolicyHandler::InitPolicyTable() {
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK_OR_RETURN(false);
-  // Subscribing to notification for system readiness to be able to get system
-  // info necessary for policy table
-  event_observer_->subscribe_on_event(
-      hmi_apis::FunctionID::BasicCommunication_OnReady);
   std::string preloaded_file = get_settings().preloaded_pt_file();
   if (file_system::FileExists(preloaded_file)) {
     const bool pt_inited =
@@ -985,12 +981,6 @@ void PolicyHandler::OnGetSystemInfo(const std::string& ccpu_version,
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK_VOID();
   policy_manager_->SetSystemInfo(ccpu_version, wers_country_code, language);
-}
-
-void PolicyHandler::OnSystemInfoUpdateRequired() {
-  LOG4CXX_AUTO_TRACE(logger_);
-  POLICY_LIB_CHECK_VOID();
-  MessageHelper::SendGetSystemInfoRequest(application_manager_);
 }
 
 void PolicyHandler::OnVIIsReady() {
@@ -1763,11 +1753,6 @@ void PolicyHandler::OnExceededTimeout() {
                 std::mem_fn(&PolicyHandlerObserver::OnPTUTimeoutExceeded));
 
   policy_manager_->OnExceededTimeout();
-}
-
-void PolicyHandler::OnSystemReady() {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->OnSystemReady();
 }
 
 const boost::optional<bool> PolicyHandler::LockScreenDismissalEnabledState()

--- a/src/components/application_manager/test/policy_event_observer_test.cc
+++ b/src/components/application_manager/test/policy_event_observer_test.cc
@@ -89,8 +89,6 @@ class PolicyEventObserverTest : public ::testing::Test {
     EXPECT_CALL(policy_handler_mock_,
                 PTUpdatedAt(Counters::KILOMETERS, field_value))
         .Times(pt_updated_calls_number);
-    EXPECT_CALL(policy_handler_mock_, OnSystemReady())
-        .Times(on_system_ready_calls_number);
     policy_event_observer_->on_event(*event_);
   }
 
@@ -123,15 +121,6 @@ TEST_F(PolicyEventObserverTest,
   CookSmartObject(hmi_apis::Common_Result::SUCCESS, field_name, field_value);
   // Check
   CheckResultsOnEvent(1u, 0u);
-}
-
-TEST_F(PolicyEventObserverTest,
-       OnEvent_EventBasicCommunication_OnReady_ExpectOnSystemReady) {
-  // Arrange
-  CreateEvent(Event::EventID::BasicCommunication_OnReady);
-  CookSmartObject(hmi_apis::Common_Result::SUCCESS, field_name, field_value);
-  // Check
-  CheckResultsOnEvent(0u, 1u);
 }
 
 }  // namespace policy_test

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -811,15 +811,6 @@ TEST_F(PolicyHandlerTest, OnExceededTimeout) {
   policy_handler_.OnExceededTimeout();
 }
 
-TEST_F(PolicyHandlerTest, OnSystemReady) {
-  // Arrange
-  EnablePolicyAndPolicyManagerMock();
-  // Check expectations
-  EXPECT_CALL(*mock_policy_manager_, OnSystemReady());
-  // Act
-  policy_handler_.OnSystemReady();
-}
-
 TEST_F(PolicyHandlerTest, PTUpdatedAt_method_UseCounter_KILOMETERS) {
   // Arrange
   EnablePolicyAndPolicyManagerMock();
@@ -1364,15 +1355,6 @@ TEST_F(PolicyHandlerTest, IsApplicationRevoked) {
   EXPECT_CALL(*mock_policy_manager_, IsApplicationRevoked(kPolicyAppId_));
   // Act
   policy_handler_.IsApplicationRevoked(kPolicyAppId_);
-}
-
-TEST_F(PolicyHandlerTest, OnSystemInfoUpdateRequired) {
-  // Arrange
-  ChangePolicyManagerToMock();
-  // Check expectations
-  EXPECT_CALL(mock_message_helper_, SendGetSystemInfoRequest(_));
-  // Act
-  policy_handler_.OnSystemInfoUpdateRequired();
 }
 
 TEST_F(PolicyHandlerTest, GetAppRequestTypes) {

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -149,7 +149,6 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
    */
   virtual uint32_t TimeoutExchangeMSec() const = 0;
   virtual void OnExceededTimeout() = 0;
-  virtual void OnSystemReady() = 0;
   virtual const boost::optional<bool> LockScreenDismissalEnabledState()
       const = 0;
   virtual const boost::optional<std::string> LockScreenDismissalWarningMessage(
@@ -312,11 +311,6 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
   virtual void OnGetSystemInfo(const std::string& ccpu_version,
                                const std::string& wers_country_code,
                                const std::string& language) = 0;
-
-  /**
-   * @brief Send request to HMI to get update on system parameters
-   */
-  virtual void OnSystemInfoUpdateRequired() = 0;
 
   /**
    * @brief Sends GetVehicleData request in case when Vechicle info is ready.

--- a/src/components/include/policy/policy_external/policy/policy_listener.h
+++ b/src/components/include/policy/policy_external/policy/policy_listener.h
@@ -60,7 +60,6 @@ class PolicyListener {
   virtual std::string OnCurrentDeviceIdUpdateRequired(
       const transport_manager::DeviceHandle& device_handle,
       const std::string& policy_app_id) = 0;
-  virtual void OnSystemInfoUpdateRequired() = 0;
   virtual custom_str::CustomString GetAppName(
       const std::string& policy_app_id) = 0;
   virtual void OnUpdateHMIAppType(

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -474,13 +474,6 @@ class PolicyManager : public usage_statistics::StatisticsManager,
   virtual bool CanAppStealFocus(const std::string& app_id) const = 0;
 
   /**
-   * @brief Runs necessary operations, which is depends on external system
-   * state, e.g. getting system-specific parameters which are need to be
-   * filled into policy table
-   */
-  virtual void OnSystemReady() = 0;
-
-  /**
    * @brief Get number of notification by priority
    * @param priority Specified priority
    * @return notification number

--- a/src/components/include/policy/policy_regular/policy/policy_listener.h
+++ b/src/components/include/policy/policy_regular/policy/policy_listener.h
@@ -58,7 +58,6 @@ class PolicyListener {
   virtual std::string OnCurrentDeviceIdUpdateRequired(
       const transport_manager::DeviceHandle& device_handle,
       const std::string& policy_app_id) = 0;
-  virtual void OnSystemInfoUpdateRequired() = 0;
   virtual custom_str::CustomString GetAppName(
       const std::string& policy_app_id) = 0;
   virtual void OnUpdateHMIAppType(

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -465,13 +465,6 @@ class PolicyManager : public usage_statistics::StatisticsManager,
   virtual bool CanAppStealFocus(const std::string& app_id) const = 0;
 
   /**
-   * @brief Runs necessary operations, which is depends on external system
-   * state, e.g. getting system-specific parameters which are need to be
-   * filled into policy table
-   */
-  virtual void OnSystemReady() = 0;
-
-  /**
    * @brief Get number of notification by priority
    * @param priority Specified priority
    * @return notification number

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -125,7 +125,6 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_CONST_METHOD0(TimeoutExchangeSec, uint32_t());
   MOCK_CONST_METHOD0(TimeoutExchangeMSec, uint32_t());
   MOCK_METHOD0(OnExceededTimeout, void());
-  MOCK_METHOD0(OnSystemReady, void());
   MOCK_CONST_METHOD0(LockScreenDismissalEnabledState,
                      const boost::optional<bool>());
   MOCK_CONST_METHOD1(LockScreenDismissalWarningMessage,
@@ -182,7 +181,6 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                void(const std::string& ccpu_version,
                     const std::string& wers_country_code,
                     const std::string& language));
-  MOCK_METHOD0(OnSystemInfoUpdateRequired, void());
   MOCK_METHOD0(OnVIIsReady, void());
   MOCK_METHOD1(OnVehicleDataUpdated,
                void(const smart_objects::SmartObject& message));

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_listener.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_listener.h
@@ -71,7 +71,6 @@ class MockPolicyListener : public ::policy::PolicyListener {
   MOCK_METHOD2(OnCurrentDeviceIdUpdateRequired,
                std::string(const transport_manager::DeviceHandle& device_handle,
                            const std::string& policy_app_id));
-  MOCK_METHOD0(OnSystemInfoUpdateRequired, void());
   MOCK_METHOD1(GetAppName,
                custom_str::CustomString(const std::string& policy_app_id));
   MOCK_METHOD0(OnUserRequestedUpdateCheckRequired, void());

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -206,7 +206,6 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(CleanupUnpairedDevices, bool());
   MOCK_CONST_METHOD1(CanAppKeepContext, bool(const std::string& app_id));
   MOCK_CONST_METHOD1(CanAppStealFocus, bool(const std::string& app_id));
-  MOCK_METHOD0(OnSystemReady, void());
   MOCK_CONST_METHOD1(GetNotificationsNumber,
                      uint32_t(const std::string& priority));
   MOCK_METHOD1(SetVINValue, void(const std::string& value));

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_listener.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_listener.h
@@ -68,7 +68,6 @@ class MockPolicyListener : public ::policy::PolicyListener {
   MOCK_METHOD2(OnCurrentDeviceIdUpdateRequired,
                std::string(const transport_manager::DeviceHandle& device_handle,
                            const std::string& policy_app_id));
-  MOCK_METHOD0(OnSystemInfoUpdateRequired, void());
   MOCK_METHOD1(GetAppName,
                custom_str::CustomString(const std::string& policy_app_id));
   MOCK_METHOD0(OnUserRequestedUpdateCheckRequired, void());

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -204,7 +204,6 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(CleanupUnpairedDevices, bool());
   MOCK_CONST_METHOD1(CanAppKeepContext, bool(const std::string& app_id));
   MOCK_CONST_METHOD1(CanAppStealFocus, bool(const std::string& app_id));
-  MOCK_METHOD0(OnSystemReady, void());
   MOCK_CONST_METHOD1(GetNotificationsNumber,
                      uint32_t(const std::string& priority));
   MOCK_METHOD1(SetVINValue, void(const std::string& value));

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -436,13 +436,6 @@ class PolicyManagerImpl : public PolicyManager {
                      const std::string& language) OVERRIDE;
 
   /**
-   * @brief Runs necessary operations, which is depends on external system
-   * state, e.g. getting system-specific parameters which are need to be
-   * filled into policy table
-   */
-  void OnSystemReady() OVERRIDE;
-
-  /**
    * @brief Get number of notification by priority
    * @param priority Specified priority
    * @return notification number

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1630,13 +1630,6 @@ void PolicyManagerImpl::SetSystemInfo(const std::string& ccpu_version,
   cache_->SetMetaInfo(ccpu_version, wers_country_code, language);
 }
 
-void PolicyManagerImpl::OnSystemReady() {
-  // Update policy table for the first time with system information
-  if (!cache_->IsMetaInfoPresent()) {
-    listener()->OnSystemInfoUpdateRequired();
-  }
-}
-
 uint32_t PolicyManagerImpl::GetNotificationsNumber(
     const std::string& priority) const {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/policy/policy_external/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_external/test/policy_manager_impl_test.cc
@@ -174,14 +174,6 @@ TEST_F(PolicyManagerImplTest2, ForcePTExchange_ExpectUpdateNeeded) {
   EXPECT_EQ("UPDATE_NEEDED", policy_manager_->GetPolicyTableStatus());
 }
 
-TEST_F(PolicyManagerImplTest2, OnSystemReady) {
-  // Arrange
-  CreateLocalPT(preloaded_pt_filename_);
-  // Check
-  EXPECT_CALL(listener_, OnSystemInfoUpdateRequired());
-  policy_manager_->OnSystemReady();
-}
-
 TEST_F(PolicyManagerImplTest2, ResetRetrySequence) {
   // Arrange
   CreateLocalPT(preloaded_pt_filename_);

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -452,13 +452,6 @@ class PolicyManagerImpl : public PolicyManager {
                      const std::string& language) OVERRIDE;
 
   /**
-   * @brief Runs necessary operations, which is depends on external system
-   * state, e.g. getting system-specific parameters which are need to be
-   * filled into policy table
-   */
-  void OnSystemReady() OVERRIDE;
-
-  /**
    * @brief Get number of notification by priority
    * @param priority Specified priority
    * @return notification number

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1212,14 +1212,6 @@ void PolicyManagerImpl::SetSystemInfo(const std::string& ccpu_version,
   LOG4CXX_AUTO_TRACE(logger_);
 }
 
-void PolicyManagerImpl::OnSystemReady() {
-  // Update policy table for the first time with system information
-  if (cache_->IsPTPreloaded()) {
-    listener()->OnSystemInfoUpdateRequired();
-    return;
-  }
-}
-
 uint32_t PolicyManagerImpl::GetNotificationsNumber(
     const std::string& priority) const {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -1428,14 +1428,6 @@ TEST_F(PolicyManagerImplTest2, ForcePTExchange_ExpectUpdateNeeded) {
   EXPECT_EQ("UPDATE_NEEDED", manager->GetPolicyTableStatus());
 }
 
-TEST_F(PolicyManagerImplTest2, OnSystemReady) {
-  // Arrange
-  CreateLocalPT("sdl_preloaded_pt.json");
-  // Check
-  EXPECT_CALL(listener, OnSystemInfoUpdateRequired());
-  manager->OnSystemReady();
-}
-
 TEST_F(PolicyManagerImplTest2, ResetRetrySequence) {
   // Arrange
   CreateLocalPT("sdl_preloaded_pt.json");


### PR DESCRIPTION
Fixes #3302 

This PR is **[not ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
ATF test script: https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2377

### Summary
SDL sends GetSystemInfo right after receiving BC.On_Ready from HMI in ApplicationManagerImpl::OnHMIStartedCooperation() - https://github.com/smartdevicelink/sdl_core/blob/develop/src/components/application_manager/src/application_manager_impl.cc#L852 
But also there was one more redundant sending of GetSystemInfo from policy_manager. So I just removed this redundant sending and some redundant functions also.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
