### PR TITLE
Increase unit tests coverage on persistence HMI

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_get_capabilities_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_get_capabilities_request_test.cc
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hmi/rc_get_capabilities_request.h"
+
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/request_to_hmi.h"
+#include "application_manager/smart_object_keys.h"
+#include "smart_objects/smart_object.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+namespace rc_get_capabilities_request {
+
+using ::testing::_;
+using ::testing::Return;
+namespace am = ::application_manager;
+namespace strings = ::application_manager::strings;
+using am::commands::CommandImpl;
+using am::commands::RequestToHMI;
+using sdl_rpc_plugin::commands::RCGetCapabilitiesRequest;
+
+typedef std::shared_ptr<RequestToHMI> RequestToHMIPtr;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const std::string kStrNumber = "123";
+}  // namespace
+
+class RCGetCapabilitiesRequestTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {};
+
+TEST_F(RCGetCapabilitiesRequestTest, RUN_SendRequest_SUCCESS) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = kStrNumber;
+  (*command_msg)[am::strings::params][am::strings::connection_key] =
+      kConnectionKey;
+
+  RequestToHMIPtr command(CreateCommand<RCGetCapabilitiesRequest>(command_msg));
+  EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(command_msg));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
+
+  EXPECT_EQ(CommandImpl::hmi_protocol_type_,
+            (*command_msg)[strings::params][strings::protocol_type].asInt());
+  EXPECT_EQ(CommandImpl::protocol_version_,
+            (*command_msg)[strings::params][strings::protocol_version].asInt());
+}
+
+TEST_F(RCGetCapabilitiesRequestTest,
+       onTimeOut_OnCapabilityInitialized_RemoveButtonsGetCapabilities) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  RequestToHMIPtr command(CreateCommand<RCGetCapabilitiesRequest>(command_msg));
+
+  EXPECT_CALL(
+      mock_hmi_capabilities_,
+      OnCapabilityInitialized(hmi_apis::FunctionID::RC_GetCapabilities));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
+  command->onTimeOut();
+}
+
+}  // namespace rc_get_capabilities_request
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_is_ready_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_is_ready_request_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Ford Motor Company
+ * Copyright (c) 2020, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,32 +30,31 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "hmi/vi_is_ready_request.h"
+#include "hmi/tts_is_ready_request.h"
 
 #include <memory>
 #include <set>
+#include <string>
 
 #include "gtest/gtest.h"
 
+#include "application_manager/commands/command_request_test.h"
 #include "application_manager/event_engine/event.h"
 #include "application_manager/hmi_interfaces.h"
 #include "application_manager/mock_application_manager.h"
 #include "application_manager/mock_hmi_capabilities.h"
 #include "application_manager/mock_hmi_interface.h"
 #include "application_manager/mock_message_helper.h"
-#include "application_manager/policies/mock_policy_handler_interface.h"
 #include "application_manager/smart_object_keys.h"
 #include "smart_objects/smart_object.h"
-#include "vehicle_info_plugin/commands/vi_command_request_test.h"
 
 namespace test {
 namespace components {
 namespace commands_test {
 namespace hmi_commands_test {
-namespace vi_is_ready_request {
+namespace tts_is_ready_request {
 
 using ::testing::_;
-using ::testing::Return;
 using ::testing::ReturnRef;
 namespace am = ::application_manager;
 namespace strings = ::application_manager::strings;
@@ -63,84 +62,106 @@ using am::commands::CommandImpl;
 using am::commands::MessageSharedPtr;
 using am::commands::RequestToHMI;
 using am::event_engine::Event;
-using vehicle_info_plugin::commands::VIIsReadyRequest;
+using sdl_rpc_plugin::commands::TTSIsReadyRequest;
 
-typedef std::shared_ptr<VIIsReadyRequest> VIIsReadyRequestPtr;
+typedef std::shared_ptr<RequestToHMI> RequestToHMIPtr;
+typedef std::shared_ptr<TTSIsReadyRequest> TTSIsReadyRequestPtr;
 
 namespace {
 const uint32_t kConnectionKey = 2u;
+const std::string kStrNumber = "123";
 }  // namespace
 
-class VIIsReadyRequestTest
-    : public VICommandRequestTest<CommandsTestMocks::kIsNice> {
+class TTSIsReadyRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  public:
-  VIIsReadyRequestTest() : command_(CreateCommandVI<VIIsReadyRequest>()) {}
+  TTSIsReadyRequestTest() : command_(CreateCommand<TTSIsReadyRequest>()) {}
 
-  void SetUpExpectations(bool is_vi_cooperating_available,
-                         bool should_message_be_sent,
-                         bool message_contains_param,
-                         am::HmiInterfaces::InterfaceState state) {
+  void SetUpExpectations(const bool is_tts_cooperating_available,
+                         const bool should_message_be_sent,
+                         const bool message_contains_param,
+                         const am::HmiInterfaces::InterfaceState state) {
+    if (should_message_be_sent) {
+      ExpectSendMessagesToHMI();
+    }
     EXPECT_CALL(mock_hmi_capabilities_,
-                set_is_ivi_cooperating(is_vi_cooperating_available));
+                set_is_tts_cooperating(is_tts_cooperating_available));
 
     if (message_contains_param) {
-      EXPECT_CALL(app_mngr_, hmi_interfaces())
-          .WillRepeatedly(ReturnRef(mock_hmi_interfaces_));
-      EXPECT_CALL(mock_hmi_interfaces_,
-                  SetInterfaceState(
-                      am::HmiInterfaces::HMI_INTERFACE_VehicleInfo, state));
+      ON_CALL(app_mngr_, hmi_interfaces())
+          .WillByDefault(ReturnRef(mock_hmi_interfaces_));
+      EXPECT_CALL(
+          mock_hmi_interfaces_,
+          SetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS, state));
     } else {
       EXPECT_CALL(app_mngr_, hmi_interfaces())
           .WillOnce(ReturnRef(mock_hmi_interfaces_));
       EXPECT_CALL(mock_hmi_interfaces_, SetInterfaceState(_, _)).Times(0);
     }
-    EXPECT_CALL(mock_policy_handler_, OnVIIsReady());
-
     EXPECT_CALL(mock_hmi_interfaces_,
-                GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_VehicleInfo))
+                GetInterfaceState(am::HmiInterfaces::HMI_INTERFACE_TTS))
         .WillOnce(Return(state));
-
-    if (should_message_be_sent) {
-      ExpectSendMessagesToHMI();
-    }
   }
 
   void ExpectSendMessagesToHMI() {
-    smart_objects::SmartObjectSPtr ivi_type;
+    smart_objects::SmartObjectSPtr language =
+        std::make_shared<smart_objects::SmartObject>(
+            smart_objects::SmartType_Map);
+    EXPECT_CALL(mock_message_helper_,
+                CreateModuleInfoSO(hmi_apis::FunctionID::TTS_GetLanguage, _))
+        .WillOnce(Return(language));
+    EXPECT_CALL(mock_hmi_capabilities_, set_handle_response_for(*language));
+    EXPECT_CALL(mock_rpc_service_, ManageHMICommand(language, _));
+
+    smart_objects::SmartObjectSPtr support_language =
+        std::make_shared<smart_objects::SmartObject>(
+            smart_objects::SmartType_Map);
     EXPECT_CALL(
         mock_message_helper_,
-        CreateModuleInfoSO(hmi_apis::FunctionID::VehicleInfo_GetVehicleType, _))
-        .WillOnce(Return(ivi_type));
-    EXPECT_CALL(mock_rpc_service_, ManageHMICommand(ivi_type, _));
+        CreateModuleInfoSO(hmi_apis::FunctionID::TTS_GetSupportedLanguages, _))
+        .WillOnce(Return(support_language));
+    EXPECT_CALL(mock_rpc_service_, ManageHMICommand(support_language, _));
+
+    smart_objects::SmartObjectSPtr capabilities =
+        std::make_shared<smart_objects::SmartObject>(
+            smart_objects::SmartType_Map);
+    EXPECT_CALL(
+        mock_message_helper_,
+        CreateModuleInfoSO(hmi_apis::FunctionID::TTS_GetCapabilities, _))
+        .WillOnce(Return(capabilities));
+    EXPECT_CALL(mock_rpc_service_, ManageHMICommand(capabilities, _));
   }
 
-  void PrepareEvent(bool message_contains_param,
-                    bool is_vi_cooperating_available,
+  void PrepareEvent(const bool message_contains_param,
+                    const bool is_tts_cooperating_available,
                     Event& out_event) {
     MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);
     if (message_contains_param) {
       (*msg)[am::strings::msg_params][am::strings::available] =
-          is_vi_cooperating_available;
+          is_tts_cooperating_available;
     }
     out_event.set_smart_object(*msg);
   }
 
   void HMICapabilitiesExpectations() {
     std::set<hmi_apis::FunctionID::eType> interfaces_to_update{
-        hmi_apis::FunctionID::VehicleInfo_GetVehicleType};
-
+        hmi_apis::FunctionID::TTS_GetLanguage,
+        hmi_apis::FunctionID::TTS_GetSupportedLanguages,
+        hmi_apis::FunctionID::TTS_GetCapabilities};
     EXPECT_CALL(mock_hmi_capabilities_, GetDefaultInitializedCapabilities())
         .WillOnce(Return(interfaces_to_update));
   }
 
-  VIIsReadyRequestPtr command_;
+  TTSIsReadyRequestPtr command_;
 };
 
-TEST_F(VIIsReadyRequestTest, RUN_SendRequest_SUCCESS) {
+TEST_F(TTSIsReadyRequestTest, RUN_SendRequest_SUCCESS) {
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[am::strings::msg_params][am::strings::number] = kStrNumber;
   (*command_msg)[am::strings::params][am::strings::connection_key] =
       kConnectionKey;
-  VIIsReadyRequestPtr command = CreateCommandVI<VIIsReadyRequest>(command_msg);
+
+  RequestToHMIPtr command(CreateCommand<TTSIsReadyRequest>(command_msg));
   EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(command_msg));
   ASSERT_TRUE(command->Init());
 
@@ -152,16 +173,17 @@ TEST_F(VIIsReadyRequestTest, RUN_SendRequest_SUCCESS) {
             (*command_msg)[strings::params][strings::protocol_version].asInt());
 }
 
-TEST_F(VIIsReadyRequestTest, Run_NoKeyAvailableInMessage_HmiInterfacesIgnored) {
-  const bool is_vi_cooperating_available = false;
+TEST_F(TTSIsReadyRequestTest,
+       Run_NoKeyAvailableInMessage_HmiInterfacesIgnored_CacheIsAbsent) {
+  const bool is_tts_cooperating_available = false;
   const bool should_message_be_sent = true;
   const bool message_contains_param = false;
   const am::HmiInterfaces::InterfaceState state =
       am::HmiInterfaces::STATE_NOT_RESPONSE;
-  Event event(hmi_apis::FunctionID::VehicleInfo_IsReady);
-  PrepareEvent(message_contains_param, is_vi_cooperating_available, event);
+  Event event(hmi_apis::FunctionID::TTS_IsReady);
+  PrepareEvent(message_contains_param, is_tts_cooperating_available, event);
   HMICapabilitiesExpectations();
-  SetUpExpectations(is_vi_cooperating_available,
+  SetUpExpectations(is_tts_cooperating_available,
                     should_message_be_sent,
                     message_contains_param,
                     state);
@@ -171,15 +193,16 @@ TEST_F(VIIsReadyRequestTest, Run_NoKeyAvailableInMessage_HmiInterfacesIgnored) {
   command_->on_event(event);
 }
 
-TEST_F(VIIsReadyRequestTest, Run_KeyAvailableEqualToFalse_StateNotAvailable) {
-  const bool is_vi_cooperating_available = false;
+TEST_F(TTSIsReadyRequestTest,
+       Run_KeyAvailableEqualToFalse_StateNotAvailable_CacheIsAbsent) {
+  const bool is_tts_cooperating_available = false;
   const bool should_message_be_sent = false;
   const bool message_contains_param = true;
   const am::HmiInterfaces::InterfaceState state =
       am::HmiInterfaces::STATE_NOT_AVAILABLE;
-  Event event(hmi_apis::FunctionID::VehicleInfo_IsReady);
-  PrepareEvent(message_contains_param, is_vi_cooperating_available, event);
-  SetUpExpectations(is_vi_cooperating_available,
+  Event event(hmi_apis::FunctionID::TTS_IsReady);
+  PrepareEvent(message_contains_param, is_tts_cooperating_available, event);
+  SetUpExpectations(is_tts_cooperating_available,
                     should_message_be_sent,
                     message_contains_param,
                     state);
@@ -189,16 +212,17 @@ TEST_F(VIIsReadyRequestTest, Run_KeyAvailableEqualToFalse_StateNotAvailable) {
   command_->on_event(event);
 }
 
-TEST_F(VIIsReadyRequestTest, Run_KeyAvailableEqualToTrue_StateAvailable) {
-  const bool is_vi_cooperating_available = true;
+TEST_F(TTSIsReadyRequestTest,
+       Run_KeyAvailableEqualToTrue_StateAvailable_CacheIsAbsnet) {
+  const bool is_tts_cooperating_available = true;
   const bool should_message_be_sent = true;
   const bool message_contains_param = true;
   const am::HmiInterfaces::InterfaceState state =
       am::HmiInterfaces::STATE_AVAILABLE;
-  Event event(hmi_apis::FunctionID::VehicleInfo_IsReady);
+  Event event(hmi_apis::FunctionID::TTS_IsReady);
+  PrepareEvent(message_contains_param, is_tts_cooperating_available, event);
   HMICapabilitiesExpectations();
-  PrepareEvent(message_contains_param, is_vi_cooperating_available, event);
-  SetUpExpectations(is_vi_cooperating_available,
+  SetUpExpectations(is_tts_cooperating_available,
                     should_message_be_sent,
                     message_contains_param,
                     state);
@@ -208,9 +232,12 @@ TEST_F(VIIsReadyRequestTest, Run_KeyAvailableEqualToTrue_StateAvailable) {
   command_->on_event(event);
 }
 
-TEST_F(VIIsReadyRequestTest, Run_HMIDoestRespond_SendMessageToHMIByTimeout) {
+TEST_F(TTSIsReadyRequestTest,
+       Run_HMIDoestRespond_SendMessageToHMIByTimeout_CacheIsAbsent) {
   std::set<hmi_apis::FunctionID::eType> interfaces_to_update{
-      hmi_apis::FunctionID::VehicleInfo_GetVehicleType};
+      hmi_apis::FunctionID::TTS_GetLanguage,
+      hmi_apis::FunctionID::TTS_GetSupportedLanguages,
+      hmi_apis::FunctionID::TTS_GetCapabilities};
   EXPECT_CALL(mock_hmi_capabilities_, GetDefaultInitializedCapabilities())
       .WillOnce(Return(interfaces_to_update));
   ExpectSendMessagesToHMI();
@@ -220,7 +247,7 @@ TEST_F(VIIsReadyRequestTest, Run_HMIDoestRespond_SendMessageToHMIByTimeout) {
   command_->onTimeOut();
 }
 
-}  // namespace vi_is_ready_request
+}  // namespace tts_is_ready_request
 }  // namespace hmi_commands_test
 }  // namespace commands_test
 }  // namespace components

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_get_vehicle_type_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_get_vehicle_type_response_test.cc
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hmi/vi_get_vehicle_type_response.h"
+
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "application_manager/application.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/response_from_hmi.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
+#include "application_manager/smart_object_keys.h"
+#include "smart_objects/smart_object.h"
+#include "vehicle_info_plugin/commands/vi_command_request_test.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+namespace vi_get_vehicle_type_response {
+
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+namespace am = ::application_manager;
+namespace strings = ::application_manager::strings;
+namespace hmi_response = am::hmi_response;
+namespace hmi_interface = ::application_manager::hmi_interface;
+using vehicle_info_plugin::commands::VIGetVehicleTypeResponse;
+
+typedef std::shared_ptr<VIGetVehicleTypeResponse> VIGetVehicleTypeResponsePtr;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const std::string kVehicleType = "vehicle_type";
+}  // namespace
+
+class VIGetVehicleTypeResponseTest
+    : public VICommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  SmartObject capabilities_;
+};
+
+TEST_F(VIGetVehicleTypeResponseTest,
+       RUN_ResultCodeSuccess_ChangeHMICapabilities) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::params][hmi_response::vehicle_type] = kVehicleType;
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+
+  VIGetVehicleTypeResponsePtr command =
+      CreateCommandVI<VIGetVehicleTypeResponse>(command_msg);
+
+  EXPECT_CALL(
+      mock_hmi_capabilities_,
+      set_vehicle_type(
+          (*command_msg)[strings::msg_params][hmi_response::vehicle_type]));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              SaveCachedCapabilitiesToFile(hmi_interface::vehicle_info, _, _));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
+  EXPECT_TRUE((*command_msg)[am::strings::msg_params].keyExists(
+      hmi_response::vehicle_type));
+}
+
+TEST_F(VIGetVehicleTypeResponseTest,
+       RUN_ResultCodeNotSuccess_DontChangeHMICapabilities) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::ABORTED;
+  (*command_msg)[strings::params][hmi_response::vehicle_type] = kVehicleType;
+
+  VIGetVehicleTypeResponsePtr command =
+      CreateCommandVI<VIGetVehicleTypeResponse>(command_msg);
+
+  EXPECT_CALL(mock_hmi_capabilities_, set_vehicle_type(_)).Times(0);
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
+
+  EXPECT_FALSE((*command_msg)[am::strings::msg_params].keyExists(
+      hmi_response::vehicle_type));
+}
+
+TEST_F(VIGetVehicleTypeResponseTest,
+       onTimeOut_Run_ResponseForInterface_ReceivedError) {
+  MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*command_msg)[strings::params][hmi_response::code] =
+      hmi_apis::Common_Result::ABORTED;
+
+  VIGetVehicleTypeResponsePtr command =
+      CreateCommandVI<VIGetVehicleTypeResponse>(command_msg);
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              OnCapabilityInitialized(
+                  hmi_apis::FunctionID::VehicleInfo_GetVehicleType));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
+}
+
+}  // namespace vi_get_vehicle_type_response
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -33,7 +33,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "application_manager/hmi_capabilities_for_testing.h"
+
 #include <algorithm>
+#include <memory>
 #include <string>
 
 #include "application_manager/hmi_capabilities.h"
@@ -43,7 +46,6 @@
 #include "smart_objects/enum_schema_item.h"
 #include "smart_objects/smart_object.h"
 
-#include "application_manager/hmi_capabilities_for_testing.h"
 #include "application_manager/mock_application_manager.h"
 #include "application_manager/mock_application_manager_settings.h"
 #include "application_manager/mock_event_dispatcher.h"
@@ -304,10 +306,10 @@ class HMICapabilitiesTest : public ::testing::Test {
     ON_CALL(mock_application_manager_settings_,
             hmi_capabilities_cache_file_name())
         .WillByDefault(ReturnRef(file_cache_name_));
-    EXPECT_CALL(mock_event_dispatcher, add_observer(_, _, _)).Times(1);
-    EXPECT_CALL(mock_event_dispatcher, remove_observer(_)).Times(1);
-    EXPECT_CALL(mock_application_manager_settings_, launch_hmi())
-        .WillOnce(Return(false));
+    EXPECT_CALL(mock_event_dispatcher, add_observer(_, _, _));
+    EXPECT_CALL(mock_event_dispatcher, remove_observer(_));
+    ON_CALL(mock_application_manager_settings_, launch_hmi())
+        .WillByDefault(Return(false));
     hmi_capabilities_test =
         std::make_shared<HMICapabilitiesForTesting>(mock_app_mngr_);
     hmi_capabilities_test->Init(last_state_wrapper_);
@@ -888,19 +890,14 @@ TEST_F(HMICapabilitiesTest,
 
   const std::string hmi_capabilities_file = "hmi_capabilities_sc1.json";
 
-  EXPECT_CALL(mock_app_mngr, event_dispatcher())
-      .WillOnce(ReturnRef(mock_dispatcher));
-  EXPECT_CALL(mock_app_mngr, get_settings())
-      .WillRepeatedly(ReturnRef(mock_application_manager_settings));
-  EXPECT_CALL(mock_application_manager_settings, hmi_capabilities_file_name())
-      .WillOnce(ReturnRef(hmi_capabilities_file));
-  EXPECT_CALL(mock_application_manager_settings,
-              hmi_capabilities_cache_file_name())
-      .WillOnce(ReturnRef(file_cache_name_));
-  EXPECT_CALL(mock_dispatcher, add_observer(_, _, _)).Times(1);
-  EXPECT_CALL(mock_dispatcher, remove_observer(_)).Times(1);
-  EXPECT_CALL(mock_application_manager_settings, launch_hmi())
-      .WillOnce(Return(false));
+  ON_CALL(mock_app_mngr, event_dispatcher())
+      .WillByDefault(ReturnRef(mock_dispatcher));
+  ON_CALL(mock_app_mngr, get_settings())
+      .WillByDefault(ReturnRef(mock_application_manager_settings));
+  ON_CALL(mock_application_manager_settings, hmi_capabilities_file_name())
+      .WillByDefault(ReturnRef(hmi_capabilities_file));
+  ON_CALL(mock_application_manager_settings, hmi_capabilities_cache_file_name())
+      .WillByDefault(ReturnRef(file_cache_name_));
 
   DeleteFileIfExists(kAppInfoDataFile);
 
@@ -929,19 +926,14 @@ TEST_F(HMICapabilitiesTest,
 
   const std::string hmi_capabilities_file = "hmi_capabilities_sc2.json";
 
-  EXPECT_CALL(mock_app_mngr, event_dispatcher())
-      .WillOnce(ReturnRef(mock_dispatcher));
-  EXPECT_CALL(mock_app_mngr, get_settings())
-      .WillRepeatedly(ReturnRef(mock_application_manager_settings));
-  EXPECT_CALL(mock_application_manager_settings, hmi_capabilities_file_name())
-      .WillOnce(ReturnRef(hmi_capabilities_file));
-  EXPECT_CALL(mock_application_manager_settings,
-              hmi_capabilities_cache_file_name())
-      .WillOnce(ReturnRef(file_cache_name_));
-  EXPECT_CALL(mock_dispatcher, add_observer(_, _, _)).Times(1);
-  EXPECT_CALL(mock_dispatcher, remove_observer(_)).Times(1);
-  EXPECT_CALL(mock_application_manager_settings, launch_hmi())
-      .WillOnce(Return(false));
+  ON_CALL(mock_app_mngr, event_dispatcher())
+      .WillByDefault(ReturnRef(mock_dispatcher));
+  ON_CALL(mock_app_mngr, get_settings())
+      .WillByDefault(ReturnRef(mock_application_manager_settings));
+  ON_CALL(mock_application_manager_settings, hmi_capabilities_file_name())
+      .WillByDefault(ReturnRef(hmi_capabilities_file));
+  ON_CALL(mock_application_manager_settings, hmi_capabilities_cache_file_name())
+      .WillByDefault(ReturnRef(file_cache_name_));
 
   DeleteFileIfExists(kAppInfoDataFile);
 
@@ -973,19 +965,15 @@ TEST_F(HMICapabilitiesTest,
 
   const std::string hmi_capabilities_file = "hmi_capabilities_old_apt.json";
 
-  EXPECT_CALL(mock_app_mngr, event_dispatcher())
-      .WillOnce(ReturnRef(mock_dispatcher));
-  EXPECT_CALL(mock_app_mngr, get_settings())
-      .WillRepeatedly(ReturnRef(mock_application_manager_settings));
-  EXPECT_CALL(mock_application_manager_settings, hmi_capabilities_file_name())
-      .WillOnce(ReturnRef(hmi_capabilities_file));
-  EXPECT_CALL(mock_application_manager_settings,
-              hmi_capabilities_cache_file_name())
-      .WillOnce(ReturnRef(file_cache_name_));
-  EXPECT_CALL(mock_dispatcher, add_observer(_, _, _)).Times(1);
-  EXPECT_CALL(mock_dispatcher, remove_observer(_)).Times(1);
-  EXPECT_CALL(mock_application_manager_settings, launch_hmi())
-      .WillOnce(Return(false));
+  ON_CALL(mock_app_mngr, event_dispatcher())
+      .WillByDefault(ReturnRef(mock_dispatcher));
+  ON_CALL(mock_app_mngr, get_settings())
+      .WillByDefault(ReturnRef(mock_application_manager_settings));
+  ON_CALL(mock_application_manager_settings, hmi_capabilities_file_name())
+      .WillByDefault(ReturnRef(hmi_capabilities_file));
+  ON_CALL(mock_application_manager_settings, hmi_capabilities_cache_file_name())
+      .WillByDefault(ReturnRef(file_cache_name_));
+
   EXPECT_CALL(*(MockMessageHelper::message_helper_mock()),
               CommonLanguageFromString(_))
       .WillRepeatedly(Invoke(TestCommonLanguageFromString));
@@ -1127,6 +1115,51 @@ TEST_F(HMICapabilitiesTest,
   EXPECT_EQ(ccpu_version_new, hmi_capabilities->ccpu_version());
 
   EXPECT_FALSE(file_system::FileExists(file_cache_name_));
+}
+
+TEST_F(HMICapabilitiesTest,
+       OnCapabilityInitialized_RespondToAllPendingRAIRequestsIfTheyHold) {
+  MockApplicationManager mock_app_mngr;
+  NiceMock<event_engine_test::MockEventDispatcher> mock_dispatcher;
+  MockApplicationManagerSettings mock_application_manager_settings;
+
+  const std::string hmi_capabilities_file = "hmi_capabilities_sc2.json";
+
+  ON_CALL(mock_app_mngr, event_dispatcher())
+      .WillByDefault(ReturnRef(mock_dispatcher));
+  ON_CALL(mock_app_mngr, get_settings())
+      .WillByDefault(ReturnRef(mock_application_manager_settings));
+  ON_CALL(mock_application_manager_settings, hmi_capabilities_file_name())
+      .WillByDefault(ReturnRef(hmi_capabilities_file));
+  ON_CALL(mock_application_manager_settings, hmi_capabilities_cache_file_name())
+      .WillByDefault(ReturnRef(file_cache_name_));
+
+  auto hmi_capabilities =
+      std::make_shared<HMICapabilitiesForTesting>(mock_app_mngr);
+  hmi_capabilities->Init(last_state_wrapper_);
+
+  EXPECT_TRUE(hmi_capabilities->navigation_supported());
+
+  smart_objects::SmartObject navigation_capability_so =
+      *(hmi_capabilities->navigation_capability());
+  EXPECT_TRUE(navigation_capability_so.keyExists("sendLocationEnabled"));
+  EXPECT_TRUE(navigation_capability_so.keyExists("getWayPointsEnabled"));
+  EXPECT_TRUE(navigation_capability_so["sendLocationEnabled"].asBool());
+  EXPECT_FALSE(navigation_capability_so["getWayPointsEnabled"].asBool());
+  EXPECT_FALSE(navigation_capability_so["getWayPointsEnabled"].asBool());
+
+  EXPECT_TRUE(hmi_capabilities->LoadCapabilitiesFromFile());
+  EXPECT_CALL(mock_app_mngr, SetHMICooperating(true));
+
+  // All pending RAI requests are responded
+  EXPECT_CALL(mock_app_mngr, IsHMICooperating()).WillOnce(Return(true));
+  hmi_capabilities->OnCapabilityInitialized(
+      hmi_apis::FunctionID::UI_GetCapabilities);
+
+  // All pending RAI requests are hold, need respond them
+  EXPECT_CALL(mock_app_mngr, IsHMICooperating()).WillOnce(Return(false));
+  hmi_capabilities->OnCapabilityInitialized(
+      hmi_apis::FunctionID::UI_GetCapabilities);
 }
 
 }  // namespace application_manager_test

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -1988,6 +1988,15 @@ TEST_F(PolicyManagerImplTest2,
   EXPECT_EQ(0u, ret.size());
 }
 
+TEST_F(PolicyManagerImplTest2, SetMetaInfo_SetCCPUVersion_SUCCESS) {
+  const std::string ccpu_version = "ccpu_version";
+  const std::string wers_country_code = "wersCountryCode";
+  const std::string language = "language";
+
+  manager->GetCache()->SetMetaInfo(ccpu_version, wers_country_code, language);
+  EXPECT_EQ(ccpu_version, (manager->GetCache())->GetCCPUVersionFromPT());
+}
+
 }  // namespace policy_test
 }  // namespace components
 }  // namespace test


### PR DESCRIPTION
This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR increase unit tests coverage on persistence HMI . The test cases related to new functionality implemented in [branch](https://github.com/smartdevicelink/sdl_core/commits/feature/persisting_hmi_capabilities)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
