### PR TITLE
Fix/Cloud and Web-engine apps disappear after refreshing the page

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -893,7 +893,9 @@ void ApplicationManagerImpl::OnHMIStartedCooperation() {
   rpc_service_->ManageHMICommand(mixing_audio_supported_request);
   resume_controller().ResetLaunchTime();
 
+  LOG4CXX_DEBUG(logger_, "[!] Refresh Cloud App Info");
   RefreshCloudAppInformation();
+  SendUpdateAppList();
 }
 
 std::string ApplicationManagerImpl::PolicyIDByIconUrl(const std::string url) {
@@ -1006,6 +1008,7 @@ void ApplicationManagerImpl::RefreshCloudAppInformation() {
   // Create a device for each newly enabled cloud app
   policy::AppProperties app_properties;
   for (; enabled_it != enabled_end; ++enabled_it) {
+    LOG4CXX_DEBUG(logger_, "[!V] Get App Properties for " << *enabled_it);
     GetPolicyHandler().GetAppProperties(*enabled_it, app_properties);
 
     if (app_properties.endpoint.empty()) {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -893,7 +893,6 @@ void ApplicationManagerImpl::OnHMIStartedCooperation() {
   rpc_service_->ManageHMICommand(mixing_audio_supported_request);
   resume_controller().ResetLaunchTime();
 
-  LOG4CXX_DEBUG(logger_, "[!] Refresh Cloud App Info");
   RefreshCloudAppInformation();
   SendUpdateAppList();
 }
@@ -1008,7 +1007,6 @@ void ApplicationManagerImpl::RefreshCloudAppInformation() {
   // Create a device for each newly enabled cloud app
   policy::AppProperties app_properties;
   for (; enabled_it != enabled_end; ++enabled_it) {
-    LOG4CXX_DEBUG(logger_, "[!V] Get App Properties for " << *enabled_it);
     GetPolicyHandler().GetAppProperties(*enabled_it, app_properties);
 
     if (app_properties.endpoint.empty()) {


### PR DESCRIPTION
Currently, Cloud and Webengine apps on both HMIs disappear after refreshing the page if core is still running. This seems to be an issue with core not sending an updateAppList upon reconnection with the HMI.

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manual testing(with cloud apps and webengine apps)

### Summary
Added a `SendUpdateAppList` call in the `OnHMIStartedCooperation` function, which is triggered whenever core receives the BC.OnReady notification(which is sent by the HMI after its connects/reconnects to core)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
