### PR TITLE
Fix/Set the sdlVersion in ini file

### DIFF
--- a/src/appMain/CMakeLists.txt
+++ b/src/appMain/CMakeLists.txt
@@ -217,7 +217,8 @@ endif ()
 # Install rules
 install(TARGETS ${PROJECT} DESTINATION bin)
 install(
-  FILES build_config.txt log4cxx.properties audio.8bit.wav test.txt smartDeviceLink.ini
+  FILES build_config.txt log4cxx.properties audio.8bit.wav test.txt
+    ${CMAKE_CURRENT_BINARY_DIR}/smartDeviceLink.ini
     hmi_capabilities.json sdl_preloaded_pt.json sample_policy_manager.py
     ${CMAKE_SOURCE_DIR}/mycert.pem ${CMAKE_SOURCE_DIR}/mykey.pem
   DESTINATION bin


### PR DESCRIPTION
Fixes #3284 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manual testing

### Summary
Updated path to smartDeviceLink.ini
in CMakeLists.txt for the install command.
sdlVersion is not defined in smartDeviceLink.ini
because the file was copied from the source directory
instead the build directory.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)