### PR TITLE
Prevent Double KMS Update

### DIFF
--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1265,6 +1265,7 @@ void PolicyManagerImpl::KmsChanged(int kilometers) {
     LOG4CXX_INFO(logger_, "Enough kilometers passed to send for PT update.");
     update_status_manager_.ScheduleUpdate();
     StartPTExchange();
+    PTUpdatedAt(KILOMETERS, kilometers);
   }
 }
 


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
SDL HMI and Core with http policies.

1. Connect an app for the first time to core and observe a PTU.
2. Change the odometer value to 5000
3. Observe PTU and brief UP_TO_DATE status in logs

Expected:
Core stays in UP_TO_DATE state

Actual:
Core gets an UPDATE_NEEDED immediately after the UP_TO_DATE state.

### Summary
Updates the Cache with the last KMS value that triggered a PTU. There was an issue where an additional GetVehicleData was sent after the OnVehicleData was received for the new odometer value and schedules another PTU update. With this check, it prevents the policy manager from scheduling another update. 

Note this code exists in external proprietary policies.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
