### PR TITLE
Fix/Create generic handler in sample policy manager for different system request types

### DIFF
--- a/src/appMain/sample_policy_manager.py
+++ b/src/appMain/sample_policy_manager.py
@@ -49,40 +49,86 @@ def crypt(data):
 def decrypt(data):
     return data
 
-def pack(file_path, encryption, add_http_header):
 
-    file = open(file_path, "r+")
-    data = file.read()
-    file.seek(0)
-    file.truncate()    
+def pack(data, encryption, add_http_header):
+    file_path = data['fileName']
+    file_ptr = open(file_path, "r+")
+
+    request_type = data['requestType']
+    pack_handler = get_handler(request_type, 'pack')
+
+    new_data = pack_handler(data, file_ptr)
+    if new_data is not None:
+        if encryption:
+            new_data = crypt(new_data)
+        if add_http_header:
+            new_data = http_header(new_data)
+
+        file_ptr.write(new_data)
+
+    file_ptr.close()
+    return file_path
+
+
+def unpack(data, encryption):
+    file_path = data['fileName']
+    file_ptr = open(file_path, 'r+')
+
+    request_type = data['requestType']
+    unpack_handler = get_handler(request_type, 'unpack')
+
+    new_data = unpack_handler(data, file_ptr)
+    if new_data is not None:
+        if encryption:
+            new_data = decrypt(new_data)
+
+        file_ptr.write(new_data)
+    file_ptr.close()
+
+    return file_path
+
+
+def get_handler(request_type, handler_type):
+    handlers_map = {
+        "PROPRIETARY": get_proprietary_handler
+    }
+    if request_type not in handlers_map:
+        print('\033[33;1mUnhandled request type: %s. Using default request handler\033[0m' % request_type)
+        default_handler = lambda data, file_ptr: None
+        return default_handler
+
+    return handlers_map[request_type](handler_type)
+
+# Handler getter template
+# def get_<request_type>_handler(handler_type):
+#   def pack(data, file_ptr):
+#       ...
+#   def unpack(data, file_ptr):
+#       ...
+# return pack if handler_type == 'pack' else unpack
+
+def get_proprietary_handler(handler_type):    
+    def pack(data, file_ptr):
+        read_data = file_ptr.read()
+        file_ptr.seek(0)
+        file_ptr.truncate()        
+        return read_data
+
+    def unpack(data, file_ptr):
+        read_data = file_ptr.read()
+        file_ptr.seek(0)
+        file_ptr.truncate()
+
+        try:
+            json_data = json.loads(read_data)
+        except ValueError:
+            print('\033[31;1mInvalid JSON data: %s\033[0m' % read_data)
+            return None
+
+        policy_data = json.dumps(json_data['data'][0])
+        return policy_data
     
-    if encryption:
-        data = crypt(data)
-    if add_http_header:
-        data = http_header(data)
-
-    file.write(data)
-    file.close()
-    return file_path
-
-
-def unpack(file_path, encryption):
-
-    file = open(file_path, 'r+')
-    read_data = file.read()
-    file.seek(0)
-    file.truncate()
-
-    json_data = json.loads(read_data)
-    policy_data = json.dumps(json_data['data'][0])
-
-    if encryption:
-        policy_data = decrypt(policy_data)
-
-    file.write(policy_data)
-    file.close()
-
-    return file_path
+    return pack if handler_type == 'pack' else unpack
 
 
 class WebSocketHandler(tornado.websocket.WebSocketHandler):
@@ -96,7 +142,19 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
         print ("Socket Connected\n")
 
     def on_message(self, data):
-        self.write_message(self.handle_func(data, self.encryption, self.add_http_header))
+        try:
+            json_data = json.loads(data)
+        except ValueError:
+            print('\033[31;1mInvalid JSON message: %s\033[0m' % data)
+            return
+        if 'requestType' not in json_data:
+            print('\033[31;1mMissing requestType parameter: %s\033[0m' % str(json_data))
+            return
+        if 'fileName' not in json_data:
+            print('\033[31;1mMissing fileName parameter: %s\033[0m' % str(json_data))
+            return
+
+        self.write_message(self.handle_func(json_data, self.encryption, self.add_http_header))
 
     def on_close(self):
         print ("Connection Closed\n")

--- a/src/appMain/sample_policy_manager.py
+++ b/src/appMain/sample_policy_manager.py
@@ -42,7 +42,7 @@ def http_header(data):
     return json.dumps(header)
 
 
-def crypt(data):
+def encrypt(data):
     return data
 
 
@@ -60,7 +60,7 @@ def pack(data, encryption, add_http_header):
     new_data = pack_handler(data, file_ptr)
     if new_data is not None:
         if encryption:
-            new_data = crypt(new_data)
+            new_data = encrypt(new_data)
         if add_http_header:
             new_data = http_header(new_data)
 


### PR DESCRIPTION
Currently, the `sample_policy_manager.py` is only designed to handle `PROPRIETARY` system requests. If a system request using a file with non json data is sent, the following error occurs when unpack is called on the file:
```python
ERROR:tornado.application:Uncaught exception GET / (127.0.0.1)
HTTPServerRequest(protocol='http', host='127.0.0.1:8089', method='GET', uri='/', version='HTTP/1.1', remote_ip='127.0.0.1')
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/tornado/websocket.py", line 649, in _run_callback
    result = callback(*args, **kwargs)
  File "sample_policy_manager.py", line 104, in on_message
    self.write_message(self.handle_func(data, self.encryption, self.add_http_header))
  File "sample_policy_manager.py", line 124, in <lambda>
    handle_func = lambda data, encryption, add_http_header: unpack(data, encryption)))])
  File "sample_policy_manager.py", line 79, in unpack
    json_data = json.loads(read_data)
  File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
Connection Closed
```

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
1. Manual testing with test_suite
2. Running ATF Regression

### Summary
This PR modifies the `sample_policy_manager.py` script to add a generic handler for non-PROPRIETARY request types. It also adds a way to easily add handlers all request types.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
