### PR TITLE
Fix/SDL expects capabilities for unavailable interfaces

### DIFF
--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -238,10 +238,10 @@ class HMICapabilitiesImpl : public HMICapabilities {
 
   bool DeleteCachedCapabilitiesFile() const OVERRIDE;
 
-  std::set<hmi_apis::FunctionID::eType> GetDefaultInitializedCapabilities()
+  std::set<hmi_apis::FunctionID::eType> GetRequestsRequiredForCapabilities()
       const OVERRIDE;
 
-  void OnCapabilityInitialized(
+  void UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::eType requested_interface) OVERRIDE;
 
   bool MatchesCCPUVersion(const std::string& ccpu_version) const OVERRIDE;
@@ -296,13 +296,13 @@ class HMICapabilitiesImpl : public HMICapabilities {
    * @brief Remove received interface from default initialized capabilities
    * @param requested_interface interface which should be removed
    */
-  void RemoveFromDefaultInitialized(
+  void RemoveFromRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::eType requested_interface);
 
   /**
    * @brief Setting HMICooperating to true for respond all holding RAI requests
    */
-  void CheckPendingDefaultInitialized() const;
+  void CheckPendingRequestsRequiredForCapabilities() const;
 
   /**
    * @brief Gets the currently active language depending on interface
@@ -451,7 +451,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
   ApplicationManager& app_mngr_;
   HMILanguageHandler hmi_language_handler_;
 
-  std::set<hmi_apis::FunctionID::eType> default_initialized_capabilities_;
+  std::set<hmi_apis::FunctionID::eType> requests_required_for_capabilities_;
 
   DISALLOW_COPY_AND_ASSIGN(HMICapabilitiesImpl);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_is_ready_request.h
@@ -83,6 +83,9 @@ class TTSIsReadyRequest : public app_mngr::commands::RequestToHMI,
   void RequestCapabilities();
 
  private:
+  std::vector<hmi_apis::FunctionID::eType>
+      requests_required_for_TTS_capabilities_;
+
   DISALLOW_COPY_AND_ASSIGN(TTSIsReadyRequest);
 };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_is_ready_request.h
@@ -83,6 +83,9 @@ class UIIsReadyRequest : public app_mngr::commands::RequestToHMI,
   void RequestCapabilities();
 
  private:
+  std::vector<hmi_apis::FunctionID::eType>
+      requests_required_for_UI_capabilities_;
+
   DISALLOW_COPY_AND_ASSIGN(UIIsReadyRequest);
 };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_is_ready_request.h
@@ -84,6 +84,9 @@ class VRIsReadyRequest : public app_mngr::commands::RequestToHMI,
   void RequestCapabilities();
 
  private:
+  std::vector<hmi_apis::FunctionID::eType>
+      requests_required_for_VR_capabilities_;
+
   DISALLOW_COPY_AND_ASSIGN(VRIsReadyRequest);
 };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_request.cc
@@ -60,7 +60,7 @@ void ButtonGetCapabilitiesRequest::Run() {
 
 void ButtonGetCapabilitiesRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::Buttons_GetCapabilities);
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_response.cc
@@ -58,7 +58,7 @@ void ButtonGetCapabilitiesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::Buttons_GetCapabilities);
 
   if (hmi_apis::Common_Result::SUCCESS != code) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_get_capabilities_request.cc
@@ -59,7 +59,7 @@ void RCGetCapabilitiesRequest::Run() {
 
 void RCGetCapabilitiesRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::RC_GetCapabilities);
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_get_capabilities_response.cc
@@ -56,7 +56,7 @@ void RCGetCapabilitiesResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::RC_GetCapabilities);
 
   if (hmi_apis::Common_Result::SUCCESS != result_code) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_request.cc
@@ -99,7 +99,7 @@ void RCIsReadyRequest::onTimeOut() {
 
 void RCIsReadyRequest::RequestCapabilities() {
   const auto default_initialized_capabilities =
-      hmi_capabilities_.GetDefaultInitializedCapabilities();
+      hmi_capabilities_.GetRequestsRequiredForCapabilities();
 
   if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::RC_GetCapabilities)) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_request.cc
@@ -77,6 +77,8 @@ void RCIsReadyRequest::on_event(const event_engine::Event& event) {
 
       if (!app_mngr::commands::CheckAvailabilityHMIInterfaces(
               application_manager_, HmiInterfaces::HMI_INTERFACE_RC)) {
+        hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+            hmi_apis::FunctionID::RC_GetCapabilities);
         LOG4CXX_INFO(logger_,
                      "HmiInterfaces::HMI_INTERFACE_RC isn't available");
         return;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_capabilities_request.cc
@@ -59,7 +59,7 @@ void TTSGetCapabilitiesRequest::Run() {
 
 void TTSGetCapabilitiesRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::TTS_GetCapabilities);
 }
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_capabilities_response.cc
@@ -55,7 +55,7 @@ void TTSGetCapabilitiesResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::TTS_GetCapabilities);
 
   if (hmi_apis::Common_Result::SUCCESS != result_code) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_language_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_language_request.cc
@@ -59,7 +59,7 @@ void TTSGetLanguageRequest::Run() {
 
 void TTSGetLanguageRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::TTS_GetLanguage);
 }
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_language_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_language_response.cc
@@ -59,7 +59,7 @@ void TTSGetLanguageResponse::Run() {
   const Common_Result::eType result_code = static_cast<Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::TTS_GetLanguage);
 
   if (Common_Result::SUCCESS != result_code) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_supported_languages_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_supported_languages_request.cc
@@ -59,7 +59,7 @@ void TTSGetSupportedLanguagesRequest::Run() {
 
 void TTSGetSupportedLanguagesRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::TTS_GetSupportedLanguages);
 }
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_supported_languages_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_supported_languages_response.cc
@@ -59,7 +59,7 @@ void TTSGetSupportedLanguagesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::TTS_GetSupportedLanguages);
 
   if (hmi_apis::Common_Result::SUCCESS != code) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_is_ready_request.cc
@@ -50,7 +50,12 @@ TTSIsReadyRequest::TTSIsReadyRequest(
                    rpc_service,
                    hmi_capabilities,
                    policy_handler)
-    , EventObserver(application_manager.event_dispatcher()) {}
+    , EventObserver(application_manager.event_dispatcher()) {
+  requests_required_for_TTS_capabilities_ = {
+      hmi_apis::FunctionID::TTS_GetLanguage,
+      hmi_apis::FunctionID::TTS_GetSupportedLanguages,
+      hmi_apis::FunctionID::TTS_GetCapabilities};
+}
 
 TTSIsReadyRequest::~TTSIsReadyRequest() {}
 
@@ -74,6 +79,9 @@ void TTSIsReadyRequest::on_event(const event_engine::Event& event) {
       hmi_capabilities.set_is_tts_cooperating(is_available);
       if (!app_mngr::commands::CheckAvailabilityHMIInterfaces(
               application_manager_, HmiInterfaces::HMI_INTERFACE_TTS)) {
+        for (auto request_id : requests_required_for_TTS_capabilities_) {
+          hmi_capabilities_.UpdateRequestsRequiredForCapabilities(request_id);
+        }
         LOG4CXX_INFO(logger_,
                      "HmiInterfaces::HMI_INTERFACE_TTS isn't available");
         return;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_is_ready_request.cc
@@ -96,7 +96,7 @@ void TTSIsReadyRequest::onTimeOut() {
 
 void TTSIsReadyRequest::RequestCapabilities() {
   const auto default_initialized_capabilities =
-      hmi_capabilities_.GetDefaultInitializedCapabilities();
+      hmi_capabilities_.GetRequestsRequiredForCapabilities();
 
   if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::TTS_GetLanguage)) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_request.cc
@@ -59,7 +59,7 @@ void UIGetCapabilitiesRequest::Run() {
 
 void UIGetCapabilitiesRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::UI_GetCapabilities);
 }
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
@@ -56,7 +56,7 @@ void UIGetCapabilitiesResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::UI_GetCapabilities);
 
   if (hmi_apis::Common_Result::SUCCESS != result_code) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_request.cc
@@ -59,7 +59,7 @@ void UIGetLanguageRequest::Run() {
 
 void UIGetLanguageRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::UI_GetLanguage);
 }
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_response.cc
@@ -59,7 +59,7 @@ void UIGetLanguageResponse::Run() {
   const Common_Result::eType result_code = static_cast<Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::UI_GetLanguage);
 
   if (Common_Result::SUCCESS != result_code) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_request.cc
@@ -59,7 +59,7 @@ void UIGetSupportedLanguagesRequest::Run() {
 
 void UIGetSupportedLanguagesRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::UI_GetSupportedLanguages);
 }
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_response.cc
@@ -59,7 +59,7 @@ void UIGetSupportedLanguagesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::UI_GetSupportedLanguages);
 
   if (hmi_apis::Common_Result::SUCCESS != code) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_is_ready_request.cc
@@ -95,7 +95,7 @@ void UIIsReadyRequest::onTimeOut() {
 
 void UIIsReadyRequest::RequestCapabilities() {
   const auto default_initialized_capabilities =
-      hmi_capabilities_.GetDefaultInitializedCapabilities();
+      hmi_capabilities_.GetRequestsRequiredForCapabilities();
 
   if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::UI_GetLanguage)) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_is_ready_request.cc
@@ -50,7 +50,12 @@ UIIsReadyRequest::UIIsReadyRequest(
                    rpc_service,
                    hmi_capabilities,
                    policy_handle)
-    , EventObserver(application_manager.event_dispatcher()) {}
+    , EventObserver(application_manager.event_dispatcher()) {
+  requests_required_for_UI_capabilities_ = {
+      hmi_apis::FunctionID::UI_GetLanguage,
+      hmi_apis::FunctionID::UI_GetSupportedLanguages,
+      hmi_apis::FunctionID::UI_GetCapabilities};
+}
 
 UIIsReadyRequest::~UIIsReadyRequest() {}
 
@@ -73,6 +78,9 @@ void UIIsReadyRequest::on_event(const event_engine::Event& event) {
       hmi_capabilities.set_is_ui_cooperating(is_available);
       if (!app_mngr::commands::CheckAvailabilityHMIInterfaces(
               application_manager_, HmiInterfaces::HMI_INTERFACE_UI)) {
+        for (auto request_id : requests_required_for_UI_capabilities_) {
+          hmi_capabilities_.UpdateRequestsRequiredForCapabilities(request_id);
+        }
         LOG4CXX_INFO(logger_,
                      "HmiInterfaces::HMI_INTERFACE_UI isn't available");
         return;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_capabilities_request.cc
@@ -59,7 +59,7 @@ void VRGetCapabilitiesRequest::Run() {
 
 void VRGetCapabilitiesRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::VR_GetCapabilities);
 }
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_capabilities_response.cc
@@ -55,7 +55,7 @@ void VRGetCapabilitiesResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::VR_GetCapabilities);
 
   if (hmi_apis::Common_Result::SUCCESS != result_code) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_language_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_language_request.cc
@@ -59,7 +59,7 @@ void VRGetLanguageRequest::Run() {
 
 void VRGetLanguageRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::VR_GetLanguage);
 }
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_language_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_language_response.cc
@@ -59,7 +59,7 @@ void VRGetLanguageResponse::Run() {
   const Common_Result::eType result_code = static_cast<Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::VR_GetLanguage);
 
   if (Common_Result::SUCCESS != result_code) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_supported_languages_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_supported_languages_request.cc
@@ -59,7 +59,7 @@ void VRGetSupportedLanguagesRequest::Run() {
 
 void VRGetSupportedLanguagesRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::VR_GetSupportedLanguages);
 }
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_supported_languages_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_supported_languages_response.cc
@@ -60,7 +60,7 @@ void VRGetSupportedLanguagesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::VR_GetSupportedLanguages);
 
   if (hmi_apis::Common_Result::SUCCESS == code) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_is_ready_request.cc
@@ -95,7 +95,7 @@ void VRIsReadyRequest::onTimeOut() {
 
 void VRIsReadyRequest::RequestCapabilities() {
   const auto default_initialized_capabilities =
-      hmi_capabilities_.GetDefaultInitializedCapabilities();
+      hmi_capabilities_.GetRequestsRequiredForCapabilities();
 
   if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::VR_GetLanguage)) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_is_ready_request.cc
@@ -49,7 +49,12 @@ VRIsReadyRequest::VRIsReadyRequest(
                    rpc_service,
                    hmi_capabilities,
                    policy_handle)
-    , EventObserver(application_manager.event_dispatcher()) {}
+    , EventObserver(application_manager.event_dispatcher()) {
+  requests_required_for_VR_capabilities_ = {
+      hmi_apis::FunctionID::VR_GetLanguage,
+      hmi_apis::FunctionID::VR_GetSupportedLanguages,
+      hmi_apis::FunctionID::VR_GetCapabilities};
+}
 
 VRIsReadyRequest::~VRIsReadyRequest() {}
 
@@ -73,6 +78,9 @@ void VRIsReadyRequest::on_event(const event_engine::Event& event) {
       hmi_capabilities.set_is_vr_cooperating(is_available);
       if (!app_mngr::commands::CheckAvailabilityHMIInterfaces(
               application_manager_, HmiInterfaces::HMI_INTERFACE_VR)) {
+        for (auto request_id : requests_required_for_VR_capabilities_) {
+          hmi_capabilities_.UpdateRequestsRequiredForCapabilities(request_id);
+        }
         LOG4CXX_INFO(logger_,
                      "HmiInterfaces::HMI_INTERFACE_VR isn't available");
         return;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/button_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/button_get_capabilities_response_test.cc
@@ -116,9 +116,9 @@ TEST_F(ButtonGetCapabilitiesResponseTest,
 
   ResponsePtr command(CreateCommand<ButtonGetCapabilitiesResponse>(msg));
 
-  EXPECT_CALL(
-      mock_hmi_capabilities_,
-      OnCapabilityInitialized(hmi_apis::FunctionID::Buttons_GetCapabilities));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              UpdateRequestsRequiredForCapabilities(
+                  hmi_apis::FunctionID::Buttons_GetCapabilities));
   ASSERT_TRUE(command->Init());
 
   command->Run();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_get_capabilities_response_test.cc
@@ -180,9 +180,9 @@ TEST_F(RCGetCapabilitiesResponseTest,
   RCGetCapabilitiesResponsePtr command(
       CreateCommand<RCGetCapabilitiesResponse>(command_msg));
 
-  EXPECT_CALL(
-      mock_hmi_capabilities_,
-      OnCapabilityInitialized(hmi_apis::FunctionID::RC_GetCapabilities));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              UpdateRequestsRequiredForCapabilities(
+                  hmi_apis::FunctionID::RC_GetCapabilities));
   ASSERT_TRUE(command->Init());
 
   command->Run();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_is_ready_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_is_ready_request_test.cc
@@ -116,7 +116,7 @@ class RCIsReadyRequestTest
   void HMICapabilitiesExpectations() {
     std::set<hmi_apis::FunctionID::eType> interfaces_to_update{
         hmi_apis::FunctionID::RC_GetCapabilities};
-    EXPECT_CALL(mock_hmi_capabilities_, GetDefaultInitializedCapabilities())
+    EXPECT_CALL(mock_hmi_capabilities_, GetRequestsRequiredForCapabilities())
         .WillOnce(Return(interfaces_to_update));
   }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_capabilities_response_test.cc
@@ -146,9 +146,9 @@ TEST_F(TTSGetCapabilitiesResponseTest,
   std::shared_ptr<TTSGetCapabilitiesResponse> command(
       CreateCommand<TTSGetCapabilitiesResponse>(msg));
 
-  EXPECT_CALL(
-      mock_hmi_capabilities_,
-      OnCapabilityInitialized(hmi_apis::FunctionID::TTS_GetCapabilities));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              UpdateRequestsRequiredForCapabilities(
+                  hmi_apis::FunctionID::TTS_GetCapabilities));
   ASSERT_TRUE(command->Init());
 
   command->Run();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_language_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_language_response_test.cc
@@ -117,7 +117,8 @@ TEST_F(TTSGetLanguageResponseTest,
       CreateCommand<TTSGetLanguageResponse>(msg));
 
   EXPECT_CALL(mock_hmi_capabilities_,
-              OnCapabilityInitialized(hmi_apis::FunctionID::TTS_GetLanguage));
+              UpdateRequestsRequiredForCapabilities(
+                  hmi_apis::FunctionID::TTS_GetLanguage));
   ASSERT_TRUE(command->Init());
 
   command->Run();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_supported_languages_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_supported_languages_response_test.cc
@@ -136,9 +136,9 @@ TEST_F(TTSGetSupportedLanguageResponseTest,
   ResponseFromHMIPtr command(
       CreateCommand<TTSGetSupportedLanguagesResponse>(command_msg));
 
-  EXPECT_CALL(
-      mock_hmi_capabilities_,
-      OnCapabilityInitialized(hmi_apis::FunctionID::TTS_GetSupportedLanguages));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              UpdateRequestsRequiredForCapabilities(
+                  hmi_apis::FunctionID::TTS_GetSupportedLanguages));
   ASSERT_TRUE(command->Init());
 
   command->Run();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_capabilities_response_test.cc
@@ -399,9 +399,9 @@ TEST_F(UIGetCapabilitiesResponseTest,
   ResponseFromHMIPtr command(
       CreateCommand<UIGetCapabilitiesResponse>(command_msg));
 
-  EXPECT_CALL(
-      mock_hmi_capabilities_,
-      OnCapabilityInitialized(hmi_apis::FunctionID::UI_GetCapabilities));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              UpdateRequestsRequiredForCapabilities(
+                  hmi_apis::FunctionID::UI_GetCapabilities));
   ASSERT_TRUE(command->Init());
 
   command->Run();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_language_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_language_response_test.cc
@@ -120,7 +120,8 @@ TEST_F(UIGetLanguageResponseTest,
       CreateCommand<UIGetLanguageResponse>(msg));
 
   EXPECT_CALL(mock_hmi_capabilities_,
-              OnCapabilityInitialized(hmi_apis::FunctionID::UI_GetLanguage));
+              UpdateRequestsRequiredForCapabilities(
+                  hmi_apis::FunctionID::UI_GetLanguage));
   ASSERT_TRUE(command->Init());
 
   command->Run();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_supported_languages_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_supported_languages_response_test.cc
@@ -130,9 +130,9 @@ TEST_F(UIGetSupportedLanguagesResponseTest,
   UIGetSupportedLanguagesResponsePtr command(
       CreateCommand<UIGetSupportedLanguagesResponse>(command_msg));
 
-  EXPECT_CALL(
-      mock_hmi_capabilities_,
-      OnCapabilityInitialized(hmi_apis::FunctionID::UI_GetSupportedLanguages));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              UpdateRequestsRequiredForCapabilities(
+                  hmi_apis::FunctionID::UI_GetSupportedLanguages));
   ASSERT_TRUE(command->Init());
 
   command->Run();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_is_ready_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_is_ready_request_test.cc
@@ -146,7 +146,7 @@ class UIIsReadyRequestTest
         hmi_apis::FunctionID::UI_GetLanguage,
         hmi_apis::FunctionID::UI_GetSupportedLanguages,
         hmi_apis::FunctionID::UI_GetCapabilities};
-    EXPECT_CALL(mock_hmi_capabilities_, GetDefaultInitializedCapabilities())
+    EXPECT_CALL(mock_hmi_capabilities_, GetRequestsRequiredForCapabilities())
         .WillOnce(Return(interfaces_to_update));
   }
 
@@ -204,7 +204,7 @@ TEST_F(UIIsReadyRequestTest, OnTimeout_SUCCESS_CacheIsAbsent) {
       hmi_apis::FunctionID::UI_GetLanguage,
       hmi_apis::FunctionID::UI_GetSupportedLanguages,
       hmi_apis::FunctionID::UI_GetCapabilities};
-  EXPECT_CALL(mock_hmi_capabilities_, GetDefaultInitializedCapabilities())
+  EXPECT_CALL(mock_hmi_capabilities_, GetRequestsRequiredForCapabilities())
       .WillOnce(Return(interfaces_to_update));
   ExpectSendMessagesToHMI();
   command_->onTimeOut();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_capabilities_response_test.cc
@@ -112,9 +112,9 @@ TEST_F(VRGetCapabilitiesResponseTest,
   VRGetCapabilitiesResponsePtr command(
       CreateCommand<VRGetCapabilitiesResponse>(command_msg));
 
-  EXPECT_CALL(
-      mock_hmi_capabilities_,
-      OnCapabilityInitialized(hmi_apis::FunctionID::VR_GetCapabilities));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              UpdateRequestsRequiredForCapabilities(
+                  hmi_apis::FunctionID::VR_GetCapabilities));
   ASSERT_TRUE(command->Init());
 
   command->Run();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_language_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_language_response_test.cc
@@ -122,7 +122,8 @@ TEST_F(VRGetLanguageResponseTest,
       CreateCommand<VRGetLanguageResponse>(msg));
 
   EXPECT_CALL(mock_hmi_capabilities_,
-              OnCapabilityInitialized(hmi_apis::FunctionID::VR_GetLanguage));
+              UpdateRequestsRequiredForCapabilities(
+                  hmi_apis::FunctionID::VR_GetLanguage));
   ASSERT_TRUE(command->Init());
 
   command->Run();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_supported_languages_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_supported_languages_response_test.cc
@@ -130,9 +130,9 @@ TEST_F(VRGetSupportedLanguagesResponseTest,
   VRGetSupportedLanguagesResponsePtr command(
       CreateCommand<VRGetSupportedLanguagesResponse>(command_msg));
 
-  EXPECT_CALL(
-      mock_hmi_capabilities_,
-      OnCapabilityInitialized(hmi_apis::FunctionID::VR_GetSupportedLanguages));
+  EXPECT_CALL(mock_hmi_capabilities_,
+              UpdateRequestsRequiredForCapabilities(
+                  hmi_apis::FunctionID::VR_GetSupportedLanguages));
   ASSERT_TRUE(command->Init());
 
   command->Run();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_is_ready_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_is_ready_request_test.cc
@@ -132,7 +132,7 @@ class VRIsReadyRequestTest
         hmi_apis::FunctionID::VR_GetLanguage,
         hmi_apis::FunctionID::VR_GetSupportedLanguages,
         hmi_apis::FunctionID::VR_GetCapabilities};
-    EXPECT_CALL(mock_hmi_capabilities_, GetDefaultInitializedCapabilities())
+    EXPECT_CALL(mock_hmi_capabilities_, GetRequestsRequiredForCapabilities())
         .WillOnce(Return(interfaces_to_update));
   }
 
@@ -189,7 +189,7 @@ TEST_F(VRIsReadyRequestTest,
       hmi_apis::FunctionID::VR_GetLanguage,
       hmi_apis::FunctionID::VR_GetSupportedLanguages,
       hmi_apis::FunctionID::VR_GetCapabilities};
-  EXPECT_CALL(mock_hmi_capabilities_, GetDefaultInitializedCapabilities())
+  EXPECT_CALL(mock_hmi_capabilities_, GetRequestsRequiredForCapabilities())
       .WillOnce(Return(interfaces_to_update));
   const bool is_send_message_by_timeout = true;
   ExpectSendMessagesToHMI(is_send_message_by_timeout);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_request.cc
@@ -56,7 +56,7 @@ void VIGetVehicleTypeRequest::Run() {
 
 void VIGetVehicleTypeRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::VehicleInfo_GetVehicleType);
 }
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_response.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_response.cc
@@ -53,7 +53,7 @@ void VIGetVehicleTypeResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.OnCapabilityInitialized(
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::VehicleInfo_GetVehicleType);
 
   if (hmi_apis::Common_Result::SUCCESS != result_code) {

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_is_ready_request.cc
@@ -79,6 +79,8 @@ void VIIsReadyRequest::on_event(const event_engine::Event& event) {
         LOG4CXX_INFO(
             logger_,
             "HmiInterfaces::HMI_INTERFACE_VehicleInfo isn't available");
+        hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+            hmi_apis::FunctionID::VehicleInfo_GetVehicleType);
         return;
       }
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_is_ready_request.cc
@@ -99,7 +99,7 @@ void VIIsReadyRequest::onTimeOut() {
 
 void VIIsReadyRequest::RequestCapabilities() {
   const auto default_initialized_capabilities =
-      hmi_capabilities_.GetDefaultInitializedCapabilities();
+      hmi_capabilities_.GetRequestsRequiredForCapabilities();
 
   if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::VehicleInfo_GetVehicleType)) {

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_is_ready_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_is_ready_request_test.cc
@@ -121,7 +121,7 @@ class VIIsReadyRequestTest
     std::set<hmi_apis::FunctionID::eType> interfaces_to_update{
         hmi_apis::FunctionID::VehicleInfo_GetVehicleType};
 
-    EXPECT_CALL(mock_hmi_capabilities_, GetDefaultInitializedCapabilities())
+    EXPECT_CALL(mock_hmi_capabilities_, GetRequestsRequiredForCapabilities())
         .WillOnce(Return(interfaces_to_update));
   }
 
@@ -172,7 +172,7 @@ TEST_F(VIIsReadyRequestTest, Run_KeyAvailableEqualToTrue_StateAvailable) {
 TEST_F(VIIsReadyRequestTest, Run_HMIDoestRespond_SendMessageToHMIByTimeout) {
   std::set<hmi_apis::FunctionID::eType> interfaces_to_update{
       hmi_apis::FunctionID::VehicleInfo_GetVehicleType};
-  EXPECT_CALL(mock_hmi_capabilities_, GetDefaultInitializedCapabilities())
+  EXPECT_CALL(mock_hmi_capabilities_, GetRequestsRequiredForCapabilities())
       .WillOnce(Return(interfaces_to_update));
   ExpectSendMessagesToHMI();
   command_->onTimeOut();

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -893,7 +893,7 @@ void ApplicationManagerImpl::RequestForInterfacesAvailability() {
   rpc_service_->ManageHMICommand(is_rc_ready);
 
   const auto default_initialized_capabilities =
-      hmi_capabilities_->GetDefaultInitializedCapabilities();
+      hmi_capabilities_->GetRequestsRequiredForCapabilities();
 
   if (helpers::in_range(default_initialized_capabilities,
                         hmi_apis::FunctionID::Buttons_GetCapabilities)) {

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -1082,7 +1082,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_language_node =
           json_ui_getter.GetJsonMember(hmi_response::language,
                                        hmi_apis::FunctionID::UI_GetLanguage,
-                                       default_initialized_capabilities_);
+                                       requests_required_for_capabilities_);
 
       if (!ui_language_node.isNull()) {
         const std::string lang = ui_language_node.asString();
@@ -1092,7 +1092,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_languages_node = json_ui_getter.GetJsonMember(
           hmi_response::languages,
           hmi_apis::FunctionID::UI_GetSupportedLanguages,
-          default_initialized_capabilities_);
+          requests_required_for_capabilities_);
       if (!ui_languages_node.isNull()) {
         smart_objects::SmartObject ui_languages_so(
             smart_objects::SmartType_Array);
@@ -1104,7 +1104,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_display_capabilities_node =
           json_ui_getter.GetJsonMember(hmi_response::display_capabilities,
                                        hmi_apis::FunctionID::UI_GetCapabilities,
-                                       default_initialized_capabilities_);
+                                       requests_required_for_capabilities_);
       if (!ui_display_capabilities_node.isNull()) {
         smart_objects::SmartObject display_capabilities_so;
         formatters::CFormatterJsonBase::jsonValueToObj(
@@ -1245,7 +1245,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_audio_pass_thru_capabilities_node =
           json_ui_getter.GetJsonMember(strings::audio_pass_thru_capabilities,
                                        hmi_apis::FunctionID::UI_GetCapabilities,
-                                       default_initialized_capabilities_);
+                                       requests_required_for_capabilities_);
       if (!ui_audio_pass_thru_capabilities_node.isNull()) {
         smart_objects::SmartObject audio_capabilities_so(
             smart_objects::SmartType_Array);
@@ -1268,7 +1268,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_pcm_stream_capabilities_node =
           json_ui_getter.GetJsonMember(strings::pcm_stream_capabilities,
                                        hmi_apis::FunctionID::UI_GetCapabilities,
-                                       default_initialized_capabilities_);
+                                       requests_required_for_capabilities_);
       if (!ui_pcm_stream_capabilities_node.isNull()) {
         smart_objects::SmartObject pcm_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Map);
@@ -1280,7 +1280,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_hmi_zone_capabilities_node =
           json_ui_getter.GetJsonMember(hmi_response::hmi_zone_capabilities,
                                        hmi_apis::FunctionID::UI_GetCapabilities,
-                                       default_initialized_capabilities_);
+                                       requests_required_for_capabilities_);
       if (!ui_hmi_zone_capabilities_node.isNull()) {
         smart_objects::SmartObject hmi_zone_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
@@ -1293,7 +1293,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_soft_button_capabilities_node =
           json_ui_getter.GetJsonMember(hmi_response::soft_button_capabilities,
                                        hmi_apis::FunctionID::UI_GetCapabilities,
-                                       default_initialized_capabilities_);
+                                       requests_required_for_capabilities_);
       if (!ui_soft_button_capabilities_node.isNull()) {
         smart_objects::SmartObject soft_button_capabilities_so;
         formatters::CFormatterJsonBase::jsonValueToObj(
@@ -1304,7 +1304,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto ui_system_capabilities_node =
           json_ui_getter.GetJsonMember(strings::system_capabilities,
                                        hmi_apis::FunctionID::UI_GetCapabilities,
-                                       default_initialized_capabilities_);
+                                       requests_required_for_capabilities_);
       if (!ui_system_capabilities_node.isNull()) {
         if (JsonIsMemberSafe(ui_system_capabilities_node,
                              strings::navigation_capability)) {
@@ -1397,7 +1397,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto rc_capabilitity_node =
           rc_json_getter.GetJsonMember(strings::rc_capability,
                                        hmi_apis::FunctionID::RC_GetCapabilities,
-                                       default_initialized_capabilities_);
+                                       requests_required_for_capabilities_);
       if (!rc_capabilitity_node.isNull()) {
         smart_objects::SmartObject rc_capability_so;
         formatters::CFormatterJsonBase::jsonValueToObj(rc_capabilitity_node,
@@ -1428,7 +1428,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto seat_location_capabilitiy_node =
           rc_json_getter.GetJsonMember(strings::seat_location_capability,
                                        hmi_apis::FunctionID::RC_GetCapabilities,
-                                       default_initialized_capabilities_);
+                                       requests_required_for_capabilities_);
 
       if (!seat_location_capabilitiy_node.isNull()) {
         smart_objects::SmartObject seat_location_capability_so;
@@ -1454,7 +1454,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto vr_language_node =
           json_vr_getter.GetJsonMember(hmi_response::language,
                                        hmi_apis::FunctionID::VR_GetLanguage,
-                                       default_initialized_capabilities_);
+                                       requests_required_for_capabilities_);
       if (!vr_language_node.isNull()) {
         const std::string lang = vr_language_node.asString();
         set_active_vr_language(MessageHelper::CommonLanguageFromString(lang));
@@ -1463,7 +1463,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto vr_languages_node = json_vr_getter.GetJsonMember(
           hmi_response::languages,
           hmi_apis::FunctionID::VR_GetSupportedLanguages,
-          default_initialized_capabilities_);
+          requests_required_for_capabilities_);
       if (!vr_languages_node.isNull()) {
         smart_objects::SmartObject vr_languages_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
@@ -1475,7 +1475,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto vr_capabilities_node =
           json_vr_getter.GetJsonMember(strings::vr_capabilities,
                                        hmi_apis::FunctionID::VR_GetCapabilities,
-                                       default_initialized_capabilities_);
+                                       requests_required_for_capabilities_);
       if (!vr_capabilities_node.isNull()) {
         smart_objects::SmartObject vr_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
@@ -1496,7 +1496,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto tts_language_node =
           json_tts_getter.GetJsonMember(hmi_response::language,
                                         hmi_apis::FunctionID::TTS_GetLanguage,
-                                        default_initialized_capabilities_);
+                                        requests_required_for_capabilities_);
       if (!tts_language_node.isNull()) {
         const std::string lang = tts_language_node.asString();
         set_active_tts_language(MessageHelper::CommonLanguageFromString(lang));
@@ -1505,7 +1505,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto tts_languages_node = json_tts_getter.GetJsonMember(
           hmi_response::languages,
           hmi_apis::FunctionID::TTS_GetSupportedLanguages,
-          default_initialized_capabilities_);
+          requests_required_for_capabilities_);
       if (!tts_languages_node.isNull()) {
         smart_objects::SmartObject tts_languages_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
@@ -1517,7 +1517,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto tts_speech_capabilities_node = json_tts_getter.GetJsonMember(
           hmi_response::speech_capabilities,
           hmi_apis::FunctionID::TTS_GetCapabilities,
-          default_initialized_capabilities_);
+          requests_required_for_capabilities_);
       if (!tts_speech_capabilities_node.isNull()) {
         smart_objects::SmartObject tts_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
@@ -1530,7 +1530,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
           json_tts_getter.GetJsonMember(
               hmi_response::prerecorded_speech_capabilities,
               hmi_apis::FunctionID::TTS_GetCapabilities,
-              default_initialized_capabilities_);
+              requests_required_for_capabilities_);
       if (!tts_prerecorded_speech_capabilities_node.isNull()) {
         smart_objects::SmartObject tts_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
@@ -1553,7 +1553,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto buttons_capabilities_node = json_buttons_getter.GetJsonMember(
           hmi_response::capabilities,
           hmi_apis::FunctionID::Buttons_GetCapabilities,
-          default_initialized_capabilities_);
+          requests_required_for_capabilities_);
       if (!buttons_capabilities_node.isNull()) {
         smart_objects::SmartObject buttons_capabilities_so;
         formatters::CFormatterJsonBase::jsonValueToObj(
@@ -1598,7 +1598,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       auto vehicle_type_node = json_vehicle_info_getter.GetJsonMember(
           hmi_response::vehicle_type,
           hmi_apis::FunctionID::VehicleInfo_GetVehicleType,
-          default_initialized_capabilities_);
+          requests_required_for_capabilities_);
       if (!vehicle_type_node.isNull()) {
         smart_objects::SmartObject vehicle_type_so;
         formatters::CFormatterJsonBase::jsonValueToObj(vehicle_type_node,
@@ -1629,11 +1629,11 @@ HMICapabilitiesImpl::GetActiveLanguageForInterface(
 }
 
 std::set<hmi_apis::FunctionID::eType>
-HMICapabilitiesImpl::GetDefaultInitializedCapabilities() const {
-  return default_initialized_capabilities_;
+HMICapabilitiesImpl::GetRequestsRequiredForCapabilities() const {
+  return requests_required_for_capabilities_;
 }
 
-void HMICapabilitiesImpl::OnCapabilityInitialized(
+void HMICapabilitiesImpl::UpdateRequestsRequiredForCapabilities(
     hmi_apis::FunctionID::eType requested_interface) {
   LOG4CXX_AUTO_TRACE(logger_);
   if (app_mngr_.IsHMICooperating()) {
@@ -1642,8 +1642,9 @@ void HMICapabilitiesImpl::OnCapabilityInitialized(
                   "because hmi_cooperating equal true already");
     return;
   }
-  RemoveFromDefaultInitialized(requested_interface);
-  CheckPendingDefaultInitialized();
+
+  RemoveFromRequestsRequiredForCapabilities(requested_interface);
+  CheckPendingRequestsRequiredForCapabilities();
 }
 
 bool HMICapabilitiesImpl::MatchesCCPUVersion(
@@ -1714,24 +1715,24 @@ bool HMICapabilitiesImpl::AllFieldsSaved(
   return true;
 }
 
-void HMICapabilitiesImpl::RemoveFromDefaultInitialized(
+void HMICapabilitiesImpl::RemoveFromRequestsRequiredForCapabilities(
     hmi_apis::FunctionID::eType requested_interface) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  auto it = find(default_initialized_capabilities_.begin(),
-                 default_initialized_capabilities_.end(),
+  auto it = find(requests_required_for_capabilities_.begin(),
+                 requests_required_for_capabilities_.end(),
                  requested_interface);
-  if (it != default_initialized_capabilities_.end()) {
-    default_initialized_capabilities_.erase(it);
+  if (it != requests_required_for_capabilities_.end()) {
+    requests_required_for_capabilities_.erase(it);
     LOG4CXX_DEBUG(logger_,
-                  "Wait for " << default_initialized_capabilities_.size()
+                  "Wait for " << requests_required_for_capabilities_.size()
                               << " responses");
   }
 }
 
-void HMICapabilitiesImpl::CheckPendingDefaultInitialized() const {
+void HMICapabilitiesImpl::CheckPendingRequestsRequiredForCapabilities() const {
   LOG4CXX_AUTO_TRACE(logger_);
-  if (default_initialized_capabilities_.empty()) {
+  if (requests_required_for_capabilities_.empty()) {
     app_mngr_.SetHMICooperating(true);
   }
 }

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -215,9 +215,9 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
                     const std::vector<std::string>& sections_to_update,
                     const smart_objects::CSmartSchema& schema));
   MOCK_CONST_METHOD0(DeleteCachedCapabilitiesFile, bool());
-  MOCK_CONST_METHOD0(GetDefaultInitializedCapabilities,
+  MOCK_CONST_METHOD0(GetRequestsRequiredForCapabilities,
                      std::set<hmi_apis::FunctionID::eType>());
-  MOCK_METHOD1(OnCapabilityInitialized,
+  MOCK_METHOD1(UpdateRequestsRequiredForCapabilities,
                void(hmi_apis::FunctionID::eType requested_interface));
 };
 

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -520,13 +520,14 @@ class HMICapabilities {
    * @return set of function id's
    */
   virtual std::set<hmi_apis::FunctionID::eType>
-  GetDefaultInitializedCapabilities() const = 0;
+  GetRequestsRequiredForCapabilities() const = 0;
 
   /**
-   * @brief Response was received for default initialized capabilities
-   * @param requested_interface interface for which received response
+   * @brief Update collection of requests that should be send to
+   * the HMI to get required HMI capabilities
+   * @param requested_interface function id
    */
-  virtual void OnCapabilityInitialized(
+  virtual void UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::eType requested_interface) = 0;
 
   /**


### PR DESCRIPTION

This PR is **[not ready]** for review.

### Risk
This PR makes **[no]** API changes.


### Summary
This is part of [Persisting-HMI-Capabilities-specific-to-headunit](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0249-Persisting-HMI-Capabilities-specific-to-headunit.md) feature implementation. According to the proposal: 

> HMI sends BC.OnReady to SDL Core.
> SDL Core should NOT set IsHMICooperating to true yet (i.e. hold all RAI requests from MOBILE).
> SDL wait for all responses from HMI for capabilities requests, and after that set IsHMICooperating to true. 

But in the current implementation, SDL expects responses from HMI for capabilities requests **even if interface is not available**. So I removed function ids of requests associated with the unavailable interface from _capabilities_to_request__ collection. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
