### PR TITLE
Fix remove_if in ClearTimerPool

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3815,16 +3815,21 @@ void ApplicationManagerImpl::ClearTimerPool() {
   LOG4CXX_AUTO_TRACE(logger_);
   {
     sync_primitives::AutoLock lock(close_app_timer_pool_lock_);
-    std::remove_if(close_app_timer_pool_.begin(),
-                   close_app_timer_pool_.end(),
-                   [](TimerSPtr timer) { return !timer->is_running(); });
+
+    close_app_timer_pool_.erase(
+        std::remove_if(close_app_timer_pool_.begin(),
+                       close_app_timer_pool_.end(),
+                       [](TimerSPtr timer) { return !timer->is_running(); }),
+        close_app_timer_pool_.end());
   }
 
   {
     sync_primitives::AutoLock lock(end_stream_timer_pool_lock_);
-    std::remove_if(end_stream_timer_pool_.begin(),
-                   end_stream_timer_pool_.end(),
-                   [](TimerSPtr timer) { return !timer->is_running(); });
+    end_stream_timer_pool_.erase(
+        std::remove_if(end_stream_timer_pool_.begin(),
+                       end_stream_timer_pool_.end(),
+                       [](TimerSPtr timer) { return !timer->is_running(); }),
+        end_stream_timer_pool_.end());
   }
 }
 


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Use this atf test
https://gist.github.com/JackLivio/7cb206be925e6760b9b753eb37a245ee

### Summary
Calls the vector erase method instead of relying on remove_if. remove_if cannot modify the size of the vector itself after deleting an object which leads to invalid timer pointers in the array.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
