### PR TITLE
unregister app who continues streaming after EndService(streaming)

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1996,14 +1996,6 @@ void ApplicationManagerImpl::OnStreamingConfigured(
 
     application(app_id)->StartStreaming(service_type);
     connection_handler().NotifyServiceStartedResult(app_id, true, empty);
-
-    // Fix: For wifi Secondary
-    // Should erase appid from deque of ForbidStreaming() push in the last time
-    std::deque<uint32_t>::const_iterator iter = std::find(
-        navi_app_to_end_stream_.begin(), navi_app_to_end_stream_.end(), app_id);
-    if (navi_app_to_end_stream_.end() != iter) {
-      navi_app_to_end_stream_.erase(iter);
-    }
   } else {
     std::vector<std::string> converted_params =
         ConvertRejectedParamList(rejected_params);
@@ -2062,8 +2054,6 @@ void ApplicationManagerImpl::StopNaviService(
     if (service_type == ServiceType::kAudio) {
       app->set_audio_streaming_allowed(false);
     }
-    //  push_back for judge in ForbidStreaming(),
-    navi_app_to_end_stream_.push_back(app_id);
   }
 
   ApplicationSharedPtr app = application(app_id);


### PR DESCRIPTION
Fixes #3324

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF (script from issue)

### Summary
Remove interaction with `navi_app_to_end_stream_` added in #3290 

### Changelog
##### Breaking Changes
* Remove `navi_app_to_end_stream_.push_back` from `StopNaviService`
* Remove `navi_app_to_end_stream_.erase` from `OnStreamingConfigured`

##### Bug Fixes
* Apps who stream past receiving EndService will once again be unregistered with PROTOCOL_VIOLATION

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
