### PR TITLE
Fix PROPRIETARY retry sequence

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -121,6 +121,7 @@ class PolicyHandler : public PolicyHandlerInterface,
    */
   std::string GetNextUpdateUrl(const PTUIterationType iteration_type,
                                uint32_t& app_id) OVERRIDE;
+  void CacheRetryInfo(const uint32_t app_id, const std::string url) OVERRIDE;
 #endif  // EXTERNAL_PROPRIETARY_MODE
   virtual bool GetPriority(const std::string& policy_app_id,
                            std::string* priority) const OVERRIDE;
@@ -919,7 +920,10 @@ class PolicyHandler : public PolicyHandlerInterface,
   std::shared_ptr<PolicyManager> policy_manager_;
   std::shared_ptr<PolicyEventObserver> event_observer_;
   uint32_t last_activated_app_id_;
+
+  // PTU retry information
   uint32_t last_ptu_app_id_;
+  std::string retry_update_url_;
 
   /**
    * @brief Contains device handles, which were sent for user consent to HMI

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -86,8 +86,8 @@ class PolicyHandler : public PolicyHandlerInterface,
   bool InitPolicyTable() OVERRIDE;
   bool ResetPolicyTable() OVERRIDE;
   bool ClearUserConsent() OVERRIDE;
-  bool SendMessageToSDK(const BinaryMessage& pt_string,
-                        const std::string& url) OVERRIDE;
+  DEPRECATED bool SendMessageToSDK(const BinaryMessage& pt_string,
+                                   const std::string& url) OVERRIDE;
   bool ReceiveMessageFromSDK(const std::string& file,
                              const BinaryMessage& pt_string) OVERRIDE;
   bool UnloadPolicyLibrary() OVERRIDE;
@@ -110,6 +110,17 @@ class PolicyHandler : public PolicyHandlerInterface,
 #else   // EXTERNAL_PROPRIETARY_MODE
   void OnSnapshotCreated(const BinaryMessage& pt_string,
                          const PTUIterationType iteration_type) OVERRIDE;
+
+  /**
+   * @brief Get the next available PTU URL and the associated application for
+   * performing the PTU
+   * @param iteration_type The iteration type of the PTU
+   * @param app_id Filled with the ID of application used to perform the PTU on
+   * success
+   * @return The next available PTU URL on success, empty string on failure
+   */
+  std::string GetNextUpdateUrl(const PTUIterationType iteration_type,
+                               uint32_t& app_id) OVERRIDE;
 #endif  // EXTERNAL_PROPRIETARY_MODE
   virtual bool GetPriority(const std::string& policy_app_id,
                            std::string* priority) const OVERRIDE;
@@ -412,11 +423,27 @@ class PolicyHandler : public PolicyHandlerInterface,
   void OnSystemError(int code) OVERRIDE;
 
   /**
-   * @brief Chooses random application id to be used for snapshot sending
-   * considering HMI level
+   * @brief Chooses and stores random application id to be used for snapshot
+   * sending considering HMI level
+   * @param iteration_type The iteration type of the request. If RetryIteration,
+   * the previously chosen app ID (via ChoosePtuApplication) will be returned if
+   * available
    * @return Application id or 0, if there are no suitable applications
    */
-  uint32_t GetAppIdForSending() const OVERRIDE;
+  uint32_t ChoosePtuApplication(
+      const PTUIterationType iteration_type =
+          PTUIterationType::DefaultIteration) OVERRIDE;
+
+  /**
+   * @brief Retrieve potential application id to be used for snapshot sending
+   * @param iteration_type The iteration type of the request. If RetryIteration,
+   * the previously chosen app ID (via ChoosePtuApplication) will be returned if
+   * available
+   * @return Application id or 0, if there are no suitable applications
+   */
+  uint32_t GetAppIdForSending(
+      const PTUIterationType iteration_type =
+          PTUIterationType::DefaultIteration) const OVERRIDE;
 
   /**
    * @brief Add application to PTU queue if no application with
@@ -877,6 +904,10 @@ class PolicyHandler : public PolicyHandlerInterface,
  private:
   static const std::string kLibrary;
 
+  bool SendMessageToSDK(const BinaryMessage& pt_string,
+                        const std::string& url,
+                        const uint32_t app_id);
+
   /**
    * @brief Collects currently registered applications ids linked to their
    * device id
@@ -888,6 +919,7 @@ class PolicyHandler : public PolicyHandlerInterface,
   std::shared_ptr<PolicyManager> policy_manager_;
   std::shared_ptr<PolicyEventObserver> event_observer_;
   uint32_t last_activated_app_id_;
+  uint32_t last_ptu_app_id_;
 
   /**
    * @brief Contains device handles, which were sent for user consent to HMI
@@ -919,15 +951,16 @@ class PolicyHandler : public PolicyHandlerInterface,
   friend class AppPermissionDelegate;
 
   /**
-   * @brief Checks if the application with the given policy
-   * application id is registered or it is default id
-   * @param app_idx Application idx from EndpointUrls vector
-   * @param urls EndpointUrls vector
+   * @brief Checks if an application is able to perform a PTU using the
+   * specified URL list
+   * @param app_id ID of application used for PTU
+   * @param app_data EndpointData struct with list of URLs
    * @return TRUE if the vector with URLs with given idx is not empty
-   * and is related to a registered application or these are default URLs,
+   * and is related to the provided application or if these are default URLs,
    * otherwise FALSE
    */
-  bool IsUrlAppIdValid(const uint32_t app_idx, const EndpointUrls& urls) const;
+  bool IsUrlAppIdValid(const std::string app_id,
+                       const EndpointData& app_data) const;
   DISALLOW_COPY_AND_ASSIGN(PolicyHandler);
 };
 

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -114,13 +114,23 @@ class PolicyHandler : public PolicyHandlerInterface,
   /**
    * @brief Get the next available PTU URL and the associated application for
    * performing the PTU
-   * @param iteration_type The iteration type of the PTU
+   * @param iteration_type The iteration type of the PTU.
+   * If this is a retry and a retry URL was cached, that URL will be returned
    * @param app_id Filled with the ID of application used to perform the PTU on
    * success
    * @return The next available PTU URL on success, empty string on failure
    */
   std::string GetNextUpdateUrl(const PTUIterationType iteration_type,
                                uint32_t& app_id) OVERRIDE;
+
+  /**
+   * @brief Update the cached URL and app ID used for policy retries
+   * @param app_id The ID of the application to be used for performing PTUs.
+   * If 0, the existing cached application will be cleared
+   * @param url The URL provided by the HMI to be used for performing PTU
+   * retries. If empty, the existing cached URL will be cleared and Core will
+   * choose which URLs to use on retry
+   */
   void CacheRetryInfo(const uint32_t app_id, const std::string url) OVERRIDE;
 #endif  // EXTERNAL_PROPRIETARY_MODE
   virtual bool GetPriority(const std::string& policy_app_id,
@@ -427,19 +437,19 @@ class PolicyHandler : public PolicyHandlerInterface,
    * @brief Chooses and stores random application id to be used for snapshot
    * sending considering HMI level
    * @param iteration_type The iteration type of the request. If RetryIteration,
-   * the previously chosen app ID (via ChoosePtuApplication) will be returned if
-   * available
+   * the previously chosen app ID (via ChoosePTUApplication or CacheRetryInfo)
+   * will be returned if available
    * @return Application id or 0, if there are no suitable applications
    */
-  uint32_t ChoosePtuApplication(
+  uint32_t ChoosePTUApplication(
       const PTUIterationType iteration_type =
           PTUIterationType::DefaultIteration) OVERRIDE;
 
   /**
    * @brief Retrieve potential application id to be used for snapshot sending
    * @param iteration_type The iteration type of the request. If RetryIteration,
-   * the previously chosen app ID (via ChoosePtuApplication) will be returned if
-   * available
+   * the previously chosen app ID (via ChoosePTUApplication or CacheRetryInfo)
+   * will be returned if available
    * @return Application id or 0, if there are no suitable applications
    */
   uint32_t GetAppIdForSending(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_request_notification.cc
@@ -130,8 +130,7 @@ void OnSystemRequestNotification::Run() {
     /* According to requirements:
        "If the requestType = PROPRIETARY, add to mobile API fileType = JSON
         If the requestType = HTTP, add to mobile API fileType = BINARY"
-       Also in Genivi SDL we don't save the PT to file - we put it directly in
-       binary_data */
+       Also we don't save the PT to file - we put it directly in binary_data */
 
 #if defined(PROPRIETARY_MODE)
     AddHeader(binary_data);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/hmi_notifications_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/hmi_notifications_test.cc
@@ -1557,7 +1557,8 @@ TEST_F(HMICommandsNotificationsTest,
   std::shared_ptr<Command> command =
       CreateCommand<OnSystemRequestNotification>(message);
 
-  EXPECT_CALL(mock_policy_handler_, GetAppIdForSending())
+  EXPECT_CALL(mock_policy_handler_,
+              GetAppIdForSending(policy::PTUIterationType::DefaultIteration))
       .WillOnce(Return(kAppId_));
   EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app_));
   ON_CALL(app_mngr_, connection_handler())
@@ -1593,7 +1594,8 @@ TEST_F(HMICommandsNotificationsTest,
   std::shared_ptr<Command> command =
       CreateCommand<OnSystemRequestNotification>(message);
 
-  EXPECT_CALL(mock_policy_handler_, GetAppIdForSending())
+  EXPECT_CALL(mock_policy_handler_,
+              GetAppIdForSending(policy::PTUIterationType::DefaultIteration))
       .WillOnce(Return(kNullApppId));
   EXPECT_CALL(app_mngr_, application(_)).Times(0);
   EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1629,8 +1629,7 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string,
   LOG4CXX_INFO(logger_, "HTTP policy");
 
   uint32_t app_id_for_sending = 0;
-  const std::string& url =
-      GetNextUpdateUrl(PTUIterationType::RetryIteration, app_id_for_sending);
+  const std::string& url = GetNextUpdateUrl(iteration_type, app_id_for_sending);
   if (0 != url.length()) {
     SendMessageToSDK(pt_string, url, app_id_for_sending);
   }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1644,6 +1644,12 @@ std::string PolicyHandler::GetNextUpdateUrl(
   POLICY_LIB_CHECK_OR_RETURN(std::string());
   app_id = ChoosePtuApplication(iteration_type);
 
+  // Use cached URL for retries if it was provided by the HMI
+  if (PTUIterationType::RetryIteration == iteration_type &&
+      !retry_update_url_.empty()) {
+    return retry_update_url_;
+  }
+
   EndpointUrls endpoint_urls;
   policy_manager_->GetUpdateUrls("0x07", endpoint_urls);
 
@@ -1681,6 +1687,12 @@ std::string PolicyHandler::GetNextUpdateUrl(
   }
   const std::string& url = data.url[app_url.second];
   return url;
+}
+
+void PolicyHandler::CacheRetryInfo(const uint32_t app_id,
+                                   const std::string url) {
+  last_ptu_app_id_ = app_id;
+  retry_update_url_ = url;
 }
 #endif  // EXTERNAL_PROPRIETARY_MODE
 

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -423,7 +423,7 @@ bool PolicyHandler::ClearUserConsent() {
   return policy_manager_->ResetUserConsent();
 }
 
-uint32_t PolicyHandler::ChoosePtuApplication(
+uint32_t PolicyHandler::ChoosePTUApplication(
     const PTUIterationType iteration_type) {
   LOG4CXX_AUTO_TRACE(logger_);
   last_ptu_app_id_ = GetAppIdForSending(iteration_type);
@@ -480,8 +480,7 @@ uint32_t PolicyHandler::GetAppIdForSending(
     return 0;
   }
 
-  app_id = ChooseRandomAppForPolicyUpdate(apps_with_none_level);
-  return app_id;
+  return ChooseRandomAppForPolicyUpdate(apps_with_none_level);
 }
 
 void PolicyHandler::PushAppIdToPTUQueue(const uint32_t app_id) {
@@ -1122,7 +1121,7 @@ void PolicyHandler::OnPendingPermissionChange(
 bool PolicyHandler::SendMessageToSDK(const BinaryMessage& pt_string,
                                      const std::string& url) {
   const uint32_t app_id =
-      ChoosePtuApplication(PTUIterationType::DefaultIteration);
+      ChoosePTUApplication(PTUIterationType::DefaultIteration);
   return SendMessageToSDK(pt_string, url, app_id);
 }
 
@@ -1642,7 +1641,7 @@ std::string PolicyHandler::GetNextUpdateUrl(
     const PTUIterationType iteration_type, uint32_t& app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK_OR_RETURN(std::string());
-  app_id = ChoosePtuApplication(iteration_type);
+  app_id = ChoosePTUApplication(iteration_type);
 
   // Use cached URL for retries if it was provided by the HMI
   if (PTUIterationType::RetryIteration == iteration_type &&
@@ -1661,7 +1660,7 @@ std::string PolicyHandler::GetNextUpdateUrl(
   auto get_ptu_app = [this](AppIdURL app_url, uint32_t& app_id) {
     if (app_url.first == 0 && app_url.second == 0) {
       // We've looped past the end of the list, choose new application
-      app_id = ChoosePtuApplication(PTUIterationType::DefaultIteration);
+      app_id = ChoosePTUApplication(PTUIterationType::DefaultIteration);
       if (0 == app_id) {
         return ApplicationSharedPtr();
       }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -299,6 +299,7 @@ PolicyHandler::PolicyHandler(const PolicySettings& settings,
                              ApplicationManager& application_manager)
     : AsyncRunner("PolicyHandler async runner thread")
     , last_activated_app_id_(0)
+    , last_ptu_app_id_(0)
     , statistic_manager_impl_(std::make_shared<StatisticManagerImpl>(this))
     , settings_(settings)
     , application_manager_(application_manager)
@@ -400,6 +401,8 @@ void PolicyHandler::OnPTInited() {
 void PolicyHandler::StopRetrySequence() {
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK_VOID();
+  // Clear cached PTU app
+  last_ptu_app_id_ = 0;
   policy_manager_->StopRetrySequence();
 }
 
@@ -420,9 +423,28 @@ bool PolicyHandler::ClearUserConsent() {
   return policy_manager_->ResetUserConsent();
 }
 
-uint32_t PolicyHandler::GetAppIdForSending() const {
+uint32_t PolicyHandler::ChoosePtuApplication(
+    const PTUIterationType iteration_type) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  last_ptu_app_id_ = GetAppIdForSending(iteration_type);
+  return last_ptu_app_id_;
+}
+
+uint32_t PolicyHandler::GetAppIdForSending(
+    const PTUIterationType iteration_type) const {
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK_OR_RETURN(0);
+  // Return the previous app chosen if this is a retry for a PTU in progress
+  if (iteration_type == PTUIterationType::RetryIteration &&
+      last_ptu_app_id_ != 0) {
+    ApplicationSharedPtr app =
+        application_manager_.application(last_ptu_app_id_);
+    if (app && app->IsRegistered()) {
+      LOG4CXX_INFO(logger_, "Previously chosen application exists, returning");
+      return last_ptu_app_id_;
+    }
+  }
+
   // fix ApplicationSet access crash
   const ApplicationSet accessor = application_manager_.applications().GetData();
 
@@ -437,11 +459,10 @@ uint32_t PolicyHandler::GetAppIdForSending() const {
                 "Number of apps with different from NONE level: "
                     << apps_without_none_level.size());
 
-  uint32_t choosen_app_id =
-      ChooseRandomAppForPolicyUpdate(apps_without_none_level);
+  uint32_t app_id = ChooseRandomAppForPolicyUpdate(apps_without_none_level);
 
-  if (choosen_app_id) {
-    return choosen_app_id;
+  if (app_id) {
+    return app_id;
   }
 
   Applications apps_with_none_level;
@@ -459,7 +480,8 @@ uint32_t PolicyHandler::GetAppIdForSending() const {
     return 0;
   }
 
-  return ChooseRandomAppForPolicyUpdate(apps_with_none_level);
+  app_id = ChooseRandomAppForPolicyUpdate(apps_with_none_level);
+  return app_id;
 }
 
 void PolicyHandler::PushAppIdToPTUQueue(const uint32_t app_id) {
@@ -1099,10 +1121,17 @@ void PolicyHandler::OnPendingPermissionChange(
 
 bool PolicyHandler::SendMessageToSDK(const BinaryMessage& pt_string,
                                      const std::string& url) {
+  const uint32_t app_id =
+      ChoosePtuApplication(PTUIterationType::DefaultIteration);
+  return SendMessageToSDK(pt_string, url, app_id);
+}
+
+bool PolicyHandler::SendMessageToSDK(const BinaryMessage& pt_string,
+                                     const std::string& url,
+                                     const uint32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK_OR_RETURN(false);
 
-  const uint32_t app_id = GetAppIdForSending();
   ApplicationSharedPtr app = application_manager_.application(app_id);
 
   if (!app) {
@@ -1152,6 +1181,9 @@ bool PolicyHandler::ReceiveMessageFromSDK(const std::string& file,
     policy_manager_->CleanupUnpairedDevices();
     SetDaysAfterEpoch();
     policy_manager_->OnPTUFinished(load_pt_result);
+
+    // Clean up retry information (used in PROPRIETARY and HTTP mode)
+    last_ptu_app_id_ = 0;
 
     uint32_t correlation_id = application_manager_.GetNextHMICorrelationID();
     event_observer_->subscribe_on_event(
@@ -1573,11 +1605,12 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string,
   POLICY_LIB_CHECK_VOID();
 #ifdef PROPRIETARY_MODE
   if (PTUIterationType::RetryIteration == iteration_type) {
-    uint32_t app_id_for_sending = GetAppIdForSending();
-
-    if (0 != app_id_for_sending) {
+    uint32_t app_id_for_sending = 0;
+    const std::string& url =
+        GetNextUpdateUrl(PTUIterationType::RetryIteration, app_id_for_sending);
+    if (0 != url.length()) {
       MessageHelper::SendPolicySnapshotNotification(
-          app_id_for_sending, pt_string, std::string(), application_manager_);
+          app_id_for_sending, pt_string, url, application_manager_);
     }
 
   } else {
@@ -1594,22 +1627,60 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string,
         application_manager_);
   }
 #else   // PROPRIETARY_MODE
-  LOG4CXX_ERROR(logger_, "HTTP policy");
-  EndpointUrls urls;
-  policy_manager_->GetUpdateUrls("0x07", urls);
+  LOG4CXX_INFO(logger_, "HTTP policy");
 
-  if (urls.empty()) {
-    LOG4CXX_ERROR(logger_, "Service URLs are empty! NOT sending PT to mobile!");
-    return;
+  uint32_t app_id_for_sending = 0;
+  const std::string& url =
+      GetNextUpdateUrl(PTUIterationType::RetryIteration, app_id_for_sending);
+  if (0 != url.length()) {
+    SendMessageToSDK(pt_string, url, app_id_for_sending);
   }
-
-  AppIdURL app_url = policy_manager_->GetNextUpdateUrl(urls);
-  while (!IsUrlAppIdValid(app_url.first, urls)) {
-    app_url = policy_manager_->GetNextUpdateUrl(urls);
-  }
-  const std::string& url = urls[app_url.first].url[app_url.second];
-  SendMessageToSDK(pt_string, url);
 #endif  // PROPRIETARY_MODE
+}
+
+std::string PolicyHandler::GetNextUpdateUrl(
+    const PTUIterationType iteration_type, uint32_t& app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  POLICY_LIB_CHECK_OR_RETURN(std::string());
+  app_id = ChoosePtuApplication(iteration_type);
+
+  EndpointUrls endpoint_urls;
+  policy_manager_->GetUpdateUrls("0x07", endpoint_urls);
+
+  if (endpoint_urls.empty()) {
+    LOG4CXX_ERROR(logger_, "Service URLs are empty!");
+    return std::string();
+  }
+
+  auto get_ptu_app = [this](AppIdURL app_url, uint32_t& app_id) {
+    if (app_url.first == 0 && app_url.second == 0) {
+      // We've looped past the end of the list, choose new application
+      app_id = ChoosePtuApplication(PTUIterationType::DefaultIteration);
+      if (0 == app_id) {
+        return ApplicationSharedPtr();
+      }
+    }
+    return application_manager_.application(app_id);
+  };
+
+  AppIdURL app_url = policy_manager_->GetNextUpdateUrl(endpoint_urls);
+  ApplicationSharedPtr app = get_ptu_app(app_url, app_id);
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "No available applications for PTU!");
+    return std::string();
+  }
+  EndpointData& data = endpoint_urls[app_url.first];
+  while (!IsUrlAppIdValid(app->policy_app_id(), data)) {
+    app_url = policy_manager_->GetNextUpdateUrl(endpoint_urls);
+    app = get_ptu_app(app_url, app_id);
+    if (!app) {
+      LOG4CXX_ERROR(logger_, "No available applications for PTU!");
+      return std::string();
+    }
+    data = endpoint_urls[app_url.first];
+  }
+  const std::string& url = data.url[app_url.second];
+  return url;
 }
 #endif  // EXTERNAL_PROPRIETARY_MODE
 
@@ -2590,28 +2661,24 @@ void PolicyHandler::Add(const std::string& app_id,
   policy_manager_->Add(app_id, type, timespan_seconds);
 }
 
-bool PolicyHandler::IsUrlAppIdValid(const uint32_t app_idx,
-                                    const EndpointUrls& urls) const {
-  const EndpointData& app_data = urls[app_idx];
-  const std::vector<std::string> app_urls = app_data.url;
-  const ApplicationSharedPtr app =
-      application_manager_.application_by_policy_id(app_data.app_id);
-
+bool PolicyHandler::IsUrlAppIdValid(const std::string app_id,
+                                    const EndpointData& app_data) const {
   if (policy::kDefaultId == app_data.app_id) {
     return true;
   }
 
-  if (app_urls.empty()) {
+  const std::vector<std::string> app_urls = app_data.url;
+  if (app_urls.empty() || app_id != app_data.app_id) {
     return false;
   }
 
-  const auto devices_ids = GetDevicesIds(app_data.app_id);
-  LOG4CXX_TRACE(logger_,
-                "Count devices: " << devices_ids.size()
-                                  << " for app_id: " << app_data.app_id);
+  const auto devices_ids = GetDevicesIds(app_id);
+  LOG4CXX_TRACE(
+      logger_,
+      "Count devices: " << devices_ids.size() << " for app_id: " << app_id);
   for (const auto& device_id : devices_ids) {
-    ApplicationSharedPtr app =
-        application_manager_.application(device_id, app_data.app_id);
+    const ApplicationSharedPtr app =
+        application_manager_.application(device_id, app_id);
     if (app && (app->IsRegistered())) {
       return true;
     }

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -2031,7 +2031,9 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_WithoutApps) {
   EXPECT_CALL(app_manager_, applications()).WillRepeatedly(Return(app_set));
   // Set does not include any applications
   EXPECT_CALL(*mock_policy_manager_, GetUserConsentForDevice(_)).Times(0);
-  EXPECT_EQ(0u, policy_handler_.GetAppIdForSending());
+  EXPECT_EQ(
+      0u,
+      policy_handler_.GetAppIdForSending(PTUIterationType::DefaultIteration));
 }
 
 TEST_F(PolicyHandlerTest, GetAppIdForSending_GetDefaultMacAddress) {
@@ -2057,7 +2059,9 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_GetDefaultMacAddress) {
   EXPECT_CALL(*mock_policy_manager_, GetUserConsentForDevice(_))
       .WillRepeatedly(Return(kDeviceAllowed));
   // Act
-  EXPECT_EQ(kAppId1_, policy_handler_.GetAppIdForSending());
+  EXPECT_EQ(
+      kAppId1_,
+      policy_handler_.GetAppIdForSending(PTUIterationType::DefaultIteration));
 }
 
 void PolicyHandlerTest::GetAppIDForSending() {
@@ -2082,7 +2086,9 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_SetMacAddress) {
   // Arrange
   GetAppIDForSending();
   // Act
-  EXPECT_EQ(kAppId1_, policy_handler_.GetAppIdForSending());
+  EXPECT_EQ(
+      kAppId1_,
+      policy_handler_.GetAppIdForSending(PTUIterationType::DefaultIteration));
 }
 
 TEST_F(PolicyHandlerTest, GetAppIdForSending_ExpectReturnAnyIdButNone) {
@@ -2146,7 +2152,9 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_ExpectReturnAnyIdButNone) {
       .WillRepeatedly(Return(kDeviceAllowed));
 
   // Act
-  EXPECT_NE(app_in_none_id, policy_handler_.GetAppIdForSending());
+  EXPECT_NE(
+      app_in_none_id,
+      policy_handler_.GetAppIdForSending(PTUIterationType::DefaultIteration));
 }
 
 TEST_F(PolicyHandlerTest, GetAppIdForSending_ExpectReturnAnyAppInNone) {
@@ -2189,66 +2197,10 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_ExpectReturnAnyAppInNone) {
 
   // Act
 
-  const uint32_t app_id = policy_handler_.GetAppIdForSending();
+  const uint32_t app_id =
+      policy_handler_.GetAppIdForSending(PTUIterationType::DefaultIteration);
 
   EXPECT_EQ(app_in_none_id_1 || app_in_none_id_2, app_id);
-}
-
-TEST_F(PolicyHandlerTest,
-       SendMessageToSDK_SuitableAppPresent_ExpectedNotificationSending) {
-  BinaryMessage msg;
-  const std::string url = "test_url";
-  EnablePolicyAndPolicyManagerMock();
-  test_app.insert(mock_app_);
-
-  EXPECT_CALL(app_manager_, application(kAppId1_))
-      .WillRepeatedly(Return(mock_app_));
-  EXPECT_CALL(*mock_app_, app_id()).WillRepeatedly(Return(kAppId1_));
-  EXPECT_CALL(*mock_app_, policy_app_id())
-      .WillRepeatedly(Return(kPolicyAppId_));
-  EXPECT_CALL(*mock_app_, hmi_level(kDefaultWindowId))
-      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
-  EXPECT_CALL(*mock_app_, IsRegistered()).WillRepeatedly(Return(true));
-
-  const connection_handler::DeviceHandle test_device_id = 1u;
-  EXPECT_CALL(*mock_app_, device()).WillRepeatedly(Return(test_device_id));
-  EXPECT_CALL(*mock_policy_manager_, GetUserConsentForDevice(_))
-      .WillOnce(Return(kDeviceAllowed));
-
-  // Act
-  EXPECT_CALL(mock_message_helper_,
-              SendPolicySnapshotNotification(kAppId1_, msg, url, _));
-  EXPECT_TRUE(policy_handler_.SendMessageToSDK(msg, url));
-}
-
-TEST_F(PolicyHandlerTest,
-       SendMessageToSDK_NoSuitableApp_ExpectedNotificationNotSent) {
-  BinaryMessage msg;
-  const std::string url = "test_url";
-  EnablePolicyAndPolicyManagerMock();
-  test_app.insert(mock_app_);
-
-  EXPECT_CALL(app_manager_, application(kAppId1_))
-      .WillRepeatedly(Return(mock_app_));
-  EXPECT_CALL(*mock_app_, app_id()).WillRepeatedly(Return(kAppId1_));
-  EXPECT_CALL(*mock_app_, policy_app_id())
-      .WillRepeatedly(Return(kPolicyAppId_));
-  EXPECT_CALL(*mock_app_, hmi_level(kDefaultWindowId))
-      .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_NONE));
-  EXPECT_CALL(*mock_app_, IsRegistered()).WillRepeatedly(Return(true));
-
-  const connection_handler::DeviceHandle test_device_id = 1u;
-  EXPECT_CALL(*mock_app_, device()).WillRepeatedly(Return(test_device_id));
-  EXPECT_CALL(*mock_policy_manager_, GetUserConsentForDevice(_))
-      .WillOnce(Return(kDeviceDisallowed));
-
-  // Expected to get 0 as application id so SDL does not have valid application
-  // with such id
-  EXPECT_CALL(app_manager_, application(0))
-      .WillOnce(
-          Return(std::shared_ptr<application_manager_test::MockApplication>()));
-
-  EXPECT_FALSE(policy_handler_.SendMessageToSDK(msg, url));
 }
 
 TEST_F(PolicyHandlerTest, CanUpdate) {

--- a/src/components/application_manager/test/rc_policy_handler_test.cc
+++ b/src/components/application_manager/test/rc_policy_handler_test.cc
@@ -151,58 +151,6 @@ class RCPolicyHandlerTest : public ::testing::Test {
   }
 };
 
-TEST_F(RCPolicyHandlerTest,
-       SendMessageToSDK_RemoteControlInvalidMobileAppId_UNSUCCESS) {
-  // Precondition
-  BinaryMessage msg;
-  EnablePolicyAndPolicyManagerMock();
-
-  EXPECT_CALL(app_manager_, applications()).WillOnce(Return(app_set));
-  test_app.insert(mock_app_);
-
-  ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId1_));
-  ON_CALL(*mock_app_, hmi_level())
-      .WillByDefault(Return(mobile_apis::HMILevel::HMI_FULL));
-  EXPECT_CALL(*mock_app_, IsRegistered()).WillOnce(Return(true));
-
-  EXPECT_CALL(app_manager_, application(kAppId1_))
-      .WillRepeatedly(Return(mock_app_));
-  const std::string empty_mobile_app_id("");
-  EXPECT_CALL(*mock_app_, policy_app_id())
-      .WillOnce(Return(empty_mobile_app_id));
-
-  EXPECT_CALL(*mock_policy_manager_, GetUserConsentForDevice(_))
-      .WillOnce(Return(kDeviceAllowed));
-
-  EXPECT_CALL(mock_message_helper_, SendPolicySnapshotNotification(_, _, _, _))
-      .Times(0);
-  EXPECT_FALSE(policy_handler_.SendMessageToSDK(msg, kUrl_));
-}
-
-TEST_F(RCPolicyHandlerTest, SendMessageToSDK_RemoteControl_SUCCESS) {
-  BinaryMessage msg;
-  EnablePolicyAndPolicyManagerMock();
-  EXPECT_CALL(app_manager_, applications()).WillOnce(Return(app_set));
-  test_app.insert(mock_app_);
-
-  ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId1_));
-  ON_CALL(*mock_app_, hmi_level())
-      .WillByDefault(Return(mobile_apis::HMILevel::HMI_FULL));
-  EXPECT_CALL(*mock_app_, IsRegistered()).WillOnce(Return(true));
-
-  EXPECT_CALL(app_manager_, application(kAppId1_))
-      .WillRepeatedly(Return(mock_app_));
-
-  EXPECT_CALL(*mock_app_, policy_app_id()).WillOnce(Return(kPolicyAppId_));
-
-  EXPECT_CALL(*mock_policy_manager_, GetUserConsentForDevice(_))
-      .WillOnce(Return(kDeviceAllowed));
-
-  EXPECT_CALL(mock_message_helper_,
-              SendPolicySnapshotNotification(kAppId1_, _, kUrl_, _));
-  EXPECT_TRUE(policy_handler_.SendMessageToSDK(msg, kUrl_));
-}
-
 TEST_F(RCPolicyHandlerTest, OnUpdateHMILevel_InvalidApp_UNSUCCESS) {
   EnablePolicyAndPolicyManagerMock();
 

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -350,7 +350,7 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
    * @brief Choose application id to be used for snapshot sending
    * @return Application id or 0, if there are no applications registered
    */
-  virtual uint32_t ChoosePtuApplication(
+  virtual uint32_t ChoosePTUApplication(
       const PTUIterationType iteration_type =
           PTUIterationType::DefaultIteration) = 0;
 

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -102,6 +102,7 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
                                  const PTUIterationType iteration_type) = 0;
   virtual std::string GetNextUpdateUrl(const PTUIterationType iteration_type,
                                        uint32_t& app_id) = 0;
+  virtual void CacheRetryInfo(const uint32_t app_id, const std::string url) = 0;
 #endif  // EXTERNAL_PROPRIETARY_MODE
 
   virtual bool GetPriority(const std::string& policy_app_id,

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -77,8 +77,9 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
   virtual bool InitPolicyTable() = 0;
   virtual bool ResetPolicyTable() = 0;
   virtual bool ClearUserConsent() = 0;
-  virtual bool SendMessageToSDK(const BinaryMessage& pt_string,
-                                const std::string& url) = 0;
+  // Deprecated in favor of private variant
+  DEPRECATED virtual bool SendMessageToSDK(const BinaryMessage& pt_string,
+                                           const std::string& url) = 0;
   virtual bool ReceiveMessageFromSDK(const std::string& file,
                                      const BinaryMessage& pt_string) = 0;
   virtual bool UnloadPolicyLibrary() = 0;
@@ -99,6 +100,8 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
 #else   // EXTERNAL_PROPRIETARY_MODE
   virtual void OnSnapshotCreated(const BinaryMessage& pt_string,
                                  const PTUIterationType iteration_type) = 0;
+  virtual std::string GetNextUpdateUrl(const PTUIterationType iteration_type,
+                                       uint32_t& app_id) = 0;
 #endif  // EXTERNAL_PROPRIETARY_MODE
 
   virtual bool GetPriority(const std::string& policy_app_id,
@@ -346,7 +349,18 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
    * @brief Choose application id to be used for snapshot sending
    * @return Application id or 0, if there are no applications registered
    */
-  virtual uint32_t GetAppIdForSending() const = 0;
+  virtual uint32_t ChoosePtuApplication(
+      const PTUIterationType iteration_type =
+          PTUIterationType::DefaultIteration) = 0;
+
+  /**
+   * @brief Retrieve an application id to be used for snapshot sending
+   * @param iteration_type
+   * @return Application id or 0, if there are no applications registered
+   */
+  virtual uint32_t GetAppIdForSending(
+      const PTUIterationType iteration_type =
+          PTUIterationType::DefaultIteration) const = 0;
 
   virtual utils::custom_string::CustomString GetAppName(
       const std::string& policy_app_id) = 0;

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -727,12 +727,13 @@ class PolicyManager : public usage_statistics::StatisticsManager,
   virtual const PolicySettings& get_settings() const = 0;
 
   /**
+   * @deprecated Unused in EXTERNAL_PROPRIETARY policies
    * @brief Finds the next URL that must be sent on OnSystemRequest retry
    * @param urls vector of vectors that contain urls for each application
    * @return Pair of policy application id and application url id from the
    * urls vector
    */
-  virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) = 0;
+  DEPRECATED virtual AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) = 0;
 
   /**
    * @brief Assigns new HMI types for specified application

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -89,6 +89,8 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD2(GetNextUpdateUrl,
                std::string(const policy::PTUIterationType iteration_type,
                            uint32_t& app_id));
+  MOCK_METHOD2(CacheRetryInfo,
+               void(const uint32_t app_id, const std::string url));
 #endif  // EXTERNAL_PROPRIETARY_MODE
 
   MOCK_CONST_METHOD2(GetPriority,

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -192,7 +192,7 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD1(RemoveDevice, void(const std::string& device_id));
   MOCK_METHOD1(AddStatisticsInfo, void(int type));
   MOCK_METHOD1(OnSystemError, void(int code));
-  MOCK_METHOD1(ChoosePtuApplication,
+  MOCK_METHOD1(ChoosePTUApplication,
                uint32_t(const policy::PTUIterationType iteration_type));
   MOCK_CONST_METHOD1(GetAppIdForSending,
                      uint32_t(const policy::PTUIterationType iteration_type));

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -86,6 +86,9 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD2(OnSnapshotCreated,
                void(const policy::BinaryMessage& pt_string,
                     const policy::PTUIterationType iteration_type));
+  MOCK_METHOD2(GetNextUpdateUrl,
+               std::string(const policy::PTUIterationType iteration_type,
+                           uint32_t& app_id));
 #endif  // EXTERNAL_PROPRIETARY_MODE
 
   MOCK_CONST_METHOD2(GetPriority,
@@ -187,7 +190,10 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD1(RemoveDevice, void(const std::string& device_id));
   MOCK_METHOD1(AddStatisticsInfo, void(int type));
   MOCK_METHOD1(OnSystemError, void(int code));
-  MOCK_CONST_METHOD0(GetAppIdForSending, uint32_t());
+  MOCK_METHOD1(ChoosePtuApplication,
+               uint32_t(const policy::PTUIterationType iteration_type));
+  MOCK_CONST_METHOD1(GetAppIdForSending,
+                     uint32_t(const policy::PTUIterationType iteration_type));
   MOCK_METHOD1(
       GetAppName,
       utils::custom_string::CustomString(const std::string& policy_app_id));

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -786,7 +786,7 @@ class PolicyManagerImpl : public PolicyManager {
    * @return Pair of policy application id and application url id from the
    * urls vector
    */
-  AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) OVERRIDE;
+  DEPRECATED AppIdURL GetNextUpdateUrl(const EndpointUrls& urls) OVERRIDE;
 
   /**
    * @brief Checks if there is existing URL in the EndpointUrls vector with

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1345,6 +1345,7 @@ void PolicyManagerImpl::ResetRetrySequence(
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock auto_lock(retry_sequence_lock_);
   retry_sequence_index_ = 0;
+  retry_sequence_url_ = RetrySequenceURL();
   ptu_requested_ = false;
   if (ResetRetryCountType::kResetWithStatusUpdate == reset_type) {
     update_status_manager_.OnResetRetrySequence();


### PR DESCRIPTION
Fixes #3232

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
1. Edit the policy table module config:
```
          ...
          "timeout_after_x_seconds": 5,
            "seconds_between_retries": [
                1,
                1,
                1,
                1,
                1
            ],
            "endpoints": {
                "0x07": {
                    "default": [
                        "http://smartdevicelink.com/api/1/policies/example1"
                    ],
                    "8675309": [
                        "http://smartdevicelink.com/api/1/policies/example2"
                    ],
                    "123456789": [
                        "http://smartdevicelink.com/api/1/policies/example3",
                        "http://smartdevicelink.com/api/1/policies/example4"
                    ]
                },
                "0x04": {
                    "default": [
                        "http://x.x.x.x:3000/api/1/softwareUpdate"
                    ]
                },
                "queryAppsUrl": {
                    "default": [
                        "http://sdl.shaid.server"
                    ]
                },
                "lock_screen_icon_url": {
                    "default": [
                        "http://i.imgur.com/TgkvOIZ.png"
                    ]
                },
                "custom_vehicle_data_mapping_url": {
                    "default": [
                        "http://x.x.x.x:3000/api/1/vehicleDataMap"
                    ]
                }
            },
            ...
```
2. Connect both apps with specific dummy URLs (`8675309` and `123456789`) in the `module_config.endpoints.0x07` section. 
3. Verify that all URLs pertaining to an app (including default URLs) are sent during the retry process before another application is chosen for performing a PTU.

### Summary
For PROPRIETARY policy updates, Core is responsible for the retry sequence and cycling through update URLs. This fixes the PROPRIETARY flow with a few specific changes:

1. Apps for PTU are chosen randomly using the existing process, but after an application is chosen, all URLs that are associated with that application will be attempted before moving onto the next application.
2. When an OnSystemRequest(PROPRIETARY) is received from the HMI in PROPRIETARY policy mode, Core will ignore the `appID` and `url` properties and populate them itself. This is because Core is responsible for providing these fields in PROPRIETARY mode.

### Changelog
##### Bug Fixes
* Fixes PROPRIETARY policy flow and URL cycling logic for PROPRIETARY and HTTP flow

### Tasks Remaining:
- [x] Fix Unit Tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
