### PR TITLE
Fix/Processing deprecated mandatory parameter

### DIFF
--- a/src/components/smart_objects/src/object_schema_item.cc
+++ b/src/components/smart_objects/src/object_schema_item.cc
@@ -126,8 +126,8 @@ errors::eType CObjectSchemaItem::validate(
 
     std::set<std::string>::const_iterator key_it = object_keys.find(key);
     if (object_keys.end() == key_it) {
-      if (correct_member && correct_member->mIsMandatory == true &&
-          correct_member->mIsRemoved == false) {
+      if (correct_member && correct_member->mIsMandatory &&
+          !correct_member->mIsDeprecated && !correct_member->mIsRemoved) {
         std::string validation_info = "Missing mandatory parameter: " + key;
         report__->set_validation_info(validation_info);
         return errors::MISSING_MANDATORY_PARAMETER;

--- a/tools/InterfaceGenerator/generator/generators/SmartFactoryBase.py
+++ b/tools/InterfaceGenerator/generator/generators/SmartFactoryBase.py
@@ -1156,7 +1156,7 @@ class CodeGenerator(object):
                     schema_items_decl=self._gen_schema_items_decls(
                         function.params.values()),
                     schema_item_fill=self._gen_schema_items_fill(
-                        function.params.values(), function.since, function.until, function.deprecated, function.removed),
+                        function.params.values(), function.since, function.until, function.removed),
                     schema_params_fill=self._gen_schema_params_fill(
                         function.message_type.name)),
                 1))


### PR DESCRIPTION
Fixes #3330 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Use scripts from
[smartdevicelink/sdl_atf_test_scripts#2388](https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2388)

### Summary
Object schema item does not take into account an deprecated property when processing a mandatory parameter.
InterfaceGenerator add depereted property in all fileds if function depereted.

* Add deprecated property to compare when processing a mandatory parameter.
* Remove inheritance of the deprecated attribute from function.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)