### PR TITLE
Do not send two END_SERVICE requests during streaming switching between apps 

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1579,6 +1579,7 @@ class ApplicationManagerImpl
   NaviServiceStatusMap navi_service_status_;
   sync_primitives::Lock navi_service_status_lock_;
   std::deque<uint32_t> navi_app_to_stop_;
+  sync_primitives::Lock navi_app_to_stop_lock_;
   std::deque<uint32_t> navi_app_to_end_stream_;
   uint32_t navi_close_app_timeout_;
   uint32_t navi_end_stream_timeout_;

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3142,6 +3142,7 @@ void ApplicationManagerImpl::UnregisterAllApplications() {
           MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
               app_to_remove->app_id(), unregister_reason_),
           commands::Command::SOURCE_SDL);
+      EndNaviServices(app_to_remove->app_id());
       UnregisterApplication(app_to_remove->app_id(),
                             mobile_apis::Result::INVALID_ENUM,
                             is_ignition_off,
@@ -3221,8 +3222,6 @@ void ApplicationManagerImpl::UnregisterApplication(
     LOG4CXX_ERROR(logger_, "Send UnsubscribeWayPoints");
     MessageHelper::SendUnsubscribedWayPoints(*this);
   }
-
-  EndNaviServices(app_id);
 
   {
     sync_primitives::AutoLock lock(navi_service_status_lock_);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3896,6 +3896,7 @@ void ApplicationManagerImpl::CloseNaviApp() {
     if (navi_service_status_.end() != it) {
       if (it->second.first || it->second.second) {
         unregister = true;
+        navi_service_status_.erase(it);
       }
     }
   }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3142,7 +3142,6 @@ void ApplicationManagerImpl::UnregisterAllApplications() {
           MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
               app_to_remove->app_id(), unregister_reason_),
           commands::Command::SOURCE_SDL);
-      EndNaviServices(app_to_remove->app_id());
       UnregisterApplication(app_to_remove->app_id(),
                             mobile_apis::Result::INVALID_ENUM,
                             is_ignition_off,
@@ -3222,6 +3221,7 @@ void ApplicationManagerImpl::UnregisterApplication(
     LOG4CXX_ERROR(logger_, "Send UnsubscribeWayPoints");
     MessageHelper::SendUnsubscribedWayPoints(*this);
   }
+  EndNaviServices(app_id);
 
   {
     sync_primitives::AutoLock lock(navi_service_status_lock_);


### PR DESCRIPTION

Fixes #3328 

This PR is **[not ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
[ 3139_04_Stop_streaming_forcibly_app_does_not_send_EndServiceAck](https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/develop/test_scripts/Defects/6_1/3139_04_Stop_streaming_forcibly_app_does_not_send_EndServiceAck.lua) 

### Summary
Check if EndService has been sent before sending it during unregistration

### Tasks Remaining:
- [x] Check regression
- [x] Check unit tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
