### PR TITLE
Hotfix/3327 sdl sends generic error if vehicle data not available

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_data_response.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_data_response.cc
@@ -55,32 +55,14 @@ void VIGetVehicleDataResponse::Run() {
 
   event_engine::Event event(hmi_apis::FunctionID::VehicleInfo_GetVehicleData);
 
-  if ((*message_)[strings::params][strings::message_type] ==
-      static_cast<int32_t>(hmi_apis::messageType::error_response)) {
-    smart_objects::SmartObject result(smart_objects::SmartType_Map);
-
-    if ((*message_)[strings::params].keyExists(strings::data)) {
-      result[strings::msg_params] = (*message_)[strings::params][strings::data];
-      result[strings::params][hmi_response::code] =
-          (*message_)[strings::params][hmi_response::code];
-      result[strings::params][strings::correlation_id] =
-          (*message_)[strings::params][strings::correlation_id];
-      result[strings::params][strings::error_msg] =
-          (*message_)[strings::params][strings::error_msg];
-      result[strings::params][strings::message_type] =
-          (*message_)[strings::params][strings::message_type];
-      result[strings::params][strings::protocol_type] =
-          (*message_)[strings::params][strings::protocol_type];
-      result[strings::params][strings::protocol_version] =
-          (*message_)[strings::params][strings::protocol_version];
-    }
-
-    event.set_smart_object(result);
-  } else {
-    event.set_smart_object(*message_);
+  const bool error_response =
+      (*message_)[strings::params][strings::message_type] ==
+      static_cast<int32_t>(hmi_apis::messageType::error_response);
+  if (!error_response) {
     policy_handler_.OnVehicleDataUpdated(*message_);
   }
 
+  event.set_smart_object(*message_);
   event.raise(application_manager_.event_dispatcher());
 }
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_get_vehicle_data_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_get_vehicle_data_response_test.cc
@@ -101,7 +101,8 @@ TEST_F(VIGetVehicleDataResponseTest, RUN_SUCCESS) {
   command->Run();
 }
 
-TEST_F(VIGetVehicleDataResponseTest, ErrorResponse_OnVehicleDataUpdated_NotCalled) {
+TEST_F(VIGetVehicleDataResponseTest,
+       ErrorResponse_OnVehicleDataUpdated_NotCalled) {
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
   (*command_msg)[strings::msg_params][strings::number] = kStrNumber;
   (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
@@ -120,7 +121,8 @@ TEST_F(VIGetVehicleDataResponseTest, ErrorResponse_OnVehicleDataUpdated_NotCalle
   VIGetVehicleDataResponsePtr command(
       CreateCommandVI<VIGetVehicleDataResponse>(command_msg));
 
-  EXPECT_CALL(mock_policy_handler_, OnVehicleDataUpdated(*command_msg)).Times(0);
+  EXPECT_CALL(mock_policy_handler_, OnVehicleDataUpdated(*command_msg))
+      .Times(0);
 
   MockEventDispatcher mock_event_dispatcher;
   EXPECT_CALL(app_mngr_, event_dispatcher())

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_get_vehicle_data_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_get_vehicle_data_response_test.cc
@@ -97,10 +97,11 @@ TEST_F(VIGetVehicleDataResponseTest, RUN_SUCCESS) {
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
 
+  ASSERT_TRUE(command->Init());
   command->Run();
 }
 
-TEST_F(VIGetVehicleDataResponseTest, ErrorResponse_SUCCESS) {
+TEST_F(VIGetVehicleDataResponseTest, ErrorResponse_OnVehicleDataUpdated_NotCalled) {
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
   (*command_msg)[strings::msg_params][strings::number] = kStrNumber;
   (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
@@ -108,7 +109,7 @@ TEST_F(VIGetVehicleDataResponseTest, ErrorResponse_SUCCESS) {
       hmi_apis::messageType::error_response;
   (*command_msg)[strings::params][strings::data][strings::slider_position] = 1;
   (*command_msg)[strings::params][hmi_response::code] =
-      hmi_apis::Common_Result::SUCCESS;
+      hmi_apis::Common_Result::ABORTED;
   (*command_msg)[strings::params][strings::correlation_id] = kCorrelationId;
   (*command_msg)[am::strings::params][am::strings::error_msg] = "test_error";
   (*command_msg)[am::strings::params][am::strings::protocol_type] =
@@ -116,33 +117,17 @@ TEST_F(VIGetVehicleDataResponseTest, ErrorResponse_SUCCESS) {
   (*command_msg)[strings::params][strings::protocol_version] =
       am::commands::CommandImpl::protocol_version_;
 
-  smart_objects::SmartObject result(smart_objects::SmartType_Map);
-  result[strings::msg_params] = (*command_msg)[strings::params][strings::data];
-  result[strings::params][hmi_response::code] =
-      (*command_msg)[strings::params][hmi_response::code];
-  result[strings::params][strings::correlation_id] =
-      (*command_msg)[strings::params][strings::correlation_id];
-  result[strings::params][strings::error_msg] =
-      (*command_msg)[strings::params][strings::error_msg];
-  result[strings::params][strings::message_type] =
-      (*command_msg)[strings::params][strings::message_type];
-  result[strings::params][strings::protocol_type] =
-      (*command_msg)[strings::params][strings::protocol_type];
-  result[strings::params][strings::protocol_version] =
-      (*command_msg)[strings::params][strings::protocol_version];
-
   VIGetVehicleDataResponsePtr command(
       CreateCommandVI<VIGetVehicleDataResponse>(command_msg));
 
-  am::event_engine::Event event(
-      hmi_apis::FunctionID::VehicleInfo_GetVehicleData);
-  event.set_smart_object(result);
+  EXPECT_CALL(mock_policy_handler_, OnVehicleDataUpdated(*command_msg)).Times(0);
 
   MockEventDispatcher mock_event_dispatcher;
   EXPECT_CALL(app_mngr_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher));
   EXPECT_CALL(mock_event_dispatcher, raise_event(_));
 
+  ASSERT_TRUE(command->Init());
   command->Run();
 }
 


### PR DESCRIPTION
Fixes #3327 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF testing

### Summary
In case of GetVehicleData error response from HMI,
SDL put only part of message to event. This way
event was not processed properly and GENERIC_ERROR
was sent to Mobile App.

This commit fixes error response message structure.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
