### PR TITLE
Fix/Send OnAppPropertiesChange in case one of nicknames is removed

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -2142,7 +2142,7 @@ PolicyHandler::AppPropertiesState PolicyHandler::GetAppPropertiesStatus(
     const smart_objects::SmartArray* nicknames_array =
         properties[strings::nicknames].asArray();
 
-    if (nicknames_array->empty() && !nicknames.empty()) {
+    if (nicknames_array->size() != nicknames.size()) {
       return AppPropertiesState::NICKNAMES_CHANGED;
     }
 


### PR DESCRIPTION
Fixes #3321 

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Use scripts from
[smartdevicelink/sdl_atf_test_scripts/onAppPropertiesChange_remove_nickname]( https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/defect/onAppPropertiesChange_remove_nickname/test_scripts/Defects/6_1/3321_OnAppPropertiesChange_remove_nickname.lua)
UTs

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
