### PR TITLE
Fix UpdateAppList/UpdateDeviceList spam

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -4034,7 +4034,7 @@ void ApplicationManagerImpl::OnApplicationListUpdateTimer() {
   const bool trigger_ptu = apps_size_ != applications_.size();
   apps_to_register_list_lock_ptr_->Release();
 
-  if (is_new_app_registered || trigger_ptu) {
+  if (is_new_app_registered) {
     SendUpdateAppList();
   }
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -894,7 +894,6 @@ void ApplicationManagerImpl::OnHMIStartedCooperation() {
   resume_controller().ResetLaunchTime();
 
   RefreshCloudAppInformation();
-  SendUpdateAppList();
 }
 
 std::string ApplicationManagerImpl::PolicyIDByIconUrl(const std::string url) {
@@ -4028,11 +4027,17 @@ bool ApplicationManagerImpl::IsHMICooperating() const {
 
 void ApplicationManagerImpl::OnApplicationListUpdateTimer() {
   LOG4CXX_DEBUG(logger_, "Application list update timer finished");
+  const bool is_new_app_registered = registered_during_timer_execution_;
   registered_during_timer_execution_ = false;
+
   apps_to_register_list_lock_ptr_->Acquire();
   const bool trigger_ptu = apps_size_ != applications_.size();
   apps_to_register_list_lock_ptr_->Release();
-  SendUpdateAppList();
+
+  if (is_new_app_registered || trigger_ptu) {
+    SendUpdateAppList();
+  }
+
   GetPolicyHandler().OnAppsSearchCompleted(trigger_ptu);
 }
 

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -1418,8 +1418,12 @@ void ConnectionHandlerImpl::ConnectToAllDevices() {
   sync_primitives::AutoReadLock lock(device_list_lock_);
   for (DeviceMap::iterator i = device_list_.begin(); i != device_list_.end();
        ++i) {
-    connection_handler::DeviceHandle device_handle = i->first;
-    ConnectToDevice(device_handle);
+    if (transport_manager::webengine_constants::kWebEngineDeviceName ==
+        i->second.user_friendly_name()) {
+      LOG4CXX_DEBUG(logger_, "No need to connect to web engine device");
+      continue;
+    }
+    ConnectToDevice(i->first);
   }
 }
 

--- a/src/components/transport_manager/include/transport_manager/transport_manager_impl.h
+++ b/src/components/transport_manager/include/transport_manager/transport_manager_impl.h
@@ -525,8 +525,9 @@ class TransportManagerImpl
   /**
    * @brief Updates total device list with info from specific transport adapter.
    * @param ta Transport adapter
+   * @return True if device list has been changed, otherwise - false
    */
-  void UpdateDeviceList(TransportAdapter* ta);
+  bool UpdateDeviceList(TransportAdapter* ta);
 };  // class TransportManagerImpl
 }  // namespace transport_manager
 #endif  // SRC_COMPONENTS_TRANSPORT_MANAGER_INCLUDE_TRANSPORT_MANAGER_TRANSPORT_MANAGER_IMPL_H_

--- a/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
+++ b/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
@@ -339,13 +339,6 @@ ConnectionStatus TransportAdapterImpl::GetConnectionStatus(
 
 void TransportAdapterImpl::ConnectionStatusUpdated(DeviceSptr device,
                                                    ConnectionStatus status) {
-  if (device->connection_status() == status) {
-    LOG4CXX_DEBUG(
-        logger_,
-        "Connection status for device " << device << " was not changed");
-    return;
-  }
-
   device->set_connection_status(status);
   for (TransportAdapterListenerList::iterator it = listeners_.begin();
        it != listeners_.end();

--- a/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
+++ b/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
@@ -339,6 +339,13 @@ ConnectionStatus TransportAdapterImpl::GetConnectionStatus(
 
 void TransportAdapterImpl::ConnectionStatusUpdated(DeviceSptr device,
                                                    ConnectionStatus status) {
+  if (device->connection_status() == status) {
+    LOG4CXX_DEBUG(
+        logger_,
+        "Connection status for device " << device << " was not changed");
+    return;
+  }
+
   device->set_connection_status(status);
   for (TransportAdapterListenerList::iterator it = listeners_.begin();
        it != listeners_.end();

--- a/src/components/transport_manager/src/transport_manager_impl.cc
+++ b/src/components/transport_manager/src/transport_manager_impl.cc
@@ -713,7 +713,6 @@ void TransportManagerImpl::CreateWebEngineDevice() {
 
   web_socket_ta->AddDevice(ws_device);
   OnDeviceListUpdated(web_socket_ta);
-  web_socket_ta->ConnectDevice(unique_device_id);
 #endif  // WEBSOCKET_SERVER_TRANSPORT_SUPPORT
 }
 


### PR DESCRIPTION
Fixes #3326 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by manual testing

### Summary
There was noticed a continuous spam of update app and device list requests from SDL to HMI even if there is no any devices connected and apps registered.
After analysis, there was found a couple of places where logic should be updated:
- In `OnHMIStartedCooperation` don't send update app list after refreshing cloud app information as this function able to trigger the same request itself when needed
- When update app list timer is expired, don't send update app list if no any apps were registered while timer was running 
- In transport manager, don't raise `OnDeviceListUpdated` event if no any devices were added/removed
- SDL should not connect web engine device in `ConnectAllDevices()` due to specific of that device. It should be connected only when some web engine application is launched.
- <s>In transport adapter, don't notify listeners via `OnConnectionStatusUpdated()` callbacks if device connection status was not actually changed</s>

All these actions together prevents all possible reasons of `UpdateAppList`/`UpdateDeviceList` spam observed before fix.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
