### PR TITLE
Move cached app logic to ChoosePTUApplication

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -110,28 +110,8 @@ class PolicyHandler : public PolicyHandlerInterface,
 #else   // EXTERNAL_PROPRIETARY_MODE
   void OnSnapshotCreated(const BinaryMessage& pt_string,
                          const PTUIterationType iteration_type) OVERRIDE;
-
-  /**
-   * @brief Get the next available PTU URL and the associated application for
-   * performing the PTU
-   * @param iteration_type The iteration type of the PTU.
-   * If this is a retry and a retry URL was cached, that URL will be returned
-   * @param app_id Filled with the ID of application used to perform the PTU on
-   * success
-   * @return The next available PTU URL on success, empty string on failure
-   */
   std::string GetNextUpdateUrl(const PTUIterationType iteration_type,
                                uint32_t& app_id) OVERRIDE;
-
-  /**
-   * @brief Update the cached URL and app ID used for policy retries
-   * @param app_id The ID of the application to be used for performing PTUs.
-   * If 0, the existing cached application will be cleared
-   * @param url The URL provided by the HMI to be used for performing PTU
-   * retries. If empty, the existing cached URL will be cleared and Core will
-   * choose which URLs to use on retry
-   */
-  void CacheRetryInfo(const uint32_t app_id, const std::string url) OVERRIDE;
 #endif  // EXTERNAL_PROPRIETARY_MODE
   virtual bool GetPriority(const std::string& policy_app_id,
                            std::string* priority) const OVERRIDE;
@@ -433,28 +413,14 @@ class PolicyHandler : public PolicyHandlerInterface,
    */
   void OnSystemError(int code) OVERRIDE;
 
-  /**
-   * @brief Chooses and stores random application id to be used for snapshot
-   * sending considering HMI level
-   * @param iteration_type The iteration type of the request. If RetryIteration,
-   * the previously chosen app ID (via ChoosePTUApplication or CacheRetryInfo)
-   * will be returned if available
-   * @return Application id or 0, if there are no suitable applications
-   */
+#ifndef EXTERNAL_PROPRIETARY_MODE
   uint32_t ChoosePTUApplication(
       const PTUIterationType iteration_type =
           PTUIterationType::DefaultIteration) OVERRIDE;
+  void CacheRetryInfo(const uint32_t app_id, const std::string url) OVERRIDE;
+#endif  // EXTERNAL_PROPRIETARY_MODE
 
-  /**
-   * @brief Retrieve potential application id to be used for snapshot sending
-   * @param iteration_type The iteration type of the request. If RetryIteration,
-   * the previously chosen app ID (via ChoosePTUApplication or CacheRetryInfo)
-   * will be returned if available
-   * @return Application id or 0, if there are no suitable applications
-   */
-  uint32_t GetAppIdForSending(
-      const PTUIterationType iteration_type =
-          PTUIterationType::DefaultIteration) const OVERRIDE;
+  uint32_t GetAppIdForSending() const OVERRIDE;
 
   /**
    * @brief Add application to PTU queue if no application with
@@ -931,9 +897,11 @@ class PolicyHandler : public PolicyHandlerInterface,
   std::shared_ptr<PolicyEventObserver> event_observer_;
   uint32_t last_activated_app_id_;
 
+#ifndef EXTERNAL_PROPRIETARY_MODE
   // PTU retry information
   uint32_t last_ptu_app_id_;
   std::string retry_update_url_;
+#endif  // EXTERNAL_PROPRIETARY_MODE
 
   /**
    * @brief Contains device handles, which were sent for user consent to HMI

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/hmi_notifications_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/hmi_notifications_test.cc
@@ -1557,8 +1557,7 @@ TEST_F(HMICommandsNotificationsTest,
   std::shared_ptr<Command> command =
       CreateCommand<OnSystemRequestNotification>(message);
 
-  EXPECT_CALL(mock_policy_handler_,
-              GetAppIdForSending(policy::PTUIterationType::DefaultIteration))
+  EXPECT_CALL(mock_policy_handler_, GetAppIdForSending())
       .WillOnce(Return(kAppId_));
   EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app_));
   ON_CALL(app_mngr_, connection_handler())
@@ -1594,8 +1593,7 @@ TEST_F(HMICommandsNotificationsTest,
   std::shared_ptr<Command> command =
       CreateCommand<OnSystemRequestNotification>(message);
 
-  EXPECT_CALL(mock_policy_handler_,
-              GetAppIdForSending(policy::PTUIterationType::DefaultIteration))
+  EXPECT_CALL(mock_policy_handler_, GetAppIdForSending())
       .WillOnce(Return(kNullApppId));
   EXPECT_CALL(app_mngr_, application(_)).Times(0);
   EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -2035,9 +2035,7 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_WithoutApps) {
   EXPECT_CALL(app_manager_, applications()).WillRepeatedly(Return(app_set));
   // Set does not include any applications
   EXPECT_CALL(*mock_policy_manager_, GetUserConsentForDevice(_)).Times(0);
-  EXPECT_EQ(
-      0u,
-      policy_handler_.GetAppIdForSending(PTUIterationType::DefaultIteration));
+  EXPECT_EQ(0u, policy_handler_.GetAppIdForSending());
 }
 
 TEST_F(PolicyHandlerTest, GetAppIdForSending_GetDefaultMacAddress) {
@@ -2063,9 +2061,7 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_GetDefaultMacAddress) {
   EXPECT_CALL(*mock_policy_manager_, GetUserConsentForDevice(_))
       .WillRepeatedly(Return(kDeviceAllowed));
   // Act
-  EXPECT_EQ(
-      kAppId1_,
-      policy_handler_.GetAppIdForSending(PTUIterationType::DefaultIteration));
+  EXPECT_EQ(kAppId1_, policy_handler_.GetAppIdForSending());
 }
 
 void PolicyHandlerTest::GetAppIDForSending() {
@@ -2090,9 +2086,7 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_SetMacAddress) {
   // Arrange
   GetAppIDForSending();
   // Act
-  EXPECT_EQ(
-      kAppId1_,
-      policy_handler_.GetAppIdForSending(PTUIterationType::DefaultIteration));
+  EXPECT_EQ(kAppId1_, policy_handler_.GetAppIdForSending());
 }
 
 TEST_F(PolicyHandlerTest, GetAppIdForSending_ExpectReturnAnyIdButNone) {
@@ -2156,9 +2150,7 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_ExpectReturnAnyIdButNone) {
       .WillRepeatedly(Return(kDeviceAllowed));
 
   // Act
-  EXPECT_NE(
-      app_in_none_id,
-      policy_handler_.GetAppIdForSending(PTUIterationType::DefaultIteration));
+  EXPECT_NE(app_in_none_id, policy_handler_.GetAppIdForSending());
 }
 
 TEST_F(PolicyHandlerTest, GetAppIdForSending_ExpectReturnAnyAppInNone) {
@@ -2201,8 +2193,7 @@ TEST_F(PolicyHandlerTest, GetAppIdForSending_ExpectReturnAnyAppInNone) {
 
   // Act
 
-  const uint32_t app_id =
-      policy_handler_.GetAppIdForSending(PTUIterationType::DefaultIteration);
+  const uint32_t app_id = policy_handler_.GetAppIdForSending();
 
   EXPECT_EQ(app_in_none_id_1 || app_in_none_id_2, app_id);
 }

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -89,8 +89,6 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD2(GetNextUpdateUrl,
                std::string(const policy::PTUIterationType iteration_type,
                            uint32_t& app_id));
-  MOCK_METHOD2(CacheRetryInfo,
-               void(const uint32_t app_id, const std::string url));
 #endif  // EXTERNAL_PROPRIETARY_MODE
 
   MOCK_CONST_METHOD2(GetPriority,
@@ -192,10 +190,13 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD1(RemoveDevice, void(const std::string& device_id));
   MOCK_METHOD1(AddStatisticsInfo, void(int type));
   MOCK_METHOD1(OnSystemError, void(int code));
+#ifndef EXTERNAL_PROPRIETARY_MODE
   MOCK_METHOD1(ChoosePTUApplication,
                uint32_t(const policy::PTUIterationType iteration_type));
-  MOCK_CONST_METHOD1(GetAppIdForSending,
-                     uint32_t(const policy::PTUIterationType iteration_type));
+  MOCK_METHOD2(CacheRetryInfo,
+               void(const uint32_t app_id, const std::string url));
+#endif
+  MOCK_CONST_METHOD0(GetAppIdForSending, uint32_t());
   MOCK_METHOD1(
       GetAppName,
       utils::custom_string::CustomString(const std::string& policy_app_id));


### PR DESCRIPTION

Fixes #3340 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Build with EXTERNAL_PROPRIETARY policy mode

### Summary
Properly separate PROPRIETARY/HTTP retry logic from EXTERNAL_PROPRIETARY build

### Changelog

##### Bug Fixes
* Fix EXTERNAL_PROPRIETARY policy build

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
