### PR TITLE
Add permission checking for all messages to and from mobile

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_impl.h
@@ -162,6 +162,20 @@ class CommandImpl : public Command {
 
  protected:
   /**
+   * @brief Checks message permissions and parameters according to policy table
+   * permissions
+   * @param source The source of the command (used to determine if a response
+   * should be sent on failure)
+   * @return true if the RPC is allowed, false otherwise
+   */
+  bool CheckAllowedParameters(const Command::CommandSource source);
+
+  /**
+   * @brief Remove from current message parameters disallowed by policy table
+   */
+  void RemoveDisallowedParameters();
+
+  /**
    * @brief Parses mobile message and replaces mobile app id with HMI app id
    * @param message Message to replace its ids
    * @return True if replacement succeeded, otherwise - false
@@ -182,6 +196,9 @@ class CommandImpl : public Command {
   rpc_service::RPCService& rpc_service_;
   HMICapabilities& hmi_capabilities_;
   policy::PolicyHandlerInterface& policy_handler_;
+
+  CommandParametersPermissions parameters_permissions_;
+  CommandParametersPermissions removed_parameters_permissions_;
 
 #ifdef ENABLE_LOG
   static log4cxx::LoggerPtr logger_;

--- a/src/components/application_manager/include/application_manager/commands/command_notification_from_mobile_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_notification_from_mobile_impl.h
@@ -50,6 +50,7 @@ class CommandNotificationFromMobileImpl : public CommandImpl {
       policy::PolicyHandlerInterface& policy_handler);
   virtual ~CommandNotificationFromMobileImpl();
   virtual bool Init();
+  bool CheckPermissions() OVERRIDE;
   virtual bool CleanUp();
   virtual void Run();
   void SendNotification();

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -236,8 +236,11 @@ class CommandRequestImpl : public CommandImpl,
   /**
    * @brief Checks message permissions and parameters according to policy table
    * permissions
+   * @param source The source of the command (used to determine if a response
+   * should be sent on failure)
+   * @return true if the RPC is allowed, false otherwise
    */
-  bool CheckAllowedParameters();
+  bool CheckAllowedParameters(const Command::CommandSource source);
 
   /**
    * @brief Checks HMI capabilities for specified button support
@@ -246,11 +249,6 @@ class CommandRequestImpl : public CommandImpl,
    * otherwise returns false
    */
   bool CheckHMICapabilities(const mobile_apis::ButtonName::eType button) const;
-
-  /**
-   * @brief Remove from current message parameters disallowed by policy table
-   */
-  void RemoveDisallowedParameters();
 
   /**
    * @brief Adds disallowed parameters back to response with appropriate
@@ -375,8 +373,6 @@ class CommandRequestImpl : public CommandImpl,
 
   RequestState current_state_;
   sync_primitives::Lock state_lock_;
-  CommandParametersPermissions parameters_permissions_;
-  CommandParametersPermissions removed_parameters_permissions_;
 
   /**
    * @brief hash_update_mode_ Defines whether request must update hash value of

--- a/src/components/application_manager/include/application_manager/commands/command_request_to_mobile.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_to_mobile.h
@@ -51,6 +51,7 @@ class CommandRequestToMobile : public CommandImpl {
                          policy::PolicyHandlerInterface& policy_handler);
   ~CommandRequestToMobile();
   bool Init() OVERRIDE;
+  bool CheckPermissions() OVERRIDE;
   bool CleanUp() OVERRIDE;
   void Run() OVERRIDE;
   void SendRequest();

--- a/src/components/application_manager/include/application_manager/commands/command_response_from_mobile.h
+++ b/src/components/application_manager/include/application_manager/commands/command_response_from_mobile.h
@@ -51,6 +51,7 @@ class CommandResponseFromMobile : public CommandImpl {
                             policy::PolicyHandlerInterface& policy_handler);
   ~CommandResponseFromMobile();
   bool Init() OVERRIDE;
+  bool CheckPermissions() OVERRIDE;
   bool CleanUp() OVERRIDE;
   void Run() OVERRIDE;
   void SendResponse();

--- a/src/components/application_manager/src/commands/command_notification_from_mobile_impl.cc
+++ b/src/components/application_manager/src/commands/command_notification_from_mobile_impl.cc
@@ -57,6 +57,10 @@ bool CommandNotificationFromMobileImpl::Init() {
   return true;
 }
 
+bool CommandNotificationFromMobileImpl::CheckPermissions() {
+  return CheckAllowedParameters(Command::CommandSource::SOURCE_MOBILE);
+}
+
 bool CommandNotificationFromMobileImpl::CleanUp() {
   return true;
 }

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -222,7 +222,7 @@ bool CommandRequestImpl::Init() {
 }
 
 bool CommandRequestImpl::CheckPermissions() {
-  return CheckAllowedParameters();
+  return CheckAllowedParameters(Command::CommandSource::SOURCE_MOBILE);
 }
 
 bool CommandRequestImpl::CleanUp() {
@@ -691,7 +691,8 @@ mobile_apis::Result::eType CommandRequestImpl::GetMobileResultCode(
   return mobile_result;
 }
 
-bool CommandRequestImpl::CheckAllowedParameters() {
+bool CommandRequestImpl::CheckAllowedParameters(
+    const Command::CommandSource source) {
   LOG4CXX_AUTO_TRACE(logger_);
 
   // RegisterAppInterface should always be allowed
@@ -700,64 +701,7 @@ bool CommandRequestImpl::CheckAllowedParameters() {
     return true;
   }
 
-  const ApplicationSharedPtr app =
-      application_manager_.application(connection_key());
-  if (!app) {
-    LOG4CXX_ERROR(logger_,
-                  "There is no registered application with "
-                  "connection key '"
-                      << connection_key() << "'");
-    return false;
-  }
-
-  RPCParams params;
-
-  const smart_objects::SmartObject& s_map = (*message_)[strings::msg_params];
-  smart_objects::SmartMap::const_iterator iter = s_map.map_begin();
-  smart_objects::SmartMap::const_iterator iter_end = s_map.map_end();
-
-  for (; iter != iter_end; ++iter) {
-    LOG4CXX_DEBUG(logger_, "Request's param: " << iter->first);
-    params.insert(iter->first);
-  }
-
-  mobile_apis::Result::eType check_result =
-      mobile_apis::Result::eType::INVALID_ID;
-  const auto current_window_id = window_id();
-  if (app->WindowIdExists(current_window_id)) {
-    check_result = application_manager_.CheckPolicyPermissions(
-        app,
-        current_window_id,
-        MessageHelper::StringifiedFunctionID(
-            static_cast<mobile_api::FunctionID::eType>(function_id())),
-        params,
-        &parameters_permissions_);
-  }
-
-  // Check, if RPC is allowed by policy
-  if (mobile_apis::Result::SUCCESS != check_result) {
-    smart_objects::SmartObjectSPtr response =
-        MessageHelper::CreateBlockedByPoliciesResponse(
-            static_cast<mobile_api::FunctionID::eType>(function_id()),
-            check_result,
-            correlation_id(),
-            app->app_id());
-
-    rpc_service_.SendMessageToMobile(response);
-    return false;
-  }
-
-  // If no parameters specified in policy table, no restriction will be
-  // applied for parameters
-  if (parameters_permissions_.allowed_params.empty() &&
-      parameters_permissions_.disallowed_params.empty() &&
-      parameters_permissions_.undefined_params.empty()) {
-    return true;
-  }
-
-  RemoveDisallowedParameters();
-
-  return true;
+  return CommandImpl::CheckAllowedParameters(source);
 }
 
 bool CommandRequestImpl::CheckHMICapabilities(
@@ -792,42 +736,6 @@ bool CommandRequestImpl::CheckHMICapabilities(
   LOG4CXX_DEBUG(logger_,
                 "Button capabilities for " << button << " was not found");
   return false;
-}
-
-void CommandRequestImpl::RemoveDisallowedParameters() {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  smart_objects::SmartObject& params = (*message_)[strings::msg_params];
-
-  for (const auto& key : params.enumerate()) {
-    if (parameters_permissions_.disallowed_params.end() !=
-        parameters_permissions_.disallowed_params.find(key)) {
-      // Remove from request all disallowed parameters
-      params.erase(key);
-      removed_parameters_permissions_.disallowed_params.insert(key);
-      LOG4CXX_INFO(logger_,
-                   "Following parameter is disallowed by user: " << key);
-    }
-
-    else if (removed_parameters_permissions_.undefined_params.end() !=
-             removed_parameters_permissions_.undefined_params.find(key)) {
-      // Remove from request all undefined yet parameters
-      params.erase(key);
-      removed_parameters_permissions_.undefined_params.insert(key);
-      LOG4CXX_INFO(logger_,
-                   "Following parameter is disallowed by policy: " << key);
-    }
-
-    else if (parameters_permissions_.allowed_params.end() ==
-             parameters_permissions_.allowed_params.find(key)) {
-      // Remove from request all parameters missed in allowed
-      params.erase(key);
-      removed_parameters_permissions_.undefined_params.insert(key);
-      LOG4CXX_INFO(logger_,
-                   "Following parameter is not found among allowed parameters '"
-                       << key << "' and will be treated as disallowed.");
-    }
-  }
 }
 
 void CommandRequestImpl::AddDissalowedParameterToInfoString(

--- a/src/components/application_manager/src/commands/command_request_to_mobile.cc
+++ b/src/components/application_manager/src/commands/command_request_to_mobile.cc
@@ -55,6 +55,10 @@ bool CommandRequestToMobile::Init() {
   return true;
 }
 
+bool CommandRequestToMobile::CheckPermissions() {
+  return CheckAllowedParameters(Command::CommandSource::SOURCE_SDL);
+}
+
 bool CommandRequestToMobile::CleanUp() {
   return true;
 }

--- a/src/components/application_manager/src/commands/command_response_from_mobile.cc
+++ b/src/components/application_manager/src/commands/command_response_from_mobile.cc
@@ -56,6 +56,10 @@ bool CommandResponseFromMobile::Init() {
   return true;
 }
 
+bool CommandResponseFromMobile::CheckPermissions() {
+  return CheckAllowedParameters(Command::CommandSource::SOURCE_MOBILE);
+}
+
 bool CommandResponseFromMobile::CleanUp() {
   return true;
 }

--- a/src/components/application_manager/src/rpc_service_impl.cc
+++ b/src/components/application_manager/src/rpc_service_impl.cc
@@ -206,7 +206,7 @@ bool RPCServiceImpl::ManageMobileCommand(
   int32_t message_type =
       (*message)[strings::params][strings::message_type].asInt();
   if (message_type == mobile_apis::messageType::response) {
-    if (command->Init()) {
+    if (command->Init() && command->CheckPermissions()) {
       command->Run();
       command->CleanUp();
     }
@@ -214,7 +214,7 @@ bool RPCServiceImpl::ManageMobileCommand(
   }
   if (message_type == mobile_apis::messageType::notification) {
     request_ctrl_.addNotification(command);
-    if (command->Init()) {
+    if (command->Init() && command->CheckPermissions()) {
       command->Run();
       if (command->CleanUp()) {
         request_ctrl_.removeNotification(command.get());
@@ -226,7 +226,7 @@ bool RPCServiceImpl::ManageMobileCommand(
 
   if (message_type == mobile_apis::messageType::request &&
       source == commands::Command::CommandSource::SOURCE_SDL) {
-    if (command->Init()) {
+    if (command->Init() && command->CheckPermissions()) {
       command->Run();
       command->CleanUp();
       return true;

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -402,6 +402,8 @@ TEST_F(CommandRequestImplTest,
   MessageSharedPtr message = CreateMessage();
   (*message)[strings::msg_params] =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
+  (*message)[strings::params][strings::message_type] =
+      mobile_apis::messageType::request;
 
   CommandPtr command = CreateCommand<UCommandRequestImpl>(message);
 


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
1. Give an app `AppServiceProvider` functional group permissions.
2. Remove OnAppServiceData from the `AppServiceProvider` functional group.
3. Publish media service
4. Send OnAppServiceData
Expected: OnAppServiceData disallowed

### Summary
Add permissions checks to all incoming and outgoing message from an app.

### Changelog
##### Bug Fixes
* Add permissions checks to all incoming and outgoing message from an app.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
