### PR TITLE
Fix mutex deadlock around app button subscriptions

### DIFF
--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1108,8 +1108,7 @@ void MessageHelper::SendAllOnButtonSubscriptionNotificationsForApp(
     return;
   }
 
-  DataAccessor<ButtonSubscriptions> button_accessor = app->SubscribedButtons();
-  ButtonSubscriptions subscriptions = button_accessor.GetData();
+  const ButtonSubscriptions subscriptions = app->SubscribedButtons().GetData();
   ButtonSubscriptions::iterator it = subscriptions.begin();
   for (; subscriptions.end() != it; ++it) {
     SendOnButtonSubscriptionNotification(

--- a/src/components/application_manager/src/resumption/resumption_data.cc
+++ b/src/components/application_manager/src/resumption/resumption_data.cc
@@ -148,20 +148,23 @@ smart_objects::SmartObject ResumptionData::GetApplicationSubscriptions(
   }
   LOG4CXX_DEBUG(logger_, "app_id:" << application->app_id());
 
-  DataAccessor<ButtonSubscriptions> button_accessor =
-      application->SubscribedButtons();
+  {
+    DataAccessor<ButtonSubscriptions> button_accessor =
+        application->SubscribedButtons();
 
-  const ButtonSubscriptions& button_subscriptions = button_accessor.GetData();
+    const ButtonSubscriptions& button_subscriptions = button_accessor.GetData();
 
-  LOG4CXX_DEBUG(logger_, "SubscribedButtons:" << button_subscriptions.size());
-  Append(button_subscriptions.begin(),
-         button_subscriptions.end(),
-         strings::application_buttons,
-         subscriptions);
+    LOG4CXX_DEBUG(logger_, "SubscribedButtons:" << button_subscriptions.size());
+    Append(button_subscriptions.begin(),
+           button_subscriptions.end(),
+           strings::application_buttons,
+           subscriptions);
+  }
 
   for (auto extension : application->Extensions()) {
     extension->SaveResumptionData(subscriptions);
   }
+
   return subscriptions;
 }
 


### PR DESCRIPTION
Fixes #3338 

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by manual testing

### Summary
Sometimes there was observed mutex deadlock while more then one thread are accessing buttons subscriptions container protected with data accessor class. The issue is happening when one thread is trying to unregister application, acquires applications lock and trying to save application resumption data which at some point requires app subscribed buttons lock to be acquired. At the same moment another thread is trying to resume application data and acquires subscribed buttons accessor after which is trying to send notifications to HMI, which at some point requires applications lock to be acquired. When these two threads have a time intersection, mutex deadlock is happening.
To resolve this deadlock, button subscription accessor has been replaced with temporary accessor + copying protected content to a local variable which allows to release that lock beforehand.

### Tasks Remaining:
- [ ] Analyze how is it possible to have the same app registration and unregistration at the same time

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
