### PR TITLE
Fix/Core dump during usb reconnection

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -51,6 +51,7 @@
 #include "smart_objects/smart_object.h"
 #include "utils/data_accessor.h"
 #include "utils/macro.h"
+#include "utils/mutable_data_accessor.h"
 #include "utils/semantic_version.h"
 
 namespace application_manager {
@@ -995,18 +996,20 @@ class Application : public virtual InitialApplicationData,
   virtual bool IsVideoApplication() const = 0;
 
   /**
+   * @brief Provides a thread safe access to registration status instance for
+   * reading and writing
+   * @return data accessor to registration status variable
+   */
+  virtual MutableDataAccessor<ApplicationRegisterState>
+  registration_status_accessor() = 0;
+
+  /**
    * @brief IsRegistered allows to distinguish if this
    * application has been registered.
    *
    * @return true if registered, false otherwise.
    */
   virtual bool IsRegistered() const = 0;
-  /**
-   * @brief MarkRegistered allows to mark application as registered.
-   */
-  void MarkRegistered() {
-    app_state_ = kRegistered;
-  }
 
   /**
    * @brief MarkUnregistered allows to mark application as unregistered.

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -34,6 +34,8 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_APPLICATION_IMPL_H_
 
 #include <stdint.h>
+
+#include <atomic>
 #include <forward_list>
 #include <list>
 #include <map>
@@ -46,14 +48,13 @@
 #include "application_manager/help_prompt_manager_impl.h"
 #include "application_manager/hmi_state.h"
 #include "application_manager/usage_statistics.h"
-#include "protocol_handler/protocol_handler.h"
-
-#include <atomic>
 #include "connection_handler/device.h"
+#include "protocol_handler/protocol_handler.h"
 #include "utils/custom_string.h"
 #include "utils/date_time.h"
 #include "utils/lock.h"
 #include "utils/macro.h"
+#include "utils/mutable_data_accessor.h"
 #include "utils/timer.h"
 
 namespace usage_statistics {
@@ -506,6 +507,9 @@ class ApplicationImpl : public virtual Application,
 
   const smart_objects::SmartObject& get_user_location() const OVERRIDE;
 
+  MutableDataAccessor<ApplicationRegisterState> registration_status_accessor()
+      OVERRIDE;
+
  protected:
   /**
    * @brief Clean up application folder. Persistent files will stay
@@ -640,6 +644,7 @@ class ApplicationImpl : public virtual Application,
   sync_primitives::Lock cmd_softbuttonid_lock_;
   mutable std::shared_ptr<sync_primitives::Lock> vi_lock_ptr_;
   mutable std::shared_ptr<sync_primitives::Lock> button_lock_ptr_;
+  mutable std::shared_ptr<sync_primitives::Lock> app_state_lock_ptr_;
   std::string folder_name_;
   ApplicationManager& application_manager_;
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -890,7 +890,18 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
   response_params[strings::icon_resumed] =
       file_system::FileExists(application->app_icon_path());
 
-  SendResponse(true, result_code, add_info.c_str(), &response_params);
+  {
+    // Set application registration status to "Registered"
+    auto accessor = application->registration_status_accessor();
+    SendResponse(true, result_code, add_info.c_str(), &response_params);
+    accessor.GetMutableData() =
+        ApplicationImpl::ApplicationRegisterState::kRegistered;
+  }
+
+  LOG4CXX_DEBUG(logger_,
+                "Registration status for app " << application->app_id()
+                                               << " was set to Registered");
+
   if (msg_params.keyExists(strings::app_hmi_type)) {
     GetPolicyHandler().SetDefaultHmiTypes(application->device(),
                                           application->policy_app_id(),

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -4549,8 +4549,7 @@ void ApplicationManagerImpl::AddAppToRegisteredAppList(
   DCHECK_OR_RETURN_VOID(application);
   sync_primitives::AutoLock lock(applications_list_lock_ptr_);
 
-  // Add application to registered app list and set appropriate mark.
-  application->MarkRegistered();
+  // Add application to registered app list.
   applications_.insert(application);
   LOG4CXX_DEBUG(
       logger_,

--- a/src/components/application_manager/test/application_impl_test.cc
+++ b/src/components/application_manager/test/application_impl_test.cc
@@ -449,7 +449,8 @@ TEST_F(ApplicationImplTest, LoadPersistentFiles) {
   // Precondition
   // Create test folder with diff files
 
-  app_impl->MarkRegistered();
+  app_impl->registration_status_accessor().GetMutableData() =
+      ApplicationImpl::ApplicationRegisterState::kRegistered;
   std::string folder_name = "";
   app_impl->set_folder_name(folder_name);
 

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -31,15 +31,19 @@
  */
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_APPLICATION_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_TEST_INCLUDE_APPLICATION_MANAGER_MOCK_APPLICATION_H_
+
 #include <string>
+
+#include "gmock/gmock.h"
+
 #include "application_manager/app_extension.h"
 #include "application_manager/application.h"
 #include "application_manager/display_capabilities_builder.h"
 #include "application_manager/hmi_state.h"
 #include "application_manager/usage_statistics.h"
-#include "gmock/gmock.h"
 #include "smart_objects/smart_object.h"
 #include "utils/custom_string.h"
+#include "utils/mutable_data_accessor.h"
 #include "utils/semantic_version.h"
 
 namespace test {
@@ -362,6 +366,8 @@ class MockApplication : public ::application_manager::Application {
   MOCK_METHOD1(set_mobile_app_id, void(const std::string& policy_app_id));
   MOCK_CONST_METHOD0(is_foreground, bool());
   MOCK_METHOD1(set_foreground, void(bool is_foreground));
+  MOCK_METHOD0(registration_status_accessor,
+               MutableDataAccessor<ApplicationRegisterState>());
   MOCK_CONST_METHOD0(IsRegistered, bool());
   MOCK_CONST_METHOD0(SchemaUrl, std::string());
   MOCK_CONST_METHOD0(PackageName, std::string());


### PR DESCRIPTION
Fixes #3345 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manual testing

### Summary
There is a problem when the SDL crashes during OnSystemCapabilityUpdated notification when registering a second application while another registered application already exists

In the current implementation ApplicationManager during application registering by the ApplicationManager::RegisterApplication method creates a new instance of the application and adds it to the collection of all registered applications. This method calls in the RegisterAppInterfaceRequest and all needed extensions will be added later in the RegisterAppInterfaceRequest.

According to the described behavior could appear case when a first application is registered successfully and all needed application extensions are successfully added too. The second application starts the registration process in someone thread, but in the other one thread, SDL receives OnSystemCapabilityUpdated notification and tries to extract required extension for the all applications from the collection of all registered applications(application_manager_.applications()).
Where a second application without extensions is already present.
Thus DCHECK (ASSERT) happens.

We try to send a notification to the application that is in the process of registration.

### Changelog
##### Breaking Changes
* Adds synchronization between registration and OnSystemCapabilityUpdated.
* Unit tests update.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
