### PR TITLE
Init usage_and_error_counts on startup

### DIFF
--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -1412,6 +1412,10 @@ std::shared_ptr<policy_table::Table> CacheManager::GenerateSnapshot() {
   snapshot_->policy_table.module_meta = pt_->policy_table.module_meta;
   snapshot_->policy_table.usage_and_error_counts =
       pt_->policy_table.usage_and_error_counts;
+  snapshot_->policy_table.usage_and_error_counts->app_level =
+      pt_->policy_table.usage_and_error_counts->app_level;
+  snapshot_->policy_table.usage_and_error_counts->mark_initialized();
+  snapshot_->policy_table.usage_and_error_counts->app_level->mark_initialized();
   snapshot_->policy_table.device_data = pt_->policy_table.device_data;
 
   if (pt_->policy_table.vehicle_data.is_initialized()) {


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Launch core and hmi with webengine appstore server.
Download and install an app.
Check the contents of the policy table snapshot for usage_and_error_counts key.

### Summary
The PTS created by core before a mobile app was connected did not include usage_and_error_counts. This could cause validation issues in the sdl server logic.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
