### PR TITLE
ResetGlobalProperties doesn't reset HELPPROMPT and VRHELPITEMS to default values

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
@@ -198,8 +198,21 @@ bool ResetGlobalPropertiesRequest::ResetHelpPromt(
     SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
     return false;
   }
+  const std::vector<std::string>& help_prompt =
+      application_manager_.get_settings().help_prompt();
+
   smart_objects::SmartObject so_help_prompt =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  for (size_t i = 0; i < help_prompt.size(); ++i) {
+    smart_objects::SmartObject help_prompt_item =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    help_prompt_item[strings::text] = help_prompt[i];
+    help_prompt_item[strings::type] =
+        hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+    so_help_prompt[i] = help_prompt_item;
+  }
+
   app->set_help_prompt(so_help_prompt);
   return true;
 }
@@ -218,7 +231,7 @@ bool ResetGlobalPropertiesRequest::ResetTimeoutPromt(
   smart_objects::SmartObject so_time_out_promt =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
 
-  for (uint32_t i = 0; i < time_out_promt.size(); ++i) {
+  for (size_t i = 0; i < time_out_promt.size(); ++i) {
     smart_objects::SmartObject timeoutPrompt =
         smart_objects::SmartObject(smart_objects::SmartType_Map);
     timeoutPrompt[strings::text] = time_out_promt[i];
@@ -238,8 +251,16 @@ bool ResetGlobalPropertiesRequest::ResetVrHelpTitleItems(
     SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
     return false;
   }
+
+  const std::string& vr_help_title =
+      application_manager_.get_settings().vr_help_title();
+  smart_objects::SmartObject so_vr_help_title =
+      smart_objects::SmartObject(smart_objects::SmartType_String);
+  so_vr_help_title[strings::vr_help_title] = vr_help_title;
+
   app->reset_vr_help_title();
   app->reset_vr_help();
+  app->set_vr_help_title(so_vr_help_title);
 
   return true;
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
@@ -256,7 +256,7 @@ bool ResetGlobalPropertiesRequest::ResetVrHelpTitleItems(
       application_manager_.get_settings().vr_help_title();
   smart_objects::SmartObject so_vr_help_title =
       smart_objects::SmartObject(smart_objects::SmartType_String);
-  so_vr_help_title[strings::vr_help_title] = vr_help_title;
+  so_vr_help_title = vr_help_title;
 
   app->reset_vr_help_title();
   app->reset_vr_help();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
@@ -275,8 +275,7 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_SUCCESS) {
               set_menu_title(msg_params[am::hmi_request::menu_title]));
 
   EXPECT_CALL(*mock_app_, help_prompt()).WillOnce(Return(&so_help_prompt));
-  EXPECT_CALL(*mock_app_, timeout_prompt())
-      .WillOnce(Return(&so_help_prompt));
+  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(&so_help_prompt));
 
   EXPECT_CALL(
       mock_rpc_service_,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
@@ -144,15 +144,15 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidVrHelp_UNSUCCESS) {
   EXPECT_CALL(app_mngr_settings_, help_prompt())
       .WillOnce(ReturnRef(help_prompt));
 
-  smart_objects::SmartObject help_prompt_ =
+  smart_objects::SmartObject so_help_prompt =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
-  help_prompt_[am::strings::text] = help_prompt[0];
-  help_prompt_[am::strings::type] =
+  so_help_prompt[am::strings::text] = help_prompt[0];
+  so_help_prompt[am::strings::type] =
       hmi_apis::Common_SpeechCapabilities::SC_TEXT;
 
   smart_objects::SmartObject so_prompt =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
-  so_prompt[0] = help_prompt_;
+  so_prompt[0] = so_help_prompt;
 
   EXPECT_CALL(*mock_app_, set_help_prompt(so_prompt));
 
@@ -180,7 +180,7 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidVrHelp_UNSUCCESS) {
 
   smart_objects::SmartObject so_vr_help_title =
       smart_objects::SmartObject(smart_objects::SmartType_String);
-  so_vr_help_title[am::strings::vr_help_title] = vr_help_title;
+  so_vr_help_title = vr_help_title;
   EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
 
   EXPECT_CALL(*mock_app_, reset_vr_help_title());
@@ -218,15 +218,15 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_SUCCESS) {
   EXPECT_CALL(app_mngr_settings_, help_prompt())
       .WillOnce(ReturnRef(help_prompt));
 
-  smart_objects::SmartObject help_prompt_ =
+  smart_objects::SmartObject so_help_prompt =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
-  help_prompt_[am::strings::text] = help_prompt[0];
-  help_prompt_[am::strings::type] =
+  so_help_prompt[am::strings::text] = help_prompt[0];
+  so_help_prompt[am::strings::type] =
       hmi_apis::Common_SpeechCapabilities::SC_TEXT;
 
   smart_objects::SmartObject so_prompt =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
-  so_prompt[0] = help_prompt_;
+  so_prompt[0] = so_help_prompt;
   EXPECT_CALL(*mock_app_, set_help_prompt(so_prompt));
 
   std::vector<std::string> time_out_prompt;
@@ -253,7 +253,7 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_SUCCESS) {
 
   smart_objects::SmartObject so_vr_help_title =
       smart_objects::SmartObject(smart_objects::SmartType_String);
-  so_vr_help_title[am::strings::vr_help_title] = vr_help_title;
+  so_vr_help_title = vr_help_title;
   EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
 
   EXPECT_CALL(*mock_app_, reset_vr_help_title());
@@ -274,12 +274,9 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_SUCCESS) {
   EXPECT_CALL(*mock_app_,
               set_menu_title(msg_params[am::hmi_request::menu_title]));
 
-  const smart_objects::SmartObjectSPtr so_help_prompt =
-      std::make_shared<smart_objects::SmartObject>(
-          smart_objects::SmartType_Map);
-  EXPECT_CALL(*mock_app_, help_prompt()).WillOnce(Return(so_help_prompt.get()));
+  EXPECT_CALL(*mock_app_, help_prompt()).WillOnce(Return(&so_help_prompt));
   EXPECT_CALL(*mock_app_, timeout_prompt())
-      .WillOnce(Return(so_help_prompt.get()));
+      .WillOnce(Return(&so_help_prompt));
 
   EXPECT_CALL(
       mock_rpc_service_,
@@ -317,7 +314,7 @@ TEST_F(ResetGlobalPropertiesRequestTest,
 
   smart_objects::SmartObject so_vr_help_title =
       smart_objects::SmartObject(smart_objects::SmartType_String);
-  so_vr_help_title[am::strings::vr_help_title] = vr_help_title;
+  so_vr_help_title = vr_help_title;
   EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
 
   EXPECT_CALL(*mock_app_, reset_vr_help_title());
@@ -422,7 +419,7 @@ TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_InvalidApp_NoHashUpdate) {
 
   smart_objects::SmartObject so_vr_help_title =
       smart_objects::SmartObject(smart_objects::SmartType_String);
-  so_vr_help_title[am::strings::vr_help_title] = vr_help_title;
+  so_vr_help_title = vr_help_title;
   EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
 
   EXPECT_CALL(*mock_app_, reset_vr_help_title());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
@@ -139,8 +139,21 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidVrHelp_UNSUCCESS) {
       mobile_apis::GlobalProperty::KEYBOARDPROPERTIES;
 
   EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+  std::vector<std::string> help_prompt = {"help_prompt"};
+
+  EXPECT_CALL(app_mngr_settings_, help_prompt())
+      .WillOnce(ReturnRef(help_prompt));
+
+  smart_objects::SmartObject help_prompt_ =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  help_prompt_[am::strings::text] = help_prompt[0];
+  help_prompt_[am::strings::type] =
+      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+
   smart_objects::SmartObject so_prompt =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
+  so_prompt[0] = help_prompt_;
+
   EXPECT_CALL(*mock_app_, set_help_prompt(so_prompt));
 
   std::vector<std::string> time_out_prompt;
@@ -160,6 +173,15 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidVrHelp_UNSUCCESS) {
   so_time_out_prompt[0] = timeout_prompt;
 
   EXPECT_CALL(*mock_app_, set_timeout_prompt(so_time_out_prompt));
+
+  std::string vr_help_title("vr_help_title");
+  EXPECT_CALL(app_mngr_settings_, vr_help_title())
+      .WillOnce(ReturnRef(vr_help_title));
+
+  smart_objects::SmartObject so_vr_help_title =
+      smart_objects::SmartObject(smart_objects::SmartType_String);
+  so_vr_help_title[am::strings::vr_help_title] = vr_help_title;
+  EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
 
   EXPECT_CALL(*mock_app_, reset_vr_help_title());
   EXPECT_CALL(*mock_app_, reset_vr_help());
@@ -190,8 +212,21 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_SUCCESS) {
       mobile_apis::GlobalProperty::KEYBOARDPROPERTIES;
 
   EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
+
+  std::vector<std::string> help_prompt = {"help_prompt"};
+
+  EXPECT_CALL(app_mngr_settings_, help_prompt())
+      .WillOnce(ReturnRef(help_prompt));
+
+  smart_objects::SmartObject help_prompt_ =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  help_prompt_[am::strings::text] = help_prompt[0];
+  help_prompt_[am::strings::type] =
+      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+
   smart_objects::SmartObject so_prompt =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
+  so_prompt[0] = help_prompt_;
   EXPECT_CALL(*mock_app_, set_help_prompt(so_prompt));
 
   std::vector<std::string> time_out_prompt;
@@ -211,6 +246,15 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_SUCCESS) {
   so_time_out_prompt[0] = timeout_prompt;
 
   EXPECT_CALL(*mock_app_, set_timeout_prompt(so_time_out_prompt));
+
+  std::string vr_help_title("vr_help_title");
+  EXPECT_CALL(app_mngr_settings_, vr_help_title())
+      .WillOnce(ReturnRef(vr_help_title));
+
+  smart_objects::SmartObject so_vr_help_title =
+      smart_objects::SmartObject(smart_objects::SmartType_String);
+  so_vr_help_title[am::strings::vr_help_title] = vr_help_title;
+  EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
 
   EXPECT_CALL(*mock_app_, reset_vr_help_title());
   EXPECT_CALL(*mock_app_, reset_vr_help());
@@ -266,6 +310,15 @@ TEST_F(ResetGlobalPropertiesRequestTest,
 
   (*msg_)[am::strings::msg_params][am::strings::properties][0] =
       mobile_apis::GlobalProperty::VRHELPTITLE;
+
+  std::string vr_help_title("vr_help_title");
+  EXPECT_CALL(app_mngr_settings_, vr_help_title())
+      .WillOnce(ReturnRef(vr_help_title));
+
+  smart_objects::SmartObject so_vr_help_title =
+      smart_objects::SmartObject(smart_objects::SmartType_String);
+  so_vr_help_title[am::strings::vr_help_title] = vr_help_title;
+  EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
 
   EXPECT_CALL(*mock_app_, reset_vr_help_title());
   EXPECT_CALL(*mock_app_, reset_vr_help());
@@ -362,6 +415,15 @@ TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_InvalidApp_NoHashUpdate) {
 
   (*msg_)[am::strings::msg_params][am::strings::properties][0] =
       mobile_apis::GlobalProperty::VRHELPTITLE;
+
+  std::string vr_help_title("vr_help_title");
+  EXPECT_CALL(app_mngr_settings_, vr_help_title())
+      .WillOnce(ReturnRef(vr_help_title));
+
+  smart_objects::SmartObject so_vr_help_title =
+      smart_objects::SmartObject(smart_objects::SmartType_String);
+  so_vr_help_title[am::strings::vr_help_title] = vr_help_title;
+  EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
 
   EXPECT_CALL(*mock_app_, reset_vr_help_title());
   EXPECT_CALL(*mock_app_, reset_vr_help());

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1316,9 +1316,20 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateAppVrHelp(
     return NULL;
   }
   smart_objects::SmartObject& vr_help = *result;
-  vr_help[strings::vr_help_title] = app->name();
+  const smart_objects::SmartObject* vr_help_title = app->vr_help_title();
+  if (vr_help_title &&
+      vr_help_title->keyExists(strings::vr_help_title)) {
+    vr_help[strings::vr_help_title] =
+        (*vr_help_title)[strings::vr_help_title].asString();
+  }
 
   int32_t index = 0;
+
+  smart_objects::SmartObject so_vr_help(smart_objects::SmartType_Map);
+  so_vr_help[strings::position] = index + 1;
+  so_vr_help[strings::text] = app->name();
+  vr_help[strings::vr_help][index++] = so_vr_help;
+
   if (app->vr_synonyms()) {
     smart_objects::SmartObject item(smart_objects::SmartType_Map);
     item[strings::text] = (*(app->vr_synonyms())).getElement(0);

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1317,10 +1317,8 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateAppVrHelp(
   }
   smart_objects::SmartObject& vr_help = *result;
   const smart_objects::SmartObject* vr_help_title = app->vr_help_title();
-  if (vr_help_title &&
-      vr_help_title->keyExists(strings::vr_help_title)) {
-    vr_help[strings::vr_help_title] =
-        (*vr_help_title)[strings::vr_help_title].asString();
+  if (vr_help_title) {
+    vr_help[strings::vr_help_title] = vr_help_title->asString();
   }
 
   int32_t index = 0;

--- a/src/components/include/application_manager/application_manager_settings.h
+++ b/src/components/include/application_manager/application_manager_settings.h
@@ -72,7 +72,9 @@ class ApplicationManagerSettings : public RequestControlerSettings,
   virtual const std::string& tts_delimiter() const = 0;
   virtual const uint32_t& put_file_in_none() const = 0;
   virtual const std::string& sdl_version() const = 0;
+  virtual const std::string& vr_help_title() const = 0;
   virtual const std::vector<std::string>& time_out_promt() const = 0;
+  virtual const std::vector<std::string>& help_prompt() const = 0;
   virtual const std::string& hmi_capabilities_file_name() const = 0;
   virtual const std::string& video_server_type() const = 0;
   virtual const std::string& audio_server_type() const = 0;

--- a/src/components/include/test/application_manager/mock_application_manager_settings.h
+++ b/src/components/include/test/application_manager/mock_application_manager_settings.h
@@ -78,6 +78,8 @@ class MockApplicationManagerSettings
   MOCK_CONST_METHOD0(tts_delimiter, const std::string&());
   MOCK_CONST_METHOD0(put_file_in_none, const uint32_t&());
   MOCK_CONST_METHOD0(sdl_version, const std::string&());
+  MOCK_CONST_METHOD0(vr_help_title, const std::string&());
+  MOCK_CONST_METHOD0(help_prompt, const std::vector<std::string>&());
   MOCK_CONST_METHOD0(time_out_promt, const std::vector<std::string>&());
   MOCK_CONST_METHOD0(hmi_capabilities_file_name, const std::string&());
   MOCK_CONST_METHOD0(video_server_type, const std::string&());


### PR DESCRIPTION
REUPLOAD #2337 (branch deleted)

Fixes #1306

Fix bug `ResetGlobalProperties` does't reset `HELPPROMPT`
and `VRHELPITEMS` to default values

Fix UT's after bugfixing

 - Fix `ResetGlobalPropertiesRequestTest`
 - Add mock function into `MockApplicationManagerSettings`

Github issue 

Co-authored-by: v-malko4 <vmalkov@luxoft.com>

UPDATES SINCE #2337

- Change `vr_help_title` smart object type to string instead of map
- Rename unit test variable `SmartObject help_prompt_` to `so_help_prompt` as a variable `help_prompt` already exists and having two so similar is confusing.