### PR TITLE
SDL does not create icons folder in case it was removed (#2649)

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_app_icon_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_app_icon_request.cc
@@ -60,6 +60,14 @@ SetAppIconRequest::SetAppIconRequest(
     , is_icons_saving_enabled_(false) {
   const std::string path =
       application_manager_.get_settings().app_icons_folder();
+
+  if (!file_system::DirectoryExists(path)) {
+    LOG4CXX_WARN(logger_, "App icons folder doesn't exist.");
+    if (!file_system::CreateDirectoryRecursively(path)) {
+      LOG4CXX_ERROR(logger_, "Unable to create app icons directory: " << path);
+    }
+  }
+
   is_icons_saving_enabled_ = file_system::IsWritingAllowed(path) &&
                              file_system::IsReadingAllowed(path);
 }


### PR DESCRIPTION
REUPLOAD #2649 (branch deleted)

Fixes #1003

The check for existence directory of app icons folder
has been added to SetAppIconRequest.

Co-authored-by: ValeriiMalkov <vmalkov@luxoft.com>

If app icons folder does not exist, core will attempt to create it.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
