### PR TITLE
Save app icons to icon folder even if it is empty

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_app_icon_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_app_icon_request.cc
@@ -170,11 +170,6 @@ void SetAppIconRequest::CopyToIconStorage(
   const uint64_t storage_size =
       static_cast<uint64_t>(file_system::DirectorySize(icon_storage));
 
-  if (0 == storage_size) {
-    LOG4CXX_ERROR(logger_, "Can't get the folder size: " << icon_storage);
-    return;
-  }
-
   if (storage_max_size < (file_size + storage_size)) {
     const uint32_t icons_amount =
         application_manager_.get_settings().app_icons_amount_to_remove();


### PR DESCRIPTION
Fixes #3360

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

This PR does introduce risk in the sense that if the `DirectorySize` function fails to read the size of the directory a save will be attempted. I looked into rewriting `DirectorySize` to return a bool and use an out parameter, but found that every use of this function treats a zero return as empty, so I adopted that behavior here.

### Testing Plan
Manually

### Summary
If `DirectorySize` returns zero, continue to save the app icon to the app icons folder.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
