### PR TITLE
Fix/Add Startup PTU trigger check

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -324,7 +324,7 @@ class PolicyHandler : public PolicyHandlerInterface,
 
   void OnSystemRequestReceived() const OVERRIDE;
 
-  void TriggerPTUIfRequired() OVERRIDE;
+  void TriggerPTUOnStartupIfRequired() OVERRIDE;
 
   /**
    * @brief Get appropriate message parameters and send them with response

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -324,6 +324,8 @@ class PolicyHandler : public PolicyHandlerInterface,
 
   void OnSystemRequestReceived() const OVERRIDE;
 
+  void TriggerPTUIfRequired() OVERRIDE;
+
   /**
    * @brief Get appropriate message parameters and send them with response
    * to HMI

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -899,7 +899,7 @@ void ApplicationManagerImpl::OnHMIStartedCooperation() {
 
   RefreshCloudAppInformation();
 
-  policy_handler_->TriggerPTUIfRequired();
+  policy_handler_->TriggerPTUOnStartupIfRequired();
 }
 
 std::string ApplicationManagerImpl::PolicyIDByIconUrl(const std::string url) {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -898,6 +898,8 @@ void ApplicationManagerImpl::OnHMIStartedCooperation() {
   resume_controller().ResetLaunchTime();
 
   RefreshCloudAppInformation();
+
+  policy_handler_->TriggerPTUIfRequired();
 }
 
 std::string ApplicationManagerImpl::PolicyIDByIconUrl(const std::string url) {

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -787,9 +787,9 @@ void PolicyHandler::OnSystemRequestReceived() const {
   policy_manager_->ResetTimeout();
 }
 
-void PolicyHandler::TriggerPTUIfRequired() {
+void PolicyHandler::TriggerPTUOnStartupIfRequired() {
 #ifndef EXTERNAL_PROPRIETARY_MODE
-  policy_manager_->TriggerPTUIfRequired();
+  policy_manager_->TriggerPTUOnStartupIfRequired();
 #endif
 }
 

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -787,6 +787,12 @@ void PolicyHandler::OnSystemRequestReceived() const {
   policy_manager_->ResetTimeout();
 }
 
+void PolicyHandler::TriggerPTUIfRequired() {
+#ifndef EXTERNAL_PROPRIETARY_MODE
+  policy_manager_->TriggerPTUIfRequired();
+#endif
+}
+
 void PolicyHandler::GetRegisteredLinks(
     std::map<std::string, std::string>& out_links) const {
   DataAccessor<ApplicationSet> accessor = application_manager_.applications();

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -769,9 +769,13 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
   virtual void OnSystemRequestReceived() const = 0;
 
   /**
-   * @brief
+   * @brief Triggers a PolicyTableUpdate on startup (only if an update is
+   * required)
+   *
+   * Currently, this function is only implemented for regular policies
+   * since the device consent is not enabled by default for external policies.
    */
-  virtual void TriggerPTUIfRequired() = 0;
+  virtual void TriggerPTUOnStartupIfRequired() = 0;
 
  private:
 /**

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -768,6 +768,11 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
    */
   virtual void OnSystemRequestReceived() const = 0;
 
+  /**
+   * @brief
+   */
+  virtual void TriggerPTUIfRequired() = 0;
+
  private:
 /**
  * @brief Processes data received via OnAppPermissionChanged notification

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -804,7 +804,7 @@ class PolicyManager : public usage_statistics::StatisticsManager,
   /**
    * @brief Trigger a PTU once on startup if it is required
    */
-  virtual void TriggerPTUIfRequired() = 0;
+  virtual void TriggerPTUOnStartupIfRequired() = 0;
 
  protected:
   /**

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -801,6 +801,11 @@ class PolicyManager : public usage_statistics::StatisticsManager,
    */
   virtual void ResetTimeout() = 0;
 
+  /**
+   * @brief Trigger a PTU once on startup if it is required
+   */
+  virtual void TriggerPTUIfRequired() = 0;
+
  protected:
   /**
    * @brief Checks is PT exceeded IgnitionCycles

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -217,7 +217,7 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_CONST_METHOD1(SendOnAppPropertiesChangeNotification,
                      void(const std::string& policy_app_id));
   MOCK_METHOD0(OnPTExchangeNeeded, void());
-  MOCK_METHOD0(TriggerPTUIfRequired, void());
+  MOCK_METHOD0(TriggerPTUOnStartupIfRequired, void());
   MOCK_METHOD1(GetAvailableApps, void(std::queue<std::string>& apps));
   MOCK_METHOD3(
       AddApplication,

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -217,6 +217,7 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_CONST_METHOD1(SendOnAppPropertiesChangeNotification,
                      void(const std::string& policy_app_id));
   MOCK_METHOD0(OnPTExchangeNeeded, void());
+  MOCK_METHOD0(TriggerPTUIfRequired, void());
   MOCK_METHOD1(GetAvailableApps, void(std::queue<std::string>& apps));
   MOCK_METHOD3(
       AddApplication,

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -262,6 +262,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(ExceededIgnitionCycles, bool());
   MOCK_METHOD0(ExceededDays, bool());
   MOCK_METHOD0(StartPTExchange, void());
+  MOCK_METHOD0(TriggerPTUIfRequired, void());
 
   // --- Statistics Manager section
   MOCK_METHOD1(Increment, void(usage_statistics::GlobalCounterId type));

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -262,7 +262,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(ExceededIgnitionCycles, bool());
   MOCK_METHOD0(ExceededDays, bool());
   MOCK_METHOD0(StartPTExchange, void());
-  MOCK_METHOD0(TriggerPTUIfRequired, void());
+  MOCK_METHOD0(TriggerPTUOnStartupIfRequired, void());
 
   // --- Statistics Manager section
   MOCK_METHOD1(Increment, void(usage_statistics::GlobalCounterId type));

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -800,7 +800,7 @@ class PolicyManagerImpl : public PolicyManager {
   /**
    * @brief Trigger a PTU once on startup if it is required
    */
-  virtual void TriggerPTUIfRequired() OVERRIDE;
+  virtual void TriggerPTUOnStartupIfRequired() OVERRIDE;
 
 #ifdef BUILD_TESTS
   /**

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -797,6 +797,11 @@ class PolicyManagerImpl : public PolicyManager {
   AppIdURL RetrySequenceUrl(const struct RetrySequenceURL& rs,
                             const EndpointUrls& urls) const OVERRIDE;
 
+  /**
+   * @brief Trigger a PTU once on startup if it is required
+   */
+  virtual void TriggerPTUIfRequired() OVERRIDE;
+
 #ifdef BUILD_TESTS
   /**
    * @brief Getter for cache_manager instance

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -713,6 +713,11 @@ void PolicyManagerImpl::UpdatePTUReadyAppsCount(const uint32_t new_app_count) {
 void PolicyManagerImpl::OnAppRegisteredOnMobile(
     const std::string& device_id, const std::string& application_id) {
   if (application_id != last_registered_policy_app_id_) {
+    if (last_registered_policy_app_id_.empty()) {
+      LOG4CXX_DEBUG(logger_, "Stopping update after first app is registered");
+      // ResetRetrySequence(ResetRetryCountType::kResetInternally);
+      StopRetrySequence();
+    }
     StartPTExchange();
     last_registered_policy_app_id_ = application_id;
   }

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1872,7 +1872,7 @@ bool PolicyManagerImpl::FunctionGroupNeedEncryption(
              : false;
 }
 
-void PolicyManagerImpl::TriggerPTUIfRequired() {
+void PolicyManagerImpl::TriggerPTUOnStartupIfRequired() {
   LOG4CXX_AUTO_TRACE(logger_);
   if (ignition_check) {
     StartPTExchange();

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1867,6 +1867,13 @@ bool PolicyManagerImpl::FunctionGroupNeedEncryption(
              : false;
 }
 
+void PolicyManagerImpl::TriggerPTUIfRequired() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (ignition_check) {
+    StartPTExchange();
+  }
+}
+
 const std::string PolicyManagerImpl::GetPolicyFunctionName(
     const uint32_t function_id) const {
   return policy_table::EnumToJsonString(


### PR DESCRIPTION
Fixes #3279 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF Test and manual tests

### Summary
Currently, the IgnitionCycles and Days PTU triggers are not checked in the regular policy mode when SDL starts.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
