### PR TITLE
RAI reply DUPLICATE_NAME when app has same id and name as existing app

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -140,7 +140,7 @@ class RegisterAppInterfaceRequest
    *
    * return TRUE if ID is known already, otherwise - FALSE
    */
-  bool IsApplicationWithSameAppIdRegistered();
+  bool IsApplicationWithSameAppIdOrAppNameRegistered();
 
   /**
    * @brief Check new application parameters (name, tts, vr) for

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
@@ -530,6 +530,10 @@ TEST_F(RegisterAppInterfaceRequestTest,
   const std::string request_hash_id = "abc123";
   (*msg_)[am::strings::msg_params][am::strings::hash_id] = request_hash_id;
 
+  ON_CALL(app_mngr_, applications())
+      .WillByDefault(
+          Return(DataAccessor<am::ApplicationSet>(app_set_, lock_ptr_)));
+
   MockAppPtr mock_app = CreateBasicMockedApp();
   app_set_.insert(mock_app);
   EXPECT_CALL(app_mngr_, reregister_application_by_policy_id(kAppId1))
@@ -543,7 +547,7 @@ TEST_F(RegisterAppInterfaceRequestTest,
   ON_CALL(mock_session_observer_, GetDataOnDeviceID(device_id, _, _, _, _))
       .WillByDefault(DoAll(SetArgPointee<3>(kMacAddress1), Return(0)));
 
-  EXPECT_CALL(*mock_app, device()).WillOnce(Return(kDeviceHandle));
+  ON_CALL(*mock_app, device()).WillByDefault(Return(kDeviceHandle));
 
   EXPECT_CALL(app_mngr_, ProcessReconnection(_, kConnectionKey));
 
@@ -576,6 +580,10 @@ TEST_F(RegisterAppInterfaceRequestTest,
 
   const std::string request_hash_id = "abc123";
   (*msg_)[am::strings::msg_params][am::strings::hash_id] = request_hash_id;
+
+  ON_CALL(app_mngr_, applications())
+      .WillByDefault(
+          Return(DataAccessor<am::ApplicationSet>(app_set_, lock_ptr_)));
 
   connection_handler::DeviceHandle device_id = 1;
   ON_CALL(mock_connection_handler_,
@@ -620,6 +628,10 @@ TEST_F(RegisterAppInterfaceRequestTest,
        SwitchApplication_NoHash_ExpectCleanupResumeFailed) {
   InitBasicMessage();
 
+  ON_CALL(app_mngr_, applications())
+      .WillByDefault(
+          Return(DataAccessor<am::ApplicationSet>(app_set_, lock_ptr_)));
+
   connection_handler::DeviceHandle device_id = 1;
   ON_CALL(mock_connection_handler_,
           GetDataOnSessionKey(kConnectionKey, _, _, _))
@@ -650,6 +662,50 @@ TEST_F(RegisterAppInterfaceRequestTest,
                                            mobile_apis::Result::RESUME_FAILED);
 
   ASSERT_TRUE(command_->Init());
+  command_->Run();
+}
+
+TEST_F(RegisterAppInterfaceRequestTest,
+       Run_Other_App_With_Same_App_Name_DUPLICATE_NAME) {
+  InitBasicMessage();
+  
+  app_set_.insert(CreateBasicMockedApp());
+
+  const uint32_t kConnection_key_ = 2u;
+  const std::string kApp_Id = "other_app_id";
+  (*msg_)[am::strings::params][am::strings::connection_key] = kConnection_key_;
+  (*msg_)[am::strings::msg_params][am::strings::app_id] = kApp_Id;
+
+  ON_CALL(app_mngr_, applications())
+      .WillByDefault(
+          Return(DataAccessor<am::ApplicationSet>(app_set_, lock_ptr_)));
+
+  EXPECT_CALL(mock_rpc_service_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_apis::Result::DUPLICATE_NAME), _));
+
+  command_->Run();
+}
+
+TEST_F(RegisterAppInterfaceRequestTest,
+       Run_Other_App_With_Same_App_ID_DUPLICATE_NAME) {
+  InitBasicMessage();
+  
+  app_set_.insert(CreateBasicMockedApp());
+
+  const uint32_t kConnection_key_ = 2u;
+  const std::string kApp_Name = "other_app_name";
+  (*msg_)[am::strings::params][am::strings::connection_key] = kConnection_key_;
+  (*msg_)[am::strings::msg_params][am::strings::app_name] = kApp_Name;
+
+  ON_CALL(app_mngr_, applications())
+      .WillByDefault(
+          Return(DataAccessor<am::ApplicationSet>(app_set_, lock_ptr_)));
+
+  EXPECT_CALL(mock_rpc_service_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_apis::Result::DUPLICATE_NAME), _));
+
   command_->Run();
 }
 


### PR DESCRIPTION
REUPLOAD #2402 (branch deleted)

Fixes #1398 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR provided bugfix when the `SDL` doesn't send `DUPLICATE_NAME` response when the second app sends `RegisterAppInterface` request to `SDL` with the same `appID` and same 'appName` as in the first.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)

### Tasks Remaining

- [ ] Check style