### PR TITLE
Fix/gufm check syntax

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_impl.h
@@ -155,6 +155,14 @@ class CommandImpl : public Command {
   static uint32_t CalcCommandInternalConsecutiveNumber(
       application_manager::ApplicationConstSharedPtr app);
 
+  /**
+   * @brief Check syntax of string from mobile
+   * @param str - string that need to be checked
+   * @param allow_empty_string if true methods allow empty sting
+   * @return true if success otherwise return false
+   */
+  bool CheckSyntax(const std::string& str, bool allow_empty_line = false) const;
+
   // members
   static const int32_t hmi_protocol_type_;
   static const int32_t mobile_protocol_type_;

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -166,14 +166,6 @@ class CommandRequestImpl : public CommandImpl,
       const smart_objects::SmartObject* response_params = NULL,
       const std::vector<uint8_t> binary_data = std::vector<uint8_t>());
 
-  /**
-   * @brief Check syntax of string from mobile
-   * @param str - string that need to be checked
-   * @param allow_empty_string if true methods allow empty sting
-   * @return true if success otherwise return false
-   */
-  bool CheckSyntax(const std::string& str, bool allow_empty_line = false);
-
   void SendProviderRequest(
       const mobile_apis::FunctionID::eType& mobile_function_id,
       const hmi_apis::FunctionID::eType& hmi_function_id,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_get_user_friendly_message_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_get_user_friendly_message_request.cc
@@ -75,7 +75,7 @@ void SDLGetUserFriendlyMessageRequest::Run() {
       SendErrorResponse(correlation_id(),
                         static_cast<hmi_apis::FunctionID::eType>(function_id()),
                         hmi_apis::Common_Result::INVALID_DATA,
-                        "");
+                        "invalid messageCode syntax");
       return;
     }
     msg_codes.push_back(str);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_get_user_friendly_message_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_get_user_friendly_message_request.cc
@@ -69,7 +69,16 @@ void SDLGetUserFriendlyMessageRequest::Run() {
   smart_objects::SmartArray::const_iterator it = msg->begin();
   smart_objects::SmartArray::const_iterator it_end = msg->end();
   for (; it != it_end; ++it) {
-    msg_codes.push_back((*it).asString());
+    std::string str = (*it).asString();
+    if (!CheckSyntax(str)) {
+      LOG4CXX_WARN(logger_, "Invalid data");
+      SendErrorResponse(correlation_id(),
+                        static_cast<hmi_apis::FunctionID::eType>(function_id()),
+                        hmi_apis::Common_Result::INVALID_DATA,
+                        "");
+      return;
+    }
+    msg_codes.push_back(str);
   }
 
   std::string required_language;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_get_user_friendly_message_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_get_user_friendly_message_request_test.cc
@@ -110,6 +110,7 @@ TEST_F(SDLGetUserFriendlyMessageRequestTest, Run_LanguageSet_SUCCESS) {
   EXPECT_CALL(mock_policy_handler_,
               OnGetUserFriendlyMessage(msg_codes, kLanguageEn, kCorrelationID));
 
+  command->Init();
   command->Run();
 }
 
@@ -136,6 +137,7 @@ TEST_F(SDLGetUserFriendlyMessageRequestTest, Run_LanguageNotSet_SUCCESS) {
   EXPECT_CALL(mock_policy_handler_,
               OnGetUserFriendlyMessage(msg_codes, kLanguageEn, kCorrelationID));
 
+  command->Init();
   command->Run();
 }
 
@@ -150,6 +152,39 @@ TEST_F(SDLGetUserFriendlyMessageRequestTest, Run_NoMsgCodes_Canceled) {
   EXPECT_CALL(mock_message_helper_, CommonLanguageToString(_)).Times(0);
   EXPECT_CALL(mock_policy_handler_, OnGetUserFriendlyMessage(_, _, _)).Times(0);
 
+  command->Init();
+  command->Run();
+}
+
+MATCHER_P(HMIRequestResultCodeIs, result_code, "") {
+  return result_code ==
+         static_cast<hmi_apis::Common_Result::eType>(
+             (*arg)[strings::params][am::hmi_response::code].asInt());
+}
+
+TEST_F(
+    SDLGetUserFriendlyMessageRequestTest,
+    RUN_InvalidRequestInvalidSymbolsStringMandatoryParam_SendInvalidDataErrorResponse) {
+  const std::string kInvalidSyntaxString = "\n\t ";
+  MessageSharedPtr msg = CreateMessage();
+  (*msg)[strings::params][strings::correlation_id] = kCorrelationID;
+  (*msg)[strings::msg_params][strings::app_id] = kAppID;
+
+  (*msg)[strings::msg_params][kMessageCodes] =
+      SmartObject(smart_objects::SmartType_Array);
+  (*msg)[strings::msg_params][kMessageCodes][0] =
+      SmartObject(kInvalidSyntaxString);
+  (*msg)[strings::msg_params][kMessageCodes][1] = SmartObject(kLanguageEn);
+
+  (*msg)[strings::msg_params][strings::language] = kLanguage;
+
+  std::shared_ptr<SDLGetUserFriendlyMessageRequest> command(
+      CreateCommand<SDLGetUserFriendlyMessageRequest>(msg));
+
+  EXPECT_CALL(mock_message_helper_, CommonLanguageToString(_)).Times(0);
+  EXPECT_CALL(mock_policy_handler_, OnGetUserFriendlyMessage(_, _, _)).Times(0);
+
+  command->Init();
   command->Run();
 }
 

--- a/src/components/application_manager/src/commands/command_impl.cc
+++ b/src/components/application_manager/src/commands/command_impl.cc
@@ -330,5 +330,24 @@ uint32_t CommandImpl::CalcCommandInternalConsecutiveNumber(
   return last_command_number + 1;
 }
 
+bool CommandImpl::CheckSyntax(const std::string& str,
+                              bool allow_empty_line) const {
+  if (std::string::npos != str.find_first_of("\t\n")) {
+    LOG4CXX_ERROR(logger_, "CheckSyntax failed! :" << str);
+    return false;
+  }
+  if (std::string::npos != str.find("\\n") ||
+      std::string::npos != str.find("\\t")) {
+    LOG4CXX_ERROR(logger_, "CheckSyntax failed! :" << str);
+    return false;
+  }
+  if (!allow_empty_line) {
+    if ((std::string::npos == str.find_first_not_of(' '))) {
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace commands
 }  // namespace application_manager

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -325,25 +325,6 @@ void CommandRequestImpl::SendResponse(
   rpc_service_.ManageMobileCommand(result, SOURCE_SDL);
 }
 
-bool CommandRequestImpl::CheckSyntax(const std::string& str,
-                                     bool allow_empty_line) {
-  if (std::string::npos != str.find_first_of("\t\n")) {
-    LOG4CXX_ERROR(logger_, "CheckSyntax failed! :" << str);
-    return false;
-  }
-  if (std::string::npos != str.find("\\n") ||
-      std::string::npos != str.find("\\t")) {
-    LOG4CXX_ERROR(logger_, "CheckSyntax failed! :" << str);
-    return false;
-  }
-  if (!allow_empty_line) {
-    if ((std::string::npos == str.find_first_not_of(' '))) {
-      return false;
-    }
-  }
-  return true;
-}
-
 smart_objects::SmartObject CreateUnsupportedResourceResponse(
     const hmi_apis::FunctionID::eType function_id,
     const uint32_t hmi_correlation_id,


### PR DESCRIPTION
REUPLOAD #2390 (rebase latest develop)

Fixes [#1862](https://github.com/smartdevicelink/sdl_core/issues/1862) 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Provide ATF tests

### Summary
According to the issues when HMI sends request with String param with invalid characters we need to log corresponding error internally and respond with 'INVALID_DATA' to HMI.
The following RPCs do not have string params:

- SDL.ActivateApp
- SDL.GetListOfPermissions
- SDL.UpdateSDL
- SDL.GetStatusUpdate
- SDL.GetURLs

we do not have any changes for them

For RPC SDL.GetUserFriendlyMessage was added desired behaviour

OpenSDL do not consist SDL.GetDeviceConnectionStatus  RPC, so this pull request add this RPC and expected behaviour for it when HMI sends request with String param with invalid characters.

UPDATES SINCE #2390

- Add info describing the result to the error message

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)