### PR TITLE
unsubscripe app from waypoints when it is unregistered

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -271,6 +271,14 @@ class ApplicationManagerImpl
 
   /**
    * @brief Checks if Application is subscribed for way points
+   * @param Application id
+   * @return true if Application is subscribed for way points
+   * otherwise false
+   */
+  bool IsAppIdSubscribedForWayPoints(uint32_t app_id) const OVERRIDE;
+
+  /**
+   * @brief Checks if Application is subscribed for way points
    * @param Application pointer
    * @return true if Application is subscribed for way points
    * otherwise false
@@ -282,6 +290,12 @@ class ApplicationManagerImpl
    * @param Application pointer
    */
   void SubscribeAppForWayPoints(ApplicationSharedPtr app) OVERRIDE;
+
+  /**
+   * @brief Unsubscribe Application for way points
+   * @param Application id
+   */
+  void UnsubscribeAppIdFromWayPoints(uint32_t app_id) OVERRIDE;
 
   /**
    * @brief Unsubscribe Application for way points

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -275,7 +275,7 @@ class ApplicationManagerImpl
    * @return true if Application is subscribed for way points
    * otherwise false
    */
-  bool IsAppIdSubscribedForWayPoints(uint32_t app_id) const OVERRIDE;
+  bool IsAppSubscribedForWayPoints(uint32_t app_id) const OVERRIDE;
 
   /**
    * @brief Checks if Application is subscribed for way points
@@ -287,6 +287,12 @@ class ApplicationManagerImpl
 
   /**
    * @brief Subscribe Application for way points
+   * @param Application id
+   */
+  void SubscribeAppForWayPoints(uint32_t app_id) OVERRIDE;
+
+  /**
+   * @brief Subscribe Application for way points
    * @param Application pointer
    */
   void SubscribeAppForWayPoints(ApplicationSharedPtr app) OVERRIDE;
@@ -295,7 +301,7 @@ class ApplicationManagerImpl
    * @brief Unsubscribe Application for way points
    * @param Application id
    */
-  void UnsubscribeAppIdFromWayPoints(uint32_t app_id) OVERRIDE;
+  void UnsubscribeAppFromWayPoints(uint32_t app_id) OVERRIDE;
 
   /**
    * @brief Unsubscribe Application for way points

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -4647,8 +4647,7 @@ bool ApplicationManagerImpl::IsAppSubscribedForWayPoints(
   return IsAppSubscribedForWayPoints(app->app_id());
 }
 
-void ApplicationManagerImpl::SubscribeAppForWayPoints(
-    uint32_t app_id) {
+void ApplicationManagerImpl::SubscribeAppForWayPoints(uint32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(subscribed_way_points_apps_lock_);
   LOG4CXX_DEBUG(logger_, "Subscribing " << app_id);
@@ -4663,8 +4662,7 @@ void ApplicationManagerImpl::SubscribeAppForWayPoints(
   SubscribeAppForWayPoints(app->app_id());
 }
 
-void ApplicationManagerImpl::UnsubscribeAppFromWayPoints(
-    uint32_t app_id) {
+void ApplicationManagerImpl::UnsubscribeAppFromWayPoints(uint32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(subscribed_way_points_apps_lock_);
   LOG4CXX_DEBUG(logger_, "Unsubscribing " << app_id);

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -344,6 +344,14 @@ class ApplicationManager {
 
   /**
    * @brief Checks if Application is subscribed for way points
+   * @param Application id
+   * @return true if Application is subscribed for way points
+   * otherwise false
+   */
+  virtual bool IsAppIdSubscribedForWayPoints(uint32_t app_id) const = 0;
+
+  /**
+   * @brief Checks if Application is subscribed for way points
    * @param Application pointer
    * @return true if Application is subscribed for way points
    * otherwise false
@@ -355,6 +363,12 @@ class ApplicationManager {
    * @param Application pointer
    */
   virtual void SubscribeAppForWayPoints(ApplicationSharedPtr app) = 0;
+
+  /**
+   * @brief Unsubscribe Application for way points
+   * @param Application id
+   */
+  virtual void UnsubscribeAppIdFromWayPoints(uint32_t app_id) = 0;
 
   /**
    * @brief Unsubscribe Application for way points

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -348,7 +348,7 @@ class ApplicationManager {
    * @return true if Application is subscribed for way points
    * otherwise false
    */
-  virtual bool IsAppIdSubscribedForWayPoints(uint32_t app_id) const = 0;
+  virtual bool IsAppSubscribedForWayPoints(uint32_t app_id) const = 0;
 
   /**
    * @brief Checks if Application is subscribed for way points
@@ -360,6 +360,12 @@ class ApplicationManager {
 
   /**
    * @brief Subscribe Application for way points
+   * @param Application id
+   */
+  virtual void SubscribeAppForWayPoints(uint32_t id) = 0;
+
+  /**
+   * @brief Subscribe Application for way points
    * @param Application pointer
    */
   virtual void SubscribeAppForWayPoints(ApplicationSharedPtr app) = 0;
@@ -368,7 +374,7 @@ class ApplicationManager {
    * @brief Unsubscribe Application for way points
    * @param Application id
    */
-  virtual void UnsubscribeAppIdFromWayPoints(uint32_t app_id) = 0;
+  virtual void UnsubscribeAppFromWayPoints(uint32_t app_id) = 0;
 
   /**
    * @brief Unsubscribe Application for way points

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -338,16 +338,13 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD2(IsSOStructValid,
                bool(const hmi_apis::StructIdentifiers::eType struct_id,
                     const smart_objects::SmartObject& display_capabilities));
-  MOCK_CONST_METHOD1(IsAppSubscribedForWayPoints,
-                     bool(uint32_t));
+  MOCK_CONST_METHOD1(IsAppSubscribedForWayPoints, bool(uint32_t));
   MOCK_CONST_METHOD1(IsAppSubscribedForWayPoints,
                      bool(application_manager::ApplicationSharedPtr));
-  MOCK_METHOD1(SubscribeAppForWayPoints,
-               void(uint32_t));
+  MOCK_METHOD1(SubscribeAppForWayPoints, void(uint32_t));
   MOCK_METHOD1(SubscribeAppForWayPoints,
                void(application_manager::ApplicationSharedPtr));
-  MOCK_METHOD1(UnsubscribeAppFromWayPoints,
-               void(uint32_t));
+  MOCK_METHOD1(UnsubscribeAppFromWayPoints, void(uint32_t));
   MOCK_METHOD1(UnsubscribeAppFromWayPoints,
                void(application_manager::ApplicationSharedPtr));
   MOCK_CONST_METHOD0(IsAnyAppSubscribedForWayPoints, bool());

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -338,10 +338,14 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD2(IsSOStructValid,
                bool(const hmi_apis::StructIdentifiers::eType struct_id,
                     const smart_objects::SmartObject& display_capabilities));
+  MOCK_CONST_METHOD1(IsAppIdSubscribedForWayPoints,
+                     bool(uint32_t));
   MOCK_CONST_METHOD1(IsAppSubscribedForWayPoints,
                      bool(application_manager::ApplicationSharedPtr));
   MOCK_METHOD1(SubscribeAppForWayPoints,
                void(application_manager::ApplicationSharedPtr));
+  MOCK_METHOD1(UnsubscribeAppIdFromWayPoints,
+               void(uint32_t));
   MOCK_METHOD1(UnsubscribeAppFromWayPoints,
                void(application_manager::ApplicationSharedPtr));
   MOCK_CONST_METHOD0(IsAnyAppSubscribedForWayPoints, bool());

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -338,13 +338,15 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD2(IsSOStructValid,
                bool(const hmi_apis::StructIdentifiers::eType struct_id,
                     const smart_objects::SmartObject& display_capabilities));
-  MOCK_CONST_METHOD1(IsAppIdSubscribedForWayPoints,
+  MOCK_CONST_METHOD1(IsAppSubscribedForWayPoints,
                      bool(uint32_t));
   MOCK_CONST_METHOD1(IsAppSubscribedForWayPoints,
                      bool(application_manager::ApplicationSharedPtr));
   MOCK_METHOD1(SubscribeAppForWayPoints,
+               void(uint32_t));
+  MOCK_METHOD1(SubscribeAppForWayPoints,
                void(application_manager::ApplicationSharedPtr));
-  MOCK_METHOD1(UnsubscribeAppIdFromWayPoints,
+  MOCK_METHOD1(UnsubscribeAppFromWayPoints,
                void(uint32_t));
   MOCK_METHOD1(UnsubscribeAppFromWayPoints,
                void(application_manager::ApplicationSharedPtr));


### PR DESCRIPTION
Fixes #2461
Fixes #3372 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
[ATF tests to be created](https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2408)

### Summary
if `IsAppIdSubscribedForWayPoints` then `UnsubscribeAppIdFromWayPoints` and also if `1 == subscribed_for_way_points_app_count` then `MessageHelper::SendUnsubscribedWayPoints`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
