### PR TITLE
Forward OnButtonPressNotifications where HMI specifies appID to apps in LIMITED HMI Level

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_press_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_press_notification.cc
@@ -67,6 +67,10 @@ void OnButtonPressNotification::Run() {
   const bool is_app_id_exists =
       (*message_)[strings::msg_params].keyExists(strings::app_id);
   ApplicationSharedPtr app;
+  if (is_app_id_exists) {
+    app = application_manager_.application(
+        (*message_)[strings::msg_params][strings::app_id].asUInt());
+  }
 
   // CUSTOM_BUTTON notification
   if (static_cast<uint32_t>(mobile_apis::ButtonName::CUSTOM_BUTTON) == btn_id) {
@@ -75,9 +79,6 @@ void OnButtonPressNotification::Run() {
       LOG4CXX_ERROR(logger_, "CUSTOM_BUTTON OnButtonPress without app_id.");
       return;
     }
-
-    app = application_manager_.application(
-        (*message_)[strings::msg_params][strings::app_id].asUInt());
 
     // custom_button_id is mandatory for CUSTOM_BUTTON notification
     if (false == (*message_)[strings::msg_params].keyExists(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_button_notification_commands_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_button_notification_commands_test.cc
@@ -351,6 +351,7 @@ TYPED_TEST(OnButtonNotificationCommandsTest, Run_SUCCESS) {
       .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
 
   ON_CALL(*mock_app, IsFullscreen()).WillByDefault(Return(true));
+  ON_CALL(this->app_mngr_, application(kAppId)).WillByDefault(Return(mock_app));
 
   EXPECT_CALL(this->app_mngr_, applications_by_button(kButtonName))
       .WillOnce(Return(subscribed_apps_list));


### PR DESCRIPTION
Fixes #2116

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manual testing

### Summary
Initialize app in `OnButtonPressNotification::Run`

##### Bug Fixes
* If in an OnButtonPressNotification the HMI specifies an appID corresponding to an app in HMI Level Limited, Core will now forward that notification to the app.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
