### PR TITLE
Fix deadlock in timer.cc

### DIFF
--- a/src/components/utils/src/timer.cc
+++ b/src/components/utils/src/timer.cc
@@ -222,6 +222,5 @@ void timer::Timer::TimerDelegate::threadMain() {
 }
 
 void timer::Timer::TimerDelegate::exitThreadMain() {
-  sync_primitives::AutoLock auto_lock(state_lock_ref_);
   state_condition_.NotifyOne();
 }


### PR DESCRIPTION

Fixes #3190

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Regression testing should be performed

### Summary

Fix deadlock in timer.cc call lock two times for Lock,
second lock was removed, cause using of it hadn't any benefits.
Regarding of Helgrind report.

### Tasks Remaining:
- [ ] Luxoft Intenal review 
- [ ] Regression testing

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
