### PR TITLE
Make refactoring in mb_controller.cc

### DIFF
--- a/src/components/hmi_message_handler/include/hmi_message_handler/mb_controller.h
+++ b/src/components/hmi_message_handler/include/hmi_message_handler/mb_controller.h
@@ -149,6 +149,8 @@ class CMessageBrokerController
   int getNextControllerId();
 
  private:
+  void CloseConnection();
+
   boost::asio::io_context ioc_;
   const std::string& address_;
   uint16_t port_;


### PR DESCRIPTION
Fixes #3185

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Automated regression will be performed
### Summary

Fix race condition regarding Helgrind issue.
Error 9 : Possible race condition in case of using assignment operator
with atomic variable 'shutdown_', fix via using 'atomic_exchange'.
Error 10: Incorrect sequence of closing boost asio objects.
Add member function into CMessageBrokerController for correct close sequence.

### Tasks Remaining:
- [ ] Luxoft internal review
- [ ] Automated regression

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
