### PR TITLE
Fix potential deadlock in PolicyHandler

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1308,18 +1308,22 @@ void PolicyHandler::OnAllowSDLFunctionalityNotification(
 
 #ifdef EXTERNAL_PROPRIETARY_MODE
 
-      DataAccessor<ApplicationSet> accessor =
-          application_manager_.applications();
+      ApplicationSet applications;
+      {
+        DataAccessor<ApplicationSet> accessor =
+            application_manager_.applications();
+        applications = accessor.GetData();
+      }
       if (!is_allowed) {
         std::for_each(
-            accessor.GetData().begin(),
-            accessor.GetData().end(),
+            applications.begin(),
+            applications.end(),
             DeactivateApplication(device_handle,
                                   application_manager_.state_controller()));
       } else {
         std::for_each(
-            accessor.GetData().begin(),
-            accessor.GetData().end(),
+            applications.begin(),
+            applications.end(),
             SDLAlowedNotification(device_handle,
                                   policy_manager_.get(),
                                   application_manager_.state_controller()));


### PR DESCRIPTION

Fixes #3176

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Script for reproducing in open sdl will be created. 

### Summary

There was a vulnerability in the PolicyHandler which causes a mutex deadlock.
For example - MessageLoop thread of RpcService handles incoming messages. In
case when SDL receives AllowSDLFunctionality notification, this thread calls
OnAllowSDLFunctionalityNotification inside PolicyHandler. At some point of time
this function captures accessor from AM which holds applications_list_lock_
there. At this moment thread AM Pool 0 of RequestController processes some RPC
from queue and captures policy_manager_lock_ in PolicyHandler. After that at
some moment thread AM Pool 0 tries to get application shared pointer from AM
and locks itself as this mutex are already locked with thread MessageLoop.
Also, MessageLoop thread at some moment tries to acquire policy_manager_lock_
and locks itself as this mutex are already locked with thread AM Pool 0, which
is waiting for applications_list_lock_ to unlock. As a result we have a
classical thread deadlock after which SDL stuck forewer.

To avoid such situations, there was analyzed all bottlenecks related to
applications_list_lock_ and its accessors. Accessors were scoped in several
places to avoid similar deadlocks in future.


### Tasks Remaining:
- [ ] Create script to reproduce
- [ ] Luxoft internal review 
- [ ] Regression testing


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
