### PR TITLE
Filter unknown enums when removing unknown parameters

### DIFF
--- a/src/components/smart_objects/include/smart_objects/array_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/array_schema_item.h
@@ -113,6 +113,8 @@ class CArraySchemaItem : public ISchemaItem {
   void BuildObjectBySchema(const SmartObject& pattern_object,
                            SmartObject& result_object) OVERRIDE;
 
+  TypeID GetType() OVERRIDE;
+
  private:
   /**
    * @brief Constructor.
@@ -124,6 +126,16 @@ class CArraySchemaItem : public ISchemaItem {
   CArraySchemaItem(const ISchemaItemPtr ElementSchemaItem,
                    const TSchemaItemParameter<size_t>& MinSize,
                    const TSchemaItemParameter<size_t>& MaxSize);
+
+  /**
+   * @brief Removes unknown parameters from array.
+   * @param Object Array to remove unknown parameters.
+   * @param MessageVersion The version to check against for which parameters are
+   *                       unknown.
+   **/
+  void RemoveUnknownParams(SmartObject& Object,
+                           const utils::SemanticVersion& MessageVersion);
+
   /**
    * @brief SchemaItem for array elements.
    **/

--- a/src/components/smart_objects/include/smart_objects/bool_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/bool_schema_item.h
@@ -51,6 +51,8 @@ class CBoolSchemaItem : public CDefaultSchemaItem<bool> {
       const TSchemaItemParameter<bool>& DefaultValue =
           TSchemaItemParameter<bool>());
 
+  TypeID GetType() OVERRIDE;
+
  private:
   explicit CBoolSchemaItem(const TSchemaItemParameter<bool>& DefaultValue);
   SmartType getSmartType() const OVERRIDE;

--- a/src/components/smart_objects/include/smart_objects/enum_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/enum_schema_item.h
@@ -166,6 +166,7 @@ class TEnumSchemaItem : public CDefaultSchemaItem<EnumType> {
                       ElementSignatures);
   SmartType getSmartType() const OVERRIDE;
   EnumType getDefaultValue() const OVERRIDE;
+  TypeID GetType() OVERRIDE;
   /**
    * @brief Set of allowed enumeration elements.
    **/
@@ -410,6 +411,11 @@ SmartType TEnumSchemaItem<EnumType>::getSmartType() const {
 template <typename EnumType>
 EnumType TEnumSchemaItem<EnumType>::getDefaultValue() const {
   return EnumType::INVALID_ENUM;
+}
+
+template <typename EnumType>
+TypeID TEnumSchemaItem<EnumType>::GetType() {
+  return TYPE_ENUM;
 }
 
 template <typename EnumType>

--- a/src/components/smart_objects/include/smart_objects/number_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/number_schema_item.h
@@ -82,6 +82,8 @@ class TNumberSchemaItem : public CDefaultSchemaItem<NumberType> {
       const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
       const bool allow_unknown_enums = false) OVERRIDE;
 
+  TypeID GetType() OVERRIDE;
+
  private:
   /**
    * @brief Get smart type for this NumberType.
@@ -189,6 +191,11 @@ errors::eType TNumberSchemaItem<NumberType>::validate(
     return errors::OUT_OF_RANGE;
   }
   return errors::OK;
+}
+
+template <typename NumberType>
+TypeID TNumberSchemaItem<NumberType>::GetType() {
+  return TYPE_NUMBER;
 }
 
 template <typename NumberType>

--- a/src/components/smart_objects/include/smart_objects/object_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/object_schema_item.h
@@ -127,8 +127,8 @@ class CObjectSchemaItem : public ISchemaItem {
    * @brief Apply schema.
    * @param Object Object to apply schema.
    * @param remove_unknown_parameters contains true if need to remove unknown
-   *parameters
-   * from smart object otherwise contains false.
+   *                                  parameters from smart object otherwise
+   *                                  contains false.
    **/
   void applySchema(SmartObject& Object,
                    const bool remove_unknown_parameters,
@@ -138,7 +138,7 @@ class CObjectSchemaItem : public ISchemaItem {
    * @brief Unapply schema.
    * @param Object Object to unapply schema.
    * @param remove_unknown_parameters contains true if need to remove unknown
-   *parameters
+   *                                  parameters
    **/
   void unapplySchema(SmartObject& Object,
                      const bool remove_unknown_parameters) OVERRIDE;
@@ -156,6 +156,8 @@ class CObjectSchemaItem : public ISchemaItem {
    */
   size_t GetMemberSize() OVERRIDE;
 
+  TypeID GetType() OVERRIDE;
+
   boost::optional<SMember&> GetMemberSchemaItem(
       const std::string& member_key) OVERRIDE;
 
@@ -171,25 +173,27 @@ class CObjectSchemaItem : public ISchemaItem {
   CObjectSchemaItem(const Members& Members);
 
   /**
-   * @brief Removes fake parameters from object.
-   * @param Object Object to remove fake parameters.
+   * @brief Removes unknown parameters from object.
+   * @param Object Object to remove unknown parameters.
+   * @param MessageVersion The version to check against for which parameters are
+   *                       unknown.
    **/
-  void RemoveFakeParams(SmartObject& Object,
-                        const utils::SemanticVersion& MessageVersion);
+  void RemoveUnknownParams(SmartObject& Object,
+                           const utils::SemanticVersion& MessageVersion);
 
   /**
    * @brief Returns the correct schema item based on message version.
    * @param member Schema member
    * @param MessageVersion Semantic Version of mobile message.
    * @return Pointer to correct schema item if item found or nullptr, if item
-   *was not found.
+   *         was not found.
    **/
   const SMember* GetCorrectMember(const SMember& member,
                                   const utils::SemanticVersion& messageVersion);
 
   /**
    * @brief Map of member name to SMember structure describing the object
-   *member.
+   *        member.
    **/
   Members mMembers;
   DISALLOW_COPY_AND_ASSIGN(CObjectSchemaItem);

--- a/src/components/smart_objects/include/smart_objects/schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/schema_item.h
@@ -49,6 +49,16 @@ namespace ns_smart_objects {
 class SmartObject;
 class SMember;
 
+enum TypeID {
+  TYPE_NONE,
+  TYPE_OBJECT,
+  TYPE_ARRAY,
+  TYPE_STRING,
+  TYPE_NUMBER,
+  TYPE_ENUM,
+  TYPE_BOOLEAN
+};
+
 /**
  * @brief Base schema item.
  **/
@@ -142,6 +152,13 @@ class ISchemaItem {
    * @return value of any parameter
    */
   virtual size_t GetMemberSize();
+
+  /**
+   * @brief Get type ID of schema
+   *
+   * @return The type ID of this schema
+   */
+  virtual TypeID GetType();
 
   virtual ~ISchemaItem() {}
 };

--- a/src/components/smart_objects/include/smart_objects/string_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/string_schema_item.h
@@ -77,6 +77,8 @@ class CStringSchemaItem : public CDefaultSchemaItem<std::string> {
       const utils::SemanticVersion& MessageVersion = utils::SemanticVersion(),
       const bool allow_unknown_enums = false) OVERRIDE;
 
+  TypeID GetType() OVERRIDE;
+
  private:
   /**
    * @brief Constructor.

--- a/src/components/smart_objects/src/bool_schema_item.cc
+++ b/src/components/smart_objects/src/bool_schema_item.cc
@@ -51,5 +51,9 @@ bool CBoolSchemaItem::getDefaultValue() const {
   return false;
 }
 
+TypeID CBoolSchemaItem::GetType() {
+  return TYPE_BOOLEAN;
+}
+
 }  // namespace ns_smart_objects
 }  // namespace ns_smart_device_link

--- a/src/components/smart_objects/src/schema_item.cc
+++ b/src/components/smart_objects/src/schema_item.cc
@@ -65,5 +65,9 @@ size_t ISchemaItem::GetMemberSize() {
   return 0;
 }
 
+TypeID ISchemaItem::GetType() {
+  return TYPE_NONE;
+}
+
 }  // namespace ns_smart_objects
 }  // namespace ns_smart_device_link

--- a/src/components/smart_objects/src/string_schema_item.cc
+++ b/src/components/smart_objects/src/string_schema_item.cc
@@ -90,6 +90,10 @@ std::string CStringSchemaItem::getDefaultValue() const {
   return std::string("");
 }
 
+TypeID CStringSchemaItem::GetType() {
+  return TYPE_STRING;
+}
+
 CStringSchemaItem::CStringSchemaItem(
     const TSchemaItemParameter<size_t>& MinLength,
     const TSchemaItemParameter<size_t>& MaxLength,


### PR DESCRIPTION

Fixes #2857
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Follow issue reproduction steps in #2857 

### Summary
Change schema logic to filter out unknown enum values when removing unknown parameter

### Changelog
##### Bug Fixes
* Fixes issue where RAI was rejected if it contained new enums before version negotiation was completed.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
