### PR TITLE
fix memory error in TcpDevice::IsSameAs

### DIFF
--- a/src/components/transport_manager/src/tcp/tcp_device.cc
+++ b/src/components/transport_manager/src/tcp/tcp_device.cc
@@ -66,9 +66,9 @@ TcpDevice::TcpDevice(const in_addr_t& in_addr,
 bool TcpDevice::IsSameAs(const Device* other) const {
   LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_DEBUG(logger_, "Device: " << other);
-  const TcpDevice* other_tcp_device = static_cast<const TcpDevice*>(other);
+  const TcpDevice* other_tcp_device = dynamic_cast<const TcpDevice*>(other);
 
-  if (other_tcp_device->in_addr_ == in_addr_) {
+  if (other_tcp_device && other_tcp_device->in_addr_ == in_addr_) {
     LOG4CXX_TRACE(
         logger_,
         "exit with TRUE. Condition: other_tcp_device->in_addr_ == in_addr_");


### PR DESCRIPTION
REUPLOAD #2263 (rebased on latest develop and removed outdated usb_handler changes)

Fixes https://github.com/smartdevicelink/sdl_core/issues/2262

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Repeat the procedure described in https://github.com/smartdevicelink/sdl_core/issues/2262 several times and confirm that valgrind doesn't detect said memory accesses.

### Summary
This PR addresses two invalid memory access issues found during `transport_manager_test`.

### Changelog
##### Breaking Changes
* None

##### Enhancements
* None

##### Bug Fixes
* fix: invalid memory access in libusb when stopping UsbHandler
* fix: invalid memory access in TcpDeviceTest.CompareWithOtherNotTCPDevice

### Tasks Remaining:
- None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)