### PR TITLE
thread delegate must be destroyed before thread

### DIFF
--- a/src/components/telemetry_monitor/src/telemetry_monitor.cc
+++ b/src/components/telemetry_monitor/src/telemetry_monitor.cc
@@ -107,6 +107,9 @@ void TelemetryMonitor::Stop() {
   if (thread_) {
     thread_->stop();
     thread_->join();
+    if (thread_->delegate()) {
+      streamer_.reset();
+    }
     threads::DeleteThread(thread_);
   }
   thread_ = NULL;

--- a/src/components/utils/src/timer.cc
+++ b/src/components/utils/src/timer.cc
@@ -65,8 +65,8 @@ timer::Timer::~Timer() {
   StopDelegate();
   single_shot_ = true;
 
-  DeleteThread(thread_);
   delegate_.reset();
+  DeleteThread(thread_);
   DCHECK(task_);
   delete task_;
   LOG4CXX_DEBUG(logger_, "Timer " << name_ << " has been destroyed");


### PR DESCRIPTION
Fixes #3387

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
manually as described in issue

### Summary
The thread delegate destructor writes on its `thread_` pointer, so we must ensure that thread delegates are destroyed before threads.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
