### PR TITLE
SDLCORE-925 Fixed Crash related to HandleOnEvent

### DIFF
--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -449,6 +449,10 @@ void RequestController::TimeoutThread() {
 
     probably_expired->request()->onTimeOut();
     if (RequestInfo::HmiConnectionKey == probably_expired->app_id()) {
+      const uint32_t function_id = probably_expired->request()->function_id();
+      event_dispatcher_.remove_observer(
+          static_cast<hmi_apis::FunctionID::eType>(function_id),
+          expired_request_id);
       LOG4CXX_DEBUG(logger_,
                     "Erase HMI request: " << probably_expired->requestId());
       waiting_for_response_.RemoveRequest(probably_expired);


### PR DESCRIPTION

Fixes #3410

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Regression check

### Summary

Added remove_observer() before calling RemoveRequest() to ensure that command object from observer is removed first and the shared pointer probably_expired
doesnt delete the object when HandleOnEvent() is in progress.


### Tasks Remaining:
- [ ] Luxoft Internal Review
- [ ] Regression testing

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
