### PR TITLE
trigger ptu on startup only in proprietary policy mode

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -790,7 +790,7 @@ void PolicyHandler::OnSystemRequestReceived() const {
 }
 
 void PolicyHandler::TriggerPTUOnStartupIfRequired() {
-#ifndef EXTERNAL_PROPRIETARY_MODE
+#ifdef PROPRIETARY_MODE
   policy_manager_->TriggerPTUOnStartupIfRequired();
 #endif
 }


### PR DESCRIPTION
Fixes #3396

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF

### Summary
only "triggerPTUonStartup" in proprietary mode

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
