### PR TITLE
Add workaround to handle problem with WebsocketSessionTest

### DIFF
--- a/src/components/hmi_message_handler/test/hmi_message_handler_impl_test.cc
+++ b/src/components/hmi_message_handler/test/hmi_message_handler_impl_test.cc
@@ -191,7 +191,14 @@ TEST_F(HMIMessageHandlerImplTest, SendMessageToHMI_Success) {
 }
 
 TEST(WebsocketSessionTest, SendMessage_UnpreparedConnection_WithoutFall) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  // Value "threadsafe" is preferable for this case, but as workaround for
+  // possible bug in gcc compiler value "fast" was set. Because of this warning
+  // message is appeared.
+
+  // ToDo: set value "threadsafe", if current version of gcc can handle
+  // this value correctly without causing of core dump.
+
+  ::testing::FLAGS_gtest_death_test_style = "fast";
 
   auto send_message = []() {
     auto message =


### PR DESCRIPTION
Fixes #3399 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Corresponding unit test is updated.

### Summary
Observed core dump is caused by possible incorrect behavior gcc compiler during execution of death test, where child process is created. gcov doesn't support multithreading, and running death unit test with flag "threadsafe" interferes with internal functionality of gcov/gcc. Some versions of gcc can handle this situation (for example, 5.4), other cannot (for example, 7.4). As workaround for solving this problem value, assigned to FLAGS_gtest_death_test_style, was changed from "threadsafe" to "fast". This solution is not optimal, and warning message will appear during execution of corresponding unit test.
There is a need in further investigation of this situation in the future with newest versions gcc, and, if possible, revert flag value "threadsafe", if this change will not cause core dump.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
