### PR TITLE
clean up choice_set_map_ in DynamicApplicationDataImpl destructor

### DIFF
--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -278,6 +278,11 @@ DynamicApplicationDataImpl::~DynamicApplicationDataImpl() {
   }
   sub_menu_.clear();
 
+  for (auto command : choice_set_map_) {
+    delete command.second;
+  }
+  choice_set_map_.clear();
+
   PerformChoiceSetMap::iterator it = performinteraction_choice_set_map_.begin();
   for (; performinteraction_choice_set_map_.end() != it; ++it) {
     PerformChoice::iterator choice_it =


### PR DESCRIPTION
Fixes #2258

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manually, unit test, valgrind

### Summary
Clean up memory used in choice_set_map_ created by new in AddChoiceSet.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
