### PR TITLE
fix build error in http unit tests

### DIFF
--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -1859,7 +1859,9 @@ TEST_F(PolicyHandlerTest, DISABLED_OnSnapshotCreated_UrlAdded) {
       .WillOnce(ReturnRef(mock_session_observer));
   EXPECT_CALL(*mock_app_, device()).WillOnce(Return(0));
   EXPECT_CALL(app_manager_, applications()).WillOnce(Return(app_set));
-  EXPECT_CALL(mock_message_helper_, SendPolicySnapshotNotification(_, testing::A<const std::vector<uint8_t>&>(), _, _));
+  EXPECT_CALL(mock_message_helper_,
+              SendPolicySnapshotNotification(
+                  _, testing::A<const std::vector<uint8_t>&>(), _, _));
   // Check expectations for get app id
   GetAppIDForSending();
   // Expectations

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -1859,7 +1859,7 @@ TEST_F(PolicyHandlerTest, DISABLED_OnSnapshotCreated_UrlAdded) {
       .WillOnce(ReturnRef(mock_session_observer));
   EXPECT_CALL(*mock_app_, device()).WillOnce(Return(0));
   EXPECT_CALL(app_manager_, applications()).WillOnce(Return(app_set));
-  EXPECT_CALL(mock_message_helper_, SendPolicySnapshotNotification(_, _, _, _));
+  EXPECT_CALL(mock_message_helper_, SendPolicySnapshotNotification(_, testing::A<const std::vector<uint8_t>&>(), _, _));
   // Check expectations for get app id
   GetAppIDForSending();
   // Expectations


### PR DESCRIPTION
Fixes #3414

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
build core with `-DBUILD_TESTS=ON -DEXTENDED_POLICY=HTTP`

### Summary
fix compile error: ambiguous call

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
