### PR TITLE
Fix App gets REJECTED instead of UNSUPPORTED_RESOURCE to Cha…

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/change_registration_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/change_registration_request.cc
@@ -177,7 +177,7 @@ void ChangeRegistrationRequest::Run() {
                 IsLanguageSupportedByVR(language) &&
                 IsLanguageSupportedByTTS(language))) {
     LOG4CXX_ERROR(logger_, "Language is not supported");
-    SendResponse(false, mobile_apis::Result::REJECTED);
+    SendResponse(false, mobile_apis::Result::UNSUPPORTED_RESOURCE);
     return;
   }
 


### PR DESCRIPTION
Fixes #3119 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by manual testing

### Summary
When `ChangeRegistration` request with not supported language, SDL uses `UNSUPPORTED_RESOURCE` as `ChangeRegistration` response `result.class`.
![image](https://user-images.githubusercontent.com/35795928/84092378-1d025400-aa32-11ea-9898-6aa0d19d9b29.png)
use `UNSUPPORTED_RESOURCE` replace `REJECTED` as `ChangeRegistration` response Result in `ChangeRegistrationRequest` class when receiving `ChangeRegistration` request with not supported language.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
