### PR TITLE
fix SDL Crash seen in SDL upon receiving rpc - OnEmergencyEvent with "enabled:true"

### DIFF
--- a/src/components/application_manager/src/hmi_state.cc
+++ b/src/components/application_manager/src/hmi_state.cc
@@ -249,8 +249,8 @@ mobile_apis::HMILevel::eType AudioSource::hmi_level() const {
 
   // Checking for NONE  is necessary to avoid issue during
   // calculation of HMI level during setting default HMI level
-  if (keep_context_ || HMILevel::HMI_NONE == parent()->hmi_level()
-    || HMILevel::INVALID_ENUM == parent()->hmi_level()) {
+  if (keep_context_ || HMILevel::HMI_NONE == parent()->hmi_level() ||
+      HMILevel::INVALID_ENUM == parent()->hmi_level()) {
     return parent()->hmi_level();
   }
 

--- a/src/components/application_manager/src/hmi_state.cc
+++ b/src/components/application_manager/src/hmi_state.cc
@@ -190,6 +190,7 @@ mobile_apis::HMILevel::eType PhoneCallHmiState::hmi_level() const {
   }
 
   if (Compare<HMILevel::eType, EQ, ONE>(parent()->hmi_level(),
+                                        HMILevel::INVALID_ENUM,
                                         HMILevel::HMI_BACKGROUND,
                                         HMILevel::HMI_NONE)) {
     return parent()->hmi_level();
@@ -223,6 +224,7 @@ mobile_apis::HMILevel::eType DeactivateHMI::hmi_level() const {
   }
 
   if (Compare<HMILevel::eType, EQ, ONE>(parent()->hmi_level(),
+                                        HMILevel::INVALID_ENUM,
                                         HMILevel::HMI_BACKGROUND,
                                         HMILevel::HMI_NONE)) {
     return parent()->hmi_level();
@@ -247,7 +249,8 @@ mobile_apis::HMILevel::eType AudioSource::hmi_level() const {
 
   // Checking for NONE  is necessary to avoid issue during
   // calculation of HMI level during setting default HMI level
-  if (keep_context_ || HMILevel::HMI_NONE == parent()->hmi_level()) {
+  if (keep_context_ || HMILevel::HMI_NONE == parent()->hmi_level()
+    || HMILevel::INVALID_ENUM == parent()->hmi_level()) {
     return parent()->hmi_level();
   }
 
@@ -267,6 +270,7 @@ mobile_apis::HMILevel::eType EmbeddedNavi::hmi_level() const {
   }
 
   if (Compare<HMILevel::eType, EQ, ONE>(parent()->hmi_level(),
+                                        HMILevel::INVALID_ENUM,
                                         HMILevel::HMI_BACKGROUND,
                                         HMILevel::HMI_NONE)) {
     return parent()->hmi_level();

--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -863,6 +863,12 @@ void StateControllerImpl::OnStateChanged(ApplicationSharedPtr app,
   LOG4CXX_DEBUG(logger_,
                 "Window #" << window_id << " new state: " << *new_state);
 
+  if ((new_state->hmi_level() == mobile_apis::HMILevel::INVALID_ENUM) &&
+    (old_state->hmi_level() == mobile_apis::HMILevel::INVALID_ENUM)) {
+     LOG4CXX_ERROR(logger_, "HMI level is invalid data.");
+    return;
+  }
+
   if (!IsStateChanged(*old_state, *new_state)) {
     LOG4CXX_DEBUG(logger_, "State has NOT been changed.");
     return;

--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -864,8 +864,8 @@ void StateControllerImpl::OnStateChanged(ApplicationSharedPtr app,
                 "Window #" << window_id << " new state: " << *new_state);
 
   if ((new_state->hmi_level() == mobile_apis::HMILevel::INVALID_ENUM) &&
-    (old_state->hmi_level() == mobile_apis::HMILevel::INVALID_ENUM)) {
-     LOG4CXX_ERROR(logger_, "HMI level is invalid data.");
+      (old_state->hmi_level() == mobile_apis::HMILevel::INVALID_ENUM)) {
+    LOG4CXX_ERROR(logger_, "HMI level is invalid data.");
     return;
   }
 


### PR DESCRIPTION
Fixes #2808 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by manual testing

### Summary
SDLCore received `OnAppRegistered` RPC. There contain 2 steps:
1. `application_manager` add Application to the list of registered applications.
2. change Application `HMILevel` from `INVALID_ENUM` to the default value.
The issue occurs time is between step 1 and step 2, HMI send `OnEmergencyEvent(true)` RPC to SDLCore at this time, which cause Application new `HMILevel` change 
to `INVALID_ENUM`，then SDL crashes with `DCHECK` failure in `RecordHmiStateChanged` function because new `HMILevel` is `INVALID_ENUM`. 
![image](https://user-images.githubusercontent.com/35795928/84105140-6498d800-aa52-11ea-9533-c8bb3c5eb53c.png)
Code modification are as follows:				

- If some application‘s `HMILevel` value is `INVALID_ENUM`, SDLCore should not change `HMILevel` to any valid `HMILevel` in `hmi_state.cc`					

 (In order to avoid `HMILevel`  has incorrect change in some cases，for example, HMI sends a `OnEventChanged(DEACTIVATE_HMI)` event to SDLCore when the `HMILevel` is `INVALID_ENUM`, 						
which will cause `HMILevel` value change to `BACKGROUND`  from `INVALID_ENUM`, as result,  SDLCore will send `OnHmiStatus(BACKGROUND)` to mobileApp）						

- If some application‘s old `HMILevel` and new `HMILevel` are both `INVALID_ENUM`(Invalid value), SDLCore should not run `OnStateChanged` function to avoid `DCHECK` failure.					

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
