### PR TITLE
App freezes on HMI after transport disconnect

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -757,6 +757,13 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
   // Timer will be started after hmi level resumption.
   resume_controller().OnAppRegistrationStart(policy_app_id, device_mac);
 
+  if (!connection_handler_->IsAppConnected(connection_key)) {
+    LOG4CXX_DEBUG(logger_,
+                  "Application with connection_key " << connection_key
+                                                     << " is not connected");
+    return ApplicationSharedPtr();
+  }
+
   AddAppToRegisteredAppList(application);
 
   // Update cloud app information, in case any pending apps are unable to be
@@ -3275,6 +3282,12 @@ void ApplicationManagerImpl::UnregisterApplication(
       if (app_id == (*it_app)->app_id()) {
         app_to_remove = *it_app;
         applications_.erase(it_app++);
+        LOG4CXX_DEBUG(
+            logger_,
+            "App with app_id: " << app_id
+                                << " has been removed from registered "
+                                   "applications list. New list size: "
+                                << applications_.size());
         break;
       } else {
         ++it_app;
@@ -4555,7 +4568,9 @@ void ApplicationManagerImpl::AddAppToRegisteredAppList(
   LOG4CXX_DEBUG(
       logger_,
       "App with app_id: " << application->app_id()
-                          << " has been added to registered applications list");
+                          << " has been added to registered applications list. "
+                             "New list size: "
+                          << applications_.size());
   if (application_list_update_timer_.is_running() &&
       !registered_during_timer_execution_) {
     GetPolicyHandler().OnAddedNewApplicationToAppList(

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -610,6 +610,8 @@ class ConnectionHandlerImpl
 
   void CreateWebEngineDevice() OVERRIDE;
 
+  bool IsAppConnected(const uint32_t connection_key) const OVERRIDE;
+
  private:
   /**
    * \brief Disconnect application.

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -874,6 +874,18 @@ void ConnectionHandlerImpl::CreateWebEngineDevice() {
   transport_manager_.CreateWebEngineDevice();
 }
 
+bool ConnectionHandlerImpl::IsAppConnected(
+    const uint32_t connection_key) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  transport_manager::ConnectionUID connection_handle = 0;
+  uint8_t session_id = 0;
+  PairFromKey(connection_key, &connection_handle, &session_id);
+
+  sync_primitives::AutoReadLock lock(connection_list_lock_);
+  return (nullptr != GetPrimaryConnection(connection_handle));
+}
+
 const std::string
 ConnectionHandlerImpl::TransportTypeProfileStringFromConnHandle(
     transport_manager::ConnectionUID connection_handle) const {

--- a/src/components/include/connection_handler/connection_handler.h
+++ b/src/components/include/connection_handler/connection_handler.h
@@ -325,6 +325,13 @@ class ConnectionHandler {
    */
   virtual void CreateWebEngineDevice() = 0;
 
+  /**
+   * @brief Checks if such an application is connected.
+   * @param connection_key Application's connection key.
+   * @return True if the application is connected.
+   **/
+  virtual bool IsAppConnected(const uint32_t connection_key) const = 0;
+
  protected:
   /**
    * \brief Destructor

--- a/src/components/include/test/connection_handler/mock_connection_handler.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler.h
@@ -135,6 +135,7 @@ class MockConnectionHandler : public connection_handler::ConnectionHandler {
            const transport_manager::ConnectionUID secondary_connection_handle));
   MOCK_METHOD0(CreateWebEngineDevice, void());
   MOCK_CONST_METHOD0(GetWebEngineDeviceInfo, transport_manager::DeviceInfo&());
+  MOCK_CONST_METHOD1(IsAppConnected, bool(const uint32_t connection_key));
 };
 
 }  // namespace connection_handler_test


### PR DESCRIPTION
Fixed #3364

This PR is **[ready]** for review.

### Summary
PR fixed the problem when one appliacation (_from many registered_) freezes on HMI after transport reconect and SDL responds to RAI request for frozen app with `APPLICATION_REGISTERED_ALREADY`. 

The problem was that the registration of the application that eventually **already registered** started, but before the moment we added it to the `application list`, there was a disconnection of the USB, and the SDL did not remove it from `application list`, since before that it had not been added there. And during the next USB connection, a case may arise when we continue the previous (_not finished_) registration and finally add application to the `application list`. After that we will begin to register applications, but one of them is will be registered already.

To avoid this, to `application list` will be added only that application, which preset in some of existing connections.

#### Testing
Manual verification is passed 150/150.
Regression passed.
Added unit test.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
