### PR TITLE
Fix SIGSEGV Crash subscribed_data

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/on_vehicle_data_notification.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/on_vehicle_data_notification.cc
@@ -79,8 +79,7 @@ void OnVehicleDataNotification::Run() {
       auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
       // Fix for Invalid object usage
       if (nullptr == &ext) {
-        LOG4CXX_ERROR(
-              logger_, "ExtractVIExtension is nullptr ");
+        LOG4CXX_ERROR(logger_, "ExtractVIExtension is nullptr");
         return false;
       }
       return ext.isSubscribedToVehicleInfo(name);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/on_vehicle_data_notification.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/on_vehicle_data_notification.cc
@@ -77,6 +77,12 @@ void OnVehicleDataNotification::Run() {
     auto subscribed_to_ivi_predicate = [&name](const ApplicationSharedPtr app) {
       DCHECK_OR_RETURN(app, false);
       auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
+      // Fix for Invalid object usage
+      if (nullptr == &ext) {
+        LOG4CXX_ERROR(
+              logger_, "ExtractVIExtension is nullptr ");
+        return false;
+      }
       return ext.isSubscribedToVehicleInfo(name);
     };
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -221,6 +221,13 @@ bool SubscribeVehicleDataRequest::SubscribePendingVehicleData(
 
     if (is_subscription_successful) {
       auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
+      // Fix for Invalid object usage
+      if (nullptr == &ext) {
+        LOG4CXX_ERROR(
+              logger_, "ExtractVIExtension is nullptr ");
+        vi_name = vi_waiting_for_subscribe_.erase(vi_name);
+        continue;
+      }
       ext.subscribeToVehicleInfo(*vi_name);
       vi_name = vi_waiting_for_subscribe_.erase(vi_name);
     } else {
@@ -266,6 +273,10 @@ struct SubscribedToIVIPredicate {
   bool operator()(const ApplicationSharedPtr app) const {
     DCHECK_OR_RETURN(app, false);
     auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
+    // Fix for Invalid object usage
+    if (nullptr == &ext) {
+      return false;
+    }
     return ext.isSubscribedToVehicleInfo(vehicle_info_);
   }
 };
@@ -352,7 +363,12 @@ void SubscribeVehicleDataRequest::CheckVISubscriptions(
 
   auto rpc_spec_vehicle_data = MessageHelper::vehicle_data();
   auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
-
+  // Fix for Invalid object usage
+  if (nullptr == &ext) {
+    LOG4CXX_ERROR(
+              logger_, "ExtractVIExtension is nullptr ");
+    return;
+  }
   VehicleInfoSubscriptions::size_type items_to_subscribe = 0;
   auto item_names = (*message_)[strings::msg_params].enumerate();
   if (!is_interface_not_available) {

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -223,8 +223,7 @@ bool SubscribeVehicleDataRequest::SubscribePendingVehicleData(
       auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
       // Fix for Invalid object usage
       if (nullptr == &ext) {
-        LOG4CXX_ERROR(
-              logger_, "ExtractVIExtension is nullptr ");
+        LOG4CXX_ERROR(logger_, "ExtractVIExtension is nullptr");
         vi_name = vi_waiting_for_subscribe_.erase(vi_name);
         continue;
       }
@@ -365,8 +364,7 @@ void SubscribeVehicleDataRequest::CheckVISubscriptions(
   auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
   // Fix for Invalid object usage
   if (nullptr == &ext) {
-    LOG4CXX_ERROR(
-              logger_, "ExtractVIExtension is nullptr ");
+    LOG4CXX_ERROR(logger_, "ExtractVIExtension is nullptr");
     return;
   }
   VehicleInfoSubscriptions::size_type items_to_subscribe = 0;

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -104,8 +104,7 @@ void UnsubscribeVehicleDataRequest::Run() {
   auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
   // Fix for Invalid object usage
   if (nullptr == &ext) {
-    LOG4CXX_ERROR(
-          logger_, "ExtractVIExtension is nullptr ");
+    LOG4CXX_ERROR(logger_, "ExtractVIExtension is nullptr");
     return;
   }
   const auto& param_names = (*message_)[strings::msg_params].enumerate();
@@ -276,8 +275,7 @@ bool UnsubscribeVehicleDataRequest::IsSomeoneSubscribedFor(
     auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
     // Fix for Invalid object usage
     if (nullptr == &ext) {
-      LOG4CXX_ERROR(
-            logger_, "ExtractVIExtension is nullptr ");
+      LOG4CXX_ERROR(logger_, "ExtractVIExtension is nullptr");
       return false;
     }
     return (ext.isSubscribedToVehicleInfo(param_name));
@@ -336,8 +334,7 @@ bool UnsubscribeVehicleDataRequest::UnsubscribePendingVehicleData(
       auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
       // Fix for Invalid object usage
       if (nullptr == &ext) {
-        LOG4CXX_ERROR(
-              logger_, "ExtractVIExtension is nullptr ");
+        LOG4CXX_ERROR(logger_, "ExtractVIExtension is nullptr");
         vi_waiting_for_unsubscribe_.erase(vi_name);
         continue;
       }

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -102,7 +102,12 @@ void UnsubscribeVehicleDataRequest::Run() {
   };
 
   auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
-
+  // Fix for Invalid object usage
+  if (nullptr == &ext) {
+    LOG4CXX_ERROR(
+          logger_, "ExtractVIExtension is nullptr ");
+    return;
+  }
   const auto& param_names = (*message_)[strings::msg_params].enumerate();
   for (const auto& name : param_names) {
     const bool enabled = (*message_)[strings::msg_params][name].asBool();
@@ -269,6 +274,12 @@ bool UnsubscribeVehicleDataRequest::IsSomeoneSubscribedFor(
       return false;
     }
     auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
+    // Fix for Invalid object usage
+    if (nullptr == &ext) {
+      LOG4CXX_ERROR(
+            logger_, "ExtractVIExtension is nullptr ");
+      return false;
+    }
     return (ext.isSubscribedToVehicleInfo(param_name));
   };
 
@@ -323,6 +334,13 @@ bool UnsubscribeVehicleDataRequest::UnsubscribePendingVehicleData(
         CheckSubscriptionStatus(converted_item, msg_params);
     if (is_unsubscription_successful) {
       auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
+      // Fix for Invalid object usage
+      if (nullptr == &ext) {
+        LOG4CXX_ERROR(
+              logger_, "ExtractVIExtension is nullptr ");
+        vi_waiting_for_unsubscribe_.erase(vi_name);
+        continue;
+      }
       ext.unsubscribeFromVehicleInfo(vi_name);
       vi_waiting_for_unsubscribe_.erase(vi_name);
     }

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -127,8 +127,7 @@ void VehicleInfoPlugin::UnsubscribeFromRemovedVDItems() {
       auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
       // iauto fix Null pointer object determines protection
       if (nullptr == &ext) {
-        LOG4CXX_ERROR(
-              logger_, "ExtractVIExtension is nullptr ");
+        LOG4CXX_ERROR(logger_, "ExtractVIExtension is nullptr");
         continue;
       }
       auto subscription_names = ext.Subscriptions();
@@ -193,8 +192,7 @@ application_manager::ApplicationSharedPtr FindAppSubscribedToIVI(
     auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
     // iauto fix Null pointer object determines protection
     if (nullptr == &ext) {
-      LOG4CXX_ERROR(
-            logger_, "ExtractVIExtension is nullptr ");
+      LOG4CXX_ERROR(logger_, "ExtractVIExtension is nullptr");
       return application_manager::ApplicationSharedPtr();
     }
     if (ext.isSubscribedToVehicleInfo(ivi_name)) {
@@ -256,8 +254,7 @@ void VehicleInfoPlugin::DeleteSubscriptions(
   auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
   // iauto fix Null pointer object determines protection
   if (nullptr == &ext) {
-    LOG4CXX_ERROR(
-          logger_, "ExtractVIExtension is nullptr ");
+    LOG4CXX_ERROR(logger_, "ExtractVIExtension is nullptr");
     return;
   }
   auto subscriptions = ext.Subscriptions();

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -125,6 +125,12 @@ void VehicleInfoPlugin::UnsubscribeFromRemovedVDItems() {
     auto applications = application_manager_->applications();
     for (auto& app : applications.GetData()) {
       auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
+      // iauto fix Null pointer object determines protection
+      if (nullptr == &ext) {
+        LOG4CXX_ERROR(
+              logger_, "ExtractVIExtension is nullptr ");
+        continue;
+      }
       auto subscription_names = ext.Subscriptions();
       for (auto& subscription_name : subscription_names) {
         if (custom_vehicle_data_manager_->IsRemovedCustomVehicleDataName(
@@ -185,6 +191,12 @@ application_manager::ApplicationSharedPtr FindAppSubscribedToIVI(
 
   for (auto& app : applications.GetData()) {
     auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
+    // iauto fix Null pointer object determines protection
+    if (nullptr == &ext) {
+      LOG4CXX_ERROR(
+            logger_, "ExtractVIExtension is nullptr ");
+      return application_manager::ApplicationSharedPtr();
+    }
     if (ext.isSubscribedToVehicleInfo(ivi_name)) {
       return app;
     }
@@ -242,6 +254,12 @@ smart_objects::SmartObjectSPtr VehicleInfoPlugin::GetUnsubscribeIVIRequest(
 void VehicleInfoPlugin::DeleteSubscriptions(
     application_manager::ApplicationSharedPtr app) {
   auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
+  // iauto fix Null pointer object determines protection
+  if (nullptr == &ext) {
+    LOG4CXX_ERROR(
+          logger_, "ExtractVIExtension is nullptr ");
+    return;
+  }
   auto subscriptions = ext.Subscriptions();
   std::vector<std::string> ivi_to_unsubscribe;
   for (auto& ivi : subscriptions) {


### PR DESCRIPTION
Fixes #3172 #3162 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by manual testing

### Summary
There is a time interval between registering an application and adding `VehicleInfoAppExtension`,
and then registering a new App when you already subscribe to the Vehicle and have an information notification, because the App object for `QueryInterface()` already exists, but `VehicleInfoAppExtension` is not Added yet. So we add judgment protection for Invalid object usage. 
![image](https://user-images.githubusercontent.com/35795928/84209937-6619dd00-aaf2-11ea-9a0e-91f6a200f2d4.png)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
