### PR TITLE
Fix multi-thread access one pointer at same time caused a ld pointer problem in HMICapabilitiesImpl class

### DIFF
--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -40,6 +40,7 @@
 #include "json/json.h"
 #include "smart_objects/smart_object.h"
 #include "utils/macro.h"
+#include "utils/rwlock.h"
 
 namespace application_manager {
 class ApplicationManager;
@@ -140,7 +141,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return Currently supported UI languages
    */
-  const smart_objects::SmartObject* ui_supported_languages() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr ui_supported_languages() const OVERRIDE;
 
   /*
    * @brief Sets supported UI languages
@@ -170,7 +171,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return Currently supported VR languages
    */
-  const smart_objects::SmartObject* vr_supported_languages() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr vr_supported_languages() const OVERRIDE;
 
   /*
    * @brief Sets supported VR languages
@@ -200,7 +201,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return Currently supported TTS languages
    */
-  const smart_objects::SmartObject* tts_supported_languages() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr tts_supported_languages() const OVERRIDE;
 
   /*
    * @brief Sets supported TTS languages
@@ -465,7 +466,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return NAVIGATION system capability
    */
-  const smart_objects::SmartObject* navigation_capability() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr navigation_capability() const OVERRIDE;
 
   /*
    * @brief Interface used to store information regarding
@@ -483,7 +484,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
    * @return PHONE_CALL system capability
    */
 
-  const smart_objects::SmartObject* phone_capability() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr phone_capability() const OVERRIDE;
 
   /*
    * @brief Sets HMI's video streaming related capability information
@@ -498,17 +499,17 @@ class HMICapabilitiesImpl : public HMICapabilities {
    *
    * @return HMI's video streaming related capability information
    */
-  const smart_objects::SmartObject* video_streaming_capability() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr video_streaming_capability() const OVERRIDE;
 
   void set_rc_capability(
       const smart_objects::SmartObject& rc_capability) OVERRIDE;
 
-  const smart_objects::SmartObject* rc_capability() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr rc_capability() const OVERRIDE;
 
   void set_seat_location_capability(
       const smart_objects::SmartObject& seat_location_capability) OVERRIDE;
 
-  const smart_objects::SmartObject* seat_location_capability() const OVERRIDE;
+  const smart_objects::SmartObjectSPtr seat_location_capability() const OVERRIDE;
 
   void Init(resumption::LastStateWrapperPtr last_state_wrapper) OVERRIDE;
 
@@ -587,9 +588,9 @@ class HMICapabilitiesImpl : public HMICapabilities {
   hmi_apis::Common_Language::eType vr_language_;
   hmi_apis::Common_Language::eType tts_language_;
   smart_objects::SmartObjectSPtr vehicle_type_;
-  smart_objects::SmartObject* ui_supported_languages_;
-  smart_objects::SmartObject* tts_supported_languages_;
-  smart_objects::SmartObject* vr_supported_languages_;
+  smart_objects::SmartObjectSPtr ui_supported_languages_;
+  smart_objects::SmartObjectSPtr tts_supported_languages_;
+  smart_objects::SmartObjectSPtr vr_supported_languages_;
   /*
    * display_capabilities_ is deprecated and replaced by
    * system_display_capabilities_. For backward compatibility
@@ -611,14 +612,16 @@ class HMICapabilitiesImpl : public HMICapabilities {
   bool is_video_streaming_supported_;
   bool is_rc_supported_;
   std::string ccpu_version_;
-  smart_objects::SmartObject* navigation_capability_;
-  smart_objects::SmartObject* phone_capability_;
-  smart_objects::SmartObject* video_streaming_capability_;
-  smart_objects::SmartObject* rc_capability_;
-  smart_objects::SmartObject* seat_location_capability_;
+  smart_objects::SmartObjectSPtr navigation_capability_;
+  smart_objects::SmartObjectSPtr phone_capability_;
+  smart_objects::SmartObjectSPtr video_streaming_capability_;
+  smart_objects::SmartObjectSPtr rc_capability_;
+  smart_objects::SmartObjectSPtr seat_location_capability_;
 
   ApplicationManager& app_mngr_;
   HMILanguageHandler hmi_language_handler_;
+
+  mutable sync_primitives::RWLock hmi_capabilities_lock_;
 
   DISALLOW_COPY_AND_ASSIGN(HMICapabilitiesImpl);
 };

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -54,8 +54,7 @@ GetInteriorVehicleDataRequest::GetInteriorVehicleDataRequest(
 
 bool GetInteriorVehicleDataRequest::ProcessCapabilities() {
   LOG4CXX_AUTO_TRACE(logger_);
-  const smart_objects::SmartObject* rc_capabilities =
-      hmi_capabilities_.rc_capability();
+  auto rc_capabilities = hmi_capabilities_.rc_capability();
 
   const std::string module_type = ModuleType();
   const std::string module_id = ModuleId();

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/release_interior_vehicle_data_module_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/release_interior_vehicle_data_module_request.cc
@@ -91,8 +91,7 @@ ReleaseInteriorVehicleDataModuleRequest::
 
 bool ReleaseInteriorVehicleDataModuleRequest::ProcessCapabilities() {
   LOG4CXX_AUTO_TRACE(logger_);
-  const smart_objects::SmartObject* rc_capabilities =
-      hmi_capabilities_.rc_capability();
+  auto rc_capabilities = hmi_capabilities_.rc_capability();
 
   const std::string module_type = ModuleType();
   const std::string module_id = ModuleId();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/change_registration_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/change_registration_request.cc
@@ -460,8 +460,7 @@ bool ChangeRegistrationRequest::PrepareResponseParameters(
 bool ChangeRegistrationRequest::IsLanguageSupportedByUI(
     const int32_t& hmi_display_lang) {
   const HMICapabilities& hmi_capabilities = hmi_capabilities_;
-  const smart_objects::SmartObject* ui_languages =
-      hmi_capabilities.ui_supported_languages();
+  auto ui_languages = hmi_capabilities.ui_supported_languages();
 
   if (!ui_languages) {
     LOG4CXX_ERROR(logger_, "NULL pointer");
@@ -482,8 +481,7 @@ bool ChangeRegistrationRequest::IsLanguageSupportedByUI(
 bool ChangeRegistrationRequest::IsLanguageSupportedByVR(
     const int32_t& hmi_display_lang) {
   const HMICapabilities& hmi_capabilities = hmi_capabilities_;
-  const smart_objects::SmartObject* vr_languages =
-      hmi_capabilities.vr_supported_languages();
+  auto vr_languages = hmi_capabilities.vr_supported_languages();
 
   if (!vr_languages) {
     LOG4CXX_ERROR(logger_, "NULL pointer");
@@ -504,8 +502,7 @@ bool ChangeRegistrationRequest::IsLanguageSupportedByVR(
 bool ChangeRegistrationRequest::IsLanguageSupportedByTTS(
     const int32_t& hmi_display_lang) {
   const HMICapabilities& hmi_capabilities = hmi_capabilities_;
-  const smart_objects::SmartObject* tts_languages =
-      hmi_capabilities.tts_supported_languages();
+  auto tts_languages = hmi_capabilities.tts_supported_languages();
 
   if (!tts_languages) {
     LOG4CXX_ERROR(logger_, "NULL pointer");

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -464,16 +464,10 @@ HMICapabilitiesImpl::HMICapabilitiesImpl(ApplicationManager& app_mngr)
 }
 
 HMICapabilitiesImpl::~HMICapabilitiesImpl() {
-  delete ui_supported_languages_;
-  delete tts_supported_languages_;
-  delete vr_supported_languages_;
-  delete navigation_capability_;
-  delete phone_capability_;
-  delete video_streaming_capability_;
-  delete rc_capability_;
 }
 
 bool HMICapabilitiesImpl::VerifyImageType(const int32_t image_type) const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   auto capabilities = display_capabilities();
   if (!capabilities) {
     return false;
@@ -567,27 +561,26 @@ HMICapabilitiesImpl::active_tts_language() const {
 
 void HMICapabilitiesImpl::set_ui_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
-  if (ui_supported_languages_) {
-    delete ui_supported_languages_;
-  }
-  ui_supported_languages_ = new smart_objects::SmartObject(supported_languages);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(supported_languages);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
+  ui_supported_languages_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_tts_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
-  if (tts_supported_languages_) {
-    delete tts_supported_languages_;
-  }
-  tts_supported_languages_ =
-      new smart_objects::SmartObject(supported_languages);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(supported_languages);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
+  tts_supported_languages_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_vr_supported_languages(
     const smart_objects::SmartObject& supported_languages) {
-  if (vr_supported_languages_) {
-    delete vr_supported_languages_;
-  }
-  vr_supported_languages_ = new smart_objects::SmartObject(supported_languages);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(supported_languages);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
+  vr_supported_languages_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_display_capabilities(
@@ -597,12 +590,14 @@ void HMICapabilitiesImpl::set_display_capabilities(
           display_capabilities)) {
     smart_objects::SmartObjectSPtr new_value =
         std::make_shared<smart_objects::SmartObject>(display_capabilities);
+    sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
     display_capabilities_.swap(new_value);
   }
 }
 
 void HMICapabilitiesImpl::set_system_display_capabilities(
     const smart_objects::SmartObject& display_capabilities) {
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
   system_display_capabilities_.reset(
       new smart_objects::SmartObject(display_capabilities));
 }
@@ -611,6 +606,7 @@ void HMICapabilitiesImpl::set_hmi_zone_capabilities(
     const smart_objects::SmartObject& hmi_zone_capabilities) {
   smart_objects::SmartObjectSPtr new_value =
       std::make_shared<smart_objects::SmartObject>(hmi_zone_capabilities);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
   hmi_zone_capabilities_.swap(new_value);
 }
 
@@ -618,6 +614,7 @@ void HMICapabilitiesImpl::set_soft_button_capabilities(
     const smart_objects::SmartObject& soft_button_capabilities) {
   smart_objects::SmartObjectSPtr new_value =
       std::make_shared<smart_objects::SmartObject>(soft_button_capabilities);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
   soft_buttons_capabilities_.swap(new_value);
 }
 
@@ -625,6 +622,7 @@ void HMICapabilitiesImpl::set_button_capabilities(
     const smart_objects::SmartObject& button_capabilities) {
   smart_objects::SmartObjectSPtr new_value =
       std::make_shared<smart_objects::SmartObject>(button_capabilities);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
   button_capabilities_.swap(new_value);
 }
 
@@ -632,6 +630,7 @@ void HMICapabilitiesImpl::set_vr_capabilities(
     const smart_objects::SmartObject& vr_capabilities) {
   smart_objects::SmartObjectSPtr new_value =
       std::make_shared<smart_objects::SmartObject>(vr_capabilities);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
   vr_capabilities_.swap(new_value);
 }
 
@@ -639,6 +638,7 @@ void HMICapabilitiesImpl::set_speech_capabilities(
     const smart_objects::SmartObject& speech_capabilities) {
   smart_objects::SmartObjectSPtr new_value =
       std::make_shared<smart_objects::SmartObject>(speech_capabilities);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
   speech_capabilities_.swap(new_value);
 }
 
@@ -647,6 +647,7 @@ void HMICapabilitiesImpl::set_audio_pass_thru_capabilities(
   smart_objects::SmartObjectSPtr new_value =
       std::make_shared<smart_objects::SmartObject>(
           audio_pass_thru_capabilities);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
   audio_pass_thru_capabilities_.swap(new_value);
 }
 
@@ -654,6 +655,7 @@ void HMICapabilitiesImpl::set_pcm_stream_capabilities(
     const smart_objects::SmartObject& pcm_stream_capabilities) {
   smart_objects::SmartObjectSPtr new_value =
       std::make_shared<smart_objects::SmartObject>(pcm_stream_capabilities);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
   pcm_stream_capabilities_.swap(new_value);
 }
 
@@ -661,6 +663,7 @@ void HMICapabilitiesImpl::set_preset_bank_capabilities(
     const smart_objects::SmartObject& preset_bank_capabilities) {
   smart_objects::SmartObjectSPtr new_value =
       std::make_shared<smart_objects::SmartObject>(preset_bank_capabilities);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
   preset_bank_capabilities_.swap(new_value);
 }
 
@@ -668,6 +671,7 @@ void HMICapabilitiesImpl::set_vehicle_type(
     const smart_objects::SmartObject& vehicle_type) {
   smart_objects::SmartObjectSPtr new_value =
       std::make_shared<smart_objects::SmartObject>(vehicle_type);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
   vehicle_type_.swap(new_value);
 }
 
@@ -675,6 +679,7 @@ void HMICapabilitiesImpl::set_prerecorded_speech(
     const smart_objects::SmartObject& prerecorded_speech) {
   smart_objects::SmartObjectSPtr new_value =
       std::make_shared<smart_objects::SmartObject>(prerecorded_speech);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
   prerecorded_speech_.swap(new_value);
 }
 
@@ -695,45 +700,42 @@ void HMICapabilitiesImpl::set_rc_supported(const bool supported) {
 
 void HMICapabilitiesImpl::set_navigation_capability(
     const smart_objects::SmartObject& navigation_capability) {
-  if (navigation_capability_) {
-    delete navigation_capability_;
-  }
-  navigation_capability_ =
-      new smart_objects::SmartObject(navigation_capability);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(navigation_capability);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
+  navigation_capability_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_phone_capability(
     const smart_objects::SmartObject& phone_capability) {
-  if (phone_capability_) {
-    delete phone_capability_;
-  }
-  phone_capability_ = new smart_objects::SmartObject(phone_capability);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(phone_capability);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
+  phone_capability_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_video_streaming_capability(
     const smart_objects::SmartObject& video_streaming_capability) {
-  if (video_streaming_capability_) {
-    delete video_streaming_capability_;
-  }
-  video_streaming_capability_ =
-      new smart_objects::SmartObject(video_streaming_capability);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(video_streaming_capability);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
+  video_streaming_capability_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_rc_capability(
     const smart_objects::SmartObject& rc_capability) {
-  if (rc_capability_) {
-    delete rc_capability_;
-  }
-  rc_capability_ = new smart_objects::SmartObject(rc_capability);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(rc_capability);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
+  rc_capability_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::set_seat_location_capability(
     const smart_objects::SmartObject& seat_location_capability) {
-  if (seat_location_capability_) {
-    delete seat_location_capability_;
-  }
-  seat_location_capability_ =
-      new smart_objects::SmartObject(seat_location_capability);
+  smart_objects::SmartObjectSPtr new_value =
+      std::make_shared<smart_objects::SmartObject>(seat_location_capability);
+  sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
+  seat_location_capability_.swap(new_value);
 }
 
 void HMICapabilitiesImpl::Init(
@@ -774,81 +776,97 @@ bool HMICapabilitiesImpl::is_rc_cooperating() const {
   return is_rc_cooperating_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::ui_supported_languages()
-    const {
+const smart_objects::SmartObjectSPtr
+HMICapabilitiesImpl::ui_supported_languages() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return ui_supported_languages_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::vr_supported_languages()
-    const {
+const smart_objects::SmartObjectSPtr
+HMICapabilitiesImpl::vr_supported_languages() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return vr_supported_languages_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::tts_supported_languages()
-    const {
+const smart_objects::SmartObjectSPtr
+HMICapabilitiesImpl::tts_supported_languages() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return tts_supported_languages_;
 }
 
-const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::display_capabilities()
-    const {
+const smart_objects::SmartObjectSPtr
+HMICapabilitiesImpl::display_capabilities() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return display_capabilities_;
 }
 
 const smart_objects::SmartObjectSPtr
 HMICapabilitiesImpl::system_display_capabilities() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return system_display_capabilities_;
 }
 
 const smart_objects::SmartObjectSPtr
 HMICapabilitiesImpl::hmi_zone_capabilities() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return hmi_zone_capabilities_;
 }
 
 const smart_objects::SmartObjectSPtr
 HMICapabilitiesImpl::soft_button_capabilities() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return soft_buttons_capabilities_;
 }
 
 const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::button_capabilities()
     const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return button_capabilities_;
 }
 
 const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::speech_capabilities()
     const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return speech_capabilities_;
 }
 
 const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::vr_capabilities()
     const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return vr_capabilities_;
 }
 
 const smart_objects::SmartObjectSPtr
 HMICapabilitiesImpl::audio_pass_thru_capabilities() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return audio_pass_thru_capabilities_;
 }
 
 const smart_objects::SmartObjectSPtr
 HMICapabilitiesImpl::pcm_stream_capabilities() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return pcm_stream_capabilities_;
 }
 
 const smart_objects::SmartObjectSPtr
 HMICapabilitiesImpl::preset_bank_capabilities() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return preset_bank_capabilities_;
 }
 
 bool HMICapabilitiesImpl::attenuated_supported() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return attenuated_supported_;
 }
 
 const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::vehicle_type() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return vehicle_type_;
 }
 
 const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::prerecorded_speech()
     const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return prerecorded_speech_;
 }
 
@@ -868,27 +886,32 @@ bool HMICapabilitiesImpl::rc_supported() const {
   return is_rc_supported_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::navigation_capability()
-    const {
+const smart_objects::SmartObjectSPtr
+HMICapabilitiesImpl::navigation_capability() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return navigation_capability_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::phone_capability()
-    const {
+const smart_objects::SmartObjectSPtr
+HMICapabilitiesImpl::phone_capability() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return phone_capability_;
 }
 
-const smart_objects::SmartObject*
+const smart_objects::SmartObjectSPtr
 HMICapabilitiesImpl::video_streaming_capability() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return video_streaming_capability_;
 }
 
-const smart_objects::SmartObject* HMICapabilitiesImpl::rc_capability() const {
+const smart_objects::SmartObjectSPtr HMICapabilitiesImpl::rc_capability() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return rc_capability_;
 }
 
-const smart_objects::SmartObject*
+const smart_objects::SmartObjectSPtr
 HMICapabilitiesImpl::seat_location_capability() const {
+  sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return seat_location_capability_;
 }
 

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -140,7 +140,7 @@ class HMICapabilities {
    *
    * @return Currently supported UI languages
    */
-  virtual const smart_objects::SmartObject* ui_supported_languages() const = 0;
+  virtual const smart_objects::SmartObjectSPtr ui_supported_languages() const = 0;
 
   /*
    * @brief Sets supported UI languages
@@ -170,7 +170,7 @@ class HMICapabilities {
    *
    * @return Currently supported VR languages
    */
-  virtual const smart_objects::SmartObject* vr_supported_languages() const = 0;
+  virtual const smart_objects::SmartObjectSPtr vr_supported_languages() const = 0;
 
   /*
    * @brief Sets supported VR languages
@@ -201,7 +201,7 @@ class HMICapabilities {
    *
    * @return Currently supported TTS languages
    */
-  virtual const smart_objects::SmartObject* tts_supported_languages() const = 0;
+  virtual const smart_objects::SmartObjectSPtr tts_supported_languages() const = 0;
 
   /*
    * @brief Sets supported TTS languages
@@ -468,7 +468,7 @@ class HMICapabilities {
    *
    * @return NAVIGATION system capability
    */
-  virtual const smart_objects::SmartObject* navigation_capability() const = 0;
+  virtual const smart_objects::SmartObjectSPtr navigation_capability() const = 0;
 
   /*
    * @brief Interface used to store information regarding
@@ -485,7 +485,7 @@ class HMICapabilities {
    *
    * @return PHONE_CALL system capability
    */
-  virtual const smart_objects::SmartObject* phone_capability() const = 0;
+  virtual const smart_objects::SmartObjectSPtr phone_capability() const = 0;
 
   /*
    * @brief Sets HMI's video streaming related capability information
@@ -500,7 +500,7 @@ class HMICapabilities {
    *
    * @return HMI's video streaming related capability information
    */
-  virtual const smart_objects::SmartObject* video_streaming_capability()
+  virtual const smart_objects::SmartObjectSPtr video_streaming_capability()
       const = 0;
 
   /**
@@ -510,7 +510,7 @@ class HMICapabilities {
   virtual void set_rc_capability(
       const smart_objects::SmartObject& rc_capability) = 0;
 
-  virtual const smart_objects::SmartObject* rc_capability() const = 0;
+  virtual const smart_objects::SmartObjectSPtr rc_capability() const = 0;
 
   /**
    * @brief Sets available SeatLocation capabilities for further usage by
@@ -525,7 +525,7 @@ class HMICapabilities {
    * seat location capability
    * @return smart object of seat location capability
    */
-  virtual const smart_objects::SmartObject* seat_location_capability()
+  virtual const smart_objects::SmartObjectSPtr seat_location_capability()
       const = 0;
 
   DEPRECATED


### PR DESCRIPTION
Fixes #3173 #2798 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by manual testing

### Summary
When one thread accessing a pointer of HMICapabilitiesImpl class, and other thread delete the pointer at the same time. 
As a result, SDL crashes because of access wild pointer.
So we make the following modifications in HMICapabilitiesImpl class to avoid wild pointer problems caused by multiple threads reading and writing pointers at the same time.
1. Change pointer to shared pointers.
(SDLCore6.1.1 has completed part of the work on this PR:https://github.com/smartdevicelink/sdl_core/pull/3116)
2. Add locks for shared pointers to avoid multithreaded access shared pointers.
![image](https://user-images.githubusercontent.com/35795928/84210766-8b0f4f80-aaf4-11ea-8805-72425f81e783.png)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
