### PR TITLE
only set language in rai response if it is valid

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -557,7 +557,10 @@ RegisterAppInterfaceRequest::GetLockScreenIconUrlNotification(
 
 void FillVRRelatedFields(smart_objects::SmartObject& response_params,
                          const HMICapabilities& hmi_capabilities) {
-  response_params[strings::language] = hmi_capabilities.active_vr_language();
+  auto active_vr_lang = hmi_capabilities.active_vr_language();
+  if (hmi_apis::Common_Language::INVALID_ENUM != active_vr_lang) {
+    response_params[strings::language] = active_vr_lang;
+  }
   auto vr_capabilities = hmi_capabilities.vr_capabilities();
   if (vr_capabilities) {
     response_params[strings::vr_capabilities] = *vr_capabilities;
@@ -574,7 +577,10 @@ void FillVIRelatedFields(smart_objects::SmartObject& response_params,
 
 void FillTTSRelatedFields(smart_objects::SmartObject& response_params,
                           const HMICapabilities& hmi_capabilities) {
-  response_params[strings::language] = hmi_capabilities.active_tts_language();
+  auto active_tts_lang = hmi_capabilities.active_tts_language();
+  if (hmi_apis::Common_Language::INVALID_ENUM != active_tts_lang) {
+    response_params[strings::language] = active_tts_lang;
+  }
   auto speech_capabilities = hmi_capabilities.speech_capabilities();
   if (speech_capabilities) {
     response_params[strings::speech_capabilities] = *speech_capabilities;
@@ -587,8 +593,10 @@ void FillTTSRelatedFields(smart_objects::SmartObject& response_params,
 
 void FillUIRelatedFields(smart_objects::SmartObject& response_params,
                          const HMICapabilities& hmi_capabilities) {
-  response_params[strings::hmi_display_language] =
-      hmi_capabilities.active_ui_language();
+  auto active_ui_lang = hmi_capabilities.active_ui_language();
+  if (hmi_apis::Common_Language::INVALID_ENUM != active_ui_lang) {
+    response_params[strings::hmi_display_language] = active_ui_lang;
+  }
 
   auto display_capabilities = hmi_capabilities.display_capabilities();
   if (display_capabilities) {


### PR DESCRIPTION
Fixes #2230 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
using rpc_builder_app_js and generic hmi @ develop before commit 0531572cf6bf4667f772218b5ee75624048ddba2

### Summary
only set the language in the rai response if it is valid, this will prevent sending integers (-1) in a string field which can cause mobile apps to crash if they don't handle this properly

## NOTE

The TTS language in the RAI response will be overwritten by the VR language as they use the same key. It was like this before, I figured the best action is just to cover both cases and leave them as they are. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
