### PR TITLE
Update to filter unknown enums

### DIFF
--- a/src/components/application_manager/include/application_manager/rpc_service_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_service_impl.h
@@ -128,6 +128,9 @@ class RPCServiceImpl : public RPCService,
   bool ManageHMICommand(const commands::MessageSharedPtr message,
                         commands::Command::CommandSource source =
                             commands::Command::SOURCE_HMI) OVERRIDE;
+  bool ManageHMICommand(const commands::MessageSharedPtr message,
+                        commands::Command::CommandSource source,
+                        const std::string warning_info) OVERRIDE;
 
   // CALLED ON messages_to_hmi_ thread!
   void Handle(const impl::MessageToHmi message) OVERRIDE;

--- a/src/components/application_manager/src/commands/request_from_hmi.cc
+++ b/src/components/application_manager/src/commands/request_from_hmi.cc
@@ -96,7 +96,19 @@ void RequestFromHMI::SendResponse(
   }
 
   (*message)[strings::msg_params][strings::success] = success;
-  (*message)[strings::msg_params][strings::result_code] = result_code;
+  if ((result_code == hmi_apis::Common_Result::SUCCESS ||
+       result_code == hmi_apis::Common_Result::WARNINGS) &&
+      !warning_info().empty()) {
+    bool has_info = (*message)[strings::params].keyExists(strings::error_msg);
+    (*message)[strings::params][strings::error_msg] =
+        has_info ? (*message)[strings::params][strings::error_msg].asString() +
+                       "\n" + warning_info()
+                 : warning_info();
+    (*message)[strings::msg_params][strings::result_code] =
+        mobile_apis::Result::WARNINGS;
+  } else {
+    (*message)[strings::msg_params][strings::result_code] = result_code;
+  }
 
   rpc_service_.ManageHMICommand(message, source);
 }

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -203,7 +203,7 @@ void RPCHandlerImpl::ProcessMessageFromHMI(
 
   LOG4CXX_DEBUG(logger_, "Converted message, trying to create hmi command");
   if (!app_manager_.GetRPCService().ManageHMICommand(
-          smart_object, commands::Command::SOURCE_SDL, warning_info)) {
+          smart_object, commands::Command::SOURCE_HMI, warning_info)) {
     LOG4CXX_ERROR(logger_, "Received command didn't run successfully");
   }
 }

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -202,7 +202,8 @@ void RPCHandlerImpl::ProcessMessageFromHMI(
   }
 
   LOG4CXX_DEBUG(logger_, "Converted message, trying to create hmi command");
-  if (!app_manager_.GetRPCService().ManageHMICommand(smart_object)) {
+  if (!app_manager_.GetRPCService().ManageHMICommand(
+          smart_object, commands::Command::SOURCE_SDL, warning_info)) {
     LOG4CXX_ERROR(logger_, "Received command didn't run successfully");
   }
 }

--- a/src/components/application_manager/src/rpc_service_impl.cc
+++ b/src/components/application_manager/src/rpc_service_impl.cc
@@ -332,6 +332,12 @@ bool RPCServiceImpl::ManageMobileCommand(
 
 bool RPCServiceImpl::ManageHMICommand(const commands::MessageSharedPtr message,
                                       commands::Command::CommandSource source) {
+  return ManageHMICommand(message, source, std::string());
+}
+
+bool RPCServiceImpl::ManageHMICommand(const commands::MessageSharedPtr message,
+                                      commands::Command::CommandSource source,
+                                      const std::string warning_info) {
   LOG4CXX_AUTO_TRACE(logger_);
 
   if (!message) {
@@ -381,6 +387,7 @@ bool RPCServiceImpl::ManageHMICommand(const commands::MessageSharedPtr message,
 
   if (kRequest == message_type) {
     LOG4CXX_DEBUG(logger_, "ManageHMICommand");
+    command->set_warning_info(warning_info);
     request_ctrl_.addHMIRequest(command);
   }
 

--- a/src/components/include/application_manager/rpc_service.h
+++ b/src/components/include/application_manager/rpc_service.h
@@ -53,7 +53,7 @@ class RPCService {
   /**
    * @brief ManageMobileCommand convert message to mobile command and execute it
    * @param message pointer to received message
-   * @param origin origin of command
+   * @param source source of command
    * @param warning_info warning message to send on a successful response. Only
    * applies to requests from mobile.
    * @return true if command is executed, otherwise return false
@@ -67,11 +67,17 @@ class RPCService {
   /**
    * @brief ManageHMICommand convert message to HMI command and execute it
    * @param message pointer to received message
+   * @param source source of command
+   * @param warning_info warning message to send on a successful response. Only
+   * applies to requests from HMI.
    * @return true if command is executed, otherwise return false
    */
   virtual bool ManageHMICommand(const commands::MessageSharedPtr message,
                                 commands::Command::CommandSource source =
                                     commands::Command::SOURCE_HMI) = 0;
+  virtual bool ManageHMICommand(const commands::MessageSharedPtr message,
+                                commands::Command::CommandSource source,
+                                const std::string warning_info) = 0;
 
   /**
    * @brief SendMessageToMobile Put message to the queue to be sent to mobile.

--- a/src/components/include/test/application_manager/mock_rpc_service.h
+++ b/src/components/include/test/application_manager/mock_rpc_service.h
@@ -17,6 +17,11 @@ class MockRPCService : public application_manager::rpc_service::RPCService {
       ManageHMICommand,
       bool(const application_manager::commands::MessageSharedPtr message,
            application_manager::commands::Command::CommandSource source));
+  MOCK_METHOD3(
+      ManageHMICommand,
+      bool(const application_manager::commands::MessageSharedPtr message,
+           application_manager::commands::Command::CommandSource source,
+           const std::string warning_info));
   MOCK_METHOD2(
       ManageMobileCommand,
       bool(const application_manager::commands::MessageSharedPtr message,

--- a/src/components/smart_objects/test/CObjectSchemaItem_test.cc
+++ b/src/components/smart_objects/test/CObjectSchemaItem_test.cc
@@ -260,22 +260,22 @@ TEST_F(ObjectSchemaItemTest, validation_invalid_param) {
   obj[S_MSG_PARAMS][Keys::SUCCESS] = 0xABC;
 
   report = rpc::ValidationReport("RPC");
-  EXPECT_EQ(errors::INVALID_VALUE, schema_item->validate(obj, &report));
+  EXPECT_EQ(errors::OUT_OF_RANGE, schema_item->validate(obj, &report));
   EXPECT_NE(std::string(""), rpc::PrettyFormat(report));
 
   obj[S_PARAMS][S_FUNCTION_ID] = 1;
   report = rpc::ValidationReport("RPC");
-  EXPECT_EQ(errors::INVALID_VALUE, schema_item->validate(obj, &report));
+  EXPECT_EQ(errors::OUT_OF_RANGE, schema_item->validate(obj, &report));
   EXPECT_NE(std::string(""), rpc::PrettyFormat(report));
 
   obj[S_PARAMS][S_CORRELATION_ID] = -0xFF1;
   report = rpc::ValidationReport("RPC");
-  EXPECT_EQ(errors::INVALID_VALUE, schema_item->validate(obj, &report));
+  EXPECT_EQ(errors::OUT_OF_RANGE, schema_item->validate(obj, &report));
   EXPECT_NE(std::string(""), rpc::PrettyFormat(report));
 
   obj[S_PARAMS][S_PROTOCOL_VERSION] = 2;
   report = rpc::ValidationReport("RPC");
-  EXPECT_EQ(errors::INVALID_VALUE, schema_item->validate(obj, &report));
+  EXPECT_EQ(errors::OUT_OF_RANGE, schema_item->validate(obj, &report));
   EXPECT_NE(std::string(""), rpc::PrettyFormat(report));
 
   obj[S_MSG_PARAMS][Keys::RESULT_CODE] = 1;
@@ -442,7 +442,7 @@ TEST_F(ObjectSchemaItemTest, validation_unexpected_param_remove) {
   EXPECT_FALSE(obj[S_MSG_PARAMS].keyExists(fake3));
   // Invalide state after enum convertion
   report = rpc::ValidationReport("RPC");
-  EXPECT_EQ(errors::INVALID_VALUE, schema_item->validate(obj, &report));
+  EXPECT_EQ(errors::OUT_OF_RANGE, schema_item->validate(obj, &report));
   EXPECT_NE(std::string(""), rpc::PrettyFormat(report));
 }
 
@@ -469,7 +469,7 @@ TEST_F(ObjectSchemaItemTest, validation_empty_params) {
   schema_item->unapplySchema(obj);
   // Invalide state after enum convertion
   report = rpc::ValidationReport("RPC");
-  EXPECT_EQ(errors::INVALID_VALUE, schema_item->validate(obj, &report));
+  EXPECT_EQ(errors::OUT_OF_RANGE, schema_item->validate(obj, &report));
   EXPECT_NE(std::string(""), rpc::PrettyFormat(report));
 }
 


### PR DESCRIPTION
Credit to original author: @jacobkeeler 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF Unknown enum test set + regression run

### Summary
Adds fixes:
- Return warnings and info string to HMI requests
- Define different behavior for sending an unknown enum vs sending the wrong data type (ie an array/struct in place of an enum would be INVALID_DATA).

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
