### PR TITLE
Fix No_Media&Media app not activated during active embedded navigation

### DIFF
--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -560,7 +560,7 @@ bool StateControllerImpl::IsStateAvailable(ApplicationSharedPtr app,
     }
   }
 
-  // fix: EMBEDDED_NAVI actived, actived navi or project app return false. 
+  // fix: EMBEDDED_NAVI actived, actived navi or project app return false.
   // other is ok.
   if (IsTempStateActive(HmiState::StateID::STATE_ID_EMBEDDED_NAVI) &&
       (app->is_navi() || app->mobile_projection_enabled())) {

--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -549,11 +549,23 @@ bool StateControllerImpl::IsStateAvailable(ApplicationSharedPtr app,
     return IsStateAvailableForResumption(app, state);
   }
 
-  if (IsTempStateActive(HmiState::StateID::STATE_ID_AUDIO_SOURCE) ||
-      IsTempStateActive(HmiState::StateID::STATE_ID_EMBEDDED_NAVI)) {
+  // fix: AUDIO_SOURCE actived, actived media app return false. other is ok.
+  if (IsTempStateActive(HmiState::StateID::STATE_ID_AUDIO_SOURCE) &&
+      app->is_media_application()) {
     if (HMILevel::HMI_FULL == state->hmi_level()) {
       LOG4CXX_DEBUG(logger_,
-                    "AUDIO_SOURCE or EMBEDDED_NAVI is active."
+                    "AUDIO_SOURCE is active."
+                        << " Requested state is not available");
+      return false;
+    }
+  }
+
+  // fix: EMBEDDED_NAVI actived, actived navi or project app return false. other is ok.
+  if (IsTempStateActive(HmiState::StateID::STATE_ID_EMBEDDED_NAVI) &&
+      (app->is_navi() || app->mobile_projection_enabled())) {
+    if (HMILevel::HMI_FULL == state->hmi_level()) {
+      LOG4CXX_DEBUG(logger_,
+                    "EMBEDDED_NAVI is active."
                         << " Requested state is not available");
       return false;
     }

--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -560,7 +560,8 @@ bool StateControllerImpl::IsStateAvailable(ApplicationSharedPtr app,
     }
   }
 
-  // fix: EMBEDDED_NAVI actived, actived navi or project app return false. other is ok.
+  // fix: EMBEDDED_NAVI actived, actived navi or project app return false. 
+  // other is ok.
   if (IsTempStateActive(HmiState::StateID::STATE_ID_EMBEDDED_NAVI) &&
       (app->is_navi() || app->mobile_projection_enabled())) {
     if (HMILevel::HMI_FULL == state->hmi_level()) {


### PR DESCRIPTION
Fixes #1907, #1903 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by manual testing

### Summary
* Reason
SDL App is started when the `EMBEDDED_NAVI` active is true.
`Application_manager StateController` uses `IsStateAvailable()` not allowed app to start.
So `SDL.ActivateApp` doesn't change `HmiState` and doesn't send `OnHmiStatus` to MobileApp.
* Sequence
![image](https://user-images.githubusercontent.com/35795928/84658235-8c0b0b80-af50-11ea-8cdd-62f29a4f691c.png)
* Solution
Allow `SDL.ActivateApp` to request `HMIStatus` change available when `EMBEDDED_NAVI/AUDIO_SOURCE` is active.
But the `NonMediaSDL` app will be started as `HMILevel`(BACKGROUND), not `FULL`. And MediaApp will be started as `HMILevel`(Limited).
* Limitation
`SDL.ActivateApp NonMediaApp` will change `HMILevel` to `BACKGROUND`, not `FULL`.     
`SDL.ActivateApp MediaApp` will change the app `HMILevel` to `LIMITED`, not `FULL`. 

Ref: https://github.com/smartdevicelink/sdl_hmi_integration_guidelines/blob/master/docs/BasicCommunication/OnEventChanged/index.md
Table: Activating apps during active `AUDIO_SOURCE or EMBEDDED_NAVI` event
  
According to the requirements of SDLC： 【EMBEDDED_NAVI(true) then Active(MediaApp) --> (FULL, AUDIBLE)】   
But current SDLCore `StateController`'s resolved `HmiState` is (`LIMITED`, `ATTENUATED`.)   
    
As the current SDLCore `HMIState` state machine, the final HMI state resolved by the combination of the previous state. 
Now SDLCore `state_controller` design to set eventually `HMIStatus` cannot set to `FULL`. 
Meanwhile, if change HMI level to `FULL`, all the `OnEventChanged`/`OnSystemContex` where use `HMIStatus` must recheck, so it has a large influence of design and coding.   

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* N/A

### Tasks Remaining:
* N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
