### PR TITLE
Add Destructor to BluetoothTransportAdapter

### DIFF
--- a/src/components/transport_manager/include/transport_manager/bluetooth/bluetooth_transport_adapter.h
+++ b/src/components/transport_manager/include/transport_manager/bluetooth/bluetooth_transport_adapter.h
@@ -56,11 +56,6 @@ class BluetoothTransportAdapter : public TransportAdapterImpl {
   BluetoothTransportAdapter(resumption::LastState&,
                             const TransportManagerSettings& settings);
 
-  /**
-   * @brief Destructor.
-   */
-  virtual ~BluetoothTransportAdapter();
-
  protected:
   /**
    * @brief Return type of device.

--- a/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner.cc
@@ -212,9 +212,40 @@ void BluetoothDeviceScanner::DoInquiry() {
   CheckSDLServiceOnDevices(
       paired_devices_, device_handle, &paired_devices_with_sdl_);
   UpdateTotalDeviceList();
+
+  LOG4CXX_INFO(logger_, "Starting hci_inquiry on device " << device_id);
+  const uint8_t inquiry_time = 8u;  // Time unit is 1.28 seconds
+  const size_t max_devices = 256u;
+  inquiry_info* inquiry_info_list = new inquiry_info[max_devices];
+
+  const int number_of_devices = hci_inquiry(device_id,
+                                            inquiry_time,
+                                            max_devices,
+                                            0,
+                                            &inquiry_info_list,
+                                            IREQ_CACHE_FLUSH);
+
+  if (number_of_devices >= 0) {
+    LOG4CXX_INFO(logger_,
+                 "hci_inquiry: found " << number_of_devices << " devices");
+    std::vector<bdaddr_t> found_devices(number_of_devices);
+    for (int i = 0; i < number_of_devices; ++i) {
+      found_devices[i] = inquiry_info_list[i].bdaddr;
+    }
+    found_devices_with_sdl_.clear();
+    CheckSDLServiceOnDevices(
+        found_devices, device_handle, &found_devices_with_sdl_);
+  }
+  UpdateTotalDeviceList();
   controller_->FindNewApplicationsRequest();
 
   close(device_handle);
+  delete[] inquiry_info_list;
+
+  if (number_of_devices < 0) {
+    LOG4CXX_DEBUG(logger_, "number_of_devices < 0");
+    controller_->SearchDeviceFailed(SearchDeviceError());
+  }
 }
 
 void BluetoothDeviceScanner::CheckSDLServiceOnDevices(

--- a/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner.cc
@@ -212,40 +212,9 @@ void BluetoothDeviceScanner::DoInquiry() {
   CheckSDLServiceOnDevices(
       paired_devices_, device_handle, &paired_devices_with_sdl_);
   UpdateTotalDeviceList();
-
-  LOG4CXX_INFO(logger_, "Starting hci_inquiry on device " << device_id);
-  const uint8_t inquiry_time = 8u;  // Time unit is 1.28 seconds
-  const size_t max_devices = 256u;
-  inquiry_info* inquiry_info_list = new inquiry_info[max_devices];
-
-  const int number_of_devices = hci_inquiry(device_id,
-                                            inquiry_time,
-                                            max_devices,
-                                            0,
-                                            &inquiry_info_list,
-                                            IREQ_CACHE_FLUSH);
-
-  if (number_of_devices >= 0) {
-    LOG4CXX_INFO(logger_,
-                 "hci_inquiry: found " << number_of_devices << " devices");
-    std::vector<bdaddr_t> found_devices(number_of_devices);
-    for (int i = 0; i < number_of_devices; ++i) {
-      found_devices[i] = inquiry_info_list[i].bdaddr;
-    }
-    found_devices_with_sdl_.clear();
-    CheckSDLServiceOnDevices(
-        found_devices, device_handle, &found_devices_with_sdl_);
-  }
-  UpdateTotalDeviceList();
   controller_->FindNewApplicationsRequest();
 
   close(device_handle);
-  delete[] inquiry_info_list;
-
-  if (number_of_devices < 0) {
-    LOG4CXX_DEBUG(logger_, "number_of_devices < 0");
-    controller_->SearchDeviceFailed(SearchDeviceError());
-  }
 }
 
 void BluetoothDeviceScanner::CheckSDLServiceOnDevices(

--- a/src/components/transport_manager/src/bluetooth/bluetooth_transport_adapter.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_transport_adapter.cc
@@ -54,8 +54,6 @@ namespace transport_adapter {
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "TransportManager")
 
-BluetoothTransportAdapter::~BluetoothTransportAdapter() {}
-
 BluetoothTransportAdapter::BluetoothTransportAdapter(
     resumption::LastStateWrapperPtr last_state_wrapper,
     const TransportManagerSettings& settings)


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Remove the override `BluetoothTransportAdapter::~BluetoothTransportAdapter` so that `BluetoothTransportAdapter` will use `~TransportAdapterImpl` as it's destructor:

https://github.com/smartdevicelink/sdl_core/blob/665d4d32bcd618776d924f9f985e76dec74edd3a/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc#L97-L120

### Testing Plan
Run ATF, unit tests

### Tasks Remaining:
- [x] Fix unit tests (fixed, i had another service running on port 8080 which stalls transport_manager_test)
- [x] run regression

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
