### PR TITLE
allow button events to be forwarded to apps in LIMITED

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_event_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_event_notification.cc
@@ -141,9 +141,7 @@ void OnButtonEventNotification::Run() {
     }
     // if OK button and "app_id" absent send notification only in HMI_FULL mode
     // otherwise send to subscribed apps in limited
-    if (is_app_id_exists ||
-        (*message_)[strings::msg_params][strings::name].asInt() !=
-            hmi_apis::Common_ButtonName::OK ||
+    if (is_app_id_exists || hmi_apis::Common_ButtonName::OK != btn_id ||
         subscribed_app->IsFullscreen()) {
       SendButtonEvent(subscribed_app);
     }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_event_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_event_notification.cc
@@ -139,8 +139,12 @@ void OnButtonEventNotification::Run() {
                        << "in FULL or LIMITED hmi level");
       continue;
     }
-    // if "app_id" absent send notification only in HMI_FULL mode
-    if (is_app_id_exists || subscribed_app->IsFullscreen()) {
+    // if OK button and "app_id" absent send notification only in HMI_FULL mode
+    // otherwise send to subscribed apps in limited
+    if (is_app_id_exists ||
+        (*message_)[strings::msg_params][strings::name].asInt() !=
+            hmi_apis::Common_ButtonName::OK ||
+        subscribed_app->IsFullscreen()) {
       SendButtonEvent(subscribed_app);
     }
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_press_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_press_notification.cc
@@ -149,8 +149,11 @@ void OnButtonPressNotification::Run() {
       if (app->app_id() == subscribed_app->app_id()) {
         SendButtonPress(subscribed_app);
       }
-    } else if (subscribed_app->IsFullscreen()) {
-      // if No "appID" - send it FULL apps only.
+    } else if ((*message_)[strings::msg_params][strings::name].asInt() !=
+                   hmi_apis::Common_ButtonName::OK ||
+               subscribed_app->IsFullscreen()) {
+      // if No "appID" and OK button - send it FULL apps only.
+      // if not OK button, send to LIMITED subscribed apps
       SendButtonPress(subscribed_app);
     }
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_press_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_button_press_notification.cc
@@ -149,8 +149,7 @@ void OnButtonPressNotification::Run() {
       if (app->app_id() == subscribed_app->app_id()) {
         SendButtonPress(subscribed_app);
       }
-    } else if ((*message_)[strings::msg_params][strings::name].asInt() !=
-                   hmi_apis::Common_ButtonName::OK ||
+    } else if (hmi_apis::Common_ButtonName::OK != btn_id ||
                subscribed_app->IsFullscreen()) {
       // if No "appID" and OK button - send it FULL apps only.
       // if not OK button, send to LIMITED subscribed apps

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -4204,10 +4204,9 @@
       </param>
       <param name="appID" type="Integer" mandatory="false">
         <description>
-                In case the ButtonName is CUSTOM_BUTTON or OK, HMI must include appID parameters to OnButtonPress notification sent to SDL.
                 If appID is not sent together with CUSTOM_BUTTON, this notification will be ignored by SDL.
                 If appID is present for OK button -> SDL transfers notification to the named app only if it is in FULL or LIMITED (ignores if app is in NONE or BACKGROUND).
-                If appID is omited for OK button -> SDL transfers notification to app in FULL
+                If appID is omitted for OK button -> SDL transfers notification to app in FULL
         </description>
       </param>
     </function>
@@ -4221,10 +4220,9 @@
         </param>
         <param name="appID" type="Integer" mandatory="false">
             <description>
-                In case the ButtonName is CUSTOM_BUTTON or OK, HMI must include appID parameters to OnButtonEvent notification sent to SDL.
                 If appID is not sent together with CUSTOM_BUTTON, this notification will be ignored by SDL.
                 If appID is present for OK button -> SDL transfers notification to the named app only if it is in FULL or LIMITED (ignores if app is in NONE or BACKGROUND).
-                If appID is omited for OK button -> SDL transfers notification to app in FULL
+                If appID is omitted for OK button -> SDL transfers notification to app in FULL
             </description>
         </param>
     </function>


### PR DESCRIPTION
Fixes #2888

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF test to be submitted (modified test 2888 with no appID param except for OK button)

### Summary
Will allow `OnButtonEvent` and `OnButtonPress` to be sent to mobile apps subscribed to that soft button while in LIMITED HMI level for all buttons besides `OK`.

Edit HMI_API description of `OnButtonEvent` and `OnButtonPress` param `appID` to remove inaccurate line:
```
In case the ButtonName is CUSTOM_BUTTON or OK, HMI must include appID parameters to OnButtonPress notification sent to SDL.
```
The next three lines describe the correct functionality in each description.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
