### PR TITLE
Cache Driver Distraction Capability

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
@@ -145,6 +145,7 @@ void UIGetCapabilitiesResponse::Run() {
             strings::driver_distraction_capability)) {
       if (!system_capabilities_so[strings::driver_distraction_capability]
                .empty()) {
+        sections_to_update.push_back(strings::driver_distraction_capability);
         hmi_capabilities_.set_driver_distraction_capability(
             system_capabilities_so[strings::driver_distraction_capability]);
         hmi_capabilities_.set_driver_distraction_supported(true);

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -1898,6 +1898,16 @@ void HMICapabilitiesImpl::PrepareUiJsonValueForSaving(
       }
     }
 
+    else if (section_to_update == strings::driver_distraction_capability) {
+      const auto driver_distraction_capability_so =
+          driver_distraction_capability();
+
+      if (driver_distraction_capability_so) {
+        (*system_capabilities)[strings::driver_distraction_capability] =
+            *driver_distraction_capability_so;
+      }
+    }
+
     else if (section_to_update == strings::display_capabilities) {
       const auto display_capabilities_so = display_capabilities();
 


### PR DESCRIPTION

Fixes issue with #3447 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run ATF regression

### Summary
Adds missing `driver_distraction_capability` to HMI capabilities cache

### Changelog
##### Bug Fixes
* Adds missing `driver_distraction_capability` to HMI capabilities cache

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
