### PR TITLE
Replace direct access with accessor for apps

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1260,7 +1260,7 @@ class ApplicationManagerImpl
                           const bool allow_unknown_parameters = false);
 
   template <typename ApplicationList>
-  void PrepareApplicationListSO(ApplicationList app_list,
+  void PrepareApplicationListSO(ApplicationList& app_list,
                                 smart_objects::SmartObject& applications,
                                 ApplicationManager& app_mngr) {
     smart_objects::SmartArray* app_array = applications.asArray();


### PR DESCRIPTION
Fixes #3157 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF

### Summary
There was found a few places inside of `ApplicationManager` where `applications_` and `apps_to_register_` members were
used without locks however these members are commonly used and must be synchronized in all places.
To avoid potential data races, direct usage of these elements were replaced with accessor for read-only operations.
Also was added a missing lock.

### Tasks Remaining:
- [ ] Prepare ATF scripts

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
