### PR TITLE
Fix streamer activity in case of suspend

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -520,6 +520,10 @@ class DynamicApplicationData {
 class Application : public virtual InitialApplicationData,
                     public virtual DynamicApplicationData {
  public:
+  /**
+   * @brief The StreamingState enum defines current streaming state
+   */
+  enum class StreamingState { kStopped, kStarted, kSuspended };
   enum ApplicationRegisterState { kRegistered = 0, kWaitingForRegistration };
 
   Application() : is_greyed_out_(false) {}

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -664,10 +664,8 @@ class Application : public virtual InitialApplicationData,
   /**
    * @brief Wakes up streaming process for application
    * @param service_type Type of streaming service
-   * @param timer_len The amount of time in ms the timer will wait
    */
-  virtual void WakeUpStreaming(protocol_handler::ServiceType service_type,
-                               uint32_t timer_len = 0) = 0;
+  virtual void WakeUpStreaming(protocol_handler::ServiceType service_type) = 0;
 
   virtual bool is_voice_communication_supported() const = 0;
   virtual void set_voice_communication_supported(

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -142,8 +142,7 @@ class ApplicationImpl : public virtual Application,
   void StopStreamingForce(protocol_handler::ServiceType service_type);
   void StopStreaming(protocol_handler::ServiceType service_type);
   void SuspendStreaming(protocol_handler::ServiceType service_type);
-  void WakeUpStreaming(protocol_handler::ServiceType service_type,
-                       uint32_t timer_len = 0);
+  void WakeUpStreaming(protocol_handler::ServiceType service_type);
 
   virtual bool is_voice_communication_supported() const;
   virtual void set_voice_communication_supported(bool option);

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -880,15 +880,9 @@ class ApplicationManagerImpl
       bool result,
       std::vector<std::string>& rejected_params) OVERRIDE;
 
-  /**
-   * @brief Callback calls when application starts/stops data streaming
-   * @param app_id Streaming application id
-   * @param service_type Streaming service type
-   * @param state Shows if streaming started or stopped
-   */
   void OnAppStreaming(uint32_t app_id,
                       protocol_handler::ServiceType service_type,
-                      bool state) OVERRIDE;
+                      const Application::StreamingState new_state) OVERRIDE;
 
   mobile_api::HMILevel::eType GetDefaultHmiLevel(
       ApplicationConstSharedPtr application) const;

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -659,10 +659,9 @@ void ApplicationImpl::SuspendStreaming(
 }
 
 void ApplicationImpl::WakeUpStreaming(
-    protocol_handler::ServiceType service_type, uint32_t timer_len) {
+    protocol_handler::ServiceType service_type) {
   using namespace protocol_handler;
   SDL_LOG_AUTO_TRACE();
-  const bool is_custom_timeout = 0 != timer_len;
 
   // See the comment in StopStreaming(). Also, please make sure that we acquire
   // streaming_stop_lock_ then xxx_streaming_suspended_lock_ in this order!
@@ -680,13 +679,8 @@ void ApplicationImpl::WakeUpStreaming(
       }
     }
 
-    if (is_custom_timeout) {
-      SDL_LOG_DEBUG("New estimated video playback time is: " << timer_len);
-    }
-
-    video_stream_suspend_timer_.Start(
-        is_custom_timeout ? timer_len : video_stream_suspend_timeout_,
-        timer::kPeriodic);
+    video_stream_suspend_timer_.Start(video_stream_suspend_timeout_,
+                                      timer::kPeriodic);
   } else if (ServiceType::kAudio == service_type) {
     {  // reduce the range of audio_streaming_suspended_lock_
       sync_primitives::AutoLock lock(audio_streaming_suspended_lock_);
@@ -698,14 +692,8 @@ void ApplicationImpl::WakeUpStreaming(
         audio_streaming_suspended_ = false;
       }
     }
-
-    if (is_custom_timeout) {
-      SDL_LOG_DEBUG("New estimated audio playback time is: " << timer_len);
-    }
-
-    audio_stream_suspend_timer_.Start(
-        is_custom_timeout ? timer_len : audio_stream_suspend_timeout_,
-        timer::kPeriodic);
+    audio_stream_suspend_timer_.Start(audio_stream_suspend_timeout_,
+                                      timer::kPeriodic);
   }
 }
 

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -661,6 +661,7 @@ void ApplicationImpl::WakeUpStreaming(
     protocol_handler::ServiceType service_type, uint32_t timer_len) {
   using namespace protocol_handler;
   SDL_LOG_AUTO_TRACE();
+  const bool is_custom_timeout = 0 != timer_len;
 
   // See the comment in StopStreaming(). Also, please make sure that we acquire
   // streaming_stop_lock_ then xxx_streaming_suspended_lock_ in this order!
@@ -677,8 +678,13 @@ void ApplicationImpl::WakeUpStreaming(
         video_streaming_suspended_ = false;
       }
     }
+
+    if (is_custom_timeout) {
+      SDL_LOG_DEBUG("New estimated video playback time is: " << timer_len);
+    }
+
     video_stream_suspend_timer_.Start(
-        timer_len == 0 ? video_stream_suspend_timeout_ : timer_len,
+        is_custom_timeout ? timer_len : video_stream_suspend_timeout_,
         timer::kPeriodic);
   } else if (ServiceType::kAudio == service_type) {
     {  // reduce the range of audio_streaming_suspended_lock_
@@ -691,8 +697,13 @@ void ApplicationImpl::WakeUpStreaming(
         audio_streaming_suspended_ = false;
       }
     }
+
+    if (is_custom_timeout) {
+      SDL_LOG_DEBUG("New estimated audio playback time is: " << timer_len);
+    }
+
     audio_stream_suspend_timer_.Start(
-        timer_len == 0 ? audio_stream_suspend_timeout_ : timer_len,
+        is_custom_timeout ? timer_len : audio_stream_suspend_timeout_,
         timer::kPeriodic);
   }
 }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3601,9 +3601,8 @@ void ApplicationManagerImpl::OnAppStreaming(
     case Application::StreamingState::kSuspended: {
       // Don't stop activity in media_manager_ in that case
       // Just cancel the temporary streaming state
-      if (protocol_handler::ServiceType::kMobileNav == service_type) {
-        state_ctrl_.OnVideoStreamingStopped(app);
-      }
+      state_ctrl_.OnVideoStreamingStopped(app);
+      media_manager_->SuspendStreaming(app_id, service_type);
       break;
     }
   }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3602,7 +3602,6 @@ void ApplicationManagerImpl::OnAppStreaming(
       // Don't stop activity in media_manager_ in that case
       // Just cancel the temporary streaming state
       state_ctrl_.OnVideoStreamingStopped(app);
-      media_manager_->SuspendStreaming(app_id, service_type);
       break;
     }
   }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3566,7 +3566,9 @@ void ApplicationManagerImpl::ForbidStreaming(
 }
 
 void ApplicationManagerImpl::OnAppStreaming(
-    uint32_t app_id, protocol_handler::ServiceType service_type, bool state) {
+    uint32_t app_id,
+    protocol_handler::ServiceType service_type,
+    const Application::StreamingState new_state) {
   SDL_LOG_AUTO_TRACE();
 
   ApplicationSharedPtr app = application(app_id);
@@ -3577,12 +3579,33 @@ void ApplicationManagerImpl::OnAppStreaming(
   }
   DCHECK_OR_RETURN_VOID(media_manager_);
 
-  if (state) {
-    state_ctrl_.OnVideoStreamingStarted(app);
-    media_manager_->StartStreaming(app_id, service_type);
-  } else {
-    media_manager_->StopStreaming(app_id, service_type);
-    state_ctrl_.OnVideoStreamingStopped(app);
+  SDL_LOG_DEBUG("New state for service " << static_cast<int32_t>(service_type)
+                                         << " is "
+                                         << static_cast<int32_t>(new_state));
+  switch (new_state) {
+    case Application::StreamingState::kStopped: {
+      // Stop activity in media_manager_ when service is stopped
+      // State controller has been already notified by kSuspended event
+      // received before
+      media_manager_->StopStreaming(app_id, service_type);
+      break;
+    }
+
+    case Application::StreamingState::kStarted: {
+      // Apply temporary streaming state and start activity in media_manager_
+      state_ctrl_.OnVideoStreamingStarted(app);
+      media_manager_->StartStreaming(app_id, service_type);
+      break;
+    }
+
+    case Application::StreamingState::kSuspended: {
+      // Don't stop activity in media_manager_ in that case
+      // Just cancel the temporary streaming state
+      if (protocol_handler::ServiceType::kMobileNav == service_type) {
+        state_ctrl_.OnVideoStreamingStopped(app);
+      }
+      break;
+    }
   }
 }
 

--- a/src/components/application_manager/test/application_impl_test.cc
+++ b/src/components/application_manager/test/application_impl_test.cc
@@ -837,7 +837,6 @@ TEST_F(ApplicationImplTest, StartStreaming_StreamingApproved) {
 TEST_F(ApplicationImplTest, SuspendNaviStreaming) {
   protocol_handler::ServiceType type =
       protocol_handler::ServiceType::kMobileNav;
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
   EXPECT_CALL(mock_application_manager_,
               ProcessOnDataStreamingNotification(type, app_id, false));
   app_impl->SuspendStreaming(type);
@@ -845,7 +844,6 @@ TEST_F(ApplicationImplTest, SuspendNaviStreaming) {
 
 TEST_F(ApplicationImplTest, SuspendAudioStreaming) {
   protocol_handler::ServiceType type = protocol_handler::ServiceType::kAudio;
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
   EXPECT_CALL(mock_application_manager_,
               ProcessOnDataStreamingNotification(type, app_id, false));
   app_impl->SuspendStreaming(type);
@@ -854,12 +852,16 @@ TEST_F(ApplicationImplTest, SuspendAudioStreaming) {
 // TODO {AKozoriz} : Fix tests with streaming (APPLINK-19289)
 TEST_F(ApplicationImplTest, DISABLED_Suspend_WakeUpAudioStreaming) {
   protocol_handler::ServiceType type = protocol_handler::ServiceType::kAudio;
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
+  EXPECT_CALL(
+      mock_application_manager_,
+      OnAppStreaming(app_id, type, Application::StreamingState::kSuspended));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendOnDataStreaming(type, false, _));
   app_impl->SuspendStreaming(type);
 
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, true));
+  EXPECT_CALL(
+      mock_application_manager_,
+      OnAppStreaming(app_id, type, Application::StreamingState::kStarted));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendOnDataStreaming(type, true, _));
   app_impl->WakeUpStreaming(type);
@@ -868,12 +870,16 @@ TEST_F(ApplicationImplTest, DISABLED_Suspend_WakeUpAudioStreaming) {
 TEST_F(ApplicationImplTest, DISABLED_Suspend_WakeUpNaviStreaming) {
   protocol_handler::ServiceType type =
       protocol_handler::ServiceType::kMobileNav;
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
+  EXPECT_CALL(
+      mock_application_manager_,
+      OnAppStreaming(app_id, type, Application::StreamingState::kSuspended));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendOnDataStreaming(type, false, _));
   app_impl->SuspendStreaming(type);
 
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, true));
+  EXPECT_CALL(
+      mock_application_manager_,
+      OnAppStreaming(app_id, type, Application::StreamingState::kStarted));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendOnDataStreaming(type, true, _));
   app_impl->WakeUpStreaming(type);
@@ -885,7 +891,9 @@ TEST_F(ApplicationImplTest, StopStreaming_StreamingApproved) {
       protocol_handler::ServiceType::kMobileNav;
   app_impl->set_video_streaming_approved(true);
 
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
+  EXPECT_CALL(
+      mock_application_manager_,
+      OnAppStreaming(app_id, type, Application::StreamingState::kStopped));
   EXPECT_CALL(mock_application_manager_,
               ProcessOnDataStreamingNotification(type, app_id, false));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
@@ -897,7 +905,9 @@ TEST_F(ApplicationImplTest, StopStreaming_StreamingApproved) {
   // Stop audio streaming
   app_impl->set_audio_streaming_approved(true);
   type = protocol_handler::ServiceType::kAudio;
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
+  EXPECT_CALL(
+      mock_application_manager_,
+      OnAppStreaming(app_id, type, Application::StreamingState::kStopped));
   EXPECT_CALL(mock_application_manager_,
               ProcessOnDataStreamingNotification(type, app_id, false));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -88,9 +88,8 @@ class MockApplication : public ::application_manager::Application {
                void(protocol_handler::ServiceType service_type));
   MOCK_METHOD1(SuspendStreaming,
                void(protocol_handler::ServiceType service_type));
-  MOCK_METHOD2(WakeUpStreaming,
-               void(protocol_handler::ServiceType service_type,
-                    uint32_t timer_len));
+  MOCK_METHOD1(WakeUpStreaming,
+               void(protocol_handler::ServiceType service_type));
   MOCK_CONST_METHOD0(is_voice_communication_supported, bool());
   MOCK_METHOD1(set_voice_communication_supported,
                void(bool is_voice_communication_supported));

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -813,11 +813,11 @@ class ApplicationManager {
    * @brief Callback calls when application starts/stops data streaming
    * @param app_id Streaming application id
    * @param service_type Streaming service type
-   * @param state Shows if streaming started or stopped
+   * @param new_state Defines new streaming state
    */
   virtual void OnAppStreaming(uint32_t app_id,
                               protocol_handler::ServiceType service_type,
-                              bool state) = 0;
+                              const Application::StreamingState new_state) = 0;
 
   /**
    * @brief CreateRegularState create regular HMI state for application

--- a/src/components/include/media_manager/media_manager.h
+++ b/src/components/include/media_manager/media_manager.h
@@ -62,14 +62,6 @@ class MediaManager {
                               protocol_handler::ServiceType service_type) = 0;
   virtual void StopStreaming(int32_t application_key,
                              protocol_handler::ServiceType service_type) = 0;
-  /**
-   * @brief Performs actions required for adapters proper suspension
-   * @param application_key connection key of suspended application
-   * @param service_type type of service to suspend
-   */
-  virtual void SuspendStreaming(int32_t application_key,
-                                protocol_handler::ServiceType service_type) = 0;
-
   virtual void FramesProcessed(int32_t application_key,
                                int32_t frame_number) = 0;
   /**

--- a/src/components/include/media_manager/media_manager.h
+++ b/src/components/include/media_manager/media_manager.h
@@ -62,6 +62,14 @@ class MediaManager {
                               protocol_handler::ServiceType service_type) = 0;
   virtual void StopStreaming(int32_t application_key,
                              protocol_handler::ServiceType service_type) = 0;
+  /**
+   * @brief Performs actions required for adapters proper suspension
+   * @param application_key connection key of suspended application
+   * @param service_type type of service to suspend
+   */
+  virtual void SuspendStreaming(int32_t application_key,
+                                protocol_handler::ServiceType service_type) = 0;
+
   virtual void FramesProcessed(int32_t application_key,
                                int32_t frame_number) = 0;
   /**

--- a/src/components/include/media_manager/media_manager.h
+++ b/src/components/include/media_manager/media_manager.h
@@ -78,14 +78,6 @@ class MediaManager {
    */
   virtual const MediaManagerSettings& settings() const = 0;
 
-  /**
-   * \brief Convert an amount of audio bytes to an estimated time in ms
-   * \param data_size number of bytes to be played
-   * \return milliseconds required to play <data_size> many bytes with
-   *          the current pcm stream capabilities
-   */
-  virtual uint32_t DataSizeToMilliseconds(uint64_t data_size) const = 0;
-
   virtual ~MediaManager() {}
 };
 

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -309,10 +309,11 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD1(OnAppUnauthorized, void(const uint32_t& app_id));
   MOCK_METHOD1(ActivateApplication,
                bool(application_manager::ApplicationSharedPtr app));
-  MOCK_METHOD3(OnAppStreaming,
-               void(uint32_t app_id,
-                    protocol_handler::ServiceType service_type,
-                    bool state));
+  MOCK_METHOD3(
+      OnAppStreaming,
+      void(uint32_t app_id,
+           protocol_handler::ServiceType service_type,
+           application_manager::Application::StreamingState new_state));
   MOCK_CONST_METHOD6(CreateRegularState,
                      application_manager::HmiStatePtr(
                          application_manager::ApplicationSharedPtr app,

--- a/src/components/include/test/media_manager/mock_media_manager.h
+++ b/src/components/include/test/media_manager/mock_media_manager.h
@@ -60,7 +60,7 @@ class MockMediaManager : public media_manager::MediaManager {
                     protocol_handler::ServiceType service_type));
   MOCK_METHOD2(StopStreaming,
                void(int32_t application_key,
-                    protocol_handler::ServiceType service_type));  
+                    protocol_handler::ServiceType service_type));
   MOCK_METHOD2(FramesProcessed,
                void(int32_t application_key, int32_t frame_number));
   MOCK_CONST_METHOD0(settings, const media_manager::MediaManagerSettings&());

--- a/src/components/include/test/media_manager/mock_media_manager.h
+++ b/src/components/include/test/media_manager/mock_media_manager.h
@@ -67,7 +67,6 @@ class MockMediaManager : public media_manager::MediaManager {
   MOCK_METHOD2(FramesProcessed,
                void(int32_t application_key, int32_t frame_number));
   MOCK_CONST_METHOD0(settings, const media_manager::MediaManagerSettings&());
-  MOCK_CONST_METHOD1(DataSizeToMilliseconds, uint32_t(uint64_t data_size));
 };
 
 }  // namespace media_manager_test

--- a/src/components/include/test/media_manager/mock_media_manager.h
+++ b/src/components/include/test/media_manager/mock_media_manager.h
@@ -60,10 +60,7 @@ class MockMediaManager : public media_manager::MediaManager {
                     protocol_handler::ServiceType service_type));
   MOCK_METHOD2(StopStreaming,
                void(int32_t application_key,
-                    protocol_handler::ServiceType service_type));
-  MOCK_METHOD2(SuspendStreaming,
-               void(int32_t application_key,
-                    protocol_handler::ServiceType service_type));
+                    protocol_handler::ServiceType service_type));  
   MOCK_METHOD2(FramesProcessed,
                void(int32_t application_key, int32_t frame_number));
   MOCK_CONST_METHOD0(settings, const media_manager::MediaManagerSettings&());

--- a/src/components/include/test/media_manager/mock_media_manager.h
+++ b/src/components/include/test/media_manager/mock_media_manager.h
@@ -61,6 +61,9 @@ class MockMediaManager : public media_manager::MediaManager {
   MOCK_METHOD2(StopStreaming,
                void(int32_t application_key,
                     protocol_handler::ServiceType service_type));
+  MOCK_METHOD2(SuspendStreaming,
+               void(int32_t application_key,
+                    protocol_handler::ServiceType service_type));
   MOCK_METHOD2(FramesProcessed,
                void(int32_t application_key, int32_t frame_number));
   MOCK_CONST_METHOD0(settings, const media_manager::MediaManagerSettings&());

--- a/src/components/media_manager/include/media_manager/media_manager_impl.h
+++ b/src/components/media_manager/include/media_manager/media_manager_impl.h
@@ -33,7 +33,6 @@
 #ifndef SRC_COMPONENTS_MEDIA_MANAGER_INCLUDE_MEDIA_MANAGER_MEDIA_MANAGER_IMPL_H_
 #define SRC_COMPONENTS_MEDIA_MANAGER_INCLUDE_MEDIA_MANAGER_MEDIA_MANAGER_IMPL_H_
 
-#include <chrono>
 #include <map>
 #include <string>
 #include "interfaces/MOBILE_API.h"
@@ -93,8 +92,6 @@ class MediaManagerImpl : public MediaManager,
 
   virtual const MediaManagerSettings& settings() const OVERRIDE;
 
-  virtual uint32_t DataSizeToMilliseconds(uint64_t data_size) const OVERRIDE;
-
 #ifdef BUILD_TESTS
   void set_mock_a2dp_player(MediaAdapter* media_adapter);
   void set_mock_mic_listener(MediaListenerPtr media_listener);
@@ -119,12 +116,6 @@ class MediaManagerImpl : public MediaManager,
 
   std::map<protocol_handler::ServiceType, MediaAdapterImplPtr> streamer_;
   std::map<protocol_handler::ServiceType, MediaListenerPtr> streamer_listener_;
-
-  uint32_t bits_per_sample_;
-  uint32_t sampling_rate_;
-  uint64_t stream_data_size_;
-  std::chrono::time_point<std::chrono::system_clock>
-      socket_audio_stream_start_time_;
 
   application_manager::ApplicationManager& application_manager_;
 

--- a/src/components/media_manager/include/media_manager/media_manager_impl.h
+++ b/src/components/media_manager/include/media_manager/media_manager_impl.h
@@ -80,6 +80,8 @@ class MediaManagerImpl : public MediaManager,
                               protocol_handler::ServiceType service_type);
   virtual void StopStreaming(int32_t application_key,
                              protocol_handler::ServiceType service_type);
+  void SuspendStreaming(int32_t application_key,
+                        protocol_handler::ServiceType service_type) OVERRIDE;
 
   virtual void SetProtocolHandler(
       protocol_handler::ProtocolHandler* protocol_handler);

--- a/src/components/media_manager/include/media_manager/media_manager_impl.h
+++ b/src/components/media_manager/include/media_manager/media_manager_impl.h
@@ -79,9 +79,6 @@ class MediaManagerImpl : public MediaManager,
                               protocol_handler::ServiceType service_type);
   virtual void StopStreaming(int32_t application_key,
                              protocol_handler::ServiceType service_type);
-  void SuspendStreaming(int32_t application_key,
-                        protocol_handler::ServiceType service_type) OVERRIDE;
-
   virtual void SetProtocolHandler(
       protocol_handler::ProtocolHandler* protocol_handler);
   virtual void OnMessageReceived(

--- a/src/components/media_manager/include/media_manager/streamer_adapter.h
+++ b/src/components/media_manager/include/media_manager/streamer_adapter.h
@@ -87,7 +87,7 @@ class StreamerAdapter : public MediaAdapterImpl {
   };
 
  private:
-  int32_t current_application_;
+  std::atomic_int current_application_;
   utils::MessageQueue<protocol_handler::RawMessagePtr> messages_;
 
   Streamer* streamer_;

--- a/src/components/media_manager/src/media_manager_impl.cc
+++ b/src/components/media_manager/src/media_manager_impl.cc
@@ -281,11 +281,6 @@ void MediaManagerImpl::StopStreaming(
   }
 }
 
-void MediaManagerImpl::SuspendStreaming(
-    int32_t application_key, protocol_handler::ServiceType service_type) {
-  SDL_LOG_AUTO_TRACE();  
-}
-
 void MediaManagerImpl::SetProtocolHandler(
     protocol_handler::ProtocolHandler* protocol_handler) {
   protocol_handler_ = protocol_handler;

--- a/src/components/media_manager/src/media_manager_impl.cc
+++ b/src/components/media_manager/src/media_manager_impl.cc
@@ -298,10 +298,26 @@ void MediaManagerImpl::StopStreaming(
     int32_t application_key, protocol_handler::ServiceType service_type) {
   SDL_LOG_AUTO_TRACE();
 
-  stream_data_size_ = 0ull;
-
   if (streamer_[service_type]) {
     streamer_[service_type]->StopActivity(application_key);
+  }
+}
+
+void MediaManagerImpl::SuspendStreaming(
+    int32_t application_key, protocol_handler::ServiceType service_type) {
+  SDL_LOG_AUTO_TRACE();
+  using namespace application_manager;
+  using namespace protocol_handler;
+
+  const auto app = application_manager_.application(application_key);
+  if (app) {
+    // Reset playback time and stream size when audio file has been played
+    if (ServiceType::kAudio == service_type &&
+        "socket" == settings().audio_server_type()) {
+      stream_data_size_ = 0ull;
+      socket_audio_stream_start_time_ =
+          std::chrono::system_clock::from_time_t(0);
+    }
   }
 }
 

--- a/src/components/media_manager/src/media_manager_impl.cc
+++ b/src/components/media_manager/src/media_manager_impl.cc
@@ -35,8 +35,6 @@
 #include "application_manager/application_impl.h"
 #include "application_manager/application_manager.h"
 #include "application_manager/message_helper.h"
-#include "application_manager/smart_object_keys.h"
-#include "interfaces/MOBILE_API.h"
 #include "media_manager/audio/from_mic_recorder_listener.h"
 #include "media_manager/streamer_listener.h"
 #include "protocol_handler/protocol_handler.h"
@@ -66,9 +64,6 @@ MediaManagerImpl::MediaManagerImpl(
     , protocol_handler_(NULL)
     , a2dp_player_(NULL)
     , from_mic_recorder_(NULL)
-    , bits_per_sample_(16)
-    , sampling_rate_(16000)
-    , stream_data_size_(0ull)
     , application_manager_(application_manager) {
   Init();
 }
@@ -164,23 +159,6 @@ void MediaManagerImpl::Init() {
   if (streamer_[ServiceType::kAudio]) {
     streamer_[ServiceType::kAudio]->AddListener(
         streamer_listener_[ServiceType::kAudio]);
-  }
-
-  if (application_manager_.hmi_capabilities().pcm_stream_capabilities()) {
-    const auto pcm_caps =
-        application_manager_.hmi_capabilities().pcm_stream_capabilities();
-
-    if (pcm_caps->keyExists(application_manager::strings::bits_per_sample)) {
-      bits_per_sample_ =
-          pcm_caps->getElement(application_manager::strings::bits_per_sample)
-              .asUInt();
-    }
-
-    if (pcm_caps->keyExists(application_manager::strings::sampling_rate)) {
-      sampling_rate_ =
-          pcm_caps->getElement(application_manager::strings::sampling_rate)
-              .asUInt();
-    }
   }
 }
 
@@ -305,20 +283,7 @@ void MediaManagerImpl::StopStreaming(
 
 void MediaManagerImpl::SuspendStreaming(
     int32_t application_key, protocol_handler::ServiceType service_type) {
-  SDL_LOG_AUTO_TRACE();
-  using namespace application_manager;
-  using namespace protocol_handler;
-
-  const auto app = application_manager_.application(application_key);
-  if (app) {
-    // Reset playback time and stream size when audio file has been played
-    if (ServiceType::kAudio == service_type &&
-        "socket" == settings().audio_server_type()) {
-      stream_data_size_ = 0ull;
-      socket_audio_stream_start_time_ =
-          std::chrono::system_clock::from_time_t(0);
-    }
-  }
+  SDL_LOG_AUTO_TRACE();  
 }
 
 void MediaManagerImpl::SetProtocolHandler(
@@ -353,25 +318,7 @@ void MediaManagerImpl::OnMessageReceived(
 
   ApplicationSharedPtr app = application_manager_.application(streaming_app_id);
   if (app) {
-    if (ServiceType::kAudio == service_type &&
-        "socket" == settings().audio_server_type()) {
-      if (stream_data_size_ == 0) {
-        socket_audio_stream_start_time_ = std::chrono::system_clock::now();
-      }
-
-      stream_data_size_ += message->data_size();
-      uint32_t ms_for_all_data = DataSizeToMilliseconds(stream_data_size_);
-      uint32_t ms_since_stream_start =
-          std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::system_clock::now() -
-              socket_audio_stream_start_time_)
-              .count();
-      uint32_t ms_stream_remaining = ms_for_all_data - ms_since_stream_start;
-
-      app->WakeUpStreaming(service_type, ms_stream_remaining);
-    } else {
-      app->WakeUpStreaming(service_type);
-    }
+    app->WakeUpStreaming(service_type);
     streamer_[service_type]->SendData(streaming_app_id, message);
   }
 }
@@ -394,8 +341,7 @@ void MediaManagerImpl::FramesProcessed(int32_t application_key,
     auto video_stream = std::dynamic_pointer_cast<StreamerAdapter>(
         streamer_[protocol_handler::ServiceType::kMobileNav]);
 
-    if (audio_stream.use_count() != 0 &&
-        "pipe" == settings().audio_server_type()) {
+    if (audio_stream.use_count() != 0) {
       size_t audio_queue_size = audio_stream->GetMsgQueueSize();
       SDL_LOG_DEBUG("# Messages in audio queue = " << audio_queue_size);
       if (audio_queue_size > 0) {
@@ -403,8 +349,7 @@ void MediaManagerImpl::FramesProcessed(int32_t application_key,
       }
     }
 
-    if (video_stream.use_count() != 0 &&
-        "pipe" == settings().video_server_type()) {
+    if (video_stream.use_count() != 0) {
       size_t video_queue_size = video_stream->GetMsgQueueSize();
       SDL_LOG_DEBUG("# Messages in video queue = " << video_queue_size);
       if (video_queue_size > 0) {
@@ -416,12 +361,6 @@ void MediaManagerImpl::FramesProcessed(int32_t application_key,
 
 const MediaManagerSettings& MediaManagerImpl::settings() const {
   return settings_;
-}
-
-uint32_t MediaManagerImpl::DataSizeToMilliseconds(uint64_t data_size) const {
-  constexpr uint16_t latency_compensation = 500;
-  return 1000 * data_size / (sampling_rate_ * bits_per_sample_ / 8) +
-         latency_compensation;
 }
 
 }  //  namespace media_manager

--- a/src/components/media_manager/src/streamer_adapter.cc
+++ b/src/components/media_manager/src/streamer_adapter.cc
@@ -59,7 +59,6 @@ void StreamerAdapter::StartActivity(int32_t application_key) {
                                               << " has been already started");
     return;
   }
-  messages_.Reset();
 
   DCHECK(thread_);
   const size_t kStackSize = 16384;
@@ -87,6 +86,7 @@ void StreamerAdapter::StopActivity(int32_t application_key) {
 
   DCHECK(streamer_);
   streamer_->exitThreadMain();
+  messages_.Reset();
 
   for (std::set<MediaListenerPtr>::iterator it = media_listeners_.begin();
        media_listeners_.end() != it;

--- a/src/components/media_manager/test/media_manager_impl_test.cc
+++ b/src/components/media_manager/test/media_manager_impl_test.cc
@@ -35,7 +35,6 @@
 #include "application_manager/message.h"
 #include "application_manager/mock_application.h"
 #include "application_manager/mock_application_manager.h"
-#include "application_manager/mock_hmi_capabilities.h"
 #include "application_manager/resumption/resume_ctrl.h"
 #include "application_manager/state_controller.h"
 #include "gmock/gmock.h"
@@ -110,10 +109,6 @@ class MediaManagerImplTest : public ::testing::Test {
         .WillByDefault(ReturnRef(kDefaultValue));
     ON_CALL(mock_media_manager_settings_, audio_server_type())
         .WillByDefault(ReturnRef(kDefaultValue));
-    ON_CALL(mock_hmi_capabilities_, pcm_stream_capabilities())
-        .WillByDefault(Return(nullptr));
-    ON_CALL(app_mngr_, hmi_capabilities())
-        .WillByDefault(ReturnRef(mock_hmi_capabilities_));
     mock_app_ = std::make_shared<MockApp>();
     media_manager_impl_.reset(
         new MediaManagerImpl(app_mngr_, mock_media_manager_settings_));
@@ -181,7 +176,7 @@ class MediaManagerImplTest : public ::testing::Test {
         .WillOnce(Return(true));
     EXPECT_CALL(app_mngr_, application(kConnectionKey))
         .WillOnce(Return(mock_app_));
-    EXPECT_CALL(*mock_app_, WakeUpStreaming(service_type, 0ull));
+    EXPECT_CALL(*mock_app_, WakeUpStreaming(service_type));
     MockMediaAdapterImplPtr mock_media_streamer =
         std::make_shared<MockMediaAdapterImpl>();
     media_manager_impl_->set_mock_streamer(service_type, mock_media_streamer);
@@ -211,7 +206,6 @@ class MediaManagerImplTest : public ::testing::Test {
   const ::testing::NiceMock<MockMediaManagerSettings>
       mock_media_manager_settings_;
   std::shared_ptr<MediaManagerImpl> media_manager_impl_;
-  application_manager_test::MockHMICapabilities mock_hmi_capabilities_;
 };
 
 TEST_F(MediaManagerImplTest,


### PR DESCRIPTION
Fixes #3160 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
[Describe how you plan to unit test the changes in this PR]

### Summary
The problem of the current implementation is that SDL kills streaming thread responsible for sending a/v streaming data to HMI when streaming timeout expires. This issue is observed when mobile app dumps 10-seconds audio file to SDL during 2 seconds and after that app does not send any data. In that case HMI will play audio file during 2 seconds + timeout = 5 seconds. At the 5th second SDL just kills streaming thread with all pending messages, however audio service is still open. As a result not a whole audio file is played.

The correct behavior from SDL side in that case is not kill streaming thread when streaming timeout was expired. SDL should kill streaming thread only when service is actually stopped.

Current SDL behavior was updated to align with a correct behavior described above.

### Tasks Remaining:
- [x] Test this fix

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
