### PR TITLE
Use atomic bool in ApplicationManager

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -35,6 +35,7 @@
 
 #include <stdint.h>
 #include <algorithm>
+#include <atomic>
 #include <deque>
 #include <map>
 #include <memory>
@@ -1666,7 +1667,6 @@ class ApplicationManagerImpl
   sync_primitives::Lock close_app_timer_pool_lock_;
   sync_primitives::Lock end_stream_timer_pool_lock_;
 
-  mutable sync_primitives::RecursiveLock stopping_application_mng_lock_;
   StateControllerImpl state_ctrl_;
   std::unique_ptr<app_launch::AppLaunchData> app_launch_dto_;
   std::unique_ptr<app_launch::AppLaunchCtrl> app_launch_ctrl_;
@@ -1700,7 +1700,7 @@ class ApplicationManagerImpl
 
   std::atomic<bool> registered_during_timer_execution_;
 
-  volatile bool is_stopping_;
+  std::atomic<bool> is_stopping_;
 
   std::unique_ptr<CommandHolder> commands_holder_;
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -229,7 +229,7 @@ ApplicationManagerImpl::ApplicationManagerImpl(
 ApplicationManagerImpl::~ApplicationManagerImpl() {
   SDL_LOG_AUTO_TRACE();
 
-  is_stopping_ = true;
+  is_stopping_.store(true);
   SendOnSDLClose();
   media_manager_ = NULL;
   hmi_handler_ = NULL;
@@ -2534,9 +2534,7 @@ bool ApplicationManagerImpl::Init(
 
 bool ApplicationManagerImpl::Stop() {
   SDL_LOG_AUTO_TRACE();
-  stopping_application_mng_lock_.Acquire();
-  is_stopping_ = true;
-  stopping_application_mng_lock_.Release();
+  is_stopping_.store(true);
   application_list_update_timer_.Stop();
   try {
     if (unregister_reason_ ==
@@ -2960,9 +2958,7 @@ void ApplicationManagerImpl::SetUnregisterAllApplicationsReason(
 void ApplicationManagerImpl::HeadUnitReset(
     mobile_api::AppInterfaceUnregisteredReason::eType reason) {
   SDL_LOG_AUTO_TRACE();
-  stopping_application_mng_lock_.Acquire();
-  is_stopping_ = true;
-  stopping_application_mng_lock_.Release();
+  is_stopping_.store(true);
   switch (reason) {
     case mobile_api::AppInterfaceUnregisteredReason::MASTER_RESET: {
       SDL_LOG_TRACE("Performing MASTER_RESET");
@@ -3368,7 +3364,6 @@ mobile_apis::Result::eType ApplicationManagerImpl::CheckPolicyPermissions(
 }
 
 bool ApplicationManagerImpl::is_stopping() const {
-  sync_primitives::AutoLock lock(stopping_application_mng_lock_);
   return is_stopping_;
 }
 


### PR DESCRIPTION
Fixes #3182 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by unit tests

### Summary
Replace bool flag 'is_stopping_' in class ApplicationManagerImpl and remove mutex 'stopping_application_mng_lock_'.

### Tasks Remaining:
- [x] Test this fix

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
