### PR TITLE
Fix/usb handler thread safe stop

### DIFF
--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2798,9 +2798,9 @@ void MessageHelper::SendSystemRequestNotification(
 
   content[strings::params][strings::connection_key] = connection_key;
   PrintSmartObject(content);
-  DCHECK(app_mngr.GetRPCService().ManageMobileCommand(
+  app_mngr.GetRPCService().ManageMobileCommand(
       std::make_shared<smart_objects::SmartObject>(content),
-      commands::Command::SOURCE_SDL));
+      commands::Command::SOURCE_SDL);
 }
 
 void MessageHelper::SendLaunchApp(const uint32_t connection_key,

--- a/src/components/transport_manager/include/transport_manager/usb/libusb/usb_handler.h
+++ b/src/components/transport_manager/include/transport_manager/usb/libusb/usb_handler.h
@@ -37,6 +37,7 @@
 #define SRC_COMPONENTS_TRANSPORT_MANAGER_INCLUDE_TRANSPORT_MANAGER_USB_LIBUSB_USB_HANDLER_H_
 
 #include <libusb-1.0/libusb.h>
+#include <atomic>
 
 #include "transport_manager/transport_adapter/transport_adapter.h"
 #include "transport_manager/usb/libusb/platform_usb_device.h"
@@ -87,7 +88,7 @@ class UsbHandler {
     UsbHandler* handler_;
   };
 
-  bool shutdown_requested_;
+  std::atomic<bool> shutdown_requested_;
   threads::Thread* thread_;
 
   friend class UsbDeviceListener;

--- a/src/components/transport_manager/include/transport_manager/usb/libusb/usb_handler.h
+++ b/src/components/transport_manager/include/transport_manager/usb/libusb/usb_handler.h
@@ -71,6 +71,11 @@ class UsbHandler {
   void SubmitControlTransfer(ControlTransferSequenceState* sequence_state);
   friend void UsbTransferSequenceCallback(libusb_transfer* transfer);
 
+  void RequestStopThread();
+  void DeregisterHotplugCallbacks();
+  void JoinAndDeleteThread();
+  void InvokeLibusbExit();
+
  private:
   class UsbHandlerDelegate : public threads::ThreadDelegate {
    public:

--- a/src/components/transport_manager/src/usb/libusb/usb_handler.cc
+++ b/src/components/transport_manager/src/usb/libusb/usb_handler.cc
@@ -105,7 +105,7 @@ UsbHandler::~UsbHandler() {
 
 void UsbHandler::RequestStopThread() {
   SDL_LOG_AUTO_TRACE();
-  shutdown_requested_ = true;
+  shutdown_requested_.store(true);
 }
 
 void UsbHandler::DeregisterHotplugCallbacks() {

--- a/src/components/transport_manager/src/usb/libusb/usb_handler.cc
+++ b/src/components/transport_manager/src/usb/libusb/usb_handler.cc
@@ -89,8 +89,27 @@ UsbHandler::UsbHandler()
 }
 
 UsbHandler::~UsbHandler() {
+  SDL_LOG_AUTO_TRACE();
+
+  // Notify Thread to stop on next iteration...
+  RequestStopThread();
+
+  // ... and unregister hotplug callbacks in order to wake
+  // libusb_handle_events()
+  DeregisterHotplugCallbacks();
+
+  // Now it is safe to join the Thread and free up resources
+  JoinAndDeleteThread();
+  InvokeLibusbExit();
+}
+
+void UsbHandler::RequestStopThread() {
+  SDL_LOG_AUTO_TRACE();
   shutdown_requested_ = true;
-  SDL_LOG_INFO("UsbHandler thread finished");
+}
+
+void UsbHandler::DeregisterHotplugCallbacks() {
+  SDL_LOG_AUTO_TRACE();
 
   if (libusb_context_) {
     // The libusb_hotplug_deregister_callback() wakes up blocking call of
@@ -99,10 +118,20 @@ UsbHandler::~UsbHandler() {
                                        arrived_callback_handle_);
     libusb_hotplug_deregister_callback(libusb_context_, left_callback_handle_);
   }
+}
 
+void UsbHandler::JoinAndDeleteThread() {
+  SDL_LOG_AUTO_TRACE();
+
+  // Let thread finish on its own
   thread_->Stop(threads::Thread::kThreadSoftStop);
   delete thread_->GetDelegate();
   threads::DeleteThread(thread_);
+  SDL_LOG_INFO("UsbHandler thread finished");
+}
+
+void UsbHandler::InvokeLibusbExit() {
+  SDL_LOG_AUTO_TRACE();
 
   if (libusb_context_) {
     libusb_exit(libusb_context_);


### PR DESCRIPTION
Fixes #3184 and #3188 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by unit tests

### Summary
- Wait for UsbHandler thread end in UsbHandler dtor 
- Using atomic bool for `shutdown_requested_` flag

### Tasks Remaining:
- [ ] Test this fix

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
