### PR TITLE
Fix deadlock in usb connection

### DIFF
--- a/src/components/transport_manager/include/transport_manager/usb/libusb/usb_connection.h
+++ b/src/components/transport_manager/include/transport_manager/usb/libusb/usb_connection.h
@@ -86,7 +86,7 @@ class UsbConnection : public Connection {
 
   std::list<protocol_handler::RawMessagePtr> out_messages_;
   protocol_handler::RawMessagePtr current_out_message_;
-  sync_primitives::Lock out_messages_mutex_;
+  sync_primitives::RecursiveLock out_messages_mutex_;
   size_t bytes_sent_;
   bool disconnecting_;
   bool waiting_in_transfer_cancel_;


### PR DESCRIPTION
Fixes #3189 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by unit tests

### Summary
In a while called method  locks mutex for protecting data and if USB connection is failed it means that method will call and will try to lock the same mutex again. That's why this mutex should be recursive.

### Tasks Remaining:
- [ ] Test this fix

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
