### PR TITLE
Fix data races in TcpClientListener

### DIFF
--- a/src/components/transport_manager/include/transport_manager/tcp/tcp_client_listener.h
+++ b/src/components/transport_manager/include/transport_manager/tcp/tcp_client_listener.h
@@ -37,6 +37,9 @@
 #define SRC_COMPONENTS_TRANSPORT_MANAGER_INCLUDE_TRANSPORT_MANAGER_TCP_TCP_CLIENT_LISTENER_H_
 
 #include "transport_manager/transport_adapter/client_connection_listener.h"
+
+#include <atomic>
+
 #include "utils/lock.h"
 #include "utils/threads/thread_delegate.h"
 
@@ -149,8 +152,8 @@ class TcpClientListener : public ClientConnectionListener {
   bool started_;
   threads::Thread* thread_;
   int socket_;
-  bool thread_stop_requested_;
-  bool remove_devices_on_terminate_;
+  std::atomic_bool thread_stop_requested_;
+  std::atomic_bool remove_devices_on_terminate_;
   int pipe_fds_[2];
   NetworkInterfaceListener* interface_listener_;
   const std::string designated_interface_;

--- a/src/components/transport_manager/src/tcp/tcp_client_listener.cc
+++ b/src/components/transport_manager/src/tcp/tcp_client_listener.cc
@@ -97,7 +97,7 @@ TcpClientListener::TcpClientListener(TransportAdapterController* controller,
 
 TransportAdapter::Error TcpClientListener::Init() {
   SDL_LOG_AUTO_TRACE();
-  thread_stop_requested_ = false;
+  thread_stop_requested_.store(false);
 
   if (!IsListeningOnSpecificInterface()) {
     // Network interface is not specified. We will listen on all interfaces
@@ -343,7 +343,7 @@ void TcpClientListener::StopLoop() {
     return;
   }
 
-  thread_stop_requested_ = true;
+  thread_stop_requested_.store(true);
 
   char dummy[1] = {0};
   int ret = write(pipe_fds_[1], dummy, sizeof(dummy));
@@ -459,7 +459,7 @@ TransportAdapter::Error TcpClientListener::StartListeningThread() {
     }
   }
 
-  thread_stop_requested_ = false;
+  thread_stop_requested_.store(false);
 
   if (!thread_->Start()) {
     return TransportAdapter::FAIL;
@@ -538,7 +538,7 @@ bool TcpClientListener::StartOnNetworkInterface() {
       }
     }
 
-    remove_devices_on_terminate_ = true;
+    remove_devices_on_terminate_.store(true);
 
     if (TransportAdapter::OK != StartListeningThread()) {
       SDL_LOG_WARN("Failed to start TCP client listener");
@@ -564,7 +564,7 @@ bool TcpClientListener::StopOnNetworkInterface() {
       socket_ = -1;
     }
 
-    remove_devices_on_terminate_ = false;
+    remove_devices_on_terminate_.store(false);
 
     SDL_LOG_INFO("TCP server socket on " << designated_interface_
                                          << " stopped");


### PR DESCRIPTION
Fixes #3187 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by unit tests

### Summary
Regarding of Helgrind report. Changed type of `TcpClientListener::thread_stop_requested_` from `bool` to `std::atomic_bool`.
The same for `remove_devices_on_terminate_`

### Tasks Remaining:
- [ ] Test this fix

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
