### PR TITLE
Fix msg_params in erroneous GetIVD response 

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -281,10 +281,8 @@ void GetInteriorVehicleDataRequest::on_event(
                       [message_params::kModuleData][data_mapping(module_type)];
       interior_data_cache_.Add(module, module_data);
     }
-  } else {
-    hmi_response[app_mngr::strings::msg_params].erase(
-        message_params::kIsSubscribed);
   }
+
   std::string response_info;
   GetInfo(hmi_response, response_info);
   SetResourceState(ModuleType(), ResourceState::FREE);
@@ -292,7 +290,7 @@ void GetInteriorVehicleDataRequest::on_event(
   SendResponse(result,
                result_code,
                response_info.c_str(),
-               &hmi_response[app_mngr::strings::msg_params]);
+               result ? &hmi_response[app_mngr::strings::msg_params] : nullptr);
 }
 
 GetInteriorVehicleDataRequest::~GetInteriorVehicleDataRequest() {}

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -732,6 +732,8 @@ TEST_F(GetInteriorVehicleDataRequestTest,
   available_hd_chanels[1] = chanel2_index;
   available_hd_chanels[2] = chanel3_index;
 
+  msg_params[message_params::kModuleData][message_params::kModuleId] =
+      kModuleId;
   msg_params[message_params::kModuleData][message_params::kRadioControlData]
             [message_params::kAvailableHdChannels] = available_hd_chanels;
 
@@ -790,6 +792,8 @@ TEST_F(GetInteriorVehicleDataRequestTest,
       smart_objects::SmartObject(smart_objects::SmartType_Boolean);
   climate_control_data = true;
 
+  msg_params[message_params::kModuleData][message_params::kModuleId] =
+      kModuleId;
   msg_params[message_params::kModuleData][message_params::kClimateControlData]
             [message_params::kClimateEnableAvailable] = climate_control_data;
 


### PR DESCRIPTION
Fixes #3514 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by manual testing

### Summary
Removed `msg_params` section forwarding for case when GetIVD response was not successful

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
