### PR TITLE
Fix GetInteriorVehicle request wrong processes result codes from HMI

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -245,7 +245,10 @@ void GetInteriorVehicleDataRequest::on_event(
       helpers::Compare<mobile_apis::Result::eType, helpers::EQ, helpers::ONE>(
           result_code,
           mobile_apis::Result::SUCCESS,
-          mobile_apis::Result::WARNINGS);
+          mobile_apis::Result::WARNINGS,
+          mobile_apis::Result::WRONG_LANGUAGE,
+          mobile_apis::Result::RETRY,
+          mobile_apis::Result::SAVED);
 
   if (mobile_apis::Result::READ_ONLY == result_code) {
     result = false;


### PR DESCRIPTION
Fixes #3517 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF script : https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2460
Unit test

### Summary
GetInteriorVehicle request RPC should process the next result codes as success: WRONG_LANGUAGE, RETRY, SAVED.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
