### PR TITLE
Optional parse PTU as array for http policies

### DIFF
--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -869,7 +869,7 @@ class PolicyManagerImpl : public PolicyManager {
   void ResetTimeout() OVERRIDE;
 
  protected:
-#ifdef USE_HMI_PTU_DECRYPTION
+#if defined USE_HMI_PTU_DECRYPTION && defined PROPRIETARY_MODE
   /**
    * @brief Parse policy table content and convert to PT object
    * @param pt_content binary content of PT

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -87,7 +87,7 @@ void PolicyManagerImpl::set_listener(PolicyListener* listener) {
   update_status_manager_.set_listener(listener);
 }
 
-#ifdef USE_HMI_PTU_DECRYPTION
+#if defined USE_HMI_PTU_DECRYPTION && defined PROPRIETARY_MODE
 
 std::shared_ptr<policy_table::Table> PolicyManagerImpl::Parse(
     const BinaryMessage& pt_content) {
@@ -331,7 +331,7 @@ PolicyManager::PtProcessingResult PolicyManagerImpl::LoadPT(
 
       "PTU content is: " << std::string(pt_content.begin(), pt_content.end()));
 
-#ifdef USE_HMI_PTU_DECRYPTION
+#if defined USE_HMI_PTU_DECRYPTION && defined PROPRIETARY_MODE
   // Assuemes Policy Table was parsed, formatted, and/or decrypted by
   // the HMI after system request before calling OnReceivedPolicyUpdate
   // Parse message into table struct


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Build with http policies and test a PTU with the SDL server and the legacy SDL Server v.1

### Summary
When building with http policies, a PTU will be processed by the function parseArray. This function is a little more forgiving than its counterpart "Parse". ParseArray checks if the PTU has the data structure included or not, and processes the data accordingly. This allows HTTP policies to work better with the newer sdl server.

Also HTTP policies does not pass the PTU to the HMI so HMI_PTU_DECRPYTION_FLAG does not apply for HTTP policies.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
