### PR TITLE
Ignore playTone if provided without TTSChunks

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_request.cc
@@ -111,10 +111,11 @@ void AlertRequest::Run() {
         (*message_)[strings::msg_params][strings::tts_chunks].length();
   }
 
-  if ((tts_chunks_exists && length_tts_chunks) ||
-      ((*message_)[strings::msg_params].keyExists(strings::play_tone) &&
-       (*message_)[strings::msg_params][strings::play_tone].asBool())) {
+  if (tts_chunks_exists && length_tts_chunks) {
     awaiting_tts_speak_response_ = true;
+  } else if ((*message_)[strings::msg_params].keyExists(strings::play_tone) &&
+             (*message_)[strings::msg_params][strings::play_tone].asBool()) {
+    set_warning_info("playTone ignored since TTS Chunks were not provided");
   }
 
   SendAlertRequest(app_id);


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Send `Alert` with `alertText1` and `playTone: true` while omitting `ttsChunks`. Verify that no `TTS.Speak` request is sent  to the HMI and a warning message is returned to the app.

### Summary
`ttsChunks` is mandatory in `TTS.Speak`, but if omitted in an Alert request, Core would send a request without this parameter. This PR makes it so Core will not send `TTS.Speak` in such a case.

### Changelog
##### Bug Fixes
* Respond with `WARNINGS` if `playTone` is provided in an `Alert` without `ttsChunks`. playTone is ignored in this case

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
