### PR TITLE
Re-order rai logic for plugins

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -370,6 +370,8 @@ class ApplicationManagerImpl
   ApplicationSharedPtr RegisterApplication(
       const std::shared_ptr<smart_objects::SmartObject>&
           request_for_registration) OVERRIDE;
+
+  void FinalizeAppRegistration(ApplicationSharedPtr application, const uint32_t connection_key) OVERRIDE;
   /*
    * @brief Closes application by id
    *

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -371,7 +371,8 @@ class ApplicationManagerImpl
       const std::shared_ptr<smart_objects::SmartObject>&
           request_for_registration) OVERRIDE;
 
-  void FinalizeAppRegistration(ApplicationSharedPtr application, const uint32_t connection_key) OVERRIDE;
+  void FinalizeAppRegistration(ApplicationSharedPtr application,
+                               const uint32_t connection_key) OVERRIDE;
   /*
    * @brief Closes application by id
    *

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -746,6 +746,9 @@ void RegisterAppInterfaceRequest::Run() {
     plugin.OnApplicationEvent(plugin_manager::kApplicationRegistered,
                               application);
   };
+  // To prevent timing issues, this event is called before an app is accessible
+  // by the applications accessor. This prevents incoming hmi rpcs from
+  // attempting to access an app before it has been fully initialized.
   application_manager_.ApplyFunctorForEachPlugin(on_app_registered);
   application_manager_.FinalizeAppRegistration(application, connection_key());
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -755,6 +755,11 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
   // Timer will be started after hmi level resumption.
   resume_controller().OnAppRegistrationStart(policy_app_id, device_mac);
 
+  return application;
+}
+
+void ApplicationManagerImpl::FinalizeAppRegistration(ApplicationSharedPtr application, const uint32_t connection_key) {
+  
   AddAppToRegisteredAppList(application);
 
   // Update cloud app information, in case any pending apps are unable to be
@@ -772,8 +777,6 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
     connection_handler::DeviceHandle secondary_device_handle = itr->second;
     application->set_secondary_device(secondary_device_handle);
   }
-
-  return application;
 }
 
 bool ApplicationManagerImpl::ActivateApplication(ApplicationSharedPtr app) {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -758,8 +758,8 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
   return application;
 }
 
-void ApplicationManagerImpl::FinalizeAppRegistration(ApplicationSharedPtr application, const uint32_t connection_key) {
-  
+void ApplicationManagerImpl::FinalizeAppRegistration(
+    ApplicationSharedPtr application, const uint32_t connection_key) {
   AddAppToRegisteredAppList(application);
 
   // Update cloud app information, in case any pending apps are unable to be

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -558,6 +558,8 @@ class ApplicationManager {
       const std::shared_ptr<smart_objects::SmartObject>&
           request_for_registration) = 0;
 
+  virtual void FinalizeAppRegistration(ApplicationSharedPtr application, const uint32_t connection_key) = 0;
+
   virtual void SendUpdateAppList() = 0;
 
   virtual void MarkAppsGreyOut(const connection_handler::DeviceHandle handle,

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -558,7 +558,8 @@ class ApplicationManager {
       const std::shared_ptr<smart_objects::SmartObject>&
           request_for_registration) = 0;
 
-  virtual void FinalizeAppRegistration(ApplicationSharedPtr application, const uint32_t connection_key) = 0;
+  virtual void FinalizeAppRegistration(ApplicationSharedPtr application,
+                                       const uint32_t connection_key) = 0;
 
   virtual void SendUpdateAppList() = 0;
 

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -554,10 +554,22 @@ class ApplicationManager {
    */
   virtual void IviInfoUpdated(const std::string& vehicle_info, int value) = 0;
 
+  /**
+   * @brief Creates the application object for a newly registered application.
+   * This method performs initialiation of the app object by setting properties
+   * and starting the resumption process if applicable.
+   * @param request_for_registration Smart Object RegisterAppInterfaceRequest
+   * message received from mobile.
+   */
   virtual ApplicationSharedPtr RegisterApplication(
       const std::shared_ptr<smart_objects::SmartObject>&
           request_for_registration) = 0;
-
+  /**
+   * @brief Completes initialization process by adding the app to the
+   * applications accessor. App is now accessible by all other Core components.
+   * @param application ApplicationSharedPtr for newly registered application.
+   * @param connection_key Internal application id of registering application.
+   */
   virtual void FinalizeAppRegistration(ApplicationSharedPtr application,
                                        const uint32_t connection_key) = 0;
 

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -220,6 +220,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                application_manager::ApplicationSharedPtr(
                    const std::shared_ptr<smart_objects::SmartObject>&
                        request_for_registration));
+  MOCK_METHOD2(FinalizeAppRegistration,
+               void(application_manager::ApplicationSharedPtr,
+                    const uint32_t connection_key));
   MOCK_METHOD0(SendUpdateAppList, void());
   MOCK_METHOD2(MarkAppsGreyOut,
                void(const connection_handler::DeviceHandle handle,


### PR DESCRIPTION
Fixes #3172 #3162 

This PR is **Ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Send on vehicle data notification at same time app registers. Core should not crash.

### Summary
Moves the call to add the newly registered app to the applications list later in the registration process. This ensures that an app has all of its necessary plugins added before it is accessible by the applications accessor.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
