### PR TITLE
Add defvalue to policy table schema

### DIFF
--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -4080,7 +4080,7 @@
                                     "key": "OEM_REF_WND_LOC_LVL",
                                     "type": "Integer",
                                     "mandatory": false,
-                                    "defvalue" : 0,
+                                    "defvalue" : "0",
                                     "minvalue": -1,
                                     "maxvalue": 100
                                 },
@@ -4089,7 +4089,7 @@
                                     "key": "OEM_REF_WND_LOC_COLSPN",
                                     "type": "Integer",
                                     "mandatory": false,
-                                    "defvalue" : 1,
+                                    "defvalue" : "1",
                                     "minvalue": 1,
                                     "maxvalue": 100
                                 },
@@ -4098,7 +4098,7 @@
                                     "key": "OEM_REF_WND_LOC_ROWSPN",
                                     "type": "Integer",
                                     "mandatory": false,
-                                    "defvalue" : 1,
+                                    "defvalue" : "1",
                                     "minvalue": 1,
                                     "maxvalue": 100
                                 },
@@ -4107,7 +4107,7 @@
                                     "key": "OEM_REF_WND_LOC_LVLSPN",
                                     "type": "Integer",
                                     "mandatory": false,
-                                    "defvalue" : 1,
+                                    "defvalue" : "1",
                                     "minvalue": 1,
                                     "maxvalue": 100
                                 }

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_data_item_schema.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_data_item_schema.cc
@@ -117,16 +117,21 @@ smart_objects::ISchemaItemPtr VehicleDataItemSchema::GetPODTypeSchema(
   using FloatItemParam = smart_objects::TSchemaItemParameter<double>;
   using StringSchemaItem = smart_objects::CStringSchemaItem;
   using StringItemParam = smart_objects::TSchemaItemParameter<size_t>;
+  using StringItemValueParam = smart_objects::TSchemaItemParameter<std::string>;
   using BoolSchemaItem = smart_objects::CBoolSchemaItem;
   using BoolItemParam = smart_objects::TSchemaItemParameter<bool>;
 
   if (policy_item.type == policy_table::VehicleDataItem::kInteger) {
-    return IntSchemaItem::create(policy_item.minvalue.is_initialized()
-                                     ? IntItemParam(*policy_item.minvalue)
-                                     : IntItemParam(),
-                                 policy_item.maxvalue.is_initialized()
-                                     ? IntItemParam(*policy_item.maxvalue)
-                                     : IntItemParam());
+    return IntSchemaItem::create(
+        policy_item.minvalue.is_initialized()
+            ? IntItemParam(*policy_item.minvalue)
+            : IntItemParam(),
+        policy_item.maxvalue.is_initialized()
+            ? IntItemParam(*policy_item.maxvalue)
+            : IntItemParam(),
+        policy_item.defvalue.is_initialized()
+            ? IntItemParam(std::stol(*policy_item.defvalue))
+            : IntItemParam());
   }
   if (policy_item.type == policy_table::VehicleDataItem::kFloat ||
       policy_item.type == policy_table::VehicleDataItem::kDouble) {
@@ -136,6 +141,9 @@ smart_objects::ISchemaItemPtr VehicleDataItemSchema::GetPODTypeSchema(
             : FloatItemParam(),
         policy_item.maxvalue.is_initialized()
             ? FloatItemParam(double(*policy_item.maxvalue))
+            : FloatItemParam(),
+        policy_item.defvalue.is_initialized()
+            ? FloatItemParam(std::stod(*policy_item.defvalue))
             : FloatItemParam());
   }
   if (policy_item.type == policy_table::VehicleDataItem::kString) {
@@ -145,10 +153,16 @@ smart_objects::ISchemaItemPtr VehicleDataItemSchema::GetPODTypeSchema(
                             : 0),
         policy_item.maxlength.is_initialized()
             ? StringItemParam(*policy_item.maxlength)
-            : StringItemParam());
+            : StringItemParam(),
+        policy_item.defvalue.is_initialized()
+            ? StringItemValueParam(std::string(*policy_item.defvalue))
+            : StringItemValueParam());
   }
   if (policy_item.type == policy_table::VehicleDataItem::kBoolean) {
-    return BoolSchemaItem::create(BoolItemParam(true));
+    return BoolSchemaItem::create(
+        policy_item.defvalue.is_initialized()
+            ? BoolItemParam(*policy_item.defvalue == "true")
+            : BoolItemParam());
   }
 
   std::string error_msg = std::string("Invalid POD type provided: ") +

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_data_item_schema_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_data_item_schema_test.cc
@@ -85,6 +85,7 @@ class VehicleDataItemSchemaTest : public ::testing::Test {
       schema.params->mark_initialized();
       schema.mandatory = true;
       *schema.array = false;
+      *schema.defvalue = "10";
       // default value bounds
       *schema.minvalue = 10;
       *schema.maxvalue = 100;

--- a/src/components/policy/policy_external/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/types.h
@@ -683,6 +683,11 @@ struct VehicleDataItem : CompositeType {
    * @return true if type is valid.
    */
   bool ValidateTypes() const;
+  /**
+   * @brief Validates default value of vehicle data item based
+   * on type, unable to validate enum values
+   * @return true if defvalue is valid.
+   */
   bool ValidateDefault() const;
   bool IsPrimitiveType() const;
   bool ValidateNaming(std::string str) const;

--- a/src/components/policy/policy_external/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/types.h
@@ -654,6 +654,7 @@ struct VehicleDataItem : CompositeType {
   Optional<String<0, 255> > until;
   Optional<Boolean> removed;
   Optional<Boolean> deprecated;
+  Optional<String<0, UINT32_MAX> > defvalue;
   Optional<Float<-INT32_MAX, INT32_MAX> > minvalue;
   Optional<Float<-INT32_MAX, INT32_MAX> > maxvalue;
   Optional<Integer<uint32_t, 0, UINT32_MAX> > minsize;
@@ -682,6 +683,7 @@ struct VehicleDataItem : CompositeType {
    * @return true if type is valid.
    */
   bool ValidateTypes() const;
+  bool ValidateDefault() const;
   bool IsPrimitiveType() const;
   bool ValidateNaming(std::string str) const;
 

--- a/src/components/policy/policy_external/src/policy_table/types.cc
+++ b/src/components/policy/policy_external/src/policy_table/types.cc
@@ -1,5 +1,8 @@
 #include "policy/policy_table/types.h"
+
 #include <algorithm>
+#include <regex>
+
 #include "rpc_base/rpc_base_json_inl.h"
 
 namespace rpc {
@@ -2216,6 +2219,7 @@ VehicleDataItem::VehicleDataItem(const VehicleDataItem& vehicle_data)
     , until(vehicle_data.until)
     , removed(vehicle_data.removed)
     , deprecated(vehicle_data.deprecated)
+    , defvalue(vehicle_data.defvalue)
     , minvalue(vehicle_data.minvalue)
     , maxvalue(vehicle_data.maxvalue)
     , minsize(vehicle_data.minsize)
@@ -2235,12 +2239,17 @@ VehicleDataItem::VehicleDataItem(const Json::Value* value__)
     , until(impl::ValueMember(value__, "until"))
     , removed(impl::ValueMember(value__, "removed"))
     , deprecated(impl::ValueMember(value__, "deprecated"))
+    , defvalue(static_cast<Json::Value*>(nullptr))
     , minvalue(impl::ValueMember(value__, "minvalue"))
     , maxvalue(impl::ValueMember(value__, "maxvalue"))
     , minsize(impl::ValueMember(value__, "minsize"))
     , maxsize(impl::ValueMember(value__, "maxsize"))
     , minlength(impl::ValueMember(value__, "minlength"))
-    , maxlength(impl::ValueMember(value__, "maxlength")) {}
+    , maxlength(impl::ValueMember(value__, "maxlength")) {
+  if (value__->isMember("defvalue")) {
+    *defvalue = impl::ValueMember(value__, "defvalue")->asString();
+  }
+}
 
 VehicleDataItem::~VehicleDataItem() {}
 
@@ -2266,6 +2275,7 @@ Json::Value VehicleDataItem::ToJsonValue() const {
   impl::WriteJsonField("until", until, &ret);
   impl::WriteJsonField("removed", removed, &ret);
   impl::WriteJsonField("deprecated", deprecated, &ret);
+  impl::WriteJsonField("defvalue", defvalue, &ret);
   impl::WriteJsonField("minvalue", minvalue, &ret);
   impl::WriteJsonField("maxvalue", maxvalue, &ret);
   impl::WriteJsonField("minsize", minsize, &ret);
@@ -2280,9 +2290,10 @@ bool VehicleDataItem::operator==(const VehicleDataItem& vd) {
           mandatory == vd.mandatory && params == vd.params &&
           array == vd.array && since == vd.since && until == vd.until &&
           removed == vd.removed && deprecated == vd.deprecated &&
-          minvalue == vd.minvalue && maxvalue == vd.maxvalue &&
-          minsize == vd.minsize && maxsize == vd.maxsize &&
-          minlength == vd.minlength && maxlength == vd.maxlength);
+          defvalue == vd.defvalue && minvalue == vd.minvalue &&
+          maxvalue == vd.maxvalue && minsize == vd.minsize &&
+          maxsize == vd.maxsize && minlength == vd.minlength &&
+          maxlength == vd.maxlength);
 }
 
 bool VehicleDataItem::is_valid() const {
@@ -2314,6 +2325,9 @@ bool VehicleDataItem::is_valid() const {
     return false;
   }
   if (!deprecated.is_valid()) {
+    return false;
+  }
+  if (!(defvalue.is_valid() && ValidateDefault())) {
     return false;
   }
   if (!minvalue.is_valid()) {
@@ -2370,6 +2384,9 @@ bool VehicleDataItem::struct_not_empty() const {
     return false;
   }
   if (!deprecated.is_initialized()) {
+    return false;
+  }
+  if (!defvalue.is_initialized()) {
     return false;
   }
   if (!minvalue.is_initialized()) {
@@ -2442,6 +2459,13 @@ void VehicleDataItem::ReportErrors(rpc::ValidationReport* report__) const {
   if (!deprecated.is_valid()) {
     deprecated.ReportErrors(&report__->ReportSubobject("deprecated"));
   }
+  if (!defvalue.is_valid()) {
+    defvalue.ReportErrors(&report__->ReportSubobject("defvalue"));
+  }
+  if (!ValidateDefault()) {
+    report__->set_validation_info("Invalid default value: " +
+                                  std::string(defvalue));
+  }
   if (!minvalue.is_valid()) {
     minvalue.ReportErrors(&report__->ReportSubobject("minvalue"));
   }
@@ -2474,6 +2498,7 @@ void VehicleDataItem::SetPolicyTableType(PolicyTableType pt_type) {
   until.SetPolicyTableType(pt_type);
   removed.SetPolicyTableType(pt_type);
   deprecated.SetPolicyTableType(pt_type);
+  defvalue.SetPolicyTableType(pt_type);
   minvalue.SetPolicyTableType(pt_type);
   maxvalue.SetPolicyTableType(pt_type);
   minsize.SetPolicyTableType(pt_type);
@@ -2507,6 +2532,46 @@ bool VehicleDataItem::ValidateNaming(std::string str) const {
 
   return !empty_string(str) && !contains_spaces(str) &&
          !contains_spec_chars(str);
+}
+
+bool VehicleDataItem::ValidateDefault() const {
+  if (!defvalue.is_initialized()) {
+    return true;
+  }
+  std::string value = std::string(*defvalue);
+  bool valid = false;
+  if (VehicleDataItem::kInteger == std::string(type)) {
+    // Match int
+    std::regex pattern("^-?\\d+$");
+    bool type_matches = std::regex_match(value, pattern);
+    if (type_matches) {
+      size_t int_value = std::stol(value);
+      valid = (!minvalue.is_initialized() || int_value >= *minvalue) &&
+              (!maxvalue.is_initialized() || int_value <= *maxvalue);
+    }
+  } else if (VehicleDataItem::kFloat == std::string(type) ||
+             VehicleDataItem::kDouble == std::string(type)) {
+    // Match double
+    std::regex pattern("^-?\\d+(\\.\\d+)?$");
+    bool type_matches = std::regex_match(value, pattern);
+    if (type_matches) {
+      double dbl_value = std::stod(value);
+      valid = (!minvalue.is_initialized() || dbl_value >= *minvalue) &&
+              (!maxvalue.is_initialized() || dbl_value <= *maxvalue);
+    }
+  } else if (VehicleDataItem::kString == std::string(type)) {
+    size_t length = value.length();
+    valid = (!minsize.is_initialized() || length >= *minsize) &&
+            (!maxsize.is_initialized() || length <= *maxsize);
+  } else if (VehicleDataItem::kBoolean == std::string(type)) {
+    valid = ("false" == value || "true" == value);
+  } else if (VehicleDataItem::kStruct != std::string(type) &&
+             !IsPrimitiveType()) {
+    // Enum values cannot be validated here
+    valid = true;
+  }
+
+  return valid;
 }
 
 bool VehicleDataItem::ValidateTypes() const {

--- a/src/components/policy/policy_external/src/policy_table/types.cc
+++ b/src/components/policy/policy_external/src/policy_table/types.cc
@@ -2464,7 +2464,7 @@ void VehicleDataItem::ReportErrors(rpc::ValidationReport* report__) const {
   }
   if (!ValidateDefault()) {
     report__->set_validation_info("Invalid default value: " +
-                                  std::string(defvalue));
+                                  std::string(*defvalue));
   }
   if (!minvalue.is_valid()) {
     minvalue.ReportErrors(&report__->ReportSubobject("minvalue"));

--- a/src/components/policy/policy_external/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_queries.cc
@@ -480,6 +480,7 @@ const std::string kCreateSchema =
     "  `until` VARCHAR(45), "
     "  `removed` BOOL, "
     "  `deprecated` BOOL, "
+    "  `defvalue` VARCHAR(65535), "
     "  `minvalue` INTEGER, "
     "  `maxvalue` INTEGER, "
     "  `minsize` INTEGER, "
@@ -759,13 +760,14 @@ const std::string kInsertVehicleDataItem =
     "  `until`, "
     "  `removed`, "
     "  `deprecated`, "
+    "  `defvalue`, "
     "  `minvalue`, "
     "  `maxvalue`, "
     "  `minsize`, "
     "  `maxsize`, "
     "  `minlength`, "
     "  `maxlength`) "
-    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
 
 const std::string kInsertVehicleDataItemParams =
     "INSERT INTO `vehicle_data_item_parameters` ("

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -1711,22 +1711,25 @@ policy_table::VehicleDataItem SQLPTRepresentation::PopulateVDIFromQuery(
     *result.deprecated = query.GetBoolean(8);
   }
   if (!query.IsNull(9)) {
-    *result.minvalue = query.GetInteger(9);
+    *result.defvalue = query.GetString(9);
   }
   if (!query.IsNull(10)) {
-    *result.maxvalue = query.GetInteger(10);
+    *result.minvalue = query.GetInteger(10);
   }
   if (!query.IsNull(11)) {
-    *result.minsize = query.GetUInteger(11);
+    *result.maxvalue = query.GetInteger(11);
   }
   if (!query.IsNull(12)) {
-    *result.maxsize = query.GetUInteger(12);
+    *result.minsize = query.GetUInteger(12);
   }
   if (!query.IsNull(13)) {
-    *result.minlength = query.GetUInteger(13);
+    *result.maxsize = query.GetUInteger(13);
   }
   if (!query.IsNull(14)) {
-    *result.maxlength = query.GetUInteger(14);
+    *result.minlength = query.GetUInteger(14);
+  }
+  if (!query.IsNull(15)) {
+    *result.maxlength = query.GetUInteger(15);
   }
   result.params->mark_initialized();
 
@@ -2630,24 +2633,27 @@ bool SQLPTRepresentation::InsertVehicleDataItem(
   vehicle_data_item.deprecated.is_initialized()
       ? query.Bind(8, *vehicle_data_item.deprecated)
       : query.Bind(8);
-  vehicle_data_item.minvalue.is_initialized()
-      ? query.Bind(9, *vehicle_data_item.minvalue)
+  vehicle_data_item.defvalue.is_initialized()
+      ? query.Bind(9, *vehicle_data_item.defvalue)
       : query.Bind(9);
-  vehicle_data_item.maxvalue.is_initialized()
-      ? query.Bind(10, *vehicle_data_item.maxvalue)
+  vehicle_data_item.minvalue.is_initialized()
+      ? query.Bind(10, *vehicle_data_item.minvalue)
       : query.Bind(10);
-  vehicle_data_item.minsize.is_initialized()
-      ? query.Bind(11, static_cast<int64_t>(*vehicle_data_item.minsize))
+  vehicle_data_item.maxvalue.is_initialized()
+      ? query.Bind(11, *vehicle_data_item.maxvalue)
       : query.Bind(11);
-  vehicle_data_item.maxsize.is_initialized()
-      ? query.Bind(12, static_cast<int64_t>(*vehicle_data_item.maxsize))
+  vehicle_data_item.minsize.is_initialized()
+      ? query.Bind(12, static_cast<int64_t>(*vehicle_data_item.minsize))
       : query.Bind(12);
-  vehicle_data_item.minlength.is_initialized()
-      ? query.Bind(13, static_cast<int64_t>(*vehicle_data_item.minlength))
+  vehicle_data_item.maxsize.is_initialized()
+      ? query.Bind(13, static_cast<int64_t>(*vehicle_data_item.maxsize))
       : query.Bind(13);
-  vehicle_data_item.maxlength.is_initialized()
-      ? query.Bind(14, static_cast<int64_t>(*vehicle_data_item.maxlength))
+  vehicle_data_item.minlength.is_initialized()
+      ? query.Bind(14, static_cast<int64_t>(*vehicle_data_item.minlength))
       : query.Bind(14);
+  vehicle_data_item.maxlength.is_initialized()
+      ? query.Bind(15, static_cast<int64_t>(*vehicle_data_item.maxlength))
+      : query.Bind(15);
 
   if (!query.Exec() || !query.Reset()) {
     SDL_LOG_ERROR("Failed to insert vehicle data item: "

--- a/src/components/policy/policy_external/test/sql_pt_representation_test.cc
+++ b/src/components/policy/policy_external/test/sql_pt_representation_test.cc
@@ -408,6 +408,7 @@ TEST_F(SQLPTRepresentationTest, VehicleDataItem_Store_Complete_Item) {
   *message.until = "5.0";
   *message.removed = false;
   *message.deprecated = false;
+  *message.defvalue = "0";
   *message.minvalue = 0;
   *message.maxvalue = 255;
   *message.minsize = 0;

--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -551,6 +551,7 @@ struct VehicleDataItem : CompositeType {
   Optional<String<0, 255> > until;
   Optional<Boolean> removed;
   Optional<Boolean> deprecated;
+  Optional<String<0, UINT32_MAX> > defvalue;
   Optional<Float<-INT32_MAX, INT32_MAX> > minvalue;
   Optional<Float<-INT32_MAX, INT32_MAX> > maxvalue;
   Optional<Integer<uint32_t, 0, UINT32_MAX> > minsize;
@@ -579,6 +580,7 @@ struct VehicleDataItem : CompositeType {
    * @return true if type is valid.
    */
   bool ValidateTypes() const;
+  bool ValidateDefault() const;
   bool IsPrimitiveType() const;
   bool ValidateNaming(std::string str) const;
 

--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -580,6 +580,11 @@ struct VehicleDataItem : CompositeType {
    * @return true if type is valid.
    */
   bool ValidateTypes() const;
+  /**
+   * @brief Validates default value of vehicle data item based
+   * on type, unable to validate enum values
+   * @return true if defvalue is valid.
+   */
   bool ValidateDefault() const;
   bool IsPrimitiveType() const;
   bool ValidateNaming(std::string str) const;

--- a/src/components/policy/policy_regular/src/policy_table/types.cc
+++ b/src/components/policy/policy_regular/src/policy_table/types.cc
@@ -1,5 +1,8 @@
 // This file is generated, do not edit
 #include "policy/policy_table/types.h"
+
+#include <regex>
+
 #include "rpc_base/rpc_base_json_inl.h"
 
 namespace rpc {
@@ -1676,6 +1679,7 @@ VehicleDataItem::VehicleDataItem(const VehicleDataItem& vehicle_data)
     , until(vehicle_data.until)
     , removed(vehicle_data.removed)
     , deprecated(vehicle_data.deprecated)
+    , defvalue(vehicle_data.defvalue)
     , minvalue(vehicle_data.minvalue)
     , maxvalue(vehicle_data.maxvalue)
     , minsize(vehicle_data.minsize)
@@ -1695,12 +1699,17 @@ VehicleDataItem::VehicleDataItem(const Json::Value* value__)
     , until(impl::ValueMember(value__, "until"))
     , removed(impl::ValueMember(value__, "removed"))
     , deprecated(impl::ValueMember(value__, "deprecated"))
+    , defvalue(static_cast<Json::Value*>(nullptr))
     , minvalue(impl::ValueMember(value__, "minvalue"))
     , maxvalue(impl::ValueMember(value__, "maxvalue"))
     , minsize(impl::ValueMember(value__, "minsize"))
     , maxsize(impl::ValueMember(value__, "maxsize"))
     , minlength(impl::ValueMember(value__, "minlength"))
-    , maxlength(impl::ValueMember(value__, "maxlength")) {}
+    , maxlength(impl::ValueMember(value__, "maxlength")) {
+  if (value__->isMember("defvalue")) {
+    *defvalue = impl::ValueMember(value__, "defvalue")->asString();
+  }
+}
 
 VehicleDataItem::~VehicleDataItem() {}
 
@@ -1726,6 +1735,7 @@ Json::Value VehicleDataItem::ToJsonValue() const {
   impl::WriteJsonField("until", until, &ret);
   impl::WriteJsonField("removed", removed, &ret);
   impl::WriteJsonField("deprecated", deprecated, &ret);
+  impl::WriteJsonField("defvalue", defvalue, &ret);
   impl::WriteJsonField("minvalue", minvalue, &ret);
   impl::WriteJsonField("maxvalue", maxvalue, &ret);
   impl::WriteJsonField("minsize", minsize, &ret);
@@ -1740,9 +1750,10 @@ bool VehicleDataItem::operator==(const VehicleDataItem& vd) {
           mandatory == vd.mandatory && params == vd.params &&
           array == vd.array && since == vd.since && until == vd.until &&
           removed == vd.removed && deprecated == vd.deprecated &&
-          minvalue == vd.minvalue && maxvalue == vd.maxvalue &&
-          minsize == vd.minsize && maxsize == vd.maxsize &&
-          minlength == vd.minlength && maxlength == vd.maxlength);
+          defvalue == vd.defvalue && minvalue == vd.minvalue &&
+          maxvalue == vd.maxvalue && minsize == vd.minsize &&
+          maxsize == vd.maxsize && minlength == vd.minlength &&
+          maxlength == vd.maxlength);
 }
 
 bool VehicleDataItem::is_valid() const {
@@ -1774,6 +1785,9 @@ bool VehicleDataItem::is_valid() const {
     return false;
   }
   if (!deprecated.is_valid()) {
+    return false;
+  }
+  if (!(defvalue.is_valid() && ValidateDefault())) {
     return false;
   }
   if (!minvalue.is_valid()) {
@@ -1830,6 +1844,9 @@ bool VehicleDataItem::struct_not_empty() const {
     return false;
   }
   if (!deprecated.is_initialized()) {
+    return false;
+  }
+  if (!defvalue.is_initialized()) {
     return false;
   }
   if (!minvalue.is_initialized()) {
@@ -1901,6 +1918,13 @@ void VehicleDataItem::ReportErrors(rpc::ValidationReport* report__) const {
   if (!deprecated.is_valid()) {
     deprecated.ReportErrors(&report__->ReportSubobject("deprecated"));
   }
+  if (!defvalue.is_valid()) {
+    defvalue.ReportErrors(&report__->ReportSubobject("defvalue"));
+  }
+  if (!ValidateDefault()) {
+    report__->set_validation_info("Invalid default value: " +
+                                  std::string(*defvalue));
+  }
   if (!minvalue.is_valid()) {
     minvalue.ReportErrors(&report__->ReportSubobject("minvalue"));
   }
@@ -1933,6 +1957,7 @@ void VehicleDataItem::SetPolicyTableType(PolicyTableType pt_type) {
   until.SetPolicyTableType(pt_type);
   removed.SetPolicyTableType(pt_type);
   deprecated.SetPolicyTableType(pt_type);
+  defvalue.SetPolicyTableType(pt_type);
   minvalue.SetPolicyTableType(pt_type);
   maxvalue.SetPolicyTableType(pt_type);
   minsize.SetPolicyTableType(pt_type);
@@ -1974,6 +1999,46 @@ bool VehicleDataItem::ValidateTypes() const {
   }
   // params should be empty for POD types and for enum values
   return (!(params.is_initialized()) || params->empty());
+}
+
+bool VehicleDataItem::ValidateDefault() const {
+  if (!defvalue.is_initialized()) {
+    return true;
+  }
+  std::string value = std::string(*defvalue);
+  bool valid = false;
+  if (VehicleDataItem::kInteger == std::string(type)) {
+    // Match int
+    std::regex pattern("^-?\\d+$");
+    bool type_matches = std::regex_match(value, pattern);
+    if (type_matches) {
+      size_t int_value = std::stol(value);
+      valid = (!minvalue.is_initialized() || int_value >= *minvalue) &&
+              (!maxvalue.is_initialized() || int_value <= *maxvalue);
+    }
+  } else if (VehicleDataItem::kFloat == std::string(type) ||
+             VehicleDataItem::kDouble == std::string(type)) {
+    // Match double
+    std::regex pattern("^-?\\d+(\\.\\d+)?$");
+    bool type_matches = std::regex_match(value, pattern);
+    if (type_matches) {
+      double dbl_value = std::stod(value);
+      valid = (!minvalue.is_initialized() || dbl_value >= *minvalue) &&
+              (!maxvalue.is_initialized() || dbl_value <= *maxvalue);
+    }
+  } else if (VehicleDataItem::kString == std::string(type)) {
+    size_t length = value.length();
+    valid = (!minsize.is_initialized() || length >= *minsize) &&
+            (!maxsize.is_initialized() || length <= *maxsize);
+  } else if (VehicleDataItem::kBoolean == std::string(type)) {
+    valid = ("false" == value || "true" == value);
+  } else if (VehicleDataItem::kStruct != std::string(type) &&
+             !IsPrimitiveType()) {
+    // Enum values cannot be validated here
+    valid = true;
+  }
+
+  return valid;
 }
 
 bool VehicleDataItem::IsPrimitiveType() const {

--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -448,6 +448,7 @@ const std::string kCreateSchema =
     "  `until` VARCHAR(45), "
     "  `removed` BOOL, "
     "  `deprecated` BOOL, "
+    "  `defvalue` VARCHAR(65535), "
     "  `minvalue` INTEGER, "
     "  `maxvalue` INTEGER, "
     "  `minsize` INTEGER, "
@@ -721,13 +722,14 @@ const std::string kInsertVehicleDataItem =
     "  `until`, "
     "  `removed`, "
     "  `deprecated`, "
+    "  `defvalue`, "
     "  `minvalue`, "
     "  `maxvalue`, "
     "  `minsize`, "
     "  `maxsize`, "
     "  `minlength`, "
     "  `maxlength`) "
-    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
 
 const std::string kInsertVehicleDataItemParams =
     "INSERT INTO `vehicle_data_item_parameters` ("

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -2625,22 +2625,25 @@ policy_table::VehicleDataItem SQLPTRepresentation::PopulateVDIFromQuery(
     *result.deprecated = query.GetBoolean(8);
   }
   if (!query.IsNull(9)) {
-    *result.minvalue = query.GetInteger(9);
+    *result.defvalue = query.GetString(9);
   }
   if (!query.IsNull(10)) {
-    *result.maxvalue = query.GetInteger(10);
+    *result.minvalue = query.GetInteger(10);
   }
   if (!query.IsNull(11)) {
-    *result.minsize = query.GetUInteger(11);
+    *result.maxvalue = query.GetInteger(11);
   }
   if (!query.IsNull(12)) {
-    *result.maxsize = query.GetUInteger(12);
+    *result.minsize = query.GetUInteger(12);
   }
   if (!query.IsNull(13)) {
-    *result.minlength = query.GetUInteger(13);
+    *result.maxsize = query.GetUInteger(13);
   }
   if (!query.IsNull(14)) {
-    *result.maxlength = query.GetUInteger(14);
+    *result.minlength = query.GetUInteger(14);
+  }
+  if (!query.IsNull(15)) {
+    *result.maxlength = query.GetUInteger(15);
   }
   result.params->mark_initialized();
 
@@ -2688,24 +2691,27 @@ bool SQLPTRepresentation::InsertVehicleDataItem(
   vehicle_data_item.deprecated.is_initialized()
       ? query.Bind(8, *vehicle_data_item.deprecated)
       : query.Bind(8);
-  vehicle_data_item.minvalue.is_initialized()
-      ? query.Bind(9, *vehicle_data_item.minvalue)
+  vehicle_data_item.defvalue.is_initialized()
+      ? query.Bind(9, *vehicle_data_item.defvalue)
       : query.Bind(9);
-  vehicle_data_item.maxvalue.is_initialized()
-      ? query.Bind(10, *vehicle_data_item.maxvalue)
+  vehicle_data_item.minvalue.is_initialized()
+      ? query.Bind(10, *vehicle_data_item.minvalue)
       : query.Bind(10);
-  vehicle_data_item.minsize.is_initialized()
-      ? query.Bind(11, static_cast<int64_t>(*vehicle_data_item.minsize))
+  vehicle_data_item.maxvalue.is_initialized()
+      ? query.Bind(11, *vehicle_data_item.maxvalue)
       : query.Bind(11);
-  vehicle_data_item.maxsize.is_initialized()
-      ? query.Bind(12, static_cast<int64_t>(*vehicle_data_item.maxsize))
+  vehicle_data_item.minsize.is_initialized()
+      ? query.Bind(12, static_cast<int64_t>(*vehicle_data_item.minsize))
       : query.Bind(12);
-  vehicle_data_item.minlength.is_initialized()
-      ? query.Bind(13, static_cast<int64_t>(*vehicle_data_item.minlength))
+  vehicle_data_item.maxsize.is_initialized()
+      ? query.Bind(13, static_cast<int64_t>(*vehicle_data_item.maxsize))
       : query.Bind(13);
-  vehicle_data_item.maxlength.is_initialized()
-      ? query.Bind(14, static_cast<int64_t>(*vehicle_data_item.maxlength))
+  vehicle_data_item.minlength.is_initialized()
+      ? query.Bind(14, static_cast<int64_t>(*vehicle_data_item.minlength))
       : query.Bind(14);
+  vehicle_data_item.maxlength.is_initialized()
+      ? query.Bind(15, static_cast<int64_t>(*vehicle_data_item.maxlength))
+      : query.Bind(15);
 
   if (!query.Exec() || !query.Reset()) {
     SDL_LOG_ERROR("Failed to insert vehicle data item: "

--- a/src/components/policy/policy_regular/test/sql_pt_representation_test.cc
+++ b/src/components/policy/policy_regular/test/sql_pt_representation_test.cc
@@ -466,6 +466,7 @@ TEST_F(SQLPTRepresentationTest, VehicleDataItem_Store_Complete_Item) {
   *message.until = "5.0";
   *message.removed = false;
   *message.deprecated = false;
+  *message.defvalue = "0";
   *message.minvalue = 0;
   *message.maxvalue = 255;
   *message.minsize = 0;

--- a/src/components/policy/policy_regular/test/vehicle_data_item_type_test.cc
+++ b/src/components/policy/policy_regular/test/vehicle_data_item_type_test.cc
@@ -123,7 +123,7 @@ class VehicleDataItemTypeTest : public ::testing::Test {
     str.AddField("until", "5.0");
     str.AddField("removed", true);
     str.AddField("deprecated", true);
-    str.AddField("defvalue", "1");
+    str.AddField("defvalue", "TestStringVal");
     str.AddField("minvalue", 1);
     str.AddField("maxvalue", 2);
     str.AddField("minsize", 10);
@@ -172,7 +172,7 @@ TEST_F(VehicleDataItemTypeTest, CheckConvertFromJsonToVehicleDataItem_Success) {
   EXPECT_TRUE((std::string)*vdi.until == "5.0");
   EXPECT_TRUE(*vdi.removed == true);
   EXPECT_TRUE(*vdi.deprecated == true);
-  EXPECT_TRUE(*vdi.defvalue == "1");
+  EXPECT_TRUE(*vdi.defvalue == "TestStringVal");
   EXPECT_TRUE(*vdi.minvalue == 1);
   EXPECT_TRUE(*vdi.maxvalue == 2);
   EXPECT_TRUE(*vdi.minsize == 10);
@@ -203,7 +203,7 @@ TEST_F(VehicleDataItemTypeTest, CheckIsValid_Struct_Success) {
   VehicleDataItem vdi(&json_);
 
   vdi.type = "Struct";
-  *vdi.defvalue = nullptr;
+  vdi.defvalue = rpc::Optional<rpc::String<0, UINT32_MAX> >();
   EXPECT_TRUE(vdi.is_valid());
 }
 
@@ -214,6 +214,7 @@ TEST_F(VehicleDataItemTypeTest, CheckIsValid_Struct_EmptyParams_Failed) {
   VehicleDataItem vdi(&json_);
 
   vdi.type = "Struct";
+  vdi.defvalue = rpc::Optional<rpc::String<0, UINT32_MAX> >();
   EXPECT_FALSE(vdi.is_valid());
 }
 
@@ -223,14 +224,15 @@ TEST_F(VehicleDataItemTypeTest, CheckIsValid_PODTypes_Success) {
 
   VehicleDataItem vdi(&json_);
 
+  vdi.type = "String";
+  EXPECT_TRUE(vdi.is_valid());
+
   vdi.type = "Integer";
+  *vdi.defvalue = "1";
   EXPECT_TRUE(vdi.is_valid());
 
   vdi.type = "Float";
-  EXPECT_TRUE(vdi.is_valid());
-
-  vdi.type = "String";
-  *vdi.defvalue = "TestStringVal";
+  *vdi.defvalue = "1.1";
   EXPECT_TRUE(vdi.is_valid());
 
   vdi.type = "Boolean";

--- a/src/components/policy/policy_regular/test/vehicle_data_item_type_test.cc
+++ b/src/components/policy/policy_regular/test/vehicle_data_item_type_test.cc
@@ -123,6 +123,7 @@ class VehicleDataItemTypeTest : public ::testing::Test {
     str.AddField("until", "5.0");
     str.AddField("removed", true);
     str.AddField("deprecated", true);
+    str.AddField("defvalue", "1");
     str.AddField("minvalue", 1);
     str.AddField("maxvalue", 2);
     str.AddField("minsize", 10);
@@ -171,6 +172,7 @@ TEST_F(VehicleDataItemTypeTest, CheckConvertFromJsonToVehicleDataItem_Success) {
   EXPECT_TRUE((std::string)*vdi.until == "5.0");
   EXPECT_TRUE(*vdi.removed == true);
   EXPECT_TRUE(*vdi.deprecated == true);
+  EXPECT_TRUE(*vdi.defvalue == "1");
   EXPECT_TRUE(*vdi.minvalue == 1);
   EXPECT_TRUE(*vdi.maxvalue == 2);
   EXPECT_TRUE(*vdi.minsize == 10);
@@ -201,6 +203,7 @@ TEST_F(VehicleDataItemTypeTest, CheckIsValid_Struct_Success) {
   VehicleDataItem vdi(&json_);
 
   vdi.type = "Struct";
+  *vdi.defvalue = nullptr;
   EXPECT_TRUE(vdi.is_valid());
 }
 
@@ -227,9 +230,11 @@ TEST_F(VehicleDataItemTypeTest, CheckIsValid_PODTypes_Success) {
   EXPECT_TRUE(vdi.is_valid());
 
   vdi.type = "String";
+  *vdi.defvalue = "TestStringVal";
   EXPECT_TRUE(vdi.is_valid());
 
   vdi.type = "Boolean";
+  *vdi.defvalue = "true";
   EXPECT_TRUE(vdi.is_valid());
 }
 

--- a/src/components/rpc_base/include/rpc_base/rpc_base_json_inl.h
+++ b/src/components/rpc_base/include/rpc_base/rpc_base_json_inl.h
@@ -94,7 +94,7 @@ inline const Json::Value* ValueMember(const Json::Value* value,
   if (value && value->isObject() && value->isMember(member_name)) {
     return &(*value)[member_name];
   }
-  return NULL;
+  return nullptr;
 }
 
 template <class T>


### PR DESCRIPTION

Fixes #3498 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Run https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/master/test_scripts/API/GetPolicyConfigurationData/001_GetPolicyConfigurationData_success.lua

### Summary
The `defvalue` field was never implemented in the policy table for custom vehicle data items when the feature was initially implemented, this PR adds support for this field.

### Changelog
##### Bug Fixes
* Adds optional `defvalue` field to the policy table schema

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
