### PR TITLE
Fix synchronization in WaypointsPendingResumptionHandler

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
@@ -115,14 +115,6 @@ void SDLRPCPlugin::ProcessResumptionSubscription(
     application_manager::Application& app, WayPointsAppExtension& ext) {
   SDL_LOG_AUTO_TRACE();
 
-  if (application_manager_->IsAnyAppSubscribedForWayPoints()) {
-    SDL_LOG_DEBUG(
-        "Subscription to waypoint already exist, no need to send "
-        "request to HMI");
-    application_manager_->SubscribeAppForWayPoints(app.app_id());
-    return;
-  }
-
   pending_resumption_handler_->HandleResumptionSubscriptionRequest(ext, app);
 }
 


### PR DESCRIPTION
Fixes #3518

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
In some situations we need to handle case, when first application has already subscribed to shared data, and second application starts it's resumption by HandleResumptionSubscriptionRequest method. Now check for already existed subscriptions is located in SDLRPCPlugin, so rarely there is a race condition, when this check is performed for second application too early right before first application has completed it's subscription process. Also note that now processes of request and response handling aren't synchronized inside of WaypointsPendingResumptionHandler, so all invoked methods of this class are executed in random order.

That's why root cause of this race condition is a time gap between check for existed subscriptions in SDLRPCPlugin and further processing of pending subscriptions in HandleResumptionSubscriptionRequest method, and also absence of certain order of execution of methods from WaypointsPendingResumptionHandler class. So there is a need in replacing above-mentioned check from SDLRPCPlugin to HandleResumptionSubscriptionRequest method, and also adding corresponding lock, due to which this check will be locked and synchronized properly.

In addition, some refactoring was completed to make methods from WaypointsPendingResumptionHandler class clearer and easier to understand, and also to align with common design approach, used in other PendingResumptionHandler classes.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
