### PR TITLE
remove unlock of lock that isn't locked

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1515,7 +1515,6 @@ void PolicyHandler::OnActivateApp(uint32_t connection_key,
   // In this case we need to activate application
   if (false == permissions.appRevoked && true == permissions.isSDLAllowed) {
     SDL_LOG_INFO("Application will be activated");
-    sync_primitives::AutoReadUnlock unlock(policy_manager_lock_);
     if (application_manager_.ActivateApplication(app)) {
       last_activated_app_id_ = 0;
     }


### PR DESCRIPTION
Fixes #3535

Since #3497 this lock will not be locked ever when this unlock line is executed because the autolock is destroyed when `LoadPolicyManager` returns.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
