### PR TITLE
Add error handling for failed hmi message send

### DIFF
--- a/src/components/hmi_message_handler/include/hmi_message_handler/mb_controller.h
+++ b/src/components/hmi_message_handler/include/hmi_message_handler/mb_controller.h
@@ -98,7 +98,7 @@ class CMessageBrokerController {
 
   void sendResponse(Json::Value& message);
 
-  void sendJsonMessage(Json::Value& message);
+  bool sendJsonMessage(Json::Value& message);
 
   void subscribeTo(std::string property);
 

--- a/src/components/hmi_message_handler/src/mb_controller.cc
+++ b/src/components/hmi_message_handler/src/mb_controller.cc
@@ -176,13 +176,13 @@ void CMessageBrokerController::sendResponse(Json::Value& message) {
   }
 }
 
-void CMessageBrokerController::sendJsonMessage(Json::Value& message) {
+bool CMessageBrokerController::sendJsonMessage(Json::Value& message) {
   if (isNotification(message)) {
     sendNotification(message);
-    return;
+    return true;
   } else if (isResponse(message)) {
     sendResponse(message);
-    return;
+    return true;
   }
 
   // Send request
@@ -205,10 +205,11 @@ void CMessageBrokerController::sendJsonMessage(Json::Value& message) {
   if (!ws) {
     SDL_LOG_ERROR(
         "A controller is not found for the method: " << component_name);
-    return;
+    return false;
   }
 
   ws->sendJsonMessage(message);
+  return true;
 }
 
 void CMessageBrokerController::subscribeTo(std::string property) {}

--- a/src/components/hmi_message_handler/src/messagebroker_adapter.cc
+++ b/src/components/hmi_message_handler/src/messagebroker_adapter.cc
@@ -70,7 +70,9 @@ void MessageBrokerAdapter::SendMessageToHMI(
     return;
   }
 
-  sendJsonMessage(json_value);
+  if (!sendJsonMessage(json_value)) {
+    handler()->OnErrorSending(message);
+  }
 }
 
 void MessageBrokerAdapter::processResponse(std::string method,


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Start core with generic hmi. Observe RC.IsReady fails in core logs because there is no RC component registered by the generic hmi. No RC.GetCapabilities should be requested.

### Summary
Adds error handling for when a hmi message is sent to a component that is not registered.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
