### PR TITLE
Keep FULL for apps after conflict resolution

### DIFF
--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -408,7 +408,11 @@ void StateControllerImpl::HmiLevelConflictResolver::operator()(
             ? mobile_apis::HMILevel::HMI_LIMITED
             : to_resolve_hmi_level;
   } else {
-    result_hmi_level = mobile_apis::HMILevel::HMI_BACKGROUND;
+    result_hmi_level =
+        mobile_apis::HMILevel::HMI_FULL == to_resolve_hmi_level &&
+                mobile_apis::HMILevel::HMI_FULL != applied_hmi_level
+            ? to_resolve_hmi_level
+            : mobile_apis::HMILevel::HMI_BACKGROUND;
   }
 
   if (std::make_tuple(to_resolve_hmi_level,


### PR DESCRIPTION
Fixes #3527 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF script

### Summary
There was found an issue in state controller related to wrong transition of non-media applications (not streamable and not audible) from FULL to BACKGROUND in case of some events. To fix that issue, SDL should check first if non-media application is currently in FULL and another application is not in FULL. If so, non-media application should stay in FULL.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
