### PR TITLE
Fix streaming retry sequence

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_audio_start_stream_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_audio_start_stream_request.h
@@ -77,13 +77,13 @@ class AudioStartStreamRequest : public app_mngr::commands::RequestToHMI,
    **/
   virtual void on_event(const app_mngr::event_engine::Event& event);
 
+ private:
   /**
    * @brief RetryStartSession resend HMI startSession request if needed.
    * If limit expired, set audio_stream_retry_number counter to 0
    */
   void RetryStartSession();
 
- private:
   uint32_t retry_number_;
   DISALLOW_COPY_AND_ASSIGN(AudioStartStreamRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_start_stream_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_start_stream_request.h
@@ -77,13 +77,13 @@ class NaviStartStreamRequest : public app_mngr::commands::RequestToHMI,
    */
   virtual void onTimeOut();
 
+ private:
   /**
    * @brief RetryStartSession resend HMI startSession request if needed.
    * If limit expired, set video_stream_retry_number counter to 0
    */
   void RetryStartSession();
 
- private:
   uint32_t retry_number_;
   DISALLOW_COPY_AND_ASSIGN(NaviStartStreamRequest);
 };


### PR DESCRIPTION
Fixes #3547 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF scripts

### Summary
There were noticed two issues related to a/v streaming:
1. Due to object self destruction after `TerminateRequest()` call any attempt to access member field of that object may cause an
undefined behavior - it might be a core crash or corrupted value sometimes. In this particular case, SDL tries to access `message_` field through `application_id()` function after object destruction. As a result, sometimes SDL crashes and sometimes this function just returns 0. Because of that, SDL was not able to find application by zero id and broke the retry sequence. This causes random failures of some ATF scripts. To avoid that issue, all retry logic was extracted into the separate function and `TerminateRequest` was moved after that function. This will guarantee that there is no attempts to access object fields after its destruction.
2. There was noticed that SDL makes one redundant retry attempt. That was because of late retry value increment. To fix that issue, increment has been placed before retry amount check.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
