### PR TITLE
remove possibility for invalid choice ID to be sent to mobile

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
@@ -1157,18 +1157,23 @@ bool PerformInteractionRequest::SetChoiceIdToResponseMsgParams(
     return false;
   }
 
-  if (mobile_apis::InteractionMode::eType::MANUAL_ONLY == interaction_mode_) {
-    msg_param[strings::choice_id] = ui_choice_id_received_;
-    return true;
+  switch (interaction_mode_) {
+    case mobile_apis::InteractionMode::eType::MANUAL_ONLY:
+      if (ui_choice_id_valid) {
+        msg_param[strings::choice_id] = ui_choice_id_received_;
+      }
+    case mobile_apis::InteractionMode::eType::VR_ONLY:
+      if (vr_choice_id_valid) {
+        msg_param[strings::choice_id] = vr_choice_id_received_;
+      }
+    default:
+      if (ui_choice_id_valid) {
+        msg_param[strings::choice_id] = ui_choice_id_received_;
+      } else if (vr_choice_id_valid) {
+        msg_param[strings::choice_id] = vr_choice_id_received_;
+      }
   }
 
-  if (mobile_apis::InteractionMode::eType::VR_ONLY == interaction_mode_) {
-    msg_param[strings::choice_id] = vr_choice_id_received_;
-    return true;
-  }
-
-  msg_param[strings::choice_id] =
-      ui_choice_id_valid ? ui_choice_id_received_ : vr_choice_id_received_;
   return true;
 }
 


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Let a Perform Interaction time out and see if it has a choiceID on it

### Summary
every time choice_id is set check if it is valid first

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
