### PR TITLE
Fix/ Postpone application activation if registration is not complete yet

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -415,6 +415,7 @@ class ApplicationManagerImpl
    * @brief Closes all registered applications
    */
   void UnregisterAllApplications();
+
   bool ActivateApplication(ApplicationSharedPtr app) OVERRIDE;
 
   /**

--- a/src/components/application_manager/include/application_manager/postponed_activation_controller.h
+++ b/src/components/application_manager/include/application_manager/postponed_activation_controller.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_POSTPONED_ACTIVATION_CONTROLLER_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_POSTPONED_ACTIVATION_CONTROLLER_H_
+
+#include "application.h"
+
+namespace application_manager {
+
+/**
+ * @brief AppToActivateSet is a map of application ids expected to be
+ * activated after the registration is completed (default hmi level is assigned)
+ * and correlation_ids of the SDLActivateApp requests
+ */
+typedef std::map<uint32_t, uint32_t> AppToActivate;
+
+class PostponedActivationController {
+ public:
+  PostponedActivationController();
+
+  /**
+   * @brief AddAppToActivate adds app_id to app_to_activate_ map
+   * @param app_id id of the app that should be activated
+   * @param corr_id correlation_id of the SDLActivateApp request
+   */
+  void AddAppToActivate(uint32_t app_id, uint32_t corr_id);
+
+  /**
+   * @brief GetPendingActivationCorrId gets the pending
+   * activation correlation id
+   * @param app_id application id
+   * @return correlation id of the SDLActivateApp requests
+   */
+  uint32_t GetPendingActivationCorrId(uint32_t app_id) const;
+
+  /**
+   * @brief RemoveAppToActivate removes app_id from app_to_activate_ map
+   * @param app_id application id
+   */
+  void RemoveAppToActivate(uint32_t app_id);
+
+ private:
+  AppToActivate app_to_activate_;
+  mutable std::shared_ptr<sync_primitives::Lock> activate_app_list_lock_ptr_;
+};
+}  // namespace application_manager
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_POSTPONED_ACTIVATION_CONTROLLER_H_

--- a/src/components/application_manager/include/application_manager/state_controller_impl.h
+++ b/src/components/application_manager/include/application_manager/state_controller_impl.h
@@ -133,6 +133,8 @@ class StateControllerImpl : public event_engine::EventObserver,
 
   void DropPostponedWindows(const uint32_t app_id) OVERRIDE;
 
+  PostponedActivationController& GetPostponedActivationController() OVERRIDE;
+
  private:
   int64_t RequestHMIStateChange(ApplicationConstSharedPtr app,
                                 hmi_apis::Common_HMILevel::eType level,
@@ -434,6 +436,7 @@ class StateControllerImpl : public event_engine::EventObserver,
   std::unordered_set<uint32_t> apps_with_pending_hmistatus_notification_;
   mutable sync_primitives::Lock apps_with_pending_hmistatus_notification_lock_;
   ApplicationManager& app_mngr_;
+  PostponedActivationController postponed_activation_controller_;
 };
 }  // namespace application_manager
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
@@ -302,6 +302,20 @@ void SDLActivateAppRequest::on_event(const event_engine::Event& event) {
         "Application not found by HMI app id: " << hmi_application_id);
     return;
   }
+
+  auto main_state =
+      app->CurrentHmiState(mobile_apis::PredefinedWindows::DEFAULT_WINDOW);
+  if (mobile_apis::HMILevel::INVALID_ENUM == main_state->hmi_level()) {
+    SDL_LOG_DEBUG(
+        "Application registration is not completed, HMI level hasn't set "
+        "yet, postpone activation");
+    auto& postponed_activation_ctrl = application_manager_.state_controller()
+                                          .GetPostponedActivationController();
+    postponed_activation_ctrl.AddAppToActivate(app->app_id(),
+                                               correlation_id());
+    return;
+  }
+
   policy_handler_.OnActivateApp(app->app_id(), correlation_id());
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_activate_app_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_activate_app_request_test.cc
@@ -40,6 +40,7 @@
 #include "application_manager/mock_message_helper.h"
 #include "application_manager/mock_state_controller.h"
 #include "application_manager/policies/mock_policy_handler_interface.h"
+#include "application_manager/postponed_activation_controller.h"
 #include "connection_handler/mock_connection_handler.h"
 #include "gtest/gtest.h"
 #include "hmi/sdl_activate_app_request.h"
@@ -139,13 +140,20 @@ TEST_F(SDLActivateAppRequestTest, Run_ActivateApp_SUCCESS) {
   std::shared_ptr<SDLActivateAppRequest> command(
       CreateCommand<SDLActivateAppRequest>(msg));
 
+  MockAppPtr mock_app(CreateMockApp());
   EXPECT_CALL(app_mngr_, WaitingApplicationByID(kAppID))
-      .WillOnce(Return(ApplicationSharedPtr()));
-  EXPECT_CALL(app_mngr_, state_controller())
-      .WillOnce(ReturnRef(mock_state_controller_));
+      .WillOnce(Return(mock_app));
+  ON_CALL(app_mngr_, state_controller())
+      .WillByDefault(ReturnRef(mock_state_controller_));
   EXPECT_CALL(mock_state_controller_,
               IsStateActive(am::HmiState::StateID::STATE_ID_DEACTIVATE_HMI))
       .WillOnce(Return(false));
+  am::HmiStatePtr state = std::make_shared<am::HmiState>(mock_app, app_mngr_);
+  state->set_hmi_level(mobile_apis::HMILevel::HMI_NONE);
+
+  EXPECT_CALL(*mock_app,
+              CurrentHmiState(mobile_apis::PredefinedWindows::DEFAULT_WINDOW))
+      .WillOnce(Return(state));
 
   EXPECT_CALL(mock_policy_handler_, OnActivateApp(kAppID, kCorrelationID));
 
@@ -303,7 +311,7 @@ TEST_F(SDLActivateAppRequestTest, FirstAppActive_SUCCESS) {
   command->Run();
 }
 
-TEST_F(SDLActivateAppRequestTest, FirstAppNotActive_SUCCESS) {
+TEST_F(SDLActivateAppRequestTest, FirstAppNotActiveNONE_SUCCESS) {
   MessageSharedPtr msg = CreateMessage();
   SetCorrelationAndAppID(msg);
 
@@ -312,12 +320,18 @@ TEST_F(SDLActivateAppRequestTest, FirstAppNotActive_SUCCESS) {
 
   MockAppPtr mock_app(CreateMockApp());
   ON_CALL(app_mngr_, application(kAppID)).WillByDefault(Return(mock_app));
-  EXPECT_CALL(app_mngr_, state_controller())
-      .WillOnce(ReturnRef(mock_state_controller_));
+  ON_CALL(app_mngr_, state_controller())
+      .WillByDefault(ReturnRef(mock_state_controller_));
   EXPECT_CALL(mock_state_controller_,
               IsStateActive(am::HmiState::StateID::STATE_ID_DEACTIVATE_HMI))
       .WillOnce(Return(false));
   EXPECT_CALL(*mock_app, IsRegistered()).WillOnce(Return(true));
+  am::HmiStatePtr state = std::make_shared<am::HmiState>(mock_app, app_mngr_);
+  state->set_hmi_level(mobile_apis::HMILevel::HMI_NONE);
+
+  EXPECT_CALL(*mock_app,
+              CurrentHmiState(mobile_apis::PredefinedWindows::DEFAULT_WINDOW))
+      .WillOnce(Return(state));
 
   EXPECT_CALL(mock_policy_handler_, OnActivateApp(kAppID, kCorrelationID));
 

--- a/src/components/application_manager/src/postponed_activation_controller.cc
+++ b/src/components/application_manager/src/postponed_activation_controller.cc
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/postponed_activation_controller.h"
+
+namespace application_manager {
+
+SDL_CREATE_LOG_VARIABLE("StateControllerImpl")
+
+PostponedActivationController::PostponedActivationController()
+    : activate_app_list_lock_ptr_(std::make_shared<sync_primitives::Lock>()) {}
+
+void PostponedActivationController::AddAppToActivate(uint32_t app_id,
+                                                     uint32_t corr_id) {
+  SDL_LOG_AUTO_TRACE();
+  sync_primitives::AutoLock lock(activate_app_list_lock_ptr_);
+  app_to_activate_.insert(std::pair<uint32_t, uint32_t>(app_id, corr_id));
+}
+
+uint32_t PostponedActivationController::GetPendingActivationCorrId(
+    uint32_t app_id) const {
+  SDL_LOG_AUTO_TRACE();
+  sync_primitives::AutoLock lock(activate_app_list_lock_ptr_);
+  auto it = app_to_activate_.find(app_id);
+  if (app_to_activate_.end() == it) {
+    return 0;
+  }
+  return it->second;
+}
+
+void PostponedActivationController::RemoveAppToActivate(uint32_t app_id) {
+  SDL_LOG_AUTO_TRACE();
+  sync_primitives::AutoLock lock(activate_app_list_lock_ptr_);
+  app_to_activate_.erase(app_id);
+}
+
+}  // namespace application_manager

--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -957,7 +957,14 @@ void StateControllerImpl::OnStateChanged(ApplicationSharedPtr app,
 
   if (new_state->hmi_level() == mobile_apis::HMILevel::HMI_NONE) {
     app->ResetDataInNone();
-    if (mobile_apis::HMILevel::INVALID_ENUM == old_state->hmi_level()) {
+  }
+
+  app_mngr_.OnHMIStateChanged(app->app_id(), old_state, new_state);
+  app->usage_report().RecordHmiStateChanged(new_state->hmi_level());
+
+  if (mobile_apis::HMILevel::INVALID_ENUM == old_state->hmi_level()) {
+    const auto app_default_hmi_level = app_mngr_.GetDefaultHmiLevel(app);
+    if (app_default_hmi_level == new_state->hmi_level()) {
       const uint32_t app_id = app->app_id();
       const uint32_t corr_id =
           postponed_activation_controller_.GetPendingActivationCorrId(app_id);
@@ -967,9 +974,6 @@ void StateControllerImpl::OnStateChanged(ApplicationSharedPtr app,
       }
     }
   }
-
-  app_mngr_.OnHMIStateChanged(app->app_id(), old_state, new_state);
-  app->usage_report().RecordHmiStateChanged(new_state->hmi_level());
 }
 
 bool StateControllerImpl::IsTempStateActive(HmiState::StateID id) const {

--- a/src/components/include/application_manager/state_controller.h
+++ b/src/components/include/application_manager/state_controller.h
@@ -35,8 +35,11 @@
 
 #include "application_manager/application.h"
 #include "application_manager/application_manager.h"
+#include "application_manager/postponed_activation_controller.h"
 #include "application_manager/request_controller_settings.h"
 #include "stdint.h"
+
+class PostponedActivationController;
 
 namespace application_manager {
 class StateController {
@@ -246,6 +249,8 @@ class StateController {
    * @param app_id id of application to check
    */
   virtual void DropPostponedWindows(const uint32_t app_id) = 0;
+
+  virtual PostponedActivationController& GetPostponedActivationController() = 0;
 };
 
 }  // namespace application_manager

--- a/src/components/include/test/application_manager/mock_state_controller.h
+++ b/src/components/include/test/application_manager/mock_state_controller.h
@@ -113,6 +113,8 @@ class MockStateController : public am::StateController {
   MOCK_METHOD2(DeactivateApp,
                void(am::ApplicationSharedPtr app,
                     const am::WindowID window_id));
+  MOCK_METHOD0(GetPostponedActivationController,
+               application_manager::PostponedActivationController&());
 };
 
 }  // namespace application_manager_test


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3549

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
Script from https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2470

### Summary
There was an issue when the SDL receives SDLActivateAppRequest from HMI and activates the app before the registration is completed and NONE HMI level is assigned. In this case, after the registration is complete SDL will assign NONE hmi level for the app that was in FULL so additional steps will be required to activate the application one more time.

To prevent such a situation additional check for app HMI level has been added during the app activation (SDLActivateAppRequest):
if the app HMI level is INVALID_ENUM - it means that the registration isn't complete yet - so we need to postpone the activation.
After the registration is completed and HMI level NONE is assigned - need to check if we have the postponed activation for the app and if yes - start the postponed activation.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
