### PR TITLE
Fix threaded socket termination

### DIFF
--- a/src/components/transport_manager/include/transport_manager/transport_adapter/threaded_socket_connection.h
+++ b/src/components/transport_manager/include/transport_manager/transport_adapter/threaded_socket_connection.h
@@ -189,7 +189,9 @@ class ThreadedSocketConnection : public Connection {
   int write_fd_;
   void threadMain();
   void Transmit();
-  void Finalize();
+  void FinalizeExpectedDisconnect();
+  void FinalizeUnexpectedDisconnect();
+  void NotifyAboutAbortedMessages();
   TransportAdapter::Error Notify() const;
   bool Receive();
   bool Send();


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3561

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF scripts

### Summary
There was noticed an issue with ThreadedSocket connection which often closes connection like an "unexpected disconnect"
calling `ConnectionAborted()` every time even if it is handled disconnect. Also, there were no any events raised to Transport
Manager for rare cases when connect is expected. To fix that, flow has been separated for handling expected and unexpected disconnect. Expected disconnect will be handled in case when external component calls `Disconnect()` and socket thread is alive. In that case should be called `DisconnectDone()` when thread is stopped.
Unexpected disconnect will be handled in case when internal thread has been aborted and `Abort()` was called. In that case internal thread `ConnectionAborted()` will be called from internal thread to notify Transport Manager that physical disconnect has happened. This issue is pretty hard to detect just because business logic handles both disconnect types in the same way for now, but this might be changed in the future.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
