### PR TITLE
Fix policy validation of OnVehicleData message

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/on_vehicle_data_notification.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/on_vehicle_data_notification.cc
@@ -103,10 +103,34 @@ void OnVehicleDataNotification::Run() {
     }
   }
 
-  SDL_LOG_DEBUG("Number of Notifications to be send: " << notify_apps.size());
-
   for (size_t idx = 0; idx < notify_apps.size(); idx++) {
-    SDL_LOG_INFO("Send OnVehicleData PRNDL notification to "
+    CommandParametersPermissions params_permissions;
+    application_manager_.CheckPolicyPermissions(
+        notify_apps[idx],
+        window_id(),
+        MessageHelper::StringifiedFunctionID(
+            mobile_api::FunctionID::OnVehicleDataID),
+        appSO[idx].enumerate(),
+        &params_permissions);
+
+    for (const auto& param : appSO[idx].enumerate()) {
+      const auto& allowed_params = params_permissions.allowed_params;
+      auto param_allowed = allowed_params.find(param);
+      if (allowed_params.end() == param_allowed) {
+        SDL_LOG_DEBUG("Param " << param << " is not allowed by policy for app "
+                               << notify_apps[idx]->app_id()
+                               << ". It will be ignored.");
+        appSO[idx].erase(param);
+      }
+    }
+
+    if (appSO[idx].empty()) {
+      SDL_LOG_DEBUG("App " << notify_apps[idx]->app_id()
+                           << " will be skipped: there is nothing to notify.");
+      continue;
+    }
+
+    SDL_LOG_INFO("Send OnVehicleData notification to "
                  << notify_apps[idx]->name().c_str() << " application id "
                  << notify_apps[idx]->app_id());
     (*message_)[strings::params][strings::connection_key] =

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/mobile/on_vehicle_data_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/mobile/on_vehicle_data_notification_test.cc
@@ -56,8 +56,10 @@ namespace on_vehicle_data_notification {
 namespace am = ::application_manager;
 
 using ::testing::_;
+using ::testing::ContainerEq;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::SetArgPointee;
 
 using am::commands::MessageSharedPtr;
 using vehicle_info_plugin::commands::OnVehicleDataNotification;
@@ -118,6 +120,15 @@ TEST_F(OnVehicleDataNotificationTest, OnVehicleDataNotification_SUCCESS) {
           QueryInterface(vehicle_info_plugin::VehicleInfoAppExtension::
                              VehicleInfoAppExtensionUID))
       .WillByDefault(Return(vi_app_extention_ptr));
+
+  am::CommandParametersPermissions params_permissions;
+  params_permissions.allowed_params.insert(am::strings::gps);
+  params_permissions.allowed_params.insert(am::strings::speed);
+  EXPECT_CALL(app_mngr_,
+              CheckPolicyPermissions(
+                  _, _, _, ContainerEq(params_permissions.allowed_params), _))
+      .WillOnce(DoAll(SetArgPointee<4>(params_permissions),
+                      Return(mobile_apis::Result::SUCCESS)));
 
   MessageSharedPtr message(CreateMessage(smart_objects::SmartType_Map));
   smart_objects::SmartObject gps_data;


### PR DESCRIPTION
Fixes #3365

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Check results for the following ATF tests:
```
test_scripts/API/VehicleData/OnVehicleData/002_OnVD_disallowed.lua
test_scripts/API/VehicleData/OnVehicleData/003_OnVD_disallowed_after_PTU.lua
```

### Summary
Adds policy checks before sending OnVehicleData message to app (changes ported from https://github.com/LuxoftSDL/sdl_core/pull/36)

### Changelog
##### Bug Fixes
* Adds policy checks before sending OnVehicleData message to app

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
