### PR TITLE
Add OnWayPointChange handling for NAVIGATION app services

### DIFF
--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -854,8 +854,7 @@
                         "hmi_levels": [
                             "FULL",
                             "LIMITED",
-                            "BACKGROUND",
-                            "NONE"
+                            "BACKGROUND"
                         ]
                     },
                     "UnpublishAppService": {

--- a/src/components/application_manager/include/application_manager/app_service_manager.h
+++ b/src/components/application_manager/include/application_manager/app_service_manager.h
@@ -215,11 +215,11 @@ class AppServiceManager {
       smart_objects::SmartObject& out_params);
 
   /**
-   * @brief Check if the active NAVIGATION service handles waypoints
-   * @return true if the active NAVIGATION service handles waypoints, false
+   * @brief Retrieve the active service for handling waypoints if available
+   * @return The active NAVIGATION service if it handles waypoints, nullptr
    * otherwise
    */
-  virtual bool IsWayPointsHandled();
+  virtual AppService* FindWayPointsHandler();
 
   /**
    * @brief Get the RPCPassingHandler tied to this object

--- a/src/components/application_manager/include/application_manager/app_service_manager.h
+++ b/src/components/application_manager/include/application_manager/app_service_manager.h
@@ -215,6 +215,13 @@ class AppServiceManager {
       smart_objects::SmartObject& out_params);
 
   /**
+   * @brief Check if the active NAVIGATION service handles waypoints
+   * @return true if the active NAVIGATION service handles waypoints, false
+   * otherwise
+   */
+  virtual bool IsWayPointsHandled();
+
+  /**
    * @brief Get the RPCPassingHandler tied to this object
    * @return The RPCPassingHandler tied to this object
    */

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -286,32 +286,22 @@ class ApplicationManagerImpl
    */
   bool IsAppSubscribedForWayPoints(Application& app) const OVERRIDE;
 
-  void SaveWayPointsMessage(
-      smart_objects::SmartObjectSPtr way_points_message) OVERRIDE;
+  void SaveWayPointsMessage(smart_objects::SmartObjectSPtr way_points_message,
+                            uint32_t app_id = 0) OVERRIDE;
 
-  /**
-   * @brief Subscribe Application for way points
-   * @param Application id
-   */
-  void SubscribeAppForWayPoints(uint32_t app_id) OVERRIDE;
+  void SubscribeAppForWayPoints(uint32_t app_id,
+                                bool response_from_hmi = true) OVERRIDE;
 
-  /**
-   * @brief Subscribe Application for way points
-   * @param Application pointer
-   */
-  void SubscribeAppForWayPoints(ApplicationSharedPtr app) OVERRIDE;
+  void SubscribeAppForWayPoints(ApplicationSharedPtr app,
+                                bool response_from_hmi = true) OVERRIDE;
 
-  /**
-   * @brief Unsubscribe Application for way points
-   * @param Application id
-   */
-  void UnsubscribeAppFromWayPoints(uint32_t app_id) OVERRIDE;
+  void UnsubscribeAppFromWayPoints(uint32_t app_id,
+                                   bool response_from_hmi = true) OVERRIDE;
 
-  /**
-   * @brief Unsubscribe Application for way points
-   * @param Application pointer
-   */
-  void UnsubscribeAppFromWayPoints(ApplicationSharedPtr app) OVERRIDE;
+  void UnsubscribeAppFromWayPoints(ApplicationSharedPtr app,
+                                   bool response_from_hmi = true) OVERRIDE;
+
+  bool IsSubscribedToHMIWayPoints() const OVERRIDE;
 
   /**
    * @brief Is Any Application is subscribed for way points
@@ -1562,7 +1552,11 @@ class ApplicationManagerImpl
    */
   std::set<uint32_t> subscribed_way_points_apps_list_;
 
-  smart_objects::SmartObjectSPtr way_points_data_;
+  bool subscribed_to_hmi_way_points_;
+
+  smart_objects::SmartObjectSPtr hmi_way_points_data_;
+
+  std::map<uint32_t, smart_objects::SmartObject> mobile_way_points_data_;
 
   /**
    * @brief Map contains applications which

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/on_way_point_change_notification_from_mobile.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/on_way_point_change_notification_from_mobile.h
@@ -30,62 +30,46 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SUBSCRIBE_WAY_POINTS_REQUEST_H_
-#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SUBSCRIBE_WAY_POINTS_REQUEST_H_
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_ON_WAY_POINT_CHANGE_NOTIFICATION_FROM_MOBILE_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_ON_WAY_POINT_CHANGE_NOTIFICATION_FROM_MOBILE_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/command_notification_from_mobile_impl.h"
+#include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
 namespace app_mngr = application_manager;
 
 namespace commands {
 
-/**
- * @brief SubsribeWayPointsRequest command class
- **/
-class SubscribeWayPointsRequest
-    : public app_mngr::commands::CommandRequestImpl {
+class OnWayPointChangeNotificationFromMobile
+    : public app_mngr::commands::CommandNotificationFromMobileImpl {
  public:
   /**
-   * \brief SubscribeWayPointsRequest class constructor
+   * @brief OnWayPointChangeNotificationFromMobile class constructor
+   *
+   * @param message Incoming SmartObject message
    **/
-  SubscribeWayPointsRequest(const app_mngr::commands::MessageSharedPtr& message,
-                            app_mngr::ApplicationManager& application_manager,
-                            app_mngr::rpc_service::RPCService& rpc_service,
-                            app_mngr::HMICapabilities& hmi_capabilities,
-                            policy::PolicyHandlerInterface& policy_handler);
+  OnWayPointChangeNotificationFromMobile(
+      const app_mngr::commands::MessageSharedPtr& message,
+      app_mngr::ApplicationManager& application_manager,
+      app_mngr::rpc_service::RPCService& rpc_service,
+      app_mngr::HMICapabilities& hmi_capabilities,
+      policy::PolicyHandlerInterface& policy_handler);
 
   /**
-   * \brief SubscribeWayPointsRequest class destructor
+   * @brief OnWayPointChangeNotificationFromMobile class destructor
    **/
-  ~SubscribeWayPointsRequest();
+  virtual ~OnWayPointChangeNotificationFromMobile();
 
   /**
    * @brief Execute command
    **/
-  void Run() FINAL;
-  /**
-   * @brief Interface method that is called whenever new event received
-   *
-   * @param event The received event
-   */
-  void on_event(const app_mngr::event_engine::Event& event) FINAL;
-
-  /**
-   * @brief Init sets hash update mode for request
-   */
-  bool Init() FINAL;
-
-  void onTimeOut() FINAL;
+  virtual void Run() OVERRIDE;
 
  private:
-  bool IsWayPointsAppServiceAvailable();
-
-  DISALLOW_COPY_AND_ASSIGN(SubscribeWayPointsRequest);
+  DISALLOW_COPY_AND_ASSIGN(OnWayPointChangeNotificationFromMobile);
 };
 
 }  // namespace commands
-
 }  // namespace sdl_rpc_plugin
-
-#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SUBSCRIBE_WAY_POINTS_REQUEST_H_
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_ON_WAY_POINT_CHANGE_NOTIFICATION_FROM_MOBILE_H_

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/subscribe_way_points_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/subscribe_way_points_request.h
@@ -79,8 +79,6 @@ class SubscribeWayPointsRequest
   void onTimeOut() FINAL;
 
  private:
-  bool IsWayPointsAppServiceAvailable();
-
   DISALLOW_COPY_AND_ASSIGN(SubscribeWayPointsRequest);
 };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/unsubscribe_way_points_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/unsubscribe_way_points_request.h
@@ -78,8 +78,6 @@ class UnsubscribeWayPointsRequest
   void onTimeOut() FINAL;
 
  private:
-  bool IsWayPointsAppServiceAvailable();
-
   DISALLOW_COPY_AND_ASSIGN(UnsubscribeWayPointsRequest);
 };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/unsubscribe_way_points_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/unsubscribe_way_points_request.h
@@ -75,7 +75,11 @@ class UnsubscribeWayPointsRequest
    */
   bool Init() FINAL;
 
+  void onTimeOut() FINAL;
+
  private:
+  bool IsWayPointsAppServiceAvailable();
+
   DISALLOW_COPY_AND_ASSIGN(UnsubscribeWayPointsRequest);
 };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_navi_way_point_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_navi_way_point_change_notification.cc
@@ -56,6 +56,7 @@ void OnNaviWayPointChangeNotification::Run() {
   // prepare SmartObject for mobile factory
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnWayPointChangeID);
+  application_manager_.SaveWayPointsMessage(message_, 0);
 
   SendNotificationToMobile(message_);
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_navi_way_point_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_navi_way_point_change_notification.cc
@@ -32,6 +32,8 @@
 
 #include "sdl_rpc_plugin/commands/hmi/on_navi_way_point_change_notification.h"
 
+#include "application_manager/app_service_manager.h"
+
 namespace sdl_rpc_plugin {
 using namespace application_manager;
 
@@ -58,7 +60,10 @@ void OnNaviWayPointChangeNotification::Run() {
       static_cast<int32_t>(mobile_apis::FunctionID::OnWayPointChangeID);
   application_manager_.SaveWayPointsMessage(message_, 0);
 
-  SendNotificationToMobile(message_);
+  if (application_manager_.GetAppServiceManager().FindWayPointsHandler() ==
+      nullptr) {
+    SendNotificationToMobile(message_);
+  }
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_way_point_change_notification_from_mobile.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_way_point_change_notification_from_mobile.cc
@@ -71,15 +71,14 @@ void OnWayPointChangeNotificationFromMobile::Run() {
   }
 
   auto service =
-      application_manager_.GetAppServiceManager().ActiveServiceForType(
-          EnumToString(mobile_apis::AppServiceType::NAVIGATION));
+      application_manager_.GetAppServiceManager().FindWayPointsHandler();
   if (!service || !service->mobile_service ||
       service->connection_key != connection_key()) {
     SDL_LOG_ERROR(
-        "OnWayPointChangeNotificationFromMobile application is not active "
-        "NAVIGATION ASP");
+        "Application is not active NAVIGATION ASP");
     return;
   }
+
   application_manager_.SaveWayPointsMessage(message_, connection_key());
 
   (*message_)[strings::params][strings::message_type] =

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_way_point_change_notification_from_mobile.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_way_point_change_notification_from_mobile.cc
@@ -74,8 +74,7 @@ void OnWayPointChangeNotificationFromMobile::Run() {
       application_manager_.GetAppServiceManager().FindWayPointsHandler();
   if (!service || !service->mobile_service ||
       service->connection_key != connection_key()) {
-    SDL_LOG_ERROR(
-        "Application is not active NAVIGATION ASP");
+    SDL_LOG_ERROR("Application is not active NAVIGATION ASP");
     return;
   }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_way_point_change_notification_from_mobile.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_way_point_change_notification_from_mobile.cc
@@ -1,6 +1,5 @@
 /*
-
- Copyright (c) 2018, Ford Motor Company
+ Copyright (c) 2020, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -31,8 +30,11 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "sdl_rpc_plugin/commands/mobile/on_way_point_change_notification.h"
-#include "application_manager/application_manager.h"
+#include "sdl_rpc_plugin/commands/mobile/on_way_point_change_notification_from_mobile.h"
+
+#include "application_manager/app_service_manager.h"
+#include "application_manager/message.h"
+#include "application_manager/message_helper.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -40,33 +42,51 @@ namespace commands {
 
 SDL_CREATE_LOG_VARIABLE("Commands")
 
-OnWayPointChangeNotification::OnWayPointChangeNotification(
+OnWayPointChangeNotificationFromMobile::OnWayPointChangeNotificationFromMobile(
     const application_manager::commands::MessageSharedPtr& message,
     ApplicationManager& application_manager,
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandNotificationImpl(message,
-                              application_manager,
-                              rpc_service,
-                              hmi_capabilities,
-                              policy_handler) {}
+    : CommandNotificationFromMobileImpl(message,
+                                        application_manager,
+                                        rpc_service,
+                                        hmi_capabilities,
+                                        policy_handler) {}
 
-OnWayPointChangeNotification::~OnWayPointChangeNotification() {}
+OnWayPointChangeNotificationFromMobile::
+    ~OnWayPointChangeNotificationFromMobile() {}
 
-void OnWayPointChangeNotification::Run() {
+void OnWayPointChangeNotificationFromMobile::Run() {
   SDL_LOG_AUTO_TRACE();
 
-  std::set<uint32_t> subscribed_for_way_points =
-      application_manager_.GetAppsSubscribedForWayPoints();
+  (*message_)[strings::params][strings::message_type] =
+      static_cast<int32_t>(application_manager::MessageType::kNotification);
+  ApplicationSharedPtr app = application_manager_.application(connection_key());
 
-  for (std::set<uint32_t>::const_iterator app_id =
-           subscribed_for_way_points.begin();
-       app_id != subscribed_for_way_points.end();
-       ++app_id) {
-    (*message_)[strings::params][strings::connection_key] = *app_id;
-    SendNotification();
+  if (app.use_count() == 0) {
+    SDL_LOG_ERROR(
+        "OnWayPointChangeNotificationFromMobile application doesn't exist");
+    return;
   }
+
+  auto service =
+      application_manager_.GetAppServiceManager().ActiveServiceForType(
+          EnumToString(mobile_apis::AppServiceType::NAVIGATION));
+  if (!service || !service->mobile_service ||
+      service->connection_key != connection_key()) {
+    SDL_LOG_ERROR(
+        "OnWayPointChangeNotificationFromMobile application is not active "
+        "NAVIGATION ASP");
+    return;
+  }
+  application_manager_.SaveWayPointsMessage(message_, connection_key());
+
+  (*message_)[strings::params][strings::message_type] =
+      static_cast<int32_t>(application_manager::MessageType::kNotification);
+  rpc_service_.ManageMobileCommand(message_, SOURCE_SDL);
 }
+
 }  // namespace commands
+
 }  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_way_points_request.cc
@@ -31,6 +31,8 @@
  */
 
 #include "sdl_rpc_plugin/commands/mobile/subscribe_way_points_request.h"
+
+#include "application_manager/app_service_manager.h"
 #include "application_manager/application_manager.h"
 #include "application_manager/message_helper.h"
 
@@ -72,8 +74,8 @@ void SubscribeWayPointsRequest::Run() {
     return;
   }
 
-  if (application_manager_.IsAnyAppSubscribedForWayPoints()) {
-    application_manager_.SubscribeAppForWayPoints(app);
+  if (application_manager_.IsSubscribedToHMIWayPoints()) {
+    application_manager_.SubscribeAppForWayPoints(app, false);
     SendResponse(true, mobile_apis::Result::SUCCESS);
     return;
   }
@@ -91,15 +93,20 @@ void SubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
     case hmi_apis::FunctionID::Navigation_SubscribeWayPoints: {
       SDL_LOG_INFO("Received Navigation_SubscribeWayPoints event");
       EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
-      const hmi_apis::Common_Result::eType result_code =
+      hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());
       std::string response_info;
       GetInfo(message, response_info);
-      const bool result = PrepareResultForMobileResponse(
+      bool result = PrepareResultForMobileResponse(
           result_code, HmiInterfaces::HMI_INTERFACE_Navigation);
       if (result) {
-        application_manager_.SubscribeAppForWayPoints(app);
+        application_manager_.SubscribeAppForWayPoints(app, true);
+      } else if (application_manager_.GetAppServiceManager()
+                     .IsWayPointsHandled()) {
+        application_manager_.SubscribeAppForWayPoints(app, false);
+        result = true;
+        result_code = hmi_apis::Common_Result::WARNINGS;
       }
       SendResponse(result,
                    MessageHelper::HMIToMobileResult(result_code),
@@ -111,6 +118,22 @@ void SubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
       SDL_LOG_ERROR("Received unknown event " << event.id());
       break;
     }
+  }
+}
+
+void SubscribeWayPointsRequest::onTimeOut() {
+  SDL_LOG_AUTO_TRACE();
+  if (application_manager_.GetAppServiceManager().IsWayPointsHandled()) {
+    ApplicationSharedPtr app =
+        application_manager_.application(connection_key());
+    application_manager_.SubscribeAppForWayPoints(app, false);
+    SendResponse(true,
+                 mobile_apis::Result::WARNINGS,
+                 "HMI request timeout expired, waypoints are available through "
+                 "NAVIGATION service");
+  } else {
+    SendResponse(
+        false, mobile_apis::Result::GENERIC_ERROR, "Request timeout expired");
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_way_points_request.cc
@@ -103,7 +103,7 @@ void SubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
       if (result) {
         application_manager_.SubscribeAppForWayPoints(app, true);
       } else if (application_manager_.GetAppServiceManager()
-                     .IsWayPointsHandled()) {
+                     .FindWayPointsHandler() != nullptr) {
         application_manager_.SubscribeAppForWayPoints(app, false);
         result = true;
         result_code = hmi_apis::Common_Result::WARNINGS;
@@ -123,7 +123,8 @@ void SubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
 
 void SubscribeWayPointsRequest::onTimeOut() {
   SDL_LOG_AUTO_TRACE();
-  if (application_manager_.GetAppServiceManager().IsWayPointsHandled()) {
+  if (application_manager_.GetAppServiceManager().FindWayPointsHandler() !=
+      nullptr) {
     ApplicationSharedPtr app =
         application_manager_.application(connection_key());
     application_manager_.SubscribeAppForWayPoints(app, false);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_way_points_request.cc
@@ -109,7 +109,7 @@ void UnsubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
       if (result) {
         application_manager_.UnsubscribeAppFromWayPoints(app, true);
       } else if (application_manager_.GetAppServiceManager()
-                     .IsWayPointsHandled()) {
+                     .FindWayPointsHandler() != nullptr) {
         application_manager_.UnsubscribeAppFromWayPoints(app, false);
         result = true;
         result_code = hmi_apis::Common_Result::WARNINGS;
@@ -129,7 +129,8 @@ void UnsubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
 
 void UnsubscribeWayPointsRequest::onTimeOut() {
   SDL_LOG_AUTO_TRACE();
-  if (application_manager_.GetAppServiceManager().IsWayPointsHandled()) {
+  if (application_manager_.GetAppServiceManager().FindWayPointsHandler() !=
+      nullptr) {
     ApplicationSharedPtr app =
         application_manager_.application(connection_key());
     application_manager_.UnsubscribeAppFromWayPoints(app, false);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_way_points_request.cc
@@ -31,6 +31,8 @@
  */
 
 #include "sdl_rpc_plugin/commands/mobile/unsubscribe_way_points_request.h"
+
+#include "application_manager/app_service_manager.h"
 #include "application_manager/application_manager.h"
 #include "application_manager/message_helper.h"
 
@@ -75,9 +77,10 @@ void UnsubscribeWayPointsRequest::Run() {
   std::set<uint32_t> subscribed_apps =
       application_manager_.GetAppsSubscribedForWayPoints();
 
-  if (subscribed_apps.size() > 1) {
+  if (subscribed_apps.size() > 1 ||
+      !application_manager_.IsSubscribedToHMIWayPoints()) {
     // More than 1 subscribed app, don't send HMI unsubscribe request
-    application_manager_.UnsubscribeAppFromWayPoints(app);
+    application_manager_.UnsubscribeAppFromWayPoints(app, false);
     SendResponse(true, mobile_apis::Result::SUCCESS, NULL);
     return;
   } else {
@@ -96,15 +99,20 @@ void UnsubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
     case hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints: {
       SDL_LOG_INFO("Received Navigation_UnsubscribeWayPoints event");
       EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_Navigation);
-      const hmi_apis::Common_Result::eType result_code =
+      hmi_apis::Common_Result::eType result_code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());
       std::string response_info;
       GetInfo(message, response_info);
-      const bool result = PrepareResultForMobileResponse(
+      bool result = PrepareResultForMobileResponse(
           result_code, HmiInterfaces::HMI_INTERFACE_Navigation);
       if (result) {
-        application_manager_.UnsubscribeAppFromWayPoints(app);
+        application_manager_.UnsubscribeAppFromWayPoints(app, true);
+      } else if (application_manager_.GetAppServiceManager()
+                     .IsWayPointsHandled()) {
+        application_manager_.UnsubscribeAppFromWayPoints(app, false);
+        result = true;
+        result_code = hmi_apis::Common_Result::WARNINGS;
       }
       SendResponse(result,
                    MessageHelper::HMIToMobileResult(result_code),
@@ -116,6 +124,22 @@ void UnsubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
       SDL_LOG_ERROR("Received unknown event " << event.id());
       break;
     }
+  }
+}
+
+void UnsubscribeWayPointsRequest::onTimeOut() {
+  SDL_LOG_AUTO_TRACE();
+  if (application_manager_.GetAppServiceManager().IsWayPointsHandled()) {
+    ApplicationSharedPtr app =
+        application_manager_.application(connection_key());
+    application_manager_.UnsubscribeAppFromWayPoints(app, false);
+    SendResponse(true,
+                 mobile_apis::Result::WARNINGS,
+                 "HMI request timeout expired, waypoints are available through "
+                 "NAVIGATION service");
+  } else {
+    SendResponse(
+        false, mobile_apis::Result::GENERIC_ERROR, "Request timeout expired");
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/mobile_command_factory.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/mobile_command_factory.cc
@@ -96,6 +96,7 @@
 #include "sdl_rpc_plugin/commands/mobile/on_update_file_notification.h"
 #include "sdl_rpc_plugin/commands/mobile/on_update_sub_menu_notification.h"
 #include "sdl_rpc_plugin/commands/mobile/on_way_point_change_notification.h"
+#include "sdl_rpc_plugin/commands/mobile/on_way_point_change_notification_from_mobile.h"
 #include "sdl_rpc_plugin/commands/mobile/perform_audio_pass_thru_request.h"
 #include "sdl_rpc_plugin/commands/mobile/perform_audio_pass_thru_response.h"
 #include "sdl_rpc_plugin/commands/mobile/perform_interaction_request.h"
@@ -490,6 +491,10 @@ CommandCreator& MobileCommandFactory::get_notification_from_mobile_creator(
   switch (id) {
     case mobile_apis::FunctionID::OnHMIStatusID: {
       return factory.GetCreator<commands::OnHMIStatusNotificationFromMobile>();
+    }
+    case mobile_apis::FunctionID::OnWayPointChangeID: {
+      return factory
+          .GetCreator<commands::OnWayPointChangeNotificationFromMobile>();
     }
     default: {}
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/waypoints_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/waypoints_pending_resumption_handler.cc
@@ -86,7 +86,7 @@ void WayPointsPendingResumptionHandler::HandleResumptionSubscriptionRequest(
     SDL_LOG_DEBUG(
         "Subscription to waypoint already exist, no need to send "
         "request to HMI");
-    application_manager_.SubscribeAppForWayPoints(app.app_id());
+    application_manager_.SubscribeAppForWayPoints(app.app_id(), false);
     return;
   }
 
@@ -170,7 +170,7 @@ void WayPointsPendingResumptionHandler::on_event(
 
   if (resumption::IsResponseSuccessful(response)) {
     SDL_LOG_DEBUG("Resumption of waypoints is successful");
-    application_manager_.SubscribeAppForWayPoints(app);
+    application_manager_.SubscribeAppForWayPoints(app, true);
   }
   ProcessNextPendingResumption();
 }
@@ -195,7 +195,7 @@ void WayPointsPendingResumptionHandler::ProcessNextPendingResumption() {
   auto pending_copy = pending;
   pending_requests_.pop_front();
   auto app = application_manager_.application(pending_copy.app_id_);
-  application_manager_.SubscribeAppForWayPoints(app);
+  application_manager_.SubscribeAppForWayPoints(app, false);
   RaiseFakeSuccessfulResponse(pending_copy.corr_id_);
   ProcessNextPendingResumption();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_way_point_change_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_way_point_change_notification_test.cc
@@ -139,7 +139,6 @@ TEST_F(OnWayPointChangeNotificationTest,
       .WillOnce(Return(apps_subscribed_for_way_points));
   EXPECT_CALL(mock_rpc_service_,
               SendMessageToMobile(CheckMessageData(kApp1Id), _));
-  EXPECT_CALL(app_mngr_, SaveWayPointsMessage(message_));
 
   command_->Run();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/subscribe_way_points_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/subscribe_way_points_request_test.cc
@@ -73,13 +73,12 @@ TEST_F(SubscribeWayPointsRequestTest, Run_SUCCESS) {
   ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
   ON_CALL(app_mngr_, IsAppSubscribedForWayPoints(Ref(*app)))
       .WillByDefault(Return(false));
-  ON_CALL(app_mngr_, IsAnyAppSubscribedForWayPoints())
-      .WillByDefault(Return(true));
+  ON_CALL(app_mngr_, IsSubscribedToHMIWayPoints()).WillByDefault(Return(true));
 
   {
     InSequence dummy;
     EXPECT_CALL(app_mngr_,
-                SubscribeAppForWayPoints(A<am::ApplicationSharedPtr>()));
+                SubscribeAppForWayPoints(A<am::ApplicationSharedPtr>(), false));
     EXPECT_CALL(*app, UpdateHash());
   }
 
@@ -112,7 +111,7 @@ TEST_F(SubscribeWayPointsRequestTest, OnEvent_SUCCESS) {
   {
     InSequence dummy;
     EXPECT_CALL(app_mngr_,
-                SubscribeAppForWayPoints(A<am::ApplicationSharedPtr>()));
+                SubscribeAppForWayPoints(A<am::ApplicationSharedPtr>(), true));
     EXPECT_CALL(mock_message_helper_, HMIToMobileResult(result_code))
         .WillOnce(Return(mobile_apis::Result::SUCCESS));
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/unsubscribe_way_points_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/unsubscribe_way_points_request_test.cc
@@ -123,6 +123,8 @@ TEST_F(UnsubscribeWayPointsRequestTest, Run_AppSubscribedForWayPoints_SUCCESS) {
   EXPECT_CALL(app_mngr_, GetAppsSubscribedForWayPoints())
       .WillOnce(Return(subscribed_apps));
 
+  EXPECT_CALL(app_mngr_, IsSubscribedToHMIWayPoints()).WillOnce(Return(true));
+
   EXPECT_CALL(mock_rpc_service_,
               ManageHMICommand(
                   HMIResultCodeIs(
@@ -156,9 +158,10 @@ TEST_F(UnsubscribeWayPointsRequestTest,
   Event event(hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints);
   event.set_smart_object(*event_msg);
 
-  EXPECT_CALL(app_mngr_,
-              UnsubscribeAppFromWayPoints(
-                  ::testing::Matcher<am::ApplicationSharedPtr>(mock_app)));
+  EXPECT_CALL(
+      app_mngr_,
+      UnsubscribeAppFromWayPoints(
+          ::testing::Matcher<am::ApplicationSharedPtr>(mock_app), true));
 
   EXPECT_CALL(
       mock_rpc_service_,

--- a/src/components/application_manager/src/app_service_manager.cc
+++ b/src/components/application_manager/src/app_service_manager.cc
@@ -617,6 +617,25 @@ bool AppServiceManager::UpdateNavigationCapabilities(
   return true;
 }
 
+bool AppServiceManager::IsWayPointsHandled() {
+  auto service = ActiveServiceForType(
+      EnumToString(mobile_apis::AppServiceType::NAVIGATION));
+  if (!service || !service->mobile_service ||
+      !service->record[strings::service_manifest].keyExists(
+          strings::handled_rpcs)) {
+    return false;
+  }
+
+  smart_objects::SmartObject& handled_rpcs =
+      service->record[strings::service_manifest][strings::handled_rpcs];
+  for (size_t i = 0; i < handled_rpcs.length(); ++i) {
+    if (handled_rpcs[i].asInt() == mobile_apis::FunctionID::GetWayPointsID) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void AppServiceManager::AppServiceUpdated(
     const smart_objects::SmartObject& service_record,
     const mobile_apis::ServiceUpdateReason::eType update_reason,

--- a/src/components/application_manager/src/app_service_manager.cc
+++ b/src/components/application_manager/src/app_service_manager.cc
@@ -617,23 +617,23 @@ bool AppServiceManager::UpdateNavigationCapabilities(
   return true;
 }
 
-bool AppServiceManager::IsWayPointsHandled() {
+AppService* AppServiceManager::FindWayPointsHandler() {
   auto service = ActiveServiceForType(
       EnumToString(mobile_apis::AppServiceType::NAVIGATION));
   if (!service || !service->mobile_service ||
       !service->record[strings::service_manifest].keyExists(
           strings::handled_rpcs)) {
-    return false;
+    return nullptr;
   }
 
   smart_objects::SmartObject& handled_rpcs =
       service->record[strings::service_manifest][strings::handled_rpcs];
   for (size_t i = 0; i < handled_rpcs.length(); ++i) {
     if (handled_rpcs[i].asInt() == mobile_apis::FunctionID::GetWayPointsID) {
-      return true;
+      return service;
     }
   }
-  return false;
+  return nullptr;
 }
 
 void AppServiceManager::AppServiceUpdated(

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -4737,7 +4737,7 @@ void ApplicationManagerImpl::SubscribeAppForWayPoints(uint32_t app_id,
   }
   SDL_LOG_DEBUG("There are applications subscribed: "
                 << subscribed_way_points_apps_list_.size());
-  if (GetAppServiceManager().IsWayPointsHandled()) {
+  if (GetAppServiceManager().FindWayPointsHandler() != nullptr) {
     auto service = GetAppServiceManager().ActiveServiceForType(
         EnumToString(mobile_apis::AppServiceType::NAVIGATION));
     auto it = mobile_way_points_data_.find(service->connection_key);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -4750,8 +4750,7 @@ void ApplicationManagerImpl::SubscribeAppForWayPoints(uint32_t app_id,
     (*way_point_notification)[strings::params][strings::connection_key] =
         app_id;
     GetRPCService().SendMessageToMobile(way_point_notification);
-  }
-  if (hmi_way_points_data_) {
+  } else if (hmi_way_points_data_) {
     smart_objects::SmartObjectSPtr way_point_notification =
         std::make_shared<smart_objects::SmartObject>(*hmi_way_points_data_);
     (*way_point_notification)[strings::params][strings::connection_key] =

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -162,6 +162,7 @@ ApplicationManagerImpl::ApplicationManagerImpl(
           std::make_shared<sync_primitives::RecursiveLock>())
     , apps_to_register_list_lock_ptr_(std::make_shared<sync_primitives::Lock>())
     , reregister_wait_list_lock_ptr_(std::make_shared<sync_primitives::Lock>())
+    , subscribed_to_hmi_way_points_(false)
     , audio_pass_thru_active_(false)
     , audio_pass_thru_app_id_(0)
     , driver_distraction_state_(hmi_apis::Common_DriverDistractionState::DD_OFF)
@@ -1731,11 +1732,11 @@ void ApplicationManagerImpl::SwitchApplication(ApplicationSharedPtr app,
 
   bool is_subscribed_to_way_points = IsAppSubscribedForWayPoints(*app);
   if (is_subscribed_to_way_points) {
-    UnsubscribeAppFromWayPoints(app);
+    UnsubscribeAppFromWayPoints(app, false);
   }
   SwitchApplicationParameters(app, connection_key, device_id, mac_address);
   if (is_subscribed_to_way_points) {
-    SubscribeAppForWayPoints(app);
+    SubscribeAppForWayPoints(app, false);
   }
 
   // Normally this is done during registration, however since switched apps are
@@ -3261,7 +3262,7 @@ void ApplicationManagerImpl::UnregisterApplication(
     }
 
     if (IsAppSubscribedForWayPoints(app_id)) {
-      UnsubscribeAppFromWayPoints(app_id);
+      UnsubscribeAppFromWayPoints(app_id, true);
       if (!IsAnyAppSubscribedForWayPoints()) {
         SDL_LOG_DEBUG("Send UnsubscribeWayPoints");
         auto request = MessageHelper::CreateUnsubscribeWayPointsRequest(
@@ -4725,42 +4726,70 @@ bool ApplicationManagerImpl::IsAppSubscribedForWayPoints(
   return IsAppSubscribedForWayPoints(app.app_id());
 }
 
-void ApplicationManagerImpl::SubscribeAppForWayPoints(uint32_t app_id) {
+void ApplicationManagerImpl::SubscribeAppForWayPoints(uint32_t app_id,
+                                                      bool response_from_hmi) {
   SDL_LOG_AUTO_TRACE();
   sync_primitives::AutoLock lock(subscribed_way_points_apps_lock_);
   SDL_LOG_DEBUG("Subscribing " << app_id);
   subscribed_way_points_apps_list_.insert(app_id);
+  if (response_from_hmi) {
+    subscribed_to_hmi_way_points_ = true;
+  }
   SDL_LOG_DEBUG("There are applications subscribed: "
                 << subscribed_way_points_apps_list_.size());
-  if (way_points_data_) {
-    smart_objects::SmartObjectSPtr way_point_notification_ =
-        std::make_shared<smart_objects::SmartObject>(*way_points_data_);
-    (*way_point_notification_)[strings::params][strings::connection_key] =
+  if (GetAppServiceManager().IsWayPointsHandled()) {
+    auto service = GetAppServiceManager().ActiveServiceForType(
+        EnumToString(mobile_apis::AppServiceType::NAVIGATION));
+    auto it = mobile_way_points_data_.find(service->connection_key);
+    if (mobile_way_points_data_.end() == it) {
+      SDL_LOG_DEBUG("No waypoint data provided by app service provider yet");
+      return;
+    }
+    smart_objects::SmartObjectSPtr way_point_notification =
+        std::make_shared<smart_objects::SmartObject>(it->second);
+    (*way_point_notification)[strings::params][strings::connection_key] =
         app_id;
-    GetRPCService().SendMessageToMobile(way_point_notification_);
+    GetRPCService().SendMessageToMobile(way_point_notification);
+  }
+  if (hmi_way_points_data_) {
+    smart_objects::SmartObjectSPtr way_point_notification =
+        std::make_shared<smart_objects::SmartObject>(*hmi_way_points_data_);
+    (*way_point_notification)[strings::params][strings::connection_key] =
+        app_id;
+    GetRPCService().SendMessageToMobile(way_point_notification);
   }
 }
 
-void ApplicationManagerImpl::SubscribeAppForWayPoints(
-    ApplicationSharedPtr app) {
-  SubscribeAppForWayPoints(app->app_id());
+void ApplicationManagerImpl::SubscribeAppForWayPoints(ApplicationSharedPtr app,
+                                                      bool response_from_hmi) {
+  SubscribeAppForWayPoints(app->app_id(), response_from_hmi);
 }
 
-void ApplicationManagerImpl::UnsubscribeAppFromWayPoints(uint32_t app_id) {
+void ApplicationManagerImpl::UnsubscribeAppFromWayPoints(
+    uint32_t app_id, bool response_from_hmi) {
   SDL_LOG_AUTO_TRACE();
   sync_primitives::AutoLock lock(subscribed_way_points_apps_lock_);
   SDL_LOG_DEBUG("Unsubscribing " << app_id);
   subscribed_way_points_apps_list_.erase(app_id);
+  if (response_from_hmi) {
+    subscribed_to_hmi_way_points_ = false;
+  }
   SDL_LOG_DEBUG("There are applications subscribed: "
                 << subscribed_way_points_apps_list_.size());
   if (subscribed_way_points_apps_list_.empty()) {
-    way_points_data_.reset();
+    hmi_way_points_data_.reset();
+    mobile_way_points_data_.clear();
   }
 }
 
 void ApplicationManagerImpl::UnsubscribeAppFromWayPoints(
-    ApplicationSharedPtr app) {
-  UnsubscribeAppFromWayPoints(app->app_id());
+    ApplicationSharedPtr app, bool response_from_hmi) {
+  UnsubscribeAppFromWayPoints(app->app_id(), response_from_hmi);
+}
+
+bool ApplicationManagerImpl::IsSubscribedToHMIWayPoints() const {
+  SDL_LOG_AUTO_TRACE();
+  return subscribed_to_hmi_way_points_;
 }
 
 bool ApplicationManagerImpl::IsAnyAppSubscribedForWayPoints() const {
@@ -4772,9 +4801,17 @@ bool ApplicationManagerImpl::IsAnyAppSubscribedForWayPoints() const {
 }
 
 void ApplicationManagerImpl::SaveWayPointsMessage(
-    std::shared_ptr<smart_objects::SmartObject> way_points_message) {
+    std::shared_ptr<smart_objects::SmartObject> way_points_message,
+    uint32_t app_id) {
   sync_primitives::AutoLock lock(subscribed_way_points_apps_lock_);
-  way_points_data_ = way_points_message;
+  // Notification from HMI
+  if (0 == app_id) {
+    hmi_way_points_data_ = way_points_message;
+  }
+  // Notification from app service provider
+  else {
+    mobile_way_points_data_[app_id] = *way_points_message;
+  }
 }
 
 const std::set<uint32_t> ApplicationManagerImpl::GetAppsSubscribedForWayPoints()

--- a/src/components/application_manager/src/helpers/application_helper.cc
+++ b/src/components/application_manager/src/helpers/application_helper.cc
@@ -9,12 +9,16 @@ namespace {
 using namespace application_manager;
 void DeleteWayPoints(ApplicationSharedPtr app,
                      ApplicationManager& app_manager) {
-  app_manager.UnsubscribeAppFromWayPoints(app);
-  if (!app_manager.IsAnyAppSubscribedForWayPoints()) {
+  std::set<uint32_t> subscribed_apps =
+      app_manager.GetAppsSubscribedForWayPoints();
+  bool send_unsubscribe =
+      subscribed_apps.size() <= 1 && app_manager.IsSubscribedToHMIWayPoints();
+  if (send_unsubscribe) {
     auto request = MessageHelper::CreateUnsubscribeWayPointsRequest(
         app_manager.GetNextHMICorrelationID());
     app_manager.GetRPCService().ManageHMICommand(request);
   }
+  app_manager.UnsubscribeAppFromWayPoints(app, send_unsubscribe);
 }
 
 void DeleteCommands(ApplicationSharedPtr app, ApplicationManager& app_manager) {

--- a/src/components/application_manager/test/application_helper_test.cc
+++ b/src/components/application_manager/test/application_helper_test.cc
@@ -209,9 +209,6 @@ TEST_F(ApplicationHelperTest, RecallApplicationData_ExpectAppDataReset) {
   EXPECT_TRUE(NULL != file_ptr);
   EXPECT_TRUE(file_ptr->file_name == filename);
 
-  EXPECT_CALL(*mock_message_helper_, CreateUnsubscribeWayPointsRequest(_))
-      .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
-
   EXPECT_CALL(*mock_message_helper_, CreateDeleteUICommandRequest(_, _, _))
       .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
 
@@ -260,9 +257,6 @@ TEST_F(ApplicationHelperTest, RecallApplicationData_ExpectHMICleanupRequests) {
   app_impl_->AddSubMenu(menu_id, cmd[strings::menu_params]);
   app_impl_->AddChoiceSet(choice_set_id, cmd[strings::msg_params]);
   app_impl_->SubscribeToButton(mobile_apis::ButtonName::AC);
-
-  EXPECT_CALL(*mock_message_helper_, CreateUnsubscribeWayPointsRequest(_))
-      .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
 
   EXPECT_CALL(*mock_message_helper_, CreateDeleteUICommandRequest(_, _, _))
       .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -499,16 +499,16 @@ TEST_F(ApplicationManagerImplTest, ProcessQueryApp_ExpectSuccess) {
 TEST_F(ApplicationManagerImplTest,
        SubscribeAppForWayPoints_ExpectSubscriptionApp) {
   auto app_ptr = std::static_pointer_cast<am::Application>(mock_app_ptr_);
-  app_manager_impl_->SubscribeAppForWayPoints(app_ptr);
+  app_manager_impl_->SubscribeAppForWayPoints(app_ptr, true);
   EXPECT_TRUE(app_manager_impl_->IsAppSubscribedForWayPoints(*app_ptr));
 }
 
 TEST_F(ApplicationManagerImplTest,
-       UnsubscribeAppForWayPoints_ExpectUnsubscriptionApp) {
+       UnsubscribeAppFromWayPoints_ExpectUnsubscriptionApp) {
   auto app_ptr = std::static_pointer_cast<am::Application>(mock_app_ptr_);
-  app_manager_impl_->SubscribeAppForWayPoints(app_ptr);
+  app_manager_impl_->SubscribeAppForWayPoints(app_ptr, true);
   EXPECT_TRUE(app_manager_impl_->IsAppSubscribedForWayPoints(*app_ptr));
-  app_manager_impl_->UnsubscribeAppFromWayPoints(app_ptr);
+  app_manager_impl_->UnsubscribeAppFromWayPoints(app_ptr, true);
   EXPECT_FALSE(app_manager_impl_->IsAppSubscribedForWayPoints(*app_ptr));
   const std::set<uint32_t> result =
       app_manager_impl_->GetAppsSubscribedForWayPoints();
@@ -520,7 +520,7 @@ TEST_F(
     IsAnyAppSubscribedForWayPoints_SubcribeAppForWayPoints_ExpectCorrectResult) {
   EXPECT_FALSE(app_manager_impl_->IsAnyAppSubscribedForWayPoints());
   auto app_ptr = std::static_pointer_cast<am::Application>(mock_app_ptr_);
-  app_manager_impl_->SubscribeAppForWayPoints(app_ptr);
+  app_manager_impl_->SubscribeAppForWayPoints(app_ptr, true);
   EXPECT_TRUE(app_manager_impl_->IsAnyAppSubscribedForWayPoints());
 }
 
@@ -528,7 +528,7 @@ TEST_F(
     ApplicationManagerImplTest,
     GetAppsSubscribedForWayPoints_SubcribeAppForWayPoints_ExpectCorrectResult) {
   auto app_ptr = std::static_pointer_cast<am::Application>(mock_app_ptr_);
-  app_manager_impl_->SubscribeAppForWayPoints(app_ptr);
+  app_manager_impl_->SubscribeAppForWayPoints(app_ptr, true);
   std::set<uint32_t> result =
       app_manager_impl_->GetAppsSubscribedForWayPoints();
   EXPECT_EQ(1u, result.size());

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -685,9 +685,9 @@ TEST_F(ResumeCtrlTest,
   extensions.insert(extensions.begin(), mock_app_extension_);
   EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
-  EXPECT_CALL(
-      mock_app_mngr_,
-      SubscribeAppForWayPoints(A<application_manager::ApplicationSharedPtr>()));
+  EXPECT_CALL(mock_app_mngr_,
+              SubscribeAppForWayPoints(
+                  A<application_manager::ApplicationSharedPtr>(), true));
   const mobile_apis::HMILevel::eType hmi_test_level =
       mobile_apis::HMILevel::HMI_FULL;
   ON_CALL(mock_app_mngr_, GetDefaultHmiLevel(const_app_))

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -345,7 +345,7 @@ class ApplicationManager {
 
   /**
    * @brief Checks if Application is subscribed for way points
-   * @param Application id
+   * @param app_id Application id
    * @return true if Application is subscribed for way points
    * otherwise false
    */
@@ -353,7 +353,7 @@ class ApplicationManager {
 
   /**
    * @brief Checks if Application is subscribed for way points
-   * @param Application reference
+   * @param app Application reference
    * @return true if Application is subscribed for way points
    * otherwise false
    */
@@ -361,27 +361,45 @@ class ApplicationManager {
 
   /**
    * @brief Subscribe Application for way points
-   * @param Application id
+   * @param app_id Application id
+   * @param response_from_hmi True if a successful HMI response was received
+   * when subscribing
    */
-  virtual void SubscribeAppForWayPoints(uint32_t id) = 0;
+  virtual void SubscribeAppForWayPoints(uint32_t app_id,
+                                        bool response_from_hmi = true) = 0;
 
   /**
    * @brief Subscribe Application for way points
-   * @param Application pointer
+   * @param app Application pointer
+   * @param response_from_hmi True if a successful HMI response was received
+   * when subscribing
    */
-  virtual void SubscribeAppForWayPoints(ApplicationSharedPtr app) = 0;
+  virtual void SubscribeAppForWayPoints(ApplicationSharedPtr app,
+                                        bool response_from_hmi = true) = 0;
 
   /**
    * @brief Unsubscribe Application for way points
-   * @param Application id
+   * @param app_id Application id
+   * @param response_from_hmi True if a successful HMI response was received
+   * when unsubscribing
    */
-  virtual void UnsubscribeAppFromWayPoints(uint32_t app_id) = 0;
+  virtual void UnsubscribeAppFromWayPoints(uint32_t app_id,
+                                           bool response_from_hmi = true) = 0;
 
   /**
    * @brief Unsubscribe Application for way points
-   * @param Application pointer
+   * @param app Application pointer
+   * @param response_from_hmi True if a successful HMI response was received
+   * when unsubscribing
    */
-  virtual void UnsubscribeAppFromWayPoints(ApplicationSharedPtr app) = 0;
+  virtual void UnsubscribeAppFromWayPoints(ApplicationSharedPtr app,
+                                           bool response_from_hmi = true) = 0;
+
+  /**
+   * @brief Is SDL Core subscribed to HMI waypoints
+   * @return true if SDL Core is subscribed to HMI waypoints, otherwise false
+   */
+  virtual bool IsSubscribedToHMIWayPoints() const = 0;
 
   /**
    * @brief Is Any Application is subscribed for way points
@@ -392,9 +410,12 @@ class ApplicationManager {
   /**
    * @brief Save message after OnWayPointsChangeNotification reception
    * @param way_points_message pointer to the smartobject
+   * @param app_id the app ID of the provider sending the way points update or 0
+   * if the HMI is the provider
    */
   virtual void SaveWayPointsMessage(
-      smart_objects::SmartObjectSPtr way_points_message) = 0;
+      smart_objects::SmartObjectSPtr way_points_message,
+      uint32_t app_id = 0) = 0;
 
   /**
    * @brief Get subscribed for way points

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -351,16 +351,17 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD1(IsAppSubscribedForWayPoints, bool(uint32_t));
   MOCK_CONST_METHOD1(IsAppSubscribedForWayPoints,
                      bool(application_manager::Application& app));
-  MOCK_METHOD1(SubscribeAppForWayPoints, void(uint32_t));
-  MOCK_METHOD1(SubscribeAppForWayPoints,
-               void(application_manager::ApplicationSharedPtr));
-  MOCK_METHOD1(UnsubscribeAppFromWayPoints, void(uint32_t));
-  MOCK_METHOD1(UnsubscribeAppFromWayPoints,
-               void(application_manager::ApplicationSharedPtr));
+  MOCK_METHOD2(SubscribeAppForWayPoints, void(uint32_t, bool));
+  MOCK_METHOD2(SubscribeAppForWayPoints,
+               void(application_manager::ApplicationSharedPtr, bool));
+  MOCK_METHOD2(UnsubscribeAppFromWayPoints, void(uint32_t, bool));
+  MOCK_METHOD2(UnsubscribeAppFromWayPoints,
+               void(application_manager::ApplicationSharedPtr, bool));
+  MOCK_CONST_METHOD0(IsSubscribedToHMIWayPoints, bool());
   MOCK_CONST_METHOD0(IsAnyAppSubscribedForWayPoints, bool());
   MOCK_CONST_METHOD0(GetAppsSubscribedForWayPoints, const std::set<uint32_t>());
-  MOCK_METHOD1(SaveWayPointsMessage,
-               void(std::shared_ptr<smart_objects::SmartObject>));
+  MOCK_METHOD2(SaveWayPointsMessage,
+               void(std::shared_ptr<smart_objects::SmartObject>, uint32_t));
   MOCK_CONST_METHOD1(
       WaitingApplicationByID,
       application_manager::ApplicationConstSharedPtr(const uint32_t));


### PR DESCRIPTION

Fixes #3569 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2486

### Summary
Add handling for OnWayPointChange notification from NAVIGATION app service. NAVIGATION app service will take over waypoints processing when active if it specifies that it can handle these messages. This allows waypoints to be used even when a system doesn't support this feature directly.

### Changelog
##### Bug Fixes
* Core now handles OnWayPointChange from app when its service handles the GetWayPoints RPC.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
