### PR TITLE
close namespace

### DIFF
--- a/src/components/smart_objects/test/SmartObjectConvertionTime_test.cc
+++ b/src/components/smart_objects/test/SmartObjectConvertionTime_test.cc
@@ -543,6 +543,7 @@ class SmartObjectConvertionTimeTest : public ::testing::Test {
 };
 }  // namespace smart_object_test
 }  // namespace components
+}  // namespace test
 
 namespace ns_smart_device_link {
 namespace ns_smart_objects {


### PR DESCRIPTION
Fixes CPPCHECK

This PR is **ready** for review.

### Background

please see discussion [here](https://github.com/smartdevicelink/sdl_core/pull/3453#discussion_r472451676) to know why this was originally changed

### Testing Plan
```
cd sdl_core
cppcheck --force -isrc/3rd_party -isrc/3rd_party-static --quiet --error-exitcode=1 src
```
watch for `src/components/smart_objects/test/SmartObjectConvertionTime_test.cc:55]: (error) Invalid number of character '{' when no macros are defined.` which should be observed before this PR but not after

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
