### PR TITLE
allow all OnSystemRequest types to contain binary data

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_request_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_request_notification.cc
@@ -109,15 +109,8 @@ void OnSystemRequestNotification::Run() {
 
   SDL_LOG_DEBUG("Processing Request type : " << stringified_request_type);
 
-  const bool binary_data_is_required =
-      Compare<mobile_apis::RequestType::eType, EQ, ONE>(
-          request_type,
-          mobile_apis::RequestType::PROPRIETARY,
-          mobile_apis::RequestType::OEM_SPECIFIC);
-
   BinaryMessage binary_data;
-  if (binary_data_is_required &&
-      (*message_)[strings::msg_params].keyExists(strings::file_name)) {
+  if ((*message_)[strings::msg_params].keyExists(strings::file_name)) {
     const std::string filename =
         (*message_)[strings::msg_params][strings::file_name].asString();
     file_system::ReadBinaryFile(filename, binary_data);
@@ -126,20 +119,13 @@ void OnSystemRequestNotification::Run() {
     binary_data = (*message_)[strings::params][strings::binary_data].asBinary();
   }
 
-  if (mobile_apis::RequestType::OEM_SPECIFIC == request_type) {
-    (*message_)[strings::params][strings::binary_data] = binary_data;
-  } else if (mobile_apis::RequestType::PROPRIETARY == request_type) {
+  if (mobile_apis::RequestType::PROPRIETARY == request_type) {
     /* According to requirements:
        "If the requestType = PROPRIETARY, add to mobile API fileType = JSON
-        If the requestType = HTTP, add to mobile API fileType = BINARY"
-       Also we don't save the PT to file - we put it directly in binary_data */
+        If the requestType = HTTP, add to mobile API fileType = BINARY" */
 
 #if defined(PROPRIETARY_MODE)
     AddHeader(binary_data);
-#endif  // PROPRIETARY_MODE
-
-#if defined(PROPRIETARY_MODE) || defined(EXTERNAL_PROPRIETARY_MODE)
-    (*message_)[strings::params][strings::binary_data] = binary_data;
 #endif  // PROPRIETARY_MODE
 
     (*message_)[strings::msg_params][strings::file_type] = FileType::JSON;
@@ -150,12 +136,20 @@ void OnSystemRequestNotification::Run() {
           policy_handler.TimeoutExchangeSec();
     }
   } else if (mobile_apis::RequestType::LOCK_SCREEN_ICON_URL == request_type) {
-    if (!(*message_)[strings::msg_params].keyExists(strings::url) ||
-        (*message_)[strings::msg_params][strings::url].empty()) {
-      SDL_LOG_ERROR("discarding LOCK_SCREEN_ICON_URL request without URL");
+    if (binary_data.empty() &&
+        (!(*message_)[strings::msg_params].keyExists(strings::url) ||
+         (*message_)[strings::msg_params][strings::url].empty())) {
+      SDL_LOG_ERROR(
+          "discarding LOCK_SCREEN_ICON_URL request with no URL or data");
       return;
     }
   }
+
+#if defined(PROPRIETARY_MODE) || defined(EXTERNAL_PROPRIETARY_MODE)
+  if (!binary_data.empty()) {
+    (*message_)[strings::params][strings::binary_data] = binary_data;
+  }
+#endif  // PROPRIETARY_MODE
 
   SendNotification();
 }


### PR DESCRIPTION
Fixes #1714

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2480

### Summary
allow binary data to be added to OnSystemRequest of any type
allow OSR of type LOCKSCREEN_ICON_URL with just binaryData and no URL

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
