### PR TITLE
Re-add messages field in policy table json

### DIFF
--- a/src/components/policy/policy_external/src/policy_table/types.cc
+++ b/src/components/policy/policy_external/src/policy_table/types.cc
@@ -1357,8 +1357,7 @@ ConsumerFriendlyMessages::ConsumerFriendlyMessages(const Json::Value* value__)
 Json::Value ConsumerFriendlyMessages::ToJsonValue() const {
   Json::Value result__(Json::objectValue);
   impl::WriteJsonField("version", version, &result__);
-  // According to requirements, it is not necessary to provide this to PTS
-  // impl::WriteJsonField("messages", messages, &result__);
+  impl::WriteJsonField("messages", messages, &result__);
   return result__;
 }
 


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/master/test_scripts/API/GetPolicyConfigurationData/001_GetPolicyConfigurationData_success.lua

### Summary
consumer_friendly_messages.messages was being omitted from the policy table json rather than just the snapshot, this reintroduces this field (this field is still cleared out when generating the snapshot in `CheckSnapshotInitialization`)

### Changelog
##### Bug Fixes
* Adds consumer_friendly_messages.messages back into the policy table JSON so that it can be retrieved in `SDL.GetPolicyConfigurationData`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
