### PR TITLE
Fix success=false after UNSUPPORTED_RESOURCE response for multiple RPCs

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_interaction_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_interaction_request.h
@@ -128,15 +128,13 @@ class PerformInteractionRequest
    * @return true if send response to mobile application otherwise
    * return false.
    */
-  bool ProcessVRResponse(const smart_objects::SmartObject& message,
-                         smart_objects::SmartObject& msg_params);
+  bool ProcessVRResponse(const smart_objects::SmartObject& message);
 
   /**
    * @brief Sends PerformInteraction response to mobile side
    * @param message which should send to mobile side
    */
-  void ProcessUIResponse(const smart_objects::SmartObject& message,
-                         smart_objects::SmartObject& msg_params);
+  void ProcessUIResponse(const smart_objects::SmartObject& message);
 
   /*
    * @brief Sends UI PerformInteraction request to HMI
@@ -279,6 +277,7 @@ class PerformInteractionRequest
   mobile_apis::InteractionMode::eType interaction_mode_;
   std::int32_t ui_choice_id_received_;
   std::int32_t vr_choice_id_received_;
+  std::string ui_text_entry_received_;
 
   bool ui_response_received_;
   bool vr_response_received_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_maneuver_request.cc
@@ -236,7 +236,6 @@ bool AlertManeuverRequest::PrepareResponseParameters(
                   application_manager_.hmi_interfaces().GetInterfaceState(
                       HmiInterfaces::HMI_INTERFACE_TTS)))) {
     result_code = mobile_apis::Result::WARNINGS;
-    return_info = std::string("Unsupported phoneme type sent in a prompt");
     return result;
   }
   result_code =

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_maneuver_request.cc
@@ -236,6 +236,8 @@ bool AlertManeuverRequest::PrepareResponseParameters(
                   application_manager_.hmi_interfaces().GetInterfaceState(
                       HmiInterfaces::HMI_INTERFACE_TTS)))) {
     result_code = mobile_apis::Result::WARNINGS;
+    return_info = app_mngr::commands::MergeInfos(
+        navigation_alert_info, info_navi_, tts_alert_info, info_tts_);
     return result;
   }
   result_code =

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_request.cc
@@ -213,19 +213,10 @@ bool AlertRequest::PrepareResponseParameters(
 
   bool result = PrepareResultForMobileResponse(ui_alert_info, tts_alert_info);
 
-  /* result=false if UI interface is ok and TTS interface = UNSUPPORTED_RESOURCE
-   * and sdl receive TTS.IsReady=true or SDL doesn't receive responce for
-   * TTS.IsReady.
-   */
-  if (result && ui_alert_info.is_ok && tts_alert_info.is_unsupported_resource &&
-      HmiInterfaces::STATE_NOT_AVAILABLE != tts_alert_info.interface_state) {
-    result = false;
-  }
   result_code = mobile_apis::Result::WARNINGS;
   if ((ui_alert_info.is_ok || ui_alert_info.is_not_used) &&
       tts_alert_info.is_unsupported_resource &&
       HmiInterfaces::STATE_AVAILABLE == tts_alert_info.interface_state) {
-    tts_response_info_ = "Unsupported phoneme type sent in a prompt";
     info = app_mngr::commands::MergeInfos(
         ui_alert_info, ui_response_info_, tts_alert_info, tts_response_info_);
     return result;
@@ -234,7 +225,10 @@ bool AlertRequest::PrepareResponseParameters(
   info = app_mngr::commands::MergeInfos(
       ui_alert_info, ui_response_info_, tts_alert_info, tts_response_info_);
   // Mobile Alert request is successful when UI_Alert is successful
-  if (is_ui_alert_sent_ && !ui_alert_info.is_ok) {
+  bool has_unsupported_data =
+      ui_alert_info.is_unsupported_resource &&
+      HmiInterfaces::STATE_NOT_AVAILABLE != ui_alert_info.interface_state;
+  if (is_ui_alert_sent_ && !ui_alert_info.is_ok && !has_unsupported_data) {
     return false;
   }
   return result;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -224,20 +224,17 @@ PerformAudioPassThruRequest::PrepareResponseParameters() {
       HmiInterfaces::HMI_INTERFACE_TTS,
       application_manager_);
 
-  // Note(dtrunov): According to requirment "WARNINGS, success:true on getting
-  // UNSUPPORTED_RESOURCE for "ttsChunks"
+  response_params_.success =
+      PrepareResultForMobileResponse(ui_perform_info, tts_perform_info);
   if (ui_perform_info.is_ok && tts_perform_info.is_unsupported_resource &&
       HmiInterfaces::STATE_AVAILABLE == tts_perform_info.interface_state) {
     response_params_.result_code = mobile_apis::Result::WARNINGS;
-    tts_info_ = "Unsupported phoneme type sent in a prompt";
     response_params_.info = app_mngr::commands::MergeInfos(
         ui_perform_info, ui_info_, tts_perform_info, tts_info_);
     response_params_.success = true;
     return response_params_;
   }
 
-  response_params_.success =
-      PrepareResultForMobileResponse(ui_perform_info, tts_perform_info);
   if (IsResultCodeUnsupported(ui_perform_info, tts_perform_info)) {
     response_params_.result_code = mobile_apis::Result::UNSUPPORTED_RESOURCE;
   } else {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subtle_alert_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subtle_alert_request.cc
@@ -206,20 +206,10 @@ bool SubtleAlertRequest::PrepareResponseParameters(
   bool result =
       PrepareResultForMobileResponse(ui_subtle_alert_info, tts_alert_info);
 
-  /* result=false if UI interface is ok and TTS interface = UNSUPPORTED_RESOURCE
-   * and sdl receive TTS.IsReady=true or SDL doesn't receive response for
-   * TTS.IsReady.
-   */
-  if (result && ui_subtle_alert_info.is_ok &&
-      tts_alert_info.is_unsupported_resource &&
-      HmiInterfaces::STATE_NOT_AVAILABLE != tts_alert_info.interface_state) {
-    result = false;
-  }
   result_code = mobile_apis::Result::WARNINGS;
   if ((ui_subtle_alert_info.is_ok || ui_subtle_alert_info.is_not_used) &&
       tts_alert_info.is_unsupported_resource &&
       HmiInterfaces::STATE_AVAILABLE == tts_alert_info.interface_state) {
-    tts_response_info_ = "Unsupported phoneme type sent in a prompt";
     info = app_mngr::commands::MergeInfos(ui_subtle_alert_info,
                                           ui_response_info_,
                                           tts_alert_info,
@@ -244,7 +234,11 @@ bool SubtleAlertRequest::PrepareResponseParameters(
                                         tts_alert_info,
                                         tts_response_info_);
   // Mobile Alert request is successful when UI_SubtleAlert is successful
-  if (is_ui_subtle_alert_sent_ && !ui_subtle_alert_info.is_ok) {
+  bool has_unsupported_data = ui_subtle_alert_info.is_unsupported_resource &&
+                              HmiInterfaces::STATE_NOT_AVAILABLE !=
+                                  ui_subtle_alert_info.interface_state;
+  if (is_ui_subtle_alert_sent_ && !ui_subtle_alert_info.is_ok &&
+      !has_unsupported_data) {
     return false;
   }
   return result;


### PR DESCRIPTION
Fixes #1596, #1597, #1583

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run ATF Tests in https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2494

### Summary
Fix issues with response parameter calculation after UNSUPPORTED_RESOURCE response for PerformInteraction, Alert, SubtleAlert, AlertManeuver, and PerformAudioPassThru

### Changelog
##### Bug Fixes
* Fix success=false after UNSUPPORTED_RESOURCE response for several RPCs
* Fix success, choiceID, and triggerSource calculation for PerformInteraction to account for UNSUPPORTED_RESOURCE response
* Remove hardcoded info messages in several places, just pass through info from the HMI

### Tasks Remaining:
- [x] Add ATF tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
