### PR TITLE
Bind protocol version when app registers

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -674,6 +674,8 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
       static_cast<protocol_handler::MajorProtocolVersion>(
           message[strings::params][strings::protocol_version].asInt());
   application->set_protocol_version(protocol_version);
+  connection_handler_->BindProtocolVersionWithSession(connection_key,
+                                                      protocol_version);
 
   // Keep HMI add id in case app is present in "waiting for registration" list
   apps_to_register_list_lock_ptr_->Acquire();


### PR DESCRIPTION
Fixes #3576 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run ATF tests mentioned in issue

### Summary
Binds a protocol version to a session when an app registers. Core does call to bind earlier but Core binds the module max version instead of the negotiated version which is decided by the app.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
