### PR TITLE
fix unit tests with with -DENABLE_SECURITY=OFF

### DIFF
--- a/src/components/include/protocol_handler/protocol_handler.h
+++ b/src/components/include/protocol_handler/protocol_handler.h
@@ -146,7 +146,7 @@ class ProtocolHandler {
 
   virtual void ProcessFailedPTU() = 0;
 
-#ifdef EXTERNAL_PROPRIETARY_MODE
+#if defined(EXTERNAL_PROPRIETARY_MODE) && defined(ENABLE_SECURITY)
   /**
    * @brief ProcessFailedCertDecrypt is called to notify security manager that
    * certificate decryption failed in the external flow

--- a/src/components/include/security_manager/security_manager.h
+++ b/src/components/include/security_manager/security_manager.h
@@ -170,7 +170,7 @@ class SecurityManager : public protocol_handler::ProtocolObserver,
 
   virtual void ProcessFailedPTU() = 0;
 
-#ifdef EXTERNAL_PROPRIETARY_MODE
+#if defined(EXTERNAL_PROPRIETARY_MODE) && defined(ENABLE_SECURITY)
   /**
    * @brief ProcessFailedCertDecrypt is called to notify listeners that
    * certificate decryption failed in the external flow

--- a/src/components/include/test/protocol_handler/mock_protocol_handler.h
+++ b/src/components/include/test/protocol_handler/mock_protocol_handler.h
@@ -71,7 +71,7 @@ class MockProtocolHandler : public ::protocol_handler::ProtocolHandler {
   MOCK_METHOD0(NotifyOnGetSystemTimeFailed, void());
   MOCK_CONST_METHOD1(IsRPCServiceSecure, bool(const uint32_t connection_key));
   MOCK_METHOD0(ProcessFailedPTU, void());
-#ifdef EXTERNAL_PROPRIETARY_MODE
+#if defined(EXTERNAL_PROPRIETARY_MODE) && defined(ENABLE_SECURITY)
   MOCK_METHOD0(ProcessFailedCertDecrypt, void());
 #endif
 };

--- a/src/components/include/test/security_manager/mock_security_manager.h
+++ b/src/components/include/test/security_manager/mock_security_manager.h
@@ -75,7 +75,7 @@ class MockSecurityManager : public ::security_manager::SecurityManager {
   MOCK_METHOD1(PostponeHandshake, void(const uint32_t));
   MOCK_CONST_METHOD0(IsSystemTimeProviderReady, bool());
   MOCK_METHOD0(ResetPendingSystemTimeRequests, void());
-#ifdef EXTERNAL_PROPRIETARY_MODE
+#if defined(EXTERNAL_PROPRIETARY_MODE) && defined(ENABLE_SECURITY)
   MOCK_METHOD0(ProcessFailedCertDecrypt, void());
 #endif
 };

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -214,7 +214,7 @@ class ProtocolHandlerImpl
 
   void ProcessFailedPTU() OVERRIDE;
 
-#ifdef EXTERNAL_PROPRIETARY_MODE
+#if defined(EXTERNAL_PROPRIETARY_MODE) && defined(ENABLE_SECURITY)
   /**
    * @brief ProcessFailedCertDecrypt is called to notify security manager that
    * certificate decryption failed in the external flow

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1169,7 +1169,7 @@ void ProtocolHandlerImpl::ProcessFailedPTU() {
 #endif  // ENABLE_SECURITY
 }
 
-#ifdef EXTERNAL_PROPRIETARY_MODE
+#if defined(EXTERNAL_PROPRIETARY_MODE) && defined(ENABLE_SECURITY)
 void ProtocolHandlerImpl::ProcessFailedCertDecrypt() {
   SDL_LOG_AUTO_TRACE();
   security_manager_->ProcessFailedCertDecrypt();

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -47,6 +47,8 @@
 #ifdef ENABLE_SECURITY
 #include "security_manager/mock_security_manager.h"
 #include "security_manager/mock_ssl_context.h"
+#else
+#include "utils/byte_order.h"
 #endif  // ENABLE_SECURITY
 #include "transport_manager/mock_transport_manager.h"
 #include "utils/mock_system_time_handler.h"

--- a/src/components/security_manager/include/security_manager/security_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/security_manager_impl.h
@@ -216,7 +216,7 @@ class SecurityManagerImpl : public SecurityManager,
 
   void ProcessFailedPTU() OVERRIDE;
 
-#ifdef EXTERNAL_PROPRIETARY_MODE
+#if defined(EXTERNAL_PROPRIETARY_MODE) && defined(ENABLE_SECURITY)
   /**
    * @brief ProcessFailedCertDecrypt is called to notify listeners that
    * certificate decryption failed in the external flow

--- a/src/components/security_manager/src/security_manager_impl.cc
+++ b/src/components/security_manager/src/security_manager_impl.cc
@@ -425,7 +425,7 @@ void SecurityManagerImpl::ProcessFailedPTU() {
   }
 }
 
-#ifdef EXTERNAL_PROPRIETARY_MODE
+#if defined(EXTERNAL_PROPRIETARY_MODE) && defined(ENABLE_SECURITY)
 void SecurityManagerImpl::ProcessFailedCertDecrypt() {
   SDL_LOG_AUTO_TRACE();
   {

--- a/src/components/transport_manager/test/websocket_server_listener_test.cc
+++ b/src/components/transport_manager/test/websocket_server_listener_test.cc
@@ -128,6 +128,7 @@ TEST_F(WebSocketListenerTest, StartListening_ClientConnect_SUCCESS) {
   ws_client->Stop();
 }
 
+#ifdef ENABLE_SECURITY
 TEST_F(WebSocketListenerTest, StartListening_ClientConnectSecure_SUCCESS) {
   const auto ws_listener = std::make_shared<WebSocketListener>(
       &mock_ta_controller_, mock_tm_settings_, kNumThreads);
@@ -254,6 +255,7 @@ TEST_F(WebSocketListenerTest, StartListening_AcceptorIsOpen_SUCCESS) {
   EXPECT_EQ(TransportAdapter::Error::OK, ws_listener->StartListening());
   ws_client->Stop();
 }
+#endif
 
 }  // namespace transport_manager_test
 }  // namespace components

--- a/src/components/utils/src/logger/log4cxxlogger.cc
+++ b/src/components/utils/src/logger/log4cxxlogger.cc
@@ -90,6 +90,7 @@ log4cxx::LevelPtr getLogLevel(LogLevel log_level) {
       return log4cxx::Level::getFatal();
     default:
       assert(false);
+      return log4cxx::Level::getTrace();
   }
 }
 


### PR DESCRIPTION
Fixes #3614 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ensure core will build in the following configurations:
cmake ../sdl_core -DBUILD_TESTS=ON -DENABLE_SECURITY=OFF
cmake ../sdl_core -DBUILD_TESTS=ON -DENABLE_SECURITY=OFF -DEXTENDED_POLICY=EXTERNAL_PROPRIETARY
cmake ../sdl_core -DCMAKE_BUILD_TYPE=Release

### Summary
When security is disabled, tests still need endian conversions.
Some WS Secure tests were disabled without ENABLE_SECURITY
A non void log4cxx function had an assert instead of a return, preventing compile in release mode

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
