### PR TITLE
Fix atomic usage for gcc 5.4.0

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1615,8 +1615,8 @@ class ApplicationManagerImpl
   ns_smart_device_link_rpc::V1::v4_protocol_v1_2_no_extra
       mobile_v4_protocol_so_factory_;
 
-  std::atomic_uint32_t mobile_correlation_id_;
-  std::atomic_uint32_t correlation_id_;
+  std::atomic<uint32_t> mobile_correlation_id_;
+  std::atomic<uint32_t> correlation_id_;
   const uint32_t max_correlation_id_;
 
   std::unique_ptr<HMICapabilities> hmi_capabilities_;


### PR DESCRIPTION
Fixes issue with #3567 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Build project in Ubuntu 16.04

### Summary
`std::atomic_uint32_t` is not available for some older versions of gcc (including 5.4.0, which is used by Ubuntu 16.04), this PR changes usages of this to use the more generic form (`std::atomic<uint32_t>`)

### Changelog
##### Bug Fixes
* Fixes usage of `std::atomic_uint32_t` for older versions of gcc

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
