### PR TITLE
Fix/Wait for IsReady responses before RAI processing

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_is_ready_request.h
@@ -72,6 +72,8 @@ class NaviIsReadyRequest : public app_mngr::commands::RequestToHMI,
    **/
   void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
+  void onTimeOut() OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(NaviIsReadyRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_is_ready_request.cc
@@ -75,6 +75,8 @@ void NaviIsReadyRequest::on_event(const event_engine::Event& event) {
 
       HMICapabilities& hmi_capabilities = hmi_capabilities_;
       hmi_capabilities.set_is_navi_cooperating(is_available);
+      hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+          hmi_apis::FunctionID::Navigation_IsReady);
       break;
     }
     default: {
@@ -82,6 +84,11 @@ void NaviIsReadyRequest::on_event(const event_engine::Event& event) {
       return;
     }
   }
+}
+
+void NaviIsReadyRequest::onTimeOut() {
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::Navigation_IsReady);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_request.cc
@@ -79,6 +79,8 @@ void RCIsReadyRequest::on_event(const event_engine::Event& event) {
       if (!is_available) {
         hmi_capabilities.set_rc_supported(false);
       }
+      hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+          hmi_apis::FunctionID::RC_IsReady);
 
       if (!app_mngr::commands::CheckAvailabilityHMIInterfaces(
               application_manager_, HmiInterfaces::HMI_INTERFACE_RC)) {
@@ -99,6 +101,8 @@ void RCIsReadyRequest::on_event(const event_engine::Event& event) {
 
 void RCIsReadyRequest::onTimeOut() {
   // Note(dtrunov): According to new requirment APPLINK-27956
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::RC_IsReady);
   RequestInterfaceCapabilities(hmi_interface::rc);
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_is_ready_request.cc
@@ -73,6 +73,8 @@ void TTSIsReadyRequest::on_event(const event_engine::Event& event) {
           application_manager_, message, HmiInterfaces::HMI_INTERFACE_TTS);
       HMICapabilities& hmi_capabilities = hmi_capabilities_;
       hmi_capabilities.set_is_tts_cooperating(is_available);
+      hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+          hmi_apis::FunctionID::TTS_IsReady);
       if (!app_mngr::commands::CheckAvailabilityHMIInterfaces(
               application_manager_, HmiInterfaces::HMI_INTERFACE_TTS)) {
         UpdateRequiredInterfaceCapabilitiesRequests(hmi_interface::tts);
@@ -92,6 +94,8 @@ void TTSIsReadyRequest::on_event(const event_engine::Event& event) {
 
 void TTSIsReadyRequest::onTimeOut() {
   // Note(dtrunov): According to new requirment  APPLINK-27956
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::TTS_IsReady);
   RequestInterfaceCapabilities(hmi_interface::tts);
 }
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_is_ready_request.cc
@@ -72,6 +72,8 @@ void UIIsReadyRequest::on_event(const event_engine::Event& event) {
           application_manager_, message, HmiInterfaces::HMI_INTERFACE_UI);
       HMICapabilities& hmi_capabilities = hmi_capabilities_;
       hmi_capabilities.set_is_ui_cooperating(is_available);
+      hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+          hmi_apis::FunctionID::UI_IsReady);
       if (!app_mngr::commands::CheckAvailabilityHMIInterfaces(
               application_manager_, HmiInterfaces::HMI_INTERFACE_UI)) {
         UpdateRequiredInterfaceCapabilitiesRequests(hmi_interface::ui);
@@ -91,6 +93,8 @@ void UIIsReadyRequest::on_event(const event_engine::Event& event) {
 
 void UIIsReadyRequest::onTimeOut() {
   // Note(dtrunov): According to new requirment APPLINK-27956
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::UI_IsReady);
   RequestInterfaceCapabilities(hmi_interface::ui);
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_is_ready_request.cc
@@ -73,6 +73,8 @@ void VRIsReadyRequest::on_event(const event_engine::Event& event) {
 
       HMICapabilities& hmi_capabilities = hmi_capabilities_;
       hmi_capabilities.set_is_vr_cooperating(is_available);
+      hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+          hmi_apis::FunctionID::VR_IsReady);
       if (!app_mngr::commands::CheckAvailabilityHMIInterfaces(
               application_manager_, HmiInterfaces::HMI_INTERFACE_VR)) {
         UpdateRequiredInterfaceCapabilitiesRequests(hmi_interface::vr);
@@ -92,6 +94,8 @@ void VRIsReadyRequest::on_event(const event_engine::Event& event) {
 
 void VRIsReadyRequest::onTimeOut() {
   // Note(dtrunov): According to new requirment APPLINK-27956
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::VR_IsReady);
   RequestInterfaceCapabilities(hmi_interface::vr);
 }
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_is_ready_request.cc
@@ -78,6 +78,8 @@ void VIIsReadyRequest::on_event(const event_engine::Event& event) {
       HMICapabilities& hmi_capabilities = hmi_capabilities_;
       hmi_capabilities.set_is_ivi_cooperating(is_available);
       policy_handler_.OnVIIsReady();
+      hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+          hmi_apis::FunctionID::VehicleInfo_IsReady);
       if (!app_mngr::commands::CheckAvailabilityHMIInterfaces(
               application_manager_, HmiInterfaces::HMI_INTERFACE_VehicleInfo)) {
         SDL_LOG_INFO(
@@ -99,6 +101,8 @@ void VIIsReadyRequest::on_event(const event_engine::Event& event) {
 
 void VIIsReadyRequest::onTimeOut() {
   // Note(dtrunov): According to new requirment APPLINK-27956
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::VehicleInfo_IsReady);
   RequestInterfaceCapabilities(hmi_interface ::vehicle_info);
 }
 

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -126,6 +126,13 @@ HMICapabilitiesImpl::HMICapabilitiesImpl(ApplicationManager& app_mngr)
     is_ivi_cooperating_ = true;
     is_rc_cooperating_ = true;
   }
+  requests_required_for_capabilities_ = {
+      hmi_apis::FunctionID::VehicleInfo_IsReady,
+      hmi_apis::FunctionID::VR_IsReady,
+      hmi_apis::FunctionID::TTS_IsReady,
+      hmi_apis::FunctionID::UI_IsReady,
+      hmi_apis::FunctionID::RC_IsReady,
+      hmi_apis::FunctionID::Navigation_IsReady};
 }
 
 HMICapabilitiesImpl::~HMICapabilitiesImpl() {}

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -130,6 +130,14 @@ const std::vector<hmi_apis::Common_LightName::eType> light_name_enum_values{
     hmi_apis::Common_LightName::eType::EXTERIOR_RIGHT_LIGHTS,
     hmi_apis::Common_LightName::eType::EXTERIOR_ALL_LIGHTS};
 
+const std::vector<hmi_apis::FunctionID::eType> is_ready_requests{
+    hmi_apis::FunctionID::RC_IsReady,
+    hmi_apis::FunctionID::VR_IsReady,
+    hmi_apis::FunctionID::UI_IsReady,
+    hmi_apis::FunctionID::TTS_IsReady,
+    hmi_apis::FunctionID::Navigation_IsReady,
+    hmi_apis::FunctionID::VehicleInfo_IsReady};
+
 bool IsLightNameExists(const hmi_apis::Common_LightName::eType& light_name) {
   auto it = std::find(
       light_name_enum_values.begin(), light_name_enum_values.end(), light_name);
@@ -155,6 +163,13 @@ class HMICapabilitiesTest : public ::testing::Test {
         .WillByDefault(ReturnRef(kHmiCapabilitiesCacheFile));
 
     hmi_capabilities_ = std::make_shared<HMICapabilitiesImpl>(mock_app_mngr_);
+    IsReadyResponsesReceived();
+  }
+
+  void IsReadyResponsesReceived() {
+    for (const auto& request : is_ready_requests) {
+      hmi_capabilities_->UpdateRequestsRequiredForCapabilities(request);
+    }
   }
 
   void TearDown() OVERRIDE {


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3628

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
Scripts attached to https://github.com/smartdevicelink/sdl_core/issues/3628

### Summary
All IsReady responses were added to `requests_required_for_capabilities_` collection, so SDL will wait for IsReady responses from HMI to set the `hmi_cooperating_` flag to true and send RAI response. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
