### PR TITLE
Feature/sdl 0264 separating the change of audible status and the change of hmi status

### DIFF
--- a/src/components/application_manager/src/hmi_state.cc
+++ b/src/components/application_manager/src/hmi_state.cc
@@ -242,11 +242,7 @@ PhoneCallHmiState::PhoneCallHmiState(std::shared_ptr<Application> app,
     : HmiState(app, app_mngr, STATE_ID_PHONE_CALL) {}
 
 mobile_apis::HMILevel::eType PhoneCallHmiState::hmi_level() const {
-  using namespace mobile_apis;
-  if (HMILevel::INVALID_ENUM == parent_hmi_level()) {
-    return parent_hmi_level();
-  }
-  return std::max(parent_hmi_level(), max_hmi_level());
+  return parent_hmi_level();
 }
 
 mobile_apis::HMILevel::eType PhoneCallHmiState::max_hmi_level() const {

--- a/src/components/application_manager/test/state_controller/state_controller_test.cc
+++ b/src/components/application_manager/test/state_controller/state_controller_test.cc
@@ -392,22 +392,22 @@ class StateControllerImplTest : public ::testing::Test {
       case APP_TYPE_MEDIA: {
         PrepareCommonStateResults(result_hmi_state);
         result_hmi_state.push_back(
-            createHmiState(HMILevel::HMI_BACKGROUND,
+            createHmiState(HMILevel::HMI_LIMITED,
                            AudioStreamingState::NOT_AUDIBLE,
                            VideoStreamingState::NOT_STREAMABLE,
                            SystemContext::SYSCTXT_MAIN));
         result_hmi_state.push_back(
-            createHmiState(HMILevel::HMI_BACKGROUND,
+            createHmiState(HMILevel::HMI_LIMITED,
                            AudioStreamingState::NOT_AUDIBLE,
                            VideoStreamingState::NOT_STREAMABLE,
                            SystemContext::SYSCTXT_MAIN));
         result_hmi_state.push_back(
-            createHmiState(HMILevel::HMI_BACKGROUND,
+            createHmiState(HMILevel::HMI_FULL,
                            AudioStreamingState::NOT_AUDIBLE,
                            VideoStreamingState::NOT_STREAMABLE,
                            SystemContext::SYSCTXT_MAIN));
         result_hmi_state.push_back(
-            createHmiState(HMILevel::HMI_BACKGROUND,
+            createHmiState(HMILevel::HMI_FULL,
                            AudioStreamingState::NOT_AUDIBLE,
                            VideoStreamingState::NOT_STREAMABLE,
                            SystemContext::SYSCTXT_MAIN));
@@ -426,12 +426,12 @@ class StateControllerImplTest : public ::testing::Test {
                            VideoStreamingState::NOT_STREAMABLE,
                            SystemContext::SYSCTXT_MAIN));
         result_hmi_state.push_back(
-            createHmiState(HMILevel::HMI_LIMITED,
+            createHmiState(HMILevel::HMI_FULL,
                            AudioStreamingState::NOT_AUDIBLE,
                            VideoStreamingState::NOT_STREAMABLE,
                            SystemContext::SYSCTXT_MAIN));
         result_hmi_state.push_back(
-            createHmiState(HMILevel::HMI_LIMITED,
+            createHmiState(HMILevel::HMI_FULL,
                            AudioStreamingState::NOT_AUDIBLE,
                            VideoStreamingState::NOT_STREAMABLE,
                            SystemContext::SYSCTXT_MAIN));


### PR DESCRIPTION
Implements #3227 

This PR is [ready] for review.

### Risk
This PR makes [no] API changes.

### Testing Plan
ATF test script from [smartdevicelink/sdl_atf_test_scripts#2524](https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2524)

### Summary
Changed to keep the HMI state of the app when receiving OnEventChanged (PHONE_CALL, active: true).

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
