### PR TITLE
Add default value for maskInputCharacters to ResetGlobalProperties

### DIFF
--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -594,6 +594,7 @@ extern const char* method_name;
 extern const char* keyboard_layout;
 extern const char* limited_character_list;
 extern const char* auto_complete_list;
+extern const char* mask_input_characters;
 extern const char* custom_keys;
 extern const char* file;
 extern const char* file_name;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_global_properties_request.cc
@@ -692,6 +692,13 @@ void SetGlobalPropertiesRequest::PrepareUIRequestMenuAndKeyboardData(
       cached_keyboard_props[hmi_request::auto_complete_list] =
           (*saved_keyboard_props)[hmi_request::auto_complete_list];
     }
+
+    if (!msg_params[hmi_request::keyboard_properties].keyExists(
+            hmi_request::mask_input_characters) &&
+        saved_keyboard_props->keyExists(hmi_request::mask_input_characters)) {
+      cached_keyboard_props[hmi_request::mask_input_characters] =
+          (*saved_keyboard_props)[hmi_request::mask_input_characters];
+    }
     app->set_keyboard_props(cached_keyboard_props);
   }
 }

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -404,6 +404,9 @@ MessageHelper::CreateUIResetGlobalPropertiesRequest(
         static_cast<int32_t>(hmi_apis::Common_KeyboardLayout::QWERTY);
     key_board_properties[hmi_request::auto_complete_list] =
         smart_objects::SmartObject(smart_objects::SmartType_Array);
+    key_board_properties[hmi_request::mask_input_characters] =
+        static_cast<int32_t>(
+            hmi_apis::Common_KeyboardInputMask::DISABLE_INPUT_KEY_MASK);
 
     key_board_properties[strings::auto_complete_text] = "";
     (*ui_reset_global_prop_request)[hmi_request::keyboard_properties] =

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -396,21 +396,22 @@ MessageHelper::CreateUIResetGlobalPropertiesRequest(
   }
 
   if (reset_result.keyboard_properties) {
-    smart_objects::SmartObject key_board_properties =
+    smart_objects::SmartObject keyboard_properties =
         smart_objects::SmartObject(smart_objects::SmartType_Map);
-    key_board_properties[strings::language] =
+    keyboard_properties[strings::language] =
         static_cast<int32_t>(hmi_apis::Common_Language::EN_US);
-    key_board_properties[hmi_request::keyboard_layout] =
+    keyboard_properties[hmi_request::keyboard_layout] =
         static_cast<int32_t>(hmi_apis::Common_KeyboardLayout::QWERTY);
-    key_board_properties[hmi_request::auto_complete_list] =
+    keyboard_properties[hmi_request::auto_complete_list] =
         smart_objects::SmartObject(smart_objects::SmartType_Array);
-    key_board_properties[hmi_request::mask_input_characters] =
+    keyboard_properties[strings::auto_complete_text] = "";
+    keyboard_properties[hmi_request::mask_input_characters] =
         static_cast<int32_t>(
             hmi_apis::Common_KeyboardInputMask::DISABLE_INPUT_KEY_MASK);
 
-    key_board_properties[strings::auto_complete_text] = "";
     (*ui_reset_global_prop_request)[hmi_request::keyboard_properties] =
-        key_board_properties;
+        keyboard_properties;
+    app->set_keyboard_props(keyboard_properties);
   }
 
   (*ui_reset_global_prop_request)[strings::app_id] = application->app_id();

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -411,7 +411,8 @@ MessageHelper::CreateUIResetGlobalPropertiesRequest(
 
     (*ui_reset_global_prop_request)[hmi_request::keyboard_properties] =
         keyboard_properties;
-    application->set_keyboard_props(keyboard_properties);
+    application->set_keyboard_props(
+        smart_objects::SmartObject(smart_objects::SmartType_Map));
   }
 
   (*ui_reset_global_prop_request)[strings::app_id] = application->app_id();

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -411,7 +411,7 @@ MessageHelper::CreateUIResetGlobalPropertiesRequest(
 
     (*ui_reset_global_prop_request)[hmi_request::keyboard_properties] =
         keyboard_properties;
-    app->set_keyboard_props(keyboard_properties);
+    application->set_keyboard_props(keyboard_properties);
   }
 
   (*ui_reset_global_prop_request)[strings::app_id] = application->app_id();

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -552,6 +552,7 @@ const char* method_name = "methodName";
 const char* keyboard_layout = "keyboardLayout";
 const char* limited_character_list = "limitedCharacterList";
 const char* auto_complete_list = "autoCompleteList";
+const char* mask_input_characters = "maskInputCharacters";
 const char* custom_keys = "customKeys";
 const char* file = "file";
 const char* file_name = "fileName";


### PR DESCRIPTION

Fixes issue with #3609 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manual test, run `ResetGlobalProperties` for `KEYBOARDPROPERTIES` and verify that `maskInputCharacters` is set to `DISABLE_INPUT_KEY_MASK`.

### Summary
Adds default value for `maskInputCharacters` when sending a `ResetGlobalProperties(KEYBOARDPROPERTIES)` request and updates cache accordingly.

### Changelog
##### Bug Fixes
* Adds default value for `maskInputCharacters` when sending a `ResetGlobalProperties(KEYBOARDPROPERTIES)` request
* Updates resumption information for keyboard properties when reset
* Merge `maskInputCharacters` when setting cached keyboard properties

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
