### PR TITLE
Common.KeyboardInputMask fix

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -3221,7 +3221,7 @@
       If empty, the auto-complete list will be removed from the screen.
     </description>
   </param>
-  <param name="maskInputCharacters" type="KeyboardInputMask" mandatory="false">
+  <param name="maskInputCharacters" type="Common.KeyboardInputMask" mandatory="false">
     <description>Allows an app to mask entered characters on HMI</description>
   </param>
   <param name="customKeys" type="String" maxlength="1" minsize="1" maxsize="10" array="true" mandatory="false">


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Build SDL Core
Confirm usage of KeyboardMaskInput parameter type.

### Summary
KeyboardMaskInput is defined inside of the common interface and needs to be referenced as such.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
