### PR TITLE
add appID param to SendHapticData HMI request

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/send_haptic_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/send_haptic_data_request.cc
@@ -70,6 +70,7 @@ void SendHapticDataRequest::Run() {
   }
 
   if (app->is_navi() || app->mobile_projection_enabled()) {
+    msg_params[strings::app_id] = connection_key();
     SendHMIRequest(hmi_apis::FunctionID::UI_SendHapticData, &msg_params, true);
   } else {
     SendResponse(false,


### PR DESCRIPTION
Fixes #3645

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
manual test

### Summary
add mandatory parameter appID when forwarding SendHapticData from mobile to HMI

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
