### PR TITLE
Check PTU triggers on startup in EXTERNAL_PROPRIETARY

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -838,7 +838,7 @@ void PolicyHandler::OnSystemRequestReceived() const {
 }
 
 void PolicyHandler::TriggerPTUOnStartupIfRequired() {
-#ifdef PROPRIETARY_MODE
+#if defined(PROPRIETARY_MODE) || defined(EXTERNAL_PROPRIETARY_MODE)
   const auto policy_manager = LoadPolicyManager();
   POLICY_LIB_CHECK_VOID(policy_manager);
   policy_manager->TriggerPTUOnStartupIfRequired();

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -871,6 +871,11 @@ class PolicyManager : public usage_statistics::StatisticsManager,
    */
   virtual void ResetTimeout() = 0;
 
+  /**
+   * @brief Trigger a PTU once on startup if it is required
+   */
+  virtual void TriggerPTUOnStartupIfRequired() = 0;
+
  protected:
   /**
    * @brief Checks is PT exceeded IgnitionCycles

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -270,6 +270,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(ExceededIgnitionCycles, bool());
   MOCK_METHOD0(ExceededDays, bool());
   MOCK_METHOD0(StartPTExchange, void());
+  MOCK_METHOD0(TriggerPTUOnStartupIfRequired, void());
   MOCK_METHOD1(Increment, void(usage_statistics::GlobalCounterId type));
   MOCK_METHOD2(Increment,
                void(const std::string& app_id,

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -1057,6 +1057,11 @@ class PolicyManagerImpl : public PolicyManager {
   void StartPTExchange() OVERRIDE;
 
   /**
+   * @brief Trigger a PTU once on startup if it is required
+   */
+  void TriggerPTUOnStartupIfRequired() OVERRIDE;
+
+  /**
    * @brief Checks is PT exceeded days
    * @return true if exceeded
    */

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -762,6 +762,13 @@ void PolicyManagerImpl::StartPTExchange() {
   }
 }
 
+void PolicyManagerImpl::TriggerPTUOnStartupIfRequired() {
+  SDL_LOG_AUTO_TRACE();
+  if (ignition_check) {
+    StartPTExchange();
+  }
+}
+
 void PolicyManagerImpl::OnAppsSearchStarted() {
   SDL_LOG_AUTO_TRACE();
   update_status_manager_.OnAppsSearchStarted();


### PR DESCRIPTION

Fixes #3648 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Manual testing using steps provided in #3648

### Summary
Checks PTU triggers upon startup in EXTERNAL_PROPRIETARY mode, allowing HMI PTU to happen immediately after connecting to the HMI

### Changelog
##### Bug Fixes
* Add check for PTU triggers upon startup in EXTERNAL_PROPRIETARY mode

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
