### PR TITLE
Remove unused includes for boost strand

### DIFF
--- a/src/components/hmi_message_handler/include/hmi_message_handler/websocket_session.h
+++ b/src/components/hmi_message_handler/include/hmi_message_handler/websocket_session.h
@@ -36,7 +36,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/asio/bind_executor.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/placeholders.hpp>
-#include <boost/asio/strand.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/make_shared.hpp>

--- a/src/components/transport_manager/include/transport_manager/websocket_server/websocket_session.h
+++ b/src/components/transport_manager/include/transport_manager/websocket_server/websocket_session.h
@@ -32,7 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define SRC_COMPONENTS_TRANSPORT_MANAGER_INCLUDE_TRANSPORT_MANAGER_WEBSOCKET_SERVER_WEBSOCKET_SESSION_H_
 
 #include <boost/asio/bind_executor.hpp>
-#include <boost/asio/strand.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/websocket.hpp>
 #include <functional>

--- a/src/components/transport_manager/test/include/transport_manager/cloud/sample_websocket_server.h
+++ b/src/components/transport_manager/test/include/transport_manager/cloud/sample_websocket_server.h
@@ -38,7 +38,6 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/placeholders.hpp>
 #include <boost/asio/ssl/stream.hpp>
-#include <boost/asio/strand.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/websocket.hpp>

--- a/src/components/transport_manager/test/include/transport_manager/websocket_server/websocket_sample_client.h
+++ b/src/components/transport_manager/test/include/transport_manager/websocket_server/websocket_sample_client.h
@@ -39,7 +39,6 @@
 #include <boost/asio/bind_executor.hpp>
 #include <boost/asio/connect.hpp>
 #include <boost/asio/ssl/stream.hpp>
-#include <boost/asio/strand.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/websocket.hpp>


### PR DESCRIPTION
Addendum to #3651 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test default build

### Summary
Remove redundant includes due to #3651 

### Changelog
##### Enhancements
* Remove redundant includes due to #3651 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
