### PR TITLE
Set boost cmake flag

### DIFF
--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -221,6 +221,7 @@ else()
 endif()
 
 set(BOOST_ROOT ${3RD_PARTY_INSTALL_PREFIX})
+set(Boost_NO_BOOST_CMAKE ON)
 find_package(Boost 1.72.0 COMPONENTS system thread date_time filesystem regex) 
 if (NOT ${Boost_FOUND})
   set(BOOST_LIB_SOURCE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/boost_src)


### PR DESCRIPTION
Fixes #3663 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Build sdl core on ubuntu 16, 18, 20 with different supported cmake versions. 3.10 was having an issue.

### Summary
Sets flag that forces cmake to use find boost module.

Related explanation:  https://stackoverflow.com/questions/56036266/boost-libraries-not-defined



### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
