### PR TITLE
Do not encrypt first frame

### DIFF
--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1418,7 +1418,7 @@ RESULT_CODE ProtocolHandlerImpl::SendMultiFrameMessage(
   const ProtocolFramePtr firstPacket(
       new protocol_handler::ProtocolPacket(connection_id,
                                            protocol_version,
-                                           needs_encryption,
+                                           false,
                                            FRAME_TYPE_FIRST,
                                            service_type,
                                            FRAME_DATA_FIRST,


### PR DESCRIPTION
Fixes #3659

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
Covered by unit test. ATF

### Summary
First frame of message shouldn't be encrypted. So 'need_encryption' argument was set to false.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
