### PR TITLE
stop waiting for certificates when ptu fails

### DIFF
--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1665,6 +1665,7 @@ void PolicyManagerImpl::ResetTimeout() {
 
 void PolicyManagerImpl::OnPTUIterationTimeout() {
   SDL_LOG_DEBUG("Start new retry sequence");
+  listener_->OnCertificateUpdated("");
 
   const bool is_exceeded_retries_count =
       (retry_sequence_seconds_.size() < retry_sequence_index_);


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3671

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manual test with steps from issue

### Summary
When PTU is retried, call ResumeHandshake on all `awaiting_certificate_connections_`
please note cert data is not actually updated by these changes

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
