### PR TITLE
Fix/Reset RC global properties on Failed Resumption

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -75,6 +75,7 @@ struct ResetGlobalPropertiesResult {
   bool menu_name;
   bool menu_icon;
   bool keyboard_properties;
+  bool user_location;
   bool vr_has_been_reset;
 
   ResetGlobalPropertiesResult()
@@ -84,6 +85,7 @@ struct ResetGlobalPropertiesResult {
       , menu_name(false)
       , menu_icon(false)
       , keyboard_properties(false)
+      , user_location(false)
       , vr_has_been_reset(false) {}
 
   bool HasUIPropertiesReset() const {
@@ -92,6 +94,10 @@ struct ResetGlobalPropertiesResult {
 
   bool HasTTSPropertiesReset() const {
     return timeout_prompt || help_prompt;
+  }
+
+  bool HasRCPropertiesReset() const {
+    return user_location;
   }
 };
 
@@ -1059,6 +1065,18 @@ class MessageHelper {
    * @return filled smart object with relevant request data
    */
   static smart_objects::SmartObjectSPtr CreateTTSResetGlobalPropertiesRequest(
+      const ResetGlobalPropertiesResult& reset_result,
+      const ApplicationSharedPtr application);
+
+  /**
+   * @brief CreateRCResetGlobalPropertiesRequest Creates request
+   * to reset global properties for RC
+   * @param reset_result struct containing result of global properties reset
+   * procedure
+   * @param application application for which properties are to be reset
+   * @return filled smart object with relevant request data
+   */
+  static smart_objects::SmartObjectSPtr CreateRCResetGlobalPropertiesRequest(
       const ResetGlobalPropertiesResult& reset_result,
       const ApplicationSharedPtr application);
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
@@ -89,6 +89,10 @@ void ResetGlobalPropertiesRequest::Run() {
     StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
   }
 
+  if (reset_global_props_result.HasRCPropertiesReset()) {
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_RC);
+  }
+
   app->set_reset_global_properties_active(true);
 
   if (reset_global_props_result.HasUIPropertiesReset()) {
@@ -109,6 +113,15 @@ void ResetGlobalPropertiesRequest::Run() {
 
     SendHMIRequest(
         hmi_apis::FunctionID::TTS_SetGlobalProperties, msg_params.get(), true);
+  }
+
+  if (reset_global_props_result.HasRCPropertiesReset()) {
+    smart_objects::SmartObjectSPtr msg_params =
+        MessageHelper::CreateRCResetGlobalPropertiesRequest(
+            reset_global_props_result, app);
+
+    SendHMIRequest(
+        hmi_apis::FunctionID::RC_SetGlobalProperties, msg_params.get(), true);
   }
 }
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -4323,6 +4323,10 @@ ResetGlobalPropertiesResult ApplicationManagerImpl::ResetGlobalProperties(
         result.keyboard_properties = true;
         break;
       }
+      case mobile_apis::GlobalProperty::USER_LOCATION: {
+        result.user_location = true;
+        break;
+      }
       default: {
         SDL_LOG_TRACE("Unknown global property: " << global_property);
         break;
@@ -4373,7 +4377,9 @@ ApplicationManagerImpl::CreateAllAppGlobalPropsIDList(
   if (application->keyboard_props()) {
     (*global_properties)[i++] = GlobalProperty::KEYBOARDPROPERTIES;
   }
-
+  if (!application->get_user_location().empty()) {
+    (*global_properties)[i++] = GlobalProperty::USER_LOCATION;
+  }
   return global_properties;
 }
 

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -53,6 +53,7 @@
 #include "application_manager/message_helper.h"
 #include "application_manager/policies/policy_handler_interface.h"
 #include "application_manager/resumption/resume_ctrl.h"
+#include "application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h"
 #include "application_manager/rpc_service.h"
 #include "connection_handler/connection_handler_impl.h"
 #include "interfaces/MOBILE_API.h"
@@ -418,6 +419,39 @@ MessageHelper::CreateUIResetGlobalPropertiesRequest(
   (*ui_reset_global_prop_request)[strings::app_id] = application->app_id();
 
   return ui_reset_global_prop_request;
+}
+
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateRCResetGlobalPropertiesRequest(
+    const ResetGlobalPropertiesResult& reset_result,
+    const ApplicationSharedPtr application) {
+  namespace rc = rc_rpc_plugin;
+
+  smart_objects::SmartObjectSPtr rc_reset_global_prop_request =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  if (reset_result.user_location) {
+    smart_objects::SmartObject user_location =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+    user_location[rc::strings::kGrid] =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    smart_objects::SmartObject& grid = user_location[rc::strings::kGrid];
+    grid[rc::strings::kRow] = 0;
+    grid[rc::strings::kCol] = 0;
+    grid[rc::strings::kLevel] = 0;
+    grid[rc::strings::kRowspan] = 1;
+    grid[rc::strings::kColspan] = 1;
+    grid[rc::strings::kLevelspan] = 1;
+
+    (*rc_reset_global_prop_request)[strings::user_location] = user_location;
+    application->set_user_location(user_location);
+  }
+
+  (*rc_reset_global_prop_request)[strings::app_id] = application->app_id();
+
+  return rc_reset_global_prop_request;
 }
 
 smart_objects::SmartObjectSPtr

--- a/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
@@ -810,6 +810,21 @@ void ResumptionDataProcessorImpl::DeleteGlobalProperties(
     (*msg)[strings::msg_params] = *msg_params;
     ProcessMessageToHMI(msg, false);
   }
+
+  if (result.HasRCPropertiesReset() &&
+      check_if_successful(hmi_apis::FunctionID::RC_SetGlobalProperties)) {
+    smart_objects::SmartObjectSPtr msg_params =
+        MessageHelper::CreateRCResetGlobalPropertiesRequest(result,
+                                                            application);
+    auto msg = MessageHelper::CreateMessageForHMI(
+        hmi_apis::messageType::request,
+        application_manager_.GetNextHMICorrelationID());
+    (*msg)[strings::params][strings::function_id] =
+        hmi_apis::FunctionID::RC_SetGlobalProperties;
+
+    (*msg)[strings::msg_params] = *msg_params;
+    ProcessMessageToHMI(msg, false);
+  }
 }
 
 void ResumptionDataProcessorImpl::AddSubscriptions(

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -182,6 +182,12 @@ class MockMessageHelper {
                smart_objects::SmartObjectSPtr(
                    const ResetGlobalPropertiesResult& reset_result,
                    ApplicationSharedPtr application));
+
+  MOCK_METHOD2(CreateRCResetGlobalPropertiesRequest,
+               smart_objects::SmartObjectSPtr(
+                   const ResetGlobalPropertiesResult& reset_result,
+                   ApplicationSharedPtr application));
+
   MOCK_METHOD2(CreateGlobalPropertiesRequestsToHMI,
                smart_objects::SmartObjectList(ApplicationConstSharedPtr app,
                                               ApplicationManager& app_mngr));

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -582,6 +582,14 @@ MessageHelper::CreateTTSResetGlobalPropertiesRequest(
       ->CreateTTSResetGlobalPropertiesRequest(reset_result, application);
 }
 
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateRCResetGlobalPropertiesRequest(
+    const ResetGlobalPropertiesResult& reset_result,
+    ApplicationSharedPtr application) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateRCResetGlobalPropertiesRequest(reset_result, application);
+}
+
 smart_objects::SmartObjectList
 MessageHelper::CreateGlobalPropertiesRequestsToHMI(
     ApplicationConstSharedPtr app, ApplicationManager& app_mngr) {


### PR DESCRIPTION
Fixes #3667 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run issue reproduction steps using Test Suite/RPC Builder

### Summary
- Implemented ResetGlobalProperties request for RC properties
- Added functions `HasRCPropertiesReset` and `CreateRCResetGlobalPropertiesRequest` to match the behaviour for TTS and UI global properties

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
