### PR TITLE
Add configurable security level to Crypto Manager

### DIFF
--- a/src/components/security_manager/src/crypto_manager_impl.cc
+++ b/src/components/security_manager/src/crypto_manager_impl.cc
@@ -54,6 +54,10 @@
 #define TLS1_1_MINIMAL_VERSION 0x1000103fL
 #define CONST_SSL_METHOD_MINIMAL_VERSION 0x00909000L
 
+// Can be configured to have stricter requirements for SSL connections depending
+// on your system's requirements
+#define SECURITY_LEVEL 1
+
 namespace security_manager {
 
 SDL_CREATE_LOG_VARIABLE("SecurityManager")
@@ -233,6 +237,7 @@ bool CryptoManagerImpl::Init() {
   // Disable SSL2 as deprecated
   // TLS 1.2 is the max supported TLS version for SDL
   SSL_CTX_set_options(context_, SSL_OP_NO_SSLv2);
+  SSL_CTX_set_security_level(context_, SECURITY_LEVEL);
 
   SaveCertificateData(get_settings().certificate_data());
 


### PR DESCRIPTION

Potentially Fixes #3664 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test secured service with DTLS1.0 on Ubuntu 20.04

### Summary
DTLS connections from Android were failing on Ubuntu 20.04 with an `unsupported protocol` message. It seems that the default security level is too strict to work with the current version of the [sdl_security_java_suite](https://github.com/smartdevicelink/sdl_security_java_suite). This PR adds a configurable value for the security level so that  OEMs can configure this value themselves, using the general default of `1` specified in the [openssl documentation](https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set_security_level.html)

### Changelog
##### Bug Fixes
* Adds configurable value for openssl security level, set to 1 for backwards compatibility.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
