### PR TITLE
Configure security level in ini file

### DIFF
--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -185,6 +185,9 @@ ForceUnprotectedService = Non
 ; The PTU will be triggered in case expiration date of certificate
 ; then certain hours amount
 UpdateBeforeHours = 24
+; Security level for openssl lib according to:
+; https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_get_security_level.html
+SecurityLevel = 1
 
 [Policy]
 EnablePolicy = true

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -552,6 +552,11 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
    */
   size_t update_before_hours() const;
 
+  /**
+   * @brief Return security level that will be configured in the OpenSSL
+   */
+  uint32_t security_level() const;
+
 #endif  // ENABLE_SECURITY
 
   /**
@@ -1073,6 +1078,7 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   std::string security_manager_protocol_name_;
   std::vector<int> force_protected_service_;
   std::vector<int> force_unprotected_service_;
+  uint32_t security_level_;
 #endif
 
   /*

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -140,6 +140,7 @@ const char* kSecurityKeyPathKey = "KeyPath";
 const char* kSecurityCipherListKey = "CipherList";
 const char* kSecurityVerifyPeerKey = "VerifyPeer";
 const char* kBeforeUpdateHours = "UpdateBeforeHours";
+const char* kSecurityLevel = "SecurityLevel";
 #endif
 
 const char* kAudioDataStoppedTimeoutKey = "AudioDataStoppedTimeout";
@@ -337,6 +338,7 @@ const char* kDefaultSecurityProtocol = "TLSv1.2";
 const char* kDefaultSSLMode = "CLIENT";
 const bool kDefaultVerifyPeer = false;
 const uint32_t kDefaultBeforeUpdateHours = 24;
+const uint32_t kDefaultSecurityLevel = 1;
 #endif  // ENABLE_SECURITY
 
 const uint32_t kDefaultHubProtocolIndex = 0;
@@ -1117,6 +1119,10 @@ const std::vector<int>& Profile::force_protected_service() const {
 const std::vector<int>& Profile::force_unprotected_service() const {
   return force_unprotected_service_;
 }
+
+uint32_t Profile::security_level() const {
+  return security_level_;
+}
 #endif  // ENABLE_SECURITY
 
 bool Profile::logs_enabled() const {
@@ -1307,6 +1313,11 @@ void Profile::UpdateValues() {
                 kDefaultBeforeUpdateHours,
                 kSecuritySection,
                 kBeforeUpdateHours);
+
+  ReadUIntValue(&security_level_,
+                kDefaultSecurityLevel,
+                kSecuritySection,
+                kSecurityLevel);
 
 #endif  // ENABLE_SECURITY
 

--- a/src/components/include/security_manager/security_manager_settings.h
+++ b/src/components/include/security_manager/security_manager_settings.h
@@ -60,6 +60,7 @@ class CryptoManagerSettings {
   virtual size_t maximum_payload_size() const = 0;
   virtual const std::vector<int>& force_protected_service() const = 0;
   virtual const std::vector<int>& force_unprotected_service() const = 0;
+  virtual uint32_t security_level() const = 0;
 };
 
 }  // namespace security_manager

--- a/src/components/include/test/security_manager/mock_security_manager_settings.h
+++ b/src/components/include/test/security_manager/mock_security_manager_settings.h
@@ -56,6 +56,7 @@ class MockCryptoManagerSettings
   MOCK_CONST_METHOD0(maximum_payload_size, size_t());
   MOCK_CONST_METHOD0(force_protected_service, const std::vector<int>&());
   MOCK_CONST_METHOD0(force_unprotected_service, const std::vector<int>&());
+  MOCK_CONST_METHOD0(security_level, uint32_t());
 };
 
 }  // namespace security_manager_test

--- a/src/components/security_manager/include/security_manager/crypto_manager_settings_impl.h
+++ b/src/components/security_manager/include/security_manager/crypto_manager_settings_impl.h
@@ -83,6 +83,10 @@ class CryptoManagerSettingsImpl : public CryptoManagerSettings {
     return profile_.force_unprotected_service();
   }
 
+  uint32_t security_level() const OVERRIDE {
+    return profile_.security_level();
+  }
+
  private:
   const profile::Profile& profile_;
   const std::string certificate_data_;

--- a/src/components/security_manager/src/crypto_manager_impl.cc
+++ b/src/components/security_manager/src/crypto_manager_impl.cc
@@ -261,6 +261,10 @@ bool CryptoManagerImpl::Init() {
 #endif
   }
 
+#if OPENSSL_VERSION_NUMBER > OPENSSL1_1_VERSION
+  SSL_CTX_set_security_level(context_, get_settings().security_level());
+#endif
+
   if (get_settings().ca_cert_path().empty()) {
     SDL_LOG_WARN("Setting up empty CA certificate location");
   }

--- a/src/components/security_manager/src/crypto_manager_impl.cc
+++ b/src/components/security_manager/src/crypto_manager_impl.cc
@@ -261,7 +261,7 @@ bool CryptoManagerImpl::Init() {
 #endif
   }
 
-#if OPENSSL_VERSION_NUMBER > OPENSSL1_1_VERSION
+#if OPENSSL_VERSION_NUMBER >= OPENSSL1_1_VERSION
   SSL_CTX_set_security_level(context_, get_settings().security_level());
 #endif
 


### PR DESCRIPTION
Fixes  #3664

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
Check secure connection with SyncProxyTester app 

### Summary
In Ubuntu 20.04, the OpenSSL 1.1.1f library has been modified to use Security Level 2 by default.
With this PR it becomes possible to change the Security Level in .ini file for establish secure connection with some applications that do not support this level.

In details about levels from openssl doc (https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_get_security_level.html):

Level 0
Everything is permitted. This retains compatibility with previous versions of OpenSSL.

Level 1
The security level corresponds to a minimum of 80 bits of security. Any parameters offering below 80 bits of security are excluded. As a result RSA, DSA and DH keys shorter than 1024 bits and ECC keys shorter than 160 bits are prohibited. All export ciphersuites are prohibited since they all offer less than 80 bits of security. SSL version 2 is prohibited. Any ciphersuite using MD5 for the MAC is also prohibited.

Level 2
Security level set to 112 bits of security. As a result RSA, DSA and DH keys shorter than 2048 bits and ECC keys shorter than 224 bits are prohibited. In addition to the level 1 exclusions any ciphersuite using RC4 is also prohibited. SSL version 3 is also not allowed. Compression is disabled.
...
(there are also levels 3,4,5 )

At this time setting the security level higher than 1 for general internet use is likely to cause considerable interoperability issues and is not recommended. This is because the SHA1 algorithm is very widely used in certificates and will be rejected at levels higher than 1 because it only offers 80 bits of security.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
