### PR TITLE
Check waypoint subscription size in resumption

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
@@ -131,10 +131,11 @@ void SDLRPCPlugin::RevertResumption(application_manager::Application& app) {
   pending_resumption_handler_->OnResumptionRevert();
 
   if (application_manager_->IsAppSubscribedForWayPoints(app)) {
-    std::set<uint32_t> subscribed_apps =
+    const auto subscribed_apps =
         application_manager_->GetAppsSubscribedForWayPoints();
-    bool send_unsubscribe = subscribed_apps.size() <= 1 &&
-                            application_manager_->IsSubscribedToHMIWayPoints();
+    const bool send_unsubscribe =
+        subscribed_apps.size() <= 1 &&
+        application_manager_->IsSubscribedToHMIWayPoints();
     if (send_unsubscribe) {
       SDL_LOG_DEBUG("Send UnsubscribeWayPoints");
       auto request =


### PR DESCRIPTION
Fixes #3683 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
See reproduction steps in issue #3683 

### Summary
Check size of waypoint subscription list before unsubscribing HMI from way points.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
