### PR TITLE
Open INI file less

### DIFF
--- a/src/components/config_profile/CMakeLists.txt
+++ b/src/components/config_profile/CMakeLists.txt
@@ -33,6 +33,7 @@ include(${CMAKE_SOURCE_DIR}/tools/cmake/helpers/sources.cmake)
 include_directories (
   ${COMPONENTS_DIR}/config_profile/include
   ${COMPONENTS_DIR}/utils/include/
+  ${COMPONENTS_DIR}/smart_objects/include
   ${POLICY_GLOBAL_INCLUDE_PATH}/
   ${LOG4CXX_INCLUDE_DIRECTORY}
   ${BOOST_INCLUDE_DIR}
@@ -44,6 +45,7 @@ set(PATHS
 )
 
 set(LIBRARIES
+  SmartObjects
   Utils
 )
 

--- a/src/components/config_profile/include/config_profile/ini_file.h
+++ b/src/components/config_profile/include/config_profile/ini_file.h
@@ -34,7 +34,6 @@
 #define SRC_COMPONENTS_CONFIG_PROFILE_INCLUDE_CONFIG_PROFILE_INI_FILE_H_
 
 #include <stdint.h>
-#include <stdio.h>
 
 namespace profile {
 
@@ -98,7 +97,7 @@ extern char* ini_write_inst(const char* fname, uint8_t flag);
  *
  * @return NULL if file or desired entry not found, otherwise pointer to value
  */
-extern char* ini_read_value(FILE* fp,
+extern char* ini_read_value(const char* fname,
                             const char* chapter,
                             const char* item,
                             char* value);

--- a/src/components/config_profile/include/config_profile/ini_file.h
+++ b/src/components/config_profile/include/config_profile/ini_file.h
@@ -88,53 +88,53 @@ extern "C" {
 /*
  * @brief Write usage instructions to the end of the file
  * @param
- * 
+ *
  * \deprecated This method will be removed in the next major release
  * See Profile::ParseConfiguration for the new ini parsing code
- * 
+ *
  * @return NULL if file or desired entry not found, otherwise pointer to fname
  */
 DEPRECATED extern char* ini_write_inst(const char* fname, uint8_t flag);
 
 /*
  * @brief Read a certain item of the specified chapter of a ini-file
- * 
+ *
  * \deprecated This method will be removed in the next major release
  * See Profile::ParseConfiguration for the new ini parsing code
  *
  * @return NULL if file or desired entry not found, otherwise pointer to value
  */
 DEPRECATED extern char* ini_read_value(const char* fname,
-                            const char* chapter,
-                            const char* item,
-                            char* value);
+                                       const char* chapter,
+                                       const char* item,
+                                       char* value);
 
 /*
  * @brief Write a certain item of the specified chapter of a ini-file
- * 
+ *
  * \deprecated This method will be removed in the next major release
  * See Profile::ParseConfiguration for the new ini parsing code
  *
  * @return NULL if file not found, otherwise pointer to value
  */
 DEPRECATED extern char ini_write_value(const char* fname,
-                            const char* chapter,
-                            const char* item,
-                            const char* value,
-                            uint8_t flag);
+                                       const char* chapter,
+                                       const char* item,
+                                       const char* value,
+                                       uint8_t flag);
 
 /*
  * @brief Parse the given line for the item and returns the value if
  *        there is one otherwise NULL
- * 
+ *
  * \deprecated This method will be removed in the next major release
  * See Profile::ParseConfiguration for the new ini parsing code
  *
  * @return NULL if desired entry not found, otherwise pointer to value
  */
 DEPRECATED extern Ini_search_id ini_parse_line(const char* line,
-                                    const char* tag,
-                                    char* value);
+                                               const char* tag,
+                                               char* value);
 
 #ifdef __cplusplus
 }

--- a/src/components/config_profile/include/config_profile/ini_file.h
+++ b/src/components/config_profile/include/config_profile/ini_file.h
@@ -34,6 +34,7 @@
 #define SRC_COMPONENTS_CONFIG_PROFILE_INCLUDE_CONFIG_PROFILE_INI_FILE_H_
 
 #include <stdint.h>
+#include <stdio.h>
 
 namespace profile {
 
@@ -97,7 +98,7 @@ extern char* ini_write_inst(const char* fname, uint8_t flag);
  *
  * @return NULL if file or desired entry not found, otherwise pointer to value
  */
-extern char* ini_read_value(const char* fname,
+extern char* ini_read_value(FILE* fp,
                             const char* chapter,
                             const char* item,
                             char* value);

--- a/src/components/config_profile/include/config_profile/ini_file.h
+++ b/src/components/config_profile/include/config_profile/ini_file.h
@@ -34,6 +34,7 @@
 #define SRC_COMPONENTS_CONFIG_PROFILE_INCLUDE_CONFIG_PROFILE_INI_FILE_H_
 
 #include <stdint.h>
+#include "utils/macro.h"
 
 namespace profile {
 
@@ -89,21 +90,21 @@ extern "C" {
  * @param
  * 
  * \deprecated This method will be removed in the next major release
- * See Profile::UpdateValues for the new ini parsing code
+ * See Profile::ParseConfiguration for the new ini parsing code
  * 
  * @return NULL if file or desired entry not found, otherwise pointer to fname
  */
-extern char* ini_write_inst(const char* fname, uint8_t flag);
+DEPRECATED extern char* ini_write_inst(const char* fname, uint8_t flag);
 
 /*
  * @brief Read a certain item of the specified chapter of a ini-file
  * 
  * \deprecated This method will be removed in the next major release
- * See Profile::UpdateValues for the new ini parsing code
+ * See Profile::ParseConfiguration for the new ini parsing code
  *
  * @return NULL if file or desired entry not found, otherwise pointer to value
  */
-extern char* ini_read_value(const char* fname,
+DEPRECATED extern char* ini_read_value(const char* fname,
                             const char* chapter,
                             const char* item,
                             char* value);
@@ -112,11 +113,11 @@ extern char* ini_read_value(const char* fname,
  * @brief Write a certain item of the specified chapter of a ini-file
  * 
  * \deprecated This method will be removed in the next major release
- * See Profile::UpdateValues for the new ini parsing code
+ * See Profile::ParseConfiguration for the new ini parsing code
  *
  * @return NULL if file not found, otherwise pointer to value
  */
-extern char ini_write_value(const char* fname,
+DEPRECATED extern char ini_write_value(const char* fname,
                             const char* chapter,
                             const char* item,
                             const char* value,
@@ -127,11 +128,11 @@ extern char ini_write_value(const char* fname,
  *        there is one otherwise NULL
  * 
  * \deprecated This method will be removed in the next major release
- * See Profile::UpdateValues for the new ini parsing code
+ * See Profile::ParseConfiguration for the new ini parsing code
  *
  * @return NULL if desired entry not found, otherwise pointer to value
  */
-extern Ini_search_id ini_parse_line(const char* line,
+DEPRECATED extern Ini_search_id ini_parse_line(const char* line,
                                     const char* tag,
                                     char* value);
 

--- a/src/components/config_profile/include/config_profile/ini_file.h
+++ b/src/components/config_profile/include/config_profile/ini_file.h
@@ -87,13 +87,19 @@ extern "C" {
 /*
  * @brief Write usage instructions to the end of the file
  * @param
- *
+ * 
+ * \deprecated This method will be removed in the next major release
+ * See Profile::UpdateValues for the new ini parsing code
+ * 
  * @return NULL if file or desired entry not found, otherwise pointer to fname
  */
 extern char* ini_write_inst(const char* fname, uint8_t flag);
 
 /*
  * @brief Read a certain item of the specified chapter of a ini-file
+ * 
+ * \deprecated This method will be removed in the next major release
+ * See Profile::UpdateValues for the new ini parsing code
  *
  * @return NULL if file or desired entry not found, otherwise pointer to value
  */
@@ -104,6 +110,9 @@ extern char* ini_read_value(const char* fname,
 
 /*
  * @brief Write a certain item of the specified chapter of a ini-file
+ * 
+ * \deprecated This method will be removed in the next major release
+ * See Profile::UpdateValues for the new ini parsing code
  *
  * @return NULL if file not found, otherwise pointer to value
  */
@@ -116,6 +125,9 @@ extern char ini_write_value(const char* fname,
 /*
  * @brief Parse the given line for the item and returns the value if
  *        there is one otherwise NULL
+ * 
+ * \deprecated This method will be removed in the next major release
+ * See Profile::UpdateValues for the new ini parsing code
  *
  * @return NULL if desired entry not found, otherwise pointer to value
  */

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -859,6 +859,18 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
 
  private:
   /**
+   * @brief Opens the configuration file
+   * @return a pointer to the FILE
+   */
+  FILE* OpenConfig();
+
+  /**
+   * @brief Closes the configuration file
+   * @param pointer to the FILE to be closed
+   */
+  void CloseConfig(FILE* config_file_);
+
+  /**
    * @brief Checks that filename consists of portable symbols
    * @param file_name - file name to check
    * @return FALSE if file name has unportable symbols otherwise TRUE

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -826,6 +826,11 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   uint32_t app_transport_change_timer_addition() const OVERRIDE;
 
   /**
+   * @brief Parses values in config_file_name_ to config_obj_ smart object
+   */
+  void ParseConfiguration();
+
+  /**
    * @brief Updates all related values from ini file
    */
   void UpdateValues();

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -989,6 +989,7 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   size_t maximum_audio_payload_size_;
   size_t maximum_video_payload_size_;
   std::string config_file_name_;
+  FILE* config_file_;
   std::string server_address_;
   uint16_t server_port_;
   uint16_t video_streaming_port_;
@@ -1114,6 +1115,13 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   int iap2_hub_connect_attempts_;
   int iap_hub_connection_wait_timeout_;
   uint16_t tts_global_properties_timeout_;
+  size_t maximum_payload_size_;
+  size_t message_frequency_count_;
+  size_t message_frequency_time_;
+  bool malformed_message_filtering_;
+  size_t malformed_frequency_count_;
+  size_t malformed_frequency_time_;
+  uint32_t multiframe_waiting_timeout_;
   uint16_t attempts_to_open_policy_db_;
   uint16_t open_attempt_timeout_ms_;
   uint32_t resumption_delay_before_ign_;

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -859,18 +859,6 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
 
  private:
   /**
-   * @brief Opens the configuration file
-   * @return a pointer to the FILE
-   */
-  FILE* OpenConfig();
-
-  /**
-   * @brief Closes the configuration file
-   * @param pointer to the FILE to be closed
-   */
-  void CloseConfig(FILE* config_file_);
-
-  /**
    * @brief Checks that filename consists of portable symbols
    * @param file_name - file name to check
    * @return FALSE if file name has unportable symbols otherwise TRUE

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -44,8 +44,8 @@
 #include "media_manager/media_manager_settings.h"
 #include "policy/policy_settings.h"
 #include "protocol_handler/protocol_handler_settings.h"
-#include "transport_manager/transport_manager_settings.h"
 #include "smart_objects/smart_object.h"
+#include "transport_manager/transport_manager_settings.h"
 #include "utils/macro.h"
 
 namespace profile {

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -45,6 +45,7 @@
 #include "policy/policy_settings.h"
 #include "protocol_handler/protocol_handler_settings.h"
 #include "transport_manager/transport_manager_settings.h"
+#include "smart_objects/smart_object.h"
 #include "utils/macro.h"
 
 namespace profile {
@@ -825,17 +826,6 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   uint32_t app_transport_change_timer_addition() const OVERRIDE;
 
   /**
-   * @brief Opens the configuration file
-   * @return true if the config opens successfully
-   */
-  bool OpenConfig();
-
-  /**
-   * @brief Closes the configuration file
-   */
-  void CloseConfig();
-
-  /**
    * @brief Updates all related values from ini file
    */
   void UpdateValues();
@@ -1000,7 +990,7 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   size_t maximum_audio_payload_size_;
   size_t maximum_video_payload_size_;
   std::string config_file_name_;
-  FILE* config_file_;
+  smart_objects::SmartObject config_obj_;
   std::string server_address_;
   uint16_t server_port_;
   uint16_t video_streaming_port_;

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -825,6 +825,17 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   uint32_t app_transport_change_timer_addition() const OVERRIDE;
 
   /**
+   * @brief Opens the configuration file
+   * @return true if the config opens successfully
+   */
+  bool OpenConfig();
+
+  /**
+   * @brief Closes the configuration file
+   */
+  void CloseConfig();
+
+  /**
    * @brief Updates all related values from ini file
    */
   void UpdateValues();

--- a/src/components/config_profile/src/ini_file.cc
+++ b/src/components/config_profile/src/ini_file.cc
@@ -55,6 +55,9 @@
 
 namespace profile {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 SDL_CREATE_LOG_VARIABLE("Profile")
 
 char* ini_write_inst(const char* fname, uint8_t flag) {
@@ -415,4 +418,7 @@ Ini_search_id ini_parse_line(const char* line, const char* tag, char* value) {
 
   return INI_NOTHING;
 }
+
+#pragma GCC diagnostic pop
+
 }  // namespace profile

--- a/src/components/config_profile/src/ini_file.cc
+++ b/src/components/config_profile/src/ini_file.cc
@@ -106,12 +106,14 @@ char* ini_read_value(FILE* fp,
   *line = '\0';
   *val = '\0';
   *tag = '\0';
-  if ((NULL == fp) || (NULL == chapter) || (NULL == item) || (NULL == value))
+  if ((NULL == fp) || (NULL == chapter) || (NULL == item) || (NULL == value)) {
     return NULL;
+  }
 
   *value = '\0';
-  if (('\0' == *chapter) || ('\0' == *item))
+  if (('\0' == *chapter) || ('\0' == *item)) {
     return NULL;
+  }
 
   snprintf(tag, INI_LINE_LEN, "%s", chapter);
   for (uint32_t i = 0; i < strlen(tag); ++i) {
@@ -300,8 +302,9 @@ Ini_search_id ini_parse_line(const char* line, const char* tag, char* value) {
     return INI_NOTHING;
   }
 
-  if (';' == *line_ptr || '*' == *line_ptr)
+  if (';' == *line_ptr || '*' == *line_ptr) {
     return INI_REMARK;
+  }
 
   if ('[' == *line_ptr && strrchr(line_ptr, ']') != NULL) {
     /* cut leading [ and whitespace */
@@ -309,8 +312,9 @@ Ini_search_id ini_parse_line(const char* line, const char* tag, char* value) {
       ++line_ptr;
     } while (is_whitespace(*line_ptr));
 
-    if (']' == *line_ptr)
+    if (']' == *line_ptr) {
       return INI_NOTHING;
+    }
 
     snprintf(temp_str, INI_LINE_LEN, "%s", line_ptr);
     char* temp_ptr = strrchr(temp_str, ']');
@@ -323,15 +327,17 @@ Ini_search_id ini_parse_line(const char* line, const char* tag, char* value) {
 
     snprintf(value, INI_LINE_LEN, "%s", temp_str);
     size_t str_len = temp_ptr - temp_str + 1;
-    for (size_t i = 0; i < str_len; i++)
+    for (size_t i = 0; i < str_len; i++) {
       temp_str[i] = toupper(temp_str[i]);
+    }
 
     return strcmp(temp_str, tag) == 0 ? INI_RIGHT_CHAPTER : INI_WRONG_CHAPTER;
   }
 
   const char* equals_ptr = strchr(line_ptr, '=');
-  if (NULL == equals_ptr)
+  if (NULL == equals_ptr) {
     return INI_NOTHING;
+  }
 
   strncpy(temp_str, line_ptr, equals_ptr - line_ptr);
 
@@ -345,16 +351,19 @@ Ini_search_id ini_parse_line(const char* line, const char* tag, char* value) {
   snprintf(value, INI_LINE_LEN, "%s", temp_str);
 
   size_t str_len = temp_back - temp_str + 1;
-  for (size_t i = 0; i < str_len; ++i)
+  for (size_t i = 0; i < str_len; ++i) {
     temp_str[i] = toupper(temp_str[i]);
+  }
 
-  if (strcmp(temp_str, tag) != 0)
+  if (strcmp(temp_str, tag) != 0) {
     return INI_WRONG_ITEM;
+  }
 
   /* skip leading whitespace on value */
   line_ptr = equals_ptr + 1;
-  while (is_whitespace(*line_ptr))
+  while (is_whitespace(*line_ptr)) {
     ++line_ptr;
+  }
 
   snprintf(value, INI_LINE_LEN, "%s", line_ptr);
 

--- a/src/components/config_profile/src/ini_file.cc
+++ b/src/components/config_profile/src/ini_file.cc
@@ -280,131 +280,94 @@ char ini_write_value(const char* fname,
 }
 #endif  // BUILD_TESTS
 
+inline bool is_whitespace(char ch) {
+  return ' ' == ch || '\t' == ch || '\n' == ch || '\r' == ch;
+}
+
 Ini_search_id ini_parse_line(const char* line, const char* tag, char* value) {
   const char* line_ptr;
-  char temp_str[INI_LINE_LEN] = "";
-  *temp_str = '\0';
-
+  char temp_str[INI_LINE_LEN] = "\0";
   snprintf(value, INI_LINE_LEN, "%s", line);
 
-  /* cut leading spaces */
+  /* cut leading whitespace */
   line_ptr = line;
-  for (uint32_t i = 0; i < strlen(line); i++) {
-    if ((line[i] == ' ') || (line[i] == 9) ||  // TAB
-        (line[i] == 10) ||                     // LF
-        (line[i] == 13)) {                     // CR
-      line_ptr++;
-    } else {
-      break;
-    }
+  while (is_whitespace(*line_ptr)) {
+    ++line_ptr;
   }
+
   if ('\0' == *line_ptr) {
     snprintf(value, INI_LINE_LEN, "\n");
     return INI_NOTHING;
   }
 
-  if ((*line_ptr == ';') || (*line_ptr == '*')) /* remark */
+  if (';' == *line_ptr || '*' == *line_ptr)
     return INI_REMARK;
 
-  if (*line_ptr == '[' && strrchr(line_ptr, ']') != NULL) {
-    line_ptr++;
+  if ('[' == *line_ptr && strrchr(line_ptr, ']') != NULL) {
+    /* cut leading [ and whitespace */
+    do {
+      ++line_ptr;
+    } while (is_whitespace(*line_ptr));
 
-    /* cut leading stuff */
-    uint16_t len = strlen(line_ptr);
-    for (int32_t i = 0; i < len; i++) {
-      if ((*line_ptr == ' ') || (*line_ptr == 9) ||  // TAB
-          (*line_ptr == 10) ||                       // LF
-          (*line_ptr == 13)) {                       // CR
-        line_ptr++;
-      } else {
-        break;
-      }
-    }
-    if (*line_ptr == '\0')
+    if (']' == *line_ptr)
       return INI_NOTHING;
 
     snprintf(temp_str, INI_LINE_LEN, "%s", line_ptr);
     char* temp_ptr = strrchr(temp_str, ']');
-    if (NULL == temp_ptr) {
-      return INI_NOTHING;
-    } else {
+
+    /* cut trailing ] and whitespace */
+    do {
       *temp_ptr = '\0';
-    }
-
-    /* cut trailing stuff */
-    for (int32_t i = strlen(temp_str) - 1; i > 0; i--) {
-      if ((temp_str[i] == ' ') || (temp_str[i] == 9) ||  // TAB
-          (temp_str[i] == 10) ||                         // LF
-          (temp_str[i] == 13)) {                         // CR
-        temp_str[i] = '\0';
-      } else {
-        break;
-      }
-    }
+      --temp_ptr;
+    } while (is_whitespace(*temp_ptr));
 
     snprintf(value, INI_LINE_LEN, "%s", temp_str);
-
-    for (uint32_t i = 0; i < strlen(temp_str); i++)
+    size_t str_len = temp_ptr - temp_str + 1;
+    for (size_t i = 0; i < str_len; i++)
       temp_str[i] = toupper(temp_str[i]);
-    if (strcmp(temp_str, tag) == 0)
-      return INI_RIGHT_CHAPTER;
-    else
-      return INI_WRONG_CHAPTER;
+
+    return strcmp(temp_str, tag) == 0 ? INI_RIGHT_CHAPTER : INI_WRONG_CHAPTER;
   }
 
-  if (NULL != strchr(line_ptr, '=')) {
-    strncpy(temp_str, line_ptr, (strchr(line_ptr, '=') - line_ptr));
-    /* cut trailing stuff */
-    for (int32_t i = strlen(temp_str) - 1; i > 0; i--) {
-      if ((temp_str[i] == '=') || (temp_str[i] == ' ') ||
-          (temp_str[i] == 9) ||   // TAB
-          (temp_str[i] == 10) ||  // LF
-          (temp_str[i] == 13)) {  // CR
-        temp_str[i] = '\0';
-      } else {
-        break;
-      }
-    }
+  const char* equals_ptr = strchr(line_ptr, '=');
+  if (NULL == equals_ptr)
+    return INI_NOTHING;
 
-    snprintf(value, INI_LINE_LEN, "%s", temp_str);
+  strncpy(temp_str, line_ptr, equals_ptr - line_ptr);
 
-    for (uint32_t i = 0; i < strlen(temp_str); i++)
-      temp_str[i] = toupper(temp_str[i]);
-    if (strcmp(temp_str, tag) == 0) {
-      line_ptr = strchr(line_ptr, '=') + 1;
-      uint16_t len = strlen(line_ptr);
-      /* cut trailing stuff */
-      for (uint32_t i = 0; i < len; i++) {
-        if ((*line_ptr == ' ') || (*line_ptr == 9) ||  // TAB
-            (*line_ptr == 10) ||                       // LF
-            (*line_ptr == 13)) {                       // CR
-          line_ptr++;
-        } else {
-          break;
-        }
-      }
+  /* ensure temp_str ends in \0 and remove whitespace */
+  char* temp_back = temp_str + (equals_ptr - line_ptr);
+  do {
+    *temp_back = '\0';
+    --temp_back;
+  } while (is_whitespace(*temp_back));
 
-      snprintf(value, INI_LINE_LEN, "%s", line_ptr);
+  snprintf(value, INI_LINE_LEN, "%s", temp_str);
 
-      if (value[0] != '\0') {
-        /* cut trailing stuff */
-        for (int32_t i = strlen(value) - 1; i > 0; i--) {
-          if ((value[i] == ' ') || (value[i] == ';') ||
-              (value[i] == 9) ||   // TAB
-              (value[i] == 10) ||  // LF
-              (value[i] == 13)) {  // CR
-            value[i] = '\0';
-          } else {
-            break;
-          }
-        }
-      }
-      return INI_RIGHT_ITEM;
-    } else {
-      return INI_WRONG_ITEM;
+  size_t str_len = temp_back - temp_str + 1;
+  for (size_t i = 0; i < str_len; ++i)
+    temp_str[i] = toupper(temp_str[i]);
+
+  if (strcmp(temp_str, tag) != 0)
+    return INI_WRONG_ITEM;
+
+  /* skip leading whitespace on value */
+  line_ptr = equals_ptr + 1;
+  while (is_whitespace(*line_ptr))
+    ++line_ptr;
+
+  snprintf(value, INI_LINE_LEN, "%s", line_ptr);
+
+  if (value[0] != '\0') {
+    /* trim trailing whitespace on value */
+    char* value_end = value + strlen(value) - 1;
+    while (is_whitespace(*value_end)) {
+      *value_end = '\0';
+      --value_end;
     }
   }
 
-  return INI_NOTHING;
+  return INI_RIGHT_ITEM;
 }
+
 }  // namespace profile

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -1220,9 +1220,7 @@ const std::string Profile::hmi_origin_id() const {
   return hmi_origin_id_;
 }
 
-void Profile::UpdateValues() {
-  SDL_LOG_AUTO_TRACE();
-
+void Profile::ParseConfiguration() {
   FILE* config_file_ = fopen(config_file_name_.c_str(), "r");
   config_obj_ = smart_objects::SmartObject(smart_objects::SmartType_Map);
 
@@ -1290,6 +1288,12 @@ void Profile::UpdateValues() {
     fclose(config_file_);
     config_file_ = nullptr;
   }
+}
+
+void Profile::UpdateValues() {
+  SDL_LOG_AUTO_TRACE();
+
+  ParseConfiguration();
 
   // SDL version
   ReadStringValue(

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -1220,10 +1220,22 @@ const std::string Profile::hmi_origin_id() const {
   return hmi_origin_id_;
 }
 
+FILE* Profile::OpenConfig() {
+  FILE* config_file_ = fopen(config_file_name_.c_str(), "r");
+  return config_file_;
+}
+
+void Profile::CloseConfig(FILE* config_file_) {
+  if (nullptr != config_file_) {
+    fclose(config_file_);
+    config_file_ = nullptr;
+  }
+}
+
 void Profile::UpdateValues() {
   SDL_LOG_AUTO_TRACE();
 
-  FILE* config_file_ = fopen(config_file_name_.c_str(), "r");
+  FILE* config_file_ = OpenConfig();
   config_obj_ = smart_objects::SmartObject(smart_objects::SmartType_Map);
 
   if (nullptr != config_file_) {
@@ -1286,10 +1298,7 @@ void Profile::UpdateValues() {
     }
   }
 
-  if (nullptr != config_file_) {
-    fclose(config_file_);
-    config_file_ = nullptr;
-  }
+  CloseConfig(config_file_);
 
   // SDL version
   ReadStringValue(

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -1220,22 +1220,10 @@ const std::string Profile::hmi_origin_id() const {
   return hmi_origin_id_;
 }
 
-FILE* Profile::OpenConfig() {
-  FILE* config_file_ = fopen(config_file_name_.c_str(), "r");
-  return config_file_;
-}
-
-void Profile::CloseConfig(FILE* config_file_) {
-  if (nullptr != config_file_) {
-    fclose(config_file_);
-    config_file_ = nullptr;
-  }
-}
-
 void Profile::UpdateValues() {
   SDL_LOG_AUTO_TRACE();
 
-  FILE* config_file_ = OpenConfig();
+  FILE* config_file_ = fopen(config_file_name_.c_str(), "r");
   config_obj_ = smart_objects::SmartObject(smart_objects::SmartType_Map);
 
   if (nullptr != config_file_) {
@@ -1298,7 +1286,10 @@ void Profile::UpdateValues() {
     }
   }
 
-  CloseConfig(config_file_);
+  if (nullptr != config_file_) {
+    fclose(config_file_);
+    config_file_ = nullptr;
+  }
 
   // SDL version
   ReadStringValue(

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -1248,7 +1248,8 @@ void Profile::UpdateValues() {
 
         if (false == line_str.empty()) {
           chapter = line_str;
-          config_obj_[chapter] = smart_objects::SmartObject(smart_objects::SmartType_Map);
+          config_obj_[chapter] =
+              smart_objects::SmartObject(smart_objects::SmartType_Map);
         }
 
         continue;
@@ -2711,7 +2712,8 @@ bool Profile::ReadValue(bool* value,
   DCHECK(value);
   bool ret = false;
 
-  if (config_obj_.keyExists(pSection) && config_obj_[pSection].keyExists(pKey)) {
+  if (config_obj_.keyExists(pSection) &&
+      config_obj_[pSection].keyExists(pKey)) {
     auto val_str = config_obj_[pSection][pKey].asString();
     const int32_t tmpVal = atoi(val_str.data());
     if ((0 == strcmp("true", val_str.data())) || (0 != tmpVal)) {
@@ -2738,7 +2740,8 @@ bool Profile::ReadValueEmpty(std::string* value,
   DCHECK(value);
   bool ret = false;
 
-  if (config_obj_.keyExists(pSection) && config_obj_[pSection].keyExists(pKey)) {
+  if (config_obj_.keyExists(pSection) &&
+      config_obj_[pSection].keyExists(pKey)) {
     *value = config_obj_[pSection][pKey].asString();
     ret = true;
   }

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -1219,11 +1219,22 @@ const std::string Profile::hmi_origin_id() const {
   return hmi_origin_id_;
 }
 
+bool Profile::OpenConfig() {
+  config_file_ = fopen(config_file_name_.c_str(), "r");
+  return nullptr != config_file_;
+}
+
+void Profile::CloseConfig() {
+  if (nullptr != config_file_) {
+    fclose(config_file_);
+    config_file_ = nullptr;
+  }
+}
+
 void Profile::UpdateValues() {
   SDL_LOG_AUTO_TRACE();
 
-  config_file_ = fopen(config_file_name_.c_str(), "r");
-  if (nullptr == config_file_) {
+  if (!OpenConfig()) {
     SDL_LOG_DEBUG(
         "Could not open configuration file, profile values will be set to "
         "defaults");
@@ -2143,9 +2154,9 @@ void Profile::UpdateValues() {
                 kProtocolHandlerSection,
                 kMalformedMessageFiltering);
 
-  LOG_UPDATED_VALUE(malformed_message_filtering_,
-                    kMalformedMessageFiltering,
-                    kProtocolHandlerSection);
+  LOG_UPDATED_BOOL_VALUE(malformed_message_filtering_,
+                         kMalformedMessageFiltering,
+                         kProtocolHandlerSection);
 
   // Count for malformed message detection
   ReadUIntValue(&malformed_frequency_count_,
@@ -2646,9 +2657,7 @@ void Profile::UpdateValues() {
     }
   }
 
-  if (nullptr != config_file_) {
-    fclose(config_file_);
-  }
+  CloseConfig();
 }
 
 bool Profile::ReadValue(bool* value,

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -41,7 +41,6 @@
 
 #include <string>
 
-#include "config_profile/ini_file.h"
 #include "utils/file_system.h"
 #include "utils/logger.h"
 #include "utils/threads/thread.h"
@@ -63,6 +62,8 @@ namespace {
                                    << key << "' in section '" << section       \
                                    << "'.");                                   \
   }
+
+#define INI_LINE_LEN 1024
 
 const char* kDefaultConfigFileName = "smartDeviceLink.ini";
 

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -1262,13 +1262,6 @@ void Profile::UpdateValues() {
 
       std::string key(line_str.data(), equals_idx);
       std::string value(line_str.data() + equals_idx + 1);
-      auto val_whitespace_len = value.find_first_not_of(" \t\r\n");
-      if (std::string::npos == val_whitespace_len) {
-        value = "";
-      } else {
-        value.erase(0, value.find_first_not_of(" \t\r\n"));
-        value.erase(value.find_last_not_of(" \t\r\n") + 1);
-      }
 
       auto key_whitespace_len = key.find_first_not_of(" \t\r\n");
       if (std::string::npos == key_whitespace_len) {
@@ -1277,9 +1270,19 @@ void Profile::UpdateValues() {
       key.erase(0, key_whitespace_len);
       key.erase(key.find_last_not_of(" \t\r\n") + 1);
 
-      if (false == config_obj_[chapter].keyExists(key)) {
-        config_obj_[chapter][key] = value;
+      if (true == config_obj_[chapter].keyExists(key)) {
+        continue;
       }
+
+      auto val_whitespace_len = value.find_first_not_of(" \t\r\n");
+      if (std::string::npos == val_whitespace_len) {
+        value = "";
+      } else {
+        value.erase(0, value.find_first_not_of(" \t\r\n"));
+        value.erase(value.find_last_not_of(" \t\r\n") + 1);
+      }
+
+      config_obj_[chapter][key] = value;
     }
   }
 

--- a/src/components/config_profile/test/CMakeLists.txt
+++ b/src/components/config_profile/test/CMakeLists.txt
@@ -33,11 +33,13 @@ include(${CMAKE_SOURCE_DIR}/tools/cmake/helpers/sources.cmake)
 include_directories (
   ${GMOCK_INCLUDE_DIRECTORY}
   ${COMPONENTS_DIR}/config_profile/include
+  ${COMPONENTS_DIR}/smart_objects/include
   )
 
 set(LIBRARIES
   gmock
   ConfigProfile
+  SmartObjects
 )
 
 collect_sources(SOURCES "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/src/components/config_profile/test/ini_file_test.cc
+++ b/src/components/config_profile/test/ini_file_test.cc
@@ -40,6 +40,9 @@ namespace profile_test {
 
 using namespace ::profile;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 TEST(IniFileTest, WriteItemReadItem) {
   // Write line in chapter
   const char* fname = "./test_ini_file.ini";
@@ -324,6 +327,8 @@ TEST(IniFileTest, ParseLineWithComment) {
   EXPECT_EQ(INI_REMARK, result);
   EXPECT_STREQ(line, res);
 }
+
+#pragma GCC diagnostic pop
 
 }  // namespace profile_test
 }  // namespace components

--- a/src/components/config_profile/test/ini_file_test.cc
+++ b/src/components/config_profile/test/ini_file_test.cc
@@ -40,21 +40,6 @@ namespace profile_test {
 
 using namespace ::profile;
 
-char* ini_read_value(const char* fname,
-                     const char* chapter,
-                     const char* item,
-                     char* val) {
-  FILE* fp = fopen(fname, "r");
-
-  auto ret = ::profile::ini_read_value(fp, chapter, item, val);
-
-  if (nullptr != fp) {
-    fclose(fp);
-    fp = nullptr;
-  }
-  return ret;
-}
-
 TEST(IniFileTest, WriteItemReadItem) {
   // Write line in chapter
   const char* fname = "./test_ini_file.ini";

--- a/src/components/config_profile/test/ini_file_test.cc
+++ b/src/components/config_profile/test/ini_file_test.cc
@@ -40,7 +40,10 @@ namespace profile_test {
 
 using namespace ::profile;
 
-char* ini_read_value(const char* fname, const char* chapter, const char* item, char* val) {
+char* ini_read_value(const char* fname,
+                     const char* chapter,
+                     const char* item,
+                     char* val) {
   FILE* fp = fopen(fname, "r");
 
   auto ret = ::profile::ini_read_value(fp, chapter, item, val);

--- a/src/components/config_profile/test/ini_file_test.cc
+++ b/src/components/config_profile/test/ini_file_test.cc
@@ -40,6 +40,18 @@ namespace profile_test {
 
 using namespace ::profile;
 
+char* ini_read_value(const char* fname, const char* chapter, const char* item, char* val) {
+  FILE* fp = fopen(fname, "r");
+
+  auto ret = ::profile::ini_read_value(fp, chapter, item, val);
+
+  if (nullptr != fp) {
+    fclose(fp);
+    fp = nullptr;
+  }
+  return ret;
+}
+
 TEST(IniFileTest, WriteItemReadItem) {
   // Write line in chapter
   const char* fname = "./test_ini_file.ini";

--- a/src/components/config_profile/test/profile_test.cc
+++ b/src/components/config_profile/test/profile_test.cc
@@ -602,7 +602,6 @@ TEST_F(ProfileTest, CheckReadStringValue) {
   profile_.set_config_file_name("smartDeviceLink_test.ini");
   EXPECT_EQ("smartDeviceLink_test.ini", profile_.config_file_name());
 
-  profile_.OpenConfig();
   std::string app_storage_folder_;
   profile_.ReadStringValue(
       &app_storage_folder_, "", "MAIN", "AppStorageFolder");
@@ -613,7 +612,6 @@ TEST_F(ProfileTest, CheckReadStringValue) {
   std::string server_address;
   profile_.ReadStringValue(&server_address, "", "HMI", "ServerAddress");
   EXPECT_EQ("127.0.0.1", server_address);
-  profile_.CloseConfig();
 }
 
 TEST_F(ProfileTest, CheckReadBoolValue) {
@@ -635,10 +633,8 @@ TEST_F(ProfileTest, CheckReadIntValue) {
   profile_.set_config_file_name("smartDeviceLink_test.ini");
   EXPECT_EQ("smartDeviceLink_test.ini", profile_.config_file_name());
 
-  profile_.OpenConfig();
   int server_port = 0;
   profile_.ReadIntValue(&server_port, 0, "HMI", "ServerPort");
-  profile_.CloseConfig();
 
   EXPECT_EQ(8088, server_port);
 }
@@ -648,12 +644,10 @@ TEST_F(ProfileTest, CheckIntContainer) {
   profile_.set_config_file_name("smartDeviceLink_test.ini");
   EXPECT_EQ("smartDeviceLink_test.ini", profile_.config_file_name());
 
-  profile_.OpenConfig();
   bool isread = false;
   std::vector<int> diagmodes_list =
       profile_.ReadIntContainer("MAIN", "SupportedDiagModes", &isread);
   EXPECT_TRUE(isread);
-  profile_.CloseConfig();
 
   std::vector<int>::iterator diag_mode =
       std::find(diagmodes_list.begin(), diagmodes_list.end(), 0x12);
@@ -681,12 +675,10 @@ TEST_F(ProfileTest, CheckVectorContainer) {
   // Get diag_modes after updating
   const std::vector<uint32_t>& diag_modes = profile_.supported_diag_modes();
 
-  profile_.OpenConfig();
   bool isread = false;
   std::vector<int> diagmodes_list =
       profile_.ReadIntContainer("MAIN", "SupportedDiagModes", &isread);
   EXPECT_TRUE(isread);
-  profile_.CloseConfig();
 
   // Compare with result of ReadIntContainer
   ASSERT_EQ(diag_modes.size(), diagmodes_list.size());
@@ -710,12 +702,10 @@ TEST_F(ProfileTest, CheckStringContainer) {
   profile_.set_config_file_name("smartDeviceLink_test.ini");
   EXPECT_EQ("smartDeviceLink_test.ini", profile_.config_file_name());
 
-  profile_.OpenConfig();
   bool isread = false;
   std::vector<std::string> diagmodes_list =
       profile_.ReadStringContainer("MAIN", "SupportedDiagModes", &isread);
   EXPECT_TRUE(isread);
-  profile_.CloseConfig();
 
   std::vector<std::string>::iterator diag_mode =
       std::find(diagmodes_list.begin(), diagmodes_list.end(), "0x12");
@@ -740,7 +730,6 @@ TEST_F(ProfileTest, CheckStringContainerEmpty) {
   profile_.set_config_file_name("smartDeviceLink_test.ini");
   EXPECT_EQ("smartDeviceLink_test.ini", profile_.config_file_name());
 
-  profile_.OpenConfig();
   bool isread = false;
   std::vector<std::string> output_list =
       profile_.ReadStringContainer("MAIN", "AppConfigFolder", &isread);
@@ -758,7 +747,6 @@ TEST_F(ProfileTest, CheckStringContainerEmpty) {
       profile_.ReadStringContainer("MAIN", "DoesNotExistKey", &isread, true);
   EXPECT_FALSE(isread);
   EXPECT_TRUE(output_list2.empty());
-  profile_.CloseConfig();
 }
 
 #ifdef ENABLE_SECURITY
@@ -767,13 +755,11 @@ TEST_F(ProfileTest, CheckIntContainerInSecurityData) {
   profile_.set_config_file_name("smartDeviceLink_test.ini");
   EXPECT_EQ("smartDeviceLink_test.ini", profile_.config_file_name());
 
-  profile_.OpenConfig();
   std::vector<int> force_unprotected_list = profile_.ReadIntContainer(
       "Security Manager", "ForceUnprotectedService", NULL);
 
   std::vector<int> force_protected_list = profile_.ReadIntContainer(
       "Security Manager", "ForceProtectedService", NULL);
-  profile_.CloseConfig();
 
   std::vector<int>::iterator res_unprotect = std::find(
       force_unprotected_list.begin(), force_unprotected_list.end(), 0x07);

--- a/src/components/config_profile/test/profile_test.cc
+++ b/src/components/config_profile/test/profile_test.cc
@@ -602,6 +602,7 @@ TEST_F(ProfileTest, CheckReadStringValue) {
   profile_.set_config_file_name("smartDeviceLink_test.ini");
   EXPECT_EQ("smartDeviceLink_test.ini", profile_.config_file_name());
 
+  profile_.OpenConfig();
   std::string app_storage_folder_;
   profile_.ReadStringValue(
       &app_storage_folder_, "", "MAIN", "AppStorageFolder");
@@ -612,6 +613,7 @@ TEST_F(ProfileTest, CheckReadStringValue) {
   std::string server_address;
   profile_.ReadStringValue(&server_address, "", "HMI", "ServerAddress");
   EXPECT_EQ("127.0.0.1", server_address);
+  profile_.CloseConfig();
 }
 
 TEST_F(ProfileTest, CheckReadBoolValue) {
@@ -633,8 +635,10 @@ TEST_F(ProfileTest, CheckReadIntValue) {
   profile_.set_config_file_name("smartDeviceLink_test.ini");
   EXPECT_EQ("smartDeviceLink_test.ini", profile_.config_file_name());
 
+  profile_.OpenConfig();
   int server_port = 0;
   profile_.ReadIntValue(&server_port, 0, "HMI", "ServerPort");
+  profile_.CloseConfig();
 
   EXPECT_EQ(8088, server_port);
 }
@@ -644,10 +648,12 @@ TEST_F(ProfileTest, CheckIntContainer) {
   profile_.set_config_file_name("smartDeviceLink_test.ini");
   EXPECT_EQ("smartDeviceLink_test.ini", profile_.config_file_name());
 
+  profile_.OpenConfig();
   bool isread = false;
   std::vector<int> diagmodes_list =
       profile_.ReadIntContainer("MAIN", "SupportedDiagModes", &isread);
   EXPECT_TRUE(isread);
+  profile_.CloseConfig();
 
   std::vector<int>::iterator diag_mode =
       std::find(diagmodes_list.begin(), diagmodes_list.end(), 0x12);
@@ -675,10 +681,13 @@ TEST_F(ProfileTest, CheckVectorContainer) {
   // Get diag_modes after updating
   const std::vector<uint32_t>& diag_modes = profile_.supported_diag_modes();
 
+  profile_.OpenConfig();
   bool isread = false;
   std::vector<int> diagmodes_list =
       profile_.ReadIntContainer("MAIN", "SupportedDiagModes", &isread);
   EXPECT_TRUE(isread);
+  profile_.CloseConfig();
+
   // Compare with result of ReadIntContainer
   ASSERT_EQ(diag_modes.size(), diagmodes_list.size());
   bool isEqual = true;
@@ -701,10 +710,12 @@ TEST_F(ProfileTest, CheckStringContainer) {
   profile_.set_config_file_name("smartDeviceLink_test.ini");
   EXPECT_EQ("smartDeviceLink_test.ini", profile_.config_file_name());
 
+  profile_.OpenConfig();
   bool isread = false;
   std::vector<std::string> diagmodes_list =
       profile_.ReadStringContainer("MAIN", "SupportedDiagModes", &isread);
   EXPECT_TRUE(isread);
+  profile_.CloseConfig();
 
   std::vector<std::string>::iterator diag_mode =
       std::find(diagmodes_list.begin(), diagmodes_list.end(), "0x12");
@@ -729,6 +740,7 @@ TEST_F(ProfileTest, CheckStringContainerEmpty) {
   profile_.set_config_file_name("smartDeviceLink_test.ini");
   EXPECT_EQ("smartDeviceLink_test.ini", profile_.config_file_name());
 
+  profile_.OpenConfig();
   bool isread = false;
   std::vector<std::string> output_list =
       profile_.ReadStringContainer("MAIN", "AppConfigFolder", &isread);
@@ -746,6 +758,7 @@ TEST_F(ProfileTest, CheckStringContainerEmpty) {
       profile_.ReadStringContainer("MAIN", "DoesNotExistKey", &isread, true);
   EXPECT_FALSE(isread);
   EXPECT_TRUE(output_list2.empty());
+  profile_.CloseConfig();
 }
 
 #ifdef ENABLE_SECURITY
@@ -754,11 +767,13 @@ TEST_F(ProfileTest, CheckIntContainerInSecurityData) {
   profile_.set_config_file_name("smartDeviceLink_test.ini");
   EXPECT_EQ("smartDeviceLink_test.ini", profile_.config_file_name());
 
+  profile_.OpenConfig();
   std::vector<int> force_unprotected_list = profile_.ReadIntContainer(
       "Security Manager", "ForceUnprotectedService", NULL);
 
   std::vector<int> force_protected_list = profile_.ReadIntContainer(
       "Security Manager", "ForceProtectedService", NULL);
+  profile_.CloseConfig();
 
   std::vector<int>::iterator res_unprotect = std::find(
       force_unprotected_list.begin(), force_unprotected_list.end(), 0x07);

--- a/src/components/transport_manager/CMakeLists.txt
+++ b/src/components/transport_manager/CMakeLists.txt
@@ -38,6 +38,7 @@ include_directories (
   ${COMPONENTS_DIR}/connection_handler/include
   ${COMPONENTS_DIR}/config_profile/include
   ${COMPONENTS_DIR}/resumption/include
+  ${COMPONENTS_DIR}/smart_objects/include
   ${POLICY_GLOBAL_INCLUDE_PATH}/
   ${JSONCPP_INCLUDE_DIRECTORY}
   ${LOG4CXX_INCLUDE_DIRECTORY}


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/2850

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Change INI value, run SDL core, ensure Core read new INI value
Unit Tests and ATF tests

### Summary
Refactor INI parsing to reduce the number of times the ini file is opened. This goal is achieved through an update to Profile::UpdateValues:
1. INI file is opened
2. all values from the file are read into a smart_object
3. INI files is closed
4. Member variables are assigned from values in smart_object

### Changelog
##### Enhancements
* SDL Core should open the ini file many times less

##### CMake
* transport_manager now requires smart_object include
* config_profile now depends on smart_object
* config_profile_test now depends on smart_object

### Tasks Remaining:
- [x] Fix unit tests
- [x] Remove ini_file changes
- [x] Deprecate ini_file?

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
