### PR TITLE
Fix/Return requesType in sample policy manager response

### DIFF
--- a/src/appMain/sample_policy_manager.py
+++ b/src/appMain/sample_policy_manager.py
@@ -51,7 +51,6 @@ def decrypt(data):
 
 
 def pack(data, encryption, add_http_header):
-    print("Pack")
     file_path = data['fileName']
     file_ptr = open(file_path, "r+")
 
@@ -72,7 +71,6 @@ def pack(data, encryption, add_http_header):
 
 
 def unpack(data, encryption):
-    print("Unpack")
     file_path = data['fileName']
     file_ptr = open(file_path, 'r+')
 

--- a/src/appMain/sample_policy_manager.py
+++ b/src/appMain/sample_policy_manager.py
@@ -51,6 +51,7 @@ def decrypt(data):
 
 
 def pack(data, encryption, add_http_header):
+    print("Pack")
     file_path = data['fileName']
     file_ptr = open(file_path, "r+")
 
@@ -71,6 +72,7 @@ def pack(data, encryption, add_http_header):
 
 
 def unpack(data, encryption):
+    print("Unpack")
     file_path = data['fileName']
     file_ptr = open(file_path, 'r+')
 
@@ -154,7 +156,11 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
             print('\033[31;1mMissing fileName parameter: %s\033[0m' % str(json_data))
             return
 
-        self.write_message(self.handle_func(json_data, self.encryption, self.add_http_header))
+        msg = {
+            "requestType": json_data['requestType'],
+            "data": self.handle_func(json_data, self.encryption, self.add_http_header) 
+        }
+        self.write_message(msg)
 
     def on_close(self):
         print ("Connection Closed\n")


### PR DESCRIPTION
Add support for https://github.com/smartdevicelink/sdl_hmi/issues/560 fix

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run the following steps for both PROPRIETARY and EXTERNAL_PROPRIETARY

1. Send SystemRequest {requestType: "CLIMATE", fileName: "climateData.json"} from the mobile app 
2. Confirm that HMI does NOT send `SDL.OnReceivedPolicyUpdate` with "climateData.json"

### Summary
Make changes to return json object with requesType param in sample_policy_manager

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
