### PR TITLE
reorder shutdown calls to prevent deadlock

### DIFF
--- a/src/appMain/life_cycle_impl.cc
+++ b/src/appMain/life_cycle_impl.cc
@@ -264,14 +264,14 @@ void LifeCycleImpl::StopComponents() {
   DCHECK_OR_RETURN_VOID(hmi_handler_);
   hmi_handler_->set_message_observer(NULL);
 
-  DCHECK_OR_RETURN_VOID(connection_handler_);
-  connection_handler_->set_connection_handler_observer(NULL);
-
   DCHECK_OR_RETURN_VOID(protocol_handler_);
   protocol_handler_->RemoveProtocolObserver(&(app_manager_->GetRPCHandler()));
 
   DCHECK_OR_RETURN_VOID(app_manager_);
   app_manager_->Stop();
+
+  DCHECK_OR_RETURN_VOID(connection_handler_);
+  connection_handler_->set_connection_handler_observer(NULL);
 
   SDL_LOG_INFO("Stopping Protocol Handler");
   DCHECK_OR_RETURN_VOID(protocol_handler_);


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3692

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
A deadlock was noticed during shutdown in obscure case:

shutdown attempts to do `connection_handler_->set_connection_handler_observer(NULL);` which requires the lock: `sync_primitives::AutoWriteLock write_lock(connection_handler_observer_lock_);`
this lock may be held by `ConnectionHandlerImpl::GetProtocolVehicleData` which can be waiting in `ApplicationManagerImpl::WaitForHmiIsReady`, but when `ApplicationManagerImpl::InitiateStopping` is called it will stop any thread waiting for HMI to be ready

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
