### PR TITLE
Remove logic sending invalid slider position

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/slider_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/slider_request.cc
@@ -153,21 +153,6 @@ void SliderRequest::on_event(const event_engine::Event& event) {
 
   SmartObject response_msg_params = message[strings::msg_params];
 
-  const bool is_timeout_aborted = Compare<Common_Result::eType, EQ, ONE>(
-      response_code, Common_Result::TIMED_OUT, Common_Result::ABORTED);
-
-  if (is_timeout_aborted) {
-    if (message[strings::params][strings::data].keyExists(
-            strings::slider_position)) {
-      // Copy slider_position info to msg_params section
-      response_msg_params[strings::slider_position] =
-          message[strings::params][strings::data][strings::slider_position];
-    } else {
-      SDL_LOG_ERROR(strings::slider_position << " field is absent"
-                                                " in response.");
-      response_msg_params[strings::slider_position] = 0;
-    }
-  }
   std::string response_info;
   GetInfo(message, response_info);
   const bool is_response_success = PrepareResultForMobileResponse(


### PR DESCRIPTION
Fixes #3676 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manual testing against SDL HMI PR (https://github.com/smartdevicelink/sdl_hmi/pull/564), app should receive sliderPosition in ABORTED or TIMED_OUT response for Slider if provided by the HMI.

### Summary
sliderPosition was being set to 0 (an invalid value) in the mobile response for Slider if an ABORTED or TIMED_OUT result was received from the HMI without this parameter. This PR removes that logic.

### Changelog
##### Bug Fixes
* Fix invalid response when sending ABORTED or TIMED_OUT response to Slider request

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
