### PR TITLE
Only call Json::Value::operator[] if PTU value is object type

### DIFF
--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -112,7 +112,8 @@ std::shared_ptr<policy_table::Table> PolicyManagerImpl::ParseArray(
 
   if (reader.parse(json, &value)) {
     // For PT Update received from SDL Server.
-    if (value["data"].size() != 0) {
+    if (Json::ValueType::objectValue == value.type() &&
+        0 != value["data"].size()) {
       Json::Value data = value["data"];
       return std::make_shared<policy_table::Table>(&data[0]);
     } else {

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -112,8 +112,7 @@ std::shared_ptr<policy_table::Table> PolicyManagerImpl::ParseArray(
 
   if (reader.parse(json, &value)) {
     // For PT Update received from SDL Server.
-    if (Json::ValueType::objectValue == value.type() &&
-        0 != value["data"].size()) {
+    if (value.isObject() && 0 != value["data"].size()) {
       Json::Value data = value["data"];
       return std::make_shared<policy_table::Table>(&data[0]);
     } else {

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -112,7 +112,7 @@ std::shared_ptr<policy_table::Table> PolicyManagerImpl::ParseArray(
 
   if (reader.parse(json, &value)) {
     // For PT Update received from SDL Server.
-    if (value.isObject() && 0 != value["data"].size()) {
+    if (value.isObject() && value["data"].isArray() && !value["data"].empty()) {
       Json::Value data = value["data"];
       return std::make_shared<policy_table::Table>(&data[0]);
     } else {


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3698

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Issue reproduction steps, Unit Tests, ATF

### Summary
Check that PTU bulkData is parsed to type object before calling `operator[]` on the value

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
