### PR TITLE
Append LD_LIBRARY_PATH in daemon.sh

### DIFF
--- a/src/appMain/daemon.sh
+++ b/src/appMain/daemon.sh
@@ -19,7 +19,7 @@ function core_start() {
     return 2
   else
     echo "Starting SmartDeviceLink Core"
-    LD_LIBRARY_PATH=$DIR ${DIR}/${CORE_APPLICATION_NAME} &
+    LD_LIBRARY_PATH=$DIR:$LD_LIBRARY_PATH ${DIR}/${CORE_APPLICATION_NAME} &
     CORE_PID=$!
     echo $CORE_PID > $CORE_PID_FILE
     return 0

--- a/src/appMain/daemon.sh
+++ b/src/appMain/daemon.sh
@@ -19,7 +19,7 @@ function core_start() {
     return 2
   else
     echo "Starting SmartDeviceLink Core"
-    LD_LIBRARY_PATH=$DIR:$LD_LIBRARY_PATH ${DIR}/${CORE_APPLICATION_NAME} &
+    ${DIR}/${CORE_APPLICATION_NAME} &
     CORE_PID=$!
     echo $CORE_PID > $CORE_PID_FILE
     return 0


### PR DESCRIPTION
Fixes #3700 

This PR is **Ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Build SDL Core with 3rd party library env var set. Run core after setting LD_LIBRARY_PATH. See issue for more details.

### Summary
Appends LD_LIBRARY_PATH instead of overwriting in the daemon script.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
