### PR TITLE
adapt API schema classes to recursive objects

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/custom_vehicle_data_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/custom_vehicle_data_manager_impl.cc
@@ -294,10 +294,8 @@ void CustomVehicleDataManagerImpl::UpdateVehicleDataItems() {
       case SMemberType::SMEMBER_VDR_MOBILE: {
         // valid since struct_schema_items is not used in
         // InitStructSchemaItem_VehicleDataResult
-        mobile_apis::MOBILE_API::TStructsSchemaItems mobile_struct_schema_items;
         auto member_schema =
-            mobile_apis::MOBILE_API::InitStructSchemaItem_VehicleDataResult(
-                mobile_struct_schema_items);
+            mobile_apis::MOBILE_API::InitStructSchemaItem_VehicleDataResult();
         return SMember(
             member_schema,
             false,  // root level items should not be mandatory
@@ -330,10 +328,8 @@ void CustomVehicleDataManagerImpl::UpdateVehicleDataItems() {
       case SMemberType::SMEMBER_VDR_HMI: {
         // valid since struct_schema_items is not used in
         // InitStructSchemaItem_Common_VehicleDataResult
-        hmi_apis::HMI_API::TStructsSchemaItems hmi_struct_schema_items;
         auto member_schema =
-            hmi_apis::HMI_API::InitStructSchemaItem_Common_VehicleDataResult(
-                hmi_struct_schema_items);
+            hmi_apis::HMI_API::InitStructSchemaItem_Common_VehicleDataResult();
         return SMember(
             member_schema, false  // root level items should not be mandatory
         );

--- a/src/components/smart_objects/include/smart_objects/array_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/array_schema_item.h
@@ -63,6 +63,13 @@ class CArraySchemaItem : public ISchemaItem {
       const TSchemaItemParameter<size_t>& MaxSize =
           TSchemaItemParameter<size_t>());
 
+  static std::shared_ptr<CArraySchemaItem> create(
+      ISchemaItem* ElementSchemaItem,
+      const TSchemaItemParameter<size_t>& MinSize =
+          TSchemaItemParameter<size_t>(),
+      const TSchemaItemParameter<size_t>& MaxSize =
+          TSchemaItemParameter<size_t>());
+
   /**
    * @brief Validate smart object.
    * @param Object Object to validate.
@@ -131,10 +138,16 @@ class CArraySchemaItem : public ISchemaItem {
                    const TSchemaItemParameter<size_t>& MinSize,
                    const TSchemaItemParameter<size_t>& MaxSize);
 
+  CArraySchemaItem(ISchemaItem* ElementSchemaItem,
+                   const TSchemaItemParameter<size_t>& MinSize,
+                   const TSchemaItemParameter<size_t>& MaxSize);
+
   /**
    * @brief SchemaItem for array elements.
    **/
-  const ISchemaItemPtr mElementSchemaItem;
+  ISchemaItem* mElementSchemaItem;
+  const ISchemaItemPtr mElementSchemaItemShared;
+
   /**
    * @brief Minimum allowed size.
    **/

--- a/src/components/smart_objects/include/smart_objects/object_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/object_schema_item.h
@@ -69,6 +69,14 @@ struct SMember {
           const bool IsRemoved = false,
           const std::vector<SMember>& history_vector = {});
 
+  SMember(ISchemaItem* SchemaItem,
+          const bool IsMandatory = true,
+          const std::string& Since = "",
+          const std::string& Until = "",
+          const bool IsDeprecated = false,
+          const bool IsRemoved = false,
+          const std::vector<SMember>& history_vector = {});
+
   /**
    * @brief Checks the version a parameter was removed (until)
    * If the mobile's msg version is greater than or
@@ -79,7 +87,8 @@ struct SMember {
   /**
    * @brief Member schema item.
    **/
-  ISchemaItemPtr mSchemaItem;
+  ISchemaItem* mSchemaItem;
+  ISchemaItemPtr mSchemaItemShared;
   /**
    * @brief true if member is mandatory, false otherwise.
    **/

--- a/src/components/smart_objects/src/array_schema_item.cc
+++ b/src/components/smart_objects/src/array_schema_item.cc
@@ -44,6 +44,14 @@ std::shared_ptr<CArraySchemaItem> CArraySchemaItem::create(
       new CArraySchemaItem(ElementSchemaItem, MinSize, MaxSize));
 }
 
+std::shared_ptr<CArraySchemaItem> CArraySchemaItem::create(
+    ISchemaItem* ElementSchemaItem,
+    const TSchemaItemParameter<size_t>& MinSize,
+    const TSchemaItemParameter<size_t>& MaxSize) {
+  return std::shared_ptr<CArraySchemaItem>(
+      new CArraySchemaItem(ElementSchemaItem, MinSize, MaxSize));
+}
+
 errors::eType CArraySchemaItem::validate(
     const SmartObject& Object,
     rpc::ValidationReport* report,
@@ -161,10 +169,19 @@ TypeID CArraySchemaItem::GetType() {
   return TYPE_ARRAY;
 }
 
-CArraySchemaItem::CArraySchemaItem(const ISchemaItemPtr ElementSchemaItem,
+CArraySchemaItem::CArraySchemaItem(ISchemaItem* ElementSchemaItem,
                                    const TSchemaItemParameter<size_t>& MinSize,
                                    const TSchemaItemParameter<size_t>& MaxSize)
     : mElementSchemaItem(ElementSchemaItem)
+    , mElementSchemaItemShared(nullptr)
+    , mMinSize(MinSize)
+    , mMaxSize(MaxSize) {}
+
+CArraySchemaItem::CArraySchemaItem(const ISchemaItemPtr ElementSchemaItem,
+                                   const TSchemaItemParameter<size_t>& MinSize,
+                                   const TSchemaItemParameter<size_t>& MaxSize)
+    : mElementSchemaItem(ElementSchemaItem.get())
+    , mElementSchemaItemShared(ElementSchemaItem)
     , mMinSize(MinSize)
     , mMaxSize(MaxSize) {}
 

--- a/src/components/smart_objects/src/object_schema_item.cc
+++ b/src/components/smart_objects/src/object_schema_item.cc
@@ -51,19 +51,21 @@ namespace ns_smart_device_link {
 namespace ns_smart_objects {
 
 SMember::SMember()
-    : mSchemaItem(CAlwaysFalseSchemaItem::create())
-    , mIsMandatory(true)
-    , mIsDeprecated(false)
-    , mIsRemoved(false) {}
+    : mIsMandatory(true), mIsDeprecated(false), mIsRemoved(false) {
+  mSchemaItemShared = CAlwaysFalseSchemaItem::create();
+  mSchemaItem = mSchemaItemShared.get();
+}
 
-SMember::SMember(const ISchemaItemPtr SchemaItem,
+SMember::SMember(ISchemaItem* SchemaItem,
                  const bool IsMandatory,
                  const std::string& Since,
                  const std::string& Until,
                  const bool IsDeprecated,
                  const bool IsRemoved,
                  const std::vector<SMember>& history_vector)
-    : mSchemaItem(SchemaItem), mIsMandatory(IsMandatory) {
+    : mSchemaItem(SchemaItem)
+    , mSchemaItemShared(nullptr)
+    , mIsMandatory(IsMandatory) {
   if (Since.size() > 0) {
     utils::SemanticVersion since_struct(Since);
     if (since_struct.isValid()) {
@@ -79,6 +81,23 @@ SMember::SMember(const ISchemaItemPtr SchemaItem,
   mIsDeprecated = IsDeprecated;
   mIsRemoved = IsRemoved;
   mHistoryVector = history_vector;
+}
+
+SMember::SMember(const ISchemaItemPtr SchemaItem,
+                 const bool IsMandatory,
+                 const std::string& Since,
+                 const std::string& Until,
+                 const bool IsDeprecated,
+                 const bool IsRemoved,
+                 const std::vector<SMember>& history_vector)
+    : SMember(SchemaItem.get(),
+              IsMandatory,
+              Since,
+              Until,
+              IsDeprecated,
+              IsRemoved,
+              history_vector) {
+  mSchemaItemShared = SchemaItem;
 }
 
 bool SMember::CheckHistoryFieldVersion(


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3689

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
unit tests, ATF tests, valgrind

### Summary
this PR prevents recursive API objects from leaking memory. prior to this PR object children schema items were saved as shared pointers. Having an object child hold a ref to itself prevents the object from being destroyed. Instead, object type schema items will now be managed in the schema class' `struct_schema_items` and a raw pointer to instances will be used by other schema objects.

##### Enhancements
* enable recursive objects in the API

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
