### PR TITLE
Fix saving to endpoint properties table

### DIFF
--- a/src/components/policy/policy_external/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_queries.cc
@@ -400,8 +400,8 @@ const std::string kCreateSchema =
     "  ON `endpoint`(`application_id` COLLATE NOCASE); "
     /*endpoint properties*/
     "CREATE TABLE IF NOT EXISTS `endpoint_properties`( "
-    "  `service` VARCHAR(100) NOT NULL, "
-    "  `version` VARCHAR(100) NOT NULL "
+    "  `service` VARCHAR(100) PRIMARY KEY NOT NULL, "
+    "  `version` VARCHAR(100) "
     ");"
     "CREATE TABLE IF NOT EXISTS `message`( "
     "  `id` INTEGER PRIMARY KEY NOT NULL, "

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -530,9 +530,13 @@ void SQLPTRepresentation::GatherModuleConfig(
   } else {
     while (endpoint_properties.Next()) {
       const std::string& service = endpoint_properties.GetString(0);
-      const std::string& version = endpoint_properties.GetString(1);
       auto& ep_properties = (*config->endpoint_properties);
-      *ep_properties[service].version = version;
+      if (!endpoint_properties.IsNull(1)) {
+        const std::string& version = endpoint_properties.GetString(1);
+        *ep_properties[service].version = version;
+      } else {
+        ep_properties[service].version = rpc::Optional<rpc::String<0, 100> >();
+      }
     }
   }
 
@@ -1581,7 +1585,9 @@ bool SQLPTRepresentation::SaveServiceEndpointProperties(
 
   for (auto& endpoint_property : endpoint_properties) {
     query.Bind(0, endpoint_property.first);
-    query.Bind(1, endpoint_property.second.version);
+    endpoint_property.second.version.is_initialized()
+        ? query.Bind(1, *endpoint_property.second.version)
+        : query.Bind(1);
 
     if (!query.Exec() || !query.Reset()) {
       SDL_LOG_WARN(

--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -371,8 +371,8 @@ const std::string kCreateSchema =
 
     /*endpoint properties*/
     "CREATE TABLE IF NOT EXISTS `endpoint_properties`( "
-    "  `service` VARCHAR(100) NOT NULL, "
-    "  `version` VARCHAR(100) NOT NULL "
+    "  `service` VARCHAR(100) PRIMARY KEY NOT NULL, "
+    "  `version` VARCHAR(100) "
     ");"
 
     "CREATE TABLE IF NOT EXISTS `message`( "


### PR DESCRIPTION


Fixes #3666 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF PR in progress, test manually by checking `endpoint_properties` field in policy table

### Summary
`EndpointProperty.version` is defined as an optional value, but was being used as a mandatory one. Also makes `service` property unique in `endpoint_properties` to prevent duplicate entries.

### Changelog
##### Bug Fixes
* Fixes incorrect saving of endpoint properties and restricts duplicate saving

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
