### PR TITLE
when non-existent app sends request reply app not registered

### DIFF
--- a/src/components/application_manager/src/commands/command_impl.cc
+++ b/src/components/application_manager/src/commands/command_impl.cc
@@ -159,6 +159,12 @@ bool CommandImpl::CheckAllowedParameters(const Command::CommandSource source) {
         "There is no registered application with "
         "connection key '"
         << connection_key() << "'");
+
+    rpc_service_.SendMessageToMobile(MessageHelper::CreateNegativeResponse(
+        connection_key(),
+        function_id(),
+        correlation_id(),
+        mobile_apis::Result::APPLICATION_NOT_REGISTERED));
     return false;
   }
 

--- a/src/components/application_manager/test/commands/command_request_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_request_impl_test.cc
@@ -363,6 +363,9 @@ TEST_F(CommandRequestImplTest,
   MessageSharedPtr message = CreateMessage();
   CommandPtr command = CreateCommand<UCommandRequestImpl>(message);
   EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(MockAppPtr()));
+  MessageSharedPtr dummy_msg(CreateMessage());
+  EXPECT_CALL(mock_message_helper_, CreateNegativeResponse(_, _, _, _))
+      .WillOnce(Return(dummy_msg));
   EXPECT_FALSE(command->CheckPermissions());
 }
 


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/1584

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF
https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2551

### Summary
When a command[ is not run](https://github.com/smartdevicelink/sdl_core/blob/master/src/components/application_manager/src/request_controller.cc#L525) because it's associated app cannot be found, send a response with code `APPLICATION_NOT_REGISTERED`


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
