### PR TITLE
allow an app to be activated while phone call is in progress

### DIFF
--- a/src/components/application_manager/include/application_manager/hmi_state.h
+++ b/src/components/application_manager/include/application_manager/hmi_state.h
@@ -440,7 +440,6 @@ class PhoneCallHmiState : public HmiState {
     return mobile_apis::AudioStreamingState::NOT_AUDIBLE;
   }
 
-  mobile_apis::HMILevel::eType max_hmi_level() const OVERRIDE;
   mobile_apis::AudioStreamingState::eType max_audio_streaming_state()
       const OVERRIDE {
     return audio_streaming_state();

--- a/src/components/application_manager/src/hmi_state.cc
+++ b/src/components/application_manager/src/hmi_state.cc
@@ -243,28 +243,28 @@ PhoneCallHmiState::PhoneCallHmiState(std::shared_ptr<Application> app,
 
 mobile_apis::HMILevel::eType PhoneCallHmiState::hmi_level() const {
   using namespace mobile_apis;
-  if (HMILevel::INVALID_ENUM == parent_hmi_level()) {
+  if (HMILevel::INVALID_ENUM == parent_hmi_level() ||
+      HMILevel::HMI_NONE == parent_hmi_level()) {
     return parent_hmi_level();
   }
-  return std::max(parent_hmi_level(), max_hmi_level());
-}
-
-mobile_apis::HMILevel::eType PhoneCallHmiState::max_hmi_level() const {
-  using namespace helpers;
-  using namespace mobile_apis;
 
   if (WindowType::WIDGET == window_type()) {
     return std::max(HMILevel::HMI_FULL, parent_max_hmi_level());
   }
 
-  auto expected = HMILevel::HMI_FULL;
+  auto expected = HMILevel::HMI_BACKGROUND;
   if (is_navi_app() || is_mobile_projection_app()) {
-    expected = HMILevel::HMI_LIMITED;
-  } else if (is_media_app() || is_voice_communication_app()) {
-    expected = HMILevel::HMI_BACKGROUND;
+    if (VideoStreamingState::STREAMABLE == video_streaming_state()) {
+      expected = HMILevel::HMI_LIMITED;
+    }
   }
 
   return std::max(expected, parent_max_hmi_level());
+}
+
+mobile_apis::HMILevel::eType PhoneCallHmiState::max_hmi_level() const {
+  using namespace mobile_apis;
+  return std::max(HMILevel::HMI_FULL, parent_max_hmi_level());
 }
 
 SafetyModeHmiState::SafetyModeHmiState(std::shared_ptr<Application> app,

--- a/src/components/application_manager/src/hmi_state.cc
+++ b/src/components/application_manager/src/hmi_state.cc
@@ -243,8 +243,7 @@ PhoneCallHmiState::PhoneCallHmiState(std::shared_ptr<Application> app,
 
 mobile_apis::HMILevel::eType PhoneCallHmiState::hmi_level() const {
   using namespace mobile_apis;
-  if (HMILevel::INVALID_ENUM == parent_hmi_level() ||
-      HMILevel::HMI_NONE == parent_hmi_level()) {
+  if (HMILevel::INVALID_ENUM == parent_hmi_level()) {
     return parent_hmi_level();
   }
 
@@ -259,12 +258,7 @@ mobile_apis::HMILevel::eType PhoneCallHmiState::hmi_level() const {
     }
   }
 
-  return std::max(expected, parent_max_hmi_level());
-}
-
-mobile_apis::HMILevel::eType PhoneCallHmiState::max_hmi_level() const {
-  using namespace mobile_apis;
-  return std::max(HMILevel::HMI_FULL, parent_max_hmi_level());
+  return std::max(expected, parent_hmi_level());
 }
 
 SafetyModeHmiState::SafetyModeHmiState(std::shared_ptr<Application> app,

--- a/src/components/application_manager/test/state_controller/state_controller_test.cc
+++ b/src/components/application_manager/test/state_controller/state_controller_test.cc
@@ -383,7 +383,7 @@ class StateControllerImplTest : public ::testing::Test {
       case APP_TYPE_NON_MEDIA: {
         PrepareCommonStateResults(result_hmi_state);
         result_hmi_state.push_back(
-            createHmiState(HMILevel::HMI_FULL,
+            createHmiState(HMILevel::HMI_BACKGROUND,
                            AudioStreamingState::NOT_AUDIBLE,
                            VideoStreamingState::NOT_STREAMABLE,
                            SystemContext::SYSCTXT_MAIN));
@@ -416,22 +416,22 @@ class StateControllerImplTest : public ::testing::Test {
       case APP_TYPE_NAVI: {
         PrepareCommonStateResults(result_hmi_state);
         result_hmi_state.push_back(
-            createHmiState(HMILevel::HMI_LIMITED,
+            createHmiState(HMILevel::HMI_BACKGROUND,
                            AudioStreamingState::NOT_AUDIBLE,
                            VideoStreamingState::NOT_STREAMABLE,
                            SystemContext::SYSCTXT_MAIN));
         result_hmi_state.push_back(
-            createHmiState(HMILevel::HMI_LIMITED,
+            createHmiState(HMILevel::HMI_BACKGROUND,
                            AudioStreamingState::NOT_AUDIBLE,
                            VideoStreamingState::NOT_STREAMABLE,
                            SystemContext::SYSCTXT_MAIN));
         result_hmi_state.push_back(
-            createHmiState(HMILevel::HMI_LIMITED,
+            createHmiState(HMILevel::HMI_BACKGROUND,
                            AudioStreamingState::NOT_AUDIBLE,
                            VideoStreamingState::NOT_STREAMABLE,
                            SystemContext::SYSCTXT_MAIN));
         result_hmi_state.push_back(
-            createHmiState(HMILevel::HMI_LIMITED,
+            createHmiState(HMILevel::HMI_BACKGROUND,
                            AudioStreamingState::NOT_AUDIBLE,
                            VideoStreamingState::NOT_STREAMABLE,
                            SystemContext::SYSCTXT_MAIN));


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/2323

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
unit tests, atf, issue steps manually

### Summary
Max HMI level during phone call is FULL, and normal hmi level logic added.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
