### PR TITLE
Fix/Mic to File recorder thread stop call

### DIFF
--- a/src/components/media_manager/src/audio/from_mic_to_file_recorder_thread.cc
+++ b/src/components/media_manager/src/audio/from_mic_to_file_recorder_thread.cc
@@ -366,7 +366,7 @@ void FromMicToFileRecorderThread::exitThreadMain() {
 
   if (sleepThread_) {
     SDL_LOG_DEBUG("Stop sleep thread\n");
-    sleepThread_->stop();
+    sleepThread_->Stop(threads::Thread::kThreadStopDelegate);
   }
 
   SDL_LOG_TRACE("Set should be stopped flag\n");


### PR DESCRIPTION
Fixes #3711 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Build SDL with `EXTENDED_MEDIA_MODE` set to ON

### Summary
Fix thread stop call in `from_mic_to_file_recorder_thread.cc`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
