### PR TITLE
check for invalid enum result code in CommandRequestImpl::SendResponse

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/alert_maneuver_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/alert_maneuver_request_test.cc
@@ -215,7 +215,7 @@ TEST_F(AlertManeuverRequestTest, OnEvent_ReceivedUnknownEvent_UNSUCCESS) {
 
   MessageSharedPtr result_msg(
       CatchMobileCommandResult(CallOnEvent(*command, event)));
-  EXPECT_EQ(mobile_apis::Result::INVALID_ENUM,
+  EXPECT_EQ(mobile_apis::Result::GENERIC_ERROR,
             static_cast<mobile_apis::Result::eType>(
                 (*result_msg)[am::strings::msg_params][am::strings::result_code]
                     .asInt()));

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/alert_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/alert_request_test.cc
@@ -335,7 +335,7 @@ TEST_F(AlertRequestTest, Run_FailToProcessSoftButtons_UNSUCCESS) {
 
   CommandPtr command(CreateCommand<AlertRequest>(msg_));
   MessageSharedPtr result_msg(CatchMobileCommandResult(CallRun(*command)));
-  EXPECT_EQ(result_code,
+  EXPECT_EQ(mobile_apis::Result::GENERIC_ERROR,
             static_cast<mobile_apis::Result::eType>(
                 (*result_msg)[am::strings::msg_params][am::strings::result_code]
                     .asInt()));

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/update_turn_list_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/update_turn_list_request_test.cc
@@ -148,7 +148,7 @@ TEST_F(UpdateTurnListRequestTest,
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
-  const mobile_result::eType kExpectedResult = mobile_result::INVALID_ENUM;
+  const mobile_result::eType kExpectedResult = mobile_result::GENERIC_ERROR;
   EXPECT_CALL(mock_message_helper_,
               ProcessSoftButtons((*command_msg_)[am::strings::msg_params],
                                  Eq(mock_app),

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -293,7 +293,7 @@ void CommandRequestImpl::SendResponse(
     response[strings::msg_params][strings::result_code] =
         mobile_apis::Result::GENERIC_ERROR;
     response[strings::msg_params][strings::info] =
-        "Invalid message received from vehicle";
+        "Invalid result received from vehicle";
   } else {
     response[strings::msg_params][strings::result_code] = result_code;
   }

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -289,6 +289,11 @@ void CommandRequestImpl::SendResponse(
                                 : warning_info();
     response[strings::msg_params][strings::result_code] =
         mobile_apis::Result::WARNINGS;
+  } else if (mobile_apis::Result::INVALID_ENUM == result_code) {
+    response[strings::msg_params][strings::result_code] =
+        mobile_apis::Result::GENERIC_ERROR;
+    response[strings::msg_params][strings::info] =
+        "Invalid message received from vehicle";
   } else {
     response[strings::msg_params][strings::result_code] = result_code;
   }


### PR DESCRIPTION
Updated version of https://github.com/smartdevicelink/sdl_core/pull/1541

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit, ATF tests

### Summary
Overwrite INVALID_ENUM with GENERIC_ERROR when sending out a result code, and add some info in this case.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
