### PR TITLE
Fix crash during resumption callback

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -983,12 +983,13 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
       file_system::FileExists(application->app_icon_path());
 
   smart_objects::SmartObject msg_params_copy = msg_params;
+  ApplicationManager& app_manager = application_manager_;
   const auto result_code = CalculateFinalResultCode();
 
   SendResponse(true, result_code, response_info_.c_str(), &response_params);
 
   FinishSendingResponseToMobile(
-      msg_params_copy, application_manager_, key, status_notifier);
+      msg_params_copy, app_manager, key, status_notifier);
 }
 
 void RegisterAppInterfaceRequest::SendChangeRegistration(

--- a/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
@@ -307,6 +307,14 @@ void ResumptionDataProcessorImpl::ProcessResponseFromHMI(
 
 void ResumptionDataProcessorImpl::FinalizeResumption(
     const ResumeCtrl::ResumptionCallBack& callback, const uint32_t app_id) {
+  auto app = application_manager_.application(app_id);
+  if (!app) {
+    SDL_LOG_ERROR("App " << app_id
+                         << " is not registered, erasing resumption data");
+    EraseAppResumptionData(app_id);
+    return;
+  } 
+  
   if (IsResumptionSuccessful(app_id)) {
     SDL_LOG_DEBUG("Resumption for app " << app_id << " successful");
     callback(mobile_apis::Result::SUCCESS, "Data resumption successful");
@@ -314,7 +322,7 @@ void ResumptionDataProcessorImpl::FinalizeResumption(
   } else {
     SDL_LOG_ERROR("Resumption for app " << app_id << " failed");
     callback(mobile_apis::Result::RESUME_FAILED, "Data resumption failed");
-    RevertRestoredData(application_manager_.application(app_id));
+    RevertRestoredData(app);
     application_manager_.state_controller().DropPostponedWindows(app_id);
   }
   EraseAppResumptionData(app_id);

--- a/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
@@ -313,8 +313,8 @@ void ResumptionDataProcessorImpl::FinalizeResumption(
                          << " is not registered, erasing resumption data");
     EraseAppResumptionData(app_id);
     return;
-  } 
-  
+  }
+
   if (IsResumptionSuccessful(app_id)) {
     SDL_LOG_DEBUG("Resumption for app " << app_id << " successful");
     callback(mobile_apis::Result::SUCCESS, "Data resumption successful");

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -315,6 +315,8 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithFiles) {
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
+  ON_CALL(mock_app_mngr_, application(kTestAppId_))
+      .WillByDefault(Return(mock_app_));
 
   smart_objects::SmartObjectList requests;
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
@@ -363,6 +365,8 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubmenues) {
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
+  ON_CALL(mock_app_mngr_, application(kTestAppId_))
+      .WillByDefault(Return(mock_app_));
 
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
 
@@ -412,6 +416,8 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithCommands) {
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
+  ON_CALL(mock_app_mngr_, application(kTestAppId_))
+      .WillByDefault(Return(mock_app_));
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
   ON_CALL(*mock_app_, help_prompt_manager())
       .WillByDefault(ReturnRef(*mock_help_prompt_manager_));
@@ -497,6 +503,8 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithChoiceSet) {
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
+  ON_CALL(mock_app_mngr_, application(kTestAppId_))
+      .WillByDefault(Return(mock_app_));
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
 
   for (uint32_t i = 0; i < count_of_choice_sets; ++i) {
@@ -538,6 +546,8 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithGlobalProperties) {
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
+  ON_CALL(mock_app_mngr_, application(kTestAppId_))
+      .WillByDefault(Return(mock_app_));
 
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
 
@@ -583,6 +593,8 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscribeOnButtons) {
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
+  ON_CALL(mock_app_mngr_, application(kTestAppId_))
+      .WillByDefault(Return(mock_app_));
 
   std::shared_ptr<sync_primitives::Lock> button_lock_ptr =
       std::make_shared<sync_primitives::Lock>();
@@ -646,6 +658,8 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToIVI) {
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
+  ON_CALL(mock_app_mngr_, application(kTestAppId_))
+      .WillByDefault(Return(mock_app_));
 
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
 
@@ -674,6 +688,8 @@ TEST_F(ResumeCtrlTest,
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
+  ON_CALL(mock_app_mngr_, application(kTestAppId_))
+      .WillByDefault(Return(mock_app_));
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
 
   smart_objects::SmartObjectSPtr subscribe_waypoints_msg;
@@ -1020,7 +1036,7 @@ TEST_F(ResumeCtrlTest,
   res_ctrl_->SetupDefaultHMILevel(mock_app_);
 }
 
-TEST_F(ResumeCtrlTest, ApplicationResumptiOnTimer_AppInFull) {
+TEST_F(ResumeCtrlTest, ApplicationResumptionTimer_AppInFull) {
   ON_CALL(mock_app_mngr_, application(kTestAppId_))
       .WillByDefault(Return(mock_app_));
 


### PR DESCRIPTION

Fixes #3720 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manual test using steps in issue description

### Summary
Adds check that app is still connected before running callback for resumption. Also fixes minor invalid read in RAI Request callback.

### Changelog
##### Bug Fixes
* Add check before running callback in FinalizeResumption
* Fix invalid read in SendRegisterAppInterfaceResponseToMobile

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
