### PR TITLE
send GetUserFriendlyMessage data in all policy modes

### DIFF
--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2290,13 +2290,11 @@ void MessageHelper::SendGetUserFriendlyMessageResponse(
 
   smart_objects::SmartObject& user_friendly_messages =
       (*message)[strings::msg_params][messages];
-#ifdef EXTERNAL_PROPRIETARY_MODE
   const std::string tts = "ttsString";
   const std::string label = "label";
   const std::string line1 = "line1";
   const std::string line2 = "line2";
   const std::string textBody = "textBody";
-#endif  // EXTERNAL_PROPRIETARY_MODE
   const std::string message_code = "messageCode";
   std::vector<policy::UserFriendlyMessage>::const_iterator it = msg.begin();
   std::vector<policy::UserFriendlyMessage>::const_iterator it_end = msg.end();
@@ -2306,7 +2304,6 @@ void MessageHelper::SendGetUserFriendlyMessageResponse(
 
     smart_objects::SmartObject& obj = user_friendly_messages[index];
     obj[message_code] = it->message_code;
-#ifdef EXTERNAL_PROPRIETARY_MODE
     if (!it->tts.empty()) {
       obj[tts] = it->tts;
     }
@@ -2322,7 +2319,6 @@ void MessageHelper::SendGetUserFriendlyMessageResponse(
     if (!it->text_body.empty()) {
       obj[textBody] = it->text_body;
     }
-#endif  // EXTERNAL_PROPRIETARY_MODE
   }
 
   app_mngr.GetRPCService().ManageHMICommand(message);


### PR DESCRIPTION
Partially closes issue #401 

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit and ATF tests

### Summary
Send message data in GetUserFriendlyMessage response regardless of policy mode.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
