### PR TITLE
Fix boost logger on release build

### DIFF
--- a/src/components/utils/CMakeLists.txt
+++ b/src/components/utils/CMakeLists.txt
@@ -71,6 +71,9 @@ endif()
 
 if (ENABLE_LOG)
   if (${LOGGER_NAME} STREQUAL "LOG4CXX")
+    list(APPEND EXCLUDE_PATHS
+      logger/boostlogger.cc
+    )
     list(APPEND LIBRARIES
     log4cxx -L${LOG4CXX_LIBS_DIRECTORY}
       apr-1 -L${APR_LIBS_DIRECTORY}

--- a/src/components/utils/CMakeLists.txt
+++ b/src/components/utils/CMakeLists.txt
@@ -89,6 +89,7 @@ else()
   list(APPEND EXCLUDE_PATHS
     auto_trace.cc
     logger/log4cxxlogger.cc
+    logger/boostlogger.cc
   )
 endif()
 

--- a/src/components/utils/src/logger/boostlogger.cc
+++ b/src/components/utils/src/logger/boostlogger.cc
@@ -138,6 +138,7 @@ logging::trivial::severity_level getBoostLogLevel(LogLevel log_level) {
       return logging::trivial::severity_level::fatal;
     default:
       assert(false);
+      return logging::trivial::severity_level::trace;
   }
 }
 


### PR DESCRIPTION
Fixes #3719 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Build sdl core with release mode

### Summary
- Add default return statement in boost logger file
- Exclude boost logger file when building log4cxx


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
