### PR TITLE
Fix cmake warning under external flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 cmake_minimum_required(VERSION 2.8.11)
+cmake_policy(SET CMP0054 NEW)
 
 set (PROJECT smartDeviceLinkCore)
 project (${PROJECT})
@@ -510,7 +511,11 @@ add_subdirectory(./src/appMain)
 add_subdirectory(./src/plugins)
 
 add_dependencies(${PROJECT} Policy)
-add_dependencies(${PROJECT} copy_policy_library)
+if(EXTENDED_POLICY STREQUAL "EXTERNAL_PROPRIETARY")
+  add_dependencies(${PROJECT} copy_library_Policy)
+else()
+  add_dependencies(${PROJECT} copy_policy_library)
+endif()
 
 # Building documentation
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 cmake_minimum_required(VERSION 2.8.11)
+cmake_policy(SET CMP0054 NEW)
 
 set (PROJECT smartDeviceLinkCore)
 project (${PROJECT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 cmake_minimum_required(VERSION 2.8.11)
-cmake_policy(SET CMP0054 NEW)
 
 set (PROJECT smartDeviceLinkCore)
 project (${PROJECT})
@@ -511,11 +510,7 @@ add_subdirectory(./src/appMain)
 add_subdirectory(./src/plugins)
 
 add_dependencies(${PROJECT} Policy)
-if(EXTENDED_POLICY STREQUAL "EXTERNAL_PROPRIETARY")
-  add_dependencies(${PROJECT} copy_library_Policy)
-else()
-  add_dependencies(${PROJECT} copy_policy_library)
-endif()
+add_dependencies(${PROJECT} copy_policy_library)
 
 # Building documentation
 

--- a/src/components/policy/policy_external/CMakeLists.txt
+++ b/src/components/policy/policy_external/CMakeLists.txt
@@ -132,7 +132,7 @@ if (ENABLE_LOG AND ${LOGGER_NAME} STREQUAL "LOG4CXX")
   target_link_libraries(Policy log4cxx -L${LOG4CXX_LIBS_DIRECTORY})
 endif()
 
-add_custom_target(copy_library_Policy ALL
+add_custom_target(copy_policy_library ALL
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
     ${CMAKE_CURRENT_BINARY_DIR}/${library_name}
     ${copy_destination}


### PR DESCRIPTION
Fixes #3544 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by CMake itself

### Summary
When CMake is called ../sdl_core -DEXTENDED_POLICY = EXTERNAL_PROPRIETARY we get a warning. Сmake did not find an added dependency. Different dependencies need to be added for different policies. EXTERNAL_PROPRIETARY has dependency "copy_library_Policy" and PROPRIETARY has copy_policy_library. So I added a policy check to establish the correct dependencies.
There was also an error with the lack of a new version of the CMP0054 policy. Added a new version of this policy.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
