### PR TITLE
Configurable time before shutdown 

### DIFF
--- a/src/appMain/main.cc
+++ b/src/appMain/main.cc
@@ -162,6 +162,7 @@ int32_t main(int32_t argc, char** argv) {
 #endif  // LOG4CXX_LOGGER
 
     logger_impl->Init(std::move(logger));
+    logger_impl->InitLoggerSettings(&profile_instance);
   }
 #endif
 

--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -411,3 +411,9 @@ RpcPassThroughTimeout = 10000
 [RCModuleConsent]
 ; The period (in days) after which consent for module_id should be removed.
 PeriodForConsentExpiration = 30
+
+[Logger]
+; Write all logs in queue to file system before shutdown 
+FlushLogMessagesBeforeShutdown = false
+; Maximum time to wait for writing all data before exit SDL in seconds
+MaxTimeBeforeShutdown = 30

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_exit_all_applications_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_exit_all_applications_notification.cc
@@ -35,6 +35,7 @@
 #include <signal.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <chrono>
 
 #include "application_manager/application_manager.h"
 #include "application_manager/resumption/resume_ctrl.h"
@@ -104,6 +105,8 @@ void OnExitAllApplicationsNotification::Run() {
           mob_reason) {
     application_manager_.HeadUnitReset(mob_reason);
   }
+
+  SDL_INIT_FLUSH_LOGS_TIME_POINT(std::chrono::system_clock::now());
   kill(getpid(), SIGINT);
 }
 

--- a/src/components/config_profile/include/config_profile/profile.h
+++ b/src/components/config_profile/include/config_profile/profile.h
@@ -46,6 +46,7 @@
 #include "protocol_handler/protocol_handler_settings.h"
 #include "smart_objects/smart_object.h"
 #include "transport_manager/transport_manager_settings.h"
+#include "utils/logger/logger_settings.h"
 #include "utils/macro.h"
 
 namespace profile {
@@ -59,7 +60,8 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
                 public media_manager::MediaManagerSettings,
                 public policy::PolicySettings,
                 public transport_manager::TransportManagerSettings,
-                public application_manager::ApplicationManagerSettings {
+                public application_manager::ApplicationManagerSettings,
+                public logger::LoggerSettings {
  public:
   // Methods section
 
@@ -589,6 +591,18 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
 
   const std::vector<std::string>& embedded_services() const OVERRIDE;
   const std::string hmi_origin_id() const OVERRIDE;
+
+  /**
+   * @brief  Returns true if writing all logs to file system before shutdown is
+   * enabled
+   */
+  bool flush_log_messages_before_shutdown() const OVERRIDE;
+  /**
+   * @brief  Returns waximum time to wait for writing all data before exit SDL
+   * in seconds
+   */
+  uint16_t max_time_before_shutdown() const OVERRIDE;
+
   /**
    * @brief Reads a string value from the profile
    *
@@ -1164,6 +1178,8 @@ class Profile : public protocol_handler::ProtocolHandlerSettings,
   int ignition_off_signal_offset_;
   uint32_t rpc_pass_through_timeout_;
   uint16_t period_for_consent_expiration_;
+  bool flush_log_messages_before_shutdown_;
+  uint16_t max_time_before_shutdown_;
 
   std::vector<std::string> embedded_services_;
 

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -97,6 +97,7 @@ const char* kLowBandwidthTransportResumptionLevelSection =
     "LowBandwidthTransportResumptionLevel";
 const char* kAppServicesSection = "AppServices";
 const char* kRCModuleConsentSection = "RCModuleConsent";
+const char* kLoggerSection = "Logger";
 
 const char* kSDLVersionKey = "SDLVersion";
 const char* kHmiCapabilitiesKey = "HMICapabilities";
@@ -307,6 +308,8 @@ const char* kMediaLowBandwidthResumptionLevelKey =
     "MediaLowBandwidthResumptionLevel";
 const char* kHMIOriginIDKey = "HMIOriginID";
 const char* kEmbeddedServicesKey = "EmbeddedServices";
+const char* kFlushLogMessagesBeforeShutdown = "FlushLogMessagesBeforeShutdown";
+const char* kMaxTimeBeforeShutdown = "MaxTimeBeforeShutdown";
 
 #ifdef WEB_HMI
 const char* kDefaultLinkToWebHMI = "HMI/index.html";
@@ -442,6 +445,9 @@ const char* kDefaultAOAFilterDescription = "SmartDeviceLink Core Component USB";
 const char* kDefaultAOAFilterVersion = "1.0";
 const char* kDefaultAOAFilterURI = "http://www.smartdevicelink.org";
 const char* kDefaultAOAFilterSerialNumber = "N000000";
+
+const bool kDefaultFlushLogMessagesBeforeShutdown = false;
+const uint16_t kDefaultMaxTimeBeforeShutdown = 30;
 }  // namespace
 
 namespace profile {
@@ -571,7 +577,10 @@ Profile::Profile()
     , wake_up_signal_offset_(kDefaultWakeUpSignalOffset)
     , ignition_off_signal_offset_(kDefaultIgnitionOffSignalOffset)
     , rpc_pass_through_timeout_(kDefaultRpcPassThroughTimeout)
-    , period_for_consent_expiration_(kDefaultPeriodForConsentExpiration) {
+    , period_for_consent_expiration_(kDefaultPeriodForConsentExpiration)
+    , flush_log_messages_before_shutdown_(
+          kDefaultFlushLogMessagesBeforeShutdown)
+    , max_time_before_shutdown_(kDefaultMaxTimeBeforeShutdown) {
 }
 
 Profile::~Profile() {}
@@ -1195,6 +1204,14 @@ const std::vector<std::string>& Profile::audio_service_transports() const {
 
 const std::vector<std::string>& Profile::video_service_transports() const {
   return video_service_transports_;
+}
+
+bool Profile::flush_log_messages_before_shutdown() const {
+  return flush_log_messages_before_shutdown_;
+}
+
+uint16_t Profile::max_time_before_shutdown() const {
+  return max_time_before_shutdown_;
 }
 
 const bool Profile::ErrorOccured() const {
@@ -2680,6 +2697,16 @@ void Profile::UpdateValues() {
                   kHMIOriginIDKey);
 
   LOG_UPDATED_VALUE(hmi_origin_id_, kHMIOriginIDKey, kAppServicesSection);
+
+  ReadBoolValue(&flush_log_messages_before_shutdown_,
+                kDefaultFlushLogMessagesBeforeShutdown,
+                kLoggerSection,
+                kFlushLogMessagesBeforeShutdown);
+
+  ReadUIntValue(&max_time_before_shutdown_,
+                kDefaultMaxTimeBeforeShutdown,
+                kLoggerSection,
+                kMaxTimeBeforeShutdown);
 
   {  // App Services map
     struct KeyPair {

--- a/src/components/include/utils/conditional_variable.h
+++ b/src/components/include/utils/conditional_variable.h
@@ -35,6 +35,7 @@
 #include <stdint.h>
 #include <boost/thread/condition_variable.hpp>
 
+#include <functional>
 #include "utils/lock.h"
 #include "utils/macro.h"
 
@@ -73,6 +74,9 @@ class ConditionalVariable {
   bool Wait(AutoLock& auto_lock);
   bool Wait(BaseLock& lock);
   WaitStatus WaitFor(AutoLock& auto_lock, uint32_t milliseconds);
+  void WaitFor(AutoLock& lock,
+               uint16_t seconds,
+               std::function<bool()> predicate);
 
  private:
   boost::condition_variable_any cond_var_;

--- a/src/components/include/utils/ilogger.h
+++ b/src/components/include/utils/ilogger.h
@@ -36,6 +36,8 @@
 #include <string>
 #include <thread>
 
+#include "utils/logger/logger_settings.h"
+
 namespace logger {
 
 enum class LogLevel {
@@ -71,6 +73,8 @@ class Logger {
   virtual void DeInit() = 0;
   virtual void Flush() = 0;
   virtual void PushLog(const LogMessage& log_message) = 0;
+  virtual void InitLoggerSettings(LoggerSettings* settings) = 0;
+  virtual void InitFlushLogsTimePoint(const TimePoint& time_point) = 0;
   static Logger& instance(Logger* pre_init = nullptr);
 };
 

--- a/src/components/include/utils/logger.h
+++ b/src/components/include/utils/logger.h
@@ -52,6 +52,9 @@
 // it's needed, for example, when crash happened
 #define SDL_FLUSH_LOGGER() logger::Logger::instance().Flush();
 
+#define SDL_INIT_FLUSH_LOGS_TIME_POINT(time_point) \
+  logger::Logger::instance().InitFlushLogsTimePoint(time_point);
+
 // Logger deinitilization function and macro, need to stop log4cxx writing
 // without this deinitilization log4cxx threads continue using some instances
 // destroyed by exit()
@@ -107,6 +110,8 @@
 #define SDL_CREATE_LOG_VARIABLE(x)
 
 #define SDL_CREATE_LOCAL_LOG_VARIABLE(x)
+
+#define SDL_INIT_FLUSH_LOGS_TIME_POINT(x)
 
 #define SDL_DEINIT_LOGGER()
 

--- a/src/components/include/utils/message_queue.h
+++ b/src/components/include/utils/message_queue.h
@@ -103,6 +103,12 @@ class MessageQueue {
   void WaitUntilEmpty();
 
   /**
+   * \brief Wait until message queue is empty for certain time
+   * \param seconds seconds to wait
+   */
+  void TimedWaitUntilEmpty(uint16_t seconds);
+
+  /**
    * \brief Shutdown the queue.
    * This leads to waking up everyone waiting on the queue
    * Queue being shut down can be drained ( with pop() )
@@ -150,6 +156,14 @@ void MessageQueue<T, Q>::WaitUntilEmpty() {
   while ((!shutting_down_) && !queue_.empty()) {
     queue_new_items_.Wait(auto_lock);
   }
+}
+
+template <typename T, class Q>
+void MessageQueue<T, Q>::TimedWaitUntilEmpty(uint16_t seconds) {
+  sync_primitives::AutoLock auto_lock(queue_lock_);
+  queue_new_items_.WaitFor(auto_lock, seconds, [this] {
+    return (queue_.empty() || shutting_down_);
+  });
 }
 
 template <typename T, class Q>

--- a/src/components/include/utils/threads/message_loop_thread.h
+++ b/src/components/include/utils/threads/message_loop_thread.h
@@ -96,6 +96,12 @@ class MessageLoopThread {
    */
   void WaitDumpQueue();
 
+  /**
+   * \brief Wait until message queue is empty for certain time
+   * \param seconds seconds to wait
+   */
+  void TimedWaitDumpQueue(uint16_t seconds);
+
  private:
   /*
    * Implementation of ThreadDelegate that actually pumps the queue and is
@@ -166,6 +172,11 @@ void MessageLoopThread<Q>::Shutdown() {
 template <class Q>
 void MessageLoopThread<Q>::WaitDumpQueue() {
   message_queue_.WaitUntilEmpty();
+}
+
+template <class Q>
+void MessageLoopThread<Q>::TimedWaitDumpQueue(uint16_t seconds) {
+  message_queue_.TimedWaitUntilEmpty(seconds);
 }
 
 //////////

--- a/src/components/utils/include/utils/logger/logger_impl.h
+++ b/src/components/utils/include/utils/logger/logger_impl.h
@@ -74,10 +74,14 @@ class LoggerImpl : public Logger, public LoggerInitializer {
   bool IsEnabledFor(const std::string& component,
                     LogLevel log_level) const override;
   void PushLog(const LogMessage& log_message) override;
+  void InitLoggerSettings(LoggerSettings* settings) override;
+  void InitFlushLogsTimePoint(const TimePoint& time_point) override;
 
   std::unique_ptr<ThirdPartyLoggerInterface> impl_;
+  LoggerSettings* settings_;
   LoopThreadPtr<LogMessageLoopThread> loop_thread_;
   bool use_message_loop_thread_;
+  TimePoint flush_logs_time_point_;
 };
 
 }  // namespace logger

--- a/src/components/utils/include/utils/logger/logger_settings.h
+++ b/src/components/utils/include/utils/logger/logger_settings.h
@@ -1,0 +1,15 @@
+#ifndef SRC_COMPONENTS_UTILS_INCLUDE_UTILS_LOGGER_SETTINGS_H_
+#define SRC_COMPONENTS_UTILS_INCLUDE_UTILS_LOGGER_SETTINGS_H_
+
+#include <stdint.h>
+
+namespace logger {
+class LoggerSettings {
+ public:
+  virtual bool flush_log_messages_before_shutdown() const = 0;
+  virtual uint16_t max_time_before_shutdown() const = 0;
+};
+
+}  // namespace logger
+
+#endif  // SRC_COMPONENTS_UTILS_INCLUDE_UTILS_LOGGER_SETTINGS_H_


### PR DESCRIPTION
Implements #1941

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF scripts

### Summary
Add Logger config settings with params for configurable time before shutdown.
Update SDL config.
Extend LoggerImpl class for shutdown configuration.
Extend MessageLoopThread, MessageQueque and ConditionlVariable classes with new wait mechanism.

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
