### PR TITLE
Fix handling of RC.SetGlobalProperties response

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -274,6 +274,22 @@ class CommandRequestImpl : public CommandImpl,
                                       ResponseInfo& out_second) const;
 
   /**
+   * @brief Checks result code from HMI for splitted RPC
+   * and returns parameter for sending to mobile app.
+   * @param first contains result_code from HMI response and
+   * interface that returns response
+   * @param second contains result_code from HMI response and
+   * interface that returns response
+   * * @param third contains result_code from HMI response and
+   * interface that returns response
+   * @return true if result code complies successful result code
+   * otherwise returns false
+   */
+  bool PrepareResultForMobileResponse(ResponseInfo& out_first,
+                                      ResponseInfo& out_second,
+                                      ResponseInfo& out_third) const;
+
+  /**
    * @brief If message from HMI contains returns this info
    * or process result code from HMI and checks state of interface
    * and create info.
@@ -295,6 +311,19 @@ class CommandRequestImpl : public CommandImpl,
    */
   mobile_apis::Result::eType PrepareResultCodeForResponse(
       const ResponseInfo& first, const ResponseInfo& second);
+
+  /**
+   * @brief Prepare result code for sending to mobile application
+   * @param first contains result_code from HMI response and
+   * interface that returns response
+   * @param second contains result_code from HMI response and
+   * interface that returns response.
+   * @return resulting code for sending to mobile application.
+   */
+  mobile_apis::Result::eType PrepareResultCodeForResponse(
+      const ResponseInfo& first,
+      const ResponseInfo& second,
+      const ResponseInfo& third);
 
   /**
    * @brief Resolves if the return code must be

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -276,11 +276,11 @@ class CommandRequestImpl : public CommandImpl,
   /**
    * @brief Checks result code from HMI for splitted RPC
    * and returns parameter for sending to mobile app.
-   * @param first contains result_code from HMI response and
+   * @param out_first Contains result_code from HMI response and
    * interface that returns response
-   * @param second contains result_code from HMI response and
+   * @param out_second Contains result_code from HMI response and
    * interface that returns response
-   * * @param third contains result_code from HMI response and
+   * @param out_third Contains result_code from HMI response and
    * interface that returns response
    * @return true if result code complies successful result code
    * otherwise returns false

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/reset_global_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/reset_global_properties_request.h
@@ -105,7 +105,9 @@ class ResetGlobalPropertiesRequest
 
   hmi_apis::Common_Result::eType ui_result_;
   hmi_apis::Common_Result::eType tts_result_;
+  hmi_apis::Common_Result::eType rc_result_;
   std::string ui_response_info_;
+  std::string rc_response_info_;
   std::string tts_response_info_;
 };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
@@ -220,7 +220,8 @@ bool ResetGlobalPropertiesRequest::PrepareResponseParameters(
 
 bool ResetGlobalPropertiesRequest::IsPendingResponseExist() {
   return IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_TTS) ||
-         IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_UI);
+         IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_UI) ||
+         IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_RC);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
@@ -282,6 +282,42 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   command_->on_event(event);
 }
 
+TEST_F(ResetGlobalPropertiesRequestTest,
+       OnEvent_RC_SetGlobalProperties_SUCCESS) {
+  am::ResetGlobalPropertiesResult result;
+  result.user_location = true;
+
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateRCResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageHMICommand(
+          HMIResultCodeIs(hmi_apis::FunctionID::RC_SetGlobalProperties), _))
+      .WillOnce(Return(true));
+
+  command_->Run();
+
+  EXPECT_CALL(mock_rpc_service_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_apis::Result::eType::SUCCESS),
+                  am::commands::Command::SOURCE_SDL));
+
+  (*msg_)[am::strings::params][am::hmi_response::code] =
+      hmi_apis::Common_Result::SUCCESS;
+
+  Event event(hmi_apis::FunctionID::RC_SetGlobalProperties);
+  event.set_smart_object(*msg_);
+
+  command_->on_event(event);
+}
+
 TEST_F(ResetGlobalPropertiesResponseTest, Run_Sendmsg_SUCCESS) {
   MessageSharedPtr message(CreateMessage());
   ResetGlobalPropertiesResponsePtr command(

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -748,6 +748,16 @@ bool CommandRequestImpl::PrepareResultForMobileResponse(
   return result;
 }
 
+bool CommandRequestImpl::PrepareResultForMobileResponse(
+    ResponseInfo& out_first,
+    ResponseInfo& out_second,
+    ResponseInfo& out_third) const {
+  SDL_LOG_AUTO_TRACE();
+  bool result = PrepareResultForMobileResponse(out_first, out_second) ||
+                PrepareResultForMobileResponse(out_second, out_third);
+  return result;
+}
+
 void CommandRequestImpl::GetInfo(
     const smart_objects::SmartObject& response_from_hmi,
     std::string& out_info) {
@@ -785,6 +795,19 @@ mobile_apis::Result::eType CommandRequestImpl::PrepareResultCodeForResponse(
   mobile_apis::Result::eType result_code =
       MessageHelper::HMIToMobileResult(std::max(first_result, second_result));
   return result_code;
+}
+
+mobile_apis::Result::eType CommandRequestImpl::PrepareResultCodeForResponse(
+    const ResponseInfo& first,
+    const ResponseInfo& second,
+    const ResponseInfo& third) {
+  SDL_LOG_AUTO_TRACE();
+
+  const auto first_comparison = PrepareResultCodeForResponse(first, second);
+  const auto second_comparison = PrepareResultCodeForResponse(second, third);
+  const auto third_comparison = PrepareResultCodeForResponse(first, third);
+
+  return std::max({first_comparison, second_comparison, third_comparison});
 }
 
 const CommandParametersPermissions& CommandRequestImpl::parameters_permissions()

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -753,8 +753,9 @@ bool CommandRequestImpl::PrepareResultForMobileResponse(
     ResponseInfo& out_second,
     ResponseInfo& out_third) const {
   SDL_LOG_AUTO_TRACE();
-  bool result = PrepareResultForMobileResponse(out_first, out_second) ||
-                PrepareResultForMobileResponse(out_second, out_third);
+  bool result = (PrepareResultForMobileResponse(out_first, out_second) ||
+                 PrepareResultForMobileResponse(out_second, out_third)) &&
+                PrepareResultForMobileResponse(out_first, out_third);
   return result;
 }
 


### PR DESCRIPTION
Fixes #3668 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Can be reproduced manually:
- Send ResetGlobalProperties with "USER_LOCATION"
- App→SDL: ResetGlobalProperties (USER_LOCATION)

**Expected Behavior**
SDL sends RC.SetGlobalProperties request with default driver seat location properties to HMI
SDL→HMI: RC.SetGlobalProperties (
{ "userLocation":{"grid":{"col":0, "level":0,"row":0, "colspan":1,"levelspan":1, "rowspan":1 }}}
HMI→SDL: RC.SetGlobalProperties ( SUCCESS )
SDL→App: ResetGlobalProperties( "success":true, resultCode":"SUCCESS" )

**Observed Behavior**
SDL→App: ResetGlobalProperties( "success":false , "resultCode":"GENERIC_ERROR")

### Summary
SDL sends `RC.SetGlobalProperties` request to HMI, however does not process a response from HMI. There was added processing of RC part of the request and covered by new unit test to fix that.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
