### PR TITLE
Remove dependency between optional params in OnRemoteControlSettings

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc
@@ -87,35 +87,34 @@ void RCOnRemoteControlSettingsNotification::DisallowRCFunctionality() {
 void RCOnRemoteControlSettingsNotification::Run() {
   SDL_LOG_AUTO_TRACE();
 
-  if (!(*message_)[app_mngr::strings::msg_params].keyExists(
-          message_params::kAllowed)) {
+  if ((*message_)[app_mngr::strings::msg_params].empty()) {
     SDL_LOG_DEBUG("Notification is ignored due to \"allow\" parameter absense");
     SDL_LOG_DEBUG("RC Functionality remains unchanged");
     return;
   }
 
+  hmi_apis::Common_RCAccessMode::eType access_mode =
+      hmi_apis::Common_RCAccessMode::INVALID_ENUM;
+  if ((*message_)[app_mngr::strings::msg_params].keyExists(
+          message_params::kAccessMode)) {
+    access_mode = static_cast<hmi_apis::Common_RCAccessMode::eType>(
+        (*message_)[app_mngr::strings::msg_params][message_params::kAccessMode]
+            .asUInt());
+    SDL_LOG_DEBUG(
+        "Setting up access mode : " << AccessModeToString(access_mode));
+  } else {
+    access_mode = resource_allocation_manager_.GetAccessMode();
+    SDL_LOG_DEBUG("No access mode received. Using last known: "
+                  << AccessModeToString(access_mode));
+  }
+  resource_allocation_manager_.SetAccessMode(access_mode);
+
   const bool is_allowed =
       (*message_)[app_mngr::strings::msg_params][message_params::kAllowed]
           .asBool();
   if (is_allowed) {
-    hmi_apis::Common_RCAccessMode::eType access_mode =
-        hmi_apis::Common_RCAccessMode::INVALID_ENUM;
     SDL_LOG_DEBUG("Allowing RC Functionality");
     resource_allocation_manager_.set_rc_enabled(true);
-    if ((*message_)[app_mngr::strings::msg_params].keyExists(
-            message_params::kAccessMode)) {
-      access_mode = static_cast<hmi_apis::Common_RCAccessMode::eType>(
-          (*message_)[app_mngr::strings::msg_params]
-                     [message_params::kAccessMode]
-                         .asUInt());
-      SDL_LOG_DEBUG(
-          "Setting up access mode : " << AccessModeToString(access_mode));
-    } else {
-      access_mode = resource_allocation_manager_.GetAccessMode();
-      SDL_LOG_DEBUG("No access mode received. Using last known: "
-                    << AccessModeToString(access_mode));
-    }
-    resource_allocation_manager_.SetAccessMode(access_mode);
   } else {
     SDL_LOG_DEBUG("Disallowing RC Functionality");
     DisallowRCFunctionality();

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc
@@ -88,7 +88,7 @@ void RCOnRemoteControlSettingsNotification::Run() {
   SDL_LOG_AUTO_TRACE();
 
   if ((*message_)[app_mngr::strings::msg_params].empty()) {
-    SDL_LOG_DEBUG("Notification is ignored due to \"allow\" parameter absense");
+    SDL_LOG_DEBUG("Notification is ignored due to absence of any parameters");
     SDL_LOG_DEBUG("RC Functionality remains unchanged");
     return;
   }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_remote_control_settings_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_remote_control_settings_test.cc
@@ -145,9 +145,10 @@ TEST_F(RCOnRemoteControlSettingsNotificationTest,
   MessageSharedPtr mobile_message = CreateBasicMessage();
   (*mobile_message)[application_manager::strings::msg_params]
                    [message_params::kAllowed] = false;
-
-  EXPECT_CALL(mock_allocation_manager_, ResetAllAllocations());
+  ON_CALL(mock_allocation_manager_, GetAccessMode())
+      .WillByDefault(Return(hmi_apis::Common_RCAccessMode::ASK_DRIVER));
   EXPECT_CALL(mock_interior_data_manager_, OnDisablingRC());
+  EXPECT_CALL(mock_allocation_manager_, ResetAllAllocations());
   EXPECT_CALL(mock_rc_consent_manger_, RemoveAllConsents());
 
   // Act


### PR DESCRIPTION
Fixes #2845

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan

##### Reproduction Steps
From HMI send a `OnRemoteControlSettings`  notification with only `accessMode` parameter.

##### Expected Behavior
SDL update its internal value of `accessMode`.

##### Observed Behavior
SDL does not update its internal value of `accessMode`.


### Summary
The current SDL behavior (please see [RCOnRemoteControlSettingsNotification::Run](https://github.com/smartdevicelink/sdl_core/blob/d36316738785c96dab2ee892762ed08c059fffde/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_on_remote_control_settings_notification.cc#95)) is to ignore the `accessMode` parameter if `allowed` parameter does not exist or `allowed=false` in the notification.
That means `allowed` is mandatory and HMI shall always include  `allowed` parameter, however it may be optional according to API.
The proposed solution removes the dependency between `accessMode` and `allowed` parameters.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
