### PR TITLE
Fix SDL crash on validation of numeric schemas with type overflow

### DIFF
--- a/src/components/smart_objects/include/smart_objects/number_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/number_schema_item.h
@@ -135,6 +135,7 @@ bool TNumberSchemaItem<NumberType>::isValidNumberType(SmartType type) {
                  typeid(int32_t),
                  typeid(uint32_t),
                  typeid(int64_t),
+                 typeid(uint64_t),
                  typeid(double))) {
     return true;
   }
@@ -238,6 +239,9 @@ SmartType TNumberSchemaItem<uint32_t>::getSmartType() const;
 
 template <>
 SmartType TNumberSchemaItem<int64_t>::getSmartType() const;
+
+template <>
+SmartType TNumberSchemaItem<uint64_t>::getSmartType() const;
 
 template <>
 SmartType TNumberSchemaItem<double>::getSmartType() const;

--- a/src/components/smart_objects/include/smart_objects/number_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/number_schema_item.h
@@ -160,17 +160,17 @@ errors::eType TNumberSchemaItem<NumberType>::validate(
 
   NumberType value(0);
   if (typeid(int32_t) == typeid(value)) {
-    if (Object.asInt() > std::numeric_limits<int32_t>::max() ||
-        Object.asInt() < std::numeric_limits<int32_t>::min()) {
+    if (Object.asInt() < std::numeric_limits<int32_t>::min() ||
+        Object.asInt() > std::numeric_limits<int32_t>::max()) {
       return errors::OUT_OF_RANGE;
     }
-    value = static_cast<int32_t>(Object.asInt());
+    value = Object.asInt();
   } else if (typeid(uint32_t) == typeid(value)) {
-    if (Object.asUInt() > std::numeric_limits<uint32_t>::max() ||
-        Object.asUInt() < std::numeric_limits<uint32_t>::min()) {
+    if (Object.asUInt() < std::numeric_limits<uint32_t>::min() ||
+        Object.asUInt() > std::numeric_limits<uint32_t>::max()) {
       return errors::OUT_OF_RANGE;
     }
-    value = static_cast<uint32_t>(Object.asUInt());
+    value = Object.asUInt();
   } else if (typeid(double) == typeid(value)) {
     value = Object.asDouble();
   } else if (typeid(int64_t) == typeid(value)) {

--- a/src/components/smart_objects/include/smart_objects/number_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/number_schema_item.h
@@ -157,11 +157,20 @@ errors::eType TNumberSchemaItem<NumberType>::validate(
     report->set_validation_info(validation_info);
     return errors::INVALID_VALUE;
   }
+
   NumberType value(0);
   if (typeid(int32_t) == typeid(value)) {
-    value = utils::SafeStaticCast<int64_t, int32_t>(Object.asInt());
+    if (Object.asInt() > std::numeric_limits<int32_t>::max() ||
+        Object.asInt() < std::numeric_limits<int32_t>::min()) {
+      return errors::OUT_OF_RANGE;
+    }
+    value = static_cast<int32_t>(Object.asInt());
   } else if (typeid(uint32_t) == typeid(value)) {
-    value = utils::SafeStaticCast<uint64_t, uint32_t>(Object.asUInt());
+    if (Object.asUInt() > std::numeric_limits<uint32_t>::max() ||
+        Object.asUInt() < std::numeric_limits<uint32_t>::min()) {
+      return errors::OUT_OF_RANGE;
+    }
+    value = static_cast<uint32_t>(Object.asUInt());
   } else if (typeid(double) == typeid(value)) {
     value = Object.asDouble();
   } else if (typeid(int64_t) == typeid(value)) {

--- a/src/components/smart_objects/include/smart_objects/number_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/number_schema_item.h
@@ -167,8 +167,8 @@ errors::eType TNumberSchemaItem<NumberType>::validate(
     }
     value = Object.asInt();
   } else if (typeid(uint32_t) == typeid(value)) {
-    if (Object.asUInt() < std::numeric_limits<uint32_t>::min() ||
-        Object.asUInt() > std::numeric_limits<uint32_t>::max()) {
+    if (Object.asInt() < std::numeric_limits<uint32_t>::min() ||
+        Object.asInt() > std::numeric_limits<uint32_t>::max()) {
       return errors::OUT_OF_RANGE;
     }
     value = Object.asUInt();

--- a/src/components/smart_objects/include/smart_objects/number_schema_item.h
+++ b/src/components/smart_objects/include/smart_objects/number_schema_item.h
@@ -163,12 +163,18 @@ errors::eType TNumberSchemaItem<NumberType>::validate(
   if (typeid(int32_t) == typeid(value)) {
     if (Object.asInt() < std::numeric_limits<int32_t>::min() ||
         Object.asInt() > std::numeric_limits<int32_t>::max()) {
+      const std::string validation_info =
+          "Value " + Object.asString() + " out of int32 range";
+      report->set_validation_info(validation_info);
       return errors::OUT_OF_RANGE;
     }
     value = Object.asInt();
   } else if (typeid(uint32_t) == typeid(value)) {
     if (Object.asInt() < std::numeric_limits<uint32_t>::min() ||
         Object.asInt() > std::numeric_limits<uint32_t>::max()) {
+      const std::string validation_info =
+          "Value " + Object.asString() + " out of uint32 range";
+      report->set_validation_info(validation_info);
       return errors::OUT_OF_RANGE;
     }
     value = Object.asUInt();

--- a/src/components/smart_objects/src/number_schema_item.cc
+++ b/src/components/smart_objects/src/number_schema_item.cc
@@ -50,6 +50,11 @@ SmartType TNumberSchemaItem<int64_t>::getSmartType() const {
 }
 
 template <>
+SmartType TNumberSchemaItem<uint64_t>::getSmartType() const {
+  return SmartType_UInteger;
+}
+
+template <>
 SmartType TNumberSchemaItem<double>::getSmartType() const {
   return SmartType_Double;
 }

--- a/src/components/utils/include/utils/convert_utils.h
+++ b/src/components/utils/include/utils/convert_utils.h
@@ -70,20 +70,6 @@ unsigned long long int ConvertUInt64ToLongLongUInt(const uint64_t value);
 uint64_t ConvertLongLongUIntToUInt64(const unsigned long long int value);
 
 /**
- * @brief Convert one number value to another type value
- * @param value to be converted
- * @return conversion result
- */
-template <typename InputType, typename OutputType>
-OutputType SafeStaticCast(const InputType value) {
-  DCHECK_OR_RETURN(value >= std::numeric_limits<OutputType>::min(),
-                   std::numeric_limits<OutputType>::min());
-  DCHECK_OR_RETURN(value <= std::numeric_limits<OutputType>::max(),
-                   std::numeric_limits<OutputType>::max());
-  return static_cast<OutputType>(value);
-}
-
-/**
  * @brief Convert binary data to a string value
  * @param data raw binary data
  * @param data_size string length. Required to check whether the data is a

--- a/tools/InterfaceGenerator/generator/generators/SmartFactoryBase.py
+++ b/tools/InterfaceGenerator/generator/generators/SmartFactoryBase.py
@@ -840,20 +840,21 @@ class CodeGenerator(object):
                     [[u"bool", None if param.default_value is None
                       else u"true" if param.default_value is True else u"false"]]))
         elif type(param) is Integer:
-            if (param.min_value is not None and param.min_value >= 0) and (param.max_value is None or param.max_value >= 2 ** 32):
-                code = self._impl_code_integer_item_template.substitute(
-                    type=u"uint64_t",
-                    params=self._gen_schema_item_param_values(
-                        [[u"uint64_t", param.min_value],
-                         [u"uint64_t", param.max_value],
-                         [u"uint64_t", param.default_value]]))
-            elif (param.min_value is not None and param.min_value >= 0) and (param.max_value is not None and param.max_value < 2 ** 32):
-                code = self._impl_code_integer_item_template.substitute(
-                    type=u"uint32_t",
-                    params=self._gen_schema_item_param_values(
-                        [[u"uint32_t", param.min_value],
-                         [u"uint32_t", param.max_value],
-                         [u"uint32_t", param.default_value]]))
+            if param.min_value is not None and param.min_value >= 0:
+                if param.max_value is None or param.max_value >= 2 ** 32:
+                    code = self._impl_code_integer_item_template.substitute(
+                        type=u"uint64_t",
+                        params=self._gen_schema_item_param_values(
+                            [[u"uint64_t", param.min_value],
+                             [u"uint64_t", param.max_value],
+                             [u"uint64_t", param.default_value]]))
+                else:
+                    code = self._impl_code_integer_item_template.substitute(
+                        type=u"uint32_t",
+                        params=self._gen_schema_item_param_values(
+                            [[u"uint32_t", param.min_value],
+                             [u"uint32_t", param.max_value],
+                             [u"uint32_t", param.default_value]]))
             elif  (param.min_value is not None and param.min_value > -(2 ** 31) and param.min_value < 0) and (param.max_value is not None and param.max_value < 2 ** 31):
                 code = self._impl_code_integer_item_template.substitute(
                     type=u"int32_t",

--- a/tools/InterfaceGenerator/generator/generators/SmartFactoryBase.py
+++ b/tools/InterfaceGenerator/generator/generators/SmartFactoryBase.py
@@ -855,14 +855,14 @@ class CodeGenerator(object):
                             [[u"uint32_t", param.min_value],
                              [u"uint32_t", param.max_value],
                              [u"uint32_t", param.default_value]]))
-            elif  (param.min_value is not None and param.min_value > -(2 ** 31) and param.min_value < 0) and (param.max_value is not None and param.max_value < 2 ** 31):
+            elif (param.min_value is not None and param.min_value >= -(2 ** 31)) and (param.max_value is not None and param.max_value < 2 ** 31):
                 code = self._impl_code_integer_item_template.substitute(
                     type=u"int32_t",
                     params=self._gen_schema_item_param_values(
-                        [[u"int32_t", param.min_value], 
+                        [[u"int32_t", param.min_value],
                          [u"int32_t", param.max_value],
                          [u"int32_t", param.default_value]]))
-            elif (param.min_value is None or param.min_value > -(2 ** 63)) and (param.max_value is None or param.max_value < 2 ** 63):
+            elif (param.min_value is None or param.min_value >= -(2 ** 63)) and (param.max_value is None or param.max_value < 2 ** 63):
                 code = self._impl_code_integer_item_template.substitute(
                     type=u"int64_t",
                     params=self._gen_schema_item_param_values(

--- a/tools/InterfaceGenerator/generator/generators/SmartFactoryBase.py
+++ b/tools/InterfaceGenerator/generator/generators/SmartFactoryBase.py
@@ -840,7 +840,7 @@ class CodeGenerator(object):
                     [[u"bool", None if param.default_value is None
                       else u"true" if param.default_value is True else u"false"]]))
         elif type(param) is Integer:
-            if (param.min_value is not None and param.min_value >= 0) and (param.max_value is None  or param.max_value >= 2 ** 31):
+            if (param.min_value is not None and param.min_value >= 0) and (param.max_value is None or param.max_value >= 2 ** 32):
                 code = self._impl_code_integer_item_template.substitute(
                     type=u"uint64_t",
                     params=self._gen_schema_item_param_values(
@@ -854,14 +854,14 @@ class CodeGenerator(object):
                         [[u"uint32_t", param.min_value],
                          [u"uint32_t", param.max_value],
                          [u"uint32_t", param.default_value]]))
-            elif  (param.min_value is None or param.min_value >= -(2 ** 31) and param.min_value < 0) and (param.max_value is not None and param.max_value < 2 ** 31):
+            elif  (param.min_value is not None and param.min_value > -(2 ** 31) and param.min_value < 0) and (param.max_value is not None and param.max_value < 2 ** 31):
                 code = self._impl_code_integer_item_template.substitute(
                     type=u"int32_t",
                     params=self._gen_schema_item_param_values(
                         [[u"int32_t", param.min_value], 
                          [u"int32_t", param.max_value],
                          [u"int32_t", param.default_value]]))
-            elif (param.min_value is None or param.min_value < -(2 ** 31) ) and (param.max_value is None or param.max_value < 2 ** 63):
+            elif (param.min_value is None or param.min_value > -(2 ** 63)) and (param.max_value is None or param.max_value < 2 ** 63):
                 code = self._impl_code_integer_item_template.substitute(
                     type=u"int64_t",
                     params=self._gen_schema_item_param_values(
@@ -869,7 +869,7 @@ class CodeGenerator(object):
                          [u"int64_t", param.max_value],
                          [u"int64_t", param.default_value]]))
             else:
-                raise GenerateError("Parameter value too large: " + str(param.max_value))
+                raise GenerateError("Parameter value too large/small: " + str(param.min_value) + "/" + str(param.max_value))
         elif type(param) is Float:
             code = self._impl_code_integer_item_template.substitute(
                 type=u"double",

--- a/tools/InterfaceGenerator/generator/generators/SmartFactoryBase.py
+++ b/tools/InterfaceGenerator/generator/generators/SmartFactoryBase.py
@@ -840,19 +840,33 @@ class CodeGenerator(object):
                     [[u"bool", None if param.default_value is None
                       else u"true" if param.default_value is True else u"false"]]))
         elif type(param) is Integer:
-            if not param.max_value or param.max_value and param.max_value < 2 ** 31:
+            if (param.min_value is not None and param.min_value >= 0) and (param.max_value is None  or param.max_value >= 2 ** 31):
+                code = self._impl_code_integer_item_template.substitute(
+                    type=u"uint64_t",
+                    params=self._gen_schema_item_param_values(
+                        [[u"uint64_t", param.min_value],
+                         [u"uint64_t", param.max_value],
+                         [u"uint64_t", param.default_value]]))
+            elif (param.min_value is not None and param.min_value >= 0) and (param.max_value is not None and param.max_value < 2 ** 32):
+                code = self._impl_code_integer_item_template.substitute(
+                    type=u"uint32_t",
+                    params=self._gen_schema_item_param_values(
+                        [[u"uint32_t", param.min_value],
+                         [u"uint32_t", param.max_value],
+                         [u"uint32_t", param.default_value]]))
+            elif  (param.min_value is None or param.min_value >= -(2 ** 31) and param.min_value < 0) and (param.max_value is not None and param.max_value < 2 ** 31):
                 code = self._impl_code_integer_item_template.substitute(
                     type=u"int32_t",
                     params=self._gen_schema_item_param_values(
-                        [[u"int32_t", param.min_value],
+                        [[u"int32_t", param.min_value], 
                          [u"int32_t", param.max_value],
                          [u"int32_t", param.default_value]]))
-            elif param.max_value < 2 ** 63:
+            elif (param.min_value is None or param.min_value < -(2 ** 31) ) and (param.max_value is None or param.max_value < 2 ** 63):
                 code = self._impl_code_integer_item_template.substitute(
                     type=u"int64_t",
                     params=self._gen_schema_item_param_values(
                         [[u"int64_t", param.min_value],
-                         [u"int64_t", str(param.max_value) + u"LL"],
+                         [u"int64_t", param.max_value],
                          [u"int64_t", param.default_value]]))
             else:
                 raise GenerateError("Parameter value too large: " + str(param.max_value))


### PR DESCRIPTION
Fixes #3226 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
##### Reproduction Steps
1. SDL and HMI are started
2. Navi_App is registered and activated
3. OnTouchEventOnlyGroup is allowed by policies
4. HMI sends OnTouchEvent notification with the 'ts' param has a value greater than maxvalue (not valid)

##### Expected Behavior
No Crash should be observed while testing

##### Observed Behavior
SDL crashed while testing

### Summary
SDL crashes when the HMI sends UI.OnTouchEvent with the 'ts' param has a value greater than maxvalue.
Was added processing for the case where the SDL gets numbers that go beyond the type limit.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
