### PR TITLE
Add method for delete empty message

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -1113,6 +1113,12 @@ class MessageHelper {
       ApplicationManager& app_mngr,
       const WindowID window_id);
 
+  /**
+   * @brief Recursively removes empty parameters of composite type from message
+   * @param msg_params smart object containing message params
+   */
+  static void RemoveEmptyMessageParams(smart_objects::SmartObject& msg_params);
+
  private:
   /**
    * @brief Allows to fill SO according to the  current permissions.

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/get_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/get_vehicle_data_request.cc
@@ -164,6 +164,8 @@ void GetVehicleDataRequest::on_event(const event_engine::Event& event) {
           }
         }
 
+        MessageHelper::RemoveEmptyMessageParams(message[strings::msg_params]);
+
         if (message[strings::msg_params].empty() &&
             hmi_apis::Common_Result::DATA_NOT_AVAILABLE != result_code) {
           response_info = "Failed to retrieve data from vehicle";

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/on_vehicle_data_notification.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/on_vehicle_data_notification.cc
@@ -70,6 +70,8 @@ void OnVehicleDataNotification::Run() {
   custom_vehicle_data_manager_.CreateMobileMessageParams(
       (*message_)[strings::msg_params]);
 
+  MessageHelper::RemoveEmptyMessageParams((*message_)[strings::msg_params]);
+
   const auto& param_names = (*message_)[strings::msg_params].enumerate();
   for (const auto& name : param_names) {
     SDL_LOG_DEBUG("vehicle_data name: " << name);

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -393,6 +393,8 @@ class MockMessageHelper {
                    application_manager::ApplicationSharedPtr application,
                    application_manager::ApplicationManager& app_mngr,
                    const application_manager::WindowID window_id));
+  MOCK_METHOD1(RemoveEmptyMessageParams,
+               void(const smart_objects::SmartObject&));
 
   static MockMessageHelper* message_helper_mock();
 };

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -689,4 +689,9 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateResponseMessageFromHmi(
   return MockMessageHelper::message_helper_mock()->CreateResponseMessageFromHmi(
       function_id, correlation_id, result_code);
 }
+void MessageHelper::RemoveEmptyMessageParams(
+    smart_objects::SmartObject& msg_params) {
+  return MockMessageHelper::message_helper_mock()->RemoveEmptyMessageParams(
+      msg_params);
+}
 }  // namespace application_manager


### PR DESCRIPTION
Fixes #3368 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
##### Reproduction Steps
1. HMI sends erray with empty structure { {} } in fuelRange on GetVehilceData_response / OnVehilceData_notification to SDL

##### Expected Behavior
for **GetVehilceData**:
SDL does respond `GENERIC_ERROR` to mobile
for **OnVehicleData**:
SDL does ignore this notification and SDL does not send OnVehicleData notifications to the mobile app.

##### Observed Behavior
for **GetVehilceData**:
SDL responds `SUCCESS` to mobile
for **OnVehicleData**:
SDL does not ignore this notification and sends OnVehicleData notification to mobile app.


### Summary
Implementation on SDL side has been updated to ignore optional parameters containing the empty structures.


### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
