### PR TITLE
fix defect with stoping video without audio streaming

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -847,10 +847,18 @@ class ApplicationManagerImpl
                     protocol_handler::ServiceType service_type) const OVERRIDE;
 
   /**
-   * @brief Ends opened navi services (audio/video) for application
+   * @brief Ends opened navi services audio and video for application
    * @param app_id Application id
    */
   void EndNaviServices(uint32_t app_id) OVERRIDE;
+
+  /**
+   * @brief Ends opened navi service audio or video for application
+   * @param app_id Application id
+   * @param service_type Service type to check
+   */
+  void EndService(const uint32_t app_id,
+                  const protocol_handler::ServiceType service_type) OVERRIDE;
 
   void ForbidStreaming(uint32_t app_id,
                        protocol_handler::ServiceType service_type) OVERRIDE;
@@ -1438,8 +1446,10 @@ class ApplicationManagerImpl
    * @brief Disallows streaming for application, but doesn't close
    * opened services. Streaming ability could be restored by AllowStreaming();
    * @param app_id Application to proceed
+   * @param service_type Type of service to disallow
    */
-  void DisallowStreaming(uint32_t app_id);
+  void DisallowStreaming(const uint32_t app_id,
+                         const protocol_handler::ServiceType service_type);
 
   /**
    * @brief Types of directories used by Application Manager

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_audio_start_stream_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_audio_start_stream_request.cc
@@ -142,6 +142,7 @@ void AudioStartStreamRequest::onTimeOut() {
 }
 
 void AudioStartStreamRequest::RetryStartSession() {
+  using namespace protocol_handler;
   SDL_LOG_AUTO_TRACE();
 
   auto retry_start_session = [this](const uint32_t hmi_app_id) {
@@ -176,7 +177,7 @@ void AudioStartStreamRequest::RetryStartSession() {
       SDL_LOG_DEBUG("Audio start stream retry sequence stopped. "
                     << "Attempts expired.");
 
-      application_manager_.EndNaviServices(app->app_id());
+      application_manager_.EndService(app->app_id(), ServiceType::kAudio);
     }
   };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_start_stream_request.cc
@@ -144,6 +144,7 @@ void NaviStartStreamRequest::onTimeOut() {
 }
 
 void NaviStartStreamRequest::RetryStartSession() {
+  using namespace protocol_handler;
   SDL_LOG_AUTO_TRACE();
 
   auto retry_start_session = [this](const uint32_t hmi_app_id) {
@@ -178,7 +179,7 @@ void NaviStartStreamRequest::RetryStartSession() {
       SDL_LOG_DEBUG("NaviStartStream retry sequence stopped. "
                     << "Attempts expired");
 
-      application_manager_.EndNaviServices(app->app_id());
+      application_manager_.EndService(app->app_id(), ServiceType::kMobileNav);
     }
   };
 

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -503,10 +503,18 @@ class ApplicationManager {
   virtual uint32_t GenerateNewHMIAppID() = 0;
 
   /**
-   * @brief Ends opened navi services (audio/video) for application
+   * @brief Ends opened navi services audio and video for application
    * @param app_id Application id
    */
   virtual void EndNaviServices(uint32_t app_id) = 0;
+
+  /**
+   * @brief Ends opened navi service audio or video for application
+   * @param app_id Application id
+   * @param service_type Service type to check
+   */
+  virtual void EndService(const uint32_t app_id,
+                          const protocol_handler::ServiceType service_type) = 0;
 
   /**
    * @brief returns true if low voltage state is active

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -194,6 +194,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD0(GetNextMobileCorrelationID, uint32_t());
   MOCK_METHOD0(GenerateNewHMIAppID, uint32_t());
   MOCK_METHOD1(EndNaviServices, void(uint32_t app_id));
+  MOCK_METHOD2(EndService,
+               void(const uint32_t app_id,
+                    const protocol_handler::ServiceType service_type));
   MOCK_METHOD1(BeginAudioPassThru, bool(uint32_t app_id));
   MOCK_METHOD1(EndAudioPassThru, bool(uint32_t app_id));
   MOCK_METHOD1(ConnectToDevice, void(const std::string& device_mac));


### PR DESCRIPTION
Fixes #3479 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
##### Reproduction Steps
1. App starts Video and Audio services and starts streaming Video
2. SDL sends requests to HMI:
   a) Navigation.StartStream
   b) Navigation.StartAudioStream
3. HMI responds to a) and doesn't respond to b)
4. SDL sends 3 more b) requests
5. HMI still doesn't respond

##### Expected Behavior
SDL does:
- stop Audio service
- not stop Video service
- continue Video streaming from App
- not unregister App with PROTOCOL_VIOLATION reason

##### Observed Behavior
SDL does:
- stop Video service
- stop Video streaming from App
- unregister App with PROTOCOL_VIOLATION reason if app continues streaming Video


### Summary
Was added function `EndService` which stops streaming for only one service (audio or video) and checks the state of another service. In case if both services are stopped, SDL will unregister the application.


### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
