### PR TITLE
IsHMIResultSuccess was moved

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_sub_menu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_sub_menu_request.cc
@@ -230,7 +230,7 @@ void DeleteSubMenuRequest::on_event(const event_engine::Event& event) {
           return;
         }
 
-        if (IsHMIResultSuccess(result_code)) {
+        if (application_manager::commands::IsHMIResultSuccess(result_code)) {
           const auto cmd_id = msg_params[strings::cmd_id].asUInt();
           SDL_LOG_DEBUG("Removing UI Command: " << cmd_id);
           app->RemoveCommand(cmd_id);
@@ -279,7 +279,7 @@ void DeleteSubMenuRequest::on_event(const event_engine::Event& event) {
           return;
         }
 
-        if (IsHMIResultSuccess(result_code)) {
+        if (application_manager::commands::IsHMIResultSuccess(result_code)) {
           const auto menu_id = msg_params[strings::menu_id].asUInt();
           SDL_LOG_DEBUG("Removing submenuID: " << menu_id);
           app->RemoveSubMenu(menu_id);


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
`IsHMIResultSuccess` was moved within 0192, while 0192 was in review a new PR was merged that dealt with DeleteSubMenu and called this new function.

This PR updates the references to `IsHMIResultSuccess` that were added in the DeleteSubMenu PR so core will build

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
