### PR TITLE
Remove minimum value for AppIconsFolderMaxSize

### DIFF
--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -1444,10 +1444,6 @@ void Profile::UpdateValues() {
                 kSDL4Section,
                 kAppIconsFolderMaxSizeKey);
 
-  if (app_icons_folder_max_size_ < kDefaultAppIconsFolderMaxSize) {
-    app_icons_folder_max_size_ = kDefaultAppIconsFolderMaxSize;
-  }
-
   LOG_UPDATED_VALUE(
       app_icons_folder_max_size_, kAppIconsFolderMaxSizeKey, kSDL4Section);
 


### PR DESCRIPTION
Fixes #2206 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Set AppIconsFolderMaxSize to 1MB, add large file to the icons folder, then attempt to set the app icon for a connected app. Verify that the large file is deleted.

### Summary
Remove restrictions for AppIconsFolderMaxSize ini parameter

### Changelog
##### Bug Fixes
* Remove restrictions for AppIconsFolderMaxSize ini parameter

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
