### PR TITLE
add language option EN-IE

### DIFF
--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -511,7 +511,7 @@ class MessageHelperTest : public ::testing::Test {
                          "AR-SA", "KO-KR", "PT-BR", "CS-CZ", "DA-DK", "NO-NO",
                          "NL-BE", "EL-GR", "HU-HU", "FI-FI", "SK-SK", "EN-IN",
                          "TH-TH", "EN-SA", "HE-IL", "RO-RO", "UK-UA", "ID-ID",
-                         "VI-VN", "MS-MY", "HI-IN"}
+                         "VI-VN", "MS-MY", "HI-IN", "EN-IE"}
       , hmi_result_strings{"SUCCESS",
                            "UNSUPPORTED_REQUEST",
                            "UNSUPPORTED_RESOURCE",

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -304,6 +304,9 @@
     <element name="HI-IN" internal_name="HI_IN">
       <description>Hindi - India</description>
     </element>
+    <element name="EN-IE" internal_name="EN_IE">
+      <description>English - Ireland</description>
+    </element>
 </enum>
 
 <enum name="SoftButtonType">

--- a/tools/intergen/test/test_hmi_interface.xml
+++ b/tools/intergen/test/test_hmi_interface.xml
@@ -221,6 +221,9 @@
     <element name="HI-IN" internal_name="HI_IN">
       <description>Hindi - India</description>
     </element>
+    <element name="EN-IE" internal_name="EN_IE">
+      <description>English - Ireland</description>
+    </element>
 </enum>
 
 <enum name="SoftButtonType">


### PR DESCRIPTION
Partially Fixes https://github.com/smartdevicelink/sdl_core/issues/1942

Depends on https://github.com/smartdevicelink/rpc_spec/pull/320

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary

Valid language `EN-IE` already exists in preloaded_pt json files

### Testing

Unit tests and ATF

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
