### PR TITLE
remove default_timeout_ adjustments from HMI interaction commands

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_alert_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_alert_request.cc
@@ -49,11 +49,7 @@ UIAlertRequest::UIAlertRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle) {
-  const auto& msg_params = (*message_)[strings::msg_params];
-  uint32_t request_timeout = msg_params[strings::duration].asUInt();
-  default_timeout_ += request_timeout;
-}
+                   policy_handle) {}
 
 UIAlertRequest::~UIAlertRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_scrollable_message_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_scrollable_message_request.cc
@@ -49,11 +49,7 @@ UIScrollableMessageRequest::UIScrollableMessageRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle) {
-  const auto& msg_params = (*message_)[strings::msg_params];
-  uint32_t request_timeout = msg_params[strings::timeout].asUInt();
-  default_timeout_ += request_timeout;
-}
+                   policy_handle) {}
 
 UIScrollableMessageRequest::~UIScrollableMessageRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_slider_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_slider_request.cc
@@ -49,11 +49,7 @@ UISliderRequest::UISliderRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle) {
-  const auto& msg_params = (*message_)[strings::msg_params];
-  uint32_t request_timeout = msg_params[strings::timeout].asUInt();
-  default_timeout_ += request_timeout;
-}
+                   policy_handle) {}
 
 UISliderRequest::~UISliderRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_subtle_alert_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_subtle_alert_request.cc
@@ -49,15 +49,7 @@ UISubtleAlertRequest::UISubtleAlertRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handler) {
-  const auto& msg_params = (*message_)[strings::msg_params];
-  if (msg_params.keyExists(strings::duration)) {
-    uint32_t request_timeout = msg_params[strings::duration].asUInt();
-    default_timeout_ += request_timeout;
-  } else {
-    default_timeout_ = 0;
-  }
-}
+                   policy_handler) {}
 
 UISubtleAlertRequest::~UISubtleAlertRequest() {}
 


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3759

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF full regression, manually testing maximum timeouts on all 4 interactions.

### Summary
remove default_timeout_ adjustments from HMI interaction commands

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
