### PR TITLE
Send REQUEST type and generated sequence number in SendHandshakeData

### DIFF
--- a/src/components/security_manager/include/security_manager/security_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/security_manager_impl.h
@@ -226,17 +226,24 @@ class SecurityManagerImpl : public SecurityManager,
 
  private:
   /**
+   * @brief NextSequentialNumber get next sequential number for request
+   * @return next sequential number
+   */
+  uint32_t NextSequentialNumber();
+
+  /**
    * \brief Sends Handshake binary data to mobile application
    * \param connection_key Unique key used by other components as session
    * identifier
    * \param data pointer to binary data array
    * \param data_size size of binary data array
-   * \param seq_number received from Mobile Application
+   * \param custom_seq_number specific sequential number of request. If omitted,
+   * this will be automatically generated
    */
   void SendHandshakeBinData(const uint32_t connection_key,
                             const uint8_t* const data,
                             const size_t data_size,
-                            const uint32_t seq_number = 0);
+                            const uint32_t custom_seq_number = 0);
   /**
    * \brief Parse SecurityMessage as HandshakeData request
    * \param inMessage SecurityMessage with binary data of handshake
@@ -326,6 +333,8 @@ class SecurityManagerImpl : public SecurityManager,
   sync_primitives::Lock connections_lock_;
   std::set<uint32_t> awaiting_certificate_connections_;
   std::set<uint32_t> awaiting_time_connections_;
+
+  uint32_t current_seq_number_;
 
   mutable sync_primitives::Lock waiters_lock_;
   volatile bool waiting_for_certificate_;

--- a/src/components/security_manager/test/security_manager_test.cc
+++ b/src/components/security_manager/test/security_manager_test.cc
@@ -152,7 +152,7 @@ class SecurityManagerTest : public ::testing::Test {
   void EmulateMobileMessageHandshake(const uint8_t* const data,
                                      const uint32_t data_size,
                                      const int repeat_count = 1) {
-    const SecurityQuery::QueryHeader header(SecurityQuery::NOTIFICATION,
+    const SecurityQuery::QueryHeader header(SecurityQuery::RESPONSE,
                                             SecurityQuery::SEND_HANDSHAKE_DATA,
                                             kSeqNumber);
     for (int c = 0; c < repeat_count; ++c) {

--- a/src/components/security_manager/test/security_query_test.cc
+++ b/src/components/security_manager/test/security_query_test.cc
@@ -53,7 +53,7 @@ class SecurityQueryTest : public ::testing::Test {
  protected:
   void SetUp() OVERRIDE {
     // init_header used for SecurityQuery initialization
-    init_header.query_type = SecurityQuery::NOTIFICATION;
+    init_header.query_type = SecurityQuery::REQUEST;
     init_header.query_id = SecurityQuery::SEND_HANDSHAKE_DATA;
     init_header.seq_number = SEQ_NUMBER;
     init_header.json_size = 0u;
@@ -107,18 +107,18 @@ TEST_F(SecurityQueryTest, QueryHeaderConstructor) {
  * Security QueryHeader shall construct with correct fields
  */
 TEST_F(SecurityQueryTest, QueryHeaderConstructor2) {
-  SecurityQuery::QueryHeader new_header(SecurityQuery::NOTIFICATION,
+  SecurityQuery::QueryHeader new_header(SecurityQuery::REQUEST,
                                         SecurityQuery::SEND_HANDSHAKE_DATA,
                                         SEQ_NUMBER);
-  ASSERT_EQ(new_header.query_type, SecurityQuery::NOTIFICATION);
+  ASSERT_EQ(new_header.query_type, SecurityQuery::REQUEST);
   ASSERT_EQ(new_header.query_id, SecurityQuery::SEND_HANDSHAKE_DATA);
   ASSERT_EQ(new_header.seq_number, SEQ_NUMBER);
   ASSERT_EQ(new_header.json_size, 0u);
 
-  SecurityQuery::QueryHeader new_header2(SecurityQuery::RESPONSE,
+  SecurityQuery::QueryHeader new_header2(SecurityQuery::NOTIFICATION,
                                          SecurityQuery::SEND_INTERNAL_ERROR,
                                          SEQ_NUMBER + 1);
-  ASSERT_EQ(new_header2.query_type, SecurityQuery::RESPONSE);
+  ASSERT_EQ(new_header2.query_type, SecurityQuery::NOTIFICATION);
   ASSERT_EQ(new_header2.query_id, SecurityQuery::SEND_INTERNAL_ERROR);
   ASSERT_EQ(new_header2.seq_number, SEQ_NUMBER + 1);
   ASSERT_EQ(new_header2.json_size, 0u);
@@ -385,7 +385,7 @@ TEST_F(SecurityQueryTest, Parse_InvalidQuery_UnknownId_Response) {
  */
 TEST_F(SecurityQueryTest, Parse_Handshake) {
   SecurityQuery::QueryHeader handshake_header(
-      SecurityQuery::NOTIFICATION,
+      SecurityQuery::REQUEST,
       SecurityQuery::SEND_HANDSHAKE_DATA,
       SEQ_NUMBER);
   // some sample data


### PR DESCRIPTION

Fixes #3755 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test against https://github.com/smartdevicelink/sdl_java_suite/pull/1724, verify that SendHandshakeData is sent with REQUEST query type when attempting to start a secured video service

### Summary
Changes query type of SendHandshakeData to REQUEST and generates sequential number automatically

### Changelog
##### Bug Fixes
* Fixes query type and sequential number of SendHandshakeData

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
