### PR TITLE
Ignore frame data for single and first frames

### DIFF
--- a/src/components/protocol_handler/src/multiframe_builder.cc
+++ b/src/components/protocol_handler/src/multiframe_builder.cc
@@ -197,6 +197,7 @@ RESULT_CODE MultiFrameBuilder::HandleFirstFrame(const ProtocolFramePtr packet) {
                 << connection_id
                 << ", session_id: " << static_cast<int>(session_id)
                 << ", message_id: " << message_id);
+  packet->set_frame_data(FRAME_DATA_FIRST);
   messageId_map[message_id] = {packet, date_time::getCurrentTime()};
   return RESULT_OK;
 }

--- a/src/components/protocol_handler/src/protocol_packet.cc
+++ b/src/components/protocol_handler/src/protocol_packet.cc
@@ -325,21 +325,8 @@ RESULT_CODE ProtocolPacket::ProtocolHeaderValidator::validate(
       break;
     }
     case FRAME_TYPE_SINGLE:
-      if (header.frameData != FRAME_DATA_SINGLE) {
-        SDL_LOG_WARN("FRAME_TYPE_SINGLE - Invalide frame data "
-                     << static_cast<int>(header.frameData));
-        return RESULT_FAIL;
-      }
-      break;
     case FRAME_TYPE_FIRST:
-      if (header.frameData != FRAME_DATA_FIRST) {
-        SDL_LOG_WARN("FRAME_TYPE_FIRST - Invalide frame data "
-                     << static_cast<int>(header.frameData));
-        return RESULT_FAIL;
-      }
-      break;
     case FRAME_TYPE_CONSECUTIVE:
-      // Could have any FrameInfo value
       break;
     default:
       SDL_LOG_WARN("Unknown frame type " << static_cast<int>(header.frameType));


### PR DESCRIPTION
Fixes #3717 

This PR is **ready** for review.

### Risk
This PR makes **no]** API changes.

### Testing Plan
1. App registered
2. App sends PutFile data
  a) as a single frame
  b) as a multi frame
3. Make sure App sends non-zero value in 'frameInfo' field of 'Single' and 'First' frames

### Summary
Updated validation for single and first frame

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
