### PR TITLE
Fix/Check AudioStreamingState before starting stream

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3473,6 +3473,7 @@ bool ApplicationManagerImpl::HMIStateAllowsStreaming(
   using namespace mobile_apis::HMILevel;
   using namespace mobile_apis::PredefinedWindows;
   using namespace mobile_apis::VideoStreamingState;
+  using namespace mobile_apis::AudioStreamingState;
   using namespace helpers;
 
   ApplicationSharedPtr app = application(app_id);
@@ -3486,7 +3487,10 @@ bool ApplicationManagerImpl::HMIStateAllowsStreaming(
       Compare<mobile_apis::HMILevel::eType, EQ, ONE>(
           hmi_state->hmi_level(), HMI_FULL, HMI_LIMITED);
   const bool allow_streaming_by_streaming_state =
-      hmi_state->video_streaming_state() == STREAMABLE;
+      (service_type == protocol_handler::SERVICE_TYPE_NAVI &&
+       hmi_state->video_streaming_state() == STREAMABLE) ||
+      (service_type == protocol_handler::SERVICE_TYPE_AUDIO &&
+       hmi_state->audio_streaming_state() != NOT_AUDIBLE);
 
   return allow_streaming_by_hmi_level && allow_streaming_by_streaming_state;
 }


### PR DESCRIPTION
Fixes #3486 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- ATF Tests
- Manually test reproduction steps for issue

### Summary
Adds check for audio streaming state in `ApplicationManagerImpl::HMIStateAllowsStreaming`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
