### PR TITLE
Fix build failure when EXTENDED_MEDIA_MODE=ON

### DIFF
--- a/src/components/media_manager/src/audio/from_mic_recorder_adapter.cc
+++ b/src/components/media_manager/src/audio/from_mic_recorder_adapter.cc
@@ -108,10 +108,6 @@ void FromMicRecorderAdapter::set_output_file(const std::string& output_file) {
   output_file_ = output_file;
 }
 
-void FromMicRecorderAdapter::set_duration(int32_t duration) {
-  duration_ = duration;
-}
-
 void FromMicRecorderAdapter::set_config(
     mobile_apis::SamplingRate::eType sampling_rate,
     mobile_apis::BitsPerSample::eType bits_per_sample,


### PR DESCRIPTION
Fixes issue with https://github.com/smartdevicelink/sdl_core/pull/3735

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test build with EXTENDED_MEDIA_MODE=ON

### Summary
Remove function definition for `FromMicRecorderAdapter::set_duration` (removed from the header in #3735)

### Changelog
##### Bug Fixes
* Remove definition for removed function `FromMicRecorderAdapter::set_duration`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
