### PR TITLE
Send a request when the policy table is disabled.

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -2873,6 +2873,10 @@ void PolicyHandler::UpdateHMILevel(ApplicationSharedPtr app,
 
 bool PolicyHandler::CheckModule(const PTString& app_id,
                                 const PTString& module) {
+  if (!PolicyEnabled()) {
+    SDL_LOG_DEBUG("Policy table is disabled");
+    return true;
+  }
   const auto policy_manager = LoadPolicyManager();
   POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
   return policy_manager->CheckModule(app_id, module);
@@ -2943,6 +2947,10 @@ bool PolicyHandler::CheckHMIType(const std::string& application_id,
                                  mobile_apis::AppHMIType::eType hmi,
                                  const smart_objects::SmartObject* app_types) {
   SDL_LOG_AUTO_TRACE();
+  if (!PolicyEnabled()) {
+    SDL_LOG_DEBUG("Policy table is disabled");
+    return true;
+  }
   const auto policy_manager = LoadPolicyManager();
   POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
   std::vector<int> policy_hmi_types;


### PR DESCRIPTION
Fixes #[2989](https://github.com/smartdevicelink/sdl_core/issues/2989)
This PR is ready for review.

Risk
This PR makes no API changes.

### Summary
When the policy table is disabled, the GetInteriorVehicleData RPC request is not sent to the HMI because the policy manager is not created. A DISALLOWED response is sent to Mobile.
Added two checks, if the table is disabled then we send a request to HMI and send responce SUCCES to mobile.

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
