### PR TITLE
Clear Parent Reference to Begin State When it is Erased

### DIFF
--- a/src/components/application_manager/src/application_state.cc
+++ b/src/components/application_manager/src/application_state.cc
@@ -204,11 +204,12 @@ void ApplicationState::RemoveHMIState(const WindowID window_id,
 
 void ApplicationState::EraseHMIState(HmiStates& hmi_states,
                                      HmiStates::iterator it) {
-  if (hmi_states.begin() == it && hmi_states.size() > 1) {
+  if (hmi_states.begin() == it) {
     HmiStates::iterator next = it;
     ++next;
-    if (*next && (*next)->parent() == *it) {
-      (*next)->set_parent(nullptr);
+    if (hmi_states.end() != next) {
+      HmiStatePtr next_state = *next;
+      next_state->set_parent(nullptr);
     }
   } else {
     HmiStates::iterator next = it;

--- a/src/components/application_manager/src/application_state.cc
+++ b/src/components/application_manager/src/application_state.cc
@@ -204,8 +204,12 @@ void ApplicationState::RemoveHMIState(const WindowID window_id,
 
 void ApplicationState::EraseHMIState(HmiStates& hmi_states,
                                      HmiStates::iterator it) {
-  if (hmi_states.begin() == it) {
-    (*it)->set_parent(nullptr);
+  if (hmi_states.begin() == it && hmi_states.size() > 1) {
+    HmiStates::iterator next = it;
+    ++next;
+    if (*next && (*next)->parent() == *it) {
+      (*next)->set_parent(nullptr);
+    }
   } else {
     HmiStates::iterator next = it;
     HmiStates::iterator prev = it;


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3768

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Issue Reproduction Steps
https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2578
Additional ATF Test Scripts updates to come

### Summary
When cancelling temp state and temp state is `hmi_states.begin()`, we must check if the next element holds reference to state we are deleting in parent property and remove it if so.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
