### PR TITLE
Fix applying functional group consent for all applications

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -720,7 +720,7 @@ void PolicyHandler::OnAppPermissionConsentInternal(
       policy_manager->SetUserConsentForApp(out_permissions);
 #endif
     }
-  } else if (!app_to_device_link_.empty()) {
+  } else {
     const ApplicationSet& accessor =
         application_manager_.applications().GetData();
     for (const auto& app : accessor) {
@@ -759,10 +759,6 @@ void PolicyHandler::OnAppPermissionConsentInternal(
       policy_manager->SetUserConsentForApp(out_permissions);
 #endif
     }
-  } else {
-    SDL_LOG_WARN(
-        "There are no applications previously stored for "
-        "setting common permissions.");
   }
 #ifdef EXTERNAL_PROPRIETARY_MODE
   if (!policy_manager->SetExternalConsentStatus(external_consent_status)) {


### PR DESCRIPTION
Fixes #2957 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
##### Reproduction Steps
0. SDL built with `EXTERNAL PROPRIETARY`
Application data for App1 (`appId = 0000001`) and App2 (`appId = 0000002`) exists in policy table 
RPC Show is exists in functional group `ShowFuncGroup` which requires `user_consent_prompt: "ShowConsent"`.
App1 and App2 have group `ShowFuncGroup` in its allowed groups in policy table.

1. SDL and HMI are running
2. Mobile device is connected to SDL and consented by the User
3. Register App1 and App2 from mobile device.
4. Activate App1 and App2 consequentially
5. HMI received list of permissions via `GetListOfPermissions` RPC and display the 'app permissions consent' message.
6. User allows `ShowConsent` permissions and HMI sends `OnAppPermissionConsent` notification without `appID` parameter (`source: "GUI", consentedFunctions: [ {name:"ShowFuncGroup", id: 12345, allowed: true }]`)
7. App1 and App2 send `Show` RPC
 

### Summary
SDL has to apply permissions provided in `SDL.OnAppPermissionConsent` notification regardless of `SDL.GetListOfPermissions`

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
