### PR TITLE
fix WebSocketServerTransportAdapter::Store write to last state

### DIFF
--- a/src/components/transport_manager/src/websocket_server/websocket_server_transport_adapter.cc
+++ b/src/components/transport_manager/src/websocket_server/websocket_server_transport_adapter.cc
@@ -100,9 +100,9 @@ TransportAdapter::Error WebSocketServerTransportAdapter::Init() {
 void WebSocketServerTransportAdapter::Store() const {
   SDL_LOG_AUTO_TRACE();
   if (webengine_device_) {
-    resumption::LastStateAccessor accessor =
-        last_state_wrapper_->get_accessor();
-    Json::Value dictionary = accessor.GetData().dictionary();
+    resumption::LastState& data =
+        last_state_wrapper_->get_accessor().GetMutableData();
+    Json::Value dictionary = data.dictionary();
     if (dictionary["TransportManager"].isMember("WebsocketServerAdapter")) {
       SDL_LOG_DEBUG(
           "WebsocketServerAdapter already exists. Storing is skipped");
@@ -116,6 +116,8 @@ void WebSocketServerTransportAdapter::Store() const {
     ws_adapter_dictionary["device"] = device_dictionary;
     dictionary["TransportManager"]["WebsocketServerAdapter"] =
         ws_adapter_dictionary;
+
+    data.set_dictionary(dictionary);
   }
 }
 

--- a/src/components/transport_manager/src/websocket_server/websocket_server_transport_adapter.cc
+++ b/src/components/transport_manager/src/websocket_server/websocket_server_transport_adapter.cc
@@ -100,8 +100,9 @@ TransportAdapter::Error WebSocketServerTransportAdapter::Init() {
 void WebSocketServerTransportAdapter::Store() const {
   SDL_LOG_AUTO_TRACE();
   if (webengine_device_) {
-    resumption::LastState& data =
-        last_state_wrapper_->get_accessor().GetMutableData();
+    resumption::LastStateAccessor accessor =
+        last_state_wrapper_->get_accessor();
+    resumption::LastState& data = accessor.GetMutableData();
     Json::Value dictionary = data.dictionary();
     if (dictionary["TransportManager"].isMember("WebsocketServerAdapter")) {
       SDL_LOG_DEBUG(


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Connect webengine app, Subscribe to a button, Ignition Cycle, 
Connect same webengine app with last receivedHash ID
App should receive SUCCESS
on develop App receives RESUME_FAILED 

### Summary
adjust `WebSocketServerTransportAdapter::Store ` so it writes the data to last state,
it hasn't since https://github.com/smartdevicelink/sdl_core/pull/3735

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
