### PR TITLE
Add missing internal error codes to security manager

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2447,7 +2447,6 @@ bool ApplicationManagerImpl::OnHandshakeDone(
           SSLContext::Handshake_Result_CertExpired,
           SSLContext::Handshake_Result_CertNotSigned,
           SSLContext::Handshake_Result_AppIDMismatch,
-          SSLContext::Handshake_Result_AppNameMismatch,
           SSLContext::Handshake_Result_NotYetValid)) {
     app->usage_report().RecordTLSError();
   }

--- a/src/components/include/security_manager/security_manager.h
+++ b/src/components/include/security_manager/security_manager.h
@@ -102,24 +102,24 @@ class SecurityManager : public protocol_handler::ProtocolObserver,
    * \param connection_key Unique key used by other components as session
    * identifier
    * \param error_id  unique error identifier
-   * \param erorr_text SSL impelmentation error text
+   * \param error_text SSL impelmentation error text
    * \param seq_number received from Mobile Application
    */
   virtual void SendInternalError(const uint32_t connection_key,
                                  const uint8_t& error_id,
-                                 const std::string& erorr_text,
+                                 const std::string& error_text,
                                  const uint32_t seq_number) = 0;
   /**
    * \brief Sends InternalError override methode for sending without seq_number
    * \param connection_key Unique key used by other components as session
    * identifier
    * \param error_id  unique error identifier
-   * \param erorr_text SSL impelmentation error text
+   * \param error_text SSL impelmentation error text
    */
   void SendInternalError(const uint32_t connection_key,
                          const uint8_t& error_id,
-                         const std::string& erorr_text) {
-    SendInternalError(connection_key, error_id, erorr_text, 0);
+                         const std::string& error_text) {
+    SendInternalError(connection_key, error_id, error_text, 0);
   }
 
   /**

--- a/src/components/include/security_manager/security_manager.h
+++ b/src/components/include/security_manager/security_manager.h
@@ -69,6 +69,9 @@ class SecurityManager : public protocol_handler::ProtocolObserver,
     ERROR_DECRYPTION_FAILED = 0x06,
     ERROR_ENCRYPTION_FAILED = 0x07,
     ERROR_SSL_INVALID_DATA = 0x08,
+    ERROR_HANDSHAKE_FAILED = 0x09,  // Handshake failed
+    ERROR_INVALID_CERT = 0x0A,      // Handshake failed because cert is invalid
+    ERROR_EXPIRED_CERT = 0x0B,      // Handshake failed because cert is expired
     ERROR_INTERNAL = 0xFF,
     ERROR_UNKNOWN_INTERNAL_ERROR = 0xFE  // error value for testing
   };

--- a/src/components/include/security_manager/ssl_context.h
+++ b/src/components/include/security_manager/ssl_context.h
@@ -73,7 +73,6 @@ class SSLContext {
     Handshake_Result_NotYetValid,
     Handshake_Result_CertNotSigned,
     Handshake_Result_AppIDMismatch,
-    Handshake_Result_AppNameMismatch,
   };
 
   struct HandshakeContext {

--- a/src/components/protocol_handler/src/handshake_handler.cc
+++ b/src/components/protocol_handler/src/handshake_handler.cc
@@ -149,8 +149,6 @@ bool HandshakeHandler::OnHandshakeDone(
             return "Certificate is not signed";
           case security_manager::SSLContext::Handshake_Result_AppIDMismatch:
             return "Trying to run handshake with wrong app id";
-          case security_manager::SSLContext::Handshake_Result_AppNameMismatch:
-            return "Trying to run handshake with wrong app name";
           case security_manager::SSLContext::Handshake_Result_AbnormalFail:
             return "Error occurred during handshake";
           case security_manager::SSLContext::Handshake_Result_Fail:

--- a/src/components/security_manager/include/security_manager/security_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/security_manager_impl.h
@@ -121,12 +121,12 @@ class SecurityManagerImpl : public SecurityManager,
    * \param connection_key Unique key used by other components as session
    * identifier
    * \param error_id  unique error identifier
-   * \param erorr_text SSL impelmentation error text
+   * \param error_text SSL impelmentation error text
    * \param seq_number received from Mobile Application
    */
   void SendInternalError(const uint32_t connection_key,
                          const uint8_t& error_id,
-                         const std::string& erorr_text,
+                         const std::string& error_text,
                          const uint32_t seq_number) OVERRIDE;
 
   using SecurityManager::SendInternalError;

--- a/src/components/security_manager/src/security_manager_impl.cc
+++ b/src/components/security_manager/src/security_manager_impl.cc
@@ -574,7 +574,7 @@ bool SecurityManagerImpl::ProcessHandshakeData(
         error_text = "Certificate is expired";
         break;
       case SSLContext::Handshake_Result_NotYetValid:
-        error_code = ERROR_EXPIRED_CERT;
+        error_code = ERROR_INVALID_CERT;
         error_text = "Certificate is not yet valid";
         break;
       case SSLContext::Handshake_Result_CertNotSigned:

--- a/src/components/security_manager/test/security_manager_test.cc
+++ b/src/components/security_manager/test/security_manager_test.cc
@@ -760,11 +760,12 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_Answer) {
                   RawMessageEqSize(raw_message_size), false, kIsFinal))
       .Times(handshake_emulates)
       .WillRepeatedly(NotifyTestAsyncWaiter(waiter));
-  EXPECT_CALL(mock_protocol_handler,
-              SendMessageToMobileApp(
-                  InternalErrorWithErrId(SecurityManager::ERROR_HANDSHAKE_FAILED),
-                  false,
-                  kIsFinal))
+  EXPECT_CALL(
+      mock_protocol_handler,
+      SendMessageToMobileApp(
+          InternalErrorWithErrId(SecurityManager::ERROR_HANDSHAKE_FAILED),
+          false,
+          kIsFinal))
       .Times(internal_error_count)
       .WillRepeatedly(NotifyTestAsyncWaiter(waiter));
   times += handshake_emulates + internal_error_count;


### PR DESCRIPTION

Adds missing security query specification details from https://github.com/smartdevicelink/protocol_spec/issues/40

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
HANDSHAKE_FAILED - can be triggered by setting `VerifyPeer=true` using the Java Security Lib [Example Certificates](https://github.com/smartdevicelink/sdl_security_java_suite/tree/master/resources/certs)
INVALID_CERT - can be triggered by sending an app certificate with an app ID which is different from the one that the app registered with
EXPIRED_CERT - can be triggered by sending an expired app certificate (or by modifying the GetSystemTime response from the HMI)

### Summary
Adds logic for missing error codes in SendInternalError query (HANDSHAKE_FAILED, ERROR_INVALID_CERT, and ERROR_EXPIRED_CERT)

### Changelog
##### Bug Fixes
* Adds logic for missing error codes in SendInternalError query

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
