### PR TITLE
Prevent HMI commands processing while SDL is stopping

### DIFF
--- a/src/components/application_manager/src/commands/request_to_hmi.cc
+++ b/src/components/application_manager/src/commands/request_to_hmi.cc
@@ -137,6 +137,7 @@ bool RequestToHMI::Init() {
 }
 
 bool RequestToHMI::CleanUp() {
+  unsubscribe_from_all_hmi_events();
   return true;
 }
 

--- a/src/components/application_manager/src/rpc_service_impl.cc
+++ b/src/components/application_manager/src/rpc_service_impl.cc
@@ -392,7 +392,9 @@ bool RPCServiceImpl::ManageHMICommand(const commands::MessageSharedPtr message,
   if (kRequest == message_type) {
     SDL_LOG_DEBUG("ManageHMICommand");
     command->set_warning_info(warning_info);
-    request_ctrl_.AddHMIRequest(command);
+    if (!app_manager_.IsStopping()) {
+      request_ctrl_.AddHMIRequest(command);
+    }
   }
 
   if (command->Init()) {


### PR DESCRIPTION
Fixes #3774

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manual, ATF

### Summary
Prevent HMI commands life time managment through RequestController while SDL is stopping.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
