### PR TITLE
Check specifically for invalid hmi level when suspending notifications

### DIFF
--- a/src/components/application_manager/src/rpc_service_impl.cc
+++ b/src/components/application_manager/src/rpc_service_impl.cc
@@ -148,8 +148,8 @@ bool RPCServiceImpl::ManageMobileCommand(
   if (app_ptr &&
       (app_manager_.IsAppInReconnectMode(app_ptr->device(),
                                          app_ptr->policy_app_id()) ||
-       (!app_ptr->WindowIdExists(window_id) &&
-        mobile_apis::PredefinedWindows::DEFAULT_WINDOW == window_id &&
+       (mobile_apis::PredefinedWindows::DEFAULT_WINDOW == window_id &&
+        mobile_apis::HMILevel::INVALID_ENUM == app_ptr->hmi_level(window_id) &&
         mobile_apis::messageType::notification == message_type))) {
     commands_holder_.Suspend(
         app_ptr, CommandHolder::CommandType::kMobileCommand, source, message);


### PR DESCRIPTION

Fixes #3674, addendum to #3675

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF Tests: https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2588

### Summary
Checking for main window ID in #3675 still allowed for a very rare race condition where the notification was not suspended when necessary, this PR changes the check to specifically cover an invalid HMI level for the main window.

### Changelog
##### Bug Fixes
* Checks specifically for an invalid HMI level before suspending notifications

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
