### PR TITLE
Added build path to lcov command

### DIFF
--- a/tools/infrastructure/collect_coverage.sh
+++ b/tools/infrastructure/collect_coverage.sh
@@ -17,7 +17,7 @@ rm -rf $COVERAGE_DIR
 rm -rf $REPORTS_DIR -
 
 mkdir $COVERAGE_DIR
-lcov --quiet --capture --directory . --output-file $COVERAGE_DIR/full_report.info
+lcov --quiet --capture --directory $BUILD_DIR --output-file $COVERAGE_DIR/full_report.info
 lcov --quiet --remove $COVERAGE_DIR/full_report.info '/usr/*' '*/test/*' '*/src/3rd*' '*/build/src/*'  --output-file $COVERAGE_DIR/coverage.info
 
 mkdir $REPORTS_DIR


### PR DESCRIPTION
Fixes #[issue number]

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
1. Build project with flags _-DBUILD_TESTS=on -DENABLE_GCOV=on_
2. Execute command 'make test'
3. Execute './tools/infrastructure/collect_coverage.sh \<path_to_build_directory\>'

Expected result:
The project source code directory is still clean.

### Summary
Added path to build directory in lcov command to avoid the saving of temporary files in the source code directory

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
