### PR TITLE
print to console on crash from signal handler

### DIFF
--- a/src/appMain/life_cycle_impl.cc
+++ b/src/appMain/life_cycle_impl.cc
@@ -237,12 +237,14 @@ void sig_handler(int sig) {
       SDL_LOG_DEBUG("SIGTERM signal has been caught");
       break;
     case SIGSEGV:
+      std::cerr << "SIGSEGV caught" << std::endl;
       SDL_LOG_DEBUG("SIGSEGV signal has been caught");
       SDL_FLUSH_LOGGER();
       // exit need to prevent endless sending SIGSEGV
       // http://stackoverflow.com/questions/2663456/how-to-write-a-signal-handler-to-catch-sigsegv
       abort();
     default:
+      std::cerr << "Unexpected signal " << sig << " caught" << std::endl;
       SDL_LOG_DEBUG("Unexpected signal has been caught");
       exit(EXIT_FAILURE);
   }


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Cause a core crash and observe the console output.

I caused a crash by reverting https://github.com/smartdevicelink/sdl_core/commit/86dd7b1c9802005657a8e1dddeae79db24ba6ae0 and sending IGNITION_OFF while streaming.
You can also send signals to core via `kill`.

### Summary
Add a print to `stderr` in the signal handler before calling `abort()` or `exit()`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
