### PR TITLE
Fix SDL build with USE_COTIRE=OFF

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/subscribe_button_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/subscribe_button_request_test.cc
@@ -33,7 +33,11 @@
 #include "hmi/subscribe_button_request.h"
 #include <memory>
 #include <string>
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_application.h"
 #include "application_manager/mock_event_dispatcher.h"
+#include "application_manager/mock_resume_ctrl.h"
+#include "application_manager/resumption/resumption_data_processor.h"
 
 #include "gtest/gtest.h"
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/subscribe_button_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/subscribe_button_response_test.cc
@@ -32,9 +32,11 @@
 
 #include <string>
 
+#include "application_manager/commands/command_request_test.h"
 #include "application_manager/mock_event_dispatcher.h"
-#include "gtest/gtest.h"
 #include "hmi/subscribe_button_response.h"
+
+#include "gtest/gtest.h"
 
 namespace test {
 namespace components {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/unsubscribe_button_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/unsubscribe_button_request_test.cc
@@ -35,7 +35,12 @@
 #include <memory>
 #include <string>
 
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_application.h"
 #include "application_manager/mock_event_dispatcher.h"
+#include "application_manager/mock_resume_ctrl.h"
+#include "application_manager/resumption/resumption_data_processor.h"
+
 #include "gtest/gtest.h"
 
 namespace test {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/unsubscribe_button_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/unsubscribe_button_response_test.cc
@@ -31,9 +31,10 @@
  */
 
 #include <string>
-
-#include "application_manager/mock_event_dispatcher.h"
 #include "gtest/gtest.h"
+
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_event_dispatcher.h"
 #include "hmi/unsubscribe_button_response.h"
 
 namespace test {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/get_system_capability_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/get_system_capability_request_test.cc
@@ -34,6 +34,7 @@
 
 #include "application_manager/commands/command_request_test.h"
 #include "application_manager/message_helper.h"
+#include "application_manager/mock_app_service_manager.h"
 #include "gtest/gtest.h"
 #include "interfaces/MOBILE_API.h"
 #include "resumption/last_state_impl.h"


### PR DESCRIPTION
Fixes #3790 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Try to build Core with -DBUILD_TESTS=ON -DUSE_COTIRE=OFF flags
- Check build finished successfully

**Expected Behavior**
Build finished successfully

### Summary
SDL build fails when USE_COTIRE is OFF

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
