### PR TITLE
Fix VR.ChangeRegistration issue

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/change_registration_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/change_registration_request.cc
@@ -230,21 +230,28 @@ void ChangeRegistrationRequest::Run() {
     SendResponse(false, mobile_apis::Result::UNSUPPORTED_RESOURCE);
     return;
   }
+
   if (HmiInterfaces::InterfaceState::STATE_NOT_AVAILABLE != vr_state) {
     StartAwaitForInterface(HmiInterfaces::InterfaceID::HMI_INTERFACE_VR);
   }
+
   if (HmiInterfaces::InterfaceState::STATE_NOT_AVAILABLE != tts_state) {
     StartAwaitForInterface(HmiInterfaces::InterfaceID::HMI_INTERFACE_TTS);
   }
 
   if (HmiInterfaces::InterfaceState::STATE_NOT_AVAILABLE != ui_state) {
+    StartAwaitForInterface(HmiInterfaces::InterfaceID::HMI_INTERFACE_UI);
+  }
+
+  if (IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_UI)) {
     SendUIRequest(app, msg_params, hmi_language);
   }
 
   if (IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_TTS)) {
     SendTTSRequest(app, msg_params);
   }
-  if (IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_UI)) {
+
+  if (IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_VR)) {
     SendVRRequest(app, msg_params);
   }
 }


### PR DESCRIPTION
Fixes #3793 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
1. App registered
2. App sends ChangeRegistration RPC

**Expected:**
Core sends 3 ChangeRegistration requests for UI, TTS and VR interfaces to HMI

### Summary
There was found a misprint for a VR interface in the `ChangeRegistration` request. Because of that, there might be situations when HMI responds to one part of the request faster than another part was actually sent.
All required ordering and checks were updated.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
