### PR TITLE
Update minimum value of MaxSupportedProtocolVersion to 2

### DIFF
--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -237,7 +237,7 @@ CloudAppRetryTimeout = 1000
 CloudAppMaxRetryAttempts = 5
 
 [ProtocolHandler]
-; SDL supported protocol version
+; SDL supported protocol version. Minimum value is 2
 MaxSupportedProtocolVersion = 5
 ; Packet with payload bigger than next value will be marked as a malformed
 ; for protocol v3 or higher

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -2298,8 +2298,8 @@ void Profile::UpdateValues() {
                 kProtocolHandlerSection,
                 kMaxSupportedProtocolVersionKey);
 
-  if (max_supported_protocol_version_ < 1) {
-    max_supported_protocol_version_ = 1;
+  if (max_supported_protocol_version_ < 2) {
+    max_supported_protocol_version_ = 2;
   } else if (max_supported_protocol_version_ >
              kDefaultMaxSupportedProtocolVersion) {
     max_supported_protocol_version_ = kDefaultMaxSupportedProtocolVersion;


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Set MaxSupportedProtocolVersion to 1, verify that app registers with protocol version 2 instead

### Summary
If MaxSupportedProtocolVersion is set to 1, no apps can register because SDL Core responds with UNSUPPORTED_VERSION to protocol V1 messages (besides the initial StartService). This PR updates the minimum value of MaxSupportedProtocolVersion to 2.

### Changelog
##### Bug Fixes
* Updates the minimum value of MaxSupportedProtocolVersion to 2

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
