### PR TITLE
Fix/sdl does not response to registerappinterface after resumption hmi has do not respond on rc.setglobalproperties

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_set_global_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_set_global_properties_request.h
@@ -58,6 +58,8 @@ class RCSetGlobalPropertiesRequest : public app_mngr::commands::RequestToHMI {
    */
   void Run() OVERRIDE;
 
+  void OnTimeOut() OVERRIDE;
+
   ~RCSetGlobalPropertiesRequest();
 };
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_set_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_set_global_properties_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "rc_rpc_plugin/commands/hmi/rc_set_global_properties_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace rc_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -51,6 +52,13 @@ RCSetGlobalPropertiesRequest::RCSetGlobalPropertiesRequest(
 void RCSetGlobalPropertiesRequest::Run() {
   SDL_LOG_AUTO_TRACE();
   SendRequest();
+}
+
+void RCSetGlobalPropertiesRequest::OnTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 RCSetGlobalPropertiesRequest::~RCSetGlobalPropertiesRequest() {}


### PR DESCRIPTION
Fixes #3802 

This PR is ready for review.

Risk
This PR makes no API changes.

Summary
SDL doesn't response to RegisterAppInterface after transport disconnect in case HMI has DO_NOT_RESPOND value for RC.SetGlobalProperties. RC.SetGlobalProperties did not have an onTimeOut method to process at the end of the processing time.



### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
