### PR TITLE
Do not modify application list while iterating it

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_tts_language_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_tts_language_change_notification.cc
@@ -88,37 +88,28 @@ void OnTTSLanguageChangeNotification::Run() {
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);
 
-  std::vector<uint32_t> app_list;
-  std::vector<uint32_t> to_unregister;
+  ApplicationSet apps;
 
   {
     const ApplicationSet& accessor =
         application_manager_.applications().GetData();
-    auto message_language =
-        (*message_)[strings::msg_params][strings::language].asInt();
-
-    for (auto app : accessor) {
-      auto app_id = app->app_id();
-      app_list.push_back(app_id);
-      if (app->language() != message_language) {
-        to_unregister.push_back(app_id);
-      }
-    }
+    apps = ApplicationSet(accessor);
   }
 
-  for (auto app_id : app_list) {
-    (*message_)[strings::params][strings::connection_key] = app_id;
+  auto message_language =
+      (*message_)[strings::msg_params][strings::language].asInt();
+  for (auto app : apps) {
+    (*message_)[strings::params][strings::connection_key] = app->app_id();
     SendNotificationToMobile(message_);
-  }
-
-  for (auto app_id : to_unregister) {
-    rpc_service_.ManageMobileCommand(
-        MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
-            app_id,
-            mobile_api::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE),
-        SOURCE_SDL);
-    application_manager_.UnregisterApplication(
-        app_id, mobile_apis::Result::SUCCESS, false);
+    if (app->language() != message_language) {
+      rpc_service_.ManageMobileCommand(
+          MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
+              app->app_id(),
+              mobile_api::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE),
+          SOURCE_SDL);
+      application_manager_.UnregisterApplication(
+          app->app_id(), mobile_apis::Result::SUCCESS, false);
+    }
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_tts_language_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_tts_language_change_notification.cc
@@ -88,28 +88,37 @@ void OnTTSLanguageChangeNotification::Run() {
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);
 
-  const auto applications = application_manager_.applications().GetData();
-  for (const auto& app : applications) {
-    if (!app->IsRegistered()) {
-      SDL_LOG_DEBUG("Skipping app "
-                    << app->app_id()
-                    << " which has not finished the registration process");
-      continue;
-    }
+  std::vector<uint32_t> app_list;
+  std::vector<uint32_t> to_unregister;
 
-    (*message_)[strings::params][strings::connection_key] = app->app_id();
+  {
+    const ApplicationSet& accessor =
+        application_manager_.applications().GetData();
+    auto message_language =
+        (*message_)[strings::msg_params][strings::language].asInt();
+
+    for (auto app : accessor) {
+      auto app_id = app->app_id();
+      app_list.push_back(app_id);
+      if (app->language() != message_language) {
+        to_unregister.push_back(app_id);
+      }
+    }
+  }
+
+  for (auto app_id : app_list) {
+    (*message_)[strings::params][strings::connection_key] = app_id;
     SendNotificationToMobile(message_);
+  }
 
-    if (static_cast<int>(app->language()) !=
-        (*message_)[strings::msg_params][strings::language].asInt()) {
-      rpc_service_.ManageMobileCommand(
-          MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
-              app->app_id(),
-              mobile_api::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE),
-          SOURCE_SDL);
-      application_manager_.UnregisterApplication(
-          app->app_id(), mobile_apis::Result::SUCCESS, false);
-    }
+  for (auto app_id : to_unregister) {
+    rpc_service_.ManageMobileCommand(
+        MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
+            app_id,
+            mobile_api::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE),
+        SOURCE_SDL);
+    application_manager_.UnregisterApplication(
+        app_id, mobile_apis::Result::SUCCESS, false);
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_tts_language_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_tts_language_change_notification.cc
@@ -88,13 +88,7 @@ void OnTTSLanguageChangeNotification::Run() {
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);
 
-  ApplicationSet apps;
-
-  {
-    const ApplicationSet& accessor =
-        application_manager_.applications().GetData();
-    apps = ApplicationSet(accessor);
-  }
+  auto apps = ApplicationSet(application_manager_.applications().GetData());
 
   auto message_language =
       (*message_)[strings::msg_params][strings::language].asInt();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_ui_language_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_ui_language_change_notification.cc
@@ -80,6 +80,7 @@ void OnUILanguageChangeNotification::Run() {
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);
 
+  std::vector<uint32_t> app_list;
   std::vector<uint32_t> to_unregister;
 
   {
@@ -89,13 +90,17 @@ void OnUILanguageChangeNotification::Run() {
         (*message_)[strings::msg_params][strings::hmi_display_language].asInt();
 
     for (auto app : accessor) {
-      (*message_)[strings::params][strings::connection_key] = app->app_id();
-      SendNotificationToMobile(message_);
-
+      auto app_id = app->app_id();
+      app_list.push_back(app_id);
       if (app->ui_language() != message_language) {
-        to_unregister.push_back(app->app_id());
+        to_unregister.push_back(app_id);
       }
     }
+  }
+
+  for (auto app_id : app_list) {
+    (*message_)[strings::params][strings::connection_key] = app_id;
+    SendNotificationToMobile(message_);
   }
 
   for (auto app_id : to_unregister) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_ui_language_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_ui_language_change_notification.cc
@@ -80,7 +80,7 @@ void OnUILanguageChangeNotification::Run() {
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);
 
-  std::vector<ApplicationSharedPtr> to_unregister;
+  std::vector<uint32_t> to_unregister;
 
   {
     const ApplicationSet& accessor =
@@ -93,19 +93,19 @@ void OnUILanguageChangeNotification::Run() {
       SendNotificationToMobile(message_);
 
       if (app->ui_language() != message_language) {
-        to_unregister.push_back(app);
+        to_unregister.push_back(app->app_id());
       }
     }
   }
 
-  for (auto app : to_unregister) {
+  for (auto app_id : to_unregister) {
     rpc_service_.ManageMobileCommand(
         MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
-            app->app_id(),
+            app_id,
             mobile_api::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE),
         SOURCE_SDL);
     application_manager_.UnregisterApplication(
-        app->app_id(), mobile_apis::Result::SUCCESS, false);
+        app_id, mobile_apis::Result::SUCCESS, false);
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_ui_language_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_ui_language_change_notification.cc
@@ -80,13 +80,7 @@ void OnUILanguageChangeNotification::Run() {
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);
 
-  ApplicationSet apps;
-
-  {
-    const ApplicationSet& accessor =
-        application_manager_.applications().GetData();
-    apps = ApplicationSet(accessor);
-  }
+  auto apps = ApplicationSet(application_manager_.applications().GetData());
 
   auto message_language =
       (*message_)[strings::msg_params][strings::hmi_display_language].asInt();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_vr_language_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_vr_language_change_notification.cc
@@ -92,11 +92,6 @@ void OnVRLanguageChangeNotification::Run() {
       app_list.push_back(app_id);
       if (app->language() != message_language) {
         to_unregister.push_back(app_id);
-        application_manager_.state_controller().SetRegularState(
-            app,
-            mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
-            mobile_apis::HMILevel::HMI_NONE,
-            false);
       }
     }
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_vr_language_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_vr_language_change_notification.cc
@@ -78,34 +78,37 @@ void OnVRLanguageChangeNotification::Run() {
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);
 
-  const auto applications = application_manager_.applications().GetData();
-  for (auto app : applications) {
-    if (!app->IsRegistered()) {
-      SDL_LOG_DEBUG("Skipping app "
-                    << app->app_id()
-                    << " which has not finished the registration process");
-      continue;
-    }
+  std::vector<uint32_t> app_list;
+  std::vector<uint32_t> to_unregister;
 
-    (*message_)[strings::params][strings::connection_key] = app->app_id();
+  {
+    const ApplicationSet& accessor =
+        application_manager_.applications().GetData();
+    auto message_language =
+        (*message_)[strings::msg_params][strings::language].asInt();
+
+    for (auto app : accessor) {
+      auto app_id = app->app_id();
+      app_list.push_back(app_id);
+      if (app->language() != message_language) {
+        to_unregister.push_back(app_id);
+      }
+    }
+  }
+
+  for (auto app_id : app_list) {
+    (*message_)[strings::params][strings::connection_key] = app_id;
     SendNotificationToMobile(message_);
+  }
 
-    if (static_cast<int32_t>(app->language()) !=
-        (*message_)[strings::msg_params][strings::language].asInt()) {
-      application_manager_.state_controller().SetRegularState(
-          app,
-          mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
-          mobile_apis::HMILevel::HMI_NONE,
-          false);
-
-      rpc_service_.ManageMobileCommand(
-          MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
-              app->app_id(),
-              mobile_api::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE),
-          SOURCE_SDL);
-      application_manager_.UnregisterApplication(
-          app->app_id(), mobile_apis::Result::SUCCESS, false);
-    }
+  for (auto app_id : to_unregister) {
+    rpc_service_.ManageMobileCommand(
+        MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
+            app_id,
+            mobile_api::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE),
+        SOURCE_SDL);
+    application_manager_.UnregisterApplication(
+        app_id, mobile_apis::Result::SUCCESS, false);
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_vr_language_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_vr_language_change_notification.cc
@@ -78,13 +78,7 @@ void OnVRLanguageChangeNotification::Run() {
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);
 
-  ApplicationSet apps;
-
-  {
-    const ApplicationSet& accessor =
-        application_manager_.applications().GetData();
-    apps = ApplicationSet(accessor);
-  }
+  auto apps = ApplicationSet(application_manager_.applications().GetData());
 
   auto message_language =
       (*message_)[strings::msg_params][strings::language].asInt();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_vr_language_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_vr_language_change_notification.cc
@@ -78,37 +78,28 @@ void OnVRLanguageChangeNotification::Run() {
   (*message_)[strings::params][strings::function_id] =
       static_cast<int32_t>(mobile_apis::FunctionID::OnLanguageChangeID);
 
-  std::vector<uint32_t> app_list;
-  std::vector<uint32_t> to_unregister;
+  ApplicationSet apps;
 
   {
     const ApplicationSet& accessor =
         application_manager_.applications().GetData();
-    auto message_language =
-        (*message_)[strings::msg_params][strings::language].asInt();
-
-    for (auto app : accessor) {
-      auto app_id = app->app_id();
-      app_list.push_back(app_id);
-      if (app->language() != message_language) {
-        to_unregister.push_back(app_id);
-      }
-    }
+    apps = ApplicationSet(accessor);
   }
 
-  for (auto app_id : app_list) {
-    (*message_)[strings::params][strings::connection_key] = app_id;
+  auto message_language =
+      (*message_)[strings::msg_params][strings::language].asInt();
+  for (auto app : apps) {
+    (*message_)[strings::params][strings::connection_key] = app->app_id();
     SendNotificationToMobile(message_);
-  }
-
-  for (auto app_id : to_unregister) {
-    rpc_service_.ManageMobileCommand(
-        MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
-            app_id,
-            mobile_api::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE),
-        SOURCE_SDL);
-    application_manager_.UnregisterApplication(
-        app_id, mobile_apis::Result::SUCCESS, false);
+    if (app->language() != message_language) {
+      rpc_service_.ManageMobileCommand(
+          MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
+              app->app_id(),
+              mobile_api::AppInterfaceUnregisteredReason::LANGUAGE_CHANGE),
+          SOURCE_SDL);
+      application_manager_.UnregisterApplication(
+          app->app_id(), mobile_apis::Result::SUCCESS, false);
+    }
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_vr_language_change_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_vr_language_change_notification.cc
@@ -92,6 +92,11 @@ void OnVRLanguageChangeNotification::Run() {
       app_list.push_back(app_id);
       if (app->language() != message_language) {
         to_unregister.push_back(app_id);
+        application_manager_.state_controller().SetRegularState(
+            app,
+            mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
+            mobile_apis::HMILevel::HMI_NONE,
+            false);
       }
     }
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
@@ -279,7 +279,7 @@ void SDLActivateAppRequest::OnTimeOut() {
   unsubscribe_from_event(BasicCommunication_OnAppRegistered);
   SendErrorResponse(correlation_id(),
                     SDL_ActivateApp,
-                    APPLICATION_NOT_REGISTERED,
+                    NO_APPS_REGISTERED,
                     "App registration timed out");
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
@@ -162,15 +162,6 @@ void SDLActivateAppRequest::Run() {
     }
     policy_handler_.OnActivateApp(application_id, correlation_id());
   }
-
-  connection_handler::DeviceHandle device_handle = app->device();
-  SDL_LOG_ERROR(
-      "Can't find regular foreground app with the same connection id: "
-      << device_handle);
-  SendErrorResponse(correlation_id(),
-                    SDL_ActivateApp,
-                    hmi_apis::Common_Result::NO_APPS_REGISTERED,
-                    "");
 }
 
 #else  // EXTERNAL_PROPRIETARY_MODE

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
@@ -148,10 +148,9 @@ void SDLActivateAppRequest::Run() {
       subscribe_on_event(BasicCommunication_OnAppRegistered);
       application_manager_.connection_handler().ConnectToDevice(app->device());
     } else {
-      connection_handler::DeviceHandle device_handle = app->device();
       SDL_LOG_ERROR(
-          "Can't find regular foreground app with the same connection id: "
-          << device_handle);
+          "Can't find registered app with the specified app id: "
+          << app_id());
       SendErrorResponse(correlation_id(),
                         SDL_ActivateApp,
                         hmi_apis::Common_Result::APPLICATION_NOT_REGISTERED,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
@@ -149,8 +149,7 @@ void SDLActivateAppRequest::Run() {
       application_manager_.connection_handler().ConnectToDevice(app->device());
     } else {
       SDL_LOG_ERROR(
-          "Can't find registered app with the specified app id: "
-          << app_id());
+          "Can't find registered app with the specified app id: " << app_id());
       SendErrorResponse(correlation_id(),
                         SDL_ActivateApp,
                         hmi_apis::Common_Result::APPLICATION_NOT_REGISTERED,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -440,8 +440,6 @@ void FinishSendingResponseToMobile(const smart_objects::SmartObject& msg_params,
                                       &(msg_params[strings::app_hmi_type]));
   }
 
-  application->MarkRegistered();
-
   // Default HMI level should be set before any permissions validation, since
   // it relies on HMI level.
   app_manager.OnApplicationRegistered(application);
@@ -734,6 +732,7 @@ void RegisterAppInterfaceRequest::Run() {
   }
 
   CheckLanguage();
+
   SendRegisterAppInterfaceResponseToMobile(
       ApplicationType::kNewApplication, status_notifier, add_info);
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_response.cc
@@ -96,7 +96,7 @@ void RegisterAppInterfaceResponse::Run() {
   }
 
   SendResponse(success, result_code, last_message);
-  if (success) {
+  if (app && success) {
     app->set_is_ready(true);
   }
   event_engine::MobileEvent event(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/hmi_notifications_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/hmi_notifications_test.cc
@@ -1414,12 +1414,6 @@ TEST_F(HMICommandsNotificationsTest,
               ManageMobileCommand(_, Command::CommandSource::SOURCE_SDL));
   EXPECT_CALL(*app_ptr_, app_id()).WillRepeatedly(Return(kAppId_));
   EXPECT_CALL(*app_ptr_, language()).WillRepeatedly(ReturnRef(kLang));
-  EXPECT_CALL(app_mngr_, state_controller())
-      .WillOnce(ReturnRef(mock_state_controller_));
-  EXPECT_CALL(
-      mock_state_controller_,
-      SetRegularState(
-          app_, kDefaultWindowId, mobile_apis::HMILevel::HMI_NONE, false));
   EXPECT_CALL(mock_message_helper_,
               GetOnAppInterfaceUnregisteredNotificationToMobile(
                   kAppId_,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/hmi_notifications_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/hmi_notifications_test.cc
@@ -1368,7 +1368,6 @@ TEST_F(HMICommandsNotificationsTest,
   EXPECT_CALL(mock_hmi_capabilities_, set_active_vr_language(_));
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(_, Command::CommandSource::SOURCE_SDL));
-  EXPECT_CALL(*app_ptr_, IsRegistered()).WillOnce(Return(true));
   EXPECT_CALL(*app_ptr_, app_id()).WillOnce(Return(kAppId_));
   EXPECT_CALL(*app_ptr_, language()).WillRepeatedly(ReturnRef(kLang));
 
@@ -1413,7 +1412,6 @@ TEST_F(HMICommandsNotificationsTest,
   EXPECT_CALL(mock_hmi_capabilities_, set_active_vr_language(_));
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(_, Command::CommandSource::SOURCE_SDL));
-  EXPECT_CALL(*app_ptr_, IsRegistered()).WillOnce(Return(true));
   EXPECT_CALL(*app_ptr_, app_id()).WillRepeatedly(Return(kAppId_));
   EXPECT_CALL(*app_ptr_, language()).WillRepeatedly(ReturnRef(kLang));
   EXPECT_CALL(app_mngr_, state_controller())
@@ -1699,7 +1697,6 @@ TEST_F(HMICommandsNotificationsTest,
   EXPECT_CALL(mock_hmi_capabilities_, set_active_tts_language(_));
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(_, Command::CommandSource::SOURCE_SDL));
-  EXPECT_CALL(*app_ptr_, IsRegistered()).WillOnce(Return(true));
   EXPECT_CALL(*app_ptr_, app_id()).WillOnce(Return(kAppId_));
   EXPECT_CALL(*app_ptr_, language()).WillRepeatedly(ReturnRef(kLang));
 
@@ -1745,7 +1742,6 @@ TEST_F(HMICommandsNotificationsTest,
   EXPECT_CALL(mock_hmi_capabilities_, set_active_tts_language(_));
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(_, Command::CommandSource::SOURCE_SDL));
-  EXPECT_CALL(*app_ptr_, IsRegistered()).WillOnce(Return(true));
   EXPECT_CALL(*app_ptr_, app_id()).WillRepeatedly(Return(kAppId_));
   EXPECT_CALL(*app_ptr_, language()).WillRepeatedly(ReturnRef(kLang));
   EXPECT_CALL(mock_message_helper_,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_activate_app_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_activate_app_request_test.cc
@@ -157,9 +157,6 @@ TEST_F(SDLActivateAppRequestTest, Run_ActivateApp_SUCCESS) {
               CurrentHmiState(mobile_apis::PredefinedWindows::DEFAULT_WINDOW))
       .WillOnce(Return(state));
 
-  EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(kAppID));
-  EXPECT_CALL(*mock_app, IsRegistered()).WillOnce(Return(true));
-
   EXPECT_CALL(mock_policy_handler_, OnActivateApp(kAppID, kCorrelationID));
 
   command->Run();
@@ -205,8 +202,8 @@ TEST_F(SDLActivateAppRequestTest, FindAppToRegister_SUCCESS) {
               IsStateActive(am::HmiState::StateID::STATE_ID_DEACTIVATE_HMI))
       .WillOnce(Return(false));
 
-  ON_CALL(*mock_app, IsRegistered()).WillByDefault(Return(false));
-  ON_CALL(*mock_app, is_cloud_app()).WillByDefault(Return(false));
+  EXPECT_CALL(*mock_app, IsRegistered()).WillOnce(Return(false));
+  EXPECT_CALL(*mock_app, is_cloud_app()).WillOnce(Return(false));
   ON_CALL(*mock_app, device()).WillByDefault(Return(kHandle));
 
   MockAppPtr mock_app_first(CreateMockApp());
@@ -267,8 +264,8 @@ TEST_F(SDLActivateAppRequestTest, DevicesAppsEmpty_SUCCESS) {
               IsStateActive(am::HmiState::StateID::STATE_ID_DEACTIVATE_HMI))
       .WillOnce(Return(false));
 
-  ON_CALL(*mock_app, IsRegistered()).WillByDefault(Return(false));
-  ON_CALL(*mock_app, is_cloud_app()).WillByDefault(Return(false));
+  EXPECT_CALL(*mock_app, IsRegistered()).WillOnce(Return(false));
+  EXPECT_CALL(*mock_app, is_cloud_app()).WillOnce(Return(false));
   ON_CALL(*mock_app, device()).WillByDefault(Return(kHandle));
 
   DataAccessor<ApplicationSet> accessor(app_list_, lock_);
@@ -330,11 +327,10 @@ TEST_F(SDLActivateAppRequestTest, FirstAppNotActiveNONE_SUCCESS) {
   EXPECT_CALL(mock_state_controller_,
               IsStateActive(am::HmiState::StateID::STATE_ID_DEACTIVATE_HMI))
       .WillOnce(Return(false));
-
-  ON_CALL(*mock_app, IsRegistered()).WillByDefault(Return(true));
-
+  EXPECT_CALL(*mock_app, IsRegistered()).WillOnce(Return(true));  // ?
   am::HmiStatePtr state = std::make_shared<am::HmiState>(mock_app, app_mngr_);
   state->set_hmi_level(mobile_apis::HMILevel::HMI_NONE);
+
   EXPECT_CALL(*mock_app,
               CurrentHmiState(mobile_apis::PredefinedWindows::DEFAULT_WINDOW))
       .WillOnce(Return(state));
@@ -361,9 +357,8 @@ TEST_F(SDLActivateAppRequestTest, FirstAppIsForeground_SUCCESS) {
   ON_CALL(app_mngr_, application(kAppID)).WillByDefault(Return(mock_app));
 
   EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
-  ON_CALL(*mock_app, IsRegistered()).WillByDefault(Return(false));
-  ON_CALL(*mock_app, is_cloud_app()).WillByDefault(Return(false));
-
+  EXPECT_CALL(*mock_app, IsRegistered()).WillOnce(Return(false));
+  EXPECT_CALL(*mock_app, is_cloud_app()).WillOnce(Return(false));
   EXPECT_CALL(app_mngr_, state_controller())
       .WillOnce(ReturnRef(mock_state_controller_));
   EXPECT_CALL(mock_state_controller_,
@@ -434,7 +429,6 @@ TEST_F(SDLActivateAppRequestTest, FirstAppNotRegistered_SUCCESS) {
   EXPECT_CALL(mock_state_controller_,
               IsStateActive(am::HmiState::StateID::STATE_ID_DEACTIVATE_HMI))
       .WillOnce(Return(false));
-
   DataAccessor<ApplicationSet> accessor(app_list_, lock_);
   EXPECT_CALL(app_mngr_, applications()).WillRepeatedly(Return(accessor));
 
@@ -466,8 +460,8 @@ TEST_F(SDLActivateAppRequestTest, WaitingCloudApplication_ConnectDevice) {
   MockAppPtr mock_app(CreateMockApp());
 
   EXPECT_CALL(*mock_app, device()).WillOnce(Return(kHandle));
-  ON_CALL(*mock_app, IsRegistered()).WillByDefault(Return(false));
-  ON_CALL(*mock_app, is_cloud_app()).WillByDefault(Return(true));
+  EXPECT_CALL(*mock_app, IsRegistered()).WillOnce(Return(false));
+  EXPECT_CALL(*mock_app, is_cloud_app()).WillOnce(Return(true));
 
 #ifndef EXTERNAL_PROPRIETARY_MODE
   EXPECT_CALL(app_mngr_, application(kAppID))

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_activate_app_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_activate_app_request_test.cc
@@ -327,7 +327,7 @@ TEST_F(SDLActivateAppRequestTest, FirstAppNotActiveNONE_SUCCESS) {
   EXPECT_CALL(mock_state_controller_,
               IsStateActive(am::HmiState::StateID::STATE_ID_DEACTIVATE_HMI))
       .WillOnce(Return(false));
-  EXPECT_CALL(*mock_app, IsRegistered()).WillOnce(Return(true));  // ?
+  EXPECT_CALL(*mock_app, IsRegistered()).WillOnce(Return(true));
   am::HmiStatePtr state = std::make_shared<am::HmiState>(mock_app, app_mngr_);
   state->set_hmi_level(mobile_apis::HMILevel::HMI_NONE);
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_activate_app_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_activate_app_request_test.cc
@@ -157,6 +157,9 @@ TEST_F(SDLActivateAppRequestTest, Run_ActivateApp_SUCCESS) {
               CurrentHmiState(mobile_apis::PredefinedWindows::DEFAULT_WINDOW))
       .WillOnce(Return(state));
 
+  EXPECT_CALL(*mock_app,IsRegistered())
+      .WillOnce(Return(true));
+
   EXPECT_CALL(mock_policy_handler_, OnActivateApp(kAppID, kCorrelationID));
 
   command->Run();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_activate_app_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_activate_app_request_test.cc
@@ -157,8 +157,7 @@ TEST_F(SDLActivateAppRequestTest, Run_ActivateApp_SUCCESS) {
               CurrentHmiState(mobile_apis::PredefinedWindows::DEFAULT_WINDOW))
       .WillOnce(Return(state));
 
-  EXPECT_CALL(*mock_app,IsRegistered())
-      .WillOnce(Return(true));
+  EXPECT_CALL(*mock_app, IsRegistered()).WillOnce(Return(true));
 
   EXPECT_CALL(mock_policy_handler_, OnActivateApp(kAppID, kCorrelationID));
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -4770,6 +4770,9 @@ void ApplicationManagerImpl::AddAppToRegisteredAppList(
   SDL_LOG_AUTO_TRACE();
   DCHECK_OR_RETURN_VOID(application);
   sync_primitives::AutoLock lock(applications_list_lock_ptr_);
+
+  // Add application to registered app list and set appropriate mark.
+  application->MarkRegistered();
   applications_.insert(application);
   SDL_LOG_DEBUG("App with app_id: "
                 << application->app_id()

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1200,6 +1200,19 @@ void ApplicationManagerImpl::CreatePendingApplication(
   application->set_hybrid_app_preference(hybrid_app_preference_enum);
   application->set_cloud_app_certificate(app_properties.certificate);
 
+  HmiStatePtr initial_state =
+      CreateRegularState(application,
+                         mobile_apis::WindowType::MAIN,
+                         mobile_apis::HMILevel::INVALID_ENUM,
+                         mobile_apis::AudioStreamingState::INVALID_ENUM,
+                         mobile_apis::VideoStreamingState::INVALID_ENUM,
+                         mobile_api::SystemContext::SYSCTXT_MAIN);
+
+  application->SetInitialState(
+      mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
+      std::string(),  // should not be tracked for main window
+      initial_state);
+
   {
     sync_primitives::AutoLock lock(apps_to_register_list_lock_ptr_);
     SDL_LOG_DEBUG(
@@ -1283,6 +1296,19 @@ void ApplicationManagerImpl::CreatePendingLocalApplication(
   application->set_cloud_app_transport_type(app_properties.transport_type);
   application->set_hybrid_app_preference(hybrid_app_preference_enum);
   application->set_cloud_app_certificate(app_properties.certificate);
+
+  HmiStatePtr initial_state =
+      CreateRegularState(application,
+                         mobile_apis::WindowType::MAIN,
+                         mobile_apis::HMILevel::INVALID_ENUM,
+                         mobile_apis::AudioStreamingState::INVALID_ENUM,
+                         mobile_apis::VideoStreamingState::INVALID_ENUM,
+                         mobile_api::SystemContext::SYSCTXT_MAIN);
+
+  application->SetInitialState(
+      mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
+      std::string(),  // should not be tracked for main window
+      initial_state);
 
   sync_primitives::AutoLock lock(apps_to_register_list_lock_ptr_);
   apps_to_register_.insert(application);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1200,19 +1200,6 @@ void ApplicationManagerImpl::CreatePendingApplication(
   application->set_hybrid_app_preference(hybrid_app_preference_enum);
   application->set_cloud_app_certificate(app_properties.certificate);
 
-  HmiStatePtr initial_state =
-      CreateRegularState(application,
-                         mobile_apis::WindowType::MAIN,
-                         mobile_apis::HMILevel::INVALID_ENUM,
-                         mobile_apis::AudioStreamingState::INVALID_ENUM,
-                         mobile_apis::VideoStreamingState::INVALID_ENUM,
-                         mobile_api::SystemContext::SYSCTXT_MAIN);
-
-  application->SetInitialState(
-      mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
-      std::string(),  // should not be tracked for main window
-      initial_state);
-
   {
     sync_primitives::AutoLock lock(apps_to_register_list_lock_ptr_);
     SDL_LOG_DEBUG(
@@ -1296,19 +1283,6 @@ void ApplicationManagerImpl::CreatePendingLocalApplication(
   application->set_cloud_app_transport_type(app_properties.transport_type);
   application->set_hybrid_app_preference(hybrid_app_preference_enum);
   application->set_cloud_app_certificate(app_properties.certificate);
-
-  HmiStatePtr initial_state =
-      CreateRegularState(application,
-                         mobile_apis::WindowType::MAIN,
-                         mobile_apis::HMILevel::INVALID_ENUM,
-                         mobile_apis::AudioStreamingState::INVALID_ENUM,
-                         mobile_apis::VideoStreamingState::INVALID_ENUM,
-                         mobile_api::SystemContext::SYSCTXT_MAIN);
-
-  application->SetInitialState(
-      mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
-      std::string(),  // should not be tracked for main window
-      initial_state);
 
   sync_primitives::AutoLock lock(apps_to_register_list_lock_ptr_);
   apps_to_register_.insert(application);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3344,7 +3344,7 @@ void ApplicationManagerImpl::UnregisterApplication(
     while (applications_.end() != it_app) {
       if (app_id == (*it_app)->app_id()) {
         app_to_remove = *it_app;
-        applications_.erase(it_app++);
+        applications_.erase(it_app);
         break;
       } else {
         ++it_app;

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1848,7 +1848,7 @@ bool MessageHelper::CreateHMIApplicationStruct(
   if (file_system::FileExists(app->app_icon_path())) {
     message[strings::icon] = icon_path;
   }
-  if (app->app_id() > 0 || app->IsRegistered()) {
+  if (app->IsRegistered()) {
     message[strings::hmi_display_language_desired] = app->ui_language();
     message[strings::is_media_application] = app->is_media_application();
   } else {


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3805 (crash in UI lang change)
Fixes https://github.com/smartdevicelink/sdl_core/issues/3783 (crash in VR lang change)

Reverts https://github.com/smartdevicelink/sdl_core/pull/3796 (alternate fix for VR lang change crash)
Therefore Fixes https://github.com/smartdevicelink/sdl_core/issues/3674 (regression caused by 3796)
(also reverts part of https://github.com/smartdevicelink/sdl_core/pull/3799, a fixup to 3796)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2602
[3674_1_HMI_sends_OnSystemRequest_before_UpdateAppList.lua](https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/master/test_scripts/Defects/8_0/3674_1_HMI_sends_OnSystemRequest_before_UpdateAppList.lua) (many iterations)
https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2603
[3797_3798_HMI_sends_SetAppProperties_and_tries_to_ActivateApp.lua](https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/develop/test_scripts/Defects/8_0/3797_3798_HMI_sends_SetAppProperties_and_tries_to_ActivateApp.lua)

### Summary
Core was modifying applications array while iterating it during language change, now we are iterating copies that won't be modified while iterating them.

Also a crash was noticed and fixed by https://github.com/smartdevicelink/sdl_core/pull/3806/commits/8be17f5cfd3350e712b52e0b3be583ace57e580a
```
Thread 8 "AM Pool 0" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff0a91700 (LWP 100005)]
0x00007fffe87559ab in sdl_rpc_plugin::commands::RegisterAppInterfaceResponse::Run (this=0x7fff900483d0) at /home/collin/core/builds/dev_no_log/sdl_core/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_response.cc:100
100	    app->set_is_ready(true);
#0  0x00007fffe87559ab in sdl_rpc_plugin::commands::RegisterAppInterfaceResponse::Run (this=0x7fff900483d0) at /home/collin/core/builds/dev_no_log/sdl_core/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_response.cc:100
        result_code = mobile_apis::Result::SUCCESS
        success = true
        last_message = false
        app = std::shared_ptr<application_manager::Application> (empty) = {get() = 0x0}
        event = {_vptr.MobileEvent = 0xf0a90620, id_ = -257357840, response_so_ = {m_type = 1476598128, m_data = {double_value = 6.9533430926564036e-310, bool_value = false, char_value = 0 '\000', int_value = 140737230997248, str_value = 0x7ffff0a90700, array_value = 0x7ffff0a90700, map_value = 0x7ffff0a90700, binary_value = 0x7ffff0a90700}, m_schema = {mSchemaItem = <error reading variable: Cannot access memory at address 0x45228a11cb85f608>}}}
        event_msg = {m_type = -382494360, m_data = {double_value = 6.9533369100995419e-310, bool_value = 40, char_value = 40 '(', int_value = 140737105860904, str_value = 0x7fffe9339928, array_value = 0x7fffe9339928, map_value = 0x7fffe9339928, binary_value = 0x7fffe9339928}, m_schema = {mSchemaItem = std::shared_ptr<ns_smart_device_link::ns_smart_objects::ISchemaItem> (use count 473122916, weak count 10276) = {get() = 0x7ffff0a90640}}}
#1  0x00005555562ee8c3 in application_manager::rpc_service::RPCServiceImpl::ManageMobileCommand (this=0x555557a8d350, message=std::shared_ptr<ns_smart_device_link::ns_smart_objects::SmartObject> (use count 4, weak count 0) = {...}, source=application_manager::commands::Command::SOURCE_SDL, warning_info="") at /home/collin/core/builds/dev_no_log/sdl_core/src/components/application_manager/src/rpc_service_impl.cc:225
        connection_key = 65537
        window_id = 0
        message_type = 1
        app_ptr = std::shared_ptr<application_manager::Application> (empty) = {get() = 0x0}
```

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
