### PR TITLE
Reset display_capabilities_ pointer after merging capabilities

### DIFF
--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -610,8 +610,7 @@ void DynamicApplicationDataImpl::set_display_capabilities(
         (*display_capabilities_)[0][strings::window_capabilities];
   }
 
-  display_capabilities_.reset(
-      new smart_objects::SmartObject(display_capabilities));
+  smart_objects::SmartObject merged_capabilities = display_capabilities;
 
   auto get_window_index = [&tmp_window_capabilities](const WindowID window_id) {
     const auto tmp_window_capabilities_arr = tmp_window_capabilities.asArray();
@@ -647,8 +646,11 @@ void DynamicApplicationDataImpl::set_display_capabilities(
     }
   }
 
-  (*display_capabilities_)[0][strings::window_capabilities] =
+  merged_capabilities[0][strings::window_capabilities] =
       tmp_window_capabilities;
+
+  display_capabilities_.reset(
+      new smart_objects::SmartObject(merged_capabilities));
 }
 
 void DynamicApplicationDataImpl::remove_window_capability(


### PR DESCRIPTION

Fixes #3800 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manually test using instructions in #3800 

### Summary
Currently `set_display_capabilities` overwrites the display capabilities, then merges them with the previous capabilities, this PR changes this process to merge them first, then overwrite the capabilities

### Changelog
##### Bug Fixes
* Resets display_capabilities_ pointer after merging capabilities, rather than before

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
