### PR TITLE
Avoid processing streaming data packets after streaming stopping

### DIFF
--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -577,8 +577,8 @@ class ApplicationImpl : public virtual Application,
   bool audio_streaming_allowed_;
   bool video_streaming_suspended_;
   bool audio_streaming_suspended_;
-  sync_primitives::Lock video_streaming_suspended_lock_;
-  sync_primitives::Lock audio_streaming_suspended_lock_;
+  bool video_streaming_stopped_;
+  bool audio_streaming_stopped_;
   sync_primitives::Lock streaming_stop_lock_;
 
   bool is_app_allowed_;

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -614,11 +614,11 @@ void ApplicationImpl::StopStreaming(
 
 void ApplicationImpl::StopNaviStreaming() {
   SDL_LOG_AUTO_TRACE();
+  video_streaming_stopped_ = true;
   video_stream_suspend_timer_.Stop();
   MessageHelper::SendNaviStopStream(app_id(), application_manager_);
   set_video_streaming_approved(false);
   set_video_stream_retry_number(0);
-  video_streaming_stopped_ = true;
 }
 
 void ApplicationImpl::StopAudioStreaming() {
@@ -662,7 +662,7 @@ void ApplicationImpl::WakeUpStreaming(
       return;
     }
     if (video_streaming_suspended_) {
-      SDL_LOG_DEBUG("Video streaming will be resumed after suspension");
+      SDL_LOG_DEBUG("Video streaming is resuming after suspension");
       application_manager_.OnAppStreaming(app_id(), service_type, true);
       application_manager_.ProcessOnDataStreamingNotification(
           service_type, app_id(), true);
@@ -679,7 +679,7 @@ void ApplicationImpl::WakeUpStreaming(
       return;
     }
     if (audio_streaming_suspended_) {
-      SDL_LOG_DEBUG("Audio streaming will be resumed after suspension");
+      SDL_LOG_DEBUG("Audio streaming is resuming after suspension");
       application_manager_.OnAppStreaming(app_id(), service_type, true);
       application_manager_.ProcessOnDataStreamingNotification(
           service_type, app_id(), true);

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -623,11 +623,11 @@ void ApplicationImpl::StopNaviStreaming() {
 
 void ApplicationImpl::StopAudioStreaming() {
   SDL_LOG_AUTO_TRACE();
+  audio_streaming_stopped_ = true;
   audio_stream_suspend_timer_.Stop();
   MessageHelper::SendAudioStopStream(app_id(), application_manager_);
   set_audio_streaming_approved(false);
   set_audio_stream_retry_number(0);
-  audio_streaming_stopped_ = true;
 }
 
 void ApplicationImpl::SuspendStreaming(

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -113,6 +113,8 @@ ApplicationImpl::ApplicationImpl(
     , audio_streaming_allowed_(false)
     , video_streaming_suspended_(true)
     , audio_streaming_suspended_(true)
+    , video_streaming_stopped_(false)
+    , audio_streaming_stopped_(false)
     , is_app_allowed_(true)
     , is_app_data_resumption_allowed_(false)
     , has_been_activated_(false)
@@ -560,6 +562,7 @@ void ApplicationImpl::StartStreaming(
 
   if (ServiceType::kMobileNav == service_type) {
     SDL_LOG_TRACE("ServiceType = Video");
+    video_streaming_stopped_ = false;
     if (!video_streaming_approved()) {
       SDL_LOG_TRACE("Video streaming not approved");
       MessageHelper::SendNaviStartStream(app_id(), application_manager_);
@@ -567,6 +570,7 @@ void ApplicationImpl::StartStreaming(
     }
   } else if (ServiceType::kAudio == service_type) {
     SDL_LOG_TRACE("ServiceType = Audio");
+    audio_streaming_stopped_ = false;
     if (!audio_streaming_approved()) {
       SDL_LOG_TRACE("Audio streaming not approved");
       MessageHelper::SendAudioStartStream(app_id(), application_manager_);
@@ -580,7 +584,6 @@ void ApplicationImpl::StopStreamingForce(
   using namespace protocol_handler;
   SDL_LOG_AUTO_TRACE();
 
-  // see the comment in StopStreaming()
   sync_primitives::AutoLock lock(streaming_stop_lock_);
 
   SuspendStreaming(service_type);
@@ -597,10 +600,6 @@ void ApplicationImpl::StopStreaming(
   using namespace protocol_handler;
   SDL_LOG_AUTO_TRACE();
 
-  // since WakeUpStreaming() is called from another thread, it is possible that
-  // the stream will be restarted after we call SuspendStreaming() and before
-  // we call StopXxxStreaming(). To avoid such timing issue, make sure that
-  // we run SuspendStreaming() and StopXxxStreaming() atomically.
   sync_primitives::AutoLock lock(streaming_stop_lock_);
 
   SuspendStreaming(service_type);
@@ -619,6 +618,7 @@ void ApplicationImpl::StopNaviStreaming() {
   MessageHelper::SendNaviStopStream(app_id(), application_manager_);
   set_video_streaming_approved(false);
   set_video_stream_retry_number(0);
+  video_streaming_stopped_ = true;
 }
 
 void ApplicationImpl::StopAudioStreaming() {
@@ -627,6 +627,7 @@ void ApplicationImpl::StopAudioStreaming() {
   MessageHelper::SendAudioStopStream(app_id(), application_manager_);
   set_audio_streaming_approved(false);
   set_audio_stream_retry_number(0);
+  audio_streaming_stopped_ = true;
 }
 
 void ApplicationImpl::SuspendStreaming(
@@ -637,12 +638,10 @@ void ApplicationImpl::SuspendStreaming(
   if (ServiceType::kMobileNav == service_type) {
     video_stream_suspend_timer_.Stop();
     application_manager_.OnAppStreaming(app_id(), service_type, false);
-    sync_primitives::AutoLock lock(video_streaming_suspended_lock_);
     video_streaming_suspended_ = true;
   } else if (ServiceType::kAudio == service_type) {
     audio_stream_suspend_timer_.Stop();
     application_manager_.OnAppStreaming(app_id(), service_type, false);
-    sync_primitives::AutoLock lock(audio_streaming_suspended_lock_);
     audio_streaming_suspended_ = true;
   }
   application_manager_.ProcessOnDataStreamingNotification(
@@ -654,32 +653,37 @@ void ApplicationImpl::WakeUpStreaming(
   using namespace protocol_handler;
   SDL_LOG_AUTO_TRACE();
 
-  // See the comment in StopStreaming(). Also, please make sure that we acquire
-  // streaming_stop_lock_ then xxx_streaming_suspended_lock_ in this order!
   sync_primitives::AutoLock lock(streaming_stop_lock_);
 
   if (ServiceType::kMobileNav == service_type) {
-    {  // reduce the range of video_streaming_suspended_lock_
-      sync_primitives::AutoLock auto_lock(video_streaming_suspended_lock_);
-      if (video_streaming_suspended_) {
-        application_manager_.OnAppStreaming(app_id(), service_type, true);
-        application_manager_.ProcessOnDataStreamingNotification(
-            service_type, app_id(), true);
-        video_streaming_suspended_ = false;
-      }
+    if (video_streaming_stopped_) {
+      SDL_LOG_WARN(
+          "Video streaming is stopped, received data packet will be dropped");
+      return;
     }
+    if (video_streaming_suspended_) {
+      SDL_LOG_DEBUG("Video streaming will be resumed after suspension");
+      application_manager_.OnAppStreaming(app_id(), service_type, true);
+      application_manager_.ProcessOnDataStreamingNotification(
+          service_type, app_id(), true);
+      video_streaming_suspended_ = false;
+    }
+
     video_stream_suspend_timer_.Start(
         timer_len == 0 ? video_stream_suspend_timeout_ : timer_len,
         timer::kPeriodic);
   } else if (ServiceType::kAudio == service_type) {
-    {  // reduce the range of audio_streaming_suspended_lock_
-      sync_primitives::AutoLock auto_lock(audio_streaming_suspended_lock_);
-      if (audio_streaming_suspended_) {
-        application_manager_.OnAppStreaming(app_id(), service_type, true);
-        application_manager_.ProcessOnDataStreamingNotification(
-            service_type, app_id(), true);
-        audio_streaming_suspended_ = false;
-      }
+    if (audio_streaming_stopped_) {
+      SDL_LOG_WARN(
+          "Audio streaming is stopped, received data packet will be dropped");
+      return;
+    }
+    if (audio_streaming_suspended_) {
+      SDL_LOG_DEBUG("Audio streaming will be resumed after suspension");
+      application_manager_.OnAppStreaming(app_id(), service_type, true);
+      application_manager_.ProcessOnDataStreamingNotification(
+          service_type, app_id(), true);
+      audio_streaming_suspended_ = false;
     }
     audio_stream_suspend_timer_.Start(
         timer_len == 0 ? audio_stream_suspend_timeout_ : timer_len,


### PR DESCRIPTION
Fixes #3811 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test scripts

### Summary
In some situations streaming data packets may be received during streaming stopping. In this case processing of such packet will be performed right after completion of streaming stopping process due to `streaming_stop_lock_`. So in this case we need to skip processing of such packet, that's why new flags `video_streaming_stopped_` and `audio_streaming_stopped_` are added for both services. Also outdated comments are removed with locks, which now are redundant due to presence of `streaming_stop_lock_`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
