### PR TITLE
fix/sdl_did_not_read_correctly_value_of_hmicapabilities_from_hmicapabilitiescachefile

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -322,6 +322,11 @@
             "audioType": "PCM"
         },
         "hmiZoneCapabilities": "FRONT",
+		"hmiCapabilities":{
+			"navigation":true,
+			"phoneCall":true,
+			"videoStreaming":true
+		},
         "softButtonCapabilities": [{
             "shortPressAvailable": true,
             "longPressAvailable": true,

--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -322,11 +322,11 @@
             "audioType": "PCM"
         },
         "hmiZoneCapabilities": "FRONT",
-		"hmiCapabilities":{
-			"navigation":true,
-			"phoneCall":true,
-			"videoStreaming":true
-		},
+        "hmiCapabilities":{
+            "navigation":true,
+            "phoneCall":true,
+            "videoStreaming":true
+        },
         "softButtonCapabilities": [{
             "shortPressAvailable": true,
             "longPressAvailable": true,

--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -135,6 +135,11 @@ class HMICapabilitiesImpl : public HMICapabilities {
   void set_hmi_zone_capabilities(
       const smart_objects::SmartObject& hmi_zone_capabilities) OVERRIDE;
 
+  const smart_objects::SmartObjectSPtr ui_hmi_capabilities() const OVERRIDE;
+
+  void set_ui_hmi_capabilities(
+      const smart_objects::SmartObject& ui_hmi_capabilities) OVERRIDE;
+
   const smart_objects::SmartObjectSPtr soft_button_capabilities()
       const OVERRIDE;
 
@@ -463,6 +468,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
   smart_objects::SmartObjectSPtr display_capabilities_;
   smart_objects::SmartObjectSPtr system_display_capabilities_;
   smart_objects::SmartObjectSPtr hmi_zone_capabilities_;
+  smart_objects::SmartObjectSPtr ui_hmi_capabilities_;
   smart_objects::SmartObjectSPtr soft_buttons_capabilities_;
   smart_objects::SmartObjectSPtr button_capabilities_;
   smart_objects::SmartObjectSPtr preset_bank_capabilities_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
@@ -104,6 +104,8 @@ void UIGetCapabilitiesResponse::Run() {
   }
 
   if (msg_params.keyExists(strings::hmi_capabilities)) {
+    hmi_capabilities_.set_ui_hmi_capabilities(
+        msg_params[strings::hmi_capabilities]);
     if (msg_params[strings::hmi_capabilities].keyExists(strings::navigation)) {
       sections_to_update.push_back(strings::navigation);
       hmi_capabilities_.set_navigation_supported(

--- a/src/components/application_manager/test/hmi_capabilities_sc1.json
+++ b/src/components/application_manager/test/hmi_capabilities_sc1.json
@@ -1,5 +1,10 @@
 {
   "UI": {
+	  "hmiCapabilities":{
+			"navigation":false,
+			"phoneCall":true,
+			"videoStreaming":false
+		},
     "systemCapabilities": {
       "phoneCapability": {
         "dialNumberEnabled": true

--- a/src/components/application_manager/test/hmi_capabilities_sc2.json
+++ b/src/components/application_manager/test/hmi_capabilities_sc2.json
@@ -1,5 +1,10 @@
 {
   "UI": {
+   "hmiCapabilities":{
+		"navigation":true,
+		"phoneCall":false,
+		"videoStreaming":false
+	},
     "language": "EN_US",
     "languages": [
             "EN_US",

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -504,6 +504,15 @@ TEST_F(HMICapabilitiesTest,
 TEST_F(
     HMICapabilitiesTest,
     LoadCapabilitiesFromFile_CheckNavigationCapabilities_SuccessLoadAndConvert) {
+  const std::string content_to_save =
+      "{\"UI\": {\"hmiCapabilities\": {\"navigation\":true}}}";
+
+  CreateFile(kHmiCapabilitiesCacheFile);
+
+  const std::vector<uint8_t> binary_data_to_save(content_to_save.begin(),
+                                                 content_to_save.end());
+  file_system::Write(kHmiCapabilitiesCacheFile, binary_data_to_save);
+
   hmi_capabilities_->Init(last_state_wrapper_);
   const auto navigation_capability_so =
       *(hmi_capabilities_->navigation_capability());
@@ -524,13 +533,42 @@ TEST_F(HMICapabilitiesTest,
 
   EXPECT_TRUE(phone_capability_so.keyExists("dialNumberEnabled"));
   EXPECT_TRUE(phone_capability_so["dialNumberEnabled"].asBool());
+}
+
+TEST_F(HMICapabilitiesTest,
+       LoadCapabilitiesFromFile_CheckHMICapabilities_SuccessLoadAndConvert) {
+  const std::string content_to_save =
+      "{\"UI\": {\"hmiCapabilities\": "
+      "{\"navigation\":true,\"phoneCall\":true,\"videoStreaming\":true}}}";
+
+  CreateFile(kHmiCapabilitiesCacheFile);
+
+  const std::vector<uint8_t> binary_data_to_save(content_to_save.begin(),
+                                                 content_to_save.end());
+  file_system::Write(kHmiCapabilitiesCacheFile, binary_data_to_save);
+  hmi_capabilities_->Init(last_state_wrapper_);
+
+  const auto ui_hmi_capability_so = *(hmi_capabilities_->ui_hmi_capabilities());
+  EXPECT_TRUE(ui_hmi_capability_so.keyExists("navigation"));
+  EXPECT_TRUE(ui_hmi_capability_so.keyExists("phoneCall"));
+  EXPECT_TRUE(ui_hmi_capability_so.keyExists("videoStreaming"));
 
   EXPECT_TRUE(hmi_capabilities_->phone_call_supported());
+  EXPECT_TRUE(hmi_capabilities_->navigation_supported());
+  EXPECT_TRUE(hmi_capabilities_->video_streaming_supported());
 }
 
 TEST_F(
     HMICapabilitiesTest,
     LoadCapabilitiesFromFile_CheckVideoStreamingCapability_SuccessLoadAndConvert) {
+  const std::string content_to_save =
+      "{\"UI\": {\"hmiCapabilities\": {\"videoStreaming\":true}}}";
+
+  CreateFile(kHmiCapabilitiesCacheFile);
+
+  const std::vector<uint8_t> binary_data_to_save(content_to_save.begin(),
+                                                 content_to_save.end());
+  file_system::Write(kHmiCapabilitiesCacheFile, binary_data_to_save);
   hmi_capabilities_->Init(last_state_wrapper_);
   const auto vs_capability_so =
       *(hmi_capabilities_->video_streaming_capability());
@@ -836,7 +874,15 @@ TEST_F(HMICapabilitiesTest,
   const std::string hmi_capabilities_file = "hmi_capabilities_sc1.json";
   ON_CALL(mock_application_manager_settings_, hmi_capabilities_file_name())
       .WillByDefault(ReturnRef(hmi_capabilities_file));
+  const std::string content_to_save =
+      "{\"UI\": {\"hmiCapabilities\": "
+      "{\"navigation\":false,\"phoneCall\":true,\"videoStreaming\":false}}}";
 
+  CreateFile(kHmiCapabilitiesCacheFile);
+
+  const std::vector<uint8_t> binary_data_to_save(content_to_save.begin(),
+                                                 content_to_save.end());
+  file_system::Write(kHmiCapabilitiesCacheFile, binary_data_to_save);
   hmi_capabilities_->Init(last_state_wrapper_);
 
   // Check system capabilities; only phone capability is available
@@ -857,6 +903,15 @@ TEST_F(HMICapabilitiesTest,
   const std::string hmi_capabilities_file = "hmi_capabilities_sc2.json";
   ON_CALL(mock_application_manager_settings_, hmi_capabilities_file_name())
       .WillByDefault(ReturnRef(hmi_capabilities_file));
+  const std::string content_to_save =
+      "{\"UI\": {\"hmiCapabilities\": "
+      "{\"navigation\":true,\"phoneCall\":false,\"videoStreaming\":false}}}";
+
+  CreateFile(kHmiCapabilitiesCacheFile);
+
+  const std::vector<uint8_t> binary_data_to_save(content_to_save.begin(),
+                                                 content_to_save.end());
+  file_system::Write(kHmiCapabilitiesCacheFile, binary_data_to_save);
 
   hmi_capabilities_->Init(last_state_wrapper_);
 
@@ -1219,7 +1274,7 @@ TEST_F(HMICapabilitiesTest,
       "\"EN-US\",\"languages\":[],\"displayCapabilities\" : "
       "{},\"audioPassThruCapabilities\":[],\"pcmStreamCapabilities\" : "
       "{},\"hmiZoneCapabilities\": \"\",\"softButtonCapabilities\" : "
-      "[],\"systemCapabilities\" : {}}}";
+      "[],\"systemCapabilities\" : {},\"hmiCapabilities\" : {}}}";
 
   const std::vector<uint8_t> binary_data_to_save(
       predefined_ui_capabilities.begin(), predefined_ui_capabilities.end());

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -114,6 +114,11 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
   MOCK_METHOD1(set_hmi_zone_capabilities,
                void(const smart_objects::SmartObject& hmi_zone_capabilities));
 
+  MOCK_CONST_METHOD0(ui_hmi_capabilities,
+                     const smart_objects::SmartObjectSPtr());
+  MOCK_METHOD1(set_ui_hmi_capabilities,
+               void(const smart_objects::SmartObject& ui_hmi_capabilities));
+
   MOCK_CONST_METHOD0(soft_button_capabilities,
                      const smart_objects::SmartObjectSPtr());
   MOCK_METHOD1(

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -253,6 +253,19 @@ class HMICapabilities {
       const smart_objects::SmartObject& hmi_zone_capabilities) = 0;
 
   /**
+   * @brief Retrieves information about the HMI capabilities
+   * @return Currently supported UI HMI capabilities
+   */
+  virtual const smart_objects::SmartObjectSPtr ui_hmi_capabilities() const = 0;
+
+  /**
+   * @brief Sets supported HMI capabilities
+   * @param ui_hmi_capabilities supported HMI capabilities
+   */
+  virtual void set_ui_hmi_capabilities(
+      const smart_objects::SmartObject& ui_hmi_capabilities) = 0;
+
+  /**
    * @brief Retrieves information about the SoftButton's capabilities
    * @return Currently supported SoftButton's capabilities
    */


### PR DESCRIPTION
Fixes #[3804](https://github.com/smartdevicelink/sdl_core/issues/3804)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
SDL sends RegisterAppInterface response with the incorrect value of "hmiCapabilities" parameters if HMICapabilitiesCacheFile exists. At the first start, we send the values of navigation, phoneCall and videoStream from the HMI response from the hmicapabilities field to mobile. And the second time we had data in the HMICapabilitiesCacheFile file, we took the value from systemcapabilities, not from hmicapabilities


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
