### PR TITLE
Move app launcher stop before unregister app

### DIFF
--- a/src/components/application_manager/include/application_manager/app_launch/app_launch_ctrl.h
+++ b/src/components/application_manager/include/application_manager/app_launch/app_launch_ctrl.h
@@ -66,6 +66,12 @@ class AppLaunchCtrl {
    * @brief OnMasterReset clear database of saved applications
    */
   virtual void OnMasterReset() = 0;
+
+  /**
+   * @brief Stop - allows to stop app launcher.
+   */
+  virtual void Stop() = 0;
+
   virtual ~AppLaunchCtrl() {}
 };
 

--- a/src/components/application_manager/include/application_manager/app_launch/app_launch_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/app_launch/app_launch_ctrl_impl.h
@@ -69,6 +69,7 @@ class AppLaunchCtrlImpl : public AppLaunchCtrl {
   void OnAppRegistered(const application_manager::Application& app) OVERRIDE;
   void OnDeviceConnected(const std::string& device_mac) OVERRIDE;
   void OnMasterReset() OVERRIDE;
+  void Stop() OVERRIDE;
 
  private:
   const AppLaunchSettings& settings_;
@@ -77,6 +78,7 @@ class AppLaunchCtrlImpl : public AppLaunchCtrl {
 
   AppsLauncher apps_launcher_;
   DeviceAppsLauncher device_apps_launcher_;
+  sync_primitives::Lock launch_ctrl_lock_;
 
   DISALLOW_COPY_AND_ASSIGN(AppLaunchCtrlImpl);
 };

--- a/src/components/application_manager/include/application_manager/app_launch/app_launch_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/app_launch/app_launch_ctrl_impl.h
@@ -78,7 +78,7 @@ class AppLaunchCtrlImpl : public AppLaunchCtrl {
 
   AppsLauncher apps_launcher_;
   DeviceAppsLauncher device_apps_launcher_;
-  sync_primitives::Lock launch_ctrl_lock_;
+  sync_primitives::Lock app_launcher_lock_;
 
   DISALLOW_COPY_AND_ASSIGN(AppLaunchCtrlImpl);
 };

--- a/src/components/application_manager/include/application_manager/app_launch/device_apps_launcher.h
+++ b/src/components/application_manager/include/application_manager/app_launch/device_apps_launcher.h
@@ -35,8 +35,11 @@ class DeviceAppsLauncherImpl {
   };
 
   bool StopLaunchingAppsOnDevice(const std::string& device_mac);
+  void StopLaunchingAppsOnAllDevices();
 
  private:
+  void StopLauncher(std::shared_ptr<Launcher> launcher);
+
   sync_primitives::Lock launchers_lock_;
   std::vector<std::shared_ptr<Launcher> > free_launchers_;
   std::vector<std::shared_ptr<Launcher> > works_launchers_;
@@ -60,6 +63,7 @@ class DeviceAppsLauncher {
       const std::string& device_mac,
       const std::vector<ApplicationDataPtr>& applications_to_launch);
   bool StopLaunchingAppsOnDevice(const std::string& device_mac);
+  void StopLaunchingAppsOnAllDevices();
 
   const AppLaunchSettings& settings() const;
 

--- a/src/components/application_manager/include/application_manager/app_launch/device_apps_launcher.h
+++ b/src/components/application_manager/include/application_manager/app_launch/device_apps_launcher.h
@@ -38,8 +38,6 @@ class DeviceAppsLauncherImpl {
   void StopLaunchingAppsOnAllDevices();
 
  private:
-  void StopLauncher(std::shared_ptr<Launcher> launcher);
-
   sync_primitives::Lock launchers_lock_;
   std::vector<std::shared_ptr<Launcher> > free_launchers_;
   std::vector<std::shared_ptr<Launcher> > works_launchers_;

--- a/src/components/application_manager/src/app_launch/app_launch_ctrl_impl.cc
+++ b/src/components/application_manager/src/app_launch/app_launch_ctrl_impl.cc
@@ -83,7 +83,7 @@ bool HmiLevelSorter(const std::pair<int32_t, ApplicationDataPtr>& lval,
 
 void AppLaunchCtrlImpl::OnDeviceConnected(const std::string& device_mac) {
   SDL_LOG_AUTO_TRACE();
-  sync_primitives::AutoLock lock(launch_ctrl_lock_);
+  sync_primitives::AutoLock lock(app_launcher_lock_);
 
   std::vector<ApplicationDataPtr> apps_on_device =
       app_launch_data_.GetApplicationDataByDevice(device_mac);
@@ -117,7 +117,7 @@ void AppLaunchCtrlImpl::OnMasterReset() {
 
 void AppLaunchCtrlImpl::Stop() {
   SDL_LOG_AUTO_TRACE();
-  sync_primitives::AutoLock lock(launch_ctrl_lock_);
+  sync_primitives::AutoLock lock(app_launcher_lock_);
   device_apps_launcher_.StopLaunchingAppsOnAllDevices();
 }
 

--- a/src/components/application_manager/src/app_launch/app_launch_ctrl_impl.cc
+++ b/src/components/application_manager/src/app_launch/app_launch_ctrl_impl.cc
@@ -83,6 +83,8 @@ bool HmiLevelSorter(const std::pair<int32_t, ApplicationDataPtr>& lval,
 
 void AppLaunchCtrlImpl::OnDeviceConnected(const std::string& device_mac) {
   SDL_LOG_AUTO_TRACE();
+  sync_primitives::AutoLock lock(launch_ctrl_lock_);
+
   std::vector<ApplicationDataPtr> apps_on_device =
       app_launch_data_.GetApplicationDataByDevice(device_mac);
   std::vector<std::pair<int32_t, ApplicationDataPtr> > apps_hmi_levels;
@@ -112,4 +114,11 @@ void AppLaunchCtrlImpl::OnMasterReset() {
   SDL_LOG_AUTO_TRACE();
   app_launch_data_.Clear();
 }
+
+void AppLaunchCtrlImpl::Stop() {
+  SDL_LOG_AUTO_TRACE();
+  sync_primitives::AutoLock lock(launch_ctrl_lock_);
+  device_apps_launcher_.StopLaunchingAppsOnAllDevices();
+}
+
 }  // namespace app_launch

--- a/src/components/application_manager/src/app_launch/device_apps_launcher.cc
+++ b/src/components/application_manager/src/app_launch/device_apps_launcher.cc
@@ -7,7 +7,6 @@
 #include "application_manager/app_launch/device_apps_launcher.h"
 #include "application_manager/resumption/resume_ctrl.h"
 
-#include <boost/bind.hpp>
 #include <iostream>
 #include "utils/timer.h"
 #include "utils/timer_task_impl.h"
@@ -158,19 +157,16 @@ bool DeviceAppsLauncherImpl::StopLaunchingAppsOnDevice(
   return true;
 }
 
-void DeviceAppsLauncherImpl::StopLauncher(LauncherPtr launcher) {
-  SDL_LOG_AUTO_TRACE();
-  launcher->Clear();
-  free_launchers_.push_back(launcher);
-}
-
 void DeviceAppsLauncherImpl::StopLaunchingAppsOnAllDevices() {
   SDL_LOG_AUTO_TRACE();
   sync_primitives::AutoLock lock(launchers_lock_);
 
   std::for_each(works_launchers_.begin(),
                 works_launchers_.end(),
-                boost::bind(&DeviceAppsLauncherImpl::StopLauncher, this, _1));
+                [this](LauncherPtr launcher) {
+                  launcher->Clear();
+                  free_launchers_.push_back(launcher);
+                });
 
   works_launchers_.clear();
 }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2650,6 +2650,11 @@ bool ApplicationManagerImpl::Init(
 bool ApplicationManagerImpl::Stop() {
   SDL_LOG_AUTO_TRACE();
   InitiateStopping();
+
+  if (app_launch_ctrl_) {
+    app_launch_ctrl_->Stop();
+  }
+
   application_list_update_timer_.Stop();
   try {
     if (unregister_reason_ ==


### PR DESCRIPTION
Fixes #2444

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
The applauncher has to be stopped before appropriate application will be unregistered. Otherwise it could lead to core crash, when Launch controller will try to run already non existed application.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
