### PR TITLE
Fix PerformInteractionChoiceSet request behavior

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -520,6 +520,25 @@ class DynamicApplicationData {
    * @return TRUE if perform interaction active, otherwise FALSE
    */
   virtual bool is_reset_global_properties_active() const = 0;
+
+  /**
+   * @brief Set allowed mode for specified choice_set_id.
+   * @param choice_set_id Choice set id.
+   * @param is_allowed TRUE if the choice set has to be allowed to perform,
+   * otherwise FALSE.
+   * Allow mode means that the choice_set is not fully processed or not fully
+   * deleted (in both cases request is being processed on HMI side, and HMI
+   * hasn't sent response with result yet)
+   */
+  virtual void set_choice_set_allow_mode(const uint32_t choice_set_id,
+                                         const bool is_allowed) = 0;
+
+  /**
+   * @brief Check if choice set allowed.
+   * @param choice_set_id Choice set id.
+   * @return TRUE if the choice set is allowed to perform, otherwise FALSE.
+   */
+  virtual bool is_choice_set_allowed(const uint32_t choice_set_id) const = 0;
 };
 
 class Application : public virtual InitialApplicationData,

--- a/src/components/application_manager/include/application_manager/application_data_impl.h
+++ b/src/components/application_manager/include/application_manager/application_data_impl.h
@@ -315,6 +315,11 @@ class DynamicApplicationDataImpl : public virtual Application {
    */
   inline bool is_reset_global_properties_active() const;
 
+  void set_choice_set_allow_mode(const uint32_t choice_set_id,
+                                 const bool is_allowed);
+
+  bool is_choice_set_allowed(const uint32_t choice_set_id) const;
+
  protected:
   smart_objects::SmartObject* help_prompt_;
   smart_objects::SmartObject* timeout_prompt_;
@@ -346,6 +351,8 @@ class DynamicApplicationDataImpl : public virtual Application {
   uint32_t is_perform_interaction_active_;
   bool is_reset_global_properties_active_;
   int32_t perform_interaction_mode_;
+  mutable sync_primitives::Lock allowed_choice_sets_lock_;
+  std::set<uint32_t> allowed_choice_sets_;
   DisplayCapabilitiesBuilder display_capabilities_builder_;
 
  private:

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -156,6 +156,11 @@ void CreateInteractionChoiceSetRequest::Run() {
     // we have VR commands
     SendVRAddCommandRequests(app);
   } else {
+    if (MessageHelper::ChoiceSetVRCommandsStatus::NONE == vr_status) {
+      // Because on_event will not be called for this choice, we set is allowed
+      // right after added.
+      app->set_choice_set_allow_mode(choice_set_id_, true);
+    }
     // we have none, just return with success
     SendResponse(true, Result::SUCCESS);
   }
@@ -461,6 +466,14 @@ void CreateInteractionChoiceSetRequest::DeleteChoices() {
 
 void CreateInteractionChoiceSetRequest::OnAllHMIResponsesReceived() {
   SDL_LOG_AUTO_TRACE();
+
+  ApplicationSharedPtr application =
+      application_manager_.application(connection_key());
+  if (!error_from_hmi_) {
+    application->set_choice_set_allow_mode(choice_set_id_, true);
+    SDL_LOG_DEBUG("Choice set with id " << choice_set_id_
+                                        << " is allowed to perform.");
+  }
 
   if (!error_from_hmi_ && should_send_warnings_) {
     SendResponse(true, mobile_apis::Result::WARNINGS, kInvalidImageWarningInfo);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_interaction_choice_set_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_interaction_choice_set_request.cc
@@ -173,6 +173,7 @@ void DeleteInteractionChoiceSetRequest::SendVrDeleteCommand(
     return;
   }
 
+  app->set_choice_set_allow_mode(choice_set_id, false);
   smart_objects::SmartObject msg_params =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
   msg_params[strings::app_id] = app->app_id();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/create_interaction_choice_set_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/create_interaction_choice_set_test.cc
@@ -836,8 +836,8 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
 
   smart_objects::SmartObject choice_set_id(smart_objects::SmartType_Null);
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app_));
+  ON_CALL(app_mngr_, application(kConnectionKey))
+      .WillByDefault(Return(mock_app_));
 
   ON_CALL(mock_message_helper_, CheckChoiceSetVRCommands(_))
       .WillByDefault(Return(am::MessageHelper::ChoiceSetVRCommandsStatus::ALL));

--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -954,12 +954,12 @@ void DynamicApplicationDataImpl::RemoveChoiceSet(uint32_t choice_set_id) {
   {
     sync_primitives::AutoLock allowed_choice_sets_lock(
         allowed_choice_sets_lock_);
-    auto choise_id_it = allowed_choice_sets_.find(choice_set_id);
-    if (allowed_choice_sets_.end() == choise_id_it) {
+    auto choice_id_it = allowed_choice_sets_.find(choice_set_id);
+    if (allowed_choice_sets_.end() == choice_id_it) {
       SDL_LOG_WARN("Choice set with id " << choice_set_id << " is not found");
       return;
     }
-    allowed_choice_sets_.erase(choise_id_it);
+    allowed_choice_sets_.erase(choice_id_it);
   }
 }
 

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -361,6 +361,8 @@ class MockApplication : public ::application_manager::Application {
                      mobile_apis::LayoutMode::eType());
   MOCK_METHOD1(set_reset_global_properties_active, void(bool active));
   MOCK_CONST_METHOD0(is_reset_global_properties_active, bool());
+  MOCK_METHOD2(set_choice_set_allow_mode, void(std::uint32_t, bool));
+  MOCK_CONST_METHOD1(is_choice_set_allowed, bool(std::uint32_t));
   MOCK_CONST_METHOD0(app_id, uint32_t());
   MOCK_CONST_METHOD0(mac_address, const std::string&());
   MOCK_CONST_METHOD0(bundle_id, const std::string&());


### PR DESCRIPTION
Fixes #1883

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test scripts, the new unit test is also added

### Summary
There is a case when DeleteInteractionChoiceSet request is sent to HMI, and SDL is waiting for response. If during this waiting period PerformInteractionChoiceSet request is sent, according to requirements SDL should reject such request.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
