### PR TITLE
Resolve a deadlock

### DIFF
--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher.h
@@ -64,15 +64,6 @@ class EventDispatcher {
   /*
    * @brief Unsubscribes the observer from specific event
    *
-   * @param event_id    The event ID to subscribe for
-   * @param hmi_correlation_id  The event HMI correlation ID
-   */
-  virtual void remove_observer(const Event::EventID& event_id,
-                               const int32_t hmi_correlation_id) = 0;
-
-  /*
-   * @brief Unsubscribes the observer from specific event
-   *
    * @param event_id    The event ID to unsubscribe from
    * @param observer    The observer to be unsubscribed
    */

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
@@ -167,8 +167,6 @@ class EventDispatcherImpl : public EventDispatcher {
 
  private:
   // Members section
-  sync_primitives::Lock state_lock_;
-  sync_primitives::Lock mobile_state_lock_;
   sync_primitives::RecursiveLock observer_lock_;
   sync_primitives::RecursiveLock mobile_observer_lock_;
   EventObserverMap observers_event_;

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
@@ -68,12 +68,6 @@ class EventDispatcherImpl : public EventDispatcher {
   EventObserverMap get_observers() const {
     return observers_event_;
   }
-  MobileEventObserverMap get_mobile_observers() const {
-    return mobile_observers_event_;
-  }
-  ObserverVector get_observers_list() const {
-    return observers_;
-  }
 #endif  // BUILD_TESTS
 
   /*
@@ -82,9 +76,6 @@ class EventDispatcherImpl : public EventDispatcher {
    * @param event Received event
    */
   void raise_event(const Event& event) OVERRIDE;
-
-  void remove_observer(const Event::EventID& event_id,
-                       const int32_t hmi_correlation_id) OVERRIDE;
 
   /*
    * @brief Subscribe the observer to event
@@ -149,20 +140,6 @@ class EventDispatcherImpl : public EventDispatcher {
   void remove_mobile_observer(EventObserver& observer) OVERRIDE;
 
  private:
-  /*
-   * @brief removes observer
-   * when occurs unsubscribe from event
-   * @param observer to be removed
-   */
-  void remove_observer_from_vector(EventObserver& observer);
-
-  /*
-   * @brief removes observer
-   * when occurs unsubscribe from event
-   * @param observer to be removed
-   */
-  void remove_mobile_observer_from_vector(EventObserver& observer);
-
   DISALLOW_COPY_AND_ASSIGN(EventDispatcherImpl);
 
  private:
@@ -171,8 +148,6 @@ class EventDispatcherImpl : public EventDispatcher {
   sync_primitives::RecursiveLock mobile_observer_lock_;
   EventObserverMap observers_event_;
   MobileEventObserverMap mobile_observers_event_;
-  ObserverVector observers_;
-  ObserverVector mobile_observers_;
 };
 
 }  // namespace event_engine

--- a/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
+++ b/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
@@ -45,24 +45,26 @@ EventDispatcherImpl::~EventDispatcherImpl() {}
 
 void EventDispatcherImpl::raise_event(const Event& event) {
   ObserverVector observers;
-  AutoLock observer_lock(observer_lock_);
 
-  // check if event is notification
-  if (hmi_apis::messageType::notification == event.smart_object_type()) {
-    const uint32_t notification_correlation_id = 0;
-    observers = observers_event_[event.id()][notification_correlation_id];
-  }
+  {
+    AutoLock observer_lock(observer_lock_);
 
-  if (hmi_apis::messageType::response == event.smart_object_type() ||
-      hmi_apis::messageType::error_response == event.smart_object_type()) {
-    observers =
-        observers_event_[event.id()][event.smart_object_correlation_id()];
+    // check if event is notification
+    if (hmi_apis::messageType::notification == event.smart_object_type()) {
+      const uint32_t notification_correlation_id = 0;
+      observers = observers_event_[event.id()][notification_correlation_id];
+    }
+
+    if (hmi_apis::messageType::response == event.smart_object_type() ||
+        hmi_apis::messageType::error_response == event.smart_object_type()) {
+      observers =
+          observers_event_[event.id()][event.smart_object_correlation_id()];
+    }
   }
 
   while (!observers.empty()) {
     EventObserver* temp = *observers.begin();
     observers.erase(observers.begin());
-    AutoUnlock unlock_observer(observer_lock);
 
     if (temp->IncrementReferenceCount()) {
       temp->HandleOnEvent(event);
@@ -90,18 +92,8 @@ struct IdCheckFunctor {
 };
 
 void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
-                                          const int32_t hmi_correlation_id) {
-  AutoLock auto_lock(observer_lock_);
-  auto& observers = observers_event_[event_id][hmi_correlation_id];
-  for (auto observer : observers) {
-    remove_observer_from_vector(*observer);
-  }
-}
-
-void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
                                           EventObserver& observer) {
   AutoLock auto_lock(observer_lock_);
-  remove_observer_from_vector(observer);
   ObserversMap::iterator it = observers_event_[event_id].begin();
 
   for (; observers_event_[event_id].end() != it; ++it) {
@@ -116,7 +108,6 @@ void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
 
 void EventDispatcherImpl::remove_observer(EventObserver& observer) {
   AutoLock auto_lock(observer_lock_);
-  remove_observer_from_vector(observer);
 
   EventObserverMap::iterator event_map = observers_event_.begin();
 
@@ -125,36 +116,32 @@ void EventDispatcherImpl::remove_observer(EventObserver& observer) {
   }
 }
 
-void EventDispatcherImpl::remove_observer_from_vector(EventObserver& observer) {
-  observers_.erase(
-      std::remove_if(
-          observers_.begin(), observers_.end(), IdCheckFunctor(observer.id())),
-      observers_.end());
-}
-
 // Mobile Events
 
 void EventDispatcherImpl::raise_mobile_event(const MobileEvent& event) {
-  AutoLock observer_lock(mobile_observer_lock_);
+  ObserverVector mobile_observers;
 
-  // check if event is notification
-  if (mobile_apis::messageType::notification == event.smart_object_type()) {
-    const uint32_t notification_correlation_id = 0;
-    mobile_observers_ =
-        mobile_observers_event_[event.id()][notification_correlation_id];
-  }
+  {
+    AutoLock observer_lock(mobile_observer_lock_);
 
-  if (mobile_apis::messageType::response == event.smart_object_type()) {
-    mobile_observers_ =
-        mobile_observers_event_[event.id()]
-                               [event.smart_object_correlation_id()];
+    // check if event is notification
+    if (mobile_apis::messageType::notification == event.smart_object_type()) {
+      const uint32_t notification_correlation_id = 0;
+      mobile_observers =
+          mobile_observers_event_[event.id()][notification_correlation_id];
+    }
+
+    if (mobile_apis::messageType::response == event.smart_object_type()) {
+      mobile_observers =
+          mobile_observers_event_[event.id()]
+                                 [event.smart_object_correlation_id()];
+    }
   }
 
   // Call observers
-  while (!mobile_observers_.empty()) {
-    EventObserver* temp = *mobile_observers_.begin();
-    mobile_observers_.erase(mobile_observers_.begin());
-    AutoUnlock unlock_observer(observer_lock);
+  while (!mobile_observers.empty()) {
+    EventObserver* temp = *mobile_observers.begin();
+    mobile_observers.erase(mobile_observers.begin());
 
     if (temp->IncrementReferenceCount()) {
       temp->HandleOnEvent(event);
@@ -174,7 +161,6 @@ void EventDispatcherImpl::add_mobile_observer(
 void EventDispatcherImpl::remove_mobile_observer(
     const MobileEvent::MobileEventID& event_id, EventObserver& observer) {
   AutoLock auto_lock(mobile_observer_lock_);
-  remove_mobile_observer_from_vector(observer);
   ObserversMap::iterator it = mobile_observers_event_[event_id].begin();
 
   for (; mobile_observers_event_[event_id].end() != it; ++it) {
@@ -188,20 +174,11 @@ void EventDispatcherImpl::remove_mobile_observer(
 }
 
 void EventDispatcherImpl::remove_mobile_observer(EventObserver& observer) {
-  remove_mobile_observer_from_vector(observer);
   MobileEventObserverMap::iterator event_map = mobile_observers_event_.begin();
 
   for (; mobile_observers_event_.end() != event_map; ++event_map) {
     remove_mobile_observer(event_map->first, observer);
   }
-}
-
-void EventDispatcherImpl::remove_mobile_observer_from_vector(
-    EventObserver& observer) {
-  mobile_observers_.erase(
-      std::remove_if(
-          observers_.begin(), observers_.end(), IdCheckFunctor(observer.id())),
-      observers_.end());
 }
 
 }  // namespace event_engine

--- a/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
+++ b/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
@@ -46,20 +46,17 @@ EventDispatcherImpl::~EventDispatcherImpl() {}
 void EventDispatcherImpl::raise_event(const Event& event) {
   ObserverVector observers;
   AutoLock observer_lock(observer_lock_);
-  {
-    AutoLock state_lock(state_lock_);
 
-    // check if event is notification
-    if (hmi_apis::messageType::notification == event.smart_object_type()) {
-      const uint32_t notification_correlation_id = 0;
-      observers = observers_event_[event.id()][notification_correlation_id];
-    }
+  // check if event is notification
+  if (hmi_apis::messageType::notification == event.smart_object_type()) {
+    const uint32_t notification_correlation_id = 0;
+    observers = observers_event_[event.id()][notification_correlation_id];
+  }
 
-    if (hmi_apis::messageType::response == event.smart_object_type() ||
-        hmi_apis::messageType::error_response == event.smart_object_type()) {
-      observers =
-          observers_event_[event.id()][event.smart_object_correlation_id()];
-    }
+  if (hmi_apis::messageType::response == event.smart_object_type() ||
+      hmi_apis::messageType::error_response == event.smart_object_type()) {
+    observers =
+        observers_event_[event.id()][event.smart_object_correlation_id()];
   }
 
   while (!observers.empty()) {
@@ -77,7 +74,7 @@ void EventDispatcherImpl::raise_event(const Event& event) {
 void EventDispatcherImpl::add_observer(const Event::EventID& event_id,
                                        int32_t hmi_correlation_id,
                                        EventObserver& observer) {
-  AutoLock auto_lock(state_lock_);
+  AutoLock auto_lock(observer_lock_);
   observers_event_[event_id][hmi_correlation_id].push_back(&observer);
 }
 
@@ -94,7 +91,7 @@ struct IdCheckFunctor {
 
 void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
                                           const int32_t hmi_correlation_id) {
-  AutoLock auto_lock(state_lock_);
+  AutoLock auto_lock(observer_lock_);
   auto& observers = observers_event_[event_id][hmi_correlation_id];
   for (auto observer : observers) {
     remove_observer_from_vector(*observer);
@@ -103,8 +100,8 @@ void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
 
 void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
                                           EventObserver& observer) {
+  AutoLock auto_lock(observer_lock_);
   remove_observer_from_vector(observer);
-  AutoLock auto_lock(state_lock_);
   ObserversMap::iterator it = observers_event_[event_id].begin();
 
   for (; observers_event_[event_id].end() != it; ++it) {
@@ -118,7 +115,9 @@ void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
 }
 
 void EventDispatcherImpl::remove_observer(EventObserver& observer) {
+  AutoLock auto_lock(observer_lock_);
   remove_observer_from_vector(observer);
+
   EventObserverMap::iterator event_map = observers_event_.begin();
 
   for (; observers_event_.end() != event_map; ++event_map) {
@@ -127,8 +126,6 @@ void EventDispatcherImpl::remove_observer(EventObserver& observer) {
 }
 
 void EventDispatcherImpl::remove_observer_from_vector(EventObserver& observer) {
-  AutoLock auto_lock(observer_lock_);
-
   observers_.erase(
       std::remove_if(
           observers_.begin(), observers_.end(), IdCheckFunctor(observer.id())),
@@ -139,21 +136,18 @@ void EventDispatcherImpl::remove_observer_from_vector(EventObserver& observer) {
 
 void EventDispatcherImpl::raise_mobile_event(const MobileEvent& event) {
   AutoLock observer_lock(mobile_observer_lock_);
-  {
-    AutoLock state_lock(mobile_state_lock_);
 
-    // check if event is notification
-    if (mobile_apis::messageType::notification == event.smart_object_type()) {
-      const uint32_t notification_correlation_id = 0;
-      mobile_observers_ =
-          mobile_observers_event_[event.id()][notification_correlation_id];
-    }
+  // check if event is notification
+  if (mobile_apis::messageType::notification == event.smart_object_type()) {
+    const uint32_t notification_correlation_id = 0;
+    mobile_observers_ =
+        mobile_observers_event_[event.id()][notification_correlation_id];
+  }
 
-    if (mobile_apis::messageType::response == event.smart_object_type()) {
-      mobile_observers_ =
-          mobile_observers_event_[event.id()]
-                                 [event.smart_object_correlation_id()];
-    }
+  if (mobile_apis::messageType::response == event.smart_object_type()) {
+    mobile_observers_ =
+        mobile_observers_event_[event.id()]
+                               [event.smart_object_correlation_id()];
   }
 
   // Call observers
@@ -173,14 +167,14 @@ void EventDispatcherImpl::add_mobile_observer(
     const MobileEvent::MobileEventID& event_id,
     int32_t mobile_correlation_id,
     EventObserver& observer) {
-  AutoLock auto_lock(mobile_state_lock_);
+  AutoLock auto_lock(mobile_observer_lock_);
   mobile_observers_event_[event_id][mobile_correlation_id].push_back(&observer);
 }
 
 void EventDispatcherImpl::remove_mobile_observer(
     const MobileEvent::MobileEventID& event_id, EventObserver& observer) {
+  AutoLock auto_lock(mobile_observer_lock_);
   remove_mobile_observer_from_vector(observer);
-  AutoLock auto_lock(mobile_state_lock_);
   ObserversMap::iterator it = mobile_observers_event_[event_id].begin();
 
   for (; mobile_observers_event_[event_id].end() != it; ++it) {
@@ -204,8 +198,6 @@ void EventDispatcherImpl::remove_mobile_observer(EventObserver& observer) {
 
 void EventDispatcherImpl::remove_mobile_observer_from_vector(
     EventObserver& observer) {
-  AutoLock auto_lock(mobile_observer_lock_);
-
   mobile_observers_.erase(
       std::remove_if(
           observers_.begin(), observers_.end(), IdCheckFunctor(observer.id())),

--- a/src/components/application_manager/src/request_controller_impl.cc
+++ b/src/components/application_manager/src/request_controller_impl.cc
@@ -335,8 +335,6 @@ void RequestControllerImpl::TerminateRequest(const uint32_t correlation_id,
     return;
   }
   if (force_terminate || request->request()->AllowedToTerminate()) {
-    event_dispatcher_.remove_observer(
-        static_cast<hmi_apis::FunctionID::eType>(function_id), correlation_id);
     waiting_for_response_.RemoveRequest(request);
     if (RequestInfo::HMIRequest == request->request_type()) {
       request_timeout_handler_.RemoveRequest(request->requestId());

--- a/src/components/application_manager/src/request_timeout_handler_impl.cc
+++ b/src/components/application_manager/src/request_timeout_handler_impl.cc
@@ -49,6 +49,7 @@ RequestTimeoutHandlerImpl::RequestTimeoutHandlerImpl(
 
 void RequestTimeoutHandlerImpl::AddRequest(const uint32_t hmi_correlation_id,
                                            const Request& request) {
+  sync_primitives::AutoLock lock(requests_lock_);
   requests_.insert(std::make_pair(hmi_correlation_id, request));
 }
 
@@ -101,6 +102,8 @@ void RequestTimeoutHandlerImpl::HandleOnEvent(
     }
     const auto hmi_corr_id =
         message[strings::msg_params][strings::request_id].asUInt();
+
+    sync_primitives::AutoLock lock(requests_lock_);
     auto it = requests_.find(hmi_corr_id);
     if (it != requests_.end()) {
       const auto& request = it->second;


### PR DESCRIPTION
Fixes #[3817](https://github.com/smartdevicelink/sdl_core/issues/3817)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Deadlock is fixed in EventDispatcherImpl class.  
Locks are added for map of requests in RequestTimeoutHandlerImpl class.
Refactoring in EventDispatcherImpl:
- **observers_** is a redundant member of class EventDispatcherImpl, because the function raise_event uses local variable (ObserverVector observers;)
- It is not correct to use erase for **mobile_observers_**, but use remove_if for **observers_** in remove_mobile_observer_from_vector. 


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)

