### PR TITLE
Replace clusterModeStatus with clusterModes and vise versa

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -226,9 +226,12 @@ bool SubscribeVehicleDataRequest::SubscribePendingVehicleData(
     } else {
       auto res_code =
           static_cast<hmi_apis::Common_VehicleDataResultCode::eType>(
-              msg_params[*vi_name][strings::result_code].asInt());
+              msg_params[ConvertRequestToResponseName(*vi_name)]
+                        [strings::result_code]
+                            .asInt());
       if (skiped_result_codes.find(res_code) != skiped_result_codes.end()) {
-        msg_params[*vi_name][strings::result_code] = res_code;
+        msg_params[ConvertRequestToResponseName(*vi_name)]
+                  [strings::result_code] = res_code;
         vi_name = vi_waiting_for_subscribe_.erase(vi_name);
       } else {
         ++vi_name;
@@ -325,11 +328,13 @@ void SubscribeVehicleDataRequest::CheckVISubscriptions(
         }
         SDL_LOG_DEBUG("App with connection key "
                       << connection_key()
-                      << " have been subscribed for VehicleDataType: "
+                      << " has been subscribed for VehicleDataType: "
                       << key_name);
         vi_already_subscribed_by_another_apps_.insert(key_name);
-        out_response_params[key_name][strings::data_type] = vd_type;
-        out_response_params[key_name][strings::result_code] =
+        const std::string converted_name =
+            ConvertRequestToResponseName(key_name);
+        out_response_params[converted_name][strings::data_type] = vd_type;
+        out_response_params[converted_name][strings::result_code] =
             mobile_apis::VehicleDataResultCode::VDRC_SUCCESS;
         ++subscribed_items;
       };

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -98,7 +98,8 @@ void UnsubscribeVehicleDataRequest::Run() {
         "VehicleDataType: "
         << key_name);
     vi_still_subscribed_by_another_apps_.insert(key_name);
-    response_params_[key_name][strings::result_code] =
+    const std::string converted_name = ConvertRequestToResponseName(key_name);
+    response_params_[converted_name][strings::result_code] =
         mobile_apis::VehicleDataResultCode::VDRC_SUCCESS;
   };
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -223,6 +223,13 @@ void VehicleInfoPendingResumptionHandler::HandleOnEvent(
   custom_vehicle_data_manager_.CreateMobileMessageParams(converted_msg_params);
   response_message[strings::msg_params] = converted_msg_params;
 
+  if (converted_msg_params.enumerate().end() !=
+      converted_msg_params.enumerate().find(strings::cluster_modes)) {
+    response_message[strings::msg_params][strings::cluster_mode_status] =
+        response_message[strings::msg_params][strings::cluster_modes];
+    response_message[strings::msg_params].erase(strings::cluster_modes);
+  }
+
   const auto vs_count_in_response =
       response_message[application_manager::strings::msg_params].length();
 


### PR DESCRIPTION
Fixes #3460

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test scripts

### Summary
There is a discrepancy between request and response names of VD parameter with data type `VEHICLEDATA_CLUSTERMODESTATUS`: according to API we should use name `clusterModeStatus` in mobile and HMI requests, but another name `clusterModes` is provided in mobile and HMI responses. To deal with this issue we need to convert request to response names and vise versa to ensure correct processing of requests and responses.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
