### PR TITLE
Fix rare crash during streaming switching

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1956,8 +1956,9 @@ bool ApplicationManagerImpl::StartNaviService(
       /* Fix: For NaviApp1 Switch to NaviApp2, App1's Endcallback() arrives
        later than App2's Startcallback(). Cause streaming issue on HMI.
       */
-      auto accessor = applications();
-      for (auto app : accessor.GetData()) {
+
+      const ApplicationSet apps = applications().GetData();
+      for (auto app : apps) {
         if (!app || (!app->is_navi() && !app->mobile_projection_enabled())) {
           SDL_LOG_DEBUG("Continue, Not Navi App Id: " << app->app_id());
           continue;


### PR DESCRIPTION
Fixes #[3824](https://github.com/smartdevicelink/sdl_core/issues/3824)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF scripts

### Summary
Thread 1 locked an applications_list_lock_ptr_ in DataAccessor.
Thread 2 is waiting an applications_list_lock_ptr_ 
Thread 1 is waiting a thread 2  in Thread::JoinDelegate

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
