### PR TITLE
Cyclic UpdateDeviceList and UpdateAppList in case device is connected

### DIFF
--- a/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner.cc
@@ -266,12 +266,12 @@ void BluetoothDeviceScanner::CheckSDLServiceOnDevices(
                               BluetoothDevice::GetUniqueDeviceId(bd_address);
                      });
 
-    const bool is_new_device = it_device == discovered_devices->end();
+    const bool is_new_device = (it_device == discovered_devices->end());
     const bool is_new_rfcomm_channel =
         !is_new_device && (*it_device)->GetApplicationList().size() !=
                               sdl_rfcomm_channels[i].size();
     if (is_new_device || is_new_rfcomm_channel) {
-      if (!discovered_devices->empty()) {
+      if (!is_new_device) {
         discovered_devices->erase(it_device);
       }
       auto bluetooth_device = std::make_shared<BluetoothDevice>(

--- a/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner.cc
@@ -206,10 +206,19 @@ void BluetoothDeviceScanner::DoInquiry() {
   SDL_LOG_INFO("Check rfcomm channel on " << paired_devices_.size()
                                           << " paired devices.");
 
-  paired_devices_with_sdl_.clear();
   CheckSDLServiceOnDevices(
       paired_devices_, device_handle, &paired_devices_with_sdl_);
-  UpdateTotalDeviceList();
+  const bool new_connect =
+      paired_devices_with_sdl_.end() !=
+      std::find_if(paired_devices_with_sdl_.begin(),
+                   paired_devices_with_sdl_.end(),
+                   [](DeviceSptr devicePtr) {
+                     return devicePtr->connection_status() !=
+                            ConnectionStatus::CONNECTED;
+                   });
+  if (new_connect) {
+    UpdateTotalDeviceList();
+  }
 
   controller_->FindNewApplicationsRequest();
 
@@ -249,13 +258,30 @@ void BluetoothDeviceScanner::CheckSDLServiceOnDevices(
       deviceName[name_len - 1] = '\0';
     }
 
-    auto bluetooth_device = std::make_shared<BluetoothDevice>(
-        bd_address, deviceName, sdl_rfcomm_channels[i]);
-    if (bluetooth_device) {
-      SDL_LOG_INFO("Bluetooth device created successfully");
-      discovered_devices->push_back(bluetooth_device);
-    } else {
-      SDL_LOG_WARN("Can't create bluetooth device " << deviceName);
+    auto it_device =
+        std::find_if(discovered_devices->begin(),
+                     discovered_devices->end(),
+                     [bd_address](DeviceSptr device) {
+                       return device->unique_device_id() ==
+                              BluetoothDevice::GetUniqueDeviceId(bd_address);
+                     });
+
+    const bool is_new_device = it_device == discovered_devices->end();
+    const bool is_new_rfcomm_channel =
+        !is_new_device && (*it_device)->GetApplicationList().size() !=
+                              sdl_rfcomm_channels[i].size();
+    if (is_new_device || is_new_rfcomm_channel) {
+      if (!discovered_devices->empty()) {
+        discovered_devices->erase(it_device);
+      }
+      auto bluetooth_device = std::make_shared<BluetoothDevice>(
+          bd_address, deviceName, sdl_rfcomm_channels[i]);
+      if (bluetooth_device) {
+        SDL_LOG_INFO("Bluetooth device created successfully");
+        discovered_devices->push_back(bluetooth_device);
+      } else {
+        SDL_LOG_WARN("Can't create bluetooth device " << deviceName);
+      }
     }
   }
   SDL_LOG_TRACE("exit");

--- a/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
+++ b/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
@@ -273,7 +273,8 @@ TransportAdapter::Error TransportAdapterImpl::ConnectDevice(
       retry_timer_pool_.push(std::make_pair(retry_timer, device_handle));
       retry_timer->Start(get_settings().cloud_app_retry_timeout(),
                          timer::kSingleShot);
-    } else if (OK == err) {
+    } else if (OK == err &&
+               ConnectionStatus::CONNECTED != device->connection_status()) {
       ConnectionStatusUpdated(device, ConnectionStatus::CONNECTED);
     }
     SDL_LOG_TRACE("exit with error: " << err);


### PR DESCRIPTION
Fixes #[3346](https://github.com/smartdevicelink/sdl_core/issues/3346)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Core runs scripts for thread delegates at intervals. Bluetooth is constantly running an event of type ON_DEVICE_LIST_UPDATED, but we do not receive new devices to connect. So I added a check to abort the script with an empty device list.
When we connect the device, it acquires the status of connected, but we only checked the response of the ConnectDevice function. Because of this, after connecting the device, we constantly run an event of type ON_CONNECTION_STATUS_UPDATED. UpdateAppList is called when processing this event.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
