### PR TITLE
Convert Common_SamplingRate and Common_BitsPerSample enums to uint

### DIFF
--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -323,6 +323,7 @@ void HMICapabilitiesImpl::set_audio_pass_thru_capabilities(
 
 void HMICapabilitiesImpl::set_pcm_stream_capabilities(
     const smart_objects::SmartObject& pcm_stream_capabilities) {
+  SDL_LOG_AUTO_TRACE();
   auto new_value =
       std::make_shared<smart_objects::SmartObject>(pcm_stream_capabilities);
   sync_primitives::AutoWriteLock lock(hmi_capabilities_lock_);
@@ -523,6 +524,7 @@ HMICapabilitiesImpl::audio_pass_thru_capabilities() const {
 
 const smart_objects::SmartObjectSPtr
 HMICapabilitiesImpl::pcm_stream_capabilities() const {
+  SDL_LOG_AUTO_TRACE();
   sync_primitives::AutoReadLock lock(hmi_capabilities_lock_);
   return pcm_stream_capabilities_;
 }

--- a/src/components/media_manager/include/media_manager/media_manager_impl.h
+++ b/src/components/media_manager/include/media_manager/media_manager_impl.h
@@ -111,8 +111,6 @@ class MediaManagerImpl : public MediaManager,
   std::map<protocol_handler::ServiceType, MediaAdapterImplPtr> streamer_;
   std::map<protocol_handler::ServiceType, MediaListenerPtr> streamer_listener_;
 
-  uint32_t bits_per_sample_;
-  uint32_t sampling_rate_;
   uint64_t stream_data_size_;
   std::chrono::time_point<std::chrono::system_clock>
       socket_audio_stream_start_time_;


### PR DESCRIPTION
Fixes #[3831](https://github.com/smartdevicelink/sdl_core/issues/3831)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF script

### Summary
- Added a conversion from enum to uint.
- Initialization bits_per_sample_ and  sampling_rate_ in Init() function is useless, because hmi_capabilities hadn't created when sdl created media_manager. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
