### PR TITLE
changed the way you add soft buttons in the subscription method

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/show_constant_tbt_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/show_constant_tbt_response.cc
@@ -60,8 +60,6 @@ ShowConstantTBTResponse::~ShowConstantTBTResponse() {}
 void ShowConstantTBTResponse::Run() {
   SDL_LOG_AUTO_TRACE();
 
-  application_manager_.UnsubscribeAppFromSoftButtons(message_);
-
   rpc_service_.SendMessageToMobile(message_);
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/update_turn_list_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/update_turn_list_response.cc
@@ -59,8 +59,6 @@ UpdateTurnListResponse::~UpdateTurnListResponse() {}
 void UpdateTurnListResponse::Run() {
   SDL_LOG_AUTO_TRACE();
 
-  application_manager_.UnsubscribeAppFromSoftButtons(message_);
-
   rpc_service_.SendMessageToMobile(message_);
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/simple_response_commands_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/simple_response_commands_test.cc
@@ -149,7 +149,6 @@ TYPED_TEST(MobileResponseWithUnsubscribeCommandsTest,
   std::shared_ptr<typename TestFixture::UnsubscribeCommand> command =
       this->template CreateCommand<typename TestFixture::UnsubscribeCommand>();
 
-  EXPECT_CALL(this->app_mngr_, UnsubscribeAppFromSoftButtons(_));
   EXPECT_CALL(this->mock_rpc_service_, SendMessageToMobile(NotNull(), _));
 
   command->Init();

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -1165,7 +1165,8 @@ void ApplicationImpl::SubscribeToSoftButtons(
     return;
   }
 
-  WindowSoftButtons new_window_soft_buttons = *subscribed_window_buttons;
+  WindowSoftButtons new_window_soft_buttons;
+  new_window_soft_buttons.first = window_id;
   new_window_soft_buttons.second.insert(window_softbuttons.second.begin(),
                                         window_softbuttons.second.end());
   command_soft_buttons.erase(subscribed_window_buttons);


### PR DESCRIPTION
Fixes #[3829](https://github.com/smartdevicelink/sdl_core/issues/3829)

This PR is ready for review.

Risk
This PR makes no API changes.

Summary
Unsubscribe to the soft buttons was in response to the request, but the window is still open. Therefore, the kernel finished processing in the subscription verification step button_notification_to_mobile.cc: 89. I changed the subscription method, the new subscription deletes the old buttons.
### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
