### PR TITLE
Add lock screen dismissal info to DD_OFF notification

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_driver_distraction_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_driver_distraction_notification.cc
@@ -161,8 +161,7 @@ void OnDriverDistractionNotification::Run() {
   const auto lock_screen_dismissal =
       application_manager_.GetPolicyHandler().LockScreenDismissalEnabledState();
 
-  if (lock_screen_dismissal &&
-      hmi_apis::Common_DriverDistractionState::DD_ON == state) {
+  if (lock_screen_dismissal) {
     (*on_driver_distraction)
         [strings::msg_params]
         [mobile_notification::lock_screen_dismissal_enabled] =

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -4654,9 +4654,7 @@ void ApplicationManagerImpl::SendDriverDistractionState(
     const auto lock_screen_dismissal =
         policy_handler_->LockScreenDismissalEnabledState();
 
-    if (lock_screen_dismissal &&
-        hmi_apis::Common_DriverDistractionState::DD_ON ==
-            driver_distraction_state()) {
+    if (lock_screen_dismissal) {
       bool dismissal_enabled = *lock_screen_dismissal;
       if (dismissal_enabled) {
         const auto language = EnumToString(application->ui_language());


### PR DESCRIPTION

Fixes #3841

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF Updates: 

### Summary
Change OnDriverDistraction logic to send lock screen dismissal info regardless of driver distraction state

##### Bug Fixes
* Change OnDriverDistraction logic to send lock screen dismissal info regardless of driver distraction state

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
