### PR TITLE
Replase clusterModeStatus with clusterModes when this parameter is di…

### DIFF
--- a/src/components/application_manager/src/commands/command_impl.cc
+++ b/src/components/application_manager/src/commands/command_impl.cc
@@ -47,12 +47,15 @@ struct InfoAppender {
   explicit InfoAppender(std::string& info) : info_(info) {}
 
   void operator()(const RPCParams::value_type& parameter) {
+    std::string param_name = parameter == strings::cluster_mode_status
+                                 ? strings::cluster_modes
+                                 : parameter;
     if (info_.empty()) {
-      info_ = "\'" + parameter + "\'";
+      info_ = "\'" + param_name + "\'";
       return;
     }
 
-    info_ = info_ + ", \'" + parameter + "\'";
+    info_ = info_ + ", \'" + param_name + "\'";
   }
 
  private:
@@ -282,9 +285,11 @@ struct DisallowedParamsInserter {
             ? mobile_apis::VehicleDataType::VEHICLEDATA_OEM_CUSTOM_DATA
             : vehicle_data->second;
 
+    std::string param_name =
+        param == strings::cluster_mode_status ? strings::cluster_modes : param;
     (*disallowed_param)[strings::data_type] = vehicle_data_type;
     (*disallowed_param)[strings::result_code] = code_;
-    response_[strings::msg_params][param.c_str()] = *disallowed_param;
+    response_[strings::msg_params][param_name.c_str()] = *disallowed_param;
     return true;
   }
 


### PR DESCRIPTION
Fixes #[3460](https://github.com/smartdevicelink/sdl_core/issues/3460)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF scripts

### Summary
- Replace clusterModeStatus with clusterModes in "info" parameter (struct InfoAppender)
- Replace name of disallowed parameter  in DisallowedParamsInserter 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
