### PR TITLE
destroy DeviceAppsLauncherImpl when parent DeviceAppsLauncher is destroyed

### DIFF
--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -222,7 +222,7 @@ if (HMIADAPTER STREQUAL "messagebroker")
     include(ExternalProject)
     ExternalProject_Add(
       Boost
-      URL https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
+      URL https://boostorg.jfrog.io/artifactory/main/release/1.66.0/source/boost_1_66_0.tar.gz
       DOWNLOAD_DIR ${BOOST_LIB_SOURCE_DIRECTORY}
       SOURCE_DIR ${BOOST_LIB_SOURCE_DIRECTORY}
       CONFIGURE_COMMAND ./bootstrap.sh --with-libraries=system --prefix=${3RD_PARTY_INSTALL_PREFIX}

--- a/src/components/application_manager/include/application_manager/app_launch/device_apps_launcher.h
+++ b/src/components/application_manager/include/application_manager/app_launch/device_apps_launcher.h
@@ -25,6 +25,7 @@ class DeviceAppsLauncher {
   DeviceAppsLauncher(application_manager::ApplicationManager& app_mngr,
                      app_launch::AppsLauncher& apps_launcher,
                      const AppLaunchSettings& settings);
+  ~DeviceAppsLauncher();
 
   bool LaunchAppsOnDevice(
       const std::string& device_mac,
@@ -36,7 +37,7 @@ class DeviceAppsLauncher {
  private:
   application_manager::ApplicationManager& app_mngr_;
   const AppLaunchSettings& settings_;
-  std::auto_ptr<DeviceAppsLauncherImpl> impl_;
+  DeviceAppsLauncherImpl* impl_;
   friend class DeviceAppsLauncherImpl;
   DISALLOW_COPY_AND_ASSIGN(DeviceAppsLauncher);
 };

--- a/src/components/application_manager/src/app_launch/device_apps_launcher.cc
+++ b/src/components/application_manager/src/app_launch/device_apps_launcher.cc
@@ -196,6 +196,12 @@ DeviceAppsLauncher::DeviceAppsLauncher(
     , settings_(settings)
     , impl_(new DeviceAppsLauncherImpl(*this, apps_launcher)) {}
 
+
+DeviceAppsLauncher::~DeviceAppsLauncher() {
+  delete impl_;
+  impl_ = nullptr;
+}
+
 bool DeviceAppsLauncher::StopLaunchingAppsOnDevice(
     const std::string& device_mac) {
   return impl_->StopLaunchingAppsOnDevice(device_mac);

--- a/src/components/application_manager/src/app_launch/device_apps_launcher.cc
+++ b/src/components/application_manager/src/app_launch/device_apps_launcher.cc
@@ -195,6 +195,7 @@ DeviceAppsLauncher::DeviceAppsLauncher(
     : app_mngr_(app_mngr)
     , settings_(settings)
     , impl_(new DeviceAppsLauncherImpl(*this, apps_launcher)) {}
+
 DeviceAppsLauncher::~DeviceAppsLauncher() {
   delete impl_;
   impl_ = nullptr;

--- a/src/components/application_manager/src/app_launch/device_apps_launcher.cc
+++ b/src/components/application_manager/src/app_launch/device_apps_launcher.cc
@@ -195,8 +195,6 @@ DeviceAppsLauncher::DeviceAppsLauncher(
     : app_mngr_(app_mngr)
     , settings_(settings)
     , impl_(new DeviceAppsLauncherImpl(*this, apps_launcher)) {}
-
-
 DeviceAppsLauncher::~DeviceAppsLauncher() {
   delete impl_;
   impl_ = nullptr;


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3482

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] valgrind
- [x] ATF
- [x] unit tests
- [x] manual tests
- [x] style

### Summary
when DeviceAppsLauncher is destroyed, also destroy its impl member

### Draft Release
https://github.com/smartdevicelink/sdl_core/releases/tag/untagged-bc368bfa0c2736f775ae

Once this PR is merged, the tag `4.5.3` will be created along with this release on branch `release/4.5.3`

### Changelog
##### Enhancements
* Prevent memory leak

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
