### PR TITLE
remove unused param FileName from OnPutFile in HMI API

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -4914,10 +4914,6 @@
         </description>
       </param>
 
-      <param name="FileName" type="String" maxlength="255" mandatory="true">
-        <description>File reference name.</description>
-      </param>
-
       <param name="syncFileName" type="String" maxlength="255" mandatory="true">
         <description>File reference name.</description>
       </param>


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3153

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
ATF, code review, manual

### Summary
Remove unused parameter from HMI RPC BC.OnPutFile

### Changelog
##### Breaking Changes
* Removes unused parameter from API spec

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
