### PR TITLE
Check that message code exists before accessing

### DIFF
--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -1695,8 +1695,13 @@ std::vector<UserFriendlyMessage> CacheManager::GetUserFriendlyMsg(
   std::vector<std::string>::const_iterator it_end = msg_codes.end();
   sync_primitives::AutoLock auto_lock(cache_lock_);
   for (; it != it_end; ++it) {
-    policy_table::MessageLanguages msg_languages =
-        (*pt_->policy_table.consumer_friendly_messages->messages)[*it];
+    auto messages = pt_->policy_table.consumer_friendly_messages->messages;
+    auto messages_it = messages->find(*it);
+    if (messages->end() == messages_it) {
+      SDL_LOG_ERROR("No entry found for message code: " << *it);
+      continue;
+    }
+    policy_table::MessageLanguages msg_languages = messages_it->second;
 
     // If message has no records with required language, fallback language
     // should be used instead.

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -987,8 +987,13 @@ std::vector<UserFriendlyMessage> CacheManager::GetUserFriendlyMsg(
   std::vector<std::string>::const_iterator it_end = msg_codes.end();
   sync_primitives::AutoLock auto_lock(cache_lock_);
   for (; it != it_end; ++it) {
-    policy_table::MessageLanguages msg_languages =
-        (*pt_->policy_table.consumer_friendly_messages->messages)[*it];
+    auto messages = pt_->policy_table.consumer_friendly_messages->messages;
+    auto messages_it = messages->find(*it);
+    if (messages->end() == messages_it) {
+      SDL_LOG_ERROR("No entry found for message code: " << *it);
+      continue;
+    }
+    policy_table::MessageLanguages msg_languages = messages_it->second;
 
     policy_table::MessageString message_string;
 


### PR DESCRIPTION

Fixes #3846 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Run ATF test `test_scripts/Policies/build_options/070_ATF_PTU_Merge_Into_Local_PT_ConsumerFriendlyMessages_Omitted_HTTP.lua` with HTTP policies

### Summary
The `GetUserFriendlyMsg` function was inadvertently creating an empty messages entry when searching for a message code which didn't exist in the policy table during the PTU process, causing the table to be corrupted. This PR adds a check to this function to prevent this from happening.

### Changelog
##### Bug Fixes
* Fix accidental creation of empty messages entry in `GetUserFriendlyMsg`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
