### PR TITLE
reject PTU system request when PTU not in progress

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -721,6 +721,8 @@ class PolicyHandler : public PolicyHandlerInterface,
 
   void StopRetrySequence() OVERRIDE;
 
+  bool IsPTUSystemRequestAllowed(const uint32_t app_id) OVERRIDE;
+
   /**
    * @brief OnDeviceSwitching Notifies policy manager on device switch event so
    * policy permissions should be processed accordingly
@@ -932,10 +934,10 @@ class PolicyHandler : public PolicyHandlerInterface,
   std::shared_ptr<PolicyManager> atomic_policy_manager_;
   std::shared_ptr<PolicyEventObserver> event_observer_;
   uint32_t last_activated_app_id_;
+  uint32_t last_ptu_app_id_;
 
 #ifndef EXTERNAL_PROPRIETARY_MODE
   // PTU retry information
-  uint32_t last_ptu_app_id_;
   std::string retry_update_url_;
   std::string policy_snapshot_path_;
 #endif  // EXTERNAL_PROPRIETARY_MODE

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
@@ -580,6 +580,16 @@ void SystemRequest::Run() {
 
   SDL_LOG_DEBUG("Binary data ok.");
 
+  if (mobile_apis::RequestType::PROPRIETARY == request_type ||
+      mobile_apis::RequestType::HTTP == request_type) {
+    auto app_id = application->app_id();
+    if (!policy_handler_.IsPTUSystemRequestAllowed(app_id)) {
+      SDL_LOG_DEBUG("Rejected PTU SystemRequest from app " << app_id);
+      SendResponse(false, mobile_apis::Result::REJECTED);
+      return;
+    }
+  }
+
   if (mobile_apis::RequestType::ICON_URL == request_type) {
     application_manager_.SetIconFileFromSystemRequest(file_name);
     SendResponse(true, mobile_apis::Result::SUCCESS);

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -300,14 +300,11 @@ PolicyHandler::PolicyHandler(const PolicySettings& settings,
                              ApplicationManager& application_manager)
     : AsyncRunner("PolicyHandler async runner thread")
     , last_activated_app_id_(0)
-#ifndef EXTERNAL_PROPRIETARY_MODE
     , last_ptu_app_id_(0)
-#endif  // EXTERNAL_PROPRIETARY_MODE
     , statistic_manager_impl_(std::make_shared<StatisticManagerImpl>(this))
     , settings_(settings)
     , application_manager_(application_manager)
-    , last_registered_policy_app_id_(std::string()) {
-}
+    , last_registered_policy_app_id_(std::string()) {}
 
 PolicyHandler::~PolicyHandler() {}
 
@@ -423,11 +420,29 @@ void PolicyHandler::StopRetrySequence() {
   SDL_LOG_AUTO_TRACE();
   const auto policy_manager = LoadPolicyManager();
   POLICY_LIB_CHECK_VOID(policy_manager);
-#ifndef EXTERNAL_PROPRIETARY_MODE
   // Clear cached PTU app
   last_ptu_app_id_ = 0;
-#endif  // EXTERNAL_PROPRIETARY_MODE
   policy_manager->StopRetrySequence();
+}
+
+bool PolicyHandler::IsPTUSystemRequestAllowed(const uint32_t app_id) {
+  SDL_LOG_AUTO_TRACE();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
+
+  if (policy_manager->GetPolicyTableStatus() != "UPDATING") {
+    SDL_LOG_DEBUG("PTU received while not UPDATING");
+    return false;
+  }
+
+  if (app_id != last_ptu_app_id_) {
+    SDL_LOG_DEBUG(
+        "PTU received from unexpected application, request was sent to "
+        << last_ptu_app_id_);
+    return false;
+  }
+
+  return true;
 }
 
 bool PolicyHandler::ResetPolicyTable() {
@@ -1286,10 +1301,8 @@ bool PolicyHandler::ReceiveMessageFromSDK(const std::string& file,
     policy_manager->CleanupUnpairedDevices();
     SetDaysAfterEpoch();
     policy_manager->OnPTUFinished(load_pt_result);
-#ifndef EXTERNAL_PROPRIETARY_MODE
     // Clean up retry information
     last_ptu_app_id_ = 0;
-#endif  // EXTERNAL_PROPRIETARY_MODE
 
     uint32_t correlation_id = application_manager_.GetNextHMICorrelationID();
     event_observer_->subscribe_on_event(

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -426,6 +426,8 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
 
   virtual void OnPTInited() = 0;
 
+  virtual bool IsPTUSystemRequestAllowed(const uint32_t app_id) = 0;
+
   /**
    * @brief Force stops retry sequence timer and resets retry sequence
    */

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -210,6 +210,7 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_METHOD1(OnCertificateUpdated, void(const std::string& certificate_data));
   MOCK_METHOD1(OnPTUFinished, void(const bool ptu_result));
   MOCK_METHOD0(OnPTInited, void());
+  MOCK_METHOD1(IsPTUSystemRequestAllowed, bool(uint32_t app_id));
   MOCK_METHOD0(StopRetrySequence, void());
   MOCK_METHOD1(OnCertificateDecrypted, void(bool is_succeeded));
   MOCK_METHOD0(CanUpdate, bool());


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3715 https://github.com/smartdevicelink/sdl_core/issues/3076

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF, manually

### Summary
Reject SystemRequest with type PROPRIETARY or HTTP when PTU is not in progress and when sent from different app than the one which Core requested the PTU from

### Changelog
##### Breaking Changes
* apps have much less ability to control policies


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
