### PR TITLE
Set Last PTU App ID when forwarding on system request in HTTP policy mode

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -429,9 +429,10 @@ class PolicyHandler : public PolicyHandlerInterface,
   void CacheRetryInfo(const uint32_t app_id = 0,
                       const std::string url = std::string(),
                       const std::string snapshot_path = std::string()) OVERRIDE;
-#else   // EXTERNAL_PROPRIETARY_MODE
-  void UpdateLastPTUApp(const uint32_t app_id) OVERRIDE;
 #endif  // EXTERNAL_PROPRIETARY_MODE
+#ifndef PROPRIETARY_MODE
+  void UpdateLastPTUApp(const uint32_t app_id) OVERRIDE;
+#endif  // PROPRIETARY_MODE
 
   uint32_t GetAppIdForSending() const OVERRIDE;
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_system_request_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_system_request_notification.cc
@@ -153,9 +153,9 @@ void OnSystemRequestNotification::Run() {
   if (helpers::Compare<RequestType, helpers::EQ, helpers::ONE>(
           request_type, RequestType::RT_PROPRIETARY, RequestType::RT_HTTP)) {
     policy_handler_.OnSystemRequestReceived();
-#ifdef EXTERNAL_PROPRIETARY_MODE
+#ifndef PROPRIETARY_MODE
     policy_handler_.UpdateLastPTUApp(app->app_id());
-#endif
+#endif  // PROPRIETARY_MODE
   }
   SendNotificationToMobile(message_);
 }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -491,12 +491,14 @@ void PolicyHandler::CacheRetryInfo(const uint32_t app_id,
   retry_update_url_ = url;
   policy_snapshot_path_ = snapshot_path;
 }
-#else   // EXTERNAL_PROPRIETARY_MODE
+#endif  // EXTERNAL_PROPRIETARY_MODE
+
+#ifndef PROPRIETARY_MODE
 void PolicyHandler::UpdateLastPTUApp(const uint32_t app_id) {
   SDL_LOG_DEBUG("UpdateLastPTUApp to " << app_id);
   last_ptu_app_id_ = app_id;
 }
-#endif  // EXTERNAL_PROPRIETARY_MODE
+#endif  // PROPRIETARY_MODE
 
 uint32_t PolicyHandler::GetAppIdForSending() const {
   SDL_LOG_AUTO_TRACE();

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -406,9 +406,10 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
       const uint32_t app_id = 0,
       const std::string url = std::string(),
       const std::string snapshot_path = std::string()) = 0;
-#else
-  virtual void UpdateLastPTUApp(const uint32_t app_id) = 0;
 #endif  // EXTERNAL_PROPRIETARY_MODE
+#ifndef PROPRIETARY_MODE
+  virtual void UpdateLastPTUApp(const uint32_t app_id) = 0;
+#endif  // PROPRIETARY_MODE
 
   /**
    * @brief Retrieve potential application id to be used for snapshot sending

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -200,7 +200,8 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                void(const uint32_t app_id,
                     const std::string url,
                     const std::string snapshot_path));
-#else
+#endif
+#ifndef PROPRIETARY_MODE
   MOCK_METHOD1(UpdateLastPTUApp, void(const uint32_t app_id));
 #endif
   MOCK_CONST_METHOD0(GetAppIdForSending, uint32_t());


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3862

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF

### Summary
The last_ptu_app_id_ is only updated in PROPRIETARY mode at the beginning of the OnSystemRequest Run:
https://github.com/smartdevicelink/sdl_core/blob/b74c738101f282143094394454d20d12aa8e0d05/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_system_request_notification.cc#L81

Because of this `UpdateLastPTUApp` should be called in every policy mode besides proprietary.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
