### PR TITLE
Check if app id exists in cloud_app_id_map_

### DIFF
--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -1487,13 +1487,12 @@ void ConnectionHandlerImpl::AddCloudAppDevice(
     const transport_manager::transport_adapter::CloudAppProperties&
         cloud_properties) {
   cloud_app_id_map_lock_.Acquire();
-  if (cloud_app_id_map_.find(policy_app_id) != cloud_app_id_map_.end()) {
-    // Cloud app already exists
-    cloud_app_id_map_lock_.Release();
-    return;
+  auto it = cloud_app_id_map_.find(policy_app_id);
+  if (cloud_app_id_map_.end() == it || cloud_properties.endpoint != it->second.first) {
+    // Init map entry if does not exist or if endpoint changed
+    cloud_app_id_map_[policy_app_id] =
+        std::make_pair(cloud_properties.endpoint, 0);
   }
-  cloud_app_id_map_[policy_app_id] =
-      std::make_pair(cloud_properties.endpoint, 0);
   cloud_app_id_map_lock_.Release();
   transport_manager_.AddCloudDevice(cloud_properties);
 }

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -1488,7 +1488,8 @@ void ConnectionHandlerImpl::AddCloudAppDevice(
         cloud_properties) {
   cloud_app_id_map_lock_.Acquire();
   auto it = cloud_app_id_map_.find(policy_app_id);
-  if (cloud_app_id_map_.end() == it || cloud_properties.endpoint != it->second.first) {
+  if (cloud_app_id_map_.end() == it ||
+      cloud_properties.endpoint != it->second.first) {
     // Init map entry if does not exist or if endpoint changed
     cloud_app_id_map_[policy_app_id] =
         std::make_pair(cloud_properties.endpoint, 0);

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -1487,6 +1487,11 @@ void ConnectionHandlerImpl::AddCloudAppDevice(
     const transport_manager::transport_adapter::CloudAppProperties&
         cloud_properties) {
   cloud_app_id_map_lock_.Acquire();
+  if (cloud_app_id_map_.find(policy_app_id) != cloud_app_id_map_.end()) {
+    // Cloud app already exists
+    cloud_app_id_map_lock_.Release();
+    return;
+  }
   cloud_app_id_map_[policy_app_id] =
       std::make_pair(cloud_properties.endpoint, 0);
   cloud_app_id_map_lock_.Release();


### PR DESCRIPTION
Fixes #3869 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Connect two cloud apps that have auth_token defined in their policy table entries. Verify both apps receive their designated auth tokens in the start service ack.

### Summary
Checks the connection handler's cloud app id map to make sure it does not overwrite the connection id. GetCloudAppID was unable to locate the policy app id after this connection id was reset. Auth token was unable to be located if the policy app id was missing.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
