### PR TITLE
Fix/Protocol NAK reason for unsigned cert

### DIFF
--- a/src/components/protocol_handler/src/handshake_handler.cc
+++ b/src/components/protocol_handler/src/handshake_handler.cc
@@ -154,7 +154,7 @@ bool HandshakeHandler::OnHandshakeDone(
           case security_manager::SSLContext::Handshake_Result_Fail:
             return "";
           default:
-            return "";
+            return "Unknown handshake result";
         }
       };
 

--- a/src/components/security_manager/src/ssl_context_impl.cc
+++ b/src/components/security_manager/src/ssl_context_impl.cc
@@ -628,6 +628,7 @@ CryptoManagerImpl::SSLContextImpl::openssl_error_convert_to_internal(
     case X509_V_ERR_SUBJECT_ISSUER_MISMATCH:
     case X509_V_ERR_CERT_SIGNATURE_FAILURE:
     case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT:
+    case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY:
     case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
       return Handshake_Result_CertNotSigned;
     default:

--- a/src/components/security_manager/test/ssl_certificate_handshake_test.cc
+++ b/src/components/security_manager/test/ssl_certificate_handshake_test.cc
@@ -450,7 +450,7 @@ TEST_P(SSLHandshakeTest, CAVerification_ClientSide_NoCACertificate) {
       << client_manager_->LastError();
 
   GTEST_TRACE(HandshakeProcedure_ClientSideFail(
-      security_manager::SSLContext::Handshake_Result_Fail));
+      security_manager::SSLContext::Handshake_Result_CertNotSigned));
 
   ASSERT_TRUE(InitClientManagers(GetParam().client_protocol,
                                  client_certificate,


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF and manual testing using test suite 

### Summary
Add additional case (`X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY`) to openssl_to_internal_error for local issuer certificate

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
