### PR TITLE
Fix crash on shutdown during streaming

### DIFF
--- a/src/components/application_manager/include/application_manager/request_controller_impl.h
+++ b/src/components/application_manager/include/application_manager/request_controller_impl.h
@@ -234,6 +234,7 @@ class RequestControllerImpl : public RequestController, threads::AsyncRunner {
    * @brief Set of HMI notifications with timeout.
    */
   std::list<RequestPtr> notification_list_;
+  sync_primitives::Lock notification_list_lock_;
 
   /**
    * @brief Map keeping track of how many duplicate messages were sent for a

--- a/src/components/application_manager/src/request_controller_impl.cc
+++ b/src/components/application_manager/src/request_controller_impl.cc
@@ -374,7 +374,7 @@ void RequestControllerImpl::TerminateWaitingForExecutionAppRequests(
   while (mobile_request_list_.end() != request_it) {
     RequestPtr request = (*request_it);
     if ((request.use_count() != 0) && (request->connection_key() == app_id)) {
-      mobile_request_list_.erase(request_it++);
+      request_it = mobile_request_list_.erase(request_it);
     } else {
       ++request_it;
     }

--- a/src/components/application_manager/src/request_controller_impl.cc
+++ b/src/components/application_manager/src/request_controller_impl.cc
@@ -236,16 +236,18 @@ void RequestControllerImpl::AddNotification(const RequestPtr ptr) {
         "Impossible to add notification due to Low Voltage is active");
     return;
   }
+  AutoLock auto_lock(notification_list_lock_);
   notification_list_.push_back(ptr);
 }
 
 void RequestControllerImpl::RemoveNotification(
     const commands::Command* notification) {
   SDL_LOG_AUTO_TRACE();
-  std::list<RequestPtr>::iterator it = notification_list_.begin();
+  AutoLock auto_lock(notification_list_lock_);
+  auto it = notification_list_.begin();
   for (; notification_list_.end() != it;) {
     if (it->get() == notification) {
-      notification_list_.erase(it++);
+      it = notification_list_.erase(it);
       SDL_LOG_DEBUG("Notification removed");
       return;
     } else {

--- a/src/components/application_manager/src/rpc_service_impl.cc
+++ b/src/components/application_manager/src/rpc_service_impl.cc
@@ -228,8 +228,8 @@ bool RPCServiceImpl::ManageMobileCommand(
     return true;
   }
   if (message_type == mobile_apis::messageType::notification) {
-    request_ctrl_.AddNotification(command);
     if (command->Init() && command->CheckPermissions()) {
+      request_ctrl_.AddNotification(command);
       command->Run();
       if (command->CleanUp()) {
         request_ctrl_.RemoveNotification(command.get());


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3878

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Start policy server
- start core
- connect app
- observe ptu
- start video stream
- while streaming shutdown core via exit application.

### Summary
A request pointer was being added to the notification struct, but the init or check permissions call were failing so the notification never even ran or had the chance to be removed from the notification list.

Updated the logic to only add the notification to the notification_list_ if it is properly init.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
