### PR TITLE
Fix/8.1.0 RC1 Coverity fixes

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1959,7 +1959,10 @@ bool ApplicationManagerImpl::StartNaviService(
 
       const ApplicationSet apps = applications().GetData();
       for (auto app : apps) {
-        if (!app || (!app->is_navi() && !app->mobile_projection_enabled())) {
+        if (!app) {
+          SDL_LOG_ERROR("NULL pointer for application");
+          continue;
+        } else if (!app->is_navi() && !app->mobile_projection_enabled()) {
           SDL_LOG_DEBUG("Continue, Not Navi App Id: " << app->app_id());
           continue;
         }
@@ -3174,12 +3177,6 @@ void ApplicationManagerImpl::SendOnSDLClose() {
       commands::CommandImpl::hmi_protocol_type_;
   (*msg)[strings::params][strings::protocol_version] =
       commands::CommandImpl::protocol_version_;
-
-  if (!msg) {
-    SDL_LOG_WARN("Null-pointer message received.");
-    NOTREACHED();
-    return;
-  }
 
   // SmartObject |message| has no way to declare priority for now
   std::shared_ptr<Message> message_to_send(

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1059,10 +1059,6 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateSetAppIcon(
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
 
-  if (!set_icon) {
-    return NULL;
-  }
-
   smart_objects::SmartObject& object = *set_icon;
   object[strings::sync_file_name][strings::value] = path_to_icon;
   // TODO(PV): need to store actual image type
@@ -1419,9 +1415,7 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateAppVrHelp(
   smart_objects::SmartObjectSPtr result =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  if (!result) {
-    return NULL;
-  }
+
   smart_objects::SmartObject& vr_help = *result;
   const smart_objects::SmartObject* vr_help_title = app->vr_help_title();
   if (vr_help_title) {
@@ -2266,9 +2260,6 @@ void MessageHelper::SendGetUserFriendlyMessageResponse(
   smart_objects::SmartObjectSPtr message =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  if (!message) {
-    return;
-  }
 
   (*message)[strings::params][strings::function_id] =
       hmi_apis::FunctionID::SDL_GetUserFriendlyMessage;
@@ -3050,9 +3041,6 @@ void MessageHelper::SendGetStatusUpdateResponse(const std::string& status,
   smart_objects::SmartObjectSPtr message =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  if (!message) {
-    return;
-  }
 
   (*message)[strings::params][strings::function_id] =
       hmi_apis::FunctionID::SDL_GetStatusUpdate;
@@ -3090,9 +3078,6 @@ void MessageHelper::SendOnStatusUpdate(const std::string& status,
   smart_objects::SmartObjectSPtr message =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  if (!message) {
-    return;
-  }
 
   (*message)[strings::params][strings::function_id] =
       hmi_apis::FunctionID::SDL_OnStatusUpdate;

--- a/src/components/application_manager/src/mobile_message_handler.cc
+++ b/src/components/application_manager/src/mobile_message_handler.cc
@@ -135,15 +135,15 @@ application_manager::Message*
 MobileMessageHandler::HandleIncomingMessageProtocolV1(
     const ::protocol_handler::RawMessagePtr message) {
   SDL_LOG_AUTO_TRACE();
+
+  if (!message) {
+    NOTREACHED();
+    return NULL;
+  }
   application_manager::Message* outgoing_message =
       new application_manager::Message(
           protocol_handler::MessagePriority::FromServiceType(
               message->service_type()));
-  if (!message) {
-    NOTREACHED();
-    delete outgoing_message;
-    return NULL;
-  }
 
   outgoing_message->set_connection_key(message->connection_key());
   outgoing_message->set_protocol_version(

--- a/src/components/transport_manager/src/cloud/websocket_client_connection.cc
+++ b/src/components/transport_manager/src/cloud/websocket_client_connection.cc
@@ -315,6 +315,10 @@ void WebsocketClientConnection::LoopThreadDelegate::DrainQueue() {
   while (!message_queue_.empty()) {
     Message message_ptr;
     message_queue_.pop(message_ptr);
+    if (!message_ptr) {
+      SDL_LOG_ERROR("Invalid message in message queue");
+      continue;
+    }
     if (!shutdown_) {
       boost::system::error_code ec;
       if (handler_.cloud_properties.cloud_transport_type == "WS") {


### PR DESCRIPTION
This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Re-run coverity

### Summary
The PR fixes the following coverity issues

- `250651 Logically dead code`: [src/components/application_manager/src/message_helper/message_helper.cc::1422](https://github.com/smartdevicelink/sdl_core/pull/3877/files#diff-59bdfbd55b32b2dae488584440e0d7a594ca6176c26d15fbf479deecc8a7f999L1422)
- `250652 Dereference before null check`: [src/components/application_manager/src/mobile_message_handler.cc::138](https://github.com/smartdevicelink/sdl_core/pull/3877/files#diff-f420f6c1935ccbfa1eddb7b995607aaa6d37a209c04be27e77a1c92599168f29L138)
- `250654 Dereference before null check`: [src/components/application_manager/src/application_manager_impl.cc:3178](https://github.com/smartdevicelink/sdl_core/pull/3877/files#diff-75bb6bf1f99ece55e57be70c7456ee2df447370d036408aaa9b6985ad153a267L3178)
- `250656 Logically dead code`: [src/components/application_manager/src/message_helper/message_helper.cc::3053](https://github.com/smartdevicelink/sdl_core/pull/3877/files#diff-59bdfbd55b32b2dae488584440e0d7a594ca6176c26d15fbf479deecc8a7f999L3053)
- `250658 Logically dead code`: [src/components/application_manager/src/message_helper/message_helper.cc::2269](https://github.com/smartdevicelink/sdl_core/pull/3877/files#diff-59bdfbd55b32b2dae488584440e0d7a594ca6176c26d15fbf479deecc8a7f999L2269)
- `250659 Logically dead code`: [src/components/application_manager/src/message_helper/message_helper.cc::3093](https://github.com/smartdevicelink/sdl_core/pull/3877/files#diff-59bdfbd55b32b2dae488584440e0d7a594ca6176c26d15fbf479deecc8a7f999L3093)
- `250666 Explicit null dereferenced`: [src/components/transport_manager/src/cloud/websocket_client_connection.cc::318](https://github.com/smartdevicelink/sdl_core/pull/3877/files#diff-5ccbb188ceddda0c49d24654b84134b72d0a14274925eb350691864070292474R318)
- `250668 Dereference after null check`: [src/components/application_manager/src/application_manager_impl.cc::1962](https://github.com/smartdevicelink/sdl_core/pull/3877/files#diff-75bb6bf1f99ece55e57be70c7456ee2df447370d036408aaa9b6985ad153a267L1962)
- `250669 Logically dead code`: [src/components/application_manager/src/message_helper/message_helper.cc::1062](https://github.com/smartdevicelink/sdl_core/pull/3877/files#diff-59bdfbd55b32b2dae488584440e0d7a594ca6176c26d15fbf479deecc8a7f999L1062)




### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
