### PR TITLE
Fix/Consumer Messages empty in PTU

### DIFF
--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -1611,9 +1611,7 @@ bool SQLPTRepresentation::SaveConsumerFriendlyMessages(
 
   utils::dbms::SQLQuery query(db());
   bool delete_query_exec_result = true;
-  if (!messages.messages->empty()) {
-    delete_query_exec_result = query.Exec(sql_pt::kDeleteMessageString);
-  }
+  delete_query_exec_result = query.Exec(sql_pt::kDeleteMessageString);
 
   if (!delete_query_exec_result) {
     SDL_LOG_WARN("Failed to delete messages from DB.");

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -1575,9 +1575,7 @@ bool SQLPTRepresentation::SaveConsumerFriendlyMessages(
 
   utils::dbms::SQLQuery query(db());
   bool delete_query_exec_result = true;
-  if (!messages.messages->empty()) {
-    delete_query_exec_result = query.Exec(sql_pt::kDeleteMessageString);
-  }
+  delete_query_exec_result = query.Exec(sql_pt::kDeleteMessageString);
 
   if (!delete_query_exec_result) {
     SDL_LOG_WARN("Failed to delete messages from DB.");


### PR DESCRIPTION
This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF regression
Manual tests

### Summary
Clear out `message` table from policy DB if `consumer_friendly_messages.messages` is empty

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
