### PR TITLE
Fix/Clear endpoint_properties in policy DB if empty properties recieved in PTU

### DIFF
--- a/src/components/policy/policy_external/include/policy/sql_pt_queries.h
+++ b/src/components/policy/policy_external/include/policy/sql_pt_queries.h
@@ -99,6 +99,7 @@ extern const std::string kInsertDeviceData;
 extern const std::string kInsertAppLevel;
 extern const std::string kDeleteSecondsBetweenRetries;
 extern const std::string kDeleteEndpoint;
+extern const std::string kDeleteEndpointProperties;
 extern const std::string kDeleteAppLevel;
 extern const std::string kDeleteMessageString;
 extern const std::string kDeleteFunctionalGroup;

--- a/src/components/policy/policy_external/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_queries.cc
@@ -918,6 +918,9 @@ const std::string kDeleteSecondsBetweenRetries =
 
 const std::string kDeleteEndpoint = "DELETE FROM `endpoint`";
 
+const std::string kDeleteEndpointProperties =
+    "DELETE FROM `endpoint_properties`";
+
 const std::string kDeleteAppLevel = "DELETE FROM `app_level`";
 
 const std::string kDeleteMessageString = "DELETE FROM `message`";

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -1575,6 +1575,18 @@ bool SQLPTRepresentation::SaveServiceEndpoints(
 bool SQLPTRepresentation::SaveServiceEndpointProperties(
     const policy_table::ServiceEndpointProperties& endpoint_properties) {
   utils::dbms::SQLQuery query(db());
+
+  if (endpoint_properties.empty()) {
+    bool delete_query_exec_result =
+        query.Exec(sql_pt::kDeleteEndpointProperties);
+
+    if (!delete_query_exec_result) {
+      SDL_LOG_WARN("Failed to delete endpoint properties from DB.");
+      return false;
+    }
+    return true;
+  }
+
   if (!query.Prepare(sql_pt::kInsertEndpointVersion)) {
     SDL_LOG_WARN(
         "Incorrect insert of endpoint property to endpoint_properties.");

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -1576,7 +1576,7 @@ bool SQLPTRepresentation::SaveServiceEndpointProperties(
     const policy_table::ServiceEndpointProperties& endpoint_properties) {
   utils::dbms::SQLQuery query(db());
 
-  if (endpoint_properties.empty()) {
+  if (endpoint_properties.is_initialized() && endpoint_properties.empty()) {
     bool delete_query_exec_result =
         query.Exec(sql_pt::kDeleteEndpointProperties);
 

--- a/src/components/policy/policy_regular/include/policy/sql_pt_queries.h
+++ b/src/components/policy/policy_regular/include/policy/sql_pt_queries.h
@@ -99,6 +99,7 @@ extern const std::string kInsertDeviceData;
 extern const std::string kInsertAppLevel;
 extern const std::string kDeleteSecondsBetweenRetries;
 extern const std::string kDeleteEndpoint;
+extern const std::string kDeleteEndpointProperties;
 extern const std::string kDeleteAppLevel;
 extern const std::string kDeleteMessageString;
 extern const std::string kDeleteFunctionalGroup;

--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -868,6 +868,9 @@ const std::string kDeleteSecondsBetweenRetries =
 
 const std::string kDeleteEndpoint = "DELETE FROM `endpoint`";
 
+const std::string kDeleteEndpointProperties =
+    "DELETE FROM `endpoint_properties`";
+
 const std::string kDeleteAppLevel = "DELETE FROM `app_level`";
 
 const std::string kDeleteMessageString = "DELETE FROM `message`";

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -1540,7 +1540,7 @@ bool SQLPTRepresentation::SaveServiceEndpointProperties(
     const policy_table::ServiceEndpointProperties& endpoint_properties) {
   utils::dbms::SQLQuery query(db());
 
-  if (endpoint_properties.empty()) {
+  if (endpoint_properties.is_initialized() && endpoint_properties.empty()) {
     bool delete_query_exec_result =
         query.Exec(sql_pt::kDeleteEndpointProperties);
 

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -1539,6 +1539,18 @@ bool SQLPTRepresentation::SaveServiceEndpoints(
 bool SQLPTRepresentation::SaveServiceEndpointProperties(
     const policy_table::ServiceEndpointProperties& endpoint_properties) {
   utils::dbms::SQLQuery query(db());
+
+  if (endpoint_properties.empty()) {
+    bool delete_query_exec_result =
+        query.Exec(sql_pt::kDeleteEndpointProperties);
+
+    if (!delete_query_exec_result) {
+      SDL_LOG_WARN("Failed to delete endpoint properties from DB.");
+      return false;
+    }
+    return true;
+  }
+
   if (!query.Prepare(sql_pt::kInsertEndpointVersion)) {
     SDL_LOG_WARN(
         "Incorrect insert of endpoint property to endpoint_properties.");


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Manual testing with sdl_server. Test sending PTU with `endpoint_properties: {}`

### Summary
Currently `endpoint_properties` is cleared from the cache if empty in PTU, but is not cleared from the policy database.

This PR 
- Adds a check for `endpoint_properties.empty()` in `SaveServiceEndpointProperties`.
- If `endpoint_properties.empty()`, executes a query to clear the `endpoint_properties` in the policy DB.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
