### PR TITLE
Obtain appID if url is sent to prop policies

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_system_request_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_system_request_notification.cc
@@ -93,6 +93,7 @@ void OnSystemRequestNotification::Run() {
       policy_handler_.CacheRetryInfo(app_id,
                                      msg_params[strings::url].asString(),
                                      msg_params[strings::file_name].asString());
+      msg_params[strings::app_id] = app_id;
     } else {
       // Clear cached retry info
       policy_handler_.CacheRetryInfo(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_system_request_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_system_request_notification.cc
@@ -83,9 +83,14 @@ void OnSystemRequestNotification::Run() {
     if (msg_params.keyExists(strings::url)) {
       // For backward-compatibility, the URL is cached for retries if provided
       // by HMI
-      policy_handler_.CacheRetryInfo(msg_params.keyExists(strings::app_id)
-                                         ? msg_params[strings::app_id].asUInt()
-                                         : 0,
+      uint32_t app_id;
+      if (msg_params.keyExists(strings::app_id)) {
+        app_id = msg_params[strings::app_id].asUInt();
+      } else {
+        app_id = policy_handler_.ChoosePTUApplication(
+            policy::PTUIterationType::DefaultIteration);
+      }
+      policy_handler_.CacheRetryInfo(app_id,
                                      msg_params[strings::url].asString(),
                                      msg_params[strings::file_name].asString());
     } else {


### PR DESCRIPTION
Fixes #3881

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF policy test scripts.

### Summary
Normally in proprietary policies a url is not included in the system request. In the policy handler `GetNextUpdateUrl()` will find an app id to send the ptu to if an app id is not provided. This method is not called when a url is provided by the hmi. A call to ChoosePTUApplication() was added to handle the missing app id.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
