### PR TITLE
Set secure wss cipher list

### DIFF
--- a/src/components/transport_manager/src/cloud/websocket_client_connection.cc
+++ b/src/components/transport_manager/src/cloud/websocket_client_connection.cc
@@ -50,7 +50,7 @@ WebsocketClientConnection::WebsocketClientConnection(
     , resolver_(ioc_)
     , ws_(ioc_)
 #ifdef ENABLE_SECURITY
-    , ctx_(ssl::context::sslv23_client)
+    , ctx_(ssl::context::tlsv12_client)
     , wss_(ioc_, ctx_)
 #endif  // ENABLE_SECURITY
     , shutdown_(false)
@@ -59,6 +59,15 @@ WebsocketClientConnection::WebsocketClientConnection(
     , device_uid_(device_uid)
     , app_handle_(app_handle)
     , io_pool_(1) {
+  // SSL_CTX_set_security_level(ctx_.native_handle(), 1);
+#ifdef ENABLE_SECURITY
+  const char* wss_ciphers =
+      "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-"
+      "CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-"
+      "SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-"
+      "AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256";
+  SSL_CTX_set_cipher_list(ctx_.native_handle(), wss_ciphers);
+#endif
 }
 
 WebsocketClientConnection::~WebsocketClientConnection() {

--- a/src/components/transport_manager/src/cloud/websocket_client_connection.cc
+++ b/src/components/transport_manager/src/cloud/websocket_client_connection.cc
@@ -59,7 +59,6 @@ WebsocketClientConnection::WebsocketClientConnection(
     , device_uid_(device_uid)
     , app_handle_(app_handle)
     , io_pool_(1) {
-  // SSL_CTX_set_security_level(ctx_.native_handle(), 1);
 #ifdef ENABLE_SECURITY
   const char* wss_ciphers =
       "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-"


### PR DESCRIPTION
Fixes #3884 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Connect cloud application using wss with a signed CA.cert

### Summary
Sets the ssl context for wss connections to only use "hardened" cipher suites. This prevents the java server from using an insecure key exchange mechanism. Resolves the dh key length issue without reducing the operating systems security level.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
