### PR TITLE
Fix/WSS re-connection loop

### DIFF
--- a/src/components/transport_manager/include/transport_manager/cloud/websocket_client_connection.h
+++ b/src/components/transport_manager/include/transport_manager/cloud/websocket_client_connection.h
@@ -150,10 +150,10 @@ class WebsocketClientConnection
   boost::beast::flat_buffer buffer_;
   std::string host_;
   std::string text_;
-  WS ws_;
+  std::shared_ptr<WS> ws_;
 #ifdef ENABLE_SECURITY
   ssl::context ctx_;
-  WSS wss_;
+  std::shared_ptr<WSS> wss_;
 #endif  // ENABLE_SECURITY
 
   std::atomic_bool shutdown_;

--- a/src/components/transport_manager/include/transport_manager/cloud/websocket_client_connection.h
+++ b/src/components/transport_manager/include/transport_manager/cloud/websocket_client_connection.h
@@ -144,6 +144,8 @@ class WebsocketClientConnection
   void OnRead(boost::system::error_code ec, std::size_t bytes_transferred);
 
  private:
+  void ResetWebsocketStream(std::string cloud_transport_type);
+
   TransportAdapterController* controller_;
   boost::asio::io_context ioc_;
   tcp::resolver resolver_;
@@ -152,6 +154,7 @@ class WebsocketClientConnection
   std::string text_;
   std::shared_ptr<WS> ws_;
 #ifdef ENABLE_SECURITY
+  const char* wss_ciphers_;
   ssl::context ctx_;
   std::shared_ptr<WSS> wss_;
 #endif  // ENABLE_SECURITY


### PR DESCRIPTION
Fixes #3889 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test WSS connection use Test Suite appJava

1. Start appJava with SSL enabled and an invalid certificate/key pair.
2. Add cloud app entry to sdl_preloaded_pt.json with valid certificate
3. Start Core and HMI
4. Activate app
- Activation fails and HMI receives UpdateAppList with `cloudConnectionStatus "NOT_CONNECTED"`
5. Restart appJava with valid certifcate/key pair
6. Activate app
-  Activation is sucessful. App goes into HMI_FULL.

### Summary
Re-connection loop occurs in the case of a succesful tcp layer connection and failed ssl handshake. This is probably due to `ShutDown()` being called during a re-activation attempt.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
