### PR TITLE
Check if JSON value is a map before accessing members in SendInternalError handler

### DIFF
--- a/src/components/security_manager/src/security_manager_impl.cc
+++ b/src/components/security_manager/src/security_manager_impl.cc
@@ -607,10 +607,11 @@ bool SecurityManagerImpl::ProcessInternalError(
   Json::Value root;
   utils::JsonReader reader;
 
-  if (!reader.parse(str, &root)) {
+  if (!reader.parse(str, &root) || !root.isObject()) {
     SDL_LOG_DEBUG("Json parsing fails.");
     return false;
   }
+
   uint8_t id = root[kErrId].asInt();
   SDL_LOG_DEBUG("Received InternalError id " << std::to_string(id) << ", text: "
                                              << root[kErrText].asString());


### PR DESCRIPTION

Fixes #3887 (partially, case 1)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Send a "SendInternalError" query with an integer value in the JSON data field
```
responseHeader.setJsonData("7".getBytes(StandardCharsets.UTF_8));
```
Verify that Core does not crash.
ATF script to be added

### Summary
If a non-object value is sent in the JSON data field of a SendInternalError query, an assertion is thrown by the JSON library. This PR adds a check to avoid this assertion.

### Changelog
##### Bug Fixes
* Check if JSON value is a map before accessing members in SendInternalError handler

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
