### PR TITLE
Fix app activation during pending cloud connection

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -187,6 +187,8 @@ class ApplicationManagerImpl
       uint32_t hmi_app_id) const OVERRIDE;
   ApplicationSharedPtr application_by_policy_id(
       const std::string& policy_app_id) const OVERRIDE;
+  ApplicationSharedPtr pending_application_by_hmi_app(
+      uint32_t hmi_app_id) const OVERRIDE;
   ApplicationSharedPtr pending_application_by_policy_id(
       const std::string& policy_app_id) const OVERRIDE;
   ApplicationSharedPtr reregister_application_by_policy_id(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
@@ -297,7 +297,13 @@ void SDLActivateAppRequest::on_event(const event_engine::Event& event) {
   if (event.id() != BasicCommunication_OnAppRegistered) {
     return;
   }
-  unsubscribe_from_event(BasicCommunication_OnAppRegistered);
+
+  ApplicationSharedPtr pending_app =
+      application_manager_.pending_application_by_hmi_app(app_id());
+  if (pending_app) {
+    SDL_LOG_ERROR("Application is still pending connection: " << app_id());
+    return;
+  }
 
   // Have to use HMI app id from event, since HMI app id from original request
   // message will be changed after app, initially requested for launch via
@@ -311,6 +317,8 @@ void SDLActivateAppRequest::on_event(const event_engine::Event& event) {
         "Application not found by HMI app id: " << hmi_application_id);
     return;
   }
+
+  unsubscribe_from_event(BasicCommunication_OnAppRegistered);
 
   auto main_state =
       app->CurrentHmiState(mobile_apis::PredefinedWindows::DEFAULT_WINDOW);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_activate_app_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_activate_app_request_test.cc
@@ -543,7 +543,7 @@ TEST_F(SDLActivateAppRequestTest, OnEvent_InvalidAppId_UNSUCCESS) {
   EXPECT_CALL(app_mngr_, application_by_hmi_app(_))
       .WillOnce(Return(invalid_mock_app));
   EXPECT_CALL(app_mngr_, pending_application_by_hmi_app(_))
-      .WillOnce(Return(nullptr));
+      .WillOnce(Return(ApplicationSharedPtr()));
 
   command->on_event(event);
 }
@@ -584,7 +584,7 @@ TEST_F(SDLActivateAppRequestTest, OnEvent_SUCCESS) {
   MockAppPtr mock_app(CreateMockApp());
   EXPECT_CALL(app_mngr_, application_by_hmi_app(_)).WillOnce(Return(mock_app));
   EXPECT_CALL(app_mngr_, pending_application_by_hmi_app(_))
-      .WillOnce(Return(nullptr));
+      .WillOnce(Return(ApplicationSharedPtr()));
 
   auto hmi_state = std::make_shared<am::HmiState>(mock_app, app_mngr_);
   hmi_state->set_hmi_level(mobile_apis::HMILevel::HMI_NONE);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -301,6 +301,13 @@ ApplicationSharedPtr ApplicationManagerImpl::application_by_policy_id(
   return FindApp(accessor, finder);
 }
 
+ApplicationSharedPtr ApplicationManagerImpl::pending_application_by_hmi_app(
+    uint32_t hmi_app_id) const {
+  HmiAppIdPredicate finder(hmi_app_id);
+  DataAccessor<AppsWaitRegistrationSet> accessor = pending_applications();
+  return FindPendingApp(accessor, finder);
+}
+
 ApplicationSharedPtr ApplicationManagerImpl::pending_application_by_policy_id(
     const std::string& policy_app_id) const {
   PolicyAppIdPredicate finder(policy_app_id);

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -216,6 +216,9 @@ class ApplicationManager {
   virtual ApplicationSharedPtr application_by_policy_id(
       const std::string& policy_app_id) const = 0;
 
+  virtual ApplicationSharedPtr pending_application_by_hmi_app(
+      uint32_t hmi_app_id) const = 0;
+
   virtual ApplicationSharedPtr pending_application_by_policy_id(
       const std::string& policy_app_id) const = 0;
 

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -113,6 +113,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD1(application_by_policy_id,
                      application_manager::ApplicationSharedPtr(
                          const std::string& policy_app_id));
+  MOCK_CONST_METHOD1(
+      pending_application_by_hmi_app,
+      application_manager::ApplicationSharedPtr(uint32_t hmi_app_id));
   MOCK_CONST_METHOD1(pending_application_by_policy_id,
                      application_manager::ApplicationSharedPtr(
                          const std::string& policy_app_id));


### PR DESCRIPTION
Fixes #3897 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test case described in issue

### Summary
Adds a check to ON_EVENT in Activate app that if the cloud app is still in the pending list, it has not connected and registered, therefore it should not activate.

- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
