### PR TITLE
Fix potential crashes by using shared pointers for app data

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -113,14 +113,15 @@ class InitialApplicationData {
  public:
   virtual ~InitialApplicationData() {}
 
-  virtual const smart_objects::SmartObject* app_types() const = 0;
-  virtual const smart_objects::SmartObject* vr_synonyms() const = 0;
+  virtual const smart_objects::SmartObjectSPtr app_types() const = 0;
+  virtual const smart_objects::SmartObjectSPtr vr_synonyms() const = 0;
   virtual const std::string& mac_address() const = 0;
   virtual const std::string& bundle_id() const = 0;
   virtual void set_bundle_id(const std::string& bundle_id) = 0;
   virtual std::string policy_app_id() const = 0;
-  virtual const smart_objects::SmartObject* tts_name() const = 0;
-  virtual const smart_objects::SmartObject* ngn_media_screen_name() const = 0;
+  virtual const smart_objects::SmartObjectSPtr tts_name() const = 0;
+  virtual const smart_objects::SmartObjectSPtr ngn_media_screen_name()
+      const = 0;
   virtual const mobile_api::Language::eType& language() const = 0;
   virtual const mobile_api::Language::eType& ui_language() const = 0;
   virtual const utils::SemanticVersion& msg_version() const = 0;
@@ -195,18 +196,18 @@ typedef std::vector<smart_objects::SmartObjectSPtr> MobileMessageQueue;
 class DynamicApplicationData {
  public:
   virtual ~DynamicApplicationData() {}
-  virtual const smart_objects::SmartObject* help_prompt() const = 0;
-  virtual const smart_objects::SmartObject* timeout_prompt() const = 0;
-  virtual const smart_objects::SmartObject* vr_help_title() const = 0;
-  virtual const smart_objects::SmartObject* vr_help() const = 0;
+  virtual const smart_objects::SmartObjectSPtr help_prompt() const = 0;
+  virtual const smart_objects::SmartObjectSPtr timeout_prompt() const = 0;
+  virtual const smart_objects::SmartObjectSPtr vr_help_title() const = 0;
+  virtual const smart_objects::SmartObjectSPtr vr_help() const = 0;
   virtual const mobile_api::TBTState::eType& tbt_state() const = 0;
-  virtual const smart_objects::SmartObject* show_command() const = 0;
-  virtual const smart_objects::SmartObject* tbt_show_command() const = 0;
+  virtual const smart_objects::SmartObjectSPtr show_command() const = 0;
+  virtual const smart_objects::SmartObjectSPtr tbt_show_command() const = 0;
   virtual DataAccessor<ButtonSubscriptions> SubscribedButtons() const = 0;
-  virtual const smart_objects::SmartObject* keyboard_props() const = 0;
-  virtual const smart_objects::SmartObject* menu_title() const = 0;
-  virtual const smart_objects::SmartObject* menu_icon() const = 0;
-  virtual const smart_objects::SmartObject* menu_layout() const = 0;
+  virtual const smart_objects::SmartObjectSPtr keyboard_props() const = 0;
+  virtual const smart_objects::SmartObjectSPtr menu_title() const = 0;
+  virtual const smart_objects::SmartObjectSPtr menu_icon() const = 0;
+  virtual const smart_objects::SmartObjectSPtr menu_layout() const = 0;
   virtual smart_objects::SmartObject day_color_scheme() const = 0;
   virtual smart_objects::SmartObject night_color_scheme() const = 0;
   virtual std::string display_layout() const = 0;
@@ -558,8 +559,10 @@ class Application : public virtual InitialApplicationData,
    * @brief Returns message belonging to the application
    * that is currently executed (i.e. on HMI).
    * @return smart_objects::SmartObject * Active message
+   * @deprecated will always return NULL
    */
-  virtual const smart_objects::SmartObject* active_message() const = 0;
+  DEPRECATED virtual const smart_objects::SmartObject* active_message()
+      const = 0;
 
   /**
    * @brief returns current hash value
@@ -615,7 +618,8 @@ class Application : public virtual InitialApplicationData,
    */
   virtual void set_app_data_resumption_allowance(const bool allowed) = 0;
 
-  virtual void CloseActiveMessage() = 0;
+  // Deprecated, has no effect
+  DEPRECATED virtual void CloseActiveMessage() = 0;
   virtual bool IsFullscreen() const = 0;
   virtual void ChangeSupportingAppHMIType() = 0;
 

--- a/src/components/application_manager/include/application_manager/application_data_impl.h
+++ b/src/components/application_manager/include/application_manager/application_data_impl.h
@@ -50,11 +50,11 @@ class InitialApplicationDataImpl : public virtual Application {
   InitialApplicationDataImpl();
   ~InitialApplicationDataImpl();
 
-  const smart_objects::SmartObject* app_types() const;
-  const smart_objects::SmartObject* vr_synonyms() const;
+  const smart_objects::SmartObjectSPtr app_types() const;
+  const smart_objects::SmartObjectSPtr vr_synonyms() const;
   virtual std::string policy_app_id() const;
-  const smart_objects::SmartObject* tts_name() const;
-  const smart_objects::SmartObject* ngn_media_screen_name() const;
+  const smart_objects::SmartObjectSPtr tts_name() const;
+  const smart_objects::SmartObjectSPtr ngn_media_screen_name() const;
   const mobile_api::Language::eType& language() const;
   const mobile_api::Language::eType& ui_language() const;
   const utils::SemanticVersion& msg_version() const;
@@ -73,11 +73,11 @@ class InitialApplicationDataImpl : public virtual Application {
   mobile_api::LayoutMode::eType perform_interaction_layout() const OVERRIDE;
 
  protected:
-  smart_objects::SmartObject* app_types_;
-  smart_objects::SmartObject* vr_synonyms_;
+  smart_objects::SmartObjectSPtr app_types_;
+  smart_objects::SmartObjectSPtr vr_synonyms_;
   std::string mobile_app_id_;
-  smart_objects::SmartObject* tts_name_;
-  smart_objects::SmartObject* ngn_media_screen_name_;
+  smart_objects::SmartObjectSPtr tts_name_;
+  smart_objects::SmartObjectSPtr ngn_media_screen_name_;
   mobile_api::Language::eType language_;
   mobile_api::Language::eType ui_language_;
   mobile_apis::LayoutMode::eType perform_interaction_layout_;
@@ -92,17 +92,17 @@ class DynamicApplicationDataImpl : public virtual Application {
   typedef std::map<WindowID, smart_objects::SmartObject> AppWindowsTemplates;
   DynamicApplicationDataImpl();
   ~DynamicApplicationDataImpl();
-  const smart_objects::SmartObject* help_prompt() const;
-  const smart_objects::SmartObject* timeout_prompt() const;
-  const smart_objects::SmartObject* vr_help_title() const;
-  const smart_objects::SmartObject* vr_help() const;
+  const smart_objects::SmartObjectSPtr help_prompt() const;
+  const smart_objects::SmartObjectSPtr timeout_prompt() const;
+  const smart_objects::SmartObjectSPtr vr_help_title() const;
+  const smart_objects::SmartObjectSPtr vr_help() const;
   const mobile_api::TBTState::eType& tbt_state() const;
-  const smart_objects::SmartObject* show_command() const;
-  const smart_objects::SmartObject* tbt_show_command() const;
-  const smart_objects::SmartObject* keyboard_props() const;
-  const smart_objects::SmartObject* menu_title() const;
-  const smart_objects::SmartObject* menu_icon() const;
-  const smart_objects::SmartObject* menu_layout() const;
+  const smart_objects::SmartObjectSPtr show_command() const;
+  const smart_objects::SmartObjectSPtr tbt_show_command() const;
+  const smart_objects::SmartObjectSPtr keyboard_props() const;
+  const smart_objects::SmartObjectSPtr menu_title() const;
+  const smart_objects::SmartObjectSPtr menu_icon() const;
+  const smart_objects::SmartObjectSPtr menu_layout() const;
 
   smart_objects::SmartObject day_color_scheme() const OVERRIDE;
   smart_objects::SmartObject night_color_scheme() const OVERRIDE;
@@ -321,17 +321,17 @@ class DynamicApplicationDataImpl : public virtual Application {
   bool is_choice_set_allowed(const uint32_t choice_set_id) const;
 
  protected:
-  smart_objects::SmartObject* help_prompt_;
-  smart_objects::SmartObject* timeout_prompt_;
-  smart_objects::SmartObject* vr_help_title_;
-  smart_objects::SmartObject* vr_help_;
+  smart_objects::SmartObjectSPtr help_prompt_;
+  smart_objects::SmartObjectSPtr timeout_prompt_;
+  smart_objects::SmartObjectSPtr vr_help_title_;
+  smart_objects::SmartObjectSPtr vr_help_;
   mobile_api::TBTState::eType tbt_state_;
-  smart_objects::SmartObject* show_command_;
-  smart_objects::SmartObject* keyboard_props_;
-  smart_objects::SmartObject* menu_title_;
-  smart_objects::SmartObject* menu_icon_;
-  smart_objects::SmartObject* menu_layout_;
-  smart_objects::SmartObject* tbt_show_command_;
+  smart_objects::SmartObjectSPtr show_command_;
+  smart_objects::SmartObjectSPtr keyboard_props_;
+  smart_objects::SmartObjectSPtr menu_title_;
+  smart_objects::SmartObjectSPtr menu_icon_;
+  smart_objects::SmartObjectSPtr menu_layout_;
+  smart_objects::SmartObjectSPtr tbt_show_command_;
   smart_objects::SmartObjectSPtr display_capabilities_;
   AppWindowsTemplates window_templates_;
 

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data.h
@@ -269,7 +269,7 @@ class ResumptionData {
    * @return smartObject from pointer
    */
   smart_objects::SmartObject PointerToSmartObj(
-      const smart_objects::SmartObject* ptr) const;
+      const smart_objects::SmartObjectSPtr ptr) const;
 
   /**
    * @brief creates smart object containing window info

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
@@ -146,7 +146,7 @@ void RCCommandRequest::Run() {
   if (!policy_handler_.CheckHMIType(
           app->policy_app_id(),
           mobile_apis::AppHMIType::eType::REMOTE_CONTROL,
-          app->app_types())) {
+          app->app_types().get())) {
     SDL_LOG_WARN("Application has no remote control functions");
     SendResponse(false, mobile_apis::Result::DISALLOWED, "");
     return;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
@@ -97,10 +97,12 @@ class ButtonPressRequestTest
     ON_CALL(mock_hmi_capabilities_, rc_capability())
         .WillByDefault(Return(rc_capabilities_));
     ON_CALL(*mock_app_, policy_app_id()).WillByDefault(Return(kPolicyAppId));
-    ON_CALL(mock_policy_handler_,
-            CheckHMIType(kPolicyAppId,
-                         mobile_apis::AppHMIType::eType::REMOTE_CONTROL,
-                         nullptr))
+    ON_CALL(*mock_app_, app_types())
+        .WillByDefault(Return(std::shared_ptr<smart_objects::SmartObject>()));
+    ON_CALL(
+        mock_policy_handler_,
+        CheckHMIType(
+            kPolicyAppId, mobile_apis::AppHMIType::eType::REMOTE_CONTROL, _))
         .WillByDefault(Return(true));
     ON_CALL(mock_allocation_manager_, is_rc_enabled())
         .WillByDefault(Return(true));

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -104,6 +104,10 @@ class GetInteriorVehicleDataRequestTest
             smart_objects::SmartType::SmartType_Array)) {
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId));
     ON_CALL(*mock_app2_, app_id()).WillByDefault(Return(kAppId2));
+    ON_CALL(*mock_app_, app_types())
+        .WillByDefault(Return(std::shared_ptr<smart_objects::SmartObject>()));
+    ON_CALL(*mock_app2_, app_types())
+        .WillByDefault(Return(std::shared_ptr<smart_objects::SmartObject>()));
     ON_CALL(*mock_app_, is_remote_control_supported())
         .WillByDefault(Return(true));
     ON_CALL(*mock_app2_, is_remote_control_supported())
@@ -158,8 +162,7 @@ class GetInteriorVehicleDataRequestTest
     ON_CALL(mock_hmi_capabilities_, rc_capability())
         .WillByDefault(Return(rc_capabilities_));
     ON_CALL(mock_policy_handler_,
-            CheckHMIType(
-                _, mobile_apis::AppHMIType::eType::REMOTE_CONTROL, nullptr))
+            CheckHMIType(_, mobile_apis::AppHMIType::eType::REMOTE_CONTROL, _))
         .WillByDefault(Return(true));
     ON_CALL(mock_policy_handler_, CheckModule(_, _))
         .WillByDefault(Return(true));

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
@@ -131,6 +131,8 @@ class RCGetInteriorVehicleDataConsentTest
     smart_objects::SmartObject control_caps((smart_objects::SmartType_Array));
     (*rc_capabilities_)[strings::kradioControlCapabilities] = control_caps;
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId));
+    ON_CALL(*mock_app_, app_types())
+        .WillByDefault(Return(std::shared_ptr<smart_objects::SmartObject>()));
     ON_CALL(app_mngr_, hmi_interfaces())
         .WillByDefault(ReturnRef(mock_hmi_interfaces_));
     ON_CALL(

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
@@ -98,6 +98,8 @@ class SetInteriorVehicleDataRequestTest
     ON_CALL(mock_allocation_manager_, AcquireResource(_, _, _))
         .WillByDefault(Return(AcquireResult::ALLOWED));
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId));
+    ON_CALL(*mock_app_, app_types())
+        .WillByDefault(Return(std::shared_ptr<smart_objects::SmartObject>()));
     ON_CALL(mock_policy_handler_,
             CheckHMIType(kPolicyAppId,
                          mobile_apis::AppHMIType::eType::REMOTE_CONTROL,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
@@ -168,6 +168,10 @@ class RegisterAppInterfaceRequestTest
     ON_CALL(*mock_app, is_cloud_app()).WillByDefault(Return(false));
     ON_CALL(*mock_app, hybrid_app_preference())
         .WillByDefault(ReturnRef(kHybridAppPreference));
+    ON_CALL(*mock_app, vr_synonyms())
+        .WillByDefault(Return(std::shared_ptr<smart_objects::SmartObject>()));
+    ON_CALL(*mock_app, tts_name())
+        .WillByDefault(Return(std::shared_ptr<smart_objects::SmartObject>()));
     ON_CALL(*mock_app, policy_app_id()).WillByDefault(Return(kAppId1));
     ON_CALL(*mock_app, msg_version())
         .WillByDefault(ReturnRef(mock_semantic_version));

--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -67,34 +67,14 @@ InitialApplicationDataImpl::InitialApplicationDataImpl()
     , language_(mobile_api::Language::INVALID_ENUM)
     , ui_language_(mobile_api::Language::INVALID_ENUM) {}
 
-InitialApplicationDataImpl::~InitialApplicationDataImpl() {
-  if (app_types_) {
-    delete app_types_;
-    app_types_ = NULL;
-  }
+InitialApplicationDataImpl::~InitialApplicationDataImpl() {}
 
-  if (vr_synonyms_) {
-    delete vr_synonyms_;
-    vr_synonyms_ = NULL;
-  }
-
-  if (tts_name_) {
-    delete tts_name_;
-    tts_name_ = NULL;
-  }
-
-  if (ngn_media_screen_name_) {
-    delete ngn_media_screen_name_;
-    ngn_media_screen_name_ = NULL;
-  }
-}
-
-const smart_objects::SmartObject* InitialApplicationDataImpl::app_types()
+const smart_objects::SmartObjectSPtr InitialApplicationDataImpl::app_types()
     const {
   return app_types_;
 }
 
-const smart_objects::SmartObject* InitialApplicationDataImpl::vr_synonyms()
+const smart_objects::SmartObjectSPtr InitialApplicationDataImpl::vr_synonyms()
     const {
   return vr_synonyms_;
 }
@@ -103,11 +83,12 @@ std::string InitialApplicationDataImpl::policy_app_id() const {
   return mobile_app_id_;
 }
 
-const smart_objects::SmartObject* InitialApplicationDataImpl::tts_name() const {
+const smart_objects::SmartObjectSPtr InitialApplicationDataImpl::tts_name()
+    const {
   return tts_name_;
 }
 
-const smart_objects::SmartObject*
+const smart_objects::SmartObjectSPtr
 InitialApplicationDataImpl::ngn_media_screen_name() const {
   return ngn_media_screen_name_;
 }
@@ -128,19 +109,12 @@ const utils::SemanticVersion& InitialApplicationDataImpl::msg_version() const {
 
 void InitialApplicationDataImpl::set_app_types(
     const smart_objects::SmartObject& app_types) {
-  if (app_types_) {
-    delete app_types_;
-  }
-
-  app_types_ = new smart_objects::SmartObject(app_types);
+  app_types_.reset(new smart_objects::SmartObject(app_types));
 }
 
 void InitialApplicationDataImpl::set_vr_synonyms(
     const smart_objects::SmartObject& vr_synonyms) {
-  if (vr_synonyms_) {
-    delete vr_synonyms_;
-  }
-  vr_synonyms_ = new smart_objects::SmartObject(vr_synonyms);
+  vr_synonyms_.reset(new smart_objects::SmartObject(vr_synonyms));
 }
 
 void InitialApplicationDataImpl::set_mobile_app_id(
@@ -150,20 +124,12 @@ void InitialApplicationDataImpl::set_mobile_app_id(
 
 void InitialApplicationDataImpl::set_tts_name(
     const smart_objects::SmartObject& tts_name) {
-  if (tts_name_) {
-    delete tts_name_;
-  }
-
-  tts_name_ = new smart_objects::SmartObject(tts_name);
+  tts_name_.reset(new smart_objects::SmartObject(tts_name));
 }
 
 void InitialApplicationDataImpl::set_ngn_media_screen_name(
     const smart_objects::SmartObject& ngn_name) {
-  if (ngn_media_screen_name_) {
-    delete ngn_media_screen_name_;
-  }
-
-  ngn_media_screen_name_ = new smart_objects::SmartObject(ngn_name);
+  ngn_media_screen_name_.reset(new smart_objects::SmartObject(ngn_name));
 }
 
 void InitialApplicationDataImpl::set_language(
@@ -192,17 +158,7 @@ InitialApplicationDataImpl::perform_interaction_layout() const {
 }
 
 DynamicApplicationDataImpl::DynamicApplicationDataImpl()
-    : help_prompt_(nullptr)
-    , timeout_prompt_(nullptr)
-    , vr_help_title_(nullptr)
-    , vr_help_(nullptr)
-    , tbt_state_(mobile_api::TBTState::INVALID_ENUM)
-    , show_command_(nullptr)
-    , keyboard_props_(nullptr)
-    , menu_title_(nullptr)
-    , menu_icon_(nullptr)
-    , menu_layout_(nullptr)
-    , tbt_show_command_(nullptr)
+    : tbt_state_(mobile_api::TBTState::INVALID_ENUM)
     , commands_()
     , commands_lock_ptr_(std::make_shared<sync_primitives::RecursiveLock>())
     , sub_menu_()
@@ -222,51 +178,6 @@ DynamicApplicationDataImpl::DynamicApplicationDataImpl()
     , display_capabilities_builder_(*this) {}
 
 DynamicApplicationDataImpl::~DynamicApplicationDataImpl() {
-  if (help_prompt_) {
-    delete help_prompt_;
-    help_prompt_ = NULL;
-  }
-
-  if (timeout_prompt_) {
-    delete timeout_prompt_;
-    timeout_prompt_ = NULL;
-  }
-
-  if (vr_help_title_) {
-    delete vr_help_title_;
-    vr_help_title_ = NULL;
-  }
-
-  if (vr_help_) {
-    delete vr_help_;
-    vr_help_ = NULL;
-  }
-
-  if (show_command_) {
-    delete show_command_;
-    show_command_ = NULL;
-  }
-
-  if (keyboard_props_) {
-    delete keyboard_props_;
-    keyboard_props_ = NULL;
-  }
-
-  if (menu_title_) {
-    delete menu_title_;
-    menu_title_ = NULL;
-  }
-
-  if (menu_icon_) {
-    delete menu_icon_;
-    menu_icon_ = NULL;
-  }
-
-  if (tbt_show_command_) {
-    delete tbt_show_command_;
-    tbt_show_command_ = NULL;
-  }
-
   for (CommandsMap::iterator command_it = commands_.begin();
        commands_.end() != command_it;
        ++command_it) {
@@ -301,22 +212,23 @@ DynamicApplicationDataImpl::~DynamicApplicationDataImpl() {
   window_params_map_.clear();
 }
 
-const smart_objects::SmartObject* DynamicApplicationDataImpl::help_prompt()
+const smart_objects::SmartObjectSPtr DynamicApplicationDataImpl::help_prompt()
     const {
   return help_prompt_;
 }
 
-const smart_objects::SmartObject* DynamicApplicationDataImpl::timeout_prompt()
-    const {
+const smart_objects::SmartObjectSPtr
+DynamicApplicationDataImpl::timeout_prompt() const {
   return timeout_prompt_;
 }
 
-const smart_objects::SmartObject* DynamicApplicationDataImpl::vr_help_title()
+const smart_objects::SmartObjectSPtr DynamicApplicationDataImpl::vr_help_title()
     const {
   return vr_help_title_;
 }
 
-const smart_objects::SmartObject* DynamicApplicationDataImpl::vr_help() const {
+const smart_objects::SmartObjectSPtr DynamicApplicationDataImpl::vr_help()
+    const {
   return vr_help_;
 }
 
@@ -325,32 +237,32 @@ const mobile_api::TBTState::eType& DynamicApplicationDataImpl::tbt_state()
   return tbt_state_;
 }
 
-const smart_objects::SmartObject* DynamicApplicationDataImpl::show_command()
+const smart_objects::SmartObjectSPtr DynamicApplicationDataImpl::show_command()
     const {
   return show_command_;
 }
 
-const smart_objects::SmartObject* DynamicApplicationDataImpl::tbt_show_command()
-    const {
+const smart_objects::SmartObjectSPtr
+DynamicApplicationDataImpl::tbt_show_command() const {
   return tbt_show_command_;
 }
 
-const smart_objects::SmartObject* DynamicApplicationDataImpl::keyboard_props()
-    const {
+const smart_objects::SmartObjectSPtr
+DynamicApplicationDataImpl::keyboard_props() const {
   return keyboard_props_;
 }
 
-const smart_objects::SmartObject* DynamicApplicationDataImpl::menu_title()
+const smart_objects::SmartObjectSPtr DynamicApplicationDataImpl::menu_title()
     const {
   return menu_title_;
 }
 
-const smart_objects::SmartObject* DynamicApplicationDataImpl::menu_icon()
+const smart_objects::SmartObjectSPtr DynamicApplicationDataImpl::menu_icon()
     const {
   return menu_icon_;
 }
 
-const smart_objects::SmartObject* DynamicApplicationDataImpl::menu_layout()
+const smart_objects::SmartObjectSPtr DynamicApplicationDataImpl::menu_layout()
     const {
   return menu_layout_;
 }
@@ -479,48 +391,30 @@ void DynamicApplicationDataImpl::load_global_properties(
 
 void DynamicApplicationDataImpl::set_help_prompt(
     const smart_objects::SmartObject& help_prompt) {
-  if (help_prompt_) {
-    delete help_prompt_;
-  }
-  help_prompt_ = new smart_objects::SmartObject(help_prompt);
+  help_prompt_.reset(new smart_objects::SmartObject(help_prompt));
 }
 
 void DynamicApplicationDataImpl::set_timeout_prompt(
     const smart_objects::SmartObject& timeout_prompt) {
-  if (timeout_prompt_) {
-    delete timeout_prompt_;
-  }
-  timeout_prompt_ = new smart_objects::SmartObject(timeout_prompt);
+  timeout_prompt_.reset(new smart_objects::SmartObject(timeout_prompt));
 }
 
 void DynamicApplicationDataImpl::set_vr_help_title(
     const smart_objects::SmartObject& vr_help_title) {
-  if (vr_help_title_) {
-    delete vr_help_title_;
-  }
-  vr_help_title_ = new smart_objects::SmartObject(vr_help_title);
+  vr_help_title_.reset(new smart_objects::SmartObject(vr_help_title));
 }
 
 void DynamicApplicationDataImpl::reset_vr_help_title() {
-  if (vr_help_title_) {
-    delete vr_help_title_;
-    vr_help_title_ = NULL;
-  }
+  vr_help_title_.reset();
 }
 
 void DynamicApplicationDataImpl::set_vr_help(
     const smart_objects::SmartObject& vr_help) {
-  if (vr_help_) {
-    delete vr_help_;
-  }
-  vr_help_ = new smart_objects::SmartObject(vr_help);
+  vr_help_.reset(new smart_objects::SmartObject(vr_help));
 }
 
 void DynamicApplicationDataImpl::reset_vr_help() {
-  if (vr_help_) {
-    delete vr_help_;
-  }
-  vr_help_ = NULL;
+  vr_help_.reset();
 }
 
 void DynamicApplicationDataImpl::set_tbt_state(
@@ -530,50 +424,32 @@ void DynamicApplicationDataImpl::set_tbt_state(
 
 void DynamicApplicationDataImpl::set_show_command(
     const smart_objects::SmartObject& show_command) {
-  if (show_command_) {
-    delete show_command_;
-  }
-  show_command_ = new smart_objects::SmartObject(show_command);
+  show_command_.reset(new smart_objects::SmartObject(show_command));
 }
 
 void DynamicApplicationDataImpl::set_tbt_show_command(
     const smart_objects::SmartObject& tbt_show) {
-  if (tbt_show_command_) {
-    delete tbt_show_command_;
-  }
-  tbt_show_command_ = new smart_objects::SmartObject(tbt_show);
+  tbt_show_command_.reset(new smart_objects::SmartObject(tbt_show));
 }
 
 void DynamicApplicationDataImpl::set_keyboard_props(
     const smart_objects::SmartObject& keyboard_props) {
-  if (keyboard_props_) {
-    delete keyboard_props_;
-  }
-  keyboard_props_ = new smart_objects::SmartObject(keyboard_props);
+  keyboard_props_.reset(new smart_objects::SmartObject(keyboard_props));
 }
 
 void DynamicApplicationDataImpl::set_menu_title(
     const smart_objects::SmartObject& menu_title) {
-  if (menu_title_) {
-    delete menu_title_;
-  }
-  menu_title_ = new smart_objects::SmartObject(menu_title);
+  menu_title_.reset(new smart_objects::SmartObject(menu_title));
 }
 
 void DynamicApplicationDataImpl::set_menu_icon(
     const smart_objects::SmartObject& menu_icon) {
-  if (menu_icon_) {
-    delete menu_icon_;
-  }
-  menu_icon_ = new smart_objects::SmartObject(menu_icon);
+  menu_icon_.reset(new smart_objects::SmartObject(menu_icon));
 }
 
 void DynamicApplicationDataImpl::set_menu_layout(
     const smart_objects::SmartObject& menu_layout) {
-  if (menu_layout_) {
-    delete menu_layout_;
-  }
-  menu_layout_ = new smart_objects::SmartObject(menu_layout);
+  menu_layout_.reset(new smart_objects::SmartObject(menu_layout));
 }
 
 void DynamicApplicationDataImpl::set_day_color_scheme(

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1856,8 +1856,9 @@ bool ApplicationManagerImpl::CheckResumptionRequiredTransportAvailable(
   const std::string secondary_transport_type =
       GetTransportTypeProfileString(application->secondary_device());
 
-  const smart_objects::SmartObject* app_types_array = application->app_types();
-  if (app_types_array == NULL || app_types_array->length() == 0) {
+  const smart_objects::SmartObjectSPtr app_types_array =
+      application->app_types();
+  if (!app_types_array || app_types_array->length() == 0) {
     // This app does not have any AppHMIType. In this case, check "EMPTY_APP"
     // entry
     std::map<std::string, std::vector<std::string> >::const_iterator it =
@@ -4493,7 +4494,7 @@ void ApplicationManagerImpl::OnUpdateHMIAppType(
   std::vector<std::string> hmi_types_from_policy;
   smart_objects::SmartObject transform_app_hmi_types(
       smart_objects::SmartType_Array);
-  bool flag_diffirence_app_hmi_type;
+  bool flag_difference_app_hmi_type;
   DataAccessor<ApplicationSet> accessor(applications());
   for (ApplicationSetIt it = accessor.GetData().begin();
        it != accessor.GetData().end();
@@ -4516,19 +4517,18 @@ void ApplicationManagerImpl::OnUpdateHMIAppType(
       }
 
       ApplicationConstSharedPtr app = *it;
-      const smart_objects::SmartObject* save_application_hmi_type =
+      const smart_objects::SmartObjectSPtr save_application_hmi_type =
           app->app_types();
 
-      if (save_application_hmi_type == NULL ||
-          ((*save_application_hmi_type).length() !=
-           transform_app_hmi_types.length())) {
-        flag_diffirence_app_hmi_type = true;
+      if (!save_application_hmi_type || (save_application_hmi_type->length() !=
+                                         transform_app_hmi_types.length())) {
+        flag_difference_app_hmi_type = true;
       } else {
-        flag_diffirence_app_hmi_type = !(CompareAppHMIType(
+        flag_difference_app_hmi_type = !(CompareAppHMIType(
             transform_app_hmi_types, *save_application_hmi_type));
       }
 
-      if (flag_diffirence_app_hmi_type) {
+      if (flag_difference_app_hmi_type) {
         ApplicationSharedPtr app = *it;
 
         app->set_app_types(transform_app_hmi_types);

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -801,8 +801,8 @@ void MessageHelper::SendResetPropertiesRequest(ApplicationSharedPtr application,
   {
     SmartObject msg_params = SmartObject(smart_objects::SmartType_Map);
 
-    msg_params[strings::help_prompt] = application->help_prompt();
-    msg_params[strings::timeout_prompt] = application->timeout_prompt();
+    msg_params[strings::help_prompt] = *(application->help_prompt());
+    msg_params[strings::timeout_prompt] = *(application->timeout_prompt());
     msg_params[strings::app_id] = application->app_id();
 
     SmartObjectSPtr message = CreateMessageForHMI(
@@ -1417,7 +1417,7 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateAppVrHelp(
           smart_objects::SmartType_Map);
 
   smart_objects::SmartObject& vr_help = *result;
-  const smart_objects::SmartObject* vr_help_title = app->vr_help_title();
+  const smart_objects::SmartObjectSPtr vr_help_title = app->vr_help_title();
   if (vr_help_title) {
     vr_help[strings::vr_help_title] = vr_help_title->asString();
   }
@@ -1646,7 +1646,7 @@ void MessageHelper::SendUIChangeRegistrationRequestToHMI(
         CreateChangeRegistration(hmi_apis::FunctionID::UI_ChangeRegistration,
                                  app->ui_language(),
                                  app->app_id(),
-                                 app->app_types(),
+                                 app->app_types().get(),
                                  app_mngr);
 
     if (ui_command) {
@@ -1823,8 +1823,8 @@ bool MessageHelper::CreateHMIApplicationStruct(
     return false;
   }
 
-  const smart_objects::SmartObject* app_types = app->app_types();
-  const smart_objects::SmartObject* ngn_media_screen_name =
+  const smart_objects::SmartObjectSPtr app_types = app->app_types();
+  const smart_objects::SmartObjectSPtr ngn_media_screen_name =
       app->ngn_media_screen_name();
   const smart_objects::SmartObject day_color_scheme = app->day_color_scheme();
   const smart_objects::SmartObject night_color_scheme =

--- a/src/components/application_manager/src/resumption/resumption_data.cc
+++ b/src/components/application_manager/src/resumption/resumption_data.cc
@@ -250,10 +250,10 @@ smart_objects::SmartObject ResumptionData::CreateWindowInfoSO(
 }
 
 smart_objects::SmartObject ResumptionData::PointerToSmartObj(
-    const smart_objects::SmartObject* ptr) const {
+    const smart_objects::SmartObjectSPtr ptr) const {
   SDL_LOG_AUTO_TRACE();
   smart_objects::SmartObject temp;
-  if (ptr != NULL) {
+  if (ptr) {
     temp = *ptr;
   }
   return temp;

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -217,12 +217,12 @@ class MockApplication : public ::application_manager::Application {
   MOCK_CONST_METHOD0(IsVideoApplication, bool());
   MOCK_METHOD0(LoadPersistentFiles, void());
   // InitialApplicationData methods
-  MOCK_CONST_METHOD0(app_types, const smart_objects::SmartObject*());
-  MOCK_CONST_METHOD0(vr_synonyms, const smart_objects::SmartObject*());
+  MOCK_CONST_METHOD0(app_types, const smart_objects::SmartObjectSPtr());
+  MOCK_CONST_METHOD0(vr_synonyms, const smart_objects::SmartObjectSPtr());
   MOCK_CONST_METHOD0(policy_app_id, std::string());
-  MOCK_CONST_METHOD0(tts_name, const smart_objects::SmartObject*());
+  MOCK_CONST_METHOD0(tts_name, const smart_objects::SmartObjectSPtr());
   MOCK_CONST_METHOD0(ngn_media_screen_name,
-                     const smart_objects::SmartObject*());
+                     const smart_objects::SmartObjectSPtr());
   MOCK_CONST_METHOD0(language, const mobile_apis::Language::eType&());
   MOCK_CONST_METHOD0(ui_language, const mobile_apis::Language::eType&());
   MOCK_CONST_METHOD0(msg_version, const utils::SemanticVersion&());
@@ -240,20 +240,20 @@ class MockApplication : public ::application_manager::Application {
                void(const mobile_apis::Language::eType& ui_language));
   MOCK_METHOD1(set_msg_version, void(const utils::SemanticVersion& version));
   // DynamicApplicationData methods
-  MOCK_CONST_METHOD0(help_prompt, const smart_objects::SmartObject*());
-  MOCK_CONST_METHOD0(timeout_prompt, const smart_objects::SmartObject*());
-  MOCK_CONST_METHOD0(vr_help_title, const smart_objects::SmartObject*());
-  MOCK_CONST_METHOD0(vr_help, const smart_objects::SmartObject*());
+  MOCK_CONST_METHOD0(help_prompt, const smart_objects::SmartObjectSPtr());
+  MOCK_CONST_METHOD0(timeout_prompt, const smart_objects::SmartObjectSPtr());
+  MOCK_CONST_METHOD0(vr_help_title, const smart_objects::SmartObjectSPtr());
+  MOCK_CONST_METHOD0(vr_help, const smart_objects::SmartObjectSPtr());
   MOCK_CONST_METHOD0(tbt_state, const mobile_apis::TBTState::eType&());
-  MOCK_CONST_METHOD0(show_command, const smart_objects::SmartObject*());
-  MOCK_CONST_METHOD0(tbt_show_command, const smart_objects::SmartObject*());
+  MOCK_CONST_METHOD0(show_command, const smart_objects::SmartObjectSPtr());
+  MOCK_CONST_METHOD0(tbt_show_command, const smart_objects::SmartObjectSPtr());
   MOCK_CONST_METHOD0(
       SubscribedButtons,
       DataAccessor< ::application_manager::ButtonSubscriptions>());
-  MOCK_CONST_METHOD0(keyboard_props, const smart_objects::SmartObject*());
-  MOCK_CONST_METHOD0(menu_title, const smart_objects::SmartObject*());
-  MOCK_CONST_METHOD0(menu_icon, const smart_objects::SmartObject*());
-  MOCK_CONST_METHOD0(menu_layout, const smart_objects::SmartObject*());
+  MOCK_CONST_METHOD0(keyboard_props, const smart_objects::SmartObjectSPtr());
+  MOCK_CONST_METHOD0(menu_title, const smart_objects::SmartObjectSPtr());
+  MOCK_CONST_METHOD0(menu_icon, const smart_objects::SmartObjectSPtr());
+  MOCK_CONST_METHOD0(menu_layout, const smart_objects::SmartObjectSPtr());
   MOCK_CONST_METHOD0(day_color_scheme, smart_objects::SmartObject());
   MOCK_CONST_METHOD0(night_color_scheme, smart_objects::SmartObject());
   MOCK_CONST_METHOD0(display_layout, std::string());

--- a/src/components/application_manager/test/include/application_manager/resumption_data_test.h
+++ b/src/components/application_manager/test/include/application_manager/resumption_data_test.h
@@ -63,15 +63,7 @@ using namespace mobile_apis;
 class ResumptionDataTest : public ::testing::Test {
  protected:
   ResumptionDataTest()
-      : help_prompt_(NULL)
-      , timeout_prompt_(NULL)
-      , vr_help_(NULL)
-      , vr_help_title_(NULL)
-      , vr_synonyms_(NULL)
-      , keyboard_props_(NULL)
-      , menu_title_(NULL)
-      , menu_icon_(NULL)
-      , kCountOfCommands_(5u)
+      : kCountOfCommands_(5u)
       , kCountOfChoice_(2u)
       , kCountOfChoiceSets_(4u)
       , kCountOfSubmenues_(3u)
@@ -106,14 +98,15 @@ class ResumptionDataTest : public ::testing::Test {
   bool is_audio_;
   const connection_handler::DeviceHandle device_handle_ = 10;
 
-  sm::SmartObject* help_prompt_;
-  sm::SmartObject* timeout_prompt_;
-  sm::SmartObject* vr_help_;
-  sm::SmartObject* vr_help_title_;
-  sm::SmartObject* vr_synonyms_;
-  sm::SmartObject* keyboard_props_;
-  sm::SmartObject* menu_title_;
-  sm::SmartObject* menu_icon_;
+  sm::SmartObjectSPtr help_prompt_;
+  sm::SmartObjectSPtr timeout_prompt_;
+  sm::SmartObjectSPtr vr_help_;
+  sm::SmartObjectSPtr vr_help_title_;
+  sm::SmartObjectSPtr vr_synonyms_;
+  sm::SmartObjectSPtr keyboard_props_;
+  sm::SmartObjectSPtr menu_title_;
+  sm::SmartObjectSPtr menu_icon_;
+  sm::SmartObjectSPtr menu_layout_;
 
   void SetCommands();
   void SetSubmenues();
@@ -121,7 +114,7 @@ class ResumptionDataTest : public ::testing::Test {
   void SetAppFiles();
   void SetGlobalProporties();
   void SetKeyboardProperties();
-  void SetMenuTitleAndIcon();
+  void SetMenuParams();
   void SetHelpAndTimeoutPrompt();
   void SetVRHelpTitle();
   void SetSubscriptions();
@@ -137,6 +130,7 @@ class ResumptionDataTest : public ::testing::Test {
   void CheckKeyboardProperties(sm::SmartObject& res_list);
   void CheckMenuTitle(sm::SmartObject& res_list);
   void CheckMenuIcon(sm::SmartObject& res_list);
+  void CheckMenuLayout(sm::SmartObject& res_list);
   void CheckHelpPrompt(sm::SmartObject& res_list);
   void CheckTimeoutPrompt(sm::SmartObject& res_list);
   void CheckVRHelp(

--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -156,10 +156,32 @@ TEST(MessageHelperTestCreate, CreateSetAppIcon_SendPathImagetype_Equal) {
 TEST(MessageHelperTestCreate,
      CreateGlobalPropertiesRequestsToHMI_SmartObject_EmptyList) {
   MockApplicationSharedPtr appSharedMock = std::make_shared<MockApplication>();
-  EXPECT_CALL(*appSharedMock, vr_help_title()).Times(AtLeast(1));
-  EXPECT_CALL(*appSharedMock, vr_help()).Times(AtLeast(1));
-  EXPECT_CALL(*appSharedMock, help_prompt()).Times(AtLeast(1));
-  EXPECT_CALL(*appSharedMock, timeout_prompt()).Times(AtLeast(1));
+  smart_objects::SmartObjectSPtr emptyObject =
+      std::shared_ptr<smart_objects::SmartObject>();
+  EXPECT_CALL(*appSharedMock, vr_help_title())
+      .Times(AtLeast(1))
+      .WillOnce(Return(emptyObject));
+  EXPECT_CALL(*appSharedMock, vr_help())
+      .Times(AtLeast(1))
+      .WillOnce(Return(emptyObject));
+  EXPECT_CALL(*appSharedMock, help_prompt())
+      .Times(AtLeast(1))
+      .WillOnce(Return(emptyObject));
+  EXPECT_CALL(*appSharedMock, timeout_prompt())
+      .Times(AtLeast(1))
+      .WillOnce(Return(emptyObject));
+  EXPECT_CALL(*appSharedMock, menu_title())
+      .Times(AtLeast(1))
+      .WillOnce(Return(emptyObject));
+  EXPECT_CALL(*appSharedMock, menu_icon())
+      .Times(AtLeast(1))
+      .WillOnce(Return(emptyObject));
+  EXPECT_CALL(*appSharedMock, menu_layout())
+      .Times(AtLeast(1))
+      .WillOnce(Return(emptyObject));
+  EXPECT_CALL(*appSharedMock, keyboard_props())
+      .Times(AtLeast(1))
+      .WillOnce(Return(emptyObject));
 
   std::shared_ptr<MockHelpPromptManager> mock_help_prompt_manager =
       std::make_shared<MockHelpPromptManager>();
@@ -185,16 +207,23 @@ TEST(MessageHelperTestCreate,
 TEST(MessageHelperTestCreate,
      CreateGlobalPropertiesRequestsToHMI_SmartObject_NotEmpty) {
   MockApplicationSharedPtr appSharedMock = std::make_shared<MockApplication>();
-  smart_objects::SmartObjectSPtr objPtr =
-      std::make_shared<smart_objects::SmartObject>();
 
-  (*objPtr)[0][strings::vr_help_title] = "111";
-  (*objPtr)[1][strings::vr_help] = "222";
-  (*objPtr)[2][strings::keyboard_properties] = "333";
-  (*objPtr)[3][strings::menu_title] = "444";
-  (*objPtr)[4][strings::menu_icon] = "555";
-  (*objPtr)[5][strings::help_prompt] = "666";
-  (*objPtr)[6][strings::timeout_prompt] = "777";
+  smart_objects::SmartObjectSPtr vrHelpTitle =
+      std::make_shared<smart_objects::SmartObject>("111");
+  smart_objects::SmartObjectSPtr vrHelp =
+      std::make_shared<smart_objects::SmartObject>("222");
+  smart_objects::SmartObjectSPtr keyboardProperties =
+      std::make_shared<smart_objects::SmartObject>("333");
+  smart_objects::SmartObjectSPtr menuTitle =
+      std::make_shared<smart_objects::SmartObject>("444");
+  smart_objects::SmartObjectSPtr menuIcon =
+      std::make_shared<smart_objects::SmartObject>("555");
+  smart_objects::SmartObjectSPtr helpPrompt =
+      std::make_shared<smart_objects::SmartObject>("666");
+  smart_objects::SmartObjectSPtr timeoutPrompt =
+      std::make_shared<smart_objects::SmartObject>("777");
+  smart_objects::SmartObjectSPtr menuLayout =
+      std::make_shared<smart_objects::SmartObject>("888");
 
   smart_objects::SmartObject user_loc =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
@@ -202,25 +231,28 @@ TEST(MessageHelperTestCreate,
 
   EXPECT_CALL(*appSharedMock, vr_help_title())
       .Times(AtLeast(3))
-      .WillRepeatedly(Return(&(*objPtr)[0]));
+      .WillRepeatedly(Return(vrHelpTitle));
   EXPECT_CALL(*appSharedMock, vr_help())
       .Times(AtLeast(2))
-      .WillRepeatedly(Return(&(*objPtr)[1]));
+      .WillRepeatedly(Return(vrHelp));
   EXPECT_CALL(*appSharedMock, help_prompt())
       .Times(AtLeast(3))
-      .WillRepeatedly(Return(&(*objPtr)[5]));
+      .WillRepeatedly(Return(helpPrompt));
   EXPECT_CALL(*appSharedMock, timeout_prompt())
       .Times(AtLeast(2))
-      .WillRepeatedly(Return(&(*objPtr)[6]));
+      .WillRepeatedly(Return(timeoutPrompt));
   EXPECT_CALL(*appSharedMock, keyboard_props())
       .Times(AtLeast(2))
-      .WillRepeatedly(Return(&(*objPtr)[2]));
+      .WillRepeatedly(Return(keyboardProperties));
   EXPECT_CALL(*appSharedMock, menu_title())
       .Times(AtLeast(2))
-      .WillRepeatedly(Return(&(*objPtr)[3]));
+      .WillRepeatedly(Return(menuTitle));
   EXPECT_CALL(*appSharedMock, menu_icon())
       .Times(AtLeast(2))
-      .WillRepeatedly(Return(&(*objPtr)[4]));
+      .WillRepeatedly(Return(menuIcon));
+  EXPECT_CALL(*appSharedMock, menu_layout())
+      .Times(AtLeast(2))
+      .WillRepeatedly(Return(menuLayout));
   EXPECT_CALL(*appSharedMock, app_id()).WillRepeatedly(Return(0));
   EXPECT_CALL(*appSharedMock, get_user_location())
       .WillRepeatedly(ReturnRef(user_loc));
@@ -242,14 +274,16 @@ TEST(MessageHelperTestCreate,
   smart_objects::SmartObject& first = *ptr[0];
   smart_objects::SmartObject& second = *ptr[1];
 
-  EXPECT_EQ((*objPtr)[0], first[strings::msg_params][strings::vr_help_title]);
-  EXPECT_EQ((*objPtr)[1], first[strings::msg_params][strings::vr_help]);
-  EXPECT_EQ((*objPtr)[2],
+  EXPECT_EQ(*vrHelpTitle, first[strings::msg_params][strings::vr_help_title]);
+  EXPECT_EQ(*vrHelp, first[strings::msg_params][strings::vr_help]);
+  EXPECT_EQ(*keyboardProperties,
             first[strings::msg_params][strings::keyboard_properties]);
-  EXPECT_EQ((*objPtr)[3], first[strings::msg_params][strings::menu_title]);
-  EXPECT_EQ((*objPtr)[4], first[strings::msg_params][strings::menu_icon]);
-  EXPECT_EQ((*objPtr)[5], second[strings::msg_params][strings::help_prompt]);
-  EXPECT_EQ((*objPtr)[6], second[strings::msg_params][strings::timeout_prompt]);
+  EXPECT_EQ(*menuTitle, first[strings::msg_params][strings::menu_title]);
+  EXPECT_EQ(*menuIcon, first[strings::msg_params][strings::menu_icon]);
+  EXPECT_EQ(*helpPrompt, second[strings::msg_params][strings::help_prompt]);
+  EXPECT_EQ(*timeoutPrompt,
+            second[strings::msg_params][strings::timeout_prompt]);
+  EXPECT_EQ(*menuLayout, first[strings::msg_params][strings::menu_layout]);
 }
 
 TEST(MessageHelperTestCreate, CreateShowRequestToHMI_SendSmartObject_Equal) {
@@ -258,11 +292,9 @@ TEST(MessageHelperTestCreate, CreateShowRequestToHMI_SendSmartObject_Equal) {
   smart_objects::SmartObjectSPtr smartObjectPtr =
       std::make_shared<smart_objects::SmartObject>();
 
-  const smart_objects::SmartObject& object = *smartObjectPtr;
-
   EXPECT_CALL(*appSharedMock, show_command())
       .Times(AtLeast(2))
-      .WillRepeatedly(Return(&object));
+      .WillRepeatedly(Return(smartObjectPtr));
 
   smart_objects::SmartObjectList ptr =
       MessageHelper::CreateShowRequestToHMI(appSharedMock, 0u);


### PR DESCRIPTION
Fixes #3892 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run ./test_scripts/Smoke/Resumption/005_Resumption_big_amount_of_data.lua repeatedly (listed in issue)

### Summary
Use shared pointers instead of raw pointers for app data to prevent potential deallocation while reading data

### Changelog
##### Bug Fixes
* Use shared pointers instead of raw pointers for app data to prevent potential deallocation while reading data

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
