### PR TITLE
Move subscribe_on_event before sending BCActivateAppRequest

### DIFF
--- a/src/components/application_manager/include/application_manager/state_controller_impl.h
+++ b/src/components/application_manager/include/application_manager/state_controller_impl.h
@@ -136,9 +136,10 @@ class StateControllerImpl : public event_engine::EventObserver,
   PostponedActivationController& GetPostponedActivationController() OVERRIDE;
 
  private:
-  int64_t RequestHMIStateChange(ApplicationConstSharedPtr app,
-                                hmi_apis::Common_HMILevel::eType level,
-                                bool send_policy_priority);
+  void RequestHMIStateChange(ApplicationConstSharedPtr app,
+                             HmiStatePtr resolved_state,
+                             hmi_apis::Common_HMILevel::eType level,
+                             bool send_policy_priority);
 
   /**
    * @brief The HmiLevelConflictResolver struct

--- a/src/components/application_manager/test/state_controller/state_controller_test.cc
+++ b/src/components/application_manager/test/state_controller/state_controller_test.cc
@@ -3654,7 +3654,11 @@ TEST_F(StateControllerImplTest,
       static_cast<hmi_apis::Common_HMILevel::eType>(new_state->hmi_level()),
       kCorrID);
 
-  smart_objects::SmartObjectSPtr bc_activate_app_request;
+  smart_objects::SmartObjectSPtr bc_activate_app_request =
+      std::make_shared<smart_objects::SmartObject>();
+  (*bc_activate_app_request)[am::strings::params][am::strings::correlation_id] =
+      kCorrID;
+
   EXPECT_CALL(message_helper_mock_, GetBCActivateAppRequestToHMI(_, _, _, _, _))
       .WillOnce(Return(bc_activate_app_request));
   EXPECT_CALL(*simple_app_ptr_, SetRegularState(_, _)).Times(0);


### PR DESCRIPTION
Fixes #[3903](https://github.com/smartdevicelink/sdl_core/issues/3903)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Moved subscribe_on_event before ManageHMICommand, because sometimes hmi sends response very quickly and sdl doesn't sent OnHmiStatus to mobile.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
