### PR TITLE
Fix/Reset VRHelp array to default values instead of null

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3991,8 +3991,9 @@ bool ApplicationManagerImpl::ResetVrHelpTitleItems(
   smart_objects::SmartObjectSPtr so_vr_help =
       MessageHelper::CreateAppVrHelp(app);
   if (!so_vr_help->keyExists(strings::vr_help)) {
-    SDL_LOG_WARN("Failed to create vr_help items");
-    return false;
+    SDL_LOG_WARN("Failed to create vr_help items. Resetting to empty array");
+    (*so_vr_help)[strings::vr_help] =
+        smart_objects::SmartObject(smart_objects::SmartType_Array);
   }
   app->set_vr_help((*so_vr_help)[strings::vr_help]);
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3986,8 +3986,15 @@ bool ApplicationManagerImpl::ResetVrHelpTitleItems(
   smart_objects::SmartObject so_vr_help_title(vr_help_title);
 
   app->reset_vr_help_title();
-  app->reset_vr_help();
   app->set_vr_help_title(so_vr_help_title);
+
+  app->reset_vr_help();
+  smart_objects::SmartObjectSPtr vr_help = MessageHelper::CreateAppVrHelp(app);
+  if (!vr_help.get()) {
+    SDL_LOG_WARN("Failed to create vr_help");
+    return false;
+  }
+  app->set_vr_help(*vr_help);
 
   return true;
 }

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3984,17 +3984,17 @@ bool ApplicationManagerImpl::ResetVrHelpTitleItems(
 
   const std::string& vr_help_title = get_settings().vr_help_title();
   smart_objects::SmartObject so_vr_help_title(vr_help_title);
-
   app->reset_vr_help_title();
   app->set_vr_help_title(so_vr_help_title);
 
   app->reset_vr_help();
-  smart_objects::SmartObjectSPtr vr_help = MessageHelper::CreateAppVrHelp(app);
-  if (!vr_help.get()) {
-    SDL_LOG_WARN("Failed to create vr_help");
+  smart_objects::SmartObjectSPtr so_vr_help =
+      MessageHelper::CreateAppVrHelp(app);
+  if (!so_vr_help->keyExists(strings::vr_help)) {
+    SDL_LOG_WARN("Failed to create vr_help items");
     return false;
   }
-  app->set_vr_help(*vr_help);
+  app->set_vr_help((*so_vr_help)[strings::vr_help]);
 
   return true;
 }

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -383,13 +383,10 @@ MessageHelper::CreateUIResetGlobalPropertiesRequest(
           smart_objects::SmartType_Map);
 
   if (reset_result.vr_help_title_items) {
-    smart_objects::SmartObjectSPtr vr_help = CreateAppVrHelp(application);
-    if (!vr_help.get()) {
-      SDL_LOG_WARN("Failed to create vr_help");
-      return smart_objects::SmartObjectSPtr();
-    } else {
-      ui_reset_global_prop_request = vr_help;
-    }
+    (*ui_reset_global_prop_request)[strings::vr_help_title] =
+        *(application->vr_help_title());
+    (*ui_reset_global_prop_request)[strings::vr_help] =
+        *(application->vr_help());
   }
   if (reset_result.menu_name) {
     (*ui_reset_global_prop_request)[hmi_request::menu_title] = "";


### PR DESCRIPTION
Fixes #3909 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Manual testing with RPC Builder with the provided reproduction steps

### Summary
At the moment, when core receives a `ResetGlobalProperties(VRHELPITEMS)` the `ApplicationManagerImpl::ResetVrHelpTitleItems` function resets the apps `vrHelp` value to null but sends different default values in the `UI.SetGlobalProperties` sent to the HMI. 

This PR adds changes to reset `vrHelp` to default values rather than null

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
