### PR TITLE
Added a lock in StartPTExchange

### DIFF
--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -1271,6 +1271,11 @@ class PolicyManagerImpl : public PolicyManager {
   sync_primitives::Lock policy_table_lock_;
 
   /**
+   * @brief lock guard for protecting policy table exchange
+   */
+  sync_primitives::Lock policy_table_exchange_lock_;
+
+  /**
    * @brief lock guard for protecting application permissions access
    */
   sync_primitives::Lock app_permissions_diff_lock_;

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -747,6 +747,9 @@ void PolicyManagerImpl::StartPTExchange() {
     return;
   }
 
+  sync_primitives::AutoLock policy_table_exchange_lock(
+      policy_table_exchange_lock_);
+
   if (update_status_manager_.IsUpdatePending()) {
     if (trigger_ptu_) {
       update_status_manager_.ScheduleUpdate();

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -1108,6 +1108,11 @@ class PolicyManagerImpl : public PolicyManager {
   sync_primitives::Lock policy_table_lock_;
 
   /**
+   * @brief lock guard for protecting policy table exchange
+   */
+  sync_primitives::Lock policy_table_exchange_lock_;
+
+  /**
    * @brief lock guard for protecting application permissions access
    */
   sync_primitives::Lock app_permissions_diff_lock_;

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -629,6 +629,9 @@ void PolicyManagerImpl::StartPTExchange() {
     return;
   }
 
+  sync_primitives::AutoLock policy_table_exchange_lock(
+      policy_table_exchange_lock_);
+
   if (update_status_manager_.IsUpdatePending() && update_required) {
     if (trigger_ptu_)
       update_status_manager_.ScheduleUpdate();


### PR DESCRIPTION
Fixes #[3895](https://github.com/smartdevicelink/sdl_core/issues/3895)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Added lock  in StartPTExchange, because two threads try to sent PolicyUpdate 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
