### PR TITLE
Send UI.ChangeRegistration for background application after PTU

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -4542,11 +4542,10 @@ void ApplicationManagerImpl::OnUpdateHMIAppType(
 
         const mobile_apis::HMILevel::eType app_hmi_level =
             (*it)->hmi_level(mobile_apis::PredefinedWindows::DEFAULT_WINDOW);
-        if (app_hmi_level == mobile_api::HMILevel::HMI_BACKGROUND) {
-          MessageHelper::SendUIChangeRegistrationRequestToHMI(*it, *this);
-        } else if ((app_hmi_level == mobile_api::HMILevel::HMI_FULL) ||
-                   (app_hmi_level == mobile_api::HMILevel::HMI_LIMITED)) {
-          MessageHelper::SendUIChangeRegistrationRequestToHMI(*it, *this);
+
+        MessageHelper::SendUIChangeRegistrationRequestToHMI(*it, *this);
+        if ((app_hmi_level == mobile_api::HMILevel::HMI_FULL) ||
+            (app_hmi_level == mobile_api::HMILevel::HMI_LIMITED)) {
           state_controller().SetRegularState(
               *it,
               mobile_apis::PredefinedWindows::DEFAULT_WINDOW,


### PR DESCRIPTION
Fixes #[3882](https://github.com/smartdevicelink/sdl_core/issues/3882)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
The SendUIChangeRegistrationRequestToHMI function was called only for activated programs. Because the HMI level is initialized only when the application is activated. So I called her before checking the HMI level.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
