### PR TITLE
Move OnTBTClientState to Navigation-1 policy group

### DIFF
--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -1078,6 +1078,13 @@
                             "LIMITED"
                         ]
                     },
+                    "OnTBTClientState": {
+                        "hmi_levels": [
+                            "BACKGROUND",
+                            "FULL",
+                            "LIMITED"
+                        ]
+                    },
                     "UpdateTurnList": {
                         "hmi_levels": [
                             "BACKGROUND",
@@ -1267,13 +1274,6 @@
                             "FULL",
                             "LIMITED",
                             "NONE"
-                        ]
-                    },
-                    "OnTBTClientState": {
-                        "hmi_levels": [
-                            "BACKGROUND",
-                            "FULL",
-                            "LIMITED"
                         ]
                     },
                     "PerformAudioPassThru": {


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3933

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Move OnTBTClientState to Navigation-1 policy group

### Changelog
##### Enhancements
* Move OnTBTClientState to Navigation-1 policy group

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
