### PR TITLE
Fix/Reset sending type on ResetGlobalProperties

### DIFF
--- a/src/components/application_manager/include/application_manager/help_prompt_manager.h
+++ b/src/components/application_manager/include/application_manager/help_prompt_manager.h
@@ -80,6 +80,14 @@ class HelpPromptManager {
       const smart_objects::SmartObject& msg, const bool is_response) = 0;
 
   /**
+   * @brief Triggered when ResetGlobalProperties request is received from an
+   * application. Reset sending_type_ based on which global properties are reset
+   * @param msg containing GlobalProperties
+   */
+  virtual void OnResetGlobalPropertiesReceived(
+      const smart_objects::SmartObject& msg) = 0;
+
+  /**
    * @brief Requests sending type behavior
    */
   enum class SendingType { kNoneSend, kSendHelpPrompt, kSendVRHelp, kSendBoth };

--- a/src/components/application_manager/include/application_manager/help_prompt_manager.h
+++ b/src/components/application_manager/include/application_manager/help_prompt_manager.h
@@ -97,6 +97,16 @@ class HelpPromptManager {
    * @return current sending type
    */
   virtual SendingType GetSendingType() const = 0;
+
+  /**
+   * @brief Construct the helpPrompt parameter
+   */
+  virtual void CreatePromptMsg(smart_objects::SmartObject& out_msg_params) = 0;
+
+  /**
+   * @brief Construct the vrHelp parameter
+   */
+  virtual void CreateVRMsg(smart_objects::SmartObject& out_msg_params) = 0;
 };
 
 }  //  namespace application_manager

--- a/src/components/application_manager/include/application_manager/help_prompt_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/help_prompt_manager_impl.h
@@ -117,6 +117,16 @@ class HelpPromptManagerImpl : public HelpPromptManager {
    */
   SendingType GetSendingType() const OVERRIDE;
 
+  /**
+   * @brief Construct the helpPrompt parameter
+   */
+  void CreatePromptMsg(smart_objects::SmartObject& out_msg_params);
+
+  /**
+   * @brief Construct the vrHelp parameter
+   */
+  void CreateVRMsg(smart_objects::SmartObject& out_msg_params);
+
  private:
   DISALLOW_COPY_AND_ASSIGN(HelpPromptManagerImpl);
 
@@ -156,16 +166,6 @@ class HelpPromptManagerImpl : public HelpPromptManager {
    * @brief Send TTS or UI or both Requests
    */
   void SendRequests();
-
-  /**
-   * @brief Construct the helpPrompt parameter
-   */
-  void CreatePromptMsg(smart_objects::SmartObject& out_msg_params);
-
-  /**
-   * @brief Construct the vrHelp parameter
-   */
-  void CreateVRMsg(smart_objects::SmartObject& out_msg_params);
 
   /**
    * @brief Setting request type to send HMI

--- a/src/components/application_manager/include/application_manager/help_prompt_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/help_prompt_manager_impl.h
@@ -104,6 +104,14 @@ class HelpPromptManagerImpl : public HelpPromptManager {
                                      const bool is_response) OVERRIDE;
 
   /**
+   * @brief Triggered when ResetGlobalProperties request is received from an
+   * application. Reset sending_type_ based on which global properties are reset
+   * @param msg containing GlobalProperties
+   */
+  void OnResetGlobalPropertiesReceived(
+      const smart_objects::SmartObject& msg) OVERRIDE;
+
+  /**
    * @brief Get current sending type
    * @return current sending type
    */

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -321,9 +321,6 @@ class MessageHelper {
   static smart_objects::SmartObjectList CreateGlobalPropertiesRequestsToHMI(
       ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
 
-  static smart_objects::SmartObjectSPtr CreateAppVrHelp(
-      ApplicationConstSharedPtr app);
-
   static smart_objects::SmartObjectList CreateShowRequestToHMI(
       ApplicationConstSharedPtr app, const uint32_t correlation_id);
   static void SendShowRequestToHMI(ApplicationConstSharedPtr app,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
@@ -123,6 +123,9 @@ void ResetGlobalPropertiesRequest::Run() {
     SendHMIRequest(
         hmi_apis::FunctionID::RC_SetGlobalProperties, msg_params.get(), true);
   }
+  auto& help_prompt_manager = app->help_prompt_manager();
+  help_prompt_manager.OnResetGlobalPropertiesReceived(
+      (*message_)[strings::msg_params]);
 }
 
 void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
@@ -81,7 +81,11 @@ class ResetGlobalPropertiesRequestTest
     : public CommandRequestTest<CommandsTestMocks::kIsNice> {
  protected:
   ResetGlobalPropertiesRequestTest()
-      : msg_(CreateMessage()), mock_app_(CreateMockApp()) {}
+      : msg_(CreateMessage()), mock_app_(CreateMockApp()) {
+    mock_help_prompt_manager_ =
+        std::shared_ptr<application_manager_test::MockHelpPromptManager>(
+            new application_manager_test::MockHelpPromptManager());
+  }
 
   void SetUp() OVERRIDE {
     (*msg_)[am::strings::params][am::strings::connection_key] = kConnectionKey;
@@ -99,6 +103,8 @@ class ResetGlobalPropertiesRequestTest
   MessageSharedPtr msg_;
   MockAppPtr mock_app_;
   ResetGlobalPropertiesRequestPtr command_;
+  std::shared_ptr<application_manager_test::MockHelpPromptManager>
+      mock_help_prompt_manager_;
 };
 
 class ResetGlobalPropertiesResponseTest
@@ -142,6 +148,9 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidVrHelp_UNSUCCESS) {
       .WillByDefault(Return(std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map)));
 
+  EXPECT_CALL(*mock_app_, help_prompt_manager())
+      .WillRepeatedly(ReturnRef(*mock_help_prompt_manager_.get()));
+  EXPECT_CALL(*mock_help_prompt_manager_, OnResetGlobalPropertiesReceived(_));
   EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
 
   command_->Run();
@@ -169,6 +178,9 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_SUCCESS) {
       .WillOnce(Return(msg_params));
   EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
       .WillOnce(Return(msg_params));
+  EXPECT_CALL(*mock_app_, help_prompt_manager())
+      .WillRepeatedly(ReturnRef(*mock_help_prompt_manager_.get()));
+  EXPECT_CALL(*mock_help_prompt_manager_, OnResetGlobalPropertiesReceived(_));
 
   EXPECT_CALL(
       mock_rpc_service_,
@@ -208,6 +220,9 @@ TEST_F(ResetGlobalPropertiesRequestTest,
 
   EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
       .WillOnce(Return(msg_params));
+  EXPECT_CALL(*mock_app_, help_prompt_manager())
+      .WillRepeatedly(ReturnRef(*mock_help_prompt_manager_.get()));
+  EXPECT_CALL(*mock_help_prompt_manager_, OnResetGlobalPropertiesReceived(_));
 
   EXPECT_CALL(
       mock_rpc_service_,
@@ -253,6 +268,9 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       .WillOnce(Return(msg_params));
   EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
       .WillOnce(Return(msg_params));
+  EXPECT_CALL(*mock_app_, help_prompt_manager())
+      .WillRepeatedly(ReturnRef(*mock_help_prompt_manager_.get()));
+  EXPECT_CALL(*mock_help_prompt_manager_, OnResetGlobalPropertiesReceived(_));
 
   MessageSharedPtr ui_msg = CreateMessage();
   (*ui_msg)[am::strings::params][am::strings::correlation_id] = kCorrelationId;
@@ -295,6 +313,9 @@ TEST_F(ResetGlobalPropertiesRequestTest,
 
   EXPECT_CALL(mock_message_helper_, CreateRCResetGlobalPropertiesRequest(_, _))
       .WillOnce(Return(msg_params));
+  EXPECT_CALL(*mock_app_, help_prompt_manager())
+      .WillRepeatedly(ReturnRef(*mock_help_prompt_manager_.get()));
+  EXPECT_CALL(*mock_help_prompt_manager_, OnResetGlobalPropertiesReceived(_));
 
   EXPECT_CALL(
       mock_rpc_service_,
@@ -349,6 +370,9 @@ TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_InvalidApp_NoHashUpdate) {
       .Times(0);
   EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
       .WillOnce(Return(msg_params));
+  EXPECT_CALL(*mock_app_, help_prompt_manager())
+      .WillRepeatedly(ReturnRef(*mock_help_prompt_manager_.get()));
+  EXPECT_CALL(*mock_help_prompt_manager_, OnResetGlobalPropertiesReceived(_));
 
   EXPECT_CALL(
       mock_rpc_service_,
@@ -400,6 +424,9 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       .WillOnce(Return(msg_params));
   EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
       .WillOnce(Return(msg_params));
+  EXPECT_CALL(*mock_app_, help_prompt_manager())
+      .WillRepeatedly(ReturnRef(*mock_help_prompt_manager_.get()));
+  EXPECT_CALL(*mock_help_prompt_manager_, OnResetGlobalPropertiesReceived(_));
 
   EXPECT_CALL(
       mock_rpc_service_,
@@ -467,6 +494,9 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       .WillOnce(Return(msg_params));
   EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
       .WillOnce(Return(msg_params));
+  EXPECT_CALL(*mock_app_, help_prompt_manager())
+      .WillRepeatedly(ReturnRef(*mock_help_prompt_manager_.get()));
+  EXPECT_CALL(*mock_help_prompt_manager_, OnResetGlobalPropertiesReceived(_));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 
@@ -535,6 +565,9 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       .WillOnce(Return(msg_params));
   EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
       .WillOnce(Return(msg_params));
+  EXPECT_CALL(*mock_app_, help_prompt_manager())
+      .WillRepeatedly(ReturnRef(*mock_help_prompt_manager_.get()));
+  EXPECT_CALL(*mock_help_prompt_manager_, OnResetGlobalPropertiesReceived(_));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3988,14 +3988,18 @@ bool ApplicationManagerImpl::ResetVrHelpTitleItems(
   app->set_vr_help_title(so_vr_help_title);
 
   app->reset_vr_help();
-  smart_objects::SmartObjectSPtr so_vr_help =
-      MessageHelper::CreateAppVrHelp(app);
-  if (!so_vr_help->keyExists(strings::vr_help)) {
+  auto& help_prompt_manager = app->help_prompt_manager();
+
+  smart_objects::SmartObject so_vr_help(smart_objects::SmartType_Map);
+  help_prompt_manager.CreateVRMsg(so_vr_help);
+
+  if (!so_vr_help.keyExists(strings::vr_help)) {
     SDL_LOG_WARN("Failed to create vr_help items. Resetting to empty array");
-    (*so_vr_help)[strings::vr_help] =
+    so_vr_help[strings::vr_help] =
         smart_objects::SmartObject(smart_objects::SmartType_Array);
   }
-  app->set_vr_help((*so_vr_help)[strings::vr_help]);
+
+  app->set_vr_help(so_vr_help[strings::vr_help]);
 
   return true;
 }

--- a/src/components/application_manager/src/commands/request_from_mobile_impl.cc
+++ b/src/components/application_manager/src/commands/request_from_mobile_impl.cc
@@ -661,7 +661,7 @@ bool RequestFromMobileImpl::PrepareResultForMobileResponse(
     ResponseInfo& out_third) const {
   SDL_LOG_AUTO_TRACE();
   bool result = (PrepareResultForMobileResponse(out_first, out_second) ||
-                 PrepareResultForMobileResponse(out_second, out_third)) &&
+                 PrepareResultForMobileResponse(out_second, out_third)) ||
                 PrepareResultForMobileResponse(out_first, out_third);
   return result;
 }

--- a/src/components/application_manager/src/help_prompt_manager_impl.cc
+++ b/src/components/application_manager/src/help_prompt_manager_impl.cc
@@ -364,12 +364,22 @@ void HelpPromptManagerImpl::CreateVRMsg(
   GenerateVrItems(out_msg_params, strings::vr_help);
 
   if (out_msg_params[strings::vr_help].empty()) {
-    out_msg_params.erase(strings::vr_help);
-    app_.reset_vr_help();
-  } else {
-    app_.set_vr_help(out_msg_params[strings::vr_help]);
+    int32_t index = 0;
+
+    smart_objects::SmartObject so_default_vr_help(smart_objects::SmartType_Map);
+    so_default_vr_help[strings::position] = index + 1;
+    so_default_vr_help[strings::text] = app_.name();
+    out_msg_params[strings::vr_help][index++] = so_default_vr_help;
+
+    if (app_.vr_synonyms()) {
+      smart_objects::SmartObject item(smart_objects::SmartType_Map);
+      item[strings::text] = (*(app_.vr_synonyms())).getElement(0);
+      item[strings::position] = index + 1;
+      out_msg_params[strings::vr_help][index++] = item;
+    }
   }
-}
+  app_.set_vr_help(out_msg_params[strings::vr_help]);
+}  // namespace application_manager
 
 void HelpPromptManagerImpl::SetSendingType(
     const smart_objects::SmartObject& msg) {

--- a/src/components/application_manager/src/help_prompt_manager_impl.cc
+++ b/src/components/application_manager/src/help_prompt_manager_impl.cc
@@ -183,6 +183,38 @@ void HelpPromptManagerImpl::OnSetGlobalPropertiesReceived(
   SetSendingType(msg);
 }
 
+void HelpPromptManagerImpl::OnResetGlobalPropertiesReceived(
+    const smart_objects::SmartObject& msg) {
+  SDL_LOG_AUTO_TRACE();
+  auto& global_properties_ids = msg[strings::properties];
+
+  for (size_t i = 0; i < global_properties_ids.length(); ++i) {
+    mobile_apis::GlobalProperty::eType global_property =
+        static_cast<mobile_apis::GlobalProperty::eType>(
+            global_properties_ids[i].asInt());
+    switch (global_property) {
+      case mobile_apis::GlobalProperty::HELPPROMPT: {
+        sending_type_ = SendingType::kNoneSend == sending_type_
+                            ? SendingType::kSendHelpPrompt
+                            : SendingType::kSendBoth;
+        break;
+      }
+      case mobile_apis::GlobalProperty::VRHELPTITLE:
+      case mobile_apis::GlobalProperty::VRHELPITEMS: {
+        sending_type_ = SendingType::kNoneSend == sending_type_
+                            ? SendingType::kSendVRHelp
+                            : SendingType::kSendBoth;
+        break;
+      }
+      default: {
+        return;
+      }
+    }
+  }
+
+  SDL_LOG_DEBUG("Sending type set to:" << static_cast<uint32_t>(sending_type_));
+}
+
 HelpPromptManagerImpl::SendingType HelpPromptManagerImpl::GetSendingType()
     const {
   return sending_type_;

--- a/src/components/application_manager/src/help_prompt_manager_impl.cc
+++ b/src/components/application_manager/src/help_prompt_manager_impl.cc
@@ -194,14 +194,16 @@ void HelpPromptManagerImpl::OnResetGlobalPropertiesReceived(
             global_properties_ids[i].asInt());
     switch (global_property) {
       case mobile_apis::GlobalProperty::HELPPROMPT: {
-        sending_type_ = SendingType::kNoneSend == sending_type_
+        sending_type_ = (SendingType::kNoneSend == sending_type_ ||
+                         SendingType::kSendHelpPrompt == sending_type_)
                             ? SendingType::kSendHelpPrompt
                             : SendingType::kSendBoth;
         break;
       }
       case mobile_apis::GlobalProperty::VRHELPTITLE:
       case mobile_apis::GlobalProperty::VRHELPITEMS: {
-        sending_type_ = SendingType::kNoneSend == sending_type_
+        sending_type_ = (SendingType::kNoneSend == sending_type_ ||
+                         SendingType::kSendVRHelp == sending_type_)
                             ? SendingType::kSendVRHelp
                             : SendingType::kSendBoth;
         break;

--- a/src/components/application_manager/test/include/application_manager/mock_help_prompt_manager.h
+++ b/src/components/application_manager/test/include/application_manager/mock_help_prompt_manager.h
@@ -51,6 +51,9 @@ class MockHelpPromptManager : public ::application_manager::HelpPromptManager {
                void(uint32_t cmd_id, const bool should_send_requests));
   MOCK_METHOD2(OnSetGlobalPropertiesReceived,
                void(const smart_objects::SmartObject& msg, bool is_response));
+  MOCK_METHOD1(OnResetGlobalPropertiesReceived,
+               void(const smart_objects::SmartObject& msg));
+
   MOCK_CONST_METHOD0(GetSendingType, SendingType());
 };
 

--- a/src/components/application_manager/test/include/application_manager/mock_help_prompt_manager.h
+++ b/src/components/application_manager/test/include/application_manager/mock_help_prompt_manager.h
@@ -55,6 +55,9 @@ class MockHelpPromptManager : public ::application_manager::HelpPromptManager {
                void(const smart_objects::SmartObject& msg));
 
   MOCK_CONST_METHOD0(GetSendingType, SendingType());
+  MOCK_METHOD1(CreatePromptMsg,
+               void(smart_objects::SmartObject& out_msg_params));
+  MOCK_METHOD1(CreateVRMsg, void(smart_objects::SmartObject& out_msg_params));
 };
 
 }  // namespace application_manager_test

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -312,8 +312,6 @@ class MockMessageHelper {
   MOCK_METHOD2(SendQueryApps,
                void(const uint32_t connection_key,
                     ApplicationManager& app_man));
-  MOCK_METHOD1(CreateAppVrHelp,
-               smart_objects::SmartObjectSPtr(ApplicationConstSharedPtr app));
   MOCK_METHOD3(VerifyImageVrHelpItems,
                mobile_apis::Result::eType(smart_objects::SmartObject& message,
                                           ApplicationConstSharedPtr app,

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -479,11 +479,6 @@ void MessageHelper::SendQueryApps(const uint32_t connection_key,
                                                           app_man);
 }
 
-smart_objects::SmartObjectSPtr MessageHelper::CreateAppVrHelp(
-    ApplicationConstSharedPtr app) {
-  return MockMessageHelper::message_helper_mock()->CreateAppVrHelp(app);
-}
-
 mobile_apis::Result::eType MessageHelper::VerifyImageVrHelpItems(
     smart_objects::SmartObject& message,
     ApplicationConstSharedPtr app,


### PR DESCRIPTION
Fixes #3931

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Submitted ATF test PR for defect

### Summary
Implements a `OnResetGlobalPropertiesReceived` method in the help_prompt_manager. When a ResetGlobalProperties request is received from an application the sending_type_ will be reset based on the global property ids in the request

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
