### PR TITLE
Core dump on ignition off when registering 20 apps

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -1181,7 +1181,8 @@ class Application : public virtual InitialApplicationData,
    * @brief Get list of available application extensions
    * @return application extensions
    */
-  virtual const std::list<AppExtensionPtr>& Extensions() const = 0;
+  virtual const DataAccessor<std::list<AppExtensionPtr> > Extensions()
+      const = 0;
 
   /**
    * @brief Get cloud app endpoint for websocket connection

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -617,7 +617,7 @@ class ApplicationImpl : public virtual Application,
   Timer audio_stream_suspend_timer_;
 
   std::list<AppExtensionPtr> extensions_;
-  mutable std::shared_ptr<sync_primitives::RecursiveLock> extensions_lock_;
+  mutable std::shared_ptr<sync_primitives::Lock> extensions_lock_;
 
   // Cloud app properties
   std::string endpoint_;

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -555,7 +555,7 @@ class ApplicationImpl : public virtual Application,
    */
   bool RemoveExtension(AppExtensionUID uid) OVERRIDE;
 
-  const std::list<AppExtensionPtr>& Extensions() const OVERRIDE;
+  const DataAccessor<std::list<AppExtensionPtr> > Extensions() const OVERRIDE;
 
   std::string hash_val_;
   uint32_t grammar_id_;
@@ -617,6 +617,7 @@ class ApplicationImpl : public virtual Application,
   Timer audio_stream_suspend_timer_;
 
   std::list<AppExtensionPtr> extensions_;
+  mutable std::shared_ptr<sync_primitives::RecursiveLock> extensions_lock_;
 
   // Cloud app properties
   std::string endpoint_;
@@ -644,7 +645,6 @@ class ApplicationImpl : public virtual Application,
   CommandSoftButtonID cmd_softbuttonid_;
   // Lock for command soft button id
   sync_primitives::Lock cmd_softbuttonid_lock_;
-  mutable std::shared_ptr<sync_primitives::Lock> vi_lock_ptr_;
   mutable std::shared_ptr<sync_primitives::Lock> button_lock_ptr_;
   std::string folder_name_;
   ApplicationManager& application_manager_;

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -617,7 +617,7 @@ class ApplicationImpl : public virtual Application,
   Timer audio_stream_suspend_timer_;
 
   std::list<AppExtensionPtr> extensions_;
-  mutable std::shared_ptr<sync_primitives::Lock> extensions_lock_;
+  mutable std::shared_ptr<sync_primitives::RecursiveLock> extensions_lock_;
 
   // Cloud app properties
   std::string endpoint_;

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1023,8 +1023,6 @@ class ApplicationManagerImpl
     rpc_service_ = std::move(rpc_service);
   }
 
-  bool is_stopping() const OVERRIDE;
-
   bool is_audio_pass_thru_active() const OVERRIDE;
   /*
    * @brief Function Should be called when Low Voltage is occured

--- a/src/components/application_manager/include/application_manager/commands/command.h
+++ b/src/components/application_manager/include/application_manager/commands/command.h
@@ -137,6 +137,8 @@ class Command {
    */
   virtual void SetAllowedToTerminate(const bool allowed) = 0;
 
+  virtual const ApplicationManager& GetApplicationManager() const = 0;
+
   enum CommandSource {
     SOURCE_SDL,
     SOURCE_MOBILE,

--- a/src/components/application_manager/include/application_manager/commands/command_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_impl.h
@@ -182,6 +182,8 @@ class CommandImpl : public Command {
    */
   void SetAllowedToTerminate(const bool allowed) OVERRIDE;
 
+  const ApplicationManager& GetApplicationManager() const OVERRIDE;
+
   void OnUpdateTimeOut() OVERRIDE;
 
   /**

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -192,10 +192,12 @@ ApplicationImpl::~ApplicationImpl() {
     set_perform_interaction_mode(-1);
   }
   CleanupFiles();
-  sync_primitives::AutoLock lock(mobile_message_lock_);
-  mobile_message_queue_.clear();
   {
-    extensions_lock_->Acquire();
+    sync_primitives::AutoLock lock(mobile_message_lock_);
+    mobile_message_queue_.clear();
+  }
+  {
+    sync_primitives::AutoLock lock(extensions_lock_);
     extensions_.clear();
     extensions_lock_->Release();
   }

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -148,7 +148,7 @@ ApplicationImpl::ApplicationImpl(
           "AudioStreamSuspend",
           new ::timer::TimerTaskImpl<ApplicationImpl>(
               this, &ApplicationImpl::OnAudioStreamSuspend))
-    , extensions_lock_(std::make_shared<sync_primitives::Lock>())
+    , extensions_lock_(std::make_shared<sync_primitives::RecursiveLock>())
     , hybrid_app_preference_(mobile_api::HybridAppPreference::INVALID_ENUM)
     , button_lock_ptr_(std::make_shared<sync_primitives::Lock>())
     , application_manager_(application_manager) {

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -1316,15 +1316,13 @@ void ApplicationImpl::set_hmi_level(
 }
 
 AppExtensionPtr ApplicationImpl::QueryInterface(AppExtensionUID uid) {
-  extensions_lock_->Acquire();
+  sync_primitives::AutoLock auto_lock_list(extensions_lock_);
   std::list<AppExtensionPtr>::const_iterator it = extensions_.begin();
   for (; it != extensions_.end(); ++it) {
     if ((*it)->uid() == uid) {
-      extensions_lock_->Release();
       return (*it);
     }
   }
-  extensions_lock_->Release();
   return AppExtensionPtr();
 }
 
@@ -1431,16 +1429,14 @@ const smart_objects::SmartObject& ApplicationImpl::get_user_location() const {
 
 void ApplicationImpl::PushMobileMessage(
     smart_objects::SmartObjectSPtr mobile_message) {
-  mobile_message_lock_.Acquire();
+  sync_primitives::AutoLock lock(mobile_message_lock_);
   mobile_message_queue_.push_back(mobile_message);
-  mobile_message_lock_.Release();
 }
 
 void ApplicationImpl::SwapMobileMessageQueue(
     MobileMessageQueue& mobile_messages) {
-  mobile_message_lock_.Acquire();
+  sync_primitives::AutoLock lock(mobile_message_lock_);
   mobile_messages.swap(mobile_message_queue_);
-  mobile_message_lock_.Release();
 }
 
 }  // namespace application_manager

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -273,8 +273,7 @@ ApplicationManagerImpl::~ApplicationManagerImpl() {
 
   {
     sync_primitives::AutoLock lock(reregister_wait_list_lock_ptr_);
-    reregister_wait_list_.erase(reregister_wait_list_.begin(),
-                                reregister_wait_list_.end());
+    reregister_wait_list_.clear();
   }
 
   {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -256,8 +256,36 @@ ApplicationManagerImpl::~ApplicationManagerImpl() {
     streaming_timer_pool_.clear();
   }
 
+  {
+    sync_primitives::AutoLock lock(navi_service_status_lock_);
+    navi_service_status_.clear();
+  }
+
+  {
+    sync_primitives::AutoLock lock(tts_global_properties_app_list_lock_);
+    tts_global_properties_app_list_.clear();
+  }
+
+  {
+    sync_primitives::AutoLock lock(apps_to_register_list_lock_ptr_);
+    apps_to_register_.clear();
+  }
+
+  {
+    sync_primitives::AutoLock lock(reregister_wait_list_lock_ptr_);
+    reregister_wait_list_.erase(reregister_wait_list_.begin(),
+                                reregister_wait_list_.end());
+  }
+
+  {
+    sync_primitives::AutoLock lock(query_apps_devices_lock_);
+    query_apps_devices_.clear();
+  }
   clear_pool_timer_.Stop();
   secondary_transport_devices_cache_.clear();
+  applications_list_lock_ptr_->Acquire();
+  applications_.clear();
+  applications_list_lock_ptr_->Release();
 }
 
 DataAccessor<ApplicationSet> ApplicationManagerImpl::applications() const {
@@ -984,7 +1012,7 @@ void ApplicationManagerImpl::RefreshCloudAppInformation() {
   return;
 #else
   SDL_LOG_AUTO_TRACE();
-  if (is_stopping()) {
+  if (IsStopping()) {
     return;
   }
   std::vector<std::string> enabled_apps;
@@ -3502,10 +3530,6 @@ mobile_apis::Result::eType ApplicationManagerImpl::CheckPolicyPermissions(
   }
   SDL_LOG_DEBUG("Request is allowed by policies. " << log_msg);
   return mobile_api::Result::SUCCESS;
-}
-
-bool ApplicationManagerImpl::is_stopping() const {
-  return is_stopping_;
 }
 
 bool ApplicationManagerImpl::is_audio_pass_thru_active() const {

--- a/src/components/application_manager/src/commands/command_impl.cc
+++ b/src/components/application_manager/src/commands/command_impl.cc
@@ -174,6 +174,10 @@ void CommandImpl::SetAllowedToTerminate(const bool allowed) {
   allowed_to_terminate_ = allowed;
 }
 
+const ApplicationManager& CommandImpl::GetApplicationManager() const {
+  return application_manager_;
+}
+
 bool CommandImpl::CheckAllowedParameters(const Command::CommandSource source) {
   SDL_LOG_AUTO_TRACE();
 

--- a/src/components/application_manager/src/request_controller_impl.cc
+++ b/src/components/application_manager/src/request_controller_impl.cc
@@ -76,22 +76,19 @@ RequestControllerImpl::~RequestControllerImpl() {
   retained_mobile_requests_.clear();
 
   {
-    notification_list_lock_.Acquire();
+    sync_primitives::AutoLock auto_lock_list(notification_list_lock_);
     notification_list_.clear();
-    notification_list_lock_.Release();
   }
 
   {
-    duplicate_message_count_lock_.Acquire();
+    sync_primitives::AutoLock auto_lock_list(duplicate_message_count_lock_);
     duplicate_message_count_.clear();
-    duplicate_message_count_lock_.Release();
   }
 
   {
-    mobile_request_list_lock_.Acquire();
+    sync_primitives::AutoLock auto_lock_list(mobile_request_list_lock_);
     mobile_request_list_.clear();
     waiting_for_response_.RemoveMobileRequests();
-    mobile_request_list_lock_.Release();
   }
 }
 

--- a/src/components/application_manager/src/request_controller_impl.cc
+++ b/src/components/application_manager/src/request_controller_impl.cc
@@ -205,7 +205,7 @@ RequestController::TResult RequestControllerImpl::AddMobileRequest(
                                     << "connection_key : "
                                     << request->connection_key());
   RequestController::TResult result = CheckPosibilitytoAdd(request, hmi_level);
-  if (TResult::SUCCESS == result && pool_state_ != TPoolState::STOPPED) {
+  if (TResult::SUCCESS == result && TPoolState::STOPPED != pool_state_) {
     AutoLock auto_lock_list(mobile_request_list_lock_);
     mobile_request_list_.push_back(request);
     SDL_LOG_DEBUG("Waiting for execution: " << mobile_request_list_.size());

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -252,7 +252,6 @@ bool ResumeCtrlImpl::SetupDefaultHMILevel(ApplicationSharedPtr application) {
 
 void ResumeCtrlImpl::ApplicationResumptiOnTimer() {
   SDL_LOG_AUTO_TRACE();
-  DataAccessor<ApplicationSet> apps = application_manager_.applications();
   sync_primitives::AutoLock auto_lock(queue_lock_);
   WaitingForTimerList::iterator it = waiting_for_timer_.begin();
 

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -252,6 +252,7 @@ bool ResumeCtrlImpl::SetupDefaultHMILevel(ApplicationSharedPtr application) {
 
 void ResumeCtrlImpl::ApplicationResumptiOnTimer() {
   SDL_LOG_AUTO_TRACE();
+  DataAccessor<ApplicationSet> apps = application_manager_.applications();
   sync_primitives::AutoLock auto_lock(queue_lock_);
   WaitingForTimerList::iterator it = waiting_for_timer_.begin();
 

--- a/src/components/application_manager/src/resumption/resumption_data.cc
+++ b/src/components/application_manager/src/resumption/resumption_data.cc
@@ -163,7 +163,8 @@ smart_objects::SmartObject ResumptionData::GetApplicationSubscriptions(
            subscriptions);
   }
 
-  for (auto extension : application->Extensions()) {
+  auto extensions = application->Extensions();
+  for (auto& extension : extensions.GetData()) {
     extension->SaveResumptionData(subscriptions);
   }
 

--- a/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
@@ -890,7 +890,8 @@ void ResumptionDataProcessorImpl::AddPluginsSubscriptions(
     const smart_objects::SmartObject& saved_app) {
   SDL_LOG_AUTO_TRACE();
 
-  for (auto& extension : application->Extensions()) {
+  auto extensions = application->Extensions();
+  for (auto& extension : extensions.GetData()) {
     extension->ProcessResumption(saved_app);
   }
 }
@@ -995,7 +996,7 @@ void ResumptionDataProcessorImpl::DeletePluginsSubscriptions(
   resumption_status_lock_.Release();
 
   auto extensions = application->Extensions();
-  for (auto& extension : extensions) {
+  for (auto& extension : extensions.GetData()) {
     extension->RevertResumption(resumption_data_to_revert);
   }
 }

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -212,7 +212,7 @@ void RPCHandlerImpl::Handle(const impl::MessageFromMobile message) {
     SDL_LOG_ERROR("Null-pointer message received.");
     return;
   }
-  if (app_manager_.is_stopping()) {
+  if (app_manager_.IsStopping()) {
     SDL_LOG_INFO("Application manager is stopping");
     return;
   }

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -404,8 +404,9 @@ class MockApplication : public ::application_manager::Application {
   MOCK_METHOD1(AddExtension,
                bool(application_manager::AppExtensionPtr extention));
   MOCK_METHOD1(RemoveExtension, bool(application_manager::AppExtensionUID uid));
-  MOCK_CONST_METHOD0(Extensions,
-                     const std::list<application_manager::AppExtensionPtr>&());
+  MOCK_CONST_METHOD0(
+      Extensions,
+      const DataAccessor<std::list<application_manager::AppExtensionPtr> >());
   MOCK_CONST_METHOD0(is_remote_control_supported, bool());
   MOCK_METHOD1(set_remote_control_supported, void(const bool allow));
   MOCK_CONST_METHOD0(cloud_app_endpoint, const std::string&());

--- a/src/components/application_manager/test/include/application_manager/mock_request.h
+++ b/src/components/application_manager/test/include/application_manager/mock_request.h
@@ -63,6 +63,8 @@ class MockRequest : public application_manager::commands::Command {
   MOCK_METHOD0(AllowedToTerminate, bool());
   MOCK_METHOD1(SetAllowedToTerminate, void(bool is_allowed));
 
+  MOCK_CONST_METHOD0(GetApplicationManager,
+                     application_manager::ApplicationManager&());
   MOCK_CONST_METHOD0(connection_key, uint32_t());
   MOCK_CONST_METHOD0(correlation_id, uint32_t());
 };

--- a/src/components/application_manager/test/include/application_manager/resumption_data_test.h
+++ b/src/components/application_manager/test/include/application_manager/resumption_data_test.h
@@ -75,7 +75,7 @@ class ResumptionDataTest : public ::testing::Test {
       , setlock_ptr_(std::make_shared<sync_primitives::Lock>())
       , btnlock_ptr_(std::make_shared<sync_primitives::Lock>())
       , ivilock_ptr_(std::make_shared<sync_primitives::Lock>())
-      , extensions_lock_(std::make_shared<sync_primitives::Lock>())
+      , extensions_lock_(std::make_shared<sync_primitives::RecursiveLock>())
       , window_params_map_lock_ptr_(std::make_shared<sync_primitives::Lock>()) {
   }
   virtual ~ResumptionDataTest();
@@ -163,7 +163,7 @@ class ResumptionDataTest : public ::testing::Test {
   std::shared_ptr<sync_primitives::Lock> setlock_ptr_;
   std::shared_ptr<sync_primitives::Lock> btnlock_ptr_;
   std::shared_ptr<sync_primitives::Lock> ivilock_ptr_;
-  std::shared_ptr<sync_primitives::Lock> extensions_lock_;
+  std::shared_ptr<sync_primitives::RecursiveLock> extensions_lock_;
   std::shared_ptr<sync_primitives::Lock> window_params_map_lock_ptr_;
   application_manager_test::MockApplicationManagerSettings
       mock_application_manager_settings_;

--- a/src/components/application_manager/test/include/application_manager/resumption_data_test.h
+++ b/src/components/application_manager/test/include/application_manager/resumption_data_test.h
@@ -75,6 +75,7 @@ class ResumptionDataTest : public ::testing::Test {
       , setlock_ptr_(std::make_shared<sync_primitives::Lock>())
       , btnlock_ptr_(std::make_shared<sync_primitives::Lock>())
       , ivilock_ptr_(std::make_shared<sync_primitives::Lock>())
+      , extensions_lock_(std::make_shared<sync_primitives::RecursiveLock>())
       , window_params_map_lock_ptr_(std::make_shared<sync_primitives::Lock>()) {
   }
   virtual ~ResumptionDataTest();
@@ -162,6 +163,7 @@ class ResumptionDataTest : public ::testing::Test {
   std::shared_ptr<sync_primitives::Lock> setlock_ptr_;
   std::shared_ptr<sync_primitives::Lock> btnlock_ptr_;
   std::shared_ptr<sync_primitives::Lock> ivilock_ptr_;
+  std::shared_ptr<sync_primitives::RecursiveLock> extensions_lock_;
   std::shared_ptr<sync_primitives::Lock> window_params_map_lock_ptr_;
   application_manager_test::MockApplicationManagerSettings
       mock_application_manager_settings_;

--- a/src/components/application_manager/test/include/application_manager/resumption_data_test.h
+++ b/src/components/application_manager/test/include/application_manager/resumption_data_test.h
@@ -75,7 +75,7 @@ class ResumptionDataTest : public ::testing::Test {
       , setlock_ptr_(std::make_shared<sync_primitives::Lock>())
       , btnlock_ptr_(std::make_shared<sync_primitives::Lock>())
       , ivilock_ptr_(std::make_shared<sync_primitives::Lock>())
-      , extensions_lock_(std::make_shared<sync_primitives::RecursiveLock>())
+      , extensions_lock_(std::make_shared<sync_primitives::Lock>())
       , window_params_map_lock_ptr_(std::make_shared<sync_primitives::Lock>()) {
   }
   virtual ~ResumptionDataTest();
@@ -163,7 +163,7 @@ class ResumptionDataTest : public ::testing::Test {
   std::shared_ptr<sync_primitives::Lock> setlock_ptr_;
   std::shared_ptr<sync_primitives::Lock> btnlock_ptr_;
   std::shared_ptr<sync_primitives::Lock> ivilock_ptr_;
-  std::shared_ptr<sync_primitives::RecursiveLock> extensions_lock_;
+  std::shared_ptr<sync_primitives::Lock> extensions_lock_;
   std::shared_ptr<sync_primitives::Lock> window_params_map_lock_ptr_;
   application_manager_test::MockApplicationManagerSettings
       mock_application_manager_settings_;

--- a/src/components/application_manager/test/request_controller/request_controller_test.cc
+++ b/src/components/application_manager/test/request_controller/request_controller_test.cc
@@ -45,7 +45,6 @@
 #include "application_manager/event_engine/event_dispatcher.h"
 #include "application_manager/mock_application_manager.h"
 
-#include "application_manager/mock_application_manager.h"
 #include "application_manager/mock_request_controller_settings.h"
 #include "application_manager/mock_request_timeout_handler.h"
 #include "application_manager/policies/policy_handler.h"
@@ -62,6 +61,7 @@ namespace request_controller_test {
 using ::application_manager::request_controller::RequestController;
 using ::application_manager::request_controller::RequestControllerImpl;
 using ::application_manager::request_controller::RequestInfo;
+using ::test::components::application_manager_test::MockApplicationManager;
 using test::components::application_manager_test::MockRequestTimeoutHandler;
 
 using ::test::components::event_engine_test::MockEventDispatcher;
@@ -168,6 +168,7 @@ class RequestControllerTestClass : public ::testing::Test {
   RequestControllerSPtr request_ctrl_;
   RequestPtr empty_mock_request_;
   const TestSettings default_settings_;
+  NiceMock<MockApplicationManager> app_mngr_;
 };
 
 TEST_F(RequestControllerTestClass,
@@ -179,6 +180,10 @@ TEST_F(RequestControllerTestClass,
   EXPECT_CALL(*request_valid, Run())
       .Times(1)
       .WillRepeatedly(NotifyTestAsyncWaiter(waiter_valid));
+  EXPECT_CALL(*request_valid, GetApplicationManager())
+      .Times(1)
+      .WillRepeatedly(ReturnRef(app_mngr_));
+  EXPECT_CALL(app_mngr_, IsStopping()).Times(1).WillRepeatedly(Return(false));
 
   EXPECT_EQ(RequestController::TResult::SUCCESS,
             AddRequest(default_settings_,
@@ -211,38 +216,16 @@ TEST_F(RequestControllerTestClass,
   // app_hmi_level_none_time_scale_max_requests_ equals 0
   // (in the default settings they setted to 0)
   for (size_t i = 0; i < kMaxRequestAmount; ++i) {
+    RequestPtr request_valid = GetMockRequest(i);
+    EXPECT_CALL(*request_valid, GetApplicationManager())
+        .WillRepeatedly(ReturnRef(app_mngr_));
+    EXPECT_CALL(app_mngr_, IsStopping()).WillRepeatedly(Return(false));
     EXPECT_EQ(RequestController::TResult::SUCCESS,
               AddRequest(default_settings_,
-                         GetMockRequest(i),
+                         request_valid,
                          RequestInfo::RequestType::MobileRequest,
                          mobile_apis::HMILevel::HMI_FULL));
   }
-}
-
-TEST_F(
-    RequestControllerTestClass,
-    CheckPosibilitytoAdd_ExcessPendingRequestsAmount_TooManyPendingRequests) {
-  TestSettings settings;
-  settings.pending_requests_amount_ = kNumberOfRequests;
-
-  request_ctrl_->DestroyThreadpool();
-
-  // Adding requests to fit in pending_requests_amount_
-  for (size_t i = 0; i < kNumberOfRequests; ++i) {
-    EXPECT_EQ(RequestController::TResult::SUCCESS,
-              AddRequest(settings,
-                         GetMockRequest(),
-                         RequestInfo::RequestType::MobileRequest,
-                         mobile_apis::HMILevel::HMI_FULL));
-  }
-
-  // Trying to add one more extra request
-  // Expect overflow and TOO_MANY_PENDING_REQUESTS result
-  EXPECT_EQ(RequestController::TResult::TOO_MANY_PENDING_REQUESTS,
-            AddRequest(settings,
-                       GetMockRequest(),
-                       RequestInfo::RequestType::MobileRequest,
-                       mobile_apis::HMILevel::HMI_FULL));
 }
 
 TEST_F(RequestControllerTestClass, IsLowVoltage_SetOnLowVoltage_TRUE) {
@@ -258,11 +241,23 @@ TEST_F(RequestControllerTestClass, IsLowVoltage_SetOnWakeUp_FALSE) {
 }
 
 TEST_F(RequestControllerTestClass, AddMobileRequest_SetValidData_SUCCESS) {
+  RequestPtr request_valid = GetMockRequest();
+  auto waiter_valid = TestAsyncWaiter::createInstance();
+  ON_CALL(*request_valid, default_timeout()).WillByDefault(Return(0));
+  EXPECT_CALL(*request_valid, Init()).WillOnce(Return(true));
+  EXPECT_CALL(*request_valid, Run())
+      .Times(1)
+      .WillRepeatedly(NotifyTestAsyncWaiter(waiter_valid));
+  EXPECT_CALL(*request_valid, GetApplicationManager())
+      .Times(1)
+      .WillRepeatedly(ReturnRef(app_mngr_));
+  EXPECT_CALL(app_mngr_, IsStopping()).Times(1).WillRepeatedly(Return(false));
   EXPECT_EQ(RequestController::TResult::SUCCESS,
             AddRequest(default_settings_,
-                       GetMockRequest(),
+                       request_valid,
                        RequestInfo::RequestType::MobileRequest,
                        mobile_apis::HMILevel::HMI_FULL));
+  EXPECT_TRUE(waiter_valid->WaitFor(1, 1000));
 }
 
 TEST_F(RequestControllerTestClass,
@@ -292,6 +287,10 @@ TEST_F(RequestControllerTestClass, OnTimer_SUCCESS) {
   const uint32_t request_timeout = 1u;
   RequestPtr mock_request = GetMockRequest(
       kDefaultCorrelationID, kDefaultConnectionKey, request_timeout);
+  EXPECT_CALL(*mock_request, GetApplicationManager())
+      .Times(1)
+      .WillRepeatedly(ReturnRef(app_mngr_));
+  EXPECT_CALL(app_mngr_, IsStopping()).Times(1).WillRepeatedly(Return(false));
 
   auto waiter = TestAsyncWaiter::createInstance();
   EXPECT_EQ(RequestController::TResult::SUCCESS,

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -98,7 +98,8 @@ class ResumeCtrlTest : public ::testing::Test {
       , kDefaultDeferredTestLevel_(eType::INVALID_ENUM)
       , kNaviLowbandwidthLevel_("LIMITED")
       , kProjectionLowbandwidthLevel_("NONE")
-      , kMediaLowbandwidthLevel_("NONE") {
+      , kMediaLowbandwidthLevel_("NONE")
+      , extensions_lock_(std::make_shared<sync_primitives::RecursiveLock>()) {
     profile::Profile profile_;
     profile_.set_config_file_name("smartDeviceLink.ini");
     resumption_delay_before_ign_ = profile_.resumption_delay_before_ign();
@@ -245,6 +246,7 @@ class ResumeCtrlTest : public ::testing::Test {
   const std::string kMediaLowbandwidthLevel_;
   NiceMock<application_manager_test::MockRPCService> mock_rpc_service_;
   resumption::ResumeCtrl::ResumptionCallBack callback_;
+  std::shared_ptr<sync_primitives::RecursiveLock> extensions_lock_;
 };
 
 /**
@@ -327,7 +329,9 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithFiles) {
       .WillRepeatedly(Return(requests));
   std::list<application_manager::AppExtensionPtr> extensions;
   extensions.insert(extensions.begin(), mock_app_extension_);
-  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+  DataAccessor<std::list<application_manager::AppExtensionPtr> > accessor(
+      extensions, extensions_lock_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(Return(accessor));
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
   for (uint32_t i = 0; i < count_of_files; ++i) {
     EXPECT_CALL(*mock_app_,
@@ -387,7 +391,9 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubmenues) {
 
   std::list<application_manager::AppExtensionPtr> extensions;
   extensions.insert(extensions.begin(), mock_app_extension_);
-  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+  DataAccessor<std::list<application_manager::AppExtensionPtr> > accessor(
+      extensions, extensions_lock_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(Return(accessor));
 
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
@@ -461,7 +467,9 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithCommands) {
       .WillRepeatedly(Return(requests));
   std::list<application_manager::AppExtensionPtr> extensions;
   extensions.insert(extensions.begin(), mock_app_extension_);
-  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+  DataAccessor<std::list<application_manager::AppExtensionPtr> > accessor(
+      extensions, extensions_lock_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(Return(accessor));
 
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
@@ -521,7 +529,9 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithChoiceSet) {
 
   std::list<application_manager::AppExtensionPtr> extensions;
   extensions.insert(extensions.begin(), mock_app_extension_);
-  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+  DataAccessor<std::list<application_manager::AppExtensionPtr> > accessor(
+      extensions, extensions_lock_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(Return(accessor));
 
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
@@ -560,9 +570,12 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithGlobalProperties) {
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
               CreateAddCommandRequestToHMI(_, _))
       .WillRepeatedly(Return(requests));
+
   std::list<application_manager::AppExtensionPtr> extensions;
   extensions.insert(extensions.begin(), mock_app_extension_);
-  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+  DataAccessor<std::list<application_manager::AppExtensionPtr> > accessor(
+      extensions, extensions_lock_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(Return(accessor));
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
@@ -613,8 +626,9 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscribeOnButtons) {
 
   std::list<application_manager::AppExtensionPtr> extensions;
   extensions.insert(extensions.begin(), mock_app_extension_);
-
-  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+  DataAccessor<std::list<application_manager::AppExtensionPtr> > accessor(
+      extensions, extensions_lock_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(Return(accessor));
 
   EXPECT_CALL(*mock_app_extension_, ProcessResumption(saved_app));
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
@@ -660,10 +674,11 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToIVI) {
   smart_objects::SmartObjectList requests;
 
   std::list<application_manager::AppExtensionPtr> extensions;
-
   extensions.insert(extensions.begin(), mock_app_extension_);
 
-  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+  DataAccessor<std::list<application_manager::AppExtensionPtr> > accessor(
+      extensions, extensions_lock_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(Return(accessor));
 
   EXPECT_CALL(*mock_app_extension_, ProcessResumption(saved_app));
   const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
@@ -693,7 +708,6 @@ TEST_F(ResumeCtrlTest,
   std::list<application_manager::AppExtensionPtr> extensions;
   // It will work only for WayPointsAppExtension, need to rework this test
   extensions.insert(extensions.begin(), mock_app_extension_);
-  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
   EXPECT_CALL(mock_app_mngr_,
               SubscribeAppForWayPoints(

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -99,7 +99,7 @@ class ResumeCtrlTest : public ::testing::Test {
       , kNaviLowbandwidthLevel_("LIMITED")
       , kProjectionLowbandwidthLevel_("NONE")
       , kMediaLowbandwidthLevel_("NONE")
-      , extensions_lock_(std::make_shared<sync_primitives::Lock>()) {
+      , extensions_lock_(std::make_shared<sync_primitives::RecursiveLock>()) {
     profile::Profile profile_;
     profile_.set_config_file_name("smartDeviceLink.ini");
     resumption_delay_before_ign_ = profile_.resumption_delay_before_ign();
@@ -246,7 +246,7 @@ class ResumeCtrlTest : public ::testing::Test {
   const std::string kMediaLowbandwidthLevel_;
   NiceMock<application_manager_test::MockRPCService> mock_rpc_service_;
   resumption::ResumeCtrl::ResumptionCallBack callback_;
-  std::shared_ptr<sync_primitives::Lock> extensions_lock_;
+  std::shared_ptr<sync_primitives::RecursiveLock> extensions_lock_;
 };
 
 /**

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -99,7 +99,7 @@ class ResumeCtrlTest : public ::testing::Test {
       , kNaviLowbandwidthLevel_("LIMITED")
       , kProjectionLowbandwidthLevel_("NONE")
       , kMediaLowbandwidthLevel_("NONE")
-      , extensions_lock_(std::make_shared<sync_primitives::RecursiveLock>()) {
+      , extensions_lock_(std::make_shared<sync_primitives::Lock>()) {
     profile::Profile profile_;
     profile_.set_config_file_name("smartDeviceLink.ini");
     resumption_delay_before_ign_ = profile_.resumption_delay_before_ign();
@@ -246,7 +246,7 @@ class ResumeCtrlTest : public ::testing::Test {
   const std::string kMediaLowbandwidthLevel_;
   NiceMock<application_manager_test::MockRPCService> mock_rpc_service_;
   resumption::ResumeCtrl::ResumptionCallBack callback_;
-  std::shared_ptr<sync_primitives::RecursiveLock> extensions_lock_;
+  std::shared_ptr<sync_primitives::Lock> extensions_lock_;
 };
 
 /**

--- a/src/components/application_manager/test/resumption/resumption_data_test.cc
+++ b/src/components/application_manager/test/resumption/resumption_data_test.cc
@@ -383,7 +383,9 @@ void ResumptionDataTest::PrepareData() {
   mock_app_extension_ =
       std::make_shared<NiceMock<application_manager_test::MockAppExtension> >();
   extensions_.insert(extensions_.begin(), mock_app_extension_);
-  ON_CALL(*app_mock, Extensions()).WillByDefault(ReturnRef(extensions_));
+  DataAccessor<std::list<application_manager::AppExtensionPtr> > accessor(
+      extensions_, extensions_lock_);
+  ON_CALL(*app_mock, Extensions()).WillByDefault(Return(accessor));
   SetGlobalProporties();
   SetCommands();
   SetSubmenues();

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -512,7 +512,6 @@ class ApplicationManager {
   get_request_timeout_handler() const = 0;
   virtual request_controller::RequestController& get_request_controller()
       const = 0;
-  virtual bool is_stopping() const = 0;
   virtual bool is_audio_pass_thru_active() const = 0;
 
   virtual uint32_t GetNextMobileCorrelationID() = 0;

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -197,7 +197,7 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD0(
       get_request_controller,
       application_manager::request_controller::RequestController&());
-  MOCK_CONST_METHOD0(is_stopping, bool());
+  MOCK_CONST_METHOD0(IsStopping, bool());
   MOCK_CONST_METHOD0(is_audio_pass_thru_active, bool());
   MOCK_METHOD0(GetNextHMICorrelationID, uint32_t());
   MOCK_METHOD0(GetNextMobileCorrelationID, uint32_t());
@@ -236,7 +236,6 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                     bool is_greyed_out));
   MOCK_CONST_METHOD1(IsAppsQueriedFrom,
                      bool(const connection_handler::DeviceHandle handle));
-  MOCK_CONST_METHOD0(IsStopping, bool());
   MOCK_METHOD0(WaitForHmiIsReady, bool());
   MOCK_METHOD1(RemoveAppFromTTSGlobalPropertiesList,
                void(const uint32_t app_id));

--- a/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
+++ b/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
@@ -645,6 +645,8 @@ class TransportAdapterImpl : public TransportAdapter,
    **/
   ConnectionMap connections_;
 
+  mutable sync_primitives::Lock connections_duplicate;
+
   /**
    * @brief Queue of retry timers.
    */

--- a/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
+++ b/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
@@ -645,8 +645,6 @@ class TransportAdapterImpl : public TransportAdapter,
    **/
   ConnectionMap connections_;
 
-  mutable sync_primitives::Lock connections_duplicate;
-
   /**
    * @brief Queue of retry timers.
    */

--- a/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
+++ b/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
@@ -138,7 +138,6 @@ void TransportAdapterImpl::Terminate() {
   std::swap(connections, connections_);
   connections_lock_.Release();
 
-  connections_duplicate.Acquire();
   for (const auto& connection : connections) {
     auto& info = connection.second;
     if (info.connection) {
@@ -146,7 +145,6 @@ void TransportAdapterImpl::Terminate() {
     }
   }
   connections.clear();
-  connections_duplicate.Release();
 
   SDL_LOG_DEBUG("Connections deleted");
 
@@ -389,7 +387,6 @@ TransportAdapter::Error TransportAdapterImpl::DisconnectDevice(
   }
   connections_lock_.Release();
 
-  connections_duplicate.Acquire();
   for (std::vector<ConnectionInfo>::const_iterator j = to_disconnect.begin();
        j != to_disconnect.end();
        ++j) {
@@ -399,7 +396,6 @@ TransportAdapter::Error TransportAdapterImpl::DisconnectDevice(
       SDL_LOG_ERROR("Error on disconnect " << error);
     }
   }
-  connections_duplicate.Release();
 
   return error;
 }

--- a/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
+++ b/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
@@ -137,6 +137,8 @@ void TransportAdapterImpl::Terminate() {
   connections_lock_.AcquireForWriting();
   std::swap(connections, connections_);
   connections_lock_.Release();
+
+  connections_duplicate.Acquire();
   for (const auto& connection : connections) {
     auto& info = connection.second;
     if (info.connection) {
@@ -144,6 +146,7 @@ void TransportAdapterImpl::Terminate() {
     }
   }
   connections.clear();
+  connections_duplicate.Release();
 
   SDL_LOG_DEBUG("Connections deleted");
 
@@ -386,6 +389,7 @@ TransportAdapter::Error TransportAdapterImpl::DisconnectDevice(
   }
   connections_lock_.Release();
 
+  connections_duplicate.Acquire();
   for (std::vector<ConnectionInfo>::const_iterator j = to_disconnect.begin();
        j != to_disconnect.end();
        ++j) {
@@ -395,6 +399,7 @@ TransportAdapter::Error TransportAdapterImpl::DisconnectDevice(
       SDL_LOG_ERROR("Error on disconnect " << error);
     }
   }
+  connections_duplicate.Release();
 
   return error;
 }


### PR DESCRIPTION
Fixes #3857 

Original PR: https://github.com/smartdevicelink/sdl_core/pull/3928

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Submitted ATF test for issue

### Summary
Fixes the following problems:

- Аn object of this class AppExtension was not given externally without protection. Therefore, I will change the return type from Extensions () to DataAccessor <std :: list >. Where the desired mutex is captured.
- ApplicationManagerImpl had unprotected deletion of objects used in other threads. Also, I found a duplicate of the is_stopping method. I deleted this one and left the IsStopping method.
- ResumeCtrlImpl captured the mutex queue_lock_, which belongs to it, and the mutex from ApplicationManagerImpl, when calling the application(..) method. This created a deadlock, and not a secure use of the application object. So I added getting all the apps and working with this list.
- It consists of two different crash of the program. The first crash when remove mobile_request_list_. The second is when deleting mobile requests from waiting_for_response_. This was due to the use of smart pointers in different threads. They are copied into threads, so we have to delete them in the thread in which we finish working with it. Since these requests are processed in a separate thread, I delete them there if the core stops working during the processing of these requests. Also added a check to see if the core stopped working while adding such requests to the list.
- This is a drop while processing data in one thread and deleting it in another thread. I created a separate mutex to protect this data. Because using the existing one, we do not invest in the time allotted to the timer to perform certain work.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
