### PR TITLE
Delete both successful and pending commands on AddComand failure

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_command_request.cc
@@ -591,16 +591,14 @@ void AddCommandRequest::RemoveCommand() {
           ui_result_,
           hmi_apis::Common_Result::INVALID_ENUM,
           hmi_apis::Common_Result::SUCCESS,
-          hmi_apis::Common_Result::WARNINGS,
-          hmi_apis::Common_Result::UNSUPPORTED_RESOURCE);
+          hmi_apis::Common_Result::WARNINGS);
 
   const bool is_vr_result_ok_or_missing =
       Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
           vr_result_,
           hmi_apis::Common_Result::INVALID_ENUM,
           hmi_apis::Common_Result::SUCCESS,
-          hmi_apis::Common_Result::WARNINGS,
-          hmi_apis::Common_Result::UNSUPPORTED_RESOURCE);
+          hmi_apis::Common_Result::WARNINGS);
 
   const uint32_t cmd_id =
       (*message_)[strings::msg_params][strings::cmd_id].asUInt();


### PR DESCRIPTION

Fixes #2468

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF PR: Todo

### Summary
Delete pending commands when AddCommand times out, assuming that the HMI might have processed them

### Changelog

##### Bug Fixes
* Delete pending commands when AddCommand times out, assuming that the HMI might have processed them

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
