### PR TITLE
Fix/Optimize Boost Logger Implementation

### DIFF
--- a/src/components/utils/include/utils/logger/boostlogger.h
+++ b/src/components/utils/include/utils/logger/boostlogger.h
@@ -32,10 +32,18 @@
 #pragma once
 
 #define BOOST_LOG_DYN_LINK 1
+
 #include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/log/sources/severity_channel_logger.hpp>
+#include <boost/log/sources/severity_logger.hpp>
+#include <boost/log/trivial.hpp>
 #include "utils/ilogger.h"
 
 namespace logger {
+
+namespace logging = boost::log;
+namespace src = boost::log::sources;
+namespace attrs = boost::log::attributes;
 
 class BoostLogger : public ThirdPartyLoggerInterface {
  public:
@@ -47,6 +55,15 @@ class BoostLogger : public ThirdPartyLoggerInterface {
   void PushLog(const LogMessage& log_message) override;
 
  private:
+  struct LogAttributes {
+    attrs::mutable_constant<boost::posix_time::ptime> timestamp_;
+    attrs::mutable_constant<std::thread::id> thread_id_;
+    attrs::mutable_constant<std::string> component_;
+    attrs::mutable_constant<std::string> file_name_;
+    attrs::mutable_constant<int> line_num_;
+    attrs::mutable_constant<std::string> trace_;
+  };
+
   boost::posix_time::ptime GetLocalPosixTime(
       const logger::TimePoint& timestamp);
 
@@ -54,6 +71,8 @@ class BoostLogger : public ThirdPartyLoggerInterface {
       const std::string& full_function_signature);
 
   std::string filename_;
+  src::severity_logger<logging::trivial::severity_level> slg_;
+  LogAttributes lg_attr_;
 };
 
 }  // namespace logger

--- a/src/components/utils/src/logger/boostlogger.cc
+++ b/src/components/utils/src/logger/boostlogger.cc
@@ -170,17 +170,14 @@ boost::posix_time::ptime BoostLogger::GetLocalPosixTime(
 
 std::string BoostLogger::GetFilteredFunctionTrace(
     const std::string& full_function_signature) {
-  boost::regex function_pattern("([^\\s]*)\\((.*)\\)");
-  boost::smatch results;
+  auto start_pos = full_function_signature.find(' ');
+  auto end_pos = full_function_signature.find('(', start_pos);
 
-  if (!boost::regex_search(
-          full_function_signature, results, function_pattern)) {
-    // Invalid pattern
-    return std::string(full_function_signature);
+  if (start_pos == std::string::npos || end_pos == std::string::npos ||
+      start_pos + 1 == full_function_signature.length()) {
+    return full_function_signature;
   }
-
-  // Get the function name(including namespaces) from the function signature
-  return std::string(results[1]);
+  return full_function_signature.substr(start_pos + 1, end_pos - start_pos - 1);
 }
 
 bool BoostLogger::IsEnabledFor(const std::string& component,


### PR DESCRIPTION
Partially Fixes #3709 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
To test performance
- Build with `-DLOGGER_NAME=BOOST`
- Start Core, deploy_server.sh and HMI. In a separate terminal tab/window run `htop` (Use F4 to filter for command smartDeviceLinkCore)
- Register navigation app and start video streaming. 

`htop` shows the CPU usage under "CPU%"

### Summary
- Use mutable attributes instead of adding attributes for every pushLog
- Simplified how function trace is filtered.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
