### PR TITLE
Fix PrepareResultForMobileResponse logic

### DIFF
--- a/src/components/application_manager/src/commands/request_from_mobile_impl.cc
+++ b/src/components/application_manager/src/commands/request_from_mobile_impl.cc
@@ -660,9 +660,16 @@ bool RequestFromMobileImpl::PrepareResultForMobileResponse(
     ResponseInfo& out_second,
     ResponseInfo& out_third) const {
   SDL_LOG_AUTO_TRACE();
-  bool result = (PrepareResultForMobileResponse(out_first, out_second) ||
-                 PrepareResultForMobileResponse(out_second, out_third)) ||
-                PrepareResultForMobileResponse(out_first, out_third);
+  bool result_first_second =
+      PrepareResultForMobileResponse(out_first, out_second);
+  bool result_second_third =
+      PrepareResultForMobileResponse(out_second, out_third);
+  bool result_first_third =
+      PrepareResultForMobileResponse(out_first, out_third);
+
+  bool result = (result_first_second && result_first_third) ||
+                (result_second_third && result_first_second) ||
+                (result_second_third && result_first_third);
   return result;
 }
 


### PR DESCRIPTION

Fixes https://github.com/smartdevicelink/sdl_core/issues/3942

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run ATF regression, plus manually test using the steps in the linked issue

### Summary
Fixes logic of 3-args overload of PrepareResultForMobileResponse, only returning true if at least two of the checks are successful (meaning that one response was successful and the other two were non-error responses)

### Changelog
##### Bug Fixes
* Fixes logic of 3-args overload of PrepareResultForMobileResponse, only returning true if at least two of the checks are successful

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
