### PR TITLE
Fix narrowing cast of time_t in resumption data

### DIFF
--- a/src/components/application_manager/include/application_manager/resumption/resumption_data.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data.h
@@ -157,7 +157,7 @@ class ResumptionData {
    * @brief Get the last ignition off time from LastState
    * @return the last ignition off time from LastState
    */
-  virtual uint32_t GetIgnOffTime() const = 0;
+  virtual int64_t GetIgnOffTime() const = 0;
 
   /**
    * @brief Checks if saved data have application

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_db.h
@@ -167,7 +167,7 @@ class ResumptionDataDB : public ResumptionData {
    * @brief Get the last ignition off time from LastState
    * @return the last ignition off time from LastState
    */
-  virtual uint32_t GetIgnOffTime() const;
+  virtual int64_t GetIgnOffTime() const;
 
   /**
    * @brief Checks if saved data have application
@@ -289,7 +289,7 @@ class ResumptionDataDB : public ResumptionData {
    * @brief Select Ign off time
    * @return Ign off time from saved data
    */
-  uint32_t SelectIgnOffTime() const;
+  int64_t SelectIgnOffTime() const;
 
   /**
    * @brief Checks existence application in DB

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_json.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_json.h
@@ -131,7 +131,7 @@ class ResumptionDataJson : public ResumptionData {
    * @brief Get the last ignition off time from LastState
    * @return the last ignition off time from LastState
    */
-  virtual uint32_t GetIgnOffTime() const;
+  virtual int64_t GetIgnOffTime() const;
 
   void IncrementGlobalIgnOnCounter() OVERRIDE;
 

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -734,7 +734,7 @@ bool ResumeCtrlImpl::CheckDelayBeforeIgnOff(
     return true;
   }
 
-  const uint32_t sec_spent_before_ign = labs(ign_off_time - time_stamp);
+  const uint64_t sec_spent_before_ign = labs(ign_off_time - time_stamp);
   SDL_LOG_DEBUG(
       "ign_off_time "
       << ign_off_time << "; app_disconnect_time " << time_stamp

--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -356,7 +356,7 @@ bool ResumptionDataDB::RemoveApplicationFromSaved(
   return result;
 }
 
-uint32_t ResumptionDataDB::GetIgnOffTime() const {
+int64_t ResumptionDataDB::GetIgnOffTime() const {
   SDL_LOG_AUTO_TRACE();
   return SelectIgnOffTime();
 }
@@ -533,14 +533,14 @@ bool ResumptionDataDB::SelectHashId(const std::string& policy_app_id,
   return false;
 }
 
-uint32_t ResumptionDataDB::SelectIgnOffTime() const {
+int64_t ResumptionDataDB::SelectIgnOffTime() const {
   SDL_LOG_AUTO_TRACE();
 
-  uint32_t ignOffTime = 0;
+  int64_t ignOffTime = 0;
   utils::dbms::SQLQuery query(db());
   if (query.Prepare(kSelectIgnOffTime)) {
     if (query.Exec()) {
-      ignOffTime = query.GetUInteger(0);
+      ignOffTime = query.GetLongInt(0);
       SDL_LOG_INFO("Last ign off time = " << ignOffTime);
       return ignOffTime;
     }
@@ -612,7 +612,7 @@ void ResumptionDataDB::SelectDataForLoadResumeData(
     SmartObject so_obj(SmartType_Map);
     so_obj[strings::hmi_level] = select_data.GetInteger(0);
     so_obj[strings::ign_off_count] = select_data.GetInteger(1);
-    so_obj[strings::time_stamp] = select_data.GetUInteger(2);
+    so_obj[strings::time_stamp] = select_data.GetLongInt(2);
     so_obj[strings::app_id] = select_data.GetString(3);
     so_obj[strings::device_id] = select_data.GetString(4);
     so_array_data[i++] = so_obj;
@@ -1470,7 +1470,7 @@ bool ResumptionDataDB::SelectDataFromAppTable(
   saved_app[strings::hmi_app_id] = query.GetUInteger(4);
   saved_app[strings::hmi_level] = query.GetInteger(5);
   saved_app[strings::ign_off_count] = query.GetInteger(6);
-  saved_app[strings::time_stamp] = query.GetUInteger(7);
+  saved_app[strings::time_stamp] = query.GetLongInt(7);
   saved_app[strings::device_id] = query.GetString(8);
   saved_app[strings::is_media_application] = query.GetBoolean(9);
   saved_app[strings::subscribed_for_way_points] = query.GetBoolean(10);

--- a/src/components/application_manager/src/resumption/resumption_data_json.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_json.cc
@@ -62,7 +62,7 @@ void ResumptionDataJson::SaveApplication(
                             << " policy_app_id : " << policy_app_id);
   const std::string hash = application->curHash();
   const uint32_t grammar_id = application->get_grammar_id();
-  const uint32_t time_stamp = (uint32_t)time(NULL);
+  const int64_t time_stamp = (int64_t)time(NULL);
   const std::string device_mac = application->mac_address();
   const mobile_apis::HMILevel::eType hmi_level =
       application->hmi_level(mobile_apis::PredefinedWindows::DEFAULT_WINDOW);
@@ -288,7 +288,7 @@ bool ResumptionDataJson::RemoveApplicationFromSaved(
   return result;
 }
 
-uint32_t ResumptionDataJson::GetIgnOffTime() const {
+int64_t ResumptionDataJson::GetIgnOffTime() const {
   using namespace app_mngr;
   SDL_LOG_AUTO_TRACE();
 
@@ -300,7 +300,7 @@ uint32_t ResumptionDataJson::GetIgnOffTime() const {
     accessor.GetMutableData().set_dictionary(dictionary);
     SDL_LOG_WARN("last_save_time section is missed");
   }
-  return resumption[strings::last_ign_off_time].asUInt();
+  return resumption[strings::last_ign_off_time].asInt64();
 }
 
 uint32_t ResumptionDataJson::GetGlobalIgnOnCounter() const {
@@ -399,7 +399,7 @@ void ResumptionDataJson::GetDataForLoadResumeData(
       smart_objects::SmartObject so(smart_objects::SmartType_Map);
       so[strings::hmi_level] = saved_app[strings::hmi_level].asInt();
       so[strings::ign_off_count] = saved_app[strings::ign_off_count].asInt();
-      so[strings::time_stamp] = saved_app[strings::time_stamp].asUInt();
+      so[strings::time_stamp] = saved_app[strings::time_stamp].asInt64();
       so[strings::app_id] = saved_app[strings::app_id].asString();
       so[strings::device_id] = saved_app[strings::device_id].asString();
       so_array_data[i++] = so;
@@ -532,7 +532,7 @@ void ResumptionDataJson::SetLastIgnOffTime(time_t ign_off_time,
 
   SDL_LOG_WARN("ign_off_time = " << ign_off_time);
   Json::Value& resumption = GetResumptionData(dictionary);
-  resumption[strings::last_ign_off_time] = static_cast<uint32_t>(ign_off_time);
+  resumption[strings::last_ign_off_time] = static_cast<int64_t>(ign_off_time);
 }
 
 bool ResumptionDataJson::Init() {

--- a/src/components/application_manager/test/include/application_manager/mock_resumption_data.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resumption_data.h
@@ -78,7 +78,7 @@ class MockResumptionData : public ::resumption::ResumptionData {
   MOCK_METHOD2(RemoveApplicationFromSaved,
                bool(const std::string& policy_app_id,
                     const std::string& device_id));
-  MOCK_CONST_METHOD0(GetIgnOffTime, uint32_t());
+  MOCK_CONST_METHOD0(GetIgnOffTime, int64_t());
   MOCK_CONST_METHOD2(IsApplicationSaved,
                      ssize_t(const std::string& policy_app_id,
                              const std::string& device_id));

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -766,8 +766,8 @@ TEST_F(ResumeCtrlTest, StartAppHmiStateResumption_AppInFull) {
   mobile_apis::HMILevel::eType restored_test_type = eType::HMI_FULL;
   uint32_t ign_off_count = 0;
   smart_objects::SmartObject saved_app;
-  const uint32_t time_offset = 5;
-  const uint32_t time_stamp =
+  const int64_t time_offset = 5;
+  const int64_t time_stamp =
       time(nullptr) - resumption_delay_before_ign_ + time_offset;
   saved_app[application_manager::strings::ign_off_count] = ign_off_count;
   saved_app[application_manager::strings::hmi_level] = restored_test_type;
@@ -822,8 +822,8 @@ TEST_F(ResumeCtrlTest, StartAppHmiStateResumption_AppHasDeferredResumption) {
   mobile_apis::HMILevel::eType deferred_level = eType::HMI_FULL;
   uint32_t ign_off_count = 0;
   smart_objects::SmartObject saved_app;
-  const uint32_t time_offset = 5;
-  const uint32_t time_stamp =
+  const int64_t time_offset = 5;
+  const int64_t time_stamp =
       time(nullptr) - resumption_delay_before_ign_ + time_offset;
   saved_app[application_manager::strings::ign_off_count] = ign_off_count;
   saved_app[application_manager::strings::hmi_level] = restored_test_type;
@@ -862,8 +862,8 @@ TEST_F(ResumeCtrlTest,
   mobile_apis::HMILevel::eType restored_test_type = eType::HMI_FULL;
   uint32_t ign_off_count = 0;
   smart_objects::SmartObject saved_app;
-  const uint32_t time_offset = 5;
-  const uint32_t time_stamp =
+  const int64_t time_offset = 5;
+  const int64_t time_stamp =
       time(nullptr) - resumption_delay_before_ign_ + time_offset;
   saved_app[application_manager::strings::ign_off_count] = ign_off_count;
   saved_app[application_manager::strings::hmi_level] = restored_test_type;
@@ -908,8 +908,8 @@ TEST_F(
   mobile_apis::HMILevel::eType restored_test_type = eType::HMI_LIMITED;
   uint32_t ign_off_count = 0;
   smart_objects::SmartObject saved_app;
-  const uint32_t time_offset = 5;
-  const uint32_t time_stamp =
+  const int64_t time_offset = 5;
+  const int64_t time_stamp =
       time(nullptr) - resumption_delay_before_ign_ + time_offset;
   saved_app[application_manager::strings::ign_off_count] = ign_off_count;
   saved_app[application_manager::strings::hmi_level] = restored_test_type;
@@ -1055,8 +1055,8 @@ TEST_F(ResumeCtrlTest, ApplicationResumptionTimer_AppInFull) {
   mobile_apis::HMILevel::eType restored_test_type = eType::HMI_FULL;
   const uint32_t ign_off_count = 0u;
   smart_objects::SmartObject saved_app;
-  const uint32_t time_offset = 5;
-  const uint32_t time_stamp =
+  const int64_t time_offset = 5;
+  const int64_t time_stamp =
       time(nullptr) - resumption_delay_before_ign_ + time_offset;
   saved_app[application_manager::strings::ign_off_count] = ign_off_count;
   saved_app[application_manager::strings::hmi_level] = restored_test_type;
@@ -1401,8 +1401,8 @@ TEST_F(
     ResumeCtrlTest,
     ResumptionLowVoltage_AppInFullUnregisteredWithinTimeFrame_HMILevelRestored) {
   const mobile_apis::HMILevel::eType restored_test_type = eType::HMI_FULL;
-  const uint32_t time_offset = 5;
-  const uint32_t time_stamp =
+  const int64_t time_offset = 5;
+  const int64_t time_stamp =
       time(nullptr) - resumption_delay_before_ign_ + time_offset;
   smart_objects::SmartObject saved_app;
   saved_app[application_manager::strings::hmi_level] = restored_test_type;
@@ -1448,8 +1448,8 @@ TEST_F(
     ResumeCtrlTest,
     ResumptionLowVoltage_AppInFullUnregisteredBeyondTimeFrame_HMILevelNotRestored) {
   const mobile_apis::HMILevel::eType restored_test_type = eType::HMI_FULL;
-  const uint32_t time_offset = 5;
-  const uint32_t time_stamp =
+  const int64_t time_offset = 5;
+  const int64_t time_stamp =
       time(nullptr) - resumption_delay_before_ign_ - time_offset;
   smart_objects::SmartObject saved_app;
   saved_app[application_manager::strings::hmi_level] = restored_test_type;
@@ -1487,8 +1487,8 @@ TEST_F(
 
 TEST_F(ResumeCtrlTest, ResumptionLowVoltage_AppInBackground_NotRestored) {
   const mobile_apis::HMILevel::eType restored_test_type = eType::HMI_BACKGROUND;
-  const uint32_t time_offset = 5;
-  const uint32_t time_stamp =
+  const int64_t time_offset = 5;
+  const int64_t time_stamp =
       time(nullptr) - resumption_delay_before_ign_ - time_offset;
   smart_objects::SmartObject saved_app;
   saved_app[application_manager::strings::hmi_level] = restored_test_type;
@@ -1515,8 +1515,8 @@ TEST_F(
     ResumeCtrlTest,
     ResumptionLowVoltage_AppInLimitedlUnregisteredWithinTimeFrame_HMILevelRestored) {
   const mobile_apis::HMILevel::eType restored_test_type = eType::HMI_LIMITED;
-  const uint32_t time_offset = 5;
-  const uint32_t time_stamp =
+  const int64_t time_offset = 5;
+  const int64_t time_stamp =
       time(nullptr) - resumption_delay_before_ign_ + time_offset;
   smart_objects::SmartObject saved_app;
   saved_app[application_manager::strings::hmi_level] = restored_test_type;
@@ -1562,8 +1562,8 @@ TEST_F(
     ResumeCtrlTest,
     ResumptionLowVoltage_AppInLimitedlUnregisteredBeyondTimeFrame_HMILevelNotRestored) {
   const mobile_apis::HMILevel::eType restored_test_type = eType::HMI_LIMITED;
-  const uint32_t time_offset = 5;
-  const uint32_t time_stamp =
+  const int64_t time_offset = 5;
+  const int64_t time_stamp =
       time(nullptr) - resumption_delay_before_ign_ - time_offset;
   smart_objects::SmartObject saved_app;
   saved_app[application_manager::strings::hmi_level] = restored_test_type;

--- a/src/components/application_manager/test/resumption/resumption_data_db_test.cc
+++ b/src/components/application_manager/test/resumption/resumption_data_db_test.cc
@@ -846,7 +846,7 @@ TEST_F(ResumptionDataDBTest, GetIgnOffTime_AfterSuspendAndAwake) {
   PrepareData();
   EXPECT_TRUE(res_db()->Init());
   SetZeroIgnOffTime();
-  uint32_t last_ign_off_time;
+  int64_t last_ign_off_time;
 
   EXPECT_CALL(*mock_app_extension_, SaveResumptionData(_));
   res_db()->SaveApplication(app_mock);
@@ -856,11 +856,11 @@ TEST_F(ResumptionDataDBTest, GetIgnOffTime_AfterSuspendAndAwake) {
 
   res_db()->IncrementIgnOffCount();
 
-  uint32_t after_suspend;
+  int64_t after_suspend;
   after_suspend = res_db()->GetIgnOffTime();
   EXPECT_LE(last_ign_off_time, after_suspend);
 
-  uint32_t after_awake;
+  int64_t after_awake;
   res_db()->DecrementIgnOffCount();
 
   after_awake = res_db()->GetIgnOffTime();

--- a/src/components/application_manager/test/resumption/resumption_data_json_test.cc
+++ b/src/components/application_manager/test/resumption/resumption_data_json_test.cc
@@ -360,7 +360,7 @@ TEST_F(ResumptionDataJsonTest, GetHashId) {
 }
 
 TEST_F(ResumptionDataJsonTest, GetIgnOffTime_AfterSuspendAndAwake) {
-  uint32_t last_ign_off_time;
+  int64_t last_ign_off_time;
   PrepareData();
   SetZeroIgnOff();
   EXPECT_CALL(*mock_app_extension_, SaveResumptionData(_));
@@ -371,11 +371,11 @@ TEST_F(ResumptionDataJsonTest, GetIgnOffTime_AfterSuspendAndAwake) {
 
   res_json.IncrementIgnOffCount();
 
-  uint32_t after_suspend;
+  int64_t after_suspend;
   after_suspend = res_json.GetIgnOffTime();
   EXPECT_LE(last_ign_off_time, after_suspend);
 
-  uint32_t after_awake;
+  int64_t after_awake;
   res_json.DecrementIgnOffCount();
 
   after_awake = res_json.GetIgnOffTime();


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/3948 (CIDs 277332 and 277353)

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- Verify that ign_off_time and timestamp are saved properly if over 32 bits on a 64 bit system
- Verify behavior is normal on 32 bit system

### Summary
Fixes narrowing cast of time_t in resumption data

### Changelog
##### Bug Fixes
* Fixed narrowing cast of time_t in resumption data

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
